### PR TITLE
[boost] unset BOOST_AUTO_LINK_NOMANGLE flag

### DIFF
--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -100,7 +100,6 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         "\n#define BOOST_ALL_DYN_LINK\n"
     )
 endif()
-file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp "\n#define BOOST_AUTO_LINK_NOMANGLE\n")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/boost RENAME copyright)
 message(STATUS "Packaging headers done")


### PR DESCRIPTION
This was a remnant of a previously enabled system install option which has been disabled in the meantime.

Fixes #397. 
Also fixes builds for other ports depending on boost (for example, cpprestsdk).
