### PR TITLE
fix Port libxmlpp

### DIFF
--- a/ports/libxmlpp/CONTROL
+++ b/ports/libxmlpp/CONTROL
@@ -1,4 +1,4 @@
 Source: libxmlpp
-Version: 2.40.1-1
+Version: 2.40.1-2
 Description: a C++ wrapper for the libxml XML parser library.
 Build-Depends: libxml2, glibmm

--- a/ports/libxmlpp/fixAutoPtrExpired.patch
+++ b/ports/libxmlpp/fixAutoPtrExpired.patch
@@ -1,0 +1,114 @@
+diff --git a/libxml++/parsers/saxparser.h b/libxml++/parsers/saxparser.h
+index 1362ca3..0bd36d2 100644
+--- a/libxml++/parsers/saxparser.h
++++ b/libxml++/parsers/saxparser.h
+@@ -221,7 +221,7 @@ private:
+   //TODO: Remove the virtual when we can break ABI?
+   virtual void parse();
+   
+-  std::auto_ptr<_xmlSAXHandler> sax_handler_;
++  std::unique_ptr<_xmlSAXHandler> sax_handler_;
+ 
+   // A separate xmlpp::Document that is just used for entity resolution,
+   // and never seen in the API:
+diff --git a/libxml++/parsers/textreader.h b/libxml++/parsers/textreader.h
+index 48901b2..17f0737 100644
+--- a/libxml++/parsers/textreader.h
++++ b/libxml++/parsers/textreader.h
+@@ -257,7 +257,7 @@ class TextReader: NonCopyable
+                               void * locator);
+     void check_for_exceptions() const;
+ 
+-    std::auto_ptr<PropertyReader> propertyreader;
++    std::unique_ptr<PropertyReader> propertyreader;
+     _xmlTextReader* impl_;
+     int severity_;
+     Glib::ustring error_;
+diff --git a/libxml++/relaxngschema.h b/libxml++/relaxngschema.h
+index 8df7089..ffe2eaa 100644
+--- a/libxml++/relaxngschema.h
++++ b/libxml++/relaxngschema.h
+@@ -23,7 +23,7 @@
+ 
+ #include <libxml++/schemabase.h>
+ #include <libxml++/document.h>
+-#include <memory> // std::auto_ptr
++#include <memory> // std::unique_ptr
+ 
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+ extern "C" {
+@@ -105,7 +105,7 @@ protected:
+ 
+ private:
+   struct Impl;
+-  std::auto_ptr<Impl> pimpl_;
++  std::unique_ptr<Impl> pimpl_;
+ };
+ 
+ } // namespace xmlpp
+diff --git a/libxml++/validators/relaxngvalidator.h b/libxml++/validators/relaxngvalidator.h
+index 5cd5ad7..cd29393 100644
+--- a/libxml++/validators/relaxngvalidator.h
++++ b/libxml++/validators/relaxngvalidator.h
+@@ -22,7 +22,7 @@
+ #define __LIBXMLPP_VALIDATOR_RELAXNGVALIDATOR_H
+ 
+ #include <libxml++/validators/schemavalidatorbase.h>
+-#include <memory> // std::auto_ptr
++#include <memory> // std::unique_ptr
+ 
+ namespace Glib
+ {
+@@ -156,7 +156,7 @@ protected:
+ 
+ private:
+   struct Impl;
+-  std::auto_ptr<Impl> pimpl_;
++  std::unique_ptr<Impl> pimpl_;
+ };
+ 
+ } // namespace xmlpp
+diff --git a/libxml++/validators/xsdvalidator.h b/libxml++/validators/xsdvalidator.h
+index 941d7f1..d64b971 100644
+--- a/libxml++/validators/xsdvalidator.h
++++ b/libxml++/validators/xsdvalidator.h
+@@ -20,7 +20,7 @@
+ #define __LIBXMLPP_VALIDATOR_XSDVALIDATOR_H
+ 
+ #include <libxml++/validators/schemavalidatorbase.h>
+-#include <memory> // std::auto_ptr
++#include <memory> // std::unique_ptr
+ 
+ namespace Glib
+ {
+@@ -146,7 +146,7 @@ protected:
+ 
+ private:
+   struct Impl;
+-  std::auto_ptr<Impl> pimpl_;
++  std::unique_ptr<Impl> pimpl_;
+ };
+ 
+ } // namespace xmlpp
+diff --git a/libxml++/xsdschema.h b/libxml++/xsdschema.h
+index 1333025..8220e4e 100644
+--- a/libxml++/xsdschema.h
++++ b/libxml++/xsdschema.h
+@@ -21,7 +21,7 @@
+ 
+ #include <libxml++/schemabase.h>
+ #include <libxml++/document.h>
+-#include <memory> // std::auto_ptr
++#include <memory> // std::unique_ptr
+ 
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+ extern "C" {
+@@ -96,7 +96,7 @@ protected:
+ 
+ private:
+   struct Impl;
+-  std::auto_ptr<Impl> pimpl_;
++  std::unique_ptr<Impl> pimpl_;
+ };
+ 
+ } // namespace xmlpp

--- a/ports/libxmlpp/portfile.cmake
+++ b/ports/libxmlpp/portfile.cmake
@@ -10,6 +10,11 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libxml++-${LIBXMLPP_VERSION}
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/fixAutoPtrExpired.patch"
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA


### PR DESCRIPTION
Since the std::auto_ptr is removed in c++17, so use std::unique_ptr to instead of it.