### PR TITLE
[beast] Update to version 58

### DIFF
--- a/ports/beast/CONTROL
+++ b/ports/beast/CONTROL
@@ -1,4 +1,4 @@
 Source: beast
-Version: v56
+Version: v58
 Build-Depends: boost
 Description: HTTP/1 and WebSocket, header-only using Boost.Asio and C++11

--- a/ports/beast/portfile.cmake
+++ b/ports/beast/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vinniefalco/Beast
-    REF 8ba182cb2e0d073724be170cb64cd3d9226f161f
-    SHA512 e8f776aaac1f79f40cc06df0abc76e68da4aa502a66fe0b8a1a51f7c8d1245ee9fe4b767e398415f582b6f79df00711b91c60b688c574a06794e7c860a1775dc
+    REF 3f8097b6fddce8463084ce5c0d69db9a9079c2b8
+    SHA512 843cc0ddea35987e4f5eeaabcbcf3317135979eec9645a324740afa2a0af5041af787ee05e14d55d2ce17c72e227eacbadbe87c49e1bb6d7a0b075ad9694d92d
     HEAD_REF master
 )
 


### PR DESCRIPTION
Version 58:

* Fix unaligned reads in utf8-checker
* Qualify size_t in message template
* Reorganize examples
* Specification for http read
* Avoid `std::string` in websocket
* Fix basic_fields insert ordering
* basic_fields::set optimization
* basic_parser::put doc
* Use static string in basic_fields::reader
* Remove redundant code
* Fix parsing chunk size with leading zeroes
* Better message formal parameter names

API Changes:

* `basic_fields::set` renamed from `basic_fields::replace`

Actions Required:

* Rename calls to `basic_fields::replace` to `basic_fields::set`
