### PR TITLE
[live555] fix linux build : invalid conversion socklen_t

### DIFF
--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -8,6 +8,10 @@ include_directories(
     UsageEnvironment/include
 )
 
+if (NOT MSVC)
+    add_compile_options(-DSOCKLEN_T=socklen_t)
+endif()
+
 file(GLOB BASIC_USAGE_ENVIRONMENT_SRCS BasicUsageEnvironment/*.c BasicUsageEnvironment/*.cpp)
 add_library(BasicUsageEnvironment ${BASIC_USAGE_ENVIRONMENT_SRCS})
 


### PR DESCRIPTION
Add a missing flag for linux platform