### PR TITLE
[grpc] update to v1.11.0

### DIFF
--- a/ports/grpc/CONTROL
+++ b/ports/grpc/CONTROL
@@ -1,4 +1,4 @@
 Source: grpc
-Version: 1.10.1-3
+Version: 1.11.0
 Build-Depends: zlib, openssl, protobuf, c-ares (!uwp)
 Description: An RPC library and framework

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -12,8 +12,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO grpc/grpc
-    REF v1.10.1
-    SHA512 2221d902c60eada6dd1547a63d26bd3b30cb6710247b5e48523bacde498a3691cc177f1dbe9db8a007b8ae341a5b0c8ec999539e26a9bcff480a8d0b02140997
+    REF v1.11.0
+    SHA512 3127cf0e66cd0712d905e6008adf6f80d787ad97eae2fba38fa3f4d343849a3dc3ca8f2ccbc82020e812fdb272e9577584c298a5b623fbdcac40c1efd7877855
     HEAD_REF master
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/disable-csharp-ext.patch


### PR DESCRIPTION
Updated grpc to 1.11.0 release.

Simplifies patches witch disabled the build of C# extensions into single one.