### PR TITLE
Fix error C4996 of GTest in VS2017.

### DIFF
--- a/ports/gtest/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch
+++ b/ports/gtest/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch
@@ -1,16 +1,3 @@
-From 1695708beda0306f3b4dffd66f4be142425894a0 Mon Sep 17 00:00:00 2001
-From: Arkady Shapkin <arkady.shapkin@gmail.com>
-Date: Wed, 2 Mar 2016 02:53:10 +0300
-Subject: [PATCH] Enable C++11 features for VS2015 (fix appveyor fail)
-
----
- .gitignore                                      | 13 ++++++++
- googlemock/test/gmock-matchers_test.cc          |  5 +++
- googletest/include/gtest/internal/gtest-port.h  | 10 ++++--
- googletest/test/gtest-printers_test.cc          | 43 ++++++++++++++++++++++---
- googletest/test/gtest_catch_exceptions_test_.cc |  2 +-
- 5 files changed, 64 insertions(+), 9 deletions(-)
-
 diff --git a/.gitignore b/.gitignore
 index ce310bc..08a67cd 100644
 --- a/.gitignore
@@ -48,7 +35,7 @@ index 9f62c3d..eaba362 100644
  
  namespace internal {
 diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
-index 0094ed5..c07c455 100644
+index 0094ed5..09779fa 100644
 --- a/googletest/include/gtest/internal/gtest-port.h
 +++ b/googletest/include/gtest/internal/gtest-port.h
 @@ -323,7 +323,7 @@
@@ -87,6 +74,25 @@ index 0094ed5..c07c455 100644
  #  define GTEST_HAS_HASH_MAP_ 1  // Indicates that hash_map is available.
  #  define GTEST_HAS_HASH_SET_ 1  // Indicates that hash_set is available.
  # endif  // _MSC_VER
+@@ -629,6 +633,9 @@ struct _RTL_CRITICAL_SECTION;
+ # if GTEST_OS_LINUX_ANDROID && defined(_STLPORT_MAJOR)
+ // STLport, provided with the Android NDK, has neither <tr1/tuple> or <tuple>.
+ #  define GTEST_HAS_TR1_TUPLE 0
++# elif defined(_MSC_VER) && (_MSC_VER >= 1910)
++// Prevent `warning C4996: 'std::tr1': warning STL4002: The non-Standard std::tr1 namespace and TR1-only machinery are deprecated and will be REMOVED.`
++#  define GTEST_HAS_TR1_TUPLE 0
+ # else
+ // The user didn't tell us not to do it, so we assume it's OK.
+ #  define GTEST_HAS_TR1_TUPLE 1
+@@ -813,7 +820,7 @@ using ::std::tuple_size;
+ // value-parameterized tests are enabled.  The implementation doesn't
+ // work on Sun Studio since it doesn't understand templated conversion
+ // operators.
+-#if GTEST_HAS_PARAM_TEST && GTEST_HAS_TR1_TUPLE && !defined(__SUNPRO_CC)
++#if GTEST_HAS_PARAM_TEST && (GTEST_HAS_TR1_TUPLE || GTEST_HAS_STD_TUPLE_) && !defined(__SUNPRO_CC)
+ # define GTEST_HAS_COMBINE 1
+ #endif
+ 
 diff --git a/googletest/test/gtest-printers_test.cc b/googletest/test/gtest-printers_test.cc
 index 3e97cc2..6320563 100644
 --- a/googletest/test/gtest-printers_test.cc
@@ -172,6 +178,3 @@ index d0fc82c..c6d953c 100644
  class CxxExceptionInDestructorTest : public Test {
   public:
    static void TearDownTestCase() {
--- 
-2.10.0.windows.1
-

--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,3 +1,3 @@
 Source: gtest
-Version: 1.8.0-5
+Version: 1.8.0-6
 Description: GoogleTest and GoogleMock testing frameworks.


### PR DESCRIPTION
I closed the old [PR](https://github.com/Microsoft/vcpkg/pull/2592), and edit the file gtest-port.h according to gtest requests([1](https://github.com/google/googletest/pull/1348), [2](https://github.com/google/googletest/pull/1374)), and edit the [patch](https://github.com/Microsoft/vcpkg/blob/master/ports/gtest/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch) to fix error C4996 of GTest in VS2017.