### PR TITLE
Fix PCL compile tools

### DIFF
--- a/ports/pcl/boost_uuid_random_generator_compat.patch
+++ b/ports/pcl/boost_uuid_random_generator_compat.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0405dca2..00e5238e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -168,6 +168,8 @@ if(CMAKE_COMPILER_IS_MSVC)
+   endif()
+ endif()
+ 
++add_definitions(-DBOOST_UUID_RANDOM_GENERATOR_COMPAT)
++
+ if(CMAKE_COMPILER_IS_PATHSCALE)
+   if("${CMAKE_CXX_FLAGS}" STREQUAL "")
+     SET(CMAKE_CXX_FLAGS "-Wno-uninitialized -zerouv -pthread -mp")

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_apply_patches(
             "${CMAKE_CURRENT_LIST_DIR}/find_openni2.patch"
             "${CMAKE_CURRENT_LIST_DIR}/find_cuda.patch"
             "${CMAKE_CURRENT_LIST_DIR}/vs2017-15.4-workaround.patch"
+            "${CMAKE_CURRENT_LIST_DIR}/boost_uuid_random_generator_compat.patch"
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)


### PR DESCRIPTION
Add missing boost-related definition
`add_definitions(-DBOOST_UUID_RANDOM_GENERATOR_COMPAT)`
using a patch at configuration time.

Fixes #3289 