### PR TITLE
[jack2] Initial port

### DIFF
--- a/ports/jack2/CMakeLists.txt
+++ b/ports/jack2/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.8)
+project(jack2 C)
+
+include_directories(common)
+
+add_library(jack2 STATIC common/JackWeakAPI.c)
+
+install(TARGETS jack2
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY common/jack DESTINATION include)

--- a/ports/jack2/CONTROL
+++ b/ports/jack2/CONTROL
@@ -1,0 +1,4 @@
+Source: jack2
+Version: 1.9.12.1
+Description: Cross-platform API that enables device sharing and inter-application audio routing
+

--- a/ports/jack2/CONTROL
+++ b/ports/jack2/CONTROL
@@ -1,4 +1,4 @@
 Source: jack2
-Version: 1.9.12.1
+Version: 1.9.12.2
 Description: Cross-platform API that enables device sharing and inter-application audio routing
 

--- a/ports/jack2/portfile.cmake
+++ b/ports/jack2/portfile.cmake
@@ -1,0 +1,35 @@
+include(vcpkg_common_functions)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "WindowsStore not supported")
+endif()
+
+set(VERSION 1.9.12)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/jack2-${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/jackaudio/jack2/releases/download/v${VERSION}/jack2-${VERSION}.tar.gz"
+    FILENAME "jack2-${VERSION}.tar.gz"
+    SHA512 f0271dfc8f8e2f2489ca52f431ad4fa420665816d6c67a01a76da1d4b5ae91f6dad8c4e3309ec5e0c159c9d312ed56021ab323d74bce828ace26f1b8d477ddfa
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+# Install headers and a statically built JackWeakAPI.c
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_install_cmake()
+
+# Remove duplicate headers
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/jack2 RENAME copyright)

--- a/ports/jack2/portfile.cmake
+++ b/ports/jack2/portfile.cmake
@@ -5,19 +5,13 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "WindowsStore not supported")
-endif()
-
-set(VERSION 1.9.12)
-
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/jack2-${VERSION})
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/jackaudio/jack2/releases/download/v${VERSION}/jack2-${VERSION}.tar.gz"
-    FILENAME "jack2-${VERSION}.tar.gz"
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jackaudio/jack2
+    REF v1.9.12
     SHA512 f0271dfc8f8e2f2489ca52f431ad4fa420665816d6c67a01a76da1d4b5ae91f6dad8c4e3309ec5e0c159c9d312ed56021ab323d74bce828ace26f1b8d477ddfa
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 # Install headers and a statically built JackWeakAPI.c
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
jack2 - Client library for JACK on Windows
http://www.jackaudio.org/faq/jack_on_windows.html
https://github.com/jackaudio/jack2

This package installs the jack headers and a static library built from JackWeakAPI.c, which is what JACK clients typically use on Windows.

Am torn about the package name; "jack", or "jack-weakapi", "jack-client" might be as good names. jack1/jack2 are different implementations of the same API headers, but jack2 runs on windows, and is what this package is based off.