### PR TITLE
added -DFLAC__NO_ASM for non-arm architectures

### DIFF
--- a/ports/libflac/CMakeLists.txt
+++ b/ports/libflac/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/libFLAC/include)
 if(NOT LIBFLAC_ARCHITECTURE MATCHES arm)
     add_definitions(-DFLAC__SSE_OS)
     add_definitions(-DFLAC__HAS_X86INTRIN)
+    add_definitions(-DFLAC__NO_ASM)
 endif()
 
 if(LIBFLAC_ARCHITECTURE MATCHES x86)


### PR DESCRIPTION
This fixes #752.

I am not sure if this is the best solution though.
I had a look at the cpu.c and it seems, that the asm is not really necessary when X86INTRIN is available.
So for me this works.