### PR TITLE
Add utfz to ports

### DIFF
--- a/ports/utfz/CONTROL
+++ b/ports/utfz/CONTROL
@@ -1,0 +1,3 @@
+Source: utfz
+Version: 1.2
+Description: A tiny C++ library for parsing and encoding utf-8

--- a/ports/utfz/portfile.cmake
+++ b/ports/utfz/portfile.cmake
@@ -1,11 +1,12 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/utfz-1.2)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/IMQS/utfz/archive/v1.2.zip"
-    FILENAME "utfz-1.2.zip"
-    SHA512 a3bef8f769c7eb15fbd3a4c3c64f2e70666bfd305ad3c24ef676c7f5a428d95fdb8dcfe18cb5bfa072069e9368a29bf375848f9a775e60bec2eae7ffa5662b55
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO IMQS/utfz
+    REF v1.2
+    SHA512 286a7a79fe860df8c5a4e1fc75f56460026fe9fbcd2f0ea3e70ecf78e4c5de73442a008339a90c2bd4ef94d5a89c0ed2fb537b91927f11aaa1aa5876d36a628b
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/utfz/portfile.cmake
+++ b/ports/utfz/portfile.cmake
@@ -1,0 +1,22 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/utfz-1.2)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/IMQS/utfz/archive/v1.2.zip"
+    FILENAME "utfz-1.2.zip"
+    SHA512 a3bef8f769c7eb15fbd3a4c3c64f2e70666bfd305ad3c24ef676c7f5a428d95fdb8dcfe18cb5bfa072069e9368a29bf375848f9a775e60bec2eae7ffa5662b55
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+# Copy the include file
+file(COPY ${SOURCE_PATH}/utfz.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/license DESTINATION ${CURRENT_PACKAGES_DIR}/share/utfz)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/utfz/license ${CURRENT_PACKAGES_DIR}/share/utfz/copyright)


### PR DESCRIPTION
utfz is a UTF-8 decoding library.

It is notably different from utfcpp because it doesn't use exceptions.