### PR TITLE
[boost] forcibly undefine BOOST_ALL_DYN_LINK in static builds

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
-Version: 1.64-4
+Version: 1.64-5
 Description: Peer-reviewed portable C++ source libraries
 Build-Depends: zlib, bzip2

--- a/ports/boost/portfile.cmake
+++ b/ports/boost/portfile.cmake
@@ -221,6 +221,9 @@ file(
 file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
 	"\n#define BOOST_ALL_NO_LIB\n"
 )
+file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp
+    "\n#undef BOOST_ALL_DYN_LINK\n"
+)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     file(APPEND ${CURRENT_PACKAGES_DIR}/include/boost/config/user.hpp


### PR DESCRIPTION
See https://github.com/Microsoft/vcpkg/pull/1125#issuecomment-304390431 and comments below. I've also been hitting this problem somewhere else.

Note: not guarded with if(static) to fix macro redefinition warnings when using dynamic boost.