### PR TITLE
Portaudio: some filing (dsound find, crt-linkage, backend-choice)

### DIFF
--- a/ports/portaudio/CONTROL
+++ b/ports/portaudio/CONTROL
@@ -1,3 +1,3 @@
 Source: portaudio
-Version: 19.0.6.00
+Version: 19.0.6.00-1
 Description: PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.

--- a/ports/portaudio/crt_linkage_build_config.patch
+++ b/ports/portaudio/crt_linkage_build_config.patch
@@ -1,0 +1,61 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,32 +10,32 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+ # project. If this is part of a larger project (i.e. the CMakeLists.txt has
+ # been imported by some other CMakeLists.txt), we don't want to trump over
+ # the top of that project's global settings.
+-IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_LIST_DIR})
+-  IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+-    MESSAGE(STATUS "Setting CMAKE_BUILD_TYPE type to 'Debug' as none was specified.")
+-    SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+-    SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
+-  ENDIF()
+-
+-  PROJECT(portaudio)
+-
+-  SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+-
+-  IF(WIN32 AND MSVC)
+-    OPTION(PA_DLL_LINK_WITH_STATIC_RUNTIME "Link with static runtime libraries (minimizes runtime dependencies)" ON)
+-    IF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
+-      FOREACH(flag_var
+-        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+-        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+-        IF(${flag_var} MATCHES "/MD")
+-          STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+-        ENDIF()
+-      ENDFOREACH()
+-    ENDIF()
+-  ENDIF()
+-ENDIF()
++# IF(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_LIST_DIR})
++  # IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
++    # MESSAGE(STATUS "Setting CMAKE_BUILD_TYPE type to 'Debug' as none was specified.")
++    # SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
++    # SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
++  # ENDIF()
++
++  # PROJECT(portaudio)
++
++  # SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
++
++  # IF(WIN32 AND MSVC)
++    # OPTION(PA_DLL_LINK_WITH_STATIC_RUNTIME "Link with static runtime libraries (minimizes runtime dependencies)" ON)
++    # IF(PA_DLL_LINK_WITH_STATIC_RUNTIME)
++      # FOREACH(flag_var
++        # CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
++        # CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
++        # CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
++        # CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
++        # IF(${flag_var} MATCHES "/MD")
++          # STRING(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
++        # ENDIF()
++      # ENDFOREACH()
++    # ENDIF()
++  # ENDIF()
++# ENDIF()
+ 
+ SET(PA_PKGCONFIG_VERSION 19)
+ 

--- a/ports/portaudio/find_dsound.patch
+++ b/ports/portaudio/find_dsound.patch
@@ -1,0 +1,114 @@
+--- a/cmake_support/FindDXSDK.cmake
++++ b/cmake_support/FindDXSDK.cmake
+@@ -16,44 +16,70 @@ else(WIN32)
+   message(FATAL_ERROR "FindDXSDK.cmake: Unsupported platform ${CMAKE_SYSTEM_NAME}" )
+ endif(WIN32)
+ 
+-find_path(DXSDK_ROOT_DIR
+-  include/dxsdkver.h
+-  HINTS
+-    $ENV{DXSDK_DIR}
+-)
+-
+-find_path(DXSDK_INCLUDE_DIR
+-  dxsdkver.h
+-  PATHS
+-    ${DXSDK_ROOT_DIR}/include 
+-)  
+-
+-IF(CMAKE_CL_64)
+-find_path(DXSDK_LIBRARY_DIR
+-  dsound.lib
+-  PATHS
+-  ${DXSDK_ROOT_DIR}/lib/x64
+-)
+-ELSE(CMAKE_CL_64)
+-find_path(DXSDK_LIBRARY_DIR
+-  dsound.lib
+-  PATHS
+-  ${DXSDK_ROOT_DIR}/lib/x86
+-)
+-ENDIF(CMAKE_CL_64)
+-
+-find_library(DXSDK_DSOUND_LIBRARY 
+-  dsound.lib
+-  PATHS
+-  ${DXSDK_LIBRARY_DIR}
+-)
+-
+-# handle the QUIETLY and REQUIRED arguments and set DXSDK_FOUND to TRUE if 
+-# all listed variables are TRUE
+-INCLUDE(FindPackageHandleStandardArgs)
+-FIND_PACKAGE_HANDLE_STANDARD_ARGS(DXSDK DEFAULT_MSG DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR)
+-
+-MARK_AS_ADVANCED(
+-    DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR
+-    DXSDK_LIBRARY_DIR DXSDK_DSOUND_LIBRARY
+-)
++# Dsound.lib is statically linked (i.e. dsound.dll not required) and DXSDK_LIBRARY_DIR not used.
++# In the environments supported by VCPKG we may as well avoid looking out for DX9 to avoid version
++# mismatch in find.
++
++if(MSVC AND MSVC_VERSION GREATER_EQUAL 1900)
++
++  # if the environment is set up properly, matching lib and header will be found
++
++  find_path(DXSDK_INCLUDE_DIR
++    dsound.h
++  )
++  find_library(DXSDK_DSOUND_LIBRARY
++    dsound.lib
++  )
++
++  INCLUDE(FindPackageHandleStandardArgs)
++  FIND_PACKAGE_HANDLE_STANDARD_ARGS(DXSDK DEFAULT_MSG DXSDK_INCLUDE_DIR DXSDK_DSOUND_LIBRARY)
++
++  MARK_AS_ADVANCED(
++    DXSDK_INCLUDE_DIR DXSDK_DSOUND_LIBRARY
++  )
++
++else()
++
++  find_path(DXSDK_ROOT_DIR
++    include/dxsdkver.h
++    HINTS
++      $ENV{DXSDK_DIR}
++  )
++
++  find_path(DXSDK_INCLUDE_DIR
++    dxsdkver.h
++    HINTS
++      ${DXSDK_ROOT_DIR}/include 
++  )  
++
++  IF(CMAKE_CL_64)
++  find_path(DXSDK_LIBRARY_DIR
++    dsound.lib
++    HINTS
++    ${DXSDK_ROOT_DIR}/lib/x64
++  )
++  ELSE(CMAKE_CL_64)
++  find_path(DXSDK_LIBRARY_DIR
++    dsound.lib
++    HINTS
++    ${DXSDK_ROOT_DIR}/lib/x86
++  )
++  ENDIF(CMAKE_CL_64)
++
++  find_library(DXSDK_DSOUND_LIBRARY 
++    dsound.lib
++    HINTS
++    ${DXSDK_LIBRARY_DIR}
++  )
++
++  # handle the QUIETLY and REQUIRED arguments and set DXSDK_FOUND to TRUE if 
++  # all listed variables are TRUE
++  INCLUDE(FindPackageHandleStandardArgs)
++  FIND_PACKAGE_HANDLE_STANDARD_ARGS(DXSDK DEFAULT_MSG DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR)
++
++  MARK_AS_ADVANCED(
++      DXSDK_ROOT_DIR DXSDK_INCLUDE_DIR
++      DXSDK_LIBRARY_DIR DXSDK_DSOUND_LIBRARY
++  )
++
++endif()

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -18,7 +18,8 @@ vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES
-                ${CMAKE_CURRENT_LIST_DIR}/cmakelists-install.patch)
+                ${CMAKE_CURRENT_LIST_DIR}/cmakelists-install.patch
+                ${CMAKE_CURRENT_LIST_DIR}/find_dsound.patch)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -19,18 +19,26 @@ vcpkg_apply_patches(
         SOURCE_PATH ${SOURCE_PATH}
         PATCHES
                 ${CMAKE_CURRENT_LIST_DIR}/cmakelists-install.patch
-                ${CMAKE_CURRENT_LIST_DIR}/find_dsound.patch)
+                ${CMAKE_CURRENT_LIST_DIR}/find_dsound.patch
+                ${CMAKE_CURRENT_LIST_DIR}/crt_linkage_build_config.patch)
 
+# NOTE: the ASIO backend will be built automatically if the ASIO-SDK is provided
+# in a sibling folder of the portaudio source in vcpkg/buildtrees/portaudio/src
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DPA_USE_DS=ON
+        -DPA_USE_WASAPI=ON
+        -DPA_USE_WDMKS=ON
+        -DPA_USE_WMME=ON
 )
 
 vcpkg_install_cmake()
 
 # Remove static builds from dynamic builds and otherwise
 # Remove x86 and x64 from resulting files
-if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 	file (REMOVE ${CURRENT_PACKAGES_DIR}/lib/portaudio_static_${VCPKG_TARGET_ARCHITECTURE}.lib)
 	file (REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/portaudio_static_${VCPKG_TARGET_ARCHITECTURE}.lib)
 


### PR DESCRIPTION
- avoid potential dsound version mismatch if DX9-sdk is installed
- let vcpkg alone handle crt linkage and build type
- add a bit of verbosity about build options in portfile

I've left out any attempt to handle ASIO semi-automatically as there is an open PR and a pending discussion on that.
