### PR TITLE
[devil] Fix 'tiff' option name.

### DIFF
--- a/ports/devil/CONTROL
+++ b/ports/devil/CONTROL
@@ -1,5 +1,5 @@
 Source: devil
-Version: 1.8.0-2
+Version: 1.8.0-3
 Build-Depends:
 Description: A full featured cross-platform image library
 Default-Features: libpng, tiff, libjpeg, openexr, jasper, lcms

--- a/ports/devil/portfile.cmake
+++ b/ports/devil/portfile.cmake
@@ -20,7 +20,7 @@ if("libpng" IN_LIST FEATURES)
 endif()
 
 set(IL_NO_TIF 1)
-if("libtiff" IN_LIST FEATURES)
+if("tiff" IN_LIST FEATURES)
     set(IL_NO_TIF 0)
 endif()
 

--- a/ports/devil/portfile.cmake
+++ b/ports/devil/portfile.cmake
@@ -1,11 +1,9 @@
 include(vcpkg_common_functions)
 
-set(DEVIL_VERSION 1.8.0)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DentonW/DevIL
-    REF v${DEVIL_VERSION}
+    REF v1.8.0
     SHA512 4aed5e50a730ece8b1eb6b2f6204374c6fb6f5334cf7c880d84c0f79645ea7c6b5118f57a7868a487510fc59c452f51472b272215d4c852f265f58b5857e17c7
     HEAD_REF master
     PATCHES


### PR DESCRIPTION
Tiff feature is always disabled because of invalid option name.