### PR TITLE
On release set HTTP_PARSER_STRICT to zero.

### DIFF
--- a/ports/http-parser/CMakeLists.txt
+++ b/ports/http-parser/CMakeLists.txt
@@ -5,13 +5,17 @@ if (BUILD_SHARED_LIBS)
   SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
+if(CMAKE_BUILD_TYPE MATCHES "Release")
+  add_definitions(-DHTTP_PARSER_STRICT=0)
+endif()
+
 add_library(http_parser http_parser.c http_parser.h)
 
 install(TARGETS http_parser
-    RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
 )
 
 if (NOT SKIP_INSTALL_HEADERS)
-    install(FILES http_parser.h DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
+  install(FILES http_parser.h DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
 endif()


### PR DESCRIPTION
This was done to match the http-parser makefile i.e. building in release mode strict parse is disabled (which is faster) else (in debug) strict parser is used.