### PR TITLE
[libwebp] Fix debug postfix and build

### DIFF
--- a/ports/libwebp/0002-add-missing-directory-to-cmake.patch
+++ b/ports/libwebp/0002-add-missing-directory-to-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9172f66..df46bd1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -249,6 +249,7 @@ parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/dec "${WEBP_SRCS}")
+ parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/demux "${WEBP_SRCS}")
+ parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/dsp "${WEBP_SRCS}")
+ parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/enc "${WEBP_SRCS}")
++parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/mux "${WEBP_SRCS}")
+ parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/utils "${WEBP_SRCS}")
+ 
+ # Remove the files specific to SIMD we don't user.

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -10,12 +10,14 @@ vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-add-install-to-cmake.patch
+            ${CMAKE_CURRENT_LIST_DIR}/0002-add-missing-directory-to-cmake.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     # dllexport support seem to be broken
     OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON
+            -DCMAKE_DEBUG_POSTFIX=d
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Add a debug postfix to libwebp, to simplify
finding the debug library in CMake, consistently
with most other libraries in vcpkg.

Add the mux directory that was not built
in the CMake-based build system.