### PR TITLE
[qt5] Update fixcmake.py for new manual-link directories

### DIFF
--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5
-Version: 5.8-5
+Version: 5.8-6
 Description: Qt5 application framework main components. Webengine, examples and tests not included.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre, harfbuzz, sqlite3, libpq, double-conversion

--- a/ports/qt5/fixcmake.py
+++ b/ports/qt5/fixcmake.py
@@ -18,6 +18,10 @@ for f in files:
             builder += "\n    " + line.replace("/bin/", "/debug/bin/")
             builder += "    endif()\n"
         elif "_install_prefix}/lib/${LIB_LOCATION}" in line:
+            # Qt5AxServer(d).lib has been moved to manual-link:
+            if '_qt5AxServer_install_prefix' in line:
+                line = line.replace('/lib/', '/lib/manual-link/')
+
             builder += "    if (${Configuration} STREQUAL \"RELEASE\")"
             builder += "\n    " + line
             builder += "    else()"
@@ -30,7 +34,8 @@ for f in files:
             builder += "\n    " + line.replace("/lib/", "/debug/lib/")
             builder += "    endif()\n"
         elif "_install_prefix}/lib/qtmaind.lib" in line:
-            builder += line.replace("/lib/", "/debug/lib/")
+            # qtmaind.lib has been moved to manual-link:
+            builder += line.replace("/lib/", "/debug/lib/manual-link/")
         elif "_install_prefix}/plugins/${PLUGIN_LOCATION}" in line:
             builder += "    if (${Configuration} STREQUAL \"RELEASE\")"
             builder += "\n    " + line
@@ -38,8 +43,9 @@ for f in files:
             builder += "\n    " + line.replace("/plugins/", "/debug/plugins/")
             builder += "    endif()\n"
         elif "_install_prefix}/lib/qtmain.lib" in line:
-            builder += line
-            builder += "    set(imported_location_debug \"${_qt5Core_install_prefix}/debug/lib/qtmaind.lib\")\n"
+            # qtmain(d).lib has been moved to manual-link:
+            builder += line.replace("/lib/", "/lib/manual-link/")
+            builder += "    set(imported_location_debug \"${_qt5Core_install_prefix}/debug/lib/manual-link/qtmaind.lib\")\n"
             builder += "\n"
             builder += "    set_target_properties(Qt5::WinMain PROPERTIES\n"
             builder += "        IMPORTED_LOCATION_DEBUG ${imported_location_debug}\n"


### PR DESCRIPTION
This PR is a follow up to _[qt5] Do not link all .lib files_ https://github.com/Microsoft/vcpkg/pull/1792.

The previous PR broke Qt applications that were built using CMake . This PR fixes `.cmake` files such that the locations of `qtmain.lib`, `qtmaind.lib`, `Qt5AxServer.lib` and `Qt5AxServerd.lib` are correct again.


Test program `hello.cpp`:
```cpp
#include <iostream>
#include <QApplication>
#include <QMainWindow>

int main(int argc, char** argv) {
    std::cout << "hello\n";
    QApplication app (argc, argv);
    QMainWindow mainWindow;
    mainWindow.show();

    return app.exec();
}
```
`CMakeLists.txt`:
```cmake
cmake_minimum_required (VERSION 3.6.0)
project(qt5test)

find_package(Qt5 REQUIRED
  Core
  Widgets
)


add_executable(hello 
  WIN32
  hello.cpp
)

target_include_directories(hello
  PRIVATE ${Qt5Widgets_INCLUDE_DIRS}
)

target_link_libraries(hello
  PRIVATE Qt5::WinMain
  PRIVATE Qt5::Core
  PRIVATE Qt5::Widgets
)
```

Build instructions (command line):
```
SET VCPCK_ROOT=c:\src\vcpkg
SET TOOLCHAIN=%VCPCK_ROOT%\scripts\buildsystems\vcpkg.cmake

mkdir build
cd build
cmake .. -DCMAKE_TOOLCHAIN_FILE=%TOOLCHAIN%
cmake --build . --config debug --target hello
```
