### PR TITLE
LuaSocket port for vcpkg

### DIFF
--- a/ports/luasocket/CMakeLists.txt
+++ b/ports/luasocket/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(luasocket)
+
+if(NOT WIN32)
+    message(FATAL_ERROR "Written for windows only")
+endif()
+
+find_path(LUA_INCLUDE_DIR lua.h PATH_SUFFIXES lua)
+find_library(LUA_LIBRARY lua)
+set(LUASOCKET_INCLUDES ${LUA_INCLUDE_DIR} src)
+set(LUASOCKET_LIBRARIES ${LUA_LIBRARY} ws2_32)
+
+add_library(socket.core
+    src/luasocket.c
+    src/timeout.c
+    src/buffer.c
+    src/io.c
+    src/auxiliar.c
+    src/options.c
+    src/inet.c
+    src/except.c
+    src/select.c
+    src/tcp.c
+    src/udp.c
+    src/compat.c
+    src/wsocket.c)
+
+add_library(mime.core
+    src/mime.c
+    src/compat.c)
+
+target_include_directories(socket.core PRIVATE ${LUASOCKET_INCLUDES})
+target_link_libraries(socket.core PRIVATE ${LUASOCKET_LIBRARIES})
+
+target_include_directories(mime.core PRIVATE ${LUASOCKET_INCLUDES})
+target_link_libraries(mime.core PRIVATE ${LUASOCKET_LIBRARIES})
+
+add_definitions(
+    "-DLUASOCKET_API=__declspec(dllexport)"
+    "-DMIME_API=__declspec(dllexport)")
+
+install(TARGETS socket.core
+    RUNTIME DESTINATION bin/socket
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
+install(TARGETS mime.core
+    RUNTIME DESTINATION bin/mime
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
+install(FILES
+    src/ltn12.lua
+    src/socket.lua
+    src/mime.lua
+    DESTINATION share/lua)
+
+install(FILES
+    src/http.lua
+    src/url.lua
+    src/tp.lua
+    src/ftp.lua
+    src/headers.lua
+    src/smtp.lua
+    DESTINATION share/lua/socket)

--- a/ports/luasocket/CONTROL
+++ b/ports/luasocket/CONTROL
@@ -1,0 +1,4 @@
+Source: luasocket
+Version: 2017.05.25.5a17f79b0301f0a1b4c7f1c73388757a7e2ed309
+Description: LuaSocket is a Lua extension library that is composed by two parts: a C core that provides support for the TCP and UDP transport layers, and a set of Lua modules that add support for functionality commonly needed by applications that deal with the Internet.
+Build-Depends: lua

--- a/ports/luasocket/portfile.cmake
+++ b/ports/luasocket/portfile.cmake
@@ -1,0 +1,48 @@
+include(vcpkg_common_functions)
+
+set(LUASOCKET_VERSION 2017.05.25.5a17f79b0301f0a1b4c7f1c73388757a7e2ed309)
+set(LUASOCKET_REVISION 5a17f79b0301f0a1b4c7f1c73388757a7e2ed309)
+set(LUASOCKET_HASH 82a827956d992c7d67a3e9aed18db0cdce34f32e5b49c44976c1d19cb96ff1c10121abb2130d306cf51125fdc5eb3be0cc491a3862e5a8fde3d944ba3b4a94b7)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/luasocket-${LUASOCKET_VERSION})
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO diegonehab/luasocket
+    REF ${LUASOCKET_REVISION}
+    SHA512 ${LUASOCKET_HASH}
+    HEAD_REF master)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH})
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+# Remove debug share
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/luasocket)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/luasocket/LICENSE ${CURRENT_PACKAGES_DIR}/share/luasocket/copyright)
+
+# Handle socket dll name
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/socket/socket.core.dll ${CURRENT_PACKAGES_DIR}/bin/socket/core.dll)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/socket/socket.core.pdb ${CURRENT_PACKAGES_DIR}/bin/socket/core.pdb)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/socket/socket.core.dll ${CURRENT_PACKAGES_DIR}/debug/bin/socket/core.dll)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/socket/socket.core.pdb ${CURRENT_PACKAGES_DIR}/debug/bin/socket/core.pdb)
+
+# Handle mime dll name
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mime/mime.core.dll ${CURRENT_PACKAGES_DIR}/bin/mime/core.dll)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mime/mime.core.pdb ${CURRENT_PACKAGES_DIR}/bin/mime/core.pdb)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/mime/mime.core.dll ${CURRENT_PACKAGES_DIR}/debug/bin/mime/core.dll)
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/mime/mime.core.pdb ${CURRENT_PACKAGES_DIR}/debug/bin/mime/core.pdb)
+
+# Allow empty include directory
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)


### PR DESCRIPTION
Port is based off the last commit, as the last release version does not
work with 64 bit Windows, and there have been a number of critical bug fixes
since the last release candidate from 2013.