### PR TITLE
Add libffi

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.0)
+project(libffi)
+
+# config variables for ffi.h.in
+set(VERSION 3.1)
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(TARGET X86_WIN32)
+else()
+    set(TARGET X86_WIN64)
+endif()
+set(HAVE_LONG_DOUBLE 0)
+set(HAVE_LONG_DOUBLE_VARIANT 0)
+set(FFI_EXEC_TRAMPOLINE_TABLE 0)
+
+# mimic layout of original buildsystem
+configure_file(include/ffi.h.in ${CMAKE_BINARY_DIR}/include/ffi.h)
+file(COPY ${FFI_CONFIG_FILE} DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY src/x86/ffitarget.h DESTINATION ${CMAKE_BINARY_DIR}/include)
+
+include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${CMAKE_BINARY_DIR})
+include_directories(include)
+
+add_definitions(-DHAVE_CONFIG_H)
+add_definitions(-DFFI_BUILDING)
+if(BUILD_SHARED_LIBS)
+    add_definitions(-DFFI_EXPORT_DATA)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(ARCH_ASM_NAME win32)
+    set(ARCH_ASSEMBLER ml /safeseh)
+else()
+    set(ARCH_ASM_NAME win64)
+    set(ARCH_ASSEMBLER ml64)
+endif()
+
+execute_process(
+    COMMAND cl /nologo /EP /I. /Iinclude ${CMAKE_SOURCE_DIR}/src/x86/${ARCH_ASM_NAME}.S 
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT_FILE ${ARCH_ASM_NAME}.asm)
+
+# Produced *.asm file could be just added to sources.
+# It works in x64 mode, but for some strange reason MASM returns error code when in x86,
+# (even though it didn't report any errors and correctly generated object file)
+# which in turn causes MSBUILD to stop.
+execute_process(
+    COMMAND ${ARCH_ASSEMBLER} /c /Zi ${ARCH_ASM_NAME}.asm
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+set(FFI_SOURCES
+    ${CMAKE_BINARY_DIR}/${ARCH_ASM_NAME}.obj
+    src/x86/ffi.c
+    src/closures.c
+    src/java_raw_api.c
+    src/prep_cif.c
+    src/raw_api.c
+    src/types.c)
+
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    list(APPEND FFI_SOURCES src/debug.c)
+    add_definitions(-DFFI_DEBUG)
+endif()
+
+add_library(libffi ${FFI_SOURCES})
+
+install(TARGETS libffi
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+
+if(NOT FFI_SKIP_HEADERS)
+    install(FILES
+        ${CMAKE_BINARY_DIR}/include/ffi.h
+        ${CMAKE_BINARY_DIR}/include/ffitarget.h
+        DESTINATION include)
+endif()

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,3 +1,3 @@
 Source: libffi
-Version: 3.2.1
+Version: 3.1
 Description: Portable, high level programming interface to various calling conventions

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,0 +1,3 @@
+Source: libffi
+Version: 3.2.1
+Description: Portable, high level programming interface to various calling conventions

--- a/ports/libffi/auto-define-static-macro.patch
+++ b/ports/libffi/auto-define-static-macro.patch
@@ -1,0 +1,14 @@
+diff --git a/ffi.h b/ffi.h
+index 8d5eac2..0b0c2f6 100644
+--- a/ffi.h
++++ b/ffi.h
+@@ -174,6 +174,9 @@ typedef struct _ffi_type
+ /* of the library, but don't worry about that.  Besides,  */
+ /* as a workaround, they can define FFI_BUILDING if they  */
+ /* *know* they are going to link with the static library. */
++
++#define FFI_BUILDING
++
+ #if defined _MSC_VER && !defined FFI_BUILDING
+ #define FFI_EXTERN extern __declspec(dllimport)
+ #else

--- a/ports/libffi/export-global-data.patch
+++ b/ports/libffi/export-global-data.patch
@@ -1,0 +1,35 @@
+diff --git a/src/types.c b/src/types.c
+index 0de5994..46c8d18 100644
+--- a/src/types.c
++++ b/src/types.c
+@@ -31,6 +31,12 @@
+ #include <ffi.h>
+ #include <ffi_common.h>
+ 
++#ifdef FFI_EXPORT_DATA
++#define FFI_EXPORT __declspec(dllexport)
++#else
++#define FFI_EXPORT
++#endif
++
+ /* Type definitions */
+ 
+ #define FFI_TYPEDEF(name, type, id)		\
+@@ -38,7 +44,7 @@ struct struct_align_##name {			\
+   char c;					\
+   type x;					\
+ };						\
+-const ffi_type ffi_type_##name = {		\
++FFI_EXPORT const ffi_type ffi_type_##name = {		\
+   sizeof(type),					\
+   offsetof(struct struct_align_##name, x),	\
+   id, NULL					\
+@@ -56,7 +62,7 @@ ffi_type ffi_type_##name = {			\
+ }
+ 
+ /* Size and alignment are fake here. They must not be 0. */
+-const ffi_type ffi_type_void = {
++FFI_EXPORT const ffi_type ffi_type_void = {
+   1, 1, FFI_TYPE_VOID, NULL
+ };
+ 

--- a/ports/libffi/fficonfig.h
+++ b/ports/libffi/fficonfig.h
@@ -1,0 +1,220 @@
+/* fficonfig.h.  Generated from fficonfig.h.in by configure.  */
+/* fficonfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
+   systems. This function is required for `alloca.c' support on those systems.
+   */
+/* #undef CRAY_STACKSEG_END */
+
+/* Define to 1 if using `alloca.c'. */
+/* #undef C_ALLOCA */
+
+/* Define to the flags needed for the .section .eh_frame directive. */
+/* #undef EH_FRAME_FLAGS */
+
+/* Define this if you want extra debugging. */
+/* #undef FFI_DEBUG */
+
+/* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
+/* #undef FFI_EXEC_TRAMPOLINE_TABLE */
+
+/* Define this if you want to enable pax emulated trampolines */
+/* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
+
+/* Cannot use malloc on this target, so, we revert to alternative means */
+/* #undef FFI_MMAP_EXEC_WRIT */
+
+/* Define this if you do not want support for the raw API. */
+/* #undef FFI_NO_RAW_API */
+
+/* Define this if you do not want support for aggregate types. */
+/* #undef FFI_NO_STRUCTS */
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#define HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+/* #undef HAVE_ALLOCA_H */
+
+/* Define if your assembler supports .ascii. */
+#ifndef _WIN64
+#define HAVE_AS_ASCII_PSEUDO_OP 1
+#endif
+
+/* Define if your assembler supports .cfi_* directives. */
+/* #undef HAVE_AS_CFI_PSEUDO_OP */
+
+/* Define if your assembler supports .register. */
+/* #undef HAVE_AS_REGISTER_PSEUDO_OP */
+
+/* Define if your assembler and linker support unaligned PC relative relocs.
+   */
+/* #undef HAVE_AS_SPARC_UA_PCREL */
+
+/* Define if your assembler supports .string. */
+#ifndef _WIN64
+#define HAVE_AS_STRING_PSEUDO_OP 1
+#endif
+
+/* Define if your assembler supports unwind section type. */
+/* #undef HAVE_AS_X86_64_UNWIND_SECTION_TYPE */
+
+/* Define if your assembler supports PC relative relocs. */
+#ifndef _WIN64
+#define HAVE_AS_X86_PCREL 1
+#endif
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define if __attribute__((visibility("hidden"))) is supported. */
+/* #undef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if you have the long double type and it is bigger than a double */
+/* #undef HAVE_LONG_DOUBLE */
+
+/* Define if you support more than one size of the long double type */
+/* #undef HAVE_LONG_DOUBLE_VARIANT */
+
+/* Define to 1 if you have the `memcpy' function. */
+/* #undef HAVE_MEMCPY */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `mmap' function. */
+/* #undef HAVE_MMAP */
+
+/* Define if mmap with MAP_ANON(YMOUS) works. */
+/* #undef HAVE_MMAP_ANON */
+
+/* Define if mmap of /dev/zero works. */
+/* #undef HAVE_MMAP_DEV_ZERO */
+
+/* Define if read-only mmap of a plain file works. */
+/* #undef HAVE_MMAP_FILE */
+
+/* Define if .eh_frame sections should be read-only. */
+/* #undef HAVE_RO_EH_FRAME */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #undef HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+/* #undef HAVE_SYS_MMAN_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #undef HAVE_UNISTD_H */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libffi"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://github.com/atgreen/libffi/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libffi"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libffi 3.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libffi"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "3.1"
+
+/* The size of `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of `long double', as computed by sizeof. */
+#define SIZEOF_LONG_DOUBLE 8
+
+/* The size of `size_t', as computed by sizeof. */
+#ifndef _WIN64
+#define SIZEOF_SIZE_T 4
+#else
+#define SIZEOF_SIZE_T 8
+#endif
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+/* #undef STACK_DIRECTION */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define if symbols are underscored. */
+#ifndef _WIN64
+#define SYMBOL_UNDERSCORE 1
+#endif
+
+/* Define this if you are using Purify and want to suppress spurious messages.
+   */
+/* #undef USING_PURIFY */
+
+/* Version number of package */
+#define VERSION "3.1"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+
+#ifdef HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name) .hidden name
+#else
+#define FFI_HIDDEN __attribute__ ((visibility ("hidden")))
+#endif
+#else
+#ifdef LIBFFI_ASM
+#define FFI_HIDDEN(name)
+#else
+#define FFI_HIDDEN
+#endif
+#endif
+

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -1,0 +1,38 @@
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL x86 AND NOT VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+    message(FATAL_ERROR "Architecture not supported")
+endif()
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libffi-3.1)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/libffi/libffi/archive/v3.1.zip"
+    FILENAME "libffi-3.1.zip"
+    SHA512 a5d4cc638262aecec29e70333119f561588a737fd8f353e18d9bf1bfa7b38eb6aba371778119ea8d35339b458815105d5b110063295b6588a8761b24dac77a7c)
+    
+vcpkg_extract_source_archive(${ARCHIVE})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/export-global-data.patch)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DFFI_CONFIG_FILE=${CMAKE_CURRENT_LIST_DIR}/fficonfig.h
+    OPTIONS_DEBUG
+        -DFFI_SKIP_HEADERS=ON)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/auto-define-static-macro.patch)
+endif()
+
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libffi)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libffi/LICENSE ${CURRENT_PACKAGES_DIR}/share/libffi/copyright)


### PR DESCRIPTION
[Foreign Function Interface library.](https://sourceware.org/libffi/)
Dependency for glib (#176).
Also could be useful for llvm (#508).

This adds version 3.1 because newer ones (3.2.*) fail to compile with vc++.