### PR TITLE
RFC:  re-import an exported archive

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Vcpkg helps you get C and C++ libraries on Windows. This tool and ecosystem are 
 ### Specifications
 
 - [Export](specifications/export-command.md)
+- [Import](specifications/import-command.md)
 
 ### Blog posts
 

--- a/docs/specifications/import-command.md
+++ b/docs/specifications/import-command.md
@@ -1,0 +1,44 @@
+# External project and exported binary Import (Mar 3, 2018)
+
+## 1. Motivation
+
+### A. Quick port of external MSBuild projects
+
+Vcpkg ports developers want to be able to bulid their project on `vcpkg` quickly. Therefore, there is a
+value to import external MSBuild project into `vcpkg` as new ports.
+
+### B. Build once, and re-use it again and again
+
+Customers and vcpkg ports developers want to be able to build their set of required libraries once,
+and then put the resulting binaries on somewhere accesible and use it on their project repeatedly.
+Typical use case is;
+
+- CI for Vcpkg Ports development, in which vcpkg ports developer want to test their updated script quickly
+  on CI on a cloud-based farm of build machines.
+
+Building once and sharing ensures that everyone gets exactly the same binaries, isolates the building effort to a small number of people and minimizes friction to obtain them.
+If we can re-import an exported binaries, vcpkg developer be also happier. 
+Therefore, there is value in enabling users to easily import to `vcpkg`.
+
+### C. Very large libraries
+
+Libraries like [Qt][] can take a very long time to build (5+ hours). Therefore, having the ability to build them and then distribute the binaries and re-import it can save a lot of time.
+
+## 2. Proposed solution
+
+This document proposes the extenstion of `vcpkg import` command not only import from external project but also
+import exported binary package by `vcpkg export`. 
+
+## 3. Command Lines
+
+### A. Import external project
+
+```
+> vcpkg import --ext --control C:\path\to\CONTROLfile --include C:\path\to\includedir --project C:\path\to\projectdir
+```
+
+### B. Import exported package file
+
+```
+> vcpkg import --vc --pkg c:\path\to\exported_package_file.7z
+```

--- a/toolsrc/include/vcpkg/import.ext.h
+++ b/toolsrc/include/vcpkg/import.ext.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vcpkg/dependencies.h>
+#include <vcpkg/vcpkgpaths.h>
+
+#include <vcpkg/base/files.h>
+
+#include <string>
+#include <vector>
+
+namespace vcpkg::Import::Ext
+{
+    struct Options
+    {
+        Optional<std::string> maybe_project_directory;
+        Optional<std::string> maybe_include_directory;
+        Optional<std::string> maybe_control_file_path;
+    };
+
+    void do_import(const VcpkgPaths& paths, const Options& opts);
+}

--- a/toolsrc/include/vcpkg/import.h
+++ b/toolsrc/include/vcpkg/import.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg::Import
+{
+    extern const CommandStructure COMMAND_STRUCTURE;
+
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, const Triplet& default_triplet);
+}

--- a/toolsrc/include/vcpkg/import.pkg.h
+++ b/toolsrc/include/vcpkg/import.pkg.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <vcpkg/dependencies.h>
+#include <vcpkg/vcpkgpaths.h>
+#include <vcpkg/base/files.h>
+
+#include <string>
+#include <vector>
+
+namespace vcpkg::Import::Pkg
+{
+    struct Options
+    {
+        Optional<std::string> maybe_vcexport_file_path;
+    };
+
+    void do_import(const VcpkgPaths& paths, const Options& opts);
+}

--- a/toolsrc/src/vcpkg/import.ext.cpp
+++ b/toolsrc/src/vcpkg/import.ext.cpp
@@ -1,0 +1,115 @@
+#include "pch.h"
+
+#include <vcpkg/base/files.h>
+#include <vcpkg/commands.h>
+#include <vcpkg/help.h>
+#include <vcpkg/paragraphs.h>
+#include <vcpkg/statusparagraph.h>
+#include <vcpkg/import.h>
+#include <vcpkg/import.ext.h>
+
+namespace vcpkg::Import::Ext
+{
+    struct Binaries
+    {
+        std::vector<fs::path> dlls;
+        std::vector<fs::path> libs;
+    };
+
+    static void check_is_directory(const LineInfo& line_info, const Files::Filesystem& fs, const fs::path& dirpath)
+    {
+        Checks::check_exit(line_info, fs.is_directory(dirpath), "The path %s is not a directory", dirpath.string());
+    }
+
+    static Binaries find_binaries_in_dir(const Files::Filesystem& fs, const fs::path& path)
+    {
+        auto files = fs.get_files_recursive(path);
+
+        check_is_directory(VCPKG_LINE_INFO, fs, path);
+
+        Binaries binaries;
+        for (auto&& file : files)
+        {
+            if (fs.is_directory(file)) continue;
+            const auto ext = file.extension();
+            if (ext == ".dll")
+                binaries.dlls.push_back(std::move(file));
+            else if (ext == ".lib")
+                binaries.libs.push_back(std::move(file));
+        }
+        return binaries;
+    }
+
+    static void copy_files_into_directory(Files::Filesystem& fs,
+                                          const std::vector<fs::path>& files,
+                                          const fs::path& destination_folder)
+    {
+        std::error_code ec;
+        fs.create_directory(destination_folder, ec);
+
+        for (auto const& src_path : files)
+        {
+            const fs::path dest_path = destination_folder / src_path.filename();
+            fs.copy(src_path, dest_path, fs::copy_options::overwrite_existing);
+        }
+    }
+
+    static void place_library_files_in(Files::Filesystem& fs,
+                                       const fs::path& include_directory,
+                                       const fs::path& project_directory,
+                                       const fs::path& destination_path)
+    {
+        check_is_directory(VCPKG_LINE_INFO, fs, include_directory);
+        check_is_directory(VCPKG_LINE_INFO, fs, project_directory);
+        check_is_directory(VCPKG_LINE_INFO, fs, destination_path);
+        const Binaries debug_binaries = find_binaries_in_dir(fs, project_directory / "Debug");
+        const Binaries release_binaries = find_binaries_in_dir(fs, project_directory / "Release");
+
+        const fs::path destination_include_directory = destination_path / "include";
+        fs.copy(include_directory,
+                destination_include_directory,
+                fs::copy_options::recursive | fs::copy_options::overwrite_existing);
+
+        copy_files_into_directory(fs, release_binaries.dlls, destination_path / "bin");
+        copy_files_into_directory(fs, release_binaries.libs, destination_path / "lib");
+
+        std::error_code ec;
+        fs.create_directory(destination_path / "debug", ec);
+        copy_files_into_directory(fs, debug_binaries.dlls, destination_path / "debug" / "bin");
+        copy_files_into_directory(fs, debug_binaries.libs, destination_path / "debug" / "lib");
+    }
+
+    static void _do_import(const VcpkgPaths& paths,
+                          const fs::path& include_directory,
+                          const fs::path& project_directory,
+                          const BinaryParagraph& control_file_data)
+    {
+        auto& fs = paths.get_filesystem();
+        const fs::path library_destination_path = paths.package_dir(control_file_data.spec);
+        std::error_code ec;
+        fs.create_directory(library_destination_path, ec);
+        place_library_files_in(paths.get_filesystem(), include_directory, project_directory, library_destination_path);
+
+        const fs::path control_file_path = library_destination_path / "CONTROL";
+        fs.write_contents(control_file_path, Strings::serialize(control_file_data));
+    }
+
+    void do_import(const VcpkgPaths& paths, const Options& opts)
+    {
+        auto& fs = paths.get_filesystem();
+        const fs::path control_file_path = fs::path(opts.maybe_control_file_path.value_or_exit(VCPKG_LINE_INFO));
+        const fs::path include_directory = fs::path(opts.maybe_include_directory.value_or_exit(VCPKG_LINE_INFO));
+        const fs::path project_directory = fs::path(opts.maybe_project_directory.value_or_exit(VCPKG_LINE_INFO));
+        const Expected<std::unordered_map<std::string, std::string>> pghs =
+            Paragraphs::get_single_paragraph(paths.get_filesystem(), control_file_path);
+        Checks::check_exit(VCPKG_LINE_INFO,
+                           pghs.get() != nullptr,
+                           "Invalid control file %s for package",
+                           control_file_path.generic_string());
+
+        StatusParagraph spgh;
+        spgh.package = BinaryParagraph(*pghs.get());
+        auto& control_file_data = spgh.package;
+        _do_import(paths, include_directory, project_directory, control_file_data);
+    }
+}

--- a/toolsrc/src/vcpkg/import.pkg.cpp
+++ b/toolsrc/src/vcpkg/import.pkg.cpp
@@ -1,0 +1,50 @@
+#include "pch.h"
+
+#include <vcpkg/base/files.h>
+#include <vcpkg/commands.h>
+#include <vcpkg/help.h>
+#include <vcpkg/paragraphs.h>
+#include <vcpkg/statusparagraph.h>
+#include <vcpkg/import.h>
+#include <vcpkg/import.pkg.h>
+
+namespace vcpkg::Import::Pkg
+{
+    void do_import(const VcpkgPaths& paths, const Options& opts)
+    {
+        auto& fs = paths.get_filesystem();
+        const fs::path vcexport_file_path = fs::path(opts.maybe_vcexport_file_path.value_or_exit(VCPKG_LINE_INFO));
+
+        // FIXME: implement me.
+        //
+        // extract exported files
+        // copy installed/x64-windows installed/x86-windows into proper directory
+        //
+        // for each  *.info file in installed/vcpkg/info
+        //      file has a filiname <libname>_<version>_<triplet>.info
+        //         for example, hoge_1.0_x86-windows.info
+        //      detect library name and store it to target.name
+        //      detect version and store it to target.version
+        //      detect triplet and store it to target.triplet
+        //
+        //      - CONTROL file
+        //        read ports/<libname>/CONTROL
+        //        modify version string to be same as exported one.
+        //        write into packages/<libname>_<triplet>/CONTROL
+        //      - BUILD_INFO file
+        //        We just put hardcoded one.
+        //        for shared
+        //           CRTLinkage: daynamic
+        //           LibraryLinkage: dynamic
+        //        for static
+        //           CRTLinkage: static
+        //           LibraryLinkage: static
+        //      - Retrieve binary files based on .info contents
+        //        read *.info line
+        //           example: hoge_x86-windows/bin/hoge.dll
+        //        copy files into packages/<libname>_<triplet>/
+        //          for exampke,  packages/hoge_x86-windows/bin/hoge.dll
+        //
+        //  endforeach
+    }
+}

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj
@@ -164,6 +164,9 @@
     <ClInclude Include="..\include\vcpkg\globalstate.h" />
     <ClInclude Include="..\include\vcpkg\help.h" />
     <ClInclude Include="..\include\vcpkg\input.h" />
+    <CIInclude Include="..\include\vcpkg\import.h" />
+    <CIInclude Include="..\include\vcpkg\import.ext.h" />
+    <CIInclude Include="..\include\vcpkg\import.pkg.h" />
     <ClInclude Include="..\include\vcpkg\install.h" />
     <ClInclude Include="..\include\vcpkg\metrics.h" />
     <ClInclude Include="..\include\vcpkg\packagespec.h" />
@@ -227,6 +230,8 @@
     <ClCompile Include="..\src\vcpkg\export.cpp" />
     <ClCompile Include="..\src\vcpkg\globalstate.cpp" />
     <ClCompile Include="..\src\vcpkg\help.cpp" />
+    <ClCompile Include="..\src\vcpkg\import.ext.cpp" />
+    <ClCompile Include="..\src\vcpkg\import.pkg.cpp" />
     <ClCompile Include="..\src\vcpkg\input.cpp" />
     <ClCompile Include="..\src\vcpkg\install.cpp" />
     <ClCompile Include="..\src\vcpkg\metrics.cpp" />


### PR DESCRIPTION
It is an early preview and request for feedback how to realize an import feature from exported archives.
Also propose to change an import command syntax, and documentation.

I'd like to ask developers against command line interface and features from a point of view on User Experience and implementation.

related issues: #1785 #2807 

Now following updates here.
- Change import command syntax and document it.
 * Add --ext subcommand option for preexist import function.
 * Introduce --control --include --project options
 * When no sub command option, assuming -ext
- Introduce --vc subcommand (not implemented the feature yet)

Signed-off-by: Hiroshi Miura <miurahr@linux.com>