### PR TITLE
[boost] Add bzip2 support

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
 Version: 1.62-11
 Description: Peer-reviewed portable C++ source libraries
-Build-Depends: zlib
+Build-Depends: zlib, bzip2

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -31,9 +31,7 @@ endif()
 message(STATUS "Bootstrapping done")
 
 set(B2_OPTIONS
-    -sZLIB_BINARY=zlib
     -sZLIB_INCLUDE="${CURRENT_INSTALLED_DIR}\\include"
-    -sZLIB_LIBPATH="${CURRENT_INSTALLED_DIR}\\lib"
     -sNO_BZIP2=1
     -j$ENV{NUMBER_OF_PROCESSORS}
     --debug-configuration
@@ -65,12 +63,15 @@ if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
 endif()
 
 # Add build type specific options
-set(B2_OPTIONS_DBG
-	${B2_OPTIONS}
+set(B2_OPTIONS_DBG 
+    ${B2_OPTIONS}
+    -sZLIB_BINARY=zlibd
     -sZLIB_LIBPATH="${CURRENT_INSTALLED_DIR}\\debug\\lib"
 )
-set(B2_OPTIONS_REL
-	${B2_OPTIONS}
+
+set(B2_OPTIONS_REL 
+    ${B2_OPTIONS}
+    -sZLIB_BINARY=zlib
     -sZLIB_LIBPATH="${CURRENT_INSTALLED_DIR}\\lib"
 )
 

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -32,7 +32,7 @@ message(STATUS "Bootstrapping done")
 
 set(B2_OPTIONS
     -sZLIB_INCLUDE="${CURRENT_INSTALLED_DIR}\\include"
-    -sNO_BZIP2=1
+    -sBZIP2_INCLUDE="${CURRENT_INSTALLED_DIR}\\include"
     -j$ENV{NUMBER_OF_PROCESSORS}
     --debug-configuration
     --hash
@@ -67,12 +67,16 @@ set(B2_OPTIONS_DBG
     ${B2_OPTIONS}
     -sZLIB_BINARY=zlibd
     -sZLIB_LIBPATH="${CURRENT_INSTALLED_DIR}\\debug\\lib"
+    -sBZIP2_BINARY=bz2
+    -sBZIP2_LIBPATH="${CURRENT_INSTALLED_DIR}\\debug\\lib"
 )
 
 set(B2_OPTIONS_REL 
     ${B2_OPTIONS}
     -sZLIB_BINARY=zlib
     -sZLIB_LIBPATH="${CURRENT_INSTALLED_DIR}\\lib"
+    -sBZIP2_BINARY=bz2
+    -sBZIP2_LIBPATH="${CURRENT_INSTALLED_DIR}\\lib"
 )
 
 file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)


### PR DESCRIPTION
Enables support for bzip2 compression in boost using the recently added bzip2 port.