### PR TITLE
Apply patch to make boost::thread on_tls_callback work with VS2017

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
-Version: 1.63-2
+Version: 1.63-3
 Description: Peer-reviewed portable C++ source libraries
 Build-Depends: zlib, bzip2

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -14,6 +14,14 @@ vcpkg_download_distfile(DIFF
     FILENAME "boost-range-has_range_iterator-hotfix_e7ebe14707130cda7b72e0ae5e93b17157fdb6a2.diff"
     SHA512 77dad42bfd9bbab2bbddf361d5b7ad3dd6f812f4294c6dd1a677bb4d0191a4fff43bca32fdd4fce05d428562abb6e38afd0fd33ca6a8b5f28481d70cd2f3dd67
 )
+
+# apply boost TLS fix for VS2017
+vcpkg_download_distfile(DIFF
+    URLS "https://github.com/boostorg/thread/commit/bd0379af57fa294df310221492da618844182658.diff"
+    FILENAME "boost-thread-on_tls_callback-bd0379af57fa294df310221492da618844182658.diff"
+    SHA512 29501de9da5d101c762c9617eb74f072ec47eb9ef0021f036545bc883cbeb09c24b2ba7f78c24fb1a5d6b1fb3d7ae1def05a75be8634fc32bde0dface571c0a8
+)
+
 FILE(READ "${DIFF}" content)
 STRING(REGEX REPLACE "include/" "" content "${content}")
 set(DIFF2 ${CURRENT_BUILDTREES_DIR}/src/boost-range-has_range_iterator-hotfix_e7ebe14707130cda7b72e0ae5e93b17157fdb6a2.diff.fixed)

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_download_distfile(DIFF
 )
 
 # apply boost TLS fix for VS2017
-vcpkg_download_distfile(DIFF
+vcpkg_download_distfile(TLS_DIFF
     URLS "https://github.com/boostorg/thread/commit/bd0379af57fa294df310221492da618844182658.diff"
     FILENAME "boost-thread-on_tls_callback-bd0379af57fa294df310221492da618844182658.diff"
     SHA512 29501de9da5d101c762c9617eb74f072ec47eb9ef0021f036545bc883cbeb09c24b2ba7f78c24fb1a5d6b1fb3d7ae1def05a75be8634fc32bde0dface571c0a8
@@ -27,6 +27,11 @@ STRING(REGEX REPLACE "include/" "" content "${content}")
 set(DIFF2 ${CURRENT_BUILDTREES_DIR}/src/boost-range-has_range_iterator-hotfix_e7ebe14707130cda7b72e0ae5e93b17157fdb6a2.diff.fixed)
 FILE(WRITE ${DIFF2} "${content}")
 vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES ${DIFF2})
+
+FILE(READ "${TLS_DIFF}" content)
+set(TLS_DIFF2 ${CURRENT_BUILDTREES_DIR}/src/boost-thread-on_tls_callback-bd0379af57fa294df310221492da618844182658.diff)
+FILE(WRITE ${TLS_DIFF2} "${content}")
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES ${TLS_DIFF2})
 
 if(NOT EXISTS ${SOURCE_PATH}/b2.exe)
     message(STATUS "Bootstrapping")

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -29,7 +29,8 @@ FILE(WRITE ${DIFF2} "${content}")
 vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES ${DIFF2})
 
 FILE(READ "${TLS_DIFF}" content)
-set(TLS_DIFF2 ${CURRENT_BUILDTREES_DIR}/src/boost-thread-on_tls_callback-bd0379af57fa294df310221492da618844182658.diff)
+STRING(REGEX REPLACE "src/win32/" "libs/thread/src/win32/" content "${content}")
+set(TLS_DIFF2 ${CURRENT_BUILDTREES_DIR}/src/boost-thread-on_tls_callback-bd0379af57fa294df310221492da618844182658.diff.fixed)
 FILE(WRITE ${TLS_DIFF2} "${content}")
 vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES ${TLS_DIFF2})
 


### PR DESCRIPTION
Boost 1.63.0 has a bug when using the VS2017 toolchain that causes a wrong TLS function signature to be used. The result is that when statically linking Boost the application can't initialize correctly because instead of an int a void is being returned. It has been fixed in the current development version of boost, but until a new release, this continues to be an issue.

Original discussion can be found here:
https://github.com/boostorg/thread/pull/114