### PR TITLE
[curl] fix a dependency error: "Error: Unable to satisfy dependency s…

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7_59_0-1
+Version: 7_59_0-2
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl
@@ -12,7 +12,7 @@ Feature: non-http
 Description: Enables protocols beyond HTTP/HTTPS/HTTP2
 
 Feature: http2
-Build-Depends: nghttp2, ssl
+Build-Depends: nghttp2, curl[ssl]
 Description: HTTP2 support
 
 Feature: ssl


### PR DESCRIPTION
When build curl[http2], a error "Unable to satisfy dependency ssl:x64-windows of curl[http2]:x64-windows" will raised.