### PR TITLE
Fix for secp256k1 and missing headers

### DIFF
--- a/ports/secp256k1/CMakeLists.txt
+++ b/ports/secp256k1/CMakeLists.txt
@@ -21,6 +21,6 @@ install(TARGETS secp256k1
 )
 
 if(INSTALL_HEADERS)
-    file(GLOB HEADERS include/secp256k1.h)
+    file(GLOB HEADERS include/*.h)
     install(FILES ${HEADERS} DESTINATION include)
 endif()

--- a/ports/secp256k1/CONTROL
+++ b/ports/secp256k1/CONTROL
@@ -1,3 +1,3 @@
 Source: secp256k1
-Version: 2017-19-10-0b7024185045a49a1a6a4c5615bf31c94f63d9c4
+Version: 2017-19-10-0b7024185045a49a1a6a4c5615bf31c94f63d9c4-1
 Description: Optimized C library for EC operations on curve


### PR DESCRIPTION
This package needs all 3 headers in the include directory rather than just the single one that was specified.