### PR TITLE
make parallel support optional

### DIFF
--- a/ports/hdf5/CONTROL
+++ b/ports/hdf5/CONTROL
@@ -1,5 +1,5 @@
 Source: hdf5
-Version: 1.10.1
+Version: 1.10.1-1
 Description: HDF5 is a data model, library, and file format for storing and managing data
 Build-Depends: zlib, szip
 

--- a/ports/hdf5/CONTROL
+++ b/ports/hdf5/CONTROL
@@ -1,4 +1,8 @@
 Source: hdf5
 Version: 1.10.1
 Description: HDF5 is a data model, library, and file format for storing and managing data
-Build-Depends: zlib, szip, msmpi
+Build-Depends: zlib, szip
+
+Feature: parallel
+Description: parallel support for HDF5
+Build-Depends: msmpi

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -21,6 +21,12 @@ vcpkg_apply_patches(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" DISABLE_STATIC_LIBS)
 
+if ("parallel" IN_LIST FEATURES)
+    set(ENABLE_PARALLEL ON)
+else()
+    set(ENABLE_PARALLEL OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -30,7 +36,7 @@ vcpkg_configure_cmake(
         -DHDF5_BUILD_EXAMPLES=OFF
         -DHDF5_BUILD_TOOLS=OFF
         -DHDF5_BUILD_CPP_LIB=OFF
-        -DHDF5_ENABLE_PARALLEL=ON
+        -DHDF5_ENABLE_PARALLEL=${ENABLE_PARALLEL}
         -DHDF5_ENABLE_Z_LIB_SUPPORT=ON
         -DHDF5_ENABLE_SZIP_SUPPORT=ON
         -DHDF5_ENABLE_SZIP_ENCODING=ON


### PR DESCRIPTION
It is more friendly to not force user to install msmpi. HDF5 library should also work without MPI support, and some development environment does not allow user to launch msmpi setup installer.