### PR TITLE
[beast] Update to version 66

### DIFF
--- a/ports/beast/CONTROL
+++ b/ports/beast/CONTROL
@@ -1,4 +1,4 @@
 Source: beast
-Version: v63
+Version: v66
 Build-Depends: boost
 Description: HTTP/1 and WebSocket, header-only using Boost.Asio and C++11

--- a/ports/beast/portfile.cmake
+++ b/ports/beast/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vinniefalco/Beast
-    REF f68dc343e7c077caee8a95b2a59a2ccb9f979567
-    SHA512 d1c4ce5ee4d4b7cb20084c96af87ce106a4474631754a54a7cc19343e0767ed7a14cdb00f27bb1958e35f411b99c90444efd578e8c77e98d7e416703ea6f28bd
+    REF 7fb75d0627f7842a6a706b810d427962509e0e52
+    SHA512 5d086d2edf18facc3f379c42ffcc2679f9c03f891d58f2c8e6cb1a9aa6ee73b232544d1c2a86ce9c42dbc9a41a58bd3480f958cc1c569e8b3b1890755ecfd7fc
     HEAD_REF master
 )
 


### PR DESCRIPTION
Version 66:

* string_param optimizations
* Add serializer request/response aliases
* Make consuming_buffers smaller
* Fix costly potential value-init in parser
* Fix unused parameter warning
* Handle bad_alloc in parser
* Tidy up message piecewise ctors
* Add header aliases
* basic_fields optimizations
* Add http-server example
* Squelch spurious warning on gcc

--------------------------------------------------------------------------------

Version 65:

* Enable narrowing warning on msvc cmake
* Fix integer types in deflate_stream::bi_reverse
* Fix narrowing in static_ostream
* Fix narrowing in ostream
* Fix narrowing in inflate_stream
* Fix narrowing in deflate_stream
* Fix integer warnings
* Enable unused variable warning on msvc cmake

--------------------------------------------------------------------------------

Version 64:

* Simplify buffered_read_stream composed op
* Simplify ssl teardown composed op
* Simplify websocket write_op
* Exemplars are compiled code
* Better User-Agent in examples
* async_write requires a non-const message
* Doc tidying
* Add link_directories to cmake

API Changes:

* Remove make_serializer

Actions Required:

* Replace calls to make_serializer with variable declarations
