### PR TITLE
[SDL2] Use Vulkan video subsystem

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DSDL_STATIC=${SDL_STATIC}
         -DSDL_SHARED=${SDL_SHARED}
-        -DVIDEO_VULKAN=OFF
+        -DVIDEO_VULKAN=ON
         -DFORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DLIBC=ON
 )


### PR DESCRIPTION
Not sure why this was disabled in the first place. A **lot** of projects use SDL + Vulkan.

Related issue: #3435 