### PR TITLE
Remove freeglut as dependency for SFML

### DIFF
--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,4 +1,4 @@
 Source: sfml
 Version: 2.5.0
 Description: Simple and fast multimedia library
-Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb, freeglut (!uwp&&!windows)
+Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb (!uwp&&!windows)

--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,4 +1,4 @@
 Source: sfml
-Version: 2.5.0
+Version: 2.5.0-1
 Description: Simple and fast multimedia library
-Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb (!uwp&&!windows)
+Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb


### PR DESCRIPTION
As suggested by @ras0219-msft on Slack here's a PR for SFML to remove the freeglut dependency as it's not actually a dependency of SFML.