### PR TITLE
[tidy-html5] Added libtidy version 5.4.0

### DIFF
--- a/ports/tidy-html5/CONTROL
+++ b/ports/tidy-html5/CONTROL
@@ -1,0 +1,3 @@
+Source: tidy-html5
+Version: 5.4.0
+Description: Tidy tidies HTML and XML. It can tidy your documents by itself, and developers can easily integrate its features into even more powerful tools.

--- a/ports/tidy-html5/CONTROL
+++ b/ports/tidy-html5/CONTROL
@@ -1,3 +1,3 @@
 Source: tidy-html5
-Version: 5.4.0
+Version: 5.4.0-1
 Description: Tidy tidies HTML and XML. It can tidy your documents by itself, and developers can easily integrate its features into even more powerful tools.

--- a/ports/tidy-html5/portfile.cmake
+++ b/ports/tidy-html5/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO htacg/tidy-html5
+    REF 5.4.0
+    SHA512 d92c89f2ef371499f9c3de6f9389783d2449433b4da1f5a29e2eb81b7a7db8dd9f68e220cdde092d446e9bd779bcbc30f84bda79013526540f29d00f438cb402
+    HEAD_REF master)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/remove_execution_character_set.patch
+)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SHARED_LIB=ON -DTIDY_CONSOLE_SHARED=ON
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/tidyd.exe)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/tidy.exe ${CURRENT_PACKAGES_DIR}/tools/tidy.exe)
+file(INSTALL ${SOURCE_PATH}/README/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/tidy-html5 RENAME copyright)

--- a/ports/tidy-html5/portfile.cmake
+++ b/ports/tidy-html5/portfile.cmake
@@ -12,16 +12,29 @@ vcpkg_apply_patches(
     PATCHES
     ${CMAKE_CURRENT_LIST_DIR}/remove_execution_character_set.patch
 )
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIB)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SHARED_LIB=ON -DTIDY_CONSOLE_SHARED=ON
+    OPTIONS
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
+        -DBUILD_SHARED_LIB=${BUILD_SHARED_LIB}
+        -DTIDY_CONSOLE_SHARED=${BUILD_SHARED_LIB}
 )
 
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/tidyd.exe)
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/tidy.exe ${CURRENT_PACKAGES_DIR}/tools/tidy.exe)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/tidy-html5)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/tidy.exe ${CURRENT_PACKAGES_DIR}/tools/tidy-html5/tidy.exe)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+
 file(INSTALL ${SOURCE_PATH}/README/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/tidy-html5 RENAME copyright)

--- a/ports/tidy-html5/remove_execution_character_set.patch
+++ b/ports/tidy-html5/remove_execution_character_set.patch
@@ -1,0 +1,90 @@
+diff --git a/src/language_en.h b/src/language_en.h
+index ab191e0..e1cd96b 100644
+--- a/src/language_en.h
++++ b/src/language_en.h
+@@ -18,10 +18,6 @@
+  * Created by Jim Derry on 11/28/15.
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"
+diff --git a/src/language_en_gb.h b/src/language_en_gb.h
+index a89f0fe..7b14d6f 100644
+--- a/src/language_en_gb.h
++++ b/src/language_en_gb.h
+@@ -31,10 +31,6 @@
+  *   PO_REVISION_DATE=2016-03-24 10:59:55
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"
+diff --git a/src/language_es.h b/src/language_es.h
+index db09f2a..1e474b5 100644
+--- a/src/language_es.h
++++ b/src/language_es.h
+@@ -31,10 +31,6 @@
+  *   PO_REVISION_DATE=2016-03-24 10:59:55
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"
+diff --git a/src/language_es_mx.h b/src/language_es_mx.h
+index 5574b3b..530c9f1 100644
+--- a/src/language_es_mx.h
++++ b/src/language_es_mx.h
+@@ -31,10 +31,6 @@
+  *   PO_REVISION_DATE=2016-03-24 10:59:55
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"
+diff --git a/src/language_fr.h b/src/language_fr.h
+index c87ae7b..91baa5e 100644
+--- a/src/language_fr.h
++++ b/src/language_fr.h
+@@ -31,10 +31,6 @@
+  *   PO_REVISION_DATE=
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"
+diff --git a/src/language_zh_cn.h b/src/language_zh_cn.h
+index 1c35fef..218203d 100644
+--- a/src/language_zh_cn.h
++++ b/src/language_zh_cn.h
+@@ -31,10 +31,6 @@
+  *   PO_REVISION_DATE=2016-03-24 10:59:55
+  */
+ 
+-#ifdef _MSC_VER
+-#pragma execution_character_set("utf-8")
+-#endif
+-
+ #include "language.h"
+ #include "access.h"
+ #include "message.h"


### PR DESCRIPTION
More information at http://www.html-tidy.org/.

I am not involved with the project, just wrote the port.

The #pragma execution_character_set("utf-8") lines conflicted with the /utf-8 flag, I figured they pretty much enable the same thing so I wrote a patch to remove the pragmas from the code rather than find a way to remove /utf-8 from c and cxx flags... which seems impossible from a port file anyway.