### PR TITLE
Remove empty directory while installing qt5 related packages

### DIFF
--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -3,3 +3,5 @@ include(vcpkg_common_functions)
 include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
 
 qt_modular_library(qtdeclarative 49b8b50932b73ea39da14ac3425044193dfd64eabceadba379aa01cf2fc141177f9870c387caf1cf93ce09e8b197828a54b8d9fcefc4d9cdf400a6c6dd9a9e90)
+
+ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools/qt5-declarative/platforminputcontexts)

--- a/ports/qt5-tools/portfile.cmake
+++ b/ports/qt5-tools/portfile.cmake
@@ -3,3 +3,5 @@ include(vcpkg_common_functions)
 include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
 
 qt_modular_library(qttools afce063e167de96dfa264cfd27dc8d80c23ef091a30f4f8119575cae83f39716c3b332427630b340f518b82d6396cca1893f28e00f3c667ba201d7e4fc2aefe1)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}//tools/qt5-tools/platforminputcontexts)


### PR DESCRIPTION
While yielding a full `vcpkg upgrade --no-dry-run` I stumbled upon a post-build error of qt5 related packages due to the presence of an empty directory, namely `platforminputcontexts`.

Here's the PR fixing the problem, as suggested by vcpkg itself.

Keep up with this very nice work ✨ 