### PR TITLE
Add support for Box2D to be build as a static library

### DIFF
--- a/ports/box2d/portfile.cmake
+++ b/ports/box2d/portfile.cmake
@@ -7,9 +7,6 @@ elseif(TRIPLET_SYSTEM_ARCH MATCHES "arm")
     message(FATAL_ERROR "ARM not supported")
 endif(TRIPLET_SYSTEM_ARCH MATCHES "x86")
 
-if(NOT VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-  message(FATAL_ERROR "Box2d only supports dynamic CRT linkage")
-endif()
 
 include(vcpkg_common_functions)
 
@@ -24,6 +21,14 @@ vcpkg_from_github(
     SHA512 39074bab01b36104aa685bfe39b40eb903d9dfb54cc3ba8098125db5291f55a8a9e578fc59563b2e8743abbbb26f419be7ae1524e235e7bd759257f99ff96bda
     HEAD_REF master
 )
+
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/use-static-linkage.patch
+    )
+endif()
 
 # Put the licence and readme files where vcpkg expects it
 message(STATUS "Packaging license")

--- a/ports/box2d/use-static-linkage.patch
+++ b/ports/box2d/use-static-linkage.patch
@@ -1,0 +1,40 @@
+diff --git a/Box2D/Build/vs2015/Box2D.vcxproj b/Box2D/Build/vs2015/Box2D.vcxproj
+index 830803c..5dda519 100644
+--- a/Box2D/Build/vs2015/Box2D.vcxproj
++++ b/Box2D/Build/vs2015/Box2D.vcxproj
+@@ -86,7 +86,7 @@
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <PrecompiledHeader>
+       </PrecompiledHeader>
+@@ -115,7 +115,7 @@
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <PrecompiledHeader>
+       </PrecompiledHeader>
+@@ -145,7 +145,7 @@
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>false</MinimalRebuild>
+       <StringPooling>true</StringPooling>
+-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <PrecompiledHeader>
+       </PrecompiledHeader>
+@@ -176,7 +176,7 @@
+       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>false</MinimalRebuild>
+       <StringPooling>true</StringPooling>
+-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <PrecompiledHeader>
+       </PrecompiledHeader>


### PR DESCRIPTION
The build for Box2D seems to have dynamic linking hardcoded into the VCXPROJ files and a hardcoded fatal error in the ports file to disable linking as a static library. 

This PR patches the vcxproj file in case we request a static library.

