### PR TITLE
[icu] force rebuild of database

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,3 +1,3 @@
 Source: icu
-Version: 58.2
+Version: 58.2-1
 Description: Mature and widely used Unicode and localization library.

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/source/allinone/allinone.sln
     PLATFORM ${BUILD_ARCH})
 
-# force rebuild of database as it sometimies gets overriden by dummy one
+# force rebuild of database as it sometimes gets overriden by dummy one
 vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/source/data/makedata.vcxproj
     PLATFORM ${BUILD_ARCH})

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -25,6 +25,11 @@ vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/source/allinone/allinone.sln
     PLATFORM ${BUILD_ARCH})
 
+# force rebuild of database as it sometimies gets overriden by dummy one
+vcpkg_build_msbuild(
+    PROJECT_PATH ${SOURCE_PATH}/source/data/makedata.vcxproj
+    PLATFORM ${BUILD_ARCH})
+
 set(ICU_VERSION 58)
 if(TRIPLET_SYSTEM_ARCH MATCHES "x64")
     set(ICU_BIN bin64)


### PR DESCRIPTION
After upgrading to 58.2 I noticed that wrong version of icu database gets installed. I'm not sure why, but apparently it [sometimes happens](http://userguide.icu-project.org/icufaq#TOC-Why-am-I-seeing-a-small-only-a-few-K-instead-of-a-large-several-megabytes-data-shared-library-icudt-Opening-ICU-services-fails-with-U_MISSING_RESOURCE_ERROR-and-u_init-returns-failure.). Forcing rebuild of `makedata.vcxproj` seems to fix this issue.