### PR TITLE
[realsense2] Update to v2.9.1

### DIFF
--- a/ports/realsense2/CONTROL
+++ b/ports/realsense2/CONTROL
@@ -1,3 +1,3 @@
 Source: realsense2
-Version: 2.9.0
+Version: 2.9.1
 Description: Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
-    REF v2.9.0
-    SHA512 10b4d165e5763567517fc2320b7094af5a078d1b5da2374cfa8480cab0715303ea29a87f04876cbc39b5d22ac72cba7d13711c0b46fa125fbd2cf13fcb1a28e6
+    REF v2.9.1
+    SHA512 065b772948ebe34d187d44110326f711f3184876b1f129de83552c5cfe333485f9b0c9e4774b391e55d7fe533619818594f0946eee07d528dfe91b2c5e96d942
     HEAD_REF master
 )
 


### PR DESCRIPTION
Update realsense2 port to [librealsense v2.9.1](https://github.com/IntelRealSense/librealsense/releases/tag/v2.9.1).