### PR TITLE
[tbb] Update to 2018_U2

### DIFF
--- a/ports/tbb/CONTROL
+++ b/ports/tbb/CONTROL
@@ -1,3 +1,3 @@
 Source: tbb
-Version: 2017_U7
+Version: 2018_U2
 Description: Intel's Threading Building Blocks.

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -5,17 +5,14 @@ endif()
 if (VCPKG_CRT_LINKAGE STREQUAL static)
     message(FATAL_ERROR "TBB does not currently support static crt linkage")
 endif()
-if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "TBB does not currently support UWP")
-endif()
 
 include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO 01org/tbb
-    REF 2017_U7
-    SHA512 e4a6fcc3cace9b57061e8661b09af9cb2be721224889af52f4c1b4faec1a130512b7c960e21171ebb8105593a81bd9b80bef20cda91bfac174d535d0f7ccb680
-    HEAD_REF tbb_2017)
+    REF 2018_U2
+    SHA512 a94b55bcabec47424be1c2d4b7bf3502a545bc714250a260e152b00431420094dbab64c0355bd0004ee9ad10d85c7b920969bf4b6d9a30b3697c7c5202518841
+    HEAD_REF tbb_2018)
 
 if(TRIPLET_SYSTEM_ARCH STREQUAL x86)
 	set(BUILD_ARCH Win32)
@@ -23,7 +20,9 @@ else()
 	set(BUILD_ARCH ${TRIPLET_SYSTEM_ARCH})
 endif()
 
-vcpkg_build_msbuild(PROJECT_PATH ${SOURCE_PATH}/build/vs2012/makefile.sln PLATFORM ${BUILD_ARCH})
+set(TBB_MSBUILD_PROJECT_DIR ${SOURCE_PATH}/build/vs2013)
+
+vcpkg_build_msbuild(PROJECT_PATH ${TBB_MSBUILD_PROJECT_DIR}/makefile.sln PLATFORM ${BUILD_ARCH})
 
 # Installation
 message(STATUS "Installing")
@@ -32,8 +31,8 @@ file(COPY
   ${SOURCE_PATH}/include/serial
   DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-set(DEBUG_OUTPUT_PATH ${SOURCE_PATH}/build/vs2012/${BUILD_ARCH}/Debug)
-set(RELEASE_OUTPUT_PATH ${SOURCE_PATH}/build/vs2012/${BUILD_ARCH}/Release)
+set(DEBUG_OUTPUT_PATH ${TBB_MSBUILD_PROJECT_DIR}/${BUILD_ARCH}/Debug)
+set(RELEASE_OUTPUT_PATH ${TBB_MSBUILD_PROJECT_DIR}/${BUILD_ARCH}/Release)
 
 file(COPY
   ${RELEASE_OUTPUT_PATH}/tbb.lib
@@ -59,7 +58,6 @@ file(COPY
 
 vcpkg_copy_pdbs()
 
-# Since 2017_U7 TBB provides a CMake script to generate config file
 include(${SOURCE_PATH}/cmake/TBBMakeConfig.cmake)
 tbb_make_config(TBB_ROOT ${CURRENT_PACKAGES_DIR}
     CONFIG_DIR TBB_CONFIG_DIR # is set to ${CURRENT_PACKAGES_DIR}/cmake


### PR DESCRIPTION
Note that UWP support was added in the [2018 version](https://software.intel.com/en-us/articles/intel-threading-building-blocks-release-notes).