### PR TITLE
[mongo-cxx-driver] using BUILD_SHARED_LIBS instead of self-defined macro

### DIFF
--- a/ports/mongo-cxx-driver/disable_shared.patch
+++ b/ports/mongo-cxx-driver/disable_shared.patch
@@ -1,5 +1,5 @@
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
-index a9a7ada..f4534b1 100644
+index a9a7ada..6b87a6d 100644
 --- a/src/bsoncxx/CMakeLists.txt
 +++ b/src/bsoncxx/CMakeLists.txt
 @@ -117,9 +117,15 @@ if (WIN32)
@@ -9,7 +9,7 @@ index a9a7ada..f4534b1 100644
 -add_library(bsoncxx SHARED
 -    ${bsoncxx_sources}
 -)
-+if(ENABLE_SHARED)
++if(BUILD_SHARED_LIBS)
 +	add_library(bsoncxx SHARED
 +		${bsoncxx_sources}
 +	)
@@ -22,7 +22,7 @@ index a9a7ada..f4534b1 100644
  set(bsoncxx_libs ${LIBBSON_LIBRARIES})
  
 diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
-index 2ef54e4..a2c8ca4 100644
+index 2ef54e4..53a13f7 100644
 --- a/src/mongocxx/CMakeLists.txt
 +++ b/src/mongocxx/CMakeLists.txt
 @@ -134,9 +134,15 @@ set_target_properties(mongocxx_mocked PROPERTIES
@@ -32,7 +32,7 @@ index 2ef54e4..a2c8ca4 100644
 -add_library(mongocxx SHARED
 -    ${mongocxx_sources}
 -)
-+if(ENABLE_SHARED)
++if(BUILD_SHARED_LIBS)
 +	add_library(mongocxx SHARED
 +		${mongocxx_sources}
 +	)

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -15,17 +15,12 @@ vcpkg_apply_patches(
 		${CMAKE_CURRENT_LIST_DIR}/disable_shared.patch
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-	set(ENABLE_SHARED ON)
-endif()
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
 	OPTIONS
 		-DLIBBSON_DIR=${CURRENT_INSTALLED_DIR}
 		-DLIBMONGOC_DIR=${CURRENT_INSTALLED_DIR}
 		-DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=ON
-		-DENABLE_SHARED=${ENABLE_SHARED}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Related to my other PR: https://github.com/Microsoft/vcpkg/pull/316

I used BUILD_SHARED_LIBS instead of self-defined macro in disable_shared.patch.