### PR TITLE
Add proposed Boost.Outcome

### DIFF
--- a/ports/boost-outcome/CONTROL
+++ b/ports/boost-outcome/CONTROL
@@ -1,0 +1,3 @@
+Source: boost-outcome
+Version: 1.0
+Description: A very lightweight monadic outcome<T>, result<T> and option<T> suitable for low latency and exceptions disable usage.

--- a/ports/boost-outcome/portfile.cmake
+++ b/ports/boost-outcome/portfile.cmake
@@ -1,0 +1,25 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://dedi4.nedprod.com/static/files/boost.outcome-v1.0-source-latest.tar.xz"
+    FILENAME "boost.outcome-v1.0-source-latest.tar.xz"
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(INSTALL ${SOURCE_PATH}/include/boost DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# boost license does not exist in source folder.
+vcpkg_download_distfile(LICENSE
+	URLS http://www.boost.org/LICENSE_1_0.txt
+	FILENAME "boost-outcome-copyright"
+	SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
+)
+file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/boost-outcome/copyright)

--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -19,7 +19,7 @@ function(vcpkg_download_distfile VAR)
         message(STATUS "Testing integrity of ${FILE_KIND}... OK")
     endfunction()
 
-    if(EXISTS ${downloaded_file_path})
+    if(EXISTS ${downloaded_file_path} AND DEFINED vcpkg_download_distfile_SHA512)
         message(STATUS "Using cached ${downloaded_file_path}")
         test_hash("cached file" "Please delete the file and retry if this file should be downloaded again.")
     else()
@@ -44,7 +44,7 @@ function(vcpkg_download_distfile VAR)
             "\n"
             "    Failed to download file.\n"
             "    Add mirrors or submit an issue at https://github.com/Microsoft/vcpkg/issues\n")
-        else()
+        elseif(DEFINED vcpkg_download_distfile_SHA512)
             test_hash("downloaded file" "The file may be corrupted.")
         endif()
     endif()


### PR DESCRIPTION
Also if SHA512 is not specified to vcpkg_download_distfile(), always download the archive without caching. The reason Outcome needs this is because its tarball is refreshed by an automated bot which only does so when all CDash tests pass all green. In other words, there are no releases with Boost.Outcome, just the last release to pass all tests green on all platforms.