### PR TITLE
[shapelib] initial port

### DIFF
--- a/ports/shapelib/CONTROL
+++ b/ports/shapelib/CONTROL
@@ -1,0 +1,3 @@
+Source: shapelib
+Version: 1.4.1
+Description: Shapefile C Library is simple C API for reading and writing ESRI Shapefiles

--- a/ports/shapelib/portfile.cmake
+++ b/ports/shapelib/portfile.cmake
@@ -1,0 +1,41 @@
+include(vcpkg_common_functions)
+
+set(SHAPELIB_VERSION 1.4.1)
+set(SHAPELIB_HASH e3e02dde8006773fed25d630896e79fd79d2008a029cc86b157fe0d92c143a9fab930fdb93d9700d4e1397c3b23ae4b86e91db1dbaca1c5388d4e3aea0309341)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/shapelib-${SHAPELIB_VERSION})
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://download.osgeo.org/shapelib/shapelib-${SHAPELIB_VERSION}.zip"
+    FILENAME "shapelib-${SHAPELIB_VERSION}.zip"
+    SHA512 ${SHAPELIB_HASH}
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_TEST=OFF)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/shapelib)
+file(REMOVE ${EXES})
+
+file(GLOB DEBUG_EXES "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
+file(REMOVE ${DEBUG_EXES})
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+	file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+	file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/shapelib)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/shapelib/COPYING ${CURRENT_PACKAGES_DIR}/share/shapelib/copyright)
+
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/shapelib)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
I propose to add Shapelib package to this great libraries collection.
http://shapelib.maptools.org
It is widely used in GIS application, can provide aditional format for GDAL etc.

This is my first PR here so the code may need checking (have some experience in CMake though not profsessional, helped with Windows support and build scripts fo several OpenStreetMap related projects). If sucessful, can provide packages for `spatialite`, `readosm`, `freexl`, 'sparsehash`, update `geos` and `gdal`,


Possible issue: some small executables for processing shapefiles are included in tools. Are they to be removed? Is there a way to add extra option allowing to pack them if user needs?

