### PR TITLE
Fix Version, "v" is not part of it.

### DIFF
--- a/ports/jansson/CONTROL
+++ b/ports/jansson/CONTROL
@@ -1,3 +1,3 @@
 Source: jansson
-Version: v2.10-1
+Version: 2.10-1
 Description: Jansson is a C library for encoding, decoding and manipulating JSON data


### PR DESCRIPTION
For instance, this fixes repology processing of jansson vcpkg package by repology:

![](https://repology.org/badge/vertical-allrepos/jansson.svg)

to which I've just added vcpkg support.