### PR TITLE
Install sqlite3.exe as part of sqlite3 port

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.0)
 project(sqlite3 C)
 
-include_directories(${SOURCE})
+include_directories(.)
 if(BUILD_SHARED_LIBS)
     set(API "-DSQLITE_API=__declspec(dllexport)")
 else()
     set(API "-DSQLITE_API=extern")
 endif()
-add_library(sqlite3 ${SOURCE}/sqlite3.c)
-
+add_library(sqlite3 sqlite3.c)
 
 target_compile_definitions(sqlite3 PRIVATE 
     $<$<CONFIG:Debug>:-DSQLITE_DEBUG>
@@ -18,18 +17,16 @@ target_compile_definitions(sqlite3 PRIVATE
     )
 target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE:include>)
 
-if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
+if(CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()
 
-
 if(NOT SQLITE3_SKIP_TOOLS)
-    add_executable(sqlite3-bin ${SOURCE}/shell.c)
+    add_executable(sqlite3-bin shell.c)
     set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME sqlite3)
     target_link_libraries(sqlite3-bin PRIVATE sqlite3)
     install(TARGETS sqlite3-bin sqlite3 RUNTIME DESTINATION tools)
 endif()
-
 
 install(TARGETS sqlite3 EXPORT sqlite3Config
     RUNTIME DESTINATION bin
@@ -37,5 +34,5 @@ install(TARGETS sqlite3 EXPORT sqlite3Config
     ARCHIVE DESTINATION lib
 )
 
-install(FILES ${SOURCE}/sqlite3.h ${SOURCE}/sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
+install(FILES sqlite3.h sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
 install(EXPORT sqlite3Config DESTINATION share/sqlite3)

--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -22,10 +22,20 @@ if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
     target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()
 
-install(TARGETS sqlite3 EXPORT sqlite3Config    
+
+if(NOT SQLITE3_SKIP_TOOLS)
+    add_executable(sqlite3-bin ${SOURCE}/shell.c)
+    set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME sqlite3)
+    target_link_libraries(sqlite3-bin PRIVATE sqlite3)
+    install(TARGETS sqlite3-bin sqlite3 RUNTIME DESTINATION tools)
+endif()
+
+
+install(TARGETS sqlite3 EXPORT sqlite3Config
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
+
 install(FILES ${SOURCE}/sqlite3.h ${SOURCE}/sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
 install(EXPORT sqlite3Config DESTINATION share/sqlite3)

--- a/ports/sqlite3/CONTROL
+++ b/ports/sqlite3/CONTROL
@@ -1,3 +1,6 @@
 Source: sqlite3
-Version: 3.21.0
+Version: 3.21.0-1
 Description: SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.
+
+Feature: tool
+Description: sqlite3 executable

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -12,14 +12,20 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+set(SQLITE3_SKIP_TOOLS ON)
+if("tool" IN_LIST FEATURES)
+    set(SQLITE3_SKIP_TOOLS OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DSOURCE=${SOURCE_PATH}
-        -DVCPKG_CMAKE_SYSTEM_NAME=${VCPKG_CMAKE_SYSTEM_NAME}
+        -DSQLITE3_SKIP_TOOLS=${SQLITE3_SKIP_TOOLS}
+    OPTIONS_DEBUG
+        -DSQLITE3_SKIP_TOOLS=ON
 )
-vcpkg_build_cmake()
+
 vcpkg_install_cmake()
 
 file(READ ${CURRENT_PACKAGES_DIR}/debug/share/sqlite3/sqlite3Config-debug.cmake SQLITE3_DEBUG_CONFIG)


### PR DESCRIPTION
The sqlite3.exe command line shell is very helpful when learning or using sqlite3.  The shell source comes with the amalgamated source drop, so let's build and install it as part of the vcpkg port.

- Modeled after the bzip2 port: If SQLITE3_SKIP_TOOLS is not
  set, build and install sqlite3.exe as part of the sqlite3
  package.  sqlite3.dll must also be copied to the tools folder
  for sqlite3.exe to be able to launch.
- Tested on Windows 10.0.16299.125 with VS 2017 15.5.2 using: .\vcpkg install sqlite3:x86-windows sqlite3:x64-windows