### PR TITLE
Fix Win10SDK detection during Bootstrap

### DIFF
--- a/scripts/getWindowsSDK.ps1
+++ b/scripts/getWindowsSDK.ps1
@@ -20,7 +20,7 @@ $validInstances = New-Object System.Collections.ArrayList
 # Windows 10 SDK
 function CheckWindows10SDK($path)
 {
-    $folder = "$path\Include"
+    $folder = (Join-Path $path "Include")
     if (!(Test-Path $folder))
     {
         Write-Verbose "$folder - Not Found"
@@ -37,7 +37,7 @@ function CheckWindows10SDK($path)
         if (!(Test-Path $windowsheader))
         {
             Write-Verbose "$windowsheader - Not Found"
-            return
+            continue
         }
         Write-Verbose "$windowsheader - Found"
 
@@ -45,7 +45,7 @@ function CheckWindows10SDK($path)
         if (!(Test-Path $ddkheader))
         {
             Write-Verbose "$ddkheader - Not Found"
-            return
+            continue
         }
 
         Write-Verbose "$ddkheader - Found"


### PR DESCRIPTION
When multiple Win10 SDK's are installed, like Insider previews,
depending on the SDK installation, it may not contain the um headers.
There is already a loop for trying to find the newest Win10 SDK
that has full headers, but it's returning at the first failure,
rather than continuing the loop to the next iteration.

Also, use Join-Path instead of manual path appending, to normalize
the extra \ at the end of the sdk root value.  In some cases paths
with double backslashes can be interpreted as a fallback syntax for
UNC paths.  Join-Path normalizes the path appropriately.