### PR TITLE
Fix processor architecture detection

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -2,7 +2,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
   set(TOOLPATH ${DOWNLOADS}/tools/msys2)
 
   # detect host architecture
-  if(ENV{PROCESSOR_ARCHITEW6432})
+  if(DEFINED ENV{PROCESSOR_ARCHITEW6432})
       set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITEW6432})
   else()
       set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITECTURE})

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -5,7 +5,7 @@ function(vcpkg_configure_cmake)
         message(FATAL_ERROR "Vcpkg has been updated with VS2017 support, however you need to rebuild vcpkg.exe by re-running bootstrap-vcpkg.bat\n")
     endif()
 
-    if(ENV{PROCESSOR_ARCHITEW6432})
+    if(DEFINED ENV{PROCESSOR_ARCHITEW6432})
         set(_csc_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITEW6432})
     else()
         set(_csc_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITECTURE})


### PR DESCRIPTION
The checks for environment variables were not correct, which resulted in always assuming the host is 32 bit.