### PR TITLE
Fix harfbuzz targets

### DIFF
--- a/ports/harfbuzz/0001-fix-cmake-export.patch
+++ b/ports/harfbuzz/0001-fix-cmake-export.patch
@@ -13,9 +13,9 @@ index e881dbd1..69496561 100644
      FRAMEWORK DESTINATION Library/Frameworks
    )
 +  install(EXPORT harfbuzzConfig
-+      NAMESPACE unofficial::harfbuzz::
-+      FILE unofficial-harfbuzz-config.cmake
-+      DESTINATION share/unofficial-harfbuzz
++      NAMESPACE harfbuzz::
++      FILE harfbuzz-config.cmake
++      DESTINATION share/harfbuzz
 +  )
    if (HB_BUILD_UTILS)
      install(TARGETS hb-view

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,5 @@
 Source: harfbuzz
-Version: 1.8.4-1
+Version: 1.8.4-2
 Description: HarfBuzz OpenType text shaping engine
 Build-Depends: freetype, ragel
 Default-Features: ucdn

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -56,11 +56,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-harfbuzz TARGET_PATH share/unofficial-harfbuzz)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/harfbuzz TARGET_PATH share/harfbuzz)
 vcpkg_copy_pdbs()
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/harfbuzz)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/harfbuzz/COPYING ${CURRENT_PACKAGES_DIR}/share/harfbuzz/copyright)
 
-vcpkg_test_cmake(PACKAGE_NAME unofficial-harfbuzz)
+vcpkg_test_cmake(PACKAGE_NAME harfbuzz)


### PR DESCRIPTION
Since commit 6a97d0f3d377a35ea691d15ac142ce043f953e71 upstream, the
target is in the harfbuzz:: namespace.