### PR TITLE
Enable some options for OpenCV port

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv
-Version: 3.3.1-4
+Version: 3.3.1-5
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, protobuf (windows)
 Description: computer vision library
 

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -101,6 +101,7 @@ vcpkg_configure_cmake(
         -DWITH_CUDA=${WITH_CUDA}
         -DWITH_FFMPEG=${WITH_FFMPEG}
         -DWITH_LAPACK=OFF
+        -DWITH_MSMF=ON
         -DWITH_OPENCLAMDBLAS=OFF
         -DWITH_OPENGL=ON
         -DWITH_QT=${WITH_QT}

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -86,6 +86,7 @@ vcpkg_configure_cmake(
         # CMAKE
         -DCMAKE_DISABLE_FIND_PACKAGE_JNI=ON
         # ENABLE
+        -DENABLE_CXX11=ON
         -DENABLE_PYLINT=OFF
         # INSTALL
         -DINSTALL_FORCE_UNIX_PATHS=ON


### PR DESCRIPTION
This pull request will be enabled some options for OpenCV port.
* Enable C++11 features.
  It is very useful features that included in OpenCV 3.3.0 or later. See [changelog](https://github.com/opencv/opencv/wiki/ChangeLog#version33) for details.
* Enable Microsoft Media Foundation (MSMF) support for Video I/O. (<code>cv::CAP_MSMF</code>)