### PR TITLE
[unrar] initial port

### DIFF
--- a/ports/unrar/CONTROL
+++ b/ports/unrar/CONTROL
@@ -1,0 +1,3 @@
+Source: unrar
+Version: 5.5.6
+Description: rarlab's unrar libary

--- a/ports/unrar/portfile.cmake
+++ b/ports/unrar/portfile.cmake
@@ -1,0 +1,50 @@
+include(vcpkg_common_functions)
+set(UNRAR_VERSION "5.5.8")
+set(UNRAR_SHA512 9eac83707fa47a03925e5f3e8adf47889064d748304b732d12a2d379ab525b441f1aa33216377d4ef445f45c4e8ad73d2cd0b560601ceac344c60571b77fd6aa)
+set(UNRAR_FILENAME unrarsrc-${UNRAR_VERSION}.tar.gz)
+set(UNRAR_URL http://www.rarlab.com/rar/${UNRAR_FILENAME})
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/unrar)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    message(FATAL_ERROR "A static build is included with the dynamic build.  Try VCPKG INSTALL UNRAR:X86-WINDOWS UNRAR:X64-WINDOWS")
+endif()
+
+#SRC
+vcpkg_download_distfile(ARCHIVE
+    URLS ${UNRAR_URL}
+    FILENAME ${UNRAR_FILENAME}
+    SHA512 ${UNRAR_SHA512}
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_build_msbuild(
+    PROJECT_PATH "${SOURCE_PATH}/UnRARDll.vcxproj"
+    OPTIONS_DEBUG /p:OutDir=../../${TARGET_TRIPLET}-dbg/
+    OPTIONS_RELEASE /p:OutDir=../../${TARGET_TRIPLET}-rel/
+    OPTIONS /VERBOSITY:Diagnostic /DETAILEDSUMMARY
+)
+
+#INCLUDE (named dll.hpp in source, and unrar.h in all rarlabs distributions)
+file(INSTALL ${SOURCE_PATH}/dll.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME unrar.h)
+
+#DLL & LIB
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/unrar.dll  DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/unrar.lib  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/unrar.dll  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/unrar.lib  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+
+#copy pdbs now, while filenames still match
+vcpkg_copy_pdbs()
+
+#RarLabs has historically distributed it's x64 architecture unrar library as UnRAR64.dll
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/unrar.dll        ${CURRENT_PACKAGES_DIR}/bin/UnRAR64.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/unrar.lib        ${CURRENT_PACKAGES_DIR}/lib/UnRAR64.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/unrar.dll  ${CURRENT_PACKAGES_DIR}/debug/bin/UnRAR64.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/unrar.lib  ${CURRENT_PACKAGES_DIR}/debug/lib/UnRAR64.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/unrar.pdb        ${CURRENT_PACKAGES_DIR}/bin/UnRAR64.pdb)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/unrar.pdb  ${CURRENT_PACKAGES_DIR}/debug/bin/UnRAR64.pdb)
+endif()
+
+#COPYRIGHT
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/unrar RENAME copyright)

--- a/toolsrc/vcpkg/vcpkg.vcxproj
+++ b/toolsrc/vcpkg/vcpkg.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -21,8 +21,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{34671B80-54F9-46F5-8310-AC429C11D4FB}</ProjectGuid>
     <RootNamespace>vcpkg</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <PlatformToolset>v140</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -21,8 +21,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B98C92B7-2874-4537-9D46-D14E5C237F04}</ProjectGuid>
     <RootNamespace>vcpkglib</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <PlatformToolset>v140</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/toolsrc/vcpkgmetricsuploader/vcpkgmetricsuploader.vcxproj
+++ b/toolsrc/vcpkgmetricsuploader/vcpkgmetricsuploader.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -21,8 +21,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7D6FDEEB-B299-4A23-85EE-F67C4DED47BE}</ProjectGuid>
     <RootNamespace>vcpkgmetricsuploader</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <PlatformToolset>v140</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/toolsrc/vcpkgtest/vcpkgtest.vcxproj
+++ b/toolsrc/vcpkgtest/vcpkgtest.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -33,8 +33,8 @@
     <ProjectGuid>{F27B8DB0-1279-4AF8-A2E3-1D49C4F0220D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vcpkgtest</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <PlatformToolset>v140</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
**Unrar library for vcpkg.**

Stuff I should have asked before:
- freeware libraries are ok right?  I read the licence.txt and I could not see a problem with distributing it.  (IANAL)

Remarks:
- Rarlabs has always distributed it's x64 version of unrar.dll as "unrar**64**.dll" (while is 32 bit version is unrar.dll).  I chose to follow the same naming pattern for the appropriate triplets.  Please advise if uniformity trumps general usage.