### PR TITLE
Change version to "20150729-vcpkg2"

### DIFF
--- a/ports/range-v3/CONTROL
+++ b/ports/range-v3/CONTROL
@@ -1,3 +1,3 @@
 Source: range-v3
-Version: 0.0.0-2
+Version: 20150729-vcpkg2
 Description: Range library for C++11/14/17.


### PR DESCRIPTION
...to reflect this is based on the upstream sources as of 20150729, and
the second release of the patch based on that same upstream.

Addresses #174 some more.
