### PR TITLE
Addition of a new port for the RedShell SDK

### DIFF
--- a/ports/redshell/CONTROL
+++ b/ports/redshell/CONTROL
@@ -1,3 +1,4 @@
 Source: redshell
 Version: 1.0.0
 Description: RedShell C++ SDK. Steam attribution tracking, www.redshell.io
+# Built-Using: openssl (= 1.0.2k-2), cpprestsdk (= 2.9.0-2), boost (= 1.64-4), websocketpp (= 0.7.0), zlib (= 1.2.11), bzip2 (= 1.0.6-1)

--- a/ports/redshell/CONTROL
+++ b/ports/redshell/CONTROL
@@ -1,0 +1,3 @@
+Source: redshell
+Version: 1.0.0
+Description: RedShell C++ SDK. Steam attribution tracking, www.redshell.io

--- a/ports/redshell/portfile.cmake
+++ b/ports/redshell/portfile.cmake
@@ -1,5 +1,13 @@
 include(vcpkg_common_functions)
 
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+  message(FATAL_ERROR "Error: redshell does not support the ARM architecture.")
+endif()
+
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    message(FATAL_ERROR "Error: redshell does not support UWP builds.")
+endif()
+
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/redshell)
 
 vcpkg_from_github(

--- a/ports/redshell/portfile.cmake
+++ b/ports/redshell/portfile.cmake
@@ -1,0 +1,47 @@
+include(vcpkg_common_functions)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/redshell)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Innervate/red-shell-cpp
+    REF 1.0.0
+    SHA512 00c79a09e92131e4ee0f46b14a2280bdb4e8c5970876dba99e8edd2294813f1b602eb0c9c8e24c9fd363a5c276dfa3daaf71f6ba2774842a8b565c803b3ff08c
+    HEAD_REF master
+)
+
+# Header .h
+file(COPY
+    "${SOURCE_PATH}/include/RedShell.h"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include/redshell
+)
+
+# Debug .lib
+file(COPY
+    "${SOURCE_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/debug/RedShell.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+)
+
+# Release .lib
+file(COPY
+    "${SOURCE_PATH}/lib/${VCPKG_TARGET_ARCHITECTURE}/RedShell.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+)
+
+# Debug .dll
+file(COPY
+    "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/debug/RedShell.dll"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+)
+
+# Release .dll
+file(COPY
+    "${SOURCE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/RedShell.dll"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+)
+
+# Copyright
+file(COPY
+    "${SOURCE_PATH}/LICENSE.txt"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/redshell/copyright
+)


### PR DESCRIPTION
This PR adds a port for the RedShell SDK
RedShell allows game developers to track Steam attribution for their game.
For more information visit innervate.us 

The portfile simply downloads the source from Github, then places the .h, .lib(s), and .dll(s) into their corresponding architecture as well as release / debug. 


CLA has been signed by 

Adam Lieb 
https://github.com/adamlieb
Innervate Inc