### PR TITLE
[libspatialite] fix download url

### DIFF
--- a/ports/libspatialite/CONTROL
+++ b/ports/libspatialite/CONTROL
@@ -1,5 +1,5 @@
 Source: libspatialite
-Version: 4.3.0a-1
+Version: 4.3.0a-2
 Description: SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.
 Build-Depends: libxml2, sqlite3, geos, proj4, zlib, freexl, libiconv
 

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -1,7 +1,7 @@
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libspatialite-4.3.0a)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.gaia-gis.it/gaia-sins/libspatialite-4.3.0a.tar.gz"
+    URLS "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
     FILENAME "libspatialite-4.3.0a.tar.gz"
     SHA512 adfd63e8dde0f370b07e4e7bb557647d2bfb5549205b60bdcaaca69ff81298a3d885e7c1ca515ef56dd0aca152ae940df8b5dbcb65bb61ae0a9337499895c3c0
 )


### PR DESCRIPTION
Download fails because original download url has been changed.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>