### PR TITLE
Upgrade Bond to 5.2.0 & download pre-compiled gbc

### DIFF
--- a/ports/bond/0001_boost_static_libs.patch
+++ b/ports/bond/0001_boost_static_libs.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/Config.cmake b/cmake/Config.cmake
+index ed225d14..1573c915 100644
+--- a/cmake/Config.cmake
++++ b/cmake/Config.cmake
+@@ -19,7 +19,7 @@ if (MSVC)
+     # disable MSVC warnings
+     add_compile_options (/bigobj /FIbond/core/warning.h /W4 /WX)
+     add_definitions (-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
+-    set (Boost_USE_STATIC_LIBS ON)
++    set (Boost_USE_STATIC_LIBS OFF)
+ endif (MSVC)
+ 
+ if (WIN32)
+@@ -90,9 +90,6 @@ if (DEFINED ENV{APPVEYOR} AND ("$ENV{BOND_BUILD}" STREQUAL "C++"))
+     endif()
+ endif()
+ 
+-# disable Boost auto-linking
+-add_definitions (-DBOOST_ALL_NO_LIB)
+-
+ # VS2015U2 fixed a bug with atomics and emits a warning without this definition.
+ add_definitions (-D_ENABLE_ATOMIC_ALIGNMENT_FIX)
+ 

--- a/ports/bond/0002_omit_rapidjson.patch
+++ b/ports/bond/0002_omit_rapidjson.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d743da4..92f91103 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,7 +39,6 @@ install (DIRECTORY
+     cpp/inc/bond
+     cpp/generated/bond
+     python/inc/bond
+-    thirdparty/rapidjson/include/rapidjson
+     DESTINATION include
+     PATTERN *.cpp EXCLUDE)
+ 

--- a/ports/bond/0003_rename_gbc_during_install.patch
+++ b/ports/bond/0003_rename_gbc_during_install.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d743da4..72d62c5e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,7 +49,14 @@ install (EXPORT bond
+ 
+ # if BOND_GBC_PATH is set we must copy over that gbc to the install location
+ if (BOND_GBC_PATH)
+-    install (FILES
+-        ${BOND_GBC_PATH}
+-        DESTINATION bin)
++  if (WIN32)
++    set(INSTALLED_GBC_NAME gbc.exe)
++  else()
++    set(INSTALLED_GBC_NAME gbc)
++  endif()
++
++  install (
++    FILES ${BOND_GBC_PATH}
++    DESTINATION bin
++    RENAME ${INSTALLED_GBC_NAME})
+ endif()

--- a/ports/bond/CONTROL
+++ b/ports/bond/CONTROL
@@ -1,5 +1,5 @@
 Source: bond
 Maintainer: bond@microsoft.com
-Version: 5.0.0-4-g53ea136
+Version: 5.2.0
 Description: Bond is a cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data. Bond is broadly used at Microsoft in high scale services. <https://github.com/Microsoft/bond>
 Build-Depends: boost, rapidjson

--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -36,6 +36,9 @@ vcpkg_apply_patches(
     # Don't install rapidjson from the (empty) submodule. With vcpkg, we get
     # rapidjson from vcpkg
     ${CMAKE_CURRENT_LIST_DIR}/0002_omit_rapidjson.patch
+    # Temporary until this is committed upstream. See
+    # https://github.com/Microsoft/bond/pull/324 for details.
+    ${CMAKE_CURRENT_LIST_DIR}/0003_rename_gbc_during_install.patch
 )
 
 vcpkg_configure_cmake(
@@ -50,6 +53,9 @@ vcpkg_install_cmake()
 # Put the license file where vcpkg expects it
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/bond)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/bond/LICENSE ${CURRENT_PACKAGES_DIR}/share/bond/copyright)
+
+# Drop a copy of gbc in tools/ so that it can be used
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/gbc.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/)
 
 # vcpkg doesn't--as of version 0.0.30--like executables such as gbc.exe in
 # the output. Just delete the bin/ directories for now.

--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -5,13 +5,27 @@ endif()
 
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/bond-5.2.0)
+
 vcpkg_download_distfile(ARCHIVE
   URLS "https://github.com/Microsoft/bond/archive/5.2.0.zip"
   FILENAME "bond-5.2.0.zip"
   SHA512  bc533d9e7431d0690b555aa4a42ca947f8025fc388f698c40cfeacf4286892ac5fd86d93df187009d4791e3eae240eb60886947cfe600838c6058274eb4d625c
-  )
+)
+vcpkg_download_distfile(GBC_ARCHIVE
+  URLS "https://github.com/Microsoft/bond/releases/download/5.2.0/gbc-5.2.0-amd64.zip"
+  FILENAME "gbc-5.2.0-amd64.zip"
+  SHA512 9413c0035939788724e08ac858bfc3b2ccefbba74ed737b22eca35ec0da576aa2bf8403e606d2ac20b3fbc827933c289630266824613e04b1921b66fef00e132
+)
 
 vcpkg_extract_source_archive(${ARCHIVE})
+
+# Extract the precompiled gbc
+vcpkg_extract_source_archive(${GBC_ARCHIVE} ${CURRENT_BUILDTREES_DIR}/tools/)
+set(FETCHED_GBC_PATH ${CURRENT_BUILDTREES_DIR}/tools/gbc-5.2.0-amd64.exe)
+
+if (NOT EXISTS ${FETCHED_GBC_PATH})
+    message(FATAL_ERROR "Fetching GBC failed. Expected '${FETCHED_GBC_PATH}' to exists, but it doesn't.")
+endif()
 
 vcpkg_apply_patches(
   SOURCE_PATH ${SOURCE_PATH}
@@ -24,21 +38,11 @@ vcpkg_apply_patches(
     ${CMAKE_CURRENT_LIST_DIR}/0002_omit_rapidjson.patch
 )
 
-# To build Bond, you'll either need to have the Haskell toolchain installed
-# or set the environment variable BOND_GBC_PATH to point to a directory that
-# contains a pre-compiled version of gbc.exe.
-#
-# You can get a pre-compiled version of gbc from the Bond.Compiler NuGet
-# package <http://www.nuget.org/packages/Bond.Compiler/>.
-#
-# For instructions on installing the Haskell toolchain and getting it to
-# work with Bond, see the Bond README
-# <https://github.com/Microsoft/bond/blob/master/README.md#windows>
-
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   OPTIONS
     -DBOND_LIBRARIES_ONLY=TRUE
+    -DBOND_GBC_PATH=${FETCHED_GBC_PATH}
 )
 
 vcpkg_install_cmake()

--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -1,15 +1,28 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
 endif()
+
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/bond-53ea13692925bee4ba494ee9de3614f15c09d85d)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/bond-5.2.0)
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://github.com/Microsoft/bond/archive/53ea13692925bee4ba494ee9de3614f15c09d85d.zip"
-  FILENAME "bond-5.0.0-4-g53ea136.zip"
-  SHA512  fe39dc211f6b99cba3f2284d78a524305dfb8dcd1f597639c45625df369f96c3321cb6782fef9eb34d34fab69c8da9015024eee34be6d0a76d730729517183da
-)
+  URLS "https://github.com/Microsoft/bond/archive/5.2.0.zip"
+  FILENAME "bond-5.2.0.zip"
+  SHA512  bc533d9e7431d0690b555aa4a42ca947f8025fc388f698c40cfeacf4286892ac5fd86d93df187009d4791e3eae240eb60886947cfe600838c6058274eb4d625c
+  )
+
 vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+  SOURCE_PATH ${SOURCE_PATH}
+  PATCHES
+    # Change Boost_USE_STATIC_LIBS to be compatible with vcpkg's treatment
+    # of Boost
+    ${CMAKE_CURRENT_LIST_DIR}/0001_boost_static_libs.patch
+    # Don't install rapidjson from the (empty) submodule. With vcpkg, we get
+    # rapidjson from vcpkg
+    ${CMAKE_CURRENT_LIST_DIR}/0002_omit_rapidjson.patch
+)
 
 # To build Bond, you'll either need to have the Haskell toolchain installed
 # or set the environment variable BOND_GBC_PATH to point to a directory that
@@ -35,10 +48,10 @@ file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/bond)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/bond/LICENSE ${CURRENT_PACKAGES_DIR}/share/bond/copyright)
 
 # vcpkg doesn't--as of version 0.0.30--like executables such as gbc.exe in
-# the output. Just delete it for now.
-file(REMOVE
-  ${CURRENT_PACKAGES_DIR}/bin/gbc.exe
-  ${CURRENT_PACKAGES_DIR}/debug/bin/gbc.exe)
+# the output. Just delete the bin/ directories for now.
+file(REMOVE_RECURSE
+  ${CURRENT_PACKAGES_DIR}/bin/
+  ${CURRENT_PACKAGES_DIR}/debug/bin/)
 
 # There's no way to supress installation of the headers in the debug build,
 # so we just delete them.


### PR DESCRIPTION
* Upgrade Bond to 5.2.0, the release from February 7, 2017
    * This also switched Bond over to always build as a set of static libs, as Bond's CMake definition doesn't currently support building DLLs for Bond itself.
* Change the port to download the Bond codegen tool, `gbc`, itself instead of requiring that the consumer of the port do this themselves and set a magic environment variable (or have the Haskell toolchain installed)