### PR TITLE
[geos] update to 3.6.3 (fix port build)

### DIFF
--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,3 +1,3 @@
 Source: geos
-Version: 3.6.3
+Version: 3.6.3-1
 Description: Geometry Engine Open Source

--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,3 +1,3 @@
 Source: geos
-Version: 3.6.2-3
+Version: 3.6.3
 Description: Geometry Engine Open Source

--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,3 +1,3 @@
 Source: geos
-Version: 3.6.3-1
+Version: 3.6.3-2
 Description: Geometry Engine Open Source

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -25,7 +25,13 @@ vcpkg_configure_cmake(
         -DGEOS_ENABLE_TESTS=False
 )
 vcpkg_install_cmake()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/geos-config)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/geos-config ${CURRENT_PACKAGES_DIR}/share/geos/geos-config)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/geos-config)
+endif()
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/geos/copyright COPYONLY)

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -7,12 +7,12 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/geos-3.6.2)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/geos-3.6.3)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://download.osgeo.org/geos/geos-3.6.2.tar.bz2"
-    FILENAME "geos-3.6.2.tar.bz2"
-    SHA512 515d8700b8a28282678e481faee355e3a43d7b70160472a63335b8d7225d9ba10437be782378f18f31a15288118126d411a2d862f01ce35d27c96f6bc0a73016
+    URLS "http://download.osgeo.org/geos/geos-3.6.3.tar.bz2"
+    FILENAME "geos-3.6.3.tar.bz2"
+    SHA512 f88adcf363433e247a51fb1a2c0b53f39b71aba8a6c01dd08aa416c2e980fe274a195e6edcb5bb5ff8ea81b889da14a1a8fb2849e04669aeba3b6d55754dc96a
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 vcpkg_apply_patches(
@@ -23,11 +23,6 @@ SOURCE_PATH ${SOURCE_PATH}
 
 # NOTE: GEOS provides CMake as optional build configuration, it might not be actively
 # maintained, so CMake build issues may happen between releases.
-
-# Pull modules referred in the main CMakeLists.txt but missing from the released package.
-# TODO: GEOS 3.6.3 or later will include the missing script in release package.
-file(DOWNLOAD http://svn.osgeo.org/geos/branches/3.6/cmake/modules/GenerateSourceGroups.cmake
-    ${SOURCE_PATH}/cmake/modules/GenerateSourceGroups.cmake)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,24 +1,17 @@
-# Common Ambient Variables:
-#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
-#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
-#   PORT is the current port name (zlib, etc)
-#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#
-
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/geos-3.6.3)
+
+set(GEOS_VERSION 3.6.3)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://download.osgeo.org/geos/geos-3.6.3.tar.bz2"
-    FILENAME "geos-3.6.3.tar.bz2"
+    URLS "http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"
+    FILENAME "geos-${GEOS_VERSION}.tar.bz2"
     SHA512 f88adcf363433e247a51fb1a2c0b53f39b71aba8a6c01dd08aa416c2e980fe274a195e6edcb5bb5ff8ea81b889da14a1a8fb2849e04669aeba3b6d55754dc96a
 )
-vcpkg_extract_source_archive(${ARCHIVE})
-vcpkg_apply_patches(
-
-SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/geos_c-static-support.patch
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${GEOS_VERSION}
+    PATCHES geos_c-static-support.patch
 )
 
 # NOTE: GEOS provides CMake as optional build configuration, it might not be actively
@@ -26,23 +19,15 @@ SOURCE_PATH ${SOURCE_PATH}
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    PREFER_NINJA
     OPTIONS
-    -DCMAKE_DEBUG_POSTFIX=d
-    -DGEOS_ENABLE_TESTS=False
+        -DCMAKE_DEBUG_POSTFIX=d
+        -DGEOS_ENABLE_TESTS=False
 )
 vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-# Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/geos)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/geos/COPYING ${CURRENT_PACKAGES_DIR}/share/geos/copyright)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libgeos.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libgeosd.lib)
-else()
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/geos.lib ${CURRENT_PACKAGES_DIR}/debug/lib/geosd.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/geos_c.lib ${CURRENT_PACKAGES_DIR}/debug/lib/geos_cd.lib)
 
-endif()
+# Handle copyright
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/geos/copyright COPYONLY)
 
 vcpkg_copy_pdbs()

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/geos-config)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/geos)
     file(RENAME ${CURRENT_PACKAGES_DIR}/bin/geos-config ${CURRENT_PACKAGES_DIR}/share/geos/geos-config)
     file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/geos-config)
 endif()


### PR DESCRIPTION
Update geos port to `3.6.3` to fix port build: 

* file `http://svn.osgeo.org/geos/branches/3.6/cmake/modules/GenerateSourceGroups.cmake` no longer exists