### PR TITLE
Update SDL2 port to 2.0.5 (its latest release; up from 2.0.4)

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,3 +1,3 @@
 Source: sdl2
-Version: 2.0.4
+Version: 2.0.5
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -3,11 +3,11 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 endif()
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2-2.0.4)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2-2.0.5)
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "http://libsdl.org/release/SDL2-2.0.4.tar.gz"
-    FILENAME "SDL2-2.0.4.tar.gz"
-    SHA512 dd0a95878639856c0f4b8a579ace8071379ab64519fa139b22d3ed857a0f0db87a75bc8480c7207e02fbffd1fdbd448e3c0b882c451675b0e2f1a945af02e1d6
+    URLS "http://libsdl.org/release/SDL2-2.0.5.tar.gz"
+    FILENAME "SDL2-2.0.5.tar.gz"
+    SHA512 6401f5df08c08316c09bc6ac5b28345c5184bb25770baa5c94c0a582ae130ddf73bb736e44bb31f4e427c1ddbbeec4755a6a5f530b6b4c3d0f13ebc78ddc1750
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 


### PR DESCRIPTION
SDL2 2.0.5 was recently released, and includes a number of bug fixes over its previous release, 2.0.4.

This pull request simply updates vcpkg's "sdl2" port to use SDL 2.0.5, as downloaded from http://libsdl.org (same as before).

Additional details on its 2.0.5 release can be found at https://forums.libsdl.org/viewtopic.php?t=12160

If anyone could use more info on this pull request, or would like modifications, please let me know.

Cheers!
-- David L.