### PR TITLE
Add hypre port

### DIFF
--- a/ports/hypre/CONTROL
+++ b/ports/hypre/CONTROL
@@ -1,0 +1,4 @@
+Source: hypre
+Version: 2.11.1
+Description: SCALABLE LINEAR SOLVERS AND MULTIGRID METHODS
+Build-Depends: msmpi

--- a/ports/hypre/fix-blas-vs14-math.patch
+++ b/ports/hypre/fix-blas-vs14-math.patch
@@ -1,0 +1,33 @@
+--- a/blas/f2c.h	Fri Sep 11 18:57:56 2015
++++ b/blas/f2c.h	Thu Dec 22 18:20:08 2016
+@@ -190,18 +190,18 @@
+ typedef struct Namelist Namelist;
+ 
+ /* The following undefs are to prevent conflicts with external libraries */
+-#undef abs
+-#define abs(x) ((x) >= 0 ? (x) : -(x))
+-#define dabs(x) (doublereal)abs(x)
+-#ifndef min
+-#define min(a,b) ((a) <= (b) ? (a) : (b))
+-#define max(a,b) ((a) >= (b) ? (a) : (b))
+-#endif
+-#define dmin(a,b) (doublereal)min(a,b)
+-#define dmax(a,b) (doublereal)max(a,b)
+-#define bit_test(a,b)	((a) >> (b) & 1)
+-#define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
+-#define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
++//#undef abs
++//#define abs(x) ((x) >= 0 ? (x) : -(x))
++//#define dabs(x) (doublereal)abs(x)
++//#ifndef min
++//#define min(a,b) ((a) <= (b) ? (a) : (b))
++//#define max(a,b) ((a) >= (b) ? (a) : (b))
++//#endif
++//#define dmin(a,b) (doublereal)min(a,b)
++//#define dmax(a,b) (doublereal)max(a,b)
++//#define bit_test(a,b)	((a) >> (b) & 1)
++//#define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
++//#define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
+ 
+ /* procedure parameter types for -A and -C++ */
+ 

--- a/ports/hypre/fix-export-global-data-symbols.patch
+++ b/ports/hypre/fix-export-global-data-symbols.patch
@@ -1,0 +1,28 @@
+--- a/utilities/_hypre_utilities.h	Thu Jun 09 15:56:18 2016
++++ b/utilities/_hypre_utilities.h	Wed Jan 04 18:08:27 2017
+@@ -13,6 +13,7 @@
+ #ifndef hypre_UTILITIES_HEADER
+ #define hypre_UTILITIES_HEADER
+ 
++#include "_hypre_export.h"
+ #include "HYPRE_utilities.h"
+ 
+ #ifdef HYPRE_USING_OPENMP
+@@ -610,7 +611,7 @@
+ #ifdef HYPRE_TIMING_GLOBALS
+ hypre_TimingType *hypre_global_timing = NULL;
+ #else
+-extern hypre_TimingType *hypre_global_timing;
++extern HYPRE_EXPORT hypre_TimingType *hypre_global_timing;
+ #endif
+ 
+ /*-------------------------------------------------------
+@@ -781,7 +782,7 @@
+  * Global variable used in hypre error checking
+  *--------------------------------------------------------------------------*/
+ 
+-extern HYPRE_Int hypre__global_error;
++extern HYPRE_EXPORT HYPRE_Int hypre__global_error;
+ #define hypre_error_flag  hypre__global_error
+ 
+ /*--------------------------------------------------------------------------

--- a/ports/hypre/fix-lapack-vs14-math.patch
+++ b/ports/hypre/fix-lapack-vs14-math.patch
@@ -1,0 +1,33 @@
+--- a/lapack/f2c.h	Fri Sep 11 18:57:56 2015
++++ b/lapack/f2c.h	Thu Dec 22 18:22:26 2016
+@@ -190,18 +190,18 @@
+ typedef struct Namelist Namelist;
+ 
+ /* The following undefs are to prevent conflicts with external libraries */
+-#undef abs
+-#define abs(x) ((x) >= 0 ? (x) : -(x))
+-#define dabs(x) (doublereal)abs(x)
+-#ifndef min
+-#define min(a,b) ((a) <= (b) ? (a) : (b))
+-#define max(a,b) ((a) >= (b) ? (a) : (b))
+-#endif
+-#define dmin(a,b) (doublereal)min(a,b)
+-#define dmax(a,b) (doublereal)max(a,b)
+-#define bit_test(a,b)	((a) >> (b) & 1)
+-#define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
+-#define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
++//#undef abs
++//#define abs(x) ((x) >= 0 ? (x) : -(x))
++//#define dabs(x) (doublereal)abs(x)
++//#ifndef min
++//#define min(a,b) ((a) <= (b) ? (a) : (b))
++//#define max(a,b) ((a) >= (b) ? (a) : (b))
++//#endif
++//#define dmin(a,b) (doublereal)min(a,b)
++//#define dmax(a,b) (doublereal)max(a,b)
++//#define bit_test(a,b)	((a) >> (b) & 1)
++//#define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
++//#define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
+ 
+ /* procedure parameter types for -A and -C++ */
+ 

--- a/ports/hypre/fix-macro-to-template.patch
+++ b/ports/hypre/fix-macro-to-template.patch
@@ -1,0 +1,38 @@
+--- a/struct_ls/pfmg3_setup_rap.c	Thu Jun 09 15:56:18 2016
++++ b/struct_ls/pfmg3_setup_rap.c	Thu Dec 22 17:45:20 2016
+@@ -19,13 +19,28 @@
+  * allow for coarsening to be done in the x- and y-directions also.
+  *--------------------------------------------------------------------------*/
+ 
+-#define MapIndex(in_index, cdir, out_index)                     \
+-   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 2);   \
+-   cdir = (cdir + 1) % 3;                                       \
+-   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 0);   \
+-   cdir = (cdir + 1) % 3;                                       \
+-   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 1);   \
+-   cdir = (cdir + 1) % 3;
++//#define MapIndex(in_index, cdir, out_index)                     \
++//   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 2);   \
++//   cdir = (cdir + 1) % 3;                                       \
++//   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 0);   \
++//   cdir = (cdir + 1) % 3;                                       \
++//   hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 1);   \
++//   cdir = (cdir + 1) % 3;
++
++template<typename T, typename U, typename V>
++void MapIndex(T& in_index, U& cdir, V& out_index)
++{
++	if(cdir > 3) cdir = cdir - (cdir / 3) * 3;
++	hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 2);
++	if(cdir == 3) cdir = 1;
++	else ++cdir;
++	hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 0);
++	if(cdir == 3) cdir = 1;
++	else ++cdir;
++	hypre_IndexD(out_index, cdir) = hypre_IndexD(in_index, 1);
++	if(cdir == 3) cdir = 1;
++	else ++cdir;
++}
+  
+ /*--------------------------------------------------------------------------
+  *  Sets up new coarse grid operator stucture.

--- a/ports/hypre/fix-root-cmakelists.patch
+++ b/ports/hypre/fix-root-cmakelists.patch
@@ -1,0 +1,56 @@
+--- a/CMakeLists.txt	Thu Jun 09 15:56:18 2016
++++ b/CMakeLists.txt	Wed Jan 04 18:27:54 2017
+@@ -1,6 +1,8 @@
+ cmake_minimum_required (VERSION 2.8.8)
+ project (hypre)
+ 
++include(GenerateExportHeader)
++
+ # The version number.
+ set (HYPRE_VERSION 2.11.1)
+ set (HYPRE_DATE    2016/06/09)
+@@ -616,6 +618,8 @@
+   struct_ls/sparse_msg_solve.c
+ )
+ 
++set_source_files_properties(struct_ls/pfmg3_setup_rap.c PROPERTIES LANGUAGE CXX)
++
+ # Headers and sources: sstruct_mv
+ list (APPEND HYPRE_HEADERS
+   sstruct_mv/HYPRE_sstruct_mv.h
+@@ -756,11 +760,11 @@
+   find_package (MPI)
+   if ((MPI_C_FOUND) AND (NOT CMAKE_C_COMPILER STREQUAL MPI_C_COMPILER))
+     include_directories (${MPI_C_INCLUDE_PATH})
+-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MPI_C_COMPILE_FLAGS}")
++    #set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MPI_C_COMPILE_FLAGS}")
+   endif ()
+   if ((MPI_CXX_FOUND) AND (NOT CMAKE_CXX_COMPILER STREQUAL MPI_CXX_COMPILER))
+     include_directories (${MPI_CXX_INCLUDE_PATH})
+-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
++    #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MPI_CXX_COMPILE_FLAGS}")
+   endif ()
+ endif (NOT HYPRE_SEQUENTIAL)
+ 
+@@ -802,8 +806,19 @@
+ endif ()
+ 
+ add_library (HYPRE ${HYPRE_SOURCES} ${FEI_LIBS})
+-
+-install (TARGETS HYPRE DESTINATION lib)
++target_link_libraries(HYPRE ${MPI_C_LIBRARIES})
++if(WIN32 AND BUILD_SHARED_LIBS)
++  set_target_properties(HYPRE PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
++endif()
++
++generate_export_header(HYPRE EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/_hypre_export.h)
++list(APPEND HYPRE_HEADERS ${CMAKE_BINARY_DIR}/_hypre_export.h)
++
++install (TARGETS HYPRE 
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)
+ install (FILES ${HYPRE_HEADERS} DESTINATION include)
+ 
+ # add_subdirectory (test EXCLUDE_FROM_ALL)

--- a/ports/hypre/portfile.cmake
+++ b/ports/hypre/portfile.cmake
@@ -1,0 +1,44 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/hypre-2.11.1/src)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/download/hypre-2.11.1.tar.gz"
+    FILENAME "hypre-2.11.1.tar.gz"
+    SHA512 4266c1b5225bcc97781246475100382f4929d7c918c854570a36b90602e8f111a4893cd1c93b95c68305c851898b970dd92ac173efe9211be5bb914d3c3c5d83
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/fix-root-cmakelists.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-macro-to-template.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-blas-vs14-math.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-lapack-vs14-math.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-export-global-data-symbols.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  set(OPTIONS -DHYPRE_SHARED=ON)
+else()
+  set(OPTIONS -DHYPRE_SHARED=OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${OPTIONS}
+    OPTIONS_RELEASE
+        -DHYPRE_BUILD_TYPE=Release
+        -DHYPRE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}
+    OPTIONS_DEBUG
+        -DHYPRE_BUILD_TYPE=Debug
+        -DHYPRE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}/debug
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/../COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/hypre/copyright)


### PR DESCRIPTION
This adds a port for HYPRE [1], an algebraic multilevel solver for linear equation systems.

[1] https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/software