### PR TITLE
Fix QHull port to use release version

### DIFF
--- a/ports/qhull/CONTROL
+++ b/ports/qhull/CONTROL
@@ -1,3 +1,3 @@
 Source: qhull
-Version:1.0
+Version: 2015.2
 Description: computes the convex hull, Delaunay triangulation, Voronoi diagram

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -1,7 +1,7 @@
 # Common Ambient Variables:
 #   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
 #   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
 #   PORT                      = current port name (zlib, etc)
 #   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
 #   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
@@ -13,33 +13,45 @@
 include(vcpkg_common_functions)
 
 vcpkg_from_github(
-	OUT_SOURCE_PATH SOURCE_PATH
+    OUT_SOURCE_PATH SOURCE_PATH
     REPO qhull/qhull
-	REF  master
-    SHA512 16aa9f93ce6fe8342a3b579881f10bb417679b0a70849e6b0cc5a89551e4de773a43bb0d54948196690d68d168f3a2a215e4600745ff1566302b0b426565fb25	
+    REF 5a79a0009454c86e9848646b3c296009125231bf # Qhull 2015.2
+    SHA512 ebcbf452eff420c62f92b734e5359b275493930b3e6798801eb1a81aa4fbf631b41e298a6071698c3b18c0939c55ddbc1b66b7019091bb4988dcfc7deb25e287
+    HEAD_REF master
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-     #PREFER_NINJA # Disable this option if project cannot be built with Ninja
-     OPTIONS 
-	-DINCLUDE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/include
-    -DMAN_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
-	-DDOC_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
-	 
-	 OPTIONS_RELEASE
-    -Dqhull_TARGETS_INSTALL=qhullcpp	 
-	-DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib
-     
-	 OPTIONS_DEBUG	 
-	-Dqhull_TARGETS_INSTALL=qhullcpp_d	  	 
-	-DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib	 
+    #PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    OPTIONS 
+        -DINCLUDE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/include
+        -DMAN_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
+        -DDOC_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
+    OPTIONS_RELEASE
+        -DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib
+    OPTIONS_DEBUG
+        -DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib
 )
 
 vcpkg_install_cmake()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(GLOB_RECURSE HTMFILES ${CURRENT_PACKAGES_DIR}/include/*.htm)
 file(REMOVE ${HTMFILES})
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc)
+
+file(GLOB EXEFILES_RELEASE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+file(GLOB EXEFILES_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/qhull)
+file(COPY ${EXEFILES_DEBUG} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/tools/qhull)
+file(REMOVE ${EXEFILES_RELEASE} ${EXEFILES_DEBUG})
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_d.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_p.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_pd.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_r.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_rd.lib)
+endif()
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/README.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/qhull)


### PR DESCRIPTION
Fix QHull port to use latest release version (2015.2), because current master/HEAD of QHull has some bugs.
Also, It is not good to always use master/HEAD. In many cases, It should be better to use release version.