### PR TITLE
[gdal] Fix linking curl libraries

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,4 +1,4 @@
 Source: gdal
-Version: 1.11.3-4
+Version: 1.11.3-5
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
 Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, libmysql, openjpeg, libwebp, libxml2, liblzma

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -55,8 +55,8 @@ file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/expat.lib" EXPAT_LIBRARY
 
 # Setup curl libraries + include path
 file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/include" CURL_INCLUDE_DIR)
-file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/lib/libcurl_imp.lib" CURL_LIBRARY_REL)
-file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/libcurl_imp.lib" CURL_LIBRARY_DBG)
+file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/lib/libcurl.lib" CURL_LIBRARY_REL)
+file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/libcurl.lib" CURL_LIBRARY_DBG)
 
 # Setup sqlite3 libraries + include path
 file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/include" SQLITE_INCLUDE_DIR)


### PR DESCRIPTION
In #1633 the import libraries for curl have been renamed from `libcurl_imp.lib` and `libcurl-d_imp.lib` to `libcurl.lib` (includes dropping the `-d` suffix for debug builds).

This PR fixes `gdal` to use these new names.