### PR TITLE
[mbedtls] Initial port.

### DIFF
--- a/ports/mbedtls/CONTROL
+++ b/ports/mbedtls/CONTROL
@@ -1,0 +1,3 @@
+Source: mbedtls
+Version: 2.6.1
+Description: An open source, portable, easy to use, readable and flexible SSL library

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -11,6 +11,8 @@
 #
 
 include(vcpkg_common_functions)
+set(VCPKG_LIBRARY_LINKAGE static)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
 	REPO ARMmbed/mbedtls

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -1,0 +1,39 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+	REPO ARMmbed/mbedtls
+	REF mbedtls-2.6.1
+    SHA512 06f8ba2a453164bac01d20ca6f5c80e691857977ef501d56685e81a0e90dddae1bedeab46c18c22f9a3b72894d45d7466f76a5c404417b6613ddae0ee4a881c8
+)
+
+list(APPEND BUILD_OPTIONS
+			-DENABLE_TESTING=OFF
+			-DENABLE_PROGRAMS=OFF
+	)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+	OPTIONS ${BUILD_OPTIONS}
+    OPTIONS_DEBUG -DCMAKE_BUILD_TYPE=Debug
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/mbedtls RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -1,35 +1,21 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
-
 include(vcpkg_common_functions)
+
 set(VCPKG_LIBRARY_LINKAGE static)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-	REPO ARMmbed/mbedtls
-	REF mbedtls-2.6.1
+    REPO ARMmbed/mbedtls
+    REF mbedtls-2.6.1
     SHA512 06f8ba2a453164bac01d20ca6f5c80e691857977ef501d56685e81a0e90dddae1bedeab46c18c22f9a3b72894d45d7466f76a5c404417b6613ddae0ee4a881c8
+    HEAD_REF master
 )
-
-list(APPEND BUILD_OPTIONS
-			-DENABLE_TESTING=OFF
-			-DENABLE_PROGRAMS=OFF
-	)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-	OPTIONS ${BUILD_OPTIONS}
-    OPTIONS_DEBUG -DCMAKE_BUILD_TYPE=Debug
+    OPTIONS
+        -DENABLE_TESTING=OFF
+        -DENABLE_PROGRAMS=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Initial port for mbedtls (from: https://github.com/ARMmbed/mbedtls)

## Notes
+ mbedtls is an open source, portable, easy to use, readable and flexible SSL library.
+ Uses cmake to build.
+ No patches applied.