### PR TITLE
Add MongoDB C++ driver.

### DIFF
--- a/ports/libbson/0001_cmake.patch
+++ b/ports/libbson/0001_cmake.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d09a298..e64a6cd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,6 @@ include(CheckIncludeFile)
+ include(CheckStructHasMember)
+ include(CheckSymbolExists)
+ include(TestBigEndian)
+-include(InstallRequiredSystemLibraries)
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/build/cmake)
+ 
+@@ -47,13 +46,6 @@ TEST_BIG_ENDIAN(BSON_BIG_ENDIAN)
+ set (BSON_PTHREAD_ONCE_INIT_NEEDS_BRACES 0)
+ set (BSON_HAVE_DECIMAL128 0)
+ 
+-#librt needed on linux for clock_gettime
+-find_library(RT_LIBRARY rt)
+-if (RT_LIBRARY)
+-   #set required libraries for CHECK_FUNCTION_EXISTS
+-   set(CMAKE_REQUIRED_LIBRARIES ${RT_LIBRARY})
+-endif()
+-
+ # See https://public.kitware.com/Bug/view.php?id=15659
+ CHECK_SYMBOL_EXISTS(snprintf stdio.h BSON_HAVE_SNPRINTF)
+ if (NOT BSON_HAVE_SNPRINTF)
+@@ -314,7 +306,7 @@ install(
+ )
+ install(
+   FILES ${HEADERS}
+-  DESTINATION "include/libbson-${BSON_API_VERSION}"
++  DESTINATION "include"
+ )
+ 
+ set(VERSION "${BSON_VERSION}")

--- a/ports/libbson/CONTROL
+++ b/ports/libbson/CONTROL
@@ -1,0 +1,3 @@
+Source: libbson
+Version: 1.4.2
+Description: libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,0 +1,26 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+find_program(POWERSHELL powershell)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libbson-1.4.2)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mongodb/libbson/releases/download/1.4.2/libbson-1.4.2.tar.gz"
+    FILENAME "libbson-1.4.2.tar.gz"
+    SHA512 4cc8f833978483af3dcbc30bede33f2a9b448930fabf7be2d5581c8368e875dc1707d31eae209c747e69be1f82fa525c7362c5ac9c4e0b6b3f3346dd5147860e
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson/COPYING ${CURRENT_PACKAGES_DIR}/share/libbson/copyright)

--- a/ports/mongo-c-driver/0001_cmake.patch
+++ b/ports/mongo-c-driver/0001_cmake.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b3fc5b9..5a106ca 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,6 @@ option(ENABLE_EXPERIMENTAL_FEATURES
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/build/cmake)
+ 
+-include(InstallRequiredSystemLibraries)
+ include(FindBSON REQUIRED)
+ 
+ if (NOT (ENABLE_SSL STREQUAL DARWIN
+@@ -563,7 +562,7 @@ install(
+ )
+ install(
+   FILES ${HEADERS}
+-  DESTINATION "include/libmongoc-${MONGOC_API_VERSION}"
++  DESTINATION "include"
+ )
+ 
+ # Define pkg-config files
+diff --git a/build/cmake/FindBSON.cmake b/build/cmake/FindBSON.cmake
+index 4ac39ea..bf6ecab 100644
+--- a/build/cmake/FindBSON.cmake
++++ b/build/cmake/FindBSON.cmake
+@@ -11,7 +11,7 @@ endif ()
+ 
+ find_path(BSON_INCLUDE_DIR
+   NAMES
+-    libbson-1.0/bson.h
++    bson.h
+   HINTS
+     ${BSON_ROOT_DIR}
+     ${_BSON_INCLUDEDIR}
+@@ -19,8 +19,6 @@ find_path(BSON_INCLUDE_DIR
+     include
+ )
+ 
+-set(BSON_INCLUDE_DIR "${BSON_INCLUDE_DIR}/libbson-1.0")
+-
+ if(WIN32 AND NOT CYGWIN)
+   if(MSVC)
+     find_library(BSON

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,0 +1,4 @@
+Source: mongo-c-driver
+Version: 1.4.2
+Build-Depends: libbson
+Description: Client library written in C for MongoDB.

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -1,0 +1,28 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+find_program(POWERSHELL powershell)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-c-driver-1.4.2)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mongodb/mongo-c-driver/releases/download/1.4.2/mongo-c-driver-1.4.2.tar.gz"
+    FILENAME "mongo-c-driver-1.4.2.tar.gz"
+    SHA512 402b9d0f2ae957a07336c9a6d971440472acef8e17a3ba5e89635ca454a13d4b7cf5f9b71151ed6182c012efb5fac6684acfc00443c6bca07cdd04b9f7eddaeb
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DBSON_ROOT_DIR=${CURRENT_PACKAGES_DIR}/../libbson_${TARGET_TRIPLET}
+)
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/COPYING ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/copyright)

--- a/ports/mongo-cxx-driver/0001_cmake.patch
+++ b/ports/mongo-cxx-driver/0001_cmake.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 695f64c..87807d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -59,7 +59,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ 
+ # Include the required modules
+ include(GenerateExportHeader)
+-include(InstallRequiredSystemLibraries)
+ 
+ # If the user did not customize the install prefix,
+ # set it to live under build so we don't inadverently pollute /usr/local
+diff --git a/cmake/FindLibBSON.cmake b/cmake/FindLibBSON.cmake
+index 52f5de0..7a0be52 100644
+--- a/cmake/FindLibBSON.cmake
++++ b/cmake/FindLibBSON.cmake
+@@ -26,7 +26,7 @@ if(LIBBSON_DIR)
+   # Trust the user's override path by default
+   set(LIBBSON_LIBRARIES bson-1.0 CACHE INTERNAL "")
+   set(LIBBSON_LIBRARY_DIRS ${LIBBSON_DIR}/lib CACHE INTERNAL "")
+-  set(LIBBSON_INCLUDE_DIRS ${LIBBSON_DIR}/include/libbson-1.0 CACHE INTERNAL "")
++  set(LIBBSON_INCLUDE_DIRS ${LIBBSON_DIR}/include CACHE INTERNAL "")
+   find_package_handle_standard_args(LIBBSON DEFAULT_MSG LIBBSON_LIBRARIES LIBBSON_LIBRARY_DIRS LIBBSON_INCLUDE_DIRS)
+ elseif (PKG_CONFIG_FOUND)
+   # The best we can do until libbson starts installing a libbson-config.cmake file
+diff --git a/cmake/FindLibMongoC.cmake b/cmake/FindLibMongoC.cmake
+index 830de11..7e0bc76 100644
+--- a/cmake/FindLibMongoC.cmake
++++ b/cmake/FindLibMongoC.cmake
+@@ -26,7 +26,7 @@ if(LIBMONGOC_DIR)
+   # Trust the user's override path by default
+   set(LIBMONGOC_LIBRARIES mongoc-1.0 CACHE INTERNAL "")
+   set(LIBMONGOC_LIBRARY_DIRS ${LIBMONGOC_DIR}/lib CACHE INTERNAL "")
+-  set(LIBMONGOC_INCLUDE_DIRS ${LIBMONGOC_DIR}/include/libmongoc-1.0 CACHE INTERNAL "")
++  set(LIBMONGOC_INCLUDE_DIRS ${LIBMONGOC_DIR}/include CACHE INTERNAL "")
+   find_package_handle_standard_args(LIBMONGOC DEFAULT_MSG LIBMONGOC_LIBRARIES LIBMONGOC_LIBRARY_DIRS LIBMONGOC_INCLUDE_DIRS)
+ elseif (PKG_CONFIG_FOUND)
+   # The best we can do until libMONGOC starts installing a libmongoc-config.cmake file
+diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
+index cea1bc9..481529c 100644
+--- a/src/bsoncxx/CMakeLists.txt
++++ b/src/bsoncxx/CMakeLists.txt
+@@ -60,7 +60,7 @@ endif()
+ 
+ set(BSONCXX_VERSION ${BSONCXX_VERSION_MAJOR}.${BSONCXX_VERSION_MINOR}.${BSONCXX_VERSION_PATCH}${BSONCXX_VERSION_EXTRA})
+ set(BSONCXX_INLINE_NAMESPACE "v${BSONCXX_ABI_VERSION}")
+-set(BSONCXX_HEADER_INSTALL_DIR "include/bsoncxx/${BSONCXX_INLINE_NAMESPACE}" CACHE INTERNAL "")
++set(BSONCXX_HEADER_INSTALL_DIR "include" CACHE INTERNAL "")
+ 
+ set(LIBBSON_REQUIRED_VERSION 1.3.4)
+ set(LIBBSON_REQUIRED_ABI_VERSION 1.0)
+diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
+index fdbe61a..7d5c2c9 100644
+--- a/src/mongocxx/CMakeLists.txt
++++ b/src/mongocxx/CMakeLists.txt
+@@ -32,7 +32,7 @@ set(MONGOCXX_ABI_VERSION _noabi)
+ 
+ set(MONGOCXX_VERSION ${MONGOCXX_VERSION_MAJOR}.${MONGOCXX_VERSION_MINOR}.${MONGOCXX_VERSION_PATCH}${MONGOCXX_VERSION_EXTRA})
+ set(MONGOCXX_INLINE_NAMESPACE "v${MONGOCXX_ABI_VERSION}")
+-set(MONGOCXX_HEADER_INSTALL_DIR "include/mongocxx/${MONGOCXX_INLINE_NAMESPACE}" CACHE INTERNAL "")
++set(MONGOCXX_HEADER_INSTALL_DIR "include" CACHE INTERNAL "")
+ 
+ add_subdirectory(config)
+ 

--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,0 +1,4 @@
+Source: mongo-cxx-driver
+Version: 3.0.2
+Build-Depends: boost,mongo-c-driver
+Description: MongoDB C++ Driver.

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,0 +1,32 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+find_program(POWERSHELL powershell)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-cxx-driver-r3.0.2)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://codeload.github.com/mongodb/mongo-cxx-driver/zip/r3.0.2"
+    FILENAME "mongo-cxx-driver-r3.0.2.zip"
+    SHA512 f3f1902df22ad58090ec2d4f22c9746d32b12552934d0eaf686b7e3b2e65ac9eeff9e28944cde75c5f5834735e8b76f879e1ca0e7095195f22e3ce6dd92b4524
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DLIBBSON_DIR=${CURRENT_PACKAGES_DIR}/../libbson_${TARGET_TRIPLET}
+		-DLIBMONGOC_DIR=${CURRENT_PACKAGES_DIR}/../mongo-c-driver_${TARGET_TRIPLET}
+)
+
+vcpkg_install_cmake()	
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/mongo-cxx-driver)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-cxx-driver/LICENSE ${CURRENT_PACKAGES_DIR}/share/mongo-cxx-driver/copyright)


### PR DESCRIPTION
This PR add MongoDB C++ 11 client, which includes libbson, mongo-c-driver, mongo-cxx-driver, three ports.
This PR relates to https://github.com/Microsoft/vcpkg/pull/146 and https://github.com/Microsoft/vcpkg/pull/145.
