### PR TITLE
[libjpeg-turbo] Fix static libraries name

### DIFF
--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -38,6 +38,14 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+# Rename libraries for static builds
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/jpeg-static.lib" "${CURRENT_PACKAGES_DIR}/lib/jpeg.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/turbojpeg-static.lib" "${CURRENT_PACKAGES_DIR}/lib/turbojpeg.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/jpeg-static.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/jpeg.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/turbojpeg-static.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/turbojpeg.lib")
+endif()
+
 file(COPY
     ${SOURCE_PATH}/LICENSE.md
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/libjpeg-turbo


### PR DESCRIPTION
The libraries with the `-static` suffix are not found by CMake.

Since shared and static libs are separated by the triplets, there is no need to have a different name.