### PR TITLE
Add PDAL 1.7.1

### DIFF
--- a/ports/pdal/0001-win32_compiler_options.cmake.patch
+++ b/ports/pdal/0001-win32_compiler_options.cmake.patch
@@ -1,0 +1,14 @@
+diff -Nuar a/cmake/win32_compiler_options.cmake b/cmake/win32_compiler_options.cmake
+--- a/cmake/win32_compiler_options.cmake	2018-04-06 20:24:17.000000000 +0200
++++ b/cmake/win32_compiler_options.cmake	2018-04-28 19:40:54.534593200 +0200
+@@ -67,10 +67,6 @@
+     endif()
+ endif()
+ 
+-set(CMAKE_INCLUDE_PATH "c:/OSGeo4W64/include;$ENV{CMAKE_INCLUDE_PATH}")
+-set(CMAKE_LIBRARY_PATH "c:/OSGeo4W64/lib;$ENV{CMAKE_LIBRARY_PATH}")
+-set(CMAKE_PREFIX_PATH "c:/OSGeo4W64/cmake;$ENV{CMAKE_LIBRARY_PATH}")
+-
+ #ABELL (& gadomski) - WHY?
+ set(PDAL_PLATFORM_WIN32 1)
+ set(WINSOCK_LIBRARY ws2_32)

--- a/ports/pdal/CONTROL
+++ b/ports/pdal/CONTROL
@@ -1,4 +1,4 @@
 Source: pdal
-Version: 1.7.1
+Version: 1.7.1-1
 Description: PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.
 Build-Depends: gdal, geos, jsoncpp, libgeotiff

--- a/ports/pdal/CONTROL
+++ b/ports/pdal/CONTROL
@@ -1,0 +1,4 @@
+Source: pdal
+Version: 1.7.1
+Description: PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.
+Build-Depends: gdal, geos, jsoncpp, libgeotiff

--- a/ports/pdal/FindGDAL.cmake
+++ b/ports/pdal/FindGDAL.cmake
@@ -1,0 +1,13 @@
+find_path(GDAL_INCLUDE_DIR gdal.h)
+
+find_library(GDAL_LIBRARY_DEBUG NAMES gdald)
+find_library(GDAL_LIBRARY_RELEASE NAMES gdal)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(GDAL)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    GDAL DEFAULT_MSG
+    GDAL_LIBRARY GDAL_INCLUDE_DIR
+)

--- a/ports/pdal/FindGEOS.cmake
+++ b/ports/pdal/FindGEOS.cmake
@@ -1,0 +1,13 @@
+find_path(GEOS_INCLUDE_DIR geos_c.h)
+
+find_library(GEOS_LIBRARY_DEBUG NAMES geos_cd)
+find_library(GEOS_LIBRARY_RELEASE NAMES geos_c)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(GEOS)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    GEOS DEFAULT_MSG
+    GEOS_LIBRARY GEOS_INCLUDE_DIR
+)

--- a/ports/pdal/FindGeoTIFF.cmake
+++ b/ports/pdal/FindGeoTIFF.cmake
@@ -1,0 +1,13 @@
+find_path(GEOTIFF_INCLUDE_DIR geotiff.h)
+
+find_library(GEOTIFF_LIBRARY_DEBUG NAMES geotiff_d)
+find_library(GEOTIFF_LIBRARY_RELEASE NAMES geotiff)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(GEOTIFF)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    GEOTIFF DEFAULT_MSG
+    GEOTIFF_LIBRARY GEOTIFF_INCLUDE_DIR
+)

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -4,10 +4,6 @@
 set(PDAL_VERSION_STR "1.7.1")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/PDAL-${PDAL_VERSION_STR}-src)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    message(FATAL_ERROR "PDAL's dependency GDAL does not support building static libraries")
-endif()
-
 include(vcpkg_common_functions)
 
 vcpkg_download_distfile(ARCHIVE
@@ -48,8 +44,7 @@ vcpkg_configure_cmake(
         -DWITH_COMPLETION:BOOL=OFF
 )
 
-vcpkg_build_cmake(ADD_BIN_TO_PATH)
-vcpkg_install_cmake()
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/pdal/cmake)
 vcpkg_copy_pdbs()
 
@@ -60,7 +55,7 @@ file(INSTALL ${SOURCE_PATH}/LICENSE.txt
 
 # Install PDAL executable
 file(GLOB _pdal_apps ${CURRENT_PACKAGES_DIR}/bin/*.exe)
-file(INSTALL ${_pdal_apps} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pdal)
+file(COPY ${_pdal_apps} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pdal)
 file(REMOVE ${_pdal_apps})
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -1,0 +1,84 @@
+# vcpkg portfile.cmake for PDAL
+#
+# NOTE: update the version string for new PDAL release
+set(PDAL_VERSION_STR "1.7.1")
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/PDAL-${PDAL_VERSION_STR}-src)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    message(FATAL_ERROR "PDAL's dependency GDAL does not support building static libraries")
+endif()
+
+include(vcpkg_common_functions)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://download.osgeo.org/pdal/PDAL-${PDAL_VERSION_STR}-src.tar.gz"
+    FILENAME "PDAL-${PDAL_VERSION_STR}-src.tar.gz"
+    SHA512 e3e63bb05930c1a28c4f46c7edfaa8e9ea20484f1888d845b660a29a76f1dd1daea3db30a98607be0c2eeb86930ec8bfd0965d5d7d84b07a4fe4cb4512da9b09
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/PDAL-${PDAL_VERSION_STR}-src
+    PATCHES
+    ${CURRENT_PORT_DIR}/0001-win32_compiler_options.cmake.patch
+)
+
+# Deploy custom CMake modules to enforce expected dependencies look-up
+foreach(_module IN ITEMS FindGDAL FindGEOS FindGeoTIFF)
+    file(REMOVE "${SOURCE_PATH}/cmake/modules/${_module}.cmake")
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/${_module}.cmake
+        DESTINATION ${SOURCE_PATH}/cmake/modules/
+    )
+endforeach()
+
+# NOTE: CMake native BUILD_SHARED_LIBS option will be set by vcpkg_configure_cmake
+# TODO: Remove this as soon as PDAL switches to use BUILD_SHARED_LIBS
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(PDAL_BUILD_STATIC OFF)
+else()
+    set(PDAL_BUILD_STATIC ON)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DPDAL_BUILD_STATIC:BOOL=${PDAL_BUILD_STATIC}
+        -DWITH_TESTS:BOOL=OFF
+        -DWITH_COMPLETION:BOOL=OFF
+)
+
+vcpkg_build_cmake(ADD_BIN_TO_PATH)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/pdal/cmake)
+vcpkg_copy_pdbs()
+
+# Install copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/pdal RENAME copyright
+)
+
+# Install PDAL executable
+file(GLOB _pdal_apps ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+file(INSTALL ${_pdal_apps} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pdal)
+file(REMOVE ${_pdal_apps})
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+
+# Post-install clean-up
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/lib/pdal
+    ${CURRENT_PACKAGES_DIR}/debug/lib/pdal
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
+else()
+    file(GLOB _pdal_bats ${CURRENT_PACKAGES_DIR}/bin/*.bat)
+    file(REMOVE ${_pdal_bats})
+    file(GLOB _pdal_bats ${CURRENT_PACKAGES_DIR}/debug/bin/*.bat)
+    file(REMOVE ${_pdal_bats})
+    file(GLOB _pdal_apps ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+    file(REMOVE ${_pdal_apps})
+endif()


### PR DESCRIPTION
First stab at porting PDAL (https://pdal.io), creates package:
- with **minimal set** of required dependencies
- with **dynamic** library only - dependency GDAL does not build as static
- with pdal executable

## Test

### Executable

```
 d:\vcpkg\installed\x64-windows\tools\pdal\pdal.exe --version
--------------------------------------------------------------------------------
pdal 1.7.1 (git-version: c795e3)
--------------------------------------------------------------------------------
```

### Library

- `CMakeLists.txt`

```
cmake_minimum_required(VERSION 3.5)
project(test_vcpkg CXX)
find_package(PDAL REQUIRED)
include_directories(${PDAL_INCLUDE_DIRS})
add_executable(use_pdal use_pdal.cpp)
target_link_libraries(use_pdal PRIVATE pdalcpp pdal_util pdal_boost pdal_arbiter pdal_kazhdan)
```

- `use_pdal.cpp`

```
#include <pdal/pdal.hpp>
int main()
{
    pdal::Options options;
    options.add("filename", "myfile.las");
}
```

- Run `cmake`

```
cd use_pdal & mkdir _build & cd _build
cmake -DCMAKE_TOOLCHAIN_FILE=d:\vcpkg\scripts\buildsystems\vcpkg.cmake -G "Visual Studio 15 2017 Win64" ..
cmake --build .
```

Successfully compiled and linked.