### PR TITLE
[date] Update HowardHinnant/date to 2.4

### DIFF
--- a/ports/date/CMakeLists.txt
+++ b/ports/date/CMakeLists.txt
@@ -14,8 +14,6 @@ add_library(tz src/tz.cpp)
 
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(tz PRIVATE -DDATE_BUILD_DLL)
-else()
-  target_compile_definitions(tz PRIVATE -DDATE_BUILD_LIB)
 endif()
 
 install(

--- a/ports/date/CONTROL
+++ b/ports/date/CONTROL
@@ -1,3 +1,3 @@
 Source: date
-Version: 2.3-c286981b3bf83c79554769df68b27415cee68d77
+Version: 2.4
 Description: A date and time library based on the C++11/14/17 <chrono> header

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -25,4 +25,11 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
+set(HEADER "${CURRENT_PACKAGES_DIR}/include/date/tz.h")
+file(READ "${HEADER}" _contents)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  string(REPLACE "ifdef DATE_BUILD_DLL" "if 1" _contents "${_contents}")
+endif()
+file(WRITE "${HEADER}" "${_contents}")
+
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/date RENAME copyright)

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -8,8 +8,8 @@ message(WARNING
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO HowardHinnant/date
-  REF c286981b3bf83c79554769df68b27415cee68d77
-  SHA512 226e2cbc2598fbbe3a451664b017ab5b4314a682a9303268bd531931ea23baa4c9677c4433a87dbbc4a7d960dcfad1fcb632ac430d5d81c9909bcc567cf7eadf
+  REF v2.4
+  SHA512 01bcc021ebf9ca0ac88c797896a291ff81834e7fae37323ad20881d3a172963c04d3c7bea0dd37cd945b756ab7f70f0a02edb18a085bf9abf8d8f10056f73f3c
   HEAD_REF master
 )
 
@@ -24,15 +24,5 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
-
-set(HEADER "${CURRENT_PACKAGES_DIR}/include/date/tz.h")
-file(READ "${HEADER}" _contents)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-  string(REPLACE "DATE_BUILD_DLL" "1" _contents "${_contents}")
-else()
-  string(REPLACE "DATE_BUILD_LIB" "1" _contents "${_contents}")
-endif()
-file(WRITE "${HEADER}" "${_contents}")
-
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/date RENAME copyright)


### PR DESCRIPTION
Updated to the latest tagged release.
I also removed the code replacing DATE_BUILD_DLL to 1 for dynamic linkage and DATE_BUILD_LIB to 1 for static linkage because I don't understand the purpose of that code and I fully admit that this might be my shortcoming here, but all it does for me is break tz.h include file by changing `#ifdef DATE_BUILD_DLL` to `#ifdef 1` which doesn't compile and in case of replacing DATE_BUILD_LIB I suppose it doesn't do anything since I can't find occurrences of DATE_BUILD_LIB anywhere in tz.h