### PR TITLE
[asio] Initial addition

### DIFF
--- a/ports/asio/CONTROL
+++ b/ports/asio/CONTROL
@@ -1,0 +1,3 @@
+Source: asio
+Version: 1.10.6
+Description: Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -1,0 +1,16 @@
+include(vcpkg_common_functions)
+SET(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/asio-asio-1-10-6/asio/)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/chriskohlhoff/asio/archive/asio-1-10-6.zip"
+    FILENAME "asio-1-10-6.zip"
+    SHA512 7e3fde7e88d305d19b88482b73c8b7a41751d65e81bd23dd8ef45eb4e3ef3a10629696b4d347e5a68f08d6fb2dede15a2f38c7ee8d18ac88be769215542da4c6
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+# Handle copyright
+file(COPY ${CURRENT_BUILDTREES_DIR}/src/asio-asio-1-10-6/asio/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/asio)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/asio/COPYING ${CURRENT_PACKAGES_DIR}/share/asio/copyright)
+
+# Copy the asio header files
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR} FILES_MATCHING PATTERN "*.hpp" PATTERN "*.ipp")
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Adds non-boost ASIO.

The only caveat being the end-user must define **ASIO_STANDALONE** and I am not sure how to indicate this or if there is a way to define it for them.
