### PR TITLE
Added libpq support to qt5

### DIFF
--- a/ports/libpq/CMakeLists.txt
+++ b/ports/libpq/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(libpq VERSION 9.6.1 LANGUAGES C)
 
 find_package(OpenSSL REQUIRED)
+set(CMAKE_DEBUG_POSTFIX "d")
 configure_file(${CMAKE_CURRENT_LIST_DIR}/src/include/pg_config.h.win32 ${CMAKE_CURRENT_LIST_DIR}/src/include/pg_config.h)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/src/include/pg_config_ext.h.win32 ${CMAKE_CURRENT_LIST_DIR}/src/include/pg_config_ext.h)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/src/include/port/win32.h ${CMAKE_CURRENT_LIST_DIR}/src/include/pg_config_os.h)
@@ -61,11 +62,14 @@ set(pg_libpq_catalog_interface
     src/include/catalog/genbki.h
 )
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
 target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY -DUSE_OPENSSL -D_CRT_SECURE_NO_WARNINGS)
 target_link_libraries(libpq PRIVATE OpenSSL::SSL ws2_32 secur32 advapi32 shell32)
 target_include_directories(libpq PRIVATE src/include src/include/port/win32 src/include/port/win32_msvc src/port)
 set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 install(TARGETS libpq
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -29,4 +29,5 @@ file(COPY ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/lib
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libpq/COPYRIGHT ${CURRENT_PACKAGES_DIR}/share/libpq/copyright)
 
 
+
 vcpkg_copy_pdbs()

--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5
 Version: 5.7-1
-Build-Depends:
 Description: Qt5 application framework main components. Webengine, examples and tests not included.
+Build-Depends: sqlite3, libpq

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -13,7 +13,8 @@ get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
 get_filename_component(JOM_EXE_PATH ${JOM} DIRECTORY)
 set(ENV{PATH} "${JOM_EXE_PATH};${PYTHON3_EXE_PATH};${PERL_EXE_PATH};$ENV{PATH}")
-
+set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")
+set(ENV{LIB} "${CURRENT_INSTALLED_DIR}/lib;$ENV{LIB}")
 vcpkg_download_distfile(ARCHIVE_FILE
     URLS "http://download.qt.io/official_releases/qt/5.7/5.7.0/single/qt-everywhere-opensource-src-5.7.0.7z"
     FILENAME "qt-5.7.0.7z"
@@ -44,7 +45,11 @@ vcpkg_execute_required_process(
     COMMAND "${SOURCE_PATH}/configure.bat"
         -confirm-license -opensource -platform win32-msvc2015
         -debug-and-release -force-debug-info ${QT_RUNTIME_LINKAGE}
+        -qt-zlib
+        -qt-libjpeg
+        -system-sqlite
         -nomake examples -nomake tests -skip webengine
+        -qt-sql-sqlite -qt-sql-psql
         -prefix ${CURRENT_PACKAGES_DIR}
         -bindir ${CURRENT_PACKAGES_DIR}/bin
         -hostbindir ${CURRENT_PACKAGES_DIR}/tools
@@ -67,7 +72,7 @@ message(STATUS "Build ${TARGET_TRIPLET} done")
 
 message(STATUS "Installing ${TARGET_TRIPLET}")
 vcpkg_execute_required_process(
-    COMMAND ${JOM} install
+    COMMAND ${JOM} -j1 install
     WORKING_DIRECTORY ${OUTPUT_PATH}
     LOGNAME install-${TARGET_TRIPLET}
 )
@@ -151,3 +156,4 @@ vcpkg_execute_required_process(
 file(INSTALL ${SOURCE_PATH}/LICENSE.LGPLv3 DESTINATION  ${CURRENT_PACKAGES_DIR}/share/qt5 RENAME copyright)
 
 vcpkg_copy_pdbs()
+


### PR DESCRIPTION
In addition to libpq support for qt5 this adds a debug postfix again to libpq, since that's what libraries seem to expect. Additionally it changes qt5 to use it's own internal versions of zlib and libjpeg. There were issues with the library names that made this required. This should not be an ABI issue unless you do something like passing a JPEG pointer from QT to the vcpkg jpeg library, and actually even then zlib and libjpeg-turbo are very stable libraries.

I've also made the install command use only one core, since it was having some trouble with multicore, this does not really slow things down at all, since builds are still done with multiple processes.