### PR TITLE
[OpenCV3] fix ffmpeg and ippicv prebuilt downloads

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv
-Version: 3.4.3-1
+Version: 3.4.3-2
 Build-Depends: zlib
 Description: computer vision library
 Default-Features: opengl, jpeg, png, tiff, eigen, flann

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -8,10 +8,6 @@ vcpkg_from_github(
     REF ${OPENCV_PORT_VERSION}
     SHA512 d653a58eb5e3939b9fdb7438ac35f77cf4385cf72d5d22bfd21722a109e1b3283dbb9407985061b7548114f0d05c9395aac9bb62b4d2bc1f68da770a49987fef
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
       "${CMAKE_CURRENT_LIST_DIR}/0001-winrt-fixes.patch"
       "${CMAKE_CURRENT_LIST_DIR}/0002-install-options.patch"
@@ -19,8 +15,6 @@ vcpkg_apply_patches(
       "${CMAKE_CURRENT_LIST_DIR}/0004-use-find-package-required.patch"
       "${CMAKE_CURRENT_LIST_DIR}/0005-remove-protobuf-target.patch"
 )
-
-file(WRITE "${CURRENT_BUILDTREES_DIR}/src/opencv-${OPENCV_PORT_VERSION}/rework.stamp")
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_WITH_STATIC_CRT)
 
@@ -127,7 +121,7 @@ if("ffmpeg" IN_LIST FEATURES)
   )
   vcpkg_download_distfile(OCV_DOWNLOAD
     URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/8041bd6f5ad37045c258904ba3030bb3442e3911/ffmpeg/ffmpeg_version.cmake"
-    FILENAME "opencv-cache/ffmpeg/3b90f67f4b429e77d3da36698cef700c-ffmpeg_version.cmake"
+    FILENAME "opencv-cache/ffmpeg/8041bd6f5ad37045c258904ba3030bb3442e3911-ffmpeg_version.cmake"
     SHA512 7d0142c30ac6f6260c1bcabc22753030fd25a708477fa28053e8df847c366967d3b93a8ac14af19a2b7b73d9f8241749a431458faf21a0c8efc7d6d99eecfdcf
   )
 endif()

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -116,17 +116,17 @@ set(WITH_FFMPEG OFF)
 if("ffmpeg" IN_LIST FEATURES)
   set(WITH_FFMPEG ON)
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/opencv_ffmpeg.dll"
-    FILENAME "opencv-cache/ffmpeg/b8120c07962d591e2e9071a1bf566fd0-opencv_ffmpeg.dll"
-    SHA512 53325e3bb04de19273270475d7b7d9190c950b0d12e1179feef63c69ba66c9f8593d8ed9b030109dee8c104ab5babea69f18c7cae7366a57d48272d67c00d871
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/8041bd6f5ad37045c258904ba3030bb3442e3911/ffmpeg/opencv_ffmpeg.dll"
+    FILENAME "opencv-cache/ffmpeg/fa5a2a4e2f37defcb95bde8ed145c2b3-opencv_ffmpeg.dll"
+    SHA512 875f922e1d9fc2fe7c8e879ede35b1001b6ad8b3c4d71feb3823421ce861f580df3418c791315b23870fcb0378d297b01e0761d3f65277ff11ec2fef8c0b08b7
   )
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/opencv_ffmpeg_64.dll"
-    FILENAME "opencv-cache/ffmpeg/dc9c50e7b05482acc25d6ce0ac61bf1d-opencv_ffmpeg_64.dll"
-    SHA512 7d90df6f5d141f842a45e5678cf1349657612321250ece4ad5c6b5fb28a50140735d91ced0ce1a6e81962ef87236cbd1669c0b4410308f70fccee341a7a5c28b
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/8041bd6f5ad37045c258904ba3030bb3442e3911/ffmpeg/opencv_ffmpeg_64.dll"
+    FILENAME "opencv-cache/ffmpeg/2cc08fc4fef8199fe80e0f126684834f-opencv_ffmpeg_64.dll"
+    SHA512 4e74aa4cb115f103b929f93bbc8dcf675de7d0c7916f8f0a80ac46761134b088634be95f959ce5827753ae9ecb2365ca40440dfbb9a9bf89f22ee11b6c8342b3
   )
   vcpkg_download_distfile(OCV_DOWNLOAD
-    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/0a0e88972a7ea97708378d0488a65f83e7cc5e69/ffmpeg/ffmpeg_version.cmake"
+    URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/8041bd6f5ad37045c258904ba3030bb3442e3911/ffmpeg/ffmpeg_version.cmake"
     FILENAME "opencv-cache/ffmpeg/3b90f67f4b429e77d3da36698cef700c-ffmpeg_version.cmake"
     SHA512 7d0142c30ac6f6260c1bcabc22753030fd25a708477fa28053e8df847c366967d3b93a8ac14af19a2b7b73d9f8241749a431458faf21a0c8efc7d6d99eecfdcf
   )
@@ -137,16 +137,16 @@ if("ipp" IN_LIST FEATURES)
   set(WITH_IPP ON)
 
   if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    vcpkg_download_distfile(IPPICV_ARCHIVE
-        URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/dfe3162c237af211e98b8960018b564bc209261d/ippicv/ippicv_2017u3_win_intel64_general_20170822.zip"
-        FILENAME "opencv-cache/ippicv/0421e642bc7ad741a2236d3ec4190bdd-ippicv_2017u3_win_intel64_general_20170822.zip"
-        SHA512 1b2b66ac60e5b6ba2fc95a3839d09b7fcfb42628dc6e01648727ee5394f6405702f69f741371627a9e1690294147c730196f1c9872339301c92a1424f159df6c
+    vcpkg_download_distfile(OCV_DOWNLOAD
+      URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/bdb7bb85f34a8cb0d35e40a81f58da431aa1557a/ippicv/ippicv_2017u3_win_intel64_general_20180518.zip"
+      FILENAME "opencv-cache/ippicv/915ff92958089ede8ea532d3c4fe7187-ippicv_2017u3_win_intel64_general_20180518.zip"
+      SHA512 8aa08292d542d521c042864446e47a7a6bdbf3896d86fc7b43255459c24a2e9f34a4e9b177023d178fed7a2e82a9db410f89d81375a542d049785d263f46c64d
     )
   else()
     vcpkg_download_distfile(OCV_DOWNLOAD
-        URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/dfe3162c237af211e98b8960018b564bc209261d/ippicv/ippicv_2017u3_win_ia32_general_20170822.zip"
-        FILENAME "opencv-cache/ippicv/8a7680ae352c192de2e2e34936164bd0-ippicv_2017u3_win_ia32_general_20170822.zip"
-        SHA512 6bbe08264b56117d4a00118088d72274396964bb904fb0719fc48beeb458ac31bea3d4d2fa2e0449f55af42471758f2c090c82061c91985c8b7994ed3b71df81
+      URLS "https://raw.githubusercontent.com/opencv/opencv_3rdparty/bdb7bb85f34a8cb0d35e40a81f58da431aa1557a/ippicv/ippicv_2017u3_win_ia32_general_20180518.zip"
+      FILENAME "opencv-cache/ippicv/928168c2d99ab284047dfcfb7a821d91-ippicv_2017u3_win_ia32_general_20180518.zip"
+      SHA512 b89b0fb739152303cafc9fb064fa8b24fd94850697137ccbb5c1e344e0f5094115603a5e3be3a25f85d0faefc5c53429a7d65da0142d012ada41e8db2bcdd6b7
     )
   endif()
 endif()


### PR DESCRIPTION
fixes for prebuilt libs downloaded on the fly. The port is broken without these new refs