### PR TITLE
Protobuf/grpc PR

### DIFF
--- a/ports/grpc/CONTROL
+++ b/ports/grpc/CONTROL
@@ -1,0 +1,4 @@
+Source: grpc
+Version: 1.1.0-dev-1674f65
+Build-Depends: zlib, openssl, protobuf
+Description: An RPC library and framework

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -1,0 +1,58 @@
+include(vcpkg_common_functions)
+find_program(GIT git)
+
+set(GIT_URL "https://github.com/grpc/grpc.git")
+set(GIT_REV "1674f650ad9411448a35b7c19c5dbdaf0ebd8916")
+
+if(NOT EXISTS "${DOWNLOADS}/grpc.git")
+    message(STATUS "Cloning")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} clone --bare ${GIT_URL} ${DOWNLOADS}/grpc.git
+        WORKING_DIRECTORY ${DOWNLOADS}
+        LOGNAME clone
+    )
+endif()
+message(STATUS "Cloning done")
+
+if(NOT EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
+    message(STATUS "Adding worktree")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} worktree add -f --detach ${CURRENT_BUILDTREES_DIR}/src ${GIT_REV}
+        WORKING_DIRECTORY ${DOWNLOADS}/grpc.git
+        LOGNAME worktree
+    )
+    message(STATUS "Updating sumbodules")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} submodule update --init third_party/nanopb
+        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src
+        LOGNAME submodule
+    )
+endif()
+message(STATUS "Adding worktree and updating sumbodules done")
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
+    OPTIONS
+        -DgRPC_INSTALL=ON
+        -DgRPC_ZLIB_PROVIDER=package
+        -DgRPC_SSL_PROVIDER=package
+        -DgRPC_PROTOBUF_PROVIDER=package
+)
+
+vcpkg_build_cmake()
+vcpkg_install_cmake()
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/grpc)
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/gRPC/gRPCConfig.cmake ${CURRENT_PACKAGES_DIR}/share/grpc/gRPCConfig.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/gRPC/gRPCConfigVersion.cmake ${CURRENT_PACKAGES_DIR}/share/grpc/gRPCConfigVersion.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/gRPC/gRPCTargets.cmake ${CURRENT_PACKAGES_DIR}/share/grpc/gRPCTargets.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/gRPC/gRPCTargets-release.cmake ${CURRENT_PACKAGES_DIR}/share/grpc/gRPCTargets-release.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/gRPC/gRPCTargets-debug.cmake ${CURRENT_PACKAGES_DIR}/share/grpc/gRPCTargets-debug.cmake)
+
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/grpc RENAME copyright)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+
+vcpkg_copy_pdbs()

--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,0 +1,4 @@
+Source: protobuf
+Version: 3.0.2
+Build-Depends: zlib
+Description: Protocol Buffers - Google's data interchange format

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,0 +1,45 @@
+include(vcpkg_common_functions)
+vcpkg_download_distfile(ARCHIVE_FILE
+    URLS "https://github.com/google/protobuf/releases/download/v3.0.2/protobuf-cpp-3.0.2.tar.gz"
+    FILENAME "protobuf-cpp-3.0.2.tar.gz"
+    SHA512 5c99fa5d20815f9333a1e30d4da7621375e179abab6e4369ef0827b6ea6a679afbfec445dda21a72b4ab11e1bdd72c0f17a4e86b153ea8e2d3298dc3bcfcd643
+)
+vcpkg_download_distfile(TOOL_ARCHIVE_FILE
+    URLS "https://github.com/google/protobuf/releases/download/v3.0.2/protoc-3.0.2-win32.zip"
+    FILENAME "protoc-3.0.2-win32.zip"
+    SHA512 51c67bd8bdc35810da70786d873935814679c58b74e653923671bdf06b8b69a1c9a0793d090b17d25e91ddafff1726bcfcdd243373dd47c4aeb9ea83fbabaeb0
+)
+vcpkg_extract_source_archive(${ARCHIVE_FILE})
+vcpkg_extract_source_archive(${TOOL_ARCHIVE_FILE} ${CURRENT_BUILDTREES_DIR}/src/protobuf-3.0.2-win32)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/protobuf-3.0.2/cmake
+    OPTIONS
+        -Dprotobuf_BUILD_SHARED_LIBS=OFF
+        -Dprotobuf_MSVC_STATIC_RUNTIME=OFF
+        -Dprotobuf_WITH_ZLIB=ON
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR=share/protobuf
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(READ ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake RELEASE_MODULE)
+string(REPLACE "\${_IMPORT_PREFIX}/bin/protoc.exe" "\${_IMPORT_PREFIX}/tools/protoc.exe" RELEASE_MODULE "${RELEASE_MODULE}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake "${RELEASE_MODULE}")
+
+file(READ ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake DEBUG_MODULE)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE "${DEBUG_MODULE}")
+string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc.exe" "\${_IMPORT_PREFIX}/tools/protoc.exe" DEBUG_MODULE "${DEBUG_MODULE}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake "${DEBUG_MODULE}")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/protoc.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/protoc.exe)
+
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/protobuf-3.0.2/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/protobuf RENAME copyright)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/protobuf-3.0.2-win32/bin/protoc.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Cannot build gRPC for vcpkg

```
vcpkg>vcpkg install grpc
-- CURRENT_INSTALLED_DIR=D:/Work/vcpkg/installed/x86-windows
-- DOWNLOADS=D:/Work/vcpkg/downloads
-- CURRENT_PACKAGES_DIR=D:/Work/vcpkg/packages/grpc_x86-windows
-- CURRENT_BUILDTREES_DIR=D:/Work/vcpkg/buildtrees/grpc
-- CURRENT_PORT_DIR=D:/Work/vcpkg/ports/grpc/.
-- Downloading https://github.com/grpc/grpc/archive/ef5a2eb2678d38d35ff79c4d692bf48603e1c439.zip...
-- Downloading https://github.com/grpc/grpc/archive/ef5a2eb2678d38d35ff79c4d692bf48603e1c439.zip... OK
-- Testing integrity of downloaded file...
-- Testing integrity of downloaded file... OK
-- Extracting source D:/Work/vcpkg/downloads/grpc-ef5a2eb267.zip
-- Extracting done
-- Configuring x86-windows-rel
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:14 (message):
  Command failed: C:/Program
  Files/CMake/bin/cmake.exe;D:/Work/vcpkg/buildtrees/grpc/src/grpc-ef5a2eb2678d38d35ff79c4d692bf48603e1c439;-DgRPC_ZLIB_PROVIDER=package;-DgRPC_SSL_PROVIDER=package;-DgRPC_PROTOBUF_PROVIDER=package;-G;Visual
  Studio 14
  2015;-DCMAKE_VERBOSE_MAKEFILE=ON;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_TOOLCHAIN_FILE=D:/Work/vcpkg/triplets/x86-windows.cmake;-DCMAKE_PREFIX_PATH=D:/Work/vcpkg/installed/x86-windows;-DCMAKE_INSTALL_PREFIX=D:/Work/vcpkg/packages/grpc_x86-windows


  Working Directory: D:/Work/vcpkg/buildtrees/grpc/x86-windows-rel

  See logs for more information:

      D:\Work\vcpkg\buildtrees\grpc\config-x86-windows-rel-out.log
      D:\Work\vcpkg\buildtrees\grpc\config-x86-windows-rel-err.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_configure_cmake.cmake:27 (vcpkg_execute_required_process)
  ports/grpc/portfile.cmake:9 (vcpkg_configure_cmake)
  scripts/ports.cmake:96 (include)


Error: build command failed
```

[config-x86-windows-rel-out.log.txt](https://github.com/Microsoft/vcpkg/files/494173/config-x86-windows-rel-out.log.txt)
[config-x86-windows-rel-err.log.txt](https://github.com/Microsoft/vcpkg/files/494172/config-x86-windows-rel-err.log.txt)
