### PR TITLE
new port: cgal

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,0 +1,4 @@
+Source: cgal
+Version: 4.11
+Build-Depends:mpfr, mpir, zlib, boost, qt5
+Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -1,0 +1,26 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO CGAL/cgal
+    REF releases/CGAL-4.11
+    SHA512 91e555d5988bee387afa31331e1e3a8990206468fd8c774fd82979d9ff169e9c4835ecc6ba3d576cda617b6cb2cd52d27657d2434e38b29ce0e7e643436810ab
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/CGAL")
+
+vcpkg_copy_pdbs()
+
+# Clean
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright of suitesparse and metis
+file(COPY ${SOURCE_PATH}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -80,6 +80,7 @@ function(vcpkg_from_github)
         else()
             # Sometimes GitHub strips a leading 'v' off the REF.
             string(REGEX REPLACE "^v" "" REF ${BASEREF})
+            string(REPLACE "/" "-" REF ${REF})
             set(SOURCE_PATH "${BASE}/${REPO_NAME}-${REF}")
             if(EXISTS ${SOURCE_PATH})
                 set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
CGAL is a good Computational Geometry Algorithms Library. Verified it compiles, and also verifies it works with downstream project via `find_package(CGAL REQUIRED)` and `target_link_libraries(${PROJECT_NAME} CGAL::CGAL)`