### PR TITLE
use TLS 1.2 for downloads

### DIFF
--- a/scripts/VcpkgPowershellUtils.ps1
+++ b/scripts/VcpkgPowershellUtils.ps1
@@ -1,3 +1,4 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 function vcpkgHasModule([Parameter(Mandatory=$true)][string]$moduleName)
 {
     return [bool](Get-Module -ListAvailable -Name $moduleName)

--- a/scripts/VcpkgPowershellUtils.ps1
+++ b/scripts/VcpkgPowershellUtils.ps1
@@ -1,4 +1,3 @@
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 function vcpkgHasModule([Parameter(Mandatory=$true)][string]$moduleName)
 {
     return [bool](Get-Module -ListAvailable -Name $moduleName)
@@ -121,10 +120,25 @@ function vcpkgDownloadFile( [Parameter(Mandatory=$true)][string]$url,
         return
     }
 
+    if ($url -match "github")
+    {
+        if ([System.Enum]::IsDefined([Net.SecurityProtocolType], "Tls12"))
+        {
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        }
+        else
+        {
+            Write-Warning "Github has dropped support for TLS versions prior to 1.2, which is not available on your system"
+            Write-Warning "Please manually download $url to $downloadPath"
+            throw "Download failed"
+        }
+    }
+
     vcpkgCreateParentDirectoryIfNotExists $downloadPath
 
     $downloadPartPath = "$downloadPath.part"
     vcpkgRemoveItem $downloadPartPath
+
 
     $wc = New-Object System.Net.WebClient
     if (!$wc.Proxy.IsBypassed($url))


### PR DESCRIPTION
@alexkaratarakis At least for me https://github.com/Microsoft/vcpkg/issues/2588 makes it impossible to bring up a new vcpkg installation from a clean checkout.

I think it's trying to download from a github.com address and it can't negotiate a TLS version. I seem to recall reading something about Github stopping support for older TLS versions, but I can't find a post about it at the moment. If I understand it correctly the powershell script is trying TLS 1.0.

This PR globally sets downloads to require TLS 1.2.
 
Fixes https://github.com/Microsoft/vcpkg/issues/2588
