### PR TITLE
Display names of environment variables correctly for non-Windows platforms in help

### DIFF
--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -7,6 +7,13 @@
 #include <vcpkg/install.h>
 #include <vcpkg/remove.h>
 
+// Write environment variable names as %VARIABLE% on Windows and $VARIABLE in *nix
+#ifdef _WIN32
+#define ENVVAR(VARNAME) "%%" #VARNAME "%%"
+#else
+#define ENVVAR(VARNAME) "$" #VARNAME
+#endif
+
 namespace vcpkg::Help
 {
     struct Topic
@@ -93,7 +100,7 @@ namespace vcpkg::Help
             "%s" // Integration help
             "\n"
             "  vcpkg export <pkg>... [opt]...  Exports a package\n"
-            "  vcpkg edit <pkg>                Open up a port for editing (uses %%EDITOR%%, default 'code')\n"
+            "  vcpkg edit <pkg>                Open up a port for editing (uses " ENVVAR(EDITOR) ", default 'code')\n"
             "  vcpkg import <pkg>              Import a pre-built library\n"
             "  vcpkg create <pkg> <url>\n"
             "             [archivename]        Create a new package\n"
@@ -104,10 +111,10 @@ namespace vcpkg::Help
             "\n"
             "Options:\n"
             "  --triplet <t>                   Specify the target architecture triplet.\n"
-            "                                  (default: %%VCPKG_DEFAULT_TRIPLET%%, see 'vcpkg help triplet')\n"
+            "                                  (default: " ENVVAR(VCPKG_DEFAULT_TRIPLET) ", see 'vcpkg help triplet')\n"
             "\n"
             "  --vcpkg-root <path>             Specify the vcpkg root directory\n"
-            "                                  (default: %%VCPKG_ROOT%%)\n"
+            "                                  (default: " ENVVAR(VCPKG_ROOT) ")\n"
             "\n"
             "For more help (including examples) see the accompanying README.md.",
             Commands::Integrate::INTEGRATE_COMMAND_HELPSTRING);


### PR DESCRIPTION
Currently vcpkg displays environment variable names in the help as %VARIABLENAME% on non-Windows platforms, where it should be $VARIABLENAME. This patch adds a macro to fix this.