### PR TITLE
Fix cuda compiler path problem in opencv

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv
-Version: 3.4.0-2
+Version: 3.4.0-3
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, protobuf (windows)
 Description: computer vision library
 

--- a/ports/opencv/fix-cuda.patch
+++ b/ports/opencv/fix-cuda.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/FindCUDA.cmake b/cmake/FindCUDA.cmake
+index 4a19d5c..d1c5b8b 100644
+--- a/cmake/FindCUDA.cmake
++++ b/cmake/FindCUDA.cmake
+@@ -450,7 +450,12 @@ option(CUDA_HOST_COMPILATION_CPP "Generated file extension" ON)
+ set(CUDA_NVCC_FLAGS "" CACHE STRING "Semi-colon delimit multiple arguments.")
+ 
+ if(CMAKE_GENERATOR MATCHES "Visual Studio")
+-  set(CUDA_HOST_COMPILER "$(VCInstallDir)bin" CACHE FILEPATH "Host side compiler used by NVCC")
++  if(MSVC_VERSION GREATER 1900)
++    # Required for CUDA to work with VS2017
++    set(CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE FILEPATH "Host side compiler used by NVCC" FORCE)
++  else()
++    set(CUDA_HOST_COMPILER "$(VCInstallDir)bin" CACHE FILEPATH "Host side compiler used by NVCC")
++  endif()
+ else()
+   # Using cc which is symlink to clang may let NVCC think it is GCC and issue
+   # unhandled -dumpspecs option to clang. Also in case neither

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_apply_patches(
             "${CMAKE_CURRENT_LIST_DIR}/no-double-expand-enable-pylint.patch"
             "${CMAKE_CURRENT_LIST_DIR}/msvs-fix-2017-u5.patch"
             "${CMAKE_CURRENT_LIST_DIR}/filesystem-uwp.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/fix-cuda.patch"
 )
 file(REMOVE_RECURSE ${SOURCE_PATH}/3rdparty/libjpeg ${SOURCE_PATH}/3rdparty/libpng ${SOURCE_PATH}/3rdparty/zlib ${SOURCE_PATH}/3rdparty/libtiff)
 


### PR DESCRIPTION
I met similar problem with #2749 and this patch can fix the problem. Besides, another problem could happen like [this issue stated](https://github.com/opencv/opencv/issues/10334). Switch to toolset v140 can prevent this. However, this is a problem related to CUDA, so it's not fixed here.