### PR TITLE
Add nanodbc

### DIFF
--- a/ports/nanodbc/0001_cmake.patch
+++ b/ports/nanodbc/0001_cmake.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f4aa71..94edd95 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,9 +201,16 @@ endif()
+ if(NANODBC_INSTALL)
+ 	install(FILES src/nanodbc.h DESTINATION include)
+ 	if(NANODBC_STATIC)
+-		install(TARGETS nanodbc ARCHIVE DESTINATION lib)
++		install(
++			TARGETS nanodbc 
++			ARCHIVE DESTINATION lib
++			LIBRARY DESTINATION lib)
+ 	else()
+-		install(TARGETS nanodbc LIBRARY DESTINATION lib)
++		install(
++			TARGETS nanodbc 
++			ARCHIVE DESTINATION lib
++			LIBRARY DESTINATION lib
++			RUNTIME DESTINATION bin)
+ 	endif()
+ 	message(STATUS "Target install: Turned on")
+ else()

--- a/ports/nanodbc/0002_msvc14_codecvt.patch
+++ b/ports/nanodbc/0002_msvc14_codecvt.patch
@@ -1,0 +1,34 @@
+diff --git a/src/nanodbc.cpp b/src/nanodbc.cpp
+index 8e02d4a..2e42b91 100644
+--- a/src/nanodbc.cpp
++++ b/src/nanodbc.cpp
+@@ -209,10 +209,11 @@ namespace
+             out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
+         #else
+             #if defined(_MSC_VER) && (_MSC_VER == 1900)
+-                // Workaround for confirmed bug in VS2015.
+-                // See: https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+-                auto p = reinterpret_cast<wide_char_t const*>(in.data());
+-                out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(p, p + in.size());
++		        // Workaround for confirmed bug in VS2015. See:
++			    // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
++			    // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
++			    auto p = reinterpret_cast<unsigned short const*>(in.data());
++		        out = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().to_bytes(p, p + in.size());
+             #else
+                 out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(in);
+             #endif
+@@ -226,9 +227,10 @@ namespace
+                 using boost::locale::conv::utf_to_utf;
+                 out = utf_to_utf<wide_char_t>(in.c_str(), in.c_str() + in.size());
+             #elif defined(_MSC_VER) && (_MSC_VER == 1900)
+-                // Workaround for confirmed bug in VS2015.
+-                // See: https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+-                auto s = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().from_bytes(in);
++                // Workaround for confirmed bug in VS2015. See:
++                // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
++                // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
++                auto s = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().from_bytes(in);
+                 auto p = reinterpret_cast<wide_char_t const*>(s.data());
+                 out.assign(p, p + s.size());
+             #else

--- a/ports/nanodbc/0003_export_def.patch
+++ b/ports/nanodbc/0003_export_def.patch
@@ -1,0 +1,509 @@
+diff --git a/src/nanodbc.cpp b/src/nanodbc.cpp
+index 8e02d4a..0483660 100644
+--- a/src/nanodbc.cpp
++++ b/src/nanodbc.cpp
+@@ -3253,10 +3253,10 @@ unsigned long statement::parameter_size(short param) const
+ 
+ // We need to instantiate each form of bind() for each of our supported data types.
+ #define NANODBC_INSTANTIATE_BINDS(type)                                                                                 \
+-    template void statement::bind(short, const type*, param_direction); /* 1-ary */                                     \
+-    template void statement::bind(short, const type*, std::size_t, param_direction); /* n-ary */                        \
+-    template void statement::bind(short, const type*, std::size_t, const type*, param_direction); /* n-ary, sentry */   \
+-    template void statement::bind(short, const type*, std::size_t, const bool*, param_direction) /* n-ary, flags */     \
++    template NANODBC_API void statement::bind(short, const type*, param_direction); /* 1-ary */                                     \
++    template NANODBC_API void statement::bind(short, const type*, std::size_t, param_direction); /* n-ary */                        \
++    template NANODBC_API void statement::bind(short, const type*, std::size_t, const type*, param_direction); /* n-ary, sentry */   \
++    template NANODBC_API void statement::bind(short, const type*, std::size_t, const bool*, param_direction) /* n-ary, flags */     \
+     /**/
+ 
+ // The following are the only supported instantiations of statement::bind().
+@@ -3875,112 +3875,112 @@ result::operator bool() const
+ }
+ 
+ // The following are the only supported instantiations of result::get_ref().
+-template void result::get_ref(short, string_type::value_type&) const;
+-template void result::get_ref(short, short&) const;
+-template void result::get_ref(short, unsigned short&) const;
+-template void result::get_ref(short, int32_t&) const;
+-template void result::get_ref(short, uint32_t&) const;
+-template void result::get_ref(short, int64_t&) const;
+-template void result::get_ref(short, uint64_t&) const;
+-template void result::get_ref(short, float&) const;
+-template void result::get_ref(short, double&) const;
+-template void result::get_ref(short, string_type&) const;
+-template void result::get_ref(short, date&) const;
+-template void result::get_ref(short, timestamp&) const;
+-
+-template void result::get_ref(const string_type&, string_type::value_type&) const;
+-template void result::get_ref(const string_type&, short&) const;
+-template void result::get_ref(const string_type&, unsigned short&) const;
+-template void result::get_ref(const string_type&, int32_t&) const;
+-template void result::get_ref(const string_type&, uint32_t&) const;
+-template void result::get_ref(const string_type&, int64_t&) const;
+-template void result::get_ref(const string_type&, uint64_t&) const;
+-template void result::get_ref(const string_type&, float&) const;
+-template void result::get_ref(const string_type&, double&) const;
+-template void result::get_ref(const string_type&, string_type&) const;
+-template void result::get_ref(const string_type&, date&) const;
+-template void result::get_ref(const string_type&, timestamp&) const;
++template NANODBC_API void result::get_ref(short, string_type::value_type&) const;
++template NANODBC_API void result::get_ref(short, short&) const;
++template NANODBC_API void result::get_ref(short, unsigned short&) const;
++template NANODBC_API void result::get_ref(short, int32_t&) const;
++template NANODBC_API void result::get_ref(short, uint32_t&) const;
++template NANODBC_API void result::get_ref(short, int64_t&) const;
++template NANODBC_API void result::get_ref(short, uint64_t&) const;
++template NANODBC_API void result::get_ref(short, float&) const;
++template NANODBC_API void result::get_ref(short, double&) const;
++template NANODBC_API void result::get_ref(short, string_type&) const;
++template NANODBC_API void result::get_ref(short, date&) const;
++template NANODBC_API void result::get_ref(short, timestamp&) const;
++
++template NANODBC_API void result::get_ref(const string_type&, string_type::value_type&) const;
++template NANODBC_API void result::get_ref(const string_type&, short&) const;
++template NANODBC_API void result::get_ref(const string_type&, unsigned short&) const;
++template NANODBC_API void result::get_ref(const string_type&, int32_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, uint32_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, int64_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, uint64_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, float&) const;
++template NANODBC_API void result::get_ref(const string_type&, double&) const;
++template NANODBC_API void result::get_ref(const string_type&, string_type&) const;
++template NANODBC_API void result::get_ref(const string_type&, date&) const;
++template NANODBC_API void result::get_ref(const string_type&, timestamp&) const;
+ 
+ // The following are the only supported instantiations of result::get_ref() with fallback.
+-template void result::get_ref(short, const string_type::value_type&, string_type::value_type&) const;
+-template void result::get_ref(short, const short&, short&) const;
+-template void result::get_ref(short, const unsigned short&, unsigned short&) const;
+-template void result::get_ref(short, const int32_t&, int32_t&) const;
+-template void result::get_ref(short, const uint32_t&, uint32_t&) const;
+-template void result::get_ref(short, const int64_t&, int64_t&) const;
+-template void result::get_ref(short, const uint64_t&, uint64_t&) const;
+-template void result::get_ref(short, const float&, float&) const;
+-template void result::get_ref(short, const double&, double&) const;
+-template void result::get_ref(short, const string_type&, string_type&) const;
+-template void result::get_ref(short, const date&, date&) const;
+-template void result::get_ref(short, const timestamp&, timestamp&) const;
+-
+-template void result::get_ref(const string_type&, const string_type::value_type&, string_type::value_type&) const;
+-template void result::get_ref(const string_type&, const short&, short&) const;
+-template void result::get_ref(const string_type&, const unsigned short&, unsigned short&) const;
+-template void result::get_ref(const string_type&, const int32_t&, int32_t&) const;
+-template void result::get_ref(const string_type&, const uint32_t&, uint32_t&) const;
+-template void result::get_ref(const string_type&, const int64_t&, int64_t&) const;
+-template void result::get_ref(const string_type&, const uint64_t&, uint64_t&) const;
+-template void result::get_ref(const string_type&, const float&, float&) const;
+-template void result::get_ref(const string_type&, const double&, double&) const;
+-template void result::get_ref(const string_type&, const string_type&, string_type&) const;
+-template void result::get_ref(const string_type&, const date&, date&) const;
+-template void result::get_ref(const string_type&, const timestamp&, timestamp&) const;
++template NANODBC_API void result::get_ref(short, const string_type::value_type&, string_type::value_type&) const;
++template NANODBC_API void result::get_ref(short, const short&, short&) const;
++template NANODBC_API void result::get_ref(short, const unsigned short&, unsigned short&) const;
++template NANODBC_API void result::get_ref(short, const int32_t&, int32_t&) const;
++template NANODBC_API void result::get_ref(short, const uint32_t&, uint32_t&) const;
++template NANODBC_API void result::get_ref(short, const int64_t&, int64_t&) const;
++template NANODBC_API void result::get_ref(short, const uint64_t&, uint64_t&) const;
++template NANODBC_API void result::get_ref(short, const float&, float&) const;
++template NANODBC_API void result::get_ref(short, const double&, double&) const;
++template NANODBC_API void result::get_ref(short, const string_type&, string_type&) const;
++template NANODBC_API void result::get_ref(short, const date&, date&) const;
++template NANODBC_API void result::get_ref(short, const timestamp&, timestamp&) const;
++
++template NANODBC_API void result::get_ref(const string_type&, const string_type::value_type&, string_type::value_type&) const;
++template NANODBC_API void result::get_ref(const string_type&, const short&, short&) const;
++template NANODBC_API void result::get_ref(const string_type&, const unsigned short&, unsigned short&) const;
++template NANODBC_API void result::get_ref(const string_type&, const int32_t&, int32_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, const uint32_t&, uint32_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, const int64_t&, int64_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, const uint64_t&, uint64_t&) const;
++template NANODBC_API void result::get_ref(const string_type&, const float&, float&) const;
++template NANODBC_API void result::get_ref(const string_type&, const double&, double&) const;
++template NANODBC_API void result::get_ref(const string_type&, const string_type&, string_type&) const;
++template NANODBC_API void result::get_ref(const string_type&, const date&, date&) const;
++template NANODBC_API void result::get_ref(const string_type&, const timestamp&, timestamp&) const;
+ 
+ // The following are the only supported instantiations of result::get().
+-template string_type::value_type result::get(short) const;
+-template short result::get(short) const;
+-template unsigned short result::get(short) const;
+-template int32_t result::get(short) const;
+-template uint32_t result::get(short) const;
+-template int64_t result::get(short) const;
+-template uint64_t result::get(short) const;
+-template float result::get(short) const;
+-template double result::get(short) const;
+-template string_type result::get(short) const;
+-template date result::get(short) const;
+-template timestamp result::get(short) const;
+-
+-template string_type::value_type result::get(const string_type&) const;
+-template short result::get(const string_type&) const;
+-template unsigned short result::get(const string_type&) const;
+-template int32_t result::get(const string_type&) const;
+-template uint32_t result::get(const string_type&) const;
+-template int64_t result::get(const string_type&) const;
+-template uint64_t result::get(const string_type&) const;
+-template float result::get(const string_type&) const;
+-template double result::get(const string_type&) const;
+-template string_type result::get(const string_type&) const;
+-template date result::get(const string_type&) const;
+-template timestamp result::get(const string_type&) const;
++template NANODBC_API string_type::value_type result::get(short) const;
++template NANODBC_API short result::get(short) const;
++template NANODBC_API unsigned short result::get(short) const;
++template NANODBC_API int32_t result::get(short) const;
++template NANODBC_API uint32_t result::get(short) const;
++template NANODBC_API int64_t result::get(short) const;
++template NANODBC_API uint64_t result::get(short) const;
++template NANODBC_API float result::get(short) const;
++template NANODBC_API double result::get(short) const;
++template NANODBC_API string_type result::get(short) const;
++template NANODBC_API date result::get(short) const;
++template NANODBC_API timestamp result::get(short) const;
++
++template NANODBC_API string_type::value_type result::get(const string_type&) const;
++template NANODBC_API short result::get(const string_type&) const;
++template NANODBC_API unsigned short result::get(const string_type&) const;
++template NANODBC_API int32_t result::get(const string_type&) const;
++template NANODBC_API uint32_t result::get(const string_type&) const;
++template NANODBC_API int64_t result::get(const string_type&) const;
++template NANODBC_API uint64_t result::get(const string_type&) const;
++template NANODBC_API float result::get(const string_type&) const;
++template NANODBC_API double result::get(const string_type&) const;
++template NANODBC_API string_type result::get(const string_type&) const;
++template NANODBC_API date result::get(const string_type&) const;
++template NANODBC_API timestamp result::get(const string_type&) const;
+ 
+ // The following are the only supported instantiations of result::get() with fallback.
+-template string_type::value_type result::get(short, const string_type::value_type&) const;
+-template short result::get(short, const short&) const;
+-template unsigned short result::get(short, const unsigned short&) const;
+-template int32_t result::get(short, const int32_t&) const;
+-template uint32_t result::get(short, const uint32_t&) const;
+-template int64_t result::get(short, const int64_t&) const;
+-template uint64_t result::get(short, const uint64_t&) const;
+-template float result::get(short, const float&) const;
+-template double result::get(short, const double&) const;
+-template string_type result::get(short, const string_type&) const;
+-template date result::get(short, const date&) const;
+-template timestamp result::get(short, const timestamp&) const;
+-
+-template string_type::value_type result::get(const string_type&, const string_type::value_type&) const;
+-template short result::get(const string_type&, const short&) const;
+-template unsigned short result::get(const string_type&, const unsigned short&) const;
+-template int32_t result::get(const string_type&, const int32_t&) const;
+-template uint32_t result::get(const string_type&, const uint32_t&) const;
+-template int64_t result::get(const string_type&, const int64_t&) const;
+-template uint64_t result::get(const string_type&, const uint64_t&) const;
+-template float result::get(const string_type&, const float&) const;
+-template double result::get(const string_type&, const double&) const;
+-template string_type result::get(const string_type&, const string_type&) const;
+-template date result::get(const string_type&, const date&) const;
+-template timestamp result::get(const string_type&, const timestamp&) const;
++template NANODBC_API string_type::value_type result::get(short, const string_type::value_type&) const;
++template NANODBC_API short result::get(short, const short&) const;
++template NANODBC_API unsigned short result::get(short, const unsigned short&) const;
++template NANODBC_API int32_t result::get(short, const int32_t&) const;
++template NANODBC_API uint32_t result::get(short, const uint32_t&) const;
++template NANODBC_API int64_t result::get(short, const int64_t&) const;
++template NANODBC_API uint64_t result::get(short, const uint64_t&) const;
++template NANODBC_API float result::get(short, const float&) const;
++template NANODBC_API double result::get(short, const double&) const;
++template NANODBC_API string_type result::get(short, const string_type&) const;
++template NANODBC_API date result::get(short, const date&) const;
++template NANODBC_API timestamp result::get(short, const timestamp&) const;
++
++template NANODBC_API string_type::value_type result::get(const string_type&, const string_type::value_type&) const;
++template NANODBC_API short result::get(const string_type&, const short&) const;
++template NANODBC_API unsigned short result::get(const string_type&, const unsigned short&) const;
++template NANODBC_API int32_t result::get(const string_type&, const int32_t&) const;
++template NANODBC_API uint32_t result::get(const string_type&, const uint32_t&) const;
++template NANODBC_API int64_t result::get(const string_type&, const int64_t&) const;
++template NANODBC_API uint64_t result::get(const string_type&, const uint64_t&) const;
++template NANODBC_API float result::get(const string_type&, const float&) const;
++template NANODBC_API double result::get(const string_type&, const double&) const;
++template NANODBC_API string_type result::get(const string_type&, const string_type&) const;
++template NANODBC_API date result::get(const string_type&, const date&) const;
++template NANODBC_API timestamp result::get(const string_type&, const timestamp&) const;
+ 
+ } // namespace nanodbc
+ 
+diff --git a/src/nanodbc.h b/src/nanodbc.h
+index f4e7b3d..cbb6fed 100644
+--- a/src/nanodbc.h
++++ b/src/nanodbc.h
+@@ -164,6 +164,16 @@ namespace nanodbc
+     #define NANODBC_NOEXCEPT noexcept
+ #endif
+ 
++#pragma warning(disable: 4275)
++#pragma warning(disable: 4251)
++#ifdef nanodbc_EXPORTS
++	/* We are building this library */
++	#define NANODBC_API __declspec(dllexport)
++#else
++	/* We are using this library */
++	#define NANODBC_API __declspec(dllimport)
++#endif
++
+ // 8888888888                                      888    888                        888 888 d8b
+ // 888                                             888    888                        888 888 Y8P
+ // 888                                             888    888                        888 888
+@@ -188,16 +198,17 @@ namespace nanodbc
+ 
+ //! \brief Type incompatible.
+ //! \see exceptions
+-class type_incompatible_error : public std::runtime_error
++class NANODBC_API type_incompatible_error : public std::runtime_error
+ {
+ public:
+     type_incompatible_error();
+     const char* what() const NANODBC_NOEXCEPT;
+ };
+ 
++
+ //! \brief Accessed null data.
+ //! \see exceptions
+-class null_access_error : public std::runtime_error
++class NANODBC_API null_access_error : public std::runtime_error
+ {
+ public:
+     null_access_error();
+@@ -206,7 +217,7 @@ public:
+ 
+ //! \brief Index out of range.
+ //! \see exceptions
+-class index_range_error : public std::runtime_error
++class NANODBC_API index_range_error : public std::runtime_error
+ {
+ public:
+     index_range_error();
+@@ -215,7 +226,7 @@ public:
+ 
+ //! \brief Programming logic error.
+ //! \see exceptions
+-class programming_error : public std::runtime_error
++class NANODBC_API programming_error : public std::runtime_error
+ {
+ public:
+     explicit programming_error(const std::string& info);
+@@ -224,7 +235,7 @@ public:
+ 
+ //! \brief General database error.
+ //! \see exceptions
+-class database_error : public std::runtime_error
++class NANODBC_API database_error : public std::runtime_error
+ {
+ public:
+     //! \brief Creates a runtime_error with a message describing the last ODBC error generated for the given handle and handle_type.
+@@ -298,7 +309,7 @@ struct timestamp
+ //! \brief A resource for managing transaction commits and rollbacks.
+ //!
+ //! \attention You will want to use transactions if you are doing batch operations because it will prevent auto commits from occurring after each individual operation is executed.
+-class transaction
++class NANODBC_API transaction
+ {
+ public:
+     //! \brief Begin a transaction on the given connection object.
+@@ -361,7 +372,7 @@ private:
+ // MARK: Statement -
+ 
+ //! \brief Represents a statement on the database.
+-class statement
++class NANODBC_API statement
+ {
+ public:
+     //! \brief Provides support for retrieving output/return parameters.
+@@ -559,7 +570,7 @@ public:
+     //! \param direction ODBC parameter direction.
+     //! \throws database_error
+     template<class T>
+-    void bind(short param, const T* value, param_direction direction = PARAM_IN);
++	void bind(short param, const T* value, param_direction direction = PARAM_IN);
+ 
+     //! \addtogroup bind_multi Binding multiple non-string values
+     //! \brief Binds the given values to the given parameter placeholder number in the prepared statement.
+@@ -582,17 +593,17 @@ public:
+     //! \brief Binds multiple values.
+     //! \see bind_multi
+     template<class T>
+-    void bind(short param, const T* values, std::size_t elements, param_direction direction = PARAM_IN);
++	void bind(short param, const T* values, std::size_t elements, param_direction direction = PARAM_IN);
+ 
+     //! \brief Binds multiple values.
+     //! \see bind_multi
+     template<class T>
+-    void bind(short param, const T* values, std::size_t elements, const T* null_sentry, param_direction direction = PARAM_IN);
++	void bind(short param, const T* values, std::size_t elements, const T* null_sentry, param_direction direction = PARAM_IN);
+ 
+     //! \brief Binds multiple values.
+     //! \see bind_multi
+     template<class T>
+-    void bind(short param, const T* values, std::size_t elements, const bool* nulls, param_direction direction = PARAM_IN);
++	void bind(short param, const T* values, std::size_t elements, const bool* nulls, param_direction direction = PARAM_IN);
+ 
+     //! @}
+ 
+@@ -734,7 +745,7 @@ private:
+ // MARK: Connection -
+ 
+ //! \brief Manages and encapsulates ODBC resources such as the connection and environment handles.
+-class connection
++class NANODBC_API connection
+ {
+ public:
+     //! \brief Create new connection object, initially not connected.
+@@ -903,7 +914,7 @@ class catalog;
+ //!
+ //! \see statement::execute(), statement::execute_direct()
+ //! \note result objects may be copied, however all copies will refer to the same underlying ODBC result set.
+-class result
++class NANODBC_API result
+ {
+ public:
+     //! Empty result set.
+@@ -986,7 +997,7 @@ public:
+     //! \param result The column's value will be written to this parameter.
+     //! \throws database_error, index_range_error, type_incompatible_error, null_access_error
+     template<class T>
+-    void get_ref(short column, T& result) const;
++	void get_ref(short column, T& result) const;
+ 
+     //! \brief Gets data from the given column of the current rowset.
+     //! If the data is null, fallback is returned instead.
+@@ -997,7 +1008,7 @@ public:
+     //! \param result The column's value will be written to this parameter.
+     //! \throws database_error, index_range_error, type_incompatible_error
+     template<class T>
+-    void get_ref(short column, const T& fallback, T& result) const;
++	void get_ref(short column, const T& fallback, T& result) const;
+ 
+     //! \brief Gets data from the given column by name of the current rowset.
+     //!
+@@ -1005,7 +1016,7 @@ public:
+     //! \param result The column's value will be written to this parameter.
+     //! \throws database_error, index_range_error, type_incompatible_error, null_access_error
+     template<class T>
+-    void get_ref(const string_type& column_name, T& result) const;
++	void get_ref(const string_type& column_name, T& result) const;
+ 
+     //! \brief Gets data from the given column by name of the current rowset.
+     //! If the data is null, fallback is returned instead.
+@@ -1015,7 +1026,7 @@ public:
+     //! \param result The column's value will be written to this parameter.
+     //! \throws database_error, index_range_error, type_incompatible_error
+     template<class T>
+-    void get_ref(const string_type& column_name, const T& fallback, T& result) const;
++	void get_ref(const string_type& column_name, const T& fallback, T& result) const;
+ 
+     //! \brief Gets data from the given column of the current rowset.
+     //!
+@@ -1023,7 +1034,7 @@ public:
+     //! \param column position.
+     //! \throws database_error, index_range_error, type_incompatible_error, null_access_error
+     template<class T>
+-    T get(short column) const;
++	T get(short column) const;
+ 
+     //! \brief Gets data from the given column of the current rowset.
+     //! If the data is null, fallback is returned instead.
+@@ -1033,14 +1044,14 @@ public:
+     //! \param fallback if value is null, return fallback instead.
+     //! \throws database_error, index_range_error, type_incompatible_error
+     template<class T>
+-    T get(short column, const T& fallback) const;
++	T get(short column, const T& fallback) const;
+ 
+     //! \brief Gets data from the given column by name of the current rowset.
+     //!
+     //! \param column_name column's name.
+     //! \throws database_error, index_range_error, type_incompatible_error, null_access_error
+     template<class T>
+-    T get(const string_type& column_name) const;
++	T get(const string_type& column_name) const;
+ 
+     //! \brief Gets data from the given column by name of the current rowset.
+     //! If the data is null, fallback is returned instead.
+@@ -1049,7 +1060,7 @@ public:
+     //! \param fallback if value is null, return fallback instead.
+     //! \throws database_error, index_range_error, type_incompatible_error
+     template<class T>
+-    T get(const string_type& column_name, const T& fallback) const;
++	T get(const string_type& column_name, const T& fallback) const;
+ 
+     //! \brief Returns true if and only if the given column of the current rowset is null.
+     //!
+@@ -1139,7 +1150,7 @@ private:
+ //                                                  "Y88P"
+ // MARK: Catalog -
+ 
+-class catalog
++class NANODBC_API catalog
+ {
+ public:
+ 
+@@ -1319,7 +1330,7 @@ private:
+ //! \return A result set object.
+ //! \attention You will want to use transactions if you are doing batch operations because it will prevent auto commits from occurring after each individual operation is executed.
+ //! \see open(), prepare(), execute(), result, transaction
+-result execute(
++result NANODBC_API execute(
+     connection& conn
+     , const string_type& query
+     , long batch_operations = 1
+@@ -1333,7 +1344,7 @@ result execute(
+ //! \return A result set object.
+ //! \attention You will want to use transactions if you are doing batch operations because it will prevent auto commits from occurring after each individual operation is executed.
+ //! \see open(), prepare(), execute(), result, transaction
+-void just_execute(
++void NANODBC_API just_execute(
+     connection& conn
+     , const string_type& query
+     , long batch_operations = 1
+@@ -1346,7 +1357,7 @@ void just_execute(
+ //! \return A result set object.
+ //! \attention You will want to use transactions if you are doing batch operations because it will prevent auto commits from occurring after each individual operation is executed.
+ //! \see open(), prepare(), execute(), result
+-result execute(statement& stmt, long batch_operations = 1);
++result NANODBC_API execute(statement& stmt, long batch_operations = 1);
+ 
+ //! \brief Execute the previously prepared query now and without creating result object.
+ //! \param stmt The prepared statement that will be executed.
+@@ -1355,7 +1366,7 @@ result execute(statement& stmt, long batch_operations = 1);
+ //! \return A result set object.
+ //! \attention You will want to use transactions if you are doing batch operations because it will prevent auto commits from occurring after each individual operation is executed.
+ //! \see open(), prepare(), execute(), result
+-void just_execute(statement& stmt, long batch_operations = 1);
++void NANODBC_API just_execute(statement& stmt, long batch_operations = 1);
+ 
+ //! \brief Execute the previously prepared query now.
+ //! Executes within the context of a transaction object and commits the transaction directly after execution.
+@@ -1364,7 +1375,7 @@ void just_execute(statement& stmt, long batch_operations = 1);
+ //! \throws database_error
+ //! \return A result set object.
+ //! \see open(), prepare(), execute(), result, transaction
+-result transact(statement& stmt, long batch_operations);
++result NANODBC_API transact(statement& stmt, long batch_operations);
+ 
+ //! \brief Execute the previously prepared query now and without creating result object.
+ //! Executes within the context of a transaction object and commits the transaction directly after execution.
+@@ -1373,7 +1384,7 @@ result transact(statement& stmt, long batch_operations);
+ //! \throws database_error
+ //! \return A result set object.
+ //! \see open(), prepare(), execute(), result, transaction
+-void just_transact(statement& stmt, long batch_operations);
++void NANODBC_API just_transact(statement& stmt, long batch_operations);
+ 
+ //! \brief Prepares the given statement to execute on it associated connection.
+ //! If the statement is not open throws programming_error.
+@@ -1382,7 +1393,7 @@ void just_transact(statement& stmt, long batch_operations);
+ //! \param timeout The number in seconds before query timeout. Default is 0 indicating no timeout.
+ //! \see open()
+ //! \throws database_error, programming_error
+-void prepare(statement& stmt, const string_type& query, long timeout = 0);
++void NANODBC_API prepare(statement& stmt, const string_type& query, long timeout = 0);
+ 
+ //! @}
+ 

--- a/ports/nanodbc/CONTROL
+++ b/ports/nanodbc/CONTROL
@@ -1,0 +1,3 @@
+Source: nanodbc
+Version: 2.12.4
+Description: A small C++ wrapper for the native C ODBC API.

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -1,0 +1,33 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/nanodbc-2.12.4)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/lexicalunit/nanodbc/archive/v2.12.4.tar.gz"
+    FILENAME "nanodbc-2.12.4.tar.gz"
+    SHA512 b9a924516b2a777e5f1497774997672320548722ed53413b0a7ad5d503e2f8ca1099f5059a912b7aae410928f4c4edcdfd02e4cfbf415976cd222697b354b4e6
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES 
+		${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+		${CMAKE_CURRENT_LIST_DIR}/0002_msvc14_codecvt.patch
+		${CMAKE_CURRENT_LIST_DIR}/0003_export_def.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DNANODBC_EXAMPLES=OFF
+		-DNANODBC_TEST=OFF
+		-DNANODBC_USE_UNICODE=OFF # it's the default value.
+)
+
+vcpkg_install_cmake()	
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/nanodbc/LICENSE ${CURRENT_PACKAGES_DIR}/share/nanodbc/copyright)


### PR DESCRIPTION
Nanodbc is a small C++ wrapper for the native C ODBC API.
Official website: http://nanodbc.lexicalunit.com/
Oficial github: https://github.com/lexicalunit/nanodbc

Note: 
Official release header file did not marked API as __dllexport, so I patched a file.
This PR does not support static build.
