### PR TITLE
[leptonica] Update to 1.76.0

### DIFF
--- a/ports/leptonica/CONTROL
+++ b/ports/leptonica/CONTROL
@@ -1,4 +1,4 @@
 Source: leptonica
-Version: 1.74.4-5
+Version: 1.76.0
 Description: An open source library containing software that is broadly useful for image processing and image analysis applications
 Build-Depends: libjpeg-turbo, zlib, libpng, tiff, giflib

--- a/ports/leptonica/fix-cmakelists.patch
+++ b/ports/leptonica/fix-cmakelists.patch
@@ -1,34 +1,12 @@
---- a/src/CMakeLists.txt	Sun Jun 11 23:04:50 2017
-+++ b/src/CMakeLists.txt	Wed Aug 16 17:29:56 2017
-@@ -27,24 +27,31 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 945100a..6daad98 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -14,7 +14,6 @@ if (MSVC)
+     set_source_files_properties(${src} PROPERTIES LANGUAGE CXX)
  endif()
  
- if (GIF_LIBRARY)
-+    target_include_directories  (leptonica PUBLIC ${GIF_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${GIF_LIBRARY})
- endif()
- if (JPEG_LIBRARY)
-+    target_include_directories  (leptonica PUBLIC ${JPEG_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${JPEG_LIBRARY})
- endif()
- if (JP2K_FOUND)
-+    target_include_directories  (leptonica PUBLIC ${JP2K_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${JP2K_LIBRARIES})
- endif()
- if (PNG_LIBRARY)
-+    target_include_directories  (leptonica PUBLIC ${PNG_INCLUDE_DIRS})
-     target_link_libraries       (leptonica ${PNG_LIBRARY})
- endif()
- if (TIFF_LIBRARY)
-+    target_include_directories  (leptonica PUBLIC ${TIFF_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${TIFF_LIBRARY})
- endif()
- if (WEBP_FOUND)
-+    target_include_directories  (leptonica PUBLIC ${WEBP_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${WEBP_LIBRARIES})
- endif()
- if (ZLIB_LIBRARY)
-+    target_include_directories  (leptonica PUBLIC ${ZLIB_INCLUDE_DIR})
-     target_link_libraries       (leptonica ${ZLIB_LIBRARY})
- endif()
+-string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE})
  
+ add_library                     (leptonica ${LIBRARY_TYPE} ${src} ${hdr})
+ set_target_properties           (leptonica PROPERTIES VERSION   ${VERSION_PLAIN})

--- a/ports/leptonica/portfile.cmake
+++ b/ports/leptonica/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DanBloomberg/leptonica
-    REF 1.74.4
-    SHA512 3b9d0be937883f733f72cbdf0b624ec245d9256a8b4622997f437d309efd7ad9695ad1cbe2224d543eb3ef8c44833567b3cc9a95e9a774ef9046b7acaf0ae744
+    REF 1.76.0
+    SHA512 0d7575dc38d1e656a228ef30412a2cbb908b9c7c8636e4e96f4a7dc0429c04709316b8ad04893285ab430c1b2063d71537fc5b989a0f9dbdbec488713e1bab1f
     HEAD_REF master
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/fix-cmakelists.patch


### PR DESCRIPTION
Leptonica version 1.74.4 contains CVE-2018-7186, which was fixed in 1.75.3