### PR TITLE
[libgd] Enable fontconfig support

### DIFF
--- a/ports/libgd/CONTROL
+++ b/ports/libgd/CONTROL
@@ -1,4 +1,4 @@
 Source: libgd
-Version: 2.2.4-1
+Version: 2.2.4-2
 Description: Open source code library for the dynamic creation of images by programmers.
-Build-Depends: freetype, libjpeg-turbo, libpng, libwebp, tiff
+Build-Depends: freetype, libjpeg-turbo, libpng, libwebp, tiff, fontconfig

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -37,7 +37,8 @@ vcpkg_configure_cmake(
             -DENABLE_JPEG=ON
             -DENABLE_TIFF=ON
             -DENABLE_FREETYPE=ON
-            -DEENABLE_WEBP=ON
+            -DENABLE_WEBP=ON
+            -DENABLE_FONTCONFIG=ON
             -DBUILD_SHARED_LIBS=${LIBGD_SHARED_LIBS}
             -DBUILD_STATIC_LIBS=${LIBGD_STATIC_LIBS}
 )


### PR DESCRIPTION
This enables fontconfig support for libgd. Needed e.g. for building gnuplot.

Furthermore the spelling of the webp support option is corrected.