### PR TITLE
[protobuf] Patch protobuf to fix the compilation error C4146 in wire_format_lite.h

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.5.1-4
+Version: 3.5.1-5
 Description: Protocol Buffers - Google's data interchange format
 
 Feature: zlib

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_apply_patches(
         "${CMAKE_CURRENT_LIST_DIR}/export-ParseGeneratorParameter.patch"
         "${CMAKE_CURRENT_LIST_DIR}/js-embed.patch"
         "${CMAKE_CURRENT_LIST_DIR}/fix-uwp.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/wire_format_lite_h_fix_error_C4146.patch"
 )
 
 if(CMAKE_HOST_WIN32)

--- a/ports/protobuf/wire_format_lite_h_fix_error_C4146.patch
+++ b/ports/protobuf/wire_format_lite_h_fix_error_C4146.patch
@@ -1,0 +1,35 @@
+From 24493eef9395e5b832360e12efabf9c363c9cb15 Mon Sep 17 00:00:00 2001
+From: Rodrigo Hernandez <kwizatz@aeongames.com>
+Date: Mon, 4 Dec 2017 19:04:42 -0600
+Subject: [PATCH] Using binary one's complement to negate an unsigned int
+
+This removes a Visual Studio warning:
+
+warning C4146: unary minus operator applied to unsigned type, result
+still unsigned.
+---
+ src/google/protobuf/wire_format_lite.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/google/protobuf/wire_format_lite.h b/src/google/protobuf/wire_format_lite.h
+index cf614c02a4..361920b8ec 100644
+--- a/src/google/protobuf/wire_format_lite.h
++++ b/src/google/protobuf/wire_format_lite.h
+@@ -860,7 +860,7 @@ inline uint32 WireFormatLite::ZigZagEncode32(int32 n) {
+
+ inline int32 WireFormatLite::ZigZagDecode32(uint32 n) {
+   // Note:  Using unsigned types prevent undefined behavior
+-  return static_cast<int32>((n >> 1) ^ -(n & 1));
++  return static_cast<int32>((n >> 1) ^ (~(n & 1) + 1));
+ }
+
+ inline uint64 WireFormatLite::ZigZagEncode64(int64 n) {
+@@ -871,7 +871,7 @@ inline uint64 WireFormatLite::ZigZagEncode64(int64 n) {
+
+ inline int64 WireFormatLite::ZigZagDecode64(uint64 n) {
+   // Note:  Using unsigned types prevent undefined behavior
+-  return static_cast<int64>((n >> 1) ^ -(n & 1));
++  return static_cast<int64>((n >> 1) ^ (~(n & 1) + 1));
+ }
+
+ // String is for UTF-8 text only, but, even so, ReadString() can simply


### PR DESCRIPTION
This will patch the protobuf code with https://github.com/google/protobuf/commit/24493eef9395e5b832360e12efabf9c363c9cb15 which fixes the C4146 error.

Fixes #3352