### PR TITLE
[pcl] Fix PCL install with HEAD

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.8.1-12
+Version: 1.8.1-13
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
 

--- a/ports/pcl/find_flann.patch
+++ b/ports/pcl/find_flann.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/Modules/FindFLANN.cmake b/cmake/Modules/FindFLANN.cmake
-index b5739dc95..d2c3fd07e 100644
+index b5739dc95..4041a2539 100644
 --- a/cmake/Modules/FindFLANN.cmake
 +++ b/cmake/Modules/FindFLANN.cmake
 @@ -10,8 +10,8 @@
@@ -13,12 +13,3 @@ index b5739dc95..d2c3fd07e 100644
  else(FLANN_USE_STATIC)
    set(FLANN_RELEASE_NAME flann_cpp)
    set(FLANN_DEBUG_NAME flann_cpp-gd)
-@@ -41,7 +41,7 @@ find_library(FLANN_LIBRARY_DEBUG
-              NAMES ${FLANN_DEBUG_NAME} ${FLANN_RELEASE_NAME}
- 	     HINTS ${PC_FLANN_LIBDIR} ${PC_FLANN_LIBRARY_DIRS} "${FLANN_ROOT}" "$ENV{FLANN_ROOT}"
- 	     PATHS "$ENV{PROGRAMFILES}/Flann" "$ENV{PROGRAMW6432}/Flann" 
--	     PATH_SUFFIXES lib)
-+	     PATH_SUFFIXES lib debug/lib)
- 
- if(NOT FLANN_LIBRARY_DEBUG)
-   set(FLANN_LIBRARY_DEBUG ${FLANN_LIBRARY})

--- a/ports/pcl/find_flann_add_search_path_suffix.patch
+++ b/ports/pcl/find_flann_add_search_path_suffix.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Modules/FindFLANN.cmake b/cmake/Modules/FindFLANN.cmake
+index 4041a2539..d2c3fd07e 100644
+--- a/cmake/Modules/FindFLANN.cmake
++++ b/cmake/Modules/FindFLANN.cmake
+@@ -41,7 +41,7 @@ find_library(FLANN_LIBRARY_DEBUG
+              NAMES ${FLANN_DEBUG_NAME} ${FLANN_RELEASE_NAME}
+ 	     HINTS ${PC_FLANN_LIBDIR} ${PC_FLANN_LIBRARY_DIRS} "${FLANN_ROOT}" "$ENV{FLANN_ROOT}"
+ 	     PATHS "$ENV{PROGRAMFILES}/Flann" "$ENV{PROGRAMW6432}/Flann" 
+-	     PATH_SUFFIXES lib)
++	     PATH_SUFFIXES lib debug/lib)
+ 
+ if(NOT FLANN_LIBRARY_DEBUG)
+   set(FLANN_LIBRARY_DEBUG ${FLANN_LIBRARY})

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
             config.patch
             config_install.patch
             find_flann.patch
+            find_flann_add_search_path_suffix.patch
             find_qhull.patch
             find_openni2.patch
             find_cuda.patch


### PR DESCRIPTION
The second part of this patch ([find_flann.patch#L16-L24](https://github.com/Microsoft/vcpkg/blob/master/ports/pcl/find_flann.patch#L16-L24)) is already merged in upstream head. 
Therefor, This patch doesn't apply when vcpkg install pcl with <code>--head</code>.
But, The first part of this patch ([find_flann.patch#L5-L15](https://github.com/Microsoft/vcpkg/blob/master/ports/pcl/find_flann.patch#L5-L15)) will continue to be necessary.
This pull request will fix pcl install with <code>--head</code> by splitting find_flann.patch.

https://github.com/PointCloudLibrary/pcl/issues/2545 