### PR TITLE
[qt5] Explicitly avoid compiling qt dependencies that could be available in vcpkg

### DIFF
--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -47,6 +47,10 @@ vcpkg_execute_required_process(
         -debug-and-release -force-debug-info ${QT_RUNTIME_LINKAGE}
         -qt-zlib
         -qt-libjpeg
+        -no-libpng
+        -no-freetype
+        -no-pcre
+        -no-harfbuzz
         -system-sqlite
         -nomake examples -nomake tests -skip webengine
         -qt-sql-sqlite -qt-sql-psql


### PR DESCRIPTION
To avoid problems such as the one described in https://github.com/Microsoft/vcpkg/issues/412 . 
If a particular dependency is actually needed, it can be added `-qt-<dep>` or `-system-<dep> to use the vcpkg version, see https://github.com/Microsoft/vcpkg/issues/455 .