### PR TITLE
Added proper window-static support

### DIFF
--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -30,9 +30,9 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/SFML)
 vcpkg_copy_pdbs()
 
-# don't force users to define SFML_STATIC while using static library
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(APPEND ${CURRENT_PACKAGES_DIR}/include/SFML/Config.hpp "#undef SFML_API_IMPORT\n#define SFML_API_IMPORT\n")
+    FILE(READ ${CURRENT_PACKAGES_DIR}/share/sfml/SFMLConfig.cmake SFML_CONFIG)
+    FILE(WRITE ${CURRENT_PACKAGES_DIR}/share/sfml/SFMLConfig.cmake "set(SFML_STATIC_LIBRARIES true)\n${SFML_CONFIG}")
 endif()
 
 # move sfml-main to manual link dir


### PR DESCRIPTION
Just replacing export symbols doesn't really do the trick as the config file still won't find the static libraries, by "forcing" the `SFML_STATIC_LIBRARIES` to 1 when using the static target, the SFMLConfig.cmake file will properly detect the static libraries and it will also set the config header correctly.