### PR TITLE
Allow to use git.cmd in addition to git.exe

### DIFF
--- a/scripts/cmake/vcpkg_apply_patches.cmake
+++ b/scripts/cmake/vcpkg_apply_patches.cmake
@@ -22,7 +22,7 @@
 function(vcpkg_apply_patches)
     cmake_parse_arguments(_ap "QUIET" "SOURCE_PATH" "PATCHES" ${ARGN})
 
-    find_program(GIT git)
+    find_program(GIT NAMES git git.cmd)
     set(PATCHNUM 0)
     foreach(PATCH ${_ap_PATCHES})
         message(STATUS "Applying patch ${PATCH}")


### PR DESCRIPTION
In respect of #682 and https://cmake.org/Bug/bug_relationship_graph.php?bug_id=9879.