### PR TITLE
Enable tolerance for similar configurations

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -41,10 +41,10 @@
 
   <ItemDefinitionGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <Link>
-      <AdditionalDependencies Condition="'$(VcpkgConfiguration)' == 'Debug' and '$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(VcpkgRoot)debug\lib\*.lib</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(VcpkgConfiguration)' == 'Release' and '$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(VcpkgRoot)lib\*.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="'$(VcpkgConfiguration)' == 'Release'">%(AdditionalLibraryDirectories);$(VcpkgRoot)lib;$(VcpkgRoot)lib\manual-link</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(VcpkgConfiguration)' == 'Debug'">%(AdditionalLibraryDirectories);$(VcpkgRoot)debug\lib;$(VcpkgRoot)debug\lib\manual-link</AdditionalLibraryDirectories>
+      <AdditionalDependencies Condition="$(VcpkgConfiguration.StartsWith('Debug')) and '$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(VcpkgRoot)debug\lib\*.lib</AdditionalDependencies>
+      <AdditionalDependencies Condition="$(VcpkgConfiguration.StartsWith('Release')) and '$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(VcpkgRoot)lib\*.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories Condition="$(VcpkgConfiguration.StartsWith('Release'))">%(AdditionalLibraryDirectories);$(VcpkgRoot)lib;$(VcpkgRoot)lib\manual-link</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(VcpkgConfiguration.StartsWith('Debug'))">%(AdditionalLibraryDirectories);$(VcpkgRoot)debug\lib;$(VcpkgRoot)debug\lib\manual-link</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(VcpkgRoot)include</AdditionalIncludeDirectories>
@@ -63,11 +63,11 @@
     <WriteLinesToFile
     File="$(TLogLocation)$(ProjectName).write.1u.tlog"
     Lines="^$(TargetPath);$([System.IO.Path]::Combine($(ProjectDir),$(IntDir)))vcpkg.applocal.log" Encoding="Unicode"/>
-    <Exec Condition="'$(VcpkgConfiguration)' == 'Debug'"
+    <Exec Condition="$(VcpkgConfiguration.StartsWith('Debug'))"
       Command="powershell.exe -ExecutionPolicy Bypass -noprofile -File %22$(MSBuildThisFileDirectory)applocal.ps1%22 %22$(TargetPath)%22 %22$(VcpkgRoot)debug\bin%22 %22$(TLogLocation)$(ProjectName).write.1u.tlog%22 %22$(IntDir)vcpkg.applocal.log%22"
       StandardOutputImportance="Normal">
     </Exec>
-    <Exec Condition="'$(VcpkgConfiguration)' == 'Release'"
+    <Exec Condition="$(VcpkgConfiguration.StartsWith('Release'))"
       Command="powershell.exe -ExecutionPolicy Bypass -noprofile -File %22$(MSBuildThisFileDirectory)applocal.ps1%22 %22$(TargetPath)%22 %22$(VcpkgRoot)bin%22 %22$(TLogLocation)$(ProjectName).write.1u.tlog%22 %22$(IntDir)vcpkg.applocal.log%22"
       StandardOutputImportance="Normal">
     </Exec>


### PR DESCRIPTION
Important: This is tied to the issue: https://github.com/Microsoft/vcpkg/issues/1638

This pull request has been done just for the case the proposed solution is accepted, in order to make things go faster.

## Description

Currently, VCPKG will only produce "Release" and "Debug" binaries, which is expected. The problem is that users can have other configurations that could be slight variations with "Release" (resp. "Debug"). And for those compatible variant configurations, there is no support.

This pull request is a mitigation solution that adds the following specification:
1 - If a configuration name is prefixed with "Release", then it is compatible with "Release".
2 - If a configuration name is prefixed with "Debug", then it is compatible with "Debug"

If the configuration is compatible with VCPKG's, then offer full VCPKG support as if it was VCPKG's configuration. I.e. adding default include directories, default library directories, binaries copy on the output directory at the end of compilation, etc.)

This could be a breaking change for cases where the user has other configurations starting with "Release" or "Debug" and do not expect them to use VCPKG's integration despite them having asked that (with "vcpkg integrate install").I believe this would be a very strange case indeed.

This could also interfere with local solutions mimicking VCPKG's support for non "Release" and non "Debug" configuration (like providing a .targets file with instructions copy-mostly-pasted from vcpkg.targets file).