### PR TITLE
Add poco.

### DIFF
--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,4 +1,4 @@
 Source: poco
 Version: 1.7.6
-Build-Depends: openssl, libmariadb
+Build-Depends: 
 Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.

--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,0 +1,4 @@
+Source: poco
+Version: 1.7.6
+Build-Depends: openssl, libmariadb
+Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.

--- a/ports/poco/config_h.patch
+++ b/ports/poco/config_h.patch
@@ -1,0 +1,13 @@
+diff --git a/Foundation/include/Poco/Config.h b/Foundation/include/Poco/Config.h
+index 003b6dc..55b8eed 100644
+--- a/Foundation/include/Poco/Config.h
++++ b/Foundation/include/Poco/Config.h
+@@ -31,7 +31,7 @@
+ 
+ 
+ // Define to disable implicit linking
+-// #define POCO_NO_AUTOMATIC_LIBS
++#define POCO_NO_AUTOMATIC_LIBS
+ 
+ 
+ // Define to disable automatic initialization

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/poco-1.7.6-all)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/poco-poco-1.7.6-release)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://pocoproject.org/releases/poco-1.7.6/poco-1.7.6-all.zip"
-    FILENAME "poco-1.7.6-all.zip"
-    SHA512 ed15c6ab69157d3caf3f5fcd861396ddbe3a98c1f3d513c2670e81601c176fb17549791836bd50014d9fb58aa3983e262312848f197e9c487af962cc27556df5
+    URLS "https://github.com/pocoproject/poco/archive/poco-1.7.6-release.tar.gz"
+    FILENAME "poco-poco-1.7.6-release.tar.gz"
+    SHA512 a02b7ff66acf080942517b3b8644d6e5c7136c5edc6e58fd13083a74b97b5619253fc9db7863284a565226f95410ad4da1fa9738d14885f560aeb03c1f7c18aa
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
@@ -16,18 +16,14 @@ vcpkg_apply_patches(
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 	set(POCO_STATIC ON)
-	set(POCO_MT     ON)
 endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 	OPTIONS
 		-DPOCO_STATIC=${POCO_STATIC}
-		-DPOCO_MT=${POCO_MT}
-		
-		-DFORCE_OPENSSL=ON
+		-DENABLE_SEVENZIP=ON
 		-DENABLE_TESTS=OFF
-		-DENABLE_MSVC_MP=ON
 		-DPOCO_UNBUNDLED=OFF # OFF means: using internal copy of sqlite, libz, pcre, expat, ...
 )
 
@@ -41,21 +37,21 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 	file(REMOVE_RECURSE 
 		${CURRENT_PACKAGES_DIR}/bin
 		${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+	file(REMOVE 
+		${CURRENT_PACKAGES_DIR}/bin/cpspc.pdb
+		${CURRENT_PACKAGES_DIR}/bin/f2cpsp.pdb
+		${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.exe
+		${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.pdb
+		${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.exe
+		${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.pdb)
+
+	file(REMOVE
+		${CURRENT_PACKAGES_DIR}/bin/vcruntime140.dll
+		${CURRENT_PACKAGES_DIR}/bin/msvcp140.dll
+		${CURRENT_PACKAGES_DIR}/debug/bin/vcruntime140.dll
+		${CURRENT_PACKAGES_DIR}/debug/bin/msvcp140.dll)
 endif()
-
-file(REMOVE 
-	${CURRENT_PACKAGES_DIR}/bin/cpspc.pdb
-	${CURRENT_PACKAGES_DIR}/bin/f2cpsp.pdb
-	${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.exe
-	${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.pdb
-	${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.exe
-	${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.pdb)
-
-file(REMOVE
-	${CURRENT_PACKAGES_DIR}/bin/vcruntime140.dll
-	${CURRENT_PACKAGES_DIR}/bin/msvcp140.dll
-	${CURRENT_PACKAGES_DIR}/debug/bin/vcruntime140.dll
-	${CURRENT_PACKAGES_DIR}/debug/bin/msvcp140.dll)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,0 +1,66 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/poco-1.7.6-all)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://pocoproject.org/releases/poco-1.7.6/poco-1.7.6-all.zip"
+    FILENAME "poco-1.7.6-all.zip"
+    SHA512 ed15c6ab69157d3caf3f5fcd861396ddbe3a98c1f3d513c2670e81601c176fb17549791836bd50014d9fb58aa3983e262312848f197e9c487af962cc27556df5
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+		${CMAKE_CURRENT_LIST_DIR}/config_h.patch
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+	set(POCO_STATIC ON)
+	set(POCO_MT     ON)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DPOCO_STATIC=${POCO_STATIC}
+		-DPOCO_MT=${POCO_MT}
+		
+		-DFORCE_OPENSSL=ON
+		-DENABLE_TESTS=OFF
+		-DENABLE_MSVC_MP=ON
+		-DPOCO_UNBUNDLED=OFF # OFF means: using internal copy of sqlite, libz, pcre, expat, ...
+)
+
+vcpkg_install_cmake()
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/cpspc.exe ${CURRENT_PACKAGES_DIR}/tools/cpspc.exe)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/f2cpsp.exe ${CURRENT_PACKAGES_DIR}/tools/f2cpsp.exe)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+	file(REMOVE_RECURSE 
+		${CURRENT_PACKAGES_DIR}/bin
+		${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+file(REMOVE 
+	${CURRENT_PACKAGES_DIR}/bin/cpspc.pdb
+	${CURRENT_PACKAGES_DIR}/bin/f2cpsp.pdb
+	${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.exe
+	${CURRENT_PACKAGES_DIR}/debug/bin/cpspc.pdb
+	${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.exe
+	${CURRENT_PACKAGES_DIR}/debug/bin/f2cpsp.pdb)
+
+file(REMOVE
+	${CURRENT_PACKAGES_DIR}/bin/vcruntime140.dll
+	${CURRENT_PACKAGES_DIR}/bin/msvcp140.dll
+	${CURRENT_PACKAGES_DIR}/debug/bin/vcruntime140.dll
+	${CURRENT_PACKAGES_DIR}/debug/bin/msvcp140.dll)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+
+# copy license
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/poco)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/poco/LICENSE ${CURRENT_PACKAGES_DIR}/share/poco/copyright)


### PR DESCRIPTION
This should fix: https://github.com/Microsoft/vcpkg/issues/124

Note:
I created a small patch to define POCO_NO_AUTOMATIC_LIBS since vcpkg would do that.
The option POCO_UNBUNDLED is now OFF, we should switch it ON when all dependency is available in vcpkg.