### PR TITLE
[freetype] specify dependencies

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,4 +1,4 @@
 Source: freetype
-Version: 2.6.3-2
-Build-Depends: zlib
+Version: 2.6.3-3
+Build-Depends: zlib, bzip2, libpng
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -17,6 +17,10 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DCONFIG_INSTALL_PATH=share/freetype
+        -DWITH_ZLIB=ON
+        -DWITH_BZip2=ON
+        -DWITH_PNG=ON
+        -DWITH_HarfBuzz=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
I noticed that every time freetype is build it is linked with different set of dependencies. This should clear things up.