### PR TITLE
Add xmplite 4.4.1

### DIFF
--- a/ports/libxmp-lite/0001-msvc-buildfix.patch
+++ b/ports/libxmp-lite/0001-msvc-buildfix.patch
@@ -1,0 +1,23 @@
+diff -Naur .\libxmp-lite-4.4.1/src/common.h .\libxmp-lite-4.4.1-orig/src/common.h
+--- a/src/common.h	2016-07-16 13:37:36 +0200
++++ b/src/common.h	2017-05-23 00:52:17 +0200
+@@ -77,19 +77,12 @@
+ #ifndef CLIB_DECL
+ #define CLIB_DECL
+ #endif
+-#ifdef DEBUG
+-#ifndef ATTR_PRINTF
+-#define ATTR_PRINTF(x,y)
+-#endif
+-void CLIB_DECL D_(const char *text, ...) ATTR_PRINTF(1,2);
+-#else
+ // VS prior to VC7.1 does not support variadic macros. VC8.0 does not optimize unused parameters passing
+ #if _MSC_VER < 1400
+ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
+ #else
+ #define D_(args, ...) do {} while (0)
+ #endif
+-#endif
+ 
+ #elif defined __ANDROID__
+ 

--- a/ports/libxmp-lite/0002-fix-symbols.patch
+++ b/ports/libxmp-lite/0002-fix-symbols.patch
@@ -1,0 +1,44 @@
+diff --git a/lite/src/format.c b/lite/src/format.c
+--- a/src/format.c
++++ b/src/format.c
+@@ -27,20 +27,20 @@
+ #endif
+ #include "format.h"
+ 
+-extern const struct format_loader xm_loader;
+-extern const struct format_loader mod_loader;
+-extern const struct format_loader it_loader;
+-extern const struct format_loader s3m_loader;
++extern const struct format_loader libxmp_loader_xm;
++extern const struct format_loader libxmp_loader_mod;
++extern const struct format_loader libxmp_loader_it;
++extern const struct format_loader libxmp_loader_s3m;
+ 
+ extern const struct pw_format *const pw_format[];
+ 
+ const struct format_loader *const format_loader[5] = {
+-	&xm_loader,
+-	&mod_loader,
++	&libxmp_loader_xm,
++	&libxmp_loader_mod,
+ #ifndef LIBXMP_CORE_DISABLE_IT
+-	&it_loader,
++	&libxmp_loader_it,
+ #endif
+-	&s3m_loader,
++	&libxmp_loader_s3m,
+ 	NULL
+ };
+ 
+diff --git a/lite/src/loaders/mod_load.c b/lite/src/loaders/mod_load.c
+--- a/src/loaders/mod_load.c
++++ b/src/loaders/mod_load.c
+@@ -36,7 +36,7 @@
+ static int mod_test (HIO_HANDLE *, char *, const int);
+ static int mod_load (struct module_data *, HIO_HANDLE *, const int);
+ 
+-const struct format_loader mod_loader = {
++const struct format_loader libxmp_loader_mod = {
+     "Protracker",
+     mod_test,
+     mod_load

--- a/ports/libxmp-lite/CMakeLists.txt
+++ b/ports/libxmp-lite/CMakeLists.txt
@@ -33,6 +33,11 @@ set(SOURCES src/virtual.c
 include_directories(include/libxmp-lite src)
 
 option(BUILD_SHARED_LIBS "Build shared libs" OFF)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    option(INSTALL_HEADERS "Install header files" OFF)
+else()
+    option(INSTALL_HEADERS "Install header files" ON)
+endif()
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
@@ -55,4 +60,6 @@ install(
     RUNTIME DESTINATION bin
 )
 
-install(FILES ${HEADERS} DESTINATION include)
+if(INSTALL_HEADERS)
+    install(FILES ${HEADERS} DESTINATION include)
+endif()

--- a/ports/libxmp-lite/CMakeLists.txt
+++ b/ports/libxmp-lite/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.4)
+project(libxmp-lite)
+
+set(HEADERS "include/libxmp-lite/xmp.h")
+
+set(SOURCES src/virtual.c
+            src/format.c
+            src/period.c
+            src/player.c
+            src/read_event.c
+            src/dataio.c
+            src/lfo.c
+            src/scan.c
+            src/control.c
+            src/filter.c
+            src/effects.c
+            src/mixer.c
+            src/mix_all.c
+            src/load_helpers.c
+            src/load.c
+            src/hio.c
+            src/smix.c
+            src/memio.c
+            src/loaders/common.c
+            src/loaders/itsex.c
+            src/loaders/sample.c
+            src/loaders/xm_load.c
+            src/loaders/mod_load.c
+            src/loaders/s3m_load.c
+            src/loaders/it_load.c
+)
+
+include_directories(include/libxmp-lite src)
+
+option(BUILD_SHARED_LIBS "Build shared libs" OFF)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+add_library(libxmp-lite ${SOURCES})
+target_compile_definitions(libxmp-lite PRIVATE
+            LIBXMP_CORE_PLAYER=1
+            inline=__inline
+            _USE_MATH_DEFINES=1
+)
+
+# Fix UWP /sdl compile errors
+# Disable C4703: Not initialized
+# Disable C4996: Deprecated
+set_target_properties(libxmp-lite PROPERTIES COMPILE_FLAGS "/wd4703 /wd4996")
+
+install(
+    TARGETS libxmp-lite
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(FILES ${HEADERS} DESTINATION include)

--- a/ports/libxmp-lite/CONTROL
+++ b/ports/libxmp-lite/CONTROL
@@ -1,0 +1,3 @@
+Source: libxmp-lite
+Version: 4.4.1
+Description: Lightweight version of libxmp that supports MOD, S3M, XM and IT modules.

--- a/ports/libxmp-lite/portfile.cmake
+++ b/ports/libxmp-lite/portfile.cmake
@@ -1,0 +1,29 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libxmp-lite-4.4.1)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://sourceforge.net/projects/xmp/files/libxmp/4.4.1/libxmp-lite-4.4.1.tar.gz"
+    FILENAME "libxmp-lite-4.4.1.tar.gz"
+    SHA512 f27e3f9fb79ff15ce90b51fb29641c01cadf7455150da57cde6860c2ba075ed497650eb44ec9143bdd3538288228c609f7db6d862c9d73f007f686eccb05543e
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/0001-msvc-buildfix.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0002-fix-symbols.patch
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/libxmp-lite RENAME copyright)

--- a/ports/libxmp-lite/portfile.cmake
+++ b/ports/libxmp-lite/portfile.cmake
@@ -23,7 +23,5 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/libxmp-lite RENAME copyright)


### PR DESCRIPTION
MIT license.

Lightweight version of libxmp that supports MOD, S3M, XM and IT modules. 

Patch 0001 fixes a linker error when DEBUG is defined

Patch 0002 fixes incorrect symbol names used in xmplite (already in upstream)

Signed the CLA

About "file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)". How do I fix this properly in the CMakeLists?
