### PR TITLE
Fix build of opencv for uwp #562

### DIFF
--- a/ports/opencv/001-fix-uwp.patch
+++ b/ports/opencv/001-fix-uwp.patch
@@ -1,0 +1,57 @@
+diff --git a/cmake/OpenCVCompilerOptions.cmake b/cmake/OpenCVCompilerOptions.cmake
+index 0dcf7ed..c722a03 100644
+--- "a/cmake/OpenCVCompilerOptions.cmake"
++++ "b/cmake/OpenCVCompilerOptions.cmake"
+@@ -21,6 +21,9 @@ if(MSVC)
+     string(REPLACE "/EHsc" "/EHa" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}"  CACHE STRING "Flags used by the compiler during all build types." FORCE)
+   endif()
++  if(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
++	 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
++  endif()
+ endif()
+ 
+ set(OPENCV_EXTRA_FLAGS "")
+ diff --git "a/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp" "b/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp"
+index f4147f3..498f414 100644
+--- "a/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp"
++++ "b/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp"
+@@ -24,6 +24,8 @@
+ // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ // POSSIBILITY OF SUCH DAMAGE.
+ 
++#include "opencv2/core/cvdef.h"
++
+ using namespace Windows::UI::Xaml::Controls;
+ 
+ namespace cv
+diff --git "a/modules/highgui/src/window_winrt_bridge.hpp" "b/modules/highgui/src/window_winrt_bridge.hpp"
+index 25f4aef..5429f0b 100644
+--- "a/modules/highgui/src/window_winrt_bridge.hpp"
++++ "b/modules/highgui/src/window_winrt_bridge.hpp"
+@@ -28,6 +28,7 @@
+ 
+ #include <map>
+ #include <opencv2\core.hpp>
++#include "opencv2/highgui/highgui_c.h"
+ 
+ using namespace Windows::UI::Xaml::Controls;
+ 
+diff --git "a/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp" "b/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp"
+index 236e227..9f5970e 100644
+--- "a/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp"
++++ "b/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp"
+@@ -94,10 +94,10 @@ Media::CaptureFrameGrabber::~CaptureFrameGrabber()
+ 
+ void Media::CaptureFrameGrabber::ShowCameraSettings()
+ {
+-#if WINAPI_FAMILY!=WINAPI_FAMILY_PHONE_APP
++#if (WINAPI_FAMILY!=WINAPI_FAMILY_PHONE_APP) && (WINAPI_FAMILY!=WINAPI_FAMILY_APP)
+     if (_state == State::Started)
+     {
+-        CameraOptionsUI::Show(_capture.Get());
++        CameraOptionsUI::Show(_capture.Get()); // TODO: Turn it back by adding reference to UWP Desktop Extensions
+     }
+ #endif
+ }
+ 

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES "${CMAKE_CURRENT_LIST_DIR}/opencv-installation-options.patch"
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/001-fix-uwp.patch"
 )
 file(REMOVE_RECURSE ${SOURCE_PATH}/3rdparty/libjpeg ${SOURCE_PATH}/3rdparty/libpng ${SOURCE_PATH}/3rdparty/zlib ${SOURCE_PATH}/3rdparty/libtiff)
 


### PR DESCRIPTION
CameraOptionsUI disabled at all. Separate issue to add reference to "Windows Desktop Extensions for the UWP" is needed to get it working