### PR TITLE
Fixes #3867 ITK install fails if hdf5 is installed

### DIFF
--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,5 +1,5 @@
 Source: itk
-Version: 4.13.0
+Version: 4.13.0-1
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
 Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, hdf5[cpp]
 

--- a/ports/itk/hdf5_config_mode_find_package.patch
+++ b/ports/itk/hdf5_config_mode_find_package.patch
@@ -1,0 +1,68 @@
+diff --git a/Modules/ThirdParty/HDF5/CMakeLists.txt b/Modules/ThirdParty/HDF5/CMakeLists.txt
+index 6caa63b..f118c73 100644
+--- a/Modules/ThirdParty/HDF5/CMakeLists.txt
++++ b/Modules/ThirdParty/HDF5/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ project(ITKHDF5)
+ set(ITKHDF5_THIRD_PARTY 1)
+ 
+-if (BUILD_SHARED_LIBS)
++if (ITK_BUILD_SHARED_LIBS)
+    add_definitions(-DH5_BUILT_AS_DYNAMIC_LIB=1)
+ endif()
+ if(ITK_USE_SYSTEM_HDF5)
+@@ -20,11 +20,10 @@ endif()
+ ")
+   endif()
+ 
+-  set(ITKHDF5_LIBRARIES )
+-  if(BUILD_SHARED_LIBS)
+-    list(APPEND ITKHDF5_LIBRARIES ${HDF5_C_SHARED_LIBRARY} ${HDF5_CXX_SHARED_LIBRARY})
++  if(ITK_BUILD_SHARED_LIBS)
++    set(ITKHDF5_LIBRARIES hdf5::hdf5-shared hdf5::hdf5_cpp-shared)
+   else()
+-    list(APPEND ITKHDF5_LIBRARIES ${HDF5_C_STATIC_LIBRARY} ${HDF5_CXX_STATIC_LIBRARY})
++    set(ITKHDF5_LIBRARIES hdf5::hdf5-static hdf5::hdf5_cpp-static)
+   endif()
+ 
+   set(ITKHDF5_INCLUDE_DIRS
+@@ -33,11 +32,6 @@ endif()
+   set(ITKHDF5_SYSTEM_INCLUDE_DIRS
+     ${HDF5_INCLUDE_DIR}
+     ${HDF5_INCLUDE_DIR_CPP}
+-    ${HDF5_INCLUDE_DIRS}
+-    ${HDF5_INCLUDE_DIR_CPP}
+-    )
+-  list(APPEND ITKHDF5_LIBRARIES
+-    ${HDF5_LIBRARIES}
+     )
+   set(ITKHDF5_NO_SRC 1)
+ else()
+@@ -45,7 +39,7 @@ else()
+     ${ITKHDF5_SOURCE_DIR}/src
+     ${ITKHDF5_BINARY_DIR}/src
+     )
+-  if(BUILD_SHARED_LIBS)
++  if(ITK_BUILD_SHARED_LIBS)
+     set(ITKHDF5_LIBRARIES hdf5_cpp-shared hdf5-shared)
+   else()
+     set(ITKHDF5_LIBRARIES hdf5_cpp-static hdf5-static)
+diff --git a/Modules/ThirdParty/HDF5/itk-module-init.cmake b/Modules/ThirdParty/HDF5/itk-module-init.cmake
+index a9207a8..e36c2d9 100644
+--- a/Modules/ThirdParty/HDF5/itk-module-init.cmake
++++ b/Modules/ThirdParty/HDF5/itk-module-init.cmake
+@@ -2,12 +2,8 @@ option(ITK_USE_SYSTEM_HDF5 "Use an outside build of HDF5." ${ITK_USE_SYSTEM_LIBR
+ mark_as_advanced(ITK_USE_SYSTEM_HDF5)
+ if(ITK_USE_SYSTEM_HDF5)
+   if(BUILD_SHARED_LIBS)
+-    find_package(HDF5 QUIET NO_MODULE COMPONENTS CXX C shared)
++    find_package(HDF5 REQUIRED NO_MODULE COMPONENTS CXX C shared)
+   else()
+-    find_package(HDF5 QUIET NO_MODULE COMPONENTS CXX C static)
+-  endif()
+-
+-  if(NOT HDF5_FOUND)
+-    find_package(HDF5 REQUIRED COMPONENTS CXX C)
++    find_package(HDF5 REQUIRED NO_MODULE COMPONENTS CXX C static)
+   endif()
+ endif()

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -45,7 +45,10 @@ vcpkg_configure_cmake(
         -DITK_USE_SYSTEM_PNG=ON
         -DITK_USE_SYSTEM_TIFF=ON
         -DITK_USE_SYSTEM_ZLIB=ON
+        # This should be turned on some day, however for now ITK does download specific versions so it shouldn't spontaneously break
         -DITK_FORBID_DOWNLOADS=OFF
+
+        -DITK_SKIP_PATH_LENGTH_CHECKS=ON
 
         # I havn't tried Python wrapping in vcpkg
         #-DITK_WRAP_PYTHON=ON

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -22,6 +22,12 @@ endif()
 file(RENAME ${SOURCE_PATH} ${ITK_BUILD_DIR})
 set(SOURCE_PATH "${ITK_BUILD_DIR}")
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+      "${CMAKE_CURRENT_LIST_DIR}/hdf5_config_mode_find_package.patch"
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -50,10 +56,9 @@ vcpkg_configure_cmake(
         #-DITK_WRAP_PYTHON=ON
         #-DITK_PYTHON_VERSION=3
 
-        # HDF5 must NOT be installed, otherwise it causes: ...\installed\x64-windows-static\include\H5Tpkg.h(25): fatal error C1189: #error:  "Do not include this file outside the H5T package!"
-        -DITK_USE_SYSTEM_HDF5=ON # if ON, causes: ...\buildtrees\itk\x64-windows-static-rel\Modules\ThirdParty\HDF5\src\itk_H5Cpp.h(25): fatal error C1083: Cannot open include file: 'H5Cpp.h': No such file or directory
+        -DITK_USE_SYSTEM_HDF5=ON
+        -DModule_ITKVtkGlue=ON # this option requires VTK to be a dependency in CONTROL file. VTK depends on HDF5!
 
-        -DModule_ITKVtkGlue=${ITKVtkGlue} # this option requires VTK to be a dependency in CONTROL file. VTK depends on HDF5!
         -DModule_IOSTL=ON # example how to turn on a non-default module
         -DModule_MorphologicalContourInterpolation=ON # example how to turn on a remote module
         -DModule_RLEImage=ON # example how to turn on a remote module

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF d92873e33e8a54e933e445b92151191f02feab42
     SHA512 0e3ebd27571543e1c497377dd9576a9bb0711129be12131109fe9b3c8413655ad14ce4d9ac6e281bac83c57e6032b614bc9ff53ed357d831544ca52f41513b62
     HEAD_REF master
+    PATCHES hdf5_config_mode_find_package.patch
 )
 
 if ("vtk" IN_LIST FEATURES)
@@ -21,12 +22,6 @@ if(EXISTS ${ITK_BUILD_DIR})
 endif()
 file(RENAME ${SOURCE_PATH} ${ITK_BUILD_DIR})
 set(SOURCE_PATH "${ITK_BUILD_DIR}")
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-      "${CMAKE_CURRENT_LIST_DIR}/hdf5_config_mode_find_package.patch"
-)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
* Enabled ITK_USE_SYSTEM_HDF5 to use vcpkg's hdf5
* Added a patch file for Modules/ThirdParty/HDF5/CMakeLists.txt. This patch ensure that find_package() found vcpkg's hdf5 correctly by config mode.

build confirmed x86-windows, x64-windows, x86-windows-static, x64-windows-static.
#3867