### PR TITLE
[cryptopp] Update to 6.1.0

### DIFF
--- a/ports/cryptopp/CONTROL
+++ b/ports/cryptopp/CONTROL
@@ -1,3 +1,3 @@
 Source: cryptopp
-Version: 5.6.5-1
+Version: 6.1.0
 Description: Crypto++ is a free C++ class library of cryptographic schemes.

--- a/ports/cryptopp/CONTROL
+++ b/ports/cryptopp/CONTROL
@@ -1,3 +1,3 @@
 Source: cryptopp
-Version: 6.1.0
+Version: 6.1.0-1
 Description: Crypto++ is a free C++ class library of cryptographic schemes.

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -31,6 +31,7 @@ file(COPY ${CMAKE_SOURCE_PATH}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
     OPTIONS
         -DBUILD_SHARED=OFF
         -DBUILD_STATIC=ON
@@ -39,18 +40,10 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/cryptopp)
 
 # There is no way to suppress installation of the headers and resource files in debug build.
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-
-# Remove executables
-file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/cryptest.exe)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/cryptest.exe)
-
-# Remove other files not required in package
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/cryptopp)

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -3,13 +3,25 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cryptopp-CRYPTOPP_5_6_5)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_5_6_5.zip"
-    FILENAME "CRYPTOPP_5_6_5.zip"
-    SHA512 abca8089e2d587f59c503d2d6412b3128d061784349c735f3ee46be1cb9e3d0d0fed9a9173765fa033eb2dc744e03810de45b8cc2f8ca1672a36e4123648ea44
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH CMAKE_SOURCE_PATH
+  REPO noloader/cryptopp-cmake
+  REF aab149932675e4bb777a9d3d6b3f8b8182583fd7
+  SHA512 748c77e936888d042bf4a72cc7ee3b7b2ecf16c003cb23296c1af413c9a0cba00cc942ecace26274fc8ac8bd4d848946beb9d7bf2253c5eab3315a4419ef5f1f
+  HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO weidai11/cryptopp
+  REF CRYPTOPP_6_1_0
+  SHA512 4bc02fef33f1859a07434a4752c2575afd781056e9a91eed99a13cebe2c91d66cbc7173e34d362da63dad6d38f9594ff291accd27e111232996ccd536bba0f39
+  HEAD_REF master
+)
+
+file(COPY ${CMAKE_SOURCE_PATH}/cryptopp-config.cmake DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_SOURCE_PATH}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 # Dynamic linking should be avoided for Crypto++ to reduce the attack surface,
 # so generate a static lib for both dynamic and static vcpkg targets.


### PR DESCRIPTION
The CMake files for CryptoPP that were previously built into the project are now available separately in cryptopp-cmake, so we pick them up from there.