### PR TITLE
Introduce catch classic

### DIFF
--- a/ports/catch-classic/CONTROL
+++ b/ports/catch-classic/CONTROL
@@ -1,5 +1,5 @@
 Source: catch-classic
-Version: 1.11.0
+Version: 1.12.0
 Description: A modern, header-only test framework for unit tests
  This is specifically the legacy 1.x branch provided for compatibility
  with older compilers.

--- a/ports/catch-classic/CONTROL
+++ b/ports/catch-classic/CONTROL
@@ -1,5 +1,5 @@
 Source: catch-classic
-Version: 1.10.0
+Version: 1.11.0
 Description: A modern, header-only test framework for unit tests
  This is specifically the legacy 1.x branch provided for compatibility
  with older compilers.

--- a/ports/catch-classic/CONTROL
+++ b/ports/catch-classic/CONTROL
@@ -1,0 +1,5 @@
+Source: catch-classic
+Version: 1.10.0
+Description: A modern, header-only test framework for unit tests
+ This is specifically the legacy 1.x branch provided for compatibility
+ with older compilers.

--- a/ports/catch-classic/portfile.cmake
+++ b/ports/catch-classic/portfile.cmake
@@ -1,0 +1,18 @@
+include(vcpkg_common_functions)
+
+set(CATCH_VERSION v1.10.0)
+
+vcpkg_download_distfile(HEADER
+    URLS "https://github.com/catchorg/Catch2/releases/download/${CATCH_VERSION}/catch.hpp"
+    FILENAME "catch-classic-${CATCH_VERSION}.hpp"
+    SHA512 275ab5b5d778cc8a91b5f3e8f241a37b680c81d1b8945ff64ad16a9708c98e6535b389746bf8cacbed07f874629f456b56bafbf1879c5a6f84fa87675c1361b6
+)
+
+vcpkg_download_distfile(LICENSE
+    URLS "https://raw.githubusercontent.com/catchorg/Catch2/${CATCH_VERSION}/LICENSE.txt"
+    FILENAME "catch-classic-LICENSE-${CATCH_VERSION}.txt"
+    SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
+)
+
+file(INSTALL ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME catch.hpp)
+file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch-classic RENAME copyright)

--- a/ports/catch-classic/portfile.cmake
+++ b/ports/catch-classic/portfile.cmake
@@ -1,11 +1,11 @@
 include(vcpkg_common_functions)
 
-set(CATCH_VERSION v1.10.0)
+set(CATCH_VERSION v1.11.0)
 
 vcpkg_download_distfile(HEADER
     URLS "https://github.com/catchorg/Catch2/releases/download/${CATCH_VERSION}/catch.hpp"
     FILENAME "catch-classic-${CATCH_VERSION}.hpp"
-    SHA512 275ab5b5d778cc8a91b5f3e8f241a37b680c81d1b8945ff64ad16a9708c98e6535b389746bf8cacbed07f874629f456b56bafbf1879c5a6f84fa87675c1361b6
+    SHA512 8ce490cfa433ec1c6b6460d76e1d9a6502966ada96fec7290fe9827a965751f3d572e97b93bbbb5e2bc97ffcf70bb547a050405b80a1a816054bd6afd1208cbe
 )
 
 vcpkg_download_distfile(LICENSE

--- a/ports/catch-classic/portfile.cmake
+++ b/ports/catch-classic/portfile.cmake
@@ -1,11 +1,11 @@
 include(vcpkg_common_functions)
 
-set(CATCH_VERSION v1.11.0)
+set(CATCH_VERSION v1.12.0)
 
 vcpkg_download_distfile(HEADER
     URLS "https://github.com/catchorg/Catch2/releases/download/${CATCH_VERSION}/catch.hpp"
     FILENAME "catch-classic-${CATCH_VERSION}.hpp"
-    SHA512 8ce490cfa433ec1c6b6460d76e1d9a6502966ada96fec7290fe9827a965751f3d572e97b93bbbb5e2bc97ffcf70bb547a050405b80a1a816054bd6afd1208cbe
+    SHA512 0334993982a4543a42b301b77622dbc7df9e9c53dfe4e49a7b32cafea59f999e057777e94e719ecc0aafebc02fa937243d7ea6301be086a2dbd9f52b0d61d807
 )
 
 vcpkg_download_distfile(LICENSE


### PR DESCRIPTION
As talked about in #2310, we needed to introduce a bugfix release for the 1.x version that supports C++98 and is otherwise considered obsolete. To avoid weird history in the main Catch port, I introduced a `catch-classic` and backfilled some of the Catch1.x releases there.
