### PR TITLE
[libflac] fix build with MSBuild generator

### DIFF
--- a/ports/libflac/CMakeLists.txt
+++ b/ports/libflac/CMakeLists.txt
@@ -25,12 +25,13 @@ endif()
 if(LIBFLAC_ARCHITECTURE MATCHES x86)
     add_definitions(-DFLAC__CPU_IA32)
     add_definitions(-DFLAC__HAS_NASM)
-    enable_language(ASM_NASM)
-    list(APPEND LIBFLAC_SOURCES
-        src/libFLAC/ia32/cpu_asm.nasm
-        src/libFLAC/ia32/fixed_asm.nasm
-        src/libFLAC/ia32/lpc_asm.nasm)
-    set(CMAKE_ASM_NASM_FLAGS "-i\"${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/\" -f win32 -d OBJ_FORMAT_win32")
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/nasm)
+    foreach(ASM_SOURCE cpu_asm fixed_asm lpc_asm)
+        execute_process(COMMAND nasm "-i${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/" -f win32 -d OBJ_FORMAT_win32 -f win32 
+            -o "${CMAKE_BINARY_DIR}/nasm/${ASM_SOURCE}.obj" "${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/${ASM_SOURCE}.nasm"
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+        list(APPEND LIBFLAC_SOURCES ${CMAKE_BINARY_DIR}/nasm/${ASM_SOURCE}.obj)
+    endforeach()
 elseif(LIBFLAC_ARCHITECTURE MATCHES x64)
     add_definitions(-DFLAC__CPU_X86_64)
     add_definitions(-DENABLE_64_BIT_WORDS)

--- a/ports/libflac/CONTROL
+++ b/ports/libflac/CONTROL
@@ -1,4 +1,4 @@
 Source: libflac
-Version: 1.3.2-1
+Version: 1.3.2-2
 Description: Library for manipulating FLAC files
 Build-Depends: libogg


### PR DESCRIPTION
CMake as of 3.8.0 doesn't support (see [here](https://gitlab.kitware.com/cmake/cmake/issues/16469)) asm-nasm language in MSBuild projects, so we need to call nasm directly. This should fix build on 32-bit systems, where Ninja cannot be used.
Fixes #968. Fixes #988.