### PR TITLE
[qt5] Do not link all .lib files

### DIFF
--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5
-Version: 5.8-4
+Version: 5.8-5
 Description: Qt5 application framework main components. Webengine, examples and tests not included.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre, harfbuzz, sqlite3, libpq, double-conversion

--- a/ports/qt5/portfile.cmake
+++ b/ports/qt5/portfile.cmake
@@ -89,6 +89,55 @@ vcpkg_execute_required_process(
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 
+
+#---------------------------------------------------------------------------
+# Qt5Bootstrap: a release-only dependency
+#---------------------------------------------------------------------------
+# Remove release-only Qt5Bootstrap.lib from debug folders:
+#file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.lib)
+#file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.prl)
+# Above approach does not work: 
+#   check_matching_debug_and_release_binaries(dbg_libs, rel_libs)
+# requires the two sets to be of equal size!
+# Alt. approach, create dummy folder instead:
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/lib/dont-use)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/dont-use)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.prl DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/dont-use)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5Bootstrap.prl)
+#---------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------
+# qtmain(d) vs. Qt5AxServer(d)
+#---------------------------------------------------------------------------
+# Qt applications have to either link to qtmain(d) or to Qt5AxServer(d),
+# never both. See http://doc.qt.io/qt-5/activeqt-server.html for more info.
+#
+# Create manual-link folders:
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+#
+# Either have users explicitly link against qtmain.lib, qtmaind.lib:
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/qtmain.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/qtmain.prl DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qtmain.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qtmain.prl)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/qtmaind.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/qtmaind.prl DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/qtmaind.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/qtmaind.prl)
+#
+# ... or have users explicitly link against Qt5AxServer.lib, Qt5AxServerd.lib:
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/Qt5AxServer.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/Qt5AxServer.prl DESTINATION ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/Qt5AxServer.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/Qt5AxServer.prl)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5AxServerd.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5AxServerd.prl DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5AxServerd.lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/Qt5AxServerd.prl)
+#---------------------------------------------------------------------------
+
 file(INSTALL ${SOURCE_PATH}/LICENSE.LGPLv3 DESTINATION  ${CURRENT_PACKAGES_DIR}/share/qt5 RENAME copyright)
 if(EXISTS ${CURRENT_PACKAGES_DIR}/plugins)
     file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/qtdeploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/plugins)


### PR DESCRIPTION
This PR addresses issue https://github.com/Microsoft/vcpkg/issues/1442

Currently, all .lib files produced in the compilation process are marked as an automatic dependency. This results in two conflicts:

1. `Qt5Bootstrap.lib` is a file that should only be used and linked against in release builds. This file is not meant to be linked against in debug builds.
2. `qtmain.lib`/`qtmaind.lib` cannot be linked against at the same time as `Qt5AxServer.lib`/`Qt5AxServerd.lib`. These two sets of lib files represent two different use cases (desktop applications vs. ActiveX servers).

The first conflict is resolved by moving `Qt5Bootstrap.lib` from `debug\lib` to a dummy subfolder. Note that simply deleting this file does not work at the moment since the warning generated by `PostBuildLint`'s `check_matching_debug_and_release_binaries(...)` is actually considered to be an error.

The second conflict is resolved by moving the .lib files to a `manual-link` subfolder. This does mean, however, that users of the `qt5` package now have to explicitly specify `qtmain.lib`/`qtmaind.lib` (or `Qt5AxServer.lib`/`Qt5AxServerd.lib`) as a lib dependency.
