### PR TITLE
[sfml] intial commit

### DIFF
--- a/ports/sfml/CMakeLists.txt
+++ b/ports/sfml/CMakeLists.txt
@@ -1,0 +1,123 @@
+cmake_minimum_required(VERSION 2.6)
+project(SFML)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${SFML_DEPENDENCIES_PATH}/include)
+
+if(NOT BUILD_SHARED_LIBS)
+    add_definitions(-DSFML_STATIC)
+endif()
+add_definitions(-DUNICODE -D_UNICODE)
+add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
+
+# import SFML's 'sfml_add_library' macro and find_package utils
+
+set(VERSION_MAJOR 2)
+set(SFML_OS_WINDOWS ON)
+set(SFML_GENERATE_PDB ON)
+include(cmake/macros.cmake)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules/)
+
+# system module
+
+file(GLOB SFML_SYSTEM_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/System/*.cpp
+    ${PROJECT_SOURCE_DIR}/src/SFML/System/Win32/*cpp)
+
+sfml_add_library(sfml-system
+    SOURCES ${SFML_SYSTEM_SOURCES}
+    EXTERNAL_LIBS winmm)
+
+# window module
+
+file(GLOB SFML_WINDOW_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/Window/*.cpp
+    ${PROJECT_SOURCE_DIR}/src/SFML/Window/Win32/*cpp)
+
+list(REMOVE_ITEM SFML_WINDOW_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/Window/EGLCheck.cpp
+    ${PROJECT_SOURCE_DIR}/src/SFML/Window/EglContext.cpp)
+
+sfml_add_library(sfml-window
+    SOURCES ${SFML_WINDOW_SOURCES}
+    DEPENDS sfml-system
+    EXTERNAL_LIBS winmm gdi32 opengl32)
+
+# network module
+
+file(GLOB SFML_NETWORK_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/Network/*.cpp
+    ${PROJECT_SOURCE_DIR}/src/SFML/Network/Win32/*cpp)
+
+sfml_add_library(sfml-network
+    SOURCES ${SFML_NETWORK_SOURCES}
+    DEPENDS sfml-system
+    EXTERNAL_LIBS ws2_32)
+
+# audio module
+
+file(GLOB SFML_AUDIO_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/Audio/*.cpp)
+
+find_package(OpenAL REQUIRED)
+find_package(Vorbis REQUIRED)
+find_package(FLAC REQUIRED)
+
+sfml_add_library(sfml-audio
+    SOURCES ${SFML_AUDIO_SOURCES}
+    DEPENDS sfml-system
+    EXTERNAL_LIBS ${OPENAL_LIBRARY} ${VORBIS_LIBRARIES} ${FLAC_LIBRARY})
+
+target_include_directories(sfml-audio SYSTEM PRIVATE ${OPENAL_INCLUDE_DIR})
+target_include_directories(sfml-audio SYSTEM PRIVATE ${VORBIS_INCLUDE_DIRS})
+target_include_directories(sfml-audio SYSTEM PRIVATE ${FLAC_INCLUDE_DIR})
+
+# graphics module
+
+file(GLOB SFML_GRAPHICS_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/SFML/Graphics/*.cpp)
+
+find_package(JPEG REQUIRED)
+find_package(Freetype REQUIRED) # fails to find debug lib
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    find_library(FREETYPE_DEBUG_LIBRARY freetyped)
+    set(FREETYPE_ACTUAL_LIBRARY ${FREETYPE_DEBUG_LIBRARY})
+else()
+    set(FREETYPE_ACTUAL_LIBRARY ${FREETYPE_LIBRARY})
+endif()
+find_path(STB_HEADERS stb_image.h)
+
+sfml_add_library(sfml-graphics
+    SOURCES ${SFML_GRAPHICS_SOURCES}
+    DEPENDS sfml-system sfml-window
+    EXTERNAL_LIBS ${FREETYPE_ACTUAL_LIBRARY} ${JPEG_LIBRARY} opengl32)
+
+target_include_directories(sfml-graphics SYSTEM PRIVATE ${STB_HEADERS})
+target_include_directories(sfml-graphics SYSTEM PRIVATE ${FREETYPE_INCLUDE_DIRS})
+target_include_directories(sfml-graphics SYSTEM PRIVATE ${JPEG_INCLUDE_DIR})
+set_target_properties(sfml-graphics PROPERTIES COMPILE_FLAGS -DSTBI_FAILURE_USERMSG)
+
+# main module
+
+add_library(sfml-main STATIC ${PROJECT_SOURCE_DIR}/src/SFML/Main/MainWin32.cpp)
+set_target_properties(sfml-main PROPERTIES DEBUG_POSTFIX -d)
+install(TARGETS sfml-main ARCHIVE DESTINATION lib)
+
+# headers
+
+if(NOT DEFINED SFML_SKIP_HEADERS)
+    install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
+endif()
+
+# log linked libraries
+
+message(STATUS "Link-time dependencies:")
+message(STATUS "  " ${VORBIS_LIBRARY})
+message(STATUS "  " ${VORBISFILE_LIBRARY})
+message(STATUS "  " ${VORBISENC_LIBRARY})
+message(STATUS "  " ${OGG_LIBRARY})
+message(STATUS "  " ${OPENAL_LIBRARY})
+message(STATUS "  " ${FLAC_LIBRARY})
+message(STATUS "  " ${FREETYPE_ACTUAL_LIBRARY})
+message(STATUS "  " ${JPEG_LIBRARY})

--- a/ports/sfml/CMakeLists.txt
+++ b/ports/sfml/CMakeLists.txt
@@ -3,7 +3,6 @@ project(SFML)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/src)
-include_directories(${SFML_DEPENDENCIES_PATH}/include)
 
 if(NOT BUILD_SHARED_LIBS)
     add_definitions(-DSFML_STATIC)

--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,0 +1,4 @@
+Source: sfml
+Version: 2.4.1
+Description: Simple and fast multimedia library
+Build-Depends: freetype, libflac, libjpeg-turbo, libogg, libvorbis, openal-soft, stb

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -1,0 +1,34 @@
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SFML-2.4.1)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.sfml-dev.org/files/SFML-2.4.1-sources.zip"
+    FILENAME "SFML-2.4.1-sources.zip"
+    SHA512 e2a49927e1db6ab94fa52b88460782fa2b28ccd4a8c75793e10c7669b24736f63aab723c2e1d8befc96f6f5cf4ed185f13da2550da721d206780003f158e5507)
+
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(REMOVE_RECURSE ${SOURCE_PATH}/extlibs)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS_DEBUG
+            -DSFML_SKIP_HEADERS=ON)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+# don't force users to define SFML_STATIC while using static library
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(APPEND ${CURRENT_PACKAGES_DIR}/include/SFML/Config.hpp "#undef SFML_API_IMPORT\n#define SFML_API_IMPORT\n")
+endif()
+
+# move sfml-main to manual link dir
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/sfml-main.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/sfml-main.lib)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/sfml-main-d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/sfml-main-d.lib)
+
+file(COPY ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sfml)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/sfml/license.txt ${CURRENT_PACKAGES_DIR}/share/sfml/copyright)


### PR DESCRIPTION
Solves #71.
Since SFML's build system has hardcoded paths to it's internal versions of dependencies in quite a few files and does a lot of unnecessary work (like spamming it's readmes all over the place), I simply rewrote it on the Windows path to avoid tons of patches. It uses SFML's own script for generating library/dll names, so they should be compatible.

Fun fact: it takes 13 dlls (not counting win32/crt ones) to run the Pong game from SFML examples
![pong](https://cloud.githubusercontent.com/assets/22731198/20989857/931030ce-bcd6-11e6-820e-579fe0badbef.png)
