### PR TITLE
Added ports for pixman 0.32.0 and cairo 1.14.6.

### DIFF
--- a/ports/cairo/CMakeLists.txt
+++ b/ports/cairo/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.0)
+project(cairo VERSION 1.14.6 LANGUAGES C CXX)
+add_subdirectory(src)

--- a/ports/cairo/CMakeLists_cairo.txt
+++ b/ports/cairo/CMakeLists_cairo.txt
@@ -1,0 +1,250 @@
+set(CURRENT_INSTALLED_DIR ${CMAKE_PREFIX_PATH})
+
+# Add include directories
+include_directories("." "./win32" "${CURRENT_INSTALLED_DIR}/include")
+
+file(GLOB SOURCES
+"cairo-analysis-surface.c"
+"cairo-arc.c"
+"cairo-array.c"
+"cairo-atomic.c"
+"cairo-base64-stream.c"
+"cairo-base85-stream.c"
+"cairo-bentley-ottmann.c"
+"cairo-bentley-ottmann-rectangular.c"
+"cairo-bentley-ottmann-rectilinear.c"
+"cairo-botor-scan-converter.c"
+"cairo-boxes.c"
+"cairo-boxes-intersect.c"
+"cairo.c"
+"cairo-cache.c"
+"cairo-clip.c"
+"cairo-clip-boxes.c"
+"cairo-clip-polygon.c"
+"cairo-clip-region.c"
+"cairo-clip-surface.c"
+"cairo-color.c"
+"cairo-composite-rectangles.c"
+"cairo-compositor.c"
+"cairo-contour.c"
+"cairo-damage.c"
+"cairo-debug.c"
+"cairo-default-context.c"
+"cairo-device.c"
+"cairo-error.c"
+"cairo-fallback-compositor.c"
+"cairo-fixed.c"
+"cairo-font-face.c"
+"cairo-font-face-twin.c"
+"cairo-font-face-twin-data.c"
+"cairo-font-options.c"
+"cairo-freelist.c"
+"cairo-freed-pool.c"
+"cairo-gstate.c"
+"cairo-hash.c"
+"cairo-hull.c"
+"cairo-image-compositor.c"
+"cairo-image-info.c"
+"cairo-image-source.c"
+"cairo-image-surface.c"
+"cairo-line.c"
+"cairo-lzw.c"
+"cairo-matrix.c"
+"cairo-mask-compositor.c"
+"cairo-mesh-pattern-rasterizer.c"
+"cairo-mempool.c"
+"cairo-misc.c"
+"cairo-mono-scan-converter.c"
+"cairo-mutex.c"
+"cairo-no-compositor.c"
+"cairo-observer.c"
+"cairo-output-stream.c"
+"cairo-paginated-surface.c"
+"cairo-path-bounds.c"
+"cairo-path.c"
+"cairo-path-fill.c"
+"cairo-path-fixed.c"
+"cairo-path-in-fill.c"
+"cairo-path-stroke.c"
+"cairo-path-stroke-boxes.c"
+"cairo-path-stroke-polygon.c"
+"cairo-path-stroke-traps.c"
+"cairo-path-stroke-tristrip.c"
+"cairo-pattern.c"
+"cairo-pen.c"
+"cairo-polygon.c"
+"cairo-polygon-intersect.c"
+"cairo-polygon-reduce.c"
+"cairo-raster-source-pattern.c"
+"cairo-recording-surface.c"
+"cairo-rectangle.c"
+"cairo-rectangular-scan-converter.c"
+"cairo-region.c"
+"cairo-rtree.c"
+"cairo-scaled-font.c"
+"cairo-shape-mask-compositor.c"
+"cairo-slope.c"
+"cairo-spans.c"
+"cairo-spans-compositor.c"
+"cairo-spline.c"
+"cairo-stroke-dash.c"
+"cairo-stroke-style.c"
+"cairo-surface.c"
+"cairo-surface-clipper.c"
+"cairo-surface-fallback.c"
+"cairo-surface-observer.c"
+"cairo-surface-offset.c"
+"cairo-surface-snapshot.c"
+"cairo-surface-subsurface.c"
+"cairo-surface-wrapper.c"
+"cairo-time.c"
+"cairo-tor-scan-converter.c"
+"cairo-tor22-scan-converter.c"
+"cairo-clip-tor-scan-converter.c"
+"cairo-toy-font-face.c"
+"cairo-traps.c"
+"cairo-tristrip.c"
+"cairo-traps-compositor.c"
+"cairo-unicode.c"
+"cairo-user-font.c"
+"cairo-version.c"
+"cairo-wideint.c"
+# win32
+"win32/cairo-win32-debug.c"
+"win32/cairo-win32-device.c"
+"win32/cairo-win32-gdi-compositor.c"
+"win32/cairo-win32-system.c"
+"win32/cairo-win32-surface.c"
+"win32/cairo-win32-display-surface.c"
+"win32/cairo-win32-printing-surface.c"
+"win32/cairo-win32-font.c"
+# generic font support
+"cairo-cff-subset.c"
+"cairo-scaled-font-subsets.c"
+"cairo-truetype-subset.c"
+"cairo-type1-fallback.c"
+"cairo-type1-glyph-names.c"
+"cairo-type1-subset.c"
+"cairo-type3-glyph-surface.c"
+# pdf
+"cairo-pdf-operators.c"
+"cairo-pdf-shading.c"
+"cairo-pdf-surface.c"
+# png
+"cairo-png.c"
+# ps surface
+"cairo-ps-surface.c"
+# deflate source
+"cairo-deflate-stream.c"
+# svg surface
+"cairo-svg-surface.c"
+# script surface
+"cairo-script-surface.c"
+)
+
+set(CMAKE_DEBUG_POSTFIX "d")
+
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  # Make the zlib library available
+  find_library(ZLIB_DEBUG_IMPLIB NAMES zlibd)
+  if (ZLIB_DEBUG_IMPLIB STREQUAL ZLIB_DEBUG_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The zlibd.lib import library could not be found. Check to ensure that zlib is properly installed.")
+  endif()
+  add_library(zlib UNKNOWN IMPORTED)
+  set_property(TARGET zlib PROPERTY IMPORTED_LOCATION "${ZLIB_DEBUG_IMPLIB}")
+
+  # Make the libpng library available
+  find_library(LIBPNG_DEBUG_IMPLIB NAMES libpng16d)
+  if (LIBPNG_DEBUG_IMPLIB STREQUAL LIBPNG_DEBUG_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The libpng16d.lib import library could not be found. Check to ensure that libpng is properly installed.")
+  endif()
+  add_library(libpng UNKNOWN IMPORTED)
+  set_property(TARGET libpng PROPERTY IMPORTED_LOCATION "${LIBPNG_DEBUG_IMPLIB}")
+
+  # Make the pixman library available
+  find_library(PIXMAN_DEBUG_IMPLIB NAMES pixman-1d)
+  if (PIXMAN_DEBUG_IMPLIB STREQUAL PIXMAN_DEBUG_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The pixman-1d.lib import library could not be found. Check to ensure that pixman is properly installed.")
+  endif()
+  add_library(pixman UNKNOWN IMPORTED)
+  set_property(TARGET pixman PROPERTY IMPORTED_LOCATION "${PIXMAN_DEBUG_IMPLIB}")
+
+elseif (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+  # Make the zlib library available
+  find_library(ZLIB_RELEASE_IMPLIB NAMES zlib)
+  if (ZLIB_RELEASE_IMPLIB STREQUAL ZLIB_RELEASE_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The zlib.lib import library could not be found. Check to ensure that zlib is properly installed.")
+  endif()
+  add_library(zlib UNKNOWN IMPORTED)
+  set_property(TARGET zlib PROPERTY IMPORTED_LOCATION "${ZLIB_RELEASE_IMPLIB}")
+
+  # Make the libpng library available
+  find_library(LIBPNG_RELEASE_IMPLIB NAMES libpng16)
+  if (LIBPNG_RELEASE_IMPLIB STREQUAL LIBPNG_RELEASE_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The libpng16.lib import library could not be found. Check to ensure that libpng is properly installed.")
+  endif()
+  add_library(libpng UNKNOWN IMPORTED)
+  set_property(TARGET libpng PROPERTY IMPORTED_LOCATION "${LIBPNG_RELEASE_IMPLIB}")
+
+  # Make the pixman library available
+  find_library(PIXMAN_RELEASE_IMPLIB NAMES pixman-1)
+  if (PIXMAN_RELEASE_IMPLIB STREQUAL PIXMAN_RELEASE_IMPLIB-NOTFOUND)
+    message(FATAL_ERROR "The pixman-1.lib import library could not be found. Check to ensure that pixman is properly installed.")
+  endif()
+  add_library(pixman UNKNOWN IMPORTED)
+  set_property(TARGET pixman PROPERTY IMPORTED_LOCATION "${PIXMAN_RELEASE_IMPLIB}")
+
+else()
+    message(FATAL_ERROR "Unexpected value '${CMAKE_BUILD_TYPE}' for CMAKE_BUILD_TYPE.")
+endif()
+
+# Make the gdi32 library available
+find_library(GDI32_LIBRARY NAMES gdi32)
+if (GDI32_LIBRARY STREQUAL GDI32_LIBRARY-NOTFOUND)
+  message(FATAL_ERROR "The gdi32.lib import library could not be found. Check to ensure that the Windows SDK is installed.")
+endif()
+add_library(gdi32 UNKNOWN IMPORTED)
+set_property(TARGET gdi32 PROPERTY IMPORTED_LOCATION "${GDI32_LIBRARY}")
+
+# Make the msimg32 library available
+find_library(MSIMG32_LIBRARY NAMES msimg32)
+if (MSIMG32_LIBRARY STREQUAL MSIMG32_LIBRARY-NOTFOUND)
+  message(FATAL_ERROR "The msimg32.lib import library could not be found. Check to ensure that the Windows SDK is installed.")
+endif()
+add_library(msimg32 UNKNOWN IMPORTED)
+set_property(TARGET msimg32 PROPERTY IMPORTED_LOCATION "${MSIMG32_LIBRARY}")
+
+# Make the user32 library available
+find_library(USER32_LIBRARY NAMES user32)
+if (USER32_LIBRARY STREQUAL USER32_LIBRARY-NOTFOUND)
+  message(FATAL_ERROR "The user32.lib import library could not be found. Check to ensure that the Windows SDK is installed.")
+endif()
+add_library(user32 UNKNOWN IMPORTED)
+set_property(TARGET user32 PROPERTY IMPORTED_LOCATION "${USER32_LIBRARY}")
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  add_library(cairo ${SOURCES})
+  # cairo produces a lot of warnings which are disabled here because they otherwise fill up the log files
+  target_compile_options(cairo PUBLIC "/wd4244" PUBLIC "/wd4146" PUBLIC "/wd4312" PUBLIC "/wd4267" PUBLIC "/wd4996" PUBLIC "/wd4311" PUBLIC "/wd4334" PUBLIC "/wd4101")
+  target_link_libraries(cairo gdi32 msimg32 user32 zlib libpng pixman)
+
+  install(TARGETS cairo
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION bin
+    ARCHIVE DESTINATION lib
+  )
+elseif (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  add_library(cairo-static ${SOURCES})
+  target_compile_options(cairo-static PUBLIC "/DCAIRO_WIN32_STATIC_BUILD=1")
+  # cairo produces a lot of warnings which are disabled here because they otherwise fill up the log files
+  target_compile_options(cairo-static PUBLIC "/wd4244" PUBLIC "/wd4146" PUBLIC "/wd4312" PUBLIC "/wd4267" PUBLIC "/wd4996" PUBLIC "/wd4311" PUBLIC "/wd4334" PUBLIC "/wd4101")
+  target_link_libraries(cairo-static gdi32 msimg32 user32 zlib libpng pixman)
+
+  install(TARGETS cairo-static
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+else()
+  message(FATAL_ERROR "VCPKG_LIBRARY_LINKAGE is not defined or has an unexpected value")
+endif()

--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,0 +1,4 @@
+Source: cairo
+Version: 1.14.6
+Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
+Build-Depends: zlib, libpng, pixman

--- a/ports/cairo/cairo-features.h
+++ b/ports/cairo/cairo-features.h
@@ -1,0 +1,27 @@
+#ifndef CAIRO_FEATURES_H
+#define CAIRO_FEATURES_H
+/* Chosen from the various possible defines in "../build/Makefile.win32.features.h""
+   guided by "../build/Makefile.win32.features". Modify at your own risk.
+*/
+
+/* Always for Win32 */
+#define CAIRO_HAS_WIN32_SURFACE 1
+#define CAIRO_HAS_WIN32_FONT 1
+
+/* Require libpng */
+#define CAIRO_HAS_PNG_FUNCTIONS 1
+#define CAIRO_HAS_PS_SURFACE 1
+#define CAIRO_HAS_PDF_SURFACE 1
+
+// Likely available
+#define CAIRO_HAS_SCRIPT_SURFACE 1
+#define CAIRO_HAS_SVG_SURFACE 1
+
+/* Always available */
+#define CAIRO_HAS_IMAGE_SURFACE 1
+#define CAIRO_HAS_MIME_SURFACE 1
+#define CAIRO_HAS_RECORDING_SURFACE 1
+#define CAIRO_HAS_OBSERVER_SURFACE 1
+#define CAIRO_HAS_USER_FONT 1
+
+#endif

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -1,0 +1,54 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cairo-1.14.6)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.cairographics.org/releases/cairo-1.14.6.tar.xz"
+    FILENAME "cairo-1.14.6.tar.xz"
+    SHA512 e2aa17a33b95b68d407b53ac321cca15b0c148eb49b8639c75b2af1e75e7b417a2168ea978dabb8581b341f0f45dc042d3b1a56b01ab525b1984015f0865316b
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_cairo.txt DESTINATION ${SOURCE_PATH}/src)
+file(RENAME ${SOURCE_PATH}/src/CMakeLists_cairo.txt ${SOURCE_PATH}/src/CMakeLists.txt)
+file(COPY ${CURRENT_PORT_DIR}/cairo-features.h DESTINATION ${SOURCE_PATH}/src)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+    )
+elseif (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+    )
+endif()
+
+vcpkg_install_cmake()
+
+# Copy the appropriate header files.
+file(COPY
+"${SOURCE_PATH}/src/cairo.h"
+"${SOURCE_PATH}/src/cairo-deprecated.h"
+"${SOURCE_PATH}/src/cairo-features.h"
+"${SOURCE_PATH}/src/cairo-pdf.h"
+"${SOURCE_PATH}/src/cairo-ps.h"
+"${SOURCE_PATH}/src/cairo-script.h"
+"${SOURCE_PATH}/src/cairo-svg.h"
+"${SOURCE_PATH}/cairo-version.h"
+"${SOURCE_PATH}/src/cairo-win32.h"
+DESTINATION
+${CURRENT_PACKAGES_DIR}/include
+)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/cairo)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/cairo/COPYING ${CURRENT_PACKAGES_DIR}/share/cairo/copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/pixman/CMakeLists.txt
+++ b/ports/pixman/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.0)
+project(pixman VERSION 0.32.0 LANGUAGES C CXX)
+
+add_subdirectory(pixman)

--- a/ports/pixman/CMakeLists_pixman.txt
+++ b/ports/pixman/CMakeLists_pixman.txt
@@ -1,0 +1,53 @@
+# Add include directories
+include_directories(".")
+
+FILE(GLOB SOURCES
+"pixman.c"
+"pixman-access.c"
+"pixman-access-accessors.c"
+"pixman-bits-image.c"
+"pixman-combine32.c"
+"pixman-combine-float.c"
+"pixman-conical-gradient.c"
+"pixman-filter.c"
+"pixman-x86.c"
+"pixman-mips.c"
+"pixman-arm.c"
+"pixman-ppc.c"
+"pixman-edge.c"
+"pixman-edge-accessors.c"
+"pixman-fast-path.c"
+"pixman-glyph.c"
+"pixman-general.c"
+"pixman-gradient-walker.c"
+"pixman-image.c"
+"pixman-implementation.c"
+"pixman-linear-gradient.c"
+"pixman-matrix.c"
+"pixman-noop.c"
+"pixman-radial-gradient.c"
+"pixman-region16.c"
+"pixman-region32.c"
+"pixman-solid-fill.c"
+"pixman-timer.c"
+"pixman-trap.c"
+"pixman-utils.c"
+"pixman-sse2.c"
+)
+
+set(CMAKE_DEBUG_POSTFIX "d")
+
+add_library(pixman-1 ${SOURCES})
+
+# pixman requires the three PACKAGE* definitions in order to compile. The USE_SSE2 definition lets it use SSE2 instructions for speed. Every target machine should have SSE2 these days.
+target_compile_definitions(pixman-1 PUBLIC PACKAGE="pixman-1" PUBLIC PACKAGE_VERSION="0.34.0" PUBLIC PACKAGE_BUGREPORT="" PUBLIC USE_SSE2)
+
+# pixman produces a lot of warnings which are disabled here because they otherwise fill up the log files
+target_compile_options(pixman-1 PUBLIC "/wd4244" PUBLIC "/wd4146" PUBLIC "/wd4996") #  PUBLIC "/D_CRT_SECURE_NO_WARNINGS"
+
+# The LIBRARY DESTINATION here is lib rather than bin because pixman must always be compiled as a static library since it has no exports.
+install(TARGETS pixman-1
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/ports/pixman/CONTROL
+++ b/ports/pixman/CONTROL
@@ -1,0 +1,3 @@
+Source: pixman
+Version: 0.34.0
+Description: Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.

--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -1,0 +1,52 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported. Building static.") # pixman does not export any symbols.
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+include(vcpkg_common_functions)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pixman-0.34.0)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.cairographics.org/releases/pixman-0.34.0.tar.gz"
+    FILENAME "pixman-0.34.0.tar.gz"
+    SHA512 81caca5b71582b53aaac473bc37145bd66ba9acebb4773fa8cdb51f4ed7fbcb6954790d8633aad85b2826dd276bcce725e26e37997a517760e9edd72e2669a6d
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_pixman.txt DESTINATION ${SOURCE_PATH}/pixman)
+file(RENAME ${SOURCE_PATH}/pixman/CMakeLists_pixman.txt ${SOURCE_PATH}/pixman/CMakeLists.txt)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+# Copy the appropriate header files.
+file(COPY
+"${SOURCE_PATH}/pixman/pixman.h"
+"${SOURCE_PATH}/pixman/pixman-accessor.h"
+"${SOURCE_PATH}/pixman/pixman-combine32.h"
+"${SOURCE_PATH}/pixman/pixman-compiler.h"
+"${SOURCE_PATH}/pixman/pixman-edge-imp.h"
+"${SOURCE_PATH}/pixman/pixman-inlines.h"
+"${SOURCE_PATH}/pixman/pixman-private.h"
+"${SOURCE_PATH}/pixman/pixman-version.h"
+DESTINATION
+${CURRENT_PACKAGES_DIR}/include
+)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/pixman)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/pixman/COPYING ${CURRENT_PACKAGES_DIR}/share/pixman/copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Note that neither support UWP (pixman can only build as a static library due to having no exports and cairo depends on GDI among other things). Also, cairo depends on pixman, libpng, and zlib.