### PR TITLE
[vcpkg-hash] Use cmake built-in hash commands instead of certutil.exe call

### DIFF
--- a/toolsrc/include/vcpkg/commands.h
+++ b/toolsrc/include/vcpkg/commands.h
@@ -119,7 +119,7 @@ namespace vcpkg::Commands
 
     namespace Hash
     {
-        void perform_and_exit(const VcpkgCmdArguments& args);
+        void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths);
     }
 
     template<class T>

--- a/toolsrc/src/vcpkg/commands.cpp
+++ b/toolsrc/src/vcpkg/commands.cpp
@@ -41,7 +41,9 @@ namespace vcpkg::Commands
             {"import", &Import::perform_and_exit},
             {"cache", &Cache::perform_and_exit},
             {"portsdiff", &PortsDiff::perform_and_exit},
-            {"autocomplete", &Autocomplete::perform_and_exit}};
+            {"autocomplete", &Autocomplete::perform_and_exit},
+            {"hash", &Hash::perform_and_exit},
+            };
         return t;
     }
 
@@ -49,8 +51,7 @@ namespace vcpkg::Commands
     {
         static std::vector<PackageNameAndFunction<CommandTypeC>> t = {
             {"version", &Version::perform_and_exit},
-            {"contact", &Contact::perform_and_exit},
-            {"hash", &Hash::perform_and_exit},
+            {"contact", &Contact::perform_and_exit}
         };
         return t;
     }

--- a/toolsrc/src/vcpkg/commands.hash.cpp
+++ b/toolsrc/src/vcpkg/commands.hash.cpp
@@ -7,15 +7,17 @@
 
 namespace vcpkg::Commands::Hash
 {
-    static void do_file_hash(fs::path const& path, std::string const& hash_type)
+    static void do_file_hash(fs::path const &cmake_exe_path, fs::path const& path, std::string const& hash_type)
     {
-        const auto cmd_line = Strings::format(R"(CertUtil.exe -hashfile "%s" %s)", path.u8string().c_str(), hash_type);
+        const std::string cmd_line = Strings::format(
+            R"("%s" -E %ssum %s)", cmake_exe_path.u8string(), Strings::ascii_to_lowercase(hash_type), path.u8string());
+
         const auto ec_data = System::cmd_execute_and_capture_output(cmd_line);
         Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
 
         std::string const& output = ec_data.output;
 
-        const auto start = output.find_first_of("\r\n");
+        const auto start = output.find_first_of(" ");
         Checks::check_exit(
             VCPKG_LINE_INFO, start != std::string::npos, "Unexpected output format from command: %s", cmd_line);
 
@@ -23,7 +25,7 @@ namespace vcpkg::Commands::Hash
         Checks::check_exit(
             VCPKG_LINE_INFO, end != std::string::npos, "Unexpected output format from command: %s", cmd_line);
 
-        auto hash = output.substr(start, end - start);
+        auto hash = output.substr(0, start);
         Util::erase_remove_if(hash, isspace);
         System::println(hash);
     }
@@ -37,17 +39,17 @@ namespace vcpkg::Commands::Hash
         nullptr,
     };
 
-    void perform_and_exit(const VcpkgCmdArguments& args)
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
         args.parse_arguments(COMMAND_STRUCTURE);
 
         if (args.command_arguments.size() == 1)
         {
-            do_file_hash(args.command_arguments[0], "SHA512");
+            do_file_hash(paths.get_cmake_exe(), args.command_arguments[0], "SHA512");
         }
         if (args.command_arguments.size() == 2)
         {
-            do_file_hash(args.command_arguments[0], args.command_arguments[1]);
+            do_file_hash(paths.get_cmake_exe(), args.command_arguments[0], args.command_arguments[1]);
         }
 
         Checks::exit_success(VCPKG_LINE_INFO);


### PR DESCRIPTION
For now vcpkg hash command call certutil.exe program. Cmake 3.10 -E mode gained support for sha1sum, sha224sum, sha256sum, sha384sum, and sha512sum.

This PR replacing certutil.exe call to cmake.exe -E call.

One step closer to crossplatform? 