### PR TITLE
UWP: use VCPKG_CMAKE_SYSTEM_NAME instead of TRIPLET_SYSTEM_NAME

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -17,7 +17,8 @@ target_compile_definitions(sqlite3 PRIVATE
     -DSQLITE_ENABLE_UNLOCK_NOTIFY
     )
 target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE:include>)
-if(TRIPLET_SYSTEM_NAME MATCHES "WindowsStore")
+
+if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()
 


### PR DESCRIPTION
This PR fixes the UWP builds. TRIPLET_SYSTEM_NAME is not available to the CMakeLists.txt in the UWP detection code. VCPKG_CMAKE_SYSTEM_NAME is available.

Note: Other ports may also not be working if they are using TRIPLET_SYSTEM_NAME to detect a UWP build, Some documentation guidance is needed.