### PR TITLE
adds line comments for CONTROL

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,4 +1,5 @@
 Source: opencv
 Version: 3.2.0
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff
+#Build-Depends: zlib, libpng, libjpeg-turbo, tiff, protobuf
 Description: computer vision library

--- a/toolsrc/src/tests_paragraph.cpp
+++ b/toolsrc/src/tests_paragraph.cpp
@@ -267,6 +267,28 @@ namespace UnitTest1
             Assert::AreEqual("v4", pghs[1]["f4"].c_str());
         }
 
+		TEST_METHOD(parse_paragraphs_comment)
+		{
+			const char* str =
+				"f1: v1\r\n"
+				"#comment\r\n"
+				"f2: v2\r\n"
+				"#comment\r\n"
+				"\r\n"
+				"#comment\r\n"
+				"f3: v3\r\n"
+				"#comment\r\n"
+				"f4: v4";
+			auto pghs = vcpkg::Paragraphs::parse_paragraphs(str).get_or_exit(VCPKG_LINE_INFO);
+			Assert::AreEqual(size_t(2), pghs.size());
+			Assert::AreEqual(size_t(2), pghs[0].size());
+			Assert::AreEqual("v1", pghs[0]["f1"].c_str());
+			Assert::AreEqual("v2", pghs[0]["f2"].c_str());
+			Assert::AreEqual(size_t(2), pghs[1].size());
+			Assert::AreEqual("v3", pghs[1]["f3"].c_str());
+			Assert::AreEqual("v4", pghs[1]["f4"].c_str());
+		}
+
         TEST_METHOD(BinaryParagraph_serialize_min)
         {
             std::stringstream ss;


### PR DESCRIPTION
Adds line comments denoted by # within CONTROL files. For the moment a comment must be start with # and is valid until the end of the line. For the moment it's not possible to add a comment like this: 
```Version: 1.0 # here goes some comment```

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>