### PR TITLE
Add port for Python 3

### DIFF
--- a/ports/python3/0001-Static-library.patch
+++ b/ports/python3/0001-Static-library.patch
@@ -1,0 +1,46 @@
+diff --git a/PCbuild/pythoncore.vcxproj b/PCbuild/pythoncore.vcxproj
+index 6ea1848..4134d7b 100644
+--- a/PCbuild/pythoncore.vcxproj
++++ b/PCbuild/pythoncore.vcxproj
+@@ -1,4 +1,4 @@
+-<?xml version="1.0" encoding="utf-8"?>
++﻿<?xml version="1.0" encoding="utf-8"?>
+ <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <ItemGroup Label="ProjectConfigurations">
+     <ProjectConfiguration Include="Debug|Win32">
+@@ -41,7 +41,7 @@
+   <Import Project="python.props" />
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Label="Configuration">
+-    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <ConfigurationType>StaticLibrary</ConfigurationType>
+     <UseOfMfc>false</UseOfMfc>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+@@ -66,12 +66,24 @@
+     <ClCompile>
+       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
+       <AdditionalIncludeDirectories>$(PySourcePath)Python;$(PySourcePath)Modules\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_NO_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+     </ClCompile>
+     <Link>
+       <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <BaseAddress>0x1e000000</BaseAddress>
+     </Link>
++    <Lib>
++      <TargetMachine Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MachineX86</TargetMachine>
++    </Lib>
++    <Lib>
++      <TargetMachine Condition="'$(Configuration)|$(Platform)'=='PGInstrument|Win32'">MachineX86</TargetMachine>
++    </Lib>
++    <Lib>
++      <TargetMachine Condition="'$(Configuration)|$(Platform)'=='PGUpdate|Win32'">MachineX86</TargetMachine>
++    </Lib>
++    <Lib>
++      <TargetMachine Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MachineX86</TargetMachine>
++    </Lib>
+   </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClInclude Include="..\Include\abstract.h" />
+-- 

--- a/ports/python3/0002-Static-CRT.patch
+++ b/ports/python3/0002-Static-CRT.patch
@@ -1,0 +1,17 @@
+diff --git a/PCbuild/pythoncore.vcxproj b/PCbuild/pythoncore.vcxproj
+index 4134d7b..ecbccf0 100644
+--- a/PCbuild/pythoncore.vcxproj
++++ b/PCbuild/pythoncore.vcxproj
+@@ -67,6 +67,10 @@
+       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
+       <AdditionalIncludeDirectories>$(PySourcePath)Python;$(PySourcePath)Modules\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_NO_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+-- 
+

--- a/ports/python3/0003-Fix-header-for-static-linkage.patch
+++ b/ports/python3/0003-Fix-header-for-static-linkage.patch
@@ -1,0 +1,14 @@
+diff --git a/PC/pyconfig.h b/PC/pyconfig.h
+index 64e7aec..aa36745 100644
+--- a/PC/pyconfig.h
++++ b/PC/pyconfig.h
+@@ -274,6 +274,7 @@ typedef int pid_t;
+ 
+ /* For Windows the Python core is in a DLL by default.  Test
+ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
++#define Py_NO_ENABLE_SHARED
+ #if !defined(MS_NO_COREDLL) && !defined(Py_NO_ENABLE_SHARED)
+ #	define Py_ENABLE_SHARED 1 /* standard symbol for shared library */
+ #	define MS_COREDLL	/* deprecated old symbol */
+-- 
+

--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -1,0 +1,3 @@
+Source: python3
+Version: 3.6.1
+Description: The Python programming language as an embeddable library

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -9,6 +9,13 @@
 #   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
 #   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
 #
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic AND VCPKG_CRT_LINKAGE STREQUAL static)
+    # Because the patches patch the same file, they have to be applied in the correct order
+    # In this scenario, only the second patch needs to be applied, which doesn't work
+    message(STATUS "Warning: Dynamic library with static CRT is not supported. Building static library.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
 
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src-${TARGET_TRIPLET})
@@ -20,7 +27,6 @@ vcpkg_from_github(
     HEAD_REF master
  )
 # We need per-triplet directories because we need to patch the project files differently based on the linkage
-file(REMOVE_RECURSE ${SOURCE_PATH})
 file(COPY ${TEMP_SOURCE_PATH} DESTINATION ${SOURCE_PATH})
 set(SOURCE_PATH ${SOURCE_PATH}/cpython-3.6.1)
 
@@ -63,6 +69,8 @@ endif()
 
 file(GLOB HEADERS ${SOURCE_PATH}/Include/*.h)
 file(COPY ${HEADERS} ${SOURCE_PATH}/PC/pyconfig.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/python3.6)
+
+file(COPY ${SOURCE_PATH}/Lib DESTINATION ${CURRENT_PACKAGES_DIR}/share/python3)
 
 file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36_d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -1,0 +1,78 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src-${TARGET_TRIPLET})
+vcpkg_from_github(
+    OUT_SOURCE_PATH TEMP_SOURCE_PATH
+    REPO python/cpython
+    REF v3.6.1
+    SHA512 1fdc1dc44d82762a793093fa19d6401c99fbc05375d8d7e378274ed5555a25dfb3537f93ef04e52ebbf95b42fda74303293dd37aba81ce0c4296a675ab75fa62 
+    HEAD_REF master
+ )
+# We need per-triplet directories because we need to patch the project files differently based on the linkage
+file(REMOVE_RECURSE ${SOURCE_PATH})
+file(COPY ${TEMP_SOURCE_PATH} DESTINATION ${SOURCE_PATH})
+set(SOURCE_PATH ${SOURCE_PATH}/cpython-3.6.1)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/0001-Static-library.patch
+    )
+endif()
+if (VCPKG_CRT_LINKAGE STREQUAL static)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/0002-Static-CRT.patch
+    )
+endif()
+
+if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+    set(BUILD_ARCH "Win32")
+    set(OUT_DIR "win32")
+elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+    set(BUILD_ARCH "x64")
+    set(OUT_DIR "amd64")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+vcpkg_build_msbuild(
+    PROJECT_PATH ${SOURCE_PATH}/PCBuild/pythoncore.vcxproj
+    PLATFORM ${BUILD_ARCH})
+    
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/0003-Fix-header-for-static-linkage.patch
+    )
+endif()
+
+file(GLOB HEADERS ${SOURCE_PATH}/Include/*.h)
+file(COPY ${HEADERS} ${SOURCE_PATH}/PC/pyconfig.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/python3.6)
+
+file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36_d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python36_d.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python3)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/python3/LICENSE ${CURRENT_PACKAGES_DIR}/share/python3/copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
This is a bare minimum port of Python 3 (the library only). I call it the bare minimum because none of the extra modules are being built for simplicity.
The name of the include directory isn't very nice, but I chose it so that CMake can find it automatically when configuring.