### PR TITLE
Add libintl.

### DIFF
--- a/ports/gettext/0001-Fix-macro-definitions.patch
+++ b/ports/gettext/0001-Fix-macro-definitions.patch
@@ -1,0 +1,45 @@
+From df8121a8822245df0b191b7d3b1654611fdac1b2 Mon Sep 17 00:00:00 2001
+From: vlj <vljn.ovi@gmail.com>
+Date: Tue, 1 Nov 2016 23:09:06 +0100
+Subject: [PATCH] Fix macro definitions.
+
+---
+ gettext-0.19/gettext-runtime/intl/printf-parse.c | 4 +++-
+ gettext-0.19/gettext-runtime/intl/xsize.h        | 6 ++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/gettext-0.19/gettext-runtime/intl/printf-parse.c b/gettext-0.19/gettext-runtime/intl/printf-parse.c
+index 0e2d2c7..8cedfc6 100644
+--- a/gettext-0.19/gettext-runtime/intl/printf-parse.c
++++ b/gettext-0.19/gettext-runtime/intl/printf-parse.c
+@@ -48,7 +48,9 @@
+ #include <stddef.h>
+ 
+ /* Get intmax_t.  */
+-#if defined IN_LIBINTL || defined IN_LIBASPRINTF
++#if _MSC_VER
++# define intmax_t long int
++#elif defined IN_LIBINTL || defined IN_LIBASPRINTF
+ # if HAVE_STDINT_H_WITH_UINTMAX
+ #  include <stdint.h>
+ # endif
+diff --git a/gettext-0.19/gettext-runtime/intl/xsize.h b/gettext-0.19/gettext-runtime/intl/xsize.h
+index c256665..d09e79f 100644
+--- a/gettext-0.19/gettext-runtime/intl/xsize.h
++++ b/gettext-0.19/gettext-runtime/intl/xsize.h
+@@ -27,6 +27,12 @@
+ # include <stdint.h>
+ #endif
+ 
++#ifdef _WIN32
++# define _GL_INLINE_HEADER_BEGIN
++# define _GL_INLINE_HEADER_END
++# define _GL_INLINE static inline
++#endif
++
+ #ifndef _GL_INLINE_HEADER_BEGIN
+  #error "Please include config.h first."
+ #endif
+-- 
+2.10.1.windows.1
+

--- a/ports/gettext/CMakeLists.txt
+++ b/ports/gettext/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(gettext-runtime)

--- a/ports/gettext/CMakeLists_libintl.txt
+++ b/ports/gettext/CMakeLists_libintl.txt
@@ -1,0 +1,54 @@
+cmake_policy(SET CMP0005 OLD)
+
+project(libintl)
+
+include_directories(".")
+
+FILE(GLOB SOURCES
+"intl/bindtextdom.c"
+"intl/dcgettext.c"
+"intl/dcigettext.c"
+"intl/dcngettext.c"
+"intl/dgettext.c"
+"intl/dngettext.c"
+"intl/explodename.c"
+"intl/finddomain.c"
+"intl/gettext.c"
+"intl/hash-string.c"
+"intl/intl-compat.c"
+"intl/l10nflist.c"
+"intl/langprefs.c"
+"intl/loadmsgcat.c"
+"intl/localcharset.c"
+"intl/localealias.c"
+"intl/localename.c"
+"intl/lock.c"
+"intl/log.c"
+"intl/ngettext.c"
+"intl/osdep.c"
+"intl/plural-exp.c"
+"intl/plural.c"
+"intl/printf.c"
+"intl/relocatable.c"
+"intl/textdomain.c"
+"intl/version.c"
+)
+
+set(LOCALDIR "c:\\gettext")
+
+add_definitions(-DLOCALEDIR=\\\"${LOCALDIR}\\\")
+add_definitions(-DLOCALE_ALIAS_PATH=\\\"${LOCALDIR}\\\")
+add_definitions(-DLIBDIR=\\\"${LOCALDIR}\\\")
+add_definitions(-DINSTALLDIR=\\\"${LOCALDIR}\\\")
+add_definitions("-DBUILDING_LIBINTL -DBUILDING_DLL -DIN_LIBINTL -DENABLE_RELOCATABLE=1 -DIN_LIBRARY")
+
+add_definitions("-DNO_XMALLOC -Dset_relocation_prefix=libintl_set_relocation_prefix -Drelocate=libintl_relocate -DDEPENDS_ON_LIBICONV=1 -DHAVE_CONFIG_H -D_CRT_SECURE_NO_WARNINGS")
+
+add_library(libintl ${SOURCES})
+
+install(TARGETS libintl
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION bin
+  ARCHIVE DESTINATION lib
+)
+

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,0 +1,3 @@
+Source: gettext
+Version: 0.19
+Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages

--- a/ports/gettext/config.h
+++ b/ports/gettext/config.h
@@ -1,0 +1,666 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to the number of bits in type 'ptrdiff_t'. */
+#define BITSIZEOF_PTRDIFF_T sizeof(ptrdiff_t)
+
+/* Define to the number of bits in type 'sig_atomic_t'. */
+#define BITSIZEOF_SIG_ATOMIC_T 32
+
+/* Define to the number of bits in type 'size_t'. */
+#define BITSIZEOF_SIZE_T sizeof(size_t)
+
+/* Define to the number of bits in type 'wchar_t'. */
+#define BITSIZEOF_WCHAR_T 16
+
+/* Define to the number of bits in type 'wint_t'. */
+#define BITSIZEOF_WINT_T 16
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+/* #undef CRAY_STACKSEG_END */
+
+/* Define if mono is the preferred C# implementation. */
+/* #undef CSHARP_CHOICE_MONO */
+
+/* Define if pnet is the preferred C# implementation. */
+/* #undef CSHARP_CHOICE_PNET */
+
+/* Define to 1 if using `alloca.c'. */
+/* #undef C_ALLOCA */
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+#define ENABLE_NLS 1
+
+/* Define to 1 if the package shall run at any location in the filesystem. */
+/* #undef ENABLE_RELOCATABLE */
+
+/* Define to 1 when using the gnulib module fwriteerror. */
+#define GNULIB_FWRITEERROR 1
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#define HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+/* #undef HAVE_ALLOCA_H */
+
+/* Define to 1 if you have the `argz_count' function. */
+/* #undef HAVE_ARGZ_COUNT */
+
+/* Define to 1 if you have the <argz.h> header file. */
+/* #undef HAVE_ARGZ_H */
+
+/* Define to 1 if you have the `argz_next' function. */
+/* #undef HAVE_ARGZ_NEXT */
+
+/* Define to 1 if you have the `argz_stringify' function. */
+/* #undef HAVE_ARGZ_STRINGIFY */
+
+/* Define to 1 if you have the `asprintf' function. */
+/* #undef HAVE_ASPRINTF */
+
+/* Define to 1 if you have the `atexit' function. */
+#define HAVE_ATEXIT 1
+
+/* Define to 1 if you have the <bp-sym.h> header file. */
+/* #undef HAVE_BP_SYM_H */
+
+/* Define to 1 if the compiler understands __builtin_expect. */
+/* #undef HAVE_BUILTIN_EXPECT */
+
+/* Define to 1 if you have the `canonicalize_file_name' function. */
+/* #undef HAVE_CANONICALIZE_FILE_NAME */
+
+/* Define to 1 if you have the MacOS X function CFLocaleCopyCurrent in the
+   CoreFoundation framework. */
+/* #undef HAVE_CFLOCALECOPYCURRENT */
+
+/* Define to 1 if you have the MacOS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+/* #undef HAVE_CFPREFERENCESCOPYAPPVALUE */
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+/* #undef HAVE_DCGETTEXT */
+
+/* Define to 1 if you have the declaration of `canonicalize_file_name', and to
+   0 if you don't. */
+#define HAVE_DECL_CANONICALIZE_FILE_NAME 0
+
+/* Define to 1 if you have the declaration of `clearerr_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_CLEARERR_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `feof_unlocked', and to 0 if you
+   don't. */
+#define HAVE_DECL_FEOF_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `ferror_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FERROR_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fflush_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FFLUSH_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fgets_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FGETS_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fputc_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FPUTC_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fputs_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FPUTS_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fread_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FREAD_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `fwrite_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_FWRITE_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `getchar_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_GETCHAR_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `getc_unlocked', and to 0 if you
+   don't. */
+#define HAVE_DECL_GETC_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `getenv', and to 0 if you don't.
+   */
+#define HAVE_DECL_GETENV 1
+
+/* Define to 1 if you have the declaration of `putchar_unlocked', and to 0 if
+   you don't. */
+#define HAVE_DECL_PUTCHAR_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `putc_unlocked', and to 0 if you
+   don't. */
+#define HAVE_DECL_PUTC_UNLOCKED 0
+
+/* Define to 1 if you have the declaration of `strdup', and to 0 if you don't.
+   */
+#define HAVE_DECL_STRDUP 1
+
+/* Define to 1 if you have the declaration of `strerror', and to 0 if you
+   don't. */
+/* #undef HAVE_DECL_STRERROR */
+
+/* Define to 1 if you have the declaration of `strerror_r', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRERROR_R 0
+
+/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRNLEN 0
+
+/* Define to 1 if you have the declaration of `wcwidth', and to 0 if you
+   don't. */
+#define HAVE_DECL_WCWIDTH 0
+
+/* Define to 1 if you have the declaration of `_snprintf', and to 0 if you
+   don't. */
+#define HAVE_DECL__SNPRINTF 1
+
+/* Define to 1 if you have the declaration of `_snwprintf', and to 0 if you
+   don't. */
+#define HAVE_DECL__SNWPRINTF 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define if you have the declaration of environ. */
+#define HAVE_ENVIRON_DECL 1
+
+/* Define to 1 if you have the `fwprintf' function. */
+#define HAVE_FWPRINTF 1
+
+/* Define to 1 if you have the `getcwd' function. */
+#define HAVE_GETCWD 1
+
+/* Define to 1 if you have the `getegid' function. */
+/* #undef HAVE_GETEGID */
+
+/* Define to 1 if you have the `geteuid' function. */
+/* #undef HAVE_GETEUID */
+
+/* Define to 1 if you have the `getgid' function. */
+/* #undef HAVE_GETGID */
+
+/* Define to 1 if you have the <getopt.h> header file. */
+/* #undef HAVE_GETOPT_H */
+
+/* Define to 1 if you have the `getopt_long_only' function. */
+/* #undef HAVE_GETOPT_LONG_ONLY */
+
+/* Define to 1 if you have the `getpagesize' function. */
+/* #undef HAVE_GETPAGESIZE */
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+/* #undef HAVE_GETTEXT */
+
+/* Define to 1 if you have the `getuid' function. */
+/* #undef HAVE_GETUID */
+
+/* Define if you have the iconv() function and it works. */
+/* #undef HAVE_ICONV */
+
+/* Define to 1 if you have the <iconv.h> header file. */
+/* #undef HAVE_ICONV_H */
+
+/* Define if your compiler supports the #include_next directive. */
+/* #undef HAVE_INCLUDE_NEXT */
+
+/* Define if you have the 'intmax_t' type in <stdint.h> or <inttypes.h>. */
+/* #undef HAVE_INTMAX_T */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+/* #undef HAVE_INTTYPES_H */
+
+/* Define if <inttypes.h> exists, doesn't clash with <sys/types.h>, and
+   declares uintmax_t. */
+/* #undef HAVE_INTTYPES_H_WITH_UINTMAX */
+
+/* Define to 1 if you have the `iswcntrl' function. */
+#define HAVE_ISWCNTRL 1
+
+/* Define if you have <langinfo.h> and nl_langinfo(CODESET). */
+/* #undef HAVE_LANGINFO_CODESET */
+
+/* Define if your <locale.h> file defines LC_MESSAGES. */
+/* #undef HAVE_LC_MESSAGES */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if the system has the type `long long int'. */
+/* #undef HAVE_LONG_LONG_INT */
+
+/* Define to 1 if you have the <mach-o/dyld.h> header file. */
+/* #undef HAVE_MACH_O_DYLD_H */
+
+/* Define if the 'malloc' function is POSIX compliant. */
+/* #undef HAVE_MALLOC_POSIX */
+
+/* Define to 1 if mbrtowc and mbstate_t are properly declared. */
+/* #undef HAVE_MBRTOWC */
+
+/* Define to 1 if <wchar.h> declares mbstate_t. */
+#define HAVE_MBSTATE_T 1
+
+/* Define to 1 if you have the `memchr' function. */
+#define HAVE_MEMCHR 1
+
+/* Define to 1 if you have the `memmove' function. */
+#define HAVE_MEMMOVE 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `mempcpy' function. */
+/* #undef HAVE_MEMPCPY */
+
+/* Define to 1 if you have a working `mmap' system call. */
+/* #undef HAVE_MMAP */
+
+/* Define to 1 if you have the `munmap' function. */
+/* #undef HAVE_MUNMAP */
+
+/* Define if you have <langinfo.h> and it defines the NL_LOCALE_NAME macro if
+   _GNU_SOURCE is defined. */
+/* #undef HAVE_NL_LOCALE_NAME */
+
+/* Define if your printf() function supports format strings with positions. */
+/* #undef HAVE_POSIX_PRINTF */
+
+/* Define if the <pthread.h> defines PTHREAD_MUTEX_RECURSIVE. */
+/* #undef HAVE_PTHREAD_MUTEX_RECURSIVE */
+
+/* Define if the POSIX multithreading library has read/write locks. */
+/* #undef HAVE_PTHREAD_RWLOCK */
+
+/* Define to 1 if you have the `putenv' function. */
+#define HAVE_PUTENV 1
+
+/* Define to 1 if you have the `readlink' function. */
+/* #undef HAVE_READLINK */
+
+/* Define to 1 if you have the <search.h> header file. */
+#define HAVE_SEARCH_H 1
+
+/* Define to 1 if you have the `setenv' function. */
+/* #undef HAVE_SETENV */
+
+/* Define to 1 if you have the `setlocale' function. */
+#define HAVE_SETLOCALE 1
+
+/* Define to 1 if 'sig_atomic_t' is a signed integer type. */
+#define HAVE_SIGNED_SIG_ATOMIC_T 1
+
+/* Define to 1 if 'wchar_t' is a signed integer type. */
+/* #undef HAVE_SIGNED_WCHAR_T */
+
+/* Define to 1 if 'wint_t' is a signed integer type. */
+/* #undef HAVE_SIGNED_WINT_T */
+
+/* Define to 1 if you have the `snprintf' function. */
+/* #undef HAVE_SNPRINTF */
+
+/* Define to 1 if stdbool.h conforms to C99. */
+/* #undef HAVE_STDBOOL_H */
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#define HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+/* #undef HAVE_STDINT_H */
+
+/* Define if <stdint.h> exists, doesn't clash with <sys/types.h>, and declares
+   uintmax_t. */
+/* #undef HAVE_STDINT_H_WITH_UINTMAX */
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `stpcpy' function. */
+/* #undef HAVE_STPCPY */
+
+/* Define to 1 if you have the `strcasecmp' function. */
+/* #undef HAVE_STRCASECMP */
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the `strerror_r' function. */
+/* #undef HAVE_STRERROR_R */
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #undef HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strtol' function. */
+#define HAVE_STRTOL 1
+
+/* Define to 1 if you have the `strtoul' function. */
+#define HAVE_STRTOUL 1
+
+/* Define to 1 if you have the <sys/bitypes.h> header file. */
+/* #undef HAVE_SYS_BITYPES_H */
+
+/* Define to 1 if you have the <sys/inttypes.h> header file. */
+/* #undef HAVE_SYS_INTTYPES_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+/* #undef HAVE_SYS_PARAM_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the `tsearch' function. */
+/* #undef HAVE_TSEARCH */
+
+/* Define if you have the 'uintmax_t' type in <stdint.h> or <inttypes.h>. */
+/* #undef HAVE_UINTMAX_T */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #undef HAVE_UNISTD_H */
+
+/* Define to 1 if the system has the type `unsigned long long int'. */
+/* #undef HAVE_UNSIGNED_LONG_LONG_INT */
+
+/* Define to 1 or 0, depending whether the compiler supports simple visibility
+   declarations. */
+#define HAVE_VISIBILITY 0
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define if you have the 'wchar_t' type. */
+#define HAVE_WCHAR_T 1
+
+/* Define to 1 if you have the `wcslen' function. */
+#define HAVE_WCSLEN 1
+
+/* Define to 1 if you have the <wctype.h> header file. */
+#define HAVE_WCTYPE_H 1
+
+/* Define to 1 if you have the `wcwidth' function. */
+/* #undef HAVE_WCWIDTH */
+
+/* Define if you have the 'wint_t' type. */
+#define HAVE_WINT_T 1
+
+/* Define to 1 if the system has the type `_Bool'. */
+/* #undef HAVE__BOOL */
+
+/* Define to 1 if you have the `_NSGetExecutablePath' function. */
+/* #undef HAVE__NSGETEXECUTABLEPATH */
+
+/* Define to 1 if you have the `__fsetlocking' function. */
+/* #undef HAVE___FSETLOCKING */
+
+/* Define as const if the declaration of iconv() needs const. */
+/* #undef ICONV_CONST */
+
+/* Define to a symbolic name denoting the flavor of iconv_open()
+   implementation. */
+/* #undef ICONV_FLAVOR */
+
+/* Define to the value of ${prefix}, as a string. */
+/* #define INSTALLPREFIX "/usr/local" */
+
+/* Define if integer division by zero raises signal SIGFPE. */
+#define INTDIV0_RAISES_SIGFPE 0
+
+/* If malloc(0) is != NULL, define this to 1. Otherwise define this to 0. */
+#define MALLOC_0_IS_NONNULL 1
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#define NO_MINUS_C_MINUS_O 1
+
+/* Name of package */
+#define PACKAGE "gettext-runtime"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME ""
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING ""
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION ""
+
+/* Define if <inttypes.h> exists and defines unusable PRI* macros. */
+/* #undef PRI_MACROS_BROKEN */
+
+/* Define if the pthread_in_use() detection is hard. */
+/* #undef PTHREAD_IN_USE_DETECTION_HARD */
+
+/* Define to l, ll, u, ul, ull, etc., as suitable for constants of type
+   'ptrdiff_t'. */
+#define PTRDIFF_T_SUFFIX 
+
+/* Define this to 1 if strerror is broken. */
+/* #undef REPLACE_STRERROR */
+
+/* Define to l, ll, u, ul, ull, etc., as suitable for constants of type
+   'sig_atomic_t'. */
+#define SIG_ATOMIC_T_SUFFIX 
+
+/* Define as the maximum value of type 'size_t', if the system doesn't define
+   it. */
+#define SIZE_MAX (((1UL << 31) - 1) * 2 + 1)
+
+/* Define to l, ll, u, ul, ull, etc., as suitable for constants of type
+   'size_t'. */
+#define SIZE_T_SUFFIX u
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+/* #undef STACK_DIRECTION */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if strerror_r returns char *. */
+/* #undef STRERROR_R_CHAR_P */
+
+/* Define if the POSIX multithreading library can be used. */
+/* #undef USE_POSIX_THREADS */
+
+/* Define if references to the POSIX multithreading library should be made
+   weak. */
+/* #undef USE_POSIX_THREADS_WEAK */
+
+/* Define if the GNU Pth multithreading library can be used. */
+/* #undef USE_PTH_THREADS */
+
+/* Define if references to the GNU Pth multithreading library should be made
+   weak. */
+/* #undef USE_PTH_THREADS_WEAK */
+
+/* Define if the old Solaris multithreading library can be used. */
+/* #undef USE_SOLARIS_THREADS */
+
+/* Define if references to the old Solaris multithreading library should be
+   made weak. */
+/* #undef USE_SOLARIS_THREADS_WEAK */
+
+/* Define to 1 if you want getc etc. to use unlocked I/O if available.
+   Unlocked I/O can improve performance in unithreaded apps, but it is not
+   safe for multithreaded apps. */
+#define USE_UNLOCKED_IO 0
+
+/* Define if the Win32 multithreading API can be used. */
+#define USE_WIN32_THREADS 1
+
+/* Version number of package */
+#define VERSION "0.17"
+
+/* Define to l, ll, u, ul, ull, etc., as suitable for constants of type
+   'wchar_t'. */
+#define WCHAR_T_SUFFIX 
+
+/* Define to l, ll, u, ul, ull, etc., as suitable for constants of type
+   'wint_t'. */
+#define WINT_T_SUFFIX 
+
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Define to rpl_ if the getopt replacement functions and variables should be
+   used. */
+#define __GETOPT_PREFIX rpl_
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+#define inline __inline
+#endif
+
+/* Define to a type if <wchar.h> does not define. */
+/* #undef mbstate_t */
+
+/* Define as the type of the result of subtracting two pointers, if the system
+   doesn't define it. */
+/* #undef ptrdiff_t */
+
+/* Define to a replacement function name for realpath(). */
+#define realpath rpl_realpath
+
+/* Define to the equivalent of the C99 'restrict' keyword, or to
+   nothing if this is not supported.  Do not define if restrict is
+   supported directly.  */
+#define restrict 
+/* Work around a bug in Sun C++: it does not support _Restrict, even
+   though the corresponding Sun C compiler does, which causes
+   "#define restrict _Restrict" in the previous line.  Perhaps some future
+   version of Sun C++ will work with _Restrict; if so, it'll probably
+   define __RESTRICT, just as Sun C does.  */
+#if defined __SUNPRO_CC && !defined __RESTRICT
+# define _Restrict
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define as a signed type of the same size as size_t. */
+#ifdef _WIN64
+#define ssize_t __int64
+#else
+#define ssize_t __int32
+#endif
+
+/* Define to rpl_strnlen if the replacement function should be used. */
+#define strnlen rpl_strnlen
+
+/* Define to unsigned long or unsigned long long if <stdint.h> and
+   <inttypes.h> don't define. */
+#ifdef _WIN64
+#define uintmax_t unsigned __int64
+#else
+#define uintmax_t unsigned __int32
+#endif
+
+#define __libc_lock_t                   gl_lock_t
+#define __libc_lock_define              gl_lock_define
+#define __libc_lock_define_initialized  gl_lock_define_initialized
+#define __libc_lock_init                gl_lock_init
+#define __libc_lock_lock                gl_lock_lock
+#define __libc_lock_unlock              gl_lock_unlock
+#define __libc_lock_recursive_t                   gl_recursive_lock_t
+#define __libc_lock_define_recursive              gl_recursive_lock_define
+#define __libc_lock_define_initialized_recursive  gl_recursive_lock_define_initialized
+#define __libc_lock_init_recursive                gl_recursive_lock_init
+#define __libc_lock_lock_recursive                gl_recursive_lock_lock
+#define __libc_lock_unlock_recursive              gl_recursive_lock_unlock
+#if 0
+#define glthread_in_use  libintl_thread_in_use
+#define glthread_lock_init     libintl_lock_init
+#define glthread_lock_lock     libintl_lock_lock
+#define glthread_lock_unlock   libintl_lock_unlock
+#define glthread_lock_destroy  libintl_lock_destroy
+#define glthread_rwlock_init     libintl_rwlock_init
+#define glthread_rwlock_rdlock   libintl_rwlock_rdlock
+#define glthread_rwlock_wrlock   libintl_rwlock_wrlock
+#define glthread_rwlock_unlock   libintl_rwlock_unlock
+#define glthread_rwlock_destroy  libintl_rwlock_destroy
+#define glthread_recursive_lock_init     libintl_recursive_lock_init
+#define glthread_recursive_lock_lock     libintl_recursive_lock_lock
+#define glthread_recursive_lock_unlock   libintl_recursive_lock_unlock
+#define glthread_recursive_lock_destroy  libintl_recursive_lock_destroy
+#define glthread_once                 libintl_once
+#define glthread_once_call            libintl_once_call
+#define glthread_once_singlethreaded  libintl_once_singlethreaded
+#endif
+
+
+/* On Windows, variables that may be in a DLL must be marked specially.  */
+#if (defined _MSC_VER && defined _DLL) && !defined IN_RELOCWRAPPER
+# define DLL_VARIABLE __declspec (dllimport)
+#else
+# define DLL_VARIABLE
+#endif
+
+/* Extra OS/2 (emx+gcc) defines.  */
+#ifdef __EMX__
+# include "intl/os2compat.h"
+#endif
+

--- a/ports/gettext/libgnuintl.h
+++ b/ports/gettext/libgnuintl.h
@@ -1,0 +1,423 @@
+/* Message catalogs for internationalization.
+Copyright (C) 1995-1997, 2000-2007 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Library General Public License as published
+by the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.  */
+
+#ifndef _LIBINTL_H
+#define _LIBINTL_H	1
+
+#ifdef BUILDING_LIBINTL
+#define LIBINTL_DLL_EXPORTED __declspec(dllexport)
+#else
+#define LIBINTL_DLL_EXPORTED
+#endif
+
+#include <locale.h>
+
+/* The LC_MESSAGES locale category is the category used by the functions
+gettext() and dgettext().  It is specified in POSIX, but not in ANSI C.
+On systems that don't define it, use an arbitrary value instead.
+On Solaris, <locale.h> defines __LOCALE_H (or _LOCALE_H in Solaris 2.5)
+then includes <libintl.h> (i.e. this file!) and then only defines
+LC_MESSAGES.  To avoid a redefinition warning, don't define LC_MESSAGES
+in this case.  */
+#if !defined LC_MESSAGES && !(defined __LOCALE_H || (defined _LOCALE_H && defined __sun))
+# define LC_MESSAGES 1729
+#endif
+
+/* We define an additional symbol to signal that we use the GNU
+implementation of gettext.  */
+#define __USE_GNU_GETTEXT 1
+
+/* Provide information about the supported file formats.  Returns the
+maximum minor revision number supported for a given major revision.  */
+#define __GNU_GETTEXT_SUPPORTED_REVISION(major) \
+  ((major) == 0 || (major) == 1 ? 1 : -1)
+
+/* Resolve a platform specific conflict on DJGPP.  GNU gettext takes
+precedence over _conio_gettext.  */
+#ifdef __DJGPP__
+# undef gettext
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+	/* Version number: (major<<16) + (minor<<8) + subminor */
+#define LIBINTL_VERSION 0x001100
+	extern LIBINTL_DLL_EXPORTED int libintl_version;
+
+
+	/* We redirect the functions to those prefixed with "libintl_".  This is
+	necessary, because some systems define gettext/textdomain/... in the C
+	library (namely, Solaris 2.4 and newer, and GNU libc 2.0 and newer).
+	If we used the unprefixed names, there would be cases where the
+	definition in the C library would override the one in the libintl.so
+	shared library.  Recall that on ELF systems, the symbols are looked
+	up in the following order:
+	1. in the executable,
+	2. in the shared libraries specified on the link command line, in order,
+	3. in the dependencies of the shared libraries specified on the link
+	command line,
+	4. in the dlopen()ed shared libraries, in the order in which they were
+	dlopen()ed.
+	The definition in the C library would override the one in libintl.so if
+	either
+	* -lc is given on the link command line and -lintl isn't, or
+	* -lc is given on the link command line before -lintl, or
+	* libintl.so is a dependency of a dlopen()ed shared library but not
+	linked to the executable at link time.
+	Since Solaris gettext() behaves differently than GNU gettext(), this
+	would be unacceptable.
+
+	The redirection happens by default through macros in C, so that &gettext
+	is independent of the compilation unit, but through inline functions in
+	C++, in order not to interfere with the name mangling of class fields or
+	class methods called 'gettext'.  */
+
+	/* The user can define _INTL_REDIRECT_INLINE or _INTL_REDIRECT_MACROS.
+	If he doesn't, we choose the method.  A third possible method is
+	_INTL_REDIRECT_ASM, supported only by GCC.  */
+#if !(defined _INTL_REDIRECT_INLINE || defined _INTL_REDIRECT_MACROS)
+# if __GNUC__ >= 2 && !(__APPLE_CC__ > 1) && !defined __MINGW32__ && !(__GNUC__ == 2 && defined _AIX) && (defined __STDC__ || defined __cplusplus)
+#  define _INTL_REDIRECT_ASM
+# else
+#  ifdef __cplusplus
+#   define _INTL_REDIRECT_INLINE
+#  else
+#   define _INTL_REDIRECT_MACROS
+#  endif
+# endif
+#endif
+	/* Auxiliary macros.  */
+#ifdef _INTL_REDIRECT_ASM
+# define _INTL_ASM(cname) __asm__ (_INTL_ASMNAME (__USER_LABEL_PREFIX__, #cname))
+# define _INTL_ASMNAME(prefix,cnamestring) _INTL_STRINGIFY (prefix) cnamestring
+# define _INTL_STRINGIFY(prefix) #prefix
+#else
+# define _INTL_ASM(cname)
+#endif
+
+	/* _INTL_MAY_RETURN_STRING_ARG(n) declares that the given function may return
+	its n-th argument literally.  This enables GCC to warn for example about
+	printf (gettext ("foo %y")).  */
+#if __GNUC__ >= 3 && !(__APPLE_CC__ > 1 && defined __cplusplus)
+# define _INTL_MAY_RETURN_STRING_ARG(n) __attribute__ ((__format_arg__ (n)))
+#else
+# define _INTL_MAY_RETURN_STRING_ARG(n)
+#endif
+
+	/* Look up MSGID in the current default message catalog for the current
+	LC_MESSAGES locale.  If not found, returns MSGID itself (the default
+	text).  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_gettext(const char *__msgid)
+		_INTL_MAY_RETURN_STRING_ARG(1);
+	static inline char *gettext(const char *__msgid)
+	{
+		return libintl_gettext(__msgid);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define gettext libintl_gettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *gettext(const char *__msgid)
+		_INTL_ASM(libintl_gettext)
+		_INTL_MAY_RETURN_STRING_ARG(1);
+#endif
+
+	/* Look up MSGID in the DOMAINNAME message catalog for the current
+	LC_MESSAGES locale.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_dgettext(const char *__domainname, const char *__msgid)
+		_INTL_MAY_RETURN_STRING_ARG(2);
+	static inline char *dgettext(const char *__domainname, const char *__msgid)
+	{
+		return libintl_dgettext(__domainname, __msgid);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define dgettext libintl_dgettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *dgettext(const char *__domainname, const char *__msgid)
+		_INTL_ASM(libintl_dgettext)
+		_INTL_MAY_RETURN_STRING_ARG(2);
+#endif
+
+	/* Look up MSGID in the DOMAINNAME message catalog for the current CATEGORY
+	locale.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_dcgettext(const char *__domainname, const char *__msgid,
+		int __category)
+		_INTL_MAY_RETURN_STRING_ARG(2);
+	static inline char *dcgettext(const char *__domainname, const char *__msgid,
+		int __category)
+	{
+		return libintl_dcgettext(__domainname, __msgid, __category);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define dcgettext libintl_dcgettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *dcgettext(const char *__domainname, const char *__msgid,
+		int __category)
+		_INTL_ASM(libintl_dcgettext)
+		_INTL_MAY_RETURN_STRING_ARG(2);
+#endif
+
+
+	/* Similar to `gettext' but select the plural form corresponding to the
+	number N.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_ngettext(const char *__msgid1, const char *__msgid2,
+		unsigned long int __n)
+		_INTL_MAY_RETURN_STRING_ARG(1) _INTL_MAY_RETURN_STRING_ARG(2);
+	static inline char *ngettext(const char *__msgid1, const char *__msgid2,
+		unsigned long int __n)
+	{
+		return libintl_ngettext(__msgid1, __msgid2, __n);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define ngettext libintl_ngettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *ngettext(const char *__msgid1, const char *__msgid2,
+		unsigned long int __n)
+		_INTL_ASM(libintl_ngettext)
+		_INTL_MAY_RETURN_STRING_ARG(1) _INTL_MAY_RETURN_STRING_ARG(2);
+#endif
+
+	/* Similar to `dgettext' but select the plural form corresponding to the
+	number N.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_dngettext(const char *__domainname, const char *__msgid1,
+		const char *__msgid2, unsigned long int __n)
+		_INTL_MAY_RETURN_STRING_ARG(2) _INTL_MAY_RETURN_STRING_ARG(3);
+	static inline char *dngettext(const char *__domainname, const char *__msgid1,
+		const char *__msgid2, unsigned long int __n)
+	{
+		return libintl_dngettext(__domainname, __msgid1, __msgid2, __n);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define dngettext libintl_dngettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *dngettext(const char *__domainname,
+		const char *__msgid1, const char *__msgid2,
+		unsigned long int __n)
+		_INTL_ASM(libintl_dngettext)
+		_INTL_MAY_RETURN_STRING_ARG(2) _INTL_MAY_RETURN_STRING_ARG(3);
+#endif
+
+	/* Similar to `dcgettext' but select the plural form corresponding to the
+	number N.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_dcngettext(const char *__domainname,
+		const char *__msgid1, const char *__msgid2,
+		unsigned long int __n, int __category)
+		_INTL_MAY_RETURN_STRING_ARG(2) _INTL_MAY_RETURN_STRING_ARG(3);
+	static inline char *dcngettext(const char *__domainname,
+		const char *__msgid1, const char *__msgid2,
+		unsigned long int __n, int __category)
+	{
+		return libintl_dcngettext(__domainname, __msgid1, __msgid2, __n, __category);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define dcngettext libintl_dcngettext
+#endif
+	extern LIBINTL_DLL_EXPORTED char *dcngettext(const char *__domainname,
+		const char *__msgid1, const char *__msgid2,
+		unsigned long int __n, int __category)
+		_INTL_ASM(libintl_dcngettext)
+		_INTL_MAY_RETURN_STRING_ARG(2) _INTL_MAY_RETURN_STRING_ARG(3);
+#endif
+
+
+
+	/* Set the current default message catalog to DOMAINNAME.
+	If DOMAINNAME is null, return the current default.
+	If DOMAINNAME is "", reset to the default of "messages".  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_textdomain(const char *__domainname);
+	static inline char *textdomain(const char *__domainname)
+	{
+		return libintl_textdomain(__domainname);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define textdomain libintl_textdomain
+#endif
+	extern LIBINTL_DLL_EXPORTED char *textdomain(const char *__domainname)
+		_INTL_ASM(libintl_textdomain);
+#endif
+
+	/* Specify that the DOMAINNAME message catalog will be found
+	in DIRNAME rather than in the system locale data base.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_bindtextdomain(const char *__domainname,
+		const char *__dirname);
+	static inline char *bindtextdomain(const char *__domainname,
+		const char *__dirname)
+	{
+		return libintl_bindtextdomain(__domainname, __dirname);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define bindtextdomain libintl_bindtextdomain
+#endif
+	extern LIBINTL_DLL_EXPORTED char *bindtextdomain(const char *__domainname, const char *__dirname)
+		_INTL_ASM(libintl_bindtextdomain);
+#endif
+
+	/* Specify the character encoding in which the messages from the
+	DOMAINNAME message catalog will be returned.  */
+#ifdef _INTL_REDIRECT_INLINE
+	extern LIBINTL_DLL_EXPORTED char *libintl_bind_textdomain_codeset(const char *__domainname,
+		const char *__codeset);
+	static inline char *bind_textdomain_codeset(const char *__domainname,
+		const char *__codeset)
+	{
+		return libintl_bind_textdomain_codeset(__domainname, __codeset);
+	}
+#else
+#ifdef _INTL_REDIRECT_MACROS
+# define bind_textdomain_codeset libintl_bind_textdomain_codeset
+#endif
+	extern LIBINTL_DLL_EXPORTED char *bind_textdomain_codeset(const char *__domainname,
+		const char *__codeset)
+		_INTL_ASM(libintl_bind_textdomain_codeset);
+#endif
+
+
+
+	/* Support for format strings with positions in *printf(), following the
+	POSIX/XSI specification.
+	Note: These replacements for the *printf() functions are visible only
+	in source files that #include <libintl.h> or #include "gettext.h".
+	Packages that use *printf() in source files that don't refer to _()
+	or gettext() but for which the format string could be the return value
+	of _() or gettext() need to add this #include.  Oh well.  */
+
+#if !0
+
+#include <stdio.h>
+#include <stddef.h>
+
+	/* Get va_list.  */
+#if __STDC__ || defined __cplusplus || defined _MSC_VER
+# include <stdarg.h>
+#else
+# include <varargs.h>
+#endif
+
+#undef fprintf
+#define fprintf libintl_fprintf
+	extern LIBINTL_DLL_EXPORTED int fprintf(FILE *, const char *, ...);
+#undef vfprintf
+#define vfprintf libintl_vfprintf
+	extern LIBINTL_DLL_EXPORTED int vfprintf(FILE *, const char *, va_list);
+
+#undef printf
+#if defined __NetBSD__ || defined __BEOS__ || defined __CYGWIN__ || defined __MINGW32__
+	/* Don't break __attribute__((format(printf,M,N))).
+	This redefinition is only possible because the libc in NetBSD, Cygwin,
+	mingw does not have a function __printf__.  */
+# define libintl_printf __printf__
+#endif
+#define printf libintl_printf
+	extern LIBINTL_DLL_EXPORTED int printf(const char *, ...);
+#undef vprintf
+#define vprintf libintl_vprintf
+	extern LIBINTL_DLL_EXPORTED int vprintf(const char *, va_list);
+
+#undef sprintf
+#define sprintf libintl_sprintf
+	extern LIBINTL_DLL_EXPORTED int sprintf(char *, const char *, ...);
+#undef vsprintf
+#define vsprintf libintl_vsprintf
+	extern LIBINTL_DLL_EXPORTED int vsprintf(char *, const char *, va_list);
+
+#if 0
+
+#undef snprintf
+#define snprintf libintl_snprintf
+	extern LIBINTL_DLL_EXPORTED int snprintf(char *, size_t, const char *, ...);
+#undef vsnprintf
+#define vsnprintf libintl_vsnprintf
+	extern LIBINTL_DLL_EXPORTED int vsnprintf(char *, size_t, const char *, va_list);
+
+#endif
+
+#if 0
+
+#undef asprintf
+#define asprintf libintl_asprintf
+	extern LIBINTL_DLL_EXPORTED int asprintf(char **, const char *, ...);
+#undef vasprintf
+#define vasprintf libintl_vasprintf
+	extern LIBINTL_DLL_EXPORTED int vasprintf(char **, const char *, va_list);
+
+#endif
+
+#if 0
+
+#undef fwprintf
+#define fwprintf libintl_fwprintf
+	extern LIBINTL_DLL_EXPORTED int fwprintf(FILE *, const wchar_t *, ...);
+#undef vfwprintf
+#define vfwprintf libintl_vfwprintf
+	extern LIBINTL_DLL_EXPORTED int vfwprintf(FILE *, const wchar_t *, va_list);
+
+#undef wprintf
+#define wprintf libintl_wprintf
+	extern LIBINTL_DLL_EXPORTED int wprintf(const wchar_t *, ...);
+#undef vwprintf
+#define vwprintf libintl_vwprintf
+	extern LIBINTL_DLL_EXPORTED int vwprintf(const wchar_t *, va_list);
+
+#undef swprintf
+#define swprintf libintl_swprintf
+	extern LIBINTL_DLL_EXPORTED int swprintf(wchar_t *, size_t, const wchar_t *, ...);
+#undef vswprintf
+#define vswprintf libintl_vswprintf
+	extern LIBINTL_DLL_EXPORTED int vswprintf(wchar_t *, size_t, const wchar_t *, va_list);
+
+#endif
+
+#endif
+
+
+	/* Support for relocatable packages.  */
+
+	/* Sets the original and the current installation prefix of the package.
+	Relocation simply replaces a pathname starting with the original prefix
+	by the corresponding pathname with the current prefix instead.  Both
+	prefixes should be directory names without trailing slash (i.e. use ""
+	instead of "/").  */
+#define libintl_set_relocation_prefix libintl_set_relocation_prefix
+	extern LIBINTL_DLL_EXPORTED void
+		libintl_set_relocation_prefix(const char *orig_prefix,
+			const char *curr_prefix);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* libintl.h */

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -1,0 +1,43 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+#Based on https://github.com/winlibs/gettext
+
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/gettext-0.19)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://ftp.gnu.org/pub/gnu/gettext/gettext-0.19.tar.gz"
+    FILENAME "gettext-0.19.tar.gz"
+    SHA512 a5db035c582ff49d45ee6eab9466b2bef918e413a882019c204a9d8903cb3770ddfecd32c971ea7c7b037c7b69476cf7c56dcabc8b498b94ab99f132516c9922
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_libintl.txt DESTINATION ${SOURCE_PATH}/gettext-runtime)
+file(RENAME ${SOURCE_PATH}/gettext-runtime/CMakeLists_libintl.txt ${SOURCE_PATH}/gettext-runtime/CMakeLists.txt)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/libgnuintl.h DESTINATION ${SOURCE_PATH}/gettext-runtime/intl)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h DESTINATION ${SOURCE_PATH}/gettext-runtime)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-Fix-macro-definitions.patch"
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+file(COPY ${SOURCE_PATH}/gettext-runtime/intl/libgnuintl.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(RENAME ${CURRENT_PACKAGES_DIR}/include/libgnuintl.h ${CURRENT_PACKAGES_DIR}/include/libintl.h)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/gettext)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/gettext/COPYING ${CURRENT_PACKAGES_DIR}/share/gettext/copyright)


### PR DESCRIPTION
I'm trying to port gettext (which is used for internationalization). This PR only adds the runtime lib which loads .mo file (which stores translation for strings used in an app).
There are several Tools like xgettext, msgfmt, msgmerge... that are bundled in the gettext source but they look harder to build hence I prefer to provide them later in vcpkg.