### PR TITLE
[openssl] Fix pathlib

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl
-Version: 1.0.2k-3
+Version: 1.0.2k-4
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl/fix-uwp-pathlib.patch
+++ b/ports/openssl/fix-uwp-pathlib.patch
@@ -1,0 +1,13 @@
+diff --git "a/ms/setVSvars.bat" "b/ms/setVSvars.bat"
+index e6ebc0a7..cde9afb2 100644
+--- "a/ms/setVSvars.bat"
++++ "b/ms/setVSvars.bat"
+@@ -179,7 +179,7 @@ exit /b
+ 	call:setVar _VS14VC VisualStudio14VC
+ 	call:setVar _WKITS10 WindowsKits10.0
+ 	set PATH=%_VS14VCBin%;%PATH%
+-	set "LIBPATH=%_WKITS10%UnionMetadata\Facade;%_VS14VC%vcpackages;%_WKITS10%references\windows.foundation.foundationcontract\1.0.0.0\;%_WKITS10%references\windows.foundation.universalapicontract\1.0.0.0\"
++	set "LIBPATH=%_WKITS10%UnionMetadata\Facade;%_VS14VC%vcpackages;%_WKITS10%references\windows.foundation.foundationcontract\2.0.0.0\;%_WKITS10%references\windows.foundation.universalapicontract\3.0.0.0\"
+ 	goto :eof
+ 
+ :end

--- a/ports/openssl/portfile-uwp.cmake
+++ b/ports/openssl/portfile-uwp.cmake
@@ -40,6 +40,13 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 
+message(STATUS ${SOURCE_PATH})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-uwp-pathlib.patch
+)
+
 file(REMOVE_RECURSE ${SOURCE_PATH}/tmp32dll)
 file(REMOVE_RECURSE ${SOURCE_PATH}/out32dll)
 file(REMOVE_RECURSE ${SOURCE_PATH}/inc32dll)

--- a/ports/openssl/portfile-uwp.cmake
+++ b/ports/openssl/portfile-uwp.cmake
@@ -40,8 +40,6 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 
-message(STATUS ${SOURCE_PATH})
-
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-uwp-pathlib.patch


### PR DESCRIPTION
Looks like these paths were outdated, and locally I wasn't able to build it. Now it builds on all uwp triplets.