### PR TITLE
Abseil no longer depends on cctz.

### DIFF
--- a/ports/abseil/CMakeLists.txt
+++ b/ports/abseil/CMakeLists.txt
@@ -85,9 +85,6 @@ target_link_public_libraries(utility base meta)
 target_link_public_libraries(time base numeric)
 target_link_public_libraries(synchronization base time)
 
-find_package(unofficial-cctz REQUIRED)
-target_link_libraries(time PUBLIC unofficial::cctz)
-
 install(
     EXPORT unofficial-abseil-targets
     FILE unofficial-abseil-config.cmake

--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -4,4 +4,4 @@ Description: an open-source collection designed to augment the C++ standard libr
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.
   In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.
   Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole.
-Build-Depends: cctz
+Build-Depends: 


### PR DESCRIPTION
Removed the dependency, tested on macOS only at this point.
