### PR TITLE
Add aws-sdk-cpp

### DIFF
--- a/ports/aws-sdk-cpp/CONTROL
+++ b/ports/aws-sdk-cpp/CONTROL
@@ -1,0 +1,3 @@
+Source: aws-sdk-cpp
+Version: 1.0.34
+Description: AWS SDK for C++

--- a/ports/aws-sdk-cpp/drop_git.patch
+++ b/ports/aws-sdk-cpp/drop_git.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d2a98a..ce58b68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ if(CMAKE_MAJOR_VERSION LESS 3)
+ endif()
+ 
+ # git is required for Android builds and optional for all other platforms
+-find_package(Git)
++#find_package(Git)
+ 
+ # Cmake invocation variables:
+ #   CUSTOM_MEMORY_MANAGEMENT - if set to 1, generates the sdk project files with custom memory management enabled, otherwise disables it

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -45,9 +45,9 @@ if(${VCPKG_LIBRARY_LINKAGE} STREQUAL dynamic)
 	file(REMOVE ${LIB_FILES} ${DEBUG_LIB_FILES})
 	
 	vcpkg_apply_patches( #define USE_IMPORT_EXPORT in SDKConfig.h
-		SOURCE_PATH ${SOURCE_PATH}
+		SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
 		PATCHES 
-			${CURRENT_PACKAGES_DIR}/include/shared_define.patch
+			${CMAKE_CURRENT_LIST_DIR}/shared_define.patch
 	)
 endif()
 

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -1,3 +1,8 @@
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    message(STATUS "Warning: Static building not supported yet. Building dynamic.") #Blocked by CRT MD link issue.
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/aws-sdk-cpp-1.0.34)
 vcpkg_download_distfile(ARCHIVE
@@ -28,11 +33,13 @@ file(REMOVE_RECURSE
 	${CURRENT_PACKAGES_DIR}/nuget
 	${CURRENT_PACKAGES_DIR}/debug/nuget)
 
-file(GLOB LIB_FILES          ${CURRENT_PACKAGES_DIR}/bin/*.lib)
-file(GLOB DEBUG_LIB_FILES    ${CURRENT_PACKAGES_DIR}/debug/bin/*.lib)
-file(COPY ${LIB_FILES}       DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-file(COPY ${DEBUG_LIB_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-file(REMOVE ${LIB_FILES} ${DEBUG_LIB_FILES})
+if(${VCPKG_LIBRARY_LINKAGE} STREQUAL dynamic)
+	file(GLOB LIB_FILES          ${CURRENT_PACKAGES_DIR}/bin/*.lib)
+	file(GLOB DEBUG_LIB_FILES    ${CURRENT_PACKAGES_DIR}/debug/bin/*.lib)
+	file(COPY ${LIB_FILES}       DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+	file(COPY ${DEBUG_LIB_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+	file(REMOVE ${LIB_FILES} ${DEBUG_LIB_FILES})
+endif()
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/aws-sdk-cpp RENAME copyright)

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -1,3 +1,8 @@
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
+    set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()
+
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/aws-sdk-cpp-1.0.34)
 vcpkg_download_distfile(ARCHIVE

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -1,8 +1,3 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/aws-sdk-cpp-1.0.34)
 vcpkg_download_distfile(ARCHIVE

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -41,6 +41,12 @@ if(${VCPKG_LIBRARY_LINKAGE} STREQUAL dynamic)
 	file(COPY ${LIB_FILES}       DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 	file(COPY ${DEBUG_LIB_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 	file(REMOVE ${LIB_FILES} ${DEBUG_LIB_FILES})
+	
+	vcpkg_apply_patches( #define USE_IMPORT_EXPORT in SDKConfig.h
+		SOURCE_PATH ${SOURCE_PATH}
+		PATCHES 
+			${CURRENT_PACKAGES_DIR}/include/shared_define.patch
+	)
 endif()
 
 # Handle copyright

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -1,8 +1,3 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.") #Blocked by CRT MD link issue.
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/aws-sdk-cpp-1.0.34)
 vcpkg_download_distfile(ARCHIVE
@@ -18,8 +13,15 @@ vcpkg_apply_patches(
 		${CMAKE_CURRENT_LIST_DIR}/drop_git.patch
 )
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+	set(FORCE_SHARED_CRT ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DENABLE_TESTING=OFF
+		-DFORCE_SHARED_CRT=${FORCE_SHARED_CRT}
 )
 
 vcpkg_install_cmake()

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -1,0 +1,23 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/aws-sdk-cpp-1.0.34)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/aws/aws-sdk-cpp/archive/1.0.34.tar.gz"
+    FILENAME "1.0.34.tar.gz"
+    SHA512 21ca03eb323eecb55c29866b73c07956a36aad7c9c051eb7ca201cfd356c3f9732c89898cf0c89660d6c1279dc52438bb389b37d613bf741bae81bb3e773a3c5
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES 
+		${CMAKE_CURRENT_LIST_DIR}/drop_git.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/aws-sdk-cpp RENAME copyright)

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_apply_patches(
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 	set(FORCE_SHARED_CRT OFF)
+else()
+	set(FORCE_SHARED_CRT ON)
 endif()
 
 vcpkg_configure_cmake(

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_apply_patches(
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-	set(FORCE_SHARED_CRT ON)
+	set(FORCE_SHARED_CRT OFF)
 endif()
 
 vcpkg_configure_cmake(

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -19,5 +19,20 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+file(REMOVE_RECURSE 
+	${CURRENT_PACKAGES_DIR}/debug/include
+	${CURRENT_PACKAGES_DIR}/lib/cmake
+	${CURRENT_PACKAGES_DIR}/lib/pkgconfig
+	${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+	${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
+	${CURRENT_PACKAGES_DIR}/nuget
+	${CURRENT_PACKAGES_DIR}/debug/nuget)
+
+file(GLOB LIB_FILES          ${CURRENT_PACKAGES_DIR}/bin/*.lib)
+file(GLOB DEBUG_LIB_FILES    ${CURRENT_PACKAGES_DIR}/debug/bin/*.lib)
+file(COPY ${LIB_FILES}       DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${DEBUG_LIB_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(REMOVE ${LIB_FILES} ${DEBUG_LIB_FILES})
+
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/aws-sdk-cpp RENAME copyright)

--- a/ports/aws-sdk-cpp/shared_define.patch
+++ b/ports/aws-sdk-cpp/shared_define.patch
@@ -1,0 +1,10 @@
+diff --git a/aws/core/SDKConfig.h b/aws/core/SDKConfig.h
+index 130c9dd..66b2630 100644
+--- a/aws/core/SDKConfig.h
++++ b/aws/core/SDKConfig.h
+@@ -17,3 +17,4 @@
+ 
+ #define JSON_USE_EXCEPTION 0
+ 
++#define USE_IMPORT_EXPORT
+\ No newline at end of file


### PR DESCRIPTION
This should close https://github.com/Microsoft/vcpkg/issues/91.

Note: 

1. Building the aws-sdk-cpp will emit a very very long cmake directory, which may exceed the windows MAX_PATH limit, so you'd better to make a hard link to vcpkg directory to a shorter path like: C:\vcpkg in following code: 
`mklink C:\vcpkg C:\users\some\very\long\path\to\vcpkg /H`
2. I added a patch to drop git because git will emit a wrong version number in file: initialize_project_version.cmake
3. Static build can compile success without error but vcpkg will report a crt linked to MD error, file "$\cmake\compiler_settings.cmake" clearly specified the MT link option when BUILD_SHARED_LIBS is ON, after a few hours I didnot figure it out why it still links to MD instead of MT, so I blocked the static build, may be you could figure it why.
4. curl, zlib and openssl are optional dependency in windows, windows will using WinHttp and Bcrypt instead, so I didnot make those to dependency.