### PR TITLE
[portaudio] fix wasapi support (#4236)

### DIFF
--- a/ports/portaudio/CONTROL
+++ b/ports/portaudio/CONTROL
@@ -1,3 +1,3 @@
 Source: portaudio
-Version: 19.0.6.00-2
+Version: 19.0.6.00-3
 Description: PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_apply_patches(
         PATCHES
                 ${CMAKE_CURRENT_LIST_DIR}/cmakelists-install.patch
                 ${CMAKE_CURRENT_LIST_DIR}/find_dsound.patch
+                ${CMAKE_CURRENT_LIST_DIR}/wasapi_support.patch
                 ${CMAKE_CURRENT_LIST_DIR}/crt_linkage_build_config.patch)
 
 # NOTE: the ASIO backend will be built automatically if the ASIO-SDK is provided

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -1,27 +1,19 @@
-# Common Ambient Variables:
-#   VCPKG_ROOT_DIR = <C:/path/to/current/vcpkg>
-#   TARGET_TRIPLET is the current triplet (${VCPKG_TARGET_ARCHITECTURE}-windows, etc)
-#   PORT is the current port name (zlib, etc)
-#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}/buildtrees/${PORT}
-#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}/packages/${PORT}_${TARGET_TRIPLET}
-#
-
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/portaudio)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz"
     FILENAME "pa_stable_v190600_20161030.tgz"
     SHA512 7ec692cbd8c23878b029fad9d9fd63a021f57e60c4921f602995a2fca070c29f17a280c7f2da5966c4aad29d28434538452f4c822eacf3a60af59a6dc8e9704c
 )
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(
-        SOURCE_PATH ${SOURCE_PATH}
-        PATCHES
-                ${CMAKE_CURRENT_LIST_DIR}/cmakelists-install.patch
-                ${CMAKE_CURRENT_LIST_DIR}/find_dsound.patch
-                ${CMAKE_CURRENT_LIST_DIR}/wasapi_support.patch
-                ${CMAKE_CURRENT_LIST_DIR}/crt_linkage_build_config.patch)
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    PATCHES
+        cmakelists-install.patch
+        find_dsound.patch
+        wasapi_support.patch
+        crt_linkage_build_config.patch
+)
 
 # NOTE: the ASIO backend will be built automatically if the ASIO-SDK is provided
 # in a sibling folder of the portaudio source in vcpkg/buildtrees/portaudio/src

--- a/ports/portaudio/wasapi_support.patch
+++ b/ports/portaudio/wasapi_support.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists_org.txt
++++ b/CMakeLists.txt
+@@ -200,7 +200,7 @@
+     SET(PA_LIBRARY_DEPENDENCIES ${PA_LIBRARY_DEPENDENCIES} ole32 uuid)
+   ENDIF()
+ 
+-  IF(MSVS)
++  IF(MSVC)
+     OPTION(PA_USE_WASAPI "Enable support for WASAPI" ON)
+   ELSE()
+     # I was unable to get WASAPI to compile outside of Visual Studio. If


### PR DESCRIPTION
This PR fixes a small typo in portaudio's CMake file, which prevents WASAPI support from being enabled (the option PA_USE_WASAPI=ON - as specified in the portfile - is ignored due to this).

A new patch file is added to the portaudio port, that replaces the misspelled variable name.

Fixes #4236