### PR TITLE
[flatbuffers] fix executable remaining in bin folder

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -30,15 +30,21 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/flatbuffers")
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin AND NOT EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/flatc)
+if(MSVC)
+    set(EXECUTABLE_SUFFIX ".exe")
+else()
+    set(EXECUTABLE_SUFFIX "")
+endif()
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin AND NOT EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/flatc${EXECUTABLE_SUFFIX})
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc.exe)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc${EXECUTABLE_SUFFIX})
     make_directory(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
     file(
         RENAME
-        ${CURRENT_PACKAGES_DIR}/bin/flatc.exe
-        ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc.exe
+        ${CURRENT_PACKAGES_DIR}/bin/flatc${EXECUTABLE_SUFFIX}
+        ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc${EXECUTABLE_SUFFIX}
     )
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
@@ -49,3 +55,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/flatbuffers)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/flatbuffers/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/flatbuffers/copyright)
+

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -30,27 +30,20 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/flatbuffers")
 
-if(MSVC)
-    set(EXECUTABLE_SUFFIX ".exe")
-else()
-    set(EXECUTABLE_SUFFIX "")
-endif()
-
-if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin AND NOT EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/flatc${EXECUTABLE_SUFFIX})
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
-endif()
-if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/flatc${EXECUTABLE_SUFFIX})
+file(GLOB flatc_path ${CURRENT_PACKAGES_DIR}/bin/flatc*)
+if(flatc_path)
     make_directory(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
+    get_filename_component(flatc_executable ${flatc_path} NAME)
     file(
         RENAME
-        ${CURRENT_PACKAGES_DIR}/bin/flatc${EXECUTABLE_SUFFIX}
-        ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/flatc${EXECUTABLE_SUFFIX}
+        ${flatc_path}
+        ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/${flatc_executable}
     )
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/flatbuffers)


### PR DESCRIPTION
fix for this message at build time : 
```
There should be no bin\ directory in a static build, but /home/user/Documents/tools/vcpkg/packages/flatbuffers_x64-linux/bin is present.
If the creation of bin\ and/or debug\bin\ cannot be disabled, use this in the portfile to remove them

    if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
    endif()

Found 1 error(s). Please correct the portfile:
    /home/user/Documents/tools/vcpkg/ports/flatbuffers/portfile.cmake
-- Performing post-build validation done
Error: Building package flatbuffers:x64-linux failed with: POST_BUILD_CHECKS_FAILED
Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: flatbuffers:x64-linux
  Vcpkg version: 0.0.113-unknownhash
```