### PR TITLE
Add option -D_DISABLE_EXTENDED_ALIGNED to disable error C2338 in Folly

### DIFF
--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,5 @@
 Source: folly
-Version: 2018.05.14.00
+Version: 2018.05.14.00-01
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread
 Default-Features: zlib

--- a/ports/folly/fixC2338.patch
+++ b/ports/folly/fixC2338.patch
@@ -1,0 +1,13 @@
+diff --git a/CMake/FollyCompilerMSVC.cmake b/CMake/FollyCompilerMSVC.cmake
+index 0b97bfd..e442c73 100644
+--- a/CMake/FollyCompilerMSVC.cmake
++++ b/CMake/FollyCompilerMSVC.cmake
+@@ -268,7 +268,7 @@ function(apply_folly_compile_options_to_target THETARGET)
+       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
+       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
+       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
+-      
++      _DISABLE_EXTENDED_ALIGNED_STORAGE
+       _STL_EXTRA_DISABLED_WARNINGS=4774\ 4987
+ 
+       $<$<BOOL:${MSVC_ENABLE_CPP_LATEST}>:_HAS_AUTO_PTR_ETC=1> # We're building in C++ 17 or greater mode, but certain dependencies (Boost) still have dependencies on unary_function and binary_function, so we have to make sure not to remove them.

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/find-gflags.patch
+		${CMAKE_CURRENT_LIST_DIR}/fixC2338.patch
 )
 
 file(COPY


### PR DESCRIPTION
Folly failed with error C2338, it should fix form the error message provides the instructions that add -D_DISABLE_EXTENDED_ALIGNED option to disable this error.