### PR TITLE
[ogdf] Initial port

### DIFF
--- a/ports/ogdf/CONTROL
+++ b/ports/ogdf/CONTROL
@@ -1,0 +1,3 @@
+Source: ogdf
+Version: snapshot_2018-03-28
+Description: OGDF is a self-contained C++ class library for the automatic layout of diagrams.

--- a/ports/ogdf/portfile.cmake
+++ b/ports/ogdf/portfile.cmake
@@ -1,0 +1,41 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/OGDF-snapshot)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://ogdf.net/lib/exe/fetch.php/tech%3aogdf-snapshot-2018-03-28.zip"
+    FILENAME "ogdf-snapshot-2018-03-28.zip"
+    SHA512 a6ddb33bc51dca4d59fcac65ff66459043b11ce5303e9d40e4fc1756adf84a0af7d0ac7debab670111e7a145dcdd9373c0e350d5b7e831b169811f246b6e19b6
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    OPTIONS
+        -DCMAKE_DEBUG_POSTFIX=d
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/OGDF")
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
+    ${CURRENT_PACKAGES_DIR}/include/ogdf/lib/minisat/doc
+)
+
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ogdf RENAME copyright)


### PR DESCRIPTION
Hello everyone,

I made a quick port of OGDF.
I  had a issue with the URL which contains a ':' character. Because how Windows interprets this character (NTFS stream) and how CMake (actually cURL is used for file(DOWNLOAD...)) write the file.
The result was a 0 byte file named "tech". To fix that, the URL must be hex escaped, here the ':' becomes a %3a.
The rest is straightforward.
