### PR TITLE
[beast] Update to v40

### DIFF
--- a/ports/beast/CONTROL
+++ b/ports/beast/CONTROL
@@ -1,4 +1,4 @@
 Source: beast
-Version: 1.0.0-b30
+Version: v40
 Build-Depends: boost
-Description: Boost.Asio based header only HTTP and WebSocket on C++11
+Description: HTTP and WebSocket, header-only using Boost.Asio and C++11

--- a/ports/beast/portfile.cmake
+++ b/ports/beast/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vinniefalco/Beast
-    REF v1.0.0-b30
-    SHA512 78b1b09d6785e8b782bea72b6849936c0be45df1fd137db832c0afe1b09af122e0fd69e25321bcd8681f03015d94345a40f9650a5560f12c73457e4cc82e2f30
+    REF f2d825594ee34ccc1ebc0b231899a1735245778d
+    SHA512 21ea2ba77ff8c1dac873e7abd4caa03da50f155c34b39783380d4319c930be02076bf2b7ffcf93a964cac60bfb0a2ec8621156c332adedd3a2af82a27ca50e1a
     HEAD_REF master
 )
 


### PR DESCRIPTION
This is the tip of Beast's _master_ branch as of 5/11/2017. The version numbering system has changed, now Beast versions are identified by a simple incrementing integer. This is in preparation for Beast becoming part of Boost pending unconditional acceptance in the upcoming Boost formal review scheduled for July 1st.