### PR TITLE
[bigint] Add missing header file #3319

### DIFF
--- a/ports/bigint/CMakeLists.txt
+++ b/ports/bigint/CMakeLists.txt
@@ -13,7 +13,7 @@ set(
 	BigInteger.cc
 	BigIntegerAlgorithms.cc
 	BigUnsignedInABase.cc
-  BigIntegerUtils.cc
+	BigIntegerUtils.cc
 )
 
 set(
@@ -24,6 +24,7 @@ set(
 	BigIntegerAlgorithms.hh
 	BigUnsignedInABase.hh
 	BigIntegerLibrary.hh
+	BigIntegerUtils.hh
 )
 
 add_library(bigint ${bigint_srcs})

--- a/ports/bigint/CONTROL
+++ b/ports/bigint/CONTROL
@@ -1,3 +1,3 @@
 Source: bigint
-Version: 2010.04.30-1
+Version: 2010.04.30-2
 Description: C++ Big Integer Library


### PR DESCRIPTION
File `BigIntegerUtils.hh`, which is required by the library, was not being copied, as described in #3319 