### PR TITLE
[glew] Fix build failure when VCPKG_BUILD_TYPE is set

### DIFF
--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -19,7 +19,15 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/glew")
 
-foreach(FILE ${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-debug.cmake ${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-release.cmake)
+set(_targets_cmake_files)
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    list(APPEND _targets_cmake_files "${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-debug.cmake")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    list(APPEND _targets_cmake_files "${CURRENT_PACKAGES_DIR}/share/glew/glew-targets-release.cmake")
+endif()
+
+foreach(FILE ${_targets_cmake_files})
     file(READ ${FILE} _contents)
     string(REPLACE "libglew32" "glew32" _contents "${_contents}")
     file(WRITE ${FILE} "${_contents}")
@@ -27,6 +35,8 @@ endforeach()
 
 if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/libglew32.lib)
     file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libglew32.lib ${CURRENT_PACKAGES_DIR}/lib/glew32.lib)
+endif()
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/libglew32d.lib)
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libglew32d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/glew32d.lib)
 endif()
 


### PR DESCRIPTION
Failure affects both dynamic and static builds.
Fixed by adding `VCPKG_BUILD_TYPE` and file existence checks.