### PR TITLE
Fix find boost when build static link library of PCL

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.8.1-3
+Version: 1.8.1-4
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: boost, eigen3, flann, qhull, vtk, openni2
 

--- a/ports/pcl/find_boost.patch
+++ b/ports/pcl/find_boost.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/pcl_find_boost.cmake b/cmake/pcl_find_boost.cmake
+index 68920ccd4..ed486f687 100644
+--- a/cmake/pcl_find_boost.cmake
++++ b/cmake/pcl_find_boost.cmake
+@@ -8,7 +8,7 @@ if(PCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32 AND WIN32)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB")
+ else(PCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32 AND WIN32)
+   if(NOT PCL_SHARED_LIBS OR WIN32)
+-    set(Boost_USE_STATIC_LIBS ON)
++    set(Boost_USE_STATIC_LIBS OFF)
+     set(Boost_USE_STATIC ON)
+   endif(NOT PCL_SHARED_LIBS OR WIN32)
+ endif(PCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32 AND WIN32)

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES "${CMAKE_CURRENT_LIST_DIR}/config.patch"
             "${CMAKE_CURRENT_LIST_DIR}/config_install.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/find_boost.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_flann.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_qhull.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_openni2.patch"


### PR DESCRIPTION
This pull request will fix find boost when build static link library of PCL. 
vcpkg always rename Boost library to same name of dynamic link library ("boost_*").
Therefore, <code>Boost_USE_STATIC_LIBS</code> (It means finding libraries that have name "libboost_\*".) must be OFF.