### PR TITLE
[cpprestsdk] Update to v2.10.8 and add brotli feature.

### DIFF
--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,10 +1,18 @@
 Source: cpprestsdk
-Version: 2.10.6-3
+Version: 2.10.7
 Build-Depends: zlib, openssl (!uwp&!windows), boost-system (!uwp&!windows), boost-date-time (!uwp&!windows), boost-regex (!uwp&!windows), boost-thread (!uwp&!windows), boost-filesystem (!uwp&!windows), boost-random (!uwp&!windows), boost-chrono (!uwp&!windows)
 Description: C++11 JSON, REST, and OAuth library
   The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services.
-Default-Features: websockets
+Default-Features: default-features
+
+Feature: default-features
+Build-Depends: cpprestsdk[brotli] (windows), cpprestsdk[websockets]
+Description: Features installed by default
 
 Feature: websockets
 Build-Depends: websocketpp (!uwp), openssl (!uwp), boost-system (!uwp), boost-date-time (!uwp), boost-regex (!uwp)
 Description: Websockets support
+
+Feature: brotli
+Build-Depends: brotli
+Description: Brotli compression support

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/cpprestsdk
-    REF v2.10.6
-    SHA512 f0848f329df80ced68132600914f0f4ba1ed42c7c16188e0f2bd41cf0c50173c27ca42c8db72ff239ca881bc8789fa4d1e3189c492832f6c22d36d504b7ce8dd
+    REF v2.10.8
+    SHA512 d80a7db59cfe81d8e0c645acff7bcc2ed9ad04e2f3d14dc4ab2a624290d0ea43a2c7adebb54b52a166fd07375352cfd5f1fe244d7c062ce94ec60b977437b2df
     HEAD_REF master
 )
 
@@ -19,6 +19,11 @@ endif()
 set(CPPREST_EXCLUDE_WEBSOCKETS ON)
 if("websockets" IN_LIST FEATURES)
     set(CPPREST_EXCLUDE_WEBSOCKETS OFF)
+endif()
+
+set(CPPREST_EXCLUDE_BROTLI ON)
+if ("brotli" IN_LIST FEATURES)
+    set(CPPREST_EXCLUDE_BROTLI OFF)
 endif()
 
 vcpkg_configure_cmake(
@@ -37,18 +42,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if (EXISTS "${CURRENT_PACKAGES_DIR}/lib/share") # transition
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/cpprestsdk)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
-else()
-    vcpkg_fixup_cmake_targets() # v2.10.6 and below
-endif()
-
-
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/cpprestsdk)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
 
 file(INSTALL
     ${SOURCE_PATH}/license.txt
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpprestsdk RENAME copyright)
 
 vcpkg_copy_pdbs()
-


### PR DESCRIPTION
The brotli feature is on by default for Windows only. We think it'll probably work on other platforms but haven't tested that extensively.