### PR TITLE
[caffe] Add new port

### DIFF
--- a/ports/caffe/0001-Use-vcpkg-dependencies.patch
+++ b/ports/caffe/0001-Use-vcpkg-dependencies.patch
@@ -1,0 +1,334 @@
+From 25b4021cb8af2be69df50a052e8eaaf11cb48cba Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Wed, 10 Jan 2018 19:05:14 +0100
+Subject: [PATCH 1/9] Use vcpkg dependencies.
+
+---
+ cmake/Dependencies.cmake       | 19 ++++++--------
+ cmake/External/gflags.cmake    | 56 -----------------------------------------
+ cmake/External/glog.cmake      | 57 ------------------------------------------
+ cmake/Modules/FindGFlags.cmake | 50 ------------------------------------
+ cmake/Modules/FindGlog.cmake   | 48 -----------------------------------
+ cmake/ProtoBuf.cmake           |  9 +++----
+ 6 files changed, 12 insertions(+), 227 deletions(-)
+ delete mode 100644 cmake/External/gflags.cmake
+ delete mode 100644 cmake/External/glog.cmake
+ delete mode 100644 cmake/Modules/FindGFlags.cmake
+ delete mode 100644 cmake/Modules/FindGlog.cmake
+
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index 4a5bac47..f8062c9e 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -5,7 +5,7 @@ set(Caffe_DEFINITIONS "")
+ set(Caffe_COMPILE_OPTIONS "")
+ 
+ # ---[ Boost
+-find_package(Boost 1.55 REQUIRED COMPONENTS system thread filesystem)
++find_package(Boost REQUIRED COMPONENTS system thread filesystem)
+ list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${Boost_INCLUDE_DIRS})
+ list(APPEND Caffe_LINKER_LIBS PUBLIC ${Boost_LIBRARIES})
+ 
+@@ -30,22 +30,19 @@ if(USE_OPENMP)
+ endif()
+ 
+ # ---[ Google-glog
+-include("cmake/External/glog.cmake")
+-list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${GLOG_INCLUDE_DIRS})
+-list(APPEND Caffe_LINKER_LIBS PUBLIC ${GLOG_LIBRARIES})
++find_package(glog REQUIRED)
++list(APPEND Caffe_LINKER_LIBS PUBLIC glog::glog)
+ 
+ # ---[ Google-gflags
+-include("cmake/External/gflags.cmake")
+-list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${GFLAGS_INCLUDE_DIRS})
+-list(APPEND Caffe_LINKER_LIBS PUBLIC ${GFLAGS_LIBRARIES})
++find_package(gflags REQUIRED)
++list(APPEND Caffe_LINKER_LIBS PUBLIC gflags)
+ 
+ # ---[ Google-protobuf
+ include(cmake/ProtoBuf.cmake)
+ 
+ # ---[ HDF5
+-find_package(HDF5 COMPONENTS HL REQUIRED)
+-list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${HDF5_INCLUDE_DIRS})
+-list(APPEND Caffe_LINKER_LIBS PUBLIC ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
++find_package(hdf5 COMPONENTS HL REQUIRED)
++list(APPEND Caffe_LINKER_LIBS PUBLIC hdf5-shared hdf5_hl-shared)
+ 
+ # ---[ LMDB
+ if(USE_LMDB)
+@@ -114,7 +111,7 @@ if(NOT APPLE)
+     list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${Atlas_INCLUDE_DIR})
+     list(APPEND Caffe_LINKER_LIBS PUBLIC ${Atlas_LIBRARIES})
+   elseif(BLAS STREQUAL "Open" OR BLAS STREQUAL "open")
+-    find_package(OpenBLAS REQUIRED)
++    find_package(openblas REQUIRED)
+     list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${OpenBLAS_INCLUDE_DIR})
+     list(APPEND Caffe_LINKER_LIBS PUBLIC ${OpenBLAS_LIB})
+   elseif(BLAS STREQUAL "MKL" OR BLAS STREQUAL "mkl")
+diff --git a/cmake/External/gflags.cmake b/cmake/External/gflags.cmake
+deleted file mode 100644
+index e3dba04f..00000000
+--- a/cmake/External/gflags.cmake
++++ /dev/null
+@@ -1,56 +0,0 @@
+-if (NOT __GFLAGS_INCLUDED) # guard against multiple includes
+-  set(__GFLAGS_INCLUDED TRUE)
+-
+-  # use the system-wide gflags if present
+-  find_package(GFlags)
+-  if (GFLAGS_FOUND)
+-    set(GFLAGS_EXTERNAL FALSE)
+-  else()
+-    # gflags will use pthreads if it's available in the system, so we must link with it
+-    find_package(Threads)
+-
+-    # build directory
+-    set(gflags_PREFIX ${CMAKE_BINARY_DIR}/external/gflags-prefix)
+-    # install directory
+-    set(gflags_INSTALL ${CMAKE_BINARY_DIR}/external/gflags-install)
+-
+-    # we build gflags statically, but want to link it into the caffe shared library
+-    # this requires position-independent code
+-    if (UNIX)
+-        set(GFLAGS_EXTRA_COMPILER_FLAGS "-fPIC")
+-    endif()
+-
+-    set(GFLAGS_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
+-    set(GFLAGS_C_FLAGS ${CMAKE_C_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
+-
+-    ExternalProject_Add(gflags
+-      PREFIX ${gflags_PREFIX}
+-      GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+-      GIT_TAG "v2.1.2"
+-      UPDATE_COMMAND ""
+-      INSTALL_DIR ${gflags_INSTALL}
+-      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-                 -DCMAKE_INSTALL_PREFIX=${gflags_INSTALL}
+-                 -DBUILD_SHARED_LIBS=OFF
+-                 -DBUILD_STATIC_LIBS=ON
+-                 -DBUILD_PACKAGING=OFF
+-                 -DBUILD_TESTING=OFF
+-                 -DBUILD_NC_TESTS=OFF
+-                 -BUILD_CONFIG_TESTS=OFF
+-                 -DINSTALL_HEADERS=ON
+-                 -DCMAKE_C_FLAGS=${GFLAGS_C_FLAGS}
+-                 -DCMAKE_CXX_FLAGS=${GFLAGS_CXX_FLAGS}
+-      LOG_DOWNLOAD 1
+-      LOG_INSTALL 1
+-      )
+-
+-    set(GFLAGS_FOUND TRUE)
+-    set(GFLAGS_INCLUDE_DIRS ${gflags_INSTALL}/include)
+-    set(GFLAGS_LIBRARIES ${gflags_INSTALL}/lib/libgflags.a ${CMAKE_THREAD_LIBS_INIT})
+-    set(GFLAGS_LIBRARY_DIRS ${gflags_INSTALL}/lib)
+-    set(GFLAGS_EXTERNAL TRUE)
+-
+-    list(APPEND external_project_dependencies gflags)
+-  endif()
+-
+-endif()
+diff --git a/cmake/External/glog.cmake b/cmake/External/glog.cmake
+deleted file mode 100644
+index f9d0549c..00000000
+--- a/cmake/External/glog.cmake
++++ /dev/null
+@@ -1,57 +0,0 @@
+-# glog depends on gflags
+-include("cmake/External/gflags.cmake")
+-
+-if (NOT __GLOG_INCLUDED)
+-  set(__GLOG_INCLUDED TRUE)
+-
+-  # try the system-wide glog first
+-  find_package(Glog)
+-  if (GLOG_FOUND)
+-      set(GLOG_EXTERNAL FALSE)
+-  else()
+-    # fetch and build glog from github
+-
+-    # build directory
+-    set(glog_PREFIX ${CMAKE_BINARY_DIR}/external/glog-prefix)
+-    # install directory
+-    set(glog_INSTALL ${CMAKE_BINARY_DIR}/external/glog-install)
+-
+-    # we build glog statically, but want to link it into the caffe shared library
+-    # this requires position-independent code
+-    if (UNIX)
+-      set(GLOG_EXTRA_COMPILER_FLAGS "-fPIC")
+-    endif()
+-
+-    set(GLOG_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${GLOG_EXTRA_COMPILER_FLAGS})
+-    set(GLOG_C_FLAGS ${CMAKE_C_FLAGS} ${GLOG_EXTRA_COMPILER_FLAGS})
+-
+-    # depend on gflags if we're also building it
+-    if (GFLAGS_EXTERNAL)
+-      set(GLOG_DEPENDS gflags)
+-    endif()
+-
+-    ExternalProject_Add(glog
+-      DEPENDS ${GLOG_DEPENDS}
+-      PREFIX ${glog_PREFIX}
+-      GIT_REPOSITORY "https://github.com/google/glog"
+-      GIT_TAG "v0.3.4"
+-      UPDATE_COMMAND ""
+-      INSTALL_DIR ${gflags_INSTALL}
+-      PATCH_COMMAND autoreconf -i ${glog_PREFIX}/src/glog
+-      CONFIGURE_COMMAND env "CFLAGS=${GLOG_C_FLAGS}" "CXXFLAGS=${GLOG_CXX_FLAGS}" ${glog_PREFIX}/src/glog/configure --prefix=${glog_INSTALL} --enable-shared=no --enable-static=yes --with-gflags=${GFLAGS_LIBRARY_DIRS}/..
+-      LOG_DOWNLOAD 1
+-      LOG_CONFIGURE 1
+-      LOG_INSTALL 1
+-      )
+-
+-    set(GLOG_FOUND TRUE)
+-    set(GLOG_INCLUDE_DIRS ${glog_INSTALL}/include)
+-    set(GLOG_LIBRARIES ${GFLAGS_LIBRARIES} ${glog_INSTALL}/lib/libglog.a)
+-    set(GLOG_LIBRARY_DIRS ${glog_INSTALL}/lib)
+-    set(GLOG_EXTERNAL TRUE)
+-
+-    list(APPEND external_project_dependencies glog)
+-  endif()
+-
+-endif()
+-
+diff --git a/cmake/Modules/FindGFlags.cmake b/cmake/Modules/FindGFlags.cmake
+deleted file mode 100644
+index 29b60f05..00000000
+--- a/cmake/Modules/FindGFlags.cmake
++++ /dev/null
+@@ -1,50 +0,0 @@
+-# - Try to find GFLAGS
+-#
+-# The following variables are optionally searched for defaults
+-#  GFLAGS_ROOT_DIR:            Base directory where all GFLAGS components are found
+-#
+-# The following are set after configuration is done:
+-#  GFLAGS_FOUND
+-#  GFLAGS_INCLUDE_DIRS
+-#  GFLAGS_LIBRARIES
+-#  GFLAGS_LIBRARYRARY_DIRS
+-
+-include(FindPackageHandleStandardArgs)
+-
+-set(GFLAGS_ROOT_DIR "" CACHE PATH "Folder contains Gflags")
+-
+-# We are testing only a couple of files in the include directories
+-if(WIN32)
+-    find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+-        PATHS ${GFLAGS_ROOT_DIR}/src/windows)
+-else()
+-    find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+-        PATHS ${GFLAGS_ROOT_DIR})
+-endif()
+-
+-if(MSVC)
+-    find_library(GFLAGS_LIBRARY_RELEASE
+-        NAMES libgflags
+-        PATHS ${GFLAGS_ROOT_DIR}
+-        PATH_SUFFIXES Release)
+-
+-    find_library(GFLAGS_LIBRARY_DEBUG
+-        NAMES libgflags-debug
+-        PATHS ${GFLAGS_ROOT_DIR}
+-        PATH_SUFFIXES Debug)
+-
+-    set(GFLAGS_LIBRARY optimized ${GFLAGS_LIBRARY_RELEASE} debug ${GFLAGS_LIBRARY_DEBUG})
+-else()
+-    find_library(GFLAGS_LIBRARY gflags)
+-endif()
+-
+-find_package_handle_standard_args(GFlags DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
+-
+-
+-if(GFLAGS_FOUND)
+-    set(GFLAGS_INCLUDE_DIRS ${GFLAGS_INCLUDE_DIR})
+-    set(GFLAGS_LIBRARIES ${GFLAGS_LIBRARY})
+-    message(STATUS "Found gflags  (include: ${GFLAGS_INCLUDE_DIR}, library: ${GFLAGS_LIBRARY})")
+-    mark_as_advanced(GFLAGS_LIBRARY_DEBUG GFLAGS_LIBRARY_RELEASE
+-                     GFLAGS_LIBRARY GFLAGS_INCLUDE_DIR GFLAGS_ROOT_DIR)
+-endif()
+diff --git a/cmake/Modules/FindGlog.cmake b/cmake/Modules/FindGlog.cmake
+deleted file mode 100644
+index 99abbe47..00000000
+--- a/cmake/Modules/FindGlog.cmake
++++ /dev/null
+@@ -1,48 +0,0 @@
+-# - Try to find Glog
+-#
+-# The following variables are optionally searched for defaults
+-#  GLOG_ROOT_DIR:            Base directory where all GLOG components are found
+-#
+-# The following are set after configuration is done:
+-#  GLOG_FOUND
+-#  GLOG_INCLUDE_DIRS
+-#  GLOG_LIBRARIES
+-#  GLOG_LIBRARYRARY_DIRS
+-
+-include(FindPackageHandleStandardArgs)
+-
+-set(GLOG_ROOT_DIR "" CACHE PATH "Folder contains Google glog")
+-
+-if(WIN32)
+-    find_path(GLOG_INCLUDE_DIR glog/logging.h
+-        PATHS ${GLOG_ROOT_DIR}/src/windows)
+-else()
+-    find_path(GLOG_INCLUDE_DIR glog/logging.h
+-        PATHS ${GLOG_ROOT_DIR})
+-endif()
+-
+-if(MSVC)
+-    find_library(GLOG_LIBRARY_RELEASE libglog_static
+-        PATHS ${GLOG_ROOT_DIR}
+-        PATH_SUFFIXES Release)
+-
+-    find_library(GLOG_LIBRARY_DEBUG libglog_static
+-        PATHS ${GLOG_ROOT_DIR}
+-        PATH_SUFFIXES Debug)
+-
+-    set(GLOG_LIBRARY optimized ${GLOG_LIBRARY_RELEASE} debug ${GLOG_LIBRARY_DEBUG})
+-else()
+-    find_library(GLOG_LIBRARY glog
+-        PATHS ${GLOG_ROOT_DIR}
+-        PATH_SUFFIXES lib lib64)
+-endif()
+-
+-find_package_handle_standard_args(Glog DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
+-
+-if(GLOG_FOUND)
+-  set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})
+-  set(GLOG_LIBRARIES ${GLOG_LIBRARY})
+-  message(STATUS "Found glog    (include: ${GLOG_INCLUDE_DIR}, library: ${GLOG_LIBRARY})")
+-  mark_as_advanced(GLOG_ROOT_DIR GLOG_LIBRARY_RELEASE GLOG_LIBRARY_DEBUG
+-                                 GLOG_LIBRARY GLOG_INCLUDE_DIR)
+-endif()
+diff --git a/cmake/ProtoBuf.cmake b/cmake/ProtoBuf.cmake
+index 8005b448..d197c1b3 100644
+--- a/cmake/ProtoBuf.cmake
++++ b/cmake/ProtoBuf.cmake
+@@ -1,9 +1,8 @@
+ # Finds Google Protocol Buffers library and compilers and extends
+ # the standard cmake script with version and python generation support
+ 
+-find_package( Protobuf REQUIRED )
+-list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${PROTOBUF_INCLUDE_DIR})
+-list(APPEND Caffe_LINKER_LIBS PUBLIC ${PROTOBUF_LIBRARIES})
++find_package( Protobuf REQUIRED )#list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${PROTOBUF_INCLUDE_DIR})
++list(APPEND Caffe_LINKER_LIBS PUBLIC protobuf::libprotobuf)
+ 
+ # As of Ubuntu 14.04 protoc is no longer a part of libprotobuf-dev package
+ # and should be installed separately as in: sudo apt-get install protobuf-compiler
+@@ -77,8 +76,8 @@ function(caffe_protobuf_generate_cpp_py output_dir srcs_var hdrs_var python_var)
+              "${output_dir}/${fil_we}.pb.h"
+              "${output_dir}/${fil_we}_pb2.py"
+       COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}"
+-      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --cpp_out    ${output_dir} ${_protoc_include} ${abs_fil}
+-      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --python_out ${output_dir} ${_protoc_include} ${abs_fil}
++      COMMAND protobuf::protoc --cpp_out    ${output_dir} ${_protoc_include} ${abs_fil}
++      COMMAND protobuf::protoc --python_out ${output_dir} ${_protoc_include} ${abs_fil}
+       DEPENDS ${abs_fil}
+       COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
+   endforeach()
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0002-Fix-permissive-strict.patch
+++ b/ports/caffe/0002-Fix-permissive-strict.patch
@@ -1,0 +1,74 @@
+From 202c971d32a35f1e160ff952e4535d4fa7a198d2 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Wed, 10 Jan 2018 19:05:58 +0100
+Subject: [PATCH 2/9] Fix permissive/strict
+
+---
+ src/caffe/net.cpp                | 2 +-
+ src/caffe/proto/caffe.proto      | 8 ++++----
+ src/caffe/util/upgrade_proto.cpp | 8 ++++----
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/caffe/net.cpp b/src/caffe/net.cpp
+index 353c2f95..59349d35 100644
+--- a/src/caffe/net.cpp
++++ b/src/caffe/net.cpp
+@@ -471,7 +471,7 @@ void Net<Dtype>::AppendParam(const NetParameter& param, const int layer_id,
+         layers_[owner_layer_id]->blobs()[owner_param_id].get();
+     const int param_size = layer_param.param_size();
+     if (param_size > param_id && (layer_param.param(param_id).share_mode() ==
+-                                  ParamSpec_DimCheckMode_PERMISSIVE)) {
++                                  ParamSpec_DimCheckMode_PERMISSIVE_)) {
+       // Permissive dimension checking -- only check counts are the same.
+       CHECK_EQ(this_blob->count(), owner_blob->count())
+           << "Cannot share param '" << param_name << "' owned by layer '"
+diff --git a/src/caffe/proto/caffe.proto b/src/caffe/proto/caffe.proto
+index c96966b5..98b854d2 100644
+--- a/src/caffe/proto/caffe.proto
++++ b/src/caffe/proto/caffe.proto
+@@ -293,9 +293,9 @@ message ParamSpec {
+   optional DimCheckMode share_mode = 2;
+   enum DimCheckMode {
+     // STRICT (default) requires that num, channels, height, width each match.
+-    STRICT = 0;
++    STRICT_ = 0;
+     // PERMISSIVE requires only the count (num*channels*height*width) to match.
+-    PERMISSIVE = 1;
++    PERMISSIVE_ = 1;
+   }
+ 
+   // The multiplier on the global learning rate for this parameter.
+@@ -1268,8 +1268,8 @@ message V1LayerParameter {
+   repeated string param = 1001;
+   repeated DimCheckMode blob_share_mode = 1002;
+   enum DimCheckMode {
+-    STRICT = 0;
+-    PERMISSIVE = 1;
++    STRICT_ = 0;
++    PERMISSIVE_ = 1;
+   }
+   repeated float blobs_lr = 7;
+   repeated float weight_decay = 8;
+diff --git a/src/caffe/util/upgrade_proto.cpp b/src/caffe/util/upgrade_proto.cpp
+index 94771c8c..530de48b 100644
+--- a/src/caffe/util/upgrade_proto.cpp
++++ b/src/caffe/util/upgrade_proto.cpp
+@@ -719,11 +719,11 @@ bool UpgradeV1LayerParameter(const V1LayerParameter& v1_layer_param,
+   for (int i = 0; i < v1_layer_param.blob_share_mode_size(); ++i) {
+     while (layer_param->param_size() <= i) { layer_param->add_param(); }
+     switch (v1_layer_param.blob_share_mode(i)) {
+-    case V1LayerParameter_DimCheckMode_STRICT:
+-      mode = ParamSpec_DimCheckMode_STRICT;
++    case V1LayerParameter_DimCheckMode_STRICT_:
++      mode = ParamSpec_DimCheckMode_STRICT_;
+       break;
+-    case V1LayerParameter_DimCheckMode_PERMISSIVE:
+-      mode = ParamSpec_DimCheckMode_PERMISSIVE;
++    case V1LayerParameter_DimCheckMode_PERMISSIVE_:
++      mode = ParamSpec_DimCheckMode_PERMISSIVE_;
+       break;
+     default:
+       LOG(FATAL) << "Unknown blob_share_mode: "
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0003-MSVC-fixes.patch
+++ b/ports/caffe/0003-MSVC-fixes.patch
@@ -1,0 +1,181 @@
+From 0ec6bfcfd33ee645cea41d9bb6de374ff99d4de9 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 13 Jan 2018 17:31:06 +0100
+Subject: [PATCH 3/9] MSVC-fixes
+
+---
+ python/caffe/_caffe.cpp           |  6 ++++--
+ src/caffe/common.cpp              |  8 ++++++++
+ src/caffe/util/db_lmdb.cpp        |  5 +++++
+ src/caffe/util/io.cpp             | 11 ++++++++++-
+ src/caffe/util/signal_handler.cpp | 26 +++++++++++++++++++++++++-
+ 5 files changed, 52 insertions(+), 4 deletions(-)
+
+diff --git a/python/caffe/_caffe.cpp b/python/caffe/_caffe.cpp
+index d7f43fff..e7d54ba7 100644
+--- a/python/caffe/_caffe.cpp
++++ b/python/caffe/_caffe.cpp
+@@ -53,15 +53,17 @@ void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
+ 
+ void InitLog() {
+   ::google::InitGoogleLogging("");
++#if !defined(_MSC_VER)
+   ::google::InstallFailureSignalHandler();
++#endif
+ }
+ void InitLogLevel(int level) {
+   FLAGS_minloglevel = level;
+   InitLog();
+ }
+-void InitLogLevelPipe(int level, bool stderr) {
++void InitLogLevelPipe(int level, bool _stderr) {
+   FLAGS_minloglevel = level;
+-  FLAGS_logtostderr = stderr;
++  FLAGS_logtostderr = _stderr;
+   InitLog();
+ }
+ void Log(const string& s) {
+diff --git a/src/caffe/common.cpp b/src/caffe/common.cpp
+index 4f6f9bcc..319adabe 100644
+--- a/src/caffe/common.cpp
++++ b/src/caffe/common.cpp
+@@ -1,3 +1,8 @@
++#if defined(_MSC_VER)
++#include <process.h>
++#define getpid() _getpid()
++#endif
++
+ #include <boost/thread.hpp>
+ #include <glog/logging.h>
+ #include <cmath>
+@@ -46,7 +51,10 @@ void GlobalInit(int* pargc, char*** pargv) {
+   // Google logging.
+   ::google::InitGoogleLogging(*(pargv)[0]);
+   // Provide a backtrace on segfault.
++  // Windows port of glogs doesn't have this function built 
++#if !defined(_MSC_VER)
+   ::google::InstallFailureSignalHandler();
++#endif
+ }
+ 
+ #ifdef CPU_ONLY  // CPU-only Caffe.
+diff --git a/src/caffe/util/db_lmdb.cpp b/src/caffe/util/db_lmdb.cpp
+index 491a9bd0..fe9e562c 100644
+--- a/src/caffe/util/db_lmdb.cpp
++++ b/src/caffe/util/db_lmdb.cpp
+@@ -1,6 +1,11 @@
+ #ifdef USE_LMDB
+ #include "caffe/util/db_lmdb.hpp"
+ 
++#if defined(_MSC_VER)
++#include <direct.h>
++#define mkdir(X, Y) _mkdir(X)
++#endif
++
+ #include <sys/stat.h>
+ 
+ #include <string>
+diff --git a/src/caffe/util/io.cpp b/src/caffe/util/io.cpp
+index 835d2d4e..5736d35a 100644
+--- a/src/caffe/util/io.cpp
++++ b/src/caffe/util/io.cpp
+@@ -1,4 +1,9 @@
+ #include <fcntl.h>
++
++#if defined(_MSC_VER)
++#include <io.h>
++#endif
++
+ #include <google/protobuf/io/coded_stream.h>
+ #include <google/protobuf/io/zero_copy_stream_impl.h>
+ #include <google/protobuf/text_format.h>
+@@ -32,7 +37,11 @@ using google::protobuf::io::CodedOutputStream;
+ using google::protobuf::Message;
+ 
+ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
++#if defined (_MSC_VER)  // for MSC compiler binary flag needs to be specified 
++  int fd = open(filename, O_RDONLY | O_BINARY);
++#else
+   int fd = open(filename, O_RDONLY);
++#endif
+   CHECK_NE(fd, -1) << "File not found: " << filename;
+   FileInputStream* input = new FileInputStream(fd);
+   bool success = google::protobuf::TextFormat::Parse(input, proto);
+@@ -50,7 +59,7 @@ void WriteProtoToTextFile(const Message& proto, const char* filename) {
+ }
+ 
+ bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
+-  int fd = open(filename, O_RDONLY);
++  int fd = open(filename, O_RDONLY | O_BINARY);
+   CHECK_NE(fd, -1) << "File not found: " << filename;
+   ZeroCopyInputStream* raw_input = new FileInputStream(fd);
+   CodedInputStream* coded_input = new CodedInputStream(raw_input);
+diff --git a/src/caffe/util/signal_handler.cpp b/src/caffe/util/signal_handler.cpp
+index 5d764ec5..7b232fbd 100644
+--- a/src/caffe/util/signal_handler.cpp
++++ b/src/caffe/util/signal_handler.cpp
+@@ -13,9 +13,15 @@ namespace {
+ 
+   void handle_signal(int signal) {
+     switch (signal) {
++#ifdef _MSC_VER 
++    case SIGBREAK:  // there is no SIGHUP in windows, take SIGBREAK instead. 
++      got_sighup = true;
++      break;
++#else
+     case SIGHUP:
+       got_sighup = true;
+       break;
++#endif
+     case SIGINT:
+       got_sigint = true;
+       break;
+@@ -27,7 +33,15 @@ namespace {
+       LOG(FATAL) << "Tried to hookup signal handlers more than once.";
+     }
+     already_hooked_up = true;
+-
++
++#ifdef _MSC_VER
++    if (signal(SIGBREAK, handle_signal) == SIG_ERR) {
++      LOG(FATAL) << "Cannot install SIGBREAK handler.";
++    }
++    if (signal(SIGINT, handle_signal) == SIG_ERR) {
++      LOG(FATAL) << "Cannot install SIGINT handler.";
++    }
++#else
+     struct sigaction sa;
+     // Setup the handler
+     sa.sa_handler = &handle_signal;
+@@ -42,11 +56,20 @@ namespace {
+     if (sigaction(SIGINT, &sa, NULL) == -1) {
+       LOG(FATAL) << "Cannot install SIGINT handler.";
+     }
++#endif
+   }
+ 
+   // Set the signal handlers to the default.
+   void UnhookHandler() {
+     if (already_hooked_up) {
++#ifdef _MSC_VER
++      if (signal(SIGBREAK, SIG_DFL) == SIG_ERR) {
++        LOG(FATAL) << "Cannot uninstall SIGBREAK handler.";
++      }
++      if (signal(SIGINT, SIG_DFL) == SIG_ERR) {
++        LOG(FATAL) << "Cannot uninstall SIGINT handler.";
++      }
++#else
+       struct sigaction sa;
+       // Setup the sighub handler
+       sa.sa_handler = SIG_DFL;
+@@ -63,6 +86,7 @@ namespace {
+       }
+ 
+       already_hooked_up = false;
++#endif
+     }
+   }
+ 
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0004-Export-fix.patch
+++ b/ports/caffe/0004-Export-fix.patch
@@ -1,0 +1,78 @@
+From cd5e717ddf8cba2dea5d1175047c66c2054ca101 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 13 Jan 2018 17:57:39 +0100
+Subject: [PATCH 4/9] Export fix
+
+---
+ python/CMakeLists.txt    | 3 +++
+ src/caffe/CMakeLists.txt | 9 +++++++++
+ src/gtest/CMakeLists.txt | 4 +++-
+ tools/CMakeLists.txt     | 3 +++
+ 4 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index c53299d2..20af0dcf 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -10,6 +10,9 @@ caffe_default_properties(pycaffe)
+ set_target_properties(pycaffe PROPERTIES PREFIX "" OUTPUT_NAME "_caffe")
+ target_include_directories(pycaffe PUBLIC ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR})
+ target_link_libraries(pycaffe PUBLIC ${Caffe_LINK} ${PYTHON_LIBRARIES})
++set_target_properties(pycaffe PROPERTIES LINK_FLAGS "/WHOLEARCHIVE:caffe.lib")
++set_target_properties(pycaffe PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
++set_target_properties(pycaffe PROPERTIES LINK_FLAGS_DEBUG "/WHOLEARCHIVE:caffe-d")
+ 
+ if(UNIX OR APPLE)
+     set(__linkname "${PROJECT_SOURCE_DIR}/python/caffe/_caffe.so")
+diff --git a/src/caffe/CMakeLists.txt b/src/caffe/CMakeLists.txt
+index b9152e92..599a3a5d 100644
+--- a/src/caffe/CMakeLists.txt
++++ b/src/caffe/CMakeLists.txt
+@@ -36,6 +36,15 @@ set_target_properties(caffe PROPERTIES
+     SOVERSION ${CAFFE_TARGET_SOVERSION}
+     )
+ 
++if(MSVC AND BUILD_SHARED_LIBS)
++  # CMake 3.4 introduced a WINDOWS_EXPORT_ALL_SYMBOLS target property that makes it possible to 
++  # build shared libraries without using the usual declspec() decoration. 
++  # See: https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/ 
++  # and https://cmake.org/cmake/help/v3.5/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html 
++  # for details. 
++  set_target_properties(caffe PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE) 
++endif()
++
+ # ---[ Tests
+  add_subdirectory(test)
+ 
+diff --git a/src/gtest/CMakeLists.txt b/src/gtest/CMakeLists.txt
+index e98254af..827e0176 100644
+--- a/src/gtest/CMakeLists.txt
++++ b/src/gtest/CMakeLists.txt
+@@ -2,7 +2,9 @@ add_library(gtest STATIC EXCLUDE_FROM_ALL gtest.h gtest-all.cpp)
+ caffe_default_properties(gtest)
+ target_include_directories(gtest PUBLIC ${Caffe_SRC_DIR})
+ target_compile_definitions(gtest PUBLIC -DGTEST_USE_OWN_TR1_TUPLE)
+-
++set_target_properties(gtest PROPERTIES LINK_FLAGS_RELEASE "/WHOLEARCHIVE:caffe")
++set_target_properties(gtest PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
++set_target_properties(gtest PROPERTIES LINK_FLAGS_DEBUG "/WHOLEARCHIVE:caffe-d")
+ 
+ #add_library(gtest_main gtest_main.cc)
+ #target_link_libraries(gtest_main gtest)
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 37894505..aab8b3da 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -14,6 +14,9 @@ foreach(source ${srcs})
+   add_executable(${name} ${source})
+   target_link_libraries(${name} ${Caffe_LINK})
+   caffe_default_properties(${name})
++  set_target_properties(${name} PROPERTIES LINK_FLAGS_RELEASE "/WHOLEARCHIVE:caffe")
++  set_target_properties(${name} PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
++  set_target_properties(${name} PROPERTIES LINK_FLAGS_DEBUG "/WHOLEARCHIVE:caffe-d")
+ 
+   # set back RUNTIME_OUTPUT_DIRECTORY
+   caffe_set_runtime_directory(${name} "${PROJECT_BINARY_DIR}/tools")
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0005-Disable-examples.patch
+++ b/ports/caffe/0005-Disable-examples.patch
@@ -1,0 +1,25 @@
+From f14cf165d12062a54fbd5bae17b6e3ac21abba1b Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 13 Jan 2018 18:09:05 +0100
+Subject: [PATCH 5/9] Disable examples
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 08f56a33..73526201 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -90,7 +90,7 @@ endif()
+ add_subdirectory(src/gtest)
+ add_subdirectory(src/caffe)
+ add_subdirectory(tools)
+-add_subdirectory(examples)
++#add_subdirectory(examples)
+ add_subdirectory(python)
+ add_subdirectory(matlab)
+ add_subdirectory(docs)
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0006-Do-not-rename-caffe.bin.exe-to-avoid-confusing-ninja.patch
+++ b/ports/caffe/0006-Do-not-rename-caffe.bin.exe-to-avoid-confusing-ninja.patch
@@ -1,0 +1,28 @@
+From 35c962ef00c6f9c5253dfbd18c7efcf81de35a84 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 13 Jan 2018 23:38:10 +0100
+Subject: [PATCH 6/9] Do not rename caffe.bin.exe to avoid confusing ninja.
+
+---
+ tools/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index aab8b3da..24d79ad0 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -25,6 +25,11 @@ foreach(source ${srcs})
+   # restore output name without suffix
+   if(name MATCHES "caffe.bin")
+     set_target_properties(${name} PROPERTIES OUTPUT_NAME caffe)
++      if(MSVC) 
++      # the exectuable will have an import library with the same name as the caffe lib 
++      # so change the import library to avoid name clashes 
++      set_target_properties(${name} PROPERTIES IMPORT_SUFFIX ".bin.lib") 
++    endif() 
+   endif()
+ 
+   # Install
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0007-Fix-dependencies.patch
+++ b/ports/caffe/0007-Fix-dependencies.patch
@@ -1,0 +1,39 @@
+From 6a5d1761d677396ec8a628e7bd6672ee9e6fa9a8 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sun, 14 Jan 2018 00:09:46 +0100
+Subject: [PATCH 7/9] Fix dependencies.
+
+---
+ python/CMakeLists.txt | 2 +-
+ tools/CMakeLists.txt  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 20af0dcf..b676ade0 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -9,7 +9,7 @@ add_library(pycaffe SHARED ${python_srcs})
+ caffe_default_properties(pycaffe)
+ set_target_properties(pycaffe PROPERTIES PREFIX "" OUTPUT_NAME "_caffe")
+ target_include_directories(pycaffe PUBLIC ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR})
+-target_link_libraries(pycaffe PUBLIC ${Caffe_LINK} ${PYTHON_LIBRARIES})
++target_link_libraries(pycaffe PUBLIC caffe ${PYTHON_LIBRARIES})
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS "/WHOLEARCHIVE:caffe.lib")
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS_DEBUG "/WHOLEARCHIVE:caffe-d")
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 24d79ad0..576dd788 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -12,7 +12,7 @@ foreach(source ${srcs})
+ 
+   # target
+   add_executable(${name} ${source})
+-  target_link_libraries(${name} ${Caffe_LINK})
++  target_link_libraries(${name} caffe)
+   caffe_default_properties(${name})
+   set_target_properties(${name} PROPERTIES LINK_FLAGS_RELEASE "/WHOLEARCHIVE:caffe")
+   set_target_properties(${name} PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0008-Make-proto-OBJECT-to-avoid-protobuf-loading-caffe-pr.patch
+++ b/ports/caffe/0008-Make-proto-OBJECT-to-avoid-protobuf-loading-caffe-pr.patch
@@ -1,0 +1,171 @@
+From 33ad943e12dd7f72802915c3c06cb68fb0ec5931 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 20 Jan 2018 15:55:02 +0100
+Subject: [PATCH 8/9] Make proto OBJECT to avoid protobuf loading caffe proto
+ file twice.
+
+---
+ python/CMakeLists.txt    |   4 +-
+ src/caffe/CMakeLists.txt | 107 ++++++++++++++++++++++++-----------------------
+ tools/CMakeLists.txt     |   8 +++-
+ 3 files changed, 64 insertions(+), 55 deletions(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index b676ade0..cd3afa56 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -5,11 +5,11 @@ endif()
+ 
+ file(GLOB_RECURSE python_srcs ${PROJECT_SOURCE_DIR}/python/*.cpp)
+ 
+-add_library(pycaffe SHARED ${python_srcs})
++add_library(pycaffe SHARED ${python_srcs} $<TARGET_OBJECTS:proto>)
+ caffe_default_properties(pycaffe)
+ set_target_properties(pycaffe PROPERTIES PREFIX "" OUTPUT_NAME "_caffe")
+ target_include_directories(pycaffe PUBLIC ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR})
+-target_link_libraries(pycaffe PUBLIC caffe ${PYTHON_LIBRARIES})
++target_link_libraries(pycaffe PUBLIC caffe ${PYTHON_LIBRARIES} ${Caffe_LINKER_LIBS} ${PROTOBUF_LIBRARIES})
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS "/WHOLEARCHIVE:caffe.lib")
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/WHOLEARCHIVE:caffe")
+ set_target_properties(pycaffe PROPERTIES LINK_FLAGS_DEBUG "/WHOLEARCHIVE:caffe-d")
+diff --git a/src/caffe/CMakeLists.txt b/src/caffe/CMakeLists.txt
+index 599a3a5d..57557ab1 100644
+--- a/src/caffe/CMakeLists.txt
++++ b/src/caffe/CMakeLists.txt
+@@ -1,41 +1,44 @@
+-# generate protobuf sources
+-file(GLOB proto_files proto/*.proto)
+-caffe_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto_python ${proto_files})
+-
+-# include python files either to force generation
+-add_library(proto STATIC ${proto_hdrs} ${proto_srcs} ${proto_python})
+-caffe_default_properties(proto)
+-target_link_libraries(proto PUBLIC ${PROTOBUF_LIBRARIES})
+-target_include_directories(proto PUBLIC ${PROTOBUF_INCLUDE_DIR})
+-
+-list(INSERT Caffe_LINKER_LIBS 0 PUBLIC proto) # note, crucial to prepend!
+-
+-# --[ Caffe library
+-
+-# creates 'test_srcs', 'srcs', 'test_cuda', 'cuda' lists
+-caffe_pickup_caffe_sources(${PROJECT_SOURCE_DIR})
+-
+-if(HAVE_CUDA)
+-  caffe_cuda_compile(cuda_objs ${cuda})
+-  list(APPEND srcs ${cuda_objs} ${cuda})
+-endif()
+-
+-add_library(caffe ${srcs})
+-caffe_default_properties(caffe)
+-target_link_libraries(caffe ${Caffe_LINKER_LIBS})
+-target_include_directories(caffe ${Caffe_INCLUDE_DIRS}
+-                                 PUBLIC
+-                                 $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
+-                                 $<INSTALL_INTERFACE:include>)
+-target_compile_definitions(caffe ${Caffe_DEFINITIONS})
+-if(Caffe_COMPILE_OPTIONS)
+-  target_compile_options(caffe ${Caffe_COMPILE_OPTIONS})
+-endif()
+-set_target_properties(caffe PROPERTIES
+-    VERSION   ${CAFFE_TARGET_VERSION}
+-    SOVERSION ${CAFFE_TARGET_SOVERSION}
+-    )
+-
++# generate protobuf sources
++file(GLOB proto_files proto/*.proto)
++caffe_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto_python ${proto_files})
++
++# include python files either to force generation
++add_library(proto OBJECT ${proto_hdrs} ${proto_srcs} ${proto_python})
++caffe_default_properties(proto)
++#target_link_libraries(proto PUBLIC ${PROTOBUF_LIBRARIES})
++target_include_directories(proto PUBLIC ${PROTOBUF_INCLUDE_DIR})
++
++#list(INSERT Caffe_LINKER_LIBS 0 PUBLIC proto) # note, crucial to prepend!
++
++# --[ Caffe library
++
++# creates 'test_srcs', 'srcs', 'test_cuda', 'cuda' lists
++caffe_pickup_caffe_sources(${PROJECT_SOURCE_DIR})
++
++if(HAVE_CUDA)
++  caffe_cuda_compile(cuda_objs ${cuda})
++  list(APPEND srcs ${cuda_objs} ${cuda})
++endif()
++
++add_library(caffe ${srcs})
++add_dependencies(caffe proto)
++caffe_default_properties(caffe)
++target_link_libraries(caffe ${Caffe_LINKER_LIBS})
++target_include_directories(caffe ${Caffe_INCLUDE_DIRS}
++                                 PUBLIC
++                                 ${PROTOBUF_INCLUDE_DIR}
++                                 $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
++                                 $<INSTALL_INTERFACE:include>)
++target_compile_definitions(caffe ${Caffe_DEFINITIONS})
++
++if(Caffe_COMPILE_OPTIONS)
++  target_compile_options(caffe ${Caffe_COMPILE_OPTIONS})
++endif()
++set_target_properties(caffe PROPERTIES
++    VERSION   ${CAFFE_TARGET_VERSION}
++    SOVERSION ${CAFFE_TARGET_SOVERSION}
++    )
++
+ if(MSVC AND BUILD_SHARED_LIBS)
+   # CMake 3.4 introduced a WINDOWS_EXPORT_ALL_SYMBOLS target property that makes it possible to 
+   # build shared libraries without using the usual declspec() decoration. 
+@@ -43,17 +46,17 @@ if(MSVC AND BUILD_SHARED_LIBS)
+   # and https://cmake.org/cmake/help/v3.5/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html 
+   # for details. 
+   set_target_properties(caffe PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE) 
+-endif()
+-
+-# ---[ Tests
+- add_subdirectory(test)
+-
+-# ---[ Install
+-install(DIRECTORY ${Caffe_INCLUDE_DIR}/caffe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-install(FILES ${proto_hdrs} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/caffe/proto)
+-install(TARGETS caffe proto EXPORT CaffeTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-
+-file(WRITE ${PROJECT_BINARY_DIR}/__init__.py)
+-list(APPEND proto_python ${PROJECT_BINARY_DIR}/__init__.py)
+-install(PROGRAMS ${proto_python} DESTINATION python/caffe/proto)
+-
++endif()
++
++# ---[ Tests
++ add_subdirectory(test)
++
++# ---[ Install
++install(DIRECTORY ${Caffe_INCLUDE_DIR}/caffe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++install(FILES ${proto_hdrs} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/caffe/proto)
++install(TARGETS caffe proto EXPORT CaffeTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
++
++file(WRITE ${PROJECT_BINARY_DIR}/__init__.py)
++list(APPEND proto_python ${PROJECT_BINARY_DIR}/__init__.py)
++install(PROGRAMS ${proto_python} DESTINATION python/caffe/proto)
++
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 576dd788..00b5ca03 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -11,7 +11,13 @@ foreach(source ${srcs})
+   endif()
+ 
+   # target
+-  add_executable(${name} ${source})
++  add_executable(${name} ${source} $<TARGET_OBJECTS:proto>)
++  target_include_directories(${name} ${Caffe_INCLUDE_DIRS}
++                                   PUBLIC
++                                   ${PROTOBUF_INCLUDE_DIR}
++                                   $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
++                                   $<INSTALL_INTERFACE:include>)
++  target_compile_definitions(${name} ${Caffe_DEFINITIONS})
+   target_link_libraries(${name} caffe)
+   caffe_default_properties(${name})
+   set_target_properties(${name} PROPERTIES LINK_FLAGS_RELEASE "/WHOLEARCHIVE:caffe")
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/0009-Fix-Cuda.patch
+++ b/ports/caffe/0009-Fix-Cuda.patch
@@ -1,0 +1,39 @@
+From bf67ffaf28274d4cdd6d36c97ebe938149c8d8f2 Mon Sep 17 00:00:00 2001
+From: Vincent Lejeune <vljn.ovi@gmail.com>
+Date: Sat, 20 Jan 2018 23:07:28 +0100
+Subject: [PATCH 9/9] Fix Cuda
+
+---
+ cmake/Cuda.cmake               | 2 +-
+ src/caffe/layers/bnll_layer.cu | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/Cuda.cmake b/cmake/Cuda.cmake
+index b2b19e8b..2fbc5bab 100644
+--- a/cmake/Cuda.cmake
++++ b/cmake/Cuda.cmake
+@@ -4,7 +4,7 @@ endif()
+ 
+ # Known NVIDIA GPU achitectures Caffe can be compiled for.
+ # This list will be used for CUDA_ARCH_NAME = All option
+-set(Caffe_known_gpu_archs "20 21(20) 30 35 50 60 61")
++set(Caffe_known_gpu_archs "30 35 50 60 61")
+ 
+ ################################################################################################
+ # A function for automatic detection of GPUs installed  (if autodetection is enabled)
+diff --git a/src/caffe/layers/bnll_layer.cu b/src/caffe/layers/bnll_layer.cu
+index 8df8ef09..768a92bb 100644
+--- a/src/caffe/layers/bnll_layer.cu
++++ b/src/caffe/layers/bnll_layer.cu
+@@ -5,7 +5,7 @@
+ 
+ namespace caffe {
+ 
+-const float kBNLL_THRESHOLD = 50.;
++__constant__ float kBNLL_THRESHOLD = 50.;
+ 
+ template <typename Dtype>
+ __global__ void BNLLForward(const int n, const Dtype* in, Dtype* out) {
+-- 
+2.14.1.windows.1
+

--- a/ports/caffe/CONTROL
+++ b/ports/caffe/CONTROL
@@ -1,0 +1,16 @@
+Source: caffe
+Version: 1.0
+Build-Depends: lmdb, gflags, glog, boost-thread, boost-filesystem, hdf5, protobuf, openblas
+Description: Deep learning framework.
+
+Feature: cuda
+Build-Depends: cuda
+Description: Cuda support
+
+Feature: python
+Build-Depends: python3, boost-python
+Description: PyCaffe
+
+Feature: opencv
+Build-Depends: opencv
+Description: Build caffe with opencv

--- a/ports/caffe/portfile.cmake
+++ b/ports/caffe/portfile.cmake
@@ -1,0 +1,130 @@
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Static building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+    message(FATAL_ERROR "Caffe cannot be built for the x86 architecture")
+endif()
+
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO BVLC/caffe
+    REF 1.0
+    HEAD_REF master
+    SHA512 6e80530a03eb11c77ad391cdaf4d6dfd5aad034e8e6966da15f38c6a0369f9a4510c49319116970b12874f17fbe22bf5d0ff5738ce980a0191b4d4e4187220d1
+)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/0001-Use-vcpkg-dependencies.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0002-Fix-permissive-strict.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0003-MSVC-fixes.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0004-Export-fix.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0005-Disable-examples.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0006-Do-not-rename-caffe.bin.exe-to-avoid-confusing-ninja.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0007-Fix-dependencies.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0008-Make-proto-OBJECT-to-avoid-protobuf-loading-caffe-pr.patch
+    ${CMAKE_CURRENT_LIST_DIR}/0009-Fix-Cuda.patch
+)
+
+set(WITH_PYTHON OFF)
+if("python" IN_LIST FEATURES)
+  set(WITH_PYTHON ON)
+endif()
+
+if("cuda" IN_LIST FEATURES) 
+    set(CPU_ONLY "") 
+else() 
+    set(CPU_ONLY "-DCPU_ONLY=ON") 
+endif() 
+
+if("opencv" IN_LIST FEATURES) 
+    set(USE_OPENCV ON) 
+else() 
+    set(USE_OPENCV OFF) 
+endif() 
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    #PREFER_NINJA
+    OPTIONS
+        -DUSE_PREBUILT_DEPENDENCIES=OFF
+        -DBLAS=Open
+        -DUSE_LEVELDB=OFF
+        -DUSE_OPENCV=${USE_OPENCV}
+        ${CPU_ONLY}
+    OPTIONS_RELEASE
+        -Dpython_version=3
+        -DBUILD_python=${WITH_PYTHON}
+    OPTIONS_DEBUG
+        -DBUILD_python=OFF
+    )
+
+vcpkg_install_cmake()
+
+# Remove folders from install
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+#file(COPY ${CURRENT_PACKAGES_DIR}/debug/lib/caffe-d.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/caffe-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/compute_image_mean-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/convert_imageset-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/device_query-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/extract_features-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/finetune_net-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/net_speed_benchmark-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/test_net-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/train_net-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/upgrade_net_proto_binary-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/upgrade_net_proto_text-d.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/upgrade_solver_proto_text-d.exe)
+#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/caffe-d.dll)
+
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/caffe.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/compute_image_mean.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/convert_imageset.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/device_query.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/extract_features.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/finetune_net.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/net_speed_benchmark.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/test_net.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/train_net.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/upgrade_net_proto_binary.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/upgrade_net_proto_text.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+file(COPY ${CURRENT_PACKAGES_DIR}/bin/upgrade_solver_proto_text.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+#file(COPY ${CURRENT_PACKAGES_DIR}/lib/caffe.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/caffe.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/compute_image_mean.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/convert_imageset.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/device_query.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/extract_features.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/finetune_net.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/net_speed_benchmark.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/test_net.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/train_net.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/upgrade_net_proto_binary.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/upgrade_net_proto_text.exe)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/upgrade_solver_proto_text.exe)
+#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/caffe.dll)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/python/caffe)
+
+if (${WITH_PYTHON})
+    file(RENAME ${CURRENT_PACKAGES_DIR}/python/caffe/_caffe.dll ${CURRENT_PACKAGES_DIR}/python/caffe/_caffe.pyd)
+endif()
+
+# install license
+file(COPY ${CURRENT_BUILDTREES_DIR}/src/caffe-1.0/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/caffe/LICENSE)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/caffe/LICENSE ${CURRENT_PACKAGES_DIR}/share/caffe/copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
This port is adding caffe-1.0 to vcpkg.
While caffe2 is newer it's not completly backward compatible which motivates this port. Additionnaly Caffe has an opencl branch (this is so far the only Deep Learning Framework with an opencl backend so far) which I'd like to bring to vcpkg through features.

Initially there is no CUDA/OpenCV/Python/Matlab support.