### PR TITLE
[liblzma] Add 'd' to debug postfix

### DIFF
--- a/ports/liblzma/CMakeLists.txt
+++ b/ports/liblzma/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 project(liblzma)
 
+set(CMAKE_DEBUG_POSTFIX d)
+
 add_definitions(-DHAVE_CONFIG_H)
 if(BUILD_SHARED_LIBS)
     add_definitions(-DLIBLZMADLL_EXPORTS)


### PR DESCRIPTION
This PR adds a 'd' postfix to the lzma debug library to make it easier to distinguish between the release and debug versions 