### PR TITLE
[WIP] Port XGBoost

### DIFF
--- a/ports/dmlc-core/CONTROL
+++ b/ports/dmlc-core/CONTROL
@@ -1,0 +1,3 @@
+Source: dmlc-core
+Version:
+Description:

--- a/ports/dmlc-core/portfile.cmake
+++ b/ports/dmlc-core/portfile.cmake
@@ -1,0 +1,40 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+set(DMLC-CORE_PORT_VERSION "v0.3")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/dmlc-core
+    REF ${DMLC-CORE_PORT_VERSION}
+    SHA512 eddec2e79ce2dc6da79cf310fe2985bc5097698342003fd0a799ae23a8f248ad0f84ade39edbd9c35dd8ec0f89d655684e7d3d474c17791df7293aedd67a856d
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/dmlc-core RENAME copyright)
+
+# Post-build test for cmake libraries
+# vcpkg_test_cmake(PACKAGE_NAME dmlc-core)

--- a/ports/rabit/CONTROL
+++ b/ports/rabit/CONTROL
@@ -1,0 +1,3 @@
+Source: rabit
+Version:
+Description:

--- a/ports/rabit/portfile.cmake
+++ b/ports/rabit/portfile.cmake
@@ -1,0 +1,48 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+set(RABIT_PORT_VERSION "v0.1")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/rabit
+    REF ${RABIT_PORT_VERSION}
+    SHA512 145fd839898cb95eaab9a88ad3301a0ccac0c8b672419ee2b8eb6ba273cc9a26e069e5ecbc37a3078e46dc64d11efb3e5ab10e5f8fed714e7add85b9e6ac2ec7
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
+
+# Consolidate cmake files in to /share/rabit
+file(GLOB RABIT_CMAKE_FILES ${CURRENT_PACKAGES_DIR}/lib/cmake/*.cmake)
+file(COPY ${RABIT_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/rabit)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/rabit RENAME copyright)
+
+#file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/x265)
+
+# Post-build test for cmake libraries
+# vcpkg_test_cmake(PACKAGE_NAME rabit)


### PR DESCRIPTION
Looks to close #2732

Have currently ported XGBoost's dependencies rabit and dmlc-core.
Remaining: cub

XGBoost uses git submodules, so if there is an easier way to work with those that I'm missing, feel free to chime in. I would guess that even after I port cub, XGBoost's assumption that its dependencies are git submodules will require some patches to work around, but I'm not sure.

I'll keep chipping away at this in the coming week