### PR TITLE
CppZMQ library version leveraged to 4.3.0.

### DIFF
--- a/ports/cppzmq/CONTROL
+++ b/ports/cppzmq/CONTROL
@@ -1,4 +1,4 @@
 Source: cppzmq
-Version: 4.2.2-1
+Version: 4.3.0
 Build-Depends: zeromq
 Description: lightweight messaging kernel, C++ bindings

--- a/ports/cppzmq/CONTROL
+++ b/ports/cppzmq/CONTROL
@@ -1,4 +1,4 @@
 Source: cppzmq
-Version: 4.3.0
+Version: 4.3.0-1
 Build-Depends: zeromq
 Description: lightweight messaging kernel, C++ bindings

--- a/ports/cppzmq/portfile.cmake
+++ b/ports/cppzmq/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/cppzmq
-    REF v4.2.2
-    SHA512 5f61ea4a16987c1363c3029cf46b3e83ddd86d65e8d639b0332d691f8fdb5cee121b5d72a9b8c89221daf52ea5892219e0bc4ea4e761bb1e7deb1659011dd3c9
+    REF v4.3.0
+    SHA512 c9e08e48795b9043c689ffa6953ac59e0fe79d9110d79e06609ab67bf76bea52147b59ecf033f7a06e57d5eb0c3c6bc79634af789966ff22d7d80091d19b135d
     HEAD_REF master
 )
 

--- a/ports/cppzmq/portfile.cmake
+++ b/ports/cppzmq/portfile.cmake
@@ -1,4 +1,3 @@
-#header-only library
 include(vcpkg_common_functions)
 
 vcpkg_from_github(
@@ -12,13 +11,14 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS -DCPPZMQ_BUILD_TESTS=OFF
 )
 
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/cppzmq)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/cppzmq/libzmq-pkg-config)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cppzmq)


### PR DESCRIPTION
Updates CppZMQ library to version 4.3.0. This resolves CMake issue: https://github.com/Microsoft/vcpkg/issues/3356