### PR TITLE
[GraphicsMagick] bug-fix: image files won't load

### DIFF
--- a/ports/blaze/portfile.cmake
+++ b/ports/blaze/portfile.cmake
@@ -6,10 +6,6 @@ vcpkg_from_bitbucket(
     REF bbe39c81b68eb0d8647da703899e1ee4a82cdfd3
     SHA512 84eb8226672d9d11d194d165e7aaa333a0d49ca090bb94472f19242e5f2ad0c3e08a30cdafe055cff51b210b603533f879800bd6784f3ffdb0d9eeca65d58b25
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
         avoid-src-dir-generation.patch
 )

--- a/ports/graphicsmagick/disable_graphicsmagick_modules.patch
+++ b/ports/graphicsmagick/disable_graphicsmagick_modules.patch
@@ -1,0 +1,11 @@
+--- a/magick/studio.h	2018-06-23 14:13:49.191541000 -0400
++++ b/magick/studio.h	2018-09-02 11:50:41.856753700 -0400
+@@ -414,7 +414,7 @@
+ #endif
+ 
+ #if defined(HasLTDL) || ( defined(MSWINDOWS) && defined(_DLL) )
+-#  define SupportMagickModules
++//#  define SupportMagickModules
+ #endif
+ 
+ #if defined(_MAGICKMOD_)

--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -19,6 +19,15 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/dynamic_bzip2.patch)
 
+# Bake GM's own modules into the .dll itself.  This fixes a bug whereby
+# 'vcpkg install graphicsmagick' did not lead to a copy of GM that could
+# load either PNG or JPEG files (due to missing GM Modules, with names
+# matching "IM_*.DLL").
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/disable_graphicsmagick_modules.patch)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS_DEBUG -DINSTALL_HEADERS=OFF

--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -1,36 +1,35 @@
 include(vcpkg_common_functions)
 
 set(GM_VERSION 1.3.30)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/graphicsmagick-${GM_VERSION}-windows-source)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}-windows-source.7z"
     FILENAME "GraphicsMagick-${GM_VERSION}-windows-source.7z"
     SHA512 9e4cfff57ae547f133e6208033213d3aa790cd8c95a061c101c63b8ae8896e7504d02f302efdd20ff24f72c07760a0a5e2b32e21fe454717ed1deb2edeef159c
-    )
-vcpkg_extract_source_archive(${ARCHIVE})
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF "${GM_VERSION}"
+    PATCHES
+        # GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
+        dynamic_bzip2.patch
+
+        # Bake GM's own modules into the .dll itself.  This fixes a bug whereby
+        # 'vcpkg install graphicsmagick' did not lead to a copy of GM that could
+        # load either PNG or JPEG files (due to missing GM Modules, with names
+        # matching "IM_*.DLL").
+        disable_graphicsmagick_modules.patch
+)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/magick_types.h DESTINATION ${SOURCE_PATH}/magick)
 
-# GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/dynamic_bzip2.patch)
-
-# Bake GM's own modules into the .dll itself.  This fixes a bug whereby
-# 'vcpkg install graphicsmagick' did not lead to a copy of GM that could
-# load either PNG or JPEG files (due to missing GM Modules, with names
-# matching "IM_*.DLL").
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/disable_graphicsmagick_modules.patch)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS_DEBUG -DINSTALL_HEADERS=OFF
+    OPTIONS_DEBUG
+        -DINSTALL_HEADERS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/openmesh/CONTROL
+++ b/ports/openmesh/CONTROL
@@ -1,3 +1,3 @@
 Source: openmesh
-Version: 6.3
+Version: 7.0
 Description: A generic and efficient polygon mesh data structure

--- a/ports/openmesh/portfile.cmake
+++ b/ports/openmesh/portfile.cmake
@@ -1,24 +1,18 @@
-# Common Ambient Variables:
-#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
-#   PORT                      = current port name (zlib, etc)
-#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
-#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
-#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
-#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
-#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
-
 include(vcpkg_common_functions)
 
-vcpkg_from_gitlab(
+set(VERSION 7.0)
+
+# Note: upstream GitLab instance at https://graphics.rwth-aachen.de:9000 often goes down
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.openmesh.org/media/Releases/${VERSION}/OpenMesh-${VERSION}.tar.gz"
+    FILENAME "OpenMesh-${VERSION}.tar.gz"
+    SHA512 29280c8fe7208d39bd923c4d0444a24463e36b95402e6a75f42adc27bc1b261df9113442f69e1001dc1a8b1198488069ffb049742dcf6eac6ac1ecf4f216fad8
+)
+
+vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    GITLAB_URL "https://graphics.rwth-aachen.de:9000"
-    REPO "OpenMesh/OpenMesh"
-    REF "OpenMesh-7.0"
-    HEAD_REF "master"
-    SHA512 "70e414088c094199af31a8694fb91fa5f9b574b3cc86b30b3fb64d938e6a218f9f38d857c559f958276b01ec9263ef71cd4039444e50a8cb38e820243aac7956"
+    ARCHIVE "${ARCHIVE}"
+    REF "${VERSION}"
 )
 
 vcpkg_configure_cmake(

--- a/scripts/cmake/vcpkg_extract_source_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive.cmake
@@ -29,25 +29,19 @@
 ## * [msgpack](https://github.com/Microsoft/vcpkg/blob/master/ports/msgpack/portfile.cmake)
 include(vcpkg_execute_required_process)
 
-function(vcpkg_extract_source_archive_ex)
-    cmake_parse_arguments(_vesae "" "ARCHIVE;WORKING_DIRECTORY" "" ${ARGN})
-
-    if(NOT _vesae_ARCHIVE)
-        message(FATAL_ERROR "Must specify ARCHIVE parameter to vcpkg_extract_source_archive_ex()")
-    endif()
-
-    if(DEFINED _vesae_WORKING_DIRECTORY)
-        set(WORKING_DIRECTORY ${_vesae_WORKING_DIRECTORY})
+function(vcpkg_extract_source_archive ARCHIVE)
+    if(NOT ARGC EQUAL 2)
+        set(WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src")
     else()
-        set(WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src)
+        set(WORKING_DIRECTORY ${ARGV1})
     endif()
 
-    get_filename_component(ARCHIVE_FILENAME ${_vesae_ARCHIVE} NAME)
+    get_filename_component(ARCHIVE_FILENAME ${ARCHIVE} NAME)
     if(NOT EXISTS ${WORKING_DIRECTORY}/${ARCHIVE_FILENAME}.extracted)
-        message(STATUS "Extracting source ${_vesae_ARCHIVE}")
+        message(STATUS "Extracting source ${ARCHIVE}")
         file(MAKE_DIRECTORY ${WORKING_DIRECTORY})
         vcpkg_execute_required_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xjf ${_vesae_ARCHIVE}
+            COMMAND ${CMAKE_COMMAND} -E tar xjf ${ARCHIVE}
             WORKING_DIRECTORY ${WORKING_DIRECTORY}
             LOGNAME extract
         )
@@ -55,13 +49,81 @@ function(vcpkg_extract_source_archive_ex)
     endif()
 endfunction()
 
-function(vcpkg_extract_source_archive ARCHIVE)
-    if(NOT ARGC EQUAL 2)
-        vcpkg_extract_source_archive_ex(ARCHIVE ${ARCHIVE})
-    else()
-        vcpkg_extract_source_archive_ex(
-            ARCHIVE ${ARCHIVE}
-            WORKING_DIRECTORY ${ARGV1}
-        )
+function(vcpkg_extract_source_archive_ex)
+    cmake_parse_arguments(_vesae "NO_REMOVE_ONE_LEVEL" "OUT_SOURCE_PATH;ARCHIVE;REF;WORKING_DIRECTORY" "PATCHES" ${ARGN})
+
+    if(NOT _vesae_ARCHIVE)
+        message(FATAL_ERROR "Must specify ARCHIVE parameter to vcpkg_extract_source_archive_ex()")
     endif()
+
+    if(NOT DEFINED _vesae_OUT_SOURCE_PATH)
+        message(FATAL_ERROR "Must specify OUT_SOURCE_PATH parameter to vcpkg_extract_source_archive_ex()")
+    endif()
+
+    if(NOT DEFINED _vesae_WORKING_DIRECTORY)
+        set(_vesae_WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src)
+    endif()
+
+    if(NOT DEFINED _vesae_REF)
+        get_filename_component(_vesae_REF ${_vesae_ARCHIVE} NAME_WE)
+    endif()
+
+    string(REPLACE "/" "-" SANITIZED_REF "${_vesae_REF}")
+
+    # Take the last 10 chars of the REF
+    set(REF_MAX_LENGTH 10)
+    string(LENGTH ${SANITIZED_REF} REF_LENGTH)
+    math(EXPR FROM_REF ${REF_LENGTH}-${REF_MAX_LENGTH})
+    if(FROM_REF LESS 0)
+        set(FROM_REF 0)
+    endif()
+    string(SUBSTRING ${SANITIZED_REF} ${FROM_REF} ${REF_LENGTH} SHORTENED_SANITIZED_REF)
+
+    # Hash the archive hash along with the patches. Take the first 10 chars of the hash
+    file(SHA512 ${ARCHIVE} PATCHSET_HASH)
+    foreach(PATCH IN LISTS _vesae_PATCHES)
+        get_filename_component(ABSOLUTE_PATCH "${PATCH}" ABSOLUTE BASE_DIR "${CURRENT_PORT_DIR}")
+        file(SHA512 ${ABSOLUTE_PATCH} CURRENT_HASH)
+        string(APPEND PATCHSET_HASH ${CURRENT_HASH})
+    endforeach()
+
+    string(SHA512 PATCHSET_HASH ${PATCHSET_HASH})
+    string(SUBSTRING ${PATCHSET_HASH} 0 10 PATCHSET_HASH)
+    set(SOURCE_PATH "${_vesae_WORKING_DIRECTORY}/${SHORTENED_SANITIZED_REF}-${PATCHSET_HASH}")
+
+    if(NOT EXISTS ${SOURCE_PATH})
+        set(TEMP_DIR "${_vesae_WORKING_DIRECTORY}/TEMP")
+        file(REMOVE_RECURSE ${TEMP_DIR})
+        vcpkg_extract_source_archive("${ARCHIVE}" "${TEMP_DIR}")
+
+        if(_vesae_NO_REMOVE_ONE_LEVEL)
+            set(TEMP_SOURCE_PATH ${TEMP_DIR})
+        else()
+            file(GLOB _ARCHIVE_FILES "${TEMP_DIR}/*")
+            list(LENGTH _ARCHIVE_FILES _NUM_ARCHIVE_FILES)
+            set(TEMP_SOURCE_PATH)
+            foreach(dir IN LISTS _ARCHIVE_FILES)
+                if (IS_DIRECTORY ${dir})
+                    set(TEMP_SOURCE_PATH "${dir}")
+                    break()
+                endif()
+            endforeach()
+
+            if(NOT _NUM_ARCHIVE_FILES EQUAL 2 OR NOT TEMP_SOURCE_PATH)
+                message(FATAL_ERROR "Could not unwrap top level directory from archive. Pass NO_REMOVE_ONE_LEVEL to disable this.")
+            endif()
+        endif()
+
+        vcpkg_apply_patches(
+            SOURCE_PATH ${TEMP_SOURCE_PATH}
+            PATCHES ${_vesae_PATCHES}
+        )
+
+        file(RENAME ${TEMP_SOURCE_PATH} ${SOURCE_PATH})
+        file(REMOVE_RECURSE ${TEMP_DIR})
+    endif()
+
+    set(${_vesae_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    message(STATUS "Using source at ${SOURCE_PATH}")
+    return()
 endfunction()

--- a/scripts/cmake/vcpkg_from_bitbucket.cmake
+++ b/scripts/cmake/vcpkg_from_bitbucket.cmake
@@ -11,6 +11,7 @@
 ##     [REF <v2.0.0>]
 ##     [SHA512 <45d0d7f8cc350...>]
 ##     [HEAD_REF <master>]
+##     [PATCHES <patch1.patch> <patch2.patch>...]
 ## )
 ## ```
 ##
@@ -40,6 +41,11 @@
 ##
 ## For most projects, this should be `master`. The chosen branch should be one that is expected to be always buildable on all supported platforms.
 ##
+## ### PATCHES
+## A list of patches to be applied to the extracted sources.
+##
+## Relative paths are based on the port directory.
+##
 ## ## Notes:
 ## At least one of `REF` and `HEAD_REF` must be specified, however it is preferable for both to be present.
 ##
@@ -50,7 +56,7 @@
 ## * [blaze](https://github.com/Microsoft/vcpkg/blob/master/ports/blaze/portfile.cmake)
 function(vcpkg_from_bitbucket)
     set(oneValueArgs OUT_SOURCE_PATH REPO REF SHA512 HEAD_REF)
-    set(multipleValuesArgs)
+    set(multipleValuesArgs PATCHES)
     cmake_parse_arguments(_vdud "" "${oneValueArgs}" "${multipleValuesArgs}" ${ARGN})
 
     if(NOT _vdud_OUT_SOURCE_PATH)
@@ -123,8 +129,14 @@ function(vcpkg_from_bitbucket)
             SHA512 "${_vdud_SHA512}"
             FILENAME "${ORG_NAME}-${REPO_NAME}-${_vdud_REF}.tar.gz"
         )
-        vcpkg_extract_source_archive_ex(ARCHIVE "${ARCHIVE}")
-        set_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src ${_version})
+
+        vcpkg_extract_source_archive_ex(
+            OUT_SOURCE_PATH SOURCE_PATH
+            ARCHIVE "${ARCHIVE}"
+            REF "${_vdud_REF}"
+            PATCHES ${_vdud_PATCHES}
+        )
+        set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
         return()
     endif()
 
@@ -164,11 +176,6 @@ function(vcpkg_from_bitbucket)
         )
     endif()
 
-    vcpkg_extract_source_archive_ex(
-        ARCHIVE "${ARCHIVE}"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
-    )
-
     # Parse the github refs response with regex.
     # TODO: use some JSON swiss-army-knife utility instead.
     file(READ "${ARCHIVE_VERSION}" _contents)
@@ -179,5 +186,12 @@ function(vcpkg_from_bitbucket)
     # exports VCPKG_HEAD_VERSION to the caller. This will get picked up by ports.cmake after the build.
     set(VCPKG_HEAD_VERSION ${_version} PARENT_SCOPE)
 
-    set_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src/head ${_vdud_HEAD_REF})
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE "${downloaded_file_path}"
+        REF "${_vdud_HEAD_REF}"
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
+        PATCHES ${_vdud_PATCHES}
+    )
+    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -80,16 +80,16 @@ function(vcpkg_from_github)
     string(REGEX REPLACE "/.*" "" ORG_NAME ${_vdud_REPO})
 
     macro(set_TEMP_SOURCE_PATH BASE BASEREF)
-    set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${BASEREF}")
-    if(NOT EXISTS ${TEMP_SOURCE_PATH})
-        # Sometimes GitHub strips a leading 'v' off the REF.
-        string(REGEX REPLACE "^v" "" REF ${BASEREF})
-        string(REPLACE "/" "-" REF ${REF})
-        set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${REF}")
+        set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${BASEREF}")
         if(NOT EXISTS ${TEMP_SOURCE_PATH})
-            message(FATAL_ERROR "Could not determine source path: '${BASE}/${REPO_NAME}-${BASEREF}' does not exist")
+            # Sometimes GitHub strips a leading 'v' off the REF.
+            string(REGEX REPLACE "^v" "" REF ${BASEREF})
+            string(REPLACE "/" "-" REF ${REF})
+            set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${REF}")
+            if(NOT EXISTS ${TEMP_SOURCE_PATH})
+                message(FATAL_ERROR "Could not determine source path: '${BASE}/${REPO_NAME}-${BASEREF}' does not exist")
+            endif()
         endif()
-    endif()
     endmacro()
 
     if(VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_HEAD_REF)
@@ -111,44 +111,14 @@ function(vcpkg_from_github)
             FILENAME "${ORG_NAME}-${REPO_NAME}-${SANITIZED_REF}.tar.gz"
         )
 
-        # Take the last 10 chars of the REF
-        set(REF_MAX_LENGTH 10)
-        string(LENGTH ${SANITIZED_REF} REF_LENGTH)
-        math(EXPR FROM_REF ${REF_LENGTH}-${REF_MAX_LENGTH})
-        if(FROM_REF LESS 0)
-            set(FROM_REF 0)
-        endif()
-        string(SUBSTRING ${SANITIZED_REF} ${FROM_REF} ${REF_LENGTH} SHORTENED_SANITIZED_REF)
-
-        # Hash the archive hash along with the patches. Take the first 10 chars of the hash
-        set(PATCHSET_HASH "${_vdud_SHA512}")
-        foreach(PATCH IN LISTS _vdud_PATCHES)
-            get_filename_component(ABSOLUTE_PATCH "${PATCH}" ABSOLUTE BASE_DIR "${CURRENT_PORT_DIR}")
-            file(SHA512 ${ABSOLUTE_PATCH} CURRENT_HASH)
-            string(APPEND PATCHSET_HASH ${CURRENT_HASH})
-        endforeach()
-
-        string(SHA512 PATCHSET_HASH ${PATCHSET_HASH})
-        string(SUBSTRING ${PATCHSET_HASH} 0 10 PATCHSET_HASH)
-        set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/${SHORTENED_SANITIZED_REF}-${PATCHSET_HASH}")
-
-        if(NOT EXISTS ${SOURCE_PATH})
-            set(TEMP_DIR "${CURRENT_BUILDTREES_DIR}/src/TEMP")
-            file(REMOVE_RECURSE ${TEMP_DIR})
-            vcpkg_extract_source_archive_ex(ARCHIVE "${ARCHIVE}" WORKING_DIRECTORY ${TEMP_DIR})
-            set_TEMP_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src/TEMP ${SANITIZED_REF})
-
-            vcpkg_apply_patches(
-                SOURCE_PATH ${TEMP_SOURCE_PATH}
-                PATCHES ${_vdud_PATCHES}
-            )
-
-            file(RENAME ${TEMP_SOURCE_PATH} ${SOURCE_PATH})
-            file(REMOVE_RECURSE ${TEMP_DIR})
-        endif()
+        vcpkg_extract_source_archive_ex(
+            OUT_SOURCE_PATH SOURCE_PATH
+            ARCHIVE "${ARCHIVE}"
+            REF "${SANITIZED_REF}"
+            PATCHES ${_vdud_PATCHES}
+        )
 
         set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-        message(STATUS "Using source at ${SOURCE_PATH}")
         return()
     endif()
 
@@ -189,11 +159,6 @@ function(vcpkg_from_github)
         )
     endif()
 
-    vcpkg_extract_source_archive_ex(
-        ARCHIVE "${ARCHIVE}"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
-    )
-
     # Parse the github refs response with regex.
     # TODO: use some JSON swiss-army-knife utility instead.
     file(READ "${ARCHIVE_VERSION}" _contents)
@@ -206,11 +171,12 @@ function(vcpkg_from_github)
         set(VCPKG_HEAD_VERSION ${_version} PARENT_SCOPE)
     endif()
 
-    set_TEMP_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src/head ${SANITIZED_HEAD_REF})
-    vcpkg_apply_patches(
-        SOURCE_PATH ${TEMP_SOURCE_PATH}
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE "${downloaded_file_path}"
+        REF "${SANITIZED_HEAD_REF}"
+        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src/head
         PATCHES ${_vdud_PATCHES}
     )
-    set(${_vdud_OUT_SOURCE_PATH} "${TEMP_SOURCE_PATH}" PARENT_SCOPE)
-    message(STATUS "Using source at ${TEMP_SOURCE_PATH}")
+    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -11,6 +11,7 @@
 ##     [REF <v10.7.3>]
 ##     [SHA512 <45d0d7f8cc350...>]
 ##     [HEAD_REF <master>]
+##     [PATCHES <patch1.patch> <patch2.patch>...]
 ## )
 ## ```
 ##
@@ -45,6 +46,11 @@
 ##
 ## For most projects, this should be `master`. The chosen branch should be one that is expected to be always buildable on all supported platforms.
 ##
+## ### PATCHES
+## A list of patches to be applied to the extracted sources.
+##
+## Relative paths are based on the port directory.
+##
 ## ## Notes:
 ## At least one of `REF` and `HEAD_REF` must be specified, however it is preferable for both to be present.
 ##
@@ -76,27 +82,13 @@ function(vcpkg_from_gitlab)
         message(FATAL_ERROR "At least one of REF and HEAD_REF must be specified.")
     endif()
 
-    string(REGEX REPLACE ".*/" "" REPO_NAME ${_vdud_REPO})
-    string(REGEX REPLACE "/.*" "" ORG_NAME ${_vdud_REPO})
-
-    macro(set_TEMP_SOURCE_PATH BASE)
-        file(GLOB _ARCHIVE_FILES "${BASE}/${REPO_NAME}*")
-        foreach(dir ${_ARCHIVE_FILES})
-            if (IS_DIRECTORY ${dir})
-                list(APPEND _ARCHIVE_DIRS "${dir}")
-            endif()
-        endforeach()
-        list(LENGTH _ARCHIVE_DIRS _NUM_ARCHIVE_DIRS)
-        if(NOT 1 EQUAL ${_NUM_ARCHIVE_DIRS})
-            message(FATAL_ERROR "Could not determine source path: There were ${_NUM_ARCHIVE_DIRS} directories extracted from the archive that start with the repo name.")
-        endif()
-        list(GET _ARCHIVE_DIRS 0 TEMP_SOURCE_PATH)
-    endmacro()
-
     if(VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_HEAD_REF)
         message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
         set(VCPKG_USE_HEAD_VERSION OFF)
     endif()
+
+    string(REGEX REPLACE ".*/" "" REPO_NAME ${_vdud_REPO})
+    string(REGEX REPLACE "/.*" "" ORG_NAME ${_vdud_REPO})
 
     # Handle --no-head scenarios
     if(NOT VCPKG_USE_HEAD_VERSION)
@@ -112,43 +104,14 @@ function(vcpkg_from_gitlab)
             FILENAME "${ORG_NAME}-${REPO_NAME}-${SANITIZED_REF}.tar.gz"
         )
 
-        # Take the last 10 chars of the REF
-        set(REF_MAX_LENGTH 10)
-        string(LENGTH ${SANITIZED_REF} REF_LENGTH)
-        math(EXPR FROM_REF ${REF_LENGTH}-${REF_MAX_LENGTH})
-        if(FROM_REF LESS 0)
-            set(FROM_REF 0)
-        endif()
-        string(SUBSTRING ${SANITIZED_REF} ${FROM_REF} ${REF_LENGTH} SHORTENED_SANITIZED_REF)
-
-        # Hash the archive hash along with the patches. Take the first 10 chars of the hash
-        set(PATCHSET_HASH "${_vdud_SHA512}")
-        foreach(PATCH IN LISTS _vdud_PATCHES)
-            file(SHA512 ${PATCH} CURRENT_HASH)
-            string(APPEND PATCHSET_HASH ${CURRENT_HASH})
-        endforeach()
-
-        string(SHA512 PATCHSET_HASH ${PATCHSET_HASH})
-        string(SUBSTRING ${PATCHSET_HASH} 0 10 PATCHSET_HASH)
-        set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/${SHORTENED_SANITIZED_REF}-${PATCHSET_HASH}")
-
-        if(NOT EXISTS ${SOURCE_PATH})
-            set(TEMP_DIR "${CURRENT_BUILDTREES_DIR}/src/TEMP")
-            file(REMOVE_RECURSE ${TEMP_DIR})
-            vcpkg_extract_source_archive_ex(ARCHIVE "${ARCHIVE}" WORKING_DIRECTORY ${TEMP_DIR})
-            set_TEMP_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src/TEMP ${SANITIZED_REF})
-
-            vcpkg_apply_patches(
-                SOURCE_PATH ${TEMP_SOURCE_PATH}
-                PATCHES ${_vdud_PATCHES}
-            )
-
-            file(RENAME ${TEMP_SOURCE_PATH} ${SOURCE_PATH})
-            file(REMOVE_RECURSE ${TEMP_DIR})
-        endif()
+        vcpkg_extract_source_archive_ex(
+            OUT_SOURCE_PATH SOURCE_PATH
+            ARCHIVE "${ARCHIVE}"
+            REF "${SANITIZED_REF}"
+            PATCHES ${_vdud_PATCHES}
+        )
 
         set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-
         return()
     endif()
 
@@ -182,10 +145,6 @@ function(vcpkg_from_gitlab)
         )
     endif()
 
-    vcpkg_extract_source_archive_ex(
-        ARCHIVE "${ARCHIVE}"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
-    )
     # There are issues with the Gitlab API project paths being URL-escaped, so we use git here to get the head revision
     execute_process(COMMAND ${GIT} ls-remote
         "${_vdud_GITLAB_URL}/${ORG_NAME}/${REPO_NAME}.git" "${_vdud_HEAD_REF}"
@@ -199,10 +158,12 @@ function(vcpkg_from_gitlab)
         set(VCPKG_HEAD_VERSION ${_version} PARENT_SCOPE)
     endif()
 
-    set_TEMP_SOURCE_PATH(${CURRENT_BUILDTREES_DIR}/src/head ${SANITIZED_HEAD_REF})
-    vcpkg_apply_patches(
-        SOURCE_PATH ${TEMP_SOURCE_PATH}
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE "${downloaded_file_path}"
+        REF "${SANITIZED_HEAD_REF}"
+        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src/head
         PATCHES ${_vdud_PATCHES}
     )
-    set(${_vdud_OUT_SOURCE_PATH} "${TEMP_SOURCE_PATH}" PARENT_SCOPE)
+    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
On Win32, GraphicsMagick is failing to load image files, notably PNG or JPEG images, as it was being compiled with support for 'GraphicsMagick Modules'.  These are files with names specific to GraphicsMagick, and of the format, 'IM_*.dll'.  vcpkg's install process for GraphicsMagick is not setting these up.

This patch makes sure that when GM is built, it embed's GM's own image-loading code into graphicsmagick.dll.  This has an end-result of making image files be loadable.