### PR TITLE
Add port for imgui library

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.8)
+project(imgui CXX)
+
+find_path(STB_INCLUDE_DIR stb_rect_pack.h stb_textedit.h stb_truetype.h)
+
+set(IMGUI_INCLUDES_PUBLIC
+    imgui.h
+    imconfig.h
+)
+
+set(IMGUI_INCLUDES_PRIVATE
+    imgui_internal.h
+)
+
+set(IMGUI_SOURCES
+    imgui.cpp
+    imgui_demo.cpp
+    imgui_draw.cpp
+)
+
+add_library(imgui STATIC
+    ${IMGUI_INCLUDES_PUBLIC}
+    ${IMGUI_INCLUDES_PRIVATE}
+    ${IMGUI_SOURCES}
+)
+
+target_include_directories(imgui
+    PRIVATE
+    ${IMGUI_INCLUDES_PRIVATE}
+    ${STB_INCLUDE_DIR}
+
+    PUBLIC
+    ${IMGUI_INCLUDES_PUBLIC}
+)
+
+install(TARGETS imgui
+    ARCHIVE DESTINATION lib
+)
+
+if(NOT IMGUI_SKIP_HEADERS)
+    install(
+        FILES ${IMGUI_INCLUDES_PUBLIC}
+        DESTINATION include
+    )
+endif()

--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(imgui CXX)
 
+set(CMAKE_DEBUG_POSTFIX d)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 find_path(STB_INCLUDE_DIR stb_rect_pack.h stb_textedit.h stb_truetype.h)
 
 set(IMGUI_INCLUDES_PUBLIC
@@ -18,22 +21,17 @@ set(IMGUI_SOURCES
     imgui_draw.cpp
 )
 
-add_library(imgui STATIC
+add_library(imgui
     ${IMGUI_INCLUDES_PUBLIC}
     ${IMGUI_INCLUDES_PRIVATE}
     ${IMGUI_SOURCES}
 )
 
-target_include_directories(imgui
-    PRIVATE
-    ${IMGUI_INCLUDES_PRIVATE}
-    ${STB_INCLUDE_DIR}
-
-    PUBLIC
-    ${IMGUI_INCLUDES_PUBLIC}
-)
+target_include_directories(imgui PUBLIC ${STB_INCLUDE_DIR})
 
 install(TARGETS imgui
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
 

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,4 +1,4 @@
 Source: imgui
-Version: 1.51
-Build-Depends: stb (windows)
+Version: 1.51-1
+Build-Depends: stb
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,0 +1,4 @@
+Source: imgui
+Version: 1.51
+Build-Depends: stb (windows)
+Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -1,13 +1,23 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/imgui-1.51)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/ocornut/imgui/archive/v1.51.zip"
-    FILENAME "imgui-1.51.zip"
-    SHA512 a3c77887396991f8371c0cf5b42d781d758877cdb194a7c6ea8b34939f4b300f55f176d601dd0e167ea2a20bd8a47b958ad1bca16864a19c1cc9b2c7a889ab29
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ocornut/imgui
+    REF v1.51
+    SHA512 33aea46d0ab8419fcd4af765c9f1a88dfb1b80ad466276b655a67f40ffedabe399db6b0d76a2ece74e551928bd6f842ae3fa42998e0b1a2206157a3852e002d6
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(GLOB STB_HEADERS ${SOURCE_PATH}/stb_*.h)
+if(STB_HEADERS)
+    file(REMOVE ${STB_HEADERS})
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -1,0 +1,23 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/imgui-1.51)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/ocornut/imgui/archive/v1.51.zip"
+    FILENAME "imgui-1.51.zip"
+    SHA512 a3c77887396991f8371c0cf5b42d781d758877cdb194a7c6ea8b34939f4b300f55f176d601dd0e167ea2a20bd8a47b958ad1bca16864a19c1cc9b2c7a889ab29
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_DEBUG
+        -DIMGUI_SKIP_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/imgui)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/imgui/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/imgui/copyright)


### PR DESCRIPTION
This port adds [`imgui`](https://github.com/ocornut/imgui). It's a small library for creating user interfaces for applications rendered in immediate mode.

The only compile time dependency is STB and there are no runtime dependencies.

There is one thing in this PR which I'm not sure about, whether it could be handled in a better manner. `imgui` offers the possiblity to provide an `imconfig.h`. If non is present, the build will break, so the empty example config is copied to the include directory. However patching the `imgui.h` doesn't seem to be a satisfying solution.

And does forcing the library being a statically linked library with `add_library(imgui STATIC` have any side effects?