### PR TITLE
Fix error C2338 in botan

### DIFF
--- a/ports/botan/CONTROL
+++ b/ports/botan/CONTROL
@@ -1,3 +1,3 @@
 Source: botan
-Version: 2.6.0-1
+Version: 2.6.0-2
 Description: A cryptography library written in C++11

--- a/ports/botan/fix-C2338.patch
+++ b/ports/botan/fix-C2338.patch
@@ -1,0 +1,13 @@
+diff --git a/cc/msvc.txt b/cc/msvc.txt
+index ed32a3c..9e78fff 100644
+--- a/cc/msvc.txt
++++ b/cc/msvc.txt
+@@ -10,7 +10,7 @@ add_include_dir_option "/I"
+ add_lib_dir_option "/LIBPATH:"
+ add_lib_option ""
+ 
+-compile_flags "/nologo /c"
++compile_flags "/nologo /c /D_ENABLE_EXTENDED_ALIGNED_STORAGE"
+ 
+ optimization_flags "/O2 /Oi"
+ size_optimization_flags "/O1 /Os"

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -11,6 +11,12 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}/src/build-data
+	PATCHES
+		${CMAKE_CURRENT_LIST_DIR}/fix-C2338.patch
+)
+
 vcpkg_find_acquire_program(JOM)
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)


### PR DESCRIPTION
1. Botan failed with error C2338, it should fix form the error message provides the instructions that add -D_ENABLE_EXTENDED_ALIGNED_STORAGE option.
2. Verified the latest botan 2.7.0 and error C2338 still exists, so add this patch in botan 2.6.0.