### PR TITLE
[openssl] Update to 1.0.2k

### DIFF
--- a/ports/openssl/CMakeLists.txt
+++ b/ports/openssl/CMakeLists.txt
@@ -3,7 +3,7 @@ project(openssl NONE)
 
 include(vcpkg_execute_required_process)
 include(vcpkg_apply_patches)
-set(SOURCE_PATH ${CMAKE_CURRENT_BINARY_DIR}/openssl-1.0.2j)
+set(SOURCE_PATH ${CMAKE_CURRENT_BINARY_DIR}/openssl-${OPENSSL_VERSION})
 
 find_program(PERL perl)
 find_program(NMAKE nmake)

--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl
-Version: 1.0.2j-2
+Version: 1.0.2k-1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -4,7 +4,8 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 endif()
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/openssl-1.0.2j)
+set(OPENSSL_VERSION 1.0.2k)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/openssl-${OPENSSL_VERSION})
 vcpkg_find_acquire_program(PERL)
 find_program(NMAKE nmake)
 
@@ -12,9 +13,9 @@ get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 set(ENV{PATH} "${PERL_EXE_PATH};$ENV{PATH}")
 
 vcpkg_download_distfile(OPENSSL_SOURCE_ARCHIVE
-    URLS "https://www.openssl.org/source/openssl-1.0.2j.tar.gz"
-    FILENAME "openssl-1.0.2j.tar.gz"
-    SHA512 7d6ccae4aa3ccec3a5d128da29c68401cdb1210cba6d212d55235fc3bc63d7085e2f119e2bbee7ddff6b7b5eef07c6196156791724cd2caf313a4c2fef724edd
+    URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+    FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
+	SHA512 0d314b42352f4b1df2c40ca1094abc7e9ad684c5c35ea997efdd58204c70f22a1abcb17291820f0fff3769620a4e06906034203d31eb1a4d540df3e0db294016
 )
 
 file(COPY
@@ -34,7 +35,7 @@ vcpkg_configure_cmake(
         -DOPENSSL_SOURCE_ARCHIVE=${OPENSSL_SOURCE_ARCHIVE}
         -DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -DTRIPLET_SYSTEM_ARCH=${TRIPLET_SYSTEM_ARCH}
-        -DVERSION=1.0.2j
+        -DVERSION=${OPENSSL_VERSION}
         -DTARGET_TRIPLET=${TARGET_TRIPLET}
 )
 


### PR DESCRIPTION
Updates openssl to 1.0.2k.

Also split the version number out of various paths and file names to simplify future updates.

This PR is a quick fix to bring **the non-UWP** part of the vcpkg port up to date with the latest security fixes in OpenSSL. The integrated tests pass, but that is all I did to ensure it was good.