### PR TITLE
remove the graphite2.exe

### DIFF
--- a/ports/graphite2/portfile.cmake
+++ b/ports/graphite2/portfile.cmake
@@ -17,8 +17,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-# file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/gr2fonttest.exe)
-# file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/gr2fonttest.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/gr2fonttest.exe)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/gr2fonttest.exe)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 


### PR DESCRIPTION
1, Because the  EXEs still exisited so that the  Performing post-build validation failed.
2. After we make it removed .then the lib will be ok
