### PR TITLE
Change OpenNI2 to feature option

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,7 +1,11 @@
 Source: pcl
-Version: 1.8.1-5
+Version: 1.8.1-6
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
-Build-Depends: boost, eigen3, flann, qhull, vtk, openni2
+Build-Depends: boost, eigen3, flann, qhull, vtk
+
+Feature: openni2
+Description: OpenNI2 support for PCL
+Build-Depends: openni2
 
 Feature: qt
 Description: Qt support for PCL

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -20,6 +20,11 @@ vcpkg_apply_patches(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)
 
+set(WITH_OPENNI2 OFF)
+if("openni2" IN_LIST FEATURES)
+    set(WITH_OPENNI2 ON)
+endif()
+
 set(WITH_QT OFF)
 if("qt" IN_LIST FEATURES)
     set(WITH_QT ON)
@@ -44,7 +49,7 @@ vcpkg_configure_cmake(
         # WITH
         -DWITH_CUDA=OFF
         -DWITH_LIBUSB=OFF
-        -DWITH_OPENNI2=ON
+        -DWITH_OPENNI2=${WITH_OPENNI2}
         -DWITH_PCAP=${WITH_PCAP}
         -DWITH_PNG=OFF
         -DWITH_QHULL=ON


### PR DESCRIPTION
OpenNI2 would be better not to the default option, because OpenNI2 port does not support building static link library. Therefore, This pull request will change OpenNI 2 to feature option.
Users will be able to install using the following standard triplets by applying this pull request.
```ps1
# standard triplets for static configuration
vcpkg install pcl:x86-windows-static
vcpkg install pcl:x64-windows-static
```