### PR TITLE
[qscintilla] Fix inconsistency in python acquisition

### DIFF
--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_find_acquire_program(PYTHON3)
 
 # Add python3 to path
-get_filename_component(PYTHON_PATH ${PYTHON} DIRECTORY)
+get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
 SET(ENV{PATH} "${PYTHON_PATH};$ENV{PATH}")
 
 vcpkg_configure_qmake(


### PR DESCRIPTION
This seemed to work in the past but now produces an error when trying to add python to the path without specifying the version.