### PR TITLE
Fix find debug dependencies of PCL

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.8.1-4
+Version: 1.8.1-5
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: boost, eigen3, flann, qhull, vtk, openni2
 

--- a/ports/pcl/config.patch
+++ b/ports/pcl/config.patch
@@ -16,7 +16,7 @@ index f4ef6a0ff..3a2c259dc 100644
      PATHS "$ENV{PROGRAMFILES}/flann 1.6.9" "$ENV{PROGRAMW6432}/flann 1.6.9" 
            "$ENV{PROGRAMFILES}/flann" "$ENV{PROGRAMW6432}/flann"
 -    PATH_SUFFIXES lib)
-+    PATH_SUFFIXES debug/lib)
++    PATH_SUFFIXES lib debug/lib)
  
    find_package_handle_standard_args(Flann DEFAULT_MSG FLANN_LIBRARY FLANN_INCLUDE_DIRS)
    if(FLANN_FOUND)

--- a/ports/pcl/config.patch
+++ b/ports/pcl/config.patch
@@ -7,7 +7,7 @@ index f4ef6a0ff..3a2c259dc 100644
      HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}"
      PATHS "$ENV{PROGRAMFILES}/qhull" "$ENV{PROGRAMW6432}/qhull" 
 -    PATH_SUFFIXES project build bin lib)
-+    PATH_SUFFIXES project build bin debug/lib)
++    PATH_SUFFIXES project build bin lib debug/lib)
    
    find_package_handle_standard_args(qhull DEFAULT_MSG QHULL_LIBRARY QHULL_INCLUDE_DIRS)
  

--- a/ports/pcl/find_flann.patch
+++ b/ports/pcl/find_flann.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/Modules/FindFLANN.cmake b/cmake/Modules/FindFLANN.cmake
-index b5739dc95..4041a2539 100644
+index b5739dc95..d2c3fd07e 100644
 --- a/cmake/Modules/FindFLANN.cmake
 +++ b/cmake/Modules/FindFLANN.cmake
 @@ -10,8 +10,8 @@
@@ -13,3 +13,12 @@ index b5739dc95..4041a2539 100644
  else(FLANN_USE_STATIC)
    set(FLANN_RELEASE_NAME flann_cpp)
    set(FLANN_DEBUG_NAME flann_cpp-gd)
+@@ -41,7 +41,7 @@ find_library(FLANN_LIBRARY_DEBUG
+              NAMES ${FLANN_DEBUG_NAME} ${FLANN_RELEASE_NAME}
+ 	     HINTS ${PC_FLANN_LIBDIR} ${PC_FLANN_LIBRARY_DIRS} "${FLANN_ROOT}" "$ENV{FLANN_ROOT}"
+ 	     PATHS "$ENV{PROGRAMFILES}/Flann" "$ENV{PROGRAMW6432}/Flann" 
+-	     PATH_SUFFIXES lib)
++	     PATH_SUFFIXES lib debug/lib)
+ 
+ if(NOT FLANN_LIBRARY_DEBUG)
+   set(FLANN_LIBRARY_DEBUG ${FLANN_LIBRARY})

--- a/ports/pcl/find_qhull.patch
+++ b/ports/pcl/find_qhull.patch
@@ -7,7 +7,7 @@ index 698bd151b..44c1d5d8d 100644
               HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}"
               PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull" 
 -             PATH_SUFFIXES project build bin lib)
-+             PATH_SUFFIXES project build bin debug/lib)
++             PATH_SUFFIXES project build bin lib debug/lib)
  
  if(NOT QHULL_LIBRARY_DEBUG)
    set(QHULL_LIBRARY_DEBUG ${QHULL_LIBRARY})


### PR DESCRIPTION
Fix find debug library of QHull.
Currently, QHull port generates debug libraries with DEBUG_POSTFIX (_d).
Therefore, It doesn't need to be override.

In addition, It also similarly fix FLANN.
Also, These fixes will be incorporated into upstream (master / HEAD) in near future.

Thanks @SergioRAgostinho,
https://github.com/Microsoft/vcpkg/commit/302f67feedf6bb0cb1163f2fcdef4a162c5a843c#commitcomment-25613966