### PR TITLE
[libbson, mongo-c-driver] bump version to 1.5.1

### DIFF
--- a/ports/libbson/CONTROL
+++ b/ports/libbson/CONTROL
@@ -1,3 +1,3 @@
 Source: libbson
-Version: 1.5.0-rc6
+Version: 1.5.1
 Description: libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-c-driver
-Version: 1.5.0-rc6
+Version: 1.5.1
 Build-Depends: libbson
 Description: Client library written in C for MongoDB.


### PR DESCRIPTION
I upgraded libbson and mongo-c-driver to 1.5.1 a few days ago but forgot to bump the version.

This PR fixed it.