### PR TITLE
Update fftw3 to 3.3.6-pl2 and add single- and long-double targets

### DIFF
--- a/ports/fftw3/CMakeLists.txt
+++ b/ports/fftw3/CMakeLists.txt
@@ -67,14 +67,12 @@ include_directories(
     simd-support
 )
 
-# Create a target for the library
-add_library(fftw3
+set(COMMON_SOURCES
     ${fftw_api_SOURCE}
     ${fftw_dft_SOURCE}
     ${fftw_dft_scalar_SOURCE}
     ${fftw_dft_scalar_codelets_SOURCE}
     ${fftw_dft_simd_SOURCE}
-    ${fftw_dft_simd_sse2_SOURCE}
     ${fftw_kernel_SOURCE}
     ${fftw_rdft_SOURCE}
     ${fftw_rdft_scalar_SOURCE}
@@ -84,13 +82,36 @@ add_library(fftw3
     ${fftw_rdft_scalar_r2r_SOURCE}
 
     ${fftw_rdft_simd_SOURCE}
-    ${fftw_rdft_simd_sse2_SOURCE}
     ${fftw_reodft_SOURCE}
     ${fftw_simd_support_SOURCE}
     ${fftw_threads_SOURCE}
 )
 
-install(TARGETS fftw3
+set(SSE2_SOURCES
+  ${fftw_dft_simd_sse2_SOURCE}
+  ${fftw_rdft_simd_sse2_SOURCE}
+)
+
+# Create default target for the library (double precision)
+add_library(fftw3 ${COMMON_SOURCES} ${SSE2_SOURCES})
+target_compile_definitions(fftw3 PRIVATE HAVE_SSE2)
+set(INSTALL_TARGETS fftw3)
+
+# Optionally add single precision
+if(BUILD_SINGLE)
+    add_library(fftw3f ${COMMON_SOURCES} ${SSE2_SOURCES})
+    target_compile_definitions(fftw3f PRIVATE FFTW_SINGLE BENCHFFT_SINGLE HAVE_SSE2)
+    set(INSTALL_TARGETS ${INSTALL_TARGETS} fftw3f)
+endif(BUILD_SINGLE)
+
+# Optionally add long-double precision (does not support SSE2)
+if(BUILD_LONG_DOUBLE)
+    add_library(fftw3l ${COMMON_SOURCES})
+    target_compile_definitions(fftw3l PRIVATE FFTW_LDOUBLE BENCHFFT_LDOUBLE)
+    set(INSTALL_TARGETS ${INSTALL_TARGETS} fftw3l)
+endif(BUILD_LONG_DOUBLE)
+
+install(TARGETS ${INSTALL_TARGETS}
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)

--- a/ports/fftw3/CONTROL
+++ b/ports/fftw3/CONTROL
@@ -1,3 +1,3 @@
 Source: fftw3
-Version: 3.3.6-p11
+Version: 3.3.6-p12
 Description: FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).

--- a/ports/fftw3/config.h
+++ b/ports/fftw3/config.h
@@ -1,13 +1,13 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Define to compile in long-double precision. */
-#undef BENCHFFT_LDOUBLE
+/*#undef BENCHFFT_LDOUBLE*/
 
 /* Define to compile in quad precision. */
 #undef BENCHFFT_QUAD
 
 /* Define to compile in single precision. */
-#undef BENCHFFT_SINGLE
+/*#undef BENCHFFT_SINGLE*/
 
 /* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
    systems. This function is required for `alloca.c' support on those systems.
@@ -53,7 +53,7 @@
 #undef FFTW_ENABLE_ALLOCA
 
 /* Define to compile in long-double precision. */
-#undef FFTW_LDOUBLE
+/*#undef FFTW_LDOUBLE*/
 
 /* Define to compile in quad precision. */
 #undef FFTW_QUAD
@@ -62,7 +62,7 @@
 #undef FFTW_RANDOM_ESTIMATOR
 
 /* Define to compile in single precision. */
-#undef FFTW_SINGLE
+/*#undef FFTW_SINGLE*/
 
 /* Define to 1 if you have the `abort' function. */
 #define HAVE_ABORT 1
@@ -216,7 +216,7 @@
 #define HAVE_SQRT 1
 
 /* Define to enable SSE/SSE2 optimizations. */
-#define HAVE_SSE2 1
+/* #define HAVE_SSE2 1 */
 
 /* Define to 1 if you have the <stddef.h> header file. */
 #define HAVE_STDDEF_H 1

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -7,14 +7,17 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/fftw-3.3.6-pl1)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/fftw-3.3.6-pl2)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.fftw.org/fftw-3.3.6-pl1.tar.gz"
-    FILENAME "fftw-3.3.6-pl1.tar.gz"
-    SHA512 e2ed33fcb068a36a841bbd898d12ceec74f4e9a0a349e7c55959878b50224a69a0f87656347dad7d7e1448ebc50d28d8f34f6da7992c43072d26942fd97c0134
+    URLS "http://www.fftw.org/fftw-3.3.6-pl2.tar.gz"
+    FILENAME "fftw-3.3.6-pl2.tar.gz"
+    SHA512 e130309856752a1555b6d151c4d0ce9eb4b2c208fff7e3e89282ca8ef6104718f865cbb5e9c4af4367b3615b69b0d50fd001a26d74fd5324ff2faabe14fe3472
 )
 
 vcpkg_extract_source_archive(${ARCHIVE})
+
+option(BUILD_SINGLE "Additionally build single precision library" ON)
+option(BUILD_LONG_DOUBLE "Additionally build long-double precision library" ON)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h DESTINATION ${SOURCE_PATH})
@@ -22,6 +25,7 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h DESTINATION ${SOURCE_PATH})
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS -DBUILD_SINGLE=${BUILD_SINGLE} -DBUILD_LONG_DOUBLE=${BUILD_LONG_DOUBLE}
 )
 
 vcpkg_install_cmake()
@@ -31,9 +35,9 @@ file(COPY ${SOURCE_PATH}/api/fftw3.h DESTINATION ${CURRENT_PACKAGES_DIR}/include
 
 if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
     vcpkg_apply_patches(
-            SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
-            PATCHES
-                    ${CMAKE_CURRENT_LIST_DIR}/fix-dynamic.patch)
+           SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
+           PATCHES
+                   ${CMAKE_CURRENT_LIST_DIR}/fix-dynamic.patch)
 endif()
 
 # Handle copyright


### PR DESCRIPTION
- using latest source for 3.3.6
- adding single- and long-double targets with affix `f` for single and `l` for long double in library names. This is customary for fftw3. Unix package-managers use lib-root-affix-version.libtype-extension for fftw3. It seems to be the policy here to reduce this to root.libtype-extension, which I regret, but I kept it. It should be made sure though that different precision versions get affixes, as is well established for fftw3. People must be able to address the precision version explicitly. There is also a quad-variant, but it seems to be very rarely used and I haven't seen it in the popular unixy package managers, nor have I tried to build it.
- two of the definitions were moved from config.h to CMakeLists.txt/target_custom_definition to allow switching SSE2 support on and off, and to control precision
- tested to build with VS2017, 32/64, dynamic/static, static+md
- the single and long-double targets can be "switched off" in the portfile, but I left them on because all package managers I know provide three precision variants (and I need single ;) ). If they are switched off, there should not be any difference to the old build, except that the newer source is used. Implicit understanding of the naming convention: no affix means double precision.

Thanks for input!
