### PR TITLE
fix small bug in find_from_PATH

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -263,7 +263,7 @@ namespace vcpkg::Files
                 for (auto&& ext : EXTS)
                 {
                     auto p = fs::u8path(base + ext.c_str());
-                    if (Util::find(ret, p) != ret.end() && this->exists(p))
+                    if (Util::find(ret, p) == ret.end() && this->exists(p))
                     {
                         ret.push_back(p);
                         Debug::println("Found path: %s", p.u8string());


### PR DESCRIPTION
Hi

I think there is a small bug in find_from_PATH (introduced in #3314845a92852d3461a86d15ca5d6b2a6ca859eb).
This forces vcpkg to download a tool like cmake even if it is already installed on the machine on Windows.
The fix is just a "==" instead of a "!=".
Could you look at it please?