### PR TITLE
Fix boost build errors when vcpkg path has spaces

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,2 +1,2 @@
 Source: boost-modular-build-helper
-Version: 1
+Version: 2

--- a/ports/boost-modular-build-helper/Jamroot.jam
+++ b/ports/boost-modular-build-helper/Jamroot.jam
@@ -129,8 +129,8 @@ if "@PORT@" != "boost-serialization"
 {
     use-project /boost/serialization : . ;
 
-    lib boost_serialization : : <file>@CURRENT_INSTALLED_DIR@/lib/@BOOST_LIB_PREFIX@boost_serialization@BOOST_LIB_RELEASE_SUFFIX@ <variant>release ;
-    lib boost_serialization : : <file>@CURRENT_INSTALLED_DIR@/debug/lib/@BOOST_LIB_PREFIX@boost_serialization@BOOST_LIB_DEBUG_SUFFIX@ <variant>debug ;
+    lib boost_serialization : : <file>"@CURRENT_INSTALLED_DIR@/lib/@BOOST_LIB_PREFIX@boost_serialization@BOOST_LIB_RELEASE_SUFFIX@" <variant>release ;
+    lib boost_serialization : : <file>"@CURRENT_INSTALLED_DIR@/debug/lib/@BOOST_LIB_PREFIX@boost_serialization@BOOST_LIB_DEBUG_SUFFIX@" <variant>debug ;
     explicit boost_serialization ;
 }
 

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -28,8 +28,8 @@ if "@PORT@" = "boost-python"
 if "@PORT@" = "boost-mpi"
 {
     using mpi : :
-        <library-path>@CURRENT_INSTALLED_DIR@/lib
-        <include>@CURRENT_INSTALLED_DIR@/include
+        <library-path>"@CURRENT_INSTALLED_DIR@/lib"
+        <include>"@CURRENT_INSTALLED_DIR@/include"
         <find-shared-library>msmpi ;
 }
 


### PR DESCRIPTION
This fixes Boost packages that depend on `boost-modular-build-helper` not installing due to an unquoted path. (eg. issue #2617)