### PR TITLE
Libgd cmake targets

### DIFF
--- a/ports/libgd/0002-export-cmake-targets.patch
+++ b/ports/libgd/0002-export-cmake-targets.patch
@@ -1,0 +1,29 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 497dd93..0ea1bb0 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -76,7 +76,7 @@ if(MSVC AND MSVC_VERSION LESS 1900)
+ endif(MSVC AND MSVC_VERSION LESS 1900)
+ 
+ include(GNUInstallDirs)
+-
++set(GD_CONFIG libgd-config)
+ if (BUILD_SHARED_LIBS)
+ 	add_library(${GD_LIB} ${LIBGD_SRC_FILES})
+ 	set_target_properties(${GD_LIB} PROPERTIES
+@@ -163,6 +163,7 @@ if (BUILD_STATIC_LIBS)
+ endif()
+ 
+ install(TARGETS ${GD_INSTALL_TARGETS}
++        EXPORT ${GD_CONFIG}
+         RUNTIME DESTINATION bin
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+@@ -182,3 +183,7 @@ install(FILES
+ 	gdfx.h
+ 	gdpp.h
+ 	DESTINATION include)
++
++install(EXPORT ${GD_CONFIG} DESTINATION cmake)
++
++export(TARGETS libgd FILE ${GD_CONFIG}.cmake)

--- a/ports/libgd/0002-export-cmake-targets.patch
+++ b/ports/libgd/0002-export-cmake-targets.patch
@@ -1,29 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 42934d0..8e7de18 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -196,6 +196,7 @@ else (USE_EXT_GD)
+ 	option(BUILD_SHARED_LIBS "Build shared libs" ON)
+ 	option(BUILD_STATIC_LIBS "Build static libs" OFF)
+ 
++	set(GD_CMAKE_CONFIG libgd-config)
+ 	if (WIN32)
+ 		SET(GD_LIB libgd)
+ 		ADD_DEFINITIONS( -DWIN32 -D_WIN32 -DMSWIN32 -DBGDWIN32 -DWINVER=0x0500  -D_WIN32_WINNT=0x0500 -D_WIN32_IE=0x0600)
+@@ -284,3 +285,10 @@ set(CPACK_SOURCE_IGNORE_FILES
+ install(FILES ${top_level_DOCFILES} DESTINATION ${DOC_DIR})
+ INCLUDE(CPack)
+ 
++# Make project importable from the install directory
++## Generate and install *-config.cmake exporting targets from install tree.
++install(EXPORT ${GD_CMAKE_CONFIG} DESTINATION "share/${GD_LIB}")
++
++# Make project importable from the build directory
++## Generate file *-config.cmake exporting targets from build tree.
++export(TARGETS ${GD_LIB} FILE ${GD_CMAKE_CONFIG}.cmake)
+\ No newline at end of file
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 497dd93..0ea1bb0 100644
+index 08fd699..c4561e0 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -76,7 +76,7 @@ if(MSVC AND MSVC_VERSION LESS 1900)
- endif(MSVC AND MSVC_VERSION LESS 1900)
- 
- include(GNUInstallDirs)
--
-+set(GD_CONFIG libgd-config)
- if (BUILD_SHARED_LIBS)
- 	add_library(${GD_LIB} ${LIBGD_SRC_FILES})
- 	set_target_properties(${GD_LIB} PROPERTIES
-@@ -163,6 +163,7 @@ if (BUILD_STATIC_LIBS)
+@@ -158,6 +158,7 @@ if (BUILD_STATIC_LIBS)
  endif()
  
  install(TARGETS ${GD_INSTALL_TARGETS}
-+        EXPORT ${GD_CONFIG}
++        EXPORT ${GD_CMAKE_CONFIG} # associate installed target files with export
          RUNTIME DESTINATION bin
          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-@@ -182,3 +183,7 @@ install(FILES
- 	gdfx.h
- 	gdpp.h
- 	DESTINATION include)
-+
-+install(EXPORT ${GD_CONFIG} DESTINATION cmake)
-+
-+export(TARGETS libgd FILE ${GD_CONFIG}.cmake)

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -13,7 +13,8 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake.patch")
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/0002-export-cmake-targets.patch")
 
 #delete CMake builtins modules
 file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/CMakeParseArguments.cmake)
@@ -50,3 +51,8 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgd)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libgd/COPYING ${CURRENT_PACKAGES_DIR}/share/libgd/copyright)
+file(RENAME ${CURRENT_PACKAGES_DIR}/cmake/libgd-config-release.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-release.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/cmake/libgd-config-debug.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-debug.cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake)

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -51,8 +51,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgd)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libgd/COPYING ${CURRENT_PACKAGES_DIR}/share/libgd/copyright)
-file(RENAME ${CURRENT_PACKAGES_DIR}/cmake/libgd-config-release.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-release.cmake)
-file(RENAME ${CURRENT_PACKAGES_DIR}/debug/cmake/libgd-config-debug.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-debug.cmake)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake)
+# Fix up paths on debug config
+file(READ ${CURRENT_PACKAGES_DIR}/debug/share/libgd/libgd-config-debug.cmake GD_DEBUG_MODULE)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" GD_DEBUG_MODULE "${GD_DEBUG_MODULE}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-config-debug.cmake "${GD_DEBUG_MODULE}")
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-config.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-config.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-config-release.cmake ${CURRENT_PACKAGES_DIR}/share/libgd/libgd-config-release.cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)


### PR DESCRIPTION
This PR patches the CMakeLists.txt in libgd to export a `.cmake` targets file so one can use `find_package(libgd)` to consume the vcpkg port.