### PR TITLE
Corrade and Magnum on Linux

### DIFF
--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -7,11 +7,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(BUILD_STATIC 1)
-else()
-    set(BUILD_STATIC 0)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 
 # Handle features
 set(_COMPONENT_FLAGS "")
@@ -45,16 +41,20 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Install tools
 if("utility" IN_LIST FEATURES)
+    file(GLOB EXES
+        ${CURRENT_PACKAGES_DIR}/bin/corrade-rc
+        ${CURRENT_PACKAGES_DIR}/bin/corrade-rc.exe
+    )
+
     # Drop a copy of tools
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/corrade-rc${CMAKE_EXECUTABLE_SUFFIX}
-         DESTINATION ${CURRENT_PACKAGES_DIR}/tools/corrade)
+    file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/corrade)
 
     # Tools require dlls
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/corrade)
 
-    file(GLOB_RECURSE TO_REMOVE
-        ${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}
-        ${CURRENT_PACKAGES_DIR}/debug/bin/*${CMAKE_EXECUTABLE_SUFFIX})
+    file(GLOB TO_REMOVE
+        ${CURRENT_PACKAGES_DIR}/bin/corrade-rc*
+        ${CURRENT_PACKAGES_DIR}/debug/bin/corrade-rc*)
     file(REMOVE ${TO_REMOVE})
 endif()
 
@@ -68,7 +68,7 @@ if(NOT FEATURES)
     # debug is completely empty, as include and share
     # have already been removed.
 
-elseif(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     # No dlls
     file(REMOVE_RECURSE
         ${CURRENT_PACKAGES_DIR}/bin

--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -45,23 +45,16 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Install tools
 if("utility" IN_LIST FEATURES)
-    # Executable suffix
-    if(WIN32)
-        set(EXECUTABLE_SUFFIX ".exe")
-    else()
-        set(EXECUTABLE_SUFFIX "")
-    endif()
-  
     # Drop a copy of tools
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/corrade-rc${EXECUTABLE_SUFFIX}
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/corrade-rc${CMAKE_EXECUTABLE_SUFFIX}
          DESTINATION ${CURRENT_PACKAGES_DIR}/tools/corrade)
 
     # Tools require dlls
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/corrade)
 
     file(GLOB_RECURSE TO_REMOVE
-        ${CURRENT_PACKAGES_DIR}/bin/*${EXECUTABLE_SUFFIX}
-        ${CURRENT_PACKAGES_DIR}/debug/bin/*${EXECUTABLE_SUFFIX})
+        ${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}
+        ${CURRENT_PACKAGES_DIR}/debug/bin/*${CMAKE_EXECUTABLE_SUFFIX})
     file(REMOVE ${TO_REMOVE})
 endif()
 

--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -45,16 +45,23 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Install tools
 if("utility" IN_LIST FEATURES)
+    # Executable suffix
+    if(WIN32)
+        set(EXECUTABLE_SUFFIX ".exe")
+    else()
+        set(EXECUTABLE_SUFFIX "")
+    endif()
+  
     # Drop a copy of tools
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/corrade-rc.exe
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/corrade-rc${EXECUTABLE_SUFFIX}
          DESTINATION ${CURRENT_PACKAGES_DIR}/tools/corrade)
 
     # Tools require dlls
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/corrade)
 
     file(GLOB_RECURSE TO_REMOVE
-        ${CURRENT_PACKAGES_DIR}/bin/*.exe
-        ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+        ${CURRENT_PACKAGES_DIR}/bin/*${EXECUTABLE_SUFFIX}
+        ${CURRENT_PACKAGES_DIR}/debug/bin/*${EXECUTABLE_SUFFIX})
     file(REMOVE ${TO_REMOVE})
 endif()
 

--- a/ports/magnum/CONTROL
+++ b/ports/magnum/CONTROL
@@ -2,7 +2,7 @@ Source: magnum
 Version: 2018.04-1
 Build-Depends: corrade[pluginmanager], corrade[utility]
 Description: C++11/C++14 graphics middleware for games and data visualization http://magnum.graphics/
-Default-Features: anyimageimporter, anyaudioimporter, anyimageconverter, anysceneimporter, debugtools, gl, meshtools, primitives, scenegraph, shaders, shapes, text, texturetools, trade, sdl2application, windowlesswglapplication
+Default-Features: anyimageimporter, anyaudioimporter, anyimageconverter, anysceneimporter, debugtools, gl, meshtools, primitives, scenegraph, shaders, shapes, text, texturetools, trade, sdl2application
 
 Feature: al-info
 Description: magnum-al-info utility

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -53,25 +53,31 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 # Drop a copy of tools
+if(NOT VCPKG_CMAKE_SYSTEM_NAME)
+    set(EXE_SUFFIX .exe)
+else()
+    set(EXE_SUFFIX)
+endif()
+
 if(distancefieldconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter${EXE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(fontconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter${EXE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(al-info IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info${EXE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(magnuminfo IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info${EXE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 
 # Tools require dlls
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/magnum)
 
 file(GLOB_RECURSE TO_REMOVE
-   ${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}
-   ${CURRENT_PACKAGES_DIR}/debug/bin/*${CMAKE_EXECUTABLE_SUFFIX})
+   ${CURRENT_PACKAGES_DIR}/bin/*${EXE_SUFFIX}
+   ${CURRENT_PACKAGES_DIR}/debug/bin/*${EXE_SUFFIX})
 if(TO_REMOVE)
     file(REMOVE ${TO_REMOVE})
 endif()
@@ -79,7 +85,7 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
    # move plugin libs to conventional place

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -52,33 +52,26 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# Executable suffix
-if (WIN32)
-    set(EXECUTABLE_SUFFIX ".exe")
-else()
-    set(EXECUTABLE_SUFFIX "")
-endif()
-
 # Drop a copy of tools
 if(distancefieldconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(fontconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(al-info IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(magnuminfo IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 
 # Tools require dlls
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/magnum)
 
 file(GLOB_RECURSE TO_REMOVE
-   ${CURRENT_PACKAGES_DIR}/bin/*${EXECUTABLE_SUFFIX}
-   ${CURRENT_PACKAGES_DIR}/debug/bin/*${EXECUTABLE_SUFFIX})
+   ${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}
+   ${CURRENT_PACKAGES_DIR}/debug/bin/*${CMAKE_EXECUTABLE_SUFFIX})
 if(TO_REMOVE)
     file(REMOVE ${TO_REMOVE})
 endif()

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -52,26 +52,33 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+# Executable suffix
+if (WIN32)
+    set(EXECUTABLE_SUFFIX ".exe")
+else()
+    set(EXECUTABLE_SUFFIX "")
+endif()
+
 # Drop a copy of tools
 if(distancefieldconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-distancefieldconverter${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(fontconverter IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-fontconverter${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(al-info IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-al-info${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 if(magnuminfo IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/magnum-info${EXECUTABLE_SUFFIX} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/magnum)
 endif()
 
 # Tools require dlls
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/magnum)
 
 file(GLOB_RECURSE TO_REMOVE
-   ${CURRENT_PACKAGES_DIR}/bin/*.exe
-   ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+   ${CURRENT_PACKAGES_DIR}/bin/*${EXECUTABLE_SUFFIX}
+   ${CURRENT_PACKAGES_DIR}/debug/bin/*${EXECUTABLE_SUFFIX})
 if(TO_REMOVE)
     file(REMOVE ${TO_REMOVE})
 endif()


### PR DESCRIPTION
To get corrade and magnum working on Linux I had to do a minor change. 
  1. Extension ".exe" was assumed for executable.
  2. Removed default feature `magnum[windowlesswglapplication]` which is Windows only

I have tested it on few [examples](https://github.com/mosra/magnum-examples) and it worked without a problem. However, a more through examination to test all possible plugins and extensions is probably necessary.