### PR TITLE
[Qt5-base] Fix qmldir for debug configuration

### DIFF
--- a/ports/qt5-base/configure_qt.cmake
+++ b/ports/qt5-base/configure_qt.cmake
@@ -36,7 +36,7 @@ function(configure_qt)
             -archdatadir ${CURRENT_INSTALLED_DIR}/share/qt5/debug
             -datadir ${CURRENT_INSTALLED_DIR}/share/qt5/debug
             -plugindir ${CURRENT_INSTALLED_DIR}/debug/plugins
-            -qmldir ${CURRENT_INSTALLED_DIR}/debug/qml
+            -qmldir ${CURRENT_INSTALLED_DIR}/qml
             -headerdir ${CURRENT_PACKAGES_DIR}/include
             -I ${CURRENT_INSTALLED_DIR}/include
             -L ${CURRENT_INSTALLED_DIR}/debug/lib


### PR DESCRIPTION
This PR fixes a regression error about `qml` directory for the `debug` configuration.

The directory was `${CURRENT_INSTALLED_DIR}/debug/qml` and should be `${CURRENT_INSTALLED_DIR}/qml`.
You can check `${CURRENT_INSTALLED_DIR}/qml` folder in the `vcpkg` folder that contains both `Release` and `Debug` dlls.

Fixes #4336 
Closes #2857 

cc @huangqinjin