### PR TITLE
Add support for gtest's dynamic CRT + static linking.

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -17,8 +17,15 @@ vcpkg_apply_patches(
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch
 )
 
+if (VCPKG_CRT_LINKAGE STREQUAL "dynamic" AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(gtest_force_shared_crt YES)
+else()
+    set(gtest_force_shared_crt NO)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS -Dgtest_force_shared_crt=${gtest_force_shared_crt}
 )
 
 vcpkg_install_cmake()

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_apply_patches(
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch
 )
 
-if (VCPKG_CRT_LINKAGE STREQUAL "dynamic" AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+if (VCPKG_CRT_LINKAGE STREQUAL "dynamic")
     set(gtest_force_shared_crt YES)
 else()
     set(gtest_force_shared_crt NO)


### PR DESCRIPTION
According to #1131, add gtest's dynamic CRT + static linking to gtest.

Becuase gtest by default uses MT when static linking. While someone would use static linking + MD runtime.

This would be helpful for triplets in future.