### PR TITLE
fix Glew:x64-windows install failure #11.

### DIFF
--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -26,22 +26,30 @@ vcpkg_build_msbuild(
 )
 
 message(STATUS "Installing")
+IF (TRIPLET_SYSTEM_ARCH MATCHES "x86")
+	SET(BUILD_ARCH "Win32")
+ELSEIF(TRIPLET_SYSTEM_ARCH MATCHES "x64")
+	SET(BUILD_ARCH "x64")
+ELSE()
+	MESSAGE(SEND_ERROR "Unknown TRIPLET_SYSTEM_ARCH")
+ENDIF()
+
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.dll
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.pdb
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${BUILD_ARCH}/glew32d.dll
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${BUILD_ARCH}/glew32d.pdb
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${TRIPLET_SYSTEM_ARCH}/glew32.dll
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${TRIPLET_SYSTEM_ARCH}/glew32.pdb
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${BUILD_ARCH}/glew32.dll
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${BUILD_ARCH}/glew32.pdb
     DESTINATION ${CURRENT_PACKAGES_DIR}/bin
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.lib
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Debug/${BUILD_ARCH}/glew32d.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Release/${TRIPLET_SYSTEM_ARCH}/glew32.lib
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Release/${BUILD_ARCH}/glew32.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/lib
 )
 file(INSTALL

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -27,21 +27,21 @@ vcpkg_build_msbuild(
 
 message(STATUS "Installing")
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/Win32/glew32d.dll
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/Win32/glew32d.pdb
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.dll
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.pdb
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/Win32/glew32.dll
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/Win32/glew32.pdb
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${TRIPLET_SYSTEM_ARCH}/glew32.dll
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/bin/Release/${TRIPLET_SYSTEM_ARCH}/glew32.pdb
     DESTINATION ${CURRENT_PACKAGES_DIR}/bin
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Debug/Win32/glew32d.lib
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Debug/${TRIPLET_SYSTEM_ARCH}/glew32d.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
 )
 file(INSTALL
-    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Release/Win32/glew32.lib
+    ${CURRENT_BUILDTREES_DIR}/src/glew-1.13.0/lib/Release/${TRIPLET_SYSTEM_ARCH}/glew32.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/lib
 )
 file(INSTALL

--- a/ports/mpir/CONTROL
+++ b/ports/mpir/CONTROL
@@ -1,0 +1,3 @@
+Source: mpir
+Version: 2.7.2
+Description: Multiple Precision Integers and Rationals.

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -1,0 +1,48 @@
+include(vcpkg_common_functions)
+vcpkg_download_distfile(ARCHIVE_FILE
+    URL "http://mpir.org/mpir-2.7.2.tar.lz"
+    FILENAME "mpir-2.7.2.tar.lz"
+    MD5 2d47419dac50cc4a89c8c23421e66db1
+)
+vcpkg_extract_source_archive(${ARCHIVE_FILE})
+
+vcpkg_build_msbuild(
+    PROJECT_PATH ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/build.vc14/dll_mpir_gc/dll_mpir_gc.vcxproj
+)
+
+IF (TRIPLET_SYSTEM_ARCH MATCHES "x86")
+	SET(BUILD_ARCH "Win32")
+ELSE()
+	SET(BUILD_ARCH ${TRIPLET_SYSTEM_ARCH})
+ENDIF()
+
+file(INSTALL
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/gmp.h
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/gmpxx.h
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/mpir.h
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/mpirxx.h
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+file(INSTALL
+    ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/mpir.dll
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/mpir.pdb
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+)
+file(INSTALL
+    ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Release/mpir.dll
+	${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Release/mpir.pdb
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+)
+file(INSTALL
+    ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Debug/mpir.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+)
+file(INSTALL
+    ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/dll/${BUILD_ARCH}/Release/mpir.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+)
+
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/mpir-2.7.2/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/mpir RENAME copyright)
+
+vcpkg_copy_pdbs()
+message(STATUS "Installing done")


### PR DESCRIPTION
/ports/glew/portfile.cmake is hard code to "Win32", using ${TRIPLET_SYSTEM_ARCH} can fix this.
