### PR TITLE
Added port for OpenMAMA 6.2.1.SNAPSHOT

### DIFF
--- a/ports/openmama/CONTROL
+++ b/ports/openmama/CONTROL
@@ -1,0 +1,4 @@
+Source: openmama
+Version: 6.2.1-a5a93a24d2f89a0def0145552c8cd4a53c69e2de
+Build-Depends: libevent, apr, qpid-proton
+Description: OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages.

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -1,0 +1,82 @@
+include(vcpkg_common_functions)
+
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(SCONS)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO OpenMAMA/OpenMAMA
+    REF a5a93a24d2f89a0def0145552c8cd4a53c69e2de
+    SHA512 ddce249da470a4b2acda3953a1f8feed93eb1e05ee6048ed798a9f32eaf7ce037d611ff331a8982a8a309d4b09c05a37f9fbe8ca90420751e46f67f7a53a555f
+    HEAD_REF next
+)
+
+set(OPENMAMA_TARGET_ARCH ${TRIPLET_SYSTEM_ARCH})
+if(${TRIPLET_SYSTEM_ARCH} STREQUAL x64)
+    set(OPENMAMA_TARGET_ARCH x86_64)
+endif()
+
+# Clean from any previous builds
+vcpkg_execute_required_process(
+    COMMAND ${SCONS}
+        -c
+        target_arch=${OPENMAMA_TARGET_ARCH}
+        libevent_home=${CURRENT_INSTALLED_DIR}
+        apr_home=${CURRENT_INSTALLED_DIR}
+        qpid_home=${CURRENT_INSTALLED_DIR}
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME clean-${TARGET_TRIPLET}.log
+)
+
+# This build
+vcpkg_execute_required_process(
+    COMMAND ${SCONS}
+        with_unittest=False
+        with_examples=False
+        product=mamda
+        lex=${FLEX}
+        middleware=qpid
+        buildtype=dynamic,dynamic-debug
+        prefix=\#install
+        with_dependency_runtimes=False
+        target_arch=${OPENMAMA_TARGET_ARCH}
+        libevent_home=${CURRENT_INSTALLED_DIR}
+        apr_home=${CURRENT_INSTALLED_DIR}
+        qpid_home=${CURRENT_INSTALLED_DIR}
+    WORKING_DIRECTORY ${SOURCE_PATH}
+    LOGNAME build-${TARGET_TRIPLET}.log
+)
+
+# Remove dependency files which build system creates for convenience
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic/libapr-1.dll)
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic/libapr-1.pdb)
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic-debug/libapr-1.dll)
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic-debug/libapr-1.pdb)
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic/qpid-proton.dll)
+file(REMOVE ${SOURCE_PATH}/install/bin/dynamic-debug/qpid-protond.dll)
+
+# Custom install target - the build system doesn't really
+# do prefixes properly and it has a different directory
+# structure than vcpkg expects so reorganizing here
+file(COPY ${SOURCE_PATH}/install/include
+     DESTINATION ${CURRENT_PACKAGES_DIR})
+file(COPY ${SOURCE_PATH}/install/lib/dynamic/
+     DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/install/lib/dynamic-debug/
+     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(COPY ${SOURCE_PATH}/install/bin/dynamic/
+     DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+     FILES_MATCHING PATTERN "*.dll")
+file(COPY ${SOURCE_PATH}/install/bin/dynamic-debug/
+     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+     FILES_MATCHING PATTERN "*.dll")
+
+# Copy across license files and copyright
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/openmama)
+file(COPY ${SOURCE_PATH}/install/LICENSE.md
+          ${SOURCE_PATH}/install/LICENSE-3RD-PARTY.txt
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/openmama/)
+file(COPY ${SOURCE_PATH}/install/LICENSE.md
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/openmama/copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_find_acquire_program(SCONS)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenMAMA/OpenMAMA
-    REF a5a93a24d2f89a0def0145552c8cd4a53c69e2de
-    SHA512 ddce249da470a4b2acda3953a1f8feed93eb1e05ee6048ed798a9f32eaf7ce037d611ff331a8982a8a309d4b09c05a37f9fbe8ca90420751e46f67f7a53a555f
+    REF 24bc69c07e3fdaf95351baea64a5fa87c15de6c9
+    SHA512 d660910fec772bad2ad2668066e5a03cb29cd40b6b443895967bb3b8ae12bbbdb8aa379a347bde7ecff81dad42e8149d2694cc542e41af17245d6ce227278afc
     HEAD_REF next
 )
 
@@ -24,6 +24,7 @@ vcpkg_execute_required_process(
         libevent_home=${CURRENT_INSTALLED_DIR}
         apr_home=${CURRENT_INSTALLED_DIR}
         qpid_home=${CURRENT_INSTALLED_DIR}
+        vcpkg_build=y
     WORKING_DIRECTORY ${SOURCE_PATH}
     LOGNAME clean-${TARGET_TRIPLET}.log
 )
@@ -43,6 +44,7 @@ vcpkg_execute_required_process(
         libevent_home=${CURRENT_INSTALLED_DIR}
         apr_home=${CURRENT_INSTALLED_DIR}
         qpid_home=${CURRENT_INSTALLED_DIR}
+        vcpkg_build=y
     WORKING_DIRECTORY ${SOURCE_PATH}
     LOGNAME build-${TARGET_TRIPLET}.log
 )


### PR DESCRIPTION
This is a snapshot version since it contains some changes
necessary to get vcpkg to play nicely with it.

When 6.2.2 is released, this port will be updated with it.