### PR TITLE
Updated libsigcpp to version 2.99.9

### DIFF
--- a/ports/libsigcpp/CMakeLists.txt
+++ b/ports/libsigcpp/CMakeLists.txt
@@ -5,14 +5,14 @@ set(SIGCPP_API_VERSION 2.0)
 
 add_definitions(-DSIGC_BUILD)
 
-include_directories(./MSVC_Net2013) # config file for windows is there
+include_directories(./MSVC_Net2017) # config file for windows is there
 include_directories(.)
+
 
 set(SICGPP_SOURCES
     sigc++/connection.cc
     sigc++/signal_base.cc
     sigc++/trackable.cc
-    sigc++/adaptors/lambda/lambda.cc
     sigc++/functors/slot_base.cc)
 
 add_library(sigc ${SICGPP_SOURCES})
@@ -20,12 +20,13 @@ set_target_properties(sigc PROPERTIES OUTPUT_NAME sigc-${SIGCPP_API_VERSION})
 install(TARGETS sigc RUNTIME DESTINATION bin ARCHIVE DESTINATION lib)
 
 if(NOT SIGCPP_SKIP_HEADERS)
-    install(FILES MSVC_Net2013/sigc++config.h DESTINATION include)
+    install(FILES MSVC_Net2017/sigc++config.h DESTINATION include)
     install(FILES sigc++/sigc++.h DESTINATION include/sigc++)
     install(FILES sigc++/bind.h DESTINATION include/sigc++)
     install(FILES sigc++/bind_return.h DESTINATION include/sigc++)
     install(FILES sigc++/connection.h DESTINATION include/sigc++)
     install(FILES sigc++/limit_reference.h DESTINATION include/sigc++)
+    install(FILES sigc++/member_method_trait.h DESTINATION include/sigc++)
     install(FILES sigc++/reference_wrapper.h DESTINATION include/sigc++)
     install(FILES sigc++/retype_return.h DESTINATION include/sigc++)
     install(FILES sigc++/signal.h DESTINATION include/sigc++)
@@ -34,24 +35,30 @@ if(NOT SIGCPP_SKIP_HEADERS)
     install(FILES sigc++/trackable.h DESTINATION include/sigc++)
     install(FILES sigc++/type_traits.h DESTINATION include/sigc++)
     install(FILES sigc++/visit_each.h DESTINATION include/sigc++)
+    install(FILES sigc++/weak_raw_ptr.h DESTINATION include/sigc++)
     install(FILES sigc++/adaptors/adaptors.h DESTINATION include/sigc++/adaptors)
+    install(FILES sigc++/adaptors/adaptor_base.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/adaptor_trait.h DESTINATION include/sigc++/adaptors)
+    install(FILES sigc++/adaptors/adapts.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/bind.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/bind_return.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/bound_argument.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/compose.h DESTINATION include/sigc++/adaptors)
-    install(FILES sigc++/adaptors/deduce_result_type.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/exception_catch.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/hide.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/retype.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/retype_return.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/adaptors/track_obj.h DESTINATION include/sigc++/adaptors)
-    install(FILES sigc++/adaptors/lambda/base.h DESTINATION include/sigc++/adaptors/lambda)
-    install(FILES sigc++/adaptors/lambda/select.h DESTINATION include/sigc++/adaptors/lambda)
+    install(FILES sigc++/adaptors/tuple_visitor_visit_each.h DESTINATION include/sigc++/adaptors)
     install(FILES sigc++/functors/functors.h DESTINATION include/sigc++/functors)
     install(FILES sigc++/functors/functor_trait.h DESTINATION include/sigc++/functors)
     install(FILES sigc++/functors/mem_fun.h DESTINATION include/sigc++/functors)
     install(FILES sigc++/functors/ptr_fun.h DESTINATION include/sigc++/functors)
     install(FILES sigc++/functors/slot.h DESTINATION include/sigc++/functors)
     install(FILES sigc++/functors/slot_base.h DESTINATION include/sigc++/functors)
+    install(FILES sigc++/tuple-utils/tuple_cdr.h DESTINATION include/sigc++/tuple-utils)
+    install(FILES sigc++/tuple-utils/tuple_end.h DESTINATION include/sigc++/tuple-utils)
+    install(FILES sigc++/tuple-utils/tuple_for_each.h DESTINATION include/sigc++/tuple-utils)
+    install(FILES sigc++/tuple-utils/tuple_start.h DESTINATION include/sigc++/tuple-utils)
+    install(FILES sigc++/tuple-utils/tuple_transform_each.h DESTINATION include/sigc++/tuple-utils)
 endif()

--- a/ports/libsigcpp/CONTROL
+++ b/ports/libsigcpp/CONTROL
@@ -1,3 +1,3 @@
 Source: libsigcpp
-Version: 2.10
+Version: 2.99
 Description: Typesafe callback framework for C++

--- a/ports/libsigcpp/portfile.cmake
+++ b/ports/libsigcpp/portfile.cmake
@@ -1,10 +1,10 @@
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libsigc++-2.10.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libsigc++-2.99.9)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz"
-    FILENAME "libsigc++-2.10.0.tar.xz"
-    SHA512 5b96df21d6bd6ba41520c7219e77695a86aabc60b7259262c7a9f4b8475ce0e2fd8dc37bcf7c17e24e818ff28c262d682b964c83e215b51bdbe000f3f58794ae)
+    URLS "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.99/libsigc++-2.99.9.tar.xz"
+    FILENAME "libsigc++-2.99.9.tar.xz"
+    SHA512 3e8f8176a4618938a16b2367466415aff8ec10d83ef84de8973373a63fc0b9708d14115ad5c039c81b570385b205944651849a68e618c37c171cd748dd5b2403)
 
 vcpkg_extract_source_archive(${ARCHIVE})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
The already existing package `libsigcpp` is at version `2.10`. That's really old (in my opinion). Due to that, my pull request updates `libsigcpp` to version `2.99.9`. This is the latest version I could find in the official source archive at http://ftp.gnome.org/pub/GNOME/sources/libsigc++/. If you have any questions, feel free to ask me.