### PR TITLE
add NVCUDASAMPLES_ROOT to environment variable whitelist

### DIFF
--- a/toolsrc/src/vcpkg_System.cpp
+++ b/toolsrc/src/vcpkg_System.cpp
@@ -106,6 +106,8 @@ namespace vcpkg::System
             L"HTTPS_PROXY",
             // Enables find_package(CUDA) in CMake
             L"CUDA_PATH",
+            // Environmental variable generated automatically by CUDA after installation
+            L"NVCUDASAMPLES_ROOT",
         };
 
         // Flush stdout before launching external process


### PR DESCRIPTION
Related issue #1887 

NVCUDASAMPLES_ROOT is an environment variable that is created by CUDA automatically after installation. Ports such as libfreenect2 relies on it to discover the location of the headers for the NVIDIA CUDA samples.