### PR TITLE
[libgit2] Update portfile.cmake

### DIFF
--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -12,11 +12,16 @@ vcpkg_from_github(
     SHA512 d27db86eb1b9f0d4057f8538ba1985ee76c3ca106e57d417fa9bff79d575f91a07ad28693112b58dc1d61d68116a82e6a145f12276158f2806b6c4964d741f61
     HEAD_REF master)
 
+set(OPT "-DBUILD_CLAR=OFF")
+
+if ((WIN32) AND (VCPKG_CRT_LINKAGE STREQUAL dynamic))
+    list(APPEND OPT "-DSTATIC_CRT=OFF")
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-        -DBUILD_CLAR=OFF
+    OPTIONS ${OPT}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
libgit2 cannot be built to static library with dynamic CRT under Windows. Change the portfile to set STATIC_CRT option based on the value of VCPKG_CRT_LINKAGE in the triplet.