### PR TITLE
Include windows.h before including consoleapi.h

### DIFF
--- a/ports/python3/0004-Fix-iomodule-for-RS4-SDK.patch
+++ b/ports/python3/0004-Fix-iomodule-for-RS4-SDK.patch
@@ -1,11 +1,12 @@
-dif --git a/Modules/_io/_iomodule.c b/Modules/_io/_iomodule.c
+diff --git a/Modules/_io/_iomodule.c b/Modules/_io/_iomodule.c
 --- a/Modules/_io/_iomodule.c
 +++ b/Modules/_io/_iomodule.c
-@@ -21,6 +21,7 @@
+@@ -21,7 +21,7 @@
  #endif /* HAVE_SYS_STAT_H */
  
  #ifdef MS_WINDOWS
+-#include <consoleapi.h>
 +#include <windows.h>
- #include <consoleapi.h>
  #endif
  
+ /* Various interned strings */

--- a/ports/python3/0004-Fix-iomodule-for-RS4-SDK.patch
+++ b/ports/python3/0004-Fix-iomodule-for-RS4-SDK.patch
@@ -1,0 +1,11 @@
+dif --git a/Modules/_io/_iomodule.c b/Modules/_io/_iomodule.c
+--- a/Modules/_io/_iomodule.c
++++ b/Modules/_io/_iomodule.c
+@@ -21,6 +21,7 @@
+ #endif /* HAVE_SYS_STAT_H */
+ 
+ #ifdef MS_WINDOWS
++#include <windows.h>
+ #include <consoleapi.h>
+ #endif
+ 

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -30,6 +30,13 @@ vcpkg_from_github(
     SHA512 32cca5e344ee66f08712ab5533e5518f724f978ec98d985f7612d0bd8d7f5cac25625363c9eead192faf1806d4ea3393515f72ba962a2a0bed26261e56d8c637 
     HEAD_REF master
  )
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${TEMP_SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/0004-Fix-iomodule-for-RS4-SDK.patch
+)
+
 # We need per-triplet directories because we need to patch the project files differently based on the linkage
 file(COPY ${TEMP_SOURCE_PATH} DESTINATION ${SOURCE_PATH})
 set(SOURCE_PATH ${SOURCE_PATH}/cpython-${PYTHON_VERSION})

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -1,17 +1,4 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic AND VCPKG_CRT_LINKAGE STREQUAL static)
-    # Because the patches patch the same file, they have to be applied in the correct order
-    # In this scenario, only the second patch needs to be applied, which doesn't work
     message(STATUS "Warning: Dynamic library with static CRT is not supported. Building static library.")
     set(VCPKG_LIBRARY_LINKAGE static)
 endif()
@@ -29,7 +16,7 @@ vcpkg_from_github(
     REF v${PYTHON_VERSION}
     SHA512 32cca5e344ee66f08712ab5533e5518f724f978ec98d985f7612d0bd8d7f5cac25625363c9eead192faf1806d4ea3393515f72ba962a2a0bed26261e56d8c637 
     HEAD_REF master
- )
+)
 
 vcpkg_apply_patches(
     SOURCE_PATH ${TEMP_SOURCE_PATH}
@@ -38,6 +25,7 @@ vcpkg_apply_patches(
 )
 
 # We need per-triplet directories because we need to patch the project files differently based on the linkage
+# Because the patches patch the same file, they have to be applied in the correct order
 file(COPY ${TEMP_SOURCE_PATH} DESTINATION ${SOURCE_PATH})
 set(SOURCE_PATH ${SOURCE_PATH}/cpython-${PYTHON_VERSION})
 


### PR DESCRIPTION
Issue: cpython fails to build against Windows Insider Preview SDK 17115

Root Cause: Failure to include windows.h before other Windows headers (consoleapi.h)

Solution: Include windows.h before consoleapi.h

If you don't include Windows.h before other Windows headers, then your code
is likely to break with new versions of the Windows Platform SDK, as headers
move around or new intraheader dependencies are added.  That is what happened
here.