### PR TITLE
[cxxopts] Install via cmake

### DIFF
--- a/ports/cxxopts/CONTROL
+++ b/ports/cxxopts/CONTROL
@@ -1,3 +1,3 @@
 Source: cxxopts
-Version: 2.1.0
+Version: 2.1.0-1
 Description: This is a lightweight C++ option parser library, supporting the standard GNU style syntax for options

--- a/ports/cxxopts/portfile.cmake
+++ b/ports/cxxopts/portfile.cmake
@@ -6,6 +6,18 @@ vcpkg_from_github(
     SHA512 b3549bb36fd3cb27b30a7164992ce19ddf129e7ee071956d58047101e4181cd9f08c8dd4c5e2d5499628deeb52a40bbc2fecfe68e9875c07396e6b7434161603
     HEAD_REF master
 )
-file(INSTALL ${SOURCE_PATH}/include/cxxopts.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCXXOPTS_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/cxxopts TARGET_PATH share/cxxopts)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cxxopts RENAME copyright)
-vcpkg_copy_pdbs()


### PR DESCRIPTION
cxxopts is a header only library, but it can be installed via cmake, which allows the     

    find_package(cxxopts CONFIG REQUIRED)
    target_link_libraries(main PRIVATE cxxopts::cxxopts)

pattern.