### PR TITLE
Do vcpkg_build_cmake before vcpkg_install_cmake

### DIFF
--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # There is no way to suppress installation of the headers in debug builds.

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)

--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_configure_cmake(
     -DBOND_LIBRARIES_ONLY=TRUE
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Put the license file where vcpkg expects it

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
         -DCASA_INSTALL_HEADERS=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(INSTALL

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
         -DBUILD_DOCUMENTATION=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # There is no way to suppress installation of the headers and resource files in debug build.

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_configure_cmake(
         -DENABLE_DEBUG=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/curl RENAME copyright)

--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH}
     OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=True)
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
 file(RENAME ${CURRENT_PACKAGES_DIR}/CMake ${CURRENT_PACKAGES_DIR}/share/double-conversion)

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
         -DBUILD_shared=${EXPAT_LINKAGE}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)

--- a/ports/fastlz/portfile.cmake
+++ b/ports/fastlz/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_configure_cmake(
         -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_configure_cmake(
 )
 
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(INSTALL ${SOURCE_PATH}/LICENSE.rst DESTINATION ${CURRENT_PACKAGES_DIR}/share/fmt RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/freeglut/portfile.cmake
+++ b/ports/freeglut/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_configure_cmake(
         -DFREEGLUT_BUILD_DEMOS=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_configure_cmake(
         -DCONFIG_INSTALL_PATH=share/freetype
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(RENAME ${CURRENT_PACKAGES_DIR}/include/freetype2/freetype ${CURRENT_PACKAGES_DIR}/include/freetype)

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(COPY ${SOURCE_PATH}/gettext-runtime/intl/libgnuintl.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/gflags/portfile.cmake
+++ b/ports/gflags/portfile.cmake
@@ -36,6 +36,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/glbinding/portfile.cmake
+++ b/ports/glbinding/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_configure_cmake(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glbinding-2.1.1)
-#vcpkg_build_cmake()
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_configure_cmake(
         -DPACKAGE_CMAKE_INSTALL_PREFIX=\${CMAKE_CURRENT_LIST_DIR}/../..
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -43,6 +43,7 @@ vcpkg_configure_cmake(
         -DgRPC_PROTOBUF_PROVIDER=package
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/grpc)

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -41,6 +41,7 @@ vcpkg_configure_cmake(
         -DBUILD_SHARED_LIBS=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/googletest/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/gtest RENAME copyright)

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_configure_cmake(
     OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/libccd/portfile.cmake
+++ b/ports/libccd/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Avoid a copy of file in debug

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Handle copyright

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -37,6 +37,7 @@ vcpkg_configure_cmake(
     OPTIONS_DEBUG -DINSTALL_HEADERS=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(COPY

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # remove debug header

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # delete debug headers

--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -36,6 +36,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 # Handle copyright

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -34,6 +34,7 @@ vcpkg_configure_cmake(
         -DSKIP_INSTALL_HEADERS=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -27,6 +27,7 @@ vcpkg_configure_cmake(
         -DINSTALL_CMAKE_MODULE_PATH=${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(COPY ${SOURCE_PATH}/FindLibRaw.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libraw/cmake/FindLibRaw.cmake)

--- a/ports/libtheora/portfile.cmake
+++ b/ports/libtheora/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -52,6 +52,7 @@ vcpkg_configure_cmake(
     OPTIONS_DEBUG -DOGG_LIBRARIES=${OGG_LIB_DBG}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_configure_cmake(
     OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)

--- a/ports/log4cplus/portfile.cmake
+++ b/ports/log4cplus/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_configure_cmake(
     OPTIONS -DLOG4CPLUS_BUILD_TESTING=OFF -DLOG4CPLUS_BUILD_LOGGINGSERVER=OFF -DWITH_UNIT_TESTS=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_configure_cmake(
         -DSKIP_INSTALL_HEADERS=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Handle copyright

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
 		-DBSON_ROOT_DIR=${CURRENT_INSTALLED_DIR}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_configure_cmake(
 		-DLIBMONGOC_DIR=${CURRENT_INSTALLED_DIR}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()	
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_configure_cmake(
 		-DNANODBC_USE_UNICODE=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()	
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
         -DALSOFT_HRTF_DEFS=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_configure_cmake(
         -DINSTALL_OTHER=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(READ ${CURRENT_PACKAGES_DIR}/debug/share/opencv/OpenCVModules-debug.cmake OPENCV_DEBUG_MODULE)

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_configure_cmake(
             -DOPENJPEG_INSTALL_PACKAGE_DIR=share/openjpeg
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/physfs/portfile.cmake
+++ b/ports/physfs/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/test_physfs.exe)

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
         -DCMAKE_INSTALL_CMAKEDIR=share/protobuf
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/ragel/portfile.cmake
+++ b/ports/ragel/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
     GENERATOR "Visual Studio 14 2015"
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/ragel.txt)

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -38,6 +38,7 @@ else()
             -DSDL_STATIC=OFF
     )
 
+    vcpkg_build_cmake()
     vcpkg_install_cmake()
 
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/sery/portfile.cmake
+++ b/ports/sery/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Removes unnecessary directories

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_configure_cmake(
     OPTIONS -Dcxx=OFF
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -22,6 +22,7 @@ SOURCE_PATH ${SOURCE_PATH}
         -DENABLE_QT4=OFF
         -DBOOST_DYNAMIC=ON
 )
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # There is no way to suppress installation of the headers and resource files in debug build.

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_configure_cmake(
         -DSKIP_INSTALL_HEADERS=ON
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 # Both dynamic and static are built, so keep only the one needed

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 )
 
+vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
Mentioned here: https://github.com/Microsoft/vcpkg/issues/258#issuecomment-259098011

This PR adds vcpkg_build_cmake to all portfiles (at time of commit) that didn't already have it