### PR TITLE
libssh2: added support for uwp builds

### DIFF
--- a/ports/libssh2/0001-Fix-UWP.patch
+++ b/ports/libssh2/0001-Fix-UWP.patch
@@ -1,0 +1,48 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 6401acf..64de3e9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -349,7 +349,7 @@ target_include_directories(libssh2 PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ # Check for the OS.
+ # Daniel's note: this should not be necessary and we need to work to
+ # get this removed.
+-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows" OR ${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+   target_compile_definitions(libssh2 PRIVATE LIBSSH2_WIN32)
+ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+   target_compile_definitions(libssh2 PRIVATE LIBSSH2_DARWIN)
+diff --git a/src/agent.c b/src/agent.c
+index c2ba422..f1799f8 100644
+--- a/src/agent.c
++++ b/src/agent.c
+@@ -51,6 +51,10 @@
+ #include "userauth.h"
+ #include "session.h"
+ 
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY != WINAPI_FAMILY_DESKTOP_APP)
++#define IS_UWP 1
++#endif  /* #if defined(WINAPI_FAMILY) */
++
+ /* Requests from client to agent for protocol 1 key operations */
+ #define SSH_AGENTC_REQUEST_RSA_IDENTITIES 1
+ #define SSH_AGENTC_RSA_CHALLENGE 3
+@@ -254,7 +258,7 @@ struct agent_ops agent_ops_unix = {
+ };
+ #endif  /* PF_UNIX */
+ 
+-#ifdef WIN32
++#if defined(WIN32) && !defined(IS_UWP)
+ /* Code to talk to Pageant was taken from PuTTY.
+  *
+  * Portions copyright Robert de Bath, Joris van Rantwijk, Delian
+@@ -362,8 +366,8 @@ static struct {
+     const char *name;
+     struct agent_ops *ops;
+ } supported_backends[] = {
+-#ifdef WIN32
+-    {"Pageant", &agent_ops_pageant},
++#if defined(WIN32) && !defined(IS_UWP)
++  {"Pageant", &agent_ops_pageant},
+ #endif  /* WIN32 */
+ #ifdef PF_UNIX
+     {"Unix", &agent_ops_unix},

--- a/ports/libssh2/portfile.cmake
+++ b/ports/libssh2/portfile.cmake
@@ -7,6 +7,10 @@ vcpkg_download_distfile(ARCHIVE_FILE
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-UWP.patch
+)
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS


### PR DESCRIPTION
This PR adds support for uwp builds. This PR depends on PR https://github.com/Microsoft/vcpkg/pull/524 to pass WACK testing. (openssl dlls were failing WACK)

This PR makes the following changes:

- A patch was added to remove the Win32 only code in agent.c when building uwp versions
- CMakeLists.txt was modified to correctly defined LIBSSH2_WIN32 for UWP builds.