### PR TITLE
[WIP] [hdf5] fix detection of  szip library

### DIFF
--- a/ports/hdf5/.gitattributes
+++ b/ports/hdf5/.gitattributes
@@ -1,0 +1,1 @@
+use-szip-config.patch text eol=crlf

--- a/ports/hdf5/use-szip-config.patch
+++ b/ports/hdf5/use-szip-config.patch
@@ -1,21 +1,22 @@
-diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
-index c2b81dc..a86d2d5 100644
---- a/CMakeFilters.cmake
-+++ b/CMakeFilters.cmake
-@@ -81,6 +81,16 @@ if (HDF5_ENABLE_SZIP_SUPPORT)
+--- a/CMakeFilters.cmake	2018-02-10 12:03:46.501616360 +0900
++++ b/CMakeFilters.cmake	2018-02-10 12:28:36.063407750 +0900
+@@ -95,7 +95,18 @@
+ if (HDF5_ENABLE_SZIP_SUPPORT)
+   option (HDF5_ENABLE_SZIP_ENCODING "Use SZip Encoding" OFF)
    if (NOT SZIP_USE_EXTERNAL)
-     find_package (SZIP NAMES ${SZIP_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
+-    find_package (SZIP NAMES ${SZIP_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
++    # explicitly specify whether static or shared component required
++    if (NOT DISABLE_STATIC_LIBS)
++      find_package (SZIP COMPONENTS static CONFIG)
++      if (SZIP_static_FOUND) # workaround for szip-config bug
++        set (SZIP_FOUND TRUE)
++      endif (SZIP_static_FOUND)
++    else (NOT DISABLE_STATIC_LIBS)
++      find_package (SZIP COMPONENTS shared CONFIG)
++      if (SZIP_shared_FOUND) # workaround for szip-config bug
++        set (SZIP_FOUND TRUE)
++      endif(SZIP_shared_FOUND)
++    endif (NOT DISABLE_STATIC_LIBS)
      if (NOT SZIP_FOUND)
-+      find_package (SZIP CONFIG)
-+      if (SZIP_FOUND)
-+        if (TARGET szip-shared)
-+          set(SZIP_LIBRARIES szip-shared)
-+        else (TARGET szip-shared)
-+          set(SZIP_LIBRARIES szip-static)
-+        endif (TARGET szip-shared)
-+      endif (SZIP_FOUND)
-+    endif (NOT SZIP_FOUND)
-+    if (NOT SZIP_FOUND)
        find_package (SZIP) # Legacy find
        if (SZIP_FOUND)
-         set (LINK_LIBS ${LINK_LIBS} ${SZIP_LIBRARIES})


### PR DESCRIPTION
Improves  SZip library detection logic and  and fix a part of #2720 problem.
This modification resulted libhdf5.settings has a full path of libszip.lib as extra library in static build.
(note: this fix does not solve all the #2720 problem. There still exist `;szip-static;szip-static` at end of extra library definition in libhdf5.settings in static build.)

It also includes #2765  workaround. Even szip-config.cmake don't return SZIP_FOUND, macro set it and continue building.

#2708 depends on this fix.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>