### PR TITLE
Add quotation marks to support user profiles with spaces in them

### DIFF
--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -403,7 +403,7 @@ namespace vcpkg::Metrics
         fs.write_contents(vcpkg_metrics_txt_path, payload);
 
         const std::string cmd_line =
-            Strings::format("start %s %s", temp_folder_path_exe.u8string(), vcpkg_metrics_txt_path.u8string());
+            Strings::format("start \"%s\" \"%s\"", temp_folder_path_exe.u8string(), vcpkg_metrics_txt_path.u8string());
         System::cmd_execute_clean(cmd_line);
 #endif
     }


### PR DESCRIPTION
When the user's main folder contains spaces, then the lack of quotation marks generates an error in metrics.cpp. Simply inserting these characters solves the problem nicely.