### PR TITLE
[libpng] use vcpkg_from_github

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,4 +1,4 @@
 Source: libpng
-Version: 1.6.34-1
+Version: 1.6.34-2
 Build-Depends: zlib
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -1,14 +1,13 @@
 include(vcpkg_common_functions)
-set(LIBPNG_VERSION 1.6.34)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libpng-${LIBPNG_VERSION})
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz"
-         "https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.xz"
-    FILENAME "libpng-${LIBPNG_VERSION}.tar.xz"
-    SHA512 89407c5abc1623faaa3992fc1e4a62def671d9a7401108dfceee895d5f16fe7030090bea89b34a36d377d8e6a5d40046886991f663ce075d1a2d31bf9eaf3c51
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO glennrp/libpng
+    REF v1.6.34
+    SHA512 23b6112a1d16a34c8037d5c5812944d4385fc96ed819a22172776bdd5acd3a34e55f073b46087b77d1c12cecc68f9e8ba7754c86b5ab6ed3016063e1c795de7a
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES


### PR DESCRIPTION
Use official repository from github instead of sourceforge. I am getting errors from the original port

``````
-- Downloading https://downloads.sourceforge.net/project/libpng/libpng16/1.6.34/libpng-1.6.34.tar.xz...
-- Downloading https://downloads.sourceforge.net/project/libpng/libpng16/1.6.34/libpng-1.6.34.tar.xz... Failed. Status: 22;"HTTP response code said error"
-- Downloading https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.34/libpng-1.6.34.tar.xz...
-- Downloading https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.34/libpng-1.6.34.tar.xz... Failed. Status: 22;"HTTP response code said error"
CMake Error at C:/dev/vcpkg/scripts/cmake/vcpkg_download_distfile.cmake:91 (message):


      Failed to download file.
      Add mirrors or submit an issue at https://github.com/Microsoft/vcpkg/issues

Call Stack (most recent call first):
  C:/dev/vcpkg/ports/libpng/portfile.cmake:5 (vcpkg_download_distfile)
  C:/dev/vcpkg/scripts/ports.cmake:72 (include)

``````

This also enables `vcpkg install libpng --head`