### PR TITLE
Add a port for https://github.com/graphql/libgraphqlparser

### DIFF
--- a/ports/graphqlparser/CONTROL
+++ b/ports/graphqlparser/CONTROL
@@ -1,0 +1,3 @@
+Source: graphqlparser
+Version: v0.7.0
+Description: A GraphQL query parser in C++ with C and C++ APIs

--- a/ports/graphqlparser/portfile.cmake
+++ b/ports/graphqlparser/portfile.cmake
@@ -21,22 +21,29 @@ vcpkg_from_github(
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/win-cmake.patch
 )
 
-vcpkg_find_acquire_program(PYTHON2)
-vcpkg_find_acquire_program(FLEX)
-vcpkg_find_acquire_program(BISON)
+if(UNIX)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+    )
+elseif(WIN32)
+    vcpkg_find_acquire_program(PYTHON2)
+    vcpkg_find_acquire_program(FLEX)
+    vcpkg_find_acquire_program(BISON)
 
-get_filename_component(VCPKG_DOWNLOADS_PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-get_filename_component(VCPKG_DOWNLOADS_FLEX_DIR "${FLEX}" DIRECTORY)
-get_filename_component(VCPKG_DOWNLOADS_BISON_DIR "${BISON}" DIRECTORY)
+    get_filename_component(VCPKG_DOWNLOADS_PYTHON2_DIR "${PYTHON2}" DIRECTORY)
+    get_filename_component(VCPKG_DOWNLOADS_FLEX_DIR "${FLEX}" DIRECTORY)
+    get_filename_component(VCPKG_DOWNLOADS_BISON_DIR "${BISON}" DIRECTORY)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DVCPKG_DOWNLOADS_PYTHON2_DIR=${VCPKG_DOWNLOADS_PYTHON2_DIR}
-        -DVCPKG_DOWNLOADS_FLEX_DIR=${VCPKG_DOWNLOADS_FLEX_DIR}
-        -DVCPKG_DOWNLOADS_BISON_DIR=${VCPKG_DOWNLOADS_BISON_DIR}
-)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DVCPKG_DOWNLOADS_PYTHON2_DIR=${VCPKG_DOWNLOADS_PYTHON2_DIR}
+            -DVCPKG_DOWNLOADS_FLEX_DIR=${VCPKG_DOWNLOADS_FLEX_DIR}
+            -DVCPKG_DOWNLOADS_BISON_DIR=${VCPKG_DOWNLOADS_BISON_DIR}
+    )
+endif()
 
 vcpkg_install_cmake()
 

--- a/ports/graphqlparser/portfile.cmake
+++ b/ports/graphqlparser/portfile.cmake
@@ -1,0 +1,44 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO graphql/libgraphqlparser
+    REF v0.7.0
+    SHA512 973292b164d0d2cfe453a2f01559dbdb1b9d22b6304f6a3aabf71e2c0a3e24ab69dfd72a086764ad5befecf0005620f8e86f552dacc324f9615a05f31de7cede
+    HEAD_REF master
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/win-cmake.patch
+)
+
+vcpkg_find_acquire_program(PYTHON2)
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(BISON)
+
+get_filename_component(VCPKG_DOWNLOADS_PYTHON2_DIR "${PYTHON2}" DIRECTORY)
+get_filename_component(VCPKG_DOWNLOADS_FLEX_DIR "${FLEX}" DIRECTORY)
+get_filename_component(VCPKG_DOWNLOADS_BISON_DIR "${BISON}" DIRECTORY)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DVCPKG_DOWNLOADS_PYTHON2_DIR=${VCPKG_DOWNLOADS_PYTHON2_DIR}
+        -DVCPKG_DOWNLOADS_FLEX_DIR=${VCPKG_DOWNLOADS_FLEX_DIR}
+        -DVCPKG_DOWNLOADS_BISON_DIR=${VCPKG_DOWNLOADS_BISON_DIR}
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/graphqlparser RENAME copyright)

--- a/ports/graphqlparser/win-cmake.patch
+++ b/ports/graphqlparser/win-cmake.patch
@@ -1,0 +1,138 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c4c8b3e..1ea9752 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,17 +2,21 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+ PROJECT(libgraphqlparser C CXX)
+ 
+ SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
++SET(CMAKE_PROGRAM_PATH "${VCPKG_DOWNLOADS_PYTHON2_DIR}" "${VCPKG_DOWNLOADS_FLEX_DIR}" "${VCPKG_DOWNLOADS_BISON_DIR}" "${CMAKE_PROGRAM_PATH}")
+ 
+ INCLUDE(version)
+ 
+-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+-
+ FIND_PACKAGE(PythonInterp 2 REQUIRED)
+ IF (NOT PYTHON_VERSION_MAJOR EQUAL 2)
+   MESSAGE(FATAL_ERROR "Python 2 is required.")
+ ENDIF()
+ 
+-FIND_PROGRAM(CTYPESGEN_FOUND ctypesgen.py)
++IF(UNIX)
++  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
++  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h")
++ELSEIF(WIN32)
++  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h --wincompat")
++ENDIF()
+ 
+ FIND_PACKAGE(BISON 3)
+ FIND_PACKAGE(FLEX)
+@@ -21,7 +25,7 @@ IF (BISON_FOUND)
+ ENDIF()
+ 
+ IF(FLEX_FOUND)
+-  FLEX_TARGET(GraphQLScanner lexer.lpp ${CMAKE_CURRENT_SOURCE_DIR}/lexer.cpp COMPILE_FLAGS "--header-file=lexer.h")
++  FLEX_TARGET(GraphQLScanner lexer.lpp ${CMAKE_CURRENT_SOURCE_DIR}/lexer.cpp COMPILE_FLAGS ${FLEX_COMPILE_FLAGS})
+   IF (BISON_FOUND)
+     ADD_FLEX_BISON_DEPENDENCY(GraphQLScanner graphqlparser)
+   ENDIF()
+@@ -31,7 +35,7 @@ FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/c)
+ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+ 
+-ADD_LIBRARY(graphqlparser SHARED
++SET(graphqlparserSources
+   JsonVisitor.cpp
+   ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
+   ${CMAKE_CURRENT_BINARY_DIR}/Ast.cpp
+@@ -52,13 +56,11 @@ ADD_LIBRARY(graphqlparser SHARED
+   lexer.h
+   GraphQLParser.cpp)
+ 
+-# Enable this and remove CMAKE_CXX_FLAGS fiddle above when we are able
+-# to upgrade to CMake 2.8.12. Blocker seems to be Travis CI being on
+-# Ubuntu Precise; Trusty has 2.8.12.
+-# TARGET_COMPILE_OPTIONS(graphqlparser PUBLIC -std=gnu++11)
+-
+-ADD_EXECUTABLE(dump_json_ast dump_json_ast.cpp)
+-TARGET_LINK_LIBRARIES(dump_json_ast graphqlparser)
++if (UNIX)
++  ADD_LIBRARY(graphqlparser SHARED ${graphqlparserSources})
++elseif (WIN32)
++  ADD_LIBRARY(graphqlparser STATIC ${graphqlparserSources})
++endif()
+ 
+ FUNCTION(GENERATE_AST_FILE FILE_TYPE FILE_RELATIVE_PATH)
+   ADD_CUSTOM_COMMAND(
+@@ -83,49 +85,28 @@ GENERATE_AST_FILE(cxx_json_visitor_header JsonVisitor.h.inc)
+ 
+ GENERATE_AST_FILE(cxx_json_visitor_impl JsonVisitor.cpp.inc)
+ 
+-ADD_SUBDIRECTORY(python)
+-
+-OPTION(test "Build tests." OFF)
+-
+-INSTALL(DIRECTORY c ${CMAKE_CURRENT_BINARY_DIR}/c DESTINATION include/graphqlparser
+-  FILES_MATCHING PATTERN "*.h"
+-  PATTERN "build" EXCLUDE)
+-
+-INSTALL(FILES
+-  ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
+-  AstNode.h
+-  ${CMAKE_CURRENT_BINARY_DIR}/AstVisitor.h
+-  GraphQLParser.h
+-  JsonVisitor.h
+-  lexer.h
+-  location.hh
+-  parser.tab.hpp
+-  position.hh
+-  stack.hh
+-  syntaxdefs.h
+-  DESTINATION include/graphqlparser)
+-INSTALL(TARGETS graphqlparser
+-  LIBRARY DESTINATION lib)
++IF (CMAKE_BUILD_TYPE STREQUAL "Release")
++  INSTALL(DIRECTORY c ${CMAKE_CURRENT_BINARY_DIR}/c DESTINATION include/graphqlparser
++    FILES_MATCHING PATTERN "*.h"
++    PATTERN "build" EXCLUDE)
++
++  INSTALL(FILES
++    ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
++    AstNode.h
++    ${CMAKE_CURRENT_BINARY_DIR}/AstVisitor.h
++    GraphQLParser.h
++    JsonVisitor.h
++    lexer.h
++    location.hh
++    parser.tab.hpp
++    position.hh
++    stack.hh
++    syntaxdefs.h
++    DESTINATION include/graphqlparser)
++ENDIF()
+ 
+ if (UNIX)
+-  # generate pkgconfig file
+-  include(FindPkgConfig QUIET)
+-  if(PKG_CONFIG_FOUND)
+-    # generate .pc and install
+-    configure_file("libgraphqlparser.pc.in" "libgraphqlparser.pc" @ONLY)
+-    install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/libgraphqlparser.pc"
+-            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+-  endif()
++  INSTALL(TARGETS graphqlparser LIBRARY DESTINATION lib)
++elseif (WIN32)
++  INSTALL(TARGETS graphqlparser ARCHIVE DESTINATION lib)
+ endif()
+-
+-IF (test)
+-  ADD_SUBDIRECTORY(test)
+-
+-  if(UNIX)
+-    # setup valgrind
+-    ADD_CUSTOM_TARGET(memcheck
+-      valgrind --leak-check=full --suppressions=./test/valgrind.supp --dsymutil=yes --error-exitcode=1 ./test/runTests  >/dev/null
+-    )
+-  endif()
+-
+-ENDIF()

--- a/ports/graphqlparser/win-cmake.patch
+++ b/ports/graphqlparser/win-cmake.patch
@@ -1,17 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c4c8b3e..1ea9752 100644
+index c4c8b3e..f19cda3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -2,17 +2,21 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
- PROJECT(libgraphqlparser C CXX)
+@@ -3,16 +3,37 @@ PROJECT(libgraphqlparser C CXX)
  
  SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
-+SET(CMAKE_PROGRAM_PATH "${VCPKG_DOWNLOADS_PYTHON2_DIR}" "${VCPKG_DOWNLOADS_FLEX_DIR}" "${VCPKG_DOWNLOADS_BISON_DIR}" "${CMAKE_PROGRAM_PATH}")
  
- INCLUDE(version)
+-INCLUDE(version)
++IF(UNIX)
++  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
++  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h")
++ELSEIF(WIN32)
++  # If we're building this with vcpkg on Windows, let portfile.cmake tell us where it
++  # stored these tools. Otherwise these variables should be empty and we'll fall back
++  # to the normal CMake FIND_PACKAGE logic for each of these programs.
++  SET(CMAKE_PROGRAM_PATH
++    "${VCPKG_DOWNLOADS_PYTHON2_DIR}"
++	"${VCPKG_DOWNLOADS_FLEX_DIR}"
++	"${VCPKG_DOWNLOADS_BISON_DIR}"
++	"${CMAKE_PROGRAM_PATH}")
++
++  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h --wincompat")
++
++  # Let CMake figure out the exports for the SHARED library (DLL) on Windows.
++  SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
++ENDIF()
  
 -SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
--
++INCLUDE(version)
+ 
  FIND_PACKAGE(PythonInterp 2 REQUIRED)
  IF (NOT PYTHON_VERSION_MAJOR EQUAL 2)
    MESSAGE(FATAL_ERROR "Python 2 is required.")
@@ -19,7 +36,6 @@ index c4c8b3e..1ea9752 100644
  
 -FIND_PROGRAM(CTYPESGEN_FOUND ctypesgen.py)
 +IF(UNIX)
-+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 +  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h")
 +ELSEIF(WIN32)
 +  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h --wincompat")
@@ -27,7 +43,7 @@ index c4c8b3e..1ea9752 100644
  
  FIND_PACKAGE(BISON 3)
  FIND_PACKAGE(FLEX)
-@@ -21,7 +25,7 @@ IF (BISON_FOUND)
+@@ -21,7 +42,7 @@ IF (BISON_FOUND)
  ENDIF()
  
  IF(FLEX_FOUND)
@@ -36,35 +52,7 @@ index c4c8b3e..1ea9752 100644
    IF (BISON_FOUND)
      ADD_FLEX_BISON_DEPENDENCY(GraphQLScanner graphqlparser)
    ENDIF()
-@@ -31,7 +35,7 @@ FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/c)
- INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
- INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
- 
--ADD_LIBRARY(graphqlparser SHARED
-+SET(graphqlparserSources
-   JsonVisitor.cpp
-   ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
-   ${CMAKE_CURRENT_BINARY_DIR}/Ast.cpp
-@@ -52,13 +56,11 @@ ADD_LIBRARY(graphqlparser SHARED
-   lexer.h
-   GraphQLParser.cpp)
- 
--# Enable this and remove CMAKE_CXX_FLAGS fiddle above when we are able
--# to upgrade to CMake 2.8.12. Blocker seems to be Travis CI being on
--# Ubuntu Precise; Trusty has 2.8.12.
--# TARGET_COMPILE_OPTIONS(graphqlparser PUBLIC -std=gnu++11)
--
--ADD_EXECUTABLE(dump_json_ast dump_json_ast.cpp)
--TARGET_LINK_LIBRARIES(dump_json_ast graphqlparser)
-+if (UNIX)
-+  ADD_LIBRARY(graphqlparser SHARED ${graphqlparserSources})
-+elseif (WIN32)
-+  ADD_LIBRARY(graphqlparser STATIC ${graphqlparserSources})
-+endif()
- 
- FUNCTION(GENERATE_AST_FILE FILE_TYPE FILE_RELATIVE_PATH)
-   ADD_CUSTOM_COMMAND(
-@@ -83,49 +85,28 @@ GENERATE_AST_FILE(cxx_json_visitor_header JsonVisitor.h.inc)
+@@ -83,11 +104,8 @@ GENERATE_AST_FILE(cxx_json_visitor_header JsonVisitor.h.inc)
  
  GENERATE_AST_FILE(cxx_json_visitor_impl JsonVisitor.cpp.inc)
  
@@ -72,57 +60,35 @@ index c4c8b3e..1ea9752 100644
 -
 -OPTION(test "Build tests." OFF)
 -
--INSTALL(DIRECTORY c ${CMAKE_CURRENT_BINARY_DIR}/c DESTINATION include/graphqlparser
--  FILES_MATCHING PATTERN "*.h"
--  PATTERN "build" EXCLUDE)
--
--INSTALL(FILES
--  ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
--  AstNode.h
--  ${CMAKE_CURRENT_BINARY_DIR}/AstVisitor.h
--  GraphQLParser.h
--  JsonVisitor.h
--  lexer.h
--  location.hh
--  parser.tab.hpp
--  position.hh
--  stack.hh
--  syntaxdefs.h
+ INSTALL(DIRECTORY c ${CMAKE_CURRENT_BINARY_DIR}/c DESTINATION include/graphqlparser
++  CONFIGURATIONS Release
+   FILES_MATCHING PATTERN "*.h"
+   PATTERN "build" EXCLUDE)
+ 
+@@ -103,9 +121,12 @@ INSTALL(FILES
+   position.hh
+   stack.hh
+   syntaxdefs.h
 -  DESTINATION include/graphqlparser)
--INSTALL(TARGETS graphqlparser
--  LIBRARY DESTINATION lib)
-+IF (CMAKE_BUILD_TYPE STREQUAL "Release")
-+  INSTALL(DIRECTORY c ${CMAKE_CURRENT_BINARY_DIR}/c DESTINATION include/graphqlparser
-+    FILES_MATCHING PATTERN "*.h"
-+    PATTERN "build" EXCLUDE)
++  DESTINATION include/graphqlparser
++  CONFIGURATIONS Release)
 +
-+  INSTALL(FILES
-+    ${CMAKE_CURRENT_BINARY_DIR}/Ast.h
-+    AstNode.h
-+    ${CMAKE_CURRENT_BINARY_DIR}/AstVisitor.h
-+    GraphQLParser.h
-+    JsonVisitor.h
-+    lexer.h
-+    location.hh
-+    parser.tab.hpp
-+    position.hh
-+    stack.hh
-+    syntaxdefs.h
-+    DESTINATION include/graphqlparser)
-+ENDIF()
+ INSTALL(TARGETS graphqlparser
+-  LIBRARY DESTINATION lib)
++  LIBRARY DESTINATION lib
++  RUNTIME DESTINATION bin)
  
  if (UNIX)
--  # generate pkgconfig file
--  include(FindPkgConfig QUIET)
--  if(PKG_CONFIG_FOUND)
--    # generate .pc and install
--    configure_file("libgraphqlparser.pc.in" "libgraphqlparser.pc" @ONLY)
--    install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/libgraphqlparser.pc"
--            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
--  endif()
-+  INSTALL(TARGETS graphqlparser LIBRARY DESTINATION lib)
-+elseif (WIN32)
-+  INSTALL(TARGETS graphqlparser ARCHIVE DESTINATION lib)
+   # generate pkgconfig file
+@@ -116,16 +137,9 @@ if (UNIX)
+     install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/libgraphqlparser.pc"
+             DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+   endif()
++elseif(WIN32)
++  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/graphqlparser.lib
++	DESTINATION lib)
++  INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/graphqlparser.pdb
++	DESTINATION bin)
  endif()
 -
 -IF (test)


### PR DESCRIPTION
The latest release of this library doesn't support building on Windows, so I included a patch which feeds the paths to win_flex, win_bison, and python2 from vcpkg_find_acquire_program into the build and adds them to the CMAKE_PROGRAM_PATH. I've tested this on Windows and Linux (with WSL).