### PR TITLE
Fix OpenNI2 deploy

### DIFF
--- a/ports/openni2/CONTROL
+++ b/ports/openni2/CONTROL
@@ -1,4 +1,4 @@
 Source: openni2
-Version: 2.2.0.33-4
+Version: 2.2.0.33-5
 Build-Depends: kinectsdk1
 Description: OpenNI is open source library for access to Natural Interaction (NI) devices such as RGB-D camera.

--- a/ports/openni2/CONTROL
+++ b/ports/openni2/CONTROL
@@ -1,4 +1,4 @@
 Source: openni2
-Version: 2.2.0.33-5
+Version: 2.2.0.33-6
 Build-Depends: kinectsdk1
 Description: OpenNI is open source library for access to Natural Interaction (NI) devices such as RGB-D camera.

--- a/ports/openni2/CONTROL
+++ b/ports/openni2/CONTROL
@@ -1,4 +1,4 @@
 Source: openni2
-Version: 2.2.0.33-6
+Version: 2.2.0.33-7
 Build-Depends: kinectsdk1
 Description: OpenNI is open source library for access to Natural Interaction (NI) devices such as RGB-D camera.

--- a/ports/openni2/openni2deploy.ps1
+++ b/ports/openni2/openni2deploy.ps1
@@ -2,15 +2,15 @@
 
 function deployOpenNI2([string]$targetBinaryDir, [string]$installedDir, [string]$targetBinaryName) {
     if ($targetBinaryName -like "OpenNI2.dll") {
-        if(Test-Path "$installedDir\OpenNI.ini") {
+        if(Test-Path "$installedDir\bin\OpenNI2\OpenNI.ini") {
             Write-Verbose "  Deploying OpenNI2 Initialization"
-            deployBinary "$targetBinaryDir" "$installedDir" "OpenNI.ini"
+            deployBinary "$targetBinaryDir" "$installedDir\bin\OpenNI2" "OpenNI.ini"
         }
-        if(Test-Path "$installedDir\OpenNI2\Drivers") {
+        if(Test-Path "$installedDir\bin\OpenNI2\Drivers") {
             Write-Verbose "  Deploying OpenNI2 Drivers"
-            New-Item "$targetBinaryDir\OpenNI2\Drivers" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
-            Get-ChildItem "$installedDir\OpenNI2\Drivers\*.*" -include "*.dll","*.ini" | % {
-                deployBinary "$targetBinaryDir\OpenNI2\Drivers" "$installedDir\OpenNI2\Drivers" $_.Name
+            New-Item "$targetBinaryDir\bin\OpenNI2\Drivers" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+            Get-ChildItem "$installedDir\bin\OpenNI2\Drivers\*.*" -include "*.dll","*.ini" | % {
+                deployBinary "$targetBinaryDir\OpenNI2\Drivers" "$installedDir\bin\OpenNI2\Drivers" $_.Name
             }
         }
     }

--- a/ports/openni2/openni2deploy.ps1
+++ b/ports/openni2/openni2deploy.ps1
@@ -8,7 +8,7 @@ function deployOpenNI2([string]$targetBinaryDir, [string]$installedDir, [string]
         }
         if(Test-Path "$installedDir\bin\OpenNI2\Drivers") {
             Write-Verbose "  Deploying OpenNI2 Drivers"
-            New-Item "$targetBinaryDir\bin\OpenNI2\Drivers" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+            New-Item "$targetBinaryDir\OpenNI2\Drivers" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
             Get-ChildItem "$installedDir\bin\OpenNI2\Drivers\*.*" -include "*.dll","*.ini" | % {
                 deployBinary "$targetBinaryDir\OpenNI2\Drivers" "$installedDir\bin\OpenNI2\Drivers" $_.Name
             }

--- a/ports/openni2/openni2deploy.ps1
+++ b/ports/openni2/openni2deploy.ps1
@@ -1,0 +1,18 @@
+# Note: This function signature and behavior is depended upon by applocal.ps1
+
+function deployOpenNI2([string]$targetBinaryDir, [string]$installedDir, [string]$targetBinaryName) {
+    if ($targetBinaryName -like "OpenNI2.dll") {
+        if(Test-Path "$installedDir\OpenNI.ini") {
+            Write-Verbose "  Deploying OpenNI2 Initialization"
+            deployBinary "$targetBinaryDir" "$installedDir" "OpenNI.ini"
+        }
+        if(Test-Path "$installedDir\OpenNI2\Drivers") {
+            Write-Verbose "  Deploying OpenNI2 Drivers"
+            New-Item "$targetBinaryDir\OpenNI2\Drivers" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+            Get-ChildItem "$installedDir\OpenNI2\Drivers\*.*" -include "*.dll","*.ini" | % {
+                deployBinary "$targetBinaryDir\OpenNI2\Drivers" "$installedDir\OpenNI2\Drivers" $_.Name
+            }
+        }
+    }
+}
+

--- a/ports/openni2/portfile.cmake
+++ b/ports/openni2/portfile.cmake
@@ -150,6 +150,12 @@ file(
 file(
     INSTALL
         "${SOURCE_CONFIG_PATH}/OpenNI.ini"
+    DESTINATION
+        ${CURRENT_PACKAGES_DIR}/bin/OpenNI2
+)
+
+file(
+    INSTALL
         "${SOURCE_BIN_PATH_RELEASE}/OpenNI2.dll"
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/bin
@@ -170,6 +176,12 @@ file(
 file(
     INSTALL
         "${SOURCE_CONFIG_PATH}/OpenNI.ini"
+    DESTINATION
+        ${CURRENT_PACKAGES_DIR}/debug/bin/OpenNI2
+)
+
+file(
+    INSTALL
         "${SOURCE_BIN_PATH_DEBUG}/OpenNI2.dll"
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/debug/bin
@@ -206,8 +218,8 @@ file(
 )
 
 # Deploy Script
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/bin/OpenNI2)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/OpenNI2)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/openni2)

--- a/ports/openni2/portfile.cmake
+++ b/ports/openni2/portfile.cmake
@@ -205,6 +205,10 @@ file(
         ${CURRENT_PACKAGES_DIR}/tools/openni2
 )
 
+# Deploy Script
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/openni2deploy.ps1 DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/openni2)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/openni2/LICENSE ${CURRENT_PACKAGES_DIR}/share/openni2/copyright)

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -49,7 +49,7 @@ function resolve([string]$targetBinary) {
         if (Test-Path "$installedDir\$_") {
             deployBinary $targetBinaryDir $installedDir "$_"
             if (Test-Path function:\deployPluginsIfQt) { deployPluginsIfQt $targetBinaryDir "$g_install_root\plugins" "$_" }
-            if (Test-Path function:\deployOpenNI2) { deployOpenNI2 $targetBinaryDir "$installedDir" "$_" }
+            if (Test-Path function:\deployOpenNI2) { deployOpenNI2 $targetBinaryDir "$g_install_root" "$_" }
             resolve "$targetBinaryDir\$_"
         } elseif (Test-Path "$targetBinaryDir\$_") {
             Write-Verbose "  ${_}: $_ not found in vcpkg; locally deployed"
@@ -68,7 +68,7 @@ if (Test-Path "$g_install_root\plugins\qtdeploy.ps1") {
 }
 
 # Note: This is a hack to make OpenNI2 work.
-if (Test-Path "$g_install_root\bin\openni2deploy.ps1") {
+if (Test-Path "$g_install_root\bin\OpenNI2\openni2deploy.ps1") {
     . "$g_install_root\bin\openni2deploy.ps1"
 }
 

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -49,6 +49,7 @@ function resolve([string]$targetBinary) {
         if (Test-Path "$installedDir\$_") {
             deployBinary $targetBinaryDir $installedDir "$_"
             if (Test-Path function:\deployPluginsIfQt) { deployPluginsIfQt $targetBinaryDir "$g_install_root\plugins" "$_" }
+            if (Test-Path function:\deployOpenNI2) { deployOpenNI2 $targetBinaryDir "$installedDir" "$_" }
             resolve "$targetBinaryDir\$_"
         } elseif (Test-Path "$targetBinaryDir\$_") {
             Write-Verbose "  ${_}: $_ not found in vcpkg; locally deployed"
@@ -64,6 +65,11 @@ function resolve([string]$targetBinary) {
 # Introduced with Qt package version 5.7.1-7
 if (Test-Path "$g_install_root\plugins\qtdeploy.ps1") {
     . "$g_install_root\plugins\qtdeploy.ps1"
+}
+
+# Note: This is a hack to make OpenNI2 work.
+if (Test-Path "$g_install_root\bin\openni2deploy.ps1") {
+    . "$g_install_root\bin\openni2deploy.ps1"
 }
 
 resolve($targetBinary)

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -69,7 +69,7 @@ if (Test-Path "$g_install_root\plugins\qtdeploy.ps1") {
 
 # Note: This is a hack to make OpenNI2 work.
 if (Test-Path "$g_install_root\bin\OpenNI2\openni2deploy.ps1") {
-    . "$g_install_root\bin\openni2deploy.ps1"
+    . "$g_install_root\bin\OpenNI2\openni2deploy.ps1"
 }
 
 resolve($targetBinary)


### PR DESCRIPTION
Fix to deploy initialization file (<code>OpenNI.ini</code>) and drivers (<code>OpenNI2/Drivers/*</code>).
These files are required in runtime.

```patch
 <OutDir>
  ├─ app.exe
+ ├─ OpenNI.ini
  ├─ OpenNI2.dll
+ └─ OpenNI2
+      └─ Drivers
+           ├─ Kinect.dll
+           ├─ OniFile.dll
+           ├─ PS1080.dll
+           ├─ PS1080.ini
+           ├─ PSLink.dll
+           └─ PSLink.ini
```

Fixes: #2231
