### PR TITLE
Qt5: Add private header paths in cmake config files via patch

### DIFF
--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5
-Version: 5.8-2
+Version: 5.8-3
 Description: Qt5 application framework main components. Webengine, examples and tests not included.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre, harfbuzz, sqlite3, libpq, double-conversion

--- a/ports/qt5/add-private-header-paths.patch
+++ b/ports/qt5/add-private-header-paths.patch
@@ -1,0 +1,801 @@
+diff --git a/Qt53DCore/Qt53DCoreConfig.cmake b/Qt53DCore/Qt53DCoreConfig.cmake
+index 80fc091..4fbaf5e 100644
+--- a/Qt53DCore/Qt53DCoreConfig.cmake
++++ b/Qt53DCore/Qt53DCoreConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DCore)
+ 
+     set(_Qt53DCore_OWN_INCLUDE_DIRS "${_qt53DCore_install_prefix}/include/" "${_qt53DCore_install_prefix}/include/Qt3DCore")
+-    set(Qt53DCore_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DCore_PRIVATE_INCLUDE_DIRS
++        "${_qt53DCore_install_prefix}/include/Qt3DCore/5.8.0"
++        "${_qt53DCore_install_prefix}/include/Qt3DCore/5.8.0/Qt3DCore"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DCore_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DExtras/Qt53DExtrasConfig.cmake b/Qt53DExtras/Qt53DExtrasConfig.cmake
+index 61de455..5f00da8 100644
+--- a/Qt53DExtras/Qt53DExtrasConfig.cmake
++++ b/Qt53DExtras/Qt53DExtrasConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DExtras)
+ 
+     set(_Qt53DExtras_OWN_INCLUDE_DIRS "${_qt53DExtras_install_prefix}/include/" "${_qt53DExtras_install_prefix}/include/Qt3DExtras")
+-    set(Qt53DExtras_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DExtras_PRIVATE_INCLUDE_DIRS
++        "${_qt53DExtras_install_prefix}/include/Qt3DExtras/5.8.0"
++        "${_qt53DExtras_install_prefix}/include/Qt3DExtras/5.8.0/Qt3DExtras"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DExtras_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DInput/Qt53DInputConfig.cmake b/Qt53DInput/Qt53DInputConfig.cmake
+index 1526967..089441e 100644
+--- a/Qt53DInput/Qt53DInputConfig.cmake
++++ b/Qt53DInput/Qt53DInputConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DInput)
+ 
+     set(_Qt53DInput_OWN_INCLUDE_DIRS "${_qt53DInput_install_prefix}/include/" "${_qt53DInput_install_prefix}/include/Qt3DInput")
+-    set(Qt53DInput_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DInput_PRIVATE_INCLUDE_DIRS
++        "${_qt53DInput_install_prefix}/include/Qt3DInput/5.8.0"
++        "${_qt53DInput_install_prefix}/include/Qt3DInput/5.8.0/Qt3DInput"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DInput_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DLogic/Qt53DLogicConfig.cmake b/Qt53DLogic/Qt53DLogicConfig.cmake
+index 336f0dc..963be42 100644
+--- a/Qt53DLogic/Qt53DLogicConfig.cmake
++++ b/Qt53DLogic/Qt53DLogicConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DLogic)
+ 
+     set(_Qt53DLogic_OWN_INCLUDE_DIRS "${_qt53DLogic_install_prefix}/include/" "${_qt53DLogic_install_prefix}/include/Qt3DLogic")
+-    set(Qt53DLogic_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DLogic_PRIVATE_INCLUDE_DIRS
++        "${_qt53DLogic_install_prefix}/include/Qt3DLogic/5.8.0"
++        "${_qt53DLogic_install_prefix}/include/Qt3DLogic/5.8.0/Qt3DLogic"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DLogic_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DQuick/Qt53DQuickConfig.cmake b/Qt53DQuick/Qt53DQuickConfig.cmake
+index cf510c9..0277c0c 100644
+--- a/Qt53DQuick/Qt53DQuickConfig.cmake
++++ b/Qt53DQuick/Qt53DQuickConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DQuick)
+ 
+     set(_Qt53DQuick_OWN_INCLUDE_DIRS "${_qt53DQuick_install_prefix}/include/" "${_qt53DQuick_install_prefix}/include/Qt3DQuick")
+-    set(Qt53DQuick_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DQuick_PRIVATE_INCLUDE_DIRS
++        "${_qt53DQuick_install_prefix}/include/Qt3DQuick/5.8.0"
++        "${_qt53DQuick_install_prefix}/include/Qt3DQuick/5.8.0/Qt3DQuick"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DQuick_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DQuickInput/Qt53DQuickInputConfig.cmake b/Qt53DQuickInput/Qt53DQuickInputConfig.cmake
+index 06fe217..f935824 100644
+--- a/Qt53DQuickInput/Qt53DQuickInputConfig.cmake
++++ b/Qt53DQuickInput/Qt53DQuickInputConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DQuickInput)
+ 
+     set(_Qt53DQuickInput_OWN_INCLUDE_DIRS "${_qt53DQuickInput_install_prefix}/include/" "${_qt53DQuickInput_install_prefix}/include/Qt3DQuickInput")
+-    set(Qt53DQuickInput_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DQuickInput_PRIVATE_INCLUDE_DIRS
++        "${_qt53DQuickInput_install_prefix}/include/Qt3DQuickInput/5.8.0"
++        "${_qt53DQuickInput_install_prefix}/include/Qt3DQuickInput/5.8.0/Qt3DQuickInput"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DQuickInput_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DQuickRender/Qt53DQuickRenderConfig.cmake b/Qt53DQuickRender/Qt53DQuickRenderConfig.cmake
+index dd5472b..ef728fd 100644
+--- a/Qt53DQuickRender/Qt53DQuickRenderConfig.cmake
++++ b/Qt53DQuickRender/Qt53DQuickRenderConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DQuickRender)
+ 
+     set(_Qt53DQuickRender_OWN_INCLUDE_DIRS "${_qt53DQuickRender_install_prefix}/include/" "${_qt53DQuickRender_install_prefix}/include/Qt3DQuickRender")
+-    set(Qt53DQuickRender_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DQuickRender_PRIVATE_INCLUDE_DIRS
++        "${_qt53DQuickRender_install_prefix}/include/Qt3DQuickRender/5.8.0"
++        "${_qt53DQuickRender_install_prefix}/include/Qt3DQuickRender/5.8.0/Qt3DQuickRender"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DQuickRender_OWN_INCLUDE_DIRS})
+diff --git a/Qt53DRender/Qt53DRenderConfig.cmake b/Qt53DRender/Qt53DRenderConfig.cmake
+index 70eff4b..271463b 100644
+--- a/Qt53DRender/Qt53DRenderConfig.cmake
++++ b/Qt53DRender/Qt53DRenderConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::3DRender)
+ 
+     set(_Qt53DRender_OWN_INCLUDE_DIRS "${_qt53DRender_install_prefix}/include/" "${_qt53DRender_install_prefix}/include/Qt3DRender")
+-    set(Qt53DRender_PRIVATE_INCLUDE_DIRS "")
++    set(Qt53DRender_PRIVATE_INCLUDE_DIRS
++        "${_qt53DRender_install_prefix}/include/Qt3DRender/5.8.0"
++        "${_qt53DRender_install_prefix}/include/Qt3DRender/5.8.0/Qt3DRender"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt53DRender_OWN_INCLUDE_DIRS})
+diff --git a/Qt5AxBase/Qt5AxBaseConfig.cmake b/Qt5AxBase/Qt5AxBaseConfig.cmake
+index 48966d5..63afee8 100644
+--- a/Qt5AxBase/Qt5AxBaseConfig.cmake
++++ b/Qt5AxBase/Qt5AxBaseConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::AxBase)
+ 
+     set(_Qt5AxBase_OWN_INCLUDE_DIRS "${_qt5AxBase_install_prefix}/include/" "${_qt5AxBase_install_prefix}/include/ActiveQt")
+-    set(Qt5AxBase_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5AxBase_PRIVATE_INCLUDE_DIRS
++        "${_qt5AxBase_install_prefix}/include/ActiveQt/5.8.0"
++        "${_qt5AxBase_install_prefix}/include/ActiveQt/5.8.0/ActiveQt"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5AxBase_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Bluetooth/Qt5BluetoothConfig.cmake b/Qt5Bluetooth/Qt5BluetoothConfig.cmake
+index 9d2f7c4..1223caf 100644
+--- a/Qt5Bluetooth/Qt5BluetoothConfig.cmake
++++ b/Qt5Bluetooth/Qt5BluetoothConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Bluetooth)
+ 
+     set(_Qt5Bluetooth_OWN_INCLUDE_DIRS "${_qt5Bluetooth_install_prefix}/include/" "${_qt5Bluetooth_install_prefix}/include/QtBluetooth")
+-    set(Qt5Bluetooth_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Bluetooth_PRIVATE_INCLUDE_DIRS
++        "${_qt5Bluetooth_install_prefix}/include/QtBluetooth/5.8.0"
++        "${_qt5Bluetooth_install_prefix}/include/QtBluetooth/5.8.0/QtBluetooth"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Bluetooth_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Charts/Qt5ChartsConfig.cmake b/Qt5Charts/Qt5ChartsConfig.cmake
+index fef4b13..52e458d 100644
+--- a/Qt5Charts/Qt5ChartsConfig.cmake
++++ b/Qt5Charts/Qt5ChartsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Charts)
+ 
+     set(_Qt5Charts_OWN_INCLUDE_DIRS "${_qt5Charts_install_prefix}/include/" "${_qt5Charts_install_prefix}/include/QtCharts")
+-    set(Qt5Charts_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Charts_PRIVATE_INCLUDE_DIRS
++        "${_qt5Charts_install_prefix}/include/QtCharts/5.8.0"
++        "${_qt5Charts_install_prefix}/include/QtCharts/5.8.0/QtCharts"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Charts_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Core/Qt5CoreConfig.cmake b/Qt5Core/Qt5CoreConfig.cmake
+index 4232dc7..c35d103 100644
+--- a/Qt5Core/Qt5CoreConfig.cmake
++++ b/Qt5Core/Qt5CoreConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Core)
+ 
+     set(_Qt5Core_OWN_INCLUDE_DIRS "${_qt5Core_install_prefix}/include/" "${_qt5Core_install_prefix}/include/QtCore")
+-    set(Qt5Core_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Core_PRIVATE_INCLUDE_DIRS
++        "${_qt5Core_install_prefix}/include/QtCore/5.8.0"
++        "${_qt5Core_install_prefix}/include/QtCore/5.8.0/QtCore"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Core_OWN_INCLUDE_DIRS})
+diff --git a/Qt5DBus/Qt5DBusConfig.cmake b/Qt5DBus/Qt5DBusConfig.cmake
+index d5e3ac6..472b928 100644
+--- a/Qt5DBus/Qt5DBusConfig.cmake
++++ b/Qt5DBus/Qt5DBusConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::DBus)
+ 
+     set(_Qt5DBus_OWN_INCLUDE_DIRS "${_qt5DBus_install_prefix}/include/" "${_qt5DBus_install_prefix}/include/QtDBus")
+-    set(Qt5DBus_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5DBus_PRIVATE_INCLUDE_DIRS
++        "${_qt5DBus_install_prefix}/include/QtDBus/5.8.0"
++        "${_qt5DBus_install_prefix}/include/QtDBus/5.8.0/QtDBus"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5DBus_OWN_INCLUDE_DIRS})
+diff --git a/Qt5DataVisualization/Qt5DataVisualizationConfig.cmake b/Qt5DataVisualization/Qt5DataVisualizationConfig.cmake
+index b518994..91559aa 100644
+--- a/Qt5DataVisualization/Qt5DataVisualizationConfig.cmake
++++ b/Qt5DataVisualization/Qt5DataVisualizationConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::DataVisualization)
+ 
+     set(_Qt5DataVisualization_OWN_INCLUDE_DIRS "${_qt5DataVisualization_install_prefix}/include/" "${_qt5DataVisualization_install_prefix}/include/QtDataVisualization")
+-    set(Qt5DataVisualization_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5DataVisualization_PRIVATE_INCLUDE_DIRS
++        "${_qt5DataVisualization_install_prefix}/include/QtDataVisualization/5.8.0"
++        "${_qt5DataVisualization_install_prefix}/include/QtDataVisualization/5.8.0/QtDataVisualization"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5DataVisualization_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Designer/Qt5DesignerConfig.cmake b/Qt5Designer/Qt5DesignerConfig.cmake
+index 69ea6dc..7b76032 100644
+--- a/Qt5Designer/Qt5DesignerConfig.cmake
++++ b/Qt5Designer/Qt5DesignerConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Designer)
+ 
+     set(_Qt5Designer_OWN_INCLUDE_DIRS "${_qt5Designer_install_prefix}/include/" "${_qt5Designer_install_prefix}/include/QtDesigner")
+-    set(Qt5Designer_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Designer_PRIVATE_INCLUDE_DIRS
++        "${_qt5Designer_install_prefix}/include/QtDesigner/5.8.0"
++        "${_qt5Designer_install_prefix}/include/QtDesigner/5.8.0/QtDesigner"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Designer_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Gamepad/Qt5GamepadConfig.cmake b/Qt5Gamepad/Qt5GamepadConfig.cmake
+index 66db87f..987ae8f 100644
+--- a/Qt5Gamepad/Qt5GamepadConfig.cmake
++++ b/Qt5Gamepad/Qt5GamepadConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Gamepad)
+ 
+     set(_Qt5Gamepad_OWN_INCLUDE_DIRS "${_qt5Gamepad_install_prefix}/include/" "${_qt5Gamepad_install_prefix}/include/QtGamepad")
+-    set(Qt5Gamepad_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Gamepad_PRIVATE_INCLUDE_DIRS
++        "${_qt5Gamepad_install_prefix}/include/QtGamepad/5.8.0"
++        "${_qt5Gamepad_install_prefix}/include/QtGamepad/5.8.0/QtGamepad"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Gamepad_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Gui/Qt5GuiConfig.cmake b/Qt5Gui/Qt5GuiConfig.cmake
+index 4718ba9..56888c1 100644
+--- a/Qt5Gui/Qt5GuiConfig.cmake
++++ b/Qt5Gui/Qt5GuiConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Gui)
+ 
+     set(_Qt5Gui_OWN_INCLUDE_DIRS "${_qt5Gui_install_prefix}/include/" "${_qt5Gui_install_prefix}/include/QtGui")
+-    set(Qt5Gui_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Gui_PRIVATE_INCLUDE_DIRS
++        "${_qt5Gui_install_prefix}/include/QtGui/5.8.0"
++        "${_qt5Gui_install_prefix}/include/QtGui/5.8.0/QtGui"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Gui_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Help/Qt5HelpConfig.cmake b/Qt5Help/Qt5HelpConfig.cmake
+index e84511c..0da7c20 100644
+--- a/Qt5Help/Qt5HelpConfig.cmake
++++ b/Qt5Help/Qt5HelpConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Help)
+ 
+     set(_Qt5Help_OWN_INCLUDE_DIRS "${_qt5Help_install_prefix}/include/" "${_qt5Help_install_prefix}/include/QtHelp")
+-    set(Qt5Help_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Help_PRIVATE_INCLUDE_DIRS
++        "${_qt5Help_install_prefix}/include/QtHelp/5.8.0"
++        "${_qt5Help_install_prefix}/include/QtHelp/5.8.0/QtHelp"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Help_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Location/Qt5LocationConfig.cmake b/Qt5Location/Qt5LocationConfig.cmake
+index a8bdf0a..f5348c2 100644
+--- a/Qt5Location/Qt5LocationConfig.cmake
++++ b/Qt5Location/Qt5LocationConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Location)
+ 
+     set(_Qt5Location_OWN_INCLUDE_DIRS "${_qt5Location_install_prefix}/include/" "${_qt5Location_install_prefix}/include/QtLocation")
+-    set(Qt5Location_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Location_PRIVATE_INCLUDE_DIRS
++        "${_qt5Location_install_prefix}/include/QtLocation/5.8.0"
++        "${_qt5Location_install_prefix}/include/QtLocation/5.8.0/QtLocation"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Location_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Multimedia/Qt5MultimediaConfig.cmake b/Qt5Multimedia/Qt5MultimediaConfig.cmake
+index 69f353f..67fa08b 100644
+--- a/Qt5Multimedia/Qt5MultimediaConfig.cmake
++++ b/Qt5Multimedia/Qt5MultimediaConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Multimedia)
+ 
+     set(_Qt5Multimedia_OWN_INCLUDE_DIRS "${_qt5Multimedia_install_prefix}/include/" "${_qt5Multimedia_install_prefix}/include/QtMultimedia")
+-    set(Qt5Multimedia_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Multimedia_PRIVATE_INCLUDE_DIRS
++        "${_qt5Multimedia_install_prefix}/include/QtMultimedia/5.8.0"
++        "${_qt5Multimedia_install_prefix}/include/QtMultimedia/5.8.0/QtMultimedia"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Multimedia_OWN_INCLUDE_DIRS})
+diff --git a/Qt5MultimediaWidgets/Qt5MultimediaWidgetsConfig.cmake b/Qt5MultimediaWidgets/Qt5MultimediaWidgetsConfig.cmake
+index 88162f8..1dcf69e 100644
+--- a/Qt5MultimediaWidgets/Qt5MultimediaWidgetsConfig.cmake
++++ b/Qt5MultimediaWidgets/Qt5MultimediaWidgetsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::MultimediaWidgets)
+ 
+     set(_Qt5MultimediaWidgets_OWN_INCLUDE_DIRS "${_qt5MultimediaWidgets_install_prefix}/include/" "${_qt5MultimediaWidgets_install_prefix}/include/QtMultimediaWidgets")
+-    set(Qt5MultimediaWidgets_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5MultimediaWidgets_PRIVATE_INCLUDE_DIRS
++        "${_qt5MultimediaWidgets_install_prefix}/include/QtMultimediaWidgets/5.8.0"
++        "${_qt5MultimediaWidgets_install_prefix}/include/QtMultimediaWidgets/5.8.0/QtMultimediaWidgets"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5MultimediaWidgets_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Network/Qt5NetworkConfig.cmake b/Qt5Network/Qt5NetworkConfig.cmake
+index 1778278..6a5d7f3 100644
+--- a/Qt5Network/Qt5NetworkConfig.cmake
++++ b/Qt5Network/Qt5NetworkConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Network)
+ 
+     set(_Qt5Network_OWN_INCLUDE_DIRS "${_qt5Network_install_prefix}/include/" "${_qt5Network_install_prefix}/include/QtNetwork")
+-    set(Qt5Network_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Network_PRIVATE_INCLUDE_DIRS
++        "${_qt5Network_install_prefix}/include/QtNetwork/5.8.0"
++        "${_qt5Network_install_prefix}/include/QtNetwork/5.8.0/QtNetwork"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Network_OWN_INCLUDE_DIRS})
+diff --git a/Qt5NetworkAuth/Qt5NetworkAuthConfig.cmake b/Qt5NetworkAuth/Qt5NetworkAuthConfig.cmake
+index 50f56e0..821080c 100644
+--- a/Qt5NetworkAuth/Qt5NetworkAuthConfig.cmake
++++ b/Qt5NetworkAuth/Qt5NetworkAuthConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::NetworkAuth)
+ 
+     set(_Qt5NetworkAuth_OWN_INCLUDE_DIRS "${_qt5NetworkAuth_install_prefix}/include/" "${_qt5NetworkAuth_install_prefix}/include/QtNetworkAuth")
+-    set(Qt5NetworkAuth_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5NetworkAuth_PRIVATE_INCLUDE_DIRS
++        "${_qt5NetworkAuth_install_prefix}/include/QtNetworkAuth/5.8.0"
++        "${_qt5NetworkAuth_install_prefix}/include/QtNetworkAuth/5.8.0/QtNetworkAuth"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5NetworkAuth_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Nfc/Qt5NfcConfig.cmake b/Qt5Nfc/Qt5NfcConfig.cmake
+index 83ffddd..d8a5ba9 100644
+--- a/Qt5Nfc/Qt5NfcConfig.cmake
++++ b/Qt5Nfc/Qt5NfcConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Nfc)
+ 
+     set(_Qt5Nfc_OWN_INCLUDE_DIRS "${_qt5Nfc_install_prefix}/include/" "${_qt5Nfc_install_prefix}/include/QtNfc")
+-    set(Qt5Nfc_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Nfc_PRIVATE_INCLUDE_DIRS
++        "${_qt5Nfc_install_prefix}/include/QtNfc/5.8.0"
++        "${_qt5Nfc_install_prefix}/include/QtNfc/5.8.0/QtNfc"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Nfc_OWN_INCLUDE_DIRS})
+diff --git a/Qt5OpenGL/Qt5OpenGLConfig.cmake b/Qt5OpenGL/Qt5OpenGLConfig.cmake
+index 6c874ac..3ac408a 100644
+--- a/Qt5OpenGL/Qt5OpenGLConfig.cmake
++++ b/Qt5OpenGL/Qt5OpenGLConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::OpenGL)
+ 
+     set(_Qt5OpenGL_OWN_INCLUDE_DIRS "${_qt5OpenGL_install_prefix}/include/" "${_qt5OpenGL_install_prefix}/include/QtOpenGL")
+-    set(Qt5OpenGL_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5OpenGL_PRIVATE_INCLUDE_DIRS
++        "${_qt5OpenGL_install_prefix}/include/QtOpenGL/5.8.0"
++        "${_qt5OpenGL_install_prefix}/include/QtOpenGL/5.8.0/QtOpenGL"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5OpenGL_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Positioning/Qt5PositioningConfig.cmake b/Qt5Positioning/Qt5PositioningConfig.cmake
+index 1aa3128..a6a2f24 100644
+--- a/Qt5Positioning/Qt5PositioningConfig.cmake
++++ b/Qt5Positioning/Qt5PositioningConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Positioning)
+ 
+     set(_Qt5Positioning_OWN_INCLUDE_DIRS "${_qt5Positioning_install_prefix}/include/" "${_qt5Positioning_install_prefix}/include/QtPositioning")
+-    set(Qt5Positioning_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Positioning_PRIVATE_INCLUDE_DIRS
++        "${_qt5Positioning_install_prefix}/include/QtPositioning/5.8.0"
++        "${_qt5Positioning_install_prefix}/include/QtPositioning/5.8.0/QtPositioning"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Positioning_OWN_INCLUDE_DIRS})
+diff --git a/Qt5PrintSupport/Qt5PrintSupportConfig.cmake b/Qt5PrintSupport/Qt5PrintSupportConfig.cmake
+index d7c6765..9a24e99 100644
+--- a/Qt5PrintSupport/Qt5PrintSupportConfig.cmake
++++ b/Qt5PrintSupport/Qt5PrintSupportConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::PrintSupport)
+ 
+     set(_Qt5PrintSupport_OWN_INCLUDE_DIRS "${_qt5PrintSupport_install_prefix}/include/" "${_qt5PrintSupport_install_prefix}/include/QtPrintSupport")
+-    set(Qt5PrintSupport_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5PrintSupport_PRIVATE_INCLUDE_DIRS
++        "${_qt5PrintSupport_install_prefix}/include/QtPrintSupport/5.8.0"
++        "${_qt5PrintSupport_install_prefix}/include/QtPrintSupport/5.8.0/QtPrintSupport"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5PrintSupport_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Purchasing/Qt5PurchasingConfig.cmake b/Qt5Purchasing/Qt5PurchasingConfig.cmake
+index b0cf03d..d0b527d 100644
+--- a/Qt5Purchasing/Qt5PurchasingConfig.cmake
++++ b/Qt5Purchasing/Qt5PurchasingConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Purchasing)
+ 
+     set(_Qt5Purchasing_OWN_INCLUDE_DIRS "${_qt5Purchasing_install_prefix}/include/" "${_qt5Purchasing_install_prefix}/include/QtPurchasing")
+-    set(Qt5Purchasing_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Purchasing_PRIVATE_INCLUDE_DIRS
++        "${_qt5Purchasing_install_prefix}/include/QtPurchasing/5.8.0"
++        "${_qt5Purchasing_install_prefix}/include/QtPurchasing/5.8.0/QtPurchasing"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Purchasing_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Qml/Qt5QmlConfig.cmake b/Qt5Qml/Qt5QmlConfig.cmake
+index 966e3ff..c59d5d1 100644
+--- a/Qt5Qml/Qt5QmlConfig.cmake
++++ b/Qt5Qml/Qt5QmlConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Qml)
+ 
+     set(_Qt5Qml_OWN_INCLUDE_DIRS "${_qt5Qml_install_prefix}/include/" "${_qt5Qml_install_prefix}/include/QtQml")
+-    set(Qt5Qml_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Qml_PRIVATE_INCLUDE_DIRS
++        "${_qt5Qml_install_prefix}/include/QtQml/5.8.0"
++        "${_qt5Qml_install_prefix}/include/QtQml/5.8.0/QtQml"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Qml_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Quick/Qt5QuickConfig.cmake b/Qt5Quick/Qt5QuickConfig.cmake
+index e1e2d05..def9557 100644
+--- a/Qt5Quick/Qt5QuickConfig.cmake
++++ b/Qt5Quick/Qt5QuickConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Quick)
+ 
+     set(_Qt5Quick_OWN_INCLUDE_DIRS "${_qt5Quick_install_prefix}/include/" "${_qt5Quick_install_prefix}/include/QtQuick")
+-    set(Qt5Quick_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Quick_PRIVATE_INCLUDE_DIRS
++        "${_qt5Quick_install_prefix}/include/QtQuick/5.8.0"
++        "${_qt5Quick_install_prefix}/include/QtQuick/5.8.0/QtQuick"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Quick_OWN_INCLUDE_DIRS})
+diff --git a/Qt5QuickControls2/Qt5QuickControls2Config.cmake b/Qt5QuickControls2/Qt5QuickControls2Config.cmake
+index cf34ce5..6f0ec96 100644
+--- a/Qt5QuickControls2/Qt5QuickControls2Config.cmake
++++ b/Qt5QuickControls2/Qt5QuickControls2Config.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::QuickControls2)
+ 
+     set(_Qt5QuickControls2_OWN_INCLUDE_DIRS "${_qt5QuickControls2_install_prefix}/include/" "${_qt5QuickControls2_install_prefix}/include/QtQuickControls2")
+-    set(Qt5QuickControls2_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5QuickControls2_PRIVATE_INCLUDE_DIRS
++        "${_qt5QuickControls2_install_prefix}/include/QtQuickControls2/5.8.0"
++        "${_qt5QuickControls2_install_prefix}/include/QtQuickControls2/5.8.0/QtQuickControls2"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5QuickControls2_OWN_INCLUDE_DIRS})
+diff --git a/Qt5QuickTest/Qt5QuickTestConfig.cmake b/Qt5QuickTest/Qt5QuickTestConfig.cmake
+index 9b2b8b2..6e1ea1d 100644
+--- a/Qt5QuickTest/Qt5QuickTestConfig.cmake
++++ b/Qt5QuickTest/Qt5QuickTestConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::QuickTest)
+ 
+     set(_Qt5QuickTest_OWN_INCLUDE_DIRS "${_qt5QuickTest_install_prefix}/include/" "${_qt5QuickTest_install_prefix}/include/QtQuickTest")
+-    set(Qt5QuickTest_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5QuickTest_PRIVATE_INCLUDE_DIRS
++        "${_qt5QuickTest_install_prefix}/include/QtQuickTest/5.8.0"
++        "${_qt5QuickTest_install_prefix}/include/QtQuickTest/5.8.0/QtQuickTest"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5QuickTest_OWN_INCLUDE_DIRS})
+diff --git a/Qt5QuickWidgets/Qt5QuickWidgetsConfig.cmake b/Qt5QuickWidgets/Qt5QuickWidgetsConfig.cmake
+index b0b8988..559b2f0 100644
+--- a/Qt5QuickWidgets/Qt5QuickWidgetsConfig.cmake
++++ b/Qt5QuickWidgets/Qt5QuickWidgetsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::QuickWidgets)
+ 
+     set(_Qt5QuickWidgets_OWN_INCLUDE_DIRS "${_qt5QuickWidgets_install_prefix}/include/" "${_qt5QuickWidgets_install_prefix}/include/QtQuickWidgets")
+-    set(Qt5QuickWidgets_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5QuickWidgets_PRIVATE_INCLUDE_DIRS
++        "${_qt5QuickWidgets_install_prefix}/include/QtQuickWidgets/5.8.0"
++        "${_qt5QuickWidgets_install_prefix}/include/QtQuickWidgets/5.8.0/QtQuickWidgets"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5QuickWidgets_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Script/Qt5ScriptConfig.cmake b/Qt5Script/Qt5ScriptConfig.cmake
+index da053f8..b2b34d6 100644
+--- a/Qt5Script/Qt5ScriptConfig.cmake
++++ b/Qt5Script/Qt5ScriptConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Script)
+ 
+     set(_Qt5Script_OWN_INCLUDE_DIRS "${_qt5Script_install_prefix}/include/" "${_qt5Script_install_prefix}/include/QtScript")
+-    set(Qt5Script_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Script_PRIVATE_INCLUDE_DIRS
++        "${_qt5Script_install_prefix}/include/QtScript/5.8.0"
++        "${_qt5Script_install_prefix}/include/QtScript/5.8.0/QtScript"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Script_OWN_INCLUDE_DIRS})
+diff --git a/Qt5ScriptTools/Qt5ScriptToolsConfig.cmake b/Qt5ScriptTools/Qt5ScriptToolsConfig.cmake
+index e4bf959..959ac50 100644
+--- a/Qt5ScriptTools/Qt5ScriptToolsConfig.cmake
++++ b/Qt5ScriptTools/Qt5ScriptToolsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::ScriptTools)
+ 
+     set(_Qt5ScriptTools_OWN_INCLUDE_DIRS "${_qt5ScriptTools_install_prefix}/include/" "${_qt5ScriptTools_install_prefix}/include/QtScriptTools")
+-    set(Qt5ScriptTools_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5ScriptTools_PRIVATE_INCLUDE_DIRS
++        "${_qt5ScriptTools_install_prefix}/include/QtScriptTools/5.8.0"
++        "${_qt5ScriptTools_install_prefix}/include/QtScriptTools/5.8.0/QtScriptTools"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5ScriptTools_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Scxml/Qt5ScxmlConfig.cmake b/Qt5Scxml/Qt5ScxmlConfig.cmake
+index 90ac06b..e78c552 100644
+--- a/Qt5Scxml/Qt5ScxmlConfig.cmake
++++ b/Qt5Scxml/Qt5ScxmlConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Scxml)
+ 
+     set(_Qt5Scxml_OWN_INCLUDE_DIRS "${_qt5Scxml_install_prefix}/include/" "${_qt5Scxml_install_prefix}/include/QtScxml")
+-    set(Qt5Scxml_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Scxml_PRIVATE_INCLUDE_DIRS
++        "${_qt5Scxml_install_prefix}/include/QtScxml/5.8.0"
++        "${_qt5Scxml_install_prefix}/include/QtScxml/5.8.0/QtScxml"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Scxml_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Sensors/Qt5SensorsConfig.cmake b/Qt5Sensors/Qt5SensorsConfig.cmake
+index 9e53e4d..2096beb 100644
+--- a/Qt5Sensors/Qt5SensorsConfig.cmake
++++ b/Qt5Sensors/Qt5SensorsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Sensors)
+ 
+     set(_Qt5Sensors_OWN_INCLUDE_DIRS "${_qt5Sensors_install_prefix}/include/" "${_qt5Sensors_install_prefix}/include/QtSensors")
+-    set(Qt5Sensors_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Sensors_PRIVATE_INCLUDE_DIRS
++        "${_qt5Sensors_install_prefix}/include/QtSensors/5.8.0"
++        "${_qt5Sensors_install_prefix}/include/QtSensors/5.8.0/QtSensors"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Sensors_OWN_INCLUDE_DIRS})
+diff --git a/Qt5SerialBus/Qt5SerialBusConfig.cmake b/Qt5SerialBus/Qt5SerialBusConfig.cmake
+index f2e4d69..8ba391c 100644
+--- a/Qt5SerialBus/Qt5SerialBusConfig.cmake
++++ b/Qt5SerialBus/Qt5SerialBusConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::SerialBus)
+ 
+     set(_Qt5SerialBus_OWN_INCLUDE_DIRS "${_qt5SerialBus_install_prefix}/include/" "${_qt5SerialBus_install_prefix}/include/QtSerialBus")
+-    set(Qt5SerialBus_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5SerialBus_PRIVATE_INCLUDE_DIRS
++        "${_qt5SerialBus_install_prefix}/include/QtSerialBus/5.8.0"
++        "${_qt5SerialBus_install_prefix}/include/QtSerialBus/5.8.0/QtSerialBus"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5SerialBus_OWN_INCLUDE_DIRS})
+diff --git a/Qt5SerialPort/Qt5SerialPortConfig.cmake b/Qt5SerialPort/Qt5SerialPortConfig.cmake
+index fa15de5..4ec1024 100644
+--- a/Qt5SerialPort/Qt5SerialPortConfig.cmake
++++ b/Qt5SerialPort/Qt5SerialPortConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::SerialPort)
+ 
+     set(_Qt5SerialPort_OWN_INCLUDE_DIRS "${_qt5SerialPort_install_prefix}/include/" "${_qt5SerialPort_install_prefix}/include/QtSerialPort")
+-    set(Qt5SerialPort_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5SerialPort_PRIVATE_INCLUDE_DIRS
++        "${_qt5SerialPort_install_prefix}/include/QtSerialPort/5.8.0"
++        "${_qt5SerialPort_install_prefix}/include/QtSerialPort/5.8.0/QtSerialPort"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5SerialPort_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Sql/Qt5SqlConfig.cmake b/Qt5Sql/Qt5SqlConfig.cmake
+index 0e5d50c..baf3f66 100644
+--- a/Qt5Sql/Qt5SqlConfig.cmake
++++ b/Qt5Sql/Qt5SqlConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Sql)
+ 
+     set(_Qt5Sql_OWN_INCLUDE_DIRS "${_qt5Sql_install_prefix}/include/" "${_qt5Sql_install_prefix}/include/QtSql")
+-    set(Qt5Sql_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Sql_PRIVATE_INCLUDE_DIRS
++        "${_qt5Sql_install_prefix}/include/QtSql/5.8.0"
++        "${_qt5Sql_install_prefix}/include/QtSql/5.8.0/QtSql"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Sql_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Svg/Qt5SvgConfig.cmake b/Qt5Svg/Qt5SvgConfig.cmake
+index 5d6ad04..b0d1aaa 100644
+--- a/Qt5Svg/Qt5SvgConfig.cmake
++++ b/Qt5Svg/Qt5SvgConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Svg)
+ 
+     set(_Qt5Svg_OWN_INCLUDE_DIRS "${_qt5Svg_install_prefix}/include/" "${_qt5Svg_install_prefix}/include/QtSvg")
+-    set(Qt5Svg_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Svg_PRIVATE_INCLUDE_DIRS
++        "${_qt5Svg_install_prefix}/include/QtSvg/5.8.0"
++        "${_qt5Svg_install_prefix}/include/QtSvg/5.8.0/QtSvg"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Svg_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Test/Qt5TestConfig.cmake b/Qt5Test/Qt5TestConfig.cmake
+index 8183efd..f15979f 100644
+--- a/Qt5Test/Qt5TestConfig.cmake
++++ b/Qt5Test/Qt5TestConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Test)
+ 
+     set(_Qt5Test_OWN_INCLUDE_DIRS "${_qt5Test_install_prefix}/include/" "${_qt5Test_install_prefix}/include/QtTest")
+-    set(Qt5Test_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Test_PRIVATE_INCLUDE_DIRS
++        "${_qt5Test_install_prefix}/include/QtTest/5.8.0"
++        "${_qt5Test_install_prefix}/include/QtTest/5.8.0/QtTest"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Test_OWN_INCLUDE_DIRS})
+diff --git a/Qt5TextToSpeech/Qt5TextToSpeechConfig.cmake b/Qt5TextToSpeech/Qt5TextToSpeechConfig.cmake
+index 2577e82..aa4bf39 100644
+--- a/Qt5TextToSpeech/Qt5TextToSpeechConfig.cmake
++++ b/Qt5TextToSpeech/Qt5TextToSpeechConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::TextToSpeech)
+ 
+     set(_Qt5TextToSpeech_OWN_INCLUDE_DIRS "${_qt5TextToSpeech_install_prefix}/include/" "${_qt5TextToSpeech_install_prefix}/include/QtTextToSpeech")
+-    set(Qt5TextToSpeech_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5TextToSpeech_PRIVATE_INCLUDE_DIRS
++        "${_qt5TextToSpeech_install_prefix}/include/QtTextToSpeech/5.8.0"
++        "${_qt5TextToSpeech_install_prefix}/include/QtTextToSpeech/5.8.0/QtTextToSpeech"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5TextToSpeech_OWN_INCLUDE_DIRS})
+diff --git a/Qt5UiTools/Qt5UiToolsConfig.cmake b/Qt5UiTools/Qt5UiToolsConfig.cmake
+index f217198..1bfa8b2 100644
+--- a/Qt5UiTools/Qt5UiToolsConfig.cmake
++++ b/Qt5UiTools/Qt5UiToolsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::UiTools)
+ 
+     set(_Qt5UiTools_OWN_INCLUDE_DIRS "${_qt5UiTools_install_prefix}/include/" "${_qt5UiTools_install_prefix}/include/QtUiTools")
+-    set(Qt5UiTools_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5UiTools_PRIVATE_INCLUDE_DIRS
++        "${_qt5UiTools_install_prefix}/include/QtUiTools/5.8.0"
++        "${_qt5UiTools_install_prefix}/include/QtUiTools/5.8.0/QtUiTools"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5UiTools_OWN_INCLUDE_DIRS})
+diff --git a/Qt5WebChannel/Qt5WebChannelConfig.cmake b/Qt5WebChannel/Qt5WebChannelConfig.cmake
+index ce8949c..c056b9d 100644
+--- a/Qt5WebChannel/Qt5WebChannelConfig.cmake
++++ b/Qt5WebChannel/Qt5WebChannelConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::WebChannel)
+ 
+     set(_Qt5WebChannel_OWN_INCLUDE_DIRS "${_qt5WebChannel_install_prefix}/include/" "${_qt5WebChannel_install_prefix}/include/QtWebChannel")
+-    set(Qt5WebChannel_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5WebChannel_PRIVATE_INCLUDE_DIRS
++        "${_qt5WebChannel_install_prefix}/include/QtWebChannel/5.8.0"
++        "${_qt5WebChannel_install_prefix}/include/QtWebChannel/5.8.0/QtWebChannel"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5WebChannel_OWN_INCLUDE_DIRS})
+diff --git a/Qt5WebSockets/Qt5WebSocketsConfig.cmake b/Qt5WebSockets/Qt5WebSocketsConfig.cmake
+index c2609da..42e21b8 100644
+--- a/Qt5WebSockets/Qt5WebSocketsConfig.cmake
++++ b/Qt5WebSockets/Qt5WebSocketsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::WebSockets)
+ 
+     set(_Qt5WebSockets_OWN_INCLUDE_DIRS "${_qt5WebSockets_install_prefix}/include/" "${_qt5WebSockets_install_prefix}/include/QtWebSockets")
+-    set(Qt5WebSockets_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5WebSockets_PRIVATE_INCLUDE_DIRS
++        "${_qt5WebSockets_install_prefix}/include/QtWebSockets/5.8.0"
++        "${_qt5WebSockets_install_prefix}/include/QtWebSockets/5.8.0/QtWebSockets"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5WebSockets_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Widgets/Qt5WidgetsConfig.cmake b/Qt5Widgets/Qt5WidgetsConfig.cmake
+index 44c7aed..658e29a 100644
+--- a/Qt5Widgets/Qt5WidgetsConfig.cmake
++++ b/Qt5Widgets/Qt5WidgetsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Widgets)
+ 
+     set(_Qt5Widgets_OWN_INCLUDE_DIRS "${_qt5Widgets_install_prefix}/include/" "${_qt5Widgets_install_prefix}/include/QtWidgets")
+-    set(Qt5Widgets_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Widgets_PRIVATE_INCLUDE_DIRS
++        "${_qt5Widgets_install_prefix}/include/QtWidgets/5.8.0"
++        "${_qt5Widgets_install_prefix}/include/QtWidgets/5.8.0/QtWidgets"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Widgets_OWN_INCLUDE_DIRS})
+diff --git a/Qt5WinExtras/Qt5WinExtrasConfig.cmake b/Qt5WinExtras/Qt5WinExtrasConfig.cmake
+index c63cee3..f9ea776 100644
+--- a/Qt5WinExtras/Qt5WinExtrasConfig.cmake
++++ b/Qt5WinExtras/Qt5WinExtrasConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::WinExtras)
+ 
+     set(_Qt5WinExtras_OWN_INCLUDE_DIRS "${_qt5WinExtras_install_prefix}/include/" "${_qt5WinExtras_install_prefix}/include/QtWinExtras")
+-    set(Qt5WinExtras_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5WinExtras_PRIVATE_INCLUDE_DIRS
++        "${_qt5WinExtras_install_prefix}/include/QtWinExtras/5.8.0"
++        "${_qt5WinExtras_install_prefix}/include/QtWinExtras/5.8.0/QtWinExtras"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5WinExtras_OWN_INCLUDE_DIRS})
+diff --git a/Qt5Xml/Qt5XmlConfig.cmake b/Qt5Xml/Qt5XmlConfig.cmake
+index fee861c..31dc6f7 100644
+--- a/Qt5Xml/Qt5XmlConfig.cmake
++++ b/Qt5Xml/Qt5XmlConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::Xml)
+ 
+     set(_Qt5Xml_OWN_INCLUDE_DIRS "${_qt5Xml_install_prefix}/include/" "${_qt5Xml_install_prefix}/include/QtXml")
+-    set(Qt5Xml_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5Xml_PRIVATE_INCLUDE_DIRS
++        "${_qt5Xml_install_prefix}/include/QtXml/5.8.0"
++        "${_qt5Xml_install_prefix}/include/QtXml/5.8.0/QtXml"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5Xml_OWN_INCLUDE_DIRS})
+diff --git a/Qt5XmlPatterns/Qt5XmlPatternsConfig.cmake b/Qt5XmlPatterns/Qt5XmlPatternsConfig.cmake
+index 662a612..45cfe8b 100644
+--- a/Qt5XmlPatterns/Qt5XmlPatternsConfig.cmake
++++ b/Qt5XmlPatterns/Qt5XmlPatternsConfig.cmake
+@@ -56,7 +56,10 @@ endmacro()
+ if (NOT TARGET Qt5::XmlPatterns)
+ 
+     set(_Qt5XmlPatterns_OWN_INCLUDE_DIRS "${_qt5XmlPatterns_install_prefix}/include/" "${_qt5XmlPatterns_install_prefix}/include/QtXmlPatterns")
+-    set(Qt5XmlPatterns_PRIVATE_INCLUDE_DIRS "")
++    set(Qt5XmlPatterns_PRIVATE_INCLUDE_DIRS
++        "${_qt5XmlPatterns_install_prefix}/include/QtXmlPatterns/5.8.0"
++        "${_qt5XmlPatterns_install_prefix}/include/QtXmlPatterns/5.8.0/QtXmlPatterns"
++    )
+     include("${CMAKE_CURRENT_LIST_DIR}/ExtraSourceIncludes.cmake" OPTIONAL)
+ 
+     foreach(_dir ${_Qt5XmlPatterns_OWN_INCLUDE_DIRS})
+

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -56,6 +56,10 @@ configure_qt(
 )
 install_qt()
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${CURRENT_PACKAGES_DIR}/lib/cmake
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/add-private-header-paths.patch"
+)
 file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake ${CURRENT_PACKAGES_DIR}/share/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
Hi,

I am offering this for consideration. It's a primitive solution to a problem of the current qt5 build, which does not provide paths to private headers in the cmake configuration files. Feel free to reject. But I have a qtwebkit(-ng) port in the drawer, that I'd like to push as PR once that qtwebkit version is released, and that depends on the availability of the private header paths in the qt5 port (only a small subset of this patch though).  I would imagine that other libraries, or users who use qt in their application build have the same problem - but might not find their way here to complain ;)
