### PR TITLE
Fix vcpkg port fastrtps

### DIFF
--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -20,7 +20,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
 file(COPY ${CURRENT_PACKAGES_DIR}/lib/fastrtps DESTINATION ${CURRENT_PACKAGES_DIR}/share)
 


### PR DESCRIPTION
1. There should be no bin\ directory in a static build, but C:\vcpkg\packages\fastrtps_x64-windows-static\bin is present.
There should be no debug\bin\ directory in a static build, but C:\vcpkg\packages\fastrtps_x64-windows-static\debug\bin is present.
2. Add 
if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
endif()
to remove them.
3.We verified the port fastrtps can be installed successfully in x86-windows,x64-windows,x86-windows-static and x64-windows-static scenarios.