### PR TITLE
[cxxopts] Update to v2.1.0

### DIFF
--- a/ports/cxxopts/CONTROL
+++ b/ports/cxxopts/CONTROL
@@ -1,3 +1,3 @@
 Source: cxxopts
-Version: 1.3.0
+Version: 2.1.0
 Description: This is a lightweight C++ option parser library, supporting the standard GNU style syntax for options

--- a/ports/cxxopts/portfile.cmake
+++ b/ports/cxxopts/portfile.cmake
@@ -2,8 +2,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jarro2783/cxxopts
-    REF  v1.3.0
-    SHA512 0c02716cdc1ca83f64c3757685042580e06c894ac51986a8df971ed30b8dd6d49448f2c9f61fff947fb34c48055f11cac446b54a9294bc880d78d91081c379b4
+    REF  v2.1.0
+    SHA512 b3549bb36fd3cb27b30a7164992ce19ddf129e7ee071956d58047101e4181cd9f08c8dd4c5e2d5499628deeb52a40bbc2fecfe68e9875c07396e6b7434161603
     HEAD_REF master
 )
 file(INSTALL ${SOURCE_PATH}/include/cxxopts.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include)


### PR DESCRIPTION
Update cxxopts to v2.1.0. This is a simple header-only library.