### PR TITLE
Update Catch to 1.8.2

### DIFF
--- a/ports/catch/CONTROL
+++ b/ports/catch/CONTROL
@@ -1,3 +1,3 @@
 Source: catch
-Version: 1.8.1
-Description: C++ Automated Test Cases in Headers 
+Version: 1.8.2
+Description: C++ Automated Test Cases in Headers

--- a/ports/catch/portfile.cmake
+++ b/ports/catch/portfile.cmake
@@ -10,14 +10,14 @@
 include(vcpkg_common_functions)
 
 vcpkg_download_distfile(HEADER
-    URLS "https://github.com/philsquared/Catch/releases/download/v1.8.1/catch.hpp"
+    URLS "https://github.com/philsquared/Catch/releases/download/v1.8.2/catch.hpp"
     FILENAME "catch.hpp"
-    SHA512 942acee9ac54d170a79f4624ce62bc5d9327a863f5565352eb71f2c028d35c2042bf0416530cb8288b27ed78a46d0d02dfaba47e1d79ae9b394943771543ea3f
+    SHA512 17ef87db95cc2f5097c46223df6832f7eaad8178266bb10532d0cc73f8ec96c61e96a21e8ace3df743830c9d06d10da2b67563435d69d211c1d5cc6980aecf67
 )
 
 vcpkg_download_distfile(LICENSE
-    URLS "https://raw.githubusercontent.com/philsquared/Catch/e27c4ee04282f60aefcc9b1062a74f92cf6c1a2b/LICENSE_1_0.txt"
-    FILENAME "License_1_0.txt"
+    URLS "https://raw.githubusercontent.com/philsquared/Catch/v1.8.2/LICENSE_1_0.txt"
+    FILENAME "LICENSE_1_0.txt"
     SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
 )
 


### PR DESCRIPTION
I also changed the licence link to respect release version.