### PR TITLE
Fix build of llvm on Linux

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,4 +1,4 @@
 Source: llvm
 Version: 6.0.0-1
 Description: The LLVM Compiler Infrastructure
-Build-Depends: atlmfc
+Build-Depends: atlmfc (windows)


### PR DESCRIPTION
The mfcatl dependency is only needed on Windows.