### PR TITLE
Remove invalid URL to bzip.org site

### DIFF
--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -2,7 +2,7 @@
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/bzip2-1.0.6)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/past-due/bzip2-mirror/releases/download/v1.0.6/bzip2-1.0.6.tar.gz" "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
+    URLS "https://github.com/past-due/bzip2-mirror/releases/download/v1.0.6/bzip2-1.0.6.tar.gz"
     FILENAME "bzip2-1.0.6.tar.gz"
     SHA512 00ace5438cfa0c577e5f578d8a808613187eff5217c35164ffe044fbafdfec9e98f4192c02a7d67e01e5a5ccced630583ad1003c37697219b0f147343a3fdd12)
     


### PR DESCRIPTION
We cannot download http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
It looks like the http://www.bzip.org domain is not registered anymore.

I have a build failing because of this:
https://ci.appveyor.com/project/dacap/laf/build/job/dvkndsw752mrvg4t
