### PR TITLE
Require the version of g++ to be at least 6

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -166,7 +166,7 @@ selectCXX()
 
     gccversion="$("$CXX" -v 2>&1)"
     gccversion="$(extractStringBetweenDelimiters "$gccversion" "gcc version " ".")"
-    if [ "$gccversion" = "5" ]; then
+    if [ "$gccversion" -lt "6" ]; then
         echo "CXX ($CXX) is too old; please install a newer compiler such as g++-7."
         echo "sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y"
         echo "sudo apt-get update -y"


### PR DESCRIPTION
On Ubuntu 16.04, the default version of g++ is 4.9. With the previous test,
the bootstrap script was not failing fast and instead was starting to
compile vcpkg before it encountered the unsupported flag -std=c++1z.
The error message was not very explicit and that was making it difficult
to the developer to understand what the problem was. However, when using
g++ 5, an clear error message was printed to help the user. This commit
shows the helpful error message anytime g++ is older than version 6.