### PR TITLE
[jxrlib] Add debug postfix and do not install Win SDK header

### DIFF
--- a/ports/jxrlib/CMakeLists.txt
+++ b/ports/jxrlib/CMakeLists.txt
@@ -8,6 +8,9 @@ project(jxrlib C)
 # Need shared libs for ABI
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+# Add a debug postfix
+set(CMAKE_DEBUG_POSTFIX "d")
+
 # helper macro to preserve original Makefile convention
 macro(JXR_MAKE_OBJ SET_NAME)
   foreach(src ${SRC_${SET_NAME}})

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -9,6 +9,10 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+# The file guiddef.h is part of the Windows SDK,
+# we then remove the local copy shipped with jxrlib
+file(REMOVE ${SOURCE_PATH}/common/include/guiddef.h)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS:BOOL=ON


### PR DESCRIPTION
Add a debug postfix to jxrlib, to simplify
finding the debug library in CMake, consistently
with most other libraries in vcpkg.

Do not use or install `guiddef.h`, that is an header
of Windows SDK of which jxrlib includes a copy for
non-Windows platforms.