### PR TITLE
[glew] Renames the glew debug output files

### DIFF
--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -57,8 +57,11 @@ message(STATUS "Installing")
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 	file(INSTALL
 		${SOURCE_PATH}/bin/Debug/${BUILD_ARCH}/glew32d.dll
+		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin RENAME glew32.dll
+	)
+	file(INSTALL
 		${SOURCE_PATH}/bin/Debug/${BUILD_ARCH}/glew32d.pdb
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin RENAME glew32.pdb
 	)
 	file(INSTALL
 		${SOURCE_PATH}/bin/Release/${BUILD_ARCH}/glew32.dll
@@ -67,7 +70,7 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 	)
 	file(INSTALL
 		${SOURCE_PATH}/lib/Debug/${BUILD_ARCH}/glew32d.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib RENAME glew32.lib
 	)
 	file(INSTALL
 		${SOURCE_PATH}/lib/Release/${BUILD_ARCH}/glew32.lib
@@ -76,13 +79,11 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 else()
 	file(INSTALL
 		${SOURCE_PATH}/lib/Debug/${BUILD_ARCH}/glew32sd.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-		RENAME glew32d.lib
+		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib RENAME glew32.lib
 	)
 	file(INSTALL
 		${SOURCE_PATH}/lib/Release/${BUILD_ARCH}/glew32s.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-		RENAME glew32.lib
+		DESTINATION ${CURRENT_PACKAGES_DIR}/lib RENAME glew32.lib
 	)
 endif()
 


### PR DESCRIPTION
The FindGlew.cmake that is official as well as several found in a quick search
don't look for the debug post-fix variant of the library. This was causing vcpkg
to not copy the DLL over on build as it was looking for glew32.dll not glew32d.dll.

An oddity was showing up though where in the installed/debug/bin folder there was glew32.pdb AND glew32d.pdb and I am uncertain of why as the output from `vcpkg install` doesn't indicate install glew32d.pdb at all.