### PR TITLE
Fix Windows curl/nghttp2 static build

### DIFF
--- a/ports/curl/0004_nghttp2_staticlib.patch
+++ b/ports/curl/0004_nghttp2_staticlib.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 490cc19..51c0a92 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -388,6 +388,9 @@ if(USE_NGHTTP2)
+   find_package(NGHTTP2 REQUIRED)
+   include_directories(${NGHTTP2_INCLUDE_DIRS})
+   list(APPEND CURL_LIBS ${NGHTTP2_LIBRARIES})
++  if(CURL_STATICLIB)
++    add_definitions(-DNGHTTP2_STATICLIB)
++  endif()
+ endif()
+
+ if(NOT CURL_DISABLE_LDAP)

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.60.0
+Version: 7.60.0-1
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
         ${CMAKE_CURRENT_LIST_DIR}/0002_fix_uwp.patch
         ${CMAKE_CURRENT_LIST_DIR}/0003_fix_libraries.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0004_nghttp2_staticlib.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
When curl is linked with a static nghttp2, NGHTTP2_STATICLIB
must be defined during the curl build phase