### PR TITLE
Add toolsrc build dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,6 +283,7 @@ __pycache__/
 /installed*/
 /packages/
 /scripts/buildsystems/tmp/
+/toolsrc/build.rel/
 #ignore custom triplets
 /triplets/*
 #add vcpkg-designed triplets back in


### PR DESCRIPTION
This directory gets generated by `bootstrap-vcpkg.sh` on Linux, but
should not be in version control.