### PR TITLE
[hwloc] build from source

### DIFF
--- a/ports/hwloc/CMakeLists.txt
+++ b/ports/hwloc/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.0)
+project(hwloc C)
+
+configure_file(contrib/windows/hwloc_config.h include/hwloc/autogen/config.h COPYONLY)
+configure_file(contrib/windows/static-components.h include/static-components.h COPYONLY)
+configure_file(contrib/windows/private_config.h include/private/autogen/config.h COPYONLY)
+
+file(READ ${CMAKE_CURRENT_BINARY_DIR}/include/private/autogen/config.h PRIVATE_CONFIG_H)
+string(REPLACE "#define HAVE_DECL_SNPRINTF 0" "#define HAVE_DECL_SNPRINTF 1" PRIVATE_CONFIG_H "${PRIVATE_CONFIG_H}")
+string(REPLACE "#define HAVE_DECL_STRTOULL 0" "#define HAVE_DECL_STRTOULL 1" PRIVATE_CONFIG_H "${PRIVATE_CONFIG_H}")
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    string(REPLACE "/* #undef HWLOC_X86_32_ARCH */" "#define HWLOC_X86_32_ARCH 1"    PRIVATE_CONFIG_H "${PRIVATE_CONFIG_H}")
+    string(REPLACE "#define HWLOC_X86_64_ARCH 1"    "/* #undef HWLOC_X86_64_ARCH */" PRIVATE_CONFIG_H "${PRIVATE_CONFIG_H}")
+    string(REPLACE "#define SIZEOF_VOID_P 8"        "#define SIZEOF_VOID_P 4"        PRIVATE_CONFIG_H "${PRIVATE_CONFIG_H}")
+endif()
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/include/private/autogen/config.h "${PRIVATE_CONFIG_H}")
+
+add_library(libhwloc
+    src/base64.c
+    src/bind.c
+    src/bitmap.c
+    src/components.c
+    src/distances.c
+    src/diff.c
+    src/misc.c
+    src/pci-common.c
+    src/topology-custom.c
+    src/topology-noos.c
+    src/topology-synthetic.c
+    src/topology-windows.c
+    src/topology-x86.c
+    src/topology-xml-nolibxml.c
+    src/topology-xml.c
+    src/topology.c
+    src/traversal.c
+    src/dolib.c)
+
+set_target_properties(libhwloc PROPERTIES DEFINE_SYMBOL _USRDLL)
+target_include_directories(libhwloc PRIVATE ./include ./src ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_compile_definitions(libhwloc PRIVATE _CRT_SECURE_NO_WARNINGS)
+
+install(TARGETS libhwloc
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+
+if(NOT HWLOC_SKIP_INCLUDES)
+    install(FILES include/hwloc.h DESTINATION include)
+    install(DIRECTORY include/hwloc DESTINATION include FILES_MATCHING PATTERN "*.h")
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/hwloc/autogen/config.h DESTINATION include/hwloc/autogen)
+endif()

--- a/ports/hwloc/CONTROL
+++ b/ports/hwloc/CONTROL
@@ -1,4 +1,4 @@
 Source: hwloc
-Version: 1.11.7
+Version: 1.11.7-1
 Description: Portable Hardware Locality (hwloc) 
   The Portable Hardware Locality (hwloc) software package provides a portable abstraction (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various system attributes such as cache and memory information as well as the locality of I/O devices such as network interfaces, InfiniBand HCAs or GPUs. 

--- a/ports/hwloc/portfile.cmake
+++ b/ports/hwloc/portfile.cmake
@@ -1,41 +1,33 @@
-include(vcpkg_common_functions)
-
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    vcpkg_download_distfile(ARCHIVE
-        URLS "https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win32-build-1.11.7.zip"
-        FILENAME "hwloc-win32-build-1.11.7.zip"
-        SHA512 c474f2400b207bbad3da94d201d03eb711df6a87aacb8429c489591ed47393eb499d99da5737a22d0745194296db11bf9e8ebbabd4bf2ecfd2d2878a773195d8
-    )
-    set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/hwloc-win32-build-1.11.7)
-elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    vcpkg_download_distfile(ARCHIVE
-        URLS "https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.7.zip"
-        FILENAME "hwloc-win64-build-1.11.7.zip"
-        SHA512 1373107f75f372fa519a7c3f686fbb6ff89e14c3750e1d64755c768daf77a01a1d962b5e7ecadc65f9917b56f45193e637db3958a0bede08cfe2dd983a335d9b
-    )
-    set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/hwloc-win64-build-1.11.7)
-else()
-    message(FATAL_ERROR "HWLOC is not available for download for the platform: ${VCPKG_TARGET_ARCHITECTURE}")
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "UWP builds not supported")
 endif()
-vcpkg_extract_source_archive(${ARCHIVE})
 
-message(STATUS "Installing")
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO open-mpi/hwloc
+    REF hwloc-1.11.7
+    SHA512 bc3a74c60bfbed1e860c2fe2b5b49956eca5cfd9c00a262f6cd3026a42ae8b5411fa296e471a95cba657d943b8853675442e796e648034398af3015e5f59476e)
 
-# copy include files
-file(COPY ${SOURCE_PATH}/include/hwloc.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${SOURCE_PATH}/include/hwloc DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-# copy binaries
-file(COPY ${SOURCE_PATH}/bin/libhwloc-5.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-file(COPY ${SOURCE_PATH}/lib/libhwloc.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH} 
+    PREFER_NINJA
+    OPTIONS_DEBUG
+        -DHWLOC_SKIP_INCLUDES=ON)
 
-file(COPY ${SOURCE_PATH}/bin/libhwloc-5.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-file(COPY ${SOURCE_PATH}/lib/libhwloc.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+vcpkg_install_cmake()
 
-message(STATUS "Installing done")
+file(READ ${CURRENT_PACKAGES_DIR}/include/hwloc/autogen/config.h PUBLIC_CONFIG_H)
+string(REPLACE "defined( DECLSPEC_EXPORTS )" "0" PUBLIC_CONFIG_H "${PUBLIC_CONFIG_H}")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    string(REPLACE "defined( _USRDLL )" "0" PUBLIC_CONFIG_H "${PUBLIC_CONFIG_H}")
+else()
+    string(REPLACE "defined( _USRDLL )" "1" PUBLIC_CONFIG_H "${PUBLIC_CONFIG_H}")
+endif()
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/hwloc/autogen/config.h "${PUBLIC_CONFIG_H}")
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING.TXT DESTINATION ${CURRENT_PACKAGES_DIR}/share/hwloc)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/hwloc/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/hwloc/copyright)
-
-set(VCPKG_POLICY_ALLOW_OBSOLETE_MSVCRT enabled)
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/hwloc)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/hwloc/COPYING ${CURRENT_PACKAGES_DIR}/share/hwloc/copyright)


### PR DESCRIPTION
It is dangerous to use binaries pre-built by MinGW, as [hwloc_bitmap_asprintf](https://github.com/open-mpi/hwloc/blob/03167cedbc404d7eabc6b3dae23e3f35050acd96/src/bitmap.c#L311-L322) returns string that the user is supposed to `::free()`. This causes any code using said function to crash.