### PR TITLE
Enable PCAP option of PCL

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,4 +1,4 @@
 Source: pcl
-Version: 1.8.1-1
-Build-Depends: boost, eigen3, flann, qhull, vtk, openni2, qt5
+Version: 1.8.1-2
+Build-Depends: boost, eigen3, flann, qhull, vtk, openni2, qt5, winpcap
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -50,7 +50,7 @@ vcpkg_configure_cmake(
         -DWITH_CUDA=OFF
         -DWITH_LIBUSB=OFF
         -DWITH_OPENNI2=ON
-        -DWITH_PCAP=OFF
+        -DWITH_PCAP=ON
         -DWITH_PNG=OFF
         -DWITH_QHULL=ON
         -DWITH_QT=ON


### PR DESCRIPTION
Enable PCAP option of PCL.
You will be able to retrieve data from PCAP file using <code>pcl::HDLGrabber</code>/<code>pcl::VLPGrabber</code>.

~~Please merge PR https://github.com/Microsoft/vcpkg/pull/1856 for fix WinPCAP port.~~
Ready to merge!