### PR TITLE
Remove non-numeric characters from Windows SDK version string

### DIFF
--- a/scripts/cmake/vcpkg_get_windows_sdk.cmake
+++ b/scripts/cmake/vcpkg_get_windows_sdk.cmake
@@ -10,7 +10,7 @@ function(vcpkg_get_windows_sdk ret)
         message(FATAL_ERROR "Could not find Windows SDK")
     endif()
 
-    # Remove trailing newline
-    string(REGEX REPLACE "\n$" "" WINDOWS_SDK "${WINDOWS_SDK}")
+    # Remove trailing newline and non-numeric characters
+    string(REGEX REPLACE "[^0-9.]" "" WINDOWS_SDK "${WINDOWS_SDK}")
     set(${ret} ${WINDOWS_SDK} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
On some windows 7 x64 installs, cmake returns a TargetPlatformVersion with a stray 0xFEFF character at the start of the string, causing a number of package builds to fail, including xerces-c and libusb. See issue #1836, #2019.

This PR removes non-numeric characters from the SDK version string.
This fix has been tested against builds of xerces-c and libusb on Windows 7 x64. 