### PR TITLE
[glfw3] Fix paths in cmake config files

### DIFF
--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -34,7 +34,13 @@ vcpkg_install_cmake()
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
 file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/glfw3 ${CURRENT_PACKAGES_DIR}/share/glfw3)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
-file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glfw3/glfw3Targets-debug.cmake ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-debug.cmake)
+file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake _contents)
+string(REPLACE "get_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)\n\n" "\n" _contents "${_contents}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake ${_contents})
+
+file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glfw3/glfw3Targets-debug.cmake _contents)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" _contents "${_contents}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-debug.cmake "${_contents}")
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
@@ -43,6 +49,13 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
     file(RENAME ${CURRENT_PACKAGES_DIR}/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/bin/glfw3.dll)
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/debug/bin/glfw3.dll)
+    foreach(_conf release
+                  debug)
+        file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake _contents)
+        string(REPLACE "lib/glfw3.dll" "bin/glfw3.dll" _contents "${_contents}")
+        file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake "${_contents}")
+    endforeach()
+
 endif()
 
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/glfw3)


### PR DESCRIPTION
CMake config files in glfw3 port contain wrong paths since the files are moved around in the installation.
This patch fixes these paths.