### PR TITLE
Extract Kinect SDK 1.x Installer using Dark

### DIFF
--- a/ports/kinectsdk1/CONTROL
+++ b/ports/kinectsdk1/CONTROL
@@ -1,3 +1,3 @@
 Source: kinectsdk1
-Version: 1.8-1
+Version: 1.8-2
 Description: Kinect for Windows SDK for Kinect v1 sensor.

--- a/ports/kinectsdk1/portfile.cmake
+++ b/ports/kinectsdk1/portfile.cmake
@@ -1,9 +1,38 @@
 include(vcpkg_common_functions)
 
-get_filename_component(KINECTSDK10_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Kinect;SDKInstallPath]" ABSOLUTE CACHE)
-if(NOT EXISTS "${KINECTSDK10_DIR}")
-    message(FATAL_ERROR "Error: Could not find Kinect for Windows SDK v1.x. It can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=40278.")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    message(FATAL_ERROR "This port does not currently support architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()
+
+set(KINECTSDK10_VERSION "v1.8")
+vcpkg_download_distfile(KINECTSDK10_INSTALLER
+    URLS "https://download.microsoft.com/download/E/1/D/E1DEC243-0389-4A23-87BF-F47DE869FC1A/KinectSDK-${KINECTSDK10_VERSION}-Setup.exe"
+    FILENAME "KinectSDK-${KINECTSDK10_VERSION}-Setup.exe"
+    SHA512 ee8a0f70c86aad80fe214108e315e4550a90ed39f278ce00a7137532174ee5bf3bdeb1d0b499fc5ffdb5e176adecfd68963ee3731e1d2f00d69d32d1b8a3c555
+)
+
+vcpkg_find_acquire_program(DARK)
+
+set(KINECTSDK10_WIX_INSTALLER "${KINECTSDK10_INSTALLER}")
+set(KINECTSDK10_WIX_EXTRACT_DIR "${CURRENT_BUILDTREES_DIR}/src/installer/wix")
+vcpkg_execute_required_process(
+    COMMAND ${DARK} -x ${KINECTSDK10_WIX_EXTRACT_DIR} ${KINECTSDK10_WIX_INSTALLER}
+    WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}
+    LOGNAME extract_wix_installer
+)
+
+file(TO_NATIVE_PATH "${KINECTSDK10_WIX_EXTRACT_DIR}/AttachedContainer/KinectSDK-${KINECTSDK10_VERSION}-${VCPKG_TARGET_ARCHITECTURE}.msi" KINECTSDK10_MSI_INSTALLER)
+file(TO_NATIVE_PATH "${CURRENT_BUILDTREES_DIR}/src/installer/msi/${VCPKG_TARGET_ARCHITECTURE}" KINECTSDK10_MSI_EXTRACT_DIR)
+file(TO_NATIVE_PATH "${CURRENT_BUILDTREES_DIR}/msiexec.log" MSIEXEC_LOG_PATH)
+set(BATCH_FILE ${CURRENT_BUILDTREES_DIR}/msiextract-msmpi.bat)
+file(WRITE ${BATCH_FILE} "msiexec.exe /a \"${KINECTSDK10_MSI_INSTALLER}\" /qn /log \"${MSIEXEC_LOG_PATH}\" TARGETDIR=\"${KINECTSDK10_MSI_EXTRACT_DIR}\"")
+vcpkg_execute_required_process(
+    COMMAND ${BATCH_FILE}
+    WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}
+    LOGNAME extract_msi_installer_${VCPKG_TARGET_ARCHITECTURE}
+)
+
+set(KINECTSDK10_DIR "${CURRENT_BUILDTREES_DIR}/src/installer/msi/${VCPKG_TARGET_ARCHITECTURE}/Microsoft SDKs/Kinect/${KINECTSDK10_VERSION}")
 
 file(
     INSTALL


### PR DESCRIPTION
Extract Kinect SDK 1.x installer using Dark.
It will be standalone extract files from installer of Kinect SDK 1.x even if Kinect SDK 1.x is not installed in user system.