### PR TITLE
[cairo] Initialize mutexes.

### DIFF
--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,4 +1,4 @@
 Source: cairo
-Version: 1.15.4-2
+Version: 1.15.4-3
 Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
 Build-Depends: zlib, libpng, pixman, glib, freetype, fontconfig

--- a/ports/cairo/Initialize-mutexes-for-static-builds-for-win32.patch
+++ b/ports/cairo/Initialize-mutexes-for-static-builds-for-win32.patch
@@ -1,0 +1,16 @@
+ src/win32/cairo-win32-device.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/win32/cairo-win32-device.c b/src/win32/cairo-win32-device.c
+index 741e49e..c60c494 100644
+--- a/src/win32/cairo-win32-device.c
++++ b/src/win32/cairo-win32-device.c
+@@ -131,6 +131,8 @@ _cairo_win32_device_get (void)
+ {
+     cairo_win32_device_t *device;
+ 
++    CAIRO_MUTEX_INITIALIZE ();
++
+     if (__cairo_win32_device)
+ 	return cairo_device_reference (__cairo_win32_device);
+ 

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -15,6 +15,11 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/Initialize-mutexes-for-static-builds-for-win32.patch"
+)
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_cairo.txt DESTINATION ${SOURCE_PATH}/src)
 file(RENAME ${SOURCE_PATH}/src/CMakeLists_cairo.txt ${SOURCE_PATH}/src/CMakeLists.txt)


### PR DESCRIPTION
In case of static builds the mutexes are not initialized for win32, so that programs using cairo surfaces crashes.

This change can be reverted once the proposed upstream patch is accepted (they proposed not to restrict the initialization call to static builds, see https://lists.cairographics.org/archives/cairo/2017-June/028131.html and https://lists.cairographics.org/archives/cairo/2017-June/028135.html).