### PR TITLE
Include libpq-events header file

### DIFF
--- a/ports/libpq/CMakeLists.txt
+++ b/ports/libpq/CMakeLists.txt
@@ -120,6 +120,7 @@ set(pg_libpq_interface
     ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config_ext.h
     ${CMAKE_CURRENT_BINARY_DIR}/include/pg_config.h
     src/interfaces/libpq/libpq-fe.h
+    src/interfaces/libpq/libpq-events.h
 )
 set(pg_libpq_catalog_interface
     src/include/catalog/pg_type.h

--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,4 +1,4 @@
 Source: libpq
-Version: 9.6.1-4
+Version: 9.6.1-5
 Description: The official database access API of postgresql
 Build-Depends: openssl, zlib (linux)


### PR DESCRIPTION
Missing the libpq events header file. This file is needed to use the asynchronous libpq interfaces.