### PR TITLE
[3fd] Initial port of 3FD project

### DIFF
--- a/ports/3fd/CONTROL
+++ b/ports/3fd/CONTROL
@@ -1,0 +1,4 @@
+Source: 3fd
+Version: 2.6.2
+Description: C++ Framework For Fast Development
+Build-Depends: boost-lockfree (windows), boost-regex (windows), poco (windows), sqlite3, rapidxml

--- a/ports/3fd/portfile.cmake
+++ b/ports/3fd/portfile.cmake
@@ -1,71 +1,72 @@
 include(vcpkg_common_functions)
 
 # Check architecture:
-if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(BUILD_ARCH "Win32")
-elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     set(BUILD_ARCH "x64")
-elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
+elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
     set(BUILD_ARCH "ARM")
 else()
     message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()
 
 # Check library linkage:
-if (NOT VCPKG_LIBRARY_LINKAGE MATCHES "static")
-    message(FATAL_ERROR "Unsupported library linkage: ${VCPKG_LIBRARY_LINKAGE}. 3FD can only be built as a static library!")
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    message("3FD only supports static library linkage. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
 endif()
 
 # Check CRT linkage:
-if (NOT VCPKG_CRT_LINKAGE MATCHES "dynamic")
-    message(FATAL_ERROR "Unsupported CRT linkage: ${VCPKG_CRT_LINKAGE}. 3FD can only be built with dynamic linkage to CRT!")
+if (VCPKG_CRT_LINKAGE STREQUAL "static")
+    message(FATAL_ERROR "3FD can only be built with dynamic linkage to CRT!")
 endif()
 
 # Get source code:
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/3fd-2.6.2)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO faburaya/3FD
-    HEAD_REF master
     REF v2.6.2
     SHA512 a2444cc07d8741540c6071ac59bc8c63785db52e412a843aa18a5dfa0144b5001d428e44bcb520238e3d476440bc74526343f025005f05d534e732645f59cbe0
+    HEAD_REF master
+    PATCHES
+        "${CMAKE_CURRENT_LIST_DIR}/remove-seekpos.patch"
 )
 
+# Copy the sources to ensure a clean, out-of-source build
+file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-all)
+file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-all)
+file(COPY ${SOURCE_PATH} DESTINATION ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-all)
+get_filename_component(LAST_DIR_NAME "${SOURCE_PATH}" NAME)
+set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-all/${LAST_DIR_NAME}")
+
 # Build:
-message(STATUS "Building...")
-if (VCPKG_CMAKE_SYSTEM_NAME MATCHES "Linux") # UWP:
-	message(FATAL_ERROR "Unsupported system: 3FD is not currently ported to VCPKG in Linux!")
-
-elseif (VCPKG_CMAKE_SYSTEM_NAME MATCHES "Darwin") # OSX:
-	message(FATAL_ERROR "Unsupported system: 3FD is not currently ported to VCPKG in Mac OS!")
-
-elseif (VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore") # UWP:
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore") # UWP:
     vcpkg_build_msbuild(
         USE_VCPKG_INTEGRATION
         PROJECT_PATH ${SOURCE_PATH}/3FD/3FD.WinRT.UWP.vcxproj
         PLATFORM ${BUILD_ARCH}
     )
-
-else() # Win32:
+elseif (NOT VCPKG_CMAKE_SYSTEM_NAME) # Win32:
     vcpkg_build_msbuild(
         USE_VCPKG_INTEGRATION
         PROJECT_PATH ${SOURCE_PATH}/3FD/3FD.vcxproj
         PLATFORM ${BUILD_ARCH}
         TARGET Build
     )
+else()
+    message(FATAL_ERROR "Unsupported system: 3FD is not currently ported to VCPKG in ${VCPKG_CMAKE_SYSTEM_NAME}!")
 endif()
 
 # Install:
-message(STATUS "Installing...")
-
 file(GLOB HEADER_FILES LIST_DIRECTORIES false "${SOURCE_PATH}/3FD/*.h")
 file(INSTALL
     ${HEADER_FILES}
     DESTINATION ${CURRENT_PACKAGES_DIR}/include/3FD
     PATTERN "*_impl*.h" EXCLUDE
-	PATTERN "*example*.h" EXCLUDE
-	PATTERN "stdafx.h" EXCLUDE
-	PATTERN "targetver.h" EXCLUDE
+    PATTERN "*example*.h" EXCLUDE
+    PATTERN "stdafx.h" EXCLUDE
+    PATTERN "targetver.h" EXCLUDE
 )
 
 file(INSTALL ${SOURCE_PATH}/btree  DESTINATION ${CURRENT_PACKAGES_DIR}/include/3FD)
@@ -77,7 +78,7 @@ file(INSTALL
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/3FD
 )
 
-if (VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore") # Visual C++, UWP app:
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore") # Visual C++, UWP app:
     file(INSTALL
         ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.WinRT.UWP/3FD.WinRT.UWP.lib
         ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.WinRT.UWP/_3FD_WinRT_UWP.pri
@@ -106,3 +107,5 @@ endif()
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/3fd RENAME copyright)
 file(INSTALL ${SOURCE_PATH}/Acknowledgements.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/3fd)
+
+vcpkg_copy_pdbs()

--- a/ports/3fd/portfile.cmake
+++ b/ports/3fd/portfile.cmake
@@ -1,0 +1,108 @@
+include(vcpkg_common_functions)
+
+# Check architecture:
+if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+    set(BUILD_ARCH "Win32")
+elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+    set(BUILD_ARCH "x64")
+elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
+    set(BUILD_ARCH "ARM")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+# Check library linkage:
+if (NOT VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    message(FATAL_ERROR "Unsupported library linkage: ${VCPKG_LIBRARY_LINKAGE}. 3FD can only be built as a static library!")
+endif()
+
+# Check CRT linkage:
+if (NOT VCPKG_CRT_LINKAGE MATCHES "dynamic")
+    message(FATAL_ERROR "Unsupported CRT linkage: ${VCPKG_CRT_LINKAGE}. 3FD can only be built with dynamic linkage to CRT!")
+endif()
+
+# Get source code:
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/3fd-2.6.2)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO faburaya/3FD
+    HEAD_REF master
+    REF v2.6.2
+    SHA512 a2444cc07d8741540c6071ac59bc8c63785db52e412a843aa18a5dfa0144b5001d428e44bcb520238e3d476440bc74526343f025005f05d534e732645f59cbe0
+)
+
+# Build:
+message(STATUS "Building...")
+if (VCPKG_CMAKE_SYSTEM_NAME MATCHES "Linux") # UWP:
+	message(FATAL_ERROR "Unsupported system: 3FD is not currently ported to VCPKG in Linux!")
+
+elseif (VCPKG_CMAKE_SYSTEM_NAME MATCHES "Darwin") # OSX:
+	message(FATAL_ERROR "Unsupported system: 3FD is not currently ported to VCPKG in Mac OS!")
+
+elseif (VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore") # UWP:
+    vcpkg_build_msbuild(
+        USE_VCPKG_INTEGRATION
+        PROJECT_PATH ${SOURCE_PATH}/3FD/3FD.WinRT.UWP.vcxproj
+        PLATFORM ${BUILD_ARCH}
+    )
+
+else() # Win32:
+    vcpkg_build_msbuild(
+        USE_VCPKG_INTEGRATION
+        PROJECT_PATH ${SOURCE_PATH}/3FD/3FD.vcxproj
+        PLATFORM ${BUILD_ARCH}
+        TARGET Build
+    )
+endif()
+
+# Install:
+message(STATUS "Installing...")
+
+file(GLOB HEADER_FILES LIST_DIRECTORIES false "${SOURCE_PATH}/3FD/*.h")
+file(INSTALL
+    ${HEADER_FILES}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include/3FD
+    PATTERN "*_impl*.h" EXCLUDE
+	PATTERN "*example*.h" EXCLUDE
+	PATTERN "stdafx.h" EXCLUDE
+	PATTERN "targetver.h" EXCLUDE
+)
+
+file(INSTALL ${SOURCE_PATH}/btree  DESTINATION ${CURRENT_PACKAGES_DIR}/include/3FD)
+file(INSTALL ${SOURCE_PATH}/OpenCL/CL DESTINATION ${CURRENT_PACKAGES_DIR}/include/3FD)
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/3FD)
+file(INSTALL
+    ${SOURCE_PATH}/3FD/3fd-config-template.xml
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/3FD
+)
+
+if (VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore") # Visual C++, UWP app:
+    file(INSTALL
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.WinRT.UWP/3FD.WinRT.UWP.lib
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.WinRT.UWP/_3FD_WinRT_UWP.pri
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/WinRT.UWP/3FD.WinRT.UWP.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    )
+    file(INSTALL
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Release/3FD.WinRT.UWP/3FD.WinRT.UWP.lib
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Release/3FD.WinRT.UWP/_3FD_WinRT_UWP.pri
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Release/WinRT.UWP/3FD.WinRT.UWP.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    )
+else() # Visual C++, Win32 app:
+    file(INSTALL
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.lib
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Debug/3FD.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+    )
+    file(INSTALL
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Release/3FD.lib
+        ${SOURCE_PATH}/3FD/${BUILD_ARCH}/Release/3FD.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    )
+endif()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/3fd RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/Acknowledgements.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/3fd)

--- a/ports/3fd/remove-seekpos.patch
+++ b/ports/3fd/remove-seekpos.patch
@@ -1,0 +1,13 @@
+diff --git a/3fd/web_wws_impl_host.cpp b/3fd/web_wws_impl_host.cpp
+index b87dc75..1cff45f 100644
+--- a/3fd/web_wws_impl_host.cpp
++++ b/3fd/web_wws_impl_host.cpp
+@@ -48,7 +48,7 @@ namespace wws
+                 throw AppException<std::runtime_error>(oss.str());
+             }
+ 
+-            const auto fileSizeBytes = inputStream.seekg(0, std::ios::end).tellg().seekpos(); // move cursor to the end to get the zize
++            const auto fileSizeBytes = inputStream.seekg(0, std::ios::end).tellg(); // move cursor to the end to get the zize
+ 
+             // File is not trunked:
+             if (fileSizeBytes > 0)

--- a/scripts/cmake/vcpkg_build_msbuild.cmake
+++ b/scripts/cmake/vcpkg_build_msbuild.cmake
@@ -15,6 +15,7 @@
 ##     [OPTIONS </p:ZLIB_INCLUDE_PATH=X>...]
 ##     [OPTIONS_RELEASE </p:ZLIB_LIB=X>...]
 ##     [OPTIONS_DEBUG </p:ZLIB_LIB=X>...]
+##     [USE_VCPKG_INTEGRATION]
 ## )
 ## ```
 ##
@@ -105,7 +106,11 @@ function(vcpkg_build_msbuild)
     endif()
 
     if(_csc_USE_VCPKG_INTEGRATION)
-        list(APPEND _csc_OPTIONS /p:ForceImportBeforeCppTargets=${VCPKG_ROOT_DIR}/scripts/buildsystems/msbuild/vcpkg.targets)
+        list(
+            APPEND _csc_OPTIONS
+            /p:ForceImportBeforeCppTargets=${VCPKG_ROOT_DIR}/scripts/buildsystems/msbuild/vcpkg.targets
+            "/p:VcpkgTriplet=${TARGET_TRIPLET}"
+        )
     endif()
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")


### PR DESCRIPTION
Initial port of 3FD to vcpkg. Currently, the project does not support building with static linkage to CRT. The user is expected to create its own tripplet specifying dynamic linkage to CRT and static linkage to the library itself. The only supported platform so far is Windows, because it depends on POCO that currently does not build successfully by vcpkg in Linux.