### PR TITLE
[qt5] Configure without -no-style-* parameters

### DIFF
--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -67,9 +67,6 @@ vcpkg_execute_required_process(
         -no-iconv
         -system-sqlite
         -opengl desktop # other options are "-no-opengl" and "-opengl angle"
-        -no-style-windowsxp
-        -no-style-windowsvista
-        -no-style-fusion
         -mp
         -nomake examples -nomake tests -no-compile-examples
         -skip webengine -skip declarative


### PR DESCRIPTION
Removed the parameters for Windows styles because they prevent proper style rendering (defaults to Windows 9x style). Please see issue #856.

Removed the parameter for the fusion style for consistency.

I am not entirely confident about these changes, both because I have only tested removal of all parameters at the same time on Windows 10, and because there must have been some reasons for disabling the styles in the first place.