### PR TITLE
Upgrade cpprestsdk to 2.9.0

### DIFF
--- a/ports/cpprestsdk/0001_cmake.patch
+++ b/ports/cpprestsdk/0001_cmake.patch
@@ -1,16 +1,5 @@
-From cc9d3ca4d1d16134a1976b89b58b11372a2798d5 Mon Sep 17 00:00:00 2001
-From: Robert Schumacher <roschuma@microsoft.com>
-Date: Wed, 4 May 2016 21:37:23 -0700
-Subject: [PATCH] Use find_package on Windows. Enable 'install' target for all
- systems.
-
----
- Release/CMakeLists.txt     | 48 ++++++++++++++--------------------------------
- Release/src/CMakeLists.txt | 13 +++++++------
- 2 files changed, 21 insertions(+), 40 deletions(-)
-
 diff --git a/Release/CMakeLists.txt b/Release/CMakeLists.txt
-index cbe840b..3045948 100644
+index 1274102..fe245e6 100644
 --- a/Release/CMakeLists.txt
 +++ b/Release/CMakeLists.txt
 @@ -89,15 +89,6 @@ elseif(UNIX) # This includes OSX
@@ -29,10 +18,11 @@ index cbe840b..3045948 100644
  elseif(WIN32)
    option(BUILD_SHARED_LIBS "Build shared Libraries." ON)
    option(BUILD_SAMPLES "Build samples." ON)
-@@ -114,36 +105,25 @@ elseif(WIN32)
+@@ -113,37 +104,25 @@ elseif(WIN32)
+     set(Casablanca_DEFINITIONS "" CACHE INTERNAL "Definitions for consume casablanca library")
    endif()
    add_definitions(${Casablanca_DEFINITIONS} -D_WINSOCK_DEPRECATED_NO_WARNINGS -DWIN32)
- 
+-
 -  if (NOT CPPREST_EXCLUDE_WEBSOCKETS)
 -    set(NUGET_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../packages")
 -    set(PACKAGE_PATHS)
@@ -58,11 +48,12 @@ index cbe840b..3045948 100644
 -    endif()
 -
 -    set(Boost_INCLUDE_DIR "${NUGET_PATH}/boost.1.58.0.0/lib/native/include")
+-  endif()
 +  if (NOT CPPREST_EXCLUDE_WEBSOCKETS AND NOT WINDOWS_STORE)
 +    find_package(ZLIB REQUIRED)
 +    find_package(OpenSSL REQUIRED)
 +    find_package(Boost REQUIRED COMPONENTS regex system date_time)
-   endif()
++   endif()
  else()
    message(FATAL_ERROR "-- Unsupported Build Platform.")
  endif()
@@ -81,7 +72,7 @@ index cbe840b..3045948 100644
  if(ANDROID)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
 diff --git a/Release/src/CMakeLists.txt b/Release/src/CMakeLists.txt
-index cf086ed..3e5fffa 100644
+index 4074905..da907e5 100644
 --- a/Release/src/CMakeLists.txt
 +++ b/Release/src/CMakeLists.txt
 @@ -144,10 +144,11 @@ elseif(ANDROID)
@@ -102,6 +93,4 @@ index cf086ed..3e5fffa 100644
 +  LIBRARY DESTINATION lib
 +  ARCHIVE DESTINATION lib
 +  )
--- 
-2.8.1.windows.1
-
+\ No newline at end of file

--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,4 +1,4 @@
 Source: cpprestsdk
-Version: 2.8
+Version: 2.9.0
 Description: C++11 JSON, REST, and OAuth library
   The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services.

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -1,49 +1,36 @@
+include(${CMAKE_TRIPLET_FILE})
 include(vcpkg_common_functions)
-find_program(GIT git)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cpprestsdk-2.9.0)
 
-set(GIT_URL "https://github.com/Microsoft/cpprestsdk")
-set(GIT_REF "3542f07")
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/Microsoft/cpprestsdk/archive/v2.9.0.tar.gz"
+    FILENAME "cpprestsdk-2.9.0.tar.gz"
+    SHA512 c75de6ad33b3e8d2c6ba7c0955ed851d557f78652fb38a565de0cfbc99e7db89cb6fa405857512e5149df80356c51ae9335abd914c3c593fa6658ac50adf4e29
+)
+vcpkg_extract_source_archive(${ARCHIVE})
 
-if(NOT EXISTS "${DOWNLOADS}/cpprestsdk.git")
-    message(STATUS "Cloning")
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} clone --bare ${GIT_URL} ${DOWNLOADS}/cpprestsdk.git
-        WORKING_DIRECTORY ${DOWNLOADS}
-        LOGNAME clone
-    )
-endif()
-message(STATUS "Cloning done")
 
-if(NOT EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
-    message(STATUS "Adding worktree and patching")
-    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} worktree add -f --detach ${CURRENT_BUILDTREES_DIR}/src ${GIT_REF}
-        WORKING_DIRECTORY ${DOWNLOADS}/cpprestsdk.git
-        LOGNAME worktree
-    )
-    message(STATUS "Patching")
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} apply ${CMAKE_CURRENT_LIST_DIR}/0001-Use-find_package-on-Windows.-Enable-install-target-f.patch --ignore-whitespace --whitespace=fix
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src
-        LOGNAME patch
-    )
-endif()
-message(STATUS "Adding worktree and patching done")
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES 
+		${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/Release
+    SOURCE_PATH ${SOURCE_PATH}/Release
     OPTIONS
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF
         -DCPPREST_EXCLUDE_WEBSOCKETS=ON
-    OPTIONS_DEBUG
-        -DCASA_INSTALL_HEADERS=OFF
 )
 
 vcpkg_install_cmake()
 
-file(COPY ${CURRENT_BUILDTREES_DIR}/src/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpprestsdk)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/cpprestsdk/license.txt ${CURRENT_PACKAGES_DIR}/share/cpprestsdk/copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL
+	${SOURCE_PATH}/license.txt
+	DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpprestsdk RENAME copyright)
+
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
Official website:
https://github.com/Microsoft/cpprestsdk
Release:
https://github.com/Microsoft/cpprestsdk/releases/tag/v2.9.0

Note:
The original cpprestsdk uses the "json-utf8-3.0" branch, which confused me a lot, and blocks me to create the "SignalR-Client-Cpp" port (https://github.com/aspnet/SignalR-Client-Cpp).
Is there any particular reason that not using the official master branch release?
