### PR TITLE
[libgeotiff] build and install utility commands

### DIFF
--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,4 +1,4 @@
 Source: libgeotiff
-Version: 1.4.2
+Version: 1.4.2-1
 Description: Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
 Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -41,11 +41,11 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
-endif()
-
 file(GLOB GEOTIFF_UTILS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
 file(INSTALL ${GEOTIFF_UTILS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/libgeotiff/)
 file(REMOVE ${GEOTIFF_UTILS})
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/libgeotiff)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
+endif()

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-            -DWITH_UTILITIES=OFF
+            -DWITH_UTILITIES=ON
             -DWITH_TIFF=ON
             -DWITH_PROJ4=ON
             -DWITH_ZLIB=ON
@@ -38,8 +38,18 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(GLOB GEOTIFF_UTILS_DBG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+file(REMOVE ${GEOTIFF_UTILS_DBG})
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
+endif()
+
+file(GLOB GEOTIFF_UTILS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+file(INSTALL ${GEOTIFF_UTILS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/libgeotiff/)
+file(REMOVE ${GEOTIFF_UTILS})
+
+if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/libgeotiff)
 endif()

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -26,11 +26,12 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-            -DWITH_UTILITIES=ON
             -DWITH_TIFF=ON
             -DWITH_PROJ4=ON
             -DWITH_ZLIB=ON
             -DWITH_JPEG=ON
+    OPTIONS_RELEASE -DWITH_UTILITIES=ON
+    OPTIONS_DEBUG   -DWITH_UTILITIES=OFF
 )
 
 vcpkg_build_cmake()
@@ -38,8 +39,6 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-file(GLOB GEOTIFF_UTILS_DBG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-file(REMOVE ${GEOTIFF_UTILS_DBG})
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
@@ -49,7 +48,4 @@ endif()
 file(GLOB GEOTIFF_UTILS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
 file(INSTALL ${GEOTIFF_UTILS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/libgeotiff/)
 file(REMOVE ${GEOTIFF_UTILS})
-
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/libgeotiff)
-endif()
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/libgeotiff)


### PR DESCRIPTION
libgeotiff has some utility commands. Now there are built and installed into
<packages>/libgeotiff/tools/libgeotiff/

Signed-off-by: Hiroshi Miura <miurahr@linux.com>