### PR TITLE
Correctly configure GTK3 to reflect recomended stable release settings

### DIFF
--- a/ports/gtk/CMakeLists.txt
+++ b/ports/gtk/CMakeLists.txt
@@ -76,8 +76,11 @@ add_definitions(
     -DGTK_DISABLE_SINGLE_INCLUDES
     -D_USE_MATH_DEFINES)
 
+add_definitions(-DG_ENABLE_DEBUG)
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    add_definitions(-DG_ENABLE_DEBUG)
+	add_definitions(-DG_ENABLE_CONSISTENCY_CHECKS)
+else()
+	add_definitions(-DG_DISABLE_CAST_CHECKS)
 endif()
 
 macro(extract_vcproj_sources VC_PROJECT OUT_VAR)

--- a/ports/gtk/CONTROL
+++ b/ports/gtk/CONTROL
@@ -1,4 +1,4 @@
 Source: gtk
-Version: 3.22.19-1
+Version: 3.22.19-2
 Description: Portable library for creating graphical user interfaces.
 Build-Depends: glib, atk, gdk-pixbuf, pango, cairo, libepoxy, gettext


### PR DESCRIPTION
GTK/Glib packaging guidelines recomends a release build to use debugging
facilities set to level 'minimum'. Disabling this is officially not
recomended for stable releases. For more info read the following link,
the section `--enable-debug`.

https://developer.gnome.org/glib/stable/glib-building.html#extra-configuration-options