### PR TITLE
Fix for BUILD_ARGS being always added in non ninja build (vcpkg_build_cmake,vcpkg_install_cmake)

### DIFF
--- a/docs/maintainers/portfile-functions.md
+++ b/docs/maintainers/portfile-functions.md
@@ -3,6 +3,7 @@
 # Portfile helper functions
 - [vcpkg\_acquire\_msys](vcpkg_acquire_msys.md)
 - [vcpkg\_apply\_patches](vcpkg_apply_patches.md)
+- [vcpkg\_build\_cmake](vcpkg_build_cmake.md)
 - [vcpkg\_build\_msbuild](vcpkg_build_msbuild.md)
 - [vcpkg\_configure\_cmake](vcpkg_configure_cmake.md)
 - [vcpkg\_copy\_pdbs](vcpkg_copy_pdbs.md)
@@ -11,5 +12,6 @@
 - [vcpkg\_execute\_required\_process](vcpkg_execute_required_process.md)
 - [vcpkg\_extract\_source\_archive](vcpkg_extract_source_archive.md)
 - [vcpkg\_find\_acquire\_program](vcpkg_find_acquire_program.md)
+- [vcpkg\_from\_bitbucket](vcpkg_from_bitbucket.md)
 - [vcpkg\_from\_github](vcpkg_from_github.md)
 - [vcpkg\_install\_cmake](vcpkg_install_cmake.md)

--- a/docs/maintainers/vcpkg_acquire_msys.md
+++ b/docs/maintainers/vcpkg_acquire_msys.md
@@ -32,7 +32,7 @@ message(STATUS "Installing MSYS Packages")
 vcpkg_execute_required_process(
     COMMAND
         ${BASH} --noprofile --norc -c
-            "pacman -Sy --noconfirm --needed make"
+            'PATH=/usr/bin:\$PATH pacman -Sy --noconfirm --needed make'
     WORKING_DIRECTORY ${MSYS_ROOT}
     LOGNAME pacman-${TARGET_TRIPLET})
 ```

--- a/docs/maintainers/vcpkg_build_cmake.md
+++ b/docs/maintainers/vcpkg_build_cmake.md
@@ -1,0 +1,31 @@
+# vcpkg_build_cmake
+
+Build a cmake project.
+
+## Usage:
+```cmake
+vcpkg_build_cmake([DISABLE_PARALLEL] [TARGET <target>])
+```
+
+## Parameters:
+### DISABLE_PARALLEL
+The underlying buildsystem will be instructed to not parallelize
+
+### TARGET
+The target passed to the cmake build command (`cmake --build . --target <target>`). If not specified, no target will
+be passed.
+
+## Notes:
+This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the
+"install" target
+
+## Examples:
+
+* [zlib](https://github.com/Microsoft/vcpkg/blob/master/ports/zlib/portfile.cmake)
+* [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
+* [poco](https://github.com/Microsoft/vcpkg/blob/master/ports/poco/portfile.cmake)
+* [opencv](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv/portfile.cmake)
+
+## Source
+[scripts/cmake/vcpkg_build_cmake.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_build_cmake.cmake)

--- a/docs/maintainers/vcpkg_find_acquire_program.md
+++ b/docs/maintainers/vcpkg_find_acquire_program.md
@@ -16,6 +16,7 @@ The current list of programs includes:
 - 7Z
 - BISON
 - FLEX
+- GASPREPROCESSOR
 - PERL
 - PYTHON2
 - PYTHON3
@@ -24,7 +25,6 @@ The current list of programs includes:
 - NASM
 - NINJA
 - YASM
-- GASPREPROCESSOR
 
 Note that msys2 has a dedicated helper function: [`vcpkg_acquire_msys`](vcpkg_acquire_msys.md).
 

--- a/docs/maintainers/vcpkg_from_bitbucket.md
+++ b/docs/maintainers/vcpkg_from_bitbucket.md
@@ -1,10 +1,11 @@
-# vcpkg_from_github
+# vcpkg_from_bitbucket
 
-Download and extract a project from GitHub. Enables support for `install --head`.
+Download and extract a project from Bitbucket.
+Enables support for installing HEAD `vcpkg.exe install --head <port>`.
 
 ## Usage:
 ```cmake
-vcpkg_from_github(
+vcpkg_from_bitbucket(
     OUT_SOURCE_PATH <SOURCE_PATH>
     REPO <Microsoft/cpprestsdk>
     [REF <v2.0.0>]
@@ -30,7 +31,7 @@ For repositories without official releases, this can be set to the full commit i
 If `REF` is specified, `SHA512` must also be specified.
 
 ### SHA512
-The SHA512 hash that should match the archive (https://github.com/${REPO}/archive/${REF}.tar.gz).
+The SHA512 hash that should match the archive (https://bitbucket.com/${REPO}/get/${REF}.tar.gz).
 
 This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
@@ -46,9 +47,7 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 
 ## Examples:
 
-* [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
-* [ms-gsl](https://github.com/Microsoft/vcpkg/blob/master/ports/ms-gsl/portfile.cmake)
-* [beast](https://github.com/Microsoft/vcpkg/blob/master/ports/beast/portfile.cmake)
+* [blaze](https://github.com/Microsoft/vcpkg/blob/master/ports/blaze/portfile.cmake)
 
 ## Source
-[scripts/cmake/vcpkg_from_github.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_from_github.cmake)
+[scripts/cmake/vcpkg_from_bitbucket.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_from_bitbucket.cmake)

--- a/docs/maintainers/vcpkg_install_cmake.md
+++ b/docs/maintainers/vcpkg_install_cmake.md
@@ -4,15 +4,15 @@ Build and install a cmake project.
 
 ## Usage:
 ```cmake
-vcpkg_install_cmake([MSVC_64_TOOLSET])
+vcpkg_install_cmake(...)
 ```
 
 ## Parameters:
-### MSVC_64_TOOLSET
-This adds the `/p:PreferredToolArchitecture=x64` switch if the underlying buildsystem is MSBuild. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
+See [`vcpkg_build_cmake()`](vcpkg_build_cmake.md).
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+This command transparently forwards to [`vcpkg_build_cmake()`](vcpkg_build_cmake.md), adding a `TARGET install`
+parameter.
 
 ## Examples:
 

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -38,7 +38,7 @@ vcpkg_configure_cmake(
 # Folly runs built executables during the build, so they need access to the installed DLLs.
 set(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
 
-vcpkg_install_cmake(MSVC_64_TOOLSET)
+vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -58,8 +58,7 @@ vcpkg_configure_cmake(
         -DCMAKE_INSTALL_CMAKEDIR=share/protobuf
 )
 
-# Using 64-bit toolset to avoid occassional Linker Out-of-Memory issues.
-vcpkg_install_cmake(MSVC_64_TOOLSET)
+vcpkg_install_cmake()
 
 # It appears that at this point the build hasn't actually finished. There is probably
 # a process spawned by the build, therefore we need to wait a bit.

--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -1,3 +1,29 @@
+## # vcpkg_build_cmake
+##
+## Build a cmake project.
+##
+## ## Usage:
+## ```cmake
+## vcpkg_build_cmake([MSVC_64_TOOLSET] [DISABLE_PARALLEL])
+## ```
+##
+## ## Parameters:
+## ### MSVC_64_TOOLSET
+## This adds the `/p:PreferredToolArchitecture=x64` switch to the underlying buildsystem parameters. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
+##
+## ### DISABLE_PARALLEL
+## The /m parameter will not be added to the underlying buildsystem parameters
+##
+## ## Notes:
+## This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+## Use [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the "install" target
+##
+## ## Examples:
+##
+## * [zlib](https://github.com/Microsoft/vcpkg/blob/master/ports/zlib/portfile.cmake)
+## * [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
+## * [poco](https://github.com/Microsoft/vcpkg/blob/master/ports/poco/portfile.cmake)
+## * [opencv](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv/portfile.cmake)
 function(vcpkg_build_cmake)
     cmake_parse_arguments(_bc "MSVC_64_TOOLSET;DISABLE_PARALLEL" "" "" ${ARGN})
 
@@ -19,7 +45,9 @@ function(vcpkg_build_cmake)
 
     if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja)
         set(BUILD_ARGS -v) # verbose output
-    else()
+	endif()
+	
+    if(_bc_MSVC_64_TOOLSET)
         set(BUILD_ARGS ${MSVC_EXTRA_ARGS})
     endif()
 

--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -4,19 +4,21 @@
 ##
 ## ## Usage:
 ## ```cmake
-## vcpkg_build_cmake([MSVC_64_TOOLSET] [DISABLE_PARALLEL])
+## vcpkg_build_cmake([DISABLE_PARALLEL] [TARGET <target>])
 ## ```
 ##
 ## ## Parameters:
-## ### MSVC_64_TOOLSET
-## This adds the `/p:PreferredToolArchitecture=x64` switch to the underlying buildsystem parameters. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
-##
 ## ### DISABLE_PARALLEL
-## The /m parameter will not be added to the underlying buildsystem parameters
+## The underlying buildsystem will be instructed to not parallelize
+##
+## ### TARGET
+## The target passed to the cmake build command (`cmake --build . --target <target>`). If not specified, no target will
+## be passed.
 ##
 ## ## Notes:
 ## This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
-## Use [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the "install" target
+## You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the
+## "install" target
 ##
 ## ## Examples:
 ##
@@ -25,45 +27,50 @@
 ## * [poco](https://github.com/Microsoft/vcpkg/blob/master/ports/poco/portfile.cmake)
 ## * [opencv](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv/portfile.cmake)
 function(vcpkg_build_cmake)
-    cmake_parse_arguments(_bc "MSVC_64_TOOLSET;DISABLE_PARALLEL" "" "" ${ARGN})
+    cmake_parse_arguments(_bc "DISABLE_PARALLEL" "TARGET;LOGFILE_ROOT" "" ${ARGN})
 
-    set(MSVC_EXTRA_ARGS
-        "/p:VCPkgLocalAppDataDisabled=true"
-        "/p:UseIntelMKL=No"
-    )
-
-    # Specifies the architecture of the toolset, NOT the architecture of the produced binary
-    # This can help libraries that cause the linker to run out of memory.
-    # https://support.microsoft.com/en-us/help/2891057/linker-fatal-error-lnk1102-out-of-memory
-    if (_bc_MSVC_64_TOOLSET)
-        list(APPEND MSVC_EXTRA_ARGS "/p:PreferredToolArchitecture=x64")
+    if(NOT _bc_LOGFILE_ROOT)
+        set(_bc_LOGFILE_ROOT "build")
     endif()
 
-    if (NOT _bc_DISABLE_PARALLEL)
-        list(APPEND MSVC_EXTRA_ARGS "/m")
+    if(_VCPKG_CMAKE_GENERATOR MATCHES "Ninja")
+        set(BUILD_ARGS "-v") # verbose output
+        if (_bc_DISABLE_PARALLEL)
+            list(APPEND BUILD_ARGS "-j1")
+        endif()
+    elseif(_VCPKG_CMAKE_GENERATOR MATCHES "Visual Studio")
+        set(BUILD_ARGS
+            "/p:VCPkgLocalAppDataDisabled=true"
+            "/p:UseIntelMKL=No"
+        )
+        if (NOT _bc_DISABLE_PARALLEL)
+            list(APPEND BUILD_ARGS "/m")
+        endif()
+    elseif(_VCPKG_CMAKE_GENERATOR MATCHES "NMake")
+        # No options are currently added for nmake builds
+    else()
+        message(FATAL_ERROR "Unrecognized GENERATOR setting from vcpkg_configure_cmake(). Valid generators are: Ninja, Visual Studio, and NMake Makefiles")
     endif()
 
-    if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja)
-        set(BUILD_ARGS -v) # verbose output
-	endif()
-	
-    if(_bc_MSVC_64_TOOLSET)
-        set(BUILD_ARGS ${MSVC_EXTRA_ARGS})
+    if(_bc_TARGET)
+        set(TARGET_PARAM "--target" ${_bc_TARGET})
+    else()
+        set(TARGET_PARAM)
     endif()
 
     message(STATUS "Build ${TARGET_TRIPLET}-rel")
     vcpkg_execute_required_process(
-        COMMAND ${CMAKE_COMMAND} --build . --config Release -- ${BUILD_ARGS}
+        COMMAND ${CMAKE_COMMAND} --build . --config Release ${TARGET_PARAM} -- ${BUILD_ARGS}
         WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
-        LOGNAME build-${TARGET_TRIPLET}-rel
+        LOGNAME ${_bc_LOGFILE_ROOT}-${TARGET_TRIPLET}-rel
     )
     message(STATUS "Build ${TARGET_TRIPLET}-rel done")
 
     message(STATUS "Build ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_required_process(
-        COMMAND ${CMAKE_COMMAND} --build . --config Debug -- ${BUILD_ARGS}
+        COMMAND ${CMAKE_COMMAND} --build . --config Debug ${TARGET_PARAM} -- ${BUILD_ARGS}
         WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
-        LOGNAME build-${TARGET_TRIPLET}-dbg
+        LOGNAME ${_bc_LOGFILE_ROOT}-${TARGET_TRIPLET}-dbg
     )
     message(STATUS "Build ${TARGET_TRIPLET}-dbg done")
 endfunction()

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -188,4 +188,6 @@ function(vcpkg_configure_cmake)
         LOGNAME config-${TARGET_TRIPLET}-dbg
     )
     message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
+
+    set(_VCPKG_CMAKE_GENERATOR "${GENERATOR}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_install_cmake.cmake
+++ b/scripts/cmake/vcpkg_install_cmake.cmake
@@ -4,15 +4,15 @@
 ##
 ## ## Usage:
 ## ```cmake
-## vcpkg_install_cmake([MSVC_64_TOOLSET])
+## vcpkg_install_cmake(...)
 ## ```
 ##
 ## ## Parameters:
-## ### MSVC_64_TOOLSET
-## This adds the `/p:PreferredToolArchitecture=x64` switch to the underlying buildsystem parameters. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
+## See [`vcpkg_build_cmake()`](vcpkg_build_cmake.md).
 ##
 ## ## Notes:
-## This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+## This command transparently forwards to [`vcpkg_build_cmake()`](vcpkg_build_cmake.md), adding a `TARGET install`
+## parameter.
 ##
 ## ## Examples:
 ##
@@ -21,45 +21,5 @@
 ## * [poco](https://github.com/Microsoft/vcpkg/blob/master/ports/poco/portfile.cmake)
 ## * [opencv](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv/portfile.cmake)
 function(vcpkg_install_cmake)
-    cmake_parse_arguments(_bc "MSVC_64_TOOLSET;DISABLE_PARALLEL" "" "" ${ARGN})
-
-    set(MSVC_EXTRA_ARGS
-        "/p:VCPkgLocalAppDataDisabled=true"
-        "/p:UseIntelMKL=No"
-    )
-
-    # Specifies the architecture of the toolset, NOT the architecture of the produced binary
-    # This can help libraries that cause the linker to run out of memory.
-    # https://support.microsoft.com/en-us/help/2891057/linker-fatal-error-lnk1102-out-of-memory
-    if (_bc_MSVC_64_TOOLSET)
-        list(APPEND MSVC_EXTRA_ARGS "/p:PreferredToolArchitecture=x64")
-    endif()
-
-    if (NOT _bc_DISABLE_PARALLEL)
-        list(APPEND MSVC_EXTRA_ARGS "/m")
-    endif()
-    
-    if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja)
-        set(BUILD_ARGS -v) # verbose output
-	endif()
-	
-    if(_bc_MSVC_64_TOOLSET)
-        set(BUILD_ARGS ${MSVC_EXTRA_ARGS})
-    endif()
-
-    message(STATUS "Package ${TARGET_TRIPLET}-rel")
-    vcpkg_execute_required_process(
-        COMMAND ${CMAKE_COMMAND} --build . --config Release --target install -- ${BUILD_ARGS}
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
-        LOGNAME package-${TARGET_TRIPLET}-rel
-    )
-    message(STATUS "Package ${TARGET_TRIPLET}-rel done")
-
-    message(STATUS "Package ${TARGET_TRIPLET}-dbg")
-    vcpkg_execute_required_process(
-        COMMAND ${CMAKE_COMMAND} --build . --config Debug --target install -- ${BUILD_ARGS}
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
-        LOGNAME package-${TARGET_TRIPLET}-dbg
-    )
-    message(STATUS "Package ${TARGET_TRIPLET}-dbg done")
+    vcpkg_build_cmake(LOGFILE_ROOT install TARGET install ${ARGN})
 endfunction()

--- a/scripts/cmake/vcpkg_install_cmake.cmake
+++ b/scripts/cmake/vcpkg_install_cmake.cmake
@@ -9,7 +9,7 @@
 ##
 ## ## Parameters:
 ## ### MSVC_64_TOOLSET
-## This adds the `/p:PreferredToolArchitecture=x64` switch if the underlying buildsystem is MSBuild. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
+## This adds the `/p:PreferredToolArchitecture=x64` switch to the underlying buildsystem parameters. Some large projects can run out of memory when linking if they use the 32-bit hosted tools.
 ##
 ## ## Notes:
 ## This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
@@ -41,7 +41,9 @@ function(vcpkg_install_cmake)
     
     if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja)
         set(BUILD_ARGS -v) # verbose output
-    else()
+	endif()
+	
+    if(_bc_MSVC_64_TOOLSET)
         set(BUILD_ARGS ${MSVC_EXTRA_ARGS})
     endif()
 


### PR DESCRIPTION
This fixes a bug introduced with https://github.com/Microsoft/vcpkg/commit/95af9aac7c39765d1524b7c9c39dc283e9f0facf.
As it is currently implemented, either the ninja build extra parameters or the mscv build extra parameters are added regardless of the value of the MSVC_64_TOOLSET parameter.  
Also changed some wording in the doc.  Since there is currently no way to check what is the underlying build system, saying that parameter X will only add the parameters if the underlying build system is msbuild is a bit of a stretch.

General thoughts I had concerning `vcpkg_build_cmake` and `vcpkg_install_cmake` while I was working on this problem:
- It looks to me like `vcpkg_build_cmake` and `vcpkg_install_cmake` are not aging well.
- The only difference between the two is that `vcpkg_install_cmake` adds `--target install` to the cmake call.  Would not a parameter asking for additional targets (defaulting to install) be enough? (and incidentally we could get rid of `vcpkg_build_cmake` (or rather it would become a wrapper call to `vcpkg_install_cmake` specifying no target)).
- Clearly the different commits on these files show that what is truly needed is the ability to pass **additional build parameters** to the underlying build system.  Something with the same terminology than what is used in `vcpkg_configure_cmake` (suggestion: BUILDSYSTEM_ARGS, BUILDSYSTEM_RELEASEARGS, BUILDSYSTEM_DEBUGARGS)
- there is currently no way to recall in a generic fashion the build system (ie the -G GENERATOR) that was used in vcpkg_configure_cmake.  Adding often forgotten parameters based on the underlying system is useful if not necessary (i'm thinking non trivial flags like `/p:VCPkgLocalAppDataDisabled=true` that no-one would think of adding).  I think this part would require some intervention in vcpkg itself to retain variables between execute_process calls (I may be wrong in this point).  In essence, a VCPKG_CMAKE_GENERATOR variable would be nice.

