### PR TITLE
Add google-cloud-cpp package

### DIFF
--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 2018-03-01
-Description: C++ Client Libraries for Google Cloud Platform APIs.
+Version: 0.1.0-pre1
 Build-Depends: grpc, gtest
+Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 0.1.0-pre1
+Version: 0.1.0-pre1-1
 Build-Depends: grpc, gtest
 Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,0 +1,4 @@
+Source: google-cloud-cpp
+Version: 2018-03-01
+Description: C++ Client Libraries for Google Cloud Platform APIs.
+Build-Depends: grpc, gtest

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 0.1.0-pre1-1
+Version: 0.1.0
 Build-Depends: grpc, gtest
 Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,11 +5,11 @@ endif()
 
 include(vcpkg_common_functions)
 
-set(GOOGLE_CLOUD_CPP_VERSION 0bd7b17b08ab4fd14fc6de580cd762f0603bffab)
+set(GOOGLE_CLOUD_CPP_VERSION 0.1.0-pre1)
 vcpkg_download_distfile(GOOGLE_CLOUD_CPP
-    URLS "https://github.com/coryan/google-cloud-cpp/archive/0bd7b17b08ab4fd14fc6de580cd762f0603bffab.zip"
+    URLS "https://github.com/GoogleCloudPlatform/google-cloud-cpp/archive/v${GOOGLE_CLOUD_CPP_VERSION}.zip"
     FILENAME "gcpp-${GOOGLE_CLOUD_CPP_VERSION}.zip"
-    SHA512 72236e4b75e86611ed6befe6a5d097dd8055648692510cd02f8419f167128359b9c278e229ab42288597ccb236dd9e946292155863839d3e93a0492a422237d4
+    SHA512 2c08818d4ce9712c5ecb7015ea88a6905ef05f55b8a3586e13b2167a5bb4b3c25488660324c05f1dc1f5c5953533c0bb319e209373fa509beeeff810be62fa54
 )
 
 set(GOOGLEAPIS_VERSION 92f10d7033c6fa36e1a5a369ab5aa8bafd564009)
@@ -42,6 +42,7 @@ vcpkg_configure_cmake(
 set(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
 
 vcpkg_install_cmake()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/bigtable/client/testing)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,8 +8,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GoogleCloudPlatform/google-cloud-cpp
-    REF v0.1.0-pre1
-    SHA512 a43feb5a93f8912124b594399238870dd9740726d5ef1ad02532e197656c83c55228c1da1f4a45e4010508d1cae25495c959aa7fe4b6e7d3b7bfb60b74756dbf
+    REF v0.1.0
+    SHA512 3947cc24ca1ed97309f055f17945afe2d6b22ae8f54f86d3395f8c491b7409d4b7bb12206889d04d07f51236e9fd5afd65b904c8c80521a3313588d8069545c2
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -1,0 +1,52 @@
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+include(vcpkg_common_functions)
+
+set(GOOGLE_CLOUD_CPP_VERSION 0bd7b17b08ab4fd14fc6de580cd762f0603bffab)
+vcpkg_download_distfile(GOOGLE_CLOUD_CPP
+    URLS "https://github.com/coryan/google-cloud-cpp/archive/0bd7b17b08ab4fd14fc6de580cd762f0603bffab.zip"
+    FILENAME "gcpp-${GOOGLE_CLOUD_CPP_VERSION}.zip"
+    SHA512 72236e4b75e86611ed6befe6a5d097dd8055648692510cd02f8419f167128359b9c278e229ab42288597ccb236dd9e946292155863839d3e93a0492a422237d4
+)
+
+set(GOOGLEAPIS_VERSION 92f10d7033c6fa36e1a5a369ab5aa8bafd564009)
+vcpkg_download_distfile(GOOGLEAPIS
+    URLS "https://github.com/google/googleapis/archive/92f10d7033c6fa36e1a5a369ab5aa8bafd564009.zip"
+    FILENAME "googleapis-${GOOGLEAPIS_VERSION}.zip"
+    SHA512 4280ece965a231f6a0bb3ea38a961d15babd9eac517f9b0d57e12f186481bbab6a27e4f0ee03ba3c587c9aa93d3c2e6c95f67f50365c65bb10594f0229279287
+)
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src/google-cloud-cpp)
+if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
+    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
+endif()
+
+vcpkg_extract_source_archive(${GOOGLE_CLOUD_CPP} ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
+file(RENAME ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src/google-cloud-cpp-${GOOGLE_CLOUD_CPP_VERSION} ${SOURCE_PATH})
+vcpkg_extract_source_archive(${GOOGLEAPIS} ${SOURCE_PATH}/third_party)
+file(REMOVE_RECURSE ${SOURCE_PATH}/third_party/googleapis)
+file(RENAME ${SOURCE_PATH}/third_party/googleapis-${GOOGLEAPIS_VERSION} ${SOURCE_PATH}/third_party/googleapis)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=vcpkg
+        -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=vcpkg
+)
+
+# gRPC runs built executables during the build, so they need access to the installed DLLs.
+set(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,11 +5,12 @@ endif()
 
 include(vcpkg_common_functions)
 
-set(GOOGLE_CLOUD_CPP_VERSION 0.1.0-pre1)
-vcpkg_download_distfile(GOOGLE_CLOUD_CPP
-    URLS "https://github.com/GoogleCloudPlatform/google-cloud-cpp/archive/v${GOOGLE_CLOUD_CPP_VERSION}.zip"
-    FILENAME "gcpp-${GOOGLE_CLOUD_CPP_VERSION}.zip"
-    SHA512 2c08818d4ce9712c5ecb7015ea88a6905ef05f55b8a3586e13b2167a5bb4b3c25488660324c05f1dc1f5c5953533c0bb319e209373fa509beeeff810be62fa54
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GoogleCloudPlatform/google-cloud-cpp
+    REF v0.1.0-pre1
+    SHA512 a43feb5a93f8912124b594399238870dd9740726d5ef1ad02532e197656c83c55228c1da1f4a45e4010508d1cae25495c959aa7fe4b6e7d3b7bfb60b74756dbf
+    HEAD_REF master
 )
 
 set(GOOGLEAPIS_VERSION 92f10d7033c6fa36e1a5a369ab5aa8bafd564009)
@@ -19,15 +20,8 @@ vcpkg_download_distfile(GOOGLEAPIS
     SHA512 4280ece965a231f6a0bb3ea38a961d15babd9eac517f9b0d57e12f186481bbab6a27e4f0ee03ba3c587c9aa93d3c2e6c95f67f50365c65bb10594f0229279287
 )
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src/google-cloud-cpp)
-if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
-    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
-endif()
-
-vcpkg_extract_source_archive(${GOOGLE_CLOUD_CPP} ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src)
-file(RENAME ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-src/google-cloud-cpp-${GOOGLE_CLOUD_CPP_VERSION} ${SOURCE_PATH})
+file(REMOVE_RECURSE ${SOURCE_PATH}/third_party)
 vcpkg_extract_source_archive(${GOOGLEAPIS} ${SOURCE_PATH}/third_party)
-file(REMOVE_RECURSE ${SOURCE_PATH}/third_party/googleapis)
 file(RENAME ${SOURCE_PATH}/third_party/googleapis-${GOOGLEAPIS_VERSION} ${SOURCE_PATH}/third_party/googleapis)
 
 vcpkg_configure_cmake(
@@ -38,16 +32,13 @@ vcpkg_configure_cmake(
         -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=vcpkg
 )
 
-# gRPC runs built executables during the build, so they need access to the installed DLLs.
-set(ENV{PATH} "$ENV{PATH};${CURRENT_INSTALLED_DIR}/bin;${CURRENT_INSTALLED_DIR}/debug/bin")
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
-vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/bigtable/client/testing)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake TARGET_PATH share/bigtable_client)
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp RENAME copyright)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
This adds support for the Google Cloud C++ libraries (currently one really).  It fixes #3093.
Feedback is welcome, as this is my first PR into this repository.
