### PR TITLE
[DirectXTK] Specify install folder for headers

### DIFF
--- a/ports/directxtk/CONTROL
+++ b/ports/directxtk/CONTROL
@@ -1,3 +1,3 @@
 Source: directxtk
-Version: oct2016
+Version: oct2016-1
 Description: A collection of helper classes for writing DirectX 11.x code in C++.

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -44,7 +44,7 @@ file(INSTALL
 
 file(INSTALL
 	${SOURCE_PATH}/Inc/
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include/DirectXTK
 )
 
 # Handle copyright


### PR DESCRIPTION
Recently added DirectX ToolKit installs it's headers directly in `installed\[triplet]\include\`
 directory. This can easily cause name clashes in compiler's search paths (some of the names are "mouse.h" or "audio.h"). This PR moves all installed headers in `...\include\DirectXTK\`.