### PR TITLE
[Boost] use default names for static linked libs

### DIFF
--- a/ports/boost/CONTROL
+++ b/ports/boost/CONTROL
@@ -1,4 +1,4 @@
 Source: boost
-Version: 1.64-5
+Version: 1.64-6
 Description: Peer-reviewed portable C++ source libraries
 Build-Depends: zlib, bzip2


### PR DESCRIPTION
As per #1338, disabling the forced renaming of static libraries now CMake can correctly find the files.
I am not a big expert in CMake nor in vcpkg, so if you see anything wrong I am happy to learn proper fixes