### PR TITLE
[szip] Fix szip-config.cmake to return SZIP_FOUND

### DIFF
--- a/ports/szip/CONTROL
+++ b/ports/szip/CONTROL
@@ -1,3 +1,3 @@
 Source: szip
-Version: 2.1.1
+Version: 2.1.1-1
 Description: Szip compression software, providing lossless compression of scientific data

--- a/ports/szip/fix-szip-config-to-set-szip-found.patch
+++ b/ports/szip/fix-szip-config-to-set-szip-found.patch
@@ -1,0 +1,11 @@
+diff -urN szip-2.1.1-a/config/cmake/szip-config.cmake.in szip-2.1.1-b/config/cmake/szip-config.cmake.in
+--- szip-2.1.1-a/config/cmake/szip-config.cmake.in	2018-02-10 11:06:46.890685077 +0900
++++ szip-2.1.1-b/config/cmake/szip-config.cmake.in	2018-02-10 11:11:25.369274127 +0900
+@@ -51,6 +51,7 @@
+       set (${SZIP_PACKAGE_NAME}_${comp}_FOUND 0)
+     else ()
+       set (${SZIP_PACKAGE_NAME}_${comp}_FOUND 1)
++      set (${SZIP_PACKAGE_NAME}_FOUND 1)
+       string(TOUPPER ${SZIP_PACKAGE_NAME}_${comp}_LIBRARY COMP_LIBRARY)
+       set (${COMP_LIBRARY} ${${COMP_LIBRARY}} @SZIP_LIB_CORENAME@-${comp})
+     endif ()

--- a/ports/szip/portfile.cmake
+++ b/ports/szip/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/disable-static-lib-in-shared-build.patch
         ${CMAKE_CURRENT_LIST_DIR}/default-component-shared.patch
+        ${CMAKE_CURRENT_LIST_DIR}/fix-szip-config-to-set-szip-found.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
szip-config.cmake returns only SZIP_static_FOUND and/or SZIP_shared_FOUND but never returns SZIP_FOUND.

szip-config.cmake calls check_required_components(SZIP) helper, but
it just set SZIP_FOUND=FALSE when it does not find required components,
but never set SZIP_FOUND=TRUE.

szip-config.cmake should set SZIP_FOUND=TRUE when it find some
components, before calling the helper function.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>