### PR TITLE
Handle symlink when installing or removing a library

### DIFF
--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -20,6 +20,7 @@ namespace fs
 
     inline bool is_regular_file(file_status s) { return stdfs::is_regular_file(s); }
     inline bool is_directory(file_status s) { return stdfs::is_directory(s); }
+    inline bool is_symlink(file_status s) { return stdfs::is_symlink(s); }
 }
 
 namespace vcpkg::Files
@@ -54,7 +55,9 @@ namespace vcpkg::Files
                                const fs::path& newpath,
                                fs::copy_options opts,
                                std::error_code& ec) = 0;
+        virtual void copy_symlink(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec) = 0;
         virtual fs::file_status status(const fs::path& path, std::error_code& ec) const = 0;
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const = 0;
 
         virtual std::vector<fs::path> find_from_PATH(const std::string& name) const = 0;
 

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -216,10 +216,18 @@ namespace vcpkg::Files
         {
             return fs::stdfs::copy_file(oldpath, newpath, opts, ec);
         }
+        virtual void copy_symlink(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec)
+        {
+            return fs::stdfs::copy_symlink(oldpath, newpath, ec);
+        }
 
         virtual fs::file_status status(const fs::path& path, std::error_code& ec) const override
         {
             return fs::stdfs::status(path, ec);
+        }
+        virtual fs::file_status symlink_status(const fs::path& path, std::error_code& ec) const override
+        {
+            return fs::stdfs::symlink_status(path, ec);
         }
         virtual void write_contents(const fs::path& file_path, const std::string& data, std::error_code& ec) override
         {

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -62,7 +62,7 @@ namespace vcpkg::Install
         auto files = fs.get_files_recursive(source_dir);
         for (auto&& file : files)
         {
-            const auto status = fs.status(file, ec);
+            const auto status = fs.symlink_status(file, ec);
             if (ec)
             {
                 System::println(System::Color::error, "failed: %s: %s", file.u8string(), ec.message());
@@ -104,6 +104,23 @@ namespace vcpkg::Install
                                         ec.message());
                     }
                     fs.copy_file(file, target, fs::copy_options::overwrite_existing, ec);
+                    if (ec)
+                    {
+                        System::println(System::Color::error, "failed: %s: %s", target.u8string(), ec.message());
+                    }
+                    output.push_back(Strings::format(R"(%s/%s)", destination_subdirectory, suffix));
+                    break;
+                }
+                case fs::file_type::symlink:
+                {
+                    if (fs.exists(target))
+                    {
+                        System::println(System::Color::warning,
+                                        "File %s was already present and will be overwritten",
+                                        target.u8string(),
+                                        ec.message());
+                    }
+                    fs.copy_symlink(file, target, ec);
                     if (ec)
                     {
                         System::println(System::Color::error, "failed: %s: %s", target.u8string(), ec.message());

--- a/toolsrc/src/vcpkg/remove.cpp
+++ b/toolsrc/src/vcpkg/remove.cpp
@@ -55,7 +55,7 @@ namespace vcpkg::Remove
 
                 auto target = paths.installed / suffix;
 
-                const auto status = fs.status(target, ec);
+                const auto status = fs.symlink_status(target, ec);
                 if (ec)
                 {
                     System::println(System::Color::error, "failed: status(%s): %s", target.u8string(), ec.message());
@@ -66,7 +66,7 @@ namespace vcpkg::Remove
                 {
                     dirs_touched.push_back(target);
                 }
-                else if (fs::is_regular_file(status))
+                else if (fs::is_regular_file(status) || fs::is_symlink(status))
                 {
                     fs.remove(target, ec);
                     if (ec)


### PR DESCRIPTION
This one is pretty simple. It's common for the install script to make symbolic links, especially for dynamic libraries. This is usually done so that one build can cover multiple versioning standards. For example, building zlib usually creates a symlink `libz.so` that points to `libz.1.so`, with `libz.1.so` being a symlink pointing to `libz.1.2.11.so` (or whatever version is built). This PR updates the Vcpkg tool so that when copying from `packages/` to `installed/`, symlinks remain as symlinks (previously, each symlink turned into a regular file, copying the linked file). It also updates the remove script so that it can handle removing symlinks as well.