### PR TITLE
Update HEAD_REF for libimobiledevice-win32 projects

### DIFF
--- a/ports/ideviceinstaller/portfile.cmake
+++ b/ports/ideviceinstaller/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/ideviceinstaller
     REF 1.1.2.23
     SHA512 d0801b3a38eb02206a6f06e05cc19b794c69a87c06895165f64522c61e07030046499c5f0e436981682f9e17f91eae87913cca091e2e039a74ee35a5136100d4
-    HEAD_REF master
+    HEAD_REF msvc-master
 )
 
 vcpkg_install_msbuild(

--- a/ports/idevicerestore/portfile.cmake
+++ b/ports/idevicerestore/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/idevicerestore
     REF 1.0.12
     SHA512 ba623be56c2f37853516d7d4c32e16f1ec72f33d512f18aa812ce6830af4b9e389f7af5321888dd0ddd168e282b652e379b60f90970680e213eabf489f406915
-    HEAD_REF master
+    HEAD_REF msvc-master
 )
 
 vcpkg_install_msbuild(

--- a/ports/libideviceactivation/portfile.cmake
+++ b/ports/libideviceactivation/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/libideviceactivation
     REF 1.0.38
     SHA512 2fd2d5636e83a6740251dca58c04429628f47661a56e573fc14f45ef68c54990717515305902cf04759a7c8fd19e66a30c8eb2ea20e6257d2c5405b690ea25a6
-    HEAD_REF master
+    HEAD_REF msvc-master
 )
 
 vcpkg_install_msbuild(

--- a/ports/libimobiledevice/portfile.cmake
+++ b/ports/libimobiledevice/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/libimobiledevice
     REF 1.2.1.215
     SHA512 192ac12eb4fdf518a934cb8061d4a40e48f483e969e34167f2a5346efac1d745e4041eff84d7175d106b1a3b3f806d5e69643daa1459e48e69bc9c38d722be3c
-    HEAD_REF master
+    HEAD_REF msvc-master
 )
 
 vcpkg_install_msbuild(

--- a/ports/libirecovery/portfile.cmake
+++ b/ports/libirecovery/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/libirecovery
     REF 1.0.25
     SHA512 0dd91d4fe3ded2bc1bbd91aea964e31e7f59bce18be01aa096e974f37dc1be281644d6c44e3f9b49470dd961e3df2e3ff8a09bcc6b803a959073e7d7d9a8d3e7
-    HEAD_REF master
+    HEAD_REF msvc-master
 )
 
 vcpkg_install_msbuild(

--- a/ports/libplist/portfile.cmake
+++ b/ports/libplist/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/libplist
     REF 2.0.1.197
     SHA512 55e1817c61d608b11646eb9c28c445f9ee801c7beb2121bd810235561117262adb73dbecb23b9ef5b0c54b0fc8089e0a46acc0e8f4845329a50a663ab004052c
-    HEAD_REF master
+    HEAD_REF msvc-master
     PATCHES dllexport.patch
 )
 

--- a/ports/libusbmuxd/portfile.cmake
+++ b/ports/libusbmuxd/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/libusbmuxd
     REF 1.0.109
     SHA512 104205ebcac96765f4bf0b42dbe5df084be4f87fc64454b4e02049fbd18caf9282d070f8949935977eda76fba68b6a909571afea58d4ad4091f02d0e6b7a08e0
-    HEAD_REF master
+    HEAD_REF msvc-master
     PATCHES dllexport.patch
 )
 

--- a/ports/usbmuxd/portfile.cmake
+++ b/ports/usbmuxd/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO libimobiledevice-win32/usbmuxd
     REF 1.1.1.133
     SHA512 1a5f9abc239deeb15e2aab419ba9e88ef41ffa80396546fb65bc06b0f419cbabc80cdf95995caf71d5628d1537fb0329a73d923202e91ea43fcc7c32b840d047
-    HEAD_REF master
+    HEAD_REF master-msvc
 )
 
 vcpkg_install_msbuild(


### PR DESCRIPTION
For all the libimobiledevice-win32 related projects, the head ref (the branch which includes MSVC support) should be msvc-master, and not master. 