### PR TITLE
[FlatBuffers] Support Non-Windows Platforms

### DIFF
--- a/ports/flatbuffers/CONTROL
+++ b/ports/flatbuffers/CONTROL
@@ -1,4 +1,4 @@
 Source: flatbuffers
-Version: 1.9.0
+Version: 1.9.0-1
 Description: Memory Efficient Serialization Library http://google.github.io/flatbuffers/
   FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility.

--- a/ports/flatbuffers/CONTROL
+++ b/ports/flatbuffers/CONTROL
@@ -1,4 +1,4 @@
 Source: flatbuffers
-Version: 1.9.0-1
+Version: 1.9.0-2
 Description: Memory Efficient Serialization Library http://google.github.io/flatbuffers/
   FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility.

--- a/ports/flatbuffers/ignore_use_of_cmake_toolchain_file.patch
+++ b/ports/flatbuffers/ignore_use_of_cmake_toolchain_file.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a3388dd..699ea3b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,7 +104,7 @@ set(FlatBuffers_GRPCTest_SRCS
+ # source_group(Compiler FILES ${FlatBuffers_Compiler_SRCS})
+ # source_group(Tests FILES ${FlatBuffers_Tests_SRCS})
+ 
+-if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
++if(EXISTS "${CMAKE_TOOLCHAIN_FILE}" AND NOT DEFINED VCPKG_TOOLCHAIN)
+   # do not apply any global settings if the toolchain
+   # is being configured externally
+ elseif(APPLE)

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -21,6 +21,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND OPTIONS -DFLATBUFFERS_BUILD_SHAREDLIB=ON)
 endif()
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/ignore_use_of_cmake_toolchain_file.patch
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
@@ -38,18 +43,18 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/flatbuffers")
 if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc.exe)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc${CMAKE_EXECUTABLE_SUFFIX})
     make_directory(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/flatc.exe ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc.exe)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/flatc${CMAKE_EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc${CMAKE_EXECUTABLE_SUFFIX})
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
 endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/flatbuffers.dll)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
     make_directory(${CURRENT_PACKAGES_DIR}/bin)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/flatbuffers.dll ${CURRENT_PACKAGES_DIR}/bin/flatbuffers.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/bin/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers.dll)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
     make_directory(${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers.dll ${CURRENT_PACKAGES_DIR}/debug/bin/flatbuffers.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/bin/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -10,51 +10,38 @@ vcpkg_from_github(
     REF v1.9.0
     SHA512 0ba07dbe5b2fde1d0a6e14ee26ee2816062541d934eda204b846a30c019362f2626761b628c900293928b9b546dba8ca477c13182e022c3e0e0a142fd67f0696
     HEAD_REF master
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/ignore_use_of_cmake_toolchain_file.patch
 )
 
+set(OPTIONS)
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     list(APPEND OPTIONS -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF)
 endif()
 
-set(OPTIONS)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    list(APPEND OPTIONS -DFLATBUFFERS_BUILD_SHAREDLIB=ON)
-endif()
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/ignore_use_of_cmake_toolchain_file.patch
-)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    PREFER_NINJA
     OPTIONS
         -DFLATBUFFERS_BUILD_TESTS=OFF
         -DFLATBUFFERS_BUILD_GRPCTEST=OFF
         ${OPTIONS}
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/flatbuffers")
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin AND NOT EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/flatc)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc${CMAKE_EXECUTABLE_SUFFIX})
+if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc.exe)
     make_directory(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/flatc${CMAKE_EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc${CMAKE_EXECUTABLE_SUFFIX})
+    file(
+        RENAME
+        ${CURRENT_PACKAGES_DIR}/bin/flatc.exe
+        ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc.exe
+    )
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
-endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
-    make_directory(${CURRENT_PACKAGES_DIR}/bin)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/bin/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
-endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
-    make_directory(${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/bin/flatbuffers${CMAKE_SHARED_LIBRARY_SUFFIX})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
Patch to ignore the use of a CMake toolchain file which allows the default compilation options to be used.

Use CMake suffixes to allow flatc and shared libraries to be copied on non-Windows systems.