### PR TITLE
Add the tools directory to CMAKE_PROGRAM_PATH

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -36,8 +36,8 @@ if(NOT VCPKG_TOOLCHAIN)
 
     include_directories(${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include)
 
-	set(CMAKE_PROGRAM_PATH ${CMAKE_PROGRAM_PATH} ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools)
-	
+    set(CMAKE_PROGRAM_PATH ${CMAKE_PROGRAM_PATH} ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools)
+
     option(OVERRIDE_ADD_EXECUTABLE "Automatically copy dependencies into the output directory for executables." ON)
     if(OVERRIDE_ADD_EXECUTABLE)
         function(add_executable name)

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -36,6 +36,8 @@ if(NOT VCPKG_TOOLCHAIN)
 
     include_directories(${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include)
 
+	set(CMAKE_PROGRAM_PATH ${CMAKE_PROGRAM_PATH} ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools)
+	
     option(OVERRIDE_ADD_EXECUTABLE "Automatically copy dependencies into the output directory for executables." ON)
     if(OVERRIDE_ADD_EXECUTABLE)
         function(add_executable name)


### PR DESCRIPTION
find_program and similar CMake functions begin their search in CMAKE_PROGRAM_PATH. This change allows finding of installed "tools" such as protoc from protobuf. As a result find_package(Protobuf REQUIRED) now locates and set Porobuf_PROTOC_EXECUTABLE properly.
