### PR TITLE
[aws-sdk-cpp] bump version to 1.0.61

### DIFF
--- a/ports/aws-sdk-cpp/CONTROL
+++ b/ports/aws-sdk-cpp/CONTROL
@@ -1,3 +1,3 @@
 Source: aws-sdk-cpp
-Version: 1.0.47
+Version: 1.0.61
 Description: AWS SDK for C++


### PR DESCRIPTION
I created a PR here: https://github.com/Microsoft/vcpkg/pull/631 but forgot to bump the aws-sdk-cpp version, I fixed it here.