### PR TITLE
mozjpeg initial port

### DIFF
--- a/ports/mozjpeg/CONTROL
+++ b/ports/mozjpeg/CONTROL
@@ -1,0 +1,3 @@
+Source: mozjpeg
+Version: 3.2
+Description: MozJPEG reduces file sizes of JPEG images while retaining quality and compatibility with the vast majority of the world's deployed decoders. It's compatible with libjpeg API and ABI, and can be used as a drop-in replacement for libjpeg.

--- a/ports/mozjpeg/CONTROL
+++ b/ports/mozjpeg/CONTROL
@@ -1,3 +1,3 @@
 Source: mozjpeg
-Version: 3.2
+Version: 3.2-1
 Description: MozJPEG reduces file sizes of JPEG images while retaining quality and compatibility with the vast majority of the world's deployed decoders. It's compatible with libjpeg API and ABI, and can be used as a drop-in replacement for libjpeg.

--- a/ports/mozjpeg/portfile.cmake
+++ b/ports/mozjpeg/portfile.cmake
@@ -1,0 +1,49 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mozjpeg-3.2)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mozilla/mozjpeg/archive/v3.2.zip"
+    FILENAME "mozjpeg.zip"
+    SHA512 a1ba53dea3e04add46616918b5e96f2c8102ef65856596f1794df29c8be27db3d9fb13e7ffc864d23626f98dff5a6b47315903cae9ae41f9905aef2cc91af0c5
+)
+
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+set(ENV{PATH} "$ENV{PATH};${NASM_EXE_PATH}")
+
+vcpkg_extract_source_archive(${ARCHIVE})
+
+if (${VCPKG_LIBRARY_LINKAGE} STREQUAL static)
+    set(OPTIONS "-DENABLE_SHARED=FALSE")
+else()
+    set(OPTIONS "-DENABLE_STATIC=FALSE")
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA 
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+#remove extra debug files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/doc)
+file(GLOB DEBUGEXES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+file(REMOVE ${DEBUGEXES})
+
+#move exes to tools
+file(GLOB EXES ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(REMOVE ${EXES})
+
+#remove empty fodlers after static build
+if (${VCPKG_LIBRARY_LINKAGE} STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/mozjpeg RENAME copyright)
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Before you accept or reject this port, please be aware that mozjpeg is meant as a drop-in replacement for libjpeg and thus the two cannot be installed for the same triplet (they have the same output files, by design).  

If one does try to install mozjpeg and libjpeg-turbo for the same triplet, the mozjpeg package will be created correctly in _vcpkg/packages/mozjpeg-your-chosen-triplet_ but the files won't be copied to the global _include/lib/tools folders_.  Also, vcpkg will consider that the build will have failed in that instance.  It can still be removed with ```vcpkg remove mozjpeg:your-triplet```.

Should I try to prevent users from installing the port altogether if libjpeg is already installed for that triplet (and modify the pull request to add the same prevention code in the libjpeg port file)?  If not prevent, with the same scenario, should I delete the mozjpeg package folder afterwards?  If you opt for that second option, it should probably be vcpkg.exe itself that does it (make sure that no package is created if there was a conflict at install time), this edge-case was probably overlooked.

For myself, I think leaving the built package there is fine, it would allow for a user to link to that package directly without having any ill effect on the rest of the system but it creates an exceptional situation where a failed install resulted in a package being created.