### PR TITLE
Change to refer Kinect SDK 1.x that installed using vcpkg port

### DIFF
--- a/ports/openni2/CONTROL
+++ b/ports/openni2/CONTROL
@@ -1,3 +1,4 @@
 Source: openni2
-Version: 2.2.0.33-1
+Version: 2.2.0.33-2
+Build-Depends: kinectsdk1
 Description: OpenNI is open source library for access to Natural Interaction (NI) devices such as RGB-D camera.

--- a/ports/openni2/portfile.cmake
+++ b/ports/openni2/portfile.cmake
@@ -36,13 +36,7 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-get_filename_component(KINECTSDK10_DIR "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Kinect;SDKInstallPath]" ABSOLUTE CACHE)
-set(KINECTSDK10_INSTALLED FALSE)
-if(EXISTS "${KINECTSDK10_DIR}")
-    set(KINECTSDK10_INSTALLED TRUE)
-endif()
-
-file(TO_NATIVE_PATH ${KINECTSDK10_DIR} KINECTSDK10_DIR)
+file(TO_NATIVE_PATH ${VCPKG_ROOT_DIR} NATIVE_VCPKG_ROOT_DIR)
 configure_file("${CMAKE_CURRENT_LIST_DIR}/replace_environment_variable.patch.in" "${CMAKE_CURRENT_LIST_DIR}/replace_environment_variable.patch" @ONLY)
 
 vcpkg_apply_patches(
@@ -51,13 +45,6 @@ vcpkg_apply_patches(
             "${CMAKE_CURRENT_LIST_DIR}/inherit_from_parent_or_project_defaults.patch"
             "${CMAKE_CURRENT_LIST_DIR}/replace_environment_variable.patch"
 )
-
-if(NOT ${KINECTSDK10_INSTALLED})
-    vcpkg_apply_patches(
-        SOURCE_PATH ${SOURCE_PATH}
-        PATCHES "${CMAKE_CURRENT_LIST_DIR}/disable_kinect.patch"
-    )
-endif()
 
 # Build OpenNI2
 vcpkg_build_msbuild(
@@ -154,6 +141,7 @@ file(
 
 file(
     INSTALL
+        "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/Kinect.dll"
         "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/OniFile.dll"
         "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/PS1080.dll"
         "${SOURCE_CONFIG_PATH}/OpenNI2/Drivers/PS1080.ini"
@@ -162,15 +150,6 @@ file(
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/bin/OpenNI2/Drivers
 )
-
-if(${KINECTSDK10_INSTALLED})
-    file(
-        INSTALL
-            "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/Kinect.dll"
-        DESTINATION
-            ${CURRENT_PACKAGES_DIR}/bin/OpenNI2/Drivers
-    )
-endif()
 
 file(
     INSTALL
@@ -182,6 +161,7 @@ file(
 
 file(
     INSTALL
+        "${SOURCE_BIN_PATH_DEBUG}/OpenNI2/Drivers/Kinect.dll"
         "${SOURCE_BIN_PATH_DEBUG}/OpenNI2/Drivers/OniFile.dll"
         "${SOURCE_BIN_PATH_DEBUG}/OpenNI2/Drivers/PS1080.dll"
         "${SOURCE_CONFIG_PATH}/OpenNI2/Drivers/PS1080.ini"
@@ -190,15 +170,6 @@ file(
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/debug/bin/OpenNI2/Drivers
 )
-
-if(${KINECTSDK10_INSTALLED})
-    file(
-        INSTALL
-            "${SOURCE_BIN_PATH_DEBUG}/OpenNI2/Drivers/Kinect.dll"
-        DESTINATION
-            ${CURRENT_PACKAGES_DIR}/debug/bin/OpenNI2/Drivers
-    )
-endif()
 
 file(
     INSTALL
@@ -210,6 +181,7 @@ file(
 
 file(
     INSTALL
+        "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/Kinect.dll"
         "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/OniFile.dll"
         "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/PS1080.dll"
         "${SOURCE_CONFIG_PATH}/OpenNI2/Drivers/PS1080.ini"
@@ -218,15 +190,6 @@ file(
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/tools/openni2/OpenNI2/Drivers
 )
-
-if(${KINECTSDK10_INSTALLED})
-    file(
-        INSTALL
-            "${SOURCE_BIN_PATH_RELEASE}/OpenNI2/Drivers/Kinect.dll"
-        DESTINATION
-            ${CURRENT_PACKAGES_DIR}/tools/openni2/OpenNI2/Drivers
-    )
-endif()
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(NUMBEROFBIT 32)

--- a/ports/openni2/replace_environment_variable.patch.in
+++ b/ports/openni2/replace_environment_variable.patch.in
@@ -7,7 +7,7 @@ index 08a49fe..7fd8620 100644
        <WarningLevel>Level3</WarningLevel>
        <Optimization>Disabled</Optimization>
 -      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;$(KINECTSDK10_DIR)\inc;</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@KINECTSDK10_DIR@\inc;</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x86-windows\include</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
        <DisableLanguageExtensions>false</DisableLanguageExtensions>
        <TreatWarningAsError>false</TreatWarningAsError>
@@ -16,7 +16,7 @@ index 08a49fe..7fd8620 100644
        <GenerateDebugInformation>true</GenerateDebugInformation>
        <AdditionalDependencies>Kinect10.lib;XnLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 -      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;$(KINECTSDK10_DIR)\lib\x86;</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@KINECTSDK10_DIR@\lib\x86;</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x86-windows\debug\lib</AdditionalLibraryDirectories>
        <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
      </Link>
    </ItemDefinitionGroup>
@@ -25,7 +25,7 @@ index 08a49fe..7fd8620 100644
        <WarningLevel>Level3</WarningLevel>
        <Optimization>Disabled</Optimization>
 -      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;$(KINECTSDK10_DIR)\inc;</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@KINECTSDK10_DIR@\inc;</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x64-windows\include</AdditionalIncludeDirectories>
        <PreprocessorDefinitions>_WINDLL;%(PreprocessorDefinitions);_WINDOWS</PreprocessorDefinitions>
        <DisableLanguageExtensions>false</DisableLanguageExtensions>
        <TreatWarningAsError>false</TreatWarningAsError>
@@ -34,7 +34,7 @@ index 08a49fe..7fd8620 100644
        <GenerateDebugInformation>true</GenerateDebugInformation>
        <AdditionalDependencies>Kinect10.lib;XnLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 -      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;$(KINECTSDK10_DIR)\lib\amd64;</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@KINECTSDK10_DIR@\lib\amd64;</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x64-windows\debug\lib</AdditionalLibraryDirectories>
        <IgnoreSpecificDefaultLibraries>
        </IgnoreSpecificDefaultLibraries>
        <IgnoreAllDefaultLibraries>
@@ -43,7 +43,7 @@ index 08a49fe..7fd8620 100644
        <FunctionLevelLinking>true</FunctionLevelLinking>
        <IntrinsicFunctions>true</IntrinsicFunctions>
 -      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;$(KINECTSDK10_DIR)\inc;</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@KINECTSDK10_DIR@\inc;</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x86-windows\include</AdditionalIncludeDirectories>
        <TreatWarningAsError>false</TreatWarningAsError>
      </ClCompile>
      <Link>
@@ -52,7 +52,7 @@ index 08a49fe..7fd8620 100644
        <OptimizeReferences>true</OptimizeReferences>
        <AdditionalDependencies>Kinect10.lib;XnLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 -      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;$(KINECTSDK10_DIR)\lib\x86;</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@KINECTSDK10_DIR@\lib\x86;</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x86-windows\lib</AdditionalLibraryDirectories>
        <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
      </Link>
    </ItemDefinitionGroup>
@@ -61,7 +61,7 @@ index 08a49fe..7fd8620 100644
        <FunctionLevelLinking>true</FunctionLevelLinking>
        <IntrinsicFunctions>true</IntrinsicFunctions>
 -      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;$(KINECTSDK10_DIR)\inc;</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@KINECTSDK10_DIR@\inc;</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>..\..\..\Include;..\..\..\ThirdParty\PSCommon\XnLib\Include;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x64-windows\include</AdditionalIncludeDirectories>
        <TreatWarningAsError>false</TreatWarningAsError>
      </ClCompile>
      <Link>
@@ -70,7 +70,7 @@ index 08a49fe..7fd8620 100644
        <OptimizeReferences>true</OptimizeReferences>
        <AdditionalDependencies>Kinect10.lib;XnLib.lib;%(AdditionalDependencies)</AdditionalDependencies>
 -      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;$(KINECTSDK10_DIR)\lib\amd64;</AdditionalLibraryDirectories>
-+      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@KINECTSDK10_DIR@\lib\amd64;</AdditionalLibraryDirectories>
++      <AdditionalLibraryDirectories>$(SolutionDir)Bin\$(Platform)-$(Configuration)\;@NATIVE_VCPKG_ROOT_DIR@\packages\kinectsdk1_x64-windows\lib</AdditionalLibraryDirectories>
        <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
      </Link>
    </ItemDefinitionGroup>

--- a/ports/openni2/upgrade_projects.patch
+++ b/ports/openni2/upgrade_projects.patch
@@ -837,7 +837,7 @@ index 56c5944..0401f3d 100644
        <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
        <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
 diff --git a/Source/Drivers/Kinect/Kinect.vcxproj b/Source/Drivers/Kinect/Kinect.vcxproj
-index f54e8b2..7f54d04 100644
+index f54e8b2..6ea2656 100644
 --- a/Source/Drivers/Kinect/Kinect.vcxproj
 +++ b/Source/Drivers/Kinect/Kinect.vcxproj
 @@ -2,4 +2,4 @@
@@ -895,6 +895,15 @@ index f54e8b2..7f54d04 100644
      </ClCompile>
      <Link>
        <GenerateDebugInformation>true</GenerateDebugInformation>
+@@ -125,7 +129,7 @@
+       </IgnoreSpecificDefaultLibraries>
+       <IgnoreAllDefaultLibraries>
+       </IgnoreAllDefaultLibraries>
+-      <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
++      <TreatLinkerWarningAsErrors>false</TreatLinkerWarningAsErrors>
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
 @@ -135,7 +139,7 @@
        <FunctionLevelLinking>true</FunctionLevelLinking>
        <IntrinsicFunctions>true</IntrinsicFunctions>


### PR DESCRIPTION
Fix according to changes of Kinect SDK 1.x port https://github.com/Microsoft/vcpkg/pull/1925.
Change to refer Kinect SDK 1.x that installed using vcpkg port.
It will be always generate the Kinect SDK 1.x driver, even when Kinect SDK 1.x is not installed in user system.