### PR TITLE
[rocksdb] Make zlib support an optional feature

### DIFF
--- a/ports/rocksdb/CONTROL
+++ b/ports/rocksdb/CONTROL
@@ -1,6 +1,7 @@
 Source: rocksdb
-Version: 5.11.3-2
+Version: 5.11.3-3
 Description: A library that provides an embeddable, persistent key-value store for fast storage
+Default-Features: zlib
 
 Feature: lz4
 Build-Depends: lz4

--- a/ports/rocksdb/CONTROL
+++ b/ports/rocksdb/CONTROL
@@ -1,7 +1,6 @@
 Source: rocksdb
-Version: 5.11.3-1
+Version: 5.11.3-2
 Description: A library that provides an embeddable, persistent key-value store for fast storage
-Build-Depends: zlib
 
 Feature: lz4
 Build-Depends: lz4
@@ -10,3 +9,7 @@ Description: lz4 support in rocksdb
 Feature: snappy
 Build-Depends: snappy
 Description: snappy support in rocksdb
+
+Feature: zlib
+Build-Depends: zlib
+Description: zlib support in rocksdb

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -42,6 +42,11 @@ if("snappy" IN_LIST FEATURES)
   set(WITH_SNAPPY ON)
 endif()
 
+set(WITH_ZLIB OFF)
+if("zlib" IN_LIST FEATURES)
+  set(WITH_ZLIB ON)
+endif()
+
 get_filename_component(ROCKSDB_VERSION "${SOURCE_PATH}" NAME)
 string(REPLACE "rocksdb-rocksdb-" "" ROCKSDB_VERSION "${ROCKSDB_VERSION}")
 
@@ -52,7 +57,7 @@ vcpkg_configure_cmake(
   -DWITH_GFLAGS=0
   -DWITH_SNAPPY=${WITH_SNAPPY}
   -DWITH_LZ4=${WITH_LZ4}
-  -DWITH_ZLIB=1
+  -DWITH_ZLIB=${WITH_ZLIB}
   -DWITH_TESTS=OFF
   -DROCKSDB_INSTALL_ON_WINDOWS=ON
   -DFAIL_ON_WARNINGS=OFF


### PR DESCRIPTION
Following up on lz4 and snappy support becoming optional in the rocksdb port, make zlib support optional as well.