### PR TITLE
Support AppVeyor CI test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
     - VCPKG_DEFAULT_TRIPLET: x86-windows-static
     - VCPKG_DEFAULT_TRIPLET: x64-windows
     - VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    - VCPKG_DEFAULT_TRIPLET: arm-uwp
 
 cache:
   - archives

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ shallow_clone: false
 clone_folder: c:\projects\vcpkg
 
 environment:
+  APPVEYOR_SAVE_CACHE_ON_ERROR: false
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
+ 
   matrix:
     - VCPKG_DEFAULT_TRIPLET: x86-windows
     - VCPKG_DEFAULT_TRIPLET: x86-windows-static
@@ -26,11 +29,17 @@ cache:
 #on_failure:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
+# Control cache save baaed on branch name
+#init:
+#  - ps: IF ($env:APPVEYOR_REPO_BRANCH -eq "develop") {$env:APPVEYOR_CACHE_SKIP_SAVE = "true"}
+
 install:
   - ps: |
       ./scripts/bootstrap.ps1
       if (-not $?) { throw $? }
       cd c:\projects\vcpkg
+      Write-Host "------Cached packages------"
+      .\vcpkg.exe cache
       # fetch upstream project which is necessary for forked project to compare with.
       git remote add upstream https://github.com/Microsoft/vcpkg.git
       git fetch -q upstream
@@ -41,11 +50,12 @@ install:
           Group-Object |
           Select-Object -Property name |
           %{$_.name}
+      # When no modified ports found
       if([string]::IsNullOrWhitespace($targets))
       {
           $targets = "zlib"
       }
-      ./vcpkg.exe cache
+      Write-Host "----Clean&build targets----"
       ./vcpkg.exe remove  ${targets} --recurse
       ./vcpkg.exe install ${targets} --recurse --keep-going
       if (-not $?) { throw $? }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,13 @@
 # Copyright 2018 Hiroshi Miura
 #
 image: Visual Studio 2017
-max_jobs: 1
 
-# shallow_clone should false for branch comparison
 shallow_clone: false
-clone_folder: c:\projects\vcpkg
 
 environment:
-  APPVEYOR_SAVE_CACHE_ON_ERROR: false
-  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
- 
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  VCPKG_FEATURE_FLAGS: "binarycaching"
+  
   matrix:
     - VCPKG_DEFAULT_TRIPLET: x86-windows
     - VCPKG_DEFAULT_TRIPLET: x86-windows-static
@@ -20,57 +17,32 @@ environment:
     - VCPKG_DEFAULT_TRIPLET: x64-windows-static
 
 cache:
-  - packages
-
-# Help developer to investigate windows build using RDP to AppVeyor.
-# see https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
-#init:
-#  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-#on_failure:
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
-# Control cache save baaed on branch name
-#init:
-#  - ps: IF ($env:APPVEYOR_REPO_BRANCH -eq "develop") {$env:APPVEYOR_CACHE_SKIP_SAVE = "true"}
+  - archives
 
 install:
   - ps: |
       ./scripts/bootstrap.ps1
-      if (-not $?) { throw $? }
-      cd c:\projects\vcpkg
-      Write-Host "------Cached packages------"
-      .\vcpkg.exe cache
+      # Detect modified ports and make changes list
       # fetch upstream project which is necessary for forked project to compare with.
       git remote add upstream https://github.com/Microsoft/vcpkg.git
       git fetch -q upstream
-      # Detect modified ports and make changes list
-      $targets = git diff --name-only upstream/master... |
-          ?{$_ -match "ports/(?<change>.*?)/"} |
-          %{$Matches.change} |
-          Group-Object |
-          Select-Object -Property name |
-          %{$_.name}
-      # When no modified ports found
-      if([string]::IsNullOrWhitespace($targets))
-      {
-          $targets = "zlib"
-      }
-      Write-Host "----Clean&build targets----"
-      ./vcpkg.exe remove  ${targets} --recurse
-      ./vcpkg.exe install ${targets} --recurse --keep-going
-      if (-not $?) { throw $? }
-      ./vcpkg.exe export  ${targets} --zip --nuget
-      if (-not $?) { throw $? }
+      $env:targets = git diff --name-only upstream/master... |
+          ?{$_ -match "ports/(?<change>.*?)/"} | %{$Matches.change} | Group-Object | % Name
+      if([string]::IsNullOrWhitespace($targets)) { $env:targets = "zlib" }
+      ./vcpkg.exe remove  $env:targets --recurse
+      ./vcpkg.exe install $env:targets --recurse --keep-going --binarycaching
 
 build: off
 
 test: off
 
-artifacts:
-  # build src and logs (include depends) are published as an artifact zip
-  # Also publishes exports for user deployment test
-  - path: buildtrees
-  - path: '*.zip'
-  - path: '*.nupkg'
-
 deploy: off
+
+on_success:
+  -ps: ./vcpkg.exe export $env:targets --zip
+
+on_failure:
+  -ps: $env:targets.Split(" ") | %{ 7z a $_-buildlog.zip buildtrees\$_\*.log }
+
+artifacts:
+  - path: '*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,19 +51,14 @@ install:
           %{$_.name}
       if([string]::IsNullOrWhitespace($targets))
       {
-          ./vcpkg.exe remove  zlib --recurse
-          ./vcpkg.exe install zlib
-          if (-not $?) { throw $? }
+          $targets = "zlib"
       }
-      else
-      {
-          ./vcpkg.exe cache
-          ./vcpkg.exe remove  ${targets} --recurse
-          ./vcpkg.exe install ${targets} --recurse --keep-going
-          if (-not $?) { throw $? }
-          ./vcpkg.exe export  ${targets} --zip --nuget
-          if (-not $?) { throw $? }
-      }
+      ./vcpkg.exe cache
+      ./vcpkg.exe remove  ${targets} --recurse
+      ./vcpkg.exe install ${targets} --recurse --keep-going
+      if (-not $?) { throw $? }
+      ./vcpkg.exe export  ${targets} --zip --nuget
+      if (-not $?) { throw $? }
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,17 +6,12 @@ image: Visual Studio 2017
 shallow_clone: false
 
 environment:
-  APPVEYOR_SAVE_CACHE_ON_ERROR: true
-  VCPKG_FEATURE_FLAGS: "binarycaching"
   matrix:
     - VCPKG_DEFAULT_TRIPLET: x86-windows
     - VCPKG_DEFAULT_TRIPLET: x86-windows-static
     - VCPKG_DEFAULT_TRIPLET: x64-windows
     - VCPKG_DEFAULT_TRIPLET: x64-windows-static
     - VCPKG_DEFAULT_TRIPLET: arm-uwp
-
-cache:
-  - archives
 
 install:
   - ps: |
@@ -29,7 +24,7 @@ install:
           ?{$_ -match "ports/(?<change>.*?)/"} | %{$Matches.change} | Group-Object | % Name
       if([string]::IsNullOrWhitespace($targets)) { $targets = "zlib" }
       ./vcpkg.exe remove  $targets --recurse
-      ./vcpkg.exe install $targets --recurse --keep-going --binarycaching
+      ./vcpkg.exe install $targets --recurse --keep-going
       ./vcpkg.exe export $targets --zip
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,11 @@
 # Copyright 2018 Hiroshi Miura
 #
 image: Visual Studio 2017
-
 shallow_clone: false
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   VCPKG_FEATURE_FLAGS: "binarycaching"
-  
   matrix:
     - VCPKG_DEFAULT_TRIPLET: x86-windows
     - VCPKG_DEFAULT_TRIPLET: x86-windows-static
@@ -27,23 +25,16 @@ install:
       # fetch upstream project which is necessary for forked project to compare with.
       git remote add upstream https://github.com/Microsoft/vcpkg.git
       git fetch -q upstream
-      $env:targets = git diff --name-only upstream/master... |
+      $targets = git diff --name-only upstream/master... |
           ?{$_ -match "ports/(?<change>.*?)/"} | %{$Matches.change} | Group-Object | % Name
-      if([string]::IsNullOrWhitespace($targets)) { $env:targets = "zlib" }
-      ./vcpkg.exe remove  $env:targets --recurse
-      ./vcpkg.exe install $env:targets --recurse --keep-going --binarycaching
+      if([string]::IsNullOrWhitespace($targets)) { $targets = "zlib" }
+      ./vcpkg.exe remove  $targets --recurse
+      ./vcpkg.exe install $targets --recurse --keep-going --binarycaching
+      ./vcpkg.exe export $targets --zip
 
 build: off
-
 test: off
-
 deploy: off
-
-on_success:
-  -ps: ./vcpkg.exe export $env:targets --zip
-
-on_failure:
-  -ps: $env:targets.Split(" ") | %{ 7z a $_-buildlog.zip buildtrees\$_\*.log }
 
 artifacts:
   - path: '*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,6 @@ environment:
     - VCPKG_DEFAULT_TRIPLET: x64-windows-static
 
 cache:
-  - downloads
-  - installed
   - packages
 
 # Help developer to investigate windows build using RDP to AppVeyor.
@@ -54,13 +52,14 @@ install:
       if([string]::IsNullOrWhitespace($targets))
       {
           ./vcpkg.exe remove  zlib --recurse
-          ./vcpkg.exe install zlib 
+          ./vcpkg.exe install zlib
           if (-not $?) { throw $? }
       }
       else
       {
+          ./vcpkg.exe cache
           ./vcpkg.exe remove  ${targets} --recurse
-          ./vcpkg.exe install ${targets} --recurse
+          ./vcpkg.exe install ${targets} --recurse --keep-going
           if (-not $?) { throw $? }
           ./vcpkg.exe export  ${targets} --zip --nuget
           if (-not $?) { throw $? }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,10 @@ clone_folder: c:\projects\vcpkg
 
 environment:
   matrix:
-    - triplet: x86-windows
-    - triplet: x86-windows-static
-    - triplet: x64-windows
-    - triplet: x64-windows-static
+    - VCPKG_DEFAULT_TRIPLET: x86-windows
+    - VCPKG_DEFAULT_TRIPLET: x86-windows-static
+    - VCPKG_DEFAULT_TRIPLET: x64-windows
+    - VCPKG_DEFAULT_TRIPLET: x64-windows-static
 
 cache:
   - downloads
@@ -45,41 +45,25 @@ install:
       git remote add upstream https://github.com/Microsoft/vcpkg.git
       git fetch -q upstream
       # Detect modified ports and make changes list
-      $changes = git diff --name-only upstream/master... |
+      $targets = git diff --name-only upstream/master... |
           ?{$_ -match "ports/(?<change>.*?)/"} |
           %{$Matches.change} |
           Group-Object |
           Select-Object -Property name |
           %{$_.name}
-      # Build package names list to export
-      $export_targets = ""
-      foreach($target in $changes)
+      if([string]::IsNullOrWhitespace($targets))
       {
-          $export_targets += " ${target}"
-      }
-      if([string]::IsNullOrWhitespace($export_targets))
-      {
-        # simple test when non-ports update
-        ./vcpkg.exe remove zlib:$env:triplet --recurse
-        ./vcpkg.exe install zlib:$env:triplet 
-        if (-not $?) { throw $? }
-        ./vcpkg.exe export zlib:$env:triplet --zip --nuget
-        if (-not $?) { throw $? }
+          ./vcpkg.exe remove  zlib --recurse
+          ./vcpkg.exe install zlib 
+          if (-not $?) { throw $? }
       }
       else
       {
-        # ports test
-        foreach($target in $changes)
-        {
-          ./vcpkg.exe remove ${target}:$env:triplet --recurse
-        }
-        foreach($target in $changes)
-        {
-          ./vcpkg.exe install ${target}:$env:triplet
+          ./vcpkg.exe remove  ${targets} --recurse
+          ./vcpkg.exe install ${targets} --recurse
           if (-not $?) { throw $? }
-        }
-        ./vcpkg.exe export ${export_targets} --zip --nuget
-        if (-not $?) { throw $? }
+          ./vcpkg.exe export  ${targets} --zip --nuget
+          if (-not $?) { throw $? }
       }
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,96 @@
+# Appveyor CI configuration for vcpkg project.
+#
+# Copyright 2018 Hiroshi Miura
+#
+image: Visual Studio 2017
+max_jobs: 1
+
+# shallow_clone should false for branch comparison
+shallow_clone: false
+clone_folder: c:\projects\vcpkg
+
+environment:
+  matrix:
+    - triplet: x86-windows
+    - triplet: x86-windows-static
+    - triplet: x64-windows
+    - triplet: x64-windows-static
+
+cache:
+  - downloads
+  - installed
+  - packages
+
+# Help developer to investigate windows build using RDP to AppVeyor.
+# see https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
+#init:
+#  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_failure:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
+install:
+  - ps: |
+      ./scripts/bootstrap.ps1
+      if (-not $?) { throw $? }
+      # Clear out any intermediate files from the previous build
+      if (Test-Path buildtrees)
+      {
+          Get-ChildItem buildtrees/*/* | ? { $_.Name -ne "src" } | Remove-Item -Recurse -Force
+      }
+      # Purge any outdated packages
+      ./vcpkg remove --outdated --recurse
+      if (-not $?) { throw $? }
+      cd c:\projects\vcpkg
+      # fetch upstream project which is necessary for forked project to compare with.
+      git remote add upstream https://github.com/Microsoft/vcpkg.git
+      git fetch -q upstream
+      # Detect modified ports and make changes list
+      $changes = git diff --name-only upstream/master... |
+          ?{$_ -match "ports/(?<change>.*?)/"} |
+          %{$Matches.change} |
+          Group-Object |
+          Select-Object -Property name |
+          %{$_.name}
+      # Build package names list to export
+      $export_targets = ""
+      foreach($target in $changes)
+      {
+          $export_targets += " ${target}"
+      }
+      if([string]::IsNullOrWhitespace($export_targets))
+      {
+        # simple test when non-ports update
+        ./vcpkg.exe remove zlib:$env:triplet --recurse
+        ./vcpkg.exe install zlib:$env:triplet 
+        if (-not $?) { throw $? }
+        ./vcpkg.exe export zlib:$env:triplet --zip --nuget
+        if (-not $?) { throw $? }
+      }
+      else
+      {
+        # ports test
+        foreach($target in $changes)
+        {
+          ./vcpkg.exe remove ${target}:$env:triplet --recurse
+        }
+        foreach($target in $changes)
+        {
+          ./vcpkg.exe install ${target}:$env:triplet
+          if (-not $?) { throw $? }
+        }
+        ./vcpkg.exe export ${export_targets} --zip --nuget
+        if (-not $?) { throw $? }
+      }
+
+build: off
+
+test: off
+
+artifacts:
+  # build src and logs (include depends) are published as an artifact zip
+  # Also publishes exports for user deployment test
+  - path: buildtrees
+  - path: '*.zip'
+  - path: '*.nupkg'
+
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,14 +30,6 @@ install:
   - ps: |
       ./scripts/bootstrap.ps1
       if (-not $?) { throw $? }
-      # Clear out any intermediate files from the previous build
-      if (Test-Path buildtrees)
-      {
-          Get-ChildItem buildtrees/*/* | ? { $_.Name -ne "src" } | Remove-Item -Recurse -Force
-      }
-      # Purge any outdated packages
-      ./vcpkg remove --outdated --recurse
-      if (-not $?) { throw $? }
       cd c:\projects\vcpkg
       # fetch upstream project which is necessary for forked project to compare with.
       git remote add upstream https://github.com/Microsoft/vcpkg.git


### PR DESCRIPTION
It is hard for contributors to test all triplets against their modifications.
Here allow contributor to setup their AppVeyor CI and run test before their PR is pushed.
Also if the vcpkg project want, maintainers can check test result on AppVeyor CI API for PR.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>