### PR TITLE
[openimageio] build with libraw support

### DIFF
--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,4 +1,4 @@
 Source: openimageio
-Version: Release-1.8.12
+Version: Release-1.8.12-1
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
-Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map
+Build-Depends: libjpeg-turbo, tiff, libpng, openexr, libraw, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map

--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,4 +1,8 @@
 Source: openimageio
 Version: Release-1.8.12-1
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
-Build-Depends: libjpeg-turbo, tiff, libpng, openexr, libraw, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map
+Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map
+
+Feature: libraw
+Build-Depends: libraw
+Description: Enable RAW image files support

--- a/ports/openimageio/fix_libraw.patch
+++ b/ports/openimageio/fix_libraw.patch
@@ -1,0 +1,40 @@
+diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
+index 5eeb7d3..3e8bfcb 100644
+--- a/src/cmake/externalpackages.cmake
++++ b/src/cmake/externalpackages.cmake
+@@ -336,7 +336,7 @@ if (USE_LIBRAW)
+         message (STATUS "Looking for LibRaw with ${LIBRAW_PATH}")
+     endif ()
+     find_package (LibRaw)
+-    if (LibRaw_r_LIBRARIES AND LibRaw_INCLUDE_DIR)
++    if (LibRaw_LIBRARIES AND LibRaw_INCLUDE_DIR)
+         set (LIBRAW_FOUND TRUE)
+         include_directories (${LibRaw_INCLUDE_DIR})
+         if (NOT LibRaw_FIND_QUIETLY)
+@@ -350,7 +350,7 @@ if (USE_LIBRAW)
+     if (LINKSTATIC)
+         find_package (Jasper)
+         find_library (LCMS2_LIBRARIES NAMES lcms2)
+-        set (LibRaw_r_LIBRARIES ${LibRaw_r_LIBRARIES} ${JASPER_LIBRARIES} ${LCMS2_LIBRARIES})
++        set (LibRaw_LIBRARIES ${LibRaw_LIBRARIES} ${JASPER_LIBRARIES} ${LCMS2_LIBRARIES})
+     endif ()
+ else ()
+     message (STATUS "Not using LibRaw")
+@@ -494,4 +494,3 @@ if (USE_DICOM)
+ endif()
+ # end DCMTK setup
+ ###########################################################################
+-
+diff --git a/src/raw.imageio/CMakeLists.txt b/src/raw.imageio/CMakeLists.txt
+index e3608a2..f503035 100644
+--- a/src/raw.imageio/CMakeLists.txt
++++ b/src/raw.imageio/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ if (USE_LIBRAW AND LIBRAW_FOUND)
+     add_oiio_plugin (rawinput.cpp
+                      INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
+-                     LINK_LIBRARIES ${LibRaw_r_LIBRARIES}
++                     LINK_LIBRARIES ${LibRaw_LIBRARIES}
+                      DEFINITIONS "-DUSE_LIBRAW=1")
+ else ()
+     message (WARNING "Raw plugin will not be built")

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -19,6 +19,15 @@ else()
     set(LINKSTATIC OFF)
 endif()
 
+
+# fix_libraw: replace 'LibRaw_r_LIBRARIES' occurences by 'LibRaw_LIBRARIES'
+#             since libraw port installs 'raw_r' library as 'raw'
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/fix_libraw.patch
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -30,7 +39,7 @@ vcpkg_configure_cmake(
         -DUSE_FIELD3D=OFF
         -DUSE_FREETYPE=OFF
         -DUSE_GIF=OFF
-        -DUSE_LIBRAW=OFF
+        -DUSE_LIBRAW=ON
         -DUSE_NUKE=OFF
         -DUSE_OCIO=OFF
         -DUSE_OPENCV=OFF

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -28,6 +28,12 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/fix_libraw.patch
 )
 
+# Features
+set(USE_LIBRAW OFF)
+if("libraw" IN_LIST FEATURES)
+    set(USE_LIBRAW ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -39,7 +45,7 @@ vcpkg_configure_cmake(
         -DUSE_FIELD3D=OFF
         -DUSE_FREETYPE=OFF
         -DUSE_GIF=OFF
-        -DUSE_LIBRAW=ON
+        -DUSE_LIBRAW=${USE_LIBRAW}
         -DUSE_NUKE=OFF
         -DUSE_OCIO=OFF
         -DUSE_OPENCV=OFF

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -6,6 +6,10 @@ vcpkg_from_github(
     REF Release-1.8.12
     SHA512 2475792ff475d34b47b6af5ca71c6cf6d9d8c60452a506b1bf740b9dbb20ea72109117dc9a531b8302095de99f6280172723f26e23dc6e038256cbb43b697145
     HEAD_REF master
+    PATCHES
+        # fix_libraw: replace 'LibRaw_r_LIBRARIES' occurences by 'LibRaw_LIBRARIES'
+        #             since libraw port installs 'raw_r' library as 'raw'
+        ${CMAKE_CURRENT_LIST_DIR}/fix_libraw.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")
@@ -18,15 +22,6 @@ else()
     set(BUILDSTATIC OFF)
     set(LINKSTATIC OFF)
 endif()
-
-
-# fix_libraw: replace 'LibRaw_r_LIBRARIES' occurences by 'LibRaw_LIBRARIES'
-#             since libraw port installs 'raw_r' library as 'raw'
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/fix_libraw.patch
-)
 
 # Features
 set(USE_LIBRAW OFF)


### PR DESCRIPTION
Patch OpenImageIO CMake files to find 'libraw' as distributed by vcpkg ('raw_r' library renamed to 'raw') and enable libraw support in OIIO build.
