### PR TITLE
[log4cplus] correct path for vcpkg_fixup_cmake_targets

### DIFF
--- a/ports/log4cplus/portfile.cmake
+++ b/ports/log4cplus/portfile.cmake
@@ -32,7 +32,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/log4cplus)
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
**Problem**: find_package (log4cplus) does not work
**Cause**: CMake searches for files in vcpkg/installed/_platform_/share/log4cplus, but files are located in vcpkg/installed/_platform_/share/log4cplus/log4cplus
**Solution**: in PR