### PR TITLE
[Live555] Add missing symbols due to missing C files and copy paste bug

### DIFF
--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(live555 CXX)
+project(live555 C CXX)
 
 include_directories(
     BasicUsageEnvironment/include
@@ -8,17 +8,17 @@ include_directories(
     UsageEnvironment/include
 )
 
-file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.cpp)
+file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
 
-file(GLOB GROUPSOCK_SRCS groupsock/*.cpp)
+file(GLOB GROUPSOCK_SRCS groupsock/*.c groupsock/*.cpp)
 add_library(groupsock ${GROUPSOCK_SRCS})
 
-file(GLOB LIVEMEDIA_SRCS liveMedia/*.cpp)
+file(GLOB LIVEMEDIA_SRCS liveMedia/*.c liveMedia/*.cpp)
 add_library(liveMedia ${LIVEMEDIA_SRCS})
 
-file(GLOB USAGE_ENVIRONMENT_SRCS UsageEnvironment/*.cpp)
-add_library(UsageEnvironment ${LIVEMEDIA_SRCS})
+file(GLOB USAGE_ENVIRONMENT_SRCS UsageEnvironment/*.c UsageEnvironment/*.cpp)
+add_library(UsageEnvironment ${USAGE_ENVIRONMENT_SRCS})
 
 install(TARGETS groupsock BasicUsageEnvironment liveMedia UsageEnvironment
     RUNTIME DESTINATION bin

--- a/ports/live555/CONTROL
+++ b/ports/live555/CONTROL
@@ -1,3 +1,3 @@
 Source: live555
-Version: 2018.07.07
+Version: 2018.07.07-1
 Description: A complete RTSP server application


### PR DESCRIPTION
When switching to VCPKG built live555 libs I noticed missing symbols. I did the minimal necessary changes to be able to build and then link successfully. Tested with X86/X64/debug/release VS2015 update 3. 