### PR TITLE
When downloading a tool, print URL and filepath

### DIFF
--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -191,6 +191,7 @@ namespace vcpkg
         if (!fs.exists(tool_data.download_path))
         {
             System::println("Downloading %s...", tool_name);
+            System::println("  %s -> %s", tool_data.url, tool_data.download_path.string());
             Downloads::download_file(fs, tool_data.url, tool_data.download_path, tool_data.sha512);
             System::println("Downloading %s... done.", tool_name);
         }


### PR DESCRIPTION
I'm seeing the error below:

  Building package zlib[core]:x86-windows...
  A suitable version of git was not found (required v2.17.1). Downloading portable git v2.17.1...
  Downloading git...
  WinHttpSendRequest() failed: 12002

I suspect the WinHttpSendRequest error is due to being behind a proxy -
most download issues seem to be this.  Or perhaps because a sys admin
somewhere has disabled WinInet, somehow.  I don't know.  I don't know
how to debug WinHttpSendRequest(); a quick google search didn't help.

By printing the URL that vcpkg is trying to download, and where it's
trying to download to, I can pop the URL in my browser, save it at the
location specified, and move on with my life.

See PR #4639