### PR TITLE
[allegro5] Update to 5.2.4.0

### DIFF
--- a/ports/allegro5/CONTROL
+++ b/ports/allegro5/CONTROL
@@ -1,4 +1,4 @@
 Source: allegro5
-Version: 5.2.3.0
+Version: 5.2.4.0
 Description: Allegro is a cross-platform library mainly aimed at video game and multimedia programming. It handles common, low-level tasks such as creating windows, accepting user input, loading data, drawing images, playing sounds, etc. and generally abstracting away the underlying platform. However, Allegro is not a game engine: you are free to design and structure your program as you like.
 Build-Depends: opengl, zlib, freetype, libogg, libvorbis, libflac, openal-soft, libpng, bzip2, physfs, libtheora, opus, opusfile

--- a/ports/allegro5/portfile.cmake
+++ b/ports/allegro5/portfile.cmake
@@ -14,8 +14,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO liballeg/allegro5
-    REF 5.2.3.0
-    SHA512 419f036d0265062dbec0e9306b153de5af5375186f7b5b2fe62a80549fc0e2c2a6afff81a6772effa7624fe2e452ed0a2830872ef25cc3b23fea93af99f60ba9
+    REF 5.2.4.0
+    SHA512 46a7c7b65ffb49ae5c81e5a33d850b4ae94b59135fc9b15174ffe86133445ff328c623c2c48298d3f631cc6310d51f4f3f07b8b952ecbd360755001292cbda8b
     HEAD_REF master
 )
 


### PR DESCRIPTION
Updated the allegro5 port to 5.2.4.0 (released 24th February 2018) from 5.2.3.0.