### PR TITLE
[qt5] Avoid printing warnings for problems in applying"confguration patches"

### DIFF
--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -32,13 +32,13 @@ if(DEFINED VCPKG_CRT_LINKAGE AND VCPKG_CRT_LINKAGE STREQUAL static)
     vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES "${CMAKE_CURRENT_LIST_DIR}/set-static-qmakespec.patch"
-	QUIET
+        QUIET
     )
 else()
     vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES "${CMAKE_CURRENT_LIST_DIR}/set-shared-qmakespec.patch"
-	QUIET
+        QUIET
     )
 endif()
 

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -32,11 +32,13 @@ if(DEFINED VCPKG_CRT_LINKAGE AND VCPKG_CRT_LINKAGE STREQUAL static)
     vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES "${CMAKE_CURRENT_LIST_DIR}/set-static-qmakespec.patch"
+	QUIET
     )
 else()
     vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES "${CMAKE_CURRENT_LIST_DIR}/set-shared-qmakespec.patch"
+	QUIET
     )
 endif()
 


### PR DESCRIPTION
The `QUIET` option for `vcpkg_apply_patches` was added in https://github.com/Microsoft/vcpkg/commit/f4c34bb42dd0fe8217d4d54a9a4a2eeecdb0f0f4 . 
Fixes https://github.com/Microsoft/vcpkg/issues/411 .