### PR TITLE
[libvorbis] Fix UWP builds

### DIFF
--- a/ports/libvorbis/0001-Add-vorbisenc.c-to-vorbis-library.patch
+++ b/ports/libvorbis/0001-Add-vorbisenc.c-to-vorbis-library.patch
@@ -1,17 +1,18 @@
-From 0046f290a31b603a4caa9b728b54447b95ee5aa1 Mon Sep 17 00:00:00 2001
-From: vlj <vljn.ovi@gmail.com>
-Date: Mon, 24 Oct 2016 23:59:55 +0200
-Subject: [PATCH] Add vorbisenc.c to vorbis library.
-
----
- lib/CMakeLists.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index a682ed4..2043294 100644
+index a682ed4..e273393 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -68,7 +68,7 @@ include_directories(.)
+@@ -61,6 +61,9 @@ if(MSVC)
+     list(APPEND VORBIS_SOURCES ../win32/vorbis.def)
+     list(APPEND VORBISENC_SOURCES ../win32/vorbisenc.def)
+     list(APPEND VORBISFILE_SOURCES ../win32/vorbisfile.def)
++    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
++    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
++    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+ endif()
+ 
+ include_directories(../include)
+@@ -68,7 +71,7 @@ include_directories(.)
  include_directories(${OGG_INCLUDE_DIRS})
  
  if (NOT BUILD_FRAMEWORK)
@@ -20,6 +21,3 @@ index a682ed4..2043294 100644
      add_library(vorbisenc ${VORBISENC_SOURCES})
      add_library(vorbisfile ${VORBISFILE_SOURCES})
  
--- 
-2.10.0.windows.1
-


### PR DESCRIPTION
This PR adds missing defines to build the UWP versions. The defines do not affect the windows builds as they will just remove warnings about deprecated functions.