### PR TITLE
[realsense2] Add tools compilation

### DIFF
--- a/ports/realsense2/CONTROL
+++ b/ports/realsense2/CONTROL
@@ -4,3 +4,7 @@ Description: Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel�
 
 Feature: avx2
 Description: rgb image decode using avx2
+
+Feature: tools
+Build-Depends: opengl
+Description: Build Intel® RealSense™ examples and tools

--- a/ports/realsense2/CONTROL
+++ b/ports/realsense2/CONTROL
@@ -1,5 +1,5 @@
 Source: realsense2
-Version: 2.10.1
+Version: 2.10.1-1
 Description: Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).
 
 Feature: avx2

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -15,6 +15,9 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/fix_rgb_using_avx2.patch # https://github.com/IntelRealSense/librealsense/pull/1245
 )
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_LIBRARY_LINKAGE)
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_CRT_LINKAGE)
+
 # This option will be deprecated in the later versions.
 # Please see Pull Request #1245. https://github.com/IntelRealSense/librealsense/pull/1245
 set(RGB_USING_AVX2 OFF)
@@ -22,15 +25,22 @@ if("avx2" IN_LIST FEATURES)
     set(RGB_USING_AVX2 ON)
 endif()
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_LIBRARY_LINKAGE)
-string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_CRT_LINKAGE)
+set(BUILD_EXAMPLES OFF)
+set(BUILD_GRAPHICAL_EXAMPLES OFF)
+if("tools" IN_LIST FEATURES)
+  set(BUILD_EXAMPLES ON)
+  set(BUILD_GRAPHICAL_EXAMPLES ON)
+  set(BUILD_TOOLS ON)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DENFORCE_METADATA=ON
-        -DBUILD_EXAMPLES=OFF
-        -DBUILD_GRAPHICAL_EXAMPLES=OFF
+        -DBUILD_EXAMPLES=${BUILD_EXAMPLES}
+        -DBUILD_GRAPHICAL_EXAMPLES=${BUILD_GRAPHICAL_EXAMPLES}
+        -DBUILD_CV_EXAMPLES=OFF
+        -DBUILD_PCL_EXAMPLES=OFF
         -DBUILD_PYTHON_BINDINGS=OFF
         -DBUILD_UNIT_TESTS=OFF
         -DBUILD_WITH_OPENMP=OFF
@@ -43,13 +53,19 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/realsense2)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-# Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/realsense2)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/realsense2/COPYING ${CURRENT_PACKAGES_DIR}/share/realsense2/copyright)
-
 vcpkg_copy_pdbs()
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(BUILD_TOOLS)
+    file(GLOB EXEFILES_RELEASE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+    file(GLOB EXEFILES_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+    file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/realsense2)
+    file(REMOVE ${EXEFILES_RELEASE} ${EXEFILES_DEBUG})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/realsense2)
+endif()
+
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/realsense2)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/realsense2/COPYING ${CURRENT_PACKAGES_DIR}/share/realsense2/copyright)


### PR DESCRIPTION
With this PR the feature `[tools]` is added to `realsense2` port.
Realsense tools are listed [here](https://github.com/IntelRealSense/librealsense/tree/master/tools) and they include viewer, configuration and debugging applications.

Tools are built and moved to `tools` directory in `vcpkg` dir tree.

I also reordered some CMake commands in the `portfile.cmake` trying to make a bit of order in the function calls.