### PR TITLE
[grpc] build statically

### DIFF
--- a/ports/grpc/CONTROL
+++ b/ports/grpc/CONTROL
@@ -1,4 +1,4 @@
 Source: grpc
-Version: 1.1.0-dev-1674f65
+Version: 1.1.0-dev-1674f65-1
 Build-Depends: zlib, openssl, protobuf
 Description: An RPC library and framework

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -1,6 +1,6 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 include(vcpkg_common_functions)
 find_program(GIT git)
@@ -55,7 +55,9 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/gRPC/gRPCTargets-debug.cmake
 file(INSTALL ${CURRENT_BUILDTREES_DIR}/src/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/grpc RENAME copyright)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
As grpc has problems with exporting symbols, it should be built statically.
Should fix #226, #444 and #535.