### PR TITLE
[cairo] Add cairo-pdf.h and cairo-svg.h to subdir cairo in includes.

### DIFF
--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,4 +1,4 @@
 Source: cairo
-Version: 1.15.4
+Version: 1.15.4-1
 Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
 Build-Depends: zlib, libpng, pixman, glib, freetype, fontconfig

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -49,6 +49,13 @@ DESTINATION
 ${CURRENT_PACKAGES_DIR}/include
 )
 
+file(COPY
+"${SOURCE_PATH}/src/cairo-pdf.h"
+"${SOURCE_PATH}/src/cairo-svg.h"
+DESTINATION
+${CURRENT_PACKAGES_DIR}/include/cairo
+)
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/cairo)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/cairo/COPYING ${CURRENT_PACKAGES_DIR}/share/cairo/copyright)

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -33,7 +33,7 @@ endif()
 vcpkg_install_cmake()
 
 # Copy the appropriate header files.
-file(COPY
+foreach(FILE
 "${SOURCE_PATH}/src/cairo.h"
 "${SOURCE_PATH}/src/cairo-deprecated.h"
 "${SOURCE_PATH}/src/cairo-features.h"
@@ -44,17 +44,10 @@ file(COPY
 "${SOURCE_PATH}/cairo-version.h"
 "${SOURCE_PATH}/src/cairo-win32.h"
 "${SOURCE_PATH}/util/cairo-gobject/cairo-gobject.h"
-"${SOURCE_PATH}/src/cairo-ft.h"
-DESTINATION
-${CURRENT_PACKAGES_DIR}/include
-)
-
-file(COPY
-"${SOURCE_PATH}/src/cairo-pdf.h"
-"${SOURCE_PATH}/src/cairo-svg.h"
-DESTINATION
-${CURRENT_PACKAGES_DIR}/include/cairo
-)
+"${SOURCE_PATH}/src/cairo-ft.h")
+  file(COPY ${FILE} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+  file(COPY ${FILE} DESTINATION ${CURRENT_PACKAGES_DIR}/include/cairo)
+endforeach()
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/cairo)


### PR DESCRIPTION
Software written for LINUX expects the two header files in sub directory cairo and therefore uses
```
#include <cairo/cairo-pdf.h>
```
which fails with the current configuration.