### PR TITLE
[xerces-c]: Add missing .c source files

### DIFF
--- a/ports/xerces-c/CONTROL
+++ b/ports/xerces-c/CONTROL
@@ -1,3 +1,3 @@
 Source: xerces-c
-Version: 3.1.4-2
+Version: 3.1.4-3
 Description: Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -47,6 +47,8 @@ file(COPY ${SOURCE_PATH}/Build/${OUTPUT_DIR}/VC14/Release/xerces-c_3_1.dll DESTI
 file(COPY ${SOURCE_PATH}/Build/${OUTPUT_DIR}/VC14/Release/xerces-c_3.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 
 file(COPY ${SOURCE_PATH}/src/xercesc DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.hpp)
+# Certain headers under xercesc/util include .c files, so we need these copied over as well
+file(COPY ${SOURCE_PATH}/src/xercesc DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.c)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/xercesc/NLS)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/xercesc/util/MsgLoaders/ICU/resources)


### PR DESCRIPTION
Certain headers of xerces-c `#include` various `.c` files that the current portfile does not copy across.

This PR updates the portfile to do this.