### PR TITLE
[beast] Update to version 63

### DIFF
--- a/ports/beast/CONTROL
+++ b/ports/beast/CONTROL
@@ -1,4 +1,4 @@
 Source: beast
-Version: v59
+Version: v63
 Build-Depends: boost
 Description: HTTP/1 and WebSocket, header-only using Boost.Asio and C++11

--- a/ports/beast/portfile.cmake
+++ b/ports/beast/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vinniefalco/Beast
-    REF 4e4bcf8b1114229713eec0cf5fd392e5bdd76717
-    SHA512 514b93dccd483b1b847d9274f8a6fe9f4c32fdae6e1c45410abd3bb3554fa901aac8d6fc666a76420e1c4fa729e2ce7f95afa459faf01614de41995040eeb7bb
+    REF f68dc343e7c077caee8a95b2a59a2ccb9f979567
+    SHA512 d1c4ce5ee4d4b7cb20084c96af87ce106a4474631754a54a7cc19343e0767ed7a14cdb00f27bb1958e35f411b99c90444efd578e8c77e98d7e416703ea6f28bd
     HEAD_REF master
 )
 


### PR DESCRIPTION
Change log:

Version 63:

* Use std::to_string instead of lexical_cast
* Don't use cached Boost
* Put num_jobs back up on Travis
* Only build and run tests in variant=coverage
* Move benchmarks to a separate project
* Only run the tests under ubasan
* Tidy up CMakeLists.txt
* Tidy up Jamfiles
* Control running with valgrind explicitly

--------------------------------------------------------------------------------

Version 62:

* Remove libssl-dev from a Travis matrix item
* Increase detail::static_ostream coverage
* Add server-framework tests
* Doc fixes and tidy
* Tidy up namespaces in examples
* Clear the error faster
* Avoid explicit operator bool for error
* Add http::is_fields trait
* Squelch harmless not_connected errors
* Put slow tests back for coverage builds

API Changes:

* parser requires basic_fields
* Refine FieldsReader concept
* message::prepare_payload replaces message::prepare

Actions Required:

* Callers using `parser` with Fields types other than basic_fields
  will need to create their own subclass of basic_parser to work
  with their custom fields type.

* Implement chunked() and keep_alive() for user defined FieldsReader types.

* Change calls to msg.prepare to msg.prepare_payload. For messages
  with a user-defined Fields, provide the function prepare_payload_impl
  in the fields type according to the Fields requirements.

--------------------------------------------------------------------------------

Version 61:

* Remove Spirit dependency
* Use generic_cateogry for errno
* Reorganize SSL examples
* Tidy up some integer conversion warnings
* Add message::header_part()
* Tidy up names in error categories
* Flush the output stream in the example
* Clean close in Secure WebSocket client
* Add server-framework SSL HTTP and WebSocket ports
* Fix shadowing warnings
* Tidy up http-crawl example
* Add multi_port to server-framework
* Tidy up resolver calls
* Use one job on CI
* Don't run slow tests on certain targets

API Changes:

* header::version is unsigned
* status-codes is unsigned

--------------------------------------------------------------------------------

Version 60:

* String comparisons are public interfaces
* Fix response message type in async websocket accept
* New server-framework, full featured server example

