### PR TITLE
Fix Boost dynamic build I recently broke.

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
-Version: 1.62-10
+Version: 1.62-11
 Description: Peer-reviewed portable C++ source libraries
 Build-Depends: zlib

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -113,6 +113,12 @@ file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
 	"\n#define BOOST_ALL_NO_LIB\n"
 )
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
+        "\n#define BOOST_ALL_DYN_LINK\n"
+    )
+endif()
+
 file(INSTALL ${SOURCE_PATH}/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/boost RENAME copyright)
 message(STATUS "Packaging headers done")
 


### PR DESCRIPTION
Some of the Boost libraries build differently depending on whether
BOOST_X_DYN_LINK is defined, so this symbol must be present in the
dynamic build, and removing it as part of disabling auto-link was wrong.

Reverts half of 5a3881a0.