### PR TITLE
Fix vcpkg port librsync

### DIFF
--- a/ports/librsync/portfile.cmake
+++ b/ports/librsync/portfile.cmake
@@ -30,6 +30,9 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/rsync.dll)
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/rsync.dll ${CURRENT_PACKAGES_DIR}/debug/bin/rsync.dll)
 endif()
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
 
 file(INSTALL
     ${SOURCE_PATH}/COPYING


### PR DESCRIPTION
1. DLLs should not be present in a static build, but the following DLLs were found in bin and debug/bin directory.
2. Add the 
if(VCPKG_LIBRARY_LINKAGE STREQUAL static)  
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)  
endif()  
to remove these two directories in static build.
3. We verified this port can be installed successfully in x86-windows, x64-windows, x86-windows-static and x64-windows-static scenarios.