### PR TITLE
[dlib] Update to 19.4 and fixed error in Debug mode

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,3 +1,3 @@
 Source: dlib
-Version: 19.2
+Version: 19.4
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -7,20 +7,19 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/dlib-19.2)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/dlib-19.4)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://dlib.net/files/dlib-19.2.tar.bz2"
-    FILENAME "dlib-19.2.tar.bz2"
-    SHA512 dcef5c8be52fe2650c1eccac6c7ac4050075dc07ee504a8bf3df6c9a597da5fdc09506e631abfa979d71c74940ce39ec5267be4c3a676a01ac66fcb14cbfe854
+    URLS "http://dlib.net/files/dlib-19.4.tar.bz2"
+    FILENAME "dlib-19.4.tar.bz2"
+    SHA512 c5ae22c507b57a13d880d79e9671730829114d0276508b0a41b373d3abae9057d960fce84fafe1be468d943910853baaa70c88f2516e20a0c41f3895bf217f7b
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
+    PREFER_NINJA
+	OPTIONS_DEBUG
+        -DLIB_ENALE_ASSERTS=ON
 )
 
 vcpkg_install_cmake()
@@ -29,12 +28,12 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/test)
-
 # Remove other files not required in package
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/all)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/test)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/travis)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/cmake_utils)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/external/libpng/arm)
 


### PR DESCRIPTION
Configure Cmake in Debug mode 

> DLIB_ENALE_ASSERTS=ON  

for fix error

> error LNK2001: unresolved external symbol USER_ERROR__missing_dlib_all_source_cpp_file__OR__inconsistent_use_of_DEBUG_or_ENABLE_ASSERTS_preprocessor_directives

Sorry, I am weak in English.