### PR TITLE
Add specific port for Catch2

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,0 +1,5 @@
+Source: catch2
+Version: 2.1.0
+Description: A modern, header-only test framework for unit testing
+
+Issues, PRs and changelogs can be found at https://github.com/catchorg/Catch2

--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,5 +1,4 @@
 Source: catch2
 Version: 2.1.0
-Description: A modern, header-only test framework for unit testing
-
-Issues, PRs and changelogs can be found at https://github.com/catchorg/Catch2
+Description: A modern, header-only test framework for unit testing.
+  Issues, PRs and changelogs can be found at https://github.com/catchorg/Catch2

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,0 +1,18 @@
+include(vcpkg_common_functions)
+
+set(CATCH_VERSION v2.1.0)
+
+vcpkg_download_distfile(HEADER
+    URLS "https://github.com/catchorg/Catch2/releases/download/${CATCH_VERSION}/catch.hpp"
+    FILENAME "catch-${CATCH_VERSION}.hpp"
+    SHA512 6c2b9d4337369362b9079ac4eb53481e2db2a235af6ed0fa9d178775336a5c2d6aba1f86967f53de736aa198ae9d1acadd15a8c3ae2348c7dec0450e6452c716
+)
+
+vcpkg_download_distfile(LICENSE
+    URLS "https://raw.githubusercontent.com/catchorg/Catch2/${CATCH_VERSION}/LICENSE.txt"
+    FILENAME "catch-LICENSE-${CATCH_VERSION}.txt"
+    SHA512 f1a8d21ccbb6436d289ecfae65b9019278e40552a2383aaf6c1dfed98affe6e7bbf364d67597a131642b62446a0c40495e66a7efca7e6dff72727c6fd3776407
+)
+
+file(INSTALL ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME catch.hpp)
+file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch RENAME copyright)

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -4,15 +4,15 @@ set(CATCH_VERSION v2.1.0)
 
 vcpkg_download_distfile(HEADER
     URLS "https://github.com/catchorg/Catch2/releases/download/${CATCH_VERSION}/catch.hpp"
-    FILENAME "catch-${CATCH_VERSION}.hpp"
-    SHA512 6c2b9d4337369362b9079ac4eb53481e2db2a235af6ed0fa9d178775336a5c2d6aba1f86967f53de736aa198ae9d1acadd15a8c3ae2348c7dec0450e6452c716
+    FILENAME "catchorg-catch2-${CATCH_VERSION}.hpp"
+    SHA512 967a9b4046ec2c72f094bebae381b5090e88358faefde9bdbca3d7e058c299c1bed0542653de79c857f78139d7969b0815bb8b8a60ff13e2144fcb7af2a2020c
 )
 
 vcpkg_download_distfile(LICENSE
     URLS "https://raw.githubusercontent.com/catchorg/Catch2/${CATCH_VERSION}/LICENSE.txt"
-    FILENAME "catch-LICENSE-${CATCH_VERSION}.txt"
-    SHA512 f1a8d21ccbb6436d289ecfae65b9019278e40552a2383aaf6c1dfed98affe6e7bbf364d67597a131642b62446a0c40495e66a7efca7e6dff72727c6fd3776407
+    FILENAME "catchorg-catch2-LICENSE-${CATCH_VERSION}.txt"
+    SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
 )
 
 file(INSTALL ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME catch.hpp)
-file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch RENAME copyright)
+file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch2 RENAME copyright)


### PR DESCRIPTION
The next step is going to be to make the current `catch` dependent on `catch2` for backcompat.

Ideally there would be a way to mark it as obsolete, but I couldn't find any.