### PR TITLE
new port: blosc

### DIFF
--- a/ports/blosc/CONTROL
+++ b/ports/blosc/CONTROL
@@ -1,0 +1,4 @@
+Source: blosc
+Version: 1.12.1
+Build-Depends: lz4, snappy, zlib, zstd
+Description: A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`

--- a/ports/blosc/portfile.cmake
+++ b/ports/blosc/portfile.cmake
@@ -1,0 +1,54 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Blosc/c-blosc
+    REF v1.12.1
+    SHA512 f65bbbfce6fc59d0c5a0889d5771dd78cae2796244c6ee69edf15b27c4563c28ce789fded9104a8626d12be3e46418d596dfdb204c43e33abae8dca40debfd92
+    HEAD_REF master
+)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/static-install-fix.patch
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(BLOSC_STATIC ON)
+    set(BLOSC_SHARED OFF)
+else()
+    set(BLOSC_STATIC OFF)
+    set(BLOSC_SHARED ON)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS -DPREFER_EXTERNAL_LZ4=ON
+            -DPREFER_EXTERNAL_SNAPPY=ON
+            -DPREFER_EXTERNAL_ZLIB=ON
+            -DPREFER_EXTERNAL_ZSTD=ON
+            -DBUILD_TESTS=OFF
+            -DBUILD_BENCHMARKS=OFF
+            -DBUILD_STATIC=${BLOSC_STATIC}
+            -DBUILD_SHARED=${BLOSC_SHARED}
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+if (BLOSC_SHARED)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/blosc.dll ${CURRENT_PACKAGES_DIR}/debug/bin/blosc.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/blosc.dll ${CURRENT_PACKAGES_DIR}/bin/blosc.dll)
+endif()
+
+# cleanup
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSES/BLOSC.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/blosc RENAME copyright)
+

--- a/ports/blosc/static-install-fix.patch
+++ b/ports/blosc/static-install-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/blosc/CMakeLists.txt b/blosc/CMakeLists.txt
+index cd163f4..8cb1bdb 100644
+--- a/blosc/CMakeLists.txt
++++ b/blosc/CMakeLists.txt
+@@ -211,7 +211,9 @@ endif(BUILD_STATIC)
+ # install
+ if(BLOSC_INSTALL)
+     install(FILES blosc.h blosc-export.h DESTINATION include COMPONENT DEV)
+-    install(TARGETS blosc_shared DESTINATION ${lib_dir} COMPONENT LIB)
++    if(BUILD_SHARED)
++        install(TARGETS blosc_shared DESTINATION ${lib_dir} COMPONENT LIB)
++    endif(BUILD_SHARED)
+     if(BUILD_STATIC)
+         install(TARGETS blosc_static DESTINATION ${lib_dir} COMPONENT DEV)
+     endif(BUILD_STATIC)


### PR DESCRIPTION
New port: **blosc** from https://github.com/Blosc/c-blosc

> A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`.

Static build patch is already in blosc's master, so may be removed with the next release.