### PR TITLE
Add libxml2

### DIFF
--- a/ports/libxml2/0001-Fix-makefile-imports.patch
+++ b/ports/libxml2/0001-Fix-makefile-imports.patch
@@ -1,0 +1,27 @@
+diff --git "a/win32/Makefile.msvc" "b/win32/Makefile.msvc"
+index d16c1a2..09d2291 100644
+--- "a/win32/Makefile.msvc"
++++ "b/win32/Makefile.msvc"	
+@@ -72,7 +72,7 @@ LIBS =
+ LIBS = $(LIBS) wsock32.lib ws2_32.lib
+ !endif 
+ !if "$(WITH_ICONV)" == "1"
+-LIBS = $(LIBS) iconv.lib
++LIBS = $(LIBS) libiconv.lib libcharset.lib
+ !endif 
+ !if "$(WITH_ICU)" == "1"
+ LIBS = $(LIBS) icu.lib
+@@ -80,7 +80,11 @@ LIBS = $(LIBS) icu.lib
+ !if "$(WITH_ZLIB)" == "1"
+ # could be named differently zdll or zlib
+ # LIBS = $(LIBS) zdll.lib
+-LIBS = $(LIBS) zlib.lib
++!if "$(DEBUG)" == "1"
++LIBS = $(LIBS) zlibd.lib
++!else
++LIBS = $(LIBS) zlib.lib
++!endif
+ !endif
+ !if "$(WITH_LZMA)" == "1"
+ LIBS = $(LIBS) liblzma.lib
+ 

--- a/ports/libxml2/CONTROL
+++ b/ports/libxml2/CONTROL
@@ -1,0 +1,4 @@
+Source: libxml2
+Version: 2.9.4
+Description: Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform)
+Build-Depends: zlib, libiconv

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,0 +1,145 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libxml2-2.9.4)
+vcpkg_download_distfile(ARCHIVE
+    URLS "ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz"
+    FILENAME "libxml2-2.9.4.tar.gz"
+    SHA512 f5174ab1a3a0ec0037a47f47aa47def36674e02bfb42b57f609563f84c6247c585dbbb133c056953a5adb968d328f18cbc102eb0d00d48eb7c95478389e5daf9
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+find_program(NMAKE nmake)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}/
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-makefile-imports.patch
+)
+
+set(SCRIPTS_DIR ${SOURCE_PATH}/win32)
+
+set(CONFIGURE_COMMAND_TEMPLATE cscript configure.js
+    zlib=yes
+    cruntime=@CRUNTIME@
+    debug=@DEBUGMODE@
+    prefix=@INSTALL_DIR@
+    include=@INCLUDE_DIR@
+    lib=@LIB_DIR@
+    bindir=@INSTALL_BIN_DIR@
+)
+
+
+#
+# Release
+#
+
+message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
+
+set(CRUNTIME /MD)
+set(DEBUGMODE no)
+set(LIB_DIR ${CURRENT_INSTALLED_DIR}/lib)
+set(INCLUDE_DIR ${CURRENT_INSTALLED_DIR}/include)
+set(INSTALL_DIR ${CURRENT_PACKAGES_DIR})
+set(INSTALL_BIN_DIR "$(PREFIX)/tools")
+file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
+file(TO_NATIVE_PATH "${INCLUDE_DIR}" INCLUDE_DIR)
+file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
+file(TO_NATIVE_PATH "${INSTALL_BIN_DIR}" INSTALL_BIN_DIR)
+string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND)
+vcpkg_execute_required_process(
+    COMMAND ${CONFIGURE_COMMAND}
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME config-${TARGET_TRIPLET}-rel
+)
+message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
+
+message(STATUS "Building ${TARGET_TRIPLET}-rel")
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} /f Makefile.msvc rebuild
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME build-${TARGET_TRIPLET}-rel
+)
+message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+
+message(STATUS "Installing ${TARGET_TRIPLET}-rel")
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} /f Makefile.msvc install
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME install-${TARGET_TRIPLET}-rel
+)
+message(STATUS "Installing ${TARGET_TRIPLET}-rel done")
+
+
+#
+# Debug
+#
+
+message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+
+set(CRUNTIME /MDd)
+set(DEBUGMODE yes)
+set(LIB_DIR ${CURRENT_INSTALLED_DIR}/debug/lib)
+set(INSTALL_DIR ${CURRENT_PACKAGES_DIR}/debug)
+file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
+file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
+string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND)
+
+vcpkg_execute_required_process(
+    COMMAND ${CONFIGURE_COMMAND}
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME config-${TARGET_TRIPLET}-dbg
+)
+message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
+
+message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} /f Makefile.msvc rebuild
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME build-${TARGET_TRIPLET}-dbg
+)
+message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
+
+message(STATUS "Installing ${TARGET_TRIPLET}-dbg")
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} /f Makefile.msvc install
+    WORKING_DIRECTORY ${SCRIPTS_DIR}
+    LOGNAME install-${TARGET_TRIPLET}-dbg
+)
+message(STATUS "Installing ${TARGET_TRIPLET}-dbg done")
+
+#
+# Cleanup
+#
+
+# Remove tools and debug include directories
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/tools)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Move includes to the expected directory
+file(RENAME ${CURRENT_PACKAGES_DIR}/include/libxml2/libxml ${CURRENT_PACKAGES_DIR}/include/libxml)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/libxml2)
+
+# The makefile builds both static and dynamic libraries, so remove the ones we don't want
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxml2_a.lib ${CURRENT_PACKAGES_DIR}/lib/libxml2_a_dll.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2_a.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2_a_dll.lib)
+else()
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxml2.lib ${CURRENT_PACKAGES_DIR}/lib/libxml2_a_dll.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2_a_dll.lib)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    # Rename the libs to match the dynamic lib names
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libxml2_a.lib ${CURRENT_PACKAGES_DIR}/lib/libxml2.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2_a.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libxml2.lib)
+endif()
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libxml2)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libxml2/COPYING ${CURRENT_PACKAGES_DIR}/share/libxml2/copyright)


### PR DESCRIPTION
Adds libxml2 for both static and dynamic builds. One thing I'm not sure about is the selection of 32- and 64-bit builds. It seems to find the correct NMake.exe depending on the target triplet, but does anyone know if this works somehow by accident or if it works as intended?
