### PR TITLE
Fix error C3615 for qt5-base

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-base
-Version: 5.9.2-6
+Version: 5.9.2-7
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/fix-C3615.patch
+++ b/ports/qt5-base/fix-C3615.patch
@@ -1,0 +1,56 @@
+diff --git a/src/corelib/tools/qalgorithms.h b/src/corelib/tools/qalgorithms.h
+index c0f7709f..3784ceff 100644
+--- a/src/corelib/tools/qalgorithms.h
++++ b/src/corelib/tools/qalgorithms.h
+@@ -590,6 +590,7 @@ Q_DECL_CONSTEXPR Q_ALWAYS_INLINE uint qt_builtin_popcountll(quint64 v) Q_DECL_NO
+ }
+ #elif defined(Q_CC_MSVC) && !defined(Q_OS_WINCE) && !defined(Q_PROCESSOR_ARM)
+ #define QT_POPCOUNT_CONSTEXPR
++#define QT_POPCOUNT_RELAXED_CONSTEXPR
+ #define QT_HAS_BUILTIN_CTZ
+ Q_ALWAYS_INLINE unsigned long qt_builtin_ctz(quint32 val)
+ {
+@@ -676,6 +677,7 @@ Q_ALWAYS_INLINE uint qt_builtin_popcountll(quint64 v) Q_DECL_NOTHROW
+ 
+ #ifndef QT_POPCOUNT_CONSTEXPR
+ #define QT_POPCOUNT_CONSTEXPR Q_DECL_CONSTEXPR
++#define QT_POPCOUNT_RELAXED_CONSTEXPR Q_DECL_RELAXED_CONSTEXPR
+ #endif
+ 
+ } //namespace QAlgorithmsPrivate
+@@ -819,7 +821,7 @@ Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint32 v) Q_DECL_NOT
+ #endif
+ }
+ 
+-Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint8 v) Q_DECL_NOTHROW
++QT_POPCOUNT_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint8 v) Q_DECL_NOTHROW
+ {
+ #if defined(QT_HAS_BUILTIN_CLZ)
+     return v ? QAlgorithmsPrivate::qt_builtin_clz(v)-24U : 8U;
+@@ -831,7 +833,7 @@ Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint8 v) Q_DECL_NOTH
+ #endif
+ }
+ 
+-Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint16 v) Q_DECL_NOTHROW
++QT_POPCOUNT_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint16 v) Q_DECL_NOTHROW
+ {
+ #if defined(QT_HAS_BUILTIN_CLZS)
+     return v ? QAlgorithmsPrivate::qt_builtin_clzs(v) : 16U;
+@@ -844,7 +846,7 @@ Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint16 v) Q_DECL_NOT
+ #endif
+ }
+ 
+-Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint64 v) Q_DECL_NOTHROW
++QT_POPCOUNT_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint64 v) Q_DECL_NOTHROW
+ {
+ #if defined(QT_HAS_BUILTIN_CLZLL)
+     return v ? QAlgorithmsPrivate::qt_builtin_clzll(v) : 64U;
+@@ -859,7 +861,7 @@ Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(quint64 v) Q_DECL_NOT
+ #endif
+ }
+ 
+-Q_DECL_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(unsigned long v) Q_DECL_NOTHROW
++QT_POPCOUNT_RELAXED_CONSTEXPR inline uint qCountLeadingZeroBits(unsigned long v) Q_DECL_NOTHROW
+ {
+     return qCountLeadingZeroBits(QIntegerForSizeof<long>::Unsigned(v));
+ }

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -45,6 +45,7 @@ vcpkg_apply_patches(
         "${CMAKE_CURRENT_LIST_DIR}/fix-system-pcre2.patch"
         "${CMAKE_CURRENT_LIST_DIR}/fix-system-freetype.patch"
         "${CMAKE_CURRENT_LIST_DIR}/fix-system-pcre2-linux.patch"
+		"${CMAKE_CURRENT_LIST_DIR}/fix-C3615.patch"
 )
 
 # This fixes issues on machines with default codepages that are not ASCII compatible, such as some CJK encodings


### PR DESCRIPTION
1. Qt5-base failed with error: "qalgorithms.h(847): error C3615: constexpr function 'qCountLeadingZeroBits' cannot result in a constant expression"
2. As STL said in bug#616379, we followed the similar patch(0002-Fix-MSVC2017-compilation-with-enabled-relaxed-conste.patch) to fix this issue and this port install passed as expected.