### PR TITLE
Fix and enhance qscintilla build

### DIFF
--- a/ports/qscintilla/CONTROL
+++ b/ports/qscintilla/CONTROL
@@ -1,4 +1,4 @@
 Source: qscintilla
-Version: 2.10
-Description: QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt))
+Version: 2.10-1
+Description: QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)
 Build-Depends: qt5

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -67,20 +67,15 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
    file(INSTALL
        ${BUILD_DIR}/release/qscintilla2_qt5.dll
        DESTINATION ${CURRENT_PACKAGES_DIR}/bin
-       RENAME qscintilla2.dll
     )
 
     file(INSTALL
         ${BUILD_DIR}/debug/qscintilla2_qt5.dll
         DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
-        RENAME qscintilla2.dll
     )
 
-    file(INSTALL
-        ${BUILD_DIR}/debug/qscintilla2_qt5.pdb
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
-        RENAME qscintilla2.pdb
-    )
+vcpkg_copy_pdbs()
+
 endif()
 
 # Handle copyright

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -25,41 +25,61 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON_PATH ${PYTHON3} DIRECTORY)
 SET(ENV{PATH} "${PYTHON_PATH};$ENV{PATH}")
 
+set(BUILD_OPTIONS
+    "${SOURCE_PATH}/Qt4Qt5/qscintilla.pro"
+    CONFIG+=build_all
+    CONFIG-=hide_symbols
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(BUILD_OPTIONS
+        ${BUILD_OPTIONS}
+        CONFIG+=staticlib
+    )
+endif()
+
 vcpkg_configure_qmake(
     SOURCE_PATH "${SOURCE_PATH}/Qt4Qt5"
     OPTIONS
-        CONFIG+=build_all
-        CONFIG-=hide_symbols
+        ${BUILD_OPTIONS}
 )
 
 vcpkg_build_qmake()
 
-# Install following vcpkg conventions (following qwt portfile)
 set(BUILD_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})
 
-file(GLOB HEADER_FILES ${SOURCE_PATH}/include/*)
-file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/qscintilla)
+file(GLOB HEADER_FILES ${SOURCE_PATH}/Qt4Qt5/Qsci/*)
+file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/Qsci)
 
 file(INSTALL
     ${BUILD_DIR}/release/qscintilla2_qt5.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME qscintilla2.lib
 )
 
 file(INSTALL
     ${BUILD_DIR}/debug/qscintilla2_qt5.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    RENAME qscintilla2.lib
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(INSTALL
-        ${BUILD_DIR}/release/qscintilla2_qt5.dll
-        DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+   file(INSTALL
+       ${BUILD_DIR}/release/qscintilla2_qt5.dll
+       DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+       RENAME qscintilla2.dll
     )
 
     file(INSTALL
         ${BUILD_DIR}/debug/qscintilla2_qt5.dll
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+        RENAME qscintilla2.dll
+    )
+
+    file(INSTALL
         ${BUILD_DIR}/debug/qscintilla2_qt5.pdb
         DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+        RENAME qscintilla2.pdb
     )
 endif()
 


### PR DESCRIPTION
The qscintilla-port was broken (I provided it myself, sorry ;))

It now

- copies the correct headers to the standard folder
- renames the target files not to use the _qtX suffix, which is unnecessary in a vcpkg context, ugly, and not common
- allows for a static build. I had ignored that option before because I thought qt5 can't be built statically, but actually it is possible to build a static qscintilla lib against dynamic qt5. I found that the app I am using it in requires a static qscintilla lib ;)

One could do more by adding the QtDesiner plugin, but I haven't had time yet.