### PR TITLE
[spaceland] Added new port for SpaceLand library

### DIFF
--- a/ports/spaceland/CONTROL
+++ b/ports/spaceland/CONTROL
@@ -1,0 +1,4 @@
+Source: spaceland
+Version: 7.8.2-0
+Description: Spaceland Lib (sl) is a suite for geometric computation, specifically adapted to OpenGL.
+Build-Depends: zlib

--- a/ports/spaceland/portfile.cmake
+++ b/ports/spaceland/portfile.cmake
@@ -1,0 +1,37 @@
+include(vcpkg_common_functions)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    message(STATUS "WARNING: Dynamic building not supported. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/sl-7.8.2-Source)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://vic.crs4.it/vic/download/pkgs/sl-7.8.2-Source.tar.gz"
+    FILENAME "sl-7.8.2-Source.tar.gz"
+    SHA512 1391dac1474ddb47d0cf0eb7baeb7db68d6356c2116f732dd57b8a050739523282ded0643cc466640f2b22f25dd6bfced00ede4e041b7ff83754a99ae6725d7d
+)
+
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DSL_TEST=OFF
+		-DSL_INSTALL_SLFIND_MODULE=OFF
+	OPTIONS_DEBUG
+        -DSL_TEST=OFF
+        -DSL_INSTALL_SLFIND_MODULE=OFF
+)
+
+vcpkg_install_cmake()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle license
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/spaceland)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/spaceland/COPYING ${CURRENT_PACKAGES_DIR}/share/spaceland/license)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/copyright.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/spaceland)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/spaceland/copyright.txt ${CURRENT_PACKAGES_DIR}/share/spaceland/copyright)


### PR DESCRIPTION
Added a new package for SpaceLand (SL) library, which is a suite of C++ template classes that support geometric computation (specifically adapted to OpenGL). SL is mostly intended for computer graphics developers and it includes many different kind of algorithms (linear algebra methods, coding/decoding tecniques, generalized data structures, utilities).  http://vic.crs4.it/vic/download/