### PR TITLE
Add CharLS.

### DIFF
--- a/ports/charls/0001_cmake.patch
+++ b/ports/charls/0001_cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1aa40a8..1051997 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,6 +33,7 @@ option (BUILD_TESTING     "Build tests"                         ON)
+ if (WIN32)
+    if (BUILD_SHARED_LIBS)
+      add_definitions(-D CHARLS_DLL)
++     set_source_files_properties(src/interface.cpp PROPERTIES COMPILE_FLAGS -DCHARLS_DLL_BUILD)
+    else()
+      add_definitions(-D CHARLS_STATIC)
+    endif()

--- a/ports/charls/CONTROL
+++ b/ports/charls/CONTROL
@@ -1,0 +1,3 @@
+Source: charls
+Version: 2.0.0
+Description: CharLS, a C++ JPEG-LS library implementation.

--- a/ports/charls/portfile.cmake
+++ b/ports/charls/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/charls-2.0.0)
+vcpkg_download_distfile(ARCHIVE_FILE
+    URLS "https://github.com/team-charls/charls/archive/2.0.0.tar.gz"
+    FILENAME "charls-2.0.0.tar.gz"
+    SHA512 0a2862fad6d65b941c81f5f838db1fdc6a4625887281ddbf27e21be9084f607d27c8a27d246d6252e08358b2ed4aa0c2b7407048ca559fb40e94313ca72487dd
+)
+vcpkg_extract_source_archive(${ARCHIVE_FILE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/charls RENAME copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Add CharLS, a C++ JPEG-LS library implementation.
It was necessary to create a patch for CMake for the shared build. This patch has also been proposed in the original project.