### PR TITLE
[tesseract] fix leptonica dependency

### DIFF
--- a/ports/tesseract/leptonica.patch
+++ b/ports/tesseract/leptonica.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/templates/TesseractConfig.cmake.in b/cmake/templates/TesseractConfig.cmake.in
+index 13838361..245ca2bc 100644
+--- a/cmake/templates/TesseractConfig.cmake.in
++++ b/cmake/templates/TesseractConfig.cmake.in
+@@ -21,6 +21,8 @@
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/TesseractTargets.cmake)
+ 
++find_package(Leptonica REQUIRED)
++
+ # ======================================================
+ #  Version variables:
+ # ======================================================

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/use-vcpkg-icu.patch
         ${CMAKE_CURRENT_LIST_DIR}/ws2-32.patch
+        ${CMAKE_CURRENT_LIST_DIR}/leptonica.patch
 )
 
 # The built-in cmake FindICU is better


### PR DESCRIPTION
This resolves issue #3590.
Now it is not neccesary to use statement `find_package(Leptonica REQUIRED)` explicitly, when incorporating tesseract library into a CMake project.