### PR TITLE
[libvorbis] Fix UWP builds 

### DIFF
--- a/ports/libvorbis/0002-Allow-deprecated-functions.patch
+++ b/ports/libvorbis/0002-Allow-deprecated-functions.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 2043294..e273393 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -61,6 +61,9 @@ if(MSVC)
+     list(APPEND VORBIS_SOURCES ../win32/vorbis.def)
+     list(APPEND VORBISENC_SOURCES ../win32/vorbisenc.def)
+     list(APPEND VORBISFILE_SOURCES ../win32/vorbisfile.def)
++    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
++    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
++    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+ endif()
+ 
+ include_directories(../include)

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -35,7 +35,9 @@ if(NOT EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
     )
     message(STATUS "Patching")
     vcpkg_execute_required_process(
-        COMMAND ${GIT} apply ${CMAKE_CURRENT_LIST_DIR}/0001-Add-vorbisenc.c-to-vorbis-library.patch --ignore-whitespace --whitespace=fix
+        COMMAND ${GIT} apply ${CMAKE_CURRENT_LIST_DIR}/0001-Add-vorbisenc.c-to-vorbis-library.patch
+            ${CMAKE_CURRENT_LIST_DIR}/0002-Allow-deprecated-functions.patch 
+             --ignore-whitespace --whitespace=fix
         WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src
         LOGNAME patch
     )


### PR DESCRIPTION
This PR adds a patch to add missing defines to build the UWP versions. The defines do not affect the windows builds as they will just remove warnings about deprecated functions. However, with UWP builds, the deprecated functions caused build errors. The add defines permit the use of these deprecated functions.