### PR TITLE
Added appveyor file and SFML 2.4.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 build_script:
   - powershell -exec bypass scripts\bootstrap.ps1
-  - for /D %l in (ports\*) do .\vcpkg.exe install %~nxl --triplet %TRIPLET%
+  - cmd: for /D %l in (ports\*) do .\vcpkg.exe install %~nxl --triplet %TRIPLET%
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 build_script:
   - powershell -exec bypass scripts\bootstrap.ps1
-  - 
+  - for /D %l in (ports\*) do .\vcpkg.exe install %~nxl --triplet %TRIPLET%
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+environment:
+  matrix:
+    - TRIPLET: "x86-windows"
+    - TRIPLET: "x64-windows"
+
+build_script:
+  - powershell -exec bypass scripts\bootstrap.ps1
+  - 
+
+matrix:
+  fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 build_script:
   - powershell -exec bypass scripts\bootstrap.ps1
-  - cmd: for /D %l in (ports\*) do .\vcpkg.exe install %~nxl --triplet %TRIPLET%
+  - cmd: for /D %%l in (ports\*) do .\vcpkg.exe install %%~nxl --triplet %TRIPLET%
 
 matrix:
   fast_finish: true

--- a/ports/cocos2d/CONTROL
+++ b/ports/cocos2d/CONTROL
@@ -1,0 +1,3 @@
+Source: cocos2d
+Version: 3.10
+Description: Cocos2d-x is a suite of open-source, cross-platform, game-development tools used by thousands of developers all over the world.

--- a/ports/sery/CONTROL
+++ b/ports/sery/CONTROL
@@ -1,0 +1,3 @@
+Source: sery
+Version: 1.0.0
+Description: Simple binary (de)serialization library

--- a/ports/sery/portfile.cmake
+++ b/ports/sery/portfile.cmake
@@ -1,0 +1,30 @@
+include(vcpkg_common_functions)
+vcpkg_download_distfile(ARCHIVE
+    URL "https://github.com/Ninetainedo/Sery/archive/v1.0.zip"
+    FILENAME "sery-1.0.0.zip"
+    MD5 6af526fb1b029dd989a35e44a6fa59a8
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+SET(SERY_ROOT_DIR "${CURRENT_BUILDTREES_DIR}/src/Sery-1.0")
+message(${CURRENT_PACKAGES_DIR})
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SERY_ROOT_DIR}
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_build_cmake()
+vcpkg_install_cmake()
+
+# Removes unnecessary directories
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/cmake)
+
+# Handle copyright
+file(COPY ${SERY_ROOT_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sery)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/sery/LICENSE ${CURRENT_PACKAGES_DIR}/share/sery/copyright)
+
+# Moves cmake files where appropriate
+file(RENAME ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/share/sery/cmake)

--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,0 +1,3 @@
+Source: sfml
+Version: 2.4.0
+Description: Simple and Fast Multimedia Library http://www.sfml-dev.org/

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -1,15 +1,15 @@
 include(vcpkg_common_functions)
 vcpkg_download_distfile(ARCHIVE
-    URL "https://github.com/Ninetainedo/Sery/archive/v1.0.zip"
-    FILENAME "sery-1.0.0.zip"
-    MD5 6af526fb1b029dd989a35e44a6fa59a8
+    URL "http://www.sfml-dev.org/files/SFML-2.4.0-sources.zip"
+    FILENAME "SFML-2.4.0.zip"
+    MD5 c15e4169b8cfeb2ab8bbc004a90c159a
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-SET(SERY_ROOT_DIR "${CURRENT_BUILDTREES_DIR}/src/Sery-1.0")
+SET(SFML_ROOT_DIR "${CURRENT_BUILDTREES_DIR}/src/SFML-2.4.0")
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SERY_ROOT_DIR}
+    SOURCE_PATH ${SFML_ROOT_DIR}
     # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
     # OPTIONS_RELEASE -DOPTIMIZE=1
     # OPTIONS_DEBUG -DDEBUGGABLE=1
@@ -23,8 +23,8 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/cmake)
 
 # Handle copyright
-file(COPY ${SERY_ROOT_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sery)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/sery/LICENSE ${CURRENT_PACKAGES_DIR}/share/sery/copyright)
+file(COPY ${SFML_ROOT_DIR}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sfml)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/sfml/license.txt ${CURRENT_PACKAGES_DIR}/share/sfml/copyright)
 
 # Moves cmake files where appropriate
-file(RENAME ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/share/sery/cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/share/sfml/cmake)

--- a/ports/tcl/CONTROL
+++ b/ports/tcl/CONTROL
@@ -1,0 +1,3 @@
+Source: tcl
+Version: 8.6.5
+Description: Scripting language

--- a/ports/tk/CONTROL
+++ b/ports/tk/CONTROL
@@ -1,0 +1,3 @@
+Source: tk
+Version: 8.6.5
+Description: Most popular Tcl extension. Provides a graphical user interface library for a variety of operating systems.


### PR DESCRIPTION
Added appveyor support to ensure proper build of everything. It will try to install everything found in ports. (Running as I write this comment : https://ci.appveyor.com/project/Ninetainedo/vcpkg)
Added missing CONTROL files for TCL, TK and COCOS2D.
Added support for SFML 2.4.0
Added support for Sery 1.0.0
