### PR TITLE
[kde frameworks 5] Added karchive, kholidays, updated kplotting from KDE Frameworks 5

### DIFF
--- a/ports/ecm/CONTROL
+++ b/ports/ecm/CONTROL
@@ -1,3 +1,3 @@
 Source: ecm
-Version: 5.40.0
+Version: 5.50.0
 Description: Extra CMake Modules (ECM), extra modules and scripts for CMake

--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/extra-cmake-modules
-    REF v5.40.0
-    SHA512 1f79d797770367e79c2c6dd73c125d32fcc5fe404b350d953b69cc6544babc1c73e2986c833635daaac85a5af966977e40fe41c01ac48ccc45d46d2e1636d21f
+    REF v5.50.0
+    SHA512 625f934b97c56cceed44d8fa0e335fb1f593806e52b8bfd2fd467561b4de2528940add756a8e903bd5502e912422cc3835e65e047cc4c205d3b8629452627abd
     HEAD_REF master
 )
 

--- a/ports/kf5archive/CONTROL
+++ b/ports/kf5archive/CONTROL
@@ -1,0 +1,4 @@
+Source: kf5archive
+Version: 5.50.0
+Description: File compression
+Build-Depends: ecm, qt5-base, zlib, bzip2

--- a/ports/kf5archive/portfile.cmake
+++ b/ports/kf5archive/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/karchive
+    REF v5.50.0
+    SHA512 519dd69ef76c9655cdf9d8f16484244469a6d5d2185c1d588bad325a401dd11f35699e3c115dfd52e5db38aa26aea3d9b35c7e83b76a36bda926574a7d3ce50f
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_HTML_DOCS=OFF
+            -DBUILD_MAN_DOCS=OFF
+            -DBUILD_QTHELP_DOCS=OFF
+            -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KF5Archive)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/etc)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/etc)
+file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/kf5archive RENAME copyright)

--- a/ports/kf5holidays/CONTROL
+++ b/ports/kf5holidays/CONTROL
@@ -1,0 +1,4 @@
+Source: kf5holidays
+Version: 5.50.0
+Description: Holiday calculation library
+Build-Depends: ecm, qt5-base, qt5-declarative, qt5-tools

--- a/ports/kf5holidays/portfile.cmake
+++ b/ports/kf5holidays/portfile.cmake
@@ -1,0 +1,31 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kholidays
+    REF v5.50.0
+    SHA512 01c1258213e1bbab90b9af9c41965599637b1ccd4cd285cbe9bc11579fae1363162567ae14c33001b8b1cc085bae4dfdf4ed79b7ff27f93187bce79db662b4e2
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_HTML_DOCS=OFF
+            -DBUILD_MAN_DOCS=OFF
+            -DBUILD_QTHELP_DOCS=OFF
+            -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KF5Holidays)
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/etc)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/etc)
+
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/qml ${CURRENT_PACKAGES_DIR}/debug/qml )
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/qml ${CURRENT_PACKAGES_DIR}/qml )
+
+file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/kf5holidays RENAME copyright)

--- a/ports/kf5plotting/CONTROL
+++ b/ports/kf5plotting/CONTROL
@@ -1,4 +1,4 @@
 Source: kf5plotting
-Version: 5.37.0
+Version: 5.50.0
 Description: Lightweight plotting framework
-Build-Depends: ecm, qt5
+Build-Depends: ecm, qt5-base

--- a/ports/kf5plotting/portfile.cmake
+++ b/ports/kf5plotting/portfile.cmake
@@ -1,11 +1,12 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/kplotting-5.37.0)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.kde.org/stable/frameworks/5.37/kplotting-5.37.0.zip"
-    FILENAME "kplotting-5.37.0.zip"
-    SHA512 3a1b3f993123dea7141d280cd53ae1b5e49b859e9df39a188bac216758576106efd8b744e8f10f96fac158f980d79ae94d2b27f3d85a48fcd5673263ffce3c4e
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kplotting
+    REF v5.50.0
+    SHA512 512a0f8e8a5147f06345d86fa29effa8d0a59b62f5a24b70a09c4ddf5204d626e13f421be7c42d2103c5634e863db5ac8e6763db886351597f0798e05bc97f33
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -21,4 +22,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KF5Plotting)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/KF5plotting RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/kf5plotting RENAME copyright)


### PR DESCRIPTION
With this pull request the following changes are made:
 * [x] [ecm]: upgraded to 5.50, the latest version
 * [x] [kf5plotting]: upgraded to 5.50, the latest version. Moved from qt5 to qt5-base dependency
 * [x] [kf5archive]: added version 5.50 of KArchive
 * [x] [kf5holidays]: added last version (not sure if it correct to move qml dirs as I did but validation was  fine in the end)

Minimal testing has been done by compiling and linking a simple project

I am planning on adding more KDE Framework libraries in the near future.