### PR TITLE
Update Apache Arrow to 0.9 and add Apache Parquet-cpp 1.4

### DIFF
--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -1,4 +1,4 @@
 Source: arrow
-Version: 0.6.0-1
+Version: 0.9.0-1
 Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algorithm, flatbuffers, rapidjson, zlib, lz4, brotli, zstd, snappy, gflags
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.

--- a/ports/arrow/all.patch
+++ b/ports/arrow/all.patch
@@ -1,51 +1,91 @@
-diff --git a/cmake_modules/FindBrotli.cmake b/cmake_modules/FindBrotli.cmake
-index f2e714c..2e475dc 100644
---- a/cmake_modules/FindBrotli.cmake
-+++ b/cmake_modules/FindBrotli.cmake
-@@ -65,16 +65,13 @@ if (BROTLI_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR BROTLI_LIBRARIES))
+diff --git a/cpp/cmake_modules/FindBrotli.cmake b/cpp/cmake_modules/FindBrotli.cmake
+index ea971f0..3e98ede 100644
+--- a/cpp/cmake_modules/FindBrotli.cmake
++++ b/cpp/cmake_modules/FindBrotli.cmake
+@@ -43,53 +43,31 @@ find_path( BROTLI_INCLUDE_DIR NAMES brotli/decode.h
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "include" )
+ 
+-find_library( BROTLI_LIBRARY_ENC NAMES libbrotlienc.a libbrotlienc-static.a brotlienc
++find_library( BROTLI_LIBRARY_ENC NAMES libbrotlienc libbrotlienc-static brotlienc brotlienc-static
+   PATHS ${_brotli_roots}
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
+ 
+-find_library( BROTLI_LIBRARY_DEC NAMES libbrotlidec.a libbrotlidec-static.a brotlidec
++find_library( BROTLI_LIBRARY_DEC NAMES libbrotlidec libbrotlidec-static brotlidec brotlidec-static
+   PATHS ${_brotli_roots}
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
+ 
+-find_library( BROTLI_LIBRARY_COMMON NAMES libbrotlicommon.a libbrotlicommon-static.a brotlicommon
++find_library( BROTLI_LIBRARY_COMMON NAMES libbrotlicommon libbrotlicommon-static brotlicommon brotlicommon-static
+   PATHS ${_brotli_roots}
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
+ 
+ set(BROTLI_LIBRARIES ${BROTLI_LIBRARY_ENC} ${BROTLI_LIBRARY_DEC}
+     ${BROTLI_LIBRARY_COMMON})
+-
++	
+ if (BROTLI_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR BROTLI_LIBRARIES))
    set(BROTLI_FOUND TRUE)
-   get_filename_component( BROTLI_LIBS ${BROTLI_LIBRARY_ENC} PATH )
-   set(BROTLI_LIB_NAME brotli)
--  if (MSVC AND NOT BROTLI_MSVC_STATIC_LIB_SUFFIX)
--    set(BROTLI_MSVC_STATIC_LIB_SUFFIX _static)
+-  get_filename_component( BROTLI_LIBS ${BROTLI_LIBRARY_ENC} PATH )
+-  set(BROTLI_LIB_NAME brotli)
+-  if (BROTLI_MSVC_STATIC_LIB_SUFFIX)
+-    set(BROTLI_STATIC_LIB_SUFFIX "${BROTLI_MSVC_STATIC_LIB_SUFFIX}")
 -  endif()
-   set(BROTLI_STATIC_LIB
--      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
--      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
--      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
--  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
--  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
--  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
-+      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${CMAKE_STATIC_LIBRARY_SUFFIX}
-+      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${CMAKE_STATIC_LIBRARY_SUFFIX}
-+      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${CMAKE_STATIC_LIBRARY_SUFFIX})
-+  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${CMAKE_STATIC_LIBRARY_SUFFIX})
-+  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${CMAKE_STATIC_LIBRARY_SUFFIX})
-+  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${CMAKE_STATIC_LIBRARY_SUFFIX})
-   set(BROTLI_SHARED_LIB
-       ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${CMAKE_SHARED_LIBRARY_SUFFIX}
-       ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${CMAKE_SHARED_LIBRARY_SUFFIX}
-diff --git a/cmake_modules/FindFlatbuffers.cmake b/cmake_modules/FindFlatbuffers.cmake
-index 804f479..ff9bde1 100644
---- a/cmake_modules/FindFlatbuffers.cmake
-+++ b/cmake_modules/FindFlatbuffers.cmake
+-  if (NOT BROTLI_STATIC_LIB_SUFFIX)
+-    if (EXISTS "${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc-static${CMAKE_STATIC_LIBRARY_SUFFIX}")
+-      set(BROTLI_STATIC_LIB_SUFFIX -static)
+-    else()
+-      if (MSVC)
+-        set(BROTLI_STATIC_LIB_SUFFIX _static)
+-      else()
+-        set(BROTLI_STATIC_LIB_SUFFIX "")
+-      endif()
+-    endif()
+-  endif()
+-  set(BROTLI_STATIC_LIB
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_SHARED_LIB
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${CMAKE_SHARED_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${CMAKE_SHARED_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${CMAKE_SHARED_LIBRARY_SUFFIX})
++  set(BROTLI_STATIC_LIB ${BROTLI_LIBRARIES})
++  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBRARY_ENC})
++  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBRARY_DEC})
++  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBRARY_COMMON})
++  set(BROTLI_SHARED_LIB ${BROTLI_LIBRARIES})
+ else ()
+   set(BROTLI_FOUND FALSE)
+ endif ()
+diff --git a/cpp/cmake_modules/FindFlatbuffers.cmake b/cpp/cmake_modules/FindFlatbuffers.cmake
+index 804f479..baac84e 100644
+--- a/cpp/cmake_modules/FindFlatbuffers.cmake
++++ b/cpp/cmake_modules/FindFlatbuffers.cmake
 @@ -53,6 +53,7 @@ endif ()
  
  find_program(FLATBUFFERS_COMPILER flatc
    "${FLATBUFFERS_HOME}/bin"
-+  "${FLATBUFFERS_HOME}/tools"
++  "${FLATBUFFERS_HOME}/tools/flatbuffers"
    /usr/local/bin
    /usr/bin
    NO_DEFAULT_PATH
-diff --git a/cmake_modules/FindLz4.cmake b/cmake_modules/FindLz4.cmake
-index 07707cf..9cbf67d 100644
---- a/cmake_modules/FindLz4.cmake
-+++ b/cmake_modules/FindLz4.cmake
-@@ -29,15 +29,7 @@ elseif ( Lz4_HOME )
+diff --git a/cpp/cmake_modules/FindLz4.cmake b/cpp/cmake_modules/FindLz4.cmake
+index 3a89c8d..3157197 100644
+--- a/cpp/cmake_modules/FindLz4.cmake
++++ b/cpp/cmake_modules/FindLz4.cmake
+@@ -29,21 +29,11 @@ elseif ( Lz4_HOME )
      list( APPEND _lz4_roots ${Lz4_HOME} )
  endif()
  
--if (MSVC AND NOT LZ4_MSVC_STATIC_LIB_SUFFIX)
+-if (MSVC AND NOT DEFINED LZ4_MSVC_STATIC_LIB_SUFFIX)
 -  set(LZ4_MSVC_STATIC_LIB_SUFFIX "_static")
 -endif()
 -
@@ -54,14 +94,20 @@ index 07707cf..9cbf67d 100644
 -
 -set(LZ4_STATIC_LIB_NAME
 -  ${CMAKE_STATIC_LIBRARY_PREFIX}lz4${LZ4_STATIC_LIB_SUFFIX})
-+set(LZ4_STATIC_LIB_NAME lz4)
- 
+-
  find_path(LZ4_INCLUDE_DIR NAMES lz4.h
    PATHS ${_lz4_roots}
-diff --git a/cmake_modules/FindSnappy.cmake b/cmake_modules/FindSnappy.cmake
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "include" )
+-find_library(LZ4_STATIC_LIB NAMES ${LZ4_STATIC_LIB_NAME} lib${LZ4_STATIC_LIB_NAME}
++find_library(LZ4_STATIC_LIB NAMES lz4 liblz4
+   PATHS ${_lz4_roots}
+   NO_DEFAULT_PATH
+   PATH_SUFFIXES "lib" )
+diff --git a/cpp/cmake_modules/FindSnappy.cmake b/cpp/cmake_modules/FindSnappy.cmake
 index 867963c..8a432db 100644
---- a/cmake_modules/FindSnappy.cmake
-+++ b/cmake_modules/FindSnappy.cmake
+--- a/cpp/cmake_modules/FindSnappy.cmake
++++ b/cpp/cmake_modules/FindSnappy.cmake
 @@ -55,7 +55,7 @@ if (SNAPPY_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR SNAPPY_LIBRARIES))
    set(SNAPPY_HEADER_NAME snappy.h)
    set(SNAPPY_HEADER ${SNAPPY_INCLUDE_DIR}/${SNAPPY_HEADER_NAME})
@@ -71,60 +117,31 @@ index 867963c..8a432db 100644
    set(SNAPPY_SHARED_LIB ${SNAPPY_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${SNAPPY_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
  else ()
    set(SNAPPY_FOUND FALSE)
-diff --git a/cmake_modules/FindZLIB.cmake b/cmake_modules/FindZLIB.cmake
-index 78b84f2..eb09001 100644
---- a/cmake_modules/FindZLIB.cmake
-+++ b/cmake_modules/FindZLIB.cmake
-@@ -62,11 +62,11 @@ if (ZLIB_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZLIB_LIBRARIES))
+diff --git a/cpp/cmake_modules/FindZLIB.cmake b/cpp/cmake_modules/FindZLIB.cmake
+index 78b84f2..56cc887 100644
+--- a/cpp/cmake_modules/FindZLIB.cmake
++++ b/cpp/cmake_modules/FindZLIB.cmake
+@@ -61,9 +61,7 @@ if (ZLIB_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZLIB_LIBRARIES))
+   set(ZLIB_HEADER ${ZLIB_INCLUDE_DIR}/${ZLIB_HEADER_NAME})
    set(ZLIB_LIB_NAME z)
    if (MSVC)
-     if (NOT ZLIB_MSVC_STATIC_LIB_SUFFIX)
+-    if (NOT ZLIB_MSVC_STATIC_LIB_SUFFIX)
 -      set(ZLIB_MSVC_STATIC_LIB_SUFFIX libstatic)
-+      set(ZLIB_MSVC_STATIC_LIB_SUFFIX lib)
-     endif()
+-    endif()
++    set(ZLIB_MSVC_STATIC_LIB_SUFFIX lib)
      set(ZLIB_MSVC_SHARED_LIB_SUFFIX lib)
    endif()
--  set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
-+  set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_SHARED_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
-   set(ZLIB_SHARED_LIB ${ZLIB_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_SHARED_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
- else ()
-   set(ZLIB_FOUND FALSE)
-diff --git a/cmake_modules/FindZSTD.cmake b/cmake_modules/FindZSTD.cmake
-index 02a0c39..73c61b5 100644
---- a/cmake_modules/FindZSTD.cmake
-+++ b/cmake_modules/FindZSTD.cmake
-@@ -29,21 +29,11 @@ elseif ( ZStd_HOME )
-     list( APPEND _zstd_roots ${ZStd_HOME} )
- endif()
- 
--if (MSVC AND NOT ZSTD_MSVC_STATIC_LIB_SUFFIX)
--  set(ZSTD_MSVC_STATIC_LIB_SUFFIX "_static")
--endif()
--
--set(ZSTD_STATIC_LIB_SUFFIX
--  "${ZSTD_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
--
--set(ZSTD_STATIC_LIB_NAME
--  ${CMAKE_STATIC_LIBRARY_PREFIX}zstd${ZSTD_STATIC_LIB_SUFFIX})
--
- find_path(ZSTD_INCLUDE_DIR NAMES zstd.h
+   set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+diff --git a/cpp/cmake_modules/FindZSTD.cmake b/cpp/cmake_modules/FindZSTD.cmake
+index 810e5c0..b483471 100644
+--- a/cpp/cmake_modules/FindZSTD.cmake
++++ b/cpp/cmake_modules/FindZSTD.cmake
+@@ -43,7 +43,7 @@ find_path(ZSTD_INCLUDE_DIR NAMES zstd.h
    PATHS ${_zstd_roots}
    NO_DEFAULT_PATH
    PATH_SUFFIXES "include" )
 -find_library(ZSTD_STATIC_LIB NAMES ${ZSTD_STATIC_LIB_NAME} lib${ZSTD_STATIC_LIB_NAME}
-+find_library(ZSTD_STATIC_LIB NAMES libzstd libzstd_static zstd zstd_static
++find_library(ZSTD_STATIC_LIB NAMES zstd ${ZSTD_STATIC_LIB_NAME} lib${ZSTD_STATIC_LIB_NAME}
    PATHS ${_zstd_roots}
    NO_DEFAULT_PATH
    PATH_SUFFIXES "lib" )
-diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
-index a888e92..0fe3629 100644
---- a/cmake_modules/ThirdpartyToolchain.cmake
-+++ b/cmake_modules/ThirdpartyToolchain.cmake
-@@ -119,6 +119,7 @@ endif()
- set(Boost_DEBUG TRUE)
- set(Boost_USE_MULTITHREADED ON)
- set(Boost_ADDITIONAL_VERSIONS
-+  "1.65.0" "1.65"  
-   "1.64.0" "1.64"
-   "1.63.0" "1.63"
-   "1.62.0" "1.61"

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -7,19 +7,18 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow
-    REF apache-arrow-0.6.0
-    SHA512  c0e89b959dfe75e895a3427edd4eee663be5ee542e9ea13f7311d0775fe7a00188eafa07ba524e3d3c0a71fc8e11213f10fe4ebfdf451754816062249ffa7f3d
+    REF apache-arrow-0.9.0
+    SHA512 789d0948eee3af20eb922e09c14eb721f20fa041ca3c0cf57bd869718fc9919b45590bd72714efafdf19196f35abb6bdbe0a3972ca74fcc2af92c1f9ade8fa00
     HEAD_REF master
 )
 
 set(CPP_SOURCE_PATH "${SOURCE_PATH}/cpp")
 
 vcpkg_apply_patches(
-    SOURCE_PATH ${CPP_SOURCE_PATH}
+    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
     "${CMAKE_CURRENT_LIST_DIR}/all.patch"
 )
-
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ARROW_BUILD_STATIC)

--- a/ports/parquet/CONTROL
+++ b/ports/parquet/CONTROL
@@ -1,0 +1,4 @@
+Source: parquet
+Version: 1.4.0
+Build-Depends: arrow, thrift, gtest, brotli
+Description: Parquet-cpp is a C++ library to read and write the Apache Parquet columnar data format.

--- a/ports/parquet/CONTROL
+++ b/ports/parquet/CONTROL
@@ -1,4 +1,4 @@
 Source: parquet
 Version: 1.4.0
-Build-Depends: arrow, thrift, gtest, brotli
+Build-Depends: arrow, thrift, gtest
 Description: Parquet-cpp is a C++ library to read and write the Apache Parquet columnar data format.

--- a/ports/parquet/all.patch
+++ b/ports/parquet/all.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 304f3fb..0f2c563 100644
+index 304f3fb..0b0fc1f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -16,7 +16,7 @@
@@ -7,7 +7,7 @@ index 304f3fb..0f2c563 100644
  
  # Require cmake that supports BYPRODUCTS in add_custom_command, ExternalProject_Add [1].
 -cmake_minimum_required(VERSION 3.2.0)
-+cmake_minimum_required(VERSION 3.11.1)
++cmake_minimum_required(VERSION 3.8)
  
  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/.parquetcppversion" PARQUET_VERSION)
  string(REPLACE "\n" "" PARQUET_VERSION "${PARQUET_VERSION}")

--- a/ports/parquet/all.patch
+++ b/ports/parquet/all.patch
@@ -1,0 +1,779 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 304f3fb..0f2c563 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,7 +16,7 @@
+ # under the License.
+ 
+ # Require cmake that supports BYPRODUCTS in add_custom_command, ExternalProject_Add [1].
+-cmake_minimum_required(VERSION 3.2.0)
++cmake_minimum_required(VERSION 3.11.1)
+ 
+ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/.parquetcppversion" PARQUET_VERSION)
+ string(REPLACE "\n" "" PARQUET_VERSION "${PARQUET_VERSION}")
+@@ -25,6 +25,10 @@ if(NOT VERSION)
+   message(FATAL_ERROR "invalid .parquetcppversion")
+ endif()
+ 
++if(NOT DEFINED ARROW_LIB_SUFFIX)
++  set(ARROW_LIB_SUFFIX "")
++endif()
++
+ project(parquet-cpp VERSION ${VERSION})
+ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ library to read and write the Apache Parquet columnar data format")
+ set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+@@ -528,37 +532,25 @@ endif()
+ #############################################################
+ # Apache Arrow linkage
+ 
+-if ("${PARQUET_ARROW_LINKAGE}" STREQUAL "shared")
++if ("${PARQUET_ARROW_LINKAGE}" STREQUAL "dynamic")
+   set(ARROW_LINK_LIBS
+-    arrow)
++    arrow_static)
+ else()
+   #############################################################
+   # Transitive Library Linkage
+-
+-  if (NOT DEFINED ENV{BROTLI_STATIC_LIB_ENC} OR
+-      NOT DEFINED ENV{BROTLI_STATIC_LIB_DEC} OR
+-      NOT DEFINED ENV{BROTLI_STATIC_LIB_COMMON} OR
+-      NOT DEFINED ENV{SNAPPY_STATIC_LIB} OR
+-      NOT DEFINED ENV{ZLIB_STATIC_LIB} OR
+-      NOT DEFINED ENV{LZ4_STATIC_LIB} OR
+-      NOT DEFINED ENV{ZSTD_STATIC_LIB})
+-    message(FATAL_ERROR "Missing transitive dependencies for Arrow static linking")
+-  endif()
+-
+-  set(BROTLI_STATIC_LIB_ENC "$ENV{BROTLI_STATIC_LIB_ENC}")
+-  set(BROTLI_STATIC_LIB_DEC "$ENV{BROTLI_STATIC_LIB_DEC}")
+-  set(BROTLI_STATIC_LIB_COMMON "$ENV{BROTLI_STATIC_LIB_COMMON}")
+-  set(SNAPPY_STATIC_LIB "$ENV{SNAPPY_STATIC_LIB}")
+-  set(ZLIB_STATIC_LIB "$ENV{ZLIB_STATIC_LIB}")
+-  set(LZ4_STATIC_LIB "$ENV{LZ4_STATIC_LIB}")
+-  set(ZSTD_STATIC_LIB "$ENV{ZSTD_STATIC_LIB}")
+-
++  
++  find_package(Brotli REQUIRED)
++  find_package(Snappy REQUIRED)
++  find_package(LZ4 REQUIRED)
++  find_package(ZLIB REQUIRED)
++  find_package(ZSTD REQUIRED)
++  
+   add_library(brotli_enc STATIC IMPORTED)
+-  set_target_properties(brotli_enc PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIB_ENC})
++  set_target_properties(brotli_enc PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIBRARY_ENC})
+   add_library(brotli_dec STATIC IMPORTED)
+-  set_target_properties(brotli_dec PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIB_DEC})
++  set_target_properties(brotli_dec PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIBRARY_DEC})
+   add_library(brotli_common STATIC IMPORTED)
+-  set_target_properties(brotli_common PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIB_COMMON})
++  set_target_properties(brotli_common PROPERTIES IMPORTED_LOCATION ${BROTLI_STATIC_LIBRARY_COMMON})
+   add_library(snappy STATIC IMPORTED)
+   set_target_properties(snappy PROPERTIES IMPORTED_LOCATION ${SNAPPY_STATIC_LIB})
+   add_library(zlib STATIC IMPORTED)
+@@ -588,9 +580,7 @@ endif()
+ #############################################################
+ # Test linking
+ 
+-set(PARQUET_MIN_TEST_LIBS
+-  gtest
+-  gtest_main)
++set(PARQUET_MIN_TEST_LIBS GTest::GTest GTest::Main)
+ 
+ if (APPLE)
+   set(PARQUET_MIN_TEST_LIBS
+diff --git a/cmake_modules/FindArrow.cmake b/cmake_modules/FindArrow.cmake
+index b63b1af..3329c4a 100644
+--- a/cmake_modules/FindArrow.cmake
++++ b/cmake_modules/FindArrow.cmake
+@@ -22,76 +22,21 @@
+ #  ARROW_SHARED_LIB, path to libarrow's shared library
+ #  ARROW_FOUND, whether arrow has been found
+ 
+-if (DEFINED ENV{ARROW_HOME})
+-  set(ARROW_HOME "$ENV{ARROW_HOME}")
+-endif()
+-
+-if ("${ARROW_HOME}" STREQUAL "")
+-  # PARQUET-955. If the user has set $ARROW_HOME in the environment, we respect
+-  # this, otherwise try to locate the pkgconfig in the system environment
+-  pkg_check_modules(ARROW arrow)
+-  if (ARROW_FOUND)
+-    # We found the pkgconfig
+-    set(ARROW_INCLUDE_DIR ${ARROW_INCLUDE_DIRS})
+-
+-    if (COMMAND pkg_get_variable)
+-      pkg_get_variable(ARROW_ABI_VERSION arrow abi_version)
+-    else()
+-      set(ARROW_ABI_VERSION "")
+-    endif()
+-    if (ARROW_ABI_VERSION STREQUAL "")
+-      set(ARROW_SHARED_LIB_SUFFIX "")
+-    else()
+-      set(ARROW_SHARED_LIB_SUFFIX ".${ARROW_ABI_VERSION}")
+-    endif()
+-
+-    set(ARROW_LIB_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}arrow)
+-
+-    if (APPLE)
+-      set(ARROW_SHARED_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${ARROW_SHARED_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+-    else()
+-      set(ARROW_SHARED_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}${ARROW_SHARED_LIB_SUFFIX})
+-    endif()
+-    set(ARROW_STATIC_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  endif()
+-else()
+-  set(ARROW_HOME "${ARROW_HOME}")
++find_path(ARROW_INCLUDE_DIR arrow/array.h
++  PATH_SUFFIXES "include" 
++  )
+ 
+-  if (MSVC AND NOT ARROW_MSVC_STATIC_LIB_SUFFIX)
+-    set(ARROW_MSVC_STATIC_LIB_SUFFIX _static)
+-  endif()
++find_library(ARROW_LIB_PATH NAMES arrow)
+ 
+-  set(ARROW_SEARCH_HEADER_PATHS
+-    ${ARROW_HOME}/include
+-    )
++if (ARROW_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ARROW_LIB_PATH))
++  set(ARROW_FOUND TRUE)
++  set(ARROW_HEADER_NAME arrow/api.h)
++  set(ARROW_HEADER ${ARROW_INCLUDE_DIR}/${ARROW_HEADER_NAME})
++  set(ARROW_LIB_NAME arrow)
+ 
+-  set(ARROW_SEARCH_LIB_PATH
+-    ${ARROW_HOME}/lib
+-    )
+-
+-  find_path(ARROW_INCLUDE_DIR arrow/array.h PATHS
+-    ${ARROW_SEARCH_HEADER_PATHS}
+-    # make sure we don't accidentally pick up a different version
+-    NO_DEFAULT_PATH
+-    )
+-
+-  find_library(ARROW_LIB_PATH NAMES arrow arrow${ARROW_MSVC_STATIC_LIB_SUFFIX}
+-    PATHS
+-    ${ARROW_SEARCH_LIB_PATH}
+-    NO_DEFAULT_PATH)
+-
+-  if (ARROW_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ARROW_LIB_PATH))
+-    set(ARROW_FOUND TRUE)
+-    set(ARROW_HEADER_NAME arrow/api.h)
+-    set(ARROW_HEADER ${ARROW_INCLUDE_DIR}/${ARROW_HEADER_NAME})
+-    set(ARROW_LIB_NAME arrow)
+-
+-    get_filename_component(ARROW_LIBS ${ARROW_LIB_PATH} DIRECTORY)
+-    set(ARROW_STATIC_LIB ${ARROW_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-    set(ARROW_SHARED_LIB ${ARROW_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+-    set(ARROW_SHARED_IMPLIB ${ARROW_LIBS}/${ARROW_LIB_NAME}.lib)
+-  endif ()
+-endif()
++  set(ARROW_STATIC_LIB ${ARROW_LIB_PATH})
++  set(ARROW_SHARED_LIB ${ARROW_LIB_PATH})
++endif ()
+ 
+ if (ARROW_FOUND)
+   if (NOT Arrow_FIND_QUIETLY)
+diff --git a/cmake_modules/FindBrotli.cmake b/cmake_modules/FindBrotli.cmake
+index f2e714c..9561660 100644
+--- a/cmake_modules/FindBrotli.cmake
++++ b/cmake_modules/FindBrotli.cmake
+@@ -17,13 +17,6 @@
+ #
+ #  find_package(Brotli)
+ #
+-# Variables used by this module, they can change the default behaviour and need
+-# to be set before calling find_package:
+-#
+-#  Brotli_HOME - When set, this path is inspected instead of standard library
+-#                locations as the root of the Brotli installation.
+-#                The environment variable BROTLI_HOME overrides this veriable.
+-#
+ # This module defines
+ #  BROTLI_INCLUDE_DIR, directory containing headers
+ #  BROTLI_LIBS, directory containing brotli libraries
+@@ -31,80 +24,37 @@
+ #  BROTLI_SHARED_LIB, path to libbrotli's shared library
+ #  BROTLI_FOUND, whether brotli has been found
+ 
+-if( NOT "${BROTLI_HOME}" STREQUAL "")
+-    file( TO_CMAKE_PATH "${BROTLI_HOME}" _native_path )
+-    list( APPEND _brotli_roots ${_native_path} )
+-elseif ( Brotli_HOME )
+-    list( APPEND _brotli_roots ${Brotli_HOME} )
+-endif()
+-
+ find_path( BROTLI_INCLUDE_DIR NAMES brotli/decode.h
+-  PATHS ${_brotli_roots}
+-  NO_DEFAULT_PATH
+   PATH_SUFFIXES "include" )
+-
+-find_library( BROTLI_LIBRARY_ENC NAMES libbrotlienc.a brotlienc
+-  PATHS ${_brotli_roots}
+-  NO_DEFAULT_PATH
+-  PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
+-
+-find_library( BROTLI_LIBRARY_DEC NAMES libbrotlidec.a brotlidec
+-  PATHS ${_brotli_roots}
+-  NO_DEFAULT_PATH
+-  PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
+-
+-find_library( BROTLI_LIBRARY_COMMON NAMES libbrotlicommon.a brotlicommon
+-  PATHS ${_brotli_roots}
+-  NO_DEFAULT_PATH
+-  PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
++  
++find_library( BROTLI_LIBRARY_ENC NAMES libbrotlienc.a brotlienc brotlienc-static )
++find_library( BROTLI_LIBRARY_DEC NAMES libbrotlidec.a brotlidec brotlidec-static )
++find_library( BROTLI_LIBRARY_COMMON NAMES libbrotlicommon.a brotlicommon brotlicommon-static )
+ 
+ set(BROTLI_LIBRARIES ${BROTLI_LIBRARY_ENC} ${BROTLI_LIBRARY_DEC}
+     ${BROTLI_LIBRARY_COMMON})
+ 
+-if (BROTLI_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR BROTLI_LIBRARIES))
++if (BROTLI_INCLUDE_DIR)
+   set(BROTLI_FOUND TRUE)
+-  get_filename_component( BROTLI_LIBS ${BROTLI_LIBRARY_ENC} PATH )
+-  set(BROTLI_LIB_NAME brotli)
+-  if (MSVC AND NOT BROTLI_MSVC_STATIC_LIB_SUFFIX)
+-    set(BROTLI_MSVC_STATIC_LIB_SUFFIX _static)
+-  endif()
+   set(BROTLI_STATIC_LIB
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${BROTLI_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
++      ${BROTLI_LIBRARY_ENC}
++      ${BROTLI_LIBRARY_DEC}
++      ${BROTLI_LIBRARY_COMMON})
++  set(BROTLI_STATIC_LIBRARY_ENC ${BROTLI_LIBRARY_ENC})
++  set(BROTLI_STATIC_LIBRARY_DEC ${BROTLI_LIBRARY_DEC})
++  set(BROTLI_STATIC_LIBRARY_COMMON ${BROTLI_LIBRARY_COMMON})
+   set(BROTLI_SHARED_LIB
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}enc${CMAKE_SHARED_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}dec${CMAKE_SHARED_LIBRARY_SUFFIX}
+-      ${BROTLI_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${BROTLI_LIB_NAME}common${CMAKE_SHARED_LIBRARY_SUFFIX})
++      ${BROTLI_LIBRARY_ENC}
++      ${BROTLI_LIBRARY_DEC}
++      ${BROTLI_LIBRARY_COMMON})
+ else ()
+   set(BROTLI_FOUND FALSE)
+ endif ()
+ 
+ if (BROTLI_FOUND)
+-  if (NOT Brotli_FIND_QUIETLY)
+-    if (PARQUET_MINIMAL_DEPENDENCY)
+-      message(STATUS "Found the Brotli headers: ${BROTLI_INCLUDE_DIR}")
+-    else ()
+-      message(STATUS "Found the Brotli library: ${BROTLI_LIBRARIES}")
+-    endif ()
+-  endif ()
++  message(STATUS "Found the Brotli library: ${BROTLI_LIBRARIES}")
+ else ()
+-  if (NOT Brotli_FIND_QUIETLY)
+-    set(BROTLI_ERR_MSG "Could not find the Brotli library. Looked in ")
+-    if ( _brotli_roots )
+-      set(BROTLI_ERR_MSG "${BROTLI_ERR_MSG} in ${_brotli_roots}.")
+-    else ()
+-      set(BROTLI_ERR_MSG "${BROTLI_ERR_MSG} system search paths.")
+-    endif ()
+-    if (Brotli_FIND_REQUIRED)
+-      message(FATAL_ERROR "${BROTLI_ERR_MSG}")
+-    else (Brotli_FIND_REQUIRED)
+-      message(STATUS "${BROTLI_ERR_MSG}")
+-    endif (Brotli_FIND_REQUIRED)
+-  endif ()
++  message(FATAL_ERROR "Could not find the Brotli library.")
+ endif ()
+ 
+ mark_as_advanced(
+diff --git a/cmake_modules/FindGTest.cmake b/cmake_modules/FindGTest.cmake
+deleted file mode 100644
+index c6ea16b..0000000
+--- a/cmake_modules/FindGTest.cmake
++++ /dev/null
+@@ -1,94 +0,0 @@
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-# http://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-#
+-# Tries to find GTest headers and libraries.
+-#
+-# Usage of this module as follows:
+-#
+-#  find_package(GTest)
+-#
+-# Variables used by this module, they can change the default behaviour and need
+-# to be set before calling find_package:
+-#
+-#  GTest_HOME - When set, this path is inspected instead of standard library
+-#                locations as the root of the GTest installation.
+-#                The environment variable GTEST_HOME overrides this veriable.
+-#
+-# This module defines
+-#  GTEST_INCLUDE_DIR, directory containing headers
+-#  GTEST_LIBS, directory containing gtest libraries
+-#  GTEST_STATIC_LIB, path to libgtest.a
+-#  GTEST_MAIN_STATIC_LIB, path to libgtest_main.a
+-#  GTEST_SHARED_LIB, path to libgtest's shared library
+-#  GTEST_FOUND, whether gtest has been found
+-
+-if( NOT "$ENV{GTEST_HOME}" STREQUAL "")
+-    file( TO_CMAKE_PATH "$ENV{GTEST_HOME}" _native_path )
+-    list( APPEND _gtest_roots ${_native_path} )
+-elseif ( GTest_HOME )
+-    list( APPEND _gtest_roots ${GTest_HOME} )
+-endif()
+-
+-# Try the parameterized roots, if they exist
+-if ( _gtest_roots )
+-    find_path( GTEST_INCLUDE_DIR NAMES gtest/gtest.h
+-        PATHS ${_gtest_roots} NO_DEFAULT_PATH
+-        PATH_SUFFIXES "include" )
+-    find_library( GTEST_LIBRARIES NAMES gtest gtest_main
+-        PATHS ${_gtest_roots} NO_DEFAULT_PATH
+-        PATH_SUFFIXES "lib" )
+-else ()
+-    find_path( GTEST_INCLUDE_DIR NAMES gtest/gtest.h )
+-    find_library( GTEST_LIBRARIES NAMES gtest )
+-endif ()
+-
+-
+-if (GTEST_INCLUDE_DIR AND GTEST_LIBRARIES)
+-  set(GTEST_FOUND TRUE)
+-  get_filename_component( GTEST_LIBS ${GTEST_LIBRARIES} PATH )
+-  set(GTEST_LIB_NAME gtest)
+-  set(GTEST_STATIC_LIB ${GTEST_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${GTEST_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(GTEST_MAIN_STATIC_LIB ${GTEST_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${GTEST_LIB_NAME}_main${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(GTEST_SHARED_LIB ${GTEST_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${GTEST_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+-else ()
+-  set(GTEST_FOUND FALSE)
+-endif ()
+-
+-if (GTEST_FOUND)
+-  if (NOT GTest_FIND_QUIETLY)
+-    message(STATUS "Found the GTest library: ${GTEST_LIBRARIES}")
+-  endif ()
+-else ()
+-  if (NOT GTest_FIND_QUIETLY)
+-    set(GTEST_ERR_MSG "Could not find the GTest library. Looked in ")
+-    if ( _gtest_roots )
+-      set(GTEST_ERR_MSG "${GTEST_ERR_MSG} in ${_gtest_roots}.")
+-    else ()
+-      set(GTEST_ERR_MSG "${GTEST_ERR_MSG} system search paths.")
+-    endif ()
+-    if (GTest_FIND_REQUIRED)
+-      message(FATAL_ERROR "${GTEST_ERR_MSG}")
+-    else (GTest_FIND_REQUIRED)
+-      message(STATUS "${GTEST_ERR_MSG}")
+-    endif (GTest_FIND_REQUIRED)
+-  endif ()
+-endif ()
+-
+-mark_as_advanced(
+-  GTEST_INCLUDE_DIR
+-  GTEST_LIBS
+-  GTEST_LIBRARIES
+-  GTEST_STATIC_LIB
+-  GTEST_MAIN_STATIC_LIB
+-  GTEST_SHARED_LIB
+-)
+diff --git a/cmake_modules/FindLZ4.cmake b/cmake_modules/FindLZ4.cmake
+new file mode 100644
+index 0000000..8458d7f
+--- /dev/null
++++ b/cmake_modules/FindLZ4.cmake
+@@ -0,0 +1,62 @@
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# Tries to find LZ4 headers and libraries.
++#
++# Usage of this module as follows:
++#
++#  find_package(Snappy)
++#
++# This module defines
++#  LZ4_INCLUDE_DIR, directory containing headers
++#  LZ4_LIBS, directory containing LZ4 libraries
++#  LZ4_STATIC_LIB, path to lz4.a
++#  LZ4_SHARED_LIB, path to lz4's shared library
++#  LZ4_FOUND, whether LZ4 has been found
++
++find_path(LZ4_INCLUDE_DIR lz4.h
++  PATH_SUFFIXES "include")
++  
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(LZ4_LIB_SUFFIX "d")
++else()
++  set(LZ4_LIB_SUFFIX "")
++endif()
++
++find_library( LZ4_LIBRARIES NAMES lz4${LZ4_LIB_SUFFIX}
++  PATH_SUFFIXES "lib")
++
++if (LZ4_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR LZ4_LIBRARIES))
++  set(LZ4_FOUND TRUE)
++  get_filename_component( LZ4_LIBS ${LZ4_LIBRARIES} PATH )
++  set(LZ4_HEADER_NAME lz4.h)
++  set(LZ4_HEADER ${LZ4_INCLUDE_DIR}/${LZ4_HEADER_NAME})
++  set(LZ4_STATIC_LIB ${LZ4_LIBRARIES})
++  set(LZ4_SHARED_LIB ${LZ4_LIBRARIES})
++else ()
++  set(LZ4_FOUND FALSE)
++endif ()
++
++if (LZ4_FOUND)
++  message(STATUS "Found the LZ4 library: ${LZ4_LIBRARIES}")
++else ()
++  message(FATAL_ERROR "Could not find the LZ4 library.")
++endif ()
++
++mark_as_advanced(
++  LZ4_INCLUDE_DIR
++  LZ4_LIBS
++  LZ4_LIBRARIES
++  LZ4_STATIC_LIB
++  LZ4_SHARED_LIB
++)
+diff --git a/cmake_modules/FindSnappy.cmake b/cmake_modules/FindSnappy.cmake
+index 867963c..cc68688 100644
+--- a/cmake_modules/FindSnappy.cmake
++++ b/cmake_modules/FindSnappy.cmake
+@@ -17,13 +17,6 @@
+ #
+ #  find_package(Snappy)
+ #
+-# Variables used by this module, they can change the default behaviour and need
+-# to be set before calling find_package:
+-#
+-#  Snappy_HOME - When set, this path is inspected instead of standard library
+-#                locations as the root of the Snappy installation.
+-#                The environment variable SNAPPY_HOME overrides this variable.
+-#
+ # This module defines
+ #  SNAPPY_INCLUDE_DIR, directory containing headers
+ #  SNAPPY_LIBS, directory containing snappy libraries
+@@ -31,22 +24,16 @@
+ #  SNAPPY_SHARED_LIB, path to libsnappy's shared library
+ #  SNAPPY_FOUND, whether snappy has been found
+ 
+-if( NOT "${SNAPPY_HOME}" STREQUAL "")
+-    file( TO_CMAKE_PATH "${SNAPPY_HOME}" _native_path )
+-    list( APPEND _snappy_roots ${_native_path} )
+-elseif ( Snappy_HOME )
+-    list( APPEND _snappy_roots ${Snappy_HOME} )
+-endif()
+-
+-message(STATUS "SNAPPY_HOME: ${SNAPPY_HOME}")
+-find_path(SNAPPY_INCLUDE_DIR snappy.h HINTS
+-  ${_snappy_roots}
+-  NO_DEFAULT_PATH
++find_path(SNAPPY_INCLUDE_DIR snappy.h
+   PATH_SUFFIXES "include")
++  
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(SNAPPY_LIB_SUFFIX "d")
++else()
++  set(SNAPPY_LIB_SUFFIX "")
++endif()
+ 
+-find_library( SNAPPY_LIBRARIES NAMES snappy PATHS
+-  ${_snappy_roots}
+-  NO_DEFAULT_PATH
++find_library( SNAPPY_LIBRARIES NAMES snappy${SNAPPY_LIB_SUFFIX}
+   PATH_SUFFIXES "lib")
+ 
+ if (SNAPPY_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR SNAPPY_LIBRARIES))
+@@ -54,9 +41,8 @@ if (SNAPPY_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR SNAPPY_LIBRARIES))
+   get_filename_component( SNAPPY_LIBS ${SNAPPY_LIBRARIES} PATH )
+   set(SNAPPY_HEADER_NAME snappy.h)
+   set(SNAPPY_HEADER ${SNAPPY_INCLUDE_DIR}/${SNAPPY_HEADER_NAME})
+-  set(SNAPPY_LIB_NAME snappy)
+-  set(SNAPPY_STATIC_LIB ${SNAPPY_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${SNAPPY_LIB_NAME}${SNAPPY_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(SNAPPY_SHARED_LIB ${SNAPPY_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${SNAPPY_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
++  set(SNAPPY_STATIC_LIB ${SNAPPY_LIBRARIES})
++  set(SNAPPY_SHARED_LIB ${SNAPPY_LIBRARIES})
+ else ()
+   set(SNAPPY_FOUND FALSE)
+ endif ()
+diff --git a/cmake_modules/FindThrift.cmake b/cmake_modules/FindThrift.cmake
+index 25f5082..f27857f 100644
+--- a/cmake_modules/FindThrift.cmake
++++ b/cmake_modules/FindThrift.cmake
+@@ -14,55 +14,28 @@
+ 
+ # - Find Thrift (a cross platform RPC lib/tool)
+ #
+-# Variables used by this module, they can change the default behaviour and need
+-# to be set before calling find_package:
+-#
+-#  Thrift_HOME - When set, this path is inspected instead of standard library
+-#                locations as the root of the Thrift installation.
+-#                The environment variable THRIFT_HOME overrides this variable.
+-#
+ # This module defines
+ #  THRIFT_VERSION, version string of ant if found
+ #  THRIFT_INCLUDE_DIR, where to find THRIFT headers
+-#  THRIFT_CONTRIB_DIR, where contrib thrift files (e.g. fb303.thrift) are installed
+ #  THRIFT_STATIC_LIB, THRIFT static library
+ #  THRIFT_FOUND, If false, do not try to use ant
+ 
+-# prefer the thrift version supplied in THRIFT_HOME
+-if( NOT "${THRIFT_HOME}" STREQUAL "")
+-    file( TO_CMAKE_PATH "${THRIFT_HOME}" _native_path )
+-    list( APPEND _thrift_roots ${_native_path} )
+-elseif ( Thrift_HOME )
+-    list( APPEND _thrift_roots ${Thrift_HOME} )
+-endif()
+-
+-message(STATUS "THRIFT_HOME: ${THRIFT_HOME}")
+-find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h HINTS
+-  ${_thrift_roots}
+-  NO_DEFAULT_PATH
++find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h
+   PATH_SUFFIXES "include"
+ )
+ 
+-find_path(THRIFT_CONTRIB_DIR share/fb303/if/fb303.thrift HINTS
+-  ${_thrift_roots}
+-  NO_DEFAULT_PATH
+-)
+-
+-if (MSVC AND NOT THRIFT_MSVC_STATIC_LIB_SUFFIX)
+-  set(THRIFT_MSVC_STATIC_LIB_SUFFIX md)
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(THRIFT_LIB_SUFFIX mdd)
++else()
++  set(THRIFT_LIB_SUFFIX md)
+ endif()
+ 
+ find_library(THRIFT_STATIC_LIB NAMES
+-  ${CMAKE_STATIC_LIBRARY_PREFIX}thrift${THRIFT_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
+-  HINTS ${_thrift_roots}
+-  NO_DEFAULT_PATH
+-  PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib"
++  thrift${THRIFT_LIB_SUFFIX}
+ )
+ 
+ find_program(THRIFT_COMPILER thrift HINTS
+-  ${_thrift_roots}
+-  NO_DEFAULT_PATH
+-  PATH_SUFFIXES "bin"
++  PATH_SUFFIXES "tools"
+ )
+ 
+ if (THRIFT_STATIC_LIB)
+@@ -94,7 +67,6 @@ else ()
+   endif ()
+ endif ()
+ 
+-
+ mark_as_advanced(
+   THRIFT_STATIC_LIB
+   THRIFT_COMPILER
+diff --git a/cmake_modules/FindZLIB.cmake b/cmake_modules/FindZLIB.cmake
+index 78b84f2..1ef0305 100644
+--- a/cmake_modules/FindZLIB.cmake
++++ b/cmake_modules/FindZLIB.cmake
+@@ -32,27 +32,17 @@
+ #  ZLIB_SHARED_LIB, path to libz's shared library
+ #  ZLIB_FOUND, whether zlib has been found
+ 
+-if( NOT "${ZLIB_HOME}" STREQUAL "")
+-    file( TO_CMAKE_PATH "${ZLIB_HOME}" _native_path )
+-    list( APPEND _zlib_roots ${_native_path} )
+-elseif ( ZLIB_HOME )
+-    list( APPEND _zlib_roots ${ZLIB_HOME} )
++find_path( ZLIB_INCLUDE_DIR NAMES zlib.h
++	PATH_SUFFIXES "include" )
++	
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(ZLIB_LIB_SUFFIX "d")
++else()
++  set(ZLIB_LIB_SUFFIX "")
+ endif()
+-
+-# Try the parameterized roots, if they exist
+-if ( _zlib_roots )
+-    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h
+-        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+-        PATH_SUFFIXES "include" )
+-    find_library( ZLIB_LIBRARIES NAMES libz.a zlib
+-        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+-        PATH_SUFFIXES "lib" )
+-else ()
+-    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h )
+-    # Only look for the static library
+-    find_library( ZLIB_LIBRARIES NAMES libz.a zlib )
+-endif ()
+-
++	
++find_library( ZLIB_LIBRARIES NAMES libz.a zlib${ZLIB_LIB_SUFFIX}
++	PATH_SUFFIXES "lib" )
+ 
+ if (ZLIB_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZLIB_LIBRARIES))
+   set(ZLIB_FOUND TRUE)
+@@ -66,8 +56,8 @@ if (ZLIB_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZLIB_LIBRARIES))
+     endif()
+     set(ZLIB_MSVC_SHARED_LIB_SUFFIX lib)
+   endif()
+-  set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+-  set(ZLIB_SHARED_LIB ${ZLIB_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${ZLIB_LIB_NAME}${ZLIB_MSVC_SHARED_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
++  set(ZLIB_STATIC_LIB ${ZLIB_LIBRARIES})
++  set(ZLIB_SHARED_LIB ${ZLIB_LIBRARIES})
+ else ()
+   set(ZLIB_FOUND FALSE)
+ endif ()
+diff --git a/cmake_modules/FindZSTD.cmake b/cmake_modules/FindZSTD.cmake
+new file mode 100644
+index 0000000..062cfa9
+--- /dev/null
++++ b/cmake_modules/FindZSTD.cmake
+@@ -0,0 +1,62 @@
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++# http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++#
++# Tries to find ZSTD headers and libraries.
++#
++# Usage of this module as follows:
++#
++#  find_package(Snappy)
++#
++# This module defines
++#  ZSTD_INCLUDE_DIR, directory containing headers
++#  ZSTD_LIBS, directory containing ZSTD libraries
++#  ZSTD_STATIC_LIB, path to zstd.a
++#  ZSTD_SHARED_LIB, path to ZSTD's shared library
++#  ZSTD_FOUND, whether ZSTD has been found
++
++find_path(ZSTD_INCLUDE_DIR ZSTD.h
++  PATH_SUFFIXES "include")
++  
++if(CMAKE_BUILD_TYPE STREQUAL "DEBUG")
++  set(ZSTD_LIB_SUFFIX "d")
++else()
++  set(ZSTD_LIB_SUFFIX "")
++endif()
++
++find_library( ZSTD_LIBRARIES NAMES zstd${ZSTD_LIB_SUFFIX} zstd_static${ZSTD_LIB_SUFFIX}
++  PATH_SUFFIXES "lib")
++
++if (ZSTD_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ZSTD_LIBRARIES))
++  set(ZSTD_FOUND TRUE)
++  get_filename_component( ZSTD_LIBS ${ZSTD_LIBRARIES} PATH )
++  set(ZSTD_HEADER_NAME zstd.h)
++  set(ZSTD_HEADER ${ZSTD_INCLUDE_DIR}/${ZSTD_HEADER_NAME})
++  set(ZSTD_STATIC_LIB ${ZSTD_LIBRARIES})
++  set(ZSTD_SHARED_LIB ${ZSTD_LIBRARIES})
++else ()
++  set(ZSTD_FOUND FALSE)
++endif ()
++
++if (ZSTD_FOUND)
++  message(STATUS "Found the ZSTD library: ${ZSTD_LIBRARIES}")
++else ()
++  message(FATAL_ERROR "Could not find the ZSTD library.")
++endif ()
++
++mark_as_advanced(
++  ZSTD_INCLUDE_DIR
++  ZSTD_LIBS
++  ZSTD_LIBRARIES
++  ZSTD_STATIC_LIB
++  ZSTD_SHARED_LIB
++)
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index 690fd0b..d74bb3d 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -276,54 +276,11 @@ endif()
+ if(PARQUET_BUILD_TESTS AND NOT IGNORE_OPTIONAL_PACKAGES)
+   add_custom_target(unittest ctest -L unittest)
+ 
+-  if("$ENV{GTEST_HOME}" STREQUAL "")
+-    if(APPLE)
+-      set(GTEST_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes")
+-    else()
+-      set(GTEST_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS}")
+-    endif()
+-
+-    set(GTEST_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest_ep-prefix/src/googletest_ep")
+-    set(GTEST_INCLUDE_DIR "${GTEST_PREFIX}/include")
+-    set(GTEST_STATIC_LIB
+-      "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
+-    set(GTEST_MAIN_STATIC_LIB
+-      "${GTEST_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
+-
+-    set(GTEST_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-                         -DCMAKE_INSTALL_PREFIX=${GTEST_PREFIX}
+-                         -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS})
+-
+-    if (MSVC AND NOT PARQUET_USE_STATIC_CRT)
+-      set(GTEST_CMAKE_ARGS ${GTEST_CMAKE_ARGS} -Dgtest_force_shared_crt=ON)
+-    endif()
+-
+-    ExternalProject_Add(googletest_ep
+-      URL "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz"
+-      BUILD_BYPRODUCTS "${GTEST_STATIC_LIB}" "${GTEST_MAIN_STATIC_LIB}"
+-      CMAKE_ARGS ${GTEST_CMAKE_ARGS}
+-      ${EP_LOG_OPTIONS})
+-    set(GTEST_VENDORED 1)
+-  else()
+-    find_package(GTest REQUIRED)
+-    set(GTEST_VENDORED 0)
+-  endif()
++  find_package(GTest REQUIRED)
++  include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
+ 
+   message(STATUS "GTest include dir: ${GTEST_INCLUDE_DIR}")
+   message(STATUS "GTest static library: ${GTEST_STATIC_LIB}")
+-  include_directories(SYSTEM ${GTEST_INCLUDE_DIR})
+-
+-  add_library(gtest STATIC IMPORTED)
+-  set_target_properties(gtest PROPERTIES IMPORTED_LOCATION ${GTEST_STATIC_LIB})
+-
+-  add_library(gtest_main STATIC IMPORTED)
+-  set_target_properties(gtest_main PROPERTIES IMPORTED_LOCATION
+-    ${GTEST_MAIN_STATIC_LIB})
+-
+-  if(GTEST_VENDORED)
+-    add_dependencies(gtest googletest_ep)
+-    add_dependencies(gtest_main googletest_ep)
+-  endif()
+ endif()
+ 
+ ## Google Benchmark

--- a/ports/parquet/portfile.cmake
+++ b/ports/parquet/portfile.cmake
@@ -1,0 +1,60 @@
+include(vcpkg_common_functions)
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+  message(FATAL_ERROR "Apache Parquet only supports x64")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO apache/parquet-cpp
+    REF apache-parquet-cpp-1.4.0
+    SHA512 a6c12e39dcae123ae1893f7fc32bae32e32a1943182b1c0c1c2726134ee4fa6470d73a6ff8e3ce312eeb250d7fa35c9b9f3c227a35ba0aa6f873ce3954217bed
+    HEAD_REF master
+)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    "${CMAKE_CURRENT_LIST_DIR}/all.patch"
+)
+
+SET(ENV{GTEST_HOME} ${CURRENT_INSTALLED_DIR})
+
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" PARQUET_BUILD_SHARED)
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" PARQUET_BUILD_STATIC)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+	-DTHRIFT_HOME=${CURRENT_INSTALLED_DIR}
+	-DARROW_HOME=${CURRENT_INSTALLED_DIR}
+    -DPARQUET_BUILD_STATIC=${PARQUET_BUILD_STATIC}
+    -DPARQUET_BUILD_SHARED=${PARQUET_BUILD_SHARED}
+	-DPARQUET_ARROW_LINKAGE=${VCPKG_LIBRARY_LINKAGE}
+	-DPARQUET_BUILD_TOOLCHAIN=${CURRENT_INSTALLED_DIR}
+	-DPARQUET_BOOST_USE_SHARED=${PARQUET_BUILD_SHARED}
+	#-DARROW_STATIC=ON
+)
+
+vcpkg_install_cmake()
+
+#if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+#    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/lib/arrow.lib)
+#    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/arrow.lib)
+#    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
+#else()
+#    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/arrow_static.lib)
+#endif()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/parquet RENAME copyright)
+
+# Put CMake files in the right place
+file(INSTALL ${CURRENT_PACKAGES_DIR}/cmake/parquet-cppConfig.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/parquet)
+file(INSTALL ${CURRENT_PACKAGES_DIR}/cmake/parquet-cppConfigVersion.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/parquet RENAME parquet-cppConfigVersion-release.cmake)
+file(INSTALL ${CURRENT_PACKAGES_DIR}/debug/cmake/parquet-cppConfigVersion.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/parquet RENAME parquet-cppConfigVersion-debug.cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/parquet/portfile.cmake
+++ b/ports/parquet/portfile.cmake
@@ -34,18 +34,9 @@ vcpkg_configure_cmake(
 	-DPARQUET_ARROW_LINKAGE=${VCPKG_LIBRARY_LINKAGE}
 	-DPARQUET_BUILD_TOOLCHAIN=${CURRENT_INSTALLED_DIR}
 	-DPARQUET_BOOST_USE_SHARED=${PARQUET_BUILD_SHARED}
-	#-DARROW_STATIC=ON
 )
 
 vcpkg_install_cmake()
-
-#if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-#    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/lib/arrow.lib)
-#    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/arrow.lib)
-#    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
-#else()
-#    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib ${CURRENT_PACKAGES_DIR}/debug/lib/arrow_static.lib)
-#endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/parquet RENAME copyright)
 


### PR DESCRIPTION
I wanted to build Parquet-cpp on Windows, so I made a port for it in Vcpkg. This also required updating the Arrow version. It all compiles for x64-windows-static and x64-windows, debug and release, but I haven't tried Linux.

I made a few changes to the original CMake code:
- The original behaviour didn't find the right .lib in many instances. So I simplified the find_* calls and trusted the default paths Vcpkg defines.
- The original FindGTest.cmake downloaded and compiled gtest if it couldn't find it, and had a different interface to the standard FindGTest.cmake. So I switched to the standard way to find/use gtest.
- In Parquet, the transitive dependencies from Arrow are now handled without needing env variables.

I hope this is suitable for inclusion. Happy to make any changes or do my best with any questions!