### PR TITLE
fix for clFFT: v2.12.2 ships outdated FindOpenCL.cmake

### DIFF
--- a/ports/clfft/portfile.cmake
+++ b/ports/clfft/portfile.cmake
@@ -13,6 +13,12 @@ vcpkg_apply_patches(
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/tweak-install.patch
 )
 
+# v2.12.2 has a very old FindOpenCL.cmake using OPENCL_ vs. OpenCL_ var names
+# conflicting with the built-in, more modern FindOpenCL.cmake 
+file(
+    REMOVE ${SOURCE_PATH}/src/FindOpenCL.cmake
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/src
     PREFER_NINJA


### PR DESCRIPTION
The latest tagged version of clFFT (not master, not develop) ships with the outdated FindOpenCL.cmake script, which is removed in favor of CMakes post-v3.7 own scripts.

After my lengthy struggles with the OpenCL SDK and clFFT, the final version that got merged into Vcpkg/master did not work. Now the clFFT package builds, and can be consumed using stock FindOpenCL.cmake in tandem with the installed clFFTConfig.cmake scripts.

When I update clFFT to either master or develop (hopefully 2.15.0 will ship sometime soonish, current dev branch), I'll remove this addition.

_Other clMath libraries inbound._