### PR TITLE
[opencv] adds opencv_contrib option

### DIFF
--- a/ports/opencv/open_contrib-remove-waldboost.patch
+++ b/ports/opencv/open_contrib-remove-waldboost.patch
@@ -1,0 +1,22 @@
+From 1721a0f7ff75176e9a9f0e04dc11f1a5d5c0f550 Mon Sep 17 00:00:00 2001
+From: Tobias Kohlbau <tobias.kohlbau@etit.tu-chemnitz.de>
+Date: Mon, 27 Mar 2017 14:53:47 +0200
+Subject: [PATCH] removes waldboost_detector binary
+
+---
+ modules/xobjdetect/CMakeLists.txt | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/modules/xobjdetect/CMakeLists.txt b/modules/xobjdetect/CMakeLists.txt
+index 567909b..2f30b41 100644
+--- a/modules/xobjdetect/CMakeLists.txt
++++ b/modules/xobjdetect/CMakeLists.txt
+@@ -1,5 +1,2 @@
+ set(the_description "Object detection algorithms")
+ ocv_define_module(xobjdetect opencv_core opencv_imgproc opencv_highgui opencv_objdetect WRAP python)
+-if (NOT APPLE_FRAMEWORK)
+-    add_subdirectory(tools)
+-endif()
+-- 
+2.12.0.windows.1
+

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -17,6 +17,20 @@ vcpkg_apply_patches(
 )
 file(REMOVE_RECURSE ${SOURCE_PATH}/3rdparty/libjpeg ${SOURCE_PATH}/3rdparty/libpng ${SOURCE_PATH}/3rdparty/zlib ${SOURCE_PATH}/3rdparty/libtiff)
 
+# Uncomment the following lines and the lines under OPTIONS to build opencv_contrib
+# Important: after uncommenting you've add protobuf dependency within CONTROL file
+#SET(CONTRIB_SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/opencv_contrib-3.2.0)
+#vcpkg_download_distfile(CONTRIB_ARCHIVE
+#    URLS "https://github.com/opencv/opencv_contrib/archive/3.2.0.zip"
+#    FILENAME "opencv_contrib-3.2.0.zip"
+#    SHA512 da6cda7a7ae1d722967e18f9b8d60895b93bbc3664dfdb1645cb4d8b337a9c4207b9073fd546a596c48a489f92d15191aa34c7c607167b536fbe4937b8424b43
+#)
+#vcpkg_extract_source_archive(${CONTRIB_ARCHIVE})
+#vcpkg_apply_patches(
+#    SOURCE_PATH ${CONTRIB_SOURCE_PATH}
+#    PATCHES "${CMAKE_CURRENT_LIST_DIR}/open_contrib-remove-waldboost.patch"
+#)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -40,6 +54,9 @@ vcpkg_configure_cmake(
         -DOPENCV_OTHER_INSTALL_PATH=share/opencv
         -DINSTALL_LICENSE=OFF
         -DWITH_CUDA=OFF
+        #-DOPENCV_EXTRA_MODULES_PATH=${CONTRIB_SOURCE_PATH}/modules # uncomment the following 3 lines to build opencv_contrib modules
+        #-DBUILD_PROTOBUF=OFF
+        #-DUPDATE_PROTO_FILES=ON
     OPTIONS_DEBUG
         -DINSTALL_HEADERS=OFF
         -DINSTALL_OTHER=OFF
@@ -55,4 +72,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/opencv)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/opencv/LICENSE ${CURRENT_PACKAGES_DIR}/share/opencv/copyright)
+
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Adds the ability to enable opencv_contrib compilation. It is disabled by
default and needs to be enabled by the user (see comments for more
information). In future release it should be an user
selectable option as soon as vcpk supports this functionality.

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>