### PR TITLE
Force ChakraCore to statically link the CRT

### DIFF
--- a/ports/chakracore/CONTROL
+++ b/ports/chakracore/CONTROL
@@ -1,3 +1,3 @@
 Source: chakracore
-Version: 1.11.1
+Version: 1.11.1-1
 Description: Core part of the Chakra Javascript engine

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -24,10 +24,7 @@ set(BUILDTREE_PATH ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})
 file(REMOVE_RECURSE ${BUILDTREE_PATH})
 file(COPY ${SOURCE_PATH}/ DESTINATION ${BUILDTREE_PATH})
 
-set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore default is static CRT linkage
-if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-	set(CHAKRA_RUNTIME_LIB "dynamic_library")
-endif()
+set(CHAKRA_RUNTIME_LIB "static_library") # ChakraCore only supports static CRT linkage
 
 vcpkg_build_msbuild(
     PROJECT_PATH ${BUILDTREE_PATH}/Build/Chakra.Core.sln


### PR DESCRIPTION
ChakraCore can only dynamically link against MSVCRT currently. To work
around this it's best just to statically link the CRT like official
builds do.

Refs: https://github.com/Microsoft/ChakraCore/issues/5725