### PR TITLE
 [wxwidgets] move setup.h to include

### DIFF
--- a/ports/wxwidgets/CONTROL
+++ b/ports/wxwidgets/CONTROL
@@ -1,4 +1,4 @@
 Source: wxwidgets
-Version: 3.1.1-1
+Version: 3.1.1-2
 Description: wxWidgets is a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.
 Build-Depends: zlib, libpng, tiff, expat

--- a/ports/wxwidgets/CONTROL
+++ b/ports/wxwidgets/CONTROL
@@ -1,4 +1,4 @@
 Source: wxwidgets
-Version: 3.1.1
+Version: 3.1.1-1
 Description: wxWidgets is a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.
 Build-Depends: zlib, libpng, tiff, expat

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -48,4 +48,8 @@ endif()
 # Handle copyright
 file(COPY ${SOURCE_PATH}/docs/licence.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/wxwidgets)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/wxwidgets/licence.txt ${CURRENT_PACKAGES_DIR}/share/wxwidgets/copyright)
+
+file(RENAME ${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h ${CURRENT_PACKAGES_DIR}/include/wx/setup.h)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/mswu)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/mswud)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -52,4 +52,5 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/share/wxwidgets/licence.txt ${CURRENT_PACKAG
 file(RENAME ${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h ${CURRENT_PACKAGES_DIR}/include/wx/setup.h)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/mswu)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/mswud)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/msvc)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -5,11 +5,7 @@ vcpkg_from_github(
     REF v3.1.1
     SHA512 f6d8974e2f48bae7e96a8938df3ad5efc403036c1dcbe2b48edd276ee7923802ba3e95e3f3bd9db17985e427b8e4f78950df0cbba83ae99d508ed04633816c95
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/disable-platform-lib-dir.patch"
+    PATCHES disable-platform-lib-dir.patch
 )
 
 vcpkg_configure_cmake(
@@ -49,7 +45,9 @@ endif()
 file(COPY ${SOURCE_PATH}/docs/licence.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/wxwidgets)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/wxwidgets/licence.txt ${CURRENT_PACKAGES_DIR}/share/wxwidgets/copyright)
 
-file(RENAME ${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h ${CURRENT_PACKAGES_DIR}/include/wx/setup.h)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h ${CURRENT_PACKAGES_DIR}/include/wx/setup.h)
+endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/mswu)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/mswud)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/msvc)


### PR DESCRIPTION
Also remove `lib/mswu` and `debug/lib/mswud`. They only contain `setup.h`.

Also remove `include/msvc` directory which only contains a "wrapper" `setup.h` that is hard-coded to include the real `setup.h` from `lib`. With the real `setup.h` moved to `include` the wrapper is now useless.

Fixes #3180.
Closes #4251.