### PR TITLE
Add a workaround for another BITS code path

### DIFF
--- a/scripts/findVisualStudioInstallationInstances.ps1
+++ b/scripts/findVisualStudioInstallationInstances.ps1
@@ -20,7 +20,21 @@ $downloadPath = "$downloadsDir\$downloadName"
 
 if (!(Test-Path $downloadPath))
 {
-    Start-BitsTransfer -Source $url -Destination $downloadPath #-ErrorAction SilentlyContinue
+    try {
+        Start-BitsTransfer -Source $url -Destination $downloadPath -ErrorAction Stop
+    }
+    catch [System.Exception] {
+        # If BITS fails for any reason, delete any potentially partially downloaded files and continue
+        if (Test-Path $downloadPath)
+        {
+            Remove-Item $downloadPath
+        }
+    }
+}
+if (!(Test-Path $downloadPath))
+{
+    Write-Host("Downloading $downloadName...")
+    (New-Object System.Net.WebClient).DownloadFile($url, $downloadPath)
 }
 
 $nugetOutput = & $nugetexe install Microsoft.VisualStudio.Setup.Configuration.Native -Pre -Source $downloadsDir -OutputDirectory $nugetPackageDir 2>&1


### PR DESCRIPTION
The fix from last week (ce9927f7327bc71ade246108a7d984deda6293fd) worked for downloading most dependencies, but there is still one BITS transfer code path, which this fix addresses.

I realize it may be better to factor this function out into a common .ps1 file, but I can't tell from the existing code whether that's really desired.