### PR TITLE
Improve mongo client port.

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,6 +1,5 @@
 include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
-find_program(POWERSHELL powershell)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libbson-1.4.2)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -1,6 +1,5 @@
 include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
-find_program(POWERSHELL powershell)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-c-driver-1.4.2)
 
 vcpkg_download_distfile(ARCHIVE
@@ -18,7 +17,7 @@ vcpkg_apply_patches(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 	OPTIONS
-		-DBSON_ROOT_DIR=${CURRENT_PACKAGES_DIR}/../libbson_${TARGET_TRIPLET}
+		-DBSON_ROOT_DIR=${CURRENT_INSTALLED_DIR}
 )
 
 vcpkg_install_cmake()

--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-cxx-driver
 Version: 3.0.2
-Build-Depends: boost,mongo-c-driver
+Build-Depends: boost,libbson,mongo-c-driver
 Description: MongoDB C++ Driver.

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,6 +1,5 @@
 include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
-find_program(POWERSHELL powershell)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-cxx-driver-r3.0.2)
 
 vcpkg_download_distfile(ARCHIVE
@@ -18,8 +17,8 @@ vcpkg_apply_patches(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 	OPTIONS
-		-DLIBBSON_DIR=${CURRENT_PACKAGES_DIR}/../libbson_${TARGET_TRIPLET}
-		-DLIBMONGOC_DIR=${CURRENT_PACKAGES_DIR}/../mongo-c-driver_${TARGET_TRIPLET}
+		-DLIBBSON_DIR=${CURRENT_INSTALLED_DIR}
+		-DLIBMONGOC_DIR=${CURRENT_INSTALLED_DIR}
 )
 
 vcpkg_install_cmake()	


### PR DESCRIPTION
This PR fixed some some small issues recorded in https://github.com/Microsoft/vcpkg/pull/148:
1. removed find_program(POWERSHELL powershell)
2. LIBBSON_DIR uses ${CURRENT_INSTALLED_DIR} instead of ${CURRENT_PACKAGES_DIR}
3. mongo-cxx-driver directly requires libbson now.

I submitted a same PR yesterday: https://github.com/Microsoft/vcpkg/pull/157, but I mistakenly deleted it, sorry for that.
