### PR TITLE
[chakracore] Fix Windows port CRT linkage

### DIFF
--- a/ports/chakracore/CONTROL
+++ b/ports/chakracore/CONTROL
@@ -1,3 +1,3 @@
 Source: chakracore
-Version: 1.10.1
+Version: 1.10.1-1
 Description: Core part of the Chakra Javascript engine

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -2,8 +2,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     message(STATUS "Warning: Static building not supported yet. Building dynamic.")
     set(VCPKG_LIBRARY_LINKAGE dynamic)
 endif()
-if(VCPKG_CRT_LINKAGE STREQUAL static)
-    message(FATAL_ERROR "Static linking of the CRT is not yet supported.")
+
+set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore default is static CRT linkage
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+	set(CHAKRA_RUNTIME_LIB "dynamic_library")
 endif()
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
@@ -32,7 +34,7 @@ file(COPY ${SOURCE_PATH}/ DESTINATION ${BUILDTREE_PATH})
 
 vcpkg_build_msbuild(
     PROJECT_PATH ${BUILDTREE_PATH}/Build/Chakra.Core.sln
-    OPTIONS "/p:DotNetSdkRoot=${NETFXSDK_PATH}/" "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props"
+    OPTIONS "/p:DotNetSdkRoot=${NETFXSDK_PATH}/" "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props" "/p:RuntimeLib=${CHAKRA_RUNTIME_LIB}"
 )
 
 file(INSTALL

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -1,18 +1,10 @@
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
-endif()
-
-set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore default is static CRT linkage
-if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-	set(CHAKRA_RUNTIME_LIB "dynamic_library")
-endif()
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "UWP is not currently supported.")
 endif()
 
 include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -32,9 +24,17 @@ set(BUILDTREE_PATH ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})
 file(REMOVE_RECURSE ${BUILDTREE_PATH})
 file(COPY ${SOURCE_PATH}/ DESTINATION ${BUILDTREE_PATH})
 
+set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore default is static CRT linkage
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+	set(CHAKRA_RUNTIME_LIB "dynamic_library")
+endif()
+
 vcpkg_build_msbuild(
     PROJECT_PATH ${BUILDTREE_PATH}/Build/Chakra.Core.sln
-    OPTIONS "/p:DotNetSdkRoot=${NETFXSDK_PATH}/" "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props" "/p:RuntimeLib=${CHAKRA_RUNTIME_LIB}"
+    OPTIONS
+        "/p:DotNetSdkRoot=${NETFXSDK_PATH}/"
+        "/p:CustomBeforeMicrosoftCommonTargets=${CMAKE_CURRENT_LIST_DIR}/no-warning-as-error.props"
+        "/p:RuntimeLib=${CHAKRA_RUNTIME_LIB}"
 )
 
 file(INSTALL
@@ -70,6 +70,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         ${BUILDTREE_PATH}/Build/VcBuild/bin/${TRIPLET_SYSTEM_ARCH}_release/GCStress.exe
         ${BUILDTREE_PATH}/Build/VcBuild/bin/${TRIPLET_SYSTEM_ARCH}_release/rl.exe
         DESTINATION ${CURRENT_PACKAGES_DIR}/tools/chakracore)
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/chakracore)
 endif()
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
ChakraCore now supports both static and dynamic CRT linkage on Windows.

Additionally, current ChakraCore defaults to **static** CRT linkage if `/p:RuntimeLib=<something>` is not specified. So this port (prior to this PR) was actually static-linking the CRT when `VCPKG_CRT_LINKAGE=dynamic` was specified).

@ras0219-msft:
(The ChakraCore [wiki on this](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore) appears to be incorrect / poorly-phrased. For reference, see: [Chakra.Build.Default.props](https://github.com/Microsoft/ChakraCore/blob/master/Build/Chakra.Build.Default.props#L21).)