### PR TITLE
replace empty-include-dir-hack with new policy

### DIFF
--- a/ports/ragel/portfile.cmake
+++ b/ports/ragel/portfile.cmake
@@ -23,7 +23,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/ragel.txt)
+# Allow empty include directory
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/ragel)


### PR DESCRIPTION
As https://github.com/Microsoft/vcpkg/blob/master/CHANGELOG.md states 0.0.78 introduced a policy to allow an empty include directory

So the workaround mentioned in https://github.com/Microsoft/vcpkg/pull/117 isn't needed anymore.

I just replaced it with the line(+comment) from https://github.com/Microsoft/vcpkg/blob/master/ports/ecm/portfile.cmake#L28