### PR TITLE
[re2] Add vcpkg_copy_pdbs

### DIFF
--- a/ports/re2/CONTROL
+++ b/ports/re2/CONTROL
@@ -1,3 +1,3 @@
 Source: re2
-Version: 2018-11-01
+Version: 2018-11-01-1
 Description: RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.

--- a/ports/re2/portfile.cmake
+++ b/ports/re2/portfile.cmake
@@ -15,6 +15,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_copy_pdbs()
+
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/re2 RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
This fixes up missing PDBs in re2, i.e. an issue with the following repro steps:

```
git clean -xdf
.\bootstrap-vcpkg.bat
.\vcpkg install re2
.\vcpkg export re2 --nuget
```

Expected: Nuget package contains DLLs and matching PDBs
Actual: Nuget package contains DLLs and no PDBs

---

This however seems to be a more widespread problem.

`vcpkg_copy_pdbs` documents:
> This command should always be called by portfiles after they have finished rearranging the binary output.

Assuming this is a requirement, a quick and dirty scan (`(ls -r -i portfile.cmake ports | ? { (sls -list -simplematch "vcpkg_install_cmake" $_) -and -not (sls -list -simplematch "vcpkg_copy_pdbs" $_) }).fullname`)  reveals 133 suspect packages. While there is a number of header- or static-only ones, there likely are true positives. I imagine this can be verified fully by building and exporting the world, and diffing *.dll with *.pdb inside the Nuget...

But maybe more a holistic solution would be to add `vcpkg_copy_pdbs()` to `vcpkg_install_cmake` (and `_meson`), like there appears to be one in [`vcpkg_install_msbuild`](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_install_msbuild.cmake#L204) ?