### PR TITLE
Fixes #4464 GLFW3 dynamic build failure on Linux

### DIFF
--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -53,15 +53,17 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/bin/glfw3.dll)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/debug/bin/glfw3.dll)
-    foreach(_conf release
-                  debug)
-        file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake _contents)
-        string(REPLACE "lib/glfw3.dll" "bin/glfw3.dll" _contents "${_contents}")
-        file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake "${_contents}")
-    endforeach()
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/glfw3.dll OR EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/glfw3.dll)
+        file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/bin/glfw3.dll)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/debug/bin/glfw3.dll)
+        foreach(_conf release
+                      debug)
+            file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake _contents)
+            string(REPLACE "lib/glfw3.dll" "bin/glfw3.dll" _contents "${_contents}")
+            file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake "${_contents}")
+        endforeach()
+    endif()
 
 endif()
 

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -1,30 +1,21 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glfw-3.2.1)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/glfw/glfw/releases/download/3.2.1/glfw-3.2.1.zip"
-    FILENAME "glfw-3.2.1.zip"
-    SHA512 73dd6d4a8d28a2b423f0fb25489659c1a845182b7ef09848d4f442cdc489528aea90f43ac84aeedb9d2301c4487f39782b647ee4959e67e83babb838372b980c
-)
-vcpkg_extract_source_archive(${ARCHIVE})
 
-if(NOT EXISTS ${SOURCE_PATH}/patch-config.stamp)
-    message(STATUS "Patching src/glfw3Config.cmake.in")
-    file(READ ${SOURCE_PATH}/src/glfw3Config.cmake.in CONFIG)
-    string(REPLACE "\"@GLFW_LIB_NAME@\"" "NAMES @GLFW_LIB_NAME@ @GLFW_LIB_NAME@dll"
-        CONFIG ${CONFIG}
-    )
-    #string(REPLACE "@PACKAGE_CMAKE_INSTALL_PREFIX@" "@PACKAGE_CMAKE_INSTALL_PREFIX@/../.."
-    #    CONFIG ${CONFIG}
-    #)
-    file(WRITE ${SOURCE_PATH}/src/glfw3Config.cmake.in "${CONFIG}")
-    file(APPEND ${SOURCE_PATH}/src/glfw3Config.cmake.in "set(GLFW3_LIBRARIES \${GLFW3_LIBRARY})\n")
-    file(WRITE ${SOURCE_PATH}/patch-config.stamp)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO glfw/glfw
+    REF 3.2.1
+    SHA512 c7921f993b9a99b3b9421fefadb039cd475c42d85f5b5a35d7c5401c70491349bb885a02fd31e527de06a8b40d9d49a1fdb92c964e13c04ae092c6b98eb491dc
+    HEAD_REF master
+    PATCHES move-cmake-min-req.patch
+)
+
+if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(
+"GLFW3 currently requires the following libraries from the system package manager:
+    xinerama
+
+These can be installed on Ubuntu systems via sudo apt install libxinerama-dev")
 endif()
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/move-cmake-min-req.patch
-)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -32,23 +23,11 @@ vcpkg_configure_cmake(
         -DGLFW_BUILD_EXAMPLES=OFF
         -DGLFW_BUILD_TESTS=OFF
         -DGLFW_BUILD_DOCS=OFF
-        -DPACKAGE_CMAKE_INSTALL_PREFIX=\${CMAKE_CURRENT_LIST_DIR}/../..
 )
 
 vcpkg_install_cmake()
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
-file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake/glfw3 ${CURRENT_PACKAGES_DIR}/share/glfw3)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
-file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake _contents)
-set(pattern "get_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)\n")
-string(REPLACE "${pattern}${pattern}${pattern}" "${pattern}${pattern}" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets.cmake "${_contents}")
-
-file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/glfw3/glfw3Targets-debug.cmake _contents)
-string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-debug.cmake "${_contents}")
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/glfw3)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
@@ -57,17 +36,15 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
         file(RENAME ${CURRENT_PACKAGES_DIR}/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/bin/glfw3.dll)
         file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/glfw3.dll ${CURRENT_PACKAGES_DIR}/debug/bin/glfw3.dll)
-        foreach(_conf release
-                      debug)
+        foreach(_conf release debug)
             file(READ ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake _contents)
             string(REPLACE "lib/glfw3.dll" "bin/glfw3.dll" _contents "${_contents}")
             file(WRITE ${CURRENT_PACKAGES_DIR}/share/glfw3/glfw3Targets-${_conf}.cmake "${_contents}")
         endforeach()
     endif()
-
 endif()
 
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/glfw3)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/glfw3/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/glfw3/copyright)
-vcpkg_copy_pdbs()
 
+vcpkg_copy_pdbs()

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -13,8 +13,9 @@ if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStor
     message(
 "GLFW3 currently requires the following libraries from the system package manager:
     xinerama
+    xcursor
 
-These can be installed on Ubuntu systems via sudo apt install libxinerama-dev")
+These can be installed on Ubuntu systems via sudo apt install libxinerama-dev libxcursor-dev")
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This resolves a compatibility issue with dynamic library builds of glfw3 on Linux. More specifically, it ensures that some Windows-only code is only run when the relevant files (.dll files) actually exist. On Linux it is not necessary or desirable to move shared object files into bin. lib is the correct place and I was able to build and run my glfw project after applying this change.