### PR TITLE
[fmt] Export all symbols

### DIFF
--- a/ports/fmt/CONTROL
+++ b/ports/fmt/CONTROL
@@ -1,3 +1,3 @@
 Source: fmt
-Version: 5.0.0
+Version: 5.0.0-1
 Description: Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_configure_cmake(
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
+        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
I have `fmt:x64-windows` installed, but the most basic use of `fmt::format` fails to link. Searching the issue tracker, it seems to be the same issue as #331. The same fix (#333) worked.