### PR TITLE
add missing dependency for openvdb[tools]

### DIFF
--- a/ports/openvdb/CONTROL
+++ b/ports/openvdb/CONTROL
@@ -5,4 +5,4 @@ Description: Sparse volume data structure and tools
 
 Feature: tools
 Description: OpenVDB utilities: view, print and render
-Build-Depends: glew, glfw3
+Build-Depends: glew, glfw3, boost-ptr-container


### PR DESCRIPTION
Currently, I get an error when building openvdb with [tools] feature (x64-windows triplet) with the following build command: 

    vcpkg.exe install openvdb[tools]:x64-windows    

Error message

    c:\...\buildtrees\openvdb\src\v5.0.0-7f1d479828\openvdb\points\IndexFilter.h(51): fatal error C1083: Cannot open include file: 'boost/ptr_container/ptr_vector.hpp': No such file or directory

Adding the dependency lets me successfully build and execute ```vdb_view.exe```. However, I need to copy ```vdb_view.exe``` into the ```<VCPKGROOT>\installed\x64-windows\bin``` directory in order for ```vdb_view.exe``` to work. I don't know if this is a deliberate decision or a bug to *not* copying the exe to this directory.



