### PR TITLE
[sdl2] make SDL use libc

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,3 +1,3 @@
 Source: sdl2
-Version: 2.0.5
+Version: 2.0.5-1
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -47,6 +47,7 @@ else()
             -DSDL_STATIC=${SDL_STATIC_LIB}
             -DSDL_SHARED=${SDL_SHARED_LIB}
             -DFORCE_STATIC_VCRT=${SDL_STATIC_CRT}
+            -DLIBC=ON
     )
 
     vcpkg_install_cmake()


### PR DESCRIPTION
By default (at least with MSVC) SDL avoids use of standard C library and reimplements some functions. This may cause name conflicts and linker errors when linking statically built SDL2.lib with other static libraries.