### PR TITLE
[libraw] fix linux

### DIFF
--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,4 +1,4 @@
 Source: libraw
-Version: 0.19.0
+Version: 0.19.0-1
 Build-Depends: lcms, jasper
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -47,6 +47,7 @@ else()
 endif()
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/libraw/libraw_types.h "${LIBRAW_H}")
 
+if(WIN32)
 # Rename thread-safe version to be "raw.lib". This is unfortunately needed
 # because otherwise libraries that build on top of libraw have to choose.
 file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/raw.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
@@ -54,16 +55,22 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/lib/raw_r.lib ${CURRENT_PACKAGES_DIR}/lib/ra
 file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/raw_rd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
 
 # Cleanup
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(GLOB RELEASE_EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/*.exe)
 file(REMOVE ${RELEASE_EXECUTABLES})
 file(GLOB DEBUG_EXECUTABLES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
 file(REMOVE ${DEBUG_EXECUTABLES})
+endif()
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+if(WIN32)
 else()
     file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/raw.dll ${CURRENT_PACKAGES_DIR}/debug/bin/rawd.dll)
 endif()
+endif()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Rename cmake module into a config in order to allow more flexible lookup rules
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/FindLibRaw.cmake ${CURRENT_PACKAGES_DIR}/share/libraw/LibRaw-config.cmake)

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -47,26 +47,26 @@ else()
 endif()
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/libraw/libraw_types.h "${LIBRAW_H}")
 
-if(WIN32)
-# Rename thread-safe version to be "raw.lib". This is unfortunately needed
-# because otherwise libraries that build on top of libraw have to choose.
-file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/raw.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
-file(RENAME ${CURRENT_PACKAGES_DIR}/lib/raw_r.lib ${CURRENT_PACKAGES_DIR}/lib/raw.lib)
-file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/raw_rd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
+if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    # Rename thread-safe version to be "raw.lib". This is unfortunately needed
+    # because otherwise libraries that build on top of libraw have to choose.
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/raw.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/raw_r.lib ${CURRENT_PACKAGES_DIR}/lib/raw.lib)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/raw_rd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
 
-# Cleanup
-file(GLOB RELEASE_EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/*.exe)
-file(REMOVE ${RELEASE_EXECUTABLES})
-file(GLOB DEBUG_EXECUTABLES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-file(REMOVE ${DEBUG_EXECUTABLES})
+    # Cleanup
+    file(GLOB RELEASE_EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+    file(REMOVE ${RELEASE_EXECUTABLES})
+    file(GLOB DEBUG_EXECUTABLES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+    file(REMOVE ${DEBUG_EXECUTABLES})
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-if(WIN32)
 else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/raw.dll ${CURRENT_PACKAGES_DIR}/debug/bin/rawd.dll)
-endif()
+    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/raw.dll ${CURRENT_PACKAGES_DIR}/debug/bin/rawd.dll)
+    endif()
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
error

```
CMake Error at ports/libraw/portfile.cmake:53 (file):
  file RENAME failed to rename
    /opt/vcpkg/packages/libraw_x64-linux/lib/raw_r.lib
  to
    /opt/vcpkg/packages/libraw_x64-linux/lib/raw.lib
  because: No such file or directory
Call Stack (most recent call first):
  scripts/ports.cmake:71 (include)
```

```
Include files should not be duplicated into the /debug/include directory. If this cannot be disabled in the project cmake, use
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
/debug/share should not exist. Please reorganize any important files, then use
    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
Found 2 error(s). Please correct the portfile:
    /opt/vcpkg/ports/libraw/portfile.cmake
-- Performing post-build validation done
```