### PR TITLE
Use CMake to build Eigen3

### DIFF
--- a/ports/eigen3/CONTROL
+++ b/ports/eigen3/CONTROL
@@ -1,3 +1,3 @@
 Source: eigen3
-Version: 3.3.3
+Version: 3.3.3-1
 Description: C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -8,20 +8,12 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-file(GLOB_RECURSE GARBAGE ${SOURCE_PATH}/Eigen/CMakeLists.* ${SOURCE_PATH}/unsupported/Eigen/CMakeLists.*)
-if(GARBAGE)
-    file(REMOVE ${GARBAGE})
-endif()
+
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 
 # Put the licence file where vcpkg expects it
 file(COPY ${SOURCE_PATH}/COPYING.README DESTINATION ${CURRENT_PACKAGES_DIR}/share/eigen3)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/eigen3/COPYING.README ${CURRENT_PACKAGES_DIR}/share/eigen3/copyright)
-
-# Copy the eigen header files
-file(COPY ${SOURCE_PATH}/Eigen ${SOURCE_PATH}/signature_of_eigen3_matrix_library
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${SOURCE_PATH}/unsupported/Eigen
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include/unsupported)
-
-# Copy signature file so tools can locate the eigen headers
-file(COPY DESTINATION ${CURRENT_PACKAGES_DIR}/include)


### PR DESCRIPTION
Since 3.3.3, Eigen has included an INTERFACE target. Use CMake to build Eigen so the generated target can be imported in your project using `target_link_libraries` rather than having to distribute `FindEigen3.cmake` with your project.

    find_package(Eigen3)
    target_link_libraries(myproject Eigen3::Eigen)