### PR TITLE
Update xerces-c port files to retrieve it from github

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -16,9 +16,6 @@ if (VCPKG_CRT_LINKAGE STREQUAL "static")
     set(VCPKG_CRT_LINKAGE "dynamic")
 endif()
 
-
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xerces-c-Xerces-C_3_1_4)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/xerces-c

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -17,12 +17,12 @@ if (VCPKG_CRT_LINKAGE STREQUAL "static")
 endif()
 
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xerces-c-3.1.4)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xerces-c-Xerces-C_3_1_4)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www-us.apache.org/dist//xerces/c/3/sources/xerces-c-3.1.4.zip"
-    FILENAME "xerces-c-3.1.4.zip"
-    SHA512 3ba1bf38875bda8a294990dba73143cfd6dbfa158b17f4db1fd0ee9a08a078af969103200eaf8957756f8363c8a661983cc95124b4978eb2162dc0344a85fff8
+    URLS "https://github.com/apache/xerces-c/archive/Xerces-C_3_1_4.zip"
+    FILENAME "Xerces-C_3_1_4.zip"
+    SHA512 3471134dacc4b2a25dece3c6eeab1d8143ca090f3652998c3a12c581e0351593bc0905334dd09c13864465c05952ca78f212a63d1c6c78bcd322d7aec23733cd
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -19,12 +19,13 @@ endif()
 
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xerces-c-Xerces-C_3_1_4)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/apache/xerces-c/archive/Xerces-C_3_1_4.zip"
-    FILENAME "Xerces-C_3_1_4.zip"
-    SHA512 3471134dacc4b2a25dece3c6eeab1d8143ca090f3652998c3a12c581e0351593bc0905334dd09c13864465c05952ca78f212a63d1c6c78bcd322d7aec23733cd
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/xerces-c
+    REF Xerces-C_3_1_4
+    SHA512 6dc3e4bb68bc32a0e8ec6dcc7ec67e21239a79c909d08ccc16c96dc5de4e73800993d1c09f589606925507baf0b2a9bf6037d28c84dae826935bf1f7a151071e
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
     set(BUILD_ARCH "Win32")


### PR DESCRIPTION
xerces-c previous link is broken.
The chosen solution is to change the port configuration file to retrieve the package from xerces' github repository instead.

See: https://github.com/Microsoft/vcpkg/issues/1726