### PR TITLE
[FMI4cpp] new port fmi4cpp (re-submission)

### DIFF
--- a/ports/fmi4cpp/CONTROL
+++ b/ports/fmi4cpp/CONTROL
@@ -1,0 +1,4 @@
+Source: fmi4cpp
+Version: 0.4.0
+Description: FMI 2.0 implementation written in modern C++
+Build-Depends: boost-property-tree, boost-ublas, boost-odeint, bzip2 (linux), openssl (linux), libzip

--- a/ports/fmi4cpp/portfile.cmake
+++ b/ports/fmi4cpp/portfile.cmake
@@ -1,0 +1,40 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO SFI-Mechatronics/FMI4cpp
+    REF v0.4.0
+    SHA512 356485da5799a5720b3bea9bd935a76c36eb5c242cecfd2325f47175bad0eafa1e088fb1b96b639b8419e2a5a39f7b07fbe9d89d3f8e568e00b8910b7e991111
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    OPTIONS 
+        -DFMI4CPP_BUILD_TESTS=OFF
+        -DFMI4CPP_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/FMI4cpp")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/fmi4cpp RENAME copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
This PR adds a port for [FMI4cpp](https://github.com/SFI-Mechatronics/FMI4cpp).
Windows and Linux have tested and supported.

This is a re-submission of https://github.com/Microsoft/vcpkg/pull/4349 as I managed to mess up the commit history beyond saving. 

closes SFI-Mechatronics/FMI4cpp#4