### PR TITLE
[ffmpeg] fix link debug bzip2.

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 3.3.3-5
+Version: 3.3.3-6
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.
 
@@ -19,6 +19,10 @@ Description: openssl support in ffmpeg
 Feature: lzma
 Build-Depends: liblzma
 Description: lzma support in ffmpeg
+
+Feature: bzip2
+Build-Depends: bzip2
+Description: bzip2 support in ffmpeg
 
 Feature: x264
 Build-Depends: x264, ffmpeg[gpl]

--- a/ports/ffmpeg/fixed-debug-bzip2-link.patch
+++ b/ports/ffmpeg/fixed-debug-bzip2-link.patch
@@ -1,0 +1,33 @@
+diff -urN a/configure b/configure
+--- a/configure	2018-09-08 20:53:33.556275600 +0800
++++ b/configure	2018-09-08 20:55:46.238584400 +0800
+@@ -4753,6 +4753,8 @@
+ enable $subarch
+ enabled spic && enable_weak pic
+ 
++bzlib_name=bz2
++
+ # OS specific
+ case $target_os in
+     aix)
+@@ -4914,6 +4916,11 @@
+         objformat="win32"
+         ranlib=:
+         enable dos_paths
++        if [ -z "${extra_cflags##*-MDd*}" ] || [ -z "${extra_cflags##*-MTd*}" ]; then
++            bzlib_name=bz2d
++        else
++            bzlib_name=bz2
++        fi
+         ;;
+     cygwin*)
+         target_os=cygwin
+@@ -5734,7 +5741,7 @@
+     check_builtin sem_timedwait semaphore.h "sem_t *s; sem_init(s,0,0); sem_timedwait(s,0); sem_destroy(s)"
+ 
+ disabled  zlib || check_lib  zlib.h      zlibVersion    -lz    || disable  zlib
+-disabled bzlib || check_lib bzlib.h BZ2_bzlibVersion    -lbz2  || disable bzlib
++disabled bzlib || check_lib bzlib.h BZ2_bzlibVersion    -l$bzlib_name  || disable bzlib
+ disabled  lzma || check_lib  lzma.h lzma_version_number -llzma || disable lzma
+ 
+ check_lib math.h sin -lm && LIBM="-lm"


### PR DESCRIPTION
By default, it is automatically linked to the released version of bzip2. Therefore, the Debug version of ffmpeg will prompt that libbz2.dll could not be found; instead of prompting for less than libbz2d.dll.

> 默认情况下会自动链接到发布版的bzip2。所以，Debug 版 ffmpeg 会提示找不到 libbz2.dll；而不是提示早不到 libbz2d.dll。