### PR TITLE
Fix link the dependency libraries in debug configuration

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,4 +1,4 @@
 Source: vtk
-Version: 7.1.1
+Version: 7.1.1-1
 Description: Software system for 3D computer graphics, image processing, and visualization
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, qt5, msmpi

--- a/ports/vtk/disable-workaround-findhdf5.patch
+++ b/ports/vtk/disable-workaround-findhdf5.patch
@@ -1,0 +1,23 @@
+diff --git a/CMake/vtkModuleMacros.cmake b/CMake/vtkModuleMacros.cmake
+index fdd83ed8fc..4986582a5b 100644
+--- a/CMake/vtkModuleMacros.cmake
++++ b/CMake/vtkModuleMacros.cmake
+@@ -885,18 +885,6 @@ macro(vtk_module_third_party _pkg)
+       set(vtk${_lower}_DEFINITIONS ${${_upper}_DEFINITIONS})
+     endif()
+ 
+-    #a workaround for bad FindHDF5 behavior in which deb or opt can
+-    #end up empty. cmake >= 2.8.12.2 makes this uneccessary
+-    string(REGEX MATCH "debug;.*optimized;.*"
+-           _remove_deb_opt "${vtk${_lower}_LIBRARIES}")
+-    if (_remove_deb_opt)
+-      set(_tmp ${vtk${_lower}_LIBRARIES})
+-      list(REMOVE_ITEM _tmp "debug")
+-      list(REMOVE_ITEM _tmp "optimized")
+-      list(REMOVE_DUPLICATES _tmp)
+-      set(vtk${_lower}_LIBRARIES ${_tmp})
+-    endif()
+-
+     set(vtk${_lower}_INCLUDE_DIRS "")
+   else()
+     if(_nolibs)

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/netcdf-use-hdf5-definitions.patch
         ${CMAKE_CURRENT_LIST_DIR}/dont-define-ssize_t.patch
         ${CMAKE_CURRENT_LIST_DIR}/fix-findhdf5-shared.patch
+        ${CMAKE_CURRENT_LIST_DIR}/disable-workaround-findhdf5.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
This pull request solves this problem https://github.com/Microsoft/vcpkg/pull/1283#issuecomment-315448512 by disable the old workaround.
(This is a PR that replaces the rejected  https://github.com/Microsoft/vcpkg/pull/1535.)