### PR TITLE
[libgeotiff] Install doc files into the correct place

### DIFF
--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,4 +1,4 @@
 Source: libgeotiff
-Version: 1.4.2-4
+Version: 1.4.2-5
 Description: Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
 Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,4 +1,4 @@
 Source: libgeotiff
-Version: 1.4.2-5
+Version: 1.4.2-6
 Description: Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
 Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -56,4 +56,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR (VCPKG_CMAKE_SYSTEM_NAME AND NOT V
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
 endif()
 
+# Move and cleanup doc files
+file(GLOB DOC_FILES "${CURRENT_PACKAGES_DIR}/doc/*") 
+file(INSTALL ${DOC_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff/doc) 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc ${CURRENT_PACKAGES_DIR}/debug/doc) 
+
 vcpkg_copy_pdbs()

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -36,7 +36,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff RENAME copyright)
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/libgeotiff/copyright COPYONLY)
 
 if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     file(GLOB GEOTIFF_UTILS ${CURRENT_PACKAGES_DIR}/bin/*)
@@ -44,7 +44,7 @@ else()
     file(GLOB GEOTIFF_UTILS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
 endif()
 
-file(INSTALL ${GEOTIFF_UTILS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/libgeotiff/)
+file(COPY ${GEOTIFF_UTILS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/libgeotiff)
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/libgeotiff)
 
 file(GLOB EXES ${CURRENT_PACKAGES_DIR}/bin/*.exe ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
@@ -57,8 +57,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR (VCPKG_CMAKE_SYSTEM_NAME AND NOT V
 endif()
 
 # Move and cleanup doc files
-file(GLOB DOC_FILES "${CURRENT_PACKAGES_DIR}/doc/*") 
-file(INSTALL ${DOC_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgeotiff/doc) 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc ${CURRENT_PACKAGES_DIR}/debug/doc) 
+file(RENAME ${CURRENT_PACKAGES_DIR}/doc ${CURRENT_PACKAGES_DIR}/share/libgeotiff/doc) 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/doc) 
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
The original portfile put documentation (authors, readme, etc.) inside of `vcpkg/installed/<triplet>/doc`. This PR modifies the portfile such that the files are installed to `vcpkg/installed/<triplet>/share/libgeotiff/doc` instead.