### PR TITLE
Add a modernized cross-platform fork of MiniSat 2.2

### DIFF
--- a/ports/minisat-master-keying/CONTROL
+++ b/ports/minisat-master-keying/CONTROL
@@ -1,5 +1,5 @@
 Source: minisat-master-keying
-Version: 2.2-mod
+Version: 2.2-mod-1
 Description: A minimalistic high-performance SAT solver
   This is a modernized, cross-platform, CMake-enabled fork of the
   original MiniSat. Since the original library is no longer under

--- a/ports/minisat-master-keying/CONTROL
+++ b/ports/minisat-master-keying/CONTROL
@@ -1,0 +1,7 @@
+Source: minisat-master-keying
+Version: 2.2-mod
+Description: A minimalistic high-performance SAT solver
+  This is a modernized, cross-platform, CMake-enabled fork of the
+  original MiniSat. Since the original library is no longer under
+  development, post issues and pull requests should be posted to
+  https://github.com/master-keying/minisat

--- a/ports/minisat-master-keying/portfile.cmake
+++ b/ports/minisat-master-keying/portfile.cmake
@@ -19,12 +19,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/MiniSat TARGET_PATH share/MiniSat)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/MiniSat TARGET_PATH share/minisat)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/MiniSat RENAME copyright)
-
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/minisat-master-keying RENAME copyright)

--- a/ports/minisat-master-keying/portfile.cmake
+++ b/ports/minisat-master-keying/portfile.cmake
@@ -1,0 +1,30 @@
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Dynamic building not supported yet. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO master-keying/minisat
+    REF 60f47c0b59a5116639a73ceb9b50eb818536af0b
+    SHA512 267b7dd44bd1390826228c45ce0e71976a78940d2086470a26b59a6c692ad5e0e911c255eda0c187c33f8138b34deab59aa53191a0e1a46df38c5b73680d74d6
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/MiniSat TARGET_PATH share/MiniSat)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/MiniSat RENAME copyright)
+


### PR DESCRIPTION
This passed `vcpkg build minisat` locally, so hopefully there are no dumb mistakes.