### PR TITLE
[atk] update to 2.24.0

### DIFF
--- a/ports/atk/CMakeLists.txt
+++ b/ports/atk/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(atk)
+project(atk C)
 
 set(ATK_LIB_SUFFIX 1.0)
 set(ATK_DLL_SUFFIX 1)

--- a/ports/atk/CONTROL
+++ b/ports/atk/CONTROL
@@ -1,4 +1,4 @@
 Source: atk
-Version: 2.22.0
+Version: 2.24.0
 Description: GNOME Accessibility Toolkit
 Build-Depends: glib, gettext

--- a/ports/atk/fix-encoding.patch
+++ b/ports/atk/fix-encoding.patch
@@ -1,0 +1,13 @@
+diff --git a/atkversion.h b/atkversion.h
+index 2634b0a..c57db2c 100644
+--- a/atkversion.h
++++ b/atkversion.h
+@@ -3,7 +3,7 @@
+  * Copyright (C) 2012 Igalia, S.L.
+  * Copyright (C) 2014 Chun-wei Fan
+  *
+- * Author: Alejandro Piñeiro Iglesias <apinheiro@igalia.com>
++ * Author: Alejandro PiÃ±eiro Iglesias <apinheiro@igalia.com>
+  *
+  * This library is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU Library General Public

--- a/ports/atk/portfile.cmake
+++ b/ports/atk/portfile.cmake
@@ -5,17 +5,23 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/atk-2.22.0)
+set(ATK_VERSION 2.24.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/atk-${ATK_VERSION})
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://ftp.gnome.org/pub/GNOME/sources/atk/2.22/atk-2.22.0.tar.xz"
-    FILENAME "atk-2.22.0.tar.xz"
-    SHA512 af3f6197eb97de869ee706f19564449b02c1444c413e5418323e4bf4c8cf1d98c7c8baa25189f6879d63606d4bc75f33799cb901f4697c087e868bb9a5643cba
-)
+    URLS "http://ftp.gnome.org/pub/GNOME/sources/atk/2.24/atk-${ATK_VERSION}.tar.xz"
+    FILENAME "atk-${ATK_VERSION}.tar.xz"
+    SHA512 3ae0a4d5f28d5619d465135c685161f690732053bcb70a47669c951fbf389b5d2ccc5c7c73d4ee8c5a3b2df14e2f5b082e812a215f10a79b27b412d077f5e962)
+
 vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}/atk
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/fix-encoding.patch)
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
     OPTIONS
         -DCMAKE_PROGRAM_PATH=${CURRENT_INSTALLED_DIR}/tools/glib
     OPTIONS_DEBUG


### PR DESCRIPTION
Also fix non-Unicode character to avoid warnings when compiling with `/utf-8` (this patch may look confusing in GitHub's UI, but in pracitice it just replaces `Windows-1252 `encoded `ñ` with UTF-8 encoded `ñ`).