### PR TITLE
[graphicsmagick] build fixes

### DIFF
--- a/ports/graphicsmagick/CMakeLists.txt
+++ b/ports/graphicsmagick/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(PNG REQUIRED)
 find_package(TIFF REQUIRED)
 find_package(Freetype REQUIRED)
 
-add_definitions(-D_MAGICKLIB_ -DMAGICK_IMPLEMENTATION)
+add_definitions(-D_MAGICKLIB_ -D_WANDLIB_ -DMAGICK_IMPLEMENTATION -D_VISUALC_)
 
 if (BUILD_SHARED_LIBS)
     add_definitions(-D_DLL -DDLL)
@@ -79,7 +79,7 @@ add_library(graphicsmagick coders/art.c coders/avs.c
 		coders/uyvy.c coders/vicar.c coders/vid.c coders/viff.c
 		coders/wbmp.c coders/webp.c coders/wmf.c coders/wpg.c
 		coders/x.c coders/xbm.c coders/xc.c coders/xcf.c
-		coders/xpm.c coders/xwd.c coders/yuv.c
+		coders/xpm.c coders/xtrn.c coders/xwd.c coders/yuv.c
 		filters/analyze.c
 		magick/analyze.c magick/animate.c magick/annotate.c magick/attribute.c
 		magick/average.c magick/bit_stream.c magick/blob.c magick/cdl.c

--- a/ports/graphicsmagick/CONTROL
+++ b/ports/graphicsmagick/CONTROL
@@ -1,4 +1,4 @@
 Source: graphicsmagick
-Version: 1.3.26
+Version: 1.3.26-1
 Build-Depends: zlib, bzip2, freetype, libjpeg-turbo, libpng, tiff
 Description: Image processing library

--- a/ports/graphicsmagick/magick_types.h
+++ b/ports/graphicsmagick/magick_types.h
@@ -1,0 +1,133 @@
+/*
+  Copyright (C) 2003 - 2012 GraphicsMagick Group
+ 
+  This program is covered by multiple licenses, which are described in
+  Copyright.txt. You should have received a copy of Copyright.txt with this
+  package; otherwise see http://www.graphicsmagick.org/www/Copyright.html.
+ 
+  GraphicsMagick types typedefs.
+
+  GraphicsMagick is expected to compile with any C '89 ANSI C compiler
+  supporting at least 16-bit 'short', 32-bit 'int', and 32-bit 'long'.
+  It is also expected to take advantage of 64-bit LP64 and Windows
+  WIN64 LLP64.  We use C '99 style types but declare our own types so
+  as to not depend on C '99 header files, and take care to depend only
+  on C '89 library functions, POSIX, or well-known extensions.  Any C
+  '99 syntax used is removed if the compiler does not support it.
+*/
+
+#ifndef _MAGICK_TYPES_H
+#define _MAGICK_TYPES_H
+
+#if defined(__cplusplus) || defined(c_plusplus)
+extern "C" {
+#endif
+
+/*
+  Assign ANSI C stdint.h-like typedefs based on the sizes of native types
+  magick_int8_t   --                       -128 to 127
+  magick_uint8_t  --                          0 to 255
+  magick_int16_t  --                    -32,768 to 32,767
+  magick_uint16_t --                          0 to 65,535
+  magick_int32_t  --             -2,147,483,648 to 2,147,483,647
+  magick_uint32_t --                          0 to 4,294,967,295
+  magick_int64_t  -- -9,223,372,036,854,775,807 to 9,223,372,036,854,775,807
+  magick_uint64_t --                          0 to 18,446,744,073,709,551,615
+
+  magick_uintmax_t -- largest native unsigned integer type ("%ju")
+                                              0 to UINTMAX_MAX
+                      UINTMAX_C(value) declares constant value
+  magick_uintptr_t -- unsigned type for storing a pointer value ("%tu")
+                                              0 to UINTPTR_MAX
+
+  ANSI C '99 stddef.h-like types
+  size_t           -- unsigned type representing sizes of objects ("%zu")
+                                              0 to SIZE_MAX
+  magick_ptrdiff_t -- signed type for subtracting two pointers ("%td")
+                                    PTRDIFF_MIN to PTRDIFF_MAX
+
+  EEE Std 1003.1, 2004 types
+  ssize_t          -- signed type for a count of bytes or an error indication ("%zd")
+                                              ? to SSIZE_MAX
+*/
+
+#if (defined(WIN32) || defined(WIN64)) && \
+  !defined(__MINGW32__) && !defined(__MINGW64__)
+
+  /* The following typedefs are used for WIN32 & WIN64 (without
+     configure) */
+  typedef signed char   magick_int8_t;
+  typedef unsigned char  magick_uint8_t;
+
+  typedef signed short  magick_int16_t;
+  typedef unsigned short magick_uint16_t;
+
+  typedef signed int  magick_int32_t;
+#  define MAGICK_INT32_F ""
+  typedef unsigned int magick_uint32_t;
+#  define MAGICK_UINT32_F ""
+
+  typedef signed __int64  magick_int64_t;
+# define MAGICK_INT64_F "I64"
+  typedef unsigned __int64 magick_uint64_t;
+# define MAGICK_UINT64_F "I64"
+
+  typedef magick_uint64_t magick_uintmax_t;
+
+#  if defined(WIN32)
+  typedef unsigned long magick_uintptr_t;
+#  define MAGICK_SIZE_T_F "l"
+#  define MAGICK_SIZE_T unsigned long
+#  define MAGICK_SSIZE_T_F "l"
+#  define MAGICK_SSIZE_T long
+#  elif defined(WIN64)
+  /* WIN64 uses the LLP64 model */
+  typedef unsigned long long magick_uintptr_t;
+#  define MAGICK_SIZE_T_F "I64"
+#  define MAGICK_SIZE_T unsigned __int64
+#  define MAGICK_SSIZE_T_F "I64"
+#  define MAGICK_SSIZE_T signed __int64
+#  endif
+
+#else
+
+  /* The following typedefs are subtituted when using Unixish configure */
+  typedef @INT8_T@   magick_int8_t;
+  typedef @UINT8_T@  magick_uint8_t;
+
+  typedef @INT16_T@  magick_int16_t;
+  typedef @UINT16_T@ magick_uint16_t;
+
+  typedef @INT32_T@  magick_int32_t;
+#  define MAGICK_INT32_F @INT32_F@
+  typedef @UINT32_T@ magick_uint32_t;
+#  define MAGICK_UINT32_F @UINT32_F@
+
+  typedef @INT64_T@  magick_int64_t;
+#  define MAGICK_INT64_F @INT64_F@
+  typedef @UINT64_T@ magick_uint64_t;
+#  define MAGICK_UINT64_F @UINT64_F@
+
+  typedef @UINTMAX_T@ magick_uintmax_t;
+#  define MAGICK_UINTMAX_F @UINTMAX_F@
+
+  typedef @UINTPTR_T@ magick_uintptr_t;
+#  define MAGICK_UINTPTR_F @UINTPTR_F@
+
+#  define MAGICK_SIZE_T_F @MAGICK_SIZE_T_F@
+#  define MAGICK_SIZE_T @MAGICK_SIZE_T@
+
+#  define MAGICK_SSIZE_T_F @MAGICK_SSIZE_T_F@
+#  define MAGICK_SSIZE_T @MAGICK_SSIZE_T@
+
+#endif
+
+  /* 64-bit file and blob offset type */
+  typedef magick_int64_t magick_off_t;
+#define MAGICK_OFF_F MAGICK_INT64_F
+
+#if defined(__cplusplus) || defined(c_plusplus)
+}
+#endif /* defined(__cplusplus) || defined(c_plusplus) */
+
+#endif /* _MAGICK_TYPES_H */

--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -1,16 +1,17 @@
 include(vcpkg_common_functions)
 
 set(GM_VERSION 1.3.26)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/graphicsmagick-${GM_VERSION})
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/graphicsmagick-${GM_VERSION}-windows-source)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.25/GraphicsMagick-${GM_VERSION}.tar.bz2"
-    FILENAME "GraphicsMagick-${GM_VERSION}.tar.bz2"
-    SHA512 c8791ec0e42527e90c602713c52826d1b8e8bbce7861f8cb48083d0f32465399c4f9a86f44342c5670f2fe54e6c5da878241ddf314c67d7fa98542b912ff61ba
-)
+    URLS "https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}-windows-source.7z"
+    FILENAME "GraphicsMagick-${GM_VERSION}-windows-source.7z"
+    SHA512 c45a054d082d9a7a2889a2235dd5b96bd564acf55bd581426ecd32c426f9797d7d56d6e5f25a5a7da8ebd26bf0d962372b5d48d86532dc6c57522d27c0d18ec8
+    )
 vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/magick_types.h DESTINATION ${SOURCE_PATH}/magick)
 
 # GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
 vcpkg_apply_patches(


### PR DESCRIPTION
Applications built with x64-windows were crashing on Windows 10. The build was incorrect. Changed to use windows-sources package and use correct defines.