### PR TITLE
Qt5: Add qt5-script

### DIFF
--- a/ports/qt5-script/CONTROL
+++ b/ports/qt5-script/CONTROL
@@ -1,0 +1,3 @@
+Source: qt5-script
+Version: 5.9.2
+Description:Qt5 Script Module.

--- a/ports/qt5-script/portfile.cmake
+++ b/ports/qt5-script/portfile.cmake
@@ -1,0 +1,5 @@
+
+include(vcpkg_common_functions)
+include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
+
+qt_modular_library(qtscript 3ce2e57a0a6b2382614f689edca0deed87afe944c1c41decb3b9f420449fa59f2b79e6330e78e01a950761a95903113eaa7fbf261886361114acf5015d93254c)


### PR DESCRIPTION
This PR adds the qt5-script package, which is considered deprecated but is still used by several projects.  
I tested  it on Windows, everything works fine.