### PR TITLE
Add code to use the system versions of CMake and Ninja if they are newer

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -91,8 +91,8 @@ err()
 }
 
 # mustToolVersion must output the version number for the given tool name on
-# stdout, or exit with an error message and error code 0.
-# Takes the tool name as an argument
+# stdout, or exit with an error message and error code 1.
+# Takes the lowercase tool name as an argument.
 mustToolVersion()
 {
     tool="$1"


### PR DESCRIPTION
Added code in `scripts/bootstrap.sh` that:

* First checks the version of CMake and Ninja, using `cmake --version` and `ninja --version`.
* If they are available, and at a higher version than specified in `vcpkgTools.xml`, the system version is used.
* If not, CMake and Ninja are downloaded as before.

This makes more sense on especially rolling release Linux distros like Arch Linux, where CMake and Ninja are always at the latest versions.

Seeing the bootstrap script download CMake and Ninja when users already have newer versions installed is a potential barrier for adoptation of `vcpkg`.

These proposed changes are tested on Arch Linux, and is highly likely to work well also on other Linux distros, but may need more testing on macOS.

I also made the booststrap script use `sha512sum`, if available. Only using `shasum -a 512` is not available on Arch Linux and breaks the script.