### PR TITLE
[folly] Fix fatal error in folly-config.cmake

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -65,6 +65,7 @@ vcpkg_configure_cmake(
         -DLIBAIO_FOUND=OFF
         -DLIBURCU_FOUND=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_LibURCU=ON
+        -DCMAKE_INSTALL_DIR=share/folly
         ${FEATURE_OPTIONS}
 )
 
@@ -72,7 +73,7 @@ vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/folly)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/folly)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
facebook/folly@10d1edd makes two simultaneous changes:
1. It uses a different mechanism for setting `FOLLY_CMAKE_DIR`, which confuses `vcpkg_fixup_cmake_targets` so the path isn't rewritten.
2. It introduces `set_and_check` validation on `FOLLY_CMAKE_DIR`, which causes a fatal cmake error if the path is missing.

The combination of these two changes is that folly-config.cmake produces a fatal error when executed.

This PR tweaks folly's build params and the `vcpkg_fixup_cmake_targets` arguments so things are rewritten correctly and everything works again.