### PR TITLE
glew cmake build

### DIFF
--- a/ports/glew/CONTROL
+++ b/ports/glew/CONTROL
@@ -1,3 +1,3 @@
 Source: glew
-Version: 2.0.0-1
+Version: 2.0.0-2
 Description: The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -1,91 +1,29 @@
 include(vcpkg_common_functions)
+
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glew-2.0.0)
+
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz"
-    FILENAME "glew-2.0.0.tgz"
-    SHA512 e9bcd5f19a4495ce6511dfd76e64b4e4d958603c513ee9063eb9fe24fc6e0413f168620661230f1baef558f2f907cef7fe7ab2bdf957a6f7bda5fe96e9319c6a
+    URLS "https://sourceforge.net/projects/glew/files/glew/snapshots/glew-20170423.tgz"
+    FILENAME "glew-20170423.tgz"
+    SHA512 2d4651196e01b4db7b210fc60505bf50ac9e37b49c8eee9c9bbfeadb4cb6f87f4c907e60e708a7371ff4b7596bee51ed35a76fba76f9a13a1f32f123121f1350
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
-IF (TRIPLET_SYSTEM_ARCH MATCHES "x86")
-	SET(BUILD_ARCH "Win32")
-ELSEIF(TRIPLET_SYSTEM_ARCH MATCHES "arm")
-	MESSAGE(FATAL_ERROR " ARM is currently not supported.")
-ELSE()
-	SET(BUILD_ARCH ${TRIPLET_SYSTEM_ARCH})
-ENDIF()
-
-# TODO: Maybe switch to glews' cmake build system in the future
-FOREACH(LINKAGE shared static)
-	if(NOT EXISTS ${SOURCE_PATH}/build/vc12/glew_${LINKAGE}14.vcxproj)
-		message(STATUS "Upgrading " ${LINKAGE} " project")
-		file(READ ${SOURCE_PATH}/build/vc12/glew_${LINKAGE}.vcxproj PROJ)
-		string(REPLACE
-			"<PlatformToolset>v120</PlatformToolset>"
-			"<PlatformToolset>v140</PlatformToolset>"
-			PROJ ${PROJ})
-		string(REPLACE
-			"opengl32.lib%"
-			"opengl32.lib\;%"
-			PROJ ${PROJ})
-			
-		if (LINKAGE STREQUAL "static")
-			string(REPLACE
-				"MultiThreadedDebugDLL"
-				"MultiThreadedDebug"
-				PROJ ${PROJ}
-			)
-		endif()
-		file(WRITE ${SOURCE_PATH}/build/vc12/glew_${LINKAGE}14.vcxproj ${PROJ})
-	endif()
-ENDFOREACH(LINKAGE)
-message(STATUS "Upgrading projects done")
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-	vcpkg_build_msbuild(
-		PROJECT_PATH ${SOURCE_PATH}/build/vc12/glew_static14.vcxproj
-	)
-else()
-	vcpkg_build_msbuild(
-		PROJECT_PATH ${SOURCE_PATH}/build/vc12/glew_shared14.vcxproj
-	)
-endif()
-
-
-message(STATUS "Installing")
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-	file(INSTALL
-		${SOURCE_PATH}/bin/Debug/${BUILD_ARCH}/glew32d.dll
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
-	)
-	file(INSTALL
-		${SOURCE_PATH}/bin/Release/${BUILD_ARCH}/glew32.dll
-		DESTINATION ${CURRENT_PACKAGES_DIR}/bin
-	)
-	file(INSTALL
-		${SOURCE_PATH}/lib/Debug/${BUILD_ARCH}/glew32d.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib RENAME glew32.lib
-	)
-	file(INSTALL
-		${SOURCE_PATH}/lib/Release/${BUILD_ARCH}/glew32.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-	)
-else()
-	file(INSTALL
-		${SOURCE_PATH}/lib/Debug/${BUILD_ARCH}/glew32sd.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib RENAME glew32.lib
-	)
-	file(INSTALL
-		${SOURCE_PATH}/lib/Release/${BUILD_ARCH}/glew32s.lib
-		DESTINATION ${CURRENT_PACKAGES_DIR}/lib RENAME glew32.lib
-	)
-endif()
-
-file(INSTALL
-    ${SOURCE_PATH}/include/GL
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/build/cmake
 )
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/glew RENAME copyright)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/glew")
+
 vcpkg_copy_pdbs()
-message(STATUS "Installing done")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/glewinfo.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/visualinfo.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/glewinfo.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/visualinfo.exe)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/glew RENAME copyright)

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -1,13 +1,13 @@
 include(vcpkg_common_functions)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glew-2.0.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/20170423/glew-2.0.0)
 
 vcpkg_download_distfile(ARCHIVE_FILE
     URLS "https://sourceforge.net/projects/glew/files/glew/snapshots/glew-20170423.tgz"
     FILENAME "glew-20170423.tgz"
     SHA512 2d4651196e01b4db7b210fc60505bf50ac9e37b49c8eee9c9bbfeadb4cb6f87f4c907e60e708a7371ff4b7596bee51ed35a76fba76f9a13a1f32f123121f1350
 )
-vcpkg_extract_source_archive(${ARCHIVE_FILE})
+vcpkg_extract_source_archive(${ARCHIVE_FILE} ${CURRENT_BUILDTREES_DIR}/src/20170423)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/build/cmake
@@ -17,13 +17,30 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/glew")
 
-vcpkg_copy_pdbs()
+foreach(FILE ${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-debug.cmake ${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-release.cmake)
+    file(READ ${FILE} _contents)
+    string(REPLACE "libglew32" "glew32" _contents "${_contents}")
+    file(WRITE ${FILE} "${_contents}")
+endforeach()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/libglew32.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libglew32.lib ${CURRENT_PACKAGES_DIR}/lib/glew32.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libglew32d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/glew32d.lib)
+endif()
+
 file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/glewinfo.exe)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/visualinfo.exe)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/glewinfo.exe)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/visualinfo.exe)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+endif()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/glew RENAME copyright)


### PR DESCRIPTION
This change builds glew with cmake. This is a must needed change because now glew-config.cmake is generated therefore we can find glew in config mode when doing find_package in cmake. For example, finding glew and linking glew will now be as simple as

``````
find_package( glew REQUIRED NO_MODULE)

target_link_libraries(${PROJECT_NAME} GLEW::glew)
``````

Note that I am not directly pulling glew from github because it won't compile. I am pulling from the latest snapshot because the latest release has a bug that won't allow glew to compile in debug mode.

