### PR TITLE
Sqlite3 unlock_notify and static build support

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -3,7 +3,11 @@ project(sqlite3 C)
 
 include_directories(${SOURCE})
 add_library(sqlite3 SHARED ${SOURCE}/sqlite3.c)
-target_compile_definitions(sqlite3 PRIVATE $<$<CONFIG:Debug>:-DSQLITE_DEBUG> "-DSQLITE_API=__declspec(dllexport)")
+target_compile_definitions(sqlite3 PRIVATE 
+    $<$<CONFIG:Debug>:-DSQLITE_DEBUG> "-DSQLITE_API=__declspec(dllexport)"
+    -DSQLITE_ENABLE_RTREE
+    -DSQLITE_ENABLE_UNLOCK_NOTIFY
+    )
 if(TRIPLET_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -16,13 +16,15 @@ target_compile_definitions(sqlite3 PRIVATE
     -DSQLITE_ENABLE_RTREE
     -DSQLITE_ENABLE_UNLOCK_NOTIFY
     )
+target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE>:include>)
 if(TRIPLET_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()
 
-install(TARGETS sqlite3
+install(TARGETS sqlite3 EXPORT sqlite3Config    
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
 install(FILES ${SOURCE}/sqlite3.h ${SOURCE}/sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
+install(EXPORT sqlite3Config DESTINATION share/sqlite3)

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -2,9 +2,17 @@ cmake_minimum_required(VERSION 3.0)
 project(sqlite3 C)
 
 include_directories(${SOURCE})
-add_library(sqlite3 SHARED ${SOURCE}/sqlite3.c)
+if(BUILD_SHARED_LIBS)
+    set(API "-DSQLITE_API=__declspec(dllexport)")
+else()
+    set(API "-DSQLITE_API=extern")
+endif()
+add_library(sqlite3 ${SOURCE}/sqlite3.c)
+
+
 target_compile_definitions(sqlite3 PRIVATE 
-    $<$<CONFIG:Debug>:-DSQLITE_DEBUG> "-DSQLITE_API=__declspec(dllexport)"
+    $<$<CONFIG:Debug>:-DSQLITE_DEBUG>
+    ${API}
     -DSQLITE_ENABLE_RTREE
     -DSQLITE_ENABLE_UNLOCK_NOTIFY
     )

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_definitions(sqlite3 PRIVATE
     -DSQLITE_ENABLE_RTREE
     -DSQLITE_ENABLE_UNLOCK_NOTIFY
     )
-target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE>:include>)
+target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE:include>)
 if(TRIPLET_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,3 +1,4 @@
+include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/sqlite-amalgamation-3150000)
 vcpkg_download_distfile(ARCHIVE
@@ -14,7 +15,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DSOURCE=${SOURCE_PATH}
 )
-
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/sqlite3/copyright "SQLite is in the Public Domain.\nhttp://www.sqlite.org/copyright.html\n")

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -18,5 +18,11 @@ vcpkg_configure_cmake(
 vcpkg_build_cmake()
 vcpkg_install_cmake()
 
+file(READ ${CURRENT_PACKAGES_DIR}/debug/share/sqlite3/sqlite3Config-debug.cmake SQLITE3_DEBUG_CONFIG)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" SQLITE3_DEBUG_CONFIG "${SQLITE3_DEBUG_CONFIG}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/sqlite3/sqlite3Config-debug.cmake "${SQLITE3_DEBUG_CONFIG}")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/sqlite3/copyright "SQLite is in the Public Domain.\nhttp://www.sqlite.org/copyright.html\n")
 vcpkg_copy_pdbs()


### PR DESCRIPTION
I modified the SQLite3 port to enable unlock_notify and rtree support as well as to fix static builds (the triplet file was not included, so all the stuff in the vcpkg_config_cmake script did not respect the triplet)

I also added back the install step (I think we should fix install causing a rebuild instead of not having the install step)
