### PR TITLE
[llvm] fix issue #3282

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,4 +1,4 @@
 Source: llvm
-Version: 6.0.0
+Version: 6.0.0-1
 Description: The LLVM Compiler Infrastructure
 Build-Depends: atlmfc

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -70,6 +70,7 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/bin
     ${CURRENT_PACKAGES_DIR}/msbuild-bin
     ${CURRENT_PACKAGES_DIR}/tools/msbuild-bin
+    ${CURRENT_PACKAGES_DIR}/include/llvm/BinaryFormat/WasmRelocs
 )
 
 # Remove one empty include subdirectory if it is indeed empty


### PR DESCRIPTION
The solution is actually as simple as adding `${CURRENT_PACKAGES_DIR}/include/llvm/BinaryFormat/WasmRelocs`. I tested and everything compiles as normal.