### PR TITLE
Updating the OpenSSL UWP port to 1.0.2l

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl
-Version: 1.0.2k-5
+Version: 1.0.21-1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl/portfile-uwp.cmake
+++ b/ports/openssl/portfile-uwp.cmake
@@ -27,7 +27,7 @@ endif()
 
 include(vcpkg_common_functions)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/openssl-OpenSSL_1_0_2k_WinRT)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/openssl-OpenSSL_1_0_2l_WinRT)
 
 vcpkg_find_acquire_program(PERL)
 vcpkg_find_acquire_program(JOM)
@@ -36,9 +36,9 @@ get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 set(ENV{PATH} "$ENV{PATH};${PERL_EXE_PATH};${JOM_EXE_PATH}")
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/Microsoft/openssl/archive/OpenSSL_1_0_2k_WinRT.zip"
-    FILENAME "openssl-microsoft-1.0.2k_WinRT.zip"
-    SHA512 afb434ef69c399f690f7ce723fabb228f77a12428f19062c5df3b8b841a2a7881c01150fdcfd2fab23867e3963292874a08ad227b37d168907b507fb1d7fede7
+    URLS "https://github.com/Microsoft/openssl/archive/OpenSSL_1_0_2l_WinRT.zip"
+    FILENAME "openssl-microsoft-1.0.2l_WinRT.zip"
+    SHA512 238b3daad7f1a2486e09d47e6d1bd4b0aa8e8a896358c6dfe11a77c2654da1b29d3c7612f9d200d5be5a020f33d96fe39cd75b99aa35aa4129feb756f7f98ee8
 )
 
 vcpkg_extract_source_archive(${ARCHIVE})


### PR DESCRIPTION
I've updated the UWP fork of OpenSSL to 1.0.2l. This PR is to update the reference for the project to reference the new version.