### PR TITLE
Use WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY when Windows 8.1 and newer

### DIFF
--- a/toolsrc/src/vcpkg/base/downloads.cpp
+++ b/toolsrc/src/vcpkg/base/downloads.cpp
@@ -4,6 +4,8 @@
 #include <vcpkg/base/util.h>
 #include <vcpkg/commands.h>
 
+#include <VersionHelpers.h>
+
 namespace vcpkg::Downloads
 {
 #if defined(_WIN32)
@@ -29,7 +31,9 @@ namespace vcpkg::Downloads
                            std::to_string(err));
 
         auto hSession = WinHttpOpen(
-            L"vcpkg/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+            L"vcpkg/1.0",
+            IsWindows8Point1OrGreater() ? WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY : WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+            WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
         Checks::check_exit(VCPKG_LINE_INFO, hSession, "WinHttpOpen() failed: %d", GetLastError());
 
         // Use Windows 10 defaults on Windows 7


### PR DESCRIPTION
In the Windows 10, the HTTP_PROXY and HTTPS_PROXY environment variables can not be awared. The WINHTTP_ACCESS_TYPE_DEFAULT_PROXY is deprecated on Windows 8.1 and newer. Use WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY instead. ([refs](https://docs.microsoft.com/zh-cn/windows/desktop/api/winhttp/nf-winhttp-winhttpopen))