### PR TITLE
[pmdk] Rename and update to version 1.4

### DIFF
--- a/ports/nvml/CONTROL
+++ b/ports/nvml/CONTROL
@@ -1,3 +1,0 @@
-Source: nvml
-Version: 1.3-0
-Description: Non-Volatile Memory Library

--- a/ports/pmdk/CONTROL
+++ b/ports/pmdk/CONTROL
@@ -1,3 +1,3 @@
 Source: pmdk
-Version: 1.4-0
+Version: 1.4-1
 Description: Persistent Memory Development Kit

--- a/ports/pmdk/CONTROL
+++ b/ports/pmdk/CONTROL
@@ -1,0 +1,3 @@
+Source: pmdk
+Version: 1.4-0
+Description: Persistent Memory Development Kit

--- a/ports/pmdk/portfile.cmake
+++ b/ports/pmdk/portfile.cmake
@@ -1,7 +1,7 @@
 
-set(NVML_VERSION 1.3)
-set(NVML_HASH 59fb552c693d5279ec86eff8eb1c36832c9c5beb6492a64b54b21c09d90ed52cba22d57912a304cf1ec17c4633da641200fd50dbe4a38355f43c674842f991bd)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${NVML_VERSION})
+set(PMDK_VERSION 1.4)
+set(PMDK_HASH 95dbea9acfea4a6cb433a25f56f7484946a93fbce1c5e0e1d6ff36e0824e3e0e9f28f37024918998358f8ff12e69d0902fcf88357b9ad12695f32e06e86ffac8)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${PMDK_VERSION})
 
 include(vcpkg_common_functions)
 
@@ -13,7 +13,7 @@ endif()
 if (TRIPLET_SYSTEM_ARCH MATCHES "arm")
     message(FATAL_ERROR "ARM is currently not supported")
 elseif (TRIPLET_SYSTEM_ARCH MATCHES "x86")
-    message(FATAL_ERROR "x86 is not supported. Please use nvml:x64-windows or set environment variable VCPKG_DEFAULT_TRIPLET to 'x64-windows'")
+    message(FATAL_ERROR "x86 is not supported. Please use pmdk:x64-windows or set environment variable VCPKG_DEFAULT_TRIPLET to 'x64-windows'")
 else ()
     set(MSBUILD_PLATFORM ${TRIPLET_SYSTEM_ARCH})
 endif()
@@ -21,18 +21,20 @@ endif()
 # Download source
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO pmem/nvml
-    REF ${NVML_VERSION}
-    SHA512 ${NVML_HASH}
+    REPO pmem/pmdk
+    REF ${PMDK_VERSION}
+    SHA512 ${PMDK_HASH}
     HEAD_REF master
 )
 
 # Build only the selected projects
 vcpkg_build_msbuild(
-    PROJECT_PATH ${SOURCE_PATH}/src/NVML.sln
+    PROJECT_PATH ${SOURCE_PATH}/src/PMDK.sln
     PLATFORM x64
-    TARGET "Solution Items\\libpmem,Solution Items\\libpmemlog,Solution Items\\libpmemblk,Solution Items\\libpmemobj,Solution Items\\libpmempool,Solution Items\\libvmem,Solution Items\\Tools\\pmempool"
-    OPTIONS /p:SRCVERSION=${NVML_VERSION}
+    PLATFORM_TOOLSET v140
+    TARGET_PLATFORM_VERSION 10.0.16299.0
+    TARGET "Solution Items\\libpmem,Solution Items\\libpmemlog,Solution Items\\libpmemblk,Solution Items\\libpmemobj,Solution Items\\libpmemcto,Solution Items\\libpmempool,Solution Items\\libvmem,Solution Items\\Tools\\pmempool"
+    OPTIONS /p:SRCVERSION=${PMDK_VERSION}
 )
 
 set(DEBUG_ARTIFACTS_PATH ${SOURCE_PATH}/src/x64/Debug)
@@ -64,11 +66,11 @@ file(GLOB LIB_RELEASE_FILES ${RELEASE_ARTIFACTS_PATH}/lib[pv]mem*.dll)
 file(INSTALL ${LIB_RELEASE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
 
 # Install tools (release only)
-file(INSTALL ${RELEASE_ARTIFACTS_PATH}/pmempool.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/nvml)
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/nvml)
+file(INSTALL ${RELEASE_ARTIFACTS_PATH}/pmempool.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pmdk)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/pmdk)
 
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nvml)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/nvml/LICENSE ${CURRENT_PACKAGES_DIR}/share/nvml/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pmdk)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/pmdk/LICENSE ${CURRENT_PACKAGES_DIR}/share/pmdk/copyright)


### PR DESCRIPTION
The NVML project has been renamed to PMDK (Persistent Memory
Development Kit).  PMDK version 1.4 is the first official release
with the new name.