### PR TITLE
[geos] Update port to latest GEOS 3.6.2

### DIFF
--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,3 +1,3 @@
 Source: geos
-Version: 3.5.0-1
+Version: 3.6.2
 Description: Geometry Engine Open Source

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -7,25 +7,26 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/3.5)
-#downloading 3.5 from their SVN repo and not the release tarball
-#because the 3.5 release did not build on windows, and fixes were backported
-#without generating a new release tarball (I don't think very many GIS people use win)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/geos-3.6.2)
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://trac.osgeo.org/geos/browser/branches/3.5?rev=4261&format=zip"
-    FILENAME "geos-3.5.0.zip"
-    SHA512 3b91e8992f60b99a3f01069d955b71bce425ae5e5c599252fa26a337494e1a5a8ea796be124766d054710d6c03806f56dc1c63539b4660e2bb894d7ef779d4b9
+    URLS "http://download.osgeo.org/geos/geos-3.6.2.tar.bz2"
+    FILENAME "geos-3.6.2.tar.bz2"
+    SHA512 515d8700b8a28282678e481faee355e3a43d7b70160472a63335b8d7225d9ba10437be782378f18f31a15288118126d411a2d862f01ce35d27c96f6bc0a73016
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-#we need to do this because GEOS deploy process is totally broken for cmake
-#file(DOWNLOAD http://svn.osgeo.org/geos/tags/3.5.0/cmake/modules/GenerateSourceGroups.cmake
-#    ${SOURCE_PATH}/cmake/modules/GenerateSourceGroups.cmake)
-file(WRITE ${SOURCE_PATH}/geos_svn_revision.h "#define GEOS_SVN_REVISION 4261")
+# NOTE: GEOS provides CMake as optional build configuration, it might not be actively
+# maintained, so CMake build issues may happen between releases.
+
+# Pull modules referred in the main CMakeLists.txt but missing from the released package.
+# TODO: GEOS 3.6.3 or later will include the missing script in release package.
+file(DOWNLOAD http://svn.osgeo.org/geos/branches/3.6/cmake/modules/GenerateSourceGroups.cmake
+    ${SOURCE_PATH}/cmake/modules/GenerateSourceGroups.cmake)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS -DGEOS_ENABLE_TESTS=False
-            -DBUILD_TESTING=False
 )
 
 vcpkg_build_cmake()


### PR DESCRIPTION
* Bump GEOS version wherever necessary
* Update download package and checksum.
* Replace download from SVN with official release source package.
* Remove generating of `geos_svn_revision.h` as unnecessary -
  released source package includes the header.
* Explain status of the missing CMake modules.
* Remove CMake option `-DBUILD_TESTING` as unused.

GEOS is important dependency of GDAL (updated in #1879;
GDAL 2.2.2 can still work with GEOS earlier than 3.6.2).