### PR TITLE
new port: stlab

### DIFF
--- a/ports/stlab/CONTROL
+++ b/ports/stlab/CONTROL
@@ -1,0 +1,5 @@
+Source: stlab
+Version: 1.3.3
+Description: 
+  stlab is the ongoing work of what was Adobe’s Software Technology Lab.
+  The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures.

--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -1,0 +1,24 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stlab/libraries
+    REF v1.3.3
+    SHA512 2c0eec5638b40f8285cc3b0d756df619b53ba44421c47713aaf45196100765a31a6aea3c5bedba4fcc44494b74e3f0a919271601e717e7f274fe15beb93f8889
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+
+# cleanup
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/cmake/stlab ${CURRENT_PACKAGES_DIR}/share/stlab)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/cmake)
+
+# handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/stlab RENAME copyright)


### PR DESCRIPTION
New port: **stlab** from [stlab.cc](http://stlab.cc/)

([https://github.com/stlab/libraries](https://github.com/stlab/libraries))

> **stlab** is the ongoing work of what was Adobe’s Software Technology Lab.
> The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures.

Tested on all *windows* and *linux* triplets.

It's a header-only library for now, so the portfile is simple.