### PR TITLE
pybind11 port

### DIFF
--- a/ports/pybind11/CONTROL
+++ b/ports/pybind11/CONTROL
@@ -1,3 +1,3 @@
 Source: pybind11
-Version: 2.0.1
+Version: 2.1.0
 Description: pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.

--- a/ports/pybind11/CONTROL
+++ b/ports/pybind11/CONTROL
@@ -1,0 +1,3 @@
+Source: pybind11
+Version: 2.0.1
+Description: pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -3,9 +3,9 @@ include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pybind11-2.0.1)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/pybind/pybind11/archive/v2.0.1.tar.gz"
-    FILENAME "pybind11-2.0.1.tar.gz"
-    SHA512 c156d01321b79eaac7992f431b30a9f4fb06e92909bf02e76a45e2d9329e7949dad686ee42a49c293214aec2a79eb400fa3373d2ba4876271895822096b50ff4
+    URLS "https://github.com/pybind/pybind11/archive/v2.1.0.tar.gz"
+    FILENAME "pybind11-2.1.0.tar.gz"
+    SHA512 2f74dcd2b82d8e41da7db36351284fe04511038bec66bdde820da9c0fce92f6d2c5aeb2e48264058a91a775a1a6a99bc757d26ebf001de3df4183d700d46efa1
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -1,0 +1,45 @@
+include(vcpkg_common_functions)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pybind11-2.0.1)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/pybind/pybind11/archive/v2.0.1.tar.gz"
+    FILENAME "pybind11-2.0.1.tar.gz"
+    SHA512 c156d01321b79eaac7992f431b30a9f4fb06e92909bf02e76a45e2d9329e7949dad686ee42a49c293214aec2a79eb400fa3373d2ba4876271895822096b50ff4
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+# link the MSVC runtime statically if set.
+if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+    set(CRUNTIME /MD)
+else()
+    set(CRUNTIME /MT)
+endif()
+
+#STREQUAL empty here means the enviroment variable is not defined.
+if(NOT $ENV{PYTHON} STREQUAL "")
+    set(PYTHON_VER $ENV{PYTHON})
+else()
+    message(FATAL_ERROR "You must set the PYTHON environment variable, eg. set PYTHON=3.5 or export PYTHON=3.5")
+endif()
+
+if(NOT $ENV{CPP} STREQUAL "")
+    set(CPP_STD $ENV{CPP})
+else()
+    message(FATAL_ERROR "You must set the CPP environment variable, eg. set CPP=11 or export CPP=11.")
+endif()
+message(STATUS "Using C++${CPP_STD} and Python ${PYTHON_VER}")
+vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+            -DPYBIND11_PYTHON_VERSION=${PYTHON_VER}
+            -DPYBIND11_CPP_STANDARD=${CPP_STD}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/)
+
+
+# copy license
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pybind11/copyright)

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pybind11-2.0.1)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pybind11-2.1.0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/pybind/pybind11/archive/v2.1.0.tar.gz"

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -16,24 +16,9 @@ else()
     set(CRUNTIME /MT)
 endif()
 
-#STREQUAL empty here means the enviroment variable is not defined.
-if(NOT $ENV{PYTHON} STREQUAL "")
-    set(PYTHON_VER $ENV{PYTHON})
-else()
-    message(FATAL_ERROR "You must set the PYTHON environment variable, eg. set PYTHON=3.5 or export PYTHON=3.5")
-endif()
-
-if(NOT $ENV{CPP} STREQUAL "")
-    set(CPP_STD $ENV{CPP})
-else()
-    message(FATAL_ERROR "You must set the CPP environment variable, eg. set CPP=11 or export CPP=11.")
-endif()
-message(STATUS "Using C++${CPP_STD} and Python ${PYTHON_VER}")
 vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
-            -DPYBIND11_PYTHON_VERSION=${PYTHON_VER}
-            -DPYBIND11_CPP_STANDARD=${CPP_STD}
 )
 
 vcpkg_install_cmake()

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -9,22 +9,14 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-# link the MSVC runtime statically if set.
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(CRUNTIME /MD)
-else()
-    set(CRUNTIME /MT)
-endif()
-
 vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
-        OPTIONS
+        OPTIONS -DPYBIND11_TEST=OFF
 )
 
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/)
-
 
 # copy license
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pybind11/copyright)


### PR DESCRIPTION
pybind11 is a header-only library that makes wrapping C++ code for Python much easier. Here is my initial attempt at a wrapper.

 As a bit of feedback about vcpkg, some of the error messages can be a bit misleading. It seems the /debug folder should be empty after installation. When I ran my initial portfile, I got:
```
Include files should not be duplicated into the /debug/include directory. If this cannot be disabled in the project cmake, use
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
```

So I put that in my portfile. Then it complained `No files should be present in /debug/share`. However, it seems that calling `file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share` is also not acceptable, as there cannot be empty directories, so the real issue is that /debug/share should not exist. Just something I ran into that tripped me up when writing the portfile. 

Anyway, feedback on the portfile welcome. 