### PR TITLE
[ffmpeg] Deal with case-sensitive env vars

### DIFF
--- a/ports/ffmpeg/build.sh
+++ b/ports/ffmpeg/build.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/bash
 set -e
 export PATH=/usr/bin:$PATH
+# Export HTTP(S)_PROXY as http(s)_proxy:
+if [ "$HTTP_PROXY" ]; then
+    export http_proxy=$HTTP_PROXY
+fi
+if [ "$HTTPS_PROXY" ]; then
+    export https_proxy=$HTTPS_PROXY
+fi
 pacman -Sy --noconfirm --needed diffutils make
 
 PATH_TO_BUILD_DIR="`cygpath "$1"`"


### PR DESCRIPTION
When behind a corporate proxy, one often needs to specify `HTTP_PROXY` and `HTTPS_PROXY` for some command line tools to work properly. However, `pacman` seems to rely on the lowercase equivalent environment variables. In a Windows command prompt environment, it is not possible to set both since Windows environment variables are not case-sensitive. As a workaround, this build script checks for the existence of `HTTP_PROXY` and `HTTPS_PROXY`. If they exist, they are exported as lowercase variables.