### PR TITLE
GraphicsMagick 1.3.28

### DIFF
--- a/ports/graphicsmagick/CMakeLists.txt
+++ b/ports/graphicsmagick/CMakeLists.txt
@@ -77,7 +77,7 @@ add_library(graphicsmagick coders/art.c coders/avs.c
 		coders/tiff.c coders/tile.c coders/tim.c coders/topol.c
 		coders/ttf.c coders/txt.c coders/uil.c coders/url.c
 		coders/uyvy.c coders/vicar.c coders/vid.c coders/viff.c
-		coders/wbmp.c coders/webp.c coders/wmf.c coders/wpg.c
+		coders/wbmp.c coders/wmf.c coders/wpg.c
 		coders/x.c coders/xbm.c coders/xc.c coders/xcf.c
 		coders/xpm.c coders/xtrn.c coders/xwd.c coders/yuv.c
 		filters/analyze.c

--- a/ports/graphicsmagick/CONTROL
+++ b/ports/graphicsmagick/CONTROL
@@ -1,4 +1,4 @@
 Source: graphicsmagick
-Version: 1.3.26-2
+Version: 1.3.28
 Build-Depends: zlib, bzip2, freetype, libjpeg-turbo, libpng, tiff
 Description: Image processing library

--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -1,12 +1,12 @@
 include(vcpkg_common_functions)
 
-set(GM_VERSION 1.3.26)
+set(GM_VERSION 1.3.28)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/graphicsmagick-${GM_VERSION}-windows-source)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}-windows-source.7z"
     FILENAME "GraphicsMagick-${GM_VERSION}-windows-source.7z"
-    SHA512 c45a054d082d9a7a2889a2235dd5b96bd564acf55bd581426ecd32c426f9797d7d56d6e5f25a5a7da8ebd26bf0d962372b5d48d86532dc6c57522d27c0d18ec8
+    SHA512  0271c187634580204dcc3173553bae9e3cd799203d621ad9e2ba64be778760ac307f25af54859b10e60f8e2589287ad98062548f1c3c94f229e68e7c83878419
     )
 vcpkg_extract_source_archive(${ARCHIVE})
 


### PR DESCRIPTION
GraphicsMagick updated to version 1.3.28

webp.c removed from build due to build errors on the upstream.