### PR TITLE
Add zziplib port

### DIFF
--- a/ports/zziplib/CMakeLists.txt
+++ b/ports/zziplib/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.0)
+
+include(GNUInstallDirs)
+
+project(zziplib C)
+
+find_package(zlib)
+
+include_directories(${ZLIB_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+if(MSVC)
+    set(CMAKE_DEBUG_POSTFIX "d")
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+# List the header files
+set(HEADERS zzip/__debug.h
+            zzip/__dirent.h
+            zzip/__fnmatch.h
+            zzip/__hints.h
+            zzip/__mmap.h
+            zzip/_config.h
+            zzip/_msvc.h
+            zzip/autoconf.h
+            zzip/conf.h
+            zzip/fetch.h
+            zzip/file.h
+            zzip/format.h
+            zzip/fseeko.h
+            zzip/info.h
+            zzip/lib.h
+            zzip/memdisk.h
+            zzip/mmapped.h
+            zzip/plugin.h
+            zzip/stdint.h
+            zzip/types.h
+            zzip/write.h
+            zzip/zzip.h
+)
+
+# List the source files
+set(SRCS zzip/dir.c
+         zzip/err.c
+         zzip/fetch.c
+         zzip/file.c
+         zzip/info.c
+         zzip/plugin.c
+         zzip/stat.c
+         zzip/zip.c
+)
+
+add_library(zziplib ${SRCS} ${HEADERS})
+
+if(${BUILD_SHARED_LIBS})
+    target_compile_definitions(zziplib PRIVATE -DZZIPLIB_EXPORTS)
+endif()
+
+target_link_libraries(zziplib ${ZLIB_LIBRARIES})
+
+install(TARGETS zziplib
+        COMPONENT runtime
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib)
+
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip)

--- a/ports/zziplib/CONTROL
+++ b/ports/zziplib/CONTROL
@@ -1,0 +1,4 @@
+Source: zziplib
+Version: 0.13.62
+Build-Depends: zlib
+Description: library providing read access on ZIP-archives

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -1,0 +1,23 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/zziplib-0.13.62)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download"
+    FILENAME "zziplib-0.13.62.tar.bz2"
+    SHA512 fd3b9e9015ba7603bdebd8f6a2ac6d11003705bfab22f3a0025f75455042664aea69440845b59e6f389417dff5ac777f49541d8cbacb2a220e67d20bb6973e25
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/zziplib)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/zziplib/COPYING.LIB ${CURRENT_PACKAGES_DIR}/share/zziplib/copyright)


### PR DESCRIPTION
To facilitate support of VS2015 in all the different configurations,
a CMake-based build system based on the one found in
https://sourceforge.net/p/zziplib/patches/17/ is used.
