### PR TITLE
[bzip2] Fix UWP builds

### DIFF
--- a/ports/bzip2/CMakeLists.txt
+++ b/ports/bzip2/CMakeLists.txt
@@ -20,6 +20,12 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(libbz2 PRIVATE -DBZ_BUILD_DLL)
 endif()
 
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
 install(TARGETS libbz2
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib


### PR DESCRIPTION
UWP builds need the following preprocessor defines:

- _CRT_SECURE_NO_WARNINGS
- _CRT_SECURE_NO_DEPRECATE
- _CRT_NONSTDC_NO_DEPRECATE

 These defines simply remove warning in the x86 and x64 builds.