### PR TITLE
[Qwt]: fix "missing zlib1.dll"

### DIFF
--- a/ports/qwt/CONTROL
+++ b/ports/qwt/CONTROL
@@ -1,4 +1,4 @@
 Source: qwt
-Version: 6.1.3-1
+Version: 6.1.3-2
 Description: Qt widgets library for technical applications
 Build-Depends: qt5

--- a/ports/qwt/portfile.cmake
+++ b/ports/qwt/portfile.cmake
@@ -21,6 +21,9 @@ else()
     )
 endif()
 
+# The qwt build requires zlib1.dll
+SET(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
+
 vcpkg_configure_qmake(
     SOURCE_PATH ${SOURCE_PATH}
 )


### PR DESCRIPTION
The build breaks with "missing zlib1.dll", so I added installed/.../bin to the path. Tested with x64-windows and x86-windows. Static not possible (I think) because qt5 cannot be built as static lib.
