### PR TITLE
Update tinyxml2 to 5.0.0

### DIFF
--- a/ports/tinyxml2/CONTROL
+++ b/ports/tinyxml2/CONTROL
@@ -1,3 +1,3 @@
 Source: tinyxml2
-Version: 3.0.0
+Version: 5.0.0
 Description: A simple, small, efficient, C++ XML parser

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -1,11 +1,24 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/tinyxml2-3.0.0)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/leethomason/tinyxml2/archive/3.0.0.zip"
-    FILENAME "tinyxml2-3.0.0.zip"
-    SHA512 3581e086e41ea01418fdf74e53b932c41cada9a45b73fb71c15424672182dc2a1e55110f030962ae44df6f5d9f060478c5b04373f886da843a78fcabae8b063c
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO leethomason/tinyxml2
+    REF 5.0.0
+    SHA512 ef310a466d0aec9dd0d25063c68f5312cd063366ee57499d8e462e25a556ea510617b66cdec1a368e8867dc082e0297e27fe09f16eb915392235be34206881e4
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -16,7 +29,19 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/tinyxml2")
+
+# changes target search path
+file(READ ${CURRENT_PACKAGES_DIR}/share/tinyxml2/tinyxml2Targets.cmake TINYXML2_TARGETS)
+string(REPLACE "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)"
+               "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)" TINYXML2_TARGETS ${TINYXML2_TARGETS})
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/tinyxml2/tinyxml2Targets.cmake "${TINYXML2_TARGETS}")
+
+vcpkg_copy_pdbs()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
 file(COPY ${SOURCE_PATH}/readme.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/tinyxml2)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/tinyxml2/readme.md ${CURRENT_PACKAGES_DIR}/share/tinyxml2/copyright)
-vcpkg_copy_pdbs()

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -1,15 +1,3 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
-
 include(vcpkg_common_functions)
 
 vcpkg_from_github(
@@ -22,20 +10,11 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/tinyxml2")
-
-# changes target search path
-file(READ ${CURRENT_PACKAGES_DIR}/share/tinyxml2/tinyxml2Targets.cmake TINYXML2_TARGETS)
-string(REPLACE "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)"
-               "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)" TINYXML2_TARGETS ${TINYXML2_TARGETS})
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/tinyxml2/tinyxml2Targets.cmake "${TINYXML2_TARGETS}")
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
Upgrade tinyxml2 to the newest 5.0.0. Crucial feature such as cmake config file is added.