### PR TITLE
install cmake config files for glog

### DIFF
--- a/ports/glog/fix-cmake-install-files.patch
+++ b/ports/glog/fix-cmake-install-files.patch
@@ -1,0 +1,47 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1429590..5ed110d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -390,7 +390,8 @@ if (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
+ endif (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
+ 
+ if (gflags_FOUND)
+-  target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})
++  # when set to PUBLIC, will cause some wrong interface_include_directory for vcpkg
++  target_include_directories (glog PRIVATE ${gflags_INCLUDE_DIR})
+   target_link_libraries (glog PUBLIC ${gflags_LIBRARIES})
+ 
+   if (NOT BUILD_SHARED_LIBS)
+@@ -557,7 +558,7 @@ endif (gflags_FOUND)
+ 
+ configure_package_config_file (glog-config.cmake.in
+   ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake
+-  INSTALL_DESTINATION lib/cmake/glog
++  INSTALL_DESTINATION share/glog
+   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+ 
+ write_basic_package_version_file (glog-config-version.cmake VERSION
+@@ -569,6 +570,6 @@ export (PACKAGE glog)
+ install (FILES
+   ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake
+   ${CMAKE_CURRENT_BINARY_DIR}/glog-config-version.cmake
+-  DESTINATION lib/cmake/glog)
++  DESTINATION share/glog)
+ 
+-install (EXPORT glog-targets NAMESPACE glog:: DESTINATION lib/cmake/glog)
++install (EXPORT glog-targets NAMESPACE glog:: DESTINATION share/glog)
+diff --git a/glog-config.cmake.in b/glog-config.cmake.in
+index e3c44ae..fb59e95 100644
+--- a/glog-config.cmake.in
++++ b/glog-config.cmake.in
+@@ -5,3 +5,10 @@ include (CMakeFindDependencyMacro)
+ @gflags_DEPENDENCY@
+ 
+ include ("${CMAKE_CURRENT_LIST_DIR}/glog-targets.cmake")
++
++# set common names for FindGlog
++# should be installed to ${CMAKE_INSTALL_PREFIX}/share/glog
++set(GLOG_FOUND ON)
++set(GLOG_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include")
++set(GLOG_LIBRARIES glog::glog)
++set_target_properties(${GLOG_LIBRARIES} PROPERTIES MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)

--- a/ports/glog/fix-cmake-install-files.patch
+++ b/ports/glog/fix-cmake-install-files.patch
@@ -30,18 +30,3 @@ index 1429590..5ed110d 100644
  
 -install (EXPORT glog-targets NAMESPACE glog:: DESTINATION lib/cmake/glog)
 +install (EXPORT glog-targets NAMESPACE glog:: DESTINATION share/glog)
-diff --git a/glog-config.cmake.in b/glog-config.cmake.in
-index e3c44ae..fb59e95 100644
---- a/glog-config.cmake.in
-+++ b/glog-config.cmake.in
-@@ -5,3 +5,10 @@ include (CMakeFindDependencyMacro)
- @gflags_DEPENDENCY@
- 
- include ("${CMAKE_CURRENT_LIST_DIR}/glog-targets.cmake")
-+
-+# set common names for FindGlog
-+# should be installed to ${CMAKE_INSTALL_PREFIX}/share/glog
-+set(GLOG_FOUND ON)
-+set(GLOG_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include")
-+set(GLOG_LIBRARIES glog::glog)
-+set_target_properties(${GLOG_LIBRARIES} PROPERTIES MAP_IMPORTED_CONFIG_RELWITHDEBINFO RELEASE)

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -14,6 +14,10 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 24506ad1cc05e8361379b925ecfc8f32cc47692a47598401cca340eb2a528fe28b8b0d3636983056c7910469d105095bd3bacacff6278bffa18d85603c3dbfa8
 )
 vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/fix-cmake-install-files.patch"
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -24,10 +28,27 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/glog)
+
+file(GLOB GLOG_CMAKE_FILES 
+    ${CURRENT_PACKAGES_DIR}/cmake/lib/glog/*.cmake 
+    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glog/*.cmake
+    ${CURRENT_PACKAGES_DIR}/debug/share/glog/*.cmake)
+file(COPY ${GLOG_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/glog)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# changes target search path
+file(READ ${CURRENT_PACKAGES_DIR}/debug/share/glog/glog-targets-debug.cmake GLOG_DEBUG_MODULE)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" GLOG_DEBUG_MODULE "${GLOG_DEBUG_MODULE}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/glog/glog-targets-debug.cmake "${GLOG_DEBUG_MODULE}")
+
+# remove not used cmake files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share )
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake )
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake )
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/glog)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/glog/COPYING ${CURRENT_PACKAGES_DIR}/share/glog/copyright)

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -31,10 +31,7 @@ vcpkg_install_cmake()
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/glog)
 
-file(GLOB GLOG_CMAKE_FILES 
-    ${CURRENT_PACKAGES_DIR}/cmake/lib/glog/*.cmake 
-    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glog/*.cmake
-    ${CURRENT_PACKAGES_DIR}/debug/share/glog/*.cmake)
+file(GLOB GLOG_CMAKE_FILES ${CURRENT_PACKAGES_DIR}/debug/share/glog/*.cmake)
 file(COPY ${GLOG_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/glog)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
There are three modifications:
1. install all the cmake stuffs into share/glog
2. change the debug targets prefix by `string(REPLACE)`
3. add `GLOG_INCLUDE_DIRS` and `GLOG_LIBRARIES` in the config file