### PR TITLE
[vcpkg] Fix setting exePath in fetchTool

### DIFF
--- a/scripts/fetchTool.ps1
+++ b/scripts/fetchTool.ps1
@@ -25,7 +25,7 @@ function fetchToolInternal([Parameter(Mandatory=$true)][string]$tool)
         throw "Unkown tool $tool"
     }
 
-    $exePath = "$downloadsDir\$($toolData.exeRelativePath)"
+    $exePath = "$downloadsDir\$(@($toolData.exeRelativePath)[0])"
 
     if (Test-Path $exePath)
     {


### PR DESCRIPTION
I tried using cmake 3.11 rc4, but I was not able to as `exePath` was getting set to `C:\projects\dependencies\vcpkg\downloads\cmake-3.11.0-rc4-win32-x86\bin\cmake.exe exeRelativePath exeRelativePath`.

I changed setting `exePath` to what other code around here does, this seems to fix the issue I ran into, but I have absolutely no idea what it does as I have zero experience with PS. Please test as required.