### PR TITLE
[Clean patching] Each portref-patchset combo gets its own hash-based dir

### DIFF
--- a/ports/azure-storage-cpp/portfile.cmake
+++ b/ports/azure-storage-cpp/portfile.cmake
@@ -10,10 +10,6 @@ vcpkg_from_github(
     REF v3.2.1
     SHA512 8d1e8de439e52f53eb28b77e8adf394468f4861c2c4c1f79ec1437c72e3fc0bc871e4e2662ee58090748915b0f12ce6736a7cc6ede619d332686b9fb6a026c9f
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/cmake.patch
         ${CMAKE_CURRENT_LIST_DIR}/static-builds.patch
@@ -35,7 +31,7 @@ vcpkg_install_cmake()
 file(INSTALL
     ${SOURCE_PATH}/LICENSE.txt
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/azure-storage-cpp RENAME copyright)
-file(REMOVE_RECURSE 
+file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_copy_pdbs()

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -20,10 +20,6 @@ vcpkg_from_github(
     REF v2018.04.16.00
     SHA512 1f14da6eece3a490bd134a40550c2a3f78356789090e19933b8f10bc356837ee774a21e6f0b88c45831a968587049092b9d0d77617f040ab8e177de224400408
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/find-gflags.patch
 )

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -154,8 +154,10 @@ namespace vcpkg::Commands::CI
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, const Triplet& default_triplet)
     {
-        Checks::check_exit(
-            VCPKG_LINE_INFO, GlobalState::g_binary_caching, "The ci command requires binary caching to be enabled.");
+        if (!GlobalState::g_binary_caching)
+        {
+            System::println(System::Color::warning, "Warning: Running ci without binary caching!");
+        }
 
         const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
 


### PR DESCRIPTION
- Hash the archive and patches in order to create a unique identifier for the src directory.
- Directory naming scheme is: [Last10charsOfREF]-[First10charsOfHash]. Previously, it was [RepoName]-[REF].
- When a patch is added/removed/changed and/or and the version is changed, a new directory will be created.
- If the directory exists, then re-use that directory instead of extracting and applying patches.
- Currently applies to `vcpkg_from_github()`
- The currently shown patching warning:
`"Applying patch failed. This is expected if this patch was previously applied."`
should no longer be relevant for ports that use `vcpkg_from_github()`. If it is shown, then the patch actually does not apply.

For example:
``` 
D:\vcpkg\buildtrees\azure-storage-cpp\src\azure-storage-cpp-v3.2.1 // Previous dir name
D:\vcpkg\buildtrees\azure-storage-cpp\src\v3.2.1-bc558d4455 // Proposed dir name
D:\vcpkg\buildtrees\azure-storage-cpp\src\head // for --head (unchanged)
```

```
D:\vcpkg\buildtrees\folly\src\folly-2017.11.27.00  // Previous dir name
D:\vcpkg\buildtrees\folly\src\7.11.27.00-0eec50b5bc // New dir name
```