### PR TITLE
Fix warning C4643 in clockutils

### DIFF
--- a/ports/clockutils/CONTROL
+++ b/ports/clockutils/CONTROL
@@ -1,3 +1,3 @@
 Source: clockutils
-Version: 1.1.1-3651f232c27074c4ceead169e223edf5f00247c5-1
+Version: 1.1.1-3651f232c27074c4ceead169e223edf5f00247c5-2
 Description: A lightweight c++ library for commonly needed tasks. Optimized for simplicity and speed.

--- a/ports/clockutils/fix-warningC4643.patch
+++ b/ports/clockutils/fix-warningC4643.patch
@@ -1,0 +1,29 @@
+diff --git a/include/clockUtils/sockets/TcpSocket.h b/include/clockUtils/sockets/TcpSocket.h
+index 6e0d9c8..3bb97a9 100644
+--- a/include/clockUtils/sockets/TcpSocket.h
++++ b/include/clockUtils/sockets/TcpSocket.h
+@@ -57,9 +57,6 @@
+ 	#define INVALID_SOCKET -1
+ #endif
+ 
+-namespace std {
+-	class thread;
+-} /* namespace std */
+ namespace clockUtils {
+ 	enum class ClockError;
+ namespace sockets {
+diff --git a/include/clockUtils/sockets/UdpSocket.h b/include/clockUtils/sockets/UdpSocket.h
+index 31eeeb5..c5da451 100644
+--- a/include/clockUtils/sockets/UdpSocket.h
++++ b/include/clockUtils/sockets/UdpSocket.h
+@@ -60,10 +60,6 @@
+ 	#define INVALID_SOCKET -1
+ #endif
+ 
+-namespace std {
+-	class thread;
+-} /* namespace std */
+-
+ namespace clockUtils {
+ 	enum class ClockError;
+ namespace sockets {

--- a/ports/clockutils/portfile.cmake
+++ b/ports/clockutils/portfile.cmake
@@ -1,23 +1,20 @@
 include(vcpkg_common_functions)
-set(VERSION 3651f232c27074c4ceead169e223edf5f00247c5)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/clockUtils-${VERSION})
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/ClockworkOrigins/clockUtils/archive/${VERSION}.tar.gz"
-    FILENAME "clockUtils-${VERSION}.tar.gz"
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ClockworkOrigins/clockUtils
+    REF 3651f232c27074c4ceead169e223edf5f00247c5
     SHA512 ddb70cae9ced25de77a2df1854dac15e58a77347042ba3ee9c691f85f49edbc6539c84929a7477d429fb9161ba24c57d24d767793b8b1180216d5ddfc5d3ed6a
+    HEAD_REF dev-1.2
+    PATCHES
+        "${CURRENT_PORT_DIR}/fix-warningC4643.patch"
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
     SET(SHARED_FLAG ON)
 else()
     SET(SHARED_FLAG OFF)
 endif()
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CURRENT_PORT_DIR}/fix-warningC4643.patch"
-)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/clockutils/portfile.cmake
+++ b/ports/clockutils/portfile.cmake
@@ -14,6 +14,11 @@ else()
     SET(SHARED_FLAG OFF)
 endif()
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES "${CURRENT_PORT_DIR}/fix-warningC4643.patch"
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS


### PR DESCRIPTION
1. C++ standard doesn't allow user to add forward declaration or definition into namespace std: after recent update, so warning C4643 occurred.
2. Remove the forward declaration "thread" in the namespace std to fix this issue. Since it will be an empty namespace std after I removed 'thread', so I removed namespace std too. 