### PR TITLE
[portaudio] Copy PDB files

### DIFF
--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -47,6 +47,8 @@ else ()
 	file (REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif ()
 
+vcpkg_copy_pdbs()
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/portaudio)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/portaudio/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/portaudio/copyright)


### PR DESCRIPTION
This helps with debugging. According to docs/maintainers/vcpkg_copy_pdbs.md this should always be done.