### PR TITLE
Add Wildmidi 0.4.1

### DIFF
--- a/ports/wildmidi/0001-add-install-target.patch
+++ b/ports/wildmidi/0001-add-install-target.patch
@@ -1,0 +1,30 @@
+--- a/src/CMakeLists.txt	2017-10-02 14:06:57.163881000 +0000
++++ b/src/CMakeLists.txt	2017-10-02 14:08:52.815977600 +0000
+@@ -313,6 +313,27 @@
+ ENDIF (WIN32 AND CMAKE_COMPILER_IS_MINGW)
+ 
+ IF (WIN32 AND MSVC)
++    # install our libraries
++    IF (WANT_STATIC)
++        INSTALL(TARGETS libwildmidi_static DESTINATION ${WILDMIDILIB_INSTALLDIR})
++        IF (WANT_PLAYERSTATIC)
++            INSTALL(TARGETS wildmidi-static DESTINATION bin)
++        ENDIF ()
++    ENDIF (WANT_STATIC)
++
++    IF (BUILD_SHARED_LIBS)
++        INSTALL(TARGETS libwildmidi_dynamic
++            ARCHIVE DESTINATION ${WILDMIDILIB_INSTALLDIR}
++            LIBRARY DESTINATION ${WILDMIDILIB_INSTALLDIR}
++            RUNTIME DESTINATION ${WILDMIDIDLL_INSTALLDIR}
++        )
++        IF (WANT_PLAYER)
++            INSTALL(TARGETS wildmidi DESTINATION bin)
++        ENDIF ()
++    ENDIF ()
++
++    INSTALL(FILES ${CMAKE_SOURCE_DIR}/include/wildmidi_lib.h DESTINATION include)
++
+     IF (WANT_MP_BUILD)
+         SET(MT_BUILD "/MP")
+     ENDIF ()

--- a/ports/wildmidi/0002-use-ansi.patch
+++ b/ports/wildmidi/0002-use-ansi.patch
@@ -1,0 +1,22 @@
+diff --git a/src/file_io.c b/src/file_io.c
+index 9db9759..7110e8b 100644
+--- a/src/file_io.c
++++ b/src/file_io.c
+@@ -118,7 +118,7 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
+ #elif defined(_WIN32)
+     int buffer_fd;
+     HANDLE h;
+-    WIN32_FIND_DATA wfd;
++    WIN32_FIND_DATAA wfd;
+ #elif defined(__OS2__) || defined(__EMX__)
+     int buffer_fd;
+     HDIR h = HDIR_CREATE;
+@@ -186,7 +186,7 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
+     }
+     *size = f.ff_fsize;
+ #elif defined(_WIN32)
+-    if ((h = FindFirstFile(buffer_file, &wfd)) == INVALID_HANDLE_VALUE) {
++    if ((h = FindFirstFileA(buffer_file, &wfd)) == INVALID_HANDLE_VALUE) {
+         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
+         free(buffer_file);
+         return NULL;

--- a/ports/wildmidi/CONTROL
+++ b/ports/wildmidi/CONTROL
@@ -1,0 +1,3 @@
+Source: wildmidi
+Version: 0.4.1
+Description: MIDI software synthesizer library.

--- a/ports/wildmidi/portfile.cmake
+++ b/ports/wildmidi/portfile.cmake
@@ -1,0 +1,51 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/wildmidi-wildmidi-0.4.1)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.1.zip"
+    FILENAME "wildmidi-0.4.1.zip"
+    SHA512 ebfbb16b57c0d39f1402f91df4dd205d80f5632f6afbe5fa99af6f06279582f0676bb247cd64ec472cdf272f6a1a2917827ed98f9cc24166aa41f050b9f7d396
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/0001-add-install-target.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0002-use-ansi.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(BUILD_SHARED_LIBS "ON")
+	set(WANT_STATIC "OFF")
+else()
+    set(BUILD_SHARED_LIBS "OFF")
+	set(WANT_STATIC "ON")
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DMSVC=ON
+        -DWANT_PLAYER=OFF
+        -DWANT_STATIC=${WANT_STATIC}
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+# Rename library to get rid of _dynamic and _static suffix
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/wildmidi_dynamic.lib ${CURRENT_PACKAGES_DIR}/lib/wildmidi.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/wildmidi_dynamic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/wildmidi.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/wildmidi_dynamic.dll ${CURRENT_PACKAGES_DIR}/bin/wildmidi.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/wildmidi_dynamic.dll ${CURRENT_PACKAGES_DIR}/debug/bin/wildmidi.dll)
+else()
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/wildmidi_static.lib ${CURRENT_PACKAGES_DIR}/lib/wildmidi.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/wildmidi_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/wildmidi.lib)
+endif()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/docs/license/LGPLv3.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/wildmidi RENAME copyright)


### PR DESCRIPTION
LGPL. MIDI software synthesizer library.

Patch 0001: The CMake file lacks install targets for everything except MSYS and UNIX
Patch 0002: Fix opening of the configuration file in Unicode mode (already upstreamed)