### PR TITLE
libflac: escape PROJECT_SOURCE_DIR

### DIFF
--- a/ports/libflac/CMakeLists.txt
+++ b/ports/libflac/CMakeLists.txt
@@ -30,7 +30,7 @@ if(LIBFLAC_ARCHITECTURE MATCHES x86)
         src/libFLAC/ia32/cpu_asm.nasm
         src/libFLAC/ia32/fixed_asm.nasm
         src/libFLAC/ia32/lpc_asm.nasm)
-    set(CMAKE_ASM_NASM_FLAGS "-i${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/ -f win32 -d OBJ_FORMAT_win32")
+    set(CMAKE_ASM_NASM_FLAGS "-i\"${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/\" -f win32 -d OBJ_FORMAT_win32")
 elseif(LIBFLAC_ARCHITECTURE MATCHES x64)
     add_definitions(-DFLAC__CPU_X86_64)
     add_definitions(-DENABLE_64_BIT_WORDS)


### PR DESCRIPTION
fixes: nasm: error: more than one input file specified