### PR TITLE
Fix integrated install wxWidgets include paths

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -65,10 +65,12 @@
       <AdditionalLibraryDirectories Condition="'$(VcpkgNormalizedConfiguration)' == 'Debug'">%(AdditionalLibraryDirectories);$(VcpkgRoot)debug\lib;$(VcpkgRoot)debug\lib\manual-link</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(VcpkgRoot)include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(VcpkgNormalizedConfiguration)' == 'Debug'">%(AdditionalIncludeDirectories);$(VcpkgRoot)include;$(VcpkgRoot)debug\lib\mswud</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(VcpkgNormalizedConfiguration)' == 'Release'">%(AdditionalIncludeDirectories);$(VcpkgRoot)include;$(VcpkgRoot)lib\mswu</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(VcpkgRoot)include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(VcpkgNormalizedConfiguration)' == 'Debug'">%(AdditionalIncludeDirectories);$(VcpkgRoot)include;$(VcpkgRoot)debug\lib\mswud</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(VcpkgNormalizedConfiguration)' == 'Release'">%(AdditionalIncludeDirectories);$(VcpkgRoot)include;$(VcpkgRoot)lib\mswu</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Added the unusual wxWidgets setup.h include path that is placed under a library directory.
This resoles issue #3180.