### PR TITLE
Add Bash shebang to bootstrap script

### DIFF
--- a/bootstrap-vcpkg.sh
+++ b/bootstrap-vcpkg.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
 $vcpkgRootDir/scripts/bootstrap.sh

--- a/bootstrap-vcpkg.sh
+++ b/bootstrap-vcpkg.sh
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 #!/usr/bin/env bash
+=======
+#!/bin/sh
+>>>>>>> Stashed changes
 
 vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
 $vcpkgRootDir/scripts/bootstrap.sh


### PR DESCRIPTION
Otherwise I get this in [Fish](https://fishshell.com):

```
$ ./bootstrap-vcpkg.sh
Failed to execute process './bootstrap-vcpkg.sh'. Reason:
exec: Exec format error
The file './bootstrap-vcpkg.sh' is marked as an executable but could not be run by the operating system.
```