### PR TITLE
Libmad: fix header include + no inline assembly

### DIFF
--- a/ports/libmad/CMakeLists.txt
+++ b/ports/libmad/CMakeLists.txt
@@ -53,5 +53,5 @@ install(
 
 install(
     FILES mad.h
-    DESTINATION include/mad
+    DESTINATION include
 )

--- a/ports/libmad/portfile.cmake
+++ b/ports/libmad/portfile.cmake
@@ -7,6 +7,11 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+  SOURCE_PATH ${SOURCE_PATH}
+  PATCHES "${CMAKE_CURRENT_LIST_DIR}/use_fpm_default.patch"
+)
+
 #The archive only contains a Visual Studio 6.0 era DSP project file, so use a custom CMakeLists.txt
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 

--- a/ports/libmad/use_fpm_default.patch
+++ b/ports/libmad/use_fpm_default.patch
@@ -1,0 +1,16 @@
+--- mad.h	2004-01-23 10:36:03.000000000 +0100
++++ mad.h	2017-08-12 16:03:38.060392600 +0200
+@@ -24,7 +24,7 @@
+ extern "C" {
+ # endif
+ 
+-# define FPM_INTEL
++# define FPM_DEFAULT
+--- msvc++/mad.h	2017-08-12 16:04:30.678146600 +0200
++++ msvc++/mad.h	2017-08-12 16:04:00.779378000 +0200
+@@ -24,7 +24,7 @@
+ extern "C" {
+ # endif
+
+-# define FPM_INTEL
++# define FPM_DEFAULT


### PR DESCRIPTION
- Put the `mad.h` header in the root of the include folder.
- Since the x64 compiler does not support inline assembly, use the default floating point module by default.