### PR TITLE
[curl] Add support of different features.

### DIFF
--- a/ports/cpr/CONTROL
+++ b/ports/cpr/CONTROL
@@ -1,4 +1,12 @@
 Source: cpr
-Version: 1.3.0-1
+Version: 1.3.0-2
 Description: C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.
 Build-Depends: curl
+
+Feature: openssl
+Build-Depends: curl[openssl]
+Description: SSL support via OpenSSL
+
+Feature: winssl
+Build-Depends: curl[winssl]
+Description: SSL support via Schannel

--- a/ports/cpr/CONTROL
+++ b/ports/cpr/CONTROL
@@ -1,12 +1,4 @@
 Source: cpr
-Version: 1.3.0-2
+Version: 1.3.0-3
 Description: C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.
-Build-Depends: curl
-
-Feature: openssl
-Build-Depends: curl[openssl]
-Description: SSL support via OpenSSL
-
-Feature: winssl
-Build-Depends: curl[winssl]
-Description: SSL support via Schannel
+Build-Depends: curl[core]

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -2,7 +2,7 @@ Source: curl
 Version: 7.58.0-4
 Build-Depends: zlib
 Description: A library for transferring data with URLs
-Default-Features: openssl, ssh, non-http
+Default-Features: ssl
 # For WINSSL add set(CURL_USE_WINSSL ON) to your triplet file
 
 Feature: tool
@@ -12,12 +12,12 @@ Feature: non-http
 Description: Enables protocols beyond HTTP/HTTPS/HTTP2
 
 Feature: http2
-Build-Depends: nghttp2, openssl
+Build-Depends: nghttp2, ssl
 Description: HTTP2 support
 
-Feature: openssl
+Feature: ssl
 Build-Depends: openssl
-Description: SSL support via OpenSSL (Note: this conflicts with CURL_USE_WINSSL)
+Description: SSL support
 
 Feature: ssh
 Build-Depends: libssh2, curl[non-http]

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.58.0-3
+Version: 7.58.0-4
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: openssl, ssh, non-http

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,26 @@
 Source: curl
-Version: 7.58.0-1
-Build-Depends: zlib, openssl, libssh2, nghttp2
+Version: 7.58.0-2
+Build-Depends: zlib
 Description: A library for transferring data with URLs
-# For WINSSL create target triplet which contains set(CURL_USE_WINSSL ON)
+Default-Features: openssl, http2, ssh
+
+Feature: curl
+Description: Builds curl executable
+
+Feature: http-only
+Description: Disables all protocols except HTTP/HTTPS/HTTP2
+
+Feature: http2
+Build-Depends: nghttp2, openssl
+Description: HTTP2 support (requires openssl)
+
+Feature: openssl
+Build-Depends: openssl
+Description: SSL support via OpenSSL
+
+Feature: winssl
+Description: SSL support via Schannel
+
+Feature: ssh
+Build-Depends: libssh2
+Description: SSH support via libssh2

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,26 +1,24 @@
 Source: curl
-Version: 7.58.0-2
+Version: 7.58.0-3
 Build-Depends: zlib
 Description: A library for transferring data with URLs
-Default-Features: openssl, http2, ssh
+Default-Features: openssl, ssh, non-http
+# For WINSSL add set(CURL_USE_WINSSL ON) to your triplet file
 
-Feature: curl
+Feature: tool
 Description: Builds curl executable
 
-Feature: http-only
-Description: Disables all protocols except HTTP/HTTPS/HTTP2
+Feature: non-http
+Description: Enables protocols beyond HTTP/HTTPS/HTTP2
 
 Feature: http2
 Build-Depends: nghttp2, openssl
-Description: HTTP2 support (requires openssl)
+Description: HTTP2 support
 
 Feature: openssl
 Build-Depends: openssl
-Description: SSL support via OpenSSL
-
-Feature: winssl
-Description: SSL support via Schannel
+Description: SSL support via OpenSSL (Note: this conflicts with CURL_USE_WINSSL)
 
 Feature: ssh
-Build-Depends: libssh2
+Build-Depends: libssh2, curl[non-http]
 Description: SSH support via libssh2

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -14,45 +14,48 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/0002_fix_uwp.patch
 )
 
-# Support HTTP2 TSL Download https://curl.haxx.se/ca/cacert.pem rename to curl-ca-bundle.crt, copy it to libcurl.dll location.
-SET(HTTP2_OPTIONS)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    SET(CURL_STATICLIB OFF)
-    SET(HTTP2_OPTIONS
-        -DUSE_NGHTTP2=ON
-    )
-else()
-    SET(CURL_STATICLIB ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)
 
-if(NOT "http2" IN_LIST FEATURES)
-    set(HTTP2_OPTIONS)
+# Support HTTP2 TSL Download https://curl.haxx.se/ca/cacert.pem rename to curl-ca-bundle.crt, copy it to libcurl.dll location.
+set(HTTP2_OPTIONS)
+if("http2" IN_LIST FEATURES)
+    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        message(FATAL_ERROR "The http2 feature cannot be enabled when building for UWP.")
+    endif()
+
+    set(HTTP2_OPTIONS -DUSE_NGHTTP2=ON)
 endif()
 
 # SSL via OpenSSL
+set(USE_OPENSSL OFF)
 if("openssl" IN_LIST FEATURES)
+    if(CURL_USE_WINSSL)
+        message(FATAL_ERROR "The openssl feature conflicts with CURL_USE_WINSSL.")
+    endif()
     set(USE_OPENSSL ON)
 endif()
 
 # SSL via Schannel
-if("winssl" IN_LIST FEATURES)
-    set(USE_OPENSSL OFF)
+set(USE_WINSSL OFF)
+if(CURL_USE_WINSSL)
     set(USE_WINSSL ON)
-    set(HTTP2_OPTIONS) ## disable HTTP2 when CURL_USE_WINSSL
 endif()
 
 # SSH
+set(USE_LIBSSH2 OFF)
 if("ssh" IN_LIST FEATURES)
     set(USE_LIBSSH2 ON)
 endif()
 
 # HTTP/HTTPS only
 # Note that `HTTP_ONLY` curl option disables everything including HTTPS, which is not an option.
-if("http-only" IN_LIST FEATURES)
-    set(USE_HTTP_ONLY ON)
+set(USE_HTTP_ONLY ON)
+if("non-http" IN_LIST FEATURES)
+    set(USE_HTTP_ONLY OFF)
 endif()
 
 # curl exe
+set(BUILD_CURL_EXE OFF)
 if("curl" IN_LIST FEATURES)
     set(BUILD_CURL_EXE ON)
 endif()
@@ -66,7 +69,6 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
         -DENABLE_IPV6=OFF
         -DENABLE_UNIX_SOCKETS=OFF
     )
-    set(HTTP2_OPTIONS) ## disable curl HTTP2 support
 endif()
 
 vcpkg_find_acquire_program(PERL)
@@ -87,7 +89,10 @@ vcpkg_configure_cmake(
         -DCMAKE_USE_WINSSL=${USE_WINSSL}
         -DCMAKE_USE_LIBSSH2=${USE_LIBSSH2}
         -DHTTP_ONLY=${USE_HTTP_ONLY}
+    OPTIONS_RELEASE
+        -DBUILD_CURL_EXE=${BUILD_CURL_EXE}
     OPTIONS_DEBUG
+        -DBUILD_CURL_EXE=OFF
         -DENABLE_DEBUG=ON
 )
 
@@ -96,22 +101,27 @@ vcpkg_install_cmake()
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/curl RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-if("curl" IN_LIST FEATURES)
-    file(INSTALL ${CURRENT_PACKAGES_DIR}/bin/curl.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl.exe ${CURRENT_PACKAGES_DIR}/debug/bin/curl-d.exe)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/curl.exe")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/curl")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/curl.exe ${CURRENT_PACKAGES_DIR}/tools/curl/curl.exe)
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/curl)
 endif()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
     # Drop debug suffix, as FindCURL.cmake does not look for it
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib")
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+    endif()
 else()
     file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl-config ${CURRENT_PACKAGES_DIR}/debug/bin/curl-config)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib ${CURRENT_PACKAGES_DIR}/lib/libcurl.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib")
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib ${CURRENT_PACKAGES_DIR}/lib/libcurl.lib)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+    endif()
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(READ ${CURRENT_PACKAGES_DIR}/include/curl/curl.h CURL_H)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -56,7 +56,7 @@ endif()
 
 # curl exe
 set(BUILD_CURL_EXE OFF)
-if("curl" IN_LIST FEATURES)
+if("tool" IN_LIST FEATURES)
     set(BUILD_CURL_EXE ON)
 endif()
 

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -26,19 +26,15 @@ if("http2" IN_LIST FEATURES)
     set(HTTP2_OPTIONS -DUSE_NGHTTP2=ON)
 endif()
 
-# SSL via OpenSSL
+# SSL
 set(USE_OPENSSL OFF)
-if("openssl" IN_LIST FEATURES)
-    if(CURL_USE_WINSSL)
-        message(FATAL_ERROR "The openssl feature conflicts with CURL_USE_WINSSL.")
-    endif()
-    set(USE_OPENSSL ON)
-endif()
-
-# SSL via Schannel
 set(USE_WINSSL OFF)
-if(CURL_USE_WINSSL)
-    set(USE_WINSSL ON)
+if("ssl" IN_LIST FEATURES)
+    if(CURL_USE_WINSSL)
+        set(USE_WINSSL ON)
+    else()
+        set(USE_OPENSSL ON)
+    endif()
 endif()
 
 # SSH


### PR DESCRIPTION
This PR adds different features for the `cURL` library and, as an example, adds corresponding parts to the `CPR` library.

Default-Features: openssl, http2, ssh (as in previous builds)

Feature: curl
Description: Builds curl executable (placed in the /tools directory)

Feature: http-only
Description: Disables all protocols except HTTP/HTTPS/HTTP2

Feature: http2
Build-Depends: nghttp2, openssl
Description: HTTP2 support (requires openssl)

Feature: openssl
Build-Depends: openssl
Description: SSL support via OpenSSL

Feature: winssl
Description: SSL support via Schannel

Feature: ssh
Build-Depends: libssh2
Description: SSH support via libssh2