### PR TITLE
Add support for response files with vcpkg

### DIFF
--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -116,6 +116,8 @@ namespace vcpkg::Help
             "  --vcpkg-root <path>             Specify the vcpkg root directory\n"
             "                                  (default: " ENVVAR(VCPKG_ROOT) ")\n"
             "\n"
+            "  @response_file                  Specify a response file to provide additional parameters\n"
+            "\n"
             "For more help (including examples) see the accompanying README.md.",
             Commands::Integrate::INTEGRATE_COMMAND_HELPSTRING);
     }


### PR DESCRIPTION
Response files are a convenient way of specifying bulk parameters,
typically supported by compilers and linkers. For vcpkg response files
provide a convenient way of installing sets of packages from simple
newline separate list files.