### PR TITLE
[libraw] fix import macro, correct dependencies

### DIFF
--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,4 +1,4 @@
 Source: libraw
-Version: 0.18.2-2
-Build-Depends: lcms, libjpeg-turbo
+Version: 0.18.2-3
+Build-Depends: lcms, jasper
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -23,12 +23,20 @@ file(COPY ${LIBRAW_CMAKE_SOURCE_PATH}/cmake DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
     OPTIONS
         -DINSTALL_CMAKE_MODULE_PATH=${CURRENT_PACKAGES_DIR}/share/libraw
 )
 
-vcpkg_build_cmake()
 vcpkg_install_cmake()
+
+file(READ ${CURRENT_PACKAGES_DIR}/include/libraw/libraw_types.h LIBRAW_H)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    string(REPLACE "#ifdef LIBRAW_NODLL" "#if 1" LIBRAW_H "${LIBRAW_H}")
+else()
+    string(REPLACE "#ifdef LIBRAW_NODLL" "#if 0" LIBRAW_H "${LIBRAW_H}")
+endif()
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/libraw/libraw_types.h "${LIBRAW_H}")
 
 # Rename thread-safe version to be "raw.lib". This is unfortunately needed
 # because otherwise libraries that build on top of libraw have to choose.


### PR DESCRIPTION
By default, libraw does not attempt to link to libjpeg, but does pick up jasper if present