### PR TITLE
[gsl] Add a "d" debug postfix

### DIFF
--- a/ports/gsl/CMakeLists.txt
+++ b/ports/gsl/CMakeLists.txt
@@ -48,6 +48,10 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gsl_types.h "${GSLTYPES_H}")
 file(GLOB_RECURSE PUBLIC_HEADERS gsl*.h)
 list(APPEND PUBLIC_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/gsl_types.h)
 
+# The debug libraries have a "d" postfix so that CMake's FindGSL.cmake 
+# module can distinguish between Release and Debug libraries
+set(CMAKE_DEBUG_POSTFIX "d")
+
 add_library(gslcblas ${CBLAS_SOURCES})
 set_target_properties(gslcblas PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/ports/gsl/CONTROL
+++ b/ports/gsl/CONTROL
@@ -1,3 +1,3 @@
 Source: gsl
-Version: 2.3-1
+Version: 2.3-2
 Description: The GNU Scientific Library is a numerical library for C and C++ programmers


### PR DESCRIPTION
See https://github.com/Microsoft/vcpkg/issues/1196#issuecomment-305751793 for details. 
With the newly released (  https://blog.kitware.com/cmake-3-9-0-available-for-download ) CMake 3.9, this modification ensures that the correct libraries are found for Release and for Debug. 
For older version of CMake, the Release library is still used for both Release and Debug, so there is no regression even for CMake <= 3.8 .