### PR TITLE
Anax shared lib support

### DIFF
--- a/ports/anax/Add-bin-output.patch
+++ b/ports/anax/Add-bin-output.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	Tue Oct 13 13:47:40 2015
++++ b/CMakeLists.txt	Tue Dec 06 11:13:23 2016
+@@ -161,6 +161,7 @@
+ # Library files
+ install(
+         TARGETS ${ANAX_LIBRARY_NAME}
++		 RUNTIME DESTINATION bin
+         LIBRARY DESTINATION lib
+         ARCHIVE DESTINATION lib
+        )

--- a/ports/anax/CONTROL
+++ b/ports/anax/CONTROL
@@ -1,3 +1,3 @@
 Source: anax
-Version: 2.1.0
+Version: 2.1.0-1
 Description: An open source C++ entity system. <https://github.com/miguelmartin75/anax>

--- a/ports/anax/portfile.cmake
+++ b/ports/anax/portfile.cmake
@@ -6,10 +6,6 @@
 #   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
 #
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
-    set(VCPKG_LIBRARY_LINKAGE static)
-endif()
 include(vcpkg_common_functions)
 
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/anax-2.1.0)
@@ -20,8 +16,15 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/Add-bin-output.patch
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+	-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON 
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
With this PR support for building anax as a shared library has been added thanks to cmake exporting of all found symbols.