### PR TITLE
fix smpeg2 to use SDL2d in debug mode

### DIFF
--- a/ports/smpeg2/CMakeLists.txt
+++ b/ports/smpeg2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6)
 project(SMPEG2 CXX)
 
 find_path(SDL_INCLUDE_DIR SDL2/SDL.h)
-find_library(SDL_LIBRARY SDL2)
+find_library(SDL_LIBRARY NAMES SDL2d SDL2)
 
 include_directories(${SDL_INCLUDE_DIR})
 include_directories(${SDL_INCLUDE_DIR}/SDL2)

--- a/ports/smpeg2/CONTROL
+++ b/ports/smpeg2/CONTROL
@@ -1,4 +1,4 @@
 Source: smpeg2
-Version: 2.0.0-2
+Version: 2.0.0-3
 Description: SDL MPEG Player Library
 Build-Depends: sdl2


### PR DESCRIPTION
Simple tweak so that smpeg2 compiled in debug mode uses SDL2d instead of SDL2.