### PR TITLE
remove libjpeg of SFML CONTROL file

### DIFF
--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,4 +1,4 @@
 Source: sfml
 Version: 2.5.0
 Description: Simple and fast multimedia library
-Build-Depends: freetype, libflac, libjpeg-turbo, libogg, libvorbis, openal-soft, stb, freeglut (!uwp&&!windows)
+Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb, freeglut (!uwp&&!windows)


### PR DESCRIPTION
according to https://en.sfml-dev.org/forums/index.php?topic=24009.msg163052#msg163052

libjpeg is no longer a dependancies of sfml :
"libjpeg is no longer a dependency of SFML, but since you use the old FindSFML.cmake it still thinks it is."