### PR TITLE
[nanodbc] add support for install --head

### DIFF
--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -45,6 +45,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/debug/cmake)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/cmake)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc RENAME copyright)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -1,17 +1,23 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(STATUS "Warning: Static building not supported yet. Building dynamic.")
-    set(VCPKG_LIBRARY_LINKAGE dynamic)
-endif()
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/nanodbc-2.12.4)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/nanodbc/nanodbc/archive/v2.12.4.tar.gz"
-    FILENAME "nanodbc-2.12.4.tar.gz"
+# Only static libraries are supported.
+# See https://github.com/nanodbc/nanodbc/issues/13
+if(VCPKG_USE_HEAD_VERSION) # v2.13
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+else() # v2.12.4
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nanodbc/nanodbc
+    REF v2.12.4
     SHA512 b9a924516b2a777e5f1497774997672320548722ed53413b0a7ad5d503e2f8ca1099f5059a912b7aae410928f4c4edcdfd02e4cfbf415976cd222697b354b4e6
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
+# Legacy, remove at release of v2.13
+if(NOT VCPKG_USE_HEAD_VERSION)
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES
@@ -20,18 +26,26 @@ vcpkg_apply_patches(
 		${CMAKE_CURRENT_LIST_DIR}/0003_export_def.patch
 		${CMAKE_CURRENT_LIST_DIR}/0004_unicode.patch
 )
+endif()
+# /Legacy
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-	OPTIONS
+    OPTIONS
+# Legacy, remove at release of v2.13
 		-DNANODBC_EXAMPLES=OFF
 		-DNANODBC_TEST=OFF
 		-DNANODBC_USE_UNICODE=ON
+# /Legacy
+        -DNANODBC_DISABLE_EXAMPLES=ON
+        -DNANODBC_DISABLE_TESTS=ON
+        -DNANODBC_ENABLE_UNICODE=ON
 )
 
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/debug/cmake)
 
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/nanodbc/LICENSE ${CURRENT_PACKAGES_DIR}/share/nanodbc/copyright)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -47,5 +47,4 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/cmake ${CURRENT_PACKAGES_DIR}/debug/cmake)
 
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/nanodbc/LICENSE ${CURRENT_PACKAGES_DIR}/share/nanodbc/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc RENAME copyright)


### PR DESCRIPTION
In issue #4607 an update for nanodbc is requested.

This commit adds support for installing from HEAD with `vcpkg install nanodbc --head`.

With the upcoming release (v2.13) a few changes are introduced:
- Only static libraries are supported: nanodbc/nanodbc#13
  Vcpkg only builds dynamic libraries for the current release.
- Cmake configuration flags have been changed. Both are now defined.

A single change when building the current release (v2.12.4):
- The use of `vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)` prevents building a dynamic library against the static CRT. (Unless explicitly configured in a triplet.)
  The previous portfile only displayed a status message.