### PR TITLE
Add `vcpkg hash file` command

### DIFF
--- a/toolsrc/include/vcpkg_Commands.h
+++ b/toolsrc/include/vcpkg_Commands.h
@@ -35,6 +35,7 @@ namespace vcpkg
 
     void version_command(const vcpkg_cmd_arguments& args);
     void contact_command(const vcpkg_cmd_arguments& args);
+    void hash_command(const vcpkg_cmd_arguments& args);
 
     using command_type_a = void(*)(const vcpkg_cmd_arguments& args, const vcpkg_paths& paths, const triplet& default_target_triplet);
     using command_type_b = void(*)(const vcpkg_cmd_arguments& args, const vcpkg_paths& paths);

--- a/toolsrc/src/commands_hash.cpp
+++ b/toolsrc/src/commands_hash.cpp
@@ -1,0 +1,37 @@
+#include "vcpkg_Commands.h"
+#include "vcpkg_System.h"
+#include <algorithm>
+
+namespace vcpkg
+{
+    void hash_command(const vcpkg_cmd_arguments& args)
+    {
+        if (args.command_arguments.size() != 1)
+        {
+            System::println(System::color::error, "Error: %s requires 1 parameter", args.command);
+            print_example(Strings::format(R"(%s C:\path\to\file)", args.command).c_str());
+            exit(EXIT_FAILURE);
+        }
+
+        const std::string& path = args.command_arguments.at(0);
+        const std::wstring cmd_line = Strings::wformat(LR"(certutil.exe -hashfile "%s" SHA512)",
+                                                       Strings::utf8_to_utf16(path));
+
+        auto ec_data = System::cmd_execute_and_capture_output(cmd_line);
+        Checks::check_exit(ec_data.exit_code == 0, "Running command:\n   %s\n failed", Strings::utf16_to_utf8(cmd_line));
+
+        const std::string& output = ec_data.output;
+        const std::string leading_text = Strings::format("SHA512 hash of file %s:", path);
+        const std::string trailing_text = "CertUtil: -hashfile command completed successfully.";
+        auto start = output.find(leading_text) + leading_text.size();
+        Checks::check_exit(start != std::string::npos, "Unexpected output format from command: %s", Strings::utf16_to_utf8(cmd_line));
+        auto end = output.find(trailing_text);
+        Checks::check_exit(end != std::string::npos, "Unexpected output format from command: %s", Strings::utf16_to_utf8(cmd_line));
+        std::string hash = output.substr(start, end - start);
+        hash.erase(std::remove_if(hash.begin(), hash.end(), isspace), hash.end());
+
+        System::println("");
+        System::println(hash.c_str());
+        System::println("");
+    }
+}

--- a/toolsrc/src/commands_other.cpp
+++ b/toolsrc/src/commands_other.cpp
@@ -21,6 +21,7 @@ namespace vcpkg
             "  vcpkg import <pkg>              Import a pre-built library\n"
             "  vcpkg create <pkg> <url>\n"
             "             [archivename]        Create a new package\n"
+            "  vcpkg hash <path-to-file>       Hash the provided file with SHA512\n"
             "  vcpkg owns <pat>                Search for files in installed packages\n"
             "  vcpkg cache                     List cached compiled packages\n"
             "  vcpkg version                   Display version information\n"
@@ -93,7 +94,8 @@ namespace vcpkg
     {
         static std::vector<package_name_and_function<command_type_c>> t = {
             {"version", &version_command},
-            {"contact", &contact_command}
+            {"contact", &contact_command},
+            {"hash" , &hash_command}
         };
         return t;
     }

--- a/toolsrc/vcpkg/vcpkg.vcxproj
+++ b/toolsrc/vcpkg/vcpkg.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="..\src\commands_cache.cpp" />
     <ClCompile Include="..\src\commands_create.cpp" />
     <ClCompile Include="..\src\commands_edit.cpp" />
+    <ClCompile Include="..\src\commands_hash.cpp" />
     <ClCompile Include="..\src\commands_import.cpp" />
     <ClCompile Include="..\src\commands_list.cpp" />
     <ClCompile Include="..\src\commands_owns.cpp" />

--- a/toolsrc/vcpkg/vcpkg.vcxproj.filters
+++ b/toolsrc/vcpkg/vcpkg.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\MachineType.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\commands_hash.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\post_build_lint.h">


### PR DESCRIPTION
It looks like this:

```
C:\path\to\vcpkg> vcpkg hash .\downloads\zlib128.zip

b0d7e71eca9032910c56fc1de6adbdc4f915bdeafd9a114591fc05701893004ef3363add8ad0e576c956b6be158f2fc339ab393f2dd40e8cc8c2885d641d807b

C:\path\to\vcpkg>
```

Under the hood, `certutil.exe` is called to do the hashing. 
