### PR TITLE
Use /etc/ssl for OpenSSL's configuration on *nix.

### DIFF
--- a/ports/openssl-unix/CMakeLists.txt
+++ b/ports/openssl-unix/CMakeLists.txt
@@ -106,7 +106,7 @@ add_custom_command(
         no-md2
         ${PLATFORM}
         "--prefix=${CMAKE_INSTALL_PREFIX}"
-        "--openssldir=${CMAKE_INSTALL_PREFIX}"
+        "--openssldir=/etc/ssl"
         ${CFLAGS}
     COMMAND "${CMAKE_COMMAND}" "-DDIR=${BUILDDIR}" -P "${CMAKE_CURRENT_LIST_DIR}/remove-deps.cmake"
     VERBATIM


### PR DESCRIPTION
This allows use of the system trusted root certificates even when building OpenSSL for static linking like vcpkg does.

Tested in cpprestsdk build here: https://dev.azure.com/vclibs/cpprestsdk/_build/results?buildId=113&view=logs