### PR TITLE
Add OpenVR

### DIFF
--- a/ports/openvr/CONTROL
+++ b/ports/openvr/CONTROL
@@ -1,0 +1,3 @@
+Source: openvr
+Version: 1.0.5
+Description: an API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting.

--- a/ports/openvr/portfile.cmake
+++ b/ports/openvr/portfile.cmake
@@ -1,0 +1,54 @@
+# Common Ambient Variables:
+#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
+#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
+#   PORT is the current port name (zlib, etc)
+#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/openvr-1.0.5)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/ValveSoftware/openvr/archive/v1.0.5.zip"
+    FILENAME "openvr-v1.0.5.zip"
+    SHA512 18c2e3f7a8754d0e9389c953d0af70788c77adf43f51d25b6664beaeb407dc8d2daa755396c45ce2b4be1b08d333b378810dbebdf3c9bb5f5a03a9d372dc97b0
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(ARCH_PATH "win64")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(ARCH_PATH "win32")
+else()
+    message(FATAL_ERROR "Package only supports x64 and x86 windows.")
+endif()
+
+if(VCPKG_CMAKE_SYSTEM_NAME)
+    message(FATAL_ERROR "Package only supports windows desktop.")
+endif()
+
+file(MAKE_DIRECTORY
+    ${CURRENT_PACKAGES_DIR}/lib
+    ${CURRENT_PACKAGES_DIR}/bin
+    ${CURRENT_PACKAGES_DIR}/debug/lib
+    ${CURRENT_PACKAGES_DIR}/debug/bin
+)
+file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(COPY
+    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
+    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+)
+file(COPY
+    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
+    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+)
+file(COPY ${SOURCE_PATH}/headers DESTINATION ${CURRENT_PACKAGES_DIR})
+file(RENAME ${CURRENT_PACKAGES_DIR}/headers ${CURRENT_PACKAGES_DIR}/include)
+
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/openvr)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/openvr/LICENSE ${CURRENT_PACKAGES_DIR}/share/openvr/copyright)


### PR DESCRIPTION
This initial port uses the prebuilt binaries; there are sources available in the downloaded archive that could be used in the future for a source-based port that would enable static variants.