### PR TITLE
[vcpkg] Fix build with feature deps

### DIFF
--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -104,11 +104,11 @@ namespace vcpkg::Build
     struct ExtendedBuildResult
     {
         ExtendedBuildResult(BuildResult code);
-        ExtendedBuildResult(BuildResult code, std::vector<PackageSpec>&& unmet_deps);
+        ExtendedBuildResult(BuildResult code, std::vector<FeatureSpec>&& unmet_deps);
         ExtendedBuildResult(BuildResult code, std::unique_ptr<BinaryControlFile>&& bcf);
 
         BuildResult code;
-        std::vector<PackageSpec> unmet_dependencies;
+        std::vector<FeatureSpec> unmet_dependencies;
         std::unique_ptr<BinaryControlFile> binary_control_file;
     };
 

--- a/toolsrc/include/vcpkg/statusparagraphs.h
+++ b/toolsrc/include/vcpkg/statusparagraphs.h
@@ -20,7 +20,21 @@ namespace vcpkg
         using iterator = container::reverse_iterator;
         using const_iterator = container::const_reverse_iterator;
 
+        /// <summary>Find the StatusParagraph for given spec.</summary>
+        /// <param name="spec">Package specification to find the status paragraph for</param>
+        /// <returns>Iterator for found spec</returns>
         const_iterator find(const PackageSpec& spec) const { return find(spec.name(), spec.triplet()); }
+
+        /// <summary>Find the StatusParagraph for given feature spec.</summary>
+        /// <param name="spec">Feature specification to find the status paragraph for</param>
+        /// <returns>Iterator for found spec</returns>
+        const_iterator find(const FeatureSpec& spec) const { return find(spec.name(), spec.triplet(), spec.feature()); }
+
+        /// <summary>Find a StatusParagraph by name, triplet and feature.</summary>
+        /// <param name="name">Package name</param>
+        /// <param name="triplet">Triplet</param>
+        /// <param name="feature">Feature name</param>
+        /// <returns>Iterator for found spec</returns>
         iterator find(const std::string& name, const Triplet& triplet, const std::string& feature = "");
         const_iterator find(const std::string& name, const Triplet& triplet, const std::string& feature = "") const;
 
@@ -28,8 +42,25 @@ namespace vcpkg
 
         Optional<InstalledPackageView> find_all_installed(const PackageSpec& spec) const;
 
+        /// <summary>Find the StatusParagraph for given spec if installed</summary>
+        /// <param name="spec">Package specification to find the status for</param>
+        /// <returns>Iterator for found spec</returns>
         const_iterator find_installed(const PackageSpec& spec) const;
+
+        /// <summary>Find the StatusParagraph for given feature spec if installed</summary>
+        /// <param name="spec">Feature specification to find the status for</param>
+        /// <returns>Iterator for found spec</returns>
+        const_iterator find_installed(const FeatureSpec& spec) const;
+
+        /// <summary>Find the StatusParagraph for given spec and return its install status</summary>
+        /// <param name="spec">Package specification to check if installed</param>
+        /// <returns>`true` if installed, `false` if not or not found.</returns>
         bool is_installed(const PackageSpec& spec) const;
+
+        /// <summary>Find the StatusParagraph for given feature spec and return its install status</summary>
+        /// <param name="spec">Feature specification to check if installed</param>
+        /// <returns>`true` if installed, `false` if not or not found.</returns>
+        bool is_installed(const FeatureSpec& spec) const;
 
         iterator insert(std::unique_ptr<StatusParagraph>);
 

--- a/toolsrc/src/tests.statusparagraphs.cpp
+++ b/toolsrc/src/tests.statusparagraphs.cpp
@@ -77,6 +77,39 @@ Status: purge ok not-installed
 
             auto it = status_db.find_installed(unsafe_pspec("ffmpeg", Triplet::X64_WINDOWS));
             Assert::IsTrue(it != status_db.end());
+
+            // Feature "openssl" is not installed and should not be found
+            auto it1 = status_db.find_installed({unsafe_pspec("ffmpeg", Triplet::X64_WINDOWS), "openssl"});
+            Assert::IsTrue(it1 == status_db.end());
+        }
+
+        TEST_METHOD(find_for_feature_packages)
+        {
+            auto pghs = parse_paragraphs(R"(
+Package: ffmpeg
+Version: 3.3.3
+Architecture: x64-windows
+Multi-Arch: same
+Description:
+Status: install ok installed
+
+Package: ffmpeg
+Feature: openssl
+Depends: openssl
+Architecture: x64-windows
+Multi-Arch: same
+Description:
+Status: install ok installed
+)");
+            Assert::IsTrue(!!pghs);
+            if (!pghs) return;
+
+            StatusParagraphs status_db(Util::fmap(
+                *pghs.get(), [](RawParagraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
+
+            // Feature "openssl" is installed and should therefore be found
+            auto it = status_db.find_installed({unsafe_pspec("ffmpeg", Triplet::X64_WINDOWS), "openssl"});
+            Assert::IsTrue(it != status_db.end());
         }
     };
 }

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -267,13 +267,16 @@ namespace vcpkg::Build
 
         const Triplet& triplet = config.triplet;
         {
-            std::vector<PackageSpec> missing_specs;
+            std::vector<FeatureSpec> missing_specs;
             for (auto&& dep : filter_dependencies(config.scf.core_paragraph->depends, triplet))
             {
-                auto dep_spec = PackageSpec::from_name_and_triplet(dep, triplet).value_or_exit(VCPKG_LINE_INFO);
-                if (!status_db.is_installed(dep_spec))
+                auto dep_specs = FeatureSpec::from_strings_and_triplet({dep}, triplet);
+                for (auto&& feature : dep_specs)
                 {
-                    missing_specs.push_back(std::move(dep_spec));
+                    if (!status_db.is_installed(feature))
+                    {
+                        missing_specs.push_back(std::move(feature));
+                    }
                 }
             }
             // Fail the build if any dependencies were missing
@@ -600,7 +603,7 @@ namespace vcpkg::Build
         : code(code), binary_control_file(std::move(bcf))
     {
     }
-    ExtendedBuildResult::ExtendedBuildResult(BuildResult code, std::vector<PackageSpec>&& unmet_deps)
+    ExtendedBuildResult::ExtendedBuildResult(BuildResult code, std::vector<FeatureSpec>&& unmet_deps)
         : code(code), unmet_dependencies(std::move(unmet_deps))
     {
     }

--- a/toolsrc/src/vcpkg/statusparagraphs.cpp
+++ b/toolsrc/src/vcpkg/statusparagraphs.cpp
@@ -83,7 +83,26 @@ namespace vcpkg
         }
     }
 
+    StatusParagraphs::const_iterator StatusParagraphs::find_installed(const FeatureSpec& spec) const
+    {
+        auto it = find(spec);
+        if (it != end() && (*it)->is_installed())
+        {
+            return it;
+        }
+        else
+        {
+            return end();
+        }
+    }
+
     bool vcpkg::StatusParagraphs::is_installed(const PackageSpec& spec) const
+    {
+        auto it = find(spec);
+        return it != end() && (*it)->is_installed();
+    }
+
+    bool vcpkg::StatusParagraphs::is_installed(const FeatureSpec& spec) const
     {
         auto it = find(spec);
         return it != end() && (*it)->is_installed();


### PR DESCRIPTION
Hi @ras0219-msft !

It appears that magnum is the first package that depends on features of other packages. (e.g. magnum on corrade[utility]). Up till now, these dependencies are not parsed as features, but packages, and a package called "corrade[utility]" is obviously never installed.

This PR fixes that and allows the build command to find the installed features of a package when listed in `Build-Depends`.

Cheers,
Jonathan.