### PR TITLE
[pcre] update to 8.40

### DIFF
--- a/ports/pcre/CONTROL
+++ b/ports/pcre/CONTROL
@@ -1,4 +1,3 @@
 Source: pcre
-Version: 8.38-1
+Version: 8.40
 Description: Perl Compatible Regular Expresions
-Build-Depends: zlib

--- a/ports/pcre/fix-option.patch
+++ b/ports/pcre/fix-option.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 42451ad..858a34b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,7 +191,7 @@ IF (MINGW)
+ ENDIF(MINGW)
+ 
+ IF(MSVC)
+-  OPTION(PCRE_STATIC_RUNTIME OFF CACHE BOOL
++  OPTION(PCRE_STATIC_RUNTIME
+ 	"ON=Compile against the static runtime (/MT)."
+ 	OFF)
+   OPTION(INSTALL_MSVC_PDB

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -6,17 +6,23 @@
 #   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
 #
 
+set(PCRE_VERSION 8.40)
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pcre-8.39)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pcre-${PCRE_VERSION})
 vcpkg_download_distfile(ARCHIVE
-    URLS "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.zip" "https://downloads.sourceforge.net/project/pcre/pcre/8.39/pcre-8.39.zip"
-    FILENAME "pcre-8.39.zip"
-    SHA512 14e6336fe603b7110ba9d54a92af8449bbd4a82fe33d14bc912a048336fc90686464354141316c7890e80e7501af88f657cb7247de6717674e80ba044a279a00
+    URLS "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${PCRE_VERSION}.zip" 
+         "https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VERSION}/pcre-${PCRE_VERSION}.zip"
+    FILENAME "pcre-${PCRE_VERSION}.zip"
+    SHA512 121c0389a739a2a1d7d5d87e5f15167601739ddfab9eed66a1f55b5bbadadb58730208430f5ad069f9342c9a84ee1817dfa07efc802c29c84f86147714ee8eff
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-option.patch)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
     OPTIONS -DPCRE_BUILD_TESTS=NO
             -DPCRE_BUILD_PCREGREP=NO
             -DPCRE_BUILD_PCRE32=YES
@@ -25,6 +31,11 @@ vcpkg_configure_cmake(
             -DPCRE_SUPPORT_JIT=YES
             -DPCRE_SUPPORT_UTF=YES
             -DPCRE_SUPPORT_UNICODE_PROPERTIES=YES
+            # optional dependencies for PCREGREP
+            -DPCRE_SUPPORT_LIBBZ2=OFF
+            -DPCRE_SUPPORT_LIBZ=OFF
+            -DPCRE_SUPPORT_LIBEDIT=OFF
+            -DPCRE_SUPPORT_LIBREADLINE=OFF
     # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
     # OPTIONS_RELEASE -DOPTIMIZE=1
     # OPTIONS_DEBUG -DDEBUGGABLE=1


### PR DESCRIPTION
This also drops unnecessary dependency on zlib - it's used only by the pcregrep tool, which is not built by the port.