### PR TITLE
Add proxy credential support

### DIFF
--- a/scripts/fetchDependency.ps1
+++ b/scripts/fetchDependency.ps1
@@ -81,6 +81,14 @@ function SelectProgram([Parameter(Mandatory=$true)][string]$Dependency)
         if ($Dependency -ne "git") # git fails with BITS
         {
             try {
+                $WC = New-Object System.Net.WebClient
+                $ProxyAuth = !$WC.Proxy.IsBypassed($url)
+                If($ProxyAuth){
+                    $ProxyCred = Get-Credential -Message "Enter credentials for Proxy Authentication"
+                    $PSDefaultParameterValues.Add("Start-BitsTransfer:ProxyAuthentication","Basic")
+                    $PSDefaultParameterValues.Add("Start-BitsTransfer:ProxyCredential",$ProxyCred)
+                }
+
                 Start-BitsTransfer -Source $url -Destination $downloadPath -ErrorAction Stop
             }
             catch [System.Exception] {


### PR DESCRIPTION
Problem: BITS wouldn't download anything from behind a typical corporate proxy

Solution: Check the URL availability and ask for proxy credentials if required.