### PR TITLE
[mman] move include/mman/sys/mman.h into original include/sys/mman.h

### DIFF
--- a/ports/mman/CONTROL
+++ b/ports/mman/CONTROL
@@ -1,3 +1,3 @@
 Source: mman
-Version: git-f5ff813-2
+Version: git-f5ff813-3
 Description: A light implementation of the mmap functions for MinGW.

--- a/ports/mman/portfile.cmake
+++ b/ports/mman/portfile.cmake
@@ -21,17 +21,14 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include/mman)
-file(RENAME ${CURRENT_PACKAGES_DIR}/include/sys ${CURRENT_PACKAGES_DIR}/include/mman/sys)
-
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/mman)
 file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/mman RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(READ ${CURRENT_PACKAGES_DIR}/include/mman/sys/mman.h _contents)
+    file(READ ${CURRENT_PACKAGES_DIR}/include/sys/mman.h _contents)
     string(REPLACE "__declspec(dllimport)" "" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/mman/sys/mman.h "${_contents}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/include/sys/mman.h "${_contents}")
 endif()
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
include/mman/sys/mman.h is not usable for Visual C++ Project System, and the mman library is a posix(mman) api wrapper for Windows Memory Management API, so I think mman.h need to move to include/sys, and the mman library is not need to build on system other than Windows.