### PR TITLE
Fix a infinite skip_comment check in Paragraphs.cpp

### DIFF
--- a/toolsrc/src/Paragraphs.cpp
+++ b/toolsrc/src/Paragraphs.cpp
@@ -34,7 +34,7 @@ namespace vcpkg::Paragraphs
 
         void skip_comment(char& ch)
         {
-            while (ch != '\r')
+            while (ch != '\r' && ch != '\n' && ch != '\0')
                 next(ch);
             if (ch == '\r')
                 next(ch);

--- a/toolsrc/src/tests_paragraph.cpp
+++ b/toolsrc/src/tests_paragraph.cpp
@@ -289,6 +289,16 @@ namespace UnitTest1
             Assert::AreEqual("v4", pghs[1]["f4"].c_str());
         }
 
+		TEST_METHOD(parse_comment_before_single_slashN)
+		{
+			const char* str =
+				"f1: v1\r\n"
+				"#comment\n";
+			auto pghs = vcpkg::Paragraphs::parse_paragraphs(str).value_or_exit(VCPKG_LINE_INFO);
+			Assert::AreEqual(size_t(1), pghs[0].size());
+			Assert::AreEqual("v1", pghs[0]["f1"].c_str());
+		}
+
         TEST_METHOD(BinaryParagraph_serialize_min)
         {
             std::stringstream ss;


### PR DESCRIPTION
This happens when git not checkout file's line break as CR-LF.
When CONTROL file contains comment followed by \n instead of \r\n, there will be a infinite skip_comment check, and will cause infinite wait in vcpkg update/vcpkg search.

Related: https://github.com/Microsoft/vcpkg/commit/0e5760e5e025aa687c93d3897b00775978929161