### PR TITLE
[libogg] export all symbols

### DIFF
--- a/ports/libogg/CONTROL
+++ b/ports/libogg/CONTROL
@@ -1,3 +1,3 @@
 Source: libogg
-Version: 2017-07-27-cab46b19847
+Version: 1.3.2-cab46b1-2
 Description: Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.

--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -9,6 +9,9 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Some newer APIs offered by libogg are not listed in bundled [.def file](https://github.com/xiph/ogg/blob/dd85929dbe38be4b3876c9c0d6d5dcb7a128f388/win32/ogg.def) (for example [ogg_stream_pageout_fill](https://github.com/xiph/ogg/blob/dd85929dbe38be4b3876c9c0d6d5dcb7a128f388/include/ogg/ogg.h#L162))