### PR TITLE
CMake variable for all features

### DIFF
--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -290,6 +290,7 @@ namespace vcpkg::Build
         const auto pre_build_info = PreBuildInfo::from_triplet_file(paths, triplet);
 
         std::string features;
+        std::string all_features;
         if (GlobalState::feature_packages)
         {
             for (auto&& feature : config.feature_list)
@@ -299,6 +300,10 @@ namespace vcpkg::Build
             if (!features.empty())
             {
                 features.pop_back();
+            }
+            for (auto& feature : config.scf.feature_paragraphs)
+            {
+                all_features.append(feature->name + ";");
             }
         }
 
@@ -317,6 +322,7 @@ namespace vcpkg::Build
                 {"_VCPKG_NO_DOWNLOADS", !Util::Enum::to_bool(config.build_package_options.allow_downloads) ? "1" : "0"},
                 {"GIT", git_exe_path},
                 {"FEATURES", features},
+                {"ALL_FEATURES", all_features},
             });
 
         const auto cmd_set_environment = make_build_env_cmd(pre_build_info, toolset);


### PR DESCRIPTION
Hi @ras0219-msft !

While continuing work on the corrade/magnum/magnum-plugins/... portfiles I noticed a cmake variable for all declared features from the CONTROL file would be very useful in the `portfile.cmake` (instead of manually specifying the list there).

Would you consider such a variable? I currently named it  `ALL_FEATURES` to be consistent with `FEATURES`.

Cheers, Jonathan.