### PR TITLE
Fix #3250

### DIFF
--- a/ports/rapidjson/CONTROL
+++ b/ports/rapidjson/CONTROL
@@ -1,3 +1,3 @@
 Source: rapidjson
-Version: 1.1.0
+Version: 1.1.0-1
 Description: A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -13,6 +13,18 @@ vcpkg_from_github(
 file(COPY ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/rapidjson)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/rapidjson/license.txt ${CURRENT_PACKAGES_DIR}/share/rapidjson/copyright)
 
-# Copy the rapidjson header files
-file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR} FILES_MATCHING PATTERN "*.h")
-vcpkg_copy_pdbs()
+# Use RapidJSON's own build process, skipping examples and tests
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DRAPIDJSON_BUILD_DOC:BOOL=OFF
+        -DRAPIDJSON_BUILD_EXAMPLES:BOOL=OFF
+        -DRAPIDJSON_BUILD_TESTS:BOOL=OFF
+)
+vcpkg_install_cmake()
+
+# Move CMake config files to the right place
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+# Delete redundant directories
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -9,10 +9,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# Put the licence file where vcpkg expects it
-file(COPY ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/rapidjson)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/rapidjson/license.txt ${CURRENT_PACKAGES_DIR}/share/rapidjson/copyright)
-
 # Use RapidJSON's own build process, skipping examples and tests
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -20,6 +16,7 @@ vcpkg_configure_cmake(
         -DRAPIDJSON_BUILD_DOC:BOOL=OFF
         -DRAPIDJSON_BUILD_EXAMPLES:BOOL=OFF
         -DRAPIDJSON_BUILD_TESTS:BOOL=OFF
+        -DCMAKE_INSTALL_DIR:STRING=cmake
 )
 vcpkg_install_cmake()
 
@@ -27,4 +24,8 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
 # Delete redundant directories
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/doc)
+
+# Put the licence file where vcpkg expects it
+file(COPY ${SOURCE_PATH}/license.txt ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/rapidjson)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/rapidjson/license.txt ${CURRENT_PACKAGES_DIR}/share/rapidjson/copyright)

--- a/ports/rapidjson/usage
+++ b/ports/rapidjson/usage
@@ -1,0 +1,4 @@
+The package rapidjson provides CMake integration:
+
+    find_package(RapidJSON REQUIRED)
+    target_include_directories(main PRIVATE ${RAPIDJSON_INCLUDE_DIRS})


### PR DESCRIPTION
RapidJSON generates CMake target files from .in templates. So we should use it's own build process rather than just copying header files.