### PR TITLE
Adds PDBs and 64bit builds to PDCurses

### DIFF
--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -15,7 +15,6 @@ set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
 set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
 
 file(READ ${SOURCE_PATH}/win32/vcwin32.mak PDC_MAK)
-string(REPLACE "-Z7" "-ZI -Fdpdcurses.pdb" PDC_MAK ${PDC_MAK})
 string(REPLACE " -pdb:none" "" PDC_MAK ${PDC_MAK})
 string(REPLACE "/MACHINE:IX86 " "" PDC_MAK ${PDC_MAK})
 file(WRITE ${SOURCE_PATH}/win32/vcpkg.mak ${PDC_MAK})

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -1,8 +1,4 @@
 
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
-    message(FATAL_ERROR "64-bit builds are not supported for PDCurses.")
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 find_program(NMAKE nmake)
@@ -14,9 +10,15 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-set(PDC_NMAKE_CMD ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y)
+set(PDC_NMAKE_CMD ${NMAKE} /A -f vcwin32.mak WIDE=Y UTF8=Y)
 set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
 set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
+
+file(READ ${SOURCE_PATH}/win32/vcwin32.mak PDC_MAK)
+string(REPLACE "-Z7" "-ZI -Fdpdcurses.pdb" PDC_MAK ${PDC_MAK})
+string(REPLACE " -pdb:none" "" PDC_MAK ${PDC_MAK})
+string(REPLACE "/MACHINE:IX86 " "" PDC_MAK ${PDC_MAK})
+file(WRITE ${SOURCE_PATH}/win32/vcwin32.mak ${PDC_MAK})
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(PDC_NMAKE_CMD ${PDC_NMAKE_CMD} DLL=Y)

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-set(PDC_NMAKE_CMD ${NMAKE} /A -f vcwin32.mak WIDE=Y UTF8=Y)
+set(PDC_NMAKE_CMD ${NMAKE} /A -f vcpkg.mak WIDE=Y UTF8=Y)
 set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
 set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
 
@@ -18,7 +18,7 @@ file(READ ${SOURCE_PATH}/win32/vcwin32.mak PDC_MAK)
 string(REPLACE "-Z7" "-ZI -Fdpdcurses.pdb" PDC_MAK ${PDC_MAK})
 string(REPLACE " -pdb:none" "" PDC_MAK ${PDC_MAK})
 string(REPLACE "/MACHINE:IX86 " "" PDC_MAK ${PDC_MAK})
-file(WRITE ${SOURCE_PATH}/win32/vcwin32.mak ${PDC_MAK})
+file(WRITE ${SOURCE_PATH}/win32/vcpkg.mak ${PDC_MAK})
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(PDC_NMAKE_CMD ${PDC_NMAKE_CMD} DLL=Y)

--- a/ports/pdcurses/portfile.cmake
+++ b/ports/pdcurses/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_extract_source_archive(${ARCHIVE})
 set(PDC_NMAKE_CMD ${NMAKE} -f vcwin32.mak WIDE=Y UTF8=Y)
 set(PDC_NMAKE_CWD ${SOURCE_PATH}/win32)
 set(PDC_PDCLIB ${SOURCE_PATH}/win32/pdcurses)
-set(PDC_OUTPUT bin)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(PDC_NMAKE_CMD ${PDC_NMAKE_CMD} DLL=Y)


### PR DESCRIPTION
By default, PDCurses builds with debugging information built into the .lib file, but vcpkg seems to prefer PDBs, so this edits the makefile to allow those PDBs to be generated separately.

Also I was able to build and test 64-bit builds by removing the cvtres option that was forcing x86 compiles.