### PR TITLE
[cairo] update port

### DIFF
--- a/ports/cairo/CMakeLists_cairo.txt
+++ b/ports/cairo/CMakeLists_cairo.txt
@@ -101,6 +101,8 @@ file(GLOB SOURCES
 "cairo-tor-scan-converter.c"
 "cairo-tor22-scan-converter.c"
 "cairo-clip-tor-scan-converter.c"
+"cairo-tag-attributes.c"
+"cairo-tag-stack.c"
 "cairo-toy-font-face.c"
 "cairo-traps.c"
 "cairo-tristrip.c"
@@ -127,6 +129,7 @@ file(GLOB SOURCES
 "cairo-type1-subset.c"
 "cairo-type3-glyph-surface.c"
 # pdf
+"cairo-pdf-interchange.c"
 "cairo-pdf-operators.c"
 "cairo-pdf-shading.c"
 "cairo-pdf-surface.c"
@@ -140,6 +143,8 @@ file(GLOB SOURCES
 "cairo-svg-surface.c"
 # script surface
 "cairo-script-surface.c"
+# fontconfig + freetype
+"cairo-ft-font.c"
 )
 
 set(CMAKE_DEBUG_POSTFIX "d")
@@ -222,11 +227,36 @@ endif()
 add_library(user32 UNKNOWN IMPORTED)
 set_property(TARGET user32 PROPERTY IMPORTED_LOCATION "${USER32_LIBRARY}")
 
+# Find dependencies of optional modules
+
+# Find FreeType
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    set(FREETYPE_SUFFIX d)
+endif()
+find_library(FREETYPE_LIBRARY freetype${FREETYPE_SUFFIX})
+if (FREETYPE_LIBRARY MATCHES NOTFOUND)
+  message(FATAL_ERROR "The freetype library could not be found. Check to ensure that it is properly installed.")
+endif()
+
+# Cairo needs to be told which features of FreeType are availible
+add_definitions(
+    -DHAVE_FT_GLYPHSLOT_EMBOLDEN=1
+    -DHAVE_FT_LIBRARY_SETLCDFILTER=1
+    -DHAVE_FT_GLYPHSLOT_OBLIQUE=1
+    -DHAVE_FT_LOAD_SFNT_TABLE=1
+    -DHAVE_FT_GET_X11_FONT_FORMAT=1)
+
+# Find FontConfig
+find_library(FONTCONFIG_LIBRARY fontconfig)
+if (FONTCONFIG_LIBRARY MATCHES NOTFOUND)
+  message(FATAL_ERROR "The fontconfig library could not be found. Check to ensure that it is properly installed.")
+endif()
+
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
   add_library(cairo ${SOURCES})
   # cairo produces a lot of warnings which are disabled here because they otherwise fill up the log files
   target_compile_options(cairo PUBLIC "/wd4244" PUBLIC "/wd4146" PUBLIC "/wd4312" PUBLIC "/wd4267" PUBLIC "/wd4996" PUBLIC "/wd4311" PUBLIC "/wd4334" PUBLIC "/wd4101")
-  target_link_libraries(cairo gdi32 msimg32 user32 zlib libpng pixman)
+  target_link_libraries(cairo gdi32 msimg32 user32 zlib libpng pixman ${FREETYPE_LIBRARY} ${FONTCONFIG_LIBRARY})
 
   install(TARGETS cairo
     RUNTIME DESTINATION bin
@@ -238,7 +268,7 @@ elseif (VCPKG_LIBRARY_LINKAGE STREQUAL static)
   target_compile_options(cairo-static PUBLIC "/DCAIRO_WIN32_STATIC_BUILD=1")
   # cairo produces a lot of warnings which are disabled here because they otherwise fill up the log files
   target_compile_options(cairo-static PUBLIC "/wd4244" PUBLIC "/wd4146" PUBLIC "/wd4312" PUBLIC "/wd4267" PUBLIC "/wd4996" PUBLIC "/wd4311" PUBLIC "/wd4334" PUBLIC "/wd4101")
-  target_link_libraries(cairo-static gdi32 msimg32 user32 zlib libpng pixman)
+  target_link_libraries(cairo-static gdi32 msimg32 user32 zlib libpng pixman ${FREETYPE_LIBRARY} ${FONTCONFIG_LIBRARY})
 
   install(TARGETS cairo-static
     RUNTIME DESTINATION bin
@@ -248,3 +278,36 @@ elseif (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 else()
   message(FATAL_ERROR "VCPKG_LIBRARY_LINKAGE is not defined or has an unexpected value")
 endif()
+
+# GObject support module
+
+set(CAIRO_GOBJECT_SOURCES
+    "../util/cairo-gobject/cairo-gobject-enums.c"
+    "../util/cairo-gobject/cairo-gobject-structs.c")
+
+# GObject support sources do not include header with export macro
+if(BUILD_SHARED_LIBS)
+    set_source_files_properties(
+        "../util/cairo-gobject/cairo-gobject-enums.c"
+        "../util/cairo-gobject/cairo-gobject-structs.c"
+        PROPERTIES COMPILE_DEFINITIONS cairo_public=__declspec\(dllexport\))
+endif()
+
+# Make GLib's GObject available
+find_library(GLIB_LIBRARY NAMES glib-2.0)
+find_library(GOBJECT_LIBRARY NAMES gobject-2.0)
+set(GLIB_LIBRARIES ${GLIB_LIBRARY} ${GOBJECT_LIBRARY})
+if (GLIB_LIBRARIES MATCHES NOTFOUND)
+  message(FATAL_ERROR "The glib library could not be found. Check to ensure that it is properly installed.")
+endif()
+
+add_library(cairo-gobject ${CAIRO_GOBJECT_SOURCES})
+if(BUILD_SHARED_LIBS)   
+    target_link_libraries(cairo-gobject cairo ${GLIB_LIBRARIES})
+else()
+    target_link_libraries(cairo-gobject cairo-static ${GLIB_LIBRARIES})
+endif()
+install(TARGETS cairo-gobject
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)

--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,4 +1,4 @@
 Source: cairo
-Version: 1.14.6
+Version: 1.15.4
 Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
-Build-Depends: zlib, libpng, pixman
+Build-Depends: zlib, libpng, pixman, glib, freetype, fontconfig

--- a/ports/cairo/cairo-features.h
+++ b/ports/cairo/cairo-features.h
@@ -24,4 +24,13 @@
 #define CAIRO_HAS_OBSERVER_SURFACE 1
 #define CAIRO_HAS_USER_FONT 1
 
+/* Require GObject */
+#define CAIRO_HAS_GOBJECT_FUNCTIONS 1
+
+/* Require FreeType */
+#define CAIRO_HAS_FT_FONT 1
+
+/* Require FontConfig */
+#define CAIRO_HAS_FC_FONT 1
+
 #endif

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -7,11 +7,11 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cairo-1.14.6)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cairo-1.15.4)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.cairographics.org/releases/cairo-1.14.6.tar.xz"
-    FILENAME "cairo-1.14.6.tar.xz"
-    SHA512 e2aa17a33b95b68d407b53ac321cca15b0c148eb49b8639c75b2af1e75e7b417a2168ea978dabb8581b341f0f45dc042d3b1a56b01ab525b1984015f0865316b
+    URLS "http://cairographics.org/snapshots/cairo-1.15.4.tar.xz"
+    FILENAME "cairo-1.15.4.tar.xz"
+    SHA512 ac3e6879fcf0876bca9f801cdf9e970ef1822644228cdd21962d0bf5db5fc074973f4ae651eb9c76b44fffd405cf0a0c7cbb228dba96b835ea137a2740277ee9
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
@@ -43,6 +43,8 @@ file(COPY
 "${SOURCE_PATH}/src/cairo-svg.h"
 "${SOURCE_PATH}/cairo-version.h"
 "${SOURCE_PATH}/src/cairo-win32.h"
+"${SOURCE_PATH}/util/cairo-gobject/cairo-gobject.h"
+"${SOURCE_PATH}/src/cairo-ft.h"
 DESTINATION
 ${CURRENT_PACKAGES_DIR}/include
 )


### PR DESCRIPTION
1. Bump version to 15.4 (15.x branch is officially a "snapshot" branch but GTK+ won't build on Windows with 14.x series (see [here](https://github.com/GNOME/gtk/blob/master/configure.ac#L603))... msys2 also uses 15.4 by default)
2. Additional font support (fontconifg + freetype)
3. GObject support (required for GNOME libraries like pango)