### PR TITLE
Fix ANGLE on Windows, Linux, and MacOS

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -7,8 +7,8 @@ else()
     set(WINDOWS_DESKTOP 0)
 endif()
 
-add_compile_options(/d2guard4 /Wv:18)
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /guard:cf")
+add_compile_options(/d2guard4 /Wv:18 /guard:cf)
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /GUARD:CF")
 
 add_definitions(
     -D_CRT_SECURE_NO_DEPRECATE

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 add_compile_options(/d2guard4 /Wv:18 /guard:cf)
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /GUARD:CF")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
 
 add_definitions(
     -D_CRT_SECURE_NO_DEPRECATE

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -226,6 +226,14 @@ else()
     set(LIBANGLE_RENDERER_PLATFORM )
 endif()
 
+if(LINUX)
+    set(LIBANGLE_RENDERER_COMPILEDEF
+        -DANGLE_USE_X11
+    )
+else()
+    set(LIBANGLE_RENDERER_COMPILEDEF )
+endif()
+
 add_library(libANGLE STATIC ${LIBANGLE_SOURCES})
 target_link_libraries(libANGLE PRIVATE
     angle::common
@@ -239,7 +247,7 @@ target_compile_definitions(libANGLE
     PRIVATE -DANGLE_ENABLE_NULL
     PUBLIC 
         -DLIBANGLE_IMPLEMENTATION 
-        $<$<BOOL:${LINUX}>:ANGLE_USE_X11>
+        ${LIBANGLE_RENDERER_COMPILEDEF}
 )
 add_library(angle::libANGLE ALIAS libANGLE)
 

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -7,8 +7,9 @@ else()
     set(WINDOWS_DESKTOP 0)
 endif()
 
-add_compile_options(/d2guard4 /Wv:18 /guard:cf)
+add_compile_options(-std=c++17 -fPIC)
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
+set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 add_definitions(
     -D_CRT_SECURE_NO_DEPRECATE
@@ -25,7 +26,7 @@ include_directories(include src ${CMAKE_CURRENT_BINARY_DIR}/include)
 ##########
 # angle::common
 file(GLOB ANGLE_COMMON_SOURCES "src/common/*.h" "src/common/*.inl" "src/common/*.cpp" "src/common/third_party/base/*.h")
-list(FILTER ANGLE_COMMON_SOURCES EXCLUDE REGEX "_unittest|event_tracer|_linux|_mac")
+list(FILTER ANGLE_COMMON_SOURCES EXCLUDE REGEX "_unittest|event_tracer|_win|_mac")
 add_library(angle_common STATIC ${ANGLE_COMMON_SOURCES})
 target_include_directories(angle_common PUBLIC src/common/third_party/base)
 add_library(angle::common ALIAS angle_common)
@@ -69,68 +70,19 @@ add_library(angle::preprocessor ALIAS angle_preprocessor)
 # libANGLE
 
 ## OpenGL Renderer
-if(WINDOWS_DESKTOP)
-    file(GLOB LIBANGLE_GL_SOURCES
-        "src/libANGLE/renderer/gl/*.cpp"
-        "src/libANGLE/renderer/gl/*.inl"
-        "src/libANGLE/renderer/gl/*.h"
-
-        "src/libANGLE/renderer/gl/wgl/*.cpp"
-        "src/libANGLE/renderer/gl/wgl/*.inl"
-        "src/libANGLE/renderer/gl/wgl/*.h"
-    )
-    list(FILTER LIBANGLE_GL_SOURCES EXCLUDE REGEX "_unittest")
-    add_library(angle_renderer_opengl INTERFACE)
-    target_sources(angle_renderer_opengl INTERFACE ${LIBANGLE_GL_SOURCES})
-    target_compile_definitions(angle_renderer_opengl INTERFACE -DANGLE_ENABLE_OPENGL)
-    add_library(angle::renderer::opengl ALIAS angle_renderer_opengl)
-endif()
-
-## All D3D Sources
-file(GLOB_RECURSE LIBANGLE_D3D_SOURCES
-    "src/libANGLE/renderer/d3d/*.cpp"
-    "src/libANGLE/renderer/d3d/*.inl"
-    "src/libANGLE/renderer/d3d/*.h"
+file(GLOB LIBANGLE_GL_SOURCES
+    "src/libANGLE/renderer/gl/*.cpp"
+    "src/libANGLE/renderer/gl/*.inl"
+    "src/libANGLE/renderer/gl/*.h"
 )
-list(FILTER LIBANGLE_D3D_SOURCES EXCLUDE REGEX "_unittest")
-
-## WinRT D3D Renderer
-if(WINDOWS_STORE)
-    set(LIBANGLE_D3D_WINRT_SOURCES ${LIBANGLE_D3D_SOURCES})
-    list(FILTER LIBANGLE_D3D_WINRT_SOURCES INCLUDE REGEX "winrt")
-    add_library(angle_renderer_winrt INTERFACE)
-    target_sources(angle_renderer_winrt INTERFACE ${LIBANGLE_D3D_WINRT_SOURCES})
-    add_library(angle::renderer::winrt ALIAS angle_renderer_winrt)
-endif()
-
-## Win32/d3d9 D3D Renderer
-if(WINDOWS_DESKTOP)
-    set(LIBANGLE_D3D_DESKTOP_SOURCES ${LIBANGLE_D3D_SOURCES})
-    list(FILTER LIBANGLE_D3D_DESKTOP_SOURCES INCLUDE REGEX "d3d9|win32")
-    find_library(D3D9_LIB NAMES d3d9)
-    add_library(angle_renderer_win32 INTERFACE)
-    target_sources(angle_renderer_win32 INTERFACE ${LIBANGLE_D3D_DESKTOP_SOURCES})
-    target_compile_definitions(angle_renderer_win32 INTERFACE -DANGLE_ENABLE_D3D9)
-    target_link_libraries(angle_renderer_win32 INTERFACE ${D3D9_LIB})
-    add_library(angle::renderer::win32 ALIAS angle_renderer_win32)
-endif()
-
-## D3D11 Base renderer
-list(FILTER LIBANGLE_D3D_SOURCES EXCLUDE REGEX "winrt|d3d9|win32")
-find_library(DXGUID_LIB NAMES dxguid)
-find_library(D3D11_LIB NAMES d3d11)
-add_library(angle_renderer_d3d INTERFACE)
-target_sources(angle_renderer_d3d INTERFACE ${LIBANGLE_D3D_SOURCES})
-target_compile_definitions(angle_renderer_d3d INTERFACE
-    -DANGLE_ENABLE_D3D11
-    "-DANGLE_PRELOADED_D3DCOMPILER_MODULE_NAMES={ \"d3dcompiler_47.dll\", \"d3dcompiler_46.dll\", \"d3dcompiler_43.dll\" }"
-)
-target_link_libraries(angle_renderer_d3d INTERFACE ${D3D11_LIB} ${DXGUID_LIB})
-add_library(angle::renderer::d3d ALIAS angle_renderer_d3d)
+list(FILTER LIBANGLE_GL_SOURCES EXCLUDE REGEX "_unittest")
+add_library(angle_renderer_opengl INTERFACE)
+target_sources(angle_renderer_opengl INTERFACE ${LIBANGLE_GL_SOURCES})
+target_compile_definitions(angle_renderer_opengl INTERFACE -DANGLE_ENABLE_OPENGL)
+add_library(angle::renderer::opengl ALIAS angle_renderer_opengl)
 
 ## Core libANGLE library
 file(GLOB LIBANGLE_SOURCES
-    "src/third_party/systeminfo/SystemInfo.cpp"
     "src/common/third_party/murmurhash/MurmurHash3.cpp"
     "src/common/event_tracer.cpp"
 
@@ -145,6 +97,14 @@ file(GLOB LIBANGLE_SOURCES
     "src/libANGLE/renderer/null/*.cpp"
     "src/libANGLE/renderer/null/*.inl"
     "src/libANGLE/renderer/null/*.h"
+
+    "src/libANGLE/renderer/gl/*.cpp"
+    "src/libANGLE/renderer/gl/*.inl"
+    "src/libANGLE/renderer/gl/*.h"
+
+    "src/libANGLE/renderer/gl/glx/*.cpp"
+    "src/libANGLE/renderer/gl/glx/*.inl"
+    "src/libANGLE/renderer/gl/glx/*.h"
 )
 list(FILTER LIBANGLE_SOURCES EXCLUDE REGEX "_unittest")
 
@@ -154,15 +114,14 @@ target_link_libraries(libANGLE PRIVATE
     angle::image_util
     angle::translator
     angle::preprocessor
-    angle::renderer::d3d
-    $<$<BOOL:${WINDOWS_STORE}>:angle::renderer::winrt>
-    $<$<BOOL:${WINDOWS_DESKTOP}>:angle::renderer::win32>
-    $<$<BOOL:${WINDOWS_DESKTOP}>:angle::renderer::opengl>
+    angle::renderer::opengl
 )
 target_include_directories(libANGLE PRIVATE "src/third_party/khronos")
 target_compile_definitions(libANGLE
     PRIVATE -DANGLE_ENABLE_NULL
-    PUBLIC -DLIBANGLE_IMPLEMENTATION
+    PUBLIC 
+        -DLIBANGLE_IMPLEMENTATION 
+        -DANGLE_USE_X11
 )
 add_library(angle::libANGLE ALIAS libANGLE)
 
@@ -190,6 +149,11 @@ add_library(libEGL
 )
 target_link_libraries(libEGL PRIVATE angle::common angle::libANGLE libGLESv2)
 target_include_directories(libEGL PUBLIC "$<INSTALL_INTERFACE:include>")
+
+
+SET_TARGET_PROPERTIES(libANGLE PROPERTIES PREFIX "")
+SET_TARGET_PROPERTIES(libGLESv2 PROPERTIES PREFIX "")
+SET_TARGET_PROPERTIES(libEGL PROPERTIES PREFIX "")
 
 install(TARGETS libEGL libGLESv2 EXPORT ANGLEExport
     RUNTIME DESTINATION bin

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -24,6 +24,9 @@ else()
     add_compile_options(-std=c++17 -fPIC)
 endif()
 
+if (APPLE)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -framework Cocoa -framework OpenGL -framework IOKit -framework CoreFoundation -framework IOSurface -framework QuartzCore -framework CoreGraphics")
+endif()
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
@@ -95,20 +98,33 @@ add_library(angle::preprocessor ALIAS angle_preprocessor)
 ## OpenGL Renderer
 if(WINDOWS_DESKTOP OR LINUX OR APPLE)
     if(WINDOWS_DESKTOP)
-        set(ANGLE_RENDERER_OPENGL_WGL 
+        set(ANGLE_RENDERER_OPENGL_PLATFORM 
             "src/libANGLE/renderer/gl/wgl/*.cpp"
             "src/libANGLE/renderer/gl/wgl/*.inl"
             "src/libANGLE/renderer/gl/wgl/*.h"
         )
-    else()
-        set(ANGLE_RENDERER_OPENGL_WGL )
+    elseif(APPLE)
+        set(ANGLE_RENDERER_OPENGL_PLATFORM 
+            "src/libANGLE/renderer/gl/cgl/*.mm"
+            "src/libANGLE/renderer/gl/cgl/*.cpp"
+            "src/libANGLE/renderer/gl/cgl/*.inl"
+            "src/libANGLE/renderer/gl/cgl/*.h"
+            "gpu_info_util/SystemInfo_mac.mm"
+        )
+    elseif(LINUX)
+        set(ANGLE_RENDERER_OPENGL_PLATFORM 
+            "src/libANGLE/renderer/gl/glx/*.cpp"
+            "src/libANGLE/renderer/gl/glx/*.inl"
+            "src/libANGLE/renderer/gl/glx/*.h"
+        )
     endif()
 
     file(GLOB LIBANGLE_GL_SOURCES
         "src/libANGLE/renderer/gl/*.cpp"
         "src/libANGLE/renderer/gl/*.inl"
         "src/libANGLE/renderer/gl/*.h"
-        ${ANGLE_RENDERER_OPENGL_WGL}
+
+        ${ANGLE_RENDERER_OPENGL_PLATFORM}
     )
     list(FILTER LIBANGLE_GL_SOURCES EXCLUDE REGEX "_unittest")
     add_library(angle_renderer_opengl INTERFACE)
@@ -163,19 +179,7 @@ if(WINDOWS_ANY)
 endif()
 
 ## Core libANGLE library
-if (LINUX OR APPLE)
-    set(LIBANGLE_SOURCES_PLATFORM 
-
-        "src/libANGLE/renderer/gl/*.cpp"
-        "src/libANGLE/renderer/gl/*.inl"
-        "src/libANGLE/renderer/gl/*.h"
-
-        "src/libANGLE/renderer/gl/glx/*.cpp"
-        "src/libANGLE/renderer/gl/glx/*.inl"
-        "src/libANGLE/renderer/gl/glx/*.h"
-
-    )
-elseif(WINDOWS_ANY)
+if(WINDOWS_ANY)
     set(LIBANGLE_SOURCES_PLATFORM
         "src/third_party/systeminfo/SystemInfo.cpp"
     )

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -209,10 +209,12 @@ if(LINUX OR APPLE)
     )
 elseif(WINDOWS_STORE)
     set(LIBANGLE_RENDERER_PLATFORM
+        angle::renderer::d3d
         angle::renderer::winrt
     )
 elseif(WINDOWS_DESKTOP)
     set(LIBANGLE_RENDERER_PLATFORM
+        angle::renderer::d3d
         angle::renderer::win32
         angle::renderer::opengl
     )

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -219,6 +219,7 @@ elseif(WINDOWS_DESKTOP)
         angle::renderer::opengl
     )
 else()
+    set(LIBANGLE_RENDERER_PLATFORM )
 endif()
 
 add_library(libANGLE STATIC ${LIBANGLE_SOURCES})

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -199,7 +199,7 @@ file(GLOB LIBANGLE_SOURCES
     "src/libANGLE/renderer/null/*.inl"
     "src/libANGLE/renderer/null/*.h"
 
-    "${LIBANGLE_SOURCES_PLATFORM}"
+    ${LIBANGLE_SOURCES_PLATFORM}
 )
 list(FILTER LIBANGLE_SOURCES EXCLUDE REGEX "_unittest")
 

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -6,8 +6,18 @@ if(WIN32 AND NOT WINDOWS_STORE)
 else()
     set(WINDOWS_DESKTOP 0)
 endif()
+set(WINDOWS_ANY WINDOWS_DESKTOP OR WINDOWS_STORE)
 
-add_compile_options(-std=c++17 -fPIC)
+if(UNIX AND NOT APPLE)
+    set(LINUX TRUE)
+endif()
+
+if(WINDOWS_ANY)
+    add_compile_options(/d2guard4 /Wv:18 /guard:cf)
+else()
+    add_compile_options(-std=c++17 -fPIC)
+endif()
+
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
 set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
@@ -25,8 +35,15 @@ include_directories(include src ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 ##########
 # angle::common
+if(WINDOWS_ANY)
+    set(ANGLE_COMMON_PLATFORM_FILTER "_linux|_mac")
+elseif(LINUX)
+    set(ANGLE_COMMON_PLATFORM_FILTER "_win|_mac")
+elseif(APPLE)
+    set(ANGLE_COMMON_PLATFORM_FILTER "_linux|_win")
+endif()
 file(GLOB ANGLE_COMMON_SOURCES "src/common/*.h" "src/common/*.inl" "src/common/*.cpp" "src/common/third_party/base/*.h")
-list(FILTER ANGLE_COMMON_SOURCES EXCLUDE REGEX "_unittest|event_tracer|_win|_mac")
+list(FILTER ANGLE_COMMON_SOURCES EXCLUDE REGEX "_unittest|event_tracer|${ANGLE_COMMON_PLATFORM_FILTER}")
 add_library(angle_common STATIC ${ANGLE_COMMON_SOURCES})
 target_include_directories(angle_common PUBLIC src/common/third_party/base)
 add_library(angle::common ALIAS angle_common)
@@ -70,19 +87,78 @@ add_library(angle::preprocessor ALIAS angle_preprocessor)
 # libANGLE
 
 ## OpenGL Renderer
-file(GLOB LIBANGLE_GL_SOURCES
-    "src/libANGLE/renderer/gl/*.cpp"
-    "src/libANGLE/renderer/gl/*.inl"
-    "src/libANGLE/renderer/gl/*.h"
-)
-list(FILTER LIBANGLE_GL_SOURCES EXCLUDE REGEX "_unittest")
-add_library(angle_renderer_opengl INTERFACE)
-target_sources(angle_renderer_opengl INTERFACE ${LIBANGLE_GL_SOURCES})
-target_compile_definitions(angle_renderer_opengl INTERFACE -DANGLE_ENABLE_OPENGL)
-add_library(angle::renderer::opengl ALIAS angle_renderer_opengl)
+if(WINDOWS_DESKTOP OR LINUX OR APPLE)
+    if(WINDOWS_DESKTOP)
+        set(ANGLE_RENDERER_OPENGL_WGL 
+            "src/libANGLE/renderer/gl/wgl/*.cpp"
+            "src/libANGLE/renderer/gl/wgl/*.inl"
+            "src/libANGLE/renderer/gl/wgl/*.h"
+        )
+    else()
+        set(ANGLE_RENDERER_OPENGL_WGL )
+    endif()
+
+    file(GLOB LIBANGLE_GL_SOURCES
+        "src/libANGLE/renderer/gl/*.cpp"
+        "src/libANGLE/renderer/gl/*.inl"
+        "src/libANGLE/renderer/gl/*.h"
+        ${ANGLE_RENDERER_OPENGL_WGL}
+    )
+    list(FILTER LIBANGLE_GL_SOURCES EXCLUDE REGEX "_unittest")
+    add_library(angle_renderer_opengl INTERFACE)
+    target_sources(angle_renderer_opengl INTERFACE ${LIBANGLE_GL_SOURCES})
+    target_compile_definitions(angle_renderer_opengl INTERFACE -DANGLE_ENABLE_OPENGL)
+    add_library(angle::renderer::opengl ALIAS angle_renderer_opengl)
+endif()
+
+# D3D Renderers
+if(WINDOWS_ANY)
+    ## All D3D Sources
+    file(GLOB_RECURSE LIBANGLE_D3D_SOURCES
+        "src/libANGLE/renderer/d3d/*.cpp"
+        "src/libANGLE/renderer/d3d/*.inl"
+        "src/libANGLE/renderer/d3d/*.h"
+    )
+    list(FILTER LIBANGLE_D3D_SOURCES EXCLUDE REGEX "_unittest")
+
+    ## WinRT D3D Renderer
+    if(WINDOWS_STORE)
+        set(LIBANGLE_D3D_WINRT_SOURCES ${LIBANGLE_D3D_SOURCES})
+        list(FILTER LIBANGLE_D3D_WINRT_SOURCES INCLUDE REGEX "winrt")
+        add_library(angle_renderer_winrt INTERFACE)
+        target_sources(angle_renderer_winrt INTERFACE ${LIBANGLE_D3D_WINRT_SOURCES})
+        add_library(angle::renderer::winrt ALIAS angle_renderer_winrt)
+    endif()
+
+    ## Win32/d3d9 D3D Renderer
+    if(WINDOWS_DESKTOP)
+        set(LIBANGLE_D3D_DESKTOP_SOURCES ${LIBANGLE_D3D_SOURCES})
+        list(FILTER LIBANGLE_D3D_DESKTOP_SOURCES INCLUDE REGEX "d3d9|win32")
+        find_library(D3D9_LIB NAMES d3d9)
+        add_library(angle_renderer_win32 INTERFACE)
+        target_sources(angle_renderer_win32 INTERFACE ${LIBANGLE_D3D_DESKTOP_SOURCES})
+        target_compile_definitions(angle_renderer_win32 INTERFACE -DANGLE_ENABLE_D3D9)
+        target_link_libraries(angle_renderer_win32 INTERFACE ${D3D9_LIB})
+        add_library(angle::renderer::win32 ALIAS angle_renderer_win32)
+    endif()
+
+    ## D3D11 Base renderer
+    list(FILTER LIBANGLE_D3D_SOURCES EXCLUDE REGEX "winrt|d3d9|win32")
+    find_library(DXGUID_LIB NAMES dxguid)
+    find_library(D3D11_LIB NAMES d3d11)
+    add_library(angle_renderer_d3d INTERFACE)
+    target_sources(angle_renderer_d3d INTERFACE ${LIBANGLE_D3D_SOURCES})
+    target_compile_definitions(angle_renderer_d3d INTERFACE
+        -DANGLE_ENABLE_D3D11
+        "-DANGLE_PRELOADED_D3DCOMPILER_MODULE_NAMES={ \"d3dcompiler_47.dll\", \"d3dcompiler_46.dll\", \"d3dcompiler_43.dll\" }"
+    )
+    target_link_libraries(angle_renderer_d3d INTERFACE ${D3D11_LIB} ${DXGUID_LIB})
+    add_library(angle::renderer::d3d ALIAS angle_renderer_d3d)
+endif()
 
 ## Core libANGLE library
 file(GLOB LIBANGLE_SOURCES
+    $<$<BOOL:${WINDOWS_ANY}>:"src/third_party/systeminfo/SystemInfo.cpp">
     "src/common/third_party/murmurhash/MurmurHash3.cpp"
     "src/common/event_tracer.cpp"
 

--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -6,10 +6,16 @@ if(WIN32 AND NOT WINDOWS_STORE)
 else()
     set(WINDOWS_DESKTOP 0)
 endif()
-set(WINDOWS_ANY WINDOWS_DESKTOP OR WINDOWS_STORE)
+if (WINDOWS_DESKTOP OR WINDOWS_STORE)
+    set(WINDOWS_ANY 1)
+else()
+    set(WINDOWS_ANY 0)
+endif()
 
 if(UNIX AND NOT APPLE)
-    set(LINUX TRUE)
+    set(LINUX 1)
+else()
+    set(LINUX 0)
 endif()
 
 if(WINDOWS_ANY)
@@ -157,8 +163,27 @@ if(WINDOWS_ANY)
 endif()
 
 ## Core libANGLE library
+if (LINUX OR APPLE)
+    set(LIBANGLE_SOURCES_PLATFORM 
+
+        "src/libANGLE/renderer/gl/*.cpp"
+        "src/libANGLE/renderer/gl/*.inl"
+        "src/libANGLE/renderer/gl/*.h"
+
+        "src/libANGLE/renderer/gl/glx/*.cpp"
+        "src/libANGLE/renderer/gl/glx/*.inl"
+        "src/libANGLE/renderer/gl/glx/*.h"
+
+    )
+elseif(WINDOWS_ANY)
+    set(LIBANGLE_SOURCES_PLATFORM
+        "src/third_party/systeminfo/SystemInfo.cpp"
+    )
+else()
+    set(LIBANGLE_SOURCES_PLATFORM )
+endif()
+
 file(GLOB LIBANGLE_SOURCES
-    $<$<BOOL:${WINDOWS_ANY}>:"src/third_party/systeminfo/SystemInfo.cpp">
     "src/common/third_party/murmurhash/MurmurHash3.cpp"
     "src/common/event_tracer.cpp"
 
@@ -174,15 +199,25 @@ file(GLOB LIBANGLE_SOURCES
     "src/libANGLE/renderer/null/*.inl"
     "src/libANGLE/renderer/null/*.h"
 
-    "src/libANGLE/renderer/gl/*.cpp"
-    "src/libANGLE/renderer/gl/*.inl"
-    "src/libANGLE/renderer/gl/*.h"
-
-    "src/libANGLE/renderer/gl/glx/*.cpp"
-    "src/libANGLE/renderer/gl/glx/*.inl"
-    "src/libANGLE/renderer/gl/glx/*.h"
+    "${LIBANGLE_SOURCES_PLATFORM}"
 )
 list(FILTER LIBANGLE_SOURCES EXCLUDE REGEX "_unittest")
+
+if(LINUX OR APPLE)
+    set(LIBANGLE_RENDERER_PLATFORM
+        angle::renderer::opengl
+    )
+elseif(WINDOWS_STORE)
+    set(LIBANGLE_RENDERER_PLATFORM
+        angle::renderer::winrt
+    )
+elseif(WINDOWS_DESKTOP)
+    set(LIBANGLE_RENDERER_PLATFORM
+        angle::renderer::win32
+        angle::renderer::opengl
+    )
+else()
+endif()
 
 add_library(libANGLE STATIC ${LIBANGLE_SOURCES})
 target_link_libraries(libANGLE PRIVATE
@@ -190,14 +225,14 @@ target_link_libraries(libANGLE PRIVATE
     angle::image_util
     angle::translator
     angle::preprocessor
-    angle::renderer::opengl
+    ${LIBANGLE_RENDERER_PLATFORM}
 )
 target_include_directories(libANGLE PRIVATE "src/third_party/khronos")
 target_compile_definitions(libANGLE
     PRIVATE -DANGLE_ENABLE_NULL
     PUBLIC 
         -DLIBANGLE_IMPLEMENTATION 
-        -DANGLE_USE_X11
+        $<$<BOOL:${LINUX}>:ANGLE_USE_X11>
 )
 add_library(angle::libANGLE ALIAS libANGLE)
 


### PR DESCRIPTION
This change fixes ANGLE to build on Windows, Linux, and MacOS. 

On Windows, the fix was to move the control flow guard flag (/guard:cf) to the compile options. The rest of it built fine.

On Linux and MacOS, the solution was primarily to exclude all D3D renderers and open up the OpenGL renderer to other platforms (it was marked as WINDOWS_DESKTOP only). 

The platform specific portions are wgl, glx, and cgl for Windows, Linux, and MacOS respectively.