### PR TITLE
[libbson, mongo-c-driver] update to 1.9.2

### DIFF
--- a/ports/libbson/CONTROL
+++ b/ports/libbson/CONTROL
@@ -1,3 +1,3 @@
 Source: libbson
-Version: 1.9.0
+Version: 1.9.2
 Description: libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libbson-1.9.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libbson-1.9.2)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/mongodb/libbson/archive/1.9.0.tar.gz"
-    FILENAME "libbson-1.9.0.tar.gz"
-    SHA512 ced5e20a043096bbb2bd97f179c50fa105498fd089a54fcf7c0e3edda52030e7a6363ff1ab75c885649590a7d8846fa8adf880026cc059772cdfd87da23a244d
+    URLS "https://github.com/mongodb/libbson/archive/1.9.2.tar.gz"
+    FILENAME "libbson-1.9.2.tar.gz"
+    SHA512 a05f1e8fbabb34e847692397e2e41fc5923ddd18dba861e5ab8a31acdf6738e13ab719eae8f9f8563f08fc43aab5c8d1f53cb6a47c38c96e132fa4a62a48d2bf
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
@@ -28,6 +28,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libbson-static-1.0")
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libbson-1.0")
+endif()
 
 # This rename is needed because the official examples expect to use #include <bson.h>
 # See Microsoft/vcpkg#904
@@ -61,26 +66,18 @@ file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/li
 file(COPY ${SOURCE_PATH}/THIRD_PARTY_NOTICES DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-file(READ ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-static-1.0/libbson-static-1.0-config.cmake LIBBSON_CONFIG_CMAKE)
-string(REPLACE "/../../../" "/../../" LIBBSON_CONFIG_CMAKE "${LIBBSON_CONFIG_CMAKE}")
+    set(PORT_POSTFIX "static-1.0")
+else()
+    set(PORT_POSTFIX "1.0")
+endif()
+
+file(READ ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config.cmake LIBBSON_CONFIG_CMAKE)
 string(REPLACE "/include/libbson-1.0" "/include" LIBBSON_CONFIG_CMAKE "${LIBBSON_CONFIG_CMAKE}")
 string(REPLACE "bson-static-1.0" "bson-1.0" LIBBSON_CONFIG_CMAKE "${LIBBSON_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config.cmake "${LIBBSON_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libbson-static-1.0/libbson-static-1.0-config.cmake "${LIBBSON_CONFIG_CMAKE}")
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-static-1.0/libbson-static-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-static-1.0-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config-version.cmake)
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-static-1.0/libbson-static-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson-static-1.0)
-else()
-file(READ ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-1.0/libbson-1.0-config.cmake LIBBSON_CONFIG_CMAKE)
-string(REPLACE "/../../../" "/../../" LIBBSON_CONFIG_CMAKE "${LIBBSON_CONFIG_CMAKE}")
-string(REPLACE "/include/libbson-1.0" "/include" LIBBSON_CONFIG_CMAKE "${LIBBSON_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config.cmake "${LIBBSON_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libbson-1.0/libbson-1.0-config.cmake "${LIBBSON_CONFIG_CMAKE}")
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-1.0/libbson-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-1.0-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config-version.cmake)
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libbson-1.0/libbson-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson-1.0)
-endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake ${CURRENT_PACKAGES_DIR}/lib/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config.cmake "${LIBBSON_CONFIG_CMAKE}")
+file(COPY ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX})
+file(COPY ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config.cmake ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-${PORT_POSTFIX}-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/libbson/libbson-config-version.cmake)
 
 vcpkg_copy_pdbs()

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-c-driver
-Version: 1.9.0
+Version: 1.9.2
 Build-Depends: libbson, openssl (uwp)
 Description: Client library written in C for MongoDB.

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-c-driver-1.9.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mongo-c-driver-1.9.2)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/mongodb/mongo-c-driver/archive/1.9.0.tar.gz"
-    FILENAME "mongo-c-driver-1.9.0.tar.gz"
-    SHA512 e7785f336c38bbf7dd519351bba2facab025b4d2bcd1eef82e98606a21510af7f799edaf4b4f074bd4c5a17ad63176c276f8c57e499b8d9afd098bce274da4ae
+    URLS "https://github.com/mongodb/mongo-c-driver/archive/1.9.2.tar.gz"
+    FILENAME "mongo-c-driver-1.9.2.tar.gz"
+    SHA512 a2c819da77aef93ce261093e98e8e8c41c449af56bd03d875e2838a067ae71b5ceb16fed2fb8df9458c84310451b813464377592806fc9ac39d9df2f4ddba83b
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
@@ -36,6 +36,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libmongoc-static-1.0")
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libmongoc-1.0")
+endif()
 
 # This rename is needed because the official examples expect to use #include <mongoc.h>
 # See Microsoft/vcpkg#904
@@ -69,26 +74,18 @@ file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/mo
 file(COPY ${SOURCE_PATH}/THIRD_PARTY_NOTICES DESTINATION ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-file(READ ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-static-1.0/libmongoc-static-1.0-config.cmake LIBMONGOC_CONFIG_CMAKE)
-string(REPLACE "/../../../" "/../../" LIBMONGOC_CONFIG_CMAKE "${LIBMONGOC_CONFIG_CMAKE}")
+    set(PORT_POSTFIX "static-1.0")
+else()
+    set(PORT_POSTFIX "1.0")
+endif()
+
+file(READ ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config.cmake LIBMONGOC_CONFIG_CMAKE)
 string(REPLACE "/include/libmongoc-1.0" "/include" LIBMONGOC_CONFIG_CMAKE "${LIBMONGOC_CONFIG_CMAKE}")
 string(REPLACE "mongoc-static-1.0" "mongoc-1.0" LIBMONGOC_CONFIG_CMAKE "${LIBMONGOC_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config.cmake "${LIBMONGOC_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libmongoc-static-1.0/libmongoc-static-1.0-config.cmake "${LIBMONGOC_CONFIG_CMAKE}")
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-static-1.0/libmongoc-static-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-static-1.0-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config-version.cmake)
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-static-1.0/libmongoc-static-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmongoc-static-1.0)
-else()
-file(READ ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-1.0/libmongoc-1.0-config.cmake LIBMONGOC_CONFIG_CMAKE)
-string(REPLACE "/../../../" "/../../" LIBMONGOC_CONFIG_CMAKE "${LIBMONGOC_CONFIG_CMAKE}")
-string(REPLACE "/include/libmongoc-1.0" "/include" LIBMONGOC_CONFIG_CMAKE "${LIBMONGOC_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config.cmake "${LIBMONGOC_CONFIG_CMAKE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/libmongoc-1.0/libmongoc-1.0-config.cmake "${LIBMONGOC_CONFIG_CMAKE}")
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-1.0/libmongoc-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-1.0-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config-version.cmake)
-file(COPY ${CURRENT_PACKAGES_DIR}/lib/cmake/libmongoc-1.0/libmongoc-1.0-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmongoc-1.0)
-endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake ${CURRENT_PACKAGES_DIR}/lib/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config.cmake "${LIBMONGOC_CONFIG_CMAKE}")
+file(COPY ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmongoc-${PORT_POSTFIX})
+file(COPY ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config-version.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmongoc-${PORT_POSTFIX})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config.cmake ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/libmongoc-${PORT_POSTFIX}-config-version.cmake ${CURRENT_PACKAGES_DIR}/share/mongo-c-driver/mongo-c-driver-config-version.cmake)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
I just changed these libs ports to use the last version (jan2018).
Cause mongo-c-driver depends on libbson, so I pull them at the same time.