### PR TITLE
Add libpng-apng as a new port

### DIFF
--- a/ports/libpng-apng/CONTROL
+++ b/ports/libpng-apng/CONTROL
@@ -1,0 +1,4 @@
+Source: libpng-apng
+Version: 1.6.34-2
+Build-Depends: zlib
+Description: libpng-apng is a library implementing an interface for reading and writing (A)PNG ((Animated) Portable Network Graphics) format files. This is backward compatible with the regular libpng, both in library usage and format.

--- a/ports/libpng-apng/portfile.cmake
+++ b/ports/libpng-apng/portfile.cmake
@@ -1,0 +1,64 @@
+include(vcpkg_common_functions)
+
+set(LIBPNG_APNG_VERSION 1.6.34)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO glennrp/libpng
+    REF v${LIBPNG_APNG_VERSION}
+    SHA512 23b6112a1d16a34c8037d5c5812944d4385fc96ed819a22172776bdd5acd3a34e55f073b46087b77d1c12cecc68f9e8ba7754c86b5ab6ed3016063e1c795de7a
+    HEAD_REF master
+)
+
+vcpkg_download_distfile(LIBPNG_APNG_PATCH_ARCHIVE
+    URLS "https://downloads.sourceforge.net/project/libpng-apng/libpng16/${LIBPNG_APNG_VERSION}/libpng-${LIBPNG_APNG_VERSION}-apng.patch.gz"
+    FILENAME "libpng-${LIBPNG_APNG_VERSION}-apng.patch.gz"
+    SHA512 0777b8e55aeee207ee92479f2258ef1f60f16d7951fdbc6d89a80ef533b86dadecd1ef659d6fe7602d8ea3a8e711a096b0f77ee09b993799b73dfffddfe5dd3c
+)
+
+vcpkg_extract_source_archive(${LIBPNG_APNG_PATCH_ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/use-abort-on-all-platforms.patch
+        ${CURRENT_BUILDTREES_DIR}/src/libpng-${LIBPNG_APNG_VERSION}-apng.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(PNG_STATIC_LIBS OFF)
+    set(PNG_SHARED_LIBS ON)
+else()
+    set(PNG_STATIC_LIBS ON)
+    set(PNG_SHARED_LIBS OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DPNG_STATIC=${PNG_STATIC_LIBS}
+        -DPNG_SHARED=${PNG_SHARED_LIBS}
+        -DPNG_TESTS=OFF
+        -DSKIP_INSTALL_PROGRAMS=ON
+        -DSKIP_INSTALL_EXECUTABLES=ON
+        -DSKIP_INSTALL_FILES=ON
+    OPTIONS_DEBUG
+        -DSKIP_INSTALL_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libpng16_static.lib ${CURRENT_PACKAGES_DIR}/lib/libpng16.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16_staticd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16d.lib)
+endif()
+
+# Remove CMake config files as they are incorrectly generated and everyone uses built-in FindPNG anyway.
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libpng ${CURRENT_PACKAGES_DIR}/debug/lib/libpng)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpng)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libpng/LICENSE ${CURRENT_PACKAGES_DIR}/share/libpng/copyright)
+
+vcpkg_copy_pdbs()
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/libpng-apng/portfile.cmake
+++ b/ports/libpng-apng/portfile.cmake
@@ -16,7 +16,20 @@ vcpkg_download_distfile(LIBPNG_APNG_PATCH_ARCHIVE
     SHA512 0777b8e55aeee207ee92479f2258ef1f60f16d7951fdbc6d89a80ef533b86dadecd1ef659d6fe7602d8ea3a8e711a096b0f77ee09b993799b73dfffddfe5dd3c
 )
 
-vcpkg_extract_source_archive(${LIBPNG_APNG_PATCH_ARCHIVE})
+vcpkg_find_acquire_program(7Z)
+
+vcpkg_execute_required_process(
+    COMMAND ${7Z} x ${LIBPNG_APNG_PATCH_ARCHIVE} -aoa
+    WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src
+    LOGNAME extract-patch.log
+)
+
+find_program(GIT NAMES git git.cmd)
+
+# sed and awk are installed with git but in a different directory
+get_filename_component(GIT_EXE_PATH ${GIT} DIRECTORY)
+set(AWK_EXE_PATH "${GIT_EXE_PATH}/../usr/bin")
+set(ENV{PATH} "$ENV{PATH};${AWK_EXE_PATH}")
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
@@ -40,6 +53,7 @@ vcpkg_configure_cmake(
         -DPNG_STATIC=${PNG_STATIC_LIBS}
         -DPNG_SHARED=${PNG_SHARED_LIBS}
         -DPNG_TESTS=OFF
+        -DPNG_PREFIX=a
         -DSKIP_INSTALL_PROGRAMS=ON
         -DSKIP_INSTALL_EXECUTABLES=ON
         -DSKIP_INSTALL_FILES=ON
@@ -56,8 +70,8 @@ endif()
 
 # Remove CMake config files as they are incorrectly generated and everyone uses built-in FindPNG anyway.
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libpng ${CURRENT_PACKAGES_DIR}/debug/lib/libpng)
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpng)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libpng/LICENSE ${CURRENT_PACKAGES_DIR}/share/libpng/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpng-apng)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libpng-apng/LICENSE ${CURRENT_PACKAGES_DIR}/share/libpng-apng/copyright)
 
 vcpkg_copy_pdbs()
 

--- a/ports/libpng-apng/usage
+++ b/ports/libpng-apng/usage
@@ -1,0 +1,4 @@
+The package libpng-apng is compatible with built-in CMake targets:
+
+    find_package(PNG REQUIRED)
+    target_link_libraries(main PRIVATE PNG::PNG)

--- a/ports/libpng-apng/use-abort-on-all-platforms.patch
+++ b/ports/libpng-apng/use-abort-on-all-platforms.patch
@@ -1,0 +1,17 @@
+diff --git a/pngpriv.h b/pngpriv.h
+index fe3355d..5a049b5 100644
+--- a/pngpriv.h
++++ b/pngpriv.h
+@@ -457,11 +457,7 @@
+ 
+ /* Memory model/platform independent fns */
+ #ifndef PNG_ABORT
+-#  ifdef _WINDOWS_
+-#    define PNG_ABORT() ExitProcess(0)
+-#  else
+-#    define PNG_ABORT() abort()
+-#  endif
++#  define PNG_ABORT() abort()
+ #endif
+ 
+ /* These macros may need to be architecture dependent. */


### PR DESCRIPTION
I've added libpng-apng as a possible new port for vcpkg. It's pretty much based off the existing libpng port, except it now downloads a patch to apply before building.

The only issue with this particular port is that CMake doesn't seem to support extracting *.gz files for some reason, which is the format that the patch is in.

Error follows:

```
CMake Error: Problem with archive_read_open_file(): Unrecognized archive format
CMake Error: Problem extracting tar: C:/Users/SomeUser/Documents/GitHub/vcpkg/downloads/libpng-1.6.34-apng.patch.gz
```

I'm not 100% sure if I'm calling this incorrectly or not. I don't see any CMake documentation indicating they support GZip compression directly - though they do say they support .tar.gz, which is interesting...

Any idea if this is just a mistaken call, or if this is indeed a missing implementation from CMake? (And if so, do we want to request such a feature from them, or alternatively just download and run some sort of g(un)zip.exe?