### PR TITLE
[curl] Add missing advapi32 link

### DIFF
--- a/ports/curl/0003_fix_libraries.patch
+++ b/ports/curl/0003_fix_libraries.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 490cc19ef8..23fe34f614 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -330,7 +330,7 @@ if(CMAKE_USE_WINSSL)
+   set(SSL_ENABLED ON)
+   set(USE_SCHANNEL ON) # Windows native SSL/TLS support
+   set(USE_WINDOWS_SSPI ON) # CMAKE_USE_WINSSL implies CURL_WINDOWS_SSPI
+-  list(APPEND CURL_LIBS "crypt32")
++  list(APPEND CURL_LIBS "crypt32" "advapi32")
+ endif()
+ if(CURL_WINDOWS_SSPI)
+   set(USE_WINDOWS_SSPI ON)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
         ${CMAKE_CURRENT_LIST_DIR}/0002_fix_uwp.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0003_fix_libraries.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
This adds missing library, advapi32, to linking. Fixes ARM builds.

The same patch is pending merge upstream:
https://github.com/curl/curl/pull/2363