### PR TITLE
Specify toolset version

### DIFF
--- a/toolsrc/include/VcpkgPaths.h
+++ b/toolsrc/include/VcpkgPaths.h
@@ -48,7 +48,10 @@ namespace vcpkg
         const fs::path& get_cmake_exe() const;
         const fs::path& get_git_exe() const;
         const fs::path& get_nuget_exe() const;
-        const Toolset& get_toolset() const;
+        const std::vector<Toolset>& get_toolsets() const;
+
+        const Toolset& get_latest_toolset() const;
+        const Toolset& get_toolset(const std::string& toolset_version) const;
 
         Files::Filesystem& get_filesystem() const;
 
@@ -56,6 +59,6 @@ namespace vcpkg
         Lazy<fs::path> cmake_exe;
         Lazy<fs::path> git_exe;
         Lazy<fs::path> nuget_exe;
-        Lazy<Toolset> toolset;
+        Lazy<std::vector<Toolset>> toolsets;
     };
 }

--- a/toolsrc/include/VcpkgPaths.h
+++ b/toolsrc/include/VcpkgPaths.h
@@ -48,9 +48,11 @@ namespace vcpkg
         const fs::path& get_cmake_exe() const;
         const fs::path& get_git_exe() const;
         const fs::path& get_nuget_exe() const;
-        const std::vector<Toolset>& get_toolsets() const;
 
-        const Toolset& get_latest_toolset() const;
+        /// <summary>Retrieve a toolset matching a VS version</summary>
+        /// <remarks>
+        ///   Valid version strings are "v140", "v141", and "". Empty string gets the latest.
+        /// </remarks>
         const Toolset& get_toolset(const std::string& toolset_version) const;
 
         Files::Filesystem& get_filesystem() const;

--- a/toolsrc/src/PostBuildLint.cpp
+++ b/toolsrc/src/PostBuildLint.cpp
@@ -733,7 +733,7 @@ namespace vcpkg::PostBuildLint
         const auto& fs = paths.get_filesystem();
 
         // for dumpbin
-        const Toolset& toolset = paths.get_toolset();
+        const Toolset& toolset = paths.get_toolset(pre_build_info.platform_toolset);
         const fs::path package_dir = paths.package_dir(spec);
 
         size_t error_count = 0;

--- a/toolsrc/src/commands_env.cpp
+++ b/toolsrc/src/commands_env.cpp
@@ -13,7 +13,7 @@ namespace vcpkg::Commands::Env
         args.check_and_get_optional_command_arguments({});
 
         auto pre_build_info = Build::PreBuildInfo::from_triplet_file(paths, default_triplet);
-        System::cmd_execute_clean(Build::make_build_env_cmd(pre_build_info, paths.get_toolset()) + L" && cmd");
+        System::cmd_execute_clean(Build::make_build_env_cmd(pre_build_info, paths.get_toolset(pre_build_info.platform_toolset)) + L" && cmd");
 
         Checks::exit_success(VCPKG_LINE_INFO);
     }

--- a/toolsrc/src/vcpkg_Build.cpp
+++ b/toolsrc/src/vcpkg_Build.cpp
@@ -128,8 +128,8 @@ namespace vcpkg::Build
         const fs::path& git_exe_path = paths.get_git_exe();
 
         const fs::path ports_cmake_script_path = paths.ports_cmake;
-        const Toolset& toolset = paths.get_toolset();
         auto pre_build_info = PreBuildInfo::from_triplet_file(paths, triplet);
+        const Toolset& toolset = paths.get_toolset(pre_build_info.platform_toolset);
         const auto cmd_set_environment = make_build_env_cmd(pre_build_info, toolset);
 
         const std::wstring cmd_launch_cmake =


### PR DESCRIPTION
Implements support to request a specific toolset version via the variable `VCPKG_PLATFORM_TOOLSET` in a triplet.

If the variable not set or empty, the latest found toolset is used.

resolves #1207 