### PR TITLE
[mongo-cxx-driver] fix static build

### DIFF
--- a/ports/mongo-cxx-driver/disable_shared.patch
+++ b/ports/mongo-cxx-driver/disable_shared.patch
@@ -1,0 +1,46 @@
+diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
+index a9a7ada..f4534b1 100644
+--- a/src/bsoncxx/CMakeLists.txt
++++ b/src/bsoncxx/CMakeLists.txt
+@@ -117,9 +117,15 @@ if (WIN32)
+     )
+ endif()
+ 
+-add_library(bsoncxx SHARED
+-    ${bsoncxx_sources}
+-)
++if(ENABLE_SHARED)
++	add_library(bsoncxx SHARED
++		${bsoncxx_sources}
++	)
++else()
++	add_library(bsoncxx SHARED
++		exception/error_code.cpp
++	)
++endif()
+ 
+ set(bsoncxx_libs ${LIBBSON_LIBRARIES})
+ 
+diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
+index 2ef54e4..a2c8ca4 100644
+--- a/src/mongocxx/CMakeLists.txt
++++ b/src/mongocxx/CMakeLists.txt
+@@ -134,9 +134,15 @@ set_target_properties(mongocxx_mocked PROPERTIES
+     VERSION ${MONGOCXX_VERSION}
+ )
+ 
+-add_library(mongocxx SHARED
+-    ${mongocxx_sources}
+-)
++if(ENABLE_SHARED)
++	add_library(mongocxx SHARED
++		${mongocxx_sources}
++	)
++else()
++	add_library(mongocxx SHARED
++		exception/error_code.cpp
++	)
++endif()
+ 
+ set_target_properties (mongocxx PROPERTIES
+     OUTPUT_NAME mongocxx

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,8 +1,3 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.") #Blocked by build failure
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-cxx-driver-r3.0.3)
 
@@ -15,8 +10,14 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/disable_test_and_example.patch
+    PATCHES 
+		${CMAKE_CURRENT_LIST_DIR}/disable_test_and_example.patch
+		${CMAKE_CURRENT_LIST_DIR}/disable_shared.patch
 )
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+	set(ENABLE_SHARED ON)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -24,6 +25,7 @@ vcpkg_configure_cmake(
 		-DLIBBSON_DIR=${CURRENT_INSTALLED_DIR}
 		-DLIBMONGOC_DIR=${CURRENT_INSTALLED_DIR}
 		-DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=ON
+		-DENABLE_SHARED=${ENABLE_SHARED}
 )
 
 vcpkg_install_cmake()

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -76,6 +76,13 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 	file(RENAME
 		${CURRENT_PACKAGES_DIR}/debug/lib/libmongocxx.lib
 		${CURRENT_PACKAGES_DIR}/debug/lib/mongocxx.lib)
+	
+	# define MONGOCXX_STATIC in config/export.hpp
+	vcpkg_apply_patches(
+		SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
+		PATCHES
+			${CMAKE_CURRENT_LIST_DIR}/static.patch
+	)
 else()
 	file(REMOVE         ${CURRENT_PACKAGES_DIR}/lib/libbsoncxx.lib)
 	file(REMOVE         ${CURRENT_PACKAGES_DIR}/debug/lib/libbsoncxx.lib)

--- a/ports/mongo-cxx-driver/static.patch
+++ b/ports/mongo-cxx-driver/static.patch
@@ -1,0 +1,12 @@
+diff --git a/mongocxx/config/export.hpp b/mongocxx/config/export.hpp
+index 61a3e74..7fc951c 100644
+--- a/mongocxx/config/export.hpp
++++ b/mongocxx/config/export.hpp
+@@ -2,6 +2,7 @@
+ #ifndef MONGOCXX_API_H
+ #define MONGOCXX_API_H
+ 
++#define MONGOCXX_STATIC
+ #ifdef MONGOCXX_STATIC
+ #  define MONGOCXX_API
+ #  define MONGOCXX_PRIVATE


### PR DESCRIPTION
note:
Actually, static build is perfectly fine but the cmake always build static and dynamic library togather, in the static environment, dynamic build will fail due link error.
I twisted a patch to the CMakeLists.txt to make dynamic build happy when building static.