### PR TITLE
[libwebsockets] add file version resource for Windows build.

### DIFF
--- a/ports/libwebsockets/CONTROL
+++ b/ports/libwebsockets/CONTROL
@@ -1,4 +1,4 @@
 Source: libwebsockets
-Version: 2.4.1
+Version: 2.4.1-1
 Build-Depends: zlib, openssl
 Description: Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.

--- a/ports/libwebsockets/add-version-resource.patch
+++ b/ports/libwebsockets/add-version-resource.patch
@@ -1,0 +1,76 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eccad2d..40409b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,6 +35,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
+ 
+ message(STATUS "CMAKE_TOOLCHAIN_FILE='${CMAKE_TOOLCHAIN_FILE}'")
+ 
++if(WIN32)
++	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/win32port/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/win32port/version.rc @ONLY)
++	set(RESOURCE_FILE ${CMAKE_CURRENT_BINARY_DIR}/win32port/version.rc)
++endif()
++
+ # Try to find the current Git hash.
+ find_package(Git)
+ if(GIT_EXECUTABLE)
+@@ -877,7 +882,8 @@ if (LWS_WITH_STATIC)
+ 	add_library(websockets STATIC
+ 				${HDR_PRIVATE}
+ 				${HDR_PUBLIC}
+-				${SOURCES})
++				${SOURCES}
++				${RESOURCE_FILE})
+ 	list(APPEND LWS_LIBRARIES websockets)
+ 
+ 	if (WIN32)
+@@ -904,7 +910,8 @@ if (LWS_WITH_SHARED)
+ 	add_library(websockets_shared SHARED
+ 				${HDR_PRIVATE}
+ 				${HDR_PUBLIC}
+-				${SOURCES})
++				${SOURCES}
++				${RESOURCE_FILE})
+ 	list(APPEND LWS_LIBRARIES websockets_shared)
+ 
+ 	# We want the shared lib to be named "libwebsockets"
+diff --git a/win32port/version.rc.in b/win32port/version.rc.in
+new file mode 100644
+index 0000000..2ae959e
+--- /dev/null
++++ b/win32port/version.rc.in
+@@ -0,0 +1,34 @@
++#include <winver.h>
++
++#define LWS_VERSION 	@LWS_LIBRARY_VERSION_MAJOR@,@LWS_LIBRARY_VERSION_MINOR@,@LWS_LIBRARY_VERSION_PATCH@,0
++#define LWS_VERSION_STR "@LWS_LIBRARY_VERSION_MAJOR@.@LWS_LIBRARY_VERSION_MINOR@.@LWS_LIBRARY_VERSION_PATCH@\0"
++#define LWS_PACKAGE_NAME "@PACKAGE@\0"
++
++VS_VERSION_INFO VERSIONINFO
++  FILEVERSION    LWS_VERSION
++  PRODUCTVERSION LWS_VERSION
++  FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
++  FILEFLAGS      0
++  FILEOS         VOS__WINDOWS32
++  FILETYPE       VFT_DLL
++BEGIN
++    BLOCK "StringFileInfo"
++    BEGIN
++        BLOCK "040904b0"
++        BEGIN
++            VALUE "ProductName", LWS_PACKAGE_NAME
++            VALUE "ProductVersion", LWS_VERSION_STR
++            VALUE "FileVersion", LWS_VERSION_STR
++            VALUE "FileDescription", "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.\0"
++			VALUE "InternalName", "websockets.dll\0"
++            VALUE "OriginalFilename", "websockets.dll\0"
++            VALUE "CompanyName", "Open Source Software community LGPL\0"
++            VALUE "LegalCopyright", "Copyright (C) Project contributors 2017\0"
++            VALUE "Comments", "https://libwebsockets.org\0"
++        END
++    END
++    BLOCK "VarFileInfo"
++    BEGIN
++        VALUE "Translation", 0x409, 1200
++    END
++END

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-UWP.patch
+		${CMAKE_CURRENT_LIST_DIR}/add-version-resource.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LWS_WITH_STATIC)


### PR DESCRIPTION
The Windows build is missing version information.
![image](https://user-images.githubusercontent.com/36075579/35737703-b8ebebb0-082c-11e8-9786-1b1414bc3acd.png)
A resource file is added that uses the LWS_LIBRARY_VERSION_... variables from the CMakeLists.txt file.