### PR TITLE
help assimp find vcpkg's copy of zlib so it does not build its own

### DIFF
--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_configure_cmake(
             -DASSIMP_BUILD_ZLIB=False
             -DASSIMP_BUILD_ASSIMP_TOOLS=False
             -DASSIMP_INSTALL_PDB=False
+            -DZLIB_HOME=${CURRENT_INSTALLED_DIR}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Without this, assimp uses its internal copy of zlib so the port installs zlibstatic.lib.