### PR TITLE
Update Catch to 1.9.1

### DIFF
--- a/ports/catch/CONTROL
+++ b/ports/catch/CONTROL
@@ -1,3 +1,3 @@
 Source: catch
-Version: 1.8.2
+Version: 1.9.1
 Description: C++ Automated Test Cases in Headers

--- a/ports/catch/portfile.cmake
+++ b/ports/catch/portfile.cmake
@@ -10,19 +10,17 @@
 include(vcpkg_common_functions)
 
 vcpkg_download_distfile(HEADER
-    URLS "https://github.com/philsquared/Catch/releases/download/v1.8.2/catch.hpp"
+    URLS "https://github.com/philsquared/Catch/releases/download/v1.9.1/catch.hpp"
     FILENAME "catch.hpp"
-    SHA512 17ef87db95cc2f5097c46223df6832f7eaad8178266bb10532d0cc73f8ec96c61e96a21e8ace3df743830c9d06d10da2b67563435d69d211c1d5cc6980aecf67
+    SHA512 129f4ed4cf7c32ee8f6ead1d4d1e8d4243929a62a857e921637dd39043066350f1674af0502a4d27cc3b29d64951558fe73e18d48d96a34e7a4dff9506ba0b48
 )
 
 vcpkg_download_distfile(LICENSE
-    URLS "https://raw.githubusercontent.com/philsquared/Catch/v1.8.2/LICENSE_1_0.txt"
-    FILENAME "LICENSE_1_0.txt"
+    URLS "https://raw.githubusercontent.com/philsquared/Catch/v1.9.1/LICENSE.txt"
+    FILENAME "LICENSE.txt"
     SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
 )
 
-file(COPY ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include ) 
+file(COPY ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include )
 file(COPY ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch )
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/catch/LICENSE_1_0.txt ${CURRENT_PACKAGES_DIR}/share/catch/copyright) 
-
-
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/catch/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/catch/copyright)


### PR DESCRIPTION
License file has been renamed in the main repository, but the contents are exactly the same.