### PR TITLE
[aws-sdk-cpp] update to 1.2.4 and fix cmake exports

### DIFF
--- a/ports/aws-sdk-cpp/CONTROL
+++ b/ports/aws-sdk-cpp/CONTROL
@@ -1,3 +1,3 @@
 Source: aws-sdk-cpp
-Version: 1.0.61-1
+Version: 1.2.4
 Description: AWS SDK for C++


### PR DESCRIPTION
This compiles without a problem, and the downstream project is able to link to it via cmake without a problem too.

Note that vcpkg_fixup_cmake_targets is not used here because something like `vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/aws-cpp-sdk-*")` does not work.