### PR TITLE
[qt5] Fix the wrong gamepads directory issue.

### DIFF
--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -131,10 +131,10 @@ foreach(file ${DEBUG_PLUGINS})
     file(RENAME ${file} "${CURRENT_PACKAGES_DIR}/debug/plugins/${rel_dir}/${file_n}")
 endforeach()
 file(RENAME 
-	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepadd.dll
+	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepad.dll
 	${CURRENT_PACKAGES_DIR}/plugins/gamepads/xinputgamepad.dll)
 file(RENAME 
-	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepadd.pdb
+	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepad.pdb
 	${CURRENT_PACKAGES_DIR}/plugins/gamepads/xinputgamepad.pdb)
 
 if(DEFINED VCPKG_CRT_LINKAGE AND VCPKG_CRT_LINKAGE STREQUAL dynamic)

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -144,4 +144,6 @@ vcpkg_execute_required_process(
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.LGPLv3 DESTINATION  ${CURRENT_PACKAGES_DIR}/share/qt5 RENAME copyright)
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/plugins/gamepads)
+
 vcpkg_copy_pdbs()

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -130,6 +130,12 @@ foreach(file ${DEBUG_PLUGINS})
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/plugins/${rel_dir}")
     file(RENAME ${file} "${CURRENT_PACKAGES_DIR}/debug/plugins/${rel_dir}/${file_n}")
 endforeach()
+file(RENAME 
+	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepadd.dll
+	${CURRENT_PACKAGES_DIR}/plugins/gamepads/xinputgamepad.dll)
+file(RENAME 
+	${CURRENT_PACKAGES_DIR}/debug/plugins/gamepads/xinputgamepadd.pdb
+	${CURRENT_PACKAGES_DIR}/plugins/gamepads/xinputgamepad.pdb)
 
 if(DEFINED VCPKG_CRT_LINKAGE AND VCPKG_CRT_LINKAGE STREQUAL dynamic)
     file(GLOB RELEASE_DLLS "${CURRENT_PACKAGES_DIR}/bin/*.dll")
@@ -143,7 +149,5 @@ vcpkg_execute_required_process(
 )
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.LGPLv3 DESTINATION  ${CURRENT_PACKAGES_DIR}/share/qt5 RENAME copyright)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/plugins/gamepads)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
When I installing the qt5, the following error output was shown: 

-- Performing post-build validation
There should be no empty directories in C:/_/3rd/vcpkg/packages/qt5_x86-windows
The following empty directories were found:

    C:/_/3rd/vcpkg/packages/qt5_x86-windows/plugins/gamepads

If a directory should be populated but is not, this might indicate an error in the portfile.
If the directories are not needed and their creation cannot be disabled, use something like this in the portfile to remove them)

    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/a/dir ${CURRENT_PACKAGES_DIR}/some/other/dir)


Found 1 error(s). Please correct the portfile:
    C:\_\3rd\vcpkg\ports\qt5\portfile.cmake







This PR removed the empty plugins/gamepads folder and everything works now.