### PR TITLE
[berkeleydb] fix exporting DLL symbols on Windows

### DIFF
--- a/ports/berkeleydb/CMakeLists.txt
+++ b/ports/berkeleydb/CMakeLists.txt
@@ -15,12 +15,12 @@ add_definitions(
 
 if (BUILD_SHARED_LIBS)
 	add_definitions(
-		-D_LIB
+		-DDB_CREATE_DLL
+		-D_USRDLL
 	)
 else()
 	add_definitions(
-		-DDB_CREATE_DLL
-		-D_USRDLL
+		-D_LIB
 	)
 endif()
 

--- a/ports/berkeleydb/CONTROL
+++ b/ports/berkeleydb/CONTROL
@@ -1,3 +1,3 @@
 Source: berkeleydb
-Version: 4.8.30-1
+Version: 4.8.30-2
 Description: A high-performance embedded database for key/value data.


### PR DESCRIPTION
Set preprocessor definitions correctly for static & shared library.
Previously DLL was unusable on Windows - the symbols were not exported.