### PR TITLE
[tests] fixes issue within tests

### DIFF
--- a/toolsrc/src/tests_arguments.cpp
+++ b/toolsrc/src/tests_arguments.cpp
@@ -10,7 +10,7 @@ using namespace vcpkg;
 
 namespace UnitTest1
 {
-    struct ArgumentTests : TestClass<ArgumentTests>
+    TEST_CLASS(ArgumentTests)
     {
         TEST_METHOD(create_from_arg_sequence_options_lower)
         {

--- a/toolsrc/src/tests_dependencies.cpp
+++ b/toolsrc/src/tests_dependencies.cpp
@@ -11,7 +11,7 @@ using namespace vcpkg;
 
 namespace UnitTest1
 {
-    struct ArgumentTests : TestClass<ArgumentTests>
+    TEST_CLASS(DependencyTests)
     {
         TEST_METHOD(parse_depends_one)
         {

--- a/toolsrc/src/tests_paragraph.cpp
+++ b/toolsrc/src/tests_paragraph.cpp
@@ -21,7 +21,7 @@ namespace Strings = vcpkg::Strings;
 
 namespace UnitTest1
 {
-    struct ArgumentTests : TestClass<ArgumentTests>
+    TEST_CLASS(ControlParsing)
     {
         TEST_METHOD(SourceParagraph_Construct_Minimum)
         {


### PR DESCRIPTION
Tests were broken due to converting TEST_CLASS(NAME) into struct
ArgumentTests : TestClass<ArgumentTests>.
See 4ad755bb69dc99a8f0d42b67b0a7c4c59b332077 for more details.

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>