### PR TITLE
Remove call to nonexistent member seekpos() of std::fpos

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,4 +1,4 @@
 Source: osg
-Version: 3.5.6-2
+Version: 3.5.6-3
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff

--- a/ports/osg/fix-C2039.patch
+++ b/ports/osg/fix-C2039.patch
@@ -1,0 +1,13 @@
+diff --git a/src/osgPlugins/osga/OSGA_Archive.cpp b/src/osgPlugins/osga/OSGA_Archive.cpp
+index f96cca3..a80969f 100644
+--- a/src/osgPlugins/osga/OSGA_Archive.cpp
++++ b/src/osgPlugins/osga/OSGA_Archive.cpp
+@@ -71,7 +71,7 @@ inline std::streampos STREAM_POS( const OSGA_Archive::pos_type pos )
+ inline OSGA_Archive::pos_type ARCHIVE_POS( const std::streampos & pos )
+ {
+ #if defined(_CPPLIB_VER)//newer Dinkumware(eg: one included with VC++ 2003,2005)
+-    fpos_t position = pos.seekpos();
++    fpos_t position = pos;
+ #else // older Dinkumware (eg: one included in Win Server 2003 Platform SDK )
+     fpos_t position = pos.get_fpos_t();
+ #endif

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -15,13 +15,16 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     message(STATUS "Warning: Static building will not support load data through plugins.")
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 endif()
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/OpenSceneGraph-OpenSceneGraph-3.5.6)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.5.6.zip"
-    FILENAME "osg-3.5.6.zip"
-    SHA512 f1745748ff86243291da96a4781af9487204a82540d3cc42b33bcbf693137ab9a6a741cad18afa74f62ef66933840ac54894397f880471f6c639210fa23e7f4b
+
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO openscenegraph/OpenSceneGraph
+	REF OpenSceneGraph-3.5.6
+	SHA512 bfd52115bc1f48dfb6eaeae1d8c62741c6487e6a8933b5ef97c979800b285e3a5300c9d55eb961e1973314c06b2525b547db683b0395c1f44b46d17cded38dba
+	HEAD_REF master
+	PATCHES
+        "${CURRENT_PORT_DIR}/fix-C2039.patch"
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
1. osg failed with error C2039: 'seekpos': is not a member of 'std::fpos<_Mbstatet>'.
2. See http://eel.is/c++draft/fpos -- to get to an offset you can convert to int; now there is no seekpos member.