### PR TITLE
Update google-cloud-cpp to 0.3.0.

### DIFF
--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 0.1.0-1
-Build-Depends: grpc, gtest
+Version: 0.3.0
+Build-Depends: grpc, gtest, curl, crc32c
 Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 0.3.0
+Version: 0.3.0-1
 Build-Depends: grpc, gtest, curl, crc32c
 Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/include-protobuf.patch
+++ b/ports/google-cloud-cpp/include-protobuf.patch
@@ -1,24 +1,13 @@
-diff --git a/bigtable/CMakeLists.txt b/bigtable/CMakeLists.txt
-index 1b8089f..771e1ec 100644
---- a/bigtable/CMakeLists.txt
-+++ b/bigtable/CMakeLists.txt
-@@ -69,6 +69,10 @@ set(PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis" "${PROJECT_SOUR
- if(GRPC_ROOT_DIR)
-     list(INSERT PROTOBUF_IMPORT_DIRS 0 "${GRPC_ROOT_DIR}/third_party/protobuf/src")
- endif(GRPC_ROOT_DIR)
+--- a/google/cloud/bigtable/CMakeLists.txt	2018-11-09 10:56:34.029389338 -0500
++++ a/google/cloud/bigtable/CMakeLists.txt	2018-11-09 10:57:18.461259917 -0500
+@@ -53,6 +53,10 @@
+ # Configure the location of proto files, particulary the googleapis protos.
+ list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"
+             "${PROJECT_SOURCE_DIR}")
 +find_path(PROTO_INCLUDE_DIR google/protobuf/descriptor.proto)
 +if(PROTO_INCLUDE_DIR)
 +    list(INSERT PROTOBUF_IMPORT_DIRS 0 "${PROTO_INCLUDE_DIR}")
 +endif()
  
- # Get the destination directories based on the GNU recommendations.
- include(GNUInstallDirs)
-@@ -110,7 +114,7 @@ enable_testing()
- 
- # Capture the compiler version and the git revision into variables, then
- # generate a config file with the values.
--if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
-+if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git AND 0)
-     execute_process(COMMAND git rev-parse --short HEAD
-             OUTPUT_VARIABLE GIT_HEAD_LOG ERROR_VARIABLE GIT_HEAD_LOG)
- else ()
+ # Include the functions to compile proto files.
+ include(CompileProtos)

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,18 +8,18 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GoogleCloudPlatform/google-cloud-cpp
-    REF v0.1.0
-    SHA512 3947cc24ca1ed97309f055f17945afe2d6b22ae8f54f86d3395f8c491b7409d4b7bb12206889d04d07f51236e9fd5afd65b904c8c80521a3313588d8069545c2
+    REF v0.3.0
+    SHA512 90f876ebf4bea40c5bc12d2bd20d27b48202f951d57a68b657c07b7d468b2ac5a00e39a3a6fca48f92030d89ba7d9706eb52b3c8e734b392aee63632af042b5d
     HEAD_REF master
     PATCHES
-        "${CMAKE_CURRENT_LIST_DIR}/include-protobuf.patch"
+        "include-protobuf.patch"
 )
 
-set(GOOGLEAPIS_VERSION 92f10d7033c6fa36e1a5a369ab5aa8bafd564009)
+set(GOOGLEAPIS_VERSION 6a3277c0656219174ff7c345f31fb20a90b30b97)
 vcpkg_download_distfile(GOOGLEAPIS
-    URLS "https://github.com/google/googleapis/archive/92f10d7033c6fa36e1a5a369ab5aa8bafd564009.zip"
+    URLS "https://github.com/google/googleapis/archive/${GOOGLEAPIS_VERSION}.zip"
     FILENAME "googleapis-${GOOGLEAPIS_VERSION}.zip"
-    SHA512 4280ece965a231f6a0bb3ea38a961d15babd9eac517f9b0d57e12f186481bbab6a27e4f0ee03ba3c587c9aa93d3c2e6c95f67f50365c65bb10594f0229279287
+    SHA512 809b7cf0429df9867c8ab558857785e9d7d70aea033c6d588b60d29d2754001e9aea5fcdd8cae22fad8145226375bedbd1516d86af7d1e9731fffea331995ad9
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/third_party)
@@ -30,16 +30,13 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=vcpkg
-        -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=vcpkg
+        -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=vcpkg
 )
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/bigtable/client/testing)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake TARGET_PATH share/bigtable_client)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp RENAME copyright)
 

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -11,8 +11,7 @@ vcpkg_from_github(
     REF v0.3.0
     SHA512 90f876ebf4bea40c5bc12d2bd20d27b48202f951d57a68b657c07b7d468b2ac5a00e39a3a6fca48f92030d89ba7d9706eb52b3c8e734b392aee63632af042b5d
     HEAD_REF master
-    PATCHES
-        "include-protobuf.patch"
+    PATCHES include-protobuf.patch
 )
 
 set(GOOGLEAPIS_VERSION 6a3277c0656219174ff7c345f31fb20a90b30b97)
@@ -31,6 +30,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=vcpkg
+        -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF
 )
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)


### PR DESCRIPTION
A new release of google-cloud-cpp, with some improvements in packaging
that simplified the patch file.