### PR TITLE
[expat] drop debug suffix

### DIFF
--- a/ports/expat/CONTROL
+++ b/ports/expat/CONTROL
@@ -1,3 +1,3 @@
 Source: expat
-Version: 2.2.4
+Version: 2.2.4-1
 Description: XML parser library written in C

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -29,6 +29,9 @@ file(INSTALL ${SOURCE_PATH}/expat/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/sh
 
 vcpkg_copy_pdbs()
 
+# CMake's FindExpat currently doesn't look for expatd.lib
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/expatd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/expat.lib)
+
 file(READ ${CURRENT_PACKAGES_DIR}/include/expat_external.h EXPAT_EXTERNAL_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     string(REPLACE "!defined(XML_STATIC)" "/* vcpkg static build !defined(XML_STATIC) */ 0" EXPAT_EXTERNAL_H "${EXPAT_EXTERNAL_H}")


### PR DESCRIPTION
Since https://github.com/Microsoft/vcpkg/pull/1686 `expat` port produces binaries with debug suffix. CMake's [builtin module](https://github.com/Kitware/CMake/blob/master/Modules/FindEXPAT.cmake) doesn't look for suffixed binaries, so let's drop the suffix for now. We can enable it later, when the world will be ready for it.
See also https://github.com/Microsoft/vcpkg/pull/1697