### PR TITLE
add MOOS V10

### DIFF
--- a/ports/moos-core/CONTROL
+++ b/ports/moos-core/CONTROL
@@ -1,4 +1,4 @@
 Source: moos-core
-Version: 10.0.4
+Version: 10.4.0
 Description: A very light weight, easy to use middleware. See the MOOS homepage at https://sites.google.com/site/moossoftware/ for more information and documentation.
 Build-Depends:

--- a/ports/moos-core/CONTROL
+++ b/ports/moos-core/CONTROL
@@ -1,0 +1,4 @@
+Source: moos-core
+Version: 10.0.4
+Description: A very light weight, easy to use middleware. See the MOOS homepage at https://sites.google.com/site/moossoftware/ for more information and documentation.
+Build-Depends:

--- a/ports/moos-core/cmake_fix.patch
+++ b/ports/moos-core/cmake_fix.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 75f367f..6ef3dc2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -190,7 +190,7 @@ add_subdirectory(Core)
+ export(
+     TARGETS MOOS
+     NAMESPACE MOOS::
+-    FILE UseMOOS.cmake
++    FILE UseMOOSTargets.cmake
+ )
+ 
+ # Support existing projects that expect to find MOOS_LIBRARIES and
+@@ -222,7 +222,7 @@ set(PROJECT_CONFIG_PATH "lib/cmake/MOOS")
+ install(
+     EXPORT MOOS
+     NAMESPACE MOOS::
+-    FILE UseMOOS.cmake
++    FILE UseMOOSTargets.cmake
+     DESTINATION ${PROJECT_CONFIG_PATH}
+ )
+ 
+diff --git a/Core/libMOOS/CMakeLists.txt b/Core/libMOOS/CMakeLists.txt
+index b74a30f..492df50 100644
+--- a/Core/libMOOS/CMakeLists.txt
++++ b/Core/libMOOS/CMakeLists.txt
+@@ -196,7 +196,7 @@ mark_as_advanced(TIME_WARP_AGGLOMERATION_CONSTANT)
+ install(
+     DIRECTORY ${INCLUDE_ROOTS}
+     DESTINATION .
+-    FILES_MATCHING PATTERN "*.h" PATTERN "*.hxx"
++    FILES_MATCHING PATTERN "*.h" PATTERN "*.hxx" PATTERN "*.hpp"
+ )
+ 
+ # install libraries
+diff --git a/MOOSConfig.cmake.in b/MOOSConfig.cmake.in
+index 10af599..dff769a 100644
+--- a/MOOSConfig.cmake.in
++++ b/MOOSConfig.cmake.in
+@@ -2,7 +2,7 @@
+ 
+ # Pick up the auto-generated file which knows how to add the imported library
+ # targets for the libraries that MOOS exports.
+-set(exports_file "${CMAKE_CURRENT_LIST_DIR}/UseMOOS.cmake")
++set(exports_file "${CMAKE_CURRENT_LIST_DIR}/UseMOOSTargets.cmake")
+ include(${exports_file})
+ 
+ include(FindPackageHandleStandardArgs)

--- a/ports/moos-core/portfile.cmake
+++ b/ports/moos-core/portfile.cmake
@@ -8,8 +8,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/cmake_fix.patch
+)
+
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
+message(STATUS "MOOS VCPKG SOURCE_PATH ${SOURCE_PATH}")
 message(STATUS "MOOS INSTALL -DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}")
 
 vcpkg_configure_cmake(
@@ -17,28 +24,22 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_SHARED_LIBS=${BUILD_SHARED}
-#        -DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}
         -DCMAKE_ENABLE_EXPORT=OFF
 )
 
 vcpkg_install_cmake()
 
-# Move CMake config files to the right place
-if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/${PORT})
-else()
-	vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/MOOS" TARGET_PATH share/${PORT})
-endif()
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/MOOS")
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/MOOS)
 if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/MOOSDB")
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/MOOSDB ${CURRENT_PACKAGES_DIR}/tools/MOOSDB)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/atm ${CURRENT_PACKAGES_DIR}/tools/atm)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/gtm ${CURRENT_PACKAGES_DIR}/tools/gtm)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/ktm ${CURRENT_PACKAGES_DIR}/tools/ktm)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mqos ${CURRENT_PACKAGES_DIR}/tools/mqos)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mtm ${CURRENT_PACKAGES_DIR}/tools/mtm)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/umm ${CURRENT_PACKAGES_DIR}/tools/umm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/MOOSDB ${CURRENT_PACKAGES_DIR}/tools/MOOS/MOOSDB)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/atm ${CURRENT_PACKAGES_DIR}/tools/MOOS/atm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/gtm ${CURRENT_PACKAGES_DIR}/tools/MOOS/gtm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/ktm ${CURRENT_PACKAGES_DIR}/tools/MOOS/ktm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mqos ${CURRENT_PACKAGES_DIR}/tools/MOOS/mqos)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mtm ${CURRENT_PACKAGES_DIR}/tools/MOOS/mtm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/umm ${CURRENT_PACKAGES_DIR}/tools/MOOS/umm)
 endif()
 
 
@@ -47,8 +48,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/MOOS/libMOOS/Thirdparty/getpot)
 
 # Put the licence file where vcpkg expects it
 file(COPY

--- a/ports/moos-core/portfile.cmake
+++ b/ports/moos-core/portfile.cmake
@@ -1,0 +1,61 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO themoos/core-moos
+    REF v10.4.0
+    SHA512 8a82074bd219bbedbe56c2187afe74a55a252b0654a675c64d1f75e62353b0874e7b405d9f677fadb297e955d11aea50a07e8f5f3546be3c4ddab76fe356a51e 
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+message(STATUS "MOOS INSTALL -DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}")
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
+#        -DCMAKE_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}
+        -DCMAKE_ENABLE_EXPORT=OFF
+)
+
+vcpkg_install_cmake()
+
+# Move CMake config files to the right place
+if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/${PORT})
+else()
+	vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/MOOS" TARGET_PATH share/${PORT})
+endif()
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/MOOSDB")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/MOOSDB ${CURRENT_PACKAGES_DIR}/tools/MOOSDB)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/atm ${CURRENT_PACKAGES_DIR}/tools/atm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/gtm ${CURRENT_PACKAGES_DIR}/tools/gtm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/ktm ${CURRENT_PACKAGES_DIR}/tools/ktm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mqos ${CURRENT_PACKAGES_DIR}/tools/mqos)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/mtm ${CURRENT_PACKAGES_DIR}/tools/mtm)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/umm ${CURRENT_PACKAGES_DIR}/tools/umm)
+endif()
+
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/MOOS/libMOOS/Thirdparty/getpot)
+
+# Put the licence file where vcpkg expects it
+file(COPY
+    ${SOURCE_PATH}/Core/GPLCore.txt
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME
+    ${CURRENT_PACKAGES_DIR}/share/${PORT}/GPLCore.txt
+    ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+
+

--- a/ports/moos-essential/CONTROL
+++ b/ports/moos-essential/CONTROL
@@ -1,0 +1,4 @@
+Source: moos-essential
+Version: 10.0.1
+Description: a set of useful applications that leverage the core-moos communications layer See the MOOS homepage at https://sites.google.com/site/moossoftware/ for more information and documentation.
+Build-Depends: moos-core

--- a/ports/moos-essential/fix.patch
+++ b/ports/moos-essential/fix.patch
@@ -1,0 +1,23 @@
+diff --git a/Essentials/pShare/CMakeLists.txt b/Essentials/pShare/CMakeLists.txt
+index 5128a50..7fee919 100644
+--- a/Essentials/pShare/CMakeLists.txt
++++ b/Essentials/pShare/CMakeLists.txt
+@@ -20,4 +20,4 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/pshare_test_scripts DESTINATION ${CMAKE_RU
+ 
+ add_custom_command(TARGET pShare POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory
+-                       ${CMAKE_SOURCE_DIR}/pshare_test_scripts ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
++                       ${CMAKE_SOURCE_DIR}/Essentials/pShare/pshare_test_scripts ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+diff --git a/Essentials/pShare/Share.cpp b/Essentials/pShare/Share.cpp
+index 7825e00..756a760 100644
+--- a/Essentials/pShare/Share.cpp
++++ b/Essentials/pShare/Share.cpp
+@@ -17,7 +17,7 @@
+ 
+ #include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
+ #include "MOOS/libMOOS/Utils/IPV4Address.h"
+-#include "MOOS/libMOOS/Thirdparty/getpot/GetPot"
++#include "MOOS/libMOOS/Thirdparty/getpot/GetPot.hpp"
+ #include "MOOS/libMOOS/Utils/SafeList.h"
+ #include "MOOS/libMOOS/Utils/ConsoleColours.h"
+ #include "MOOS/libMOOS/Utils/KeyboardCapture.h"

--- a/ports/moos-essential/portfile.cmake
+++ b/ports/moos-essential/portfile.cmake
@@ -1,0 +1,54 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO themoos/essential-moos
+    REF b897ea86dba8b61412dc48ac0cfb5ff34cdaf5f6
+    SHA512 7284744d211dcdcb0cd321eec96f3632ccda690e8894261f4f09a06bc8faefb2de68f4f2f755f4eeef5bb586044e98ac65cdd18c15193a1a4632bd2f4208c52f 
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+
+#LIST(APPEND CMAKE_PREFIX_PATH ${CURRENT_INSTALLED_DIR} )
+#find_package(MOOS REQUIRED)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
+#        -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=
+#        -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=
+#        -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=
+
+
+)
+
+vcpkg_install_cmake()
+
+## Move CMake config files to the right place
+#if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
+#    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/${PORT})
+#else()
+#	vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/MOOS" TARGET_PATH share/${PORT})
+#endif()
+#
+#if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+#    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+#endif()
+#
+#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/MOOS/libMOOS/Thirdparty/getpot)
+#
+## Put the licence file where vcpkg expects it
+#file(COPY
+#    ${SOURCE_PATH}/Core/GPLCore.txt
+#    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+#file(RENAME
+#    ${CURRENT_PACKAGES_DIR}/share/${PORT}/GPLCore.txt
+#    ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+#
+#

--- a/ports/moos-essential/portfile.cmake
+++ b/ports/moos-essential/portfile.cmake
@@ -8,47 +8,40 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+message(STATUS "MOOS Essential Source Path: ${SOURCE_PATH}")
+message(STATUS "MOOS Essential CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix.patch
+)
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
-
-
-#LIST(APPEND CMAKE_PREFIX_PATH ${CURRENT_INSTALLED_DIR} )
-#find_package(MOOS REQUIRED)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DBUILD_SHARED_LIBS=${BUILD_SHARED}
-#        -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=
-#        -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=
-#        -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=
-
-
 )
 
 vcpkg_install_cmake()
 
-## Move CMake config files to the right place
-#if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
-#    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/${PORT})
-#else()
-#	vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/MOOS" TARGET_PATH share/${PORT})
-#endif()
-#
-#if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-#    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-#endif()
-#
-#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-#file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/MOOS/libMOOS/Thirdparty/getpot)
-#
-## Put the licence file where vcpkg expects it
-#file(COPY
-#    ${SOURCE_PATH}/Core/GPLCore.txt
-#    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-#file(RENAME
-#    ${CURRENT_PACKAGES_DIR}/share/${PORT}/GPLCore.txt
-#    ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/MOOS)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/pAntler")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pAntler ${CURRENT_PACKAGES_DIR}/tools/MOOS/pAntler)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pLogger ${CURRENT_PACKAGES_DIR}/tools/MOOS/pLoggers)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pMOOSBridge ${CURRENT_PACKAGES_DIR}/tools/MOOS/pMOOSBridge)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pScheduler ${CURRENT_PACKAGES_DIR}/tools/MOOS/pScheduler)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pShare ${CURRENT_PACKAGES_DIR}/tools/MOOS/pShare)
+endif()
+
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug)
+endif()
+
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/fake_header.h "// fake header to pass vcpkg post install check \n")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright "see moos-core for copyright\n" )
 #
 #

--- a/ports/moos-ui/CONTROL
+++ b/ports/moos-ui/CONTROL
@@ -1,0 +1,6 @@
+Source: moos-ui
+Version: 10.0.1
+Description: set of user interface tools to use and leverage the MOOS project. See the MOOS homepage at https://sites.google.com/site/moossoftware/ for more information and documentation.
+Build-Depends: moos-core
+
+

--- a/ports/moos-ui/portfile.cmake
+++ b/ports/moos-ui/portfile.cmake
@@ -1,0 +1,55 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO themoos/ui-moos
+    REF ba7dd1db7db1848acb3e68b9e54d3da9d7014684
+    SHA512 96225216973656a9029d4e8ac8a8b69df15db5c160bcbd02755cd291bfe5817dbde3a6a5f46b71a138ddf4a389c3c702d4d502ade91ad88554042d7b9d75f843
+    HEAD_REF master
+)
+
+#vcpkg_apply_patches(
+#    SOURCE_PATH ${SOURCE_PATH}
+#    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fltk.patch
+#)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+
+#if ("gui" IN_LIST FEATURES)
+#    set(BUILD_GRAPHICAL_TOOLS            ON )
+#    message(STATUS "Building graphical tools")
+#else()
+#    set(BUILD_GRAPHICAL_TOOLS            OFF )
+#    message(STATUS "Not building graphical tools")
+#endif()
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
+        -DBUILD_CONSOLE_TOOLS=ON
+        -DBUILD_GRAPHICAL_TOOLS=OFF #${BUILD_GRAPHICAL_TOOLS}
+)
+
+vcpkg_install_cmake()
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/MOOS)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/uPoke")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite)
+endif()
+
+#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uMS ${CURRENT_PACKAGES_DIR}/tools/uMS)
+#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPlayback ${CURRENT_PACKAGES_DIR}/tools/uPlayback)
+#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pShare ${CURRENT_PACKAGES_DIR}/tools/pShare)
+#endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug)
+endif()
+
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/fake_header_ui.h "// fake header to pass vcpkg post install check \n")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright "see moos-core for copyright\n" )


### PR DESCRIPTION
I'm trying to add the MOOS V10 middleware library.  The entire library is broken up into a couple components that are maintained in different github repos: core-moos is the base library, essential-moos and ui-moos are add-ons.  I've been able to get core-moos (which I named in vcpkg moos-core) to install successfully under vcpkg, but am having a hard time getting moos-essential to successfully install.  I get the following error:
`Error: Building package moos-essential:x64-linux failed with: BUILD_FAILED`
looking in
`vcpkg/buildtrees/moos-essential/config-x64-linux-dbg-err.log`
I see
```
CMake Error at /home/jason/mysource/vcpkg/installed/x64-linux/share/moos-core/UseMOOS.cmake:79 (message):
  The imported target "MOOS::MOOS" references the file

     "/home/jason/mysource/vcpkg/installed/debug/lib/libMOOS.a"

  but this file does not exist. 
```

It appears the imported target is missing the triplet in the path as the actual location of the file is
`/home/jason/mysource/vcpkg/installed/x64-linux/debug/lib/libMOOS.a`

My environment is Ubuntu 16.04--I've used this library extensively before I started looking at vcpkg and never had an issue installing it--I'm sure I've got a stupid mistake in the port file of either moos-essential or moos-core, I just don't have enough experience with cmake to figure out what it is. Any thoughts?
Thanks,
Jason
  