### PR TITLE
libpng: remove unnecessary PREFER_NINJA argument

### DIFF
--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -31,7 +31,6 @@ endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DPNG_STATIC=${PNG_STATIC_LIBS}
         -DPNG_SHARED=${PNG_SHARED_LIBS}


### PR DESCRIPTION
Before the changes:
```
J:\build\vcpkg>.\vcpkg install libpng:x64-windows
The following packages will be built and installed:
    libpng:x64-windows
Building package libpng:x64-windows...
-- CURRENT_INSTALLED_DIR=J:/build/vcpkg/installed/x64-windows
-- DOWNLOADS=J:/build/vcpkg/downloads
-- CURRENT_PACKAGES_DIR=J:/build/vcpkg/packages/libpng_x64-windows
-- CURRENT_BUILDTREES_DIR=J:/build/vcpkg/buildtrees/libpng
-- CURRENT_PORT_DIR=J:/build/vcpkg/ports/libpng/.
-- Using cached J:/build/vcpkg/downloads/libpng-1.6.31.tar.xz
-- Testing integrity of cached file...
-- Testing integrity of cached file... OK
-- Extracting source J:/build/vcpkg/downloads/libpng-1.6.31.tar.xz
-- Extracting done
-- Applying patch J:/build/vcpkg/ports/libpng/use-abort-on-all-platforms.patch
-- Applying patch J:/build/vcpkg/ports/libpng/use-abort-on-all-platforms.patch d
one
-- Configuring x64-windows-rel
CMake Error at J:/build/vcpkg/scripts/cmake/vcpkg_execute_required_process.cmake
:43 (message):
    Command failed: J:/build/vcpkg/downloads/cmake-3.9.1-win32-x86/bin/cmake.exe
;J:/build/vcpkg/buildtrees/libpng/src/libpng-1.6.31;-DPNG_STATIC=OFF;-DPNG_SHARE
D=ON;-DPNG_TESTS=OFF;-DSKIP_INSTALL_PROGRAMS=ON;-DSKIP_INSTALL_EXECUTABLES=ON;-D
SKIP_INSTALL_FILES=ON;-DCMAKE_SYSTEM_PROCESSOR=AMD64;-DBUILD_SHARED_LIBS=ON;-DVC
PKG_TARGET_TRIPLET=x64-windows;-DCMAKE_CXX_FLAGS= /DWIN32 /D_WINDOWS /W3 /utf-8
/GR /EHsc /MP ;-DCMAKE_C_FLAGS= /DWIN32 /D_WINDOWS /W3 /utf-8 /MP ;-DCMAKE_EXPOR
T_NO_PACKAGE_REGISTRY=ON;-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON;-DCMAKE_FIN
D_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON;-DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP
=TRUE;-DCMAKE_VERBOSE_MAKEFILE=ON;-DVCPKG_APPLOCAL_DEPS=OFF;-DCMAKE_TOOLCHAIN_FI
LE=J:/build/vcpkg/scripts/buildsystems/vcpkg.cmake;-DCMAKE_ERROR_ON_ABSOLUTE_INS
TALL_DESTINATION=ON;-DCMAKE_CXX_FLAGS_RELEASE=/MD /O2 /Oi /Gy /DNDEBUG /Zi ;-DCM
AKE_C_FLAGS_RELEASE=/MD /O2 /Oi /Gy /DNDEBUG /Zi ;-DCMAKE_SHARED_LINKER_FLAGS_RE
LEASE=/DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF ;-DCMAKE_EXE_LINKER_FLAGS_RELEASE
=/DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF ;-G;Ninja;-DCMAKE_BUILD_TYPE=Release;-
DCMAKE_INSTALL_PREFIX=J:/build/vcpkg/packages/libpng_x64-windows
    Working Directory: J:/build/vcpkg/buildtrees/libpng/x64-windows-rel
    See logs for more information:
      J:\build\vcpkg\buildtrees\libpng\config-x64-windows-rel-out.log
      J:\build\vcpkg\buildtrees\libpng\config-x64-windows-rel-err.log

Call Stack (most recent call first):
  J:/build/vcpkg/scripts/cmake/vcpkg_configure_cmake.cmake:170 (vcpkg_execute_re
quired_process)
  J:/build/vcpkg/ports/libpng/portfile.cmake:32 (vcpkg_configure_cmake)
  J:/build/vcpkg/scripts/ports.cmake:72 (include)


Error: Building package libpng:x64-windows failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: libpng:x64-windows
  Vcpkg version: 0.0.84-34bd87c9fcfb1ac9269c75db96852b64ed754d11

Additionally, attach any relevant sections from the log files above.
```
Then remove `PREFER_NINJA` argument in `vcpkg_configure_cmake` command:
```
J:\build\vcpkg>.\vcpkg install libpng:x64-windows
The following packages will be built and installed:
    libpng:x64-windows
Building package libpng:x64-windows...
-- CURRENT_INSTALLED_DIR=J:/build/vcpkg/installed/x64-windows
-- DOWNLOADS=J:/build/vcpkg/downloads
-- CURRENT_PACKAGES_DIR=J:/build/vcpkg/packages/libpng_x64-windows
-- CURRENT_BUILDTREES_DIR=J:/build/vcpkg/buildtrees/libpng
-- CURRENT_PORT_DIR=J:/build/vcpkg/ports/libpng/.
-- Using cached J:/build/vcpkg/downloads/libpng-1.6.31.tar.xz
-- Testing integrity of cached file...
-- Testing integrity of cached file... OK
-- Extracting done
-- Applying patch J:/build/vcpkg/ports/libpng/use-abort-on-all-platforms.patch
-- Applying patch failed. This is expected if this patch was previously applied.

-- Applying patch J:/build/vcpkg/ports/libpng/use-abort-on-all-platforms.patch d
one
-- Configuring x64-windows-rel
-- Configuring x64-windows-rel done
-- Configuring x64-windows-dbg
-- Configuring x64-windows-dbg done
-- Package x64-windows-rel
-- Package x64-windows-rel done
-- Package x64-windows-dbg
-- Package x64-windows-dbg done
-- Performing post-build validation
-- Performing post-build validation done
Building package libpng:x64-windows... done
Installing package libpng:x64-windows...
Installing package libpng:x64-windows... done
```