### PR TITLE
[libuv] Update to version 1.24.0 and fix build on Linux/FreeBSD.

### DIFF
--- a/ports/libuv/CMakeLists.txt
+++ b/ports/libuv/CMakeLists.txt
@@ -19,22 +19,32 @@ file(GLOB UV_SOURCES_UNIX
     src/unix/stream.c
     src/unix/tcp.c
     src/unix/thread.c
-    src/unix/timer.c
     src/unix/tty.c
     src/unix/udp.c
-    src/unix/proctitle.c
 )
 file(GLOB UV_SOURCES_LINUX
+    src/unix/proctitle.c
     src/unix/linux-core.c
     src/unix/linux-inotify.c
     src/unix/linux-syscalls.c
+    src/unix/procfs-exepath.c
+    src/unix/sysinfo-loadavg.c
+    src/unix/sysinfo-memory.c
 )
 file(GLOB UV_SOURCES_DARWIN
-    src/unix/kqueue.c
+    src/unix/proctitle.c
     src/unix/darwin.c
     src/unix/fsevents.c
-    src/unix/pthread-barrier.c
     src/unix/darwin-proctitle.c
+    src/unix/bsd-ifaddrs.c
+    src/unix/kqueue.c
+)
+file(GLOB UV_SOURCES_FREEBSD
+    src/unix/freebsd.c
+    src/unix/posix-hrtime.c
+    src/unix/bsd-proctitle.c
+    src/unix/bsd-ifaddrs.c
+    src/unix/kqueue.c
 )
 file(GLOB UV_SOURCES_WIN src/win/*.c)
 
@@ -44,6 +54,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsSt
     target_link_libraries(libuv iphlpapi psapi shell32 userenv ws2_32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_UNIX} ${UV_SOURCES_DARWIN})
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_UNIX} ${UV_SOURCES_FREEBSD})
 else() # Assume some Linux variant
     add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_UNIX} ${UV_SOURCES_LINUX})
 endif()

--- a/ports/libuv/CONTROL
+++ b/ports/libuv/CONTROL
@@ -1,3 +1,3 @@
 Source: libuv
-Version: 1.23.2
+Version: 1.24.0
 Description: libuv is a multi-platform support library with a focus on asynchronous I/O.

--- a/ports/libuv/portfile.cmake
+++ b/ports/libuv/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libuv/libuv
-    REF v1.23.2
-    SHA512 f91accf4ba9987fad23cc546a9821c3d643f8505cae22e0cbe28c4d5d5cb6b370b3483c6d95195cff3bcddd1e94f1bdab740075c3eaf22f8f673f7a57c1fdfc5
+    REF v1.24.0
+    SHA512 b75dac19e99497b059b9b8ce646266c4fa10f1259f5fd74554f7f614f7b70f4b62b9c756316d9a3eed6cf6b9d61f5acde9f6eedb88d30431f6a5c87169487ec6
     HEAD_REF v1.x
 )
 


### PR DESCRIPTION
Update libuv to version 1.24.0.
Fix build on Linux/FreeBSD with uv.gyp.