### PR TITLE
[alembic] fix string replace eats semicolon problem

### DIFF
--- a/ports/alembic/CONTROL
+++ b/ports/alembic/CONTROL
@@ -1,4 +1,4 @@
 Source: alembic
-Version: 1.7.4
+Version: 1.7.4-1
 Build-Depends: ilmbase, hdf5
 Description: Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications. http://alembic.io/

--- a/ports/alembic/portfile.cmake
+++ b/ports/alembic/portfile.cmake
@@ -44,12 +44,12 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/Alembic.dll ${CURRENT_PACKAGES_DIR
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/Alembic/AlembicTargets-debug.cmake DEBUG_CONFIG)
 string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/Alembic.dll"
-               "\${_IMPORT_PREFIX}/debug/bin/Alembic.dll" DEBUG_CONFIG ${DEBUG_CONFIG})
+               "\${_IMPORT_PREFIX}/debug/bin/Alembic.dll" DEBUG_CONFIG "${DEBUG_CONFIG}")
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/Alembic/AlembicTargets-debug.cmake "${DEBUG_CONFIG}")
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/Alembic/AlembicTargets-release.cmake RELEASE_CONFIG)
 string(REPLACE "\${_IMPORT_PREFIX}/lib/Alembic.dll"
-               "\${_IMPORT_PREFIX}/bin/Alembic.dll" RELEASE_CONFIG ${RELEASE_CONFIG})
+               "\${_IMPORT_PREFIX}/bin/Alembic.dll" RELEASE_CONFIG "${RELEASE_CONFIG}")
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/Alembic/AlembicTargets-release.cmake "${RELEASE_CONFIG}")
 
 # Put the license file where vcpkg expects it


### PR DESCRIPTION
Needs the double quote otherwise the string replace will remove the semi colon inside `AlembicTargets-debug.cmake` and `AlembicTargets-release.cmake`

Fix discovered at https://public.kitware.com/pipermail/cmake/2007-August/015579.html