### PR TITLE
Add glslang.

### DIFF
--- a/ports/glslang/0001-Fix-export-symbol-for-Windows.patch
+++ b/ports/glslang/0001-Fix-export-symbol-for-Windows.patch
@@ -1,0 +1,86 @@
+From 1ccadd2cb6db3ce5a00635f65db21e561eb7f705 Mon Sep 17 00:00:00 2001
+From: vlj <vljn.ovi@gmail.com>
+Date: Fri, 25 Nov 2016 17:12:35 +0100
+Subject: [PATCH] Fix export symbol for Windows.
+
+---
+ StandAlone/CMakeLists.txt     |  1 +
+ StandAlone/ResourceLimits.cpp |  3 +++
+ StandAlone/ResourceLimits.h   | 10 ++++++++++
+ 3 files changed, 14 insertions(+)
+
+diff --git a/StandAlone/CMakeLists.txt b/StandAlone/CMakeLists.txt
+index 231ba27..3aff02e 100644
+--- a/StandAlone/CMakeLists.txt
++++ b/StandAlone/CMakeLists.txt
+@@ -2,6 +2,7 @@ add_library(glslang-default-resource-limits
+     ${CMAKE_CURRENT_SOURCE_DIR}/ResourceLimits.cpp
+ )
+ set_property(TARGET glslang-default-resource-limits PROPERTY FOLDER glslang)
++set_property(TARGET glslang-default-resource-limits PROPERTY COMPILE_DEFINITIONS DLLEXPORT)
+ 
+ target_include_directories(glslang-default-resource-limits
+     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+diff --git a/StandAlone/ResourceLimits.cpp b/StandAlone/ResourceLimits.cpp
+index e22ec80..634d9c9 100644
+--- a/StandAlone/ResourceLimits.cpp
++++ b/StandAlone/ResourceLimits.cpp
+@@ -41,6 +41,7 @@
+ 
+ namespace glslang {
+ 
++DLL_EXPORT
+ const TBuiltInResource DefaultTBuiltInResource = {
+     /* .MaxLights = */ 32,
+     /* .MaxClipPlanes = */ 6,
+@@ -137,6 +138,7 @@ const TBuiltInResource DefaultTBuiltInResource = {
+         /* .generalConstantMatrixVectorIndexing = */ 1,
+     }};
+ 
++DLL_EXPORT
+ std::string GetDefaultTBuiltInResourceString()
+ {
+     std::ostringstream ostream;
+@@ -239,6 +241,7 @@ std::string GetDefaultTBuiltInResourceString()
+     return ostream.str();
+ }
+ 
++DLL_EXPORT
+ void DecodeResourceLimits(TBuiltInResource* resources, char* config)
+ {
+     static const char* delims = " \t\n\r";
+diff --git a/StandAlone/ResourceLimits.h b/StandAlone/ResourceLimits.h
+index 9c3eb3e..932a59f 100644
+--- a/StandAlone/ResourceLimits.h
++++ b/StandAlone/ResourceLimits.h
+@@ -39,17 +39,27 @@
+ 
+ #include "glslang/Include/ResourceLimits.h"
+ 
++#ifdef DLLEXPORT
++#define DLL_EXPORT __declspec(dllexport)
++#else
++#define DLL_EXPORT __declspec(dllimport)
++#endif
++
+ namespace glslang {
+ 
+ // These are the default resources for TBuiltInResources, used for both
+ //  - parsing this string for the case where the user didn't supply one,
+ //  - dumping out a template for user construction of a config file.
++
++DLL_EXPORT
+ extern const TBuiltInResource DefaultTBuiltInResource;
+ 
+ // Returns the DefaultTBuiltInResource as a human-readable string.
++DLL_EXPORT
+ std::string GetDefaultTBuiltInResourceString();
+ 
+ // Decodes the resource limits from |config| to |resources|.
++DLL_EXPORT
+ void DecodeResourceLimits(TBuiltInResource* resources, char* config);
+ 
+ }  // end namespace glslang
+-- 
+2.10.2.windows.1
+

--- a/ports/glslang/CONTROL
+++ b/ports/glslang/CONTROL
@@ -1,0 +1,3 @@
+Source: glslang
+Version: 1c573fbcfba6b3d631008b1babc838501ca925d3
+Description: Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator 

--- a/ports/glslang/copyright
+++ b/ports/glslang/copyright
@@ -1,0 +1,35 @@
+//
+//Copyright (C) 2002-2005 3Dlabs Inc. Ltd.
+//Copyright (C) 2012-2013 LunarG, Inc.
+//
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms, with or without
+//modification, are permitted provided that the following conditions
+//are met:
+//
+// Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following
+// disclaimer in the documentation and/or other materials provided
+// with the distribution.
+//
+// Neither the name of 3Dlabs Inc. Ltd. nor the names of its
+// contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//POSSIBILITY OF SUCH DAMAGE.
+//

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -1,0 +1,68 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(vcpkg_common_functions)
+find_program(GIT git)
+
+set(GIT_URL "https://github.com/KhronosGroup/glslang.git")
+set(GIT_REF "1c573fbcfba6b3d631008b1babc838501ca925d3")
+
+if(NOT EXISTS "${DOWNLOADS}/glslang.git")
+    message(STATUS "Cloning")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} clone --bare ${GIT_URL} ${DOWNLOADS}/glslang.git
+        WORKING_DIRECTORY ${DOWNLOADS}
+        LOGNAME clone
+    )
+endif()
+
+if(NOT EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
+    message(STATUS "Adding worktree and patching")
+    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} worktree add -f --detach ${CURRENT_BUILDTREES_DIR}/src ${GIT_REF}
+        WORKING_DIRECTORY ${DOWNLOADS}/glslang.git
+        LOGNAME worktree
+    )
+    message(STATUS "Patching")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} apply ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-export-symbol-for-Windows.patch --ignore-whitespace --whitespace=fix
+        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src
+        LOGNAME patch
+    )
+endif()
+
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src"
+)
+
+vcpkg_install_cmake()
+
+file(COPY "${CURRENT_BUILDTREES_DIR}/src/glslang/Public/ShaderLang.h" DESTINATION ${CURRENT_PACKAGES_DIR}/include/glslang)
+file(COPY "${CURRENT_PACKAGES_DIR}/bin/glslangValidator.exe" DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/glslangValidator.exe")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/glslangValidator.exe")
+file(COPY "${CURRENT_PACKAGES_DIR}/bin/spirv-remap.exe" DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/spirv-remap.exe")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/spirv-remap.exe")
+
+file(GLOB BIN_DIR "${CURRENT_PACKAGES_DIR}/bin/*")
+list(LENGTH BIN_DIR BIN_DIR_SIZE)
+if(${BIN_DIR_SIZE} EQUAL 0)
+	file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+file(GLOB DEBUG_BIN_DIR "${CURRENT_PACKAGES_DIR}/debug/bin/*")
+list(LENGTH DEBUG_BIN_DIR DEBUG_BIN_DIR_SIZE)
+if(${DEBUG_BIN_DIR_SIZE} EQUAL 0)
+	file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+# Handle copyright
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/glslang)


### PR DESCRIPTION
This package adds glslang lib and the standalone Tools that can be used to generate SPIR-V binaries.