### PR TITLE
Cleanup leftover build artifacts before compile

### DIFF
--- a/ports/openssl/portfile-uwp.cmake
+++ b/ports/openssl/portfile-uwp.cmake
@@ -40,9 +40,9 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 
-# file(REMOVE_RECURSE ${SOURCE_PATH}/tmp32dll)
-# file(REMOVE_RECURSE ${SOURCE_PATH}/out32dll)
-# file(REMOVE_RECURSE ${SOURCE_PATH}/inc32dll)
+file(REMOVE_RECURSE ${SOURCE_PATH}/tmp32dll)
+file(REMOVE_RECURSE ${SOURCE_PATH}/out32dll)
+file(REMOVE_RECURSE ${SOURCE_PATH}/inc32dll)
 
 file(COPY
 ${CMAKE_CURRENT_LIST_DIR}/setVSvars.bat


### PR DESCRIPTION
Leftover build artifacts must be removed from the buildtree, otherwise building the 2nd time will just take the leftover results from the previous build, even if these are from a different architecture.