### PR TITLE
[speex] Fix release mode .def file. Add missing exports

### DIFF
--- a/ports/speex/CMakeLists.txt
+++ b/ports/speex/CMakeLists.txt
@@ -16,12 +16,16 @@ include_directories(win32 include)
 set(CMAKE_DEBUG_POSTFIX d)
 
 file(READ "win32/libspeex.def" _contents)
-string(REPLACE "LIBRARY libspeex" "LIBRARY libspeexd" _contents "${_contents}")
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  string(REPLACE "LIBRARY libspeex" "LIBRARY libspeexd" _contents "${_contents}")
+endif()
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libspeex.def"
   "${_contents}\n"
   "speex_nb_mode\n"
   "speex_wb_mode\n"
   "speex_uwb_mode\n"
+  "speex_mode_list\n"
+  "speex_header_free\n"
 )
 
 set(SRC

--- a/ports/speex/CMakeLists.txt
+++ b/ports/speex/CMakeLists.txt
@@ -16,7 +16,9 @@ include_directories(win32 include)
 set(CMAKE_DEBUG_POSTFIX d)
 
 file(READ "win32/libspeex.def" _contents)
-string(REPLACE "LIBRARY libspeex" "LIBRARY libspeexd" _contents "${_contents}")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  string(REPLACE "LIBRARY libspeex" "LIBRARY libspeexd" _contents "${_contents}")
+endif()
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libspeex.def"
   "${_contents}\n"
   "speex_nb_mode\n"

--- a/ports/speex/CONTROL
+++ b/ports/speex/CONTROL
@@ -1,3 +1,3 @@
 Source: speex
-Version: 1.2.0-2
+Version: 1.2.0-3
 Description: Speex is an Open Source/Free Software patent-free audio compression format designed for speech.


### PR DESCRIPTION
Fixed .def file in release mode (it is bugged after #2293 fix in d5395ac793d1db78ab97ca144d5e89eabf49a735) https://github.com/Microsoft/vcpkg/issues/2293#issuecomment-350449317
Added exports for `speex_header_free` and `speex_mode_list` https://github.com/Microsoft/vcpkg/issues/2292#issuecomment-348773393