### PR TITLE
Fixes for libwebp build.

### DIFF
--- a/ports/freeimage/CONTROL
+++ b/ports/freeimage/CONTROL
@@ -1,4 +1,4 @@
 Source: freeimage
-Version: 3.17.0-3
+Version: 3.17.0-4
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp, libraw, jxrlib, openexr
 Description: Support library for graphics image formats

--- a/ports/freeimage/cmake/FindWEBP.cmake
+++ b/ports/freeimage/cmake/FindWEBP.cmake
@@ -10,17 +10,17 @@ find_path(WEBP_INCLUDE_DIRS
 )
 mark_as_advanced(WEBP_INCLUDE_DIRS)
 
-find_library(
-    WEBP_LIBRARIES
-    NAMES webp
-)
-
 find_library(WEBP_LIBRARY_RELEASE NAMES webp PATH_SUFFIXES lib)
 find_library(WEBP_LIBRARY_DEBUG NAMES webpd PATH_SUFFIXES lib)
+
+find_library(WEBPMUX_LIBRARY_RELEASE NAMES webpmux PATH_SUFFIXES lib)
+find_library(WEBPMUX_LIBRARY_DEBUG NAMES webpmuxd PATH_SUFFIXES lib)
+
 include(SelectLibraryConfigurations)
 select_library_configurations(WEBP)
+select_library_configurations(WEBPMUX)
 
-set(WEBP_LIBRARIES ${WEBP_LIBRARY})
+set(WEBP_LIBRARIES ${WEBPMUX_LIBRARY} ${WEBP_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(WEBP DEFAULT_MSG WEBP_INCLUDE_DIRS WEBP_LIBRARIES)

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,3 +1,3 @@
 Source: libwebp
-Version: 0.6.1
+Version: 0.6.1-1
 Description: Lossy compression of digital photographic images.

--- a/ports/libwebp/build_fixes.patch
+++ b/ports/libwebp/build_fixes.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3b105e37..f9b806c4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,6 +106,9 @@ endforeach()
+ if(MSVC)
+   # avoid security warnings for e.g., fopen() used in the examples.
+   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
++  if(BUILD_SHARED_LIBS)
++    add_definitions(-DWEBP_EXTERN=__declspec\(dllexport\))
++  endif()
+ else()
+   add_definitions(-Wall)
+ endif()
+@@ -235,6 +238,10 @@ if(WEBP_BUILD_GIF2WEBP AND NOT GIF_FOUND)
+ endif()
+ 
+ if(WEBP_BUILD_GIF2WEBP OR WEBP_BUILD_IMG2WEBP)
++  set(WEBP_BUILD_MUX ON)
++endif()
++
++if(WEBP_BUILD_MUX)
+   parse_Makefile_am(${CMAKE_CURRENT_SOURCE_DIR}/src/mux "WEBP_MUX_SRCS"
+     "")
+   add_library(webpmux ${WEBP_MUX_SRCS})
+@@ -322,6 +329,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/webp/decode.h
+               ${CMAKE_CURRENT_SOURCE_DIR}/src/webp/types.h
+         DESTINATION include/webp)
+ install(TARGETS ${INSTALLED_LIBRARIES}
++        RUNTIME DESTINATION bin
+         LIBRARY DESTINATION lib
+         ARCHIVE DESTINATION lib)
+ 

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -11,15 +11,20 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/build_fixes.patch
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    # dllexport support seem to be broken
-    OPTIONS -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
-            -DCMAKE_DEBUG_POSTFIX=d
+    OPTIONS
+        -DCMAKE_DEBUG_POSTFIX=d
+        -DWEBP_BUILD_MUX=ON
 )
 
-vcpkg_build_cmake()
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
Current version of libwebp suffers from several issues that I'm trying to fix.

This update contains the following changes:
- Fixed dll files not being installed to bin folder for dynamic build (#2699)
- Enabled webpmux library because it was disabled by default but FreeImage can not be built properly without it's functions. I guess this library was always enabled in earlier libwebp versions. Right now it is build only when exe tools are enabled (#2618).
- Removed CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS switch from port file in favor of WEBP_EXTERN usage (which is native libwebp macro for exported functions).
