### PR TITLE
[vcpkg] Fix misspelled configuration name

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -345,7 +345,7 @@ if ($win64)
 $arguments = (
 "`"/p:VCPKG_VERSION=-nohash`"",
 "`"/p:DISABLE_METRICS=$disableMetricsValue`"",
-"/p:Configuration=release",
+"/p:Configuration=Release",
 "/p:Platform=$platform",
 "/p:PlatformToolset=$platformToolset",
 "/p:TargetPlatformVersion=$windowsSDK",


### PR DESCRIPTION
This fixes some warnings during bootstraping on windows, namely

>   Vcpkg is unable to link because we cannot decide between Release and Debug libraries. Please define the property VcpkgConfiguration to be 'Release' or 'Debug' (currently 'release').

Disclaimer: I did not try to understand how "bootstrap.ps1" actually works. I've just assumed that this was a typo and made no further investigation if there are better solutions or other things that should be changed.