### PR TITLE
fix ceres find_package error for downstream project

### DIFF
--- a/ports/ceres/CONTROL
+++ b/ports/ceres/CONTROL
@@ -1,4 +1,4 @@
 Source: ceres
-Version: 1.12.0-3
+Version: 1.12.0-4
 Build-Depends:suitesparse, eigen3, clapack, gflags, glog
 Description: non-linear optimization package

--- a/ports/ceres/portfile.cmake
+++ b/ports/ceres/portfile.cmake
@@ -52,10 +52,6 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake")
 
-file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/CeresConfig.cmake CERES_MODULE)
-string(REPLACE "\${CERES_CURRENT_CONFIG_DIR}/../" "\${CERES_CURRENT_CONFIG_DIR}/../../" CERES_MODULE "${CERES_MODULE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/CeresConfig.cmake "${CERES_MODULE}")
-
 vcpkg_copy_pdbs()
 
 # Changes target search path


### PR DESCRIPTION
Using the current ceres will cause problem for downstream project, this PR will fix it