### PR TITLE
Use remove_if instead of partition when filtering containers.

### DIFF
--- a/toolsrc/include/vcpkg/base/util.h
+++ b/toolsrc/include/vcpkg/base/util.h
@@ -72,18 +72,6 @@ namespace vcpkg::Util
     }
 
     template<class Container, class Pred>
-    void stable_keep_if(Container& cont, Pred pred)
-    {
-        cont.erase(std::stable_partition(cont.begin(), cont.end(), pred), cont.end());
-    }
-
-    template<class Container, class Pred>
-    void unstable_keep_if(Container& cont, Pred pred)
-    {
-        cont.erase(std::partition(cont.begin(), cont.end(), pred), cont.end());
-    }
-
-    template<class Container, class Pred>
     void erase_remove_if(Container& cont, Pred pred)
     {
         cont.erase(std::remove_if(cont.begin(), cont.end(), pred), cont.end());

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -63,7 +63,7 @@ namespace vcpkg::Build::Command
                            spec.name());
 
         const StatusParagraphs status_db = database_load_check(paths);
-        const Build::BuildPackageOptions build_package_options {
+        const Build::BuildPackageOptions build_package_options{
             Build::UseHeadVersion::NO,
             Build::AllowDownloads::YES,
             Build::CleanBuildtrees::NO,
@@ -76,8 +76,8 @@ namespace vcpkg::Build::Command
         std::set<std::string> features_as_set(full_spec.features.begin(), full_spec.features.end());
         features_as_set.emplace("core");
 
-        const Build::BuildPackageConfig build_config {
-            *scf, spec.triplet(), fs::path {port_dir}, build_package_options, features_as_set};
+        const Build::BuildPackageConfig build_config{
+            *scf, spec.triplet(), fs::path{port_dir}, build_package_options, features_as_set};
 
         const auto build_timer = Chrono::ElapsedTimer::create_started();
         const auto result = Build::build_package(paths, build_config, status_db);
@@ -470,22 +470,22 @@ namespace vcpkg::Build
 
         std::vector<AbiEntry> abi_tag_entries(dependency_abis.begin(), dependency_abis.end());
 
-        abi_tag_entries.emplace_back(AbiEntry {"cmake", paths.get_tool_version(Tools::CMAKE)});
+        abi_tag_entries.emplace_back(AbiEntry{"cmake", paths.get_tool_version(Tools::CMAKE)});
 
         abi_tag_entries.emplace_back(
-            AbiEntry {"portfile", vcpkg::Hash::get_file_hash(fs, config.port_dir / "portfile.cmake", "SHA1")});
+            AbiEntry{"portfile", vcpkg::Hash::get_file_hash(fs, config.port_dir / "portfile.cmake", "SHA1")});
         abi_tag_entries.emplace_back(
-            AbiEntry {"control", vcpkg::Hash::get_file_hash(fs, config.port_dir / "CONTROL", "SHA1")});
+            AbiEntry{"control", vcpkg::Hash::get_file_hash(fs, config.port_dir / "CONTROL", "SHA1")});
 
         abi_tag_entries.emplace_back(AbiEntry{"vcpkg_fixup_cmake_targets", "1"});
 
         abi_tag_entries.emplace_back(AbiEntry{"triplet", pre_build_info.triplet_abi_tag});
 
         const std::string features = Strings::join(";", config.feature_list);
-        abi_tag_entries.emplace_back(AbiEntry {"features", features});
+        abi_tag_entries.emplace_back(AbiEntry{"features", features});
 
         if (config.build_package_options.use_head_version == UseHeadVersion::YES)
-            abi_tag_entries.emplace_back(AbiEntry {"head", ""});
+            abi_tag_entries.emplace_back(AbiEntry{"head", ""});
 
         Util::sort(abi_tag_entries);
 
@@ -503,7 +503,7 @@ namespace vcpkg::Build
         }
 
         auto abi_tag_entries_missing = abi_tag_entries;
-        Util::stable_keep_if(abi_tag_entries_missing, [](const AbiEntry& p) { return p.value.empty(); });
+        Util::erase_remove_if(abi_tag_entries_missing, [](const AbiEntry& p) { return !p.value.empty(); });
 
         if (abi_tag_entries_missing.empty())
         {
@@ -512,7 +512,7 @@ namespace vcpkg::Build
             const auto abi_file_path = paths.buildtrees / name / (triplet.canonical_name() + ".vcpkg_abi_info.txt");
             fs.write_contents(abi_file_path, full_abi_info);
 
-            return AbiTagAndFile {Hash::get_file_hash(fs, abi_file_path, "SHA1"), abi_file_path};
+            return AbiTagAndFile{Hash::get_file_hash(fs, abi_file_path, "SHA1"), abi_file_path};
         }
 
         System::println(
@@ -581,8 +581,8 @@ namespace vcpkg::Build
         Util::sort_unique_erase(dep_pspecs);
 
         // Find all features that aren't installed. This mutates required_fspecs.
-        Util::unstable_keep_if(required_fspecs, [&](FeatureSpec const& fspec) {
-            return !status_db.is_installed(fspec) && fspec.name() != name;
+        Util::erase_remove_if(required_fspecs, [&](FeatureSpec const& fspec) {
+            return status_db.is_installed(fspec) || fspec.name() == name;
         });
 
         if (!required_fspecs.empty())
@@ -602,7 +602,7 @@ namespace vcpkg::Build
             const auto status_it = status_db.find_installed(pspec);
             Checks::check_exit(VCPKG_LINE_INFO, status_it != status_db.end());
             dependency_abis.emplace_back(
-                AbiEntry {status_it->get()->package.spec.name(), status_it->get()->package.abi});
+                AbiEntry{status_it->get()->package.spec.name(), status_it->get()->package.abi});
         }
 
         const auto pre_build_info = PreBuildInfo::from_triplet_file(paths, triplet);
@@ -648,7 +648,7 @@ namespace vcpkg::Build
             System::println("Could not locate cached archive: %s", archive_path.u8string());
 
             ExtendedBuildResult result = do_build_package_and_clean_buildtrees(
-                paths, pre_build_info, spec, maybe_abi_tag_and_file.value_or(AbiTagAndFile {}).tag, config);
+                paths, pre_build_info, spec, maybe_abi_tag_and_file.value_or(AbiTagAndFile{}).tag, config);
 
             std::error_code ec;
             fs.create_directories(paths.package_dir(spec) / "share" / spec.name(), ec);
@@ -685,7 +685,7 @@ namespace vcpkg::Build
         }
 
         return do_build_package_and_clean_buildtrees(
-            paths, pre_build_info, spec, maybe_abi_tag_and_file.value_or(AbiTagAndFile {}).tag, config);
+            paths, pre_build_info, spec, maybe_abi_tag_and_file.value_or(AbiTagAndFile{}).tag, config);
     }
 
     const std::string& to_string(const BuildResult build_result)
@@ -850,21 +850,21 @@ namespace vcpkg::Build
             if (variable_name == "VCPKG_PLATFORM_TOOLSET")
             {
                 pre_build_info.platform_toolset =
-                    variable_value.empty() ? nullopt : Optional<std::string> {variable_value};
+                    variable_value.empty() ? nullopt : Optional<std::string>{variable_value};
                 continue;
             }
 
             if (variable_name == "VCPKG_VISUAL_STUDIO_PATH")
             {
                 pre_build_info.visual_studio_path =
-                    variable_value.empty() ? nullopt : Optional<fs::path> {variable_value};
+                    variable_value.empty() ? nullopt : Optional<fs::path>{variable_value};
                 continue;
             }
 
             if (variable_name == "VCPKG_CHAINLOAD_TOOLCHAIN_FILE")
             {
                 pre_build_info.external_toolchain_file =
-                    variable_value.empty() ? nullopt : Optional<std::string> {variable_value};
+                    variable_value.empty() ? nullopt : Optional<std::string>{variable_value};
                 continue;
             }
 

--- a/toolsrc/src/vcpkg/commands.autocomplete.cpp
+++ b/toolsrc/src/vcpkg/commands.autocomplete.cpp
@@ -40,27 +40,25 @@ namespace vcpkg::Commands::Autocomplete
             const std::string requested_command = match[1].str();
 
             // First try public commands
-            std::vector<std::string> public_commands = {
-                "install",
-                "search",
-                "remove",
-                "list",
-                "update",
-                "hash",
-                "help",
-                "integrate",
-                "export",
-                "edit",
-                "create",
-                "owns",
-                "cache",
-                "version",
-                "contact",
-                "upgrade"
-            };
+            std::vector<std::string> public_commands = {"install",
+                                                        "search",
+                                                        "remove",
+                                                        "list",
+                                                        "update",
+                                                        "hash",
+                                                        "help",
+                                                        "integrate",
+                                                        "export",
+                                                        "edit",
+                                                        "create",
+                                                        "owns",
+                                                        "cache",
+                                                        "version",
+                                                        "contact",
+                                                        "upgrade"};
 
-            Util::unstable_keep_if(public_commands, [&](const std::string& s) {
-                return Strings::case_insensitive_ascii_starts_with(s, requested_command);
+            Util::erase_remove_if(public_commands, [&](const std::string& s) {
+                return !Strings::case_insensitive_ascii_starts_with(s, requested_command);
             });
 
             if (!public_commands.empty())
@@ -79,8 +77,8 @@ namespace vcpkg::Commands::Autocomplete
                 "portsdiff",
             };
 
-            Util::unstable_keep_if(private_commands, [&](const std::string& s) {
-                return Strings::case_insensitive_ascii_starts_with(s, requested_command);
+            Util::erase_remove_if(private_commands, [&](const std::string& s) {
+                return !Strings::case_insensitive_ascii_starts_with(s, requested_command);
             });
 
             output_sorted_results_and_exit(VCPKG_LINE_INFO, std::move(private_commands));
@@ -99,8 +97,8 @@ namespace vcpkg::Commands::Autocomplete
             }
 
             std::vector<std::string> triplets = paths.get_available_triplets();
-            Util::unstable_keep_if(triplets, [&](const std::string& s) {
-                return Strings::case_insensitive_ascii_starts_with(s, triplet_prefix);
+            Util::erase_remove_if(triplets, [&](const std::string& s) {
+                return !Strings::case_insensitive_ascii_starts_with(s, triplet_prefix);
             });
 
             auto result = combine_port_with_triplets(port_name, triplets);
@@ -152,8 +150,8 @@ namespace vcpkg::Commands::Autocomplete
                     }
                 }
 
-                Util::unstable_keep_if(results, [&](const std::string& s) {
-                    return Strings::case_insensitive_ascii_starts_with(s, prefix);
+                Util::erase_remove_if(results, [&](const std::string& s) {
+                    return !Strings::case_insensitive_ascii_starts_with(s, prefix);
                 });
 
                 if (command.name == "install" && results.size() == 1 && !is_option)

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -16,9 +16,9 @@ using vcpkg::Build::PreBuildInfo;
 
 namespace vcpkg::PostBuildLint
 {
-    static auto has_extension_pred(const Files::Filesystem& fs, const std::string& ext)
+    static auto not_extension_pred(const Files::Filesystem& fs, const std::string& ext)
     {
-        return [&fs, ext](const fs::path& path) { return !fs.is_directory(path) && path.extension() == ext; };
+        return [&fs, ext](const fs::path& path) { return fs.is_directory(path) || path.extension() != ext; };
     }
 
     enum class LintStatus
@@ -104,8 +104,8 @@ namespace vcpkg::PostBuildLint
 
         std::vector<fs::path> files_found = fs.get_files_recursive(debug_include_dir);
 
-        Util::unstable_keep_if(
-            files_found, [&fs](const fs::path& path) { return !fs.is_directory(path) && path.extension() != ".ifc"; });
+        Util::erase_remove_if(
+            files_found, [&fs](const fs::path& path) { return fs.is_directory(path) || path.extension() == ".ifc"; });
 
         if (!files_found.empty())
         {
@@ -206,7 +206,7 @@ namespace vcpkg::PostBuildLint
     static LintStatus check_for_dlls_in_lib_dir(const Files::Filesystem& fs, const fs::path& package_dir)
     {
         std::vector<fs::path> dlls = fs.get_files_recursive(package_dir / "lib");
-        Util::unstable_keep_if(dlls, has_extension_pred(fs, ".dll"));
+        Util::erase_remove_if(dlls, not_extension_pred(fs, ".dll"));
 
         if (!dlls.empty())
         {
@@ -280,7 +280,7 @@ namespace vcpkg::PostBuildLint
     static LintStatus check_for_exes(const Files::Filesystem& fs, const fs::path& package_dir)
     {
         std::vector<fs::path> exes = fs.get_files_recursive(package_dir / "bin");
-        Util::unstable_keep_if(exes, has_extension_pred(fs, ".exe"));
+        Util::erase_remove_if(exes, not_extension_pred(fs, ".exe"));
 
         if (!exes.empty())
         {
@@ -572,8 +572,8 @@ namespace vcpkg::PostBuildLint
     {
         std::vector<fs::path> empty_directories = fs.get_files_recursive(dir);
 
-        Util::unstable_keep_if(empty_directories, [&fs](const fs::path& current) {
-            return fs.is_directory(current) && fs.is_empty(current);
+        Util::erase_remove_if(empty_directories, [&fs](const fs::path& current) {
+            return !fs.is_directory(current) || !fs.is_empty(current);
         });
 
         if (!empty_directories.empty())
@@ -707,12 +707,15 @@ namespace vcpkg::PostBuildLint
     static LintStatus check_no_files_in_dir(const Files::Filesystem& fs, const fs::path& dir)
     {
         std::vector<fs::path> misplaced_files = fs.get_files_non_recursive(dir);
-        Util::unstable_keep_if(misplaced_files, [&fs](const fs::path& path) {
+        Util::erase_remove_if(misplaced_files, [&fs](const fs::path& path) {
             const std::string filename = path.filename().generic_string();
             if (Strings::case_insensitive_ascii_equals(filename.c_str(), "CONTROL") ||
                 Strings::case_insensitive_ascii_equals(filename.c_str(), "BUILD_INFO"))
-                return false;
-            return !fs.is_directory(path);
+            {
+                return true;
+            }
+
+            return fs.is_directory(path);
         });
 
         if (!misplaced_files.empty())
@@ -764,9 +767,9 @@ namespace vcpkg::PostBuildLint
         const fs::path release_bin_dir = package_dir / "bin";
 
         std::vector<fs::path> debug_libs = fs.get_files_recursive(debug_lib_dir);
-        Util::unstable_keep_if(debug_libs, has_extension_pred(fs, ".lib"));
+        Util::erase_remove_if(debug_libs, not_extension_pred(fs, ".lib"));
         std::vector<fs::path> release_libs = fs.get_files_recursive(release_lib_dir);
-        Util::unstable_keep_if(release_libs, has_extension_pred(fs, ".lib"));
+        Util::erase_remove_if(release_libs, not_extension_pred(fs, ".lib"));
 
         if (!pre_build_info.build_type)
             error_count += check_matching_debug_and_release_binaries(debug_libs, release_libs);
@@ -780,9 +783,9 @@ namespace vcpkg::PostBuildLint
         }
 
         std::vector<fs::path> debug_dlls = fs.get_files_recursive(debug_bin_dir);
-        Util::unstable_keep_if(debug_dlls, has_extension_pred(fs, ".dll"));
+        Util::erase_remove_if(debug_dlls, not_extension_pred(fs, ".dll"));
         std::vector<fs::path> release_dlls = fs.get_files_recursive(release_bin_dir);
-        Util::unstable_keep_if(release_dlls, has_extension_pred(fs, ".dll"));
+        Util::erase_remove_if(release_dlls, not_extension_pred(fs, ".dll"));
 
         switch (build_info.library_linkage)
         {

--- a/toolsrc/src/vcpkg/statusparagraph.cpp
+++ b/toolsrc/src/vcpkg/statusparagraph.cpp
@@ -105,7 +105,7 @@ namespace vcpkg
         {
             dep.erase(std::find(dep.begin(), dep.end(), '['), dep.end());
         }
-        Util::unstable_keep_if(deps, [&](auto&& e) { return e != l_spec.name(); });
+        Util::erase_remove_if(deps, [&](auto&& e) { return e == l_spec.name(); });
         // </hack>
         Util::sort_unique_erase(deps);
 

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -137,8 +137,8 @@ namespace vcpkg
 
         if (tsv && vsp)
         {
-            Util::stable_keep_if(
-                candidates, [&](const Toolset* t) { return *tsv == t->version && *vsp == t->visual_studio_root_path; });
+            Util::erase_remove_if(
+                candidates, [&](const Toolset* t) { return *tsv != t->version || *vsp != t->visual_studio_root_path; });
             Checks::check_exit(VCPKG_LINE_INFO,
                                !candidates.empty(),
                                "Could not find Visual Studio instance at %s with %s toolset.",
@@ -151,7 +151,7 @@ namespace vcpkg
 
         if (tsv)
         {
-            Util::stable_keep_if(candidates, [&](const Toolset* t) { return *tsv == t->version; });
+            Util::erase_remove_if(candidates, [&](const Toolset* t) { return *tsv != t->version; });
             Checks::check_exit(
                 VCPKG_LINE_INFO, !candidates.empty(), "Could not find Visual Studio instance with %s toolset.", *tsv);
         }
@@ -159,8 +159,8 @@ namespace vcpkg
         if (vsp)
         {
             const fs::path vs_root_path = *vsp;
-            Util::stable_keep_if(candidates,
-                                 [&](const Toolset* t) { return vs_root_path == t->visual_studio_root_path; });
+            Util::erase_remove_if(candidates,
+                                  [&](const Toolset* t) { return vs_root_path != t->visual_studio_root_path; });
             Checks::check_exit(VCPKG_LINE_INFO,
                                !candidates.empty(),
                                "Could not find Visual Studio instance at %s.",

--- a/toolsrc/src/vcpkg/visualstudio.cpp
+++ b/toolsrc/src/vcpkg/visualstudio.cpp
@@ -130,9 +130,9 @@ namespace vcpkg::VisualStudio
         {
             // We want lexically_normal(), but it is not available
             // Correct root path might be 2 or 3 levels up, depending on if the path has trailing backslash. Try both.
-            auto common7_tools = fs::path {*path_as_string};
-            append_if_has_cl(fs::path {*path_as_string}.parent_path().parent_path());
-            append_if_has_cl(fs::path {*path_as_string}.parent_path().parent_path().parent_path());
+            auto common7_tools = fs::path{*path_as_string};
+            append_if_has_cl(fs::path{*path_as_string}.parent_path().parent_path());
+            append_if_has_cl(fs::path{*path_as_string}.parent_path().parent_path().parent_path());
         }
 
         // VS2015 instance from Program Files
@@ -143,7 +143,7 @@ namespace vcpkg::VisualStudio
 
     std::vector<std::string> get_visual_studio_instances(const VcpkgPaths& paths)
     {
-        std::vector<VisualStudioInstance> sorted {get_visual_studio_instances_internal(paths)};
+        std::vector<VisualStudioInstance> sorted{get_visual_studio_instances_internal(paths)};
         std::sort(sorted.begin(), sorted.end(), VisualStudioInstance::preferred_first_comparator);
         return Util::fmap(sorted, [](const VisualStudioInstance& instance) { return instance.to_string(); });
     }
@@ -160,8 +160,8 @@ namespace vcpkg::VisualStudio
         std::vector<Toolset> found_toolsets;
         std::vector<Toolset> excluded_toolsets;
 
-        const SortedVector<VisualStudioInstance> sorted {get_visual_studio_instances_internal(paths),
-                                                         VisualStudioInstance::preferred_first_comparator};
+        const SortedVector<VisualStudioInstance> sorted{get_visual_studio_instances_internal(paths),
+                                                        VisualStudioInstance::preferred_first_comparator};
 
         const bool v140_is_available = Util::find_if(sorted, [&](const VisualStudioInstance& vs_instance) {
                                            return vs_instance.major_version() == "14";
@@ -202,8 +202,8 @@ namespace vcpkg::VisualStudio
                 // Locate the "best" MSVC toolchain version
                 const fs::path msvc_path = vc_dir / "Tools" / "MSVC";
                 std::vector<fs::path> msvc_subdirectories = fs.get_files_non_recursive(msvc_path);
-                Util::unstable_keep_if(msvc_subdirectories,
-                                       [&fs](const fs::path& path) { return fs.is_directory(path); });
+                Util::erase_remove_if(msvc_subdirectories,
+                                      [&fs](const fs::path& path) { return !fs.is_directory(path); });
 
                 // Sort them so that latest comes first
                 std::sort(
@@ -217,7 +217,7 @@ namespace vcpkg::VisualStudio
                     paths_examined.push_back(dumpbin_path);
                     if (fs.exists(dumpbin_path))
                     {
-                        const Toolset v141_toolset {
+                        const Toolset v141_toolset{
                             vs_instance.root_path, dumpbin_path, vcvarsall_bat, {}, V_141, supported_architectures};
 
                         const auto english_language_pack = dumpbin_path.parent_path() / "1033";
@@ -232,12 +232,12 @@ namespace vcpkg::VisualStudio
 
                         if (v140_is_available)
                         {
-                            const Toolset v140_toolset {vs_instance.root_path,
-                                                        dumpbin_path,
-                                                        vcvarsall_bat,
-                                                        {"-vcvars_ver=14.0"},
-                                                        V_140,
-                                                        supported_architectures};
+                            const Toolset v140_toolset{vs_instance.root_path,
+                                                       dumpbin_path,
+                                                       vcvarsall_bat,
+                                                       {"-vcvars_ver=14.0"},
+                                                       V_140,
+                                                       supported_architectures};
                             found_toolsets.push_back(v140_toolset);
                         }
 


### PR DESCRIPTION
remove_if is already stable, so separate stable and unstable versions are unnecessary.

https://iterator.wordpress.com/2016/01/31/algorithms_0/

Unstable remove_if algorithms are possible that might win, as indicated in that article; but plain remove_if provides the most consistent behavior.