### PR TITLE
[sdl2] link to CRT libraries

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,3 +1,3 @@
 Source: sdl2
-Version: 2.0.5-1
+Version: 2.0.5-2
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl2/dont-ignore-default-libs.patch
+++ b/ports/sdl2/dont-ignore-default-libs.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54a23f0..91c5736 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1549,7 +1549,7 @@ if(SDL_SHARED)
+       SOVERSION ${LT_REVISION}
+       OUTPUT_NAME "SDL2")
+   endif()
+-  if(MSVC)
++  if(MSVC AND NOT LIBC)
+     # Don't try to link with the default set of libraries.
+     set_target_properties(SDL2 PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB")
+     set_target_properties(SDL2 PROPERTIES LINK_FLAGS_DEBUG "/NODEFAULTLIB")
+@@ -1564,7 +1564,7 @@ if(SDL_STATIC)
+   add_library(SDL2-static STATIC ${SOURCE_FILES})
+   set_target_properties(SDL2-static PROPERTIES OUTPUT_NAME "SDL2")
+   set_target_properties(SDL2-static PROPERTIES POSITION_INDEPENDENT_CODE ${SDL_STATIC_PIC})
+-  if(MSVC)
++  if(MSVC AND NOT LIBC)
+     set_target_properties(SDL2-static PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB")
+     set_target_properties(SDL2-static PROPERTIES LINK_FLAGS_DEBUG "/NODEFAULTLIB")
+     set_target_properties(SDL2-static PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB")

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -7,6 +7,12 @@ vcpkg_download_distfile(ARCHIVE_FILE
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/dont-ignore-default-libs.patch
+)
+
 if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
     vcpkg_build_msbuild(
         PROJECT_PATH ${SOURCE_PATH}/VisualC-WinRT/UWP_VS2015/SDL-UWP.vcxproj


### PR DESCRIPTION
This prevents SDL2 from passing `/NODEFAULTLIB` flag when usage of stardard C library is explicitly requested.
Should fix #469.