### PR TITLE
[wxwidgets] rename expat.lib to expatd.lib

### DIFF
--- a/ports/wxwidgets/CONTROL
+++ b/ports/wxwidgets/CONTROL
@@ -1,4 +1,4 @@
 Source: wxwidgets
-Version: 3.1.0-1
+Version: 3.1.0-2
 Description: wxWidgets is a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.
 Build-Depends: zlib, libpng, tiff, expat

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -81,7 +81,7 @@ message(STATUS "Building ${TARGET_TRIPLET}-rel done")
 # Debug build
 ################
 message(STATUS "Building ${TARGET_TRIPLET}-dbg")
-set(ENV{_LINK_} ${CURRENT_INSTALLED_DIR}/debug/lib/expat.lib)
+set(ENV{_LINK_} ${CURRENT_INSTALLED_DIR}/debug/lib/expatd.lib)
 vcpkg_execute_required_process(
     COMMAND ${NMAKE} -f makefile.vc ${NMAKE_OPTIONS_DBG}
     WORKING_DIRECTORY ${SOURCE_PATH}/build/msw


### PR DESCRIPTION
The debug version of expat.lib is actually named expatd.lib. This commit fixes a build error where wxwidgets tries to link against expat.lib, which is not found.