### PR TITLE
[Catch2] Update to 2.3.0

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,4 +1,4 @@
 Source: catch2
-Version: 2.2.3
+Version: 2.3.0
 Description: A modern, header-only test framework for unit testing.
   Issues, PRs and changelogs can be found at https://github.com/catchorg/Catch2

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
-    REF v2.2.3
-    SHA512 d065d5797045ce85f576977f78cbdc77a1e8ab820e164aafd91d305aa10a29f7f306734d484714ec05078858457d0a17a57a6246166da3c8f3c708a23a2adc46
+    REF v2.3.0
+    SHA512 e9a089b504c339e87bda0fb1a4040d9d19c932a4bc7dca41bdad6edfcf8c428f4152ff1e0c898dfdf6b20bd5d901c343bed00ad89351fa5182f3c106e0fb4b03
     HEAD_REF master
 )
 
@@ -22,9 +22,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2 TARGET_PATH share/catch2)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
 
-if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch/catch.hpp)
+if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
     message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
 endif()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch/catch.hpp>")
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/catch2 RENAME copyright)


### PR DESCRIPTION
This updates catch2 to 2.3.0

Among other things, with this release, the include path for catch2 header files changes from 

    #include <catch/catch.hpp> 

to 

    #include <catch2/catch.hpp> 

I could add a compatibility forwarder just as it is currently possible to use #include <catch.hpp>, but to be completely honest, I'd rather encourage people to switch to the new official include path than encouraging more and more software to rely on the deprecated one (which was only valid for a relatively short period of time anyway).

Sooner or later, I'd also suggest to remove the current compatibility header that allows `#include <catch.hpp>`.
