### PR TITLE
[posh-vcpkg] Add `vcpkg integrate powershell` for enabling tab-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Finally, create a New Project (or open an existing one) in Visual Studio 2017 or
 
 For CMake projects, simply include our toolchain file. See our [using a package](docs/examples/using-sqlite.md) example for the specifics.
 
+## Tab-Completion / Auto-Completion
+`Vcpkg` supports auto-completion of commands, package names, options etc. To enable tab-completion in Powershell, use
+```
+.\vcpkg integrate powershell
+```
+and restart Powershell.
+
+
 ## Examples
 See the [documentation](docs/index.md) for specific walkthroughs, including [using a package](docs/examples/using-sqlite.md) and [adding a new package](docs/examples/packaging-zlib.md).
 

--- a/scripts/addPoshVcpkgToPowershellProfile.ps1
+++ b/scripts/addPoshVcpkgToPowershellProfile.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param()
+
+function findExistingImportModuleDirectives([Parameter(Mandatory=$true)][string]$path)
+{
+    if (!(Test-Path $path))
+    {
+        return $false
+    }
+
+    $fileContents = Get-Content $path
+    return $fileContents -match 'Import-Module.+?(?=posh-vcpkg)'
+}
+
+$scriptsDir = split-path -parent $MyInvocation.MyCommand.Definition
+. "$scriptsDir\VcpkgPowershellUtils.ps1"
+
+$profileEntry = "Import-Module '$scriptsDir\posh-vcpkg'"
+$profilePath = $PROFILE # Implicit powershell variable
+if (!(Test-Path $profilePath))
+{
+    $profileDir = Split-Path $profilePath -Parent
+    vcpkgCreateDirectoryIfNotExists $profileDir
+}
+
+Write-Host "`nAdding the following line to ${profilePath}:"
+Write-Host "    $profileEntry"
+
+# @() Needed to force Array in PowerShell 2.0
+[Array]$existingImports = @(findExistingImportModuleDirectives $profilePath)
+if ($existingImports.Count -gt 0)
+{
+    $existingImportsOut = $existingImports -join "`n    "
+    Write-Host "`nposh-vcpkg is already imported to your PowerShell profile. The following entries were found:"
+    Write-Host "    $existingImportsOut"
+    Write-Host "`nPlease make sure you have started a new Powershell window for the changes to take effect."
+    return
+}
+
+# Posh-git does the following check, so we should too.
+# https://github.com/dahlbyk/posh-git/blob/master/src/Utils.ps1
+# If the profile script exists and is signed, then we should not modify it
+if (Test-Path $profilePath)
+{
+    $sig = Get-AuthenticodeSignature $profilePath
+    if ($null -ne $sig.SignerCertificate)
+    {
+        Write-Warning "Skipping add of posh-vcpkg import to profile; '$profilePath' appears to be signed."
+        Write-Warning "Please manually add the line '$profileEntry' to your profile and resign it."
+        return
+    }
+}
+
+Add-Content $profilePath -Value "`n$profileEntry" -Encoding UTF8
+Write-Host "`nSuccessfully added posh-vcpkg to your PowerShell profile. Please start a new Powershell window for the changes to take effect."

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -324,18 +324,20 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         "  vcpkg integrate install         Make installed packages available user-wide. Requires admin privileges on "
         "first use\n"
         "  vcpkg integrate remove          Remove user-wide integration\n"
-        "  vcpkg integrate project         Generate a referencing nuget package for individual VS project use\n";
+        "  vcpkg integrate project         Generate a referencing nuget package for individual VS project use\n"
+        "  vcpkg integrate powershell      Enable PowerShell Tab-Completion\n";
 
     namespace Subcommand
     {
         static const std::string INSTALL = "install";
         static const std::string REMOVE = "remove";
         static const std::string PROJECT = "project";
+        static const std::string POWERSHELL = "powershell";
     }
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths&)
     {
-        return {Subcommand::INSTALL, Subcommand::REMOVE, Subcommand::PROJECT};
+        return {Subcommand::INSTALL, Subcommand::REMOVE, Subcommand::PROJECT, Subcommand::POWERSHELL};
     }
 
     const CommandStructure COMMAND_STRUCTURE = {
@@ -364,6 +366,12 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         if (args.command_arguments[0] == Subcommand::PROJECT)
         {
             return integrate_project(paths);
+        }
+        if (args.command_arguments[0] == Subcommand::POWERSHELL)
+        {
+            System::powershell_execute("PowerShell Tab-Completion",
+                                       paths.scripts / "addPoshVcpkgToPowershellProfile.ps1");
+            Checks::exit_success(VCPKG_LINE_INFO);
         }
 #endif
 


### PR DESCRIPTION
`vcpkg integrate powershell` will automatically add a directive like the following:
```Import-Module "D:\workspace\vcpkg\scripts\posh-vcpkg"```

in your PowerShell profile. 
This will enable Tab-Completion for `vcpkg` in PowerShell. 

Note: To use bash-style tab-completion (as opposed to the default Powershell-style tab-completion), add this to your `$profile`:
`Set-PSReadlineKeyHandler -Key Tab -Function Complete`
(This affects all PowerShell tab-completions, so the script does NOT add this)