### PR TITLE
Enable Windows ARM32 build of OpenSSL LTS

### DIFF
--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl-windows
-Version: 1.0.2p
+Version: 1.0.2p-1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl-windows/EnableWinARM32.patch
+++ b/ports/openssl-windows/EnableWinARM32.patch
@@ -1,0 +1,21 @@
+diff --git a/util/pl/VC-32.pl b/util/pl/VC-32.pl
+index dba96cba5e..7fd99959f1 100644
+--- a/util/pl/VC-32.pl
++++ b/util/pl/VC-32.pl
+@@ -261,6 +261,8 @@ if ($shlib && $FLAVOR !~ /CE/)
+        {
+        $mlflags.=" $lflags /dll";
+        $lib_cflag.=" -D_WINDLL";
++       if ($base_cflags !~ /-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE/)
++       {
+        #
+        # Engage Applink...
+        #
+@@ -286,6 +288,7 @@ ___
+ CRYPTOOBJ=ms\uptable.obj $(CRYPTOOBJ)
+ ___
+        }
++       }
+ elsif ($shlib && $FLAVOR =~ /CE/)
+        {
+        $mlflags.=" $lflags /dll";

--- a/ports/openssl-windows/portfile.cmake
+++ b/ports/openssl-windows/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_apply_patches(
     SOURCE_PATH ${MASTER_COPY_SOURCE_PATH}
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/ConfigureIncludeQuotesFix.patch
             ${CMAKE_CURRENT_LIST_DIR}/STRINGIFYPatch.patch
+            ${CMAKE_CURRENT_LIST_DIR}/EnableWinARM32.patch
             ${CMAKE_CURRENT_LIST_DIR}/EmbedSymbolsInStaticLibsZ7.patch
 )
 
@@ -44,6 +45,13 @@ if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     set(OPENSSL_ARCH VC-WIN64A)
     set(OPENSSL_DO "ms\\do_win64a.bat")
+elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    set(OPENSSL_ARCH VC-WIN32)
+    set(OPENSSL_DO "ms\\do_ms.bat")
+    set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
+        no-asm
+        -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+    )
 else()
     message(FATAL_ERROR "Unsupported target architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()

--- a/ports/osgearth/CONTROL
+++ b/ports/osgearth/CONTROL
@@ -1,4 +1,4 @@
 Source: osgearth
-Version: 2.9-1
+Version: 2.9-2
 Description:  osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.
 Build-Depends: osg

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -16,12 +16,20 @@ if(NOT OSG_PLUGINS_SUBDIR_LENGTH EQUAL 1)
 endif()
 string(REPLACE "${CURRENT_INSTALLED_DIR}/tools/osg/" "" OSG_PLUGINS_SUBDIR "${OSG_PLUGINS_SUBDIR}")
 
+vcpkg_download_distfile(
+    VS2017PATCH
+    URLS "https://github.com/remoe/osgearth/commit/f7081cc4f9991c955c6a0ef7b7b50e48360d14fd.diff"
+    FILENAME "osgearth-f7081cc4f9991c955c6a0ef7b7b50e48360d14fd.patch"
+    SHA512 eadb47a5713c00c05add8627e5cad22844db041da34081d59104151a1a1e2d5ac9552909d67171bfc0449a3e4d2930dd3a7914d3ec7ef7ff1015574e9c9a6105
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gwaldron/osgearth
     REF d1884d819d4a43de32b7ca1ded655c73964bed17
     SHA512 525ad4ce8bcbd7d73a2ed66e7fbcd9d302582276f26dda1ef2baa3828da5c1e302ba81aac95d0a0632c7395cbcd072d2b19d084ba641c1ba92872d42bb6f769c
     HEAD_REF master
+    PATCHES ${VS2017PATCH}
 )
 
 vcpkg_configure_cmake(

--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.1.0-1
+Version: 8.1.0-2
 Description: Software system for 3D computer graphics, image processing, and visualization
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora
 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -2,15 +2,6 @@ include(vcpkg_common_functions)
 
 set(VTK_SHORT_VERSION "8.1")
 set(VTK_LONG_VERSION "${VTK_SHORT_VERSION}.0")
-
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO "Kitware/VTK"
-    REF "v${VTK_LONG_VERSION}"
-    SHA512 09e110cba4ad9a6684e9b2af0cbb5b9053e3596ccb62aab96cd9e71aa4a96c809d96e13153ff44c28ad83015a61ba5195f7d34056707b62654c1bc057f9b9edf
-    HEAD_REF "master"
-)
-
 # =============================================================================
 # Options:
 
@@ -46,13 +37,18 @@ endif()
 
 set(VTK_WITH_ALL_MODULES                 OFF) # IMPORTANT: if ON make sure `qt5`, `mpi`, `python3`, `ffmpeg`, `gdal`, `fontconfig`,
                                               #            `libmysql` and `atlmfc` are  listed as dependency in the CONTROL file
+
 # =============================================================================
-# Apply patches to the source code
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
+# Clone & patch
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "Kitware/VTK"
+    REF "v${VTK_LONG_VERSION}"
+    SHA512 09e110cba4ad9a6684e9b2af0cbb5b9053e3596ccb62aab96cd9e71aa4a96c809d96e13153ff44c28ad83015a61ba5195f7d34056707b62654c1bc057f9b9edf
+    HEAD_REF "master"
     PATCHES
         # Disable ssize_t because this can conflict with ssize_t that is defined on windows.
-        ${CMAKE_CURRENT_LIST_DIR}/dont-define-ssize_t.patch
+        dont-define-ssize_t.patch
 
         # We force CMake to use it's own version of the FindHDF5 module since newer versions
         # shipped with CMake behave differently. E.g. the one shipped with CMake 3.9 always
@@ -61,16 +57,16 @@ vcpkg_apply_patches(
         # Maybe in the future we can disable the patch and use the new version shipped with CMake
         # together with the hdf5-config.cmake that is written by HDF5 itself, but currently VTK
         # disables taking the config into account explicitly.
-        ${CMAKE_CURRENT_LIST_DIR}/use-fixed-find-hdf5.patch
+        use-fixed-find-hdf5.patch
 
         # We disable a workaround in the VTK CMake scripts that can lead to the fact that a dependency
         # will link to both, the debug and the release library.
-        ${CMAKE_CURRENT_LIST_DIR}/disable-workaround-findhdf5.patch
+        disable-workaround-findhdf5.patch
 
-        ${CMAKE_CURRENT_LIST_DIR}/fix-find-libproj4.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-find-libharu.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-find-mysql.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-find-odbc.patch
+        fix-find-libproj4.patch
+        fix-find-libharu.patch
+        fix-find-mysql.patch
+        fix-find-odbc.patch
 )
 
 # Remove the FindGLEW.cmake and FindPythonLibs.cmake that are distributed with VTK,
@@ -292,6 +288,14 @@ endforeach()
 file(READ "${CURRENT_PACKAGES_DIR}/share/vtk/VTKTargets.cmake" VTK_TARGETS_CONTENT)
 string(REGEX REPLACE "${CURRENT_INSTALLED_DIR}/lib/[^\\.]*\\.lib" "" VTK_TARGETS_CONTENT "${VTK_TARGETS_CONTENT}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/vtk/VTKTargets.cmake" "${VTK_TARGETS_CONTENT}")
+
+# Remove any remaining stray absolute references to the installed directory.
+file(GLOB_RECURSE CMAKE_FILES ${CURRENT_PACKAGES_DIR}/share/vtk/*.cmake)
+foreach(FILE IN LISTS CMAKE_FILES)
+    file(READ "${FILE}" _contents)
+    string(REPLACE "${CURRENT_INSTALLED_DIR}" "\${VTK_INSTALL_PREFIX}" _contents "${_contents}")
+    file(WRITE "${FILE}" "${_contents}")
+endforeach()
 
 # =============================================================================
 # Move executable to tools directory and clean-up other directories


### PR DESCRIPTION
Currently, when building dlls for Windows, -DOPENSSL_USE_APPLINK is added to $cflags. This in turn enables the ms/uplink.h include through cryptlib.h (gleaned from VC-32.pl). It also builds and adds for linking ms\applink.c and ms\uplink.c. The problem with applink is that it requires architecture specific assembly code. uplink-x86.pl generates the assembly code for x86 using x86asm.pl. uplink-x86)x64.pl does this for x64 using x86_6x-xlate.pl. The corresponding ARM32 architecture specific assembly code is missing.

We have noticed that not all projects require the applink functionality to work properly. We propose to disable uplink for Windows ARM32 until the applink functionality is implemented for ARM32. 

Given that 1.0.2 is in maintenance and not accepting new changes other than bug fixes and security fixes (as per https://github.com/openssl/openssl/issues/7448#issuecomment-431557964), we would like to add the proposed patch to unblock ARM32 in the meantime.