### PR TITLE
[lua] Don't export from executables

### DIFF
--- a/ports/lua/CMakeLists.txt
+++ b/ports/lua/CMakeLists.txt
@@ -25,15 +25,15 @@ src/ltable.c src/ltablib.c src/ltm.c src/lundump.c src/lutf8lib.c src/lvm.c src/
 # append headers to sources to make them show up in MSVC GUI
 LIST(APPEND SRC_LIBLUA ${HDR_LIBLUA})
 
-IF (BUILD_SHARED_LIBS)
-    ADD_DEFINITIONS ( -DLUA_BUILD_AS_DLL )
-ENDIF ()
-
 # remove warnings
 ADD_DEFINITIONS (-D_CRT_SECURE_NO_WARNINGS )
 
 #DLL
 ADD_LIBRARY ( lua ${SRC_LIBLUA} )
+
+IF (BUILD_SHARED_LIBS)
+    TARGET_COMPILE_DEFINITIONS (lua PRIVATE -DLUA_BUILD_AS_DLL )
+ENDIF ()
 
 INSTALL ( TARGETS lua
     RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin

--- a/ports/lua/CONTROL
+++ b/ports/lua/CONTROL
@@ -1,3 +1,3 @@
 Source: lua
-Version: 5.3.3-1
+Version: 5.3.3-2
 Description: a powerful, fast, lightweight, embeddable scripting language


### PR DESCRIPTION
Since #383 lua installation builds compiler and interpreter in addition to library. However, in dynamic builds `-DLUA_BUILD_AS_DLL` is set project-wide, symbols are exported also from executables and` lua.lib` is created for interpreter causing name clash with dll's import lib.