### PR TITLE
Disable protobuf compiler on UWP 

### DIFF
--- a/ports/protobuf/001-add-compiler-flag.patch
+++ b/ports/protobuf/001-add-compiler-flag.patch
@@ -1,0 +1,99 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index 7618ba21..bd92b09d 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -165,8 +165,11 @@ endif (protobuf_UNICODE)
+ 
+ include(libprotobuf-lite.cmake)
+ include(libprotobuf.cmake)
+-include(libprotoc.cmake)
+-include(protoc.cmake)
++
++if(protobuf_BUILD_COMPILER)
++  include(libprotoc.cmake)
++  include(protoc.cmake)
++endif()
+ 
+ if (protobuf_BUILD_TESTS)
+   include(tests.cmake)
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index 28dc90dc..44e4939c 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -1,21 +1,38 @@
+ include(GNUInstallDirs)
+ 
+-foreach(_library
+-  libprotobuf-lite
+-  libprotobuf
+-  libprotoc)
+-  set_property(TARGET ${_library}
+-    PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+-    $<BUILD_INTERFACE:${protobuf_source_dir}/src>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+-  install(TARGETS ${_library} EXPORT protobuf-targets
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
+-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
+-endforeach()
++if(protobuf_BUILD_COMPILER)
++  foreach(_library
++    libprotobuf-lite
++    libprotobuf
++    libprotoc)
++    set_property(TARGET ${_library}
++      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
++      $<BUILD_INTERFACE:${protobuf_source_dir}/src>
++      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++    install(TARGETS ${_library} EXPORT protobuf-targets
++      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
++      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
++      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
++  endforeach()
++else()
++  foreach(_library
++    libprotobuf-lite
++    libprotobuf)
++    set_property(TARGET ${_library}
++      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
++      $<BUILD_INTERFACE:${protobuf_source_dir}/src>
++      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++    install(TARGETS ${_library} EXPORT protobuf-targets
++      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
++      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
++      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
++  endforeach()
++endif()
+ 
+-install(TARGETS protoc EXPORT protobuf-targets
+-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
++if(protobuf_BUILD_COMPILER)
++  install(TARGETS protoc EXPORT protobuf-targets
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
++endif()
+ 
+ file(STRINGS extract_includes.bat.in _extract_strings
+   REGEX "^copy")
+@@ -94,10 +111,18 @@ configure_file(protobuf-options.cmake
+   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-options.cmake @ONLY)
+ 
+ # Allows the build directory to be used as a find directory.
+-export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
+-  NAMESPACE protobuf::
+-  FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+-)
++if(protobuf_BUILD_COMPILER)
++  export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
++    NAMESPACE protobuf::
++    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
++  )
++else()
++  export(TARGETS libprotobuf-lite libprotobuf
++    NAMESPACE protobuf::
++    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
++  )
++endif()
++
+ 
+ install(EXPORT protobuf-targets
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"

--- a/ports/protobuf/001-add-compiler-flag.patch
+++ b/ports/protobuf/001-add-compiler-flag.patch
@@ -17,53 +17,28 @@ index 7618ba21..bd92b09d 100644
  if (protobuf_BUILD_TESTS)
    include(tests.cmake)
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 28dc90dc..44e4939c 100644
+index 28dc90dc..52c1f721 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -1,21 +1,38 @@
+@@ -1,9 +1,12 @@
  include(GNUInstallDirs)
  
--foreach(_library
++set(LIBRARIES_TO_SET_DEST libprotobuf-lite libprotobuf)
++if(protobuf_BUILD_COMPILER)
++  list(APPEND LIBRARIES_TO_SET_DEST libprotoc)
++endif()
++
+ foreach(_library
 -  libprotobuf-lite
 -  libprotobuf
 -  libprotoc)
--  set_property(TARGET ${_library}
--    PROPERTY INTERFACE_INCLUDE_DIRECTORIES
--    $<BUILD_INTERFACE:${protobuf_source_dir}/src>
--    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
--  install(TARGETS ${_library} EXPORT protobuf-targets
--    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
--    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
--    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
--endforeach()
-+if(protobuf_BUILD_COMPILER)
-+  foreach(_library
-+    libprotobuf-lite
-+    libprotobuf
-+    libprotoc)
-+    set_property(TARGET ${_library}
-+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-+      $<BUILD_INTERFACE:${protobuf_source_dir}/src>
-+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-+    install(TARGETS ${_library} EXPORT protobuf-targets
-+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
-+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
-+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
-+  endforeach()
-+else()
-+  foreach(_library
-+    libprotobuf-lite
-+    libprotobuf)
-+    set_property(TARGET ${_library}
-+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-+      $<BUILD_INTERFACE:${protobuf_source_dir}/src>
-+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-+    install(TARGETS ${_library} EXPORT protobuf-targets
-+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${_library}
-+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library}
-+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
-+  endforeach()
-+endif()
++  ${LIBRARIES_TO_SET_DEST})
+   set_property(TARGET ${_library}
+     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+     $<BUILD_INTERFACE:${protobuf_source_dir}/src>
+@@ -14,8 +17,10 @@ foreach(_library
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
+ endforeach()
  
 -install(TARGETS protoc EXPORT protobuf-targets
 -  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
@@ -74,26 +49,17 @@ index 28dc90dc..44e4939c 100644
  
  file(STRINGS extract_includes.bat.in _extract_strings
    REGEX "^copy")
-@@ -94,10 +111,18 @@ configure_file(protobuf-options.cmake
+@@ -94,7 +99,12 @@ configure_file(protobuf-options.cmake
    ${CMAKE_INSTALL_CMAKEDIR}/protobuf-options.cmake @ONLY)
  
  # Allows the build directory to be used as a find directory.
 -export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
--  NAMESPACE protobuf::
--  FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
--)
++set(FIND_DIRS libprotobuf-lite libprotobuf)
 +if(protobuf_BUILD_COMPILER)
-+  export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
-+    NAMESPACE protobuf::
-+    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
-+  )
-+else()
-+  export(TARGETS libprotobuf-lite libprotobuf
-+    NAMESPACE protobuf::
-+    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
-+  )
++  list(APPEND FIND_DIRS libprotoc protoc)
 +endif()
 +
- 
- install(EXPORT protobuf-targets
-   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
++export(TARGETS ${FIND_DIRS}
+   NAMESPACE protobuf::
+   FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+ )

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -20,13 +20,22 @@ vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
 # Patch to fix the missing export of fixed_address_empty_string,
 # see https://github.com/google/protobuf/pull/3216
+# Add a flag that can be set to disable the protobuf compiler
 vcpkg_apply_patches(
     SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/protobuf-${PROTOBUF_VERSION}
     PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-missing-export.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/001-add-compiler-flag.patch"
 )
 
 
 vcpkg_extract_source_archive(${TOOL_ARCHIVE_FILE} ${TOOL_PATH})
+
+# Disable the protobuf compiler when targeting UWP
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+  set(protobuf_BUILD_COMPILER OFF)
+else()
+  set(protobuf_BUILD_COMPILER ON)
+endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(protobuf_BUILD_SHARED_LIBS ON)
@@ -47,6 +56,7 @@ vcpkg_configure_cmake(
         -Dprotobuf_MSVC_STATIC_RUNTIME=${protobuf_MSVC_STATIC_RUNTIME}
         -Dprotobuf_WITH_ZLIB=ON
         -Dprotobuf_BUILD_TESTS=OFF
+        -Dprotobuf_BUILD_COMPILER=${protobuf_BUILD_COMPILER}
         -DCMAKE_INSTALL_CMAKEDIR=share/protobuf
 )
 


### PR DESCRIPTION
Protobuf's compiler component is not UWP compatible. However some libraries that require protobuf do not use its compiler API, such as opencv_contrib. 

This pull request makes protobuf skip building the compiler component when targeting UWP, allowing other libraries, like opencv_contrib, to be built for UWP.
