### PR TITLE
[matroska] Initial port

### DIFF
--- a/ports/matroska/CMakeLists.txt
+++ b/ports/matroska/CMakeLists.txt
@@ -1,0 +1,110 @@
+cmake_minimum_required(VERSION 3.1.2)
+
+project(matroska VERSION 1.4.8)
+
+option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
+option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
+
+find_package(ebml 1.3.5 REQUIRED)
+
+include(GNUInstallDirs)
+
+set(libmatroska_SOURCES
+  src/FileKax.cpp
+  src/KaxAttached.cpp
+  src/KaxAttachments.cpp
+  src/KaxBlock.cpp
+  src/KaxBlockData.cpp
+  src/KaxCluster.cpp
+  src/KaxContexts.cpp
+  src/KaxCues.cpp
+  src/KaxCuesData.cpp
+  src/KaxInfoData.cpp
+  src/KaxSeekHead.cpp
+  src/KaxSegment.cpp
+  src/KaxSemantic.cpp
+  src/KaxTracks.cpp
+  src/KaxVersion.cpp)
+
+set(libmatroska_PUBLIC_HEADERS
+  matroska/FileKax.h
+  matroska/KaxAttached.h
+  matroska/KaxAttachments.h
+  matroska/KaxBlockData.h
+  matroska/KaxBlock.h
+  matroska/KaxChapters.h
+  matroska/KaxClusterData.h
+  matroska/KaxCluster.h
+  matroska/KaxConfig.h
+  matroska/KaxContentEncoding.h
+  matroska/KaxContexts.h
+  matroska/KaxCuesData.h
+  matroska/KaxCues.h
+  matroska/KaxDefines.h
+  matroska/KaxInfoData.h
+  matroska/KaxInfo.h
+  matroska/KaxSeekHead.h
+  matroska/KaxSegment.h
+  matroska/KaxSemantic.h
+  matroska/KaxTag.h
+  matroska/KaxTags.h
+  matroska/KaxTrackAudio.h
+  matroska/KaxTrackEntryData.h
+  matroska/KaxTracks.h
+  matroska/KaxTrackVideo.h
+  matroska/KaxTypes.h
+  matroska/KaxVersion.h)
+
+set (libmatroska_C_PUBLIC_HEADERS
+  matroska/c/libmatroska.h
+  matroska/c/libmatroska_t.h)
+
+add_library(matroska ${libmatroska_SOURCES} ${limatroska_PUBLIC_HEADERS} ${libmatroska_C_PUBLIC_HEADERS})
+target_link_libraries(matroska PUBLIC ebml)
+set_target_properties(matroska PROPERTIES
+  VERSION 6.0.0
+  SOVERSION 6)
+target_include_directories(matroska PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+if(MSVC)
+  target_compile_definitions(matroska PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(matroska PUBLIC MATROSKA_DLL)
+  set_target_properties(matroska PROPERTIES DEFINE_SYMBOL "MATROSKA_DLL_EXPORT")
+endif()
+
+install(TARGETS matroska
+  EXPORT MatroskaTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES ${libmatroska_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matroska)
+install(FILES ${libmatroska_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matroska/c)
+
+if(NOT DISABLE_PKGCONFIG)
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+  set(exec_prefix "\$\{prefix\}")
+  set(libdir "\$\{prefix\}/${CMAKE_INSTALL_LIBDIR}")
+  set(includedir "\$\{prefix\}/${CMAKE_INSTALL_INCLUDEDIR}")
+  set(PACKAGE_VERSION ${PROJECT_VERSION})
+  configure_file(libmatroska.pc.in libmatroska.pc @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libmatroska.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
+
+if(NOT DISABLE_CMAKE_CONFIG)
+  if(WIN32)
+    set(CMAKE_INSTALL_PACKAGEDIR cmake)
+  elseif(WIN32)
+    set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  endif()
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(MatroskaConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+  install(EXPORT MatroskaTargets DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/MatroskaConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MatroskaConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_PACKAGEDIR})
+endif()

--- a/ports/matroska/CONTROL
+++ b/ports/matroska/CONTROL
@@ -1,0 +1,4 @@
+Source: matroska
+Version: 1.4.8
+Description: a C++ libary to parse Matroska files (.mkv and .mka)
+Build-Depends: ebml

--- a/ports/matroska/MatroskaConfig.cmake
+++ b/ports/matroska/MatroskaConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/MatroskaTargets.cmake)

--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -1,0 +1,45 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "${PORT} does not currently support UWP")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Matroska-Org/libmatroska
+    REF release-1.4.8
+    SHA512 3591508674ff69a185d143b4ce5c34a4c9913ad806ad94c6a96b694752f3e67b029037573564ab3bf5d9303a4b6c5fdd55865f140ab0d26df53b051b71957d0a
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/MatroskaConfig.cmake DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    OPTIONS -DDISABLE_PKGCONFIG=1
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.LGPL DESTINATION ${CURRENT_PACKAGES_DIR}/share/matroska RENAME copyright)


### PR DESCRIPTION
# LibMatroska port

[LibMatroska](https://github.com/Matroska-Org/libmatroska) ia C++ libary to parse and create Matroska files.

## Notes

* LibMatroska v1.4.8 (latest)
* Uses hand made CMakeLists.txt (Pulled to origial repo as https://github.com/Matroska-Org/libmatroska/pull/13, not accepted yet)
* Requires `LibEbml` (#2812)
* Works for x86 & x64, WindowsStore is not supported (as `LibEBML` uses ANSI debugging calls in library)
