### PR TITLE
CURL: allow building of http2 option for uwp

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.0
+Version: 7.61.1
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1
+Version: 7.61.0
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -21,10 +21,6 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)
 # Support HTTP2 TSL Download https://curl.haxx.se/ca/cacert.pem rename to curl-ca-bundle.crt, copy it to libcurl.dll location.
 set(HTTP2_OPTIONS)
 if("http2" IN_LIST FEATURES)
-    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        message(FATAL_ERROR "The http2 feature cannot be enabled when building for UWP.")
-    endif()
-
     set(HTTP2_OPTIONS -DUSE_NGHTTP2=ON)
 endif()
 


### PR DESCRIPTION
This PR removes the uwp restriction when the http2 option for curl is enabled. The uwp version built with the http2 option builds and works fine.