### PR TITLE
Fix vcpkg port gainput

### DIFF
--- a/ports/gainput/portfile.cmake
+++ b/ports/gainput/portfile.cmake
@@ -40,7 +40,8 @@ file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/ga
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/gainputstatic.lib)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/gainputstatic-d.lib)
         file(RENAME ${CURRENT_PACKAGES_DIR}/lib/gainputstatic.lib ${CURRENT_PACKAGES_DIR}/lib/gainput.lib)
         file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/gainputstaticd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/gainputd.lib)
     endif()


### PR DESCRIPTION
1. When installed port gainput, It will shows " C:/vcpkg/packages/gainput_x86-windows-static/debug/lib/gainputstaticd.lib:No such file or directory". The actual file is "C:/vcpkg/packages/gainput_x86-windows-static/debug/lib/gainputstatic-d.lib". 
2. Then tried to install again,  It shows "There should be no bin\ or debug\bin directory in a static build, but they are present."
3. add
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
to remove them.
4. We verified it can be installed successfully in x86-windows, x64-windows, x86-windows-static and x64-windows-static. 