### PR TITLE
[osg] Update to 3.6.2

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,4 +1,4 @@
 Source: osg
-Version: 3.6.2-rc3
+Version: 3.6.2
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -19,8 +19,8 @@ endif()
 vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO openscenegraph/OpenSceneGraph
-	REF OpenSceneGraph-3.6.2-rc3
-	SHA512 369c0790ad990cc0f5403209b6e8afe73069f4a467883f9031ac0539bdd090f2cd71487285e515da39bb5a5f67a15548edd479d489dc57374b481ed32ebed0eb
+	REF OpenSceneGraph-3.6.2
+	SHA512 6949dd4dea9dcffe4228086b72eafdb253bf1403b3b7a70a4727848c3cde23ad0270f41b1c3e2bdbfd410ec067ecce2052a5d26c61b032b6d46ce84b8c931bfb
 	HEAD_REF master
 )
 


### PR DESCRIPTION
1. Osg installation failed with https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.2-rc3.tar.gz can't be found.
2. After checking the https://github.com/openscenegraph/OpenSceneGraph/releases , there is no 3.6.2-rc3.
3. Update the version to 3.6.2.
4. Update the SHA512 hash too.