### PR TITLE
Fix for Issue #2729

### DIFF
--- a/scripts/VcpkgPowershellUtils.ps1
+++ b/scripts/VcpkgPowershellUtils.ps1
@@ -160,7 +160,7 @@ function vcpkgExtractFile(  [Parameter(Mandatory=$true)][string]$file,
     }
     else
     {
-        Move-Item -Path $destinationPartial -Destination $output
+        Move-Item -Path "$destinationPartial" -Destination $output
     }
 }
 


### PR DESCRIPTION
Allows PowerShell to change the name of the downloaded directory correctly.