### PR TITLE
FixPmdkFailure

### DIFF
--- a/ports/pmdk/CONTROL
+++ b/ports/pmdk/CONTROL
@@ -1,3 +1,3 @@
 Source: pmdk
-Version: 1.4-1
+Version: 1.4-2
 Description: Persistent Memory Development Kit

--- a/ports/pmdk/addPowerShellExecutionPolicy.patch
+++ b/ports/pmdk/addPowerShellExecutionPolicy.patch
@@ -1,7 +1,7 @@
-diff --git a/srcversion.vcxproj b/srcversion.vcxproj
+diff --git a/src/windows/srcversion/srcversion.vcxproj b/src/windows/srcversion/srcversion.vcxproj
 index 8761197..795d1a7 100644
---- a/srcversion.vcxproj
-+++ b/srcversion.vcxproj
+--- a/src/windows/srcversion/srcversion.vcxproj
++++ b/src/windows/srcversion/srcversion.vcxproj
 @@ -72,7 +72,7 @@
        </Command>
      </PreBuildEvent>

--- a/ports/pmdk/addPowerShellExecutionPolicy.patch
+++ b/ports/pmdk/addPowerShellExecutionPolicy.patch
@@ -1,0 +1,22 @@
+diff --git a/srcversion.vcxproj b/srcversion.vcxproj
+index 8761197..795d1a7 100644
+--- a/srcversion.vcxproj
++++ b/srcversion.vcxproj
+@@ -72,7 +72,7 @@
+       </Command>
+     </PreBuildEvent>
+     <CustomBuildStep>
+-      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
++      <Command>powershell.exe -ExecutionPolicy Bypass -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
+       <Outputs>__NON_EXISTENT_FILE__</Outputs>
+       <Message>generate srcversion.h</Message>
+     </CustomBuildStep>
+@@ -99,7 +99,7 @@
+       </Command>
+     </PreBuildEvent>
+     <CustomBuildStep>
+-      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
++      <Command>powershell.exe -ExecutionPolicy Bypass -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
+       <Outputs>__NON_EXISTENT_FILE__</Outputs>
+       <Message>generate srcversion.h</Message>
+     </CustomBuildStep>

--- a/ports/pmdk/portfile.cmake
+++ b/ports/pmdk/portfile.cmake
@@ -26,6 +26,11 @@ vcpkg_from_github(
 get_filename_component(PMDK_VERSION "${SOURCE_PATH}" NAME)
 string(REPLACE "pmdk-" "" PMDK_VERSION "${PMDK_VERSION}")
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}/src/windows/srcversion
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/addPowerShellExecutionPolicy.patch"
+)
+
 # Build only the selected projects
 vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/src/PMDK.sln

--- a/ports/pmdk/portfile.cmake
+++ b/ports/pmdk/portfile.cmake
@@ -21,22 +21,17 @@ vcpkg_from_github(
     REF 1.4
     SHA512 95dbea9acfea4a6cb433a25f56f7484946a93fbce1c5e0e1d6ff36e0824e3e0e9f28f37024918998358f8ff12e69d0902fcf88357b9ad12695f32e06e86ffac8
     HEAD_REF master
+    PATCHES
+        "${CMAKE_CURRENT_LIST_DIR}/addPowerShellExecutionPolicy.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/v141.patch"
 )
 
 get_filename_component(PMDK_VERSION "${SOURCE_PATH}" NAME)
 string(REPLACE "pmdk-" "" PMDK_VERSION "${PMDK_VERSION}")
 
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}/src/windows/srcversion
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/addPowerShellExecutionPolicy.patch"
-)
-
 # Build only the selected projects
 vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/src/PMDK.sln
-    PLATFORM x64
-    PLATFORM_TOOLSET v140
-    TARGET_PLATFORM_VERSION 10.0.16299.0
     TARGET "Solution Items\\libpmem,Solution Items\\libpmemlog,Solution Items\\libpmemblk,Solution Items\\libpmemobj,Solution Items\\libpmemcto,Solution Items\\libpmempool,Solution Items\\libvmem,Solution Items\\Tools\\pmempool"
     OPTIONS /p:SRCVERSION=${PMDK_VERSION}
 )

--- a/ports/pmdk/v141.patch
+++ b/ports/pmdk/v141.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/util.h b/src/common/util.h
+index 04b098f..33a64c2 100644
+--- a/src/common/util.h
++++ b/src/common/util.h
+@@ -284,7 +284,7 @@ typedef enum {
+ #error MSVC ports of util_atomic_ only work on X86_64
+ #endif
+ 
+-#if _MSC_VER > 1911
++#if _MSC_VER >= 2000
+ #error util_atomic_ utility functions not tested with this version of VC++
+ #error These utility functions are not future proof, as they are not
+ #error based on publicly available documentation.


### PR DESCRIPTION
1. Since Pmdk x64-windows installation failed with error: "File SRCVERSION.ps1 cannot be loaded, the file SRCVERSION.ps1 is not digitally signed", so add -ExecutionPolicy Bypass to fix this issue.
2. After verification, this ports install successfully.

