### PR TITLE
Fix gettext arm build

### DIFF
--- a/ports/gettext/0002-Fix-uwp-build.patch
+++ b/ports/gettext/0002-Fix-uwp-build.patch
@@ -1,0 +1,77 @@
+diff --git "a/gettext-0.19/gettext-runtime/intl/langprefs.c" "b/gettext-0.19/gettext-runtime/intl/langprefs.c"
+index aeb1c4e9..2ac531be 100644
+--- "a/gettext-0.19/gettext-runtime/intl/langprefs.c"
++++ "b/gettext-0.19/gettext-runtime/intl/langprefs.c"
+@@ -33,7 +33,13 @@ extern void _nl_locale_name_canonicalize (char *name);
+ #endif
+ 
+ #if defined _WIN32 || defined __WIN32__
+-# define WIN32_NATIVE
++# if !defined(WINAPI_FAMILY)
++#	define WIN32_NATIVE
++# else
++#	if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
++#		define WIN32_NATIVE
++#   endif
++# endif
+ #endif
+ 
+ #ifdef WIN32_NATIVE
+diff --git "a/gettext-0.19/gettext-runtime/intl/localcharset.c" "b/gettext-0.19/gettext-runtime/intl/localcharset.c"
+index 670b8e6c..035a96bd 100644
+--- "a/gettext-0.19/gettext-runtime/intl/localcharset.c"
++++ "b/gettext-0.19/gettext-runtime/intl/localcharset.c"
+@@ -36,6 +36,16 @@
+ # define WINDOWS_NATIVE
+ #endif
+ 
++#if defined _WIN32 || defined __WIN32__
++# if !defined(WINAPI_FAMILY)
++#	define HAVE_ACP
++# else
++#	if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
++#		define HAVE_ACP
++#   endif
++# endif
++#endif
++
+ #if defined __EMX__
+ /* Assume EMX program runs on OS/2, even if compiled under DOS.  */
+ # ifndef OS2
+@@ -361,7 +371,7 @@ STATIC
+ const char *
+ locale_charset (void)
+ {
+-  const char *codeset;
++  const char *codeset = NULL;
+   const char *aliases;
+ 
+ #if !(defined WINDOWS_NATIVE || defined OS2)
+@@ -457,7 +467,7 @@ locale_charset (void)
+ 
+ # endif
+ 
+-#elif defined WINDOWS_NATIVE
++#elif defined WINDOWS_NATIVE && defined HAVE_ACP
+ 
+   static char buf[2 + 10 + 1];
+ 
+diff --git "a/gettext-0.19/gettext-runtime/intl/localename.c" "b/gettext-0.19/gettext-runtime/intl/localename.c"
+index 108dd6f1..ace3aa88 100644
+--- "a/gettext-0.19/gettext-runtime/intl/localename.c"
++++ "b/gettext-0.19/gettext-runtime/intl/localename.c"
+@@ -54,7 +54,13 @@
+ #endif
+ 
+ #if defined _WIN32 || defined __WIN32__
+-# define WINDOWS_NATIVE
++# if !defined(WINAPI_FAMILY)
++#	define WINDOWS_NATIVE
++# else
++#	if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
++#		define WINDOWS_NATIVE
++#   endif
++# endif
+ #endif
+ 
+ #if defined WINDOWS_NATIVE || defined __CYGWIN__ /* Native Windows or Cygwin */

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,3 +1,3 @@
 Source: gettext
-Version: 0.19
+Version: 0.19-1
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages

--- a/ports/gettext/config.h
+++ b/ports/gettext/config.h
@@ -1,6 +1,9 @@
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Disable function deprecated warnings */
+#define _CRT_NONSTDC_NO_WARNINGS
+
 /* Define to the number of bits in type 'ptrdiff_t'. */
 #define BITSIZEOF_PTRDIFF_T sizeof(ptrdiff_t)
 

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -26,6 +26,7 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h DESTINATION ${SOURCE_PATH}/gettext-
 vcpkg_apply_patches(
     SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/
     PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-Fix-macro-definitions.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/0002-Fix-uwp-build.patch"
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
HAVE_STRDUP implies using of strdup, which is deprecated, and produces warnings as errors.
If I specify to undefine HAVE_STRDUP, gettext uses it's own manual implementation of strdup.
Another approach would be to replace using of strdup to strdup_s, which IMO needs more efforts regarding to patches and so on.