### PR TITLE
Fix protobuf dynamic build

### DIFF
--- a/ports/protobuf/0001-fix-missing-export.patch
+++ b/ports/protobuf/0001-fix-missing-export.patch
@@ -1,0 +1,13 @@
+diff --git a/src/google/protobuf/generated_message_util.h b/src/google/protobuf/generated_message_util.h
+index 4417446..a7154b4 100644
+--- a/src/google/protobuf/generated_message_util.h
++++ b/src/google/protobuf/generated_message_util.h
+@@ -164,7 +164,7 @@ class ExplicitlyConstructed {
+ 
+ // Default empty string object. Don't use this directly. Instead, call
+ // GetEmptyString() to get the reference.
+-extern ExplicitlyConstructed< ::std::string> fixed_address_empty_string;
++LIBPROTOBUF_EXPORT extern ExplicitlyConstructed< ::std::string> fixed_address_empty_string;
+ LIBPROTOBUF_EXPORT extern ProtobufOnceType empty_string_once_init_;
+ LIBPROTOBUF_EXPORT void InitEmptyString();
+ 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -17,6 +17,15 @@ set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/protobuf-${PROTOBUF_VERSION})
 set(TOOL_PATH ${CURRENT_BUILDTREES_DIR}/src/protobuf-${PROTOBUF_VERSION}-win32)
 
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
+
+# Patch to fix the missing export of fixed_address_empty_string,
+# see https://github.com/google/protobuf/pull/3216
+vcpkg_apply_patches(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/protobuf-${PROTOBUF_VERSION}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-missing-export.patch"
+)
+
+
 vcpkg_extract_source_archive(${TOOL_ARCHIVE_FILE} ${TOOL_PATH})
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
Backport https://github.com/google/protobuf/pull/3216 

Without this fix, build of libraries depending on protobuf will give the following linking error:
~~~
contactsensor.pb.obj : error LNK2001: unresolved external symbol "class google::protobuf::internal::ExplicitlyConstructed<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > google::protobuf::internal::fixed_address_empty_string" (?fixed_address_empty_string@internal@protobuf@google@@3V?$ExplicitlyConstructed@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@123@A) [C:\src\gazebo-superbuild\build\osrf\ignition-msgs0\ignition\msgs\ignition-msgs0.vcxproj] [C:\src\gazebo-superbuild\build\ignition-msgs0.vcxproj]
~~~

cc @KindDragon 