### PR TITLE
[liblzma] Update to 2.5.4

### DIFF
--- a/ports/liblzma/CMakeLists.txt
+++ b/ports/liblzma/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT MSVC)
 endif()
 
 if(WIN32)
-    include_directories(windows)
+    include_directories(windows/vs2017)
 else()
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h

--- a/ports/liblzma/CONTROL
+++ b/ports/liblzma/CONTROL
@@ -1,3 +1,3 @@
 Source: liblzma
-Version: 5.2.3-2
+Version: 5.2.4
 Description: Compression library with an API similar to that of zlib.

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -7,8 +7,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xz-mirror/xz
-    REF 06eebd4543196ded36fa9b8b9544195b38b24ef2
-    SHA512 978f49412bb8edaf3ca9b3db958f2f558cceb674a8b1dc641e8030249e48a08a14ed4a637140a922ac2a873fc66a610e4bb87bcb8812f80a072caa29403fdc8c
+    REF v5.2.4
+    SHA512 fce7dc65e77a9b89dbdd6192cb37efc39e3f2cf343f79b54d2dfcd845025dab0e1d5b0f59c264eab04e5cbaf914eeb4818d14cdaac3ae0c1c5de24418656a4b7
     HEAD_REF master
 )
 

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -7,8 +7,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xz-mirror/xz
-    REF v5.2.3
-    SHA512 d126666e58c6536aa7ae6aa6aac480f421e25aa61c4b5e7adb3de7b99423275a94d583ceaf0b15d559eaf9bc9be18f381cd46e49b1f8cb238c1d715876731063
+    REF 06eebd4543196ded36fa9b8b9544195b38b24ef2
+    SHA512 978f49412bb8edaf3ca9b3db958f2f558cceb674a8b1dc641e8030249e48a08a14ed4a637140a922ac2a873fc66a610e4bb87bcb8812f80a072caa29403fdc8c
     HEAD_REF master
 )
 


### PR DESCRIPTION
This updates liblzma to 2.5.4. The location of the `config.h` file from Windows changed from `/windows/config.h` to `/windows/vs2017/config.h`, so the portsfile was updated to reflect that.

See https://tukaani.org/xz/ for the release history.