### PR TITLE
Fix issue with compiling vcpkg.exe (#4149)

### DIFF
--- a/scripts/cleanEnvironmentHelper.ps1
+++ b/scripts/cleanEnvironmentHelper.ps1
@@ -17,7 +17,7 @@ foreach ($name in $nameSet)
     }
 
     # PATH needs to be concatenated as it has values in both machine and user environment. Any other values should be set.
-    if ($name -match '^path$')
+    if ($name -eq 'path')
     {
         $pathValuePartial = @()
         # Machine values before user values

--- a/scripts/cleanEnvironmentHelper.ps1
+++ b/scripts/cleanEnvironmentHelper.ps1
@@ -17,7 +17,7 @@ foreach ($name in $nameSet)
     }
 
     # PATH needs to be concatenated as it has values in both machine and user environment. Any other values should be set.
-    if ($name -match 'path')
+    if ($name -match '^path$')
     {
         $pathValuePartial = @()
         # Machine values before user values


### PR DESCRIPTION
The check for environment variable PATH match other environment variables. 
When environment variable VCTargetsPath used by msbuild is changed in cleanEnvironmentHelper.ps1 the path is broken. This makes the compilation of vcpkg.exe fail.

This commit fix the issue by checking that environment variable PATH is exactly PATH.