### PR TITLE
[vcpkg] Fix bug with missing dependencies introduced in #2697

### DIFF
--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -454,14 +454,14 @@ namespace vcpkg::Dependencies
                             return res;
                         }
                     }
+                }
 
-                    // "core" is always an implicit default feature. In case we did not add it as
-                    // a dependency above (e.g. no default features), add it here.
-                    auto res = mark_plus("core", cluster, graph, graph_plan, prevent_default_features);
-                    if (res != MarkPlusResult::SUCCESS)
-                    {
-                        return res;
-                    }
+                // "core" is always an implicit default feature. In case we did not add it as
+                // a dependency above (e.g. no default features), add it here.
+                auto res = mark_plus("core", cluster, graph, graph_plan, prevent_default_features);
+                if (res != MarkPlusResult::SUCCESS)
+                {
+                    return res;
                 }
 
                 return MarkPlusResult::SUCCESS;


### PR DESCRIPTION
Hi @ras0219-msft !

I'm very sorry, this one is my fault.

~~~
When a package dependency was not found (has no source control file),
install would exit with "Value was null" when trying to install its default
features, as the dependency would be marked erroneously as found in this
case.
~~~

E.g.
~~~
$ vcpkg install a // a depends on b, for which there is no port file
Value was null
~~~

I would have liked to create a test case for this, but would need to assert that a "Checks::check_exit()" has been called. While gtests seems to be able to tests for `exit()` calls, I did not find a way to achieve this with CppUnit.

Cheers, Jonathan.