### PR TITLE
[pcl] Add cuda and tools option

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,7 +1,7 @@
 Source: pcl
 Version: 1.8.1-10
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
-Build-Depends: eigen3, flann, qhull, vtk, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
+Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
 
 Feature: openni2
 Description: OpenNI2 support for PCL

--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.8.1-9
+Version: 1.8.1-10
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
 
@@ -14,3 +14,11 @@ Build-Depends: vtk[qt]
 Feature: pcap
 Description: PCAP support for PCL
 Build-Depends: winpcap
+
+Feature: tools
+Description: Build PCL utilities
+Build-Depends: boost-accumulators
+
+Feature: cuda
+Description: CUDA support for PCL
+Build-Depends: cuda

--- a/ports/pcl/find_cuda.patch
+++ b/ports/pcl/find_cuda.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/pcl_find_cuda.cmake b/cmake/pcl_find_cuda.cmake
+index fd9cfa9..ae9e612 100644
+--- a/cmake/pcl_find_cuda.cmake
++++ b/cmake/pcl_find_cuda.cmake
+@@ -43,7 +43,9 @@ if(CUDA_FOUND)
+ 	
+ 	# Find a complete list for CUDA compute capabilities at http://developer.nvidia.com/cuda-gpus
+ 
+-        if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "8.0")
++        if(NOT ${CUDA_VERSION_STRING} VERSION_LESS "9.0")
++                set(__cuda_arch_bin "3.0 3.5 5.0 5.2 5.3 6.0 6.1 7.0")
++        elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "8.0")
+                 set(__cuda_arch_bin "2.0 2.1(2.0) 3.0 3.5 5.0 5.2 5.3 6.0 6.1")
+         elseif(NOT ${CUDA_VERSION_STRING} VERSION_LESS "6.5")
+                 set(__cuda_arch_bin "2.0 2.1(2.0) 3.0 3.5 5.0 5.2")

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -36,23 +36,35 @@ if("pcap" IN_LIST FEATURES)
     set(WITH_PCAP ON)
 endif()
 
+set(WITH_CUDA OFF)
+if("cuda" IN_LIST FEATURES)
+    set(WITH_CUDA ON)
+endif()
+
+set(BUILD_TOOLS OFF)
+if("tools" IN_LIST FEATURES)
+    set(BUILD_TOOLS ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         # BUILD
         -DBUILD_surface_on_nurbs=ON
-        -DBUILD_tools=OFF
+        -DBUILD_tools=${BUILD_TOOLS}
+        -DBUILD_CUDA=${WITH_CUDA}
+        -DBUILD_GPU=${WITH_CUDA} # build GPU when use CUDA
         # PCL
         -DPCL_BUILD_WITH_BOOST_DYNAMIC_LINKING_WIN32=${PCL_SHARED_LIBS}
         -DPCL_BUILD_WITH_FLANN_DYNAMIC_LINKING_WIN32=${PCL_SHARED_LIBS}
         -DPCL_SHARED_LIBS=${PCL_SHARED_LIBS}
         # WITH
-        -DWITH_CUDA=OFF
+        -DWITH_CUDA=${WITH_CUDA}
         -DWITH_LIBUSB=OFF
         -DWITH_OPENNI2=${WITH_OPENNI2}
         -DWITH_PCAP=${WITH_PCAP}
-        -DWITH_PNG=OFF
+        -DWITH_PNG=ON
         -DWITH_QHULL=ON
         -DWITH_QT=${WITH_QT}
         -DWITH_VTK=ON
@@ -63,6 +75,13 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/pcl)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(BUILD_TOOLS)
+    file(GLOB EXEFILES_RELEASE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+    file(GLOB EXEFILES_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+    file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pcl)
+    file(REMOVE ${EXEFILES_RELEASE} ${EXEFILES_DEBUG})
+endif()
 
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/pcl)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/pcl/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/pcl/copyright)

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_apply_patches(
             "${CMAKE_CURRENT_LIST_DIR}/find_flann.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_qhull.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_openni2.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/find_cuda.patch"
             "${CMAKE_CURRENT_LIST_DIR}/vs2017-15.4-workaround.patch"
 )
 

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -81,6 +81,7 @@ if(BUILD_TOOLS)
     file(GLOB EXEFILES_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
     file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pcl)
     file(REMOVE ${EXEFILES_RELEASE} ${EXEFILES_DEBUG})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/pcl)
 endif()
 
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/pcl)


### PR DESCRIPTION
With this portfile, pcl can be theoretically compiled against cuda. However, I met problems when building it with cuda like #2749. How I solved this is exactly described [here at StackOverflow](https://stackoverflow.com/questions/45918446/compiling-opencv-3-3-with-cuda-9-0rc) which was caused by CUDA cmake bug.

In addition, with current cuda version (8.0), only toolset along with VS2015 can be used to compile .cu files (while I am using VS2017). The problem is also describe in [another post at StackOverflow](https://stackoverflow.com/questions/42003849/nvcc-host-compiler-targets-unsupported-os), workarounds are mentioned in both posts. I am able to build pcl with cuda when specifying CUDA_HOST_COMPILER as the cl compiler in toolset v140. So the problem is with cuda rather than with pcl/opencv in my opinion, which could be solved or at least warned in the portfile of cuda. 