### PR TITLE
[leveldb] force static build when triplet is dynamic

### DIFF
--- a/ports/leveldb/CONTROL
+++ b/ports/leveldb/CONTROL
@@ -1,3 +1,3 @@
 Source: leveldb
-Version: 2017-10-25-8b1cd3753b184341e837b30383832645135d3d73
+Version: 2017-10-25-8b1cd3753b184341e837b30383832645135d3d73-1
 Description: LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.

--- a/ports/leveldb/portfile.cmake
+++ b/ports/leveldb/portfile.cmake
@@ -1,8 +1,6 @@
 include(vcpkg_common_functions)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    message(FATAL_ERROR "leveldb doesn't currently support dynamic buildsas there are no export symbols defined.")
-endif()
+set(VCPKG_LIBRARY_LINKAGE static)
 
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/leveldb-8b1cd3753b184341e837b30383832645135d3d73)
 


### PR DESCRIPTION
So it will continue to build instead of showing an error