### PR TITLE
Add hash command

### DIFF
--- a/toolsrc/include/vcpkg_Commands.h
+++ b/toolsrc/include/vcpkg_Commands.h
@@ -35,6 +35,7 @@ namespace vcpkg
 
     void version_command(const vcpkg_cmd_arguments& args);
     void contact_command(const vcpkg_cmd_arguments& args);
+	void hash_command(const vcpkg_cmd_arguments& args);
 
     using command_type_a = void(*)(const vcpkg_cmd_arguments& args, const vcpkg_paths& paths, const triplet& default_target_triplet);
     using command_type_b = void(*)(const vcpkg_cmd_arguments& args, const vcpkg_paths& paths);

--- a/toolsrc/src/commands_hash.cpp
+++ b/toolsrc/src/commands_hash.cpp
@@ -9,14 +9,24 @@ namespace fs = std::tr2::sys;
 
 namespace vcpkg
 {
-	void file_hash_sha512(fs::path const & path, char const * hash)
+	void file_hash_sha512(fs::path const & path, std::wstring const & hashType)
 	{
-		auto cmd_line = Strings::format("Powershell -Command (Get-FileHash %s -Algorithm %s).Hash.ToLower()", 
-			Strings::utf16_to_utf8(path.c_str()), 
-			hash);
-		auto ec_data = System::cmd_execute_and_capture_output(Strings::utf8_to_utf16(cmd_line));
-		Checks::check_exit(ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
-		System::print(ec_data.output.c_str());
+		auto cmd_line = Strings::wformat(LR"(CertUtil.exe -hashfile "%s" %s)",
+			path.c_str(), hashType.c_str());
+		auto ec_data = System::cmd_execute_and_capture_output(cmd_line);
+		Checks::check_exit(ec_data.exit_code == 0, "Running command:\n   %s\n failed", Strings::utf16_to_utf8(cmd_line));
+
+		std::string const & output = ec_data.output;
+
+		auto start = output.find_first_of("\r\n");
+		Checks::check_exit(start != std::string::npos, "Unexpected output format from command: %s", Strings::utf16_to_utf8(cmd_line));
+
+		auto end = output.find_first_of("\r\n", start + 1);
+		Checks::check_exit(end != std::string::npos, "Unexpected output format from command: %s", Strings::utf16_to_utf8(cmd_line));
+
+		auto hash = output.substr(start, end - start);
+		hash.erase(std::remove_if(hash.begin(), hash.end(), isspace), hash.end());
+		System::println(hash.c_str());
 	}
 
 	void hash_command(const vcpkg_cmd_arguments& args)
@@ -28,11 +38,11 @@ namespace vcpkg
 
 		if (args.command_arguments.size() == 1)
 		{
-			file_hash_sha512(args.command_arguments[0], "SHA512");
+			file_hash_sha512(args.command_arguments[0], L"SHA512");
 		}
 		if (args.command_arguments.size() == 2)
 		{
-			file_hash_sha512(args.command_arguments[0], args.command_arguments[1].c_str());
+			file_hash_sha512(args.command_arguments[0], Strings::utf8_to_utf16(args.command_arguments[1]));
 		}
 
 		exit(EXIT_SUCCESS);

--- a/toolsrc/src/commands_hash.cpp
+++ b/toolsrc/src/commands_hash.cpp
@@ -1,0 +1,40 @@
+#include "vcpkg_Commands.h"
+#include "vcpkg_System.h"
+#include "vcpkg.h"
+#include <iostream>
+#include <iomanip>
+#include <Windows.h>
+
+namespace fs = std::tr2::sys;
+
+namespace vcpkg
+{
+	void file_hash_sha512(fs::path const & path, char const * hash)
+	{
+		auto cmd_line = Strings::format("Powershell -Command (Get-FileHash %s -Algorithm %s).Hash.ToLower()", 
+			Strings::utf16_to_utf8(path.c_str()), 
+			hash);
+		auto ec_data = System::cmd_execute_and_capture_output(Strings::utf8_to_utf16(cmd_line));
+		Checks::check_exit(ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
+		System::print(ec_data.output.c_str());
+	}
+
+	void hash_command(const vcpkg_cmd_arguments& args)
+	{
+		static const std::string example = Strings::format(
+			"The argument should be a file path\n%s", create_example_string("hash boost_1_62_0.tar.bz2"));
+		args.check_min_arg_count(1, example.c_str());
+		args.check_max_arg_count(2, example.c_str());
+
+		if (args.command_arguments.size() == 1)
+		{
+			file_hash_sha512(args.command_arguments[0], "SHA512");
+		}
+		if (args.command_arguments.size() == 2)
+		{
+			file_hash_sha512(args.command_arguments[0], args.command_arguments[1].c_str());
+		}
+
+		exit(EXIT_SUCCESS);
+	}
+}

--- a/toolsrc/src/commands_other.cpp
+++ b/toolsrc/src/commands_other.cpp
@@ -14,6 +14,7 @@ namespace vcpkg
             "  vcpkg remove --purge <pkg>      Uninstall and delete a package. \n"
             "  vcpkg list                      List installed packages\n"
             "  vcpkg update                    Display list of packages for updating\n"
+			"  vcpkg hash <file> [alg]         Hash a file by specific algorithm, default SHA512\n"
             "\n"
             "%s" // Integration help
             "\n"
@@ -93,7 +94,8 @@ namespace vcpkg
     {
         static std::vector<package_name_and_function<command_type_c>> t = {
             {"version", &version_command},
-            {"contact", &contact_command}
+            {"contact", &contact_command}, 
+			{"hash",    &hash_command },
         };
         return t;
     }

--- a/toolsrc/vcpkg/commands_hash.cpp
+++ b/toolsrc/vcpkg/commands_hash.cpp
@@ -1,0 +1,40 @@
+#include "vcpkg_Commands.h"
+#include "vcpkg_System.h"
+#include "vcpkg.h"
+#include <iostream>
+#include <iomanip>
+#include <Windows.h>
+
+namespace fs = std::tr2::sys;
+
+namespace vcpkg
+{
+	void file_hash_sha512(fs::path const & path, char const * hash)
+	{
+		auto cmd_line = Strings::format("Powershell -Command (Get-FileHash %s -Algorithm %s).Hash.ToLower()", 
+			Strings::utf16_to_utf8(path.c_str()), 
+			hash);
+		auto ec_data = System::cmd_execute_and_capture_output(Strings::utf8_to_utf16(cmd_line));
+		Checks::check_exit(ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
+		System::print(ec_data.output.c_str());
+	}
+
+	void hash_command(const vcpkg_cmd_arguments& args)
+	{
+		static const std::string example = Strings::format(
+			"The argument should be a file path\n%s", create_example_string("hash boost_1_62_0.tar.bz2 "));
+		args.check_min_arg_count(1, example.c_str());
+		args.check_max_arg_count(2, example.c_str());
+
+		if (args.command_arguments.size() == 1)
+		{
+			file_hash_sha512(args.command_arguments[0], "SHA512");
+		}
+		if (args.command_arguments.size() == 2)
+		{
+			file_hash_sha512(args.command_arguments[0], args.command_arguments[1].c_str());
+		}
+
+		exit(EXIT_SUCCESS);
+	}
+}

--- a/toolsrc/vcpkg/vcpkg.vcxproj
+++ b/toolsrc/vcpkg/vcpkg.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="..\src\commands_cache.cpp" />
     <ClCompile Include="..\src\commands_create.cpp" />
     <ClCompile Include="..\src\commands_edit.cpp" />
+    <ClCompile Include="..\src\commands_hash.cpp" />
     <ClCompile Include="..\src\commands_import.cpp" />
     <ClCompile Include="..\src\commands_list.cpp" />
     <ClCompile Include="..\src\commands_owns.cpp" />

--- a/toolsrc/vcpkg/vcpkg.vcxproj.filters
+++ b/toolsrc/vcpkg/vcpkg.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\MachineType.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\commands_hash.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\post_build_lint.h">


### PR DESCRIPTION
This should fix https://github.com/Microsoft/vcpkg/issues/89.

Example: 
- vcpkg hash boost_1_62_0.tar.bz2
- vcpkg hash boost_1_62_0.tar.bz2 SHA1
