### PR TITLE
Add missing version.rc file to sdl2 libraries.

### DIFF
--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(SDL2_image
     IMG_xpm.c
     IMG_xv.c
     IMG_xxx.c
+    version.rc
     )
 
 set_target_properties(SDL2_image PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)

--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-image
-Version: 2.0.2
+Version: 2.0.2-1
 Build-Depends: sdl2, libpng, libjpeg-turbo, tiff, libwebp
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV
 

--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -68,7 +68,8 @@ add_library(SDL2_mixer
     music_timidity.c
     music_wav.c
     native_midi/native_midi_common.c
-    native_midi/native_midi_win32.c)
+    native_midi/native_midi_win32.c
+    version.rc)
 
 set_target_properties(SDL2_mixer PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_compile_definitions(SDL2_mixer PRIVATE ${SDL_MIXER_DEFINES})

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-mixer
-Version: 2.0.2-1
+Version: 2.0.2-2
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2, libflac, mpg123, libmodplug, libvorbis

--- a/ports/sdl2-net/CMakeLists.txt
+++ b/ports/sdl2-net/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244 /wd4996")
 find_path(SDL_INCLUDE_DIR SDL2/SDL.h)
 find_library(SDL_LIBRARY NAMES SDL2d SDL2)
 
-add_library(SDL2_net SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c)
+add_library(SDL2_net SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c version.rc)
 
 set_target_properties(SDL2_net PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_compile_definitions(SDL2_net PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)

--- a/ports/sdl2-net/CONTROL
+++ b/ports/sdl2-net/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-net
-Version: 2.0.1-3
+Version: 2.0.1-4
 Description: Networking library for SDL
 Build-Depends: sdl2

--- a/ports/sdl2-ttf/CMakeLists.txt
+++ b/ports/sdl2-ttf/CMakeLists.txt
@@ -5,7 +5,7 @@ find_path(SDL_INCLUDE_DIR SDL2/SDL.h)
 find_library(SDL_LIBRARY NAMES SDL2d SDL2)
 find_package(FreeType REQUIRED)
 
-add_library(SDL2_ttf SDL_ttf.c)
+add_library(SDL2_ttf SDL_ttf.c version.rc)
 
 set_target_properties(SDL2_ttf PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_include_directories(SDL2_ttf PRIVATE ${SDL_INCLUDE_DIR}/SDL2 ${FREETYPE_INCLUDE_DIR_ft2build})

--- a/ports/sdl2-ttf/CONTROL
+++ b/ports/sdl2-ttf/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-ttf
-Version: 2.0.14-3
+Version: 2.0.14-4
 Description: A library for rendering TrueType fonts with SDL
 Build-Depends: sdl2, freetype


### PR DESCRIPTION
Affected sdl2 libraries:
- sdl2-image
- sdl2-mixer
- sdl2-net
- sdl2-ttf