### PR TITLE
Adding UnitTest++ Port

### DIFF
--- a/ports/unittest-cpp/CONTROL
+++ b/ports/unittest-cpp/CONTROL
@@ -1,0 +1,3 @@
+Source: unittest-cpp
+Version: 2.0.0
+Description: A lightweight unit testing framework for C++

--- a/ports/unittest-cpp/portfile.cmake
+++ b/ports/unittest-cpp/portfile.cmake
@@ -1,16 +1,6 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
+# UnitTest++ 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    message(STATUS "Warning: Dynamic building not supported by libvpx yet. Building static.")
+    message(STATUS "Warning: Dynamic building not supported by unittest-cpp yet. Building static.")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 

--- a/ports/unittest-cpp/portfile.cmake
+++ b/ports/unittest-cpp/portfile.cmake
@@ -1,36 +1,29 @@
-# UnitTest++ 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     message(STATUS "Warning: Dynamic building not supported by unittest-cpp yet. Building static.")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/unittest-cpp-2.0.0)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.zip"
-    FILENAME "unittest-cpp-2.0.0.zip"
-    SHA512 2f1bdedc9cd8dcfeccca8be034dcc07544d991f8fc183166d9224d466f5e47100e0769b8c2b85dd45ca9ff57e42460bf41478a9e52fe2d2df4663fb22fe8cb6e
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO unittest-cpp/unittest-cpp
+    REF v2.0.0
+    SHA512 39318f4ed31534c116679a3257bf1438a6c4b3bef1894dfd40aea934950c6c8197af6a7f61539b8e9ddc67327c9388d7e8a6f8a3e0e966ad26c07554e2429cab
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
+    PREFER_NINJA
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/UnitTest++)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/unittest-cpp ${CURRENT_PACKAGES_DIR}/share/unittest++)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/unittest-cpp RENAME copyright)
 
 # Remove duplicate includes
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-# Clean up cmake files and move to share
-file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/UnitTest++/ DESTINATION ${CURRENT_PACKAGES_DIR}/lib/cmake/UnitTest++/debug)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/UnitTest++/ DESTINATION ${CURRENT_PACKAGES_DIR}/share/unittest-cpp/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)

--- a/ports/unittest-cpp/portfile.cmake
+++ b/ports/unittest-cpp/portfile.cmake
@@ -1,0 +1,46 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported by libvpx yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/unittest-cpp-2.0.0)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/unittest-cpp/unittest-cpp/archive/v2.0.0.zip"
+    FILENAME "unittest-cpp-2.0.0.zip"
+    SHA512 2f1bdedc9cd8dcfeccca8be034dcc07544d991f8fc183166d9224d466f5e47100e0769b8c2b85dd45ca9ff57e42460bf41478a9e52fe2d2df4663fb22fe8cb6e
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/unittest-cpp RENAME copyright)
+
+# Remove duplicate includes
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Clean up cmake files and move to share
+file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/UnitTest++/ DESTINATION ${CURRENT_PACKAGES_DIR}/lib/cmake/UnitTest++/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/UnitTest++/ DESTINATION ${CURRENT_PACKAGES_DIR}/share/unittest-cpp/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -54,19 +54,19 @@ function(vcpkg_from_github)
     set(multipleValuesArgs)
     cmake_parse_arguments(_vdud "" "${oneValueArgs}" "${multipleValuesArgs}" ${ARGN})
 
-    if(NOT _vdud_OUT_SOURCE_PATH)
+    if(NOT DEFINED _vdud_OUT_SOURCE_PATH)
         message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
     endif()
 
-    if((_vdud_REF AND NOT _vdud_SHA512) OR (NOT _vdud_REF AND _vdud_SHA512))
+    if((DEFINED _vdud_REF AND NOT DEFINED _vdud_SHA512) OR (NOT DEFINED _vdud_REF AND DEFINED _vdud_SHA512))
         message(FATAL_ERROR "SHA512 must be specified if REF is specified.")
     endif()
 
-    if(NOT _vdud_REPO)
+    if(NOT DEFINED _vdud_REPO)
         message(FATAL_ERROR "The GitHub repository must be specified.")
     endif()
 
-    if(NOT _vdud_REF AND NOT _vdud_HEAD_REF)
+    if(NOT DEFINED _vdud_REF AND NOT DEFINED _vdud_HEAD_REF)
         message(FATAL_ERROR "At least one of REF and HEAD_REF must be specified.")
     endif()
 
@@ -90,7 +90,7 @@ function(vcpkg_from_github)
         endif()
     endmacro()
 
-    if(VCPKG_USE_HEAD_VERSION AND NOT _vdud_HEAD_REF)
+    if(VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_HEAD_REF)
         message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
         set(VCPKG_USE_HEAD_VERSION OFF)
     endif()


### PR DESCRIPTION
Added a port for UnitTest++, works on multiple machines for me but I couldn't figure out how to use the bind for github with the `vcpkg_from_github` function, so fell back to using `vcpkg_download_distfile` via `.\vcpkg create ...`.