### PR TITLE
Add libgeotiff port

### DIFF
--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,4 +1,4 @@
 Source: libgeotiff
 Version: 1.4.2
-Description: libgeotiff.
+Description: Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
 Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,0 +1,4 @@
+Source: libgeotiff
+Version: 1.4.2
+Description: libgeotiff.
+Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/fix-cmake-tiff-detection.patch
+++ b/ports/libgeotiff/fix-cmake-tiff-detection.patch
@@ -1,0 +1,21 @@
+--- a/CMakeLists.txt	2016-08-12 00:40:12.000000000 +0900
++++ b/CMakeLists.txt	2018-02-09 13:27:05.721561755 +0900
+@@ -192,7 +192,8 @@
+     IF(TIFF_FOUND)
+         # Confirm required API is available
+         INCLUDE(CheckFunctionExists)
+-        SET(CMAKE_REQUIRED_LIBRARIES ${TIFF_LIBRARIES})
++        FIND_PACKAGE(LibLZMA)
++        SET(CMAKE_REQUIRED_LIBRARIES ${TIFF_LIBRARIES} ${ZLIB_LIBRARIES} ${JPEG_LIBRARIES} ${LIBLZMA_LIBRARIES})
+ 
+         CHECK_FUNCTION_EXISTS(TIFFOpen HAVE_TIFFOPEN)
+         IF(NOT HAVE_TIFFOPEN)
+@@ -205,7 +206,7 @@
+             SET(TIFF_FOUND) # ReSET to NOT found for TIFF library
+             MESSAGE(FATAL_ERROR "Failed to link with libtiff - TIFFMergeFieldInfo function not found. libtiff 3.6.0 Beta or later required. Please upgrade or use an older version of libgeotiff")
+         ENDIF()
+-
++        SET(CMAKE_REQUIRED_LIBRARIES)
+         INCLUDE_DIRECTORIES(${TIFF_INCLUDE_DIR})
+         ADD_DEFINITIONS(-DHAVE_TIFF=1)
+     ENDIF(TIFF_FOUND)

--- a/ports/libgeotiff/fix-directory-output.patch
+++ b/ports/libgeotiff/fix-directory-output.patch
@@ -1,0 +1,14 @@
+diff -urN a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+--- a/cmake/CMakeLists.txt	2016-08-12 00:40:10.000000000 +0900
++++ b/cmake/CMakeLists.txt	2018-02-09 07:12:40.422110239 +0900
+@@ -10,8 +10,8 @@
+   set (INSTALL_CMAKE_DIR "share/cmake/${PROJECT_NAME}")
+   set (PROJECT_ROOT_DIR "../../..")
+ else ()
+-  set (INSTALL_CMAKE_DIR "cmake")
+-  set (PROJECT_ROOT_DIR "..")
++  set (INSTALL_CMAKE_DIR "share/${PROJECT_NAME}")
++  set (PROJECT_ROOT_DIR "../..")
+ endif ()
+ 
+ configure_file (project-config.cmake.in project-config.cmake @ONLY)

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -13,7 +13,8 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/fix-directory-output.patch")
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/fix-directory-output.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/fix-cmake-tiff-detection.patch")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
   set(BUILD_SHARED_LIBS ON)
@@ -26,6 +27,10 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
             -DWITH_UTILITIES=OFF
+            -DWITH_TIFF=ON
+            -DWITH_PROJ4=ON
+            -DWITH_ZLIB=ON
+            -DWITH_JPEG=ON
 )
 
 vcpkg_build_cmake()

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -11,6 +11,10 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/fix-directory-output.patch")
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
   set(BUILD_SHARED_LIBS ON)
 else()

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+set(LIBGEOTIFF_VERSION 1.4.2)
+set(LIBGEOTIFF_HASH 059c6e05eb0c47f17b102c7217a2e1636e76d622c4d1bdcf0bd89fb3505f3130bffa881e21c73cfd2ca0d6863b81322f85784658ba3539b53b63c3a8f38d1deb)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libgeotiff-${LIBGEOTIFF_VERSION})
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-${LIBGEOTIFF_VERSION}.tar.gz"
+    FILENAME "libgeotiff-${LIBGEOTIFF_VERSION}.tar.gz"
+    SHA512 ${LIBGEOTIFF_HASH})
+
+vcpkg_extract_source_archive(${ARCHIVE})
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  set(BUILD_SHARED_LIBS ON)
+else()
+  set(BUILD_SHARED_LIBS OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+            -DWITH_UTILITIES=OFF
+)
+
+vcpkg_build_cmake()
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -39,3 +39,7 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
+endif()


### PR DESCRIPTION
Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
It depends on tiff, proj4, zlib, libjpeg-turbo and liblzma(thru tiff).