### PR TITLE
Added package for PDCurses

### DIFF
--- a/ports/pdcurses/CONTROL
+++ b/ports/pdcurses/CONTROL
@@ -1,0 +1,3 @@
+Source: pdcurses
+Version: 3.4
+Description: Public Domain Curses - a curses library for environments that don't fit the termcap/terminfo model.

--- a/ports/pdcurses/LICENSE
+++ b/ports/pdcurses/LICENSE
@@ -1,0 +1,7 @@
+The core package is in the public domain, but small portions of PDCurses are subject to copyright under various licenses.
+
+The win32 files are released to the public domain.
+
+If you use PDCurses in an application, an acknowledgement would be appreciated, but is not mandatory. If you make corrections or enhancements to PDCurses, please forward them to the current maintainer for the benefit of other users.
+
+This software is provided AS IS with NO WARRANTY whatsoever.

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -13,16 +13,13 @@ vcpkg_extract_source_archive(${ARCHIVE})
 set(PDC_NMAKE_CMD ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y)
 set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
 set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
-set(PDC_PANELLIB ${SOURCE_PATH}/win32/panel)
 set(PDC_OUTPUT bin)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     set(PDC_PDCLIB ${PDC_PDCLIB}.lib)
-    set(PDC_PANELLIB ${PDC_PANELLIB}.lib)
     set(PDC_OUTPUT lib)
 else()
     set(PDC_PDCLIB ${PDC_PDCLIB}.dll)
-    set(PDC_PANELLIB ${PDC_PANELLIB}.dll)
     set(PDC_NMAKE_CMD ${PDC_NMAKE_CMD} DLL=Y)
 endif()
 
@@ -34,7 +31,7 @@ vcpkg_execute_required_process(
 )
 message(STATUS "Build ${TARGET_TRIPLET}-rel done")
 file (
-    COPY ${PDC_PDCLIB} ${PDC_PANELLIB}
+    COPY ${PDC_PDCLIB}
     DESTINATION ${CURRENT_PACKAGES_DIR}/${PDC_OUTPUT}
 )
 
@@ -46,7 +43,7 @@ vcpkg_execute_required_process(
 )
 message(STATUS "Build ${TARGET_TRIPLET}-dbg done")
 file (
-    COPY ${PDC_PDCLIB} ${PDC_PANELLIB}
+    COPY ${PDC_PDCLIB}
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/${PDC_OUTPUT}
 )
 

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -10,17 +10,48 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-message(STATUS "Build ${TARGET_TRIPLET}")
-vcpkg_execute_required_process(
-    COMMAND ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y
-    WORKING_DIRECTORY ${SOURCE_PATH}/win32
-    LOGNAME build-${TARGET_TRIPLET}
-)
-message(STATUS "Build ${TARGET_TRIPLET} done")
+set(PDC_NMAKE_CMD ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y)
+set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
+set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
+set(PDC_PANELLIB ${SOURCE_PATH}/win32/panel)
+set(PDC_OUTPUT bin)
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(PDC_PDCLIB ${PDC_PDCLIB}.lib)
+    set(PDC_PANELLIB ${PDC_PANELLIB}.lib)
+    set(PDC_OUTPUT lib)
+else()
+    set(PDC_PDCLIB ${PDC_PDCLIB}.dll)
+    set(PDC_PANELLIB ${PDC_PANELLIB}.dll)
+    set(PDC_NMAKE_CMD ${PDC_NMAKE_CMD} DLL=Y)
+endif()
+
+message(STATUS "Build ${TARGET_TRIPLET}-rel")
+vcpkg_execute_required_process(
+    COMMAND ${PDC_NMAKE_CMD}
+    WORKING_DIRECTORY ${PDC_NMAKE_CWD}
+    LOGNAME build-${TARGET_TRIPLET}-rel
+)
+message(STATUS "Build ${TARGET_TRIPLET}-rel done")
+file (
+    COPY ${PDC_PDCLIB} ${PDC_PANELLIB}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/${PDC_OUTPUT}
+)
+
+message(STATUS "Build ${TARGET_TRIPLET}-dbg")
+vcpkg_execute_required_process(
+    COMMAND ${PDC_NMAKE_CMD} DEBUG=Y
+    WORKING_DIRECTORY ${PDC_NMAKE_CWD}
+    LOGNAME build-${TARGET_TRIPLET}-dbg
+)
+message(STATUS "Build ${TARGET_TRIPLET}-dbg done")
+file (
+    COPY ${PDC_PDCLIB} ${PDC_PANELLIB}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/${PDC_OUTPUT}
+)
+
+file(
+    COPY ${SOURCE_PATH}/curses.h ${SOURCE_PATH}/panel.h ${SOURCE_PATH}/term.h
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pdcurses RENAME copyright)
-file(COPY ${SOURCE_PATH}/win32/pdcurses.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-file(COPY ${SOURCE_PATH}/win32/panel.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-file(COPY ${SOURCE_PATH}/curses.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${SOURCE_PATH}/panel.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${SOURCE_PATH}/term.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -1,4 +1,9 @@
 include(${CMAKE_TRIPLET_FILE})
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+    message(FATAL_ERROR "64-bit builds are not supported for PDCurses.")
+endif()
+
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 find_program(NMAKE nmake)

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -1,18 +1,18 @@
 include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/PDCurses-3.4)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 find_program(NMAKE nmake)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://sourceforge.net/projects/pdcurses/files/latest/download?source=files"
+    URLS "http://downloads.sourceforge.net/project/pdcurses/pdcurses/3.4/pdcurs34.zip"
     FILENAME "pdcurs34.zip"
-    SHA512 cf2144359935ea553954e60e74318168d4c6fcee48648dfec74325742a61786b285c59ad0a014cc1f4039a332c3dbf2031c64865025a0cd25ef8faacc5827d05
+    SHA512 0b916bfe37517abb80df7313608cc4e1ed7659a41ce82763000dfdfa5b8311ffd439193c74fc84a591f343147212bf1caf89e7db71f1f7e4fa70f534834cb039
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
 message(STATUS "Build ${TARGET_TRIPLET}")
 vcpkg_execute_required_process(
-    COMMAND ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y PDCLIBS
+    COMMAND ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y
     WORKING_DIRECTORY ${SOURCE_PATH}/win32
     LOGNAME build-${TARGET_TRIPLET}
 )

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -1,0 +1,26 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/PDCurses-3.4)
+find_program(NMAKE nmake)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://sourceforge.net/projects/pdcurses/files/latest/download?source=files"
+    FILENAME "pdcurs34.zip"
+    SHA512 cf2144359935ea553954e60e74318168d4c6fcee48648dfec74325742a61786b285c59ad0a014cc1f4039a332c3dbf2031c64865025a0cd25ef8faacc5827d05
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+message(STATUS "Build ${TARGET_TRIPLET}")
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y PDCLIBS
+    WORKING_DIRECTORY ${SOURCE_PATH}/win32
+    LOGNAME build-${TARGET_TRIPLET}
+)
+message(STATUS "Build ${TARGET_TRIPLET} done")
+
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pdcurses RENAME copyright)
+file(COPY ${SOURCE_PATH}/win32/pdcurses.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/win32/panel.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/curses.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${SOURCE_PATH}/panel.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${SOURCE_PATH}/term.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)


### PR DESCRIPTION
Per #188, adds PDCurses package.

Since the preferred way to build PDCurses on Windows is to use the included NMake file, this implementation simply calls NMake and then copies the relevant files.
