### PR TITLE
[gdal]: Use libmariadb instead of libmysql

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,4 +1,4 @@
 Source: gdal
-Version: 2.2.2-1
+Version: 2.2.2-2
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
-Build-Depends: proj4, libpng, geos, sqlite3, curl, expat, libpq, libmysql, openjpeg, libwebp, libxml2, liblzma
+Build-Depends: proj4, libpng, geos, sqlite3, curl, expat, libpq, libmariadb, openjpeg, libwebp, libxml2, liblzma

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -74,8 +74,8 @@ file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/sqlite3.lib" SQLITE_LIBR
 
 # Setup MySQL libraries + include path
 file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/include/mysql" MYSQL_INCLUDE_DIR)
-file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/lib/libmysql.lib" MYSQL_LIBRARY_REL)
-file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/libmysql.lib" MYSQL_LIBRARY_DBG)
+file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/lib/libmariadb.lib" MYSQL_LIBRARY_REL)
+file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/debug/lib/libmariadb.lib" MYSQL_LIBRARY_DBG)
 
 # Setup PostgreSQL libraries + include path
 file(TO_NATIVE_PATH "${CURRENT_INSTALLED_DIR}/include" PGSQL_INCLUDE_DIR)


### PR DESCRIPTION
Can't build gdal for 32-bit because the libmysql dependency is now 64-bit only. Use libmariadb instead.