### PR TITLE
[ReadOSM] initial port

### DIFF
--- a/ports/readosm/CONTROL
+++ b/ports/readosm/CONTROL
@@ -1,0 +1,4 @@
+Source: readosm
+Version: 1.1.0
+Description: ReadOSM is an open source library to extract valid data from within an Open Street Map input file (.osm or .osm.pbf)
+Build-Depends: expat, zlib

--- a/ports/readosm/fix-makefiles.patch
+++ b/ports/readosm/fix-makefiles.patch
@@ -1,0 +1,49 @@
+diff --git a/makefile.vc b/makefile.vc
+index 791aedf..d294548 100644
+--- a/makefile.vc
++++ b/makefile.vc
+@@ -8,7 +8,7 @@ LIBOBJ	               =	src\readosm.obj src\osmxml.obj \
+ 							src\protobuf.obj src\osm_objects.obj
+ READOSM_DLL	 	       =	readosm$(VERSION).dll
+ 
+-CFLAGS	=	/nologo -IC:\OSGeo4W\include -Iheaders $(OPTFLAGS)
++CFLAGS	=	/nologo -I$(INSTALLED_ROOT)\include -Iheaders $(OPTFLAGS)
+ 
+ default:	all
+ 
+@@ -21,9 +21,9 @@ readosm.lib:	$(LIBOBJ)
+ $(READOSM_DLL):	readosm_i.lib
+ 
+ readosm_i.lib:	$(LIBOBJ)
+-	link /debug /dll /out:$(READOSM_DLL) \
++	link $(LINK_FLAGS) /dll /out:$(READOSM_DLL) \
+ 		/implib:readosm_i.lib $(LIBOBJ) \
+-		C:\OSGeo4w\lib\libexpat.lib C:\OSGeo4w\lib\zlib.lib
++		$(LIBS_ALL)
+ 	if exist $(READOSM_DLL).manifest mt -manifest \
+ 		$(READOSM_DLL).manifest -outputresource:$(READOSM_DLL);2 
+ 		
+@@ -35,7 +35,7 @@ clean:
+ 	del *.exp
+ 	del *.manifest
+ 	del *.lib
+-	del *.obj
++	del src\*.obj
+ 	del *.pdb
+ 
+ install: all
+diff --git a/nmake.opt b/nmake.opt
+index 5e45c0e..61c44f9 100644
+--- a/nmake.opt
++++ b/nmake.opt
+@@ -1,8 +1,8 @@
+ # Directory tree where ReadOSM will be installed.
+-INSTDIR=C:\OSGeo4W
++INSTDIR=$(INST_DIR)
+ 
+ # Uncomment the first for an optimized build, or the second for debug.
+-OPTFLAGS=	/nologo /Ox /fp:precise /W3 /MD /D_CRT_SECURE_NO_WARNINGS \
++OPTFLAGS=	/nologo /fp:precise /W3 $(CL_FLAGS) /D_CRT_SECURE_NO_WARNINGS \
+ 			/DDLL_EXPORT
+ #OPTFLAGS=	/nologo /Zi /MD /Fdreadosm.pdb /DDLL_EXPORT
+

--- a/ports/readosm/fix-version-macro.patch
+++ b/ports/readosm/fix-version-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/src/readosm.c b/src/readosm.c
+index e1dda27..7977339 100644
+--- a/src/readosm.c
++++ b/src/readosm.c
+@@ -50,7 +50,7 @@
+ 
+ #if defined(_WIN32) && !defined(__MINGW32__)
+ /* MSVC: avoiding to include at all config.h */
+-#define VERSION	1.1.0
++#define VERSION	"1.1.0"
+ #else
+ #include "config.h"
+ #endif

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -1,0 +1,78 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/readosm-1.1.0)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.gaia-gis.it/gaia-sins/readosm-1.1.0.tar.gz"
+    FILENAME "readosm-1.1.0.tar.gz"
+    SHA512 d3581f564c4461c6a1a3d5fd7d18a262c884b2ac935530064bfaebd6c05d692fb92cc600fb40e87e03f7160ebf0eeeb05f51a0e257935d056b233fe28fc01a11
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/fix-makefiles.patch
+    ${CMAKE_CURRENT_LIST_DIR}/fix-version-macro.patch
+)
+
+find_program(NMAKE nmake)
+
+set(LIBS_ALL_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/expat.lib ${CURRENT_INSTALLED_DIR}/debug/lib/zlibd.lib")
+set(LIBS_ALL_REL "${CURRENT_INSTALLED_DIR}/lib/expat.lib ${CURRENT_INSTALLED_DIR}/lib/zlib.lib")
+
+if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+	set(CL_FLAGS_DBG "/MDd /Zi")
+	set(CL_FLAGS_REL "/MD /Ox")
+else()
+	set(CL_FLAGS_DBG "/MTd /Zi")
+	set(CL_FLAGS_REL "/MT /Ox")
+endif()
+
+################
+# Debug build
+################
+message(STATUS "Building ${TARGET_TRIPLET}-dbg")
+
+file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}/debug" INST_DIR_DBG)
+
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} -f makefile.vc clean install
+    INST_DIR=${INST_DIR_DBG} INSTALLED_ROOT=${CURRENT_INSTALLED_DIR} "LINK_FLAGS=/debug" "CL_FLAGS=${CL_FLAGS_DBG}"
+    "LIBS_ALL=${LIBS_ALL_DBG}"
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME nmake-build-${TARGET_TRIPLET}-debug
+)
+vcpkg_copy_pdbs()
+message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
+
+################
+# Release build
+################
+message(STATUS "Building ${TARGET_TRIPLET}-rel")
+
+file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR_REL)
+vcpkg_execute_required_process(
+    COMMAND ${NMAKE} -f makefile.vc clean install
+    INST_DIR=${INST_DIR_REL} INSTALLED_ROOT=${CURRENT_INSTALLED_DIR} "LINK_FLAGS=" "CL_FLAGS=${CL_FLAGS_REL}"
+    "LIBS_ALL=${LIBS_ALL_REL}"
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME nmake-build-${TARGET_TRIPLET}-release
+)
+message(STATUS "Building ${TARGET_TRIPLET}-rel done")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/readosm RENAME copyright)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib)
+else()
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/readosm.lib)
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib ${CURRENT_PACKAGES_DIR}/lib/readosm.lib)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib ${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib)
+endif()
+
+
+message(STATUS "Packaging ${TARGET_TRIPLET} done")


### PR DESCRIPTION
Readosm is the library to read OpenStreetMap files (pure C). Needed it to build spatialite-tools. The package structure is analogous to https://github.com/Microsoft/vcpkg/pull/1906 , so in case of needed changes both PRs can be fixed. Had to fix one compile error of missing quoutes, very strange but necessary.