### PR TITLE
[libzip] Update to 1.3.2

### DIFF
--- a/ports/libzip/enable-static.patch
+++ b/ports/libzip/enable-static.patch
@@ -1,18 +1,24 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d443757..303dfe2 100644
+index deceb65..1283013 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -102,14 +102,20 @@ IF(MSVC)
- ADD_DEFINITIONS("-D_CRT_SECURE_NO_WARNINGS")
+@@ -113,6 +113,15 @@ ADD_DEFINITIONS("-D_CRT_SECURE_NO_WARNINGS")
+ ADD_DEFINITIONS("-D_CRT_NONSTDC_NO_DEPRECATE")
  ENDIF(MSVC)
  
 +OPTION(ENABLE_STATIC "Enable static builds" OFF)
 +IF(ENABLE_STATIC)
++  set(BUILD_SHARED_LIBS OFF)
 +  set(ZIP_EXTERN_OVERRIDE ON)
 +  set(ZIP_EXTERN ON)
++ELSE(ENABLE_STATIC)
++  set(BUILD_SHARED_LIBS ON)
 +ENDIF(ENABLE_STATIC)
 +
  ADD_DEFINITIONS("-DHAVE_CONFIG_H")
+ 
+ # rpath handling: use rpath in installed binaries
+@@ -121,10 +130,10 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  
  # Targets
  ADD_SUBDIRECTORY(lib)
@@ -25,10 +31,23 @@ index d443757..303dfe2 100644
 +# ADD_SUBDIRECTORY(regress)
 +# ADD_SUBDIRECTORY(examples)
  
- # TODO: pkgconfig file
+ # pkgconfig file
+ SET(prefix ${CMAKE_INSTALL_PREFIX})
+diff --git a/cmake-config.h.in b/cmake-config.h.in
+index 0d1839c..dd450ff 100644
+--- a/cmake-config.h.in
++++ b/cmake-config.h.in
+@@ -60,7 +60,7 @@
+ #cmakedefine WORDS_BIGENDIAN
+ /* END DEFINES */
+ #define PACKAGE "@PACKAGE@"
+-#define VERSION "@VERSION@"
++#define LIBZIP_VERSION "@VERSION@"
  
+ #ifndef HAVE_SSIZE_T_LIBZIP
+ #  if SIZE_T_LIBZIP == INT_LIBZIP
 diff --git a/cmake-zipconf.h.in b/cmake-zipconf.h.in
-index 17edc6c..ac9c394 100644
+index 6a276f6..410c898 100644
 --- a/cmake-zipconf.h.in
 +++ b/cmake-zipconf.h.in
 @@ -118,4 +118,10 @@ typedef unsigned long long zip_uint64_t;
@@ -42,49 +61,8 @@ index 17edc6c..ac9c394 100644
 +#endif
 +
  #endif /* zipconf.h */
-diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
-index 1596f30..eb55fc0 100644
---- a/lib/CMakeLists.txt
-+++ b/lib/CMakeLists.txt
-@@ -191,19 +191,20 @@ IF(NOT HAVE_MKSTEMP)
-   SET(LIBZIP_EXTRA_FILES mkstemp.c)
- ENDIF(NOT HAVE_MKSTEMP)
- 
--ADD_LIBRARY(zip SHARED ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
--SET_TARGET_PROPERTIES(zip PROPERTIES VERSION 3.0 SOVERSION 3 )
--TARGET_LINK_LIBRARIES(zip ${ZLIB_LIBRARY})
--INSTALL(TARGETS zip
--  RUNTIME DESTINATION bin
--  ARCHIVE DESTINATION lib
--  LIBRARY DESTINATION lib)
--#CREATE_LIBTOOL_FILE(zip lib)
--
--#ADD_LIBRARY(zipstatic STATIC ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
--#SET_TARGET_PROPERTIES(zipstatic PROPERTIES VERSION 3.0 SOVERSION 3 )
--#TARGET_LINK_LIBRARIES(zipstatic ${ZLIB_LIBRARY})
--#INSTALL(TARGETS zipstatic
--#  RUNTIME DESTINATION bin
--#  ARCHIVE DESTINATION lib
--#  LIBRARY DESTINATION lib)
-+IF(ENABLE_STATIC)
-+  ADD_LIBRARY(zipstatic STATIC ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
-+  SET_TARGET_PROPERTIES(zipstatic PROPERTIES VERSION 3.0 SOVERSION 3 )
-+  TARGET_LINK_LIBRARIES(zipstatic ${ZLIB_LIBRARY})
-+  INSTALL(TARGETS zipstatic
-+    RUNTIME DESTINATION bin
-+    ARCHIVE DESTINATION lib
-+    LIBRARY DESTINATION lib)
-+ELSE(ENABLE_STATIC)
-+  ADD_LIBRARY(zip SHARED ${LIBZIP_SOURCES} ${LIBZIP_EXTRA_FILES} ${LIBZIP_OPSYS_FILES})
-+  SET_TARGET_PROPERTIES(zip PROPERTIES VERSION 3.0 SOVERSION 3 )
-+  TARGET_LINK_LIBRARIES(zip ${ZLIB_LIBRARY})
-+  INSTALL(TARGETS zip
-+    RUNTIME DESTINATION bin
-+    ARCHIVE DESTINATION lib
-+    LIBRARY DESTINATION lib)
-+ENDIF(ENABLE_STATIC)
 diff --git a/lib/compat.h b/lib/compat.h
-index 4c9e3a0..d667fe3 100644
+index 625c84e..8943587 100644
 --- a/lib/compat.h
 +++ b/lib/compat.h
 @@ -42,7 +42,9 @@

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -1,9 +1,9 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libzip-1.2.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libzip-1.3.2)
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "https://nih.at/libzip/libzip-1.2.0.tar.gz"
-    FILENAME "libzip-1.2.0.tar.gz"
-    SHA512 b71642a80f8e2573c9082d513018bfd2d1d155663ac83fdf7ec969a08d5230fcbc76f2cf89c26ff1d1288e9f407ba9fa234604d813ed3bab816ca1670f7a53f3
+    URLS "https://nih.at/libzip/libzip-1.3.2.tar.gz"
+    FILENAME "libzip-1.3.2.tar.gz"
+    SHA512 75b7e6f541be30e721275723f264c20f9a3be5335d954b5909acdddb0f6dd9b2420166904c9b88206692a57a4aa54e4fe8ed4d62c1f4b900aebf6ad40f767376
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 
@@ -26,11 +26,6 @@ else()
 endif()
 
 vcpkg_install_cmake()
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/lib/zip.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/zipstatic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/zip.lib)
-endif()
 
 # Move zipconf.h to include and remove include directories from lib
 file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libzip/include/zipconf.h ${CURRENT_PACKAGES_DIR}/include/zipconf.h)


### PR DESCRIPTION
Upstream have merged some of the patches: nih-at/libzip@34f24a1

There is one new changed required to change `VERSION` to `LIBZIP_VERSION` in `cmake-config.h.in`, which I have already sent as a patch to maintainers.