### PR TITLE
[curl] fix curl[tool] support HTTP2 use WinSSL

### DIFF
--- a/ports/curl/0005_winssl_http2.patch
+++ b/ports/curl/0005_winssl_http2.patch
@@ -1,0 +1,79 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bf25b1f79..dac74d7f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1104,12 +1104,17 @@ include(CMake/OtherTests.cmake)
+ 
+ add_definitions(-DHAVE_CONFIG_H)
+ 
+-# For windows, all compilers used by cmake should support large files
++# For Windows, all compilers used by CMake should support large files
+ if(WIN32)
+   set(USE_WIN32_LARGE_FILES ON)
++
++  # Use the manifest embedded in the Windows Resource
++  set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -DCURL_EMBED_MANIFEST")
+ endif(WIN32)
+ 
+ if(MSVC)
++  # Disable default manifest added by CMake
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
+   add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+   if(CMAKE_C_FLAGS MATCHES "/W[0-4]")
+     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+diff --git a/src/curl.rc b/src/curl.rc
+index 5f49d2236..f54c4b234 100644
+--- a/src/curl.rc
++++ b/src/curl.rc
+@@ -61,3 +61,51 @@ BEGIN
+     VALUE "Translation", 0x409, 1200
+   END
+ END
++
++/* Manifest */
++
++#if defined(CURL_EMBED_MANIFEST)
++
++/* String escaping rules:
++     https://msdn.microsoft.com/library/aa381050
++   Application Manifest doc, including the list of 'supportedOS Id's:
++     https://msdn.microsoft.com/library/aa374191 */
++
++#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
++#define CREATEPROCESS_MANIFEST_RESOURCE_ID  1
++#endif
++#ifndef RT_MANIFEST
++#define RT_MANIFEST  24
++#endif
++
++#define _STR(macro)   _STR_(macro)
++#define _STR_(macro)  #macro
++
++CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
++BEGIN
++  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"
++  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"">"
++    "<assemblyIdentity name=""The curl executable"" version="""
++      _STR(LIBCURL_VERSION_MAJOR) "."
++      _STR(LIBCURL_VERSION_MINOR) "."
++      _STR(LIBCURL_VERSION_PATCH) ".0"" type=""win32""/>"
++    "<compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">"
++      "<application>"
++        "<supportedOS Id=""{e2011457-1546-43c5-a5fe-008deee3d3f0}""/>"  /* Vista / Server 2008 */
++        "<supportedOS Id=""{35138b9a-5d96-4fbd-8e2d-a2440225f93a}""/>"  /* 7 / Server 2008 R2 */
++        "<supportedOS Id=""{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}""/>"  /* 8 / Server 2012 */
++        "<supportedOS Id=""{1f676c76-80e1-4239-95bb-83d0f6d0da78}""/>"  /* 8.1 / Server 2012 R2 */
++        "<supportedOS Id=""{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}""/>"  /* 10 / Server 2016 */
++      "</application>"
++    "</compatibility>"
++    "<trustInfo xmlns=""urn:schemas-microsoft-com:asm.v3"">"
++      "<security>"
++        "<requestedPrivileges>"
++          "<requestedExecutionLevel level=""asInvoker"" uiAccess=""false""/>"
++        "</requestedPrivileges>"
++      "</security>"
++    "</trustInfo>"
++  "</assembly>"
++END
++
++#endif

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.60.0-1
+Version: 7.60.0-2
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/0002_fix_uwp.patch
         ${CMAKE_CURRENT_LIST_DIR}/0003_fix_libraries.patch
         ${CMAKE_CURRENT_LIST_DIR}/0004_nghttp2_staticlib.patch
+        ${CMAKE_CURRENT_LIST_DIR}/0005_winssl_http2.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
CURL not include manifest, `Curl_verify_windows_version` failed detect os version.

About details: 
https://github.com/curl/curl/issues/2591
https://github.com/curl/curl/pull/1221