### PR TITLE
[libspatialite] fix compile error on non-latin env

### DIFF
--- a/ports/libspatialite/fix-latin-literals.patch
+++ b/ports/libspatialite/fix-latin-literals.patch
@@ -1,0 +1,108 @@
+diff --git a/src/srsinit/epsg_inlined_prussian.c b/src/srsinit/epsg_inlined_prussian.c
+index a5c8334..dd75dde 100644
+--- a/src/srsinit/epsg_inlined_prussian.c
++++ b/src/srsinit/epsg_inlined_prussian.c
+@@ -282,10 +282,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",17.11233917],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187913\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187914,"mj10777.de",187914,"DHDN / Soldner 14 Gröditzberg I");
++    p = add_epsg_def(filter,first,last,187914,"mj10777.de",187914,u8"DHDN / Soldner 14 Gr\u00f6ditzberg I");
+     add_proj4text(p,0,"+proj=cass +lat_0=51.17819342 +lon_0=15.76127086 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 14 Gröditzberg I\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 14 Gr\u00f6ditzberg I\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -346,10 +346,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",14.70144539],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187916\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187918,"mj10777.de",187918,"DHDN / Soldner 18 Müggelberg 600");
++    p = add_epsg_def(filter,first,last,187918,u8"mj10777.de",187918,"DHDN / Soldner 18 M\u00fcggelberg 600");
+     add_proj4text(p,0,"+proj=cass +lat_0=52.41864827777778 +lon_0=13.62720366666667 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 18 Müggelberg 600\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 18 M\u00fcggelberg 600\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -362,10 +362,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",13.62720366666667],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187918\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187919,"mj10777.de",187919,"DHDN / Soldner 19 Götzer Berg 650");
++    p = add_epsg_def(filter,first,last,187919,"mj10777.de",187919,u8"DHDN / Soldner 19 G\u00f6tzer Berg 650");
+     add_proj4text(p,0,"+proj=cass +lat_0=52.43725961111112 +lon_0=12.72882972222223 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 19 Götzer Berg 650\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 19 G\u00f6tzer Berg 650\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -458,10 +458,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",9.23411097],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187924\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187925,"mj10777.de",187925,"DHDN / Soldner 25 Rathkrügen");
++    p = add_epsg_def(filter,first,last,187925,"mj10777.de",187925,u8"DHDN / Soldner 25 Rathkr\u00fcgen");
+     add_proj4text(p,0,"+proj=cass +lat_0=53.81839364 +lon_0=10.04220189 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 25 Rathkrügen\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 25 Rathkr\u00fcgen\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -570,10 +570,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",8.84051853],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187931\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187932,"mj10777.de",187932,"DHDN / Soldner 32 Münster");
++    p = add_epsg_def(filter,first,last,187932,"mj10777.de",187932,u8"DHDN / Soldner 32 M\u00fcnster");
+     add_proj4text(p,0,"+proj=cass +lat_0=51.96547642 +lon_0=7.62334994 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 32 Münster\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 32 M\u00fcnster\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -634,10 +634,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",9.50203072],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187935\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187936,"mj10777.de",187936,"DHDN / Soldner 36 Schaumburg, Schloßturm");
++    p = add_epsg_def(filter,first,last,187936,"mj10777.de",187936,u8"DHDN / Soldner 36 Schaumburg, Schlo\u00dfturm");
+     add_proj4text(p,0,"+proj=cass +lat_0=50.34048964 +lon_0=7.97808156 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 36 Schaumburg, Schloßturm\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 36 Schaumburg, Schlo\u00dfturm\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -666,10 +666,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",7.60594289],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187937\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187938,"mj10777.de",187938,"DHDN / Soldner 38 Cöln, Dom");
++    p = add_epsg_def(filter,first,last,187938,"mj10777.de",187938,u8"DHDN / Soldner 38 C\u00f6ln, Dom");
+     add_proj4text(p,0,"+proj=cass +lat_0=50.94257242 +lon_0=6.95897600 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 38 Cöln, Dom\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 38 C\u00f6ln, Dom\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");
+@@ -682,10 +682,10 @@ initialize_epsg_prussian(int filter,struct epsg_defs **first, struct epsg_defs *
+     add_srs_wkt(p,10,"PARAMETER[\"central_meridian\",6.95897600],");
+     add_srs_wkt(p,11,"PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],");
+     add_srs_wkt(p,12,"AUTHORITY[\"mj10777.de\",\"187938\"],AXIS[\"x\",NORTH],AXIS[\"y\",EAST]]");
+-    p = add_epsg_def(filter,first,last,187939,"mj10777.de",187939,"DHDN / Soldner 39 Langschoß");
++    p = add_epsg_def(filter,first,last,187939,u8"mj10777.de",187939,"DHDN / Soldner 39 Langscho\u00df");
+     add_proj4text(p,0,"+proj=cass +lat_0=50.66738711 +lon_0=6.28935703 ");
+     add_proj4text(p,1,"+x_0=0 +y_0=0 +ellps=bessel +datum=potsdam +units=m +no_defs");
+-    add_srs_wkt(p,0,"PROJCS[\"DHDN / Soldner 39 Langschoß\",");
++    add_srs_wkt(p,0,u8"PROJCS[\"DHDN / Soldner 39 Langscho\u00df\",");
+     add_srs_wkt(p,1,"GEOGCS[\"DHDN\",");
+     add_srs_wkt(p,2,"DATUM[\"Deutsches_Hauptdreiecksnetz\",SPHEROID[\"Bessel 1841\",");
+     add_srs_wkt(p,3,"6377397.155,299.1528128,AUTHORITY[\"EPSG\",\"7004\"]],");

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/fix-makefiles.patch
         ${CMAKE_CURRENT_LIST_DIR}/fix-sources.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-latin-literals.patch
 )
 
 # fix most of the problems when spacebar is in the path


### PR DESCRIPTION
It has literals with latin chars in a C source.
Unfortunately VC++ recognize source file without BOM as in OEM code not in UTF-8.
It cause a strange behavior of VC++ compiler, and fails with
"epsg_inlined_prussian.c(685): error C2001: newline in constant."
It happens on non-latin Windows such as Japanese(CP932).

It also work when changing Windows configuration
"system locale for non-unicode applications" to latin one such as English(US)(CP432),
but it affects all applications and users in Windows system.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>