### PR TITLE
[openssl] Fix OpenSSL version number

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl
-Version: 1.0.21-1
+Version: 1.0.2l-1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.


### PR DESCRIPTION
PR #1344 had a typo in the version number - 'two one' instead of 'two L'.  This fixes it.  I'm not sure what's the best way to handle this situation, but the issue should either be fixed quickly or have some more complicated solution.