### PR TITLE
Fix vcpkg port clblas

### DIFF
--- a/ports/clblas/portfile.cmake
+++ b/ports/clblas/portfile.cmake
@@ -32,7 +32,9 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL


### PR DESCRIPTION
1. There should be no bin\ or debug\bin\ directory in a static build, but C:\vcpkg\packages\clblas_x64-windows-static\bin and C:\vcpkg\packages\clblas_x64-windows-static\debug\bin is present.
2. To add 
if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
endif()
to remove these two directories.
3. We verified this port can be installed successfully in x86-windows, x64-windows, x86-windows-static and x64-windows-static scenarios.