### PR TITLE
[libpng] Fix static build failure when VCPKG_BUILD_TYPE is set

### DIFF
--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -40,9 +40,13 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND EXISTS ${CURRENT_PACKAGES_DIR}/lib/libpng16_static.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libpng16_static.lib ${CURRENT_PACKAGES_DIR}/lib/libpng16.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16_staticd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16d.lib)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/libpng16_static.lib)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libpng16_static.lib ${CURRENT_PACKAGES_DIR}/lib/libpng16.lib)
+    endif()
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16_staticd.lib)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16_staticd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libpng16d.lib)
+    endif()
 endif()
 
 # Remove CMake config files as they are incorrectly generated and everyone uses built-in FindPNG anyway.


### PR DESCRIPTION
portfile previously only checked for the existence of the release lib.