### PR TITLE
[xerces-c] Avoid building executables

### DIFF
--- a/ports/xerces-c/CONTROL
+++ b/ports/xerces-c/CONTROL
@@ -1,3 +1,3 @@
 Source: xerces-c
-Version: 3.2.2-4
+Version: 3.2.2-5
 Description: Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.

--- a/ports/xerces-c/disable-tests.patch
+++ b/ports/xerces-c/disable-tests.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4254f89..aa08565 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -175,10 +175,16 @@ install(
+   COMPONENT "development")
+ 
+ # Process subdirectories
++if(NOT DISABLE_DOC)
+ add_subdirectory(doc)
++endif()
+ add_subdirectory(src)
++if(NOT DISABLE_TESTS)
+ add_subdirectory(tests)
++endif()
++if(NOT DISABLE_SAMPLES)
+ add_subdirectory(samples)
++endif()
+ 
+ # Display configuration summary
+ message(STATUS "")

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -6,11 +6,16 @@ vcpkg_from_github(
     REF Xerces-C_3_2_2
     SHA512 66f60fe9194376ac0ca99d13ea5bce23ada86e0261dde30686c21ceb5499e754dab8eb0a98adadd83522bda62709377715501f6dac49763e3a686f9171cc63ea
     HEAD_REF trunk
+    PATCHES disable-tests.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DDISABLE_TESTS=ON
+        -DDISABLE_DOC=ON
+        -DDISABLE_SAMPLES=ON
 )
 
 vcpkg_install_cmake()
@@ -19,16 +24,6 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/cmake)
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/xercesc)
 else()
     vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/XercesC TARGET_PATH share/xercesc)
-endif()
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-else()
-    file(GLOB release_exe "${CURRENT_PACKAGES_DIR}/bin/*.exe")
-    file(GLOB debug_exe "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
-    if(release_exe OR debug_exe)
-        file(REMOVE ${release_exe} ${debug_exe})
-    endif()
 endif()
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfigInternal.cmake _contents)


### PR DESCRIPTION
This patch avoids building samples, docs, and tests (our current policy).

@rleigh-codelibre for potential upstream interest
