### PR TITLE
physfs: fix-up CONTROL for v3.0.1

### DIFF
--- a/ports/physfs/CONTROL
+++ b/ports/physfs/CONTROL
@@ -1,4 +1,4 @@
 Source: physfs
-Version: 2.0.3-2
+Version: 3.0.1
 Description: a library to provide abstract access to various archives
 Build-Depends: zlib


### PR DESCRIPTION
Updated _[Version]_ string in **CONTROL** to match current version in _/ports/physfs/portfile.cmake_:

```
Source: physfs
Version: 3.0.1
Description: a library to provide abstract access to various archives
Build-Depends: zlib
```