### PR TITLE
Upgrade protobuf to 3.6.1.

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.6.0.1
+Version: 3.6.1
 Description: Protocol Buffers - Google's data interchange format
 
 Feature: zlib

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/protobuf
-    REF v3.6.0.1
-    SHA512 63cd799d5d6edbb05a87bc07992271c5bdb9595366d698b4dc5476cc89dc278d1c43186b9e56340958aefea2ce23e15a9c3a550158414add868b56e789ceafe4
+    REF v3.6.1
+    SHA512 1bc175d24b49de1b1e41eaf39598194e583afffb924c86c8d2e569d935af21874be76b2cbd4d9655a1d38bac3d4cd811de88bc2c72d81bad79115e69e5b0d839
     HEAD_REF master
     PATCHES
         "${CMAKE_CURRENT_LIST_DIR}/js-embed.patch"


### PR DESCRIPTION
The 3.6.0.1 version of protobuf did not work correctly on Windows,
the 3.6.1 version allegedly does (and my tests pass).