### PR TITLE
Disable Boost auto-link.

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
-Version: 1.62-9
+Version: 1.62-10
 Description: Peer-reviewed portable C++ source libraries
 Build-Depends: zlib

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -108,11 +108,10 @@ file(
     DESTINATION ${CURRENT_PACKAGES_DIR}/include
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
-        "\n#define BOOST_ALL_DYN_LINK\n"
-    )
-endif()
+# Disable Boost auto-link.
+file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
+	"\n#define BOOST_ALL_NO_LIB\n"
+)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/boost RENAME copyright)
 message(STATUS "Packaging headers done")


### PR DESCRIPTION
Fixes #483. vcpkg always links with all installed libraries for the target triplet; Boost's own auto-link feature is therefore redundant.

Note: This works with MSBuild. I have no idea whether it breaks CMake, but building vcpkg libraries that depend on Boost does work afterwards.