### PR TITLE
Add IE Proxy fallback for Win7

### DIFF
--- a/toolsrc/src/vcpkg/base/downloads.cpp
+++ b/toolsrc/src/vcpkg/base/downloads.cpp
@@ -42,6 +42,28 @@ namespace vcpkg::Downloads
                                     0);
         Checks::check_exit(VCPKG_LINE_INFO, hSession, "WinHttpOpen() failed: %d", GetLastError());
 
+        // Win7 IE Proxy fallback
+        if (IsWindows7OrGreater() && !IsWindows8Point1OrGreater()) {
+            // First check if any proxy has been found automatically
+            WINHTTP_PROXY_INFO proxyInfo;
+            DWORD proxyInfoSize = sizeof(WINHTTP_PROXY_INFO);
+            auto noProxyFound = 
+                !WinHttpQueryOption(hSession, WINHTTP_OPTION_PROXY, &proxyInfo, &proxyInfoSize) 
+                || proxyInfo.dwAccessType == WINHTTP_ACCESS_TYPE_NO_PROXY;
+
+            // If no proxy was found automatically, use IE's proxy settings, if any
+            if (noProxyFound) {
+                WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ieProxy;
+                if (WinHttpGetIEProxyConfigForCurrentUser(&ieProxy) && ieProxy.lpszProxy != nullptr) {
+                    WINHTTP_PROXY_INFO proxy;
+                    proxy.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+                    proxy.lpszProxy = ieProxy.lpszProxy;
+                    proxy.lpszProxyBypass = ieProxy.lpszProxyBypass;
+                    WinHttpSetOption(hSession, WINHTTP_OPTION_PROXY, &proxy, sizeof(proxy));
+                }
+            }
+        }
+
         // Use Windows 10 defaults on Windows 7
         DWORD secure_protocols(WINHTTP_FLAG_SECURE_PROTOCOL_SSL3 | WINHTTP_FLAG_SECURE_PROTOCOL_TLS1 |
                                WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_1 | WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2);


### PR DESCRIPTION
Currently, vcpkg will automatically try to find the correct proxy settings using a feature introduced in Windows 8.1 (`WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY`). On Windows 7, however, it has to rely on `WINHTTP_ACCESS_TYPE_DEFAULT_PROXY`, which obtains proxy information from `proxycfg` or `netsh`. In practice, proxy settings are not always configured using these utilities and it is not uncommon to see the settings being configured through the IE proxy settings dialog.

This PR will make vcpkg check, if no proxy has been found and the user is running Win7, if IE has any proxy settings. If it has, it will configure the WinHTTP client to use them.

Relevant issues:
https://github.com/Microsoft/vcpkg/issues/3675
