### PR TITLE
Add libccd

### DIFF
--- a/ports/libccd/CONTROL
+++ b/ports/libccd/CONTROL
@@ -1,0 +1,3 @@
+Source: libccd
+Version: 2.0.0
+Description: Library for collision detection between two convex shapes

--- a/ports/libccd/portfile.cmake
+++ b/ports/libccd/portfile.cmake
@@ -1,0 +1,33 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libccd-16b9379fb6e8610566fe5e1396166daf7106f165)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/danfis/libccd/archive/16b9379fb6e8610566fe5e1396166daf7106f165.zip"
+    FILENAME "libccd-16b9379fb6e8610566fe5e1396166daf7106f165.zip"
+    SHA512 6cb3ea713f1b1ac1bf48c9ee7e14cb85b3ec5c822ce239330913edc00cb84c846b49ec090cbfa226ef8de70bac97199eb2bf4c651225e3cfc6f6a9dd441aa7db
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+# Avoid a copy of file in debug
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/BSD-LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libccd)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libccd/BSD-LICENSE ${CURRENT_PACKAGES_DIR}/share/libccd/copyright)


### PR DESCRIPTION
`libccd` is library for a collision detection between two convex shapes. libccd implements variation on Gilbert–Johnson–Keerthi algorithm plus Expand Polytope Algorithm (EPA) and also implements algorithm Minkowski Portal Refinement (MPR, a.k.a. XenoCollide) as described in Game Programming Gems 7. `libccd` is currently part of [ODE](http://www.ode.org/), [FCL](http://www.ros.org/wiki/fcl), and [Bullet3](http://bulletphysics.org/).

This PR closes #92.
