### PR TITLE
[documentation] Add note to "delete CMake cache after editing CMakeSettings.json"

### DIFF
--- a/docs/examples/using-sqlite.md
+++ b/docs/examples/using-sqlite.md
@@ -109,6 +109,7 @@ If you are using CMake through Open Folder with Visual Studio 2017 you can defin
   }]
 }
 ```
+*Note: It might be necessary to delete the CMake cache folder of each modified configuration, to force a full regeneration. In the `CMake` menu, under `Cache (<configuration name>)` you'll find `Delete Cache Folders`.*
 
 Now let's make a simple CMake project with a main file.
 ```cmake

--- a/docs/examples/using-sqlite.md
+++ b/docs/examples/using-sqlite.md
@@ -89,7 +89,8 @@ To remove the integration for your user, you can use `.\vcpkg integrate remove`.
 <a name="cmake"></a>
 #### CMake (Toolchain File)
 
-The best way to use installed libraries with cmake is via the toolchain file `scripts\buildsystems\vcpkg.cmake`. To use this file, you simply need to add it onto your CMake command line as `-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.
+The best way to use installed libraries with cmake is via the toolchain file `scripts\buildsystems\vcpkg.cmake`. To use this file, you simply need to add it onto your CMake command line as:  
+`-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.
 
 If you are using CMake through Open Folder with Visual Studio 2017 you can define `CMAKE_TOOLCHAIN_FILE` by adding a "variables" section to each of your `CMakeSettings.json` configurations:
 


### PR DESCRIPTION
This tripped me up, and took more time than I'm willing to admit.

After adding the `CMAKE_TOOLCHAIN_FILE` variable to the `CmakeSettings.json`, both `find_package()` and `find_path()` couldn't find any library in vcpkg.
Just regenerating the cache was not enough to get CMake in VS2017 (v15.9.0) to use the newly added variable.