### PR TITLE
Update gitignore to exclude the `vcpkg` binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+vcpkg
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
When you run `./bootstrap-cvpkg.sh`, the binary isn't excluded from the git repo

I have updated the gitignore to ignore the vcpkg binary.