### PR TITLE
[cgal] Update to 4.13.

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,5 +1,5 @@
 Source: cgal
-Version: 4.13
+Version: 4.13-1
 Build-Depends: mpfr, mpir, zlib, boost-format, boost-container, boost-iterator, boost-variant, boost-any, boost-unordered, boost-random, boost-foreach, boost-graph, boost-heap, boost-logic
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 

--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,8 +1,8 @@
 Source: cgal
-Version: 4.12
+Version: 4.13
 Build-Depends: mpfr, mpir, zlib, boost-format, boost-container, boost-iterator, boost-variant, boost-any, boost-unordered, boost-random, boost-foreach, boost-graph, boost-heap, boost-logic
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 
 Feature: qt
-Build-Depends: qt5
+Build-Depends: qt5-base, qt5-3d, qt5-svg, qt5-xmlpatterns, qt5-script, eigen3
 Description: Qt GUI support for CGAL

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -1,15 +1,16 @@
 include(vcpkg_common_functions)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO CGAL/cgal
-    REF f7c3c8212b56c0d6dae63787efc99093f4383415
-    SHA512 fc40483b5f0e2071c3458cbd67ee7e503f68b7f6a1bbb525b6003d1a440e662cb85c257167ce6d55a73e0cc49b27a7d2b56dcf6b5eeddc78772567fdc48ba160
-    HEAD_REF master
-)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/CGAL-4.13)
+vcpkg_download_distfile(ARCHIVE
+    URLS 
+"https://github.com/CGAL/cgal/releases/download/releases%2FCGAL-4.13/CGAL-4.13.zip"
+    FILENAME "CGAL-4.13.zip"
+    SHA512 f6d3477cf049272984d8d6d283a8b21413d87066f6c2a4b481abae58e35d7890ed22e4f8093a7a6f42c0728a9a3b4272d1bfbb9b72fa2811767372bf9d483f05)
+    
+vcpkg_extract_source_archive(${ARCHIVE})
 
 set(WITH_CGAL_Qt5  OFF)
-if("qt5" IN_LIST FEATURES)
+if("qt" IN_LIST FEATURES)
   set(WITH_CGAL_Qt5 ON)
 endif()
 
@@ -18,7 +19,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DCGAL_INSTALL_CMAKE_DIR=share/cgal
-        -DWITH_CGAL_Qt5=${WITH_CGAL_Qt5}
+        -DWITH_CGAL_Qt5==${WITH_CGAL_Qt5}
 )
 
 vcpkg_install_cmake()
@@ -34,7 +35,13 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(READ ${CURRENT_PACKAGES_DIR}/share/cgal/CGALConfig.cmake _contents)
 string(REPLACE "CGAL_IGNORE_PRECONFIGURED_GMP" "1" _contents "${_contents}")
 string(REPLACE "CGAL_IGNORE_PRECONFIGURED_MPFR" "1" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/cgal/CGALConfig.cmake "${_contents}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/lib/cgal/CGALConfig.cmake "${_contents}")
+file(COPY ${CURRENT_BUILDTREES_DIR}/src/CGAL-4.13/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/cgal/LICENSE ${CURRENT_PACKAGES_DIR}/share/cgal/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE.BSL DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
+file(COPY ${SOURCE_PATH}/LICENSE.FREE_USE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
+file(COPY ${SOURCE_PATH}/LICENSE.GPL DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
+file(COPY ${SOURCE_PATH}/LICENSE.LGPL DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
 
 # Handle copyright of suitesparse and metis
-file(COPY ${SOURCE_PATH}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
+#file(COPY ${SOURCE_PATH}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -58,5 +58,3 @@ file(
         ${SOURCE_PATH}/Installation/LICENSE.LGPL
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal
 )
-
-vcpkg_test_cmake(PACKAGE_NAME CGAL)


### PR DESCRIPTION
This PR updates CGAL to 4.13 and reduces the dependencies to qt to only the necessary packages. This includes qt-script, so this PR depends on #4389.

Successfully tested on Windows.