### PR TITLE
Fix crc32c CMake configuration directory.

### DIFF
--- a/ports/crc32c/CONTROL
+++ b/ports/crc32c/CONTROL
@@ -1,3 +1,3 @@
 Source: crc32c
-Version: 1.0.5
+Version: 1.0.5-1
 Description: CRC32C implementation with support for CPU-specific acceleration instructions.

--- a/ports/crc32c/portfile.cmake
+++ b/ports/crc32c/portfile.cmake
@@ -1,9 +1,6 @@
 include(vcpkg_common_functions)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-  message(WARNING "building static")
-  set(VCPKG_LIBRARY_LINKAGE static)
-endif()
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
@@ -13,14 +10,13 @@ vcpkg_from_github(
   HEAD_REF master
 )
 
-
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
   OPTIONS
-  -DCRC32C_BUILD_TESTS=OFF
-  -DCRC32C_BUILD_BENCHMARKS=OFF
-  -DCRC32C_USE_GLOG=OFF
+    -DCRC32C_BUILD_TESTS=OFF
+    -DCRC32C_BUILD_BENCHMARKS=OFF
+    -DCRC32C_USE_GLOG=OFF
 )
 
 vcpkg_install_cmake()
@@ -30,9 +26,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/Crc32c")
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/Crc32c RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/crc32c RENAME copyright)

--- a/ports/crc32c/portfile.cmake
+++ b/ports/crc32c/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake")
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/Crc32c")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
@@ -35,4 +35,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/crc32c RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/Crc32c RENAME copyright)


### PR DESCRIPTION
The port was installing the CMake configuration files for Crc32c in
share/crc32c/Crc32c/Crc32cConfig.cmake, where find_package() cannot
find them.  They should be installed in share/crc32c/Crc32cConfig.cmake.