### PR TITLE
[libflac,libsndfile] patches for UWP builds

### DIFF
--- a/ports/libflac/CONTROL
+++ b/ports/libflac/CONTROL
@@ -1,4 +1,4 @@
 Source: libflac
-Version: 1.3.2-3
+Version: 1.3.2-4
 Description: Library for manipulating FLAC files
 Build-Depends: libogg

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -1,8 +1,3 @@
- # libFLAC uses winapi functions not available in WindowsStore
-if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "Error: UWP builds are currently not supported.")
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/flac-1.3.2)
 vcpkg_download_distfile(ARCHIVE
@@ -11,6 +6,17 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 63910e8ebbe508316d446ffc9eb6d02efbd5f47d29d2ea7864da9371843c8e671854db6e89ba043fe08aef1845b8ece70db80f1cce853f591ca30d56ef7c3a15)
 
 vcpkg_extract_source_archive(${ARCHIVE})
+
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+	vcpkg_apply_patches(
+		SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/flac-1.3.2
+		PATCHES
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-return-default-console-width.patch"
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-use-createfile2-instead.patch"
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-use-loadpackagedlibrary-instead.patch"
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-ignore-writeconsolew-calls.patch"
+	)
+endif()
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
     vcpkg_find_acquire_program(NASM)

--- a/ports/libflac/uwp-ignore-writeconsolew-calls.patch
+++ b/ports/libflac/uwp-ignore-writeconsolew-calls.patch
@@ -1,0 +1,33 @@
+diff --git a/src/share/win_utf8_io/win_utf8_io.c b/src/share/win_utf8_io/win_utf8_io.c
+index 15a76d4..00e57b6 100644
+--- a/src/share/win_utf8_io/win_utf8_io.c
++++ b/src/share/win_utf8_io/win_utf8_io.c
+@@ -171,28 +171,8 @@ int win_get_console_width(void)
+ 
+ static int wprint_console(FILE *stream, const wchar_t *text, size_t len)
+ {
+-	DWORD out;
+ 	int ret;
+ 
+-	do {
+-		if (stream == stdout) {
+-			HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+-			if (hOut == INVALID_HANDLE_VALUE || hOut == NULL || GetFileType(hOut) != FILE_TYPE_CHAR)
+-				break;
+-			if (WriteConsoleW(hOut, text, len, &out, NULL) == 0)
+-				return -1;
+-			return out;
+-		}
+-		if (stream == stderr) {
+-			HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+-			if (hErr == INVALID_HANDLE_VALUE || hErr == NULL || GetFileType(hErr) != FILE_TYPE_CHAR)
+-				break;
+-			if (WriteConsoleW(hErr, text, len, &out, NULL) == 0)
+-				return -1;
+-			return out;
+-		}
+-	} while(0);
+-
+ 	ret = fputws(text, stream);
+ 	if (ret < 0)
+ 		return ret;

--- a/ports/libflac/uwp-return-default-console-width.patch
+++ b/ports/libflac/uwp-return-default-console-width.patch
@@ -1,0 +1,16 @@
+diff --git a/src/share/win_utf8_io/win_utf8_io.c b/src/share/win_utf8_io/win_utf8_io.c
+index c61d27f..5b0e8f0 100644
+--- a/src/share/win_utf8_io/win_utf8_io.c
++++ b/src/share/win_utf8_io/win_utf8_io.c
+@@ -164,11 +164,6 @@ size_t strlen_utf8(const char *str)
+ int win_get_console_width(void)
+ {
+ 	int width = 80;
+-	CONSOLE_SCREEN_BUFFER_INFO csbi;
+-	HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+-	if(hOut != INVALID_HANDLE_VALUE && hOut != NULL)
+-		if (GetConsoleScreenBufferInfo(hOut, &csbi) != 0)
+-			width = csbi.dwSize.X;
+ 	return width;
+ }
+ 

--- a/ports/libflac/uwp-use-createfile2-instead.patch
+++ b/ports/libflac/uwp-use-createfile2-instead.patch
@@ -1,0 +1,37 @@
+diff --git a/src/libFLAC/windows_unicode_filenames.c b/src/libFLAC/windows_unicode_filenames.c
+index 2404e31..b73f94e 100644
+--- a/src/libFLAC/windows_unicode_filenames.c
++++ b/src/libFLAC/windows_unicode_filenames.c
+@@ -185,17 +185,20 @@ int flac_internal_rename_utf8(const char *oldname, const char *newname)
+ 
+ HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
+ {
+-	if (!utf8_filenames) {
+-		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+-	} else {
+-		wchar_t *wname;
+-		HANDLE handle = INVALID_HANDLE_VALUE;
+-
+-		if ((wname = wchar_from_utf8(lpFileName)) != NULL) {
+-			handle = CreateFileW(wname, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+-			free(wname);
+-		}
+-
+-		return handle;
++	wchar_t *wname;
++	HANDLE handle = INVALID_HANDLE_VALUE;
++	CREATEFILE2_EXTENDED_PARAMETERS createExParams = {0};
++	createExParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
++	createExParams.dwFileAttributes = dwFlagsAndAttributes & FILE_ATTRIBUTE_NORMAL;
++	createExParams.dwFileFlags = 0;
++	createExParams.dwSecurityQosFlags = 0;
++	createExParams.lpSecurityAttributes = lpSecurityAttributes;
++	createExParams.hTemplateFile = hTemplateFile;
++
++	if ((wname = wchar_from_utf8(lpFileName)) != NULL) {
++		handle = CreateFile2(wname, dwDesiredAccess, dwShareMode, dwCreationDisposition, &createExParams);
++		free(wname);
+ 	}
++
++	return handle;
+ }

--- a/ports/libflac/uwp-use-loadpackagedlibrary-instead.patch
+++ b/ports/libflac/uwp-use-loadpackagedlibrary-instead.patch
@@ -1,0 +1,13 @@
+diff --git a/src/share/win_utf8_io/win_utf8_io.c b/src/share/win_utf8_io/win_utf8_io.c
+index 5b0e8f0..c536874 100644
+--- a/src/share/win_utf8_io/win_utf8_io.c
++++ b/src/share/win_utf8_io/win_utf8_io.c
+@@ -110,7 +110,7 @@ int get_utf8_argv(int *argc, char ***argv)
+ 	char **utf8argv;
+ 	int ret, i;
+ 
+-	if ((handle = LoadLibrary("msvcrt.dll")) == NULL) return 1;
++	if ((handle = LoadPackagedLibrary("msvcrt.dll", 0)) == NULL) return 1;
+ 	if ((wgetmainargs = (wgetmainargs_t)GetProcAddress(handle, "__wgetmainargs")) == NULL) {
+ 		FreeLibrary(handle);
+ 		return 1;

--- a/ports/libsndfile/CONTROL
+++ b/ports/libsndfile/CONTROL
@@ -1,4 +1,4 @@
 Source: libsndfile
-Version: 1.0.29-6830c42-1
+Version: 1.0.29-6830c42-2
 Description: Library to read, write and manipulate many soundfile types. Authored by Eric de Castro Lopo
 Build-Depends: libogg, libflac, libvorbis

--- a/ports/libsndfile/portfile.cmake
+++ b/ports/libsndfile/portfile.cmake
@@ -19,6 +19,15 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+	vcpkg_apply_patches(
+		SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libsndfile-6830c421899e32f8d413a903a21a9b6cf384d369
+		PATCHES
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-createfile.patch"
+			"${CMAKE_CURRENT_LIST_DIR}/uwp-getfilesize.patch"
+	)
+endif()
+
 if (VCPKG_CRT_LINKAGE STREQUAL "dynamic")
     set(CRT_LIB_STATIC 0)
 elseif (VCPKG_CRT_LINKAGE STREQUAL "static")

--- a/ports/libsndfile/uwp-createfile.patch
+++ b/ports/libsndfile/uwp-createfile.patch
@@ -1,0 +1,38 @@
+diff --git a/src/file_io.c b/src/file_io.c
+index 7cf8f0c..ce15578 100644
+--- a/src/file_io.c
++++ b/src/file_io.c
+@@ -787,26 +787,13 @@ psf_open_handle (PSF_FILE * pfile)
+ 				return NULL ;
+ 		} ;
+ 
+-	if (pfile->use_wchar)
+-		handle = CreateFileW (
+-					pfile->path.wc,				/* pointer to name of the file */
+-					dwDesiredAccess,			/* access (read-write) mode */
+-					dwShareMode,				/* share mode */
+-					0,							/* pointer to security attributes */
+-					dwCreationDistribution,		/* how to create */
+-					FILE_ATTRIBUTE_NORMAL,		/* file attributes (could use FILE_FLAG_SEQUENTIAL_SCAN) */
+-					NULL						/* handle to file with attributes to copy */
+-					) ;
+-	else
+-		handle = CreateFile (
+-					pfile->path.c,				/* pointer to name of the file */
+-					dwDesiredAccess,			/* access (read-write) mode */
+-					dwShareMode,				/* share mode */
+-					0,							/* pointer to security attributes */
+-					dwCreationDistribution,		/* how to create */
+-					FILE_ATTRIBUTE_NORMAL,		/* file attributes (could use FILE_FLAG_SEQUENTIAL_SCAN) */
+-					NULL						/* handle to file with attributes to copy */
+-					) ;
++	if (!pfile->use_wchar)
++		return NULL;
++
++	CREATEFILE2_EXTENDED_PARAMETERS createExParams = {0};
++	createExParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
++	createExParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
++	handle = CreateFile2(pfile->path.wc, dwDesiredAccess, dwShareMode, dwCreationDistribution, &createExParams);
+ 
+ 	if (handle == INVALID_HANDLE_VALUE)
+ 		return NULL ;

--- a/ports/libsndfile/uwp-getfilesize.patch
+++ b/ports/libsndfile/uwp-getfilesize.patch
@@ -1,0 +1,46 @@
+diff --git a/src/file_io.c b/src/file_io.c
+index ce15578..43b32d9 100644
+--- a/src/file_io.c
++++ b/src/file_io.c
+@@ -1092,17 +1092,33 @@ psf_is_pipe (SF_PRIVATE *psf)
+ /* USE_WINDOWS_API */ sf_count_t
+ psf_get_filelen_handle (HANDLE handle)
+ {	sf_count_t filelen ;
+-	DWORD dwFileSizeLow, dwFileSizeHigh, dwError = NO_ERROR ;
+-
+-	dwFileSizeLow = GetFileSize (handle, &dwFileSizeHigh) ;
++	sf_count_t failed = (sf_count_t) -1;
++	ULONG infoSize;
++	PFILE_STREAM_INFO info;
++
++	infoSize = sizeof(FILE_STREAM_INFO) + (sizeof(WCHAR) * MAX_PATH);
++retry:
++	info = (PFILE_STREAM_INFO)LocalAlloc(LMEM_ZEROINIT, infoSize);
++
++	if (info == NULL)
++		return failed;
++
++	if (!GetFileInformationByHandleEx(handle, FileStreamInfo, info, infoSize))
++	{
++		if (GetLastError() == ERROR_MORE_DATA)
++		{
++			LocalFree(info);
++			infoSize *= 2;
++			goto retry;
++		}
+ 
+-	if (dwFileSizeLow == 0xFFFFFFFF)
+-		dwError = GetLastError () ;
++		LocalFree(info);
++		return failed;
++	}
+ 
+-	if (dwError != NO_ERROR)
+-		return (sf_count_t) -1 ;
++	LocalFree(info);
+ 
+-	filelen = dwFileSizeLow + ((__int64) dwFileSizeHigh << 32) ;
++	filelen = (sf_count_t)info->StreamSize.QuadPart;
+ 
+ 	return filelen ;
+ } /* psf_get_filelen_handle */


### PR DESCRIPTION
**Description of the patches :**

[**uwp-use-loadpackagedlibrary-instead.patch :**](https://github.com/aybe/vcpkg/blob/76197ac5bac5f1359f6d3705046dc49e1308dba3/ports/libflac/uwp-use-loadpackagedlibrary-instead.patch)
Nothing special, replaced `LoadLibrary` by `LoadPackagedLibrary`.

[**uwp-use-createfile2-instead.patch :**](https://github.com/aybe/vcpkg/blob/76197ac5bac5f1359f6d3705046dc49e1308dba3/ports/libflac/uwp-use-createfile2-instead.patch)
I replaced `CreateFile` by `CreateFile2` which is supported on UWP, for the parameters I've simply converted those found throughout the sources.

**These two below likely need further tweaking:**

[**uwp-return-default-console-width.patch :**](https://github.com/aybe/vcpkg/blob/76197ac5bac5f1359f6d3705046dc49e1308dba3/ports/libflac/uwp-return-default-console-width.patch)
Since there's no console in UWP, I simply return a default value of `80`.

[**uwp-ignore-writeconsolew-calls.patch :**](https://github.com/aybe/vcpkg/blob/76197ac5bac5f1359f6d3705046dc49e1308dba3/ports/libflac/uwp-ignore-writeconsolew-calls.patch)
For this one it's a bit a weird and likely to need some intervention, `WriteConsole` is supposed to be available ([APIs present on all Windows 10 devices](https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-apis)) and even though I have the same mentioned Win10 version, the build process fails to find that method. I've decided to comment out this part since there's no console in UWP.

So, libflac now builds but it'd be great if someone could improve these patches somehow !