### PR TITLE
[sndfile] Add new port sndfile

### DIFF
--- a/ports/sndfile/CONTROL
+++ b/ports/sndfile/CONTROL
@@ -1,0 +1,8 @@
+Source: sndfile
+Version: 1.0.29-cebfdf2-1
+Description: Library to read, write and manipulate many soundfile types. Authored by Eric de Castro Lopo
+Default-Features: external-libs
+
+Feature: external-libs
+Description: Support Ogg Vorbis and FLAC audio files
+Build-Depends: libogg, libflac, libvorbis

--- a/ports/sndfile/portfile.cmake
+++ b/ports/sndfile/portfile.cmake
@@ -33,7 +33,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-+if(WIN32)
+if(WIN32)
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 else()
     vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/SndFile)

--- a/ports/sndfile/portfile.cmake
+++ b/ports/sndfile/portfile.cmake
@@ -33,7 +33,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
++if(WIN32)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/SndFile)
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/sndfile/portfile.cmake
+++ b/ports/sndfile/portfile.cmake
@@ -22,6 +22,10 @@ else()
     set(SNDFILE_WITH_EXTERNAL_LIBS OFF)
 endif()
 
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
+vcpkg_add_to_path(${PYTHON3_EXE_PATH})
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/sndfile/portfile.cmake
+++ b/ports/sndfile/portfile.cmake
@@ -1,0 +1,54 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO erikd/libsndfile
+    REF cebfdf275e6173259bee6bfd40de22c8c102cf23
+    SHA512  b981b9a5a457b73f444f4b134a76d9d7ab328369171a0043f89cfcf4567ca29a91ff75abfb362c4bc76c5fb0d25cb88cc397c37dd8f9d98b8892999c2e4e4123
+    HEAD_REF master
+    PATCHES
+        "${CMAKE_CURRENT_LIST_DIR}/uwp-createfile-getfilesize.patch"
+        "${CMAKE_CURRENT_LIST_DIR}/uwp-createfile-getfilesize-addendum.patch"
+)
+
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" CRT_LIB_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+
+option(BUILD_EXECUTABLES "Build sndfile tools and install to folder tools" OFF)
+
+if("external-libs" IN_LIST FEATURES)
+    set(SNDFILE_WITH_EXTERNAL_LIBS ON)
+else()
+    set(SNDFILE_WITH_EXTERNAL_LIBS OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_EXAMPLES=0 -DBUILD_REGTEST=0 -DBUILD_TESTING=0 -DENABLE_STATIC_RUNTIME=${CRT_LIB_STATIC} -DBUILD_STATIC_LIBS=${BUILD_STATIC} -DENABLE_EXTERNAL_LIBS=${SNDFILE_WITH_EXTERNAL_LIBS}
+    OPTIONS_RELEASE -DBUILD_PROGRAMS=${BUILD_EXECUTABLES}
+    # Setting ENABLE_PACKAGE_CONFIG=0 has no effect
+    OPTIONS_DEBUG -DBUILD_PROGRAMS=0
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc/libsndfile ${CURRENT_PACKAGES_DIR}/share/${PORT}/doc)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
+
+if(BUILD_EXECUTABLES)
+    file(GLOB TOOLS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+    file(COPY ${TOOLS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    file(REMOVE ${TOOLS})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+endif(BUILD_EXECUTABLES)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)

--- a/ports/sndfile/uwp-createfile-getfilesize-addendum.patch
+++ b/ports/sndfile/uwp-createfile-getfilesize-addendum.patch
@@ -1,0 +1,13 @@
+diff --git a/src/file_io.c b/src/file_io.c
+index 47351bc..54741c9 100644
+--- a/src/file_io.c
++++ b/src/file_io.c
+@@ -799,6 +799,8 @@ psf_open_handle (PSF_FILE * pfile)
+ 
+ 	if (handle == INVALID_HANDLE_VALUE)
+ 		return NULL;
++
++	return handle;
+ #else
+ 	if (pfile->use_wchar)
+ 		handle = CreateFileW (

--- a/ports/sndfile/uwp-createfile-getfilesize.patch
+++ b/ports/sndfile/uwp-createfile-getfilesize.patch
@@ -1,0 +1,58 @@
+diff --git a/src/file_io.c b/src/file_io.c
+index 7cf8f0c..47351bc 100644
+--- a/src/file_io.c
++++ b/src/file_io.c
+@@ -787,6 +787,19 @@ psf_open_handle (PSF_FILE * pfile)
+ 				return NULL ;
+ 		} ;
+ 
++#if defined (WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
++	if (!pfile->use_wchar)
++		return NULL;
++
++	CREATEFILE2_EXTENDED_PARAMETERS cfParams = {0};
++	cfParams.dwSize = sizeof(CREATEFILE2_EXTENDED_PARAMETERS);
++	cfParams.dwFileAttributes = FILE_ATTRIBUTE_NORMAL;
++
++	handle = CreateFile2(pfile->path.wc, dwDesiredAccess, dwShareMode, dwCreationDistribution, &cfParams);
++
++	if (handle == INVALID_HANDLE_VALUE)
++		return NULL;
++#else
+ 	if (pfile->use_wchar)
+ 		handle = CreateFileW (
+ 					pfile->path.wc,				/* pointer to name of the file */
+@@ -812,6 +825,7 @@ psf_open_handle (PSF_FILE * pfile)
+ 		return NULL ;
+ 
+ 	return handle ;
++#endif
+ } /* psf_open_handle */
+ 
+ /* USE_WINDOWS_API */ static void
+@@ -1104,7 +1118,16 @@ psf_is_pipe (SF_PRIVATE *psf)
+ 
+ /* USE_WINDOWS_API */ sf_count_t
+ psf_get_filelen_handle (HANDLE handle)
+-{	sf_count_t filelen ;
++{
++#if defined (WINAPI_FAMILY_PARTITION) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
++	LARGE_INTEGER size;
++
++	if (!GetFileSizeEx(handle, &size) && GetLastError() != NO_ERROR)
++		return (sf_count_t) -1 ;
++
++	return size.QuadPart;
++#else
++	sf_count_t filelen ;
+ 	DWORD dwFileSizeLow, dwFileSizeHigh, dwError = NO_ERROR ;
+ 
+ 	dwFileSizeLow = GetFileSize (handle, &dwFileSizeHigh) ;
+@@ -1118,6 +1141,7 @@ psf_get_filelen_handle (HANDLE handle)
+ 	filelen = dwFileSizeLow + ((__int64) dwFileSizeHigh << 32) ;
+ 
+ 	return filelen ;
++#endif
+ } /* psf_get_filelen_handle */
+ 
+ /* USE_WINDOWS_API */ void


### PR DESCRIPTION
This alternative to libsndfile port. As CMake developer for libsndfile I've made huge amout of changes to libsndfile CMake build system, so i think we need to recreate port with new name because:

* CMake package search name is now SndFile:
   `(find_package(SndFile)`
* Library target is now `SndFile::sndfile`:
  `target_link_libraries(Foo PRIVATE SndFile::sndfile)`
* Library name is now generated by build system, it is `sndfile.dll` under Windows

Old `libsndfile` is untouched and still works.