### PR TITLE
[dlib] update to 19.10

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,5 +1,5 @@
 Source: dlib
-Version: 19.9-1
+Version: 19.10
 Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas, clapack
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
 

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davisking/dlib
-    REF v19.9
-    SHA512 1e2123c22e1b13cc84108fa627bfa92eadc9dee63f93a9f45676bbf2b752c8728117d915ac327f5223b0cdbce87dd3bef2f4d8d5ed3f8f5a314ffa9e8962a246
+    REF v19.10
+    SHA512 88c5b41c12219e6166c6621b654b3869ca4a2af777a8fa55429b833b90b048e3e74ea7ad752d7440809b8171bbd38090cb24a29770391fc3a9d53f9a5fba3341
     HEAD_REF master
 )
 
@@ -35,6 +35,7 @@ vcpkg_configure_cmake(
         -DDLIB_USE_CUDA=${WITH_CUDA}
         -DDLIB_GIF_SUPPORT=OFF
         -DDLIB_USE_MKL_FFT=OFF
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
     OPTIONS_DEBUG
         -DDLIB_ENABLE_ASSERTS=ON
         #-DDLIB_ENABLE_STACK_TRACE=ON


### PR DESCRIPTION
Tested both `vcpkg install dlib and dlib[*]` and everything compiles as usual. Note that dlib now export dll starting from 19.10, but they didn't handle the dll macros in the headers hence we need to add `-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE` in the cmake options.