### PR TITLE
[zlib] disable parallel configure

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -14,8 +14,9 @@ vcpkg_apply_patches(
 )
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+    SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DSKIP_INSTALL_FILES=ON
         -DSKIP_BUILD_EXAMPLES=ON


### PR DESCRIPTION
Parallel configure should be disabled to avoid the following error (rare, but it just occurred to me):
```
CMake Error at CMakeLists.txt:78 (file):
  file RENAME failed to rename

    C:/src/vcpkg/buildtrees/zlib/src/zlib-1.2.11/zconf.h

  to

    C:/src/vcpkg/buildtrees/zlib/src/zlib-1.2.11/zconf.h.included

  because: No such file or directory
```