### PR TITLE
[libflac] link to correct version of ogg

### DIFF
--- a/ports/libflac/CMakeLists.txt
+++ b/ports/libflac/CMakeLists.txt
@@ -3,10 +3,6 @@ cmake_policy(SET CMP0005 NEW) # do not escape preprocessor defines
 
 project(libflac)
 
-if(NOT DEFINED LIBFLAC_OGG_LIB OR NOT DEFINED LIBFLAC_OGG_INCLUDES)
-    message(FATAL_ERROR "Ogg library required")
-endif()
-
 if(NOT DEFINED LIBFLAC_ARCHITECTURE)
     message(FATAL_ERROR "Target architecture not specified")
 endif()
@@ -20,7 +16,6 @@ file(GLOB LIBFLACXX_SOURCES
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src/libFLAC/include)
-include_directories(${LIBFLAC_OGG_INCLUDES})
 
 if(NOT LIBFLAC_ARCHITECTURE MATCHES arm)
     add_definitions(-DFLAC__SSE_OS)
@@ -49,7 +44,11 @@ add_library(libFLACXX ${LIBFLACXX_SOURCES})
 set_target_properties(libFLAC PROPERTIES OUTPUT_NAME flac)
 set_target_properties(libFLACXX PROPERTIES OUTPUT_NAME flac++)
 
-target_link_libraries(libFLAC ${LIBFLAC_OGG_LIB})
+find_library(OGG_LIBRARY ogg)
+find_path(OGG_INCLUDE_DIR ogg/ogg.h)
+
+include_directories(${OGG_INCLUDE_DIR})
+target_link_libraries(libFLAC ${OGG_LIBRARY})
 target_link_libraries(libFLACXX libFLAC)
 
 if(BUILD_SHARED_LIBS)

--- a/ports/libflac/CONTROL
+++ b/ports/libflac/CONTROL
@@ -1,4 +1,4 @@
 Source: libflac
-Version: 1.3.1
+Version: 1.3.1-1
 Description: Library for manipulating FLAC files
 Build-Depends: libogg

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -18,8 +18,6 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
             -DLIBFLAC_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}
-            -DLIBFLAC_OGG_LIB=${VCPKG_ROOT_DIR}/installed/${TARGET_TRIPLET}/lib/ogg.lib
-            -DLIBFLAC_OGG_INCLUDES=${VCPKG_ROOT_DIR}/installed/${TARGET_TRIPLET}/include
         OPTIONS_DEBUG
             -DLIBFLAC_SKIP_HEADERS=ON)
 


### PR DESCRIPTION
In initial port, release version of libogg was linked in debug mode, which punished me with weird linker errors.