### PR TITLE
[ffmpeg] Allow static builds of ffmpeg

### DIFF
--- a/ports/ffmpeg/create-lib-libraries.patch
+++ b/ports/ffmpeg/create-lib-libraries.patch
@@ -1,0 +1,26 @@
+From 5f7c72d6c93fb1f4a730e2315fff6e5eb9bb95c8 Mon Sep 17 00:00:00 2001
+From: Anonymous Maarten <anonymous.maarten@gmail.com>
+Date: Wed, 27 Sep 2017 15:50:40 +0200
+Subject: [PATCH] configure: create .lib static libraries using MSVC compiler
+ (instead of .a)
+
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index ba38a73906..0a3f308323 100755
+--- a/configure
++++ b/configure
+@@ -5031,6 +5031,8 @@ case $target_os in
+         fi
+         enabled x86_32 && check_ldflags -LARGEADDRESSAWARE
+         shlibdir_default="$bindir_default"
++        LIBPREF=""
++        LIBSUF=".lib"
+         SLIBPREF=""
+         SLIBSUF=".dll"
+         SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
+-- 
+2.14.1.windows.1
+

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -1,8 +1,3 @@
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    message(STATUS "Building as static libraries not currently supported. Building as DLLs instead.")
-    set(VCPKG_LIBRARY_LINKAGE "dynamic")
-endif()
-
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/ffmpeg-3.3.3)
 vcpkg_download_distfile(ARCHIVE
@@ -13,7 +8,9 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/detect-openssl.patch
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/create-lib-libraries.patch
+        ${CMAKE_CURRENT_LIST_DIR}/detect-openssl.patch
 )
 
 vcpkg_find_acquire_program(YASM)


### PR DESCRIPTION
ffmpeg creates static .a libraries, so change the suffix to .lib