### PR TITLE
Add spirv-tools and use it to build shaderc.

### DIFF
--- a/ports/shaderc/CMakeLists_spirv.txt
+++ b/ports/shaderc/CMakeLists_spirv.txt
@@ -1,0 +1,14 @@
+option(SUFFIX_D "Add d Suffix to lib" ${SUFFIX_D})
+if(NOT ${SUFFIX_D})
+    find_library(SPIRVTOOLSOPT spirv-tools-opt)
+    find_library(SPIRVTOOLS spirv-tools)
+ELSE()
+    find_library(SPIRVTOOLSOPT spirv-tools-opt)
+    find_library(SPIRVTOOLS spirv-tools)
+ENDIF()
+
+add_library(SPIRV-Tools-opt STATIC IMPORTED GLOBAL)
+set_property(TARGET SPIRV-Tools-opt PROPERTY IMPORTED_LOCATION "${SPIRVTOOLSOPT}")
+
+add_library(SPIRV-Tools STATIC IMPORTED GLOBAL)
+set_property(TARGET SPIRV-Tools PROPERTY IMPORTED_LOCATION "${SPIRVTOOLS}")

--- a/ports/shaderc/CONTROL
+++ b/ports/shaderc/CONTROL
@@ -1,4 +1,4 @@
 Source: shaderc
 Version: 2df47b51d83ad83cbc2e7f8ff2b56776293e8958
 Description: A collection of tools, libraries and tests for shader compilation.
-Build-Depends: glslang
+Build-Depends: glslang, spirv-tools

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -37,48 +37,9 @@ if(NOT EXISTS "${SOURCE_PATH}/.git")
     )
 endif()
 
-set(SPIRVTOOLS_GIT_URL "https://github.com/KhronosGroup/SPIRV-Tools.git")
-set(SPIRVTOOLS_GIT_REF "f72189c249ba143c6a89a4cf1e7d53337b2ddd40")
-set(SPIRVHEADERS_GIT_URL "https://github.com/KhronosGroup/SPIRV-Headers.git")
-set(SPIRVHEADERS_GIT_REF "bd47a9abaefac00be692eae677daed1b977e625c")
-
-if(NOT EXISTS "${DOWNLOADS}/SPIRV-Tools.git")
-    message(STATUS "Cloning")
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} clone --bare ${SPIRVTOOLS_GIT_URL} ${DOWNLOADS}/SPIRV-Tools.git
-        WORKING_DIRECTORY ${DOWNLOADS}
-        LOGNAME clone
-    )
-endif()
-if(NOT EXISTS "${DOWNLOADS}/SPIRV-Headers.git")
-    message(STATUS "Cloning")
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} clone --bare ${SPIRVHEADERS_GIT_URL} ${DOWNLOADS}/SPIRV-Headers.git
-        WORKING_DIRECTORY ${DOWNLOADS}
-        LOGNAME clone
-    )
-endif()
-
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/third_party/glslang)
-if(NOT EXISTS "${SOURCE_PATH}/third_party/spirv-tools/.git")
-    message(STATUS "Adding worktree and patching")
-    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} worktree add -f --detach ${SOURCE_PATH}/third_party/spirv-tools ${SPIRVTOOLS_GIT_REF}
-        WORKING_DIRECTORY ${DOWNLOADS}/SPIRV-Tools.git
-        LOGNAME worktree
-    )
-endif()
-if(NOT EXISTS "${SOURCE_PATH}/third_party/spirv-tools/external/spirv-headers/.git")
-    message(STATUS "Adding worktree and patching")
-    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
-    vcpkg_execute_required_process(
-        COMMAND ${GIT} worktree add -f --detach ${SOURCE_PATH}/third_party/spirv-tools/external/spirv-headers ${SPIRVHEADERS_GIT_REF}
-        WORKING_DIRECTORY ${DOWNLOADS}/SPIRV-Headers.git
-        LOGNAME worktree
-    )
-endif()
-
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_spirv.txt DESTINATION ${SOURCE_PATH}/third_party/spirv-tools)
+file(RENAME ${SOURCE_PATH}/third_party/spirv-tools/CMakeLists_spirv.txt ${SOURCE_PATH}/third_party/spirv-tools/CMakeLists.txt)
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/build-version.inc DESTINATION ${SOURCE_PATH}/glslc/src)
 
 #Note: glslang and spir tools doesn't export symbol and need to be build as static lib for cmake to work
@@ -102,13 +63,16 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
 file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
 
 #Safe to remove as libs are static
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
+
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/shaderc.txt)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/shaderc)

--- a/ports/spirv-tools/CONTROL
+++ b/ports/spirv-tools/CONTROL
@@ -1,0 +1,3 @@
+Source: spirv-tools
+Version:
+Description:

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -1,0 +1,78 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(vcpkg_common_functions)
+find_program(GIT git)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
+
+set(GIT_URL "https://github.com/KhronosGroup/SPIRV-Tools.git")
+set(GIT_REF "f72189c249ba143c6a89a4cf1e7d53337b2ddd40")
+
+if(NOT EXISTS "${DOWNLOADS}/spirv-tools.git")
+    message(STATUS "Cloning")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} clone --bare ${GIT_URL} ${DOWNLOADS}/spirv-tools.git
+        WORKING_DIRECTORY ${DOWNLOADS}
+        LOGNAME clone
+    )
+endif()
+
+if(NOT EXISTS "${SOURCE_PATH}/.git")
+    message(STATUS "Adding worktree and patching")
+    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} worktree add -f --detach ${SOURCE_PATH} ${GIT_REF}
+        WORKING_DIRECTORY ${DOWNLOADS}/spirv-tools.git
+        LOGNAME worktree
+    )
+    message(STATUS "Patching")
+endif()
+
+set(SPIRVHEADERS_GIT_URL "https://github.com/KhronosGroup/SPIRV-Headers.git")
+set(SPIRVHEADERS_GIT_REF "bd47a9abaefac00be692eae677daed1b977e625c")
+
+if(NOT EXISTS "${DOWNLOADS}/SPIRV-Headers.git")
+    message(STATUS "Cloning")
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} clone --bare ${SPIRVHEADERS_GIT_URL} ${DOWNLOADS}/SPIRV-Headers.git
+        WORKING_DIRECTORY ${DOWNLOADS}
+        LOGNAME clone
+    )
+endif()
+
+if(NOT EXISTS "${SOURCE_PATH}/external/spirv-headers/.git")
+    message(STATUS "Adding worktree and patching")
+    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR})
+    vcpkg_execute_required_process(
+        COMMAND ${GIT} worktree add -f --detach ${SOURCE_PATH}/external/spirv-headers ${SPIRVHEADERS_GIT_REF}
+        WORKING_DIRECTORY ${DOWNLOADS}/SPIRV-Headers.git
+        LOGNAME worktree
+    )
+endif()
+
+set(VCPKG_LIBRARY_LINKAGE "static")
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src"
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(REMOVE ${EXES})
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spirv-tools)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/spirv-tools/LICENSE ${CURRENT_PACKAGES_DIR}/share/spirv-tools/copyright)


### PR DESCRIPTION
This PR adds spirv-tools ; it also drop the spirv-tools clone in shaderc and use the same CMakeLists.txt replacement that imports installed spirv Tools.

There's an issue though : it looks like shaderc doesn't use the proper installation directory when built in static mode (which is mandatory to avoid linkage error) : ./vcpkg build shaderc:x86-windows-static will fetch spirv-tools lib and include in installed/x86-windows and not in installed/x86-windows-static so I need to manually copy/paste the lib and include files from the later to the former before building. Not sure it's a vcpkg or a script bug.