### PR TITLE
[FreeXL] initial port

### DIFF
--- a/ports/freexl/CONTROL
+++ b/ports/freexl/CONTROL
@@ -1,0 +1,5 @@
+Source: freexl
+Version: 1.0.4
+Description: FreeXL is an open source library to extract valid data from within an Excel (.xls) spreadsheet
+Build-Depends: libiconv
+

--- a/ports/freexl/fix-makefiles.patch
+++ b/ports/freexl/fix-makefiles.patch
@@ -1,0 +1,43 @@
+diff --git a/makefile.vc b/makefile.vc
+index 0aacbc7..d95d859 100644
+--- a/makefile.vc
++++ b/makefile.vc
+@@ -7,7 +7,7 @@
+ LIBOBJ	               =	freexl.obj
+ FREEXL_DLL	 	       =	freexl$(VERSION).dll
+ 
+-CFLAGS	=	/nologo -IC:\OSGeo4W\include -I. -Iheaders $(OPTFLAGS)
++CFLAGS	=	/nologo -I$(INSTALLED_ROOT)\include -I. -Iheaders $(OPTFLAGS)
+ 
+ default:	all
+ 
+@@ -23,9 +23,9 @@ freexl.lib:	$(LIBOBJ)
+ $(FREEXL_DLL):	freexl_i.lib
+ 
+ freexl_i.lib:	$(LIBOBJ)
+-	link /debug /dll /out:$(FREEXL_DLL) \
++	link $(LINK_FLAGS) /dll /out:$(FREEXL_DLL) \
+ 		/implib:freexl_i.lib $(LIBOBJ) \
+-		C:\OSGeo4w\lib\iconv.lib
++		$(LIBS_ALL)
+ 	if exist $(FREEXL_DLL).manifest mt -manifest \
+ 		$(FREEXL_DLL).manifest -outputresource:$(FREEXL_DLL);2 
+ 
+diff --git a/nmake.opt b/nmake.opt
+index 35f9242..efb6f77 100644
+--- a/nmake.opt
++++ b/nmake.opt
+@@ -1,10 +1,10 @@
+ # Directory tree where FreeXL will be installed.
+-INSTDIR=C:\OSGeo4W
++INSTDIR=$(INST_DIR)
+ 
+ # Uncomment the first for an optimized build, or the second for debug.
+-OPTFLAGS=	/nologo /Ox /fp:precise /W3 /MD /D_CRT_SECURE_NO_WARNINGS \
++OPTFLAGS=	/nologo /fp:precise /W3 $(CL_FLAGS) /D_CRT_SECURE_NO_WARNINGS \
+ 			/DDLL_EXPORT
+-#OPTFLAGS=	/nologo /Zi /MD /Fdfreexl.pdb /DDLL_EXPORT
++#OPTFLAGS=	/nologo $(CL_FLAGS) /Fdfreexl.pdb /DDLL_EXPORT
+ 
+ # Set the version number for the DLL.  Normally we leave this blank since
+ # we want software that is dynamically loading the DLL to have no problem

--- a/ports/freexl/fix-sources.patch
+++ b/ports/freexl/fix-sources.patch
@@ -1,0 +1,35 @@
+diff --git a/config-msvc.h b/config-msvc.h
+index a39d4e7..37f1c0b 100644
+--- a/config-msvc.h
++++ b/config-msvc.h
+@@ -66,7 +66,7 @@
+ #define HAVE_SYS_TYPES_H 1
+ 
+ /* Define to 1 if you have the <unistd.h> header file. */
+-#define HAVE_UNISTD_H 1
++#undef HAVE_UNISTD_H
+ 
+ /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
+    slash. */
+diff --git a/src/freexl.c b/src/freexl.c
+index a0b255a..92163a9 100644
+--- a/src/freexl.c
++++ b/src/freexl.c
+@@ -92,7 +92,7 @@ freexl_version (void)
+ #if defined(_WIN32) && !defined(__MINGW32__)
+ /* MSVC compiler doesn't support lround() at all */
+ static double
+-round (double num)
++round_old (double num)
+ {
+     double integer = ceil (num);
+     if (num > 0)
+@@ -101,7 +101,7 @@ round (double num)
+ }
+ 
+ static long
+-lround (double num)
++lround_old (double num)
+ {
+     long integer = (long) round (num);
+     return integer;

--- a/ports/freexl/portfile.cmake
+++ b/ports/freexl/portfile.cmake
@@ -1,0 +1,82 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/freexl-1.0.4)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.gaia-gis.it/gaia-sins/freexl-1.0.4.tar.gz"
+    FILENAME "freexl-1.0.4.tar.gz"
+    SHA512 d72561f7b82e0281cb211fbf249e5e45411a7cdd009cfb58da3696f0a0341ea7df210883bfde794be28738486aeb4ffc67ec2c98fd2acde5280e246e204ce788
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/fix-makefiles.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-sources.patch
+)
+find_program(NMAKE nmake)
+
+set(LIBS_ALL_DBG 
+	"${CURRENT_INSTALLED_DIR}/debug/lib/libiconv.lib \
+	${CURRENT_INSTALLED_DIR}/debug/lib/libcharset.lib"
+   )
+set(LIBS_ALL_REL 
+	"${CURRENT_INSTALLED_DIR}/lib/libiconv.lib \
+	${CURRENT_INSTALLED_DIR}/lib/libcharset.lib"
+   )
+
+
+if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+	set(CL_FLAGS_DBG "/MDd /Zi")
+	set(CL_FLAGS_REL "/MD /Ox")
+else()
+	set(CL_FLAGS_DBG "/MTd /Zi")
+	set(CL_FLAGS_REL "/MT /Ox")
+endif()
+
+
+################
+# Debug build
+################
+message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+
+file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}/debug" INST_DIR_DBG)
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} -f makefile.vc clean install
+    INST_DIR=${INST_DIR_DBG} INSTALLED_ROOT=${CURRENT_INSTALLED_DIR} "LINK_FLAGS=/debug" "CL_FLAGS=${CL_FLAGS_DBG}" "LIBS_ALL=${LIBS_ALL_DBG}"
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME nmake-build-${TARGET_TRIPLET}-debug
+)
+message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
+vcpkg_copy_pdbs()
+
+################
+# Release build
+################
+message(STATUS "Building ${TARGET_TRIPLET}-rel")
+
+file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR_REL)
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} -f makefile.vc clean install
+    INST_DIR=${INST_DIR_REL} INSTALLED_ROOT=${CURRENT_INSTALLED_DIR} "LINK_FLAGS=" "CL_FLAGS=${CL_FLAGS_REL}" "LIBS_ALL=${LIBS_ALL_REL}"
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME nmake-build-${TARGET_TRIPLET}-release
+)
+message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/freexl RENAME copyright)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/freexl_i.lib)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/freexl_i.lib)
+else()
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/freexl.lib)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/freexl.lib)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/lib/freexl_i.lib ${CURRENT_PACKAGES_DIR}/lib/freexl.lib)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/freexl_i.lib ${CURRENT_PACKAGES_DIR}/debug/lib/freexl.lib)
+endif()
+
+
+message(STATUS "Packaging ${TARGET_TRIPLET} done")


### PR DESCRIPTION
FreeXL is a library to read legacy xls files. I needed it to build spatialite library and tools.
The library is pure C, Windows build is based on provided nmake makefile.

The most work with the patch is removing hardcoded paths and flags from makefiles and passing them as options for `nmake`. Also only in-source build is supported, so `make clean` is essential between builds (else debug and release obj and libs mix),