### PR TITLE
Adding support for FFmpeg in UWP.

### DIFF
--- a/docs/maintainers/vcpkg_find_acquire_program.md
+++ b/docs/maintainers/vcpkg_find_acquire_program.md
@@ -24,6 +24,7 @@ The current list of programs includes:
 - NASM
 - NINJA
 - YASM
+- GASPREPROCESSOR
 
 Note that msys2 has a dedicated helper function: [`vcpkg_acquire_msys`](vcpkg_acquire_msys.md).
 

--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,4 +1,4 @@
 Source: ffmpeg
-Version: 3.2.4-2
+Version: 3.2.4-3
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -39,10 +39,11 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 
         ## Get Perl and GCC for MSYS2
         vcpkg_execute_required_process(
-            COMMAND ${BASH} --noprofile --norc -c "PATH=/usr/bin:\$PATH;pacman -Sy --noconfirm --needed perl gcc"
+            COMMAND ${BASH} --noprofile --norc -c 'PATH=/usr/bin:\$PATH;pacman -Sy --noconfirm --needed perl gcc'
             WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}
             LOGNAME msys-${TARGET_TRIPLET}
         )
+
     elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     else()

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -25,16 +25,55 @@ file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg ${CURRENT_BU
 
 set(OPTIONS "--disable-ffmpeg --disable-ffprobe --disable-doc --enable-debug")
 set(OPTIONS "${OPTIONS} --enable-runtime-cpudetect")
+
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    SET(UWP TRUE)
+    set(OPTIONS "${OPTIONS} --disable-programs --enable-cross-compile --target-os=win32 --arch=${VCPKG_TARGET_ARCHITECTURE}")
+    set(OPTIONS "${OPTIONS} --extra-cflags=-DWINAPI_FAMILY=WINAPI_FAMILY_APP --extra-cflags=-D_WIN32_WINNT=0x0A00")
+
+    if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        set(UWP_PLATFORM  "arm")
+        vcpkg_find_acquire_program(GASPREPROCESSOR)
+        foreach(GAS_PATH ${GASPREPROCESSOR})
+            get_filename_component(GAS_ITEM_PATH ${GAS_PATH} DIRECTORY)
+            set(ENV{PATH} "$ENV{PATH};${GAS_ITEM_PATH}")
+        endforeach(GAS_PATH)
+
+        ## Get Perl and GCC for MSYS2
+        execute_process(
+            COMMAND ${BASH} --noprofile --norc -c "PATH=/usr/bin:\$PATH;pacman -Sy --noconfirm --needed perl gcc"
+        )
+
+    elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(UWP_PLATFORM  "x64")
+    elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        set(UWP_PLATFORM  "Win32")
+    else ()
+        message(FATAL_ERROR "Unsupported architecture")
+    endif()
+endif()
+
 set(OPTIONS_DEBUG "") # Note: --disable-optimizations can't be used due to http://ffmpeg.org/pipermail/libav-user/2013-March/003945.html
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(OPTIONS "${OPTIONS} --disable-static --enable-shared")
+    if (UWP)
+        set(OPTIONS "${OPTIONS} --extra-ldflags=-APPCONTAINER --extra-ldflags=WindowsApp.lib")
+    endif()
 endif()
 
 if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-    set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-cflags=-MDd --extra-cxxflags=-MDd --extra-ldflags=-NODEFAULTLIB:libcmt")
+    set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-cflags=-MDd --extra-cxxflags=-MDd")
+    if (NOT UWP)
+        set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-ldflags=-NODEFAULTLIB:libcmt")
+    endif()
+    set(OPTIONS "${OPTIONS} --extra-cflags=-MD --extra-cxxflags=-MD")
 else()
-    set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-cflags=-MTd --extra-cxxflags=-MTd --extra-ldflags=-NODEFAULTLIB:libcmt")
+    set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-cflags=-MTd --extra-cxxflags=-MTd")
+    if (NOT UWP)
+        set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-ldflags=-NODEFAULTLIB:libcmt")
+    endif()
+    set(OPTIONS "${OPTIONS} --extra-cflags=-MT --extra-cxxflags=-MT")
 endif()
 
 message(STATUS "Building ${_csc_PROJECT_PATH} for Release")

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -84,6 +84,10 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin:\$PATH;pacman-key --init;pacman-key --populate"
       WORKING_DIRECTORY ${TOOLPATH}
     )
+    execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin:\$PATH;pacman -Syu --noconfirm"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
     file(WRITE "${TOOLPATH}/${STAMP}" "0")
     message(STATUS "Acquiring MSYS2... OK")
   endif()

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -16,6 +16,7 @@
 ## - 7Z
 ## - BISON
 ## - FLEX
+## - GASPREPROCESSOR
 ## - PERL
 ## - PYTHON2
 ## - PYTHON3
@@ -142,6 +143,15 @@ function(vcpkg_find_acquire_program VAR)
     set(URL "https://sourceforge.net/projects/gnuwin32/files/gperf/3.0.1/gperf-3.0.1-bin.zip/download")
     set(ARCHIVE "gperf-3.0.1-bin.zip")
     set(HASH 3f2d3418304390ecd729b85f65240a9e4d204b218345f82ea466ca3d7467789f43d0d2129fcffc18eaad3513f49963e79775b10cc223979540fa2e502fe7d4d9)
+  elseif(VAR MATCHES "GASPREPROCESSOR")
+    set(NOEXTRACT true)
+    set(PROGNAME gas-preprocessor)
+    set(REQUIRED_INTERPRETER PERL)
+    set(SCRIPTNAME "gas-preprocessor.pl")
+    set(PATHS ${DOWNLOADS}/tools/gas-preprocessor)
+    set(URL "https://raw.githubusercontent.com/FFmpeg/gas-preprocessor/36bacb4cba27003c572e5bf7a9c4dfe3c9a8d40d/gas-preprocessor.pl")
+    set(ARCHIVE "gas-preprocessor.pl")
+    set(HASH a25caadccd1457a0fd2abb5a0da9aca1713b2c351d76daf87a4141e52021f51aa09e95a62942c6f0764f79cc1fa65bf71584955b09e62ee7da067b5c82baf6b3)
   else()
     message(FATAL "unknown tool ${VAR} -- unable to acquire.")
   endif()
@@ -151,8 +161,8 @@ function(vcpkg_find_acquire_program VAR)
       find_program(${VAR} ${PROGNAME} PATHS ${PATHS})
     else()
       vcpkg_find_acquire_program(${REQUIRED_INTERPRETER})
-      find_file(SCIRPT ${SCRIPTNAME} PATHS ${PATHS})
-      set(${VAR} ${${REQUIRED_INTERPRETER}} ${SCIRPT})
+      find_file(SCRIPT ${SCRIPTNAME} PATHS ${PATHS})
+      set(${VAR} ${${REQUIRED_INTERPRETER}} ${SCRIPT})
     endif()
   endmacro()
 


### PR DESCRIPTION
This enables ffmpeg to be compiled as a UWP as well as a desktop app.

Adding support to download gas-preprocessor as an acquire_program.
Update all packages when installing msys2
Download perl and gcc for ARM assembly in ffmpeg through msys (for gas-preprocessor.pl).