### PR TITLE
Add Visual Studio 2013 Support for Qt5

### DIFF
--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -69,6 +69,8 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
         set(PLATFORM "win32-msvc2015")
     elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
         set(PLATFORM "win32-msvc2017")
+    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v120")
+        set(PLATFORM "win32-msvc2013")
     endif()
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Add check for `v120` tool set which corresponds to visual studio 2013. 

With this check I was able to successfully build `Qt5` using `vcpkg` and a custom triplet to build with visual studio 2013 (`x64-windows-vs2013`). Note that I did not try to build a static `Qt5` build. 