### PR TITLE
Add support build options to PCL port

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,4 +1,12 @@
 Source: pcl
-Version: 1.8.1-2
-Build-Depends: boost, eigen3, flann, qhull, vtk, openni2, qt5, winpcap
+Version: 1.8.1-3
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
+Build-Depends: boost, eigen3, flann, qhull, vtk, openni2
+
+Feature: qt
+Description: Qt support for PCL
+Build-Depends: vtk[qt]
+
+Feature: pcap
+Description: PCAP support for PCL
+Build-Depends: winpcap

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -35,6 +35,16 @@ elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     set(LIBRARY_LINKAGE OFF)
 endif()
 
+set(WITH_QT OFF)
+if("qt" IN_LIST FEATURES)
+    set(WITH_QT ON)
+endif()
+
+set(WITH_PCAP OFF)
+if("pcap" IN_LIST FEATURES)
+    set(WITH_PCAP ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -50,10 +60,10 @@ vcpkg_configure_cmake(
         -DWITH_CUDA=OFF
         -DWITH_LIBUSB=OFF
         -DWITH_OPENNI2=ON
-        -DWITH_PCAP=ON
+        -DWITH_PCAP=${WITH_PCAP}
         -DWITH_PNG=OFF
         -DWITH_QHULL=ON
-        -DWITH_QT=ON
+        -DWITH_QT=${WITH_QT}
         -DWITH_VTK=ON
 )
 


### PR DESCRIPTION
Add support build options (pcap, qt) to PCL port.
This pull request depends on #2071. Please merge this pull request after merged it.
```
vcpkg install pcl[pcap,qt] --featurepackages
```