### PR TITLE
[dimcli] update to 3.1.1

### DIFF
--- a/ports/dimcli/CONTROL
+++ b/ports/dimcli/CONTROL
@@ -1,3 +1,3 @@
 Source: dimcli
-Version: 2.0.0-1
+Version: 3.1.1-1
 Description: C++ command line parser toolkit

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gknowles/dimcli
-    REF  v2.0.0
-    SHA512 55ff29e3ddd6a96946f58e661231a1d2197f56a86c9260142f083589738aaa5e2f7721c754fa4a86b450a943c19367e1c4f82aec57e5b7ae7336f989e0194dec
+    REF  v3.1.1
+    SHA512 ed9aeedc59a9d48c59aa8dd1adb9cb110771c1eab0bbab8f8b518e12a45cdafb0ea94301d082ed3a033ca2428c19c8d990c76f666d1e9822cddf6e744f1db701
     HEAD_REF master
 )
 set(staticCrt OFF)
@@ -13,7 +13,7 @@ if(VCPKG_CRT_LINKAGE STREQUAL static)
 endif()
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS -DLINK_STATIC_RUNTIME:BOOL=${staticCrt}
+    OPTIONS -DLINK_STATIC_RUNTIME:BOOL=${staticCrt} -DINSTALL_LIBS:BOOL=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This is pretty straight forward, the only change is that I added an option (INSTALL_LIBS:BOOL=ON) because the lib's CMakeLists.txt no longer creates the install target by default.
