### PR TITLE
Track updated Boost version.

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,3 +1,3 @@
 Source: boost
-Version: 1.61
+Version: 1.62
 Description: Peer-reviewed portable C++ source libraries


### PR DESCRIPTION
Today's update to portfile.cmake changed the Boost version to 1.62, but did not update the control file.
