### PR TITLE
Autocomplete: Command to enable tab completion 

### DIFF
--- a/toolsrc/include/vcpkg_Commands.h
+++ b/toolsrc/include/vcpkg_Commands.h
@@ -194,6 +194,11 @@ namespace vcpkg::Commands
         void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
     }
 
+	namespace Autocomplete
+	{
+		void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
+	}
+
     namespace Help
     {
         void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);

--- a/toolsrc/src/commands_autocomplete.cpp
+++ b/toolsrc/src/commands_autocomplete.cpp
@@ -14,8 +14,33 @@ namespace vcpkg::Commands::Autocomplete
             Strings::format("The argument should be a command line to autocomplete.\n%s",
                             Commands::Help::create_example_string("autocomplete install z"));
 
-        args.check_max_arg_count(1, EXAMPLE);
+        args.check_min_arg_count(1, EXAMPLE);
+        args.check_max_arg_count(2, EXAMPLE);
         args.check_and_get_optional_command_arguments({});
+
+        const std::string requested_command = args.command_arguments.at(0);
+        const std::string start_with =
+            args.command_arguments.size() > 1 ? args.command_arguments.at(1) : Strings::EMPTY;
+
+        auto sources_and_errors = Paragraphs::try_load_all_ports(paths.get_filesystem(), paths.ports);
+        auto& source_paragraphs = sources_and_errors.paragraphs;
+
+        const auto& istartswith = Strings::case_insensitive_ascii_starts_with;
+
+        std::vector<std::string> results;
+        for (const auto& source_control_file : source_paragraphs)
+        {
+            auto&& sp = *source_control_file->core_paragraph;
+
+            if (istartswith(sp.name, start_with))
+            {
+                results.push_back(sp.name);
+            }
+        }
+
+        System::println(Strings::join(" ", results));
+
+        auto all_ports = Paragraphs::try_load_all_ports(paths.get_filesystem(), paths.ports);
 
         Checks::exit_success(VCPKG_LINE_INFO);
     }

--- a/toolsrc/src/commands_autocomplete.cpp
+++ b/toolsrc/src/commands_autocomplete.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+
+#include "Paragraphs.h"
+#include "SortedVector.h"
+#include "vcpkg_Commands.h"
+#include "vcpkg_Maps.h"
+#include "vcpkg_System.h"
+
+namespace vcpkg::Commands::Autocomplete
+{
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
+    {
+        static const std::string EXAMPLE =
+            Strings::format("The argument should be a command line to autocomplete.\n%s",
+                            Commands::Help::create_example_string("autocomplete install z"));
+
+        args.check_max_arg_count(1, EXAMPLE);
+        args.check_and_get_optional_command_arguments({});
+
+        Checks::exit_success(VCPKG_LINE_INFO);
+    }
+}

--- a/toolsrc/src/commands_autocomplete.cpp
+++ b/toolsrc/src/commands_autocomplete.cpp
@@ -5,6 +5,7 @@
 #include "vcpkg_Commands.h"
 #include "vcpkg_Maps.h"
 #include "vcpkg_System.h"
+#include "vcpkglib.h"
 
 namespace vcpkg::Commands::Autocomplete
 {
@@ -25,6 +26,25 @@ namespace vcpkg::Commands::Autocomplete
         }
         return results;
     }
+
+    std::vector<std::string> autocomplete_remove(std::vector<StatusParagraph*> installed_packages,
+                                                 const std::string& start_with)
+    {
+        std::vector<std::string> results;
+        const auto& istartswith = Strings::case_insensitive_ascii_starts_with;
+
+        for (const auto& installed_package : installed_packages)
+        {
+            auto sp = installed_package->package.displayname();
+
+            if (istartswith(sp, start_with))
+            {
+                results.push_back(sp);
+            }
+        }
+        return results;
+    }
+
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
         static const std::string EXAMPLE =
@@ -46,6 +66,13 @@ namespace vcpkg::Commands::Autocomplete
 
             results = autocomplete_install(source_paragraphs, start_with);
         }
+        else if (requested_command == "remove")
+        {
+            const StatusParagraphs status_db = database_load_check(paths);
+            std::vector<StatusParagraph*> installed_packages = get_installed_ports(status_db);
+            results = autocomplete_remove(installed_packages, start_with);
+        }
+
         System::println(Strings::join(" ", results));
         Checks::exit_success(VCPKG_LINE_INFO);
     }

--- a/toolsrc/src/commands_available_commands.cpp
+++ b/toolsrc/src/commands_available_commands.cpp
@@ -34,7 +34,7 @@ namespace vcpkg::Commands
             {"import", &Import::perform_and_exit},
             {"cache", &Cache::perform_and_exit},
             {"portsdiff", &PortsDiff::perform_and_exit},
-        };
+            {"autocomplete", &Autocomplete::perform_and_exit}};
         return t;
     }
 

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj
@@ -181,6 +181,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\BinaryParagraph.cpp" />
+    <ClCompile Include="..\src\commands_autocomplete.cpp" />
     <ClCompile Include="..\src\commands_ci.cpp" />
     <ClCompile Include="..\src\commands_depends.cpp" />
     <ClCompile Include="..\src\commands_env.cpp" />

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj.filters
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="..\src\vcpkg_GlobalState.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\commands_autocomplete.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\SourceParagraph.h">


### PR DESCRIPTION
Add new command `vcpkg autocomplete`. This is needed to allow tab completion in PowerShell (which is being worked on). Currently, `install` and `remove` are supported. 