### PR TITLE
Remove use of wildcard in integration installation dest path.

### DIFF
--- a/toolsrc/src/commands_integration.cpp
+++ b/toolsrc/src/commands_integration.cpp
@@ -195,7 +195,7 @@ namespace vcpkg
             const fs::path sys_src_path = tmp_dir / "vcpkg.system.targets";
             std::ofstream(sys_src_path) << create_system_targets_shortcut();
 
-            const std::string param = Strings::format(R"(/c XCOPY "%s" "%s*" /Y > nul)", sys_src_path.string(), system_wide_targets_file.string());
+            const std::string param = Strings::format(R"(/c echo f | XCOPY "%s" "%s" /Y > nul)", sys_src_path.string(), system_wide_targets_file.string());
             elevation_prompt_user_choice user_choice = elevated_cmd_execute(param);
             switch (user_choice)
             {


### PR DESCRIPTION
This seemed to be used in order to stop XPATH blocking on the file/directory dialog. It was causing odd issues I mentioned in #62. Instead used "echo f" to assure XCOPY that we're dealing with files.

Fixes #62.
