### PR TITLE
add cereal port

### DIFF
--- a/ports/cereal/CONTROL
+++ b/ports/cereal/CONTROL
@@ -1,0 +1,3 @@
+Source: cereal
+Version: 1.2.1
+Description: a header-only C++11 serialization library (built in support for binary, XML and JSon)

--- a/ports/cereal/portfile.cmake
+++ b/ports/cereal/portfile.cmake
@@ -1,0 +1,18 @@
+#header-only library
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cereal-1.2.1)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/USCiLab/cereal/archive/v1.2.1.tar.gz"
+    FILENAME "cereal-1.2.1.tar.gz"
+    SHA512 f0050f27433a4b544e7785aa94fc7b14a57eed6d542e25d3d0fda4d27cf55ea55e796be2138bf80809c96c392436513fe42764b3a456938395bf7f7177dd1c73
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cereal)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/cereal/LICENSE ${CURRENT_PACKAGES_DIR}/share/cereal/copyright)
+
+# Copy the cereal header files
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory 
+				${SOURCE_PATH}/include/cereal/
+                ${CURRENT_PACKAGES_DIR}/include/cereal)


### PR DESCRIPTION
Description from GitHub page:
cereal is a header-only C++11 serialization library. cereal takes arbitrary data types and reversibly turns them into different representations, such as compact binary encodings, XML, or JSON. cereal was designed to be fast, light-weight, and easy to extend - it has no external dependencies and can be easily bundled with other code or used standalone.

Website: http://uscilab.github.com/cereal
Git: https://github.com/USCiLab/cereal