### PR TITLE
[dlib] Use vcpkg version of BLAS and LAPACK

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,10 +1,7 @@
 Source: dlib
 Version: 19.8
-Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3
+Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas, clapack
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
-
-Feature: blas
-Description: BLAS support for dlib
 
 Feature: cuda
 Build-Depends: cuda

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -17,11 +17,6 @@ file(READ "${SOURCE_PATH}/dlib/CMakeLists.txt" DLIB_CMAKE)
 string(REPLACE "PNG_LIBRARY" "PNG_LIBRARIES" DLIB_CMAKE "${DLIB_CMAKE}")
 file(WRITE "${SOURCE_PATH}/dlib/CMakeLists.txt" "${DLIB_CMAKE}")
 
-set(WITH_BLAS OFF)
-if("blas" IN_LIST FEATURES)
-  set(WITH_BLAS ON)
-endif()
-
 set(WITH_CUDA OFF)
 if("cuda" IN_LIST FEATURES)
   set(WITH_CUDA ON)
@@ -35,8 +30,8 @@ vcpkg_configure_cmake(
         -DDLIB_USE_FFTW=ON
         -DDLIB_PNG_SUPPORT=ON
         -DDLIB_JPEG_SUPPORT=ON
-        -DDLIB_USE_BLAS=${WITH_BLAS}
-        -DDLIB_USE_LAPACK=OFF
+        -DDLIB_USE_BLAS=ON
+        -DDLIB_USE_LAPACK=ON
         -DDLIB_USE_CUDA=${WITH_CUDA}
         -DDLIB_GIF_SUPPORT=OFF
         -DDLIB_USE_MKL_FFT=OFF


### PR DESCRIPTION
The new version of dlib, 19.8, detects the versions of BLAS and LAPACK provided by vcpkg correctly.
This PR modifies the dlib portfiles to install and detect these packages