### PR TITLE
fix the TRIPLET_SYSTEM_ARCH initialization

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -32,8 +32,6 @@ endif()
 
 
 if(CMD MATCHES "^BUILD$")
-    string(REGEX REPLACE "([^-]*)-([^-]*)" "\\1" TRIPLET_SYSTEM_ARCH ${TARGET_TRIPLET})
-
     set(CMAKE_TRIPLET_FILE ${VCPKG_ROOT_DIR}/triplets/${TARGET_TRIPLET}.cmake)
     if(NOT EXISTS ${CMAKE_TRIPLET_FILE})
         message(FATAL_ERROR "Unsupported target triplet. Triplet file does not exist: ${CMAKE_TRIPLET_FILE}")
@@ -70,6 +68,7 @@ if(CMD MATCHES "^BUILD$")
     file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR} ${CURRENT_PACKAGES_DIR})
 
     include(${CMAKE_TRIPLET_FILE})
+    set(TRIPLET_SYSTEM_ARCH ${VCPKG_TARGET_ARCHITECTURE})
     include(${CURRENT_PORT_DIR}/portfile.cmake)
 
     set(BUILD_INFO_FILE_PATH ${CURRENT_PACKAGES_DIR}/BUILD_INFO)


### PR DESCRIPTION
Previously, the TRIPLET_SYSTEM_ARCH CMake variable was initialized by parsing the triplet name, which imposed to the triplet name an implicit specification (i.e. start with either x64-, x86- or -arm).

Now, it will be initialized using VCPKG_TARGET_ARCHITECTURE, just after the triplet file is be included.

This (at least) corrects installation failures of the following packages when the triplet name was not prefixed by either x64-, x86- or arm-:
- ace
- box2d
- chakracore
- cppzmq
- directxmesh
- directxtex
- directxtk
- dxut
- embree
- libopusenc
- libusb
- libvpx
- mdnsresponder
- mpir
- ode
- opengl
- opus
- opusfile
- tbb
- uvatlas
- zeromq

P.S.: For a complete history of the problem, please see: https://github.com/Microsoft/vcpkg/issues/1463