### PR TITLE
Patch Antlr4 VS project file with dynamic CRT linkage

### DIFF
--- a/ports/antlr4/crt_md.patch
+++ b/ports/antlr4/crt_md.patch
@@ -1,0 +1,36 @@
+﻿diff --git a/runtime/antlr4cpp-vs2015.vcxproj b/runtime/antlr4cpp-vs2015.vcxproj
+index 85fa3da..540f031 100644
+--- a/runtime/antlr4cpp-vs2015.vcxproj
++++ b/runtime/antlr4cpp-vs2015.vcxproj
+@@ -201,6 +201,7 @@
+       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+       <MinimalRebuild>false</MinimalRebuild>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <SubSystem>Windows</SubSystem>
+@@ -239,6 +240,7 @@
+       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+       <MinimalRebuild>false</MinimalRebuild>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <SubSystem>Windows</SubSystem>
+@@ -281,6 +283,7 @@
+       </ForcedIncludeFiles>
+       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <SubSystem>Windows</SubSystem>
+@@ -325,6 +328,7 @@
+       </ForcedIncludeFiles>
+       <DisableSpecificWarnings>4251</DisableSpecificWarnings>
+       <MultiProcessorCompilation>true</MultiProcessorCompilation>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <SubSystem>Windows</SubSystem>

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -24,8 +24,7 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
     SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
-    PATCHES     ${CMAKE_CURRENT_LIST_DIR}/crt_mt.patch
-                ${CMAKE_CURRENT_LIST_DIR}/Fix-building-in-Visual-Studio-2017.patch
+    PATCHES     ${CMAKE_CURRENT_LIST_DIR}/Fix-building-in-Visual-Studio-2017.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -34,6 +33,18 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 else()
     set(DEBUG_CONFIG   "Debug DLL")
     set(RELEASE_CONFIG "Release DLL")
+endif()
+
+if (VCPKG_CRT_LINKAGE STREQUAL "static")
+    vcpkg_apply_patches(
+        SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
+        PATCHES     ${CMAKE_CURRENT_LIST_DIR}/crt_mt.patch
+    )
+else()
+    vcpkg_apply_patches(
+        SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src
+        PATCHES     ${CMAKE_CURRENT_LIST_DIR}/crt_md.patch
+    )
 endif()
 
 vcpkg_build_msbuild(


### PR DESCRIPTION
The Antlr4 runtime port currently only builds against the static CRT (via the `crt_mt` patch that's applied by the `portfile.cmake`).

This seems the wrong thing to do a) if the user requests the dynamic CRT, and b) because building the dynamic version of the Antlr runtime against the static CRT seems [problematic](https://msdn.microsoft.com/en-gb/library/ms235460.aspx?f=255&MSPPError=-2147217396).

The attached patch alters `portfile.cmake` to apply `crt_mt.patch` if the user has requested the static CRT, but to apply a different patch, `crt_md.patch` if the dynamic CRT is requested. These select the static and dynamic CRTs respectively.