### PR TITLE
Fix glfw3:x64-linux producing incorrect target

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,5 +1,5 @@
 Source: dlib
-Version: 19.13
+Version: 19.13-1
 Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas, clapack
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
 

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -69,7 +69,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/dlib/external/libpng/arm)
 file(READ ${CURRENT_PACKAGES_DIR}/include/dlib/config.h _contents)
 string(REPLACE "/* #undef ENABLE_ASSERTS */" "#if defined(_DEBUG)\n#define ENABLE_ASSERTS\n#endif" _contents ${_contents})
 string(REPLACE "#define DLIB_DISABLE_ASSERTS" "#if !defined(_DEBUG)\n#define DLIB_DISABLE_ASSERTS\n#endif" _contents ${_contents})
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/dlib/config.h ${_contents})
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/dlib/config.h "${_contents}")
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/dlib/dlib.cmake _contents)
 string(REPLACE

--- a/ports/glfw3/CONTROL
+++ b/ports/glfw3/CONTROL
@@ -1,3 +1,3 @@
 Source: glfw3
-Version: 3.2.1-2
+Version: 3.2.1-3
 Description: GLFW is a free, Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development. It provides a simple, platform-independent API for creating windows, contexts and surfaces, reading input, handling events, etc.

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -43,7 +43,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
 file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake _contents)
 set(pattern "get_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)\n")
 string(REPLACE "${pattern}${pattern}${pattern}" "${pattern}${pattern}" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake ${_contents})
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake "${_contents}")
 
 file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glfw3/glfw3Targets-debug.cmake _contents)
 string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" _contents "${_contents}")

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -16,7 +16,7 @@ if(NOT EXISTS ${SOURCE_PATH}/patch-config.stamp)
     #string(REPLACE "@PACKAGE_CMAKE_INSTALL_PREFIX@" "@PACKAGE_CMAKE_INSTALL_PREFIX@/../.."
     #    CONFIG ${CONFIG}
     #)
-    file(WRITE ${SOURCE_PATH}/src/glfw3Config.cmake.in ${CONFIG})
+    file(WRITE ${SOURCE_PATH}/src/glfw3Config.cmake.in "${CONFIG}")
     file(APPEND ${SOURCE_PATH}/src/glfw3Config.cmake.in "set(GLFW3_LIBRARIES \${GLFW3_LIBRARY})\n")
     file(WRITE ${SOURCE_PATH}/patch-config.stamp)
 endif()

--- a/ports/libodb/CONTROL
+++ b/ports/libodb/CONTROL
@@ -1,3 +1,3 @@
 Source: libodb
-Version: 2.4.0-2
+Version: 2.4.0-3
 Description: ODB library, base runtime for the ODB ORM solution

--- a/ports/libodb/portfile.cmake
+++ b/ports/libodb/portfile.cmake
@@ -43,6 +43,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 else()
     string(REPLACE "#ifdef LIBODB_STATIC_LIB" "#if 0" LIBODB_HEADER ${LIBODB_HEADER})
 endif()
-file(WRITE ${LIBODB_HEADER_PATH} ${LIBODB_HEADER})
+file(WRITE ${LIBODB_HEADER_PATH} ""${LIBODB_HEADER}")
 
 vcpkg_copy_pdbs()

--- a/ports/libodb/portfile.cmake
+++ b/ports/libodb/portfile.cmake
@@ -43,6 +43,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 else()
     string(REPLACE "#ifdef LIBODB_STATIC_LIB" "#if 0" LIBODB_HEADER ${LIBODB_HEADER})
 endif()
-file(WRITE ${LIBODB_HEADER_PATH} ""${LIBODB_HEADER}")
+file(WRITE ${LIBODB_HEADER_PATH} "${LIBODB_HEADER}")
 
 vcpkg_copy_pdbs()

--- a/ports/signalrclient/0001_cmake.patch
+++ b/ports/signalrclient/0001_cmake.patch
@@ -26,7 +26,7 @@ index 8c73730..4cd9074 100644
 +else()
 +	file(READ include/signalrclient/_exports.h EXPORTS_H)
 +	string(REPLACE "#ifdef NO_SIGNALRCLIENT_EXPORTS" "#if 1" EXPORTS_H_2 ${EXPORTS_H})
-+	file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/_exports.h ${EXPORTS_H_2})
++	file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/_exports.h "${EXPORTS_H_2}")
 +
 +	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/_exports.h DESTINATION include/signalrclient)
 +endif()

--- a/ports/signalrclient/CONTROL
+++ b/ports/signalrclient/CONTROL
@@ -1,4 +1,4 @@
 Source: signalrclient
-Version: 1.0.0-beta1-3
+Version: 1.0.0-beta1-4
 Build-Depends: cpprestsdk
 Description: C++ client for SignalR.

--- a/ports/signalrclient/portfile.cmake
+++ b/ports/signalrclient/portfile.cmake
@@ -1,6 +1,4 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SignalR-Client-Cpp-1.0.0-beta1)
-
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -8,10 +6,6 @@ vcpkg_from_github(
     REF 1.0.0-beta1
     SHA512 b38f6f946f1499080071949cbcf574405118f9acfb469441e5b5b0df3e5f0d277a83b30e0d613dc5e54732b9071e3273dac1ee65129f994d5a60eef0e45bdf6c
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/0001_cmake.patch
 )


### PR DESCRIPTION
This fixes #3802

The problem was caused by cmake stripping the semicolons. I've also done this in some other files in case this problem occurs with them.