### PR TITLE
Fix issue with vcpkg.system.targets not copied when ImportBefore does not exist

### DIFF
--- a/toolsrc/src/commands_integration.cpp
+++ b/toolsrc/src/commands_integration.cpp
@@ -190,7 +190,7 @@ namespace vcpkg
             const fs::path sys_src_path = tmp_dir / "vcpkg.system.targets";
             std::ofstream(sys_src_path) << create_system_targets_shortcut();
 
-            const std::string param = Strings::format(R"(/c COPY "%s" "%s" /Y > nul)", sys_src_path.string(), system_wide_targets_file.string());
+            const std::string param = Strings::format(R"(/c XCOPY "%s" "%s*" /Y > nul)", sys_src_path.string(), system_wide_targets_file.string());
             elevation_prompt_user_choice user_choice = elevated_cmd_execute(param);
             switch (user_choice)
             {


### PR DESCRIPTION
`vcpkg integrate install` exits successfully but `vcpkg.system.targets` is not copied if "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.Targets\ImportBefore" does not exist - which was the case for my freshly installed VS 2015. This PR should fix it. 
