### PR TITLE
Fix up double-conversion and harfbuzz

### DIFF
--- a/ports/double-conversion/CONTROL
+++ b/ports/double-conversion/CONTROL
@@ -1,3 +1,3 @@
 Source: double-conversion
-Version: 3.0.0-2
+Version: 3.1.0
 Description: Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles.

--- a/ports/double-conversion/portfile.cmake
+++ b/ports/double-conversion/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/double-conversion
-    REF v3.0.0
-    SHA512 5057af6e72f2aaace56ebdd9a0ddfa34318cbdfeabec5c361b60e6c92f160c8999c046c50f8c6f8d590eb8e97aa70bb6e97ba8148f0dc95dbc42f204fcdc1abf
+    REF 3.1.0
+    SHA512 ba797a7203bc7eb8ba697dc758a3341578f0405b5ab42fbd5a22d9fac09d11dd8cb5ed9ff9ff369e8ae9397ec74c04c62fca29d1bc469c6d2ea1a84a6dff9188
     HEAD_REF master
 )
 
@@ -25,35 +25,6 @@ vcpkg_install_cmake()
 # Rename exported target files into something vcpkg_fixup_cmake_targets expects
 if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/double-conversion)
     vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/double-conversion)
-endif()
-if(NOT VCPKG_USE_HEAD_VERSION)
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
-        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-            file(RENAME ${CURRENT_PACKAGES_DIR}/debug/CMake/double-conversionLibraryDepends-debug.cmake
-                        ${CURRENT_PACKAGES_DIR}/debug/CMake/double-conversionTargets-debug.cmake)
-        endif()
-        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-            file(RENAME ${CURRENT_PACKAGES_DIR}/CMake/double-conversionLibraryDepends-release.cmake
-                        ${CURRENT_PACKAGES_DIR}/CMake/double-conversionTargets-release.cmake)
-        endif()
-        file(RENAME ${CURRENT_PACKAGES_DIR}/CMake/double-conversionLibraryDepends.cmake
-                    ${CURRENT_PACKAGES_DIR}/CMake/double-conversionTargets.cmake)
-
-        file(READ ${CURRENT_PACKAGES_DIR}/CMake/double-conversionTargets.cmake TARGETS_FILE)
-        string(REPLACE "double-conversionLibraryDepends" "double-conversionTargets" TARGETS_FILE "${TARGETS_FILE}")
-        file(WRITE ${CURRENT_PACKAGES_DIR}/CMake/double-conversionTargets.cmake "${TARGETS_FILE}")
-
-        # Remove hardcoded paths from config file
-        file(READ ${CURRENT_PACKAGES_DIR}/CMake/double-conversionConfig.cmake CONFIG_FILE)
-        string(REPLACE "${CURRENT_PACKAGES_DIR}/lib/cmake/double-conversion/double-conversionLibraryDepends.cmake"
-                    "\${double-conversion_CMAKE_DIR}/double-conversionTargets.cmake" CONFIG_FILE "${CONFIG_FILE}")
-        string(REPLACE "${CURRENT_PACKAGES_DIR}"
-                    "\${double-conversion_CMAKE_DIR}/../.." CONFIG_FILE "${CONFIG_FILE}")
-        file(WRITE ${CURRENT_PACKAGES_DIR}/CMake/double-conversionConfig.cmake "${CONFIG_FILE}")
-
-        vcpkg_fixup_cmake_targets(CONFIG_PATH CMake)
-    endif()
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 endif()
 
 vcpkg_copy_pdbs()

--- a/ports/harfbuzz/0001-fix-cmake-export.patch
+++ b/ports/harfbuzz/0001-fix-cmake-export.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e881dbd1..69496561 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -761,11 +761,16 @@ endif ()
+ 
+ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+   install(TARGETS harfbuzz
++    EXPORT harfbuzzConfig
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     FRAMEWORK DESTINATION Library/Frameworks
+   )
++  install(EXPORT harfbuzzConfig
++      NAMESPACE harfbuzz::
++      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/harfbuzz
++  )
+   if (HB_BUILD_UTILS)
+     install(TARGETS hb-view
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/ports/harfbuzz/0001-fix-cmake-export.patch
+++ b/ports/harfbuzz/0001-fix-cmake-export.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e881dbd1..69496561 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -761,11 +761,16 @@ endif ()
+@@ -761,11 +761,17 @@ endif ()
  
  if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    install(TARGETS harfbuzz
@@ -13,8 +13,9 @@ index e881dbd1..69496561 100644
      FRAMEWORK DESTINATION Library/Frameworks
    )
 +  install(EXPORT harfbuzzConfig
-+      NAMESPACE harfbuzz::
-+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/harfbuzz
++      NAMESPACE unofficial::harfbuzz::
++      FILE unofficial-harfbuzz-config.cmake
++      DESTINATION share/unofficial-harfbuzz
 +  )
    if (HB_BUILD_UTILS)
      install(TARGETS hb-view

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,5 @@
 Source: harfbuzz
-Version: 1.8.4
+Version: 1.8.4-1
 Description: HarfBuzz OpenType text shaping engine
 Build-Depends: freetype, ragel
 Default-Features: ucdn

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -6,15 +6,11 @@ vcpkg_from_github(
     REF 1.8.4
     SHA512 92742b754713d1df8975d4d8467de04765784d7fd566b7e07e7e7a261b0338e997a5fc11fa4fe282d6d5540d242db40c993812fbc4a881becd95fd3aae598c80
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
-        "${CMAKE_CURRENT_LIST_DIR}/0001-fix-uwp-build.patch"
-        "${CMAKE_CURRENT_LIST_DIR}/find-package-freetype-2.patch"
-        "${CMAKE_CURRENT_LIST_DIR}/glib-cmake.patch"
-        "${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake-export.patch"
+        0001-fix-uwp-build.patch
+        find-package-freetype-2.patch
+        glib-cmake.patch
+        0001-fix-cmake-export.patch
 )
 
 SET(HB_HAVE_ICU "OFF")
@@ -60,9 +56,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/harfbuzz)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-harfbuzz TARGET_PATH share/unofficial-harfbuzz)
 vcpkg_copy_pdbs()
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/harfbuzz)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/harfbuzz/COPYING ${CURRENT_PACKAGES_DIR}/share/harfbuzz/copyright)
+
+vcpkg_test_cmake(PACKAGE_NAME unofficial-harfbuzz)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_apply_patches(
         "${CMAKE_CURRENT_LIST_DIR}/0001-fix-uwp-build.patch"
         "${CMAKE_CURRENT_LIST_DIR}/find-package-freetype-2.patch"
         "${CMAKE_CURRENT_LIST_DIR}/glib-cmake.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake-export.patch"
 )
 
 SET(HB_HAVE_ICU "OFF")
@@ -59,6 +60,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/harfbuzz)
 vcpkg_copy_pdbs()
 
 # Handle copyright


### PR DESCRIPTION
This pull request fixes the double-conversion build on Linux (implicitly, through bumping to upstream that has fixed cmake targets) and also fixes external harfbuzz usage.