### PR TITLE
Add freeimage port

### DIFF
--- a/ports/freeimage/CMakeLists.txt
+++ b/ports/freeimage/CMakeLists.txt
@@ -1,0 +1,148 @@
+cmake_minimum_required(VERSION 3.4)
+
+include(GNUInstallDirs)
+
+project(FreeImage C CXX)
+
+find_package(zlib REQUIRED)
+find_package(PNG REQUIRED)
+find_package(JPEG REQUIRED)
+find_package(TIFF REQUIRED)
+find_package(OPENJPEG REQUIRED)
+
+# Include some custom Find***.cmake modules 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+find_package(WEBP REQUIRED)
+find_package(JXR  REQUIRED)
+find_package(LibRaw REQUIRED)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
+set(REAL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Source)
+
+# Add a debug postfix
+set(CMAKE_DEBUG_POSTFIX "d")
+ 
+# For now the internal copy of OpenEXR is used (as a private always static library)
+file(GLOB OPENEXR_PRIVATE_HEADERS ${REAL_SOURCE_DIR}/OpenEXR/Half/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/Iex/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/IexMath/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/IlmImf/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/IlmThread/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/Imath/*.h
+                                  ${REAL_SOURCE_DIR}/OpenEXR/*.h)
+                                  
+file(GLOB OPENEXR_SRCS ${REAL_SOURCE_DIR}/OpenEXR/Half/*.cpp
+                       ${REAL_SOURCE_DIR}/OpenEXR/Iex/*.cpp
+                       ${REAL_SOURCE_DIR}/OpenEXR/IexMath/*.cpp
+                       ${REAL_SOURCE_DIR}/OpenEXR/IlmImf/*.cpp
+                       ${REAL_SOURCE_DIR}/OpenEXR/IlmThread/*.cpp
+                       ${REAL_SOURCE_DIR}/OpenEXR/Imath/*.cpp)
+                       
+add_library(FreeImage_Private_OpenEXR STATIC ${OPENEXR_PRIVATE_HEADERS} ${OPENEXR_SRCS})
+
+set(FreeImage_Private_OpenEXR_INCLUDE_DIRS ${REAL_SOURCE_DIR}/OpenEXR
+                                           ${REAL_SOURCE_DIR}/OpenEXR/Half
+                                           ${REAL_SOURCE_DIR}/OpenEXR/Iex
+                                           ${REAL_SOURCE_DIR}/OpenEXR/IexMath
+                                           ${REAL_SOURCE_DIR}/OpenEXR/IlmImf
+                                           ${REAL_SOURCE_DIR}/OpenEXR/IlmThread
+                                           ${REAL_SOURCE_DIR}/OpenEXR/Imath)
+
+target_include_directories(FreeImage_Private_OpenEXR PRIVATE ${FreeImage_Private_OpenEXR_INCLUDE_DIRS}
+                                                             ${ZLIB_INCLUDE_DIRS})
+
+# List the public header files
+set(PUBLIC_HEADERS ${REAL_SOURCE_DIR}/FreeImage.h)
+
+# List the private header files
+set(ROOT_PRIVATE_HEADERS ${REAL_SOURCE_DIR}/CacheFile.h 
+                         ${REAL_SOURCE_DIR}/FreeImageIO.h 
+                         ${REAL_SOURCE_DIR}/MapIntrospector.h
+                         ${REAL_SOURCE_DIR}/Plugin.h 
+                         ${REAL_SOURCE_DIR}/Quantizers.h 
+                         ${REAL_SOURCE_DIR}/ToneMapping.h 
+                         ${REAL_SOURCE_DIR}/Utilities.h
+                         ${REAL_SOURCE_DIR}/DeprecationManager/DeprecationMgr.h)
+                         
+file(GLOB FREEIMAGE_PRIVATE_HEADERS ${REAL_SOURCE_DIR}/FreeImage/*.h)
+file(GLOB FREEIMAGE_TOOLKIT_PRIVATE_HEADERS ${REAL_SOURCE_DIR}/FreeImageToolkit/*.h)
+file(GLOB METADATA_PRIVATE_HEADERS ${REAL_SOURCE_DIR}/Metadata/*.h)
+
+set(PRIVATE_HEADERS ${ROOT_PRIVATE_HEADERS}
+                    ${FREEIMAGE_PRIVATE_HEADERS}
+                    ${FREEIMAGE_TOOLKIT_PRIVATE_HEADERS}
+                    ${METADATA_PRIVATE_HEADERS})
+
+# List the source files
+file(GLOB DEPRECATION_SRCS ${REAL_SOURCE_DIR}/DeprecationManager/*.cpp)
+file(GLOB FREEIMAGE_TOOLKIT_SRCS ${REAL_SOURCE_DIR}/FreeImageToolkit/*.cpp)
+file(GLOB FREEIMAGE_SRCS ${REAL_SOURCE_DIR}/FreeImage/*.cpp)
+file(GLOB METADATA_SRCS ${REAL_SOURCE_DIR}/Metadata/*.cpp)
+
+# The G3 plugin is disabled because it require the private copy of tiff
+list(REMOVE_ITEM FREEIMAGE_SRCS ${REAL_SOURCE_DIR}/FreeImage/PluginG3.cpp)
+
+# The JPEGTransform plugin is disable because it requires a private copy of jpeg 
+list(REMOVE_ITEM FREEIMAGE_TOOLKIT_SRCS ${REAL_SOURCE_DIR}/FreeImageToolkit/JPEGTransform.cpp)
+
+
+set(SRCS ${DEPRECATION_SRCS}
+         ${FREEIMAGE_SRCS}
+         ${FREEIMAGE_TOOLKIT_SRCS}
+         ${METADATA_SRCS}
+)
+
+# If FreeImage is used as a static library, FREEIMAGE_LIB 
+# needs to be defined (at the C preprocessor level) to correctly 
+# define (to nothing instead of _declspec(dllimport) ) the DLL_API macro.
+# For this purpouse we include (depending on the BUILD_SHARED_LIBS )
+# the appropriate FreeImageConfig.h .
+if(${BUILD_SHARED_LIBS})
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/FreeImageConfig-dynamic.h ${CMAKE_CURRENT_BINARY_DIR}/FreeImageConfig.h)
+else()
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/FreeImageConfig-static.h ${CMAKE_CURRENT_BINARY_DIR}/FreeImageConfig.h)
+endif()
+list(APPEND PUBLIC_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/FreeImageConfig.h)
+
+add_library(FreeImage ${SRCS} ${PRIVATE_HEADERS} ${PUBLIC_HEADERS})
+
+if(${BUILD_SHARED_LIBS})
+    target_compile_definitions(FreeImage PRIVATE -DFREEIMAGE_EXPORTS)
+else()
+    target_compile_definitions(FreeImage PRIVATE -DFREEIMAGE_LIB)
+endif()
+
+target_include_directories(FreeImage PRIVATE ${REAL_SOURCE_DIR}
+                                             ${ZLIB_INCLUDE_DIRS} 
+                                             ${JPEG_INCLUDE_DIRS}
+                                             ${TIFF_INCLUDE_DIRS}
+                                             ${PNG_INCLUDE_DIRS}
+                                             ${OPENJPEG_INCLUDE_DIRS}
+                                             ${WEBP_INCLUDE_DIRS}
+                                             ${JXR_INCLUDE_DIRS}
+                                             ${LibRaw_INCLUDE_DIRS}
+                                             ${FreeImage_Private_OpenEXR_INCLUDE_DIRS}
+                                             ${CMAKE_CURRENT_BINARY_DIR})
+                                             
+
+target_link_libraries(FreeImage ${ZLIB_LIBRARIES}
+                                ${JPEG_LIBRARIES}
+                                ${TIFF_LIBRARIES}
+                                ${PNG_LIBRARIES}
+                                ${OPENJPEG_LIBRARIES}
+                                ${WEBP_LIBRARIES}
+                                ${JXR_LIBRARIES}
+                                ${LibRaw_LIBRARIES}
+                                FreeImage_Private_OpenEXR)
+
+target_compile_definitions(FreeImage PRIVATE ${PNG_DEFINITIONS})
+
+install(TARGETS FreeImage
+        COMPONENT runtime
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT lib)
+
+install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/ports/freeimage/CONTROL
+++ b/ports/freeimage/CONTROL
@@ -1,0 +1,4 @@
+Source: freeimage
+Version: 3.17.0
+Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp, libraw, jxrlib
+Description: Support library for graphics image formats

--- a/ports/freeimage/FreeImageConfig-dynamic.h
+++ b/ports/freeimage/FreeImageConfig-dynamic.h
@@ -1,0 +1,5 @@
+#ifndef FREEIMAGE_CONFIG_H
+#define FREEIMAGE_CONFIG_H
+
+
+#endif

--- a/ports/freeimage/FreeImageConfig-static.h
+++ b/ports/freeimage/FreeImageConfig-static.h
@@ -1,0 +1,8 @@
+#ifndef FREEIMAGE_CONFIG_H
+#define FREEIMAGE_CONFIG_H
+
+#ifndef
+#define FREEIMAGE_LIB 
+#endif
+
+#endif

--- a/ports/freeimage/cmake/FindJXR.cmake
+++ b/ports/freeimage/cmake/FindJXR.cmake
@@ -1,0 +1,28 @@
+# - Find JXR
+# Find the JXR library 
+# This module defines
+#  JXR_INCLUDE_DIRS, where to find jxrlib/JXRGlue.h
+#  JXR_LIBRARIES, the libraries needed to use JXR
+#
+
+find_path(JXR_INCLUDE_DIRS
+    NAMES JXRGlue.h
+    PATH_SUFFIXES jxrlib
+)
+mark_as_advanced(JXR_INCLUDE_DIRS)
+
+include(SelectLibraryConfigurations)
+
+find_library(JPEGXR_LIBRARY_RELEASE NAMES jpegxr PATH_SUFFIXES lib)
+find_library(JPEGXR_LIBRARY_DEBUG NAMES jpegxrd PATH_SUFFIXES lib)
+select_library_configurations(JPEGXR)
+
+find_library(JXRGLUE_LIBRARY_RELEASE NAMES jxrglue PATH_SUFFIXES lib)
+find_library(JXRGLUE_LIBRARY_DEBUG NAMES jxrglued PATH_SUFFIXES lib)
+select_library_configurations(JXRGLUE)
+
+set(JXR_LIBRARIES ${JPEGXR_LIBRARY} ${JXRGLUE_LIBRARY})
+mark_as_advanced(JXR_LIBRARIES)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(JXR DEFAULT_MSG JXR_INCLUDE_DIRS JXR_LIBRARIES)

--- a/ports/freeimage/cmake/FindWEBP.cmake
+++ b/ports/freeimage/cmake/FindWEBP.cmake
@@ -1,0 +1,26 @@
+# - Find WEBP
+# Find the WEBP library 
+# This module defines
+#  WEBP_INCLUDE_DIRS, where to find webp/decode.h
+#  WEBP_LIBRARIES, the libraries needed to use WEBP
+#
+
+find_path(WEBP_INCLUDE_DIRS
+    NAMES webp/decode.h
+)
+mark_as_advanced(WEBP_INCLUDE_DIRS)
+
+find_library(
+    WEBP_LIBRARIES
+    NAMES webp
+)
+
+find_library(WEBP_LIBRARY_RELEASE NAMES webp PATH_SUFFIXES lib)
+find_library(WEBP_LIBRARY_DEBUG NAMES webpd PATH_SUFFIXES lib)
+include(SelectLibraryConfigurations)
+select_library_configurations(WEBP)
+
+set(WEBP_LIBRARIES ${WEBP_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(WEBP DEFAULT_MSG WEBP_INCLUDE_DIRS WEBP_LIBRARIES)

--- a/ports/freeimage/disable-plugins-depending-on-internal-third-party-libraries.patch
+++ b/ports/freeimage/disable-plugins-depending-on-internal-third-party-libraries.patch
@@ -1,0 +1,71 @@
+diff --git a/Source/FreeImage.h b/Source/FreeImage.h
+index e2d1c5a..cc66b7d 100644
+--- a/Source/FreeImage.h
++++ b/Source/FreeImage.h
+@@ -410,7 +410,11 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
+ 	FIF_DDS		= 24,
+ 	FIF_GIF     = 25,
+ 	FIF_HDR		= 26,
+-	FIF_FAXG3	= 27,
++/* vcpkg: The G3 fax format plugin is deliberately disabled in our build of
++   FreeImage, since it requires usage of the vendored copy of libtiff. */
++#if 0
++ 	FIF_FAXG3	= 27,
++#endif
+ 	FIF_SGI		= 28,
+ 	FIF_EXR		= 29,
+ 	FIF_J2K		= 30,
+@@ -476,6 +480,9 @@ FI_ENUM(FREE_IMAGE_DITHER) {
+ /** Lossless JPEG transformations
+ Constants used in FreeImage_JPEGTransform
+ */
++/* vcpkg: The JPEGTransform functions are deliberately disabled in our build
++   of FreeImage, since they require usage of the vendored copy of libjpeg. */
++#if 0
+ FI_ENUM(FREE_IMAGE_JPEG_OPERATION) {
+ 	FIJPEG_OP_NONE			= 0,	//! no transformation
+ 	FIJPEG_OP_FLIP_H		= 1,	//! horizontal flip
+@@ -486,6 +493,7 @@ FI_ENUM(FREE_IMAGE_JPEG_OPERATION) {
+ 	FIJPEG_OP_ROTATE_180	= 6,	//! 180-degree rotation
+ 	FIJPEG_OP_ROTATE_270	= 7		//! 270-degree clockwise (or 90 ccw)
+ };
++#endif
+ 
+ /** Tone mapping operators.
+ Constants used in FreeImage_ToneMapping.
+@@ -1077,6 +1085,9 @@ DLL_API const char* DLL_CALLCONV FreeImage_TagToString(FREE_IMAGE_MDMODEL model,
+ // JPEG lossless transformation routines
+ // --------------------------------------------------------------------------
+ 
++/* vcpkg: The JPEGTransform functions are deliberately disabled in our build
++   of FreeImage, since they require usage of the vendored copy of libjpeg. */
++#if 0
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransform(const char *src_file, const char *dst_file, FREE_IMAGE_JPEG_OPERATION operation, BOOL perfect FI_DEFAULT(TRUE));
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransformU(const wchar_t *src_file, const wchar_t *dst_file, FREE_IMAGE_JPEG_OPERATION operation, BOOL perfect FI_DEFAULT(TRUE));
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGCrop(const char *src_file, const char *dst_file, int left, int top, int right, int bottom);
+@@ -1085,7 +1096,7 @@ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransformFromHandle(FreeImageIO* src_io,
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransformCombined(const char *src_file, const char *dst_file, FREE_IMAGE_JPEG_OPERATION operation, int* left, int* top, int* right, int* bottom, BOOL perfect FI_DEFAULT(TRUE));
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransformCombinedU(const wchar_t *src_file, const wchar_t *dst_file, FREE_IMAGE_JPEG_OPERATION operation, int* left, int* top, int* right, int* bottom, BOOL perfect FI_DEFAULT(TRUE));
+ DLL_API BOOL DLL_CALLCONV FreeImage_JPEGTransformCombinedFromMemory(FIMEMORY* src_stream, FIMEMORY* dst_stream, FREE_IMAGE_JPEG_OPERATION operation, int* left, int* top, int* right, int* bottom, BOOL perfect FI_DEFAULT(TRUE));
+-
++#endif
+ 
+ // --------------------------------------------------------------------------
+ // Image manipulation toolkit
+diff --git a/Source/FreeImage/Plugin.cpp b/Source/FreeImage/Plugin.cpp
+index 57ebffd..a93440f 100644
+--- a/Source/FreeImage/Plugin.cpp
++++ b/Source/FreeImage/Plugin.cpp
+@@ -263,7 +263,11 @@ FreeImage_Initialise(BOOL load_local_plugins_only) {
+ 			s_plugins->AddNode(InitDDS);
+ 	        s_plugins->AddNode(InitGIF);
+ 	        s_plugins->AddNode(InitHDR);
+-			s_plugins->AddNode(InitG3);
++/* vcpkg: The G3 fax format plugin is deliberately disabled in our build of FreeImage
+++   since it requires usage of the vendored copy of libtiff. */
++#if 0
++ 			s_plugins->AddNode(InitG3);
++#endif
+ 			s_plugins->AddNode(InitSGI);
+ 			s_plugins->AddNode(InitEXR);
+ 			s_plugins->AddNode(InitJ2K);

--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -52,3 +52,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 # Handle copyright
 file(COPY ${SOURCE_PATH}/license-fi.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/freeimage)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/freeimage/license-fi.txt ${CURRENT_PACKAGES_DIR}/share/freeimage/copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -1,0 +1,54 @@
+include(${CMAKE_TRIPLET_FILE})
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/FreeImage)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://downloads.sourceforge.net/freeimage/FreeImage3170.zip"
+    FILENAME "FreeImage3170.zip"
+    SHA512 703c2626c0bcfe73eb40d720f45745208ca9650a7730759680a2b38ad3f6c719a43008477032bc70b76a95761f7d4b6f901b961359d36b54ace906dd78fb391b
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/FreeImageConfig-static.h DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/FreeImageConfig-dynamic.h DESTINATION ${SOURCE_PATH})
+
+# Copy some useful Find***.cmake modules 
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake DESTINATION ${SOURCE_PATH})
+
+# This is not strictly necessary, but to make sure 
+# that no "internal" libraries are used by removing them
+# Note that the only "internal" dependency used is OpenEXR
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibJPEG)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibPNG)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibTIFF4)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/ZLib)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibOpenJPEG)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibJXR)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibWebP)
+file(REMOVE_RECURSE ${SOURCE_PATH}/Source/LibRawLite)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/disable-plugins-depending-on-internal-third-party-libraries.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-jpeg.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-jxrlib.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-libtiff.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-openjpeg.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-png-zlib.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-rawlib.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-external-webp.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/use-freeimage-config-include.patch"
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/license-fi.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/freeimage)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/freeimage/license-fi.txt ${CURRENT_PACKAGES_DIR}/share/freeimage/copyright)

--- a/ports/freeimage/use-external-jpeg.patch
+++ b/ports/freeimage/use-external-jpeg.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/FreeImage/PluginJPEG.cpp b/Source/FreeImage/PluginJPEG.cpp
+index 573989c..aaeefa4 100644
+--- a/Source/FreeImage/PluginJPEG.cpp
++++ b/Source/FreeImage/PluginJPEG.cpp
+@@ -35,9 +35,9 @@ extern "C" {
+ #undef FAR
+ #include <setjmp.h>
+ 
+-#include "../LibJPEG/jinclude.h"
+-#include "../LibJPEG/jpeglib.h"
+-#include "../LibJPEG/jerror.h"
++#include <stdio.h>
++#include <jpeglib.h>
++#include <jerror.h>
+ }
+ 
+ #include "FreeImage.h"

--- a/ports/freeimage/use-external-jxrlib.patch
+++ b/ports/freeimage/use-external-jxrlib.patch
@@ -1,0 +1,14 @@
+diff --git a/Source/FreeImage/PluginJXR.cpp b/Source/FreeImage/PluginJXR.cpp
+index 0e14e09..8eb9d5d 100644
+--- a/Source/FreeImage/PluginJXR.cpp
++++ b/Source/FreeImage/PluginJXR.cpp
+@@ -23,7 +23,8 @@
+ #include "Utilities.h"
+ #include "../Metadata/FreeImageTag.h"
+ 
+-#include "../LibJXR/jxrgluelib/JXRGlue.h"
++#define INITGUID
++#include <JXRGlue.h>
+ 
+ // ==========================================================
+ // Plugin Interface

--- a/ports/freeimage/use-external-libtiff.patch
+++ b/ports/freeimage/use-external-libtiff.patch
@@ -1,0 +1,174 @@
+diff --git a/Source/FreeImage/PluginTIFF.cpp b/Source/FreeImage/PluginTIFF.cpp
+index 1b45453..562fdd7 100644
+--- a/Source/FreeImage/PluginTIFF.cpp
++++ b/Source/FreeImage/PluginTIFF.cpp
+@@ -37,7 +37,7 @@
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"
+-#include "../LibTIFF4/tiffiop.h"
++#include <tiffio.h>
+ #include "../Metadata/FreeImageTag.h"
+ #include "../OpenEXR/Half/half.h"
+ 
+diff --git a/Source/Metadata/XTIFF.cpp b/Source/Metadata/XTIFF.cpp
+index d5be902..8dbcd5d 100644
+--- a/Source/Metadata/XTIFF.cpp
++++ b/Source/Metadata/XTIFF.cpp
+@@ -29,7 +29,7 @@
+ #pragma warning (disable : 4786) // identifier was truncated to 'number' characters
+ #endif
+ 
+-#include "../LibTIFF4/tiffiop.h"
++#include <tiffio.h>
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"
+@@ -40,6 +40,43 @@
+ //   Extended TIFF Directory GEO Tag Support
+ // ----------------------------------------------------------
+ 
++// vcpkg: function imported from libtiff/tif_dirinfo.c, in which it is not exported 
++/*
++ * Return size of TIFFDataType in bytes.
++ *
++ * XXX: We need a separate function to determine the space needed
++ * to store the value. For TIFF_RATIONAL values TIFFDataWidth() returns 8,
++ * but we use 4-byte float to represent rationals.
++ */
++int
++FreeImage_TIFFDataSize(TIFFDataType type)
++{
++	switch (type)
++	{
++		case TIFF_BYTE:
++		case TIFF_SBYTE:
++		case TIFF_ASCII:
++		case TIFF_UNDEFINED:
++		    return 1;
++		case TIFF_SHORT:
++		case TIFF_SSHORT:
++		    return 2;
++		case TIFF_LONG:
++		case TIFF_SLONG:
++		case TIFF_FLOAT:
++		case TIFF_IFD:
++		case TIFF_RATIONAL:
++		case TIFF_SRATIONAL:
++		    return 4;
++		case TIFF_DOUBLE:
++		case TIFF_LONG8:
++		case TIFF_SLONG8:
++		case TIFF_IFD8:
++		    return 8;
++		default:
++		    return 0;
++	}
++}
+ /**
+   Tiff info structure.
+   Entry format:
+@@ -224,6 +261,33 @@ tiff_write_geotiff_profile(TIFF *tif, FIBITMAP *dib) {
+ //   TIFF EXIF tag reading & writing
+ // ----------------------------------------------------------
+ 
++static uint32 exif_tag_ids[] = {
++  EXIFTAG_EXPOSURETIME, EXIFTAG_FNUMBER, EXIFTAG_EXPOSUREPROGRAM,
++  EXIFTAG_SPECTRALSENSITIVITY, EXIFTAG_ISOSPEEDRATINGS, EXIFTAG_OECF,
++  EXIFTAG_EXIFVERSION, EXIFTAG_DATETIMEORIGINAL, EXIFTAG_DATETIMEDIGITIZED,
++  EXIFTAG_COMPONENTSCONFIGURATION, EXIFTAG_COMPRESSEDBITSPERPIXEL,
++  EXIFTAG_SHUTTERSPEEDVALUE, EXIFTAG_APERTUREVALUE,
++  EXIFTAG_BRIGHTNESSVALUE, EXIFTAG_EXPOSUREBIASVALUE,
++  EXIFTAG_MAXAPERTUREVALUE, EXIFTAG_SUBJECTDISTANCE, EXIFTAG_METERINGMODE,
++  EXIFTAG_LIGHTSOURCE, EXIFTAG_FLASH, EXIFTAG_FOCALLENGTH,
++  EXIFTAG_SUBJECTAREA, EXIFTAG_MAKERNOTE, EXIFTAG_USERCOMMENT,
++  EXIFTAG_SUBSECTIME, EXIFTAG_SUBSECTIMEORIGINAL,
++  EXIFTAG_SUBSECTIMEDIGITIZED, EXIFTAG_FLASHPIXVERSION, EXIFTAG_COLORSPACE,
++  EXIFTAG_PIXELXDIMENSION, EXIFTAG_PIXELYDIMENSION,
++  EXIFTAG_RELATEDSOUNDFILE, EXIFTAG_FLASHENERGY,
++  EXIFTAG_SPATIALFREQUENCYRESPONSE, EXIFTAG_FOCALPLANEXRESOLUTION,
++  EXIFTAG_FOCALPLANEYRESOLUTION, EXIFTAG_FOCALPLANERESOLUTIONUNIT,
++  EXIFTAG_SUBJECTLOCATION, EXIFTAG_EXPOSUREINDEX, EXIFTAG_SENSINGMETHOD,
++  EXIFTAG_FILESOURCE, EXIFTAG_SCENETYPE, EXIFTAG_CFAPATTERN,
++  EXIFTAG_CUSTOMRENDERED, EXIFTAG_EXPOSUREMODE, EXIFTAG_WHITEBALANCE,
++  EXIFTAG_DIGITALZOOMRATIO, EXIFTAG_FOCALLENGTHIN35MMFILM,
++  EXIFTAG_SCENECAPTURETYPE, EXIFTAG_GAINCONTROL, EXIFTAG_CONTRAST,
++  EXIFTAG_SATURATION, EXIFTAG_SHARPNESS, EXIFTAG_DEVICESETTINGDESCRIPTION,
++  EXIFTAG_SUBJECTDISTANCERANGE, EXIFTAG_GAINCONTROL, EXIFTAG_GAINCONTROL,
++  EXIFTAG_IMAGEUNIQUEID
++};
++static int nExifTags = sizeof(exif_tag_ids) / sizeof(exif_tag_ids[0]);
++
+ /**
+ Read a single Exif tag
+ 
+@@ -575,43 +639,10 @@ tiff_read_exif_tags(TIFF *tif, TagLib::MDMODEL md_model, FIBITMAP *dib) {
+ 
+ 	// loop over all Core Directory Tags
+ 	// ### uses private data, but there is no other way
++    // -> vcpkg: Best we can do without private headers is to hard-code a list of known EXIF tags and read those
+ 	if(md_model == TagLib::EXIF_MAIN) {
+-		const TIFFDirectory *td = &tif->tif_dir;
+-
+-		uint32 lastTag = 0;	//<- used to prevent reading some tags twice (as stored in tif_fieldinfo)
+-
+-		for (int fi = 0, nfi = (int)tif->tif_nfields; nfi > 0; nfi--, fi++) {
+-			const TIFFField *fld = tif->tif_fields[fi];
+-
+-			const uint32 tag_id = TIFFFieldTag(fld);
+-
+-			if(tag_id == lastTag) {
+-				continue;
+-			}
+-
+-			// test if tag value is set
+-			// (lifted directly from LibTiff _TIFFWriteDirectory)
+-
+-			if( fld->field_bit == FIELD_CUSTOM ) {
+-				int is_set = FALSE;
+-
+-				for(int ci = 0; ci < td->td_customValueCount; ci++ ) {
+-					is_set |= (td->td_customValues[ci].info == fld);
+-				}
+-
+-				if( !is_set ) {
+-					continue;
+-				}
+-
+-			} else if(!TIFFFieldSet(tif, fld->field_bit)) {
+-				continue;
+-			}
+-
+-			// process *all* other tags (some will be ignored)
+-
+-			tiff_read_exif_tag(tif, tag_id, dib, md_model);
+-
+-			lastTag = tag_id;
++		for (int i = 0; i < nExifTags; ++i) {
++			tiff_read_exif_tag(tif, exif_tag_ids[i], dib, md_model);
+ 		}
+ 
+ 	}
+@@ -723,10 +754,9 @@ tiff_write_exif_tags(TIFF *tif, TagLib::MDMODEL md_model, FIBITMAP *dib) {
+ 	
+ 	TagLib& tag_lib = TagLib::instance();
+ 	
+-	for (int fi = 0, nfi = (int)tif->tif_nfields; nfi > 0; nfi--, fi++) {
+-		const TIFFField *fld = tif->tif_fields[fi];
+-		
+-		const uint32 tag_id = TIFFFieldTag(fld);
++	for (int fi = 0, nfi = nExifTags; nfi > 0; nfi--, fi++) {
++		const uint32 tag_id = exif_tag_ids[fi];
++		const TIFFField *fld = TIFFFieldWithTag(tif, tag_id);
+ 
+ 		if(skip_write_field(tif, tag_id)) {
+ 			// skip tags that are already handled by the LibTIFF writing process
+@@ -749,7 +779,7 @@ tiff_write_exif_tags(TIFF *tif, TagLib::MDMODEL md_model, FIBITMAP *dib) {
+ 				continue;
+ 			}
+ 			// type of storage may differ (e.g. rationnal array vs float array type)
+-			if((unsigned)_TIFFDataSize(tif_tag_type) != FreeImage_TagDataWidth(tag_type)) {
++			if((unsigned)FreeImage_TIFFDataSize(tif_tag_type) != FreeImage_TagDataWidth(tag_type)) {
+ 				// skip tag or _TIFFmemcpy will fail
+ 				continue;
+ 			}

--- a/ports/freeimage/use-external-openjpeg.patch
+++ b/ports/freeimage/use-external-openjpeg.patch
@@ -1,0 +1,39 @@
+diff --git a/Source/FreeImage/J2KHelper.cpp b/Source/FreeImage/J2KHelper.cpp
+index 1776c3b..538f1c5 100644
+--- a/Source/FreeImage/J2KHelper.cpp
++++ b/Source/FreeImage/J2KHelper.cpp
+@@ -21,7 +21,7 @@
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"
+-#include "../LibOpenJPEG/openjpeg.h"
++#include <openjpeg.h>
+ #include "J2KHelper.h"
+ 
+ // --------------------------------------------------------------------------
+diff --git a/Source/FreeImage/PluginJ2K.cpp b/Source/FreeImage/PluginJ2K.cpp
+index b8bcfc8..621a903 100644
+--- a/Source/FreeImage/PluginJ2K.cpp
++++ b/Source/FreeImage/PluginJ2K.cpp
+@@ -21,7 +21,7 @@
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"
+-#include "../LibOpenJPEG/openjpeg.h"
++#include <openjpeg.h>
+ #include "J2KHelper.h"
+ 
+ // ==========================================================
+diff --git a/Source/FreeImage/PluginJP2.cpp b/Source/FreeImage/PluginJP2.cpp
+index 742fe2c..c57f626 100644
+--- a/Source/FreeImage/PluginJP2.cpp
++++ b/Source/FreeImage/PluginJP2.cpp
+@@ -21,7 +21,7 @@
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"
+-#include "../LibOpenJPEG/openjpeg.h"
++#include <openjpeg.h>
+ #include "J2KHelper.h"
+ 
+ // ==========================================================

--- a/ports/freeimage/use-external-png-zlib.patch
+++ b/ports/freeimage/use-external-png-zlib.patch
@@ -1,0 +1,40 @@
+diff --git a/Source/FreeImage/PluginPNG.cpp b/Source/FreeImage/PluginPNG.cpp
+index ba2ef17..c3c5cd6 100644
+--- a/Source/FreeImage/PluginPNG.cpp
++++ b/Source/FreeImage/PluginPNG.cpp
+@@ -40,8 +40,8 @@
+ 
+ // ----------------------------------------------------------
+ 
+-#include "../ZLib/zlib.h"
+-#include "../LibPNG/png.h"
++#include <zlib.h>
++#include <png.h>
+ 
+ // ----------------------------------------------------------
+ 
+diff --git a/Source/FreeImage/ZLibInterface.cpp b/Source/FreeImage/ZLibInterface.cpp
+index 3ab6d32..725618b 100644
+--- a/Source/FreeImage/ZLibInterface.cpp
++++ b/Source/FreeImage/ZLibInterface.cpp
+@@ -19,10 +19,9 @@
+ // Use at your own risk!
+ // ==========================================================
+ 
+-#include "../ZLib/zlib.h"
++#include <zlib.h>
+ #include "FreeImage.h"
+ #include "Utilities.h"
+-#include "../ZLib/zutil.h"	/* must be the last header because of error C3163 in VS2008 (_vsnprintf defined in stdio.h) */
+ 
+ /**
+ Compresses a source buffer into a target buffer, using the ZLib library. 
+@@ -115,7 +114,7 @@ FreeImage_ZLibGZip(BYTE *target, DWORD target_size, BYTE *source, DWORD source_s
+ 			return 0;
+         case Z_OK: {
+             // patch header, setup crc and length (stolen from mod_trace_output)
+-            BYTE *p = target + 8; *p++ = 2; *p = OS_CODE; // xflags, os_code
++            BYTE *p = target + 8; *p++ = 2; *p = 0x03; // xflags, os_code
+  	        crc = crc32(crc, source, source_size);
+ 	        memcpy(target + 4 + dest_len, &crc, 4);
+ 	        memcpy(target + 8 + dest_len, &source_size, 4);

--- a/ports/freeimage/use-external-rawlib.patch
+++ b/ports/freeimage/use-external-rawlib.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/FreeImage/PluginRAW.cpp b/Source/FreeImage/PluginRAW.cpp
+index e9bd5bf..c7f8758 100644
+--- a/Source/FreeImage/PluginRAW.cpp
++++ b/Source/FreeImage/PluginRAW.cpp
+@@ -19,7 +19,7 @@
+ // Use at your own risk!
+ // ==========================================================
+ 
+-#include "../LibRawLite/libraw/libraw.h"
++#include <libraw/libraw.h>
+ 
+ #include "FreeImage.h"
+ #include "Utilities.h"

--- a/ports/freeimage/use-external-webp.patch
+++ b/ports/freeimage/use-external-webp.patch
@@ -1,0 +1,18 @@
+diff --git a/Source/FreeImage/PluginWebP.cpp b/Source/FreeImage/PluginWebP.cpp
+index 9fb0b69..c401447 100644
+--- a/Source/FreeImage/PluginWebP.cpp
++++ b/Source/FreeImage/PluginWebP.cpp
+@@ -24,10 +24,9 @@
+ 
+ #include "../Metadata/FreeImageTag.h"
+ 
+-#include "../LibWebP/src/webp/decode.h"
+-#include "../LibWebP/src/webp/encode.h"
+-#include "../LibWebP/src/enc/vp8enci.h"
+-#include "../LibWebP/src/webp/mux.h"
++#include <webp/decode.h>
++#include <webp/encode.h>
++#include <webp/mux.h>
+ 
+ // ==========================================================
+ // Plugin Interface

--- a/ports/freeimage/use-freeimage-config-include.patch
+++ b/ports/freeimage/use-freeimage-config-include.patch
@@ -1,0 +1,16 @@
+diff --git a/Source/FreeImage.h b/Source/FreeImage.h
+index cc66b7d..cc66812 100644
+--- a/Source/FreeImage.h
++++ b/Source/FreeImage.h
+@@ -32,6 +32,11 @@
+ #define FREEIMAGE_MINOR_VERSION   17
+ #define FREEIMAGE_RELEASE_SERIAL  0
+ 
++// vcpkg specific includes --------------------------------------------------
++// Include FreeImageConfig.h to define FREEIMAGE_LIB in static builds,
++// or do not define it in dynamic builds
++#include "FreeImageConfig.h"
++
+ // Compiler options ---------------------------------------------------------
+ 
+ #include <wchar.h>	// needed for UNICODE functions


### PR DESCRIPTION
Extensive modification have been done to support building with
external dependencies, rather then the version of the dependencies bundled with freeimage.
The biggest change is a new CMake-based build system.

Several patches are based on the equivalent ones used in Debian
packaging, see http://sources.debian.net/patches/freeimage .

The only dependency for which the internal version is still used is
OpenEXR, as the build system of the OpenEXR upstream runs executables
compiled by the project itself, that would be complicated to build on arm architecture.
My current plan (if maintainers agree) is to merge the freeimage port as it is (that 
builds its own internal OpenEXR) and then open a separate issue about the packaging 
of OpenEXR. When OpenEXR is properly package in vcpkg, we can then modify the freeimage
port to use the vcpkg version. 

Fix https://github.com/Microsoft/vcpkg/issues/3 . 