### PR TITLE
[libsodium] Install sodium.h

### DIFF
--- a/ports/libsodium/CONTROL
+++ b/ports/libsodium/CONTROL
@@ -1,3 +1,3 @@
 Source: libsodium
-Version: 1.0.16
+Version: 1.0.16-1
 Description: A modern and easy-to-use crypto library

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -34,6 +34,10 @@ ELSE()
     SET(BUILD_ARCH ${VCPKG_TARGET_ARCHITECTURE})
 ENDIF()
 
+file(INSTALL
+    ${SOURCE_PATH}/src/libsodium/include/sodium.h
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
 
 file(GLOB LIBSODIUM_HEADERS "${SOURCE_PATH}/src/libsodium/include/sodium/*.h")
 file(INSTALL


### PR DESCRIPTION
libsodium have a header file "sodium.h", but vcpkg don't install it.