### PR TITLE
[libxml2] Add http mirror

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -9,7 +9,7 @@
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libxml2-2.9.4)
 vcpkg_download_distfile(ARCHIVE
-    URLS "ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz"
+    URLS "ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz" "http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz"
     FILENAME "libxml2-2.9.4.tar.gz"
     SHA512 f5174ab1a3a0ec0037a47f47aa47def36674e02bfb42b57f609563f84c6247c585dbbb133c056953a5adb968d328f18cbc102eb0d00d48eb7c95478389e5daf9
 )


### PR DESCRIPTION
On some networks, access to FTP sites is restricted. In order to still download, build and install libxml2, an http mirror has to be added to the cmake file.