### PR TITLE
Patch curl to find the libssh2 library

### DIFF
--- a/ports/curl/0001_cmake.patch
+++ b/ports/curl/0001_cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMake/FindLibSSH2.cmake b/CMake/FindLibSSH2.cmake
+index 12a7c61..9839c67 100644
+--- a/CMake/FindLibSSH2.cmake
++++ b/CMake/FindLibSSH2.cmake
+@@ -12,7 +12,7 @@ endif (LIBSSH2_INCLUDE_DIR AND LIBSSH2_LIBRARY)
+ FIND_PATH(LIBSSH2_INCLUDE_DIR libssh2.h
+ )
+ 
+-FIND_LIBRARY(LIBSSH2_LIBRARY NAMES ssh2
++FIND_LIBRARY(LIBSSH2_LIBRARY NAMES ssh2 libssh2
+ )
+ 
+ if(LIBSSH2_INCLUDE_DIR)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -7,6 +7,12 @@ vcpkg_download_distfile(ARCHIVE_FILE
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
+)
+
 if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
     SET(CURL_STATICLIB OFF)
 else()


### PR DESCRIPTION
When installing curl, it can look for libssh2 and use it to enable the SCP and SFTP protocols support.
I did not set libssh2 as a Build-Depends of curl, as it is not necessarily the behavior everyone wants.