### PR TITLE
[freeglut] rename static library for compatibility with FindGLUT.cmake

### DIFF
--- a/ports/freeglut/CONTROL
+++ b/ports/freeglut/CONTROL
@@ -1,3 +1,3 @@
 Source: freeglut
-Version: 3.0.0-2
+Version: 3.0.0-3
 Description: Open source implementation of GLUT with source and binary backwards compatibility.

--- a/ports/freeglut/portfile.cmake
+++ b/ports/freeglut/portfile.cmake
@@ -35,10 +35,16 @@ vcpkg_install_cmake()
 # Patch header
 file(READ ${CURRENT_PACKAGES_DIR}/include/GL/freeglut_std.h FREEGLUT_STDH)
 string(REPLACE "pragma comment (lib, \"freeglut_staticd.lib\")"
-               "pragma comment (lib, \"freeglut_static.lib\")" FREEGLUT_STDH "${FREEGLUT_STDH}")
+               "pragma comment (lib, \"freeglut.lib\")" FREEGLUT_STDH "${FREEGLUT_STDH}")
 string(REPLACE "pragma comment (lib, \"freeglutd.lib\")"
                "pragma comment (lib, \"freeglut.lib\")" FREEGLUT_STDH "${FREEGLUT_STDH}")
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/GL/freeglut_std.h "${FREEGLUT_STDH}")
+
+# Rename static lib (otherwise it's incompatible with FindGLUT.cmake)
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/freeglut_static.lib ${CURRENT_PACKAGES_DIR}/lib/freeglut.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/freeglut_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/freeglut.lib)
+endif()
 
 # Clean
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
As described in https://github.com/Microsoft/vcpkg/issues/1701 I have some problems linking with freeglut when using it as a static library, since FindGLUT.cmake only looks for library whose name can be `glut glut32 freeglut`, but not `freeglut_static` as is named without my patch.
Instead of working on FindGLUT and have compatibility only in the future, I think that renaming the library to have the usual common name is the best choice.