### PR TITLE
Update libpng cmake wrapper for dynamic libraries

### DIFF
--- a/ports/libgd/CONTROL
+++ b/ports/libgd/CONTROL
@@ -1,4 +1,4 @@
 Source: libgd
-Version: 2.2.4-3
+Version: 2.2.4-4
 Description: Open source code library for the dynamic creation of images by programmers.
 Build-Depends: freetype, libjpeg-turbo, libpng, libwebp, tiff, fontconfig

--- a/ports/libgd/no-write-source-dir.patch
+++ b/ports/libgd/no-write-source-dir.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b16d4a4..5126085 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,7 +191,8 @@ else (USE_EXT_GD)
+ 	CHECK_INCLUDE_FILE("stdint.h"	HAVE_STDINT_H)
+ 	CHECK_INCLUDE_FILE("inttypes.h"	HAVE_INTTYPES_H)
+ 
+-	CONFIGURE_FILE(${GD_SOURCE_DIR}/src/config.h.cmake ${GD_SOURCE_DIR}/src/config.h ESCAPE_QUOTES)
++	CONFIGURE_FILE(${GD_SOURCE_DIR}/src/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/src/config.h ESCAPE_QUOTES)
++	include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
+ 
+ 	option(BUILD_SHARED_LIBS "Build shared libs" ON)
+ 	option(BUILD_STATIC_LIBS "Build static libs" OFF)

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -1,19 +1,15 @@
 include(vcpkg_common_functions)
 
-set(LIBGD_VERSION 2.2.4)
-set(LIBGD_HASH 02ce40c45f31cf1645ad1d3fd9b9b498323b2709d40b0681cd403c11072a1f2149f5af844a6bf9e695c29e3247013bb94c57c0225a54189d728f64caf0a938ee)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libgd-gd-${LIBGD_VERSION})
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/libgd/libgd/archive/gd-${LIBGD_VERSION}.tar.gz"
-    FILENAME "gd-${LIBGD_VERSION}.tar.gz"
-    SHA512 ${LIBGD_HASH})
-
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake.patch")
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libgd/libgd
+    REF gd-2.2.4
+    SHA512 02ce40c45f31cf1645ad1d3fd9b9b498323b2709d40b0681cd403c11072a1f2149f5af844a6bf9e695c29e3247013bb94c57c0225a54189d728f64caf0a938ee
+    HEAD_REF master
+    PATCHES
+        0001-fix-cmake.patch
+        no-write-source-dir.patch
+)
 
 #delete CMake builtins modules
 file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/CMakeParseArguments.cmake)

--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,4 +1,4 @@
 Source: libpng
-Version: 1.6.35
+Version: 1.6.35-1
 Build-Depends: zlib
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/vcpkg-cmake-wrapper.cmake
+++ b/ports/libpng/vcpkg-cmake-wrapper.cmake
@@ -1,4 +1,6 @@
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../lib/libpng16.a")
     set(PNG_LIBRARY_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../../lib/libpng16.a" CACHE FILEPATH "")
+elseif(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../../lib/libpng16${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(PNG_LIBRARY_RELEASE "${CMAKE_CURRENT_LIST_DIR}/../../lib/libpng16${CMAKE_SHARED_LIBRARY_SUFFIX}" CACHE FILEPATH "")
 endif()
 _find_package(${ARGS})


### PR DESCRIPTION
This is fairly straightforward. This adds the dynamic library as an option to the CMake wrapper for libpng. This makes building dynamic libraries on Linux and macOS (using a custom triplet) work better.