### PR TITLE
update rxcpp to 3.0.0

### DIFF
--- a/ports/rxcpp/CONTROL
+++ b/ports/rxcpp/CONTROL
@@ -1,3 +1,3 @@
 Source: rxcpp
-Version: 2.3.0
+Version: 3.0.0
 Description: Reactive Extensions for C++

--- a/ports/rxcpp/portfile.cmake
+++ b/ports/rxcpp/portfile.cmake
@@ -1,20 +1,15 @@
 #header-only library
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/RxCpp-2.3.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/RxCpp-3.0.0)
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "https://github.com/Reactive-Extensions/RxCpp/archive/v2.3.0.tar.gz"
-    FILENAME "RxCpp-2.3.0.tar.gz"
-    SHA512 180cf36777b0c14e989b4b79f01fcda7ecabfe4b3cee3ad7343138497578af02745de63f74941ec228eac3fccca4a7dfdfdd1c4d16a89438022dca6f9968953f
+    URLS "https://github.com/Reactive-Extensions/RxCpp/archive/v3.0.0.tar.gz"
+    FILENAME "RxCpp-3.0.0.tar.gz"
+    SHA512 f30f71cefee25f86297d66a49e752a44bdb8ad9a1a92249bf944101afd91b432564e9b8c9e8853f7042608030bffaa4d58d294f18a61f394701cee347f42bcbb
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
 file(INSTALL
-	${SOURCE_PATH}/Rx/v2/src/rxcpp
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
-)
-
-file(INSTALL
-	${SOURCE_PATH}/Ix/CPP/src/cpplinq
+	${SOURCE_PATH}/Rx/v2/src
     DESTINATION ${CURRENT_PACKAGES_DIR}/include
 )
 


### PR DESCRIPTION
I released a new version of rxcpp today.
I changed the installed path in this port because the samples all reference "rxcpp/rx.hpp"
