### PR TITLE
[tinyxml2] update to 7.0.1

### DIFF
--- a/ports/fastrtps/CONTROL
+++ b/ports/fastrtps/CONTROL
@@ -1,4 +1,4 @@
 Source: fastrtps
-Version: 1.5.0-1
+Version: 1.5.0-2
 Description: Eprosima Fast RTPS is a C++ implementation of the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.
 Build-Depends: openssl, asio, tinyxml2

--- a/ports/fastrtps/namespace_tinyxml2.patch
+++ b/ports/fastrtps/namespace_tinyxml2.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/modules/FindTinyXML2.cmake b/cmake/modules/FindTinyXML2.cmake
+index 24aa98a..4e2188e 100644
+--- a/cmake/modules/FindTinyXML2.cmake
++++ b/cmake/modules/FindTinyXML2.cmake
+@@ -7,10 +7,10 @@ option(TINYXML2_FROM_SOURCE "Integrate TinyXML2 source code inside Fast RTPS" OF
+ find_package(TinyXML2 CONFIG QUIET)
+ if(TinyXML2_FOUND)
+     message(STATUS "Found TinyXML2: ${TinyXML2_DIR}")
+-    if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2)
++    if(NOT TINYXML2_LIBRARY AND TARGET tinyxml2::tinyxml2)
+         # in this case, we're probably using TinyXML2 version 5.0.0 or greater
+         # in which case tinyxml2 is an exported target and we should use that
+-        set(TINYXML2_LIBRARY tinyxml2)
++        set(TINYXML2_LIBRARY tinyxml2::tinyxml2)
+     endif()
+ else()
+     if(THIRDPARTY)

--- a/ports/fastrtps/portfile.cmake
+++ b/ports/fastrtps/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF b1779b608c7b5b2dcb101728f4213c58bdde74ee # waiting for next release
     SHA512 9ec4a1e41296df1c0bc00926d925e0947602fabb68e9b28311e92739b0e1909a2993b15fc05eb31aeb9842ed50127f8d56571d09e57dd64ac6f37d0fed6cea73
     HEAD_REF master
-    PATCHES fix-install.patch
+    PATCHES 
+        fix-install.patch 
+        namespace_tinyxml2.patch 
 )
 
 vcpkg_configure_cmake(

--- a/ports/tinyexif/CONTROL
+++ b/ports/tinyexif/CONTROL
@@ -1,4 +1,4 @@
 Source: tinyexif
-Version: 1.0.1-1
+Version: 1.0.1-2
 Build-Depends: tinyxml2
 Description: tiny ISO-compliant C++ EXIF and XMP parsing library for JPEG images

--- a/ports/tinyexif/namespace_tinyxml2.patch
+++ b/ports/tinyexif/namespace_tinyxml2.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f22584b..1ba8329 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,7 +84,7 @@ if(BUILD_SHARED_LIBS)
+ 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251") # needs to have dll-interface
+ 	endif()
+ 
+-	target_link_libraries(TinyEXIF tinyxml2)
++	target_link_libraries(TinyEXIF tinyxml2::tinyxml2)
+ 	set_target_properties(TinyEXIF PROPERTIES
+ 		COMPILE_DEFINITIONS "TINYEXIF_EXPORT"
+ 		VERSION "${GENERIC_LIB_VERSION}"
+@@ -121,7 +121,7 @@ endif()
+ if(BUILD_STATIC_LIBS)
+ 	add_library(TinyEXIFstatic STATIC TinyEXIF.cpp TinyEXIF.h)
+ 	
+-	target_link_libraries(TinyEXIFstatic tinyxml2)
++	target_link_libraries(TinyEXIFstatic tinyxml2::tinyxml2)
+ 	set_target_properties(TinyEXIFstatic PROPERTIES
+ 			OUTPUT_NAME TinyEXIF
+ 			VERSION "${GENERIC_LIB_VERSION}"
+@@ -162,7 +162,7 @@ if(BUILD_DEMO)
+ 		target_compile_definitions(TinyEXIFdemo PRIVATE TINYEXIF_IMPORT)
+ 	else(BUILD_STATIC_LIBS)
+ 		add_dependencies(TinyEXIFdemo TinyEXIFstatic)
+-		target_link_libraries(TinyEXIFdemo TinyEXIFstatic tinyxml2)
++		target_link_libraries(TinyEXIFdemo TinyEXIFstatic tinyxml2::tinyxml2)
+ 	endif()
+ endif()
+ 

--- a/ports/tinyexif/portfile.cmake
+++ b/ports/tinyexif/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 1.0.1
     SHA512 d018d882adbcebf9fa8ad67a78304a1dd21ffd3a01e3cf2d269fa34efedc5ec5f293767f3a21d62cb1bb9b88b2c364977a9125e9b88b2eac7866a8d6b27c2f23
     HEAD_REF master
+    PATCHES
+        namespace_tinyxml2.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)

--- a/ports/tinyxml2/CONTROL
+++ b/ports/tinyxml2/CONTROL
@@ -1,3 +1,3 @@
 Source: tinyxml2
-Version: 6.2.0
+Version: 7.0.1
 Description: A simple, small, efficient, C++ XML parser

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -3,21 +3,13 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO leethomason/tinyxml2
-    REF 6.2.0
-    SHA512 ef784240aeb090ab04aad659352ad4b224c431feecf485f33aca7936bcaa0ef4ab9d0a2e0692d3cf6036ac3e8012019d65665e780a920bbad3d4820f736445b1
+    REF 7.0.1
+    SHA512 623cd7eff542d20b434a67111ac98110101c95a18767318bf906e5e56d8cc25622269f740f50477fe907a4c52d875b614cb6167f4760d42ab18dc55b9d4bf380
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-  set(BUILD_STATIC_LIBS 1)
-else()
-  set(BUILD_STATIC_LIBS 0)
-endif()
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-      -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
 )
 
 vcpkg_install_cmake()
@@ -31,7 +23,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(COPY
   ${SOURCE_PATH}/readme.md
-  ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake
   DESTINATION ${CURRENT_PACKAGES_DIR}/share/tinyxml2
 )
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/tinyxml2/readme.md ${CURRENT_PACKAGES_DIR}/share/tinyxml2/copyright)

--- a/ports/tinyxml2/vcpkg-cmake-wrapper.cmake
+++ b/ports/tinyxml2/vcpkg-cmake-wrapper.cmake
@@ -1,5 +1,0 @@
-_find_package(${ARGS})
-if(TARGET tinyxml2_static AND NOT TARGET tinyxml2)
-    _add_library(tinyxml2 INTERFACE IMPORTED)
-    set_target_properties(tinyxml2 PROPERTIES INTERFACE_LINK_LIBRARIES "tinyxml2_static")
-endif()


### PR DESCRIPTION
There are major improvements in the cmake for this new release. 

1. now tinyxml2 uses namespaces, so `tinyxml2::tinyxml2` instead of just `tinyxml2`
2. no more manual separation of shared library and static library, now it depends on the standard `BUILD_SHARED_LIBS` macro, hence the major simplification of the portfile.

Tested both shared and static and it compiles and works with my downstream project.