### PR TITLE
[libzip] Add libzip port, version 1.2.0

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,4 +1,4 @@
 Source: libzip
-Version: 1.2.0
+Version: 1.2.0-1
 Build-Depends: zlib
 Description: A library for reading, creating, and modifying zip archives.

--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,0 +1,4 @@
+Source: libzip
+Version: 1.2.0
+Build-Depends: zlib
+Description: A library for reading, creating, and modifying zip archives.

--- a/ports/libzip/LICENSE
+++ b/ports/libzip/LICENSE
@@ -1,0 +1,66 @@
+Copyright (C) 1999-2016 Dieter Baron and Thomas Klausner
+
+The authors can be contacted at <libzip@nih.at>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+
+3. The names of the authors may not be used to endorse or promote
+  products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+For AES encryption support, files under the following license are used:
+
+---------------------------------------------------------------------------
+Copyright (c) 2002, Dr Brian Gladman <                 >, Worcester, UK.
+All rights reserved.
+
+LICENSE TERMS
+
+The free distribution and use of this software in both source and binary
+form is allowed (with or without changes) provided that:
+
+  1. distributions of this source code include the above copyright
+     notice, this list of conditions and the following disclaimer;
+
+  2. distributions in binary form include the above copyright
+     notice, this list of conditions and the following disclaimer
+     in the documentation and/or other associated materials;
+
+  3. the copyright holder's name is not used to endorse products
+     built using this software without specific written permission.
+
+ALTERNATIVELY, provided that this notice is retained in full, this product
+may be distributed under the terms of the GNU General Public License (GPL),
+in which case the provisions of the GPL apply INSTEAD OF those given above.
+
+DISCLAIMER
+
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its properties, including, but not limited to, correctness
+and/or fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 18th November 2008

--- a/ports/libzip/enable-static.patch
+++ b/ports/libzip/enable-static.patch
@@ -1,0 +1,99 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d443757..303dfe2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -102,14 +102,20 @@ IF(MSVC)
+ ADD_DEFINITIONS("-D_CRT_SECURE_NO_WARNINGS")
+ ENDIF(MSVC)
+ 
++OPTION(ENABLE_STATIC "Enable static builds" OFF)
++IF(ENABLE_STATIC)
++  set(ZIP_EXTERN_OVERRIDE ON)
++  set(ZIP_EXTERN ON)
++ENDIF(ENABLE_STATIC)
++
+ ADD_DEFINITIONS("-DHAVE_CONFIG_H")
+ 
+ # Targets
+ ADD_SUBDIRECTORY(lib)
+-ADD_SUBDIRECTORY(man)
+-ADD_SUBDIRECTORY(src)
+-ADD_SUBDIRECTORY(regress)
+-ADD_SUBDIRECTORY(examples)
++# ADD_SUBDIRECTORY(man)
++# ADD_SUBDIRECTORY(src)
++# ADD_SUBDIRECTORY(regress)
++# ADD_SUBDIRECTORY(examples)
+ 
+ # TODO: pkgconfig file
+ 
+diff --git a/cmake-zipconf.h.in b/cmake-zipconf.h.in
+index 17edc6c..ac9c394 100644
+--- a/cmake-zipconf.h.in
++++ b/cmake-zipconf.h.in
+@@ -118,4 +118,10 @@ typedef unsigned long long zip_uint64_t;
+ #define ZIP_INT64_MAX	 0x7fffffffffffffffLL
+ #define ZIP_UINT64_MAX	 0xffffffffffffffffULL
+ 
++#cmakedefine ZIP_EXTERN_OVERRIDE
++#ifdef ZIP_EXTERN_OVERRIDE
++#undef ZIP_EXTERN
++#cmakedefine ZIP_EXTERN
++#endif
++
+ #endif /* zipconf.h */
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index 1596f30..eb55fc0 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -191,19 +191,20 @@ IF(NOT HAVE_MKSTEMP)
+   SET(LIBZIP_EXTRA_FILES mkstemp.c)
+ ENDIF(NOT HAVE_MKSTEMP)
+ 
+-ADD_LIBRARY(zip SHARED ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
+-SET_TARGET_PROPERTIES(zip PROPERTIES VERSION 3.0 SOVERSION 3 )
+-TARGET_LINK_LIBRARIES(zip ${ZLIB_LIBRARY})
+-INSTALL(TARGETS zip
+-  RUNTIME DESTINATION bin
+-  ARCHIVE DESTINATION lib
+-  LIBRARY DESTINATION lib)
+-#CREATE_LIBTOOL_FILE(zip lib)
+-
+-#ADD_LIBRARY(zipstatic STATIC ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
+-#SET_TARGET_PROPERTIES(zipstatic PROPERTIES VERSION 3.0 SOVERSION 3 )
+-#TARGET_LINK_LIBRARIES(zipstatic ${ZLIB_LIBRARY})
+-#INSTALL(TARGETS zipstatic
+-#  RUNTIME DESTINATION bin
+-#  ARCHIVE DESTINATION lib
+-#  LIBRARY DESTINATION lib)
++IF(ENABLE_STATIC)
++  ADD_LIBRARY(zipstatic STATIC ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
++  SET_TARGET_PROPERTIES(zipstatic PROPERTIES VERSION 3.0 SOVERSION 3 )
++  TARGET_LINK_LIBRARIES(zipstatic ${ZLIB_LIBRARY})
++  INSTALL(TARGETS zipstatic
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib)
++ELSE(ENABLE_STATIC)
++  ADD_LIBRARY(zip SHARED ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
++  SET_TARGET_PROPERTIES(zip PROPERTIES VERSION 3.0 SOVERSION 3 )
++  TARGET_LINK_LIBRARIES(zip ${ZLIB_LIBRARY})
++  INSTALL(TARGETS zip
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib
++    LIBRARY DESTINATION lib)
++ENDIF(ENABLE_STATIC)
+diff --git a/lib/compat.h b/lib/compat.h
+index 4c9e3a0..d667fe3 100644
+--- a/lib/compat.h
++++ b/lib/compat.h
+@@ -42,7 +42,9 @@
+ #define __STDC_LIMIT_MACROS
+ 
+ #ifdef _WIN32
++#ifndef ZIP_EXTERN_OVERRIDE
+ #define ZIP_EXTERN __declspec(dllexport)
++#endif
+ /* for dup(), close(), etc. */
+ #include <io.h>
+ #endif

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -1,0 +1,47 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libzip-1.2.0)
+vcpkg_download_distfile(ARCHIVE_FILE
+    URLS "https://nih.at/libzip/libzip-1.2.0.tar.gz"
+    FILENAME "libzip-1.2.0.tar.gz"
+    SHA512 b71642a80f8e2573c9082d513018bfd2d1d155663ac83fdf7ec969a08d5230fcbc76f2cf89c26ff1d1288e9f407ba9fa234604d813ed3bab816ca1670f7a53f3
+)
+vcpkg_extract_source_archive(${ARCHIVE_FILE})
+
+# Patch cmake and configuration to allow static builds
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/enable-static.patch"
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS -DENABLE_STATIC=OFF
+    )
+else()
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS -DENABLE_STATIC=ON
+    )
+endif()
+
+vcpkg_install_cmake()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/zip.dll ${CURRENT_PACKAGES_DIR}/debug/bin/zipd.dll)
+else()
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/lib/zip.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/zipd.lib)
+endif()
+
+# Move zipconf.h to include and remove include directories from lib
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libzip/include/zipconf.h ${CURRENT_PACKAGES_DIR}/include/zipconf.h)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libzip ${CURRENT_PACKAGES_DIR}/debug/lib/libzip)
+
+# Remove debug include
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Copy copright information
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libzip RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -27,11 +27,9 @@ endif()
 
 vcpkg_install_cmake()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/zip.dll ${CURRENT_PACKAGES_DIR}/debug/bin/zipd.dll)
-else()
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(RENAME ${CURRENT_PACKAGES_DIR}/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/lib/zip.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/zipd.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/zip.lib)
 endif()
 
 # Move zipconf.h to include and remove include directories from lib


### PR DESCRIPTION
libzip unfortunately does not have support for static builds, therefore a large amount of hack patching was required to build both a static and share variant.