### PR TITLE
[cpr] Fixed wrong include folder

### DIFF
--- a/ports/cpr/enable-install.patch
+++ b/ports/cpr/enable-install.patch
@@ -13,5 +13,5 @@ index a6db5bd..b4982d1 100644
 +    ARCHIVE DESTINATION lib
 +)
 +if(NOT DISABLE_INSTALL_HEADERS)
-+    install(DIRECTORY ${CPR_INCLUDE_DIRS} DESTINATION include)
++    install(DIRECTORY ${CPR_INCLUDE_DIRS}/cpr DESTINATION include)
 +endif()


### PR DESCRIPTION
The port used to install include header into "include/cpr" instead of "cpr". As a result, attempting to use the cpr header would fail as the header includes "cpr/\<header file\>". In addition having to include "\<include/cpr/cpr.h\>" breaks the general vcpkg conventions.