### PR TITLE
[vcpkg-export-ifw] Safe description

### DIFF
--- a/toolsrc/src/commands_export_ifw.cpp
+++ b/toolsrc/src/commands_export_ifw.cpp
@@ -26,6 +26,14 @@ namespace vcpkg::Commands::Export::IFW
         return date_time_as_string;
     }
 
+    std::string safe_rich_from_plain_text(const std::string& text)
+    {
+        // match standalone ampersand, no HTML number or name
+        std::regex standalone_ampersand(R"###(&(?!(#[0-9]+|\w+);))###");
+
+        return std::regex_replace(text, standalone_ampersand, "&amp;");
+    }
+
     fs::path get_packages_dir_path(const std::string& export_id, const Options& ifw_options, const VcpkgPaths& paths)
     {
         return ifw_options.maybe_packages_dir_path.has_value()
@@ -156,7 +164,7 @@ namespace vcpkg::Commands::Export::IFW
 </Package>
 )###",
                                   action.spec.name(),
-                                  binary_paragraph.description,
+                                  safe_rich_from_plain_text(binary_paragraph.description),
                                   binary_paragraph.version,
                                   create_release_date()));
         }


### PR DESCRIPTION
QtIFW support rich text for component description,
bu some port has not safe ampersand symbol
in description text (for example 'openexr' package),
that should be replaced to '&amp;' symbol name