### PR TITLE
[harfbuzz] 1.6.3

### DIFF
--- a/ports/harfbuzz/0001-fix-uwp-build.patch
+++ b/ports/harfbuzz/0001-fix-uwp-build.patch
@@ -1,7 +1,7 @@
-diff --git "a/harfbuzz-1.6.3/src/hb-ft.cc" "b/harfbuzz-1.6.3/src/hb-ft.cc"
-index 48d6a0ef..f4ce6608 100644
---- "a/harfbuzz-1.6.3/src/hb-ft.cc"
-+++ "b/harfbuzz-1.6.3/src/hb-ft.cc"
+diff --git a/src/hb-ft.cc b/src/hb-ft.cc
+index f578e9d..f224c07 100644
+--- a/src/hb-ft.cc
++++ b/src/hb-ft.cc
 @@ -31,6 +31,10 @@
  
  #include "hb-ft.h"
@@ -12,4 +12,4 @@ index 48d6a0ef..f4ce6608 100644
 +
  #include "hb-font-private.hh"
  
- #include "hb-cache-private.hh" // Maybe use in the future?
+ #include FT_ADVANCES_H

--- a/ports/harfbuzz/0001-fix-uwp-build.patch
+++ b/ports/harfbuzz/0001-fix-uwp-build.patch
@@ -1,7 +1,7 @@
-diff --git "a/harfbuzz-1.4.6/src/hb-ft.cc" "b/harfbuzz-1.4.6/src/hb-ft.cc"
+diff --git "a/harfbuzz-1.6.3/src/hb-ft.cc" "b/harfbuzz-1.6.3/src/hb-ft.cc"
 index 48d6a0ef..f4ce6608 100644
---- "a/harfbuzz-1.4.6/src/hb-ft.cc"
-+++ "b/harfbuzz-1.4.6/src/hb-ft.cc"
+--- "a/harfbuzz-1.6.3/src/hb-ft.cc"
++++ "b/harfbuzz-1.6.3/src/hb-ft.cc"
 @@ -31,6 +31,10 @@
  
  #include "hb-ft.h"

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,4 +1,4 @@
 Source: harfbuzz
-Version: 1.4.6-2
+Version: 1.6.3
 Description: HarfBuzz OpenType text shaping engine
 Build-Depends: freetype, glib (windows)

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,4 +1,4 @@
 Source: harfbuzz
-Version: 1.6.3
+Version: 1.6.3-1
 Description: HarfBuzz OpenType text shaping engine
 Build-Depends: freetype, glib (windows)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
-    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/
+    SOURCE_PATH ${SOURCE_PATH}
     PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-uwp-build.patch"
 )
 

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,9 +1,9 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/harfbuzz-1.4.6)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/harfbuzz-1.6.3)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/behdad/harfbuzz/releases/download/1.4.6/harfbuzz-1.4.6.tar.bz2"
-    FILENAME "harfbuzz-1.4.6.tar.bz2"
-    SHA512 aade3902adadf3a8339ba1d05279e639da7cb53981adc64e2a2d32a5d49335a6a9782a62cdf80beca569ec8a639792bf0368c0b6ecad08f35bc85878678aa096
+    URLS "https://github.com/behdad/harfbuzz/releases/download/1.6.3/harfbuzz-1.6.3.tar.bz2"
+    FILENAME "harfbuzz-1.6.3.tar.bz2"
+    SHA512 37d1a161d9074e9898d9ef6cca6dffffc725005828d700744553b0145373b69bcd3b08f507d49f4c2e05850d9275a54f15983356c547c86e5e3c202cc7cbfbe8
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 


### PR DESCRIPTION
After lots of changes on harfbuzz cmake port, specially its freetype part, I like to see whether its vcpkg packaging is still working or should be tweaked. This is not tested from my side, I'll try to test it tomorrow but it would be nice if others could check it also.