### PR TITLE
New package: cutelyst2

### DIFF
--- a/ports/cutelyst2/CONTROL
+++ b/ports/cutelyst2/CONTROL
@@ -1,4 +1,4 @@
 Source: cutelyst2
-Version: 2.5.2
+Version: 2.5.2-1
 Description: A C++ Web Framework built on top of Qt, using the simple approach of Catalyst (Perl) framework
 Build-Depends: qt5-base

--- a/ports/cutelyst2/CONTROL
+++ b/ports/cutelyst2/CONTROL
@@ -1,0 +1,4 @@
+Source: cutelyst2
+Version: 2.5.2
+Description: A C++ Web Framework built on top of Qt, using the simple approach of Catalyst (Perl) framework
+Build-Depends: qt5-base

--- a/ports/cutelyst2/portfile.cmake
+++ b/ports/cutelyst2/portfile.cmake
@@ -1,30 +1,48 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cutelyst-2.5.2)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/cutelyst/cutelyst/archive/v2.5.2.tar.gz"
-    FILENAME "v2.5.2.tar.gz"
-    SHA512 462214168026733e38fa0090c22caa468a3933066b04115cefffb57e499077456a479ec1c48a758e66a8fa078a78a5fb32df16a00e7a5f349c69c7aa06c89693
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cutelyst/cutelyst
+    REF 7f594d2b2d227e9e6a0474a55906db7d1ee1cd7e
+    SHA512 de04efd7bd9b07f7b0dd2b014eed93e26f0760ef8e458f8c56dc655977235f237bbc71cfe1c05d6791c2237073497ca4566548327ad01b99b4dbec7c491542c7
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    # PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    PREFER_NINJA
     OPTIONS
         -DBUILD_TESTS:BOOL=OFF
-        -DCMAKE_INSTALL_DIR:STRING=cmake
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()
 
 # Move CMake config files to the right place
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Cutelyst2Qt5 TARGET_PATH share/cutelyst2qt5)
+
+file(GLOB EXES ${CURRENT_PACKAGES_DIR}/bin/cutelyst2 ${CURRENT_PACKAGES_DIR}/bin/cutelyst2-wsgi ${CURRENT_PACKAGES_DIR}/bin/cutelyst2.exe ${CURRENT_PACKAGES_DIR}/bin/cutelyst-wsgi2.exe)
+file(GLOB DEBUG_EXES ${CURRENT_PACKAGES_DIR}/debug/bin/cutelyst2 ${CURRENT_PACKAGES_DIR}/debug/bin/cutelyst2-wsgi ${CURRENT_PACKAGES_DIR}/debug/bin/cutelyst2.exe ${CURRENT_PACKAGES_DIR}/debug/bin/cutelyst-wsgi2.exe)
+if(EXES OR DEBUG_EXES)
+    file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/cutelyst2)
+    file(REMOVE ${EXES} ${DEBUG_EXES})
+    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/cutelyst2)
+endif()
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cutelyst2-plugins/ActionREST.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cutelyst2-plugins ${CURRENT_PACKAGES_DIR}/bin/cutelyst2-plugins)
+endif()
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/cutelyst2-plugins/ActionREST.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/cutelyst2-plugins ${CURRENT_PACKAGES_DIR}/debug/bin/cutelyst2-plugins)
+endif()
+
+file(GLOB BINS ${CURRENT_PACKAGES_DIR}/bin/* ${CURRENT_PACKAGES_DIR}/debug/bin/*)
+if(NOT BINS)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/cutelyst2 RENAME copyright)
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/cutelyst2/copyright COPYONLY)
 
-# Post-build test for cmake libraries
-# vcpkg_test_cmake(PACKAGE_NAME cutelyst2)
+vcpkg_copy_pdbs()

--- a/ports/cutelyst2/portfile.cmake
+++ b/ports/cutelyst2/portfile.cmake
@@ -1,0 +1,30 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/cutelyst-2.5.2)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/cutelyst/cutelyst/archive/v2.5.2.tar.gz"
+    FILENAME "v2.5.2.tar.gz"
+    SHA512 462214168026733e38fa0090c22caa468a3933066b04115cefffb57e499077456a479ec1c48a758e66a8fa078a78a5fb32df16a00e7a5f349c69c7aa06c89693
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    # PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    OPTIONS
+        -DBUILD_TESTS:BOOL=OFF
+        -DCMAKE_INSTALL_DIR:STRING=cmake
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
+
+vcpkg_install_cmake()
+
+# Move CMake config files to the right place
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/cutelyst2 RENAME copyright)
+
+# Post-build test for cmake libraries
+# vcpkg_test_cmake(PACKAGE_NAME cutelyst2)


### PR DESCRIPTION
A C++ Web Framework built on top of Qt, using the simple approach of Catalyst (Perl) framework.

when I do vcpkg build cutelyst2 vcpkg reports 9 errors related to CMake, in this commit:
https://github.com/cutelyst/cutelyst/commit/7f594d2b2d227e9e6a0474a55906db7d1ee1cd7e
I improved the CMake a bit making .dlls being installed in /bin with the .exe files, but even if I change the portfile to use Cutelyst's master branch it still complains about locations.
I don't know much about Windows dev so any help is appreciated. 