### PR TITLE
Changed so "optional:" is in italics rather than all of "optional: CMake 3.10.2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prerequisites:
 - Windows 10, 8.1, 7, Linux, or MacOS
 - Visual Studio 2017 or Visual Studio 2015 Update 3 (on Windows)
 - Git
-- *Optional: CMake 3.10.2*
+- *Optional:* CMake 3.10.2
 
 To get started:
 ```


### PR DESCRIPTION
Changed
*Optional: CMake 3.10.2*


to 
*Optional:* CMake 3.10.2

in the README, Just a bit nicer formatting