### PR TITLE
[ebml] Apply path to export missing symbol from DLL

### DIFF
--- a/ports/ebml/CONTROL
+++ b/ports/ebml/CONTROL
@@ -1,3 +1,3 @@
 Source: ebml
-Version: 1.3.5
+Version: 1.3.5-1
 Description: a C++ libary to parse EBML files

--- a/ports/ebml/export-endofstreamx.patch
+++ b/ports/ebml/export-endofstreamx.patch
@@ -1,0 +1,25 @@
+From d880a71996ba50c18d2e2d33ce4018b22566d9f4 Mon Sep 17 00:00:00 2001
+From: evpobr <evpobr@gmail.com>
+Date: Sat, 17 Feb 2018 12:39:27 +0500
+Subject: [PATCH] Export SafeReadIOCallback::EndOfStreamX class from DLL
+
+---
+ ebml/SafeReadIOCallback.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ebml/SafeReadIOCallback.h b/ebml/SafeReadIOCallback.h
+index ea96727..3d9de07 100644
+--- a/ebml/SafeReadIOCallback.h
++++ b/ebml/SafeReadIOCallback.h
+@@ -45,7 +45,7 @@ class EBML_DLL_API EbmlBinary;
+ 
+ class EBML_DLL_API SafeReadIOCallback {
+ public:
+-  class EndOfStreamX {
++  class EBML_DLL_API EndOfStreamX {
+   public:
+     size_t mMissingBytes;
+     EndOfStreamX(std::size_t MissingBytes);
+-- 
+2.15.1.windows.2
+

--- a/ports/ebml/portfile.cmake
+++ b/ports/ebml/portfile.cmake
@@ -28,6 +28,11 @@ vcpkg_from_github(
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/EbmlConfig.cmake DESTINATION ${SOURCE_PATH})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/export-endofstreamx.patch
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Failed to build libMatroska because of missing `SafeReadIOCallback::EndOfStreamX` not exported from DLL.