### PR TITLE
[geos] allow geos_c static library cretation (libgeos_c.lib)

### DIFF
--- a/ports/geos/geos_c-static-support.patch
+++ b/ports/geos/geos_c-static-support.patch
@@ -1,0 +1,110 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 927a0fe..8e6c3ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,11 +66,7 @@ if(NOT MSVC)
+     "Set to ON|OFF (default) to build GEOS with assert() macro enabled" OFF)
+ endif()
+ 
+-option(GEOS_BUILD_STATIC
+-  "Set to OFF|ON (default) to build GEOS static libraries" ON)
+-
+-option(GEOS_BUILD_SHARED
+-  "Set to OFF|ON (default) to build GEOS shared libraries" ON)
++option(BUILD_SHARED_LIBS "Build GEOS as a shared library" ON)
+ 
+ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+   option(GEOS_ENABLE_FLOATSTORE
+diff --git a/capi/CMakeLists.txt b/capi/CMakeLists.txt
+index 859722b..b6e44b6 100644
+--- a/capi/CMakeLists.txt
++++ b/capi/CMakeLists.txt
+@@ -23,15 +23,23 @@ file(GLOB geos_capi_HEADERS ${CMAKE_BINARY_DIR}/capi/*.h) # fix source_group iss
+ 
+ if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK) 
+   # if building OS X framework, CAPI built into C++ library 
+-  add_library(geos_c SHARED ${geos_c_SOURCES}) 
++  add_library(geos_c ${geos_c_SOURCES})
+ 
+   target_link_libraries(geos_c geos)
+ 
+   if (WIN32)
+-    set_target_properties(geos_c
+-      PROPERTIES
+-      VERSION ${CAPI_VERSION}
+-      CLEAN_DIRECT_OUTPUT 1)
++    if(BUILD_SHARED_LIBS)
++      set_target_properties(geos_c
++        PROPERTIES
++        VERSION ${CAPI_VERSION}
++        CLEAN_DIRECT_OUTPUT 1)
++    else()
++      set_target_properties(geos_c
++        PROPERTIES
++        OUTPUT_NAME "geos_c"
++        PREFIX "lib"
++        CLEAN_DIRECT_OUTPUT 1)
++    endif()
+   else()
+     set_target_properties(geos_c
+       PROPERTIES
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4a1e688..a33b5f6 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -23,7 +23,7 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
+     ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_c.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_ts_c.cpp)
+ 
+-  add_library(GEOS SHARED ${geos_SOURCES} ${geos_c_SOURCES})
++  add_library(GEOS ${geos_SOURCES} ${geos_c_SOURCES})
+ 
+   math(EXPR CVERSION "${VERSION_MAJOR} + 1") 
+  	# VERSION = current version, SOVERSION = compatibility version 
+@@ -61,37 +61,27 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
+ 
+ else()
+ 
+-  if(GEOS_BUILD_SHARED)
+-    add_library(geos SHARED ${geos_SOURCES} ${geos_ALL_HEADERS})
++  add_library(geos ${geos_SOURCES} ${geos_ALL_HEADERS})
+ 
++  if(BUILD_SHARED_LIBS)
+     set_target_properties(geos
+       PROPERTIES
+       DEFINE_SYMBOL GEOS_DLL_EXPORT
+       VERSION ${VERSION}
+       CLEAN_DIRECT_OUTPUT 1)
+-
+-    install(TARGETS geos
+-      RUNTIME DESTINATION bin
+-      LIBRARY DESTINATION lib
+-      ARCHIVE DESTINATION lib)
+-  endif()
+-
+-  if(GEOS_BUILD_STATIC)
+-    add_library(geos-static STATIC ${geos_SOURCES} ${geos_ALL_HEADERS})
+-
+-    set_target_properties(geos-static
++  else()
++    set_target_properties(geos
+       PROPERTIES
+       OUTPUT_NAME "geos"
+       PREFIX "lib"
+       CLEAN_DIRECT_OUTPUT 1)
+-
+-    install(TARGETS geos-static
+-      RUNTIME DESTINATION bin
+-      LIBRARY DESTINATION lib
+-      ARCHIVE DESTINATION lib)
+-
+   endif()
+ 
++  install(TARGETS geos
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib)
++
+ endif() # (GEOS_ENABLE_MACOSX_FRAMEWORK)
+ 
+ # if(APPLE)

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -15,6 +15,11 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 515d8700b8a28282678e481faee355e3a43d7b70160472a63335b8d7225d9ba10437be782378f18f31a15288118126d411a2d862f01ce35d27c96f6bc0a73016
 )
 vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_apply_patches(
+
+SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/geos_c-static-support.patch
+)
 
 # NOTE: GEOS provides CMake as optional build configuration, it might not be actively
 # maintained, so CMake build issues may happen between releases.


### PR DESCRIPTION
When building libraries that depends on geos, there are missing library errors in case of static build.
Noticed that in capi folder CMakeLists.txt contains only shared library creation. Had to duplicate the code with `add_library(geos_c-static STATIC ${geos_c_SOURCES})` to support static library creation (only for BUILD_STATIC=true). Will also send the patch to upstream but they are usually very slow to accept (most likely with next Geos version).

@mloskot 