### PR TITLE
compatible with non-English version of Windows

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -333,7 +333,7 @@ $vcpkgReleaseDir = "$vcpkgSourcesPath\release"
 if ($win64)
 {
     $architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
-    if ($architecture -ne "64-bit")
+    if (-not $architecture -like "*64*")
     {
         throw "Cannot build 64-bit on non-64-bit system"
     }


### PR DESCRIPTION
previous architecture checking technique assumes an English version of Windows, so `$architecture` returns `64 位` on the Chinese version, which makes checking failed.