### PR TITLE
[qt5] Turn -no-pcre in -qt-pcre

### DIFF
--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5
-Version: 5.7.1-1
+Version: 5.7.1-2
 Description: Qt5 application framework main components. Webengine, examples and tests not included.
 Build-Depends: sqlite3, libpq

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -49,7 +49,7 @@ vcpkg_execute_required_process(
         -qt-libjpeg
         -no-libpng
         -no-freetype
-        -no-pcre
+        -qt-pcre
         -no-harfbuzz
         -system-sqlite
         -nomake examples -nomake tests -skip webengine


### PR DESCRIPTION
As before, this PR is related to https://github.com/Microsoft/vcpkg/issues/412 .
Despite Qt documentation ( http://doc.qt.io/qt-5/configure-options.html ) `-no-pcre` is not recognized as an option, while `-qt-pcre` is recognized as an option.