### PR TITLE
[OpenCV] update to 3.4.1

### DIFF
--- a/ports/opencv/0001-winrt-fixes.patch
+++ b/ports/opencv/0001-winrt-fixes.patch
@@ -1,23 +1,6 @@
-From 005963d571f95fc536f60aa77098b9ecbb17128c Mon Sep 17 00:00:00 2001
-From: Robert Schumacher <roschuma@microsoft.com>
-Date: Wed, 21 Feb 2018 17:03:30 -0800
-Subject: [PATCH 1/5] winrt-fixes
-
----
- CMakeLists.txt                                            |  2 +-
- cmake/OpenCVCompilerOptions.cmake                         |  3 +++
- cmake/OpenCVModule.cmake                                  |  2 +-
- modules/core/src/utils/filesystem.cpp                     | 14 ++++++++++++--
- modules/highgui/include/opencv2/highgui/highgui_winrt.hpp |  1 +
- modules/highgui/src/window_winrt_bridge.hpp               |  1 +
- modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp     |  4 ++--
- 7 files changed, 21 insertions(+), 6 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4464441..6bfbecd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -296,7 +296,7 @@ OCV_OPTION(INSTALL_TESTS            "Install accuracy and performance test binar
+@@ -311,7 +311,7 @@ OCV_OPTION(INSTALL_TESTS            "Install accuracy and performance test binar
  # OpenCV build options
  # ===================================================
  OCV_OPTION(ENABLE_CCACHE              "Use ccache"                                               (UNIX AND NOT IOS AND (CMAKE_GENERATOR MATCHES "Makefile" OR CMAKE_GENERATOR MATCHES "Ninja")) )
@@ -26,104 +9,45 @@ index 4464441..6bfbecd 100644
  OCV_OPTION(ENABLE_SOLUTION_FOLDERS    "Solution folder in Visual Studio or in other IDEs"        (MSVC_IDE OR CMAKE_GENERATOR MATCHES Xcode) )
  OCV_OPTION(ENABLE_PROFILING           "Enable profiling in the GCC compiler (Add flags: -g -pg)" OFF  IF CMAKE_COMPILER_IS_GNUCXX )
  OCV_OPTION(ENABLE_COVERAGE            "Enable coverage collection with  GCov"                    OFF  IF CMAKE_COMPILER_IS_GNUCXX )
-diff --git a/cmake/OpenCVCompilerOptions.cmake b/cmake/OpenCVCompilerOptions.cmake
-index 353ee12..8f4aa3b 100644
---- a/cmake/OpenCVCompilerOptions.cmake
-+++ b/cmake/OpenCVCompilerOptions.cmake
-@@ -37,6 +37,9 @@ if(MSVC)
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHa")
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}"  CACHE STRING "Flags used by the compiler during all build types." FORCE)
-   endif()
-+  if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZW")
-+  endif()
- endif()
- 
- set(OPENCV_EXTRA_FLAGS "")
-diff --git a/cmake/OpenCVModule.cmake b/cmake/OpenCVModule.cmake
-index a84bbff..8feb6df 100644
 --- a/cmake/OpenCVModule.cmake
 +++ b/cmake/OpenCVModule.cmake
-@@ -785,7 +785,7 @@ macro(ocv_create_module)
+@@ -842,7 +842,7 @@ macro(ocv_create_module)
      set(the_module_target ${the_module})
    endif()
- 
+
 -  if(WINRT)
 +  if(WINRT AND BUILD_TESTS)
      # removing APPCONTAINER from modules to run from console
      # in case of usual starting of WinRT test apps output is missing
      # so starting of console version w/o APPCONTAINER is required to get test results
-diff --git a/modules/core/src/utils/filesystem.cpp b/modules/core/src/utils/filesystem.cpp
-index 266a92f..1d5a302 100644
---- a/modules/core/src/utils/filesystem.cpp
-+++ b/modules/core/src/utils/filesystem.cpp
-@@ -186,7 +186,7 @@ bool createDirectory(const cv::String& path)
-     wchar_t wpath[MAX_PATH];
-     size_t copied = mbstowcs(wpath, path.c_str(), MAX_PATH);
-     CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
--    int result = CreateDirectoryA(wpath, NULL) ? 0 : -1;
-+    int result = CreateDirectoryW(wpath, NULL) ? 0 : -1;
- #else
-     int result = _mkdir(path.c_str());
- #endif
-@@ -248,8 +248,16 @@ struct FileLock::Impl
-         int numRetries = 5;
-         do
-         {
-+#ifdef WINRT
-+            wchar_t wpath[MAX_PATH];
-+            size_t copied = mbstowcs(wpath, fname, MAX_PATH);
-+            CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
-+            handle = ::CreateFile2(wpath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
-+                                OPEN_EXISTING, NULL);
-+#else
-             handle = ::CreateFileA(fname, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-                                 OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-+#endif
-             if (INVALID_HANDLE_VALUE == handle)
-             {
-                 if (ERROR_SHARING_VIOLATION == GetLastError())
-@@ -399,7 +407,9 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
-     if (cache_path.empty())
-     {
-         cv::String default_cache_path;
--#ifdef _WIN32
-+#if WINRT
-+        // no defaults
-+#elif defined _WIN32
-         char tmp_path_buf[MAX_PATH+1] = {0};
-         DWORD res = GetTempPath(MAX_PATH, tmp_path_buf);
-         if (res > 0 && res <= MAX_PATH)
-diff --git a/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp b/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp
-index f4147f3..b92efdd 100644
 --- a/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp
 +++ b/modules/highgui/include/opencv2/highgui/highgui_winrt.hpp
 @@ -24,6 +24,7 @@
  // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  // POSSIBILITY OF SUCH DAMAGE.
- 
+
 +#include "opencv2/core/cvdef.h"
  using namespace Windows::UI::Xaml::Controls;
- 
+
  namespace cv
 diff --git a/modules/highgui/src/window_winrt_bridge.hpp b/modules/highgui/src/window_winrt_bridge.hpp
 index 25f4aef..5429f0b 100644
 --- a/modules/highgui/src/window_winrt_bridge.hpp
 +++ b/modules/highgui/src/window_winrt_bridge.hpp
 @@ -28,6 +28,7 @@
- 
+
  #include <map>
  #include <opencv2\core.hpp>
 +#include "opencv2/highgui/highgui_c.h"
- 
+
  using namespace Windows::UI::Xaml::Controls;
- 
+
 diff --git a/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp b/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp
 index 236e227..e2417dc 100644
 --- a/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp
 +++ b/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp
 @@ -94,10 +94,10 @@ Media::CaptureFrameGrabber::~CaptureFrameGrabber()
- 
+
  void Media::CaptureFrameGrabber::ShowCameraSettings()
  {
 -#if WINAPI_FAMILY!=WINAPI_FAMILY_PHONE_APP
@@ -135,6 +59,3 @@ index 236e227..e2417dc 100644
      }
  #endif
  }
--- 
-2.15.1.windows.2
-

--- a/ports/opencv/0002-install-options.patch
+++ b/ports/opencv/0002-install-options.patch
@@ -1,22 +1,6 @@
-From 5d4d154117b39d9e11fda709ede7aadf6b960a7d Mon Sep 17 00:00:00 2001
-From: Robert Schumacher <roschuma@microsoft.com>
-Date: Wed, 21 Feb 2018 17:05:16 -0800
-Subject: [PATCH 2/5] install-options
-
----
- CMakeLists.txt               | 20 +++++++++++---------
- cmake/OpenCVGenConfig.cmake  |  4 ++--
- cmake/OpenCVGenHeaders.cmake |  8 ++++++--
- cmake/OpenCVModule.cmake     |  4 +++-
- data/CMakeLists.txt          |  6 ++++--
- include/CMakeLists.txt       | 16 +++++++++-------
- 6 files changed, 35 insertions(+), 23 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6bfbecd..0156eeb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -292,6 +292,10 @@ OCV_OPTION(INSTALL_PYTHON_EXAMPLES  "Install Python examples"   OFF )
+@@ -307,6 +307,10 @@ OCV_OPTION(INSTALL_PYTHON_EXAMPLES  "Install Python examples"   OFF )
  OCV_OPTION(INSTALL_ANDROID_EXAMPLES "Install Android examples"  OFF IF ANDROID )
  OCV_OPTION(INSTALL_TO_MANGLED_PATHS "Enables mangled install paths, that help with side by side installs." OFF IF (UNIX AND NOT ANDROID AND NOT APPLE_FRAMEWORK AND BUILD_SHARED_LIBS) )
  OCV_OPTION(INSTALL_TESTS            "Install accuracy and performance test binaries and test data" OFF)
@@ -24,21 +8,21 @@ index 6bfbecd..0156eeb 100644
 +OCV_OPTION(INSTALL_LICENSE          "Install license file"      ON)
 +OCV_OPTION(INSTALL_OTHER            "Install other files"       ON)
 +OCV_OPTION(INSTALL_FORCE_UNIX_PATHS "Force unix-style installation" OFF)
- 
+
  # OpenCV build options
  # ===================================================
-@@ -319,7 +323,7 @@ OCV_OPTION(CV_ENABLE_INTRINSICS       "Use intrinsic-based optimized code" ON )
+@@ -335,7 +339,7 @@ OCV_OPTION(CV_ENABLE_INTRINSICS       "Use intrinsic-based optimized code" ON )
  OCV_OPTION(CV_DISABLE_OPTIMIZATION    "Disable explicit optimized code (dispatched code/intrinsics/loop unrolling/etc)" OFF )
  OCV_OPTION(CV_TRACE                   "Enable OpenCV code trace" ON)
- 
+
 -OCV_OPTION(ENABLE_PYLINT              "Add target with Pylint checks"                            (${BUILD_DOCS} OR ${BUILD_EXAMPLES}) IF (NOT CMAKE_CROSSCOMPILING AND NOT APPLE_FRAMEWORK) )
 +OCV_OPTION(ENABLE_PYLINT              "Add target with Pylint checks"                            (BUILD_DOCS OR BUILD_EXAMPLES) IF (NOT CMAKE_CROSSCOMPILING AND NOT APPLE_FRAMEWORK) )
- 
+
  if(ENABLE_IMPL_COLLECTION)
    add_definitions(-DCV_COLLECT_IMPL_DATA)
-@@ -355,7 +359,9 @@ else()
+@@ -372,7 +376,9 @@ else()
  endif()
- 
+
  if(WIN32 AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
 -  if(DEFINED OpenCV_RUNTIME AND DEFINED OpenCV_ARCH)
 +  if(DEFINED OpenCV_DISABLE_ARCH_PATH)
@@ -47,9 +31,9 @@ index 6bfbecd..0156eeb 100644
      ocv_update(OpenCV_INSTALL_BINARIES_PREFIX "${OpenCV_ARCH}/${OpenCV_RUNTIME}/")
    else()
      message(STATUS "Can't detect runtime and/or arch")
-@@ -409,12 +415,8 @@ else()
+@@ -427,12 +433,8 @@ else()
    ocv_update(3P_LIBRARY_OUTPUT_PATH      "${OpenCV_BINARY_DIR}/3rdparty/lib${LIB_SUFFIX}")
- 
+
    if(WIN32 AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
 -    if(OpenCV_STATIC)
 -      ocv_update(OPENCV_LIB_INSTALL_PATH   "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib${LIB_SUFFIX}")
@@ -59,32 +43,30 @@ index 6bfbecd..0156eeb 100644
 -    ocv_update(OPENCV_3P_LIB_INSTALL_PATH  "${OpenCV_INSTALL_BINARIES_PREFIX}staticlib${LIB_SUFFIX}")
 +    ocv_update(OPENCV_LIB_INSTALL_PATH     "${OpenCV_INSTALL_BINARIES_PREFIX}lib${LIB_SUFFIX}")
 +    ocv_update(OPENCV_3P_LIB_INSTALL_PATH  "${OpenCV_INSTALL_BINARIES_PREFIX}lib${LIB_SUFFIX}")
-     ocv_update(OPENCV_SAMPLES_SRC_INSTALL_PATH    samples/native)
+     ocv_update(OPENCV_SAMPLES_SRC_INSTALL_PATH    samples)
      ocv_update(OPENCV_JAR_INSTALL_PATH java)
      ocv_update(OPENCV_OTHER_INSTALL_PATH   etc)
-@@ -856,7 +858,7 @@ if(NOT OPENCV_LICENSE_FILE)
+@@ -895,7 +897,7 @@ if(NOT OPENCV_LICENSE_FILE)
  endif()
- 
+
  # for UNIX it does not make sense as LICENSE and readme will be part of the package automatically
 -if(ANDROID OR NOT UNIX)
 +if(ANDROID OR NOT UNIX AND INSTALL_LICENSE)
    install(FILES ${OPENCV_LICENSE_FILE}
          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
          DESTINATION ./ COMPONENT libs)
-diff --git a/cmake/OpenCVGenConfig.cmake b/cmake/OpenCVGenConfig.cmake
-index 57c79f2..23f1012 100644
 --- a/cmake/OpenCVGenConfig.cmake
 +++ b/cmake/OpenCVGenConfig.cmake
-@@ -103,7 +103,7 @@ function(ocv_gen_config TMP_DIR NESTED_PATH ROOT_NAME)
+@@ -105,7 +105,7 @@ function(ocv_gen_config TMP_DIR NESTED_PATH ROOT_NAME)
    endif()
  endfunction()
- 
+
 -if((CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" OR UNIX) AND NOT ANDROID)
 +if(((CMAKE_HOST_SYSTEM_NAME MATCHES "Linux" OR UNIX) AND NOT ANDROID) OR INSTALL_FORCE_UNIX_PATHS)
    ocv_gen_config("${CMAKE_BINARY_DIR}/unix-install" "" "")
  endif()
- 
-@@ -115,7 +115,7 @@ endif()
+
+@@ -117,7 +117,7 @@ endif()
  # --------------------------------------------------------------------------------------------
  #  Part 3/3: ${BIN_DIR}/win-install/OpenCVConfig.cmake  -> For use within binary installers/packages
  # --------------------------------------------------------------------------------------------
@@ -93,8 +75,6 @@ index 57c79f2..23f1012 100644
    if(CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
      if(BUILD_SHARED_LIBS)
        set(_lib_suffix "lib")
-diff --git a/cmake/OpenCVGenHeaders.cmake b/cmake/OpenCVGenHeaders.cmake
-index 477b910..beace28 100644
 --- a/cmake/OpenCVGenHeaders.cmake
 +++ b/cmake/OpenCVGenHeaders.cmake
 @@ -1,7 +1,9 @@
@@ -105,22 +85,20 @@ index 477b910..beace28 100644
 +if(INSTALL_HEADERS)
 +  install(FILES "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/cvconfig.h" DESTINATION ${OPENCV_INCLUDE_INSTALL_PATH}/opencv2 COMPONENT dev)
 +endif()
- 
+
  # platform-specific config file
  ocv_compiler_optimization_fill_cpu_config()
 @@ -29,4 +31,6 @@ set(OPENCV_MODULE_DEFINITIONS_CONFIGMAKE "${OPENCV_MODULE_DEFINITIONS_CONFIGMAKE
  #endforeach()
- 
+
  configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/opencv_modules.hpp.in" "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/opencv_modules.hpp")
 -install(FILES "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/opencv_modules.hpp" DESTINATION ${OPENCV_INCLUDE_INSTALL_PATH}/opencv2 COMPONENT dev)
 +if(INSTALL_HEADERS)
 +  install(FILES "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/opencv_modules.hpp" DESTINATION ${OPENCV_INCLUDE_INSTALL_PATH}/opencv2 COMPONENT dev)
 +endif()
-diff --git a/cmake/OpenCVModule.cmake b/cmake/OpenCVModule.cmake
-index 8feb6df..1a098c4 100644
 --- a/cmake/OpenCVModule.cmake
 +++ b/cmake/OpenCVModule.cmake
-@@ -930,7 +930,9 @@ macro(_ocv_create_module)
+@@ -994,7 +994,9 @@ macro(_ocv_create_module)
      foreach(hdr ${OPENCV_MODULE_${the_module}_HEADERS})
        string(REGEX REPLACE "^.*opencv2/" "opencv2/" hdr2 "${hdr}")
        if(NOT hdr2 MATCHES "private" AND hdr2 MATCHES "^(opencv2/?.*)/[^/]+.h(..)?$" )
@@ -131,25 +109,21 @@ index 8feb6df..1a098c4 100644
        endif()
      endforeach()
    endif()
-diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
-index 1f0d720..86b9d89 100644
 --- a/data/CMakeLists.txt
 +++ b/data/CMakeLists.txt
 @@ -1,8 +1,10 @@
  file(GLOB HAAR_CASCADES haarcascades/*.xml)
  file(GLOB LBP_CASCADES lbpcascades/*.xml)
- 
+
 -install(FILES ${HAAR_CASCADES} DESTINATION ${OPENCV_OTHER_INSTALL_PATH}/haarcascades COMPONENT libs)
 -install(FILES ${LBP_CASCADES}  DESTINATION ${OPENCV_OTHER_INSTALL_PATH}/lbpcascades  COMPONENT libs)
 +if(INSTALL_OTHER)
 +  install(FILES ${HAAR_CASCADES} DESTINATION ${OPENCV_OTHER_INSTALL_PATH}/haarcascades COMPONENT libs)
 +  install(FILES ${LBP_CASCADES}  DESTINATION ${OPENCV_OTHER_INSTALL_PATH}/lbpcascades  COMPONENT libs)
 +endif()
- 
+
  if(INSTALL_TESTS AND OPENCV_TEST_DATA_PATH)
    install(DIRECTORY "${OPENCV_TEST_DATA_PATH}/" DESTINATION "${OPENCV_TEST_DATA_INSTALL_PATH}" COMPONENT "tests")
-diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
-index b4e48e6..5ac6f16 100644
 --- a/include/CMakeLists.txt
 +++ b/include/CMakeLists.txt
 @@ -1,7 +1,9 @@
@@ -169,6 +143,3 @@ index b4e48e6..5ac6f16 100644
 +        DESTINATION ${OPENCV_INCLUDE_INSTALL_PATH}/opencv2
 +        COMPONENT dev)
 +endif()
--- 
-2.15.1.windows.2
-

--- a/ports/opencv/0003-disable-downloading.patch
+++ b/ports/opencv/0003-disable-downloading.patch
@@ -1,14 +1,3 @@
-From 692f6f4fcf9bfddaf8779ba622f190c3a8c772f9 Mon Sep 17 00:00:00 2001
-From: Robert Schumacher <roschuma@microsoft.com>
-Date: Wed, 21 Feb 2018 17:20:22 -0800
-Subject: [PATCH 3/5] disable-downloading
-
----
- cmake/OpenCVDownload.cmake | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/cmake/OpenCVDownload.cmake b/cmake/OpenCVDownload.cmake
-index f660502..90785f1 100644
 --- a/cmake/OpenCVDownload.cmake
 +++ b/cmake/OpenCVDownload.cmake
 @@ -151,6 +151,8 @@ function(ocv_download)
@@ -20,6 +9,3 @@ index f660502..90785f1 100644
      file(DOWNLOAD "${DL_URL}" "${CACHE_CANDIDATE}"
           INACTIVITY_TIMEOUT 60
           TIMEOUT 600
--- 
-2.15.1.windows.2
-

--- a/ports/opencv/0004-use-find-package-required.patch
+++ b/ports/opencv/0004-use-find-package-required.patch
@@ -1,14 +1,3 @@
-From 7e02db97d43cb9aa331da0dbfce8c372c19ad32b Mon Sep 17 00:00:00 2001
-From: Robert Schumacher <roschuma@microsoft.com>
-Date: Wed, 21 Feb 2018 17:20:49 -0800
-Subject: [PATCH 4/5] use-find-package-required
-
----
- cmake/OpenCVFindLibsGrfmt.cmake | 18 +++++++++---------
- 1 file changed, 9 insertions(+), 9 deletions(-)
-
-diff --git a/cmake/OpenCVFindLibsGrfmt.cmake b/cmake/OpenCVFindLibsGrfmt.cmake
-index 0ae58c8..5832d56 100644
 --- a/cmake/OpenCVFindLibsGrfmt.cmake
 +++ b/cmake/OpenCVFindLibsGrfmt.cmake
 @@ -6,7 +6,7 @@
@@ -18,18 +7,18 @@ index 0ae58c8..5832d56 100644
 -  find_package(ZLIB "${MIN_VER_ZLIB}")
 +  find_package(ZLIB "${MIN_VER_ZLIB}" REQUIRED)
    if(ZLIB_FOUND AND ANDROID)
-     if(ZLIB_LIBRARIES STREQUAL "${ANDROID_SYSROOT}/usr/lib/libz.so" OR
-         ZLIB_LIBRARIES STREQUAL "${ANDROID_SYSROOT}/usr/lib64/libz.so")
-@@ -31,7 +31,7 @@ if(WITH_JPEG)
+     if(ZLIB_LIBRARIES MATCHES "/usr/(lib|lib32|lib64)/libz.so$")
+       set(ZLIB_LIBRARIES z)
+@@ -30,7 +30,7 @@ if(WITH_JPEG)
    if(BUILD_JPEG)
      ocv_clear_vars(JPEG_FOUND)
    else()
 -    include(FindJPEG)
 +    find_package(JPEG REQUIRED)
    endif()
- 
+
    if(NOT JPEG_FOUND)
-@@ -52,7 +52,7 @@ if(WITH_TIFF)
+@@ -51,7 +51,7 @@ if(WITH_TIFF)
    if(BUILD_TIFF)
      ocv_clear_vars(TIFF_FOUND)
    else()
@@ -38,7 +27,7 @@ index 0ae58c8..5832d56 100644
      if(TIFF_FOUND)
        ocv_parse_header("${TIFF_INCLUDE_DIR}/tiff.h" TIFF_VERSION_LINES TIFF_VERSION_CLASSIC TIFF_VERSION_BIG TIFF_VERSION TIFF_BIGTIFF_VERSION)
      endif()
-@@ -95,7 +95,7 @@ if(WITH_WEBP)
+@@ -94,7 +94,7 @@ if(WITH_WEBP)
    if(BUILD_WEBP)
      ocv_clear_vars(WEBP_FOUND WEBP_LIBRARY WEBP_LIBRARIES WEBP_INCLUDE_DIR)
    else()
@@ -47,16 +36,16 @@ index 0ae58c8..5832d56 100644
      if(WEBP_FOUND)
        set(HAVE_WEBP 1)
      endif()
-@@ -136,7 +136,7 @@ if(WITH_JASPER)
+@@ -135,7 +135,7 @@ if(WITH_JASPER)
    if(BUILD_JASPER)
      ocv_clear_vars(JASPER_FOUND)
    else()
 -    include(FindJasper)
 +    find_package(Jasper REQUIRED)
    endif()
- 
+
    if(NOT JASPER_FOUND)
-@@ -160,7 +160,7 @@ if(WITH_PNG)
+@@ -159,7 +159,7 @@ if(WITH_PNG)
    if(BUILD_PNG)
      ocv_clear_vars(PNG_FOUND)
    else()
@@ -65,33 +54,30 @@ index 0ae58c8..5832d56 100644
      if(PNG_FOUND)
        include(CheckIncludeFile)
        check_include_file("${PNG_PNG_INCLUDE_DIR}/libpng/png.h" HAVE_LIBPNG_PNG_H)
-@@ -192,7 +192,7 @@ if(WITH_OPENEXR)
+@@ -191,7 +191,7 @@ if(WITH_OPENEXR)
    if(BUILD_OPENEXR)
      ocv_clear_vars(OPENEXR_FOUND)
    else()
 -    include("${OpenCV_SOURCE_DIR}/cmake/OpenCVFindOpenEXR.cmake")
 +    find_package(OpenEXR REQUIRED)
    endif()
- 
+
    if(NOT OPENEXR_FOUND)
-@@ -208,7 +208,7 @@ endif()
- 
+@@ -207,7 +207,7 @@ endif()
+
  # --- GDAL (optional) ---
  if(WITH_GDAL)
 -    find_package(GDAL QUIET)
 +    find_package(GDAL REQUIRED)
- 
+
      if(NOT GDAL_FOUND)
          set(HAVE_GDAL NO)
-@@ -220,7 +220,7 @@ if(WITH_GDAL)
+@@ -219,7 +219,7 @@ if(WITH_GDAL)
  endif()
- 
+
  if (WITH_GDCM)
 -  find_package(GDCM QUIET)
 +  find_package(GDCM REQUIRED)
    if(NOT GDCM_FOUND)
      set(HAVE_GDCM NO)
      ocv_clear_vars(GDCM_VERSION GDCM_LIBRARIES)
--- 
-2.15.1.windows.2
-

--- a/ports/opencv/0005-remove-protobuf-target.patch
+++ b/ports/opencv/0005-remove-protobuf-target.patch
@@ -1,0 +1,31 @@
+--- a/cmake/OpenCVFindProtobuf.cmake
++++ b/cmake/OpenCVFindProtobuf.cmake
+@@ -44,17 +44,6 @@ else()
+   # end of compatibility block
+ 
+   if(Protobuf_FOUND)
+-    if(TARGET protobuf::libprotobuf)
+-      add_library(libprotobuf INTERFACE)
+-      target_link_libraries(libprotobuf INTERFACE protobuf::libprotobuf)
+-    else()
+-      add_library(libprotobuf UNKNOWN IMPORTED)
+-      set_target_properties(libprotobuf PROPERTIES
+-        IMPORTED_LOCATION "${Protobuf_LIBRARY}"
+-        INTERFACE_INCLUDE_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
+-      )
+-      get_protobuf_version(Protobuf_VERSION "${Protobuf_INCLUDE_DIR}")
+-    endif()
+     set(HAVE_PROTOBUF TRUE)
+   endif()
+ endif()
+--- a/modules/dnn/CMakeLists.txt
++++ b/modules/dnn/CMakeLists.txt
+@@ -65,7 +65,7 @@ endif()
+ 
+ ocv_module_include_directories(${fw_inc} ${CMAKE_CURRENT_LIST_DIR}/src/ocl4dnn/include ${OPENCL_INCLUDE_DIRS})
+ ocv_glob_module_sources(SOURCES ${fw_srcs})
+-ocv_create_module(libprotobuf ${LAPACK_LIBRARIES})
++ocv_create_module()
+ ocv_add_samples()
+ ocv_add_accuracy_tests()
+ ocv_add_perf_tests()

--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,8 +1,23 @@
 Source: opencv
-Version: 3.4.0-3
-Build-Depends: opengl, zlib, protobuf (windows)
+Version: 3.4.1
+Build-Depends: zlib
 Description: computer vision library
-Default-Features: jpeg, png, tiff, eigen
+Default-Features: opengl, jpeg, png, tiff, eigen, flann
+
+Feature: opengl
+Build-Depends: opengl
+Description: opengl support for opencv
+
+Feature: dnn
+Build-Depends: protobuf
+Description: opencv_dnn module
+
+Feature: ovis
+Build-Depends: ogre
+Description: opencv_ovis module
+
+Feature: flann
+Description: opencv_flann module
 
 Feature: sfm
 Build-Depends: eigen3, glog, gflags, ceres

--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -24,6 +24,7 @@ Build-Depends: eigen3, glog, gflags, ceres
 Description: opencv_sfm module
 
 Feature: contrib
+Build-Depends: opencv[flann]
 Description: opencv_contrib module
 
 Feature: cuda

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -1,20 +1,12 @@
 include(vcpkg_common_functions)
 
-set(OPENCV_PORT_VERSION "3.4.0")
-
-# This is to ensure we are patching clean sources. These lines can be removed when the OpenCV version is next upgraded.
-if(EXISTS "${CURRENT_BUILDTREES_DIR}/src/opencv-${OPENCV_PORT_VERSION}" AND NOT EXISTS "${CURRENT_BUILDTREES_DIR}/src/opencv-${OPENCV_PORT_VERSION}/rework.stamp")
-  file(REMOVE_RECURSE
-    "${CURRENT_BUILDTREES_DIR}/src/opencv-opencv-${OPENCV_PORT_VERSION}.tar.gz.extracted"
-    "${CURRENT_BUILDTREES_DIR}/src/opencv-${OPENCV_PORT_VERSION}"
-  )
-endif()
+set(OPENCV_PORT_VERSION "3.4.1")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO opencv/opencv
     REF ${OPENCV_PORT_VERSION}
-    SHA512 aa7e475f356ffdaeb2ae9f7e9380c92cae58fabde9cd3b23c388f9190b8fde31ee70d16648042d0c43c03b2ff1f15e4be950be7851133ea0aa82cf6e42ba4710
+    SHA512 e1fc14285090c6fe9e26e721f2d67d7096650c523147e925567426ef76aa7f4c6f12035d6f6ce3ec7991a75a6828a810fd4f9b75f78ed5fcccecefbadd79944b
     HEAD_REF master
 )
 
@@ -25,19 +17,38 @@ vcpkg_apply_patches(
       "${CMAKE_CURRENT_LIST_DIR}/0002-install-options.patch"
       "${CMAKE_CURRENT_LIST_DIR}/0003-disable-downloading.patch"
       "${CMAKE_CURRENT_LIST_DIR}/0004-use-find-package-required.patch"
+      "${CMAKE_CURRENT_LIST_DIR}/0005-remove-protobuf-target.patch"
 )
 
 file(WRITE "${CURRENT_BUILDTREES_DIR}/src/opencv-${OPENCV_PORT_VERSION}/rework.stamp")
 
-vcpkg_download_distfile(TINYDNN_ARCHIVE
-    URLS "https://github.com/tiny-dnn/tiny-dnn/archive/v1.0.0a3.tar.gz"
-    FILENAME "opencv-cache/tiny_dnn/adb1c512e09ca2c7a6faef36f9c53e59-v1.0.0a3.tar.gz"
-    SHA512 5f2c1a161771efa67e85b1fea395953b7744e29f61187ac5a6c54c912fb195b3aef9a5827135c3668bd0eeea5ae04a33cc433e1f6683e2b7955010a2632d168b
-)
-
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_WITH_STATIC_CRT)
 
 set(CMAKE_MODULE_PATH)
+
+set(BUILD_opencv_dnn OFF)
+set(WITH_PROTOBUF OFF)
+if("dnn" IN_LIST FEATURES)
+  set(BUILD_opencv_dnn ON)
+  set(WITH_PROTOBUF ON)
+  set(PROTOBUF_UPDATE_FILES ON)
+  set(UPDATE_PROTO_FILES ON)
+  vcpkg_download_distfile(TINYDNN_ARCHIVE
+    URLS "https://github.com/tiny-dnn/tiny-dnn/archive/v1.0.0a3.tar.gz"
+    FILENAME "opencv-cache/tiny_dnn/adb1c512e09ca2c7a6faef36f9c53e59-v1.0.0a3.tar.gz"
+    SHA512 5f2c1a161771efa67e85b1fea395953b7744e29f61187ac5a6c54c912fb195b3aef9a5827135c3668bd0eeea5ae04a33cc433e1f6683e2b7955010a2632d168b
+  )
+endif()
+
+set(BUILD_opencv_flann OFF)
+if("flann" IN_LIST FEATURES)
+  set(BUILD_opencv_flann ON)
+endif()
+
+set(BUILD_opencv_ovis OFF)
+if("ovis" IN_LIST FEATURES)
+  set(BUILD_opencv_ovis ON)
+endif()
 
 set(BUILD_opencv_sfm OFF)
 if("sfm" IN_LIST FEATURES)
@@ -99,19 +110,19 @@ set(WITH_FFMPEG OFF)
 if("ffmpeg" IN_LIST FEATURES)
   set(WITH_FFMPEG ON)
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/66b1fed06cf3510235f367f96aa26da5cb234a15/ffmpeg/opencv_ffmpeg.dll"
-    FILENAME "opencv-cache/ffmpeg/3ae76b105113d944984b2351c61e21c6-opencv_ffmpeg.dll"
-    SHA512 62ad0d6de7a7887a08313e20c474b4f98ae7746a2c10cce2ea5eae284250830e721b81308a401d0fadd238dda85c3ec0f347b41361fd56e473e790e3c40fa554
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/opencv_ffmpeg.dll"
+    FILENAME "opencv-cache/ffmpeg/b8120c07962d591e2e9071a1bf566fd0-opencv_ffmpeg.dll"
+    SHA512 53325e3bb04de19273270475d7b7d9190c950b0d12e1179feef63c69ba66c9f8593d8ed9b030109dee8c104ab5babea69f18c7cae7366a57d48272d67c00d871
   )
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/66b1fed06cf3510235f367f96aa26da5cb234a15/ffmpeg/opencv_ffmpeg_64.dll"
-    FILENAME "opencv-cache/ffmpeg/cf3bb5bc9d393b022ea7a42eb63e794d-opencv_ffmpeg_64.dll"
-    SHA512 5de95a180895aaa5186578572dd1968d2ff3ce8d24c46755c94d768ea6f463c92416c86e851b06b15fc314dd852a456282a56f5b14d6fb9130a054ac9e8230bd
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/opencv_ffmpeg_64.dll"
+    FILENAME "opencv-cache/ffmpeg/dc9c50e7b05482acc25d6ce0ac61bf1d-opencv_ffmpeg_64.dll"
+    SHA512 7d90df6f5d141f842a45e5678cf1349657612321250ece4ad5c6b5fb28a50140735d91ced0ce1a6e81962ef87236cbd1669c0b4410308f70fccee341a7a5c28b
   )
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/66b1fed06cf3510235f367f96aa26da5cb234a15/ffmpeg/ffmpeg_version.cmake"
-    FILENAME "opencv-cache/ffmpeg/ec59008da403fb18ab3c1ed66aed583b-ffmpeg_version.cmake"
-    SHA512 97784032256b104ed9bb3e3f71824985c551b3e4a86928bcf60d3beef50817f66cf276256e140e645e78e04f4463f3665bdda0574585d05af640fb43d0ba4cb9
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/ffmpeg_version.cmake"
+    FILENAME "opencv-cache/ffmpeg/3b90f67f4b429e77d3da36698cef700c-ffmpeg_version.cmake"
+    SHA512 7d0142c30ac6f6260c1bcabc22753030fd25a708477fa28053e8df847c366967d3b93a8ac14af19a2b7b73d9f8241749a431458faf21a0c8efc7d6d99eecfdcf
   )
 endif()
 
@@ -155,6 +166,11 @@ if("gdcm" IN_LIST FEATURES)
   set(WITH_GDCM ON)
 endif()
 
+set(WITH_OPENGL OFF)
+if("opengl" IN_LIST FEATURES)
+  set(WITH_OPENGL ON)
+endif()
+
 set(WITH_OPENEXR OFF)
 if("openexr" IN_LIST FEATURES)
   set(WITH_OPENEXR ON)
@@ -196,12 +212,13 @@ if(BUILD_opencv_contrib)
       OUT_SOURCE_PATH CONTRIB_SOURCE_PATH
       REPO opencv/opencv_contrib
       REF ${OPENCV_PORT_VERSION}
-      SHA512 53f6127304f314d3be834f79520d4bc8a75e14cad8c9c14a66a7a6b37908ded114d24e3a2c664d4ec2275903db08ac826f29433e810c6400f3adc2714a3c5be7
+      SHA512 431dfba0f413071d7faa18bc6e6f5e4f015285e2cc730c5dd69b2a4d6aa4250b7e0bcb1814ac6f06f5c76f103aea1f93f72f32aee6bc0cd7ddacdaf1f40075c1
       HEAD_REF master
   )
   set(BUILD_WITH_CONTRIB_FLAG "-DOPENCV_EXTRA_MODULES_PATH=${CONTRIB_SOURCE_PATH}/modules")
 endif()
 
+set(WITH_ZLIB ON)
 set(BUILD_opencv_line_descriptor ON)
 set(BUILD_opencv_saliency ON)
 set(BUILD_opencv_bgsegm ON)
@@ -219,11 +236,10 @@ vcpkg_configure_cmake(
     OPTIONS
         # Ungrouped Entries
         -DOpenCV_DISABLE_ARCH_PATH=ON
-        -DPROTOBUF_UPDATE_FILES=ON
-        -DUPDATE_PROTO_FILES=ON
-        # BUILD
+        # Do not build docs/examples
         -DBUILD_DOCS=OFF
         -DBUILD_EXAMPLES=OFF
+        # Do not build integrated libraries, use external ones whenever possible
         -DBUILD_JASPER=OFF
         -DBUILD_JPEG=OFF
         -DBUILD_OPENEXR=OFF
@@ -237,16 +253,20 @@ vcpkg_configure_cmake(
         -DBUILD_WITH_DEBUG_INFO=ON
         -DBUILD_WITH_STATIC_CRT=${BUILD_WITH_STATIC_CRT}
         -DBUILD_ZLIB=OFF
+        # Select which OpenCV modules should be built
         -DBUILD_opencv_apps=OFF
-        -DBUILD_opencv_dnn=ON
-        -DBUILD_opencv_flann=ON
+        -DBUILD_opencv_bgsegm=${BUILD_opencv_bgsegm}
+        -DBUILD_opencv_dnn=${BUILD_opencv_dnn}
+        -DBUILD_opencv_flann=${BUILD_opencv_flann}
+        -DBUILD_opencv_line_descriptor=${BUILD_opencv_line_descriptor}
+        -DBUILD_opencv_ovis=${BUILD_opencv_ovis}
         -DBUILD_opencv_python2=OFF
         -DBUILD_opencv_python3=OFF
-        -DBUILD_opencv_sfm=${BUILD_opencv_sfm}
-        -DBUILD_opencv_line_descriptor=${BUILD_opencv_line_descriptor}
         -DBUILD_opencv_saliency=${BUILD_opencv_saliency}
-        -DBUILD_opencv_bgsegm=${BUILD_opencv_bgsegm}
-
+        -DBUILD_opencv_sfm=${BUILD_opencv_sfm}
+        # PROTOBUF
+        -DPROTOBUF_UPDATE_FILES=${PROTOBUF_UPDATE_FILES}
+        -DUPDATE_PROTO_FILES=${UPDATE_PROTO_FILES}
         # CMAKE
         -DCMAKE_DISABLE_FIND_PACKAGE_JNI=ON
         "-DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}"
@@ -264,22 +284,24 @@ vcpkg_configure_cmake(
         # WITH
         -DWITH_CUBLAS=OFF
         -DWITH_CUDA=${WITH_CUDA}
+        -DWITH_EIGEN=${WITH_EIGEN}
         -DWITH_FFMPEG=${WITH_FFMPEG}
+        -DWITH_GDCM=${WITH_GDCM}
         -DWITH_IPP=${WITH_IPP}
+        -DWITH_JASPER=${WITH_JASPER}
+        -DWITH_JPEG=${WITH_JPEG}
         -DWITH_LAPACK=OFF
         -DWITH_MSMF=${WITH_MSMF}
         -DWITH_OPENCLAMDBLAS=OFF
-        -DWITH_OPENGL=ON
-        -DWITH_QT=${WITH_QT}
-        -DWITH_VTK=${WITH_VTK}
-        -DWITH_GDCM=${WITH_GDCM}
-        -DWITH_WEBP=${WITH_WEBP}
         -DWITH_OPENEXR=${WITH_OPENEXR}
-        -DWITH_TIFF=${WITH_TIFF}
-        -DWITH_JPEG=${WITH_JPEG}
+        -DWITH_OPENGL=${WITH_OPENGL}
         -DWITH_PNG=${WITH_PNG}
-        -DWITH_JASPER=${WITH_JASPER}
-        -DWITH_EIGEN=${WITH_EIGEN}
+        -DWITH_PROTOBUF=${WITH_PROTOBUF}
+        -DWITH_QT=${WITH_QT}
+        -DWITH_TIFF=${WITH_TIFF}
+        -DWITH_VTK=${WITH_VTK}
+        -DWITH_WEBP=${WITH_WEBP}
+        -DWITH_ZLIB=${WITH_ZLIB}
     OPTIONS_DEBUG
         -DINSTALL_HEADERS=OFF
         -DINSTALL_OTHER=OFF

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -66,6 +66,12 @@ if("contrib" IN_LIST FEATURES)
     SHA512 c16e60a6c4bb4de3ab39b876ae3c3f320ea56f69c93e9303bd2dff8760841dcd71be4161fff8bc71e8fe4fe8747fa8465d49d6bd8f5ebcdaea161f4bc2da7c93
   )
 
+  vcpkg_download_distfile(TINYDNN_ARCHIVE
+    URLS "https://github.com/tiny-dnn/tiny-dnn/archive/v1.0.0a3.tar.gz"
+    FILENAME "opencv-cache/tiny_dnn/adb1c512e09ca2c7a6faef36f9c53e59-v1.0.0a3.tar.gz"
+    SHA512 5f2c1a161771efa67e85b1fea395953b7744e29f61187ac5a6c54c912fb195b3aef9a5827135c3668bd0eeea5ae04a33cc433e1f6683e2b7955010a2632d168b
+  )
+
   function(download_opencv_3rdparty ID COMMIT HASH)
     if(NOT EXISTS "${DOWNLOADS}/opencv-cache/${ID}/${COMMIT}.stamp")
       vcpkg_download_distfile(OCV_DOWNLOAD


### PR DESCRIPTION
- [x] Port patchset to 3.4.1
- [x] check for updates for 3rd party libraries download by our port file

Working features:
```
opengl, dnn, flann, contrib, ffmpeg, ipp, webp, tiff, png, jpeg, jasper, eigen
```

Untested features:
```
cuda, qt
```

Broken features:
```
ovis, vtk, sfm, gdcm: missing library dir when linking in subprojects (only for static builds)
openexr: drastic Failure due to mismatch debug/release
```

Regarding the *missing library dir when linking in subprojects* of some broken features (should be valid only for static builds, dynamic builds should be ok but I'd like a confirmation), when dependencies are found through the XXXXConfig.cmake script and not a FindXXXX.cmake one, the libraries are appended to the OpenCV dependencies without the full path and so any downstream project cannot properly link (without looking for that library too, in order to append the proper search path to the linker). I discussed the problem upstream with OpenCV devs and they told me it's a known issue with CMake. Now I am discussing the problem with CMake devs 😉 

Regarding the *debug/release mismatch* (present also in some working features but in a non-drastic way), in my previous PR I tried to fix many of them with invasive modifications to the dependencies, implementing a proper suffix (`d`) for the libraries when built in debug mode, so that the two were distinguishable by `CMake`. As of now, on the other hand, having the same name, when the library dependencies are collected and merged, only the debug ones survive and they trigger a link to the debug runtime also when used for release.
I opened many merge requests on the official CMake repository in the meantime, with fixes and improvements for the various FindXXXX.cmake modules, to be ready to look for libraries with a `d` suffix (this should be the right approach, but unfortunately we live in a world which has to be retro compatible, so it will be a long and bumpy road before the final merge). In the meantime, I'd like also to reopen the discussion about jumping the gun here in vcpkg, add a suffix to libraries that still miss it and deploy a custom CMake module if necessary for each one. This would fix *real world usage* of those libraries, otherwise it is very difficult to use them correctly (the problem that emerges with OpenCV is common to any other project which has them as a dependency).

As a side note, shall we reduce the base install to "no default features" (tested, it works)?