### PR TITLE
fix qt tools

### DIFF
--- a/ports/qt5-modularscripts/qt.conf
+++ b/ports/qt5-modularscripts/qt.conf
@@ -1,0 +1,13 @@
+[Paths]
+Prefix = ../../
+Documentation = share/qt5/doc
+Headers = include
+Libraries = lib
+Binaries = tools/qt5
+LibraryExecutables = tools/qt5
+Plugins = plugins
+Qml2Imports = qml
+Data = share/qt5
+ArchData = share/qt5
+HostData = share/qt5
+HostBinaries = tools/qt5

--- a/ports/qt5-modularscripts/qt_modular_library.cmake
+++ b/ports/qt5-modularscripts/qt_modular_library.cmake
@@ -111,6 +111,13 @@ function(qt_modular_library NAME HASH)
 
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/qt5/debug/include)
 
+    #Install a qt.conf file in tools/{PORT}
+    file(GLOB QTEXECUTABLE ${CURRENT_PACKAGES_DIR}/tools/${PORT}/*.exe)
+    if (QTEXECUTABLE)
+        file(COPY ${VCPKG_ROOT_DIR}/ports/qt5-modularscripts/qt.conf 
+             DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}/)
+    endif()
+
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 
     #Find the relevant license file and install it


### PR DESCRIPTION
## A note for testers
Although not readily apparent by checking out this branch, proper testing for this branch should be done **with an inactive/empty fixcmake.py** as (i think) it is used not only to allow for the discovery of qt5 components by cmake at build time (find_package and the like) but also to patch up some paths and so have an impact on the generated executables.  The other - much easier - way to test this branch is to use the tools in an exported vcpkg branch (```vcpkg export qt5-tools``` for example).

## Why this patch 
Although building successfully, the different qt5 tools like designer, qml, linguist and others are missing some functionality as they are currently built/installed.  This is particularly true once the tools are exported, as their _baked-in-at-compile-time_ values are no longer effective.  

## How does it work
Don't read this part if you are familiar with qtApps, it's pedantic and boring - it's only in here because patches need to be justified.  Tools like the designer, qml, assistant, qmake, qtpaths etc. are QApplications. By virtue of being QApplications, they all inherit the same behavior, i.e. if a qt.conf file is present in the same folder they are installed in, it will be read and used to find whatever they need to work.

So for example, after installing the aforementioned qt.conf in tools/qt5-tools, designer will suddenly find it's plugins installed in ../../plugins/designer **without the need of any further patching** (the plugin may be missing dependencies however, as qt_deploy doesn't detect/install plugin dependencies in tools/qt5-tools (@ras0219-msft will need to intervene here I think)).  

## What does it fix
Pretty much any qt tools that is based on qApplicaitons, which is most of them.  For the record, winqtdeploy is not a qApplication btw, so it remains broken.

## Notes 
Not being an expert in all things QT, I know that some values in qt.conf are missing or not quite right for some tools, or may be unnecessary.  For example, some tools would benefit from qt.conf having a **Translations** value but I don't know what that value should be.  **Imports** could also be added, but I don't use qml.  HostBinaries and HostData values are likely unnecessary.

Tests should be done from the **installed/vcpkg_triplet/tools/** section of the vcpkg tree and not from packages/port-name_vcpkg_triplet/tools (for exported trees, that is the only folder present in any case).  

This patch and the included qt.conf has no relation whatsoever with qtdebug.conf, qtrelease.conf used to build the qt modules.

Although incomplete I can attest this patch has no negative impacts and has some positive ones.

If this patch seems a bit rushed, that's because it is.  I am sending it in as is because am I seeing quite a few reports of "this tool is broken" this simple fix will fix most tools without the need for any further work.  

Also, am I hoping that any further patching work be upstreamable - as qt tools should use the values from qt.conf to find whatever they need to work.  If they don't, then that's a bug with the tool itself, not a problem with vcpkg.

closes https://github.com/Microsoft/vcpkg/issues/2908
closes https://github.com/Microsoft/vcpkg/issues/2857
