### PR TITLE
[cgal] Fix installation with --head

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,4 +1,4 @@
 Source: cgal
-Version: 4.11-1
+Version: 4.11-2
 Build-Depends: mpfr, mpir, zlib, qt5, boost-format, boost-container, boost-iterator, boost-variant, boost-any, boost-unordered, boost-random
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -11,11 +11,13 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DCGAL_INSTALL_CMAKE_DIR=share/cgal
 )
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/CGAL")
+vcpkg_fixup_cmake_targets()
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
In the CGAL head version the default install path for the cmake files has been changed from `lib/CGAL` to `lib/cmake/CGAL` which makes the `vcpkg_fixup_cmake_targets` fail.

This PR sets the option `CGAL_INSTALL_CMAKE_DIR` to force the installation of the CMake files into the folder that vcpkg prefers. This changes works with the current stable release 4.11 and the next upcoming version 4.12 of CGAL.