### PR TITLE
[curl] Change BUILD_CURL_TESTS to BUILD_TESTING

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_extract_source_archive(${ARCHIVE_FILE})
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        -DBUILD_CURL_TESTS=OFF
+        -DBUILD_TESTING=OFF
         -DBUILD_CURL_EXE=OFF
         -DENABLE_MANUAL=OFF
     OPTIONS_DEBUG


### PR DESCRIPTION
It was changed between the previous version and the current one (https://github.com/curl/curl/commit/12e21fab26bd83dfa75f009a24380d144ea51857)

According to the commit the default is off so it shouldn't make a difference to builds (no need to bump-version), because of this the variable could probably also be removed.

edit: this also (possibly) fixed an issue I had where the packaging step never finished