### PR TITLE
[gtest] Fix missing debug information

### DIFF
--- a/ports/gtest/0002-Fix-z7-override.patch
+++ b/ports/gtest/0002-Fix-z7-override.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 777b91e..75a13c9 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -55,7 +55,7 @@ macro(config_compiler_and_linker)
+   if (MSVC)
+     # Newlines inside flags variables break CMake's NMake generator.
+     # TODO(vladl@google.com): Add -RTCs and -RTCu to debug builds.
+-    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J -Zi")
++    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J")
+     if (MSVC_VERSION LESS 1400)  # 1400 is Visual Studio 2005
+       # Suppress spurious warnings MSVC 7.1 sometimes issues.
+       # Forcing value to bool.

--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,3 +1,3 @@
 Source: gtest
-Version: 1.8.0-7
+Version: 1.8.0-8
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/0001-Enable-C-11-features-for-VS2015-fix-appveyor-fail.patch
+            ${CMAKE_CURRENT_LIST_DIR}/0002-Fix-z7-override.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)


### PR DESCRIPTION
Patch a CMake file in gtest not to override the /Z7 compiler option that embeds debug info in the .lib with /Zi that places it in a .pdb. This fixes linker warning LNK4099 when linking with gmock.lib:

```
gmock.lib(gtest-all.cc.obj) : warning LNK4099: PDB 'gmock.pdb' was not found with 'gmock.lib(gtest-all.cc.obj)' or at '...\gmock.pdb'; linking object as if no debug info
```

Without this change, the following message appears in the build log:
```
cl : Command line warning D9025 : overriding '/Z7' with '/Zi'
```

If there's a better way to do this, without patching gtest, I'd be glad to hear about it.