### PR TITLE
[curl] add option to build with winssl

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,4 +1,5 @@
 Source: curl
-Version: 7.57.0-1
+Version: 7.57.0-2
 Build-Depends: zlib, openssl, libssh2
 Description: A library for transferring data with URLs
+# For WINSSL create target triplet which contains set(CURL_USE_WINSSL ON)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -20,6 +20,12 @@ else()
     SET(CURL_STATICLIB ON)
 endif()
 
+set(USE_OPENSSL ON)
+if(CURL_USE_WINSSL)
+    set(USE_OPENSSL OFF)
+    set(USE_WINSSL ON)
+endif()
+
 set(UWP_OPTIONS)
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     set(UWP_OPTIONS
@@ -43,7 +49,8 @@ vcpkg_configure_cmake(
         -DBUILD_CURL_EXE=OFF
         -DENABLE_MANUAL=OFF
         -DCURL_STATICLIB=${CURL_STATICLIB}
-        -DCMAKE_USE_OPENSSL=ON
+        -DCMAKE_USE_OPENSSL=${USE_OPENSSL}
+        -DCMAKE_USE_WINSSL=${USE_WINSSL}
     OPTIONS_DEBUG
         -DENABLE_DEBUG=ON
 )


### PR DESCRIPTION
Sometimes curl needs to be build with winssl,
use vcpkg install curl[winssl].

Should fix #1910

Signed-off-by: Tobias Kohlbau <tobias@kohlbau.de>