### PR TITLE
libbson installation issue on Linux fixed

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,16 +1,16 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libbson-1.9.2)
 
+set(LIBBSON_VERSION 1.9.2)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/mongodb/libbson/archive/1.9.2.tar.gz"
-    FILENAME "libbson-1.9.2.tar.gz"
+    URLS "https://github.com/mongodb/libbson/archive/${LIBBSON_VERSION}.tar.gz"
+    FILENAME "libbson-${LIBBSON_VERSION}.tar.gz"
     SHA512 a05f1e8fbabb34e847692397e2e41fc5923ddd18dba861e5ab8a31acdf6738e13ab719eae8f9f8563f08fc43aab5c8d1f53cb6a47c38c96e132fa4a62a48d2bf
 )
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-uwp.patch
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${LIBBSON_VERSION}
+    PATCHES fix-uwp.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -45,27 +45,26 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/temp ${CURRENT_PACKAGES_DIR}/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-	if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-		file(RENAME
-	        ${CURRENT_PACKAGES_DIR}/lib/libbson-static-1.0.a
-	        ${CURRENT_PACKAGES_DIR}/lib/libbson-1.0.a)
-	    file(RENAME
-	        ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-static-1.0.a
-	        ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-1.0.a)
-	else()
-		file(RENAME
-	        ${CURRENT_PACKAGES_DIR}/lib/bson-static-1.0.lib
-	        ${CURRENT_PACKAGES_DIR}/lib/bson-1.0.lib)
-	    file(RENAME
-	        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-static-1.0.lib
-	        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-1.0.lib)
-	endif()
+    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/lib/libbson-static-1.0.a
+            ${CURRENT_PACKAGES_DIR}/lib/libbson-1.0.a)
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-static-1.0.a
+            ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-1.0.a)
+    else()
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/lib/bson-static-1.0.lib
+            ${CURRENT_PACKAGES_DIR}/lib/bson-1.0.lib)
+        file(RENAME
+            ${CURRENT_PACKAGES_DIR}/debug/lib/bson-static-1.0.lib
+            ${CURRENT_PACKAGES_DIR}/debug/lib/bson-1.0.lib)
+    endif()
 
     # drop the __declspec(dllimport) when building static
     vcpkg_apply_patches(
         SOURCE_PATH ${CURRENT_PACKAGES_DIR}/include
-        PATCHES
-            ${CMAKE_CURRENT_LIST_DIR}/static.patch
+        PATCHES static.patch
     )
 
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -45,12 +45,21 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/temp ${CURRENT_PACKAGES_DIR}/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(RENAME
-        ${CURRENT_PACKAGES_DIR}/lib/bson-static-1.0.lib
-        ${CURRENT_PACKAGES_DIR}/lib/bson-1.0.lib)
-    file(RENAME
-        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-static-1.0.lib
-        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-1.0.lib)
+	if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+		file(RENAME
+	        ${CURRENT_PACKAGES_DIR}/lib/libbson-static-1.0.a
+	        ${CURRENT_PACKAGES_DIR}/lib/libbson-1.0.a)
+	    file(RENAME
+	        ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-static-1.0.a
+	        ${CURRENT_PACKAGES_DIR}/debug/lib/libbson-1.0.a)
+	else()
+		file(RENAME
+	        ${CURRENT_PACKAGES_DIR}/lib/bson-static-1.0.lib
+	        ${CURRENT_PACKAGES_DIR}/lib/bson-1.0.lib)
+	    file(RENAME
+	        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-static-1.0.lib
+	        ${CURRENT_PACKAGES_DIR}/debug/lib/bson-1.0.lib)
+	endif()
 
     # drop the __declspec(dllimport) when building static
     vcpkg_apply_patches(


### PR DESCRIPTION
This is related to the discussion in #4451. It doesn't actually solve that issue because the `mongo-c-driver` itself also fails to build, but this fixes a prerequisite (libbson).