### PR TITLE
Fix pcl/CMakeLists fot Visual Studio 2017

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.8.1-7
+Version: 1.8.1-8
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: boost, eigen3, flann, qhull, vtk
 

--- a/ports/pcl/cmakelists.patch
+++ b/ports/pcl/cmakelists.patch
@@ -1,7 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d36a581fb..9b0195324 100644
+index d36a581fb..b68962e97 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -258,7 +258,7 @@ if(OPENMP_FOUND)
+       set(OPENMP_DLL VCOMP120)
+     elseif(MSVC_VERSION EQUAL 1900)
+       set(OPENMP_DLL VCOMP140)
+-    elseif(MSVC_VERSION EQUAL 1910)
++    elseif(MSVC_VERSION MATCHES "^191[0-9]$")
+       set(OPENMP_DLL VCOMP140)
+     endif()
+     if(OPENMP_DLL)
 @@ -327,9 +327,9 @@ endif(WITH_PNG)
  # Qhull
  option(WITH_QHULL "Include convex-hull operations" TRUE)


### PR DESCRIPTION
Fix conditional branch for Visual C++ 2017.
Visual C++ 2017 has a version number <code>191x</code>.