### PR TITLE
[fcl] add missing dependencies within cmake

### DIFF
--- a/ports/fcl/0002-fix_dependencies.patch
+++ b/ports/fcl/0002-fix_dependencies.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 5ce1f77..1f3e863 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -10,8 +10,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
+   SOVERSION ${FCL_ABI_VERSION})
+ 
+ target_link_libraries(${PROJECT_NAME}
+-  PUBLIC ${OCTOMAP_LIBRARIES}
+-  PRIVATE ${CCD_LIBRARIES}
++  PUBLIC octomap octomath ccd
+   PRIVATE ${Boost_LIBRARIES})
+ 
+ target_include_directories(${PROJECT_NAME} INTERFACE

--- a/ports/fcl/CONTROL
+++ b/ports/fcl/CONTROL
@@ -1,4 +1,4 @@
 Source: fcl
-Version: 0.5.0-2
+Version: 0.5.0-3
 Description: a library for performing three types of proximity queries on a pair of geometric models composed of triangles
 Build-Depends: boost, ccd, octomap

--- a/ports/fcl/portfile.cmake
+++ b/ports/fcl/portfile.cmake
@@ -16,7 +16,8 @@ vcpkg_from_github(
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/0001_fix_package_detection.patch)
+        ${CMAKE_CURRENT_LIST_DIR}/0001_fix_package_detection.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0002-fix_dependencies.patch)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(FCL_STATIC_LIBRARY ON)
@@ -36,6 +37,11 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake/")
+
+file(READ ${CURRENT_PACKAGES_DIR}/share/fcl/fclConfig.cmake FCL_CONFIG)
+string(REPLACE "unset(_expectedTargets)"
+               "unset(_expectedTargets)\n\nfind_package(octomap REQUIRED)\nfind_package(ccd REQUIRED)" FCL_CONFIG "${FCL_CONFIG}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/fcl/fclConfig.cmake "${FCL_CONFIG}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
FCL needs ccd and octomap as public dependencies otherwise compilation fails.
It's fixed already [upstream](https://github.com/flexible-collision-library/fcl/blob/master/src/CMakeLists.txt#L39) but no new version of fcl is released.

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>