### PR TITLE
[qt5-winextras] remove atlmfc dependency

### DIFF
--- a/ports/qt5-winextras/CONTROL
+++ b/ports/qt5-winextras/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-winextras
-Version: 5.11.1
+Version: 5.11.1-1
 Description: Qt5 Windows Extras Module. Provides platform-specific APIs for Windows.
-Build-Depends: qt5-modularscripts, qt5-base, atlmfc
+Build-Depends: qt5-modularscripts, qt5-base


### PR DESCRIPTION
Removed the `atlmfc` dependency from `qt5-winextras` as it seems to work just fine without it and people who use Qt are likely to not install MFC in the first place.