### PR TITLE
[tesseract] Update Tesseract port to 4.0.0

### DIFF
--- a/ports/tesseract/CONTROL
+++ b/ports/tesseract/CONTROL
@@ -1,4 +1,4 @@
 Source: tesseract
-Version: 3.05.02
+Version: 4.0.0
 Description: An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.
 Build-Depends: leptonica, icu

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -8,8 +8,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tesseract-ocr/tesseract
-    REF 3.05.02
-    SHA512 4cb23a6981dd5ec9eefea7b9674847ae88a411a7308ee6d946a920c76eefcf5fe7a90f6cb3ff00493a0e69b5c327d052fa8514d7f3ed506bccbe4b0163065793
+    REF 4.0.0
+    SHA512 69e57d4ba1fc43d212fd0fff69a2b5d48a3b37cfee7054fdc083cbb7e04d92317609a32e457229661d70ce8d9b16c9d25e81bfc3861db660dd2c8f292202d447
     HEAD_REF master
 )
 


### PR DESCRIPTION
This PR updates Tesseract to [version 4](https://github.com/tesseract-ocr/tesseract/wiki/ReleaseNotes#tesseract-release-notes-oct-29-2018---v400). New in this version is a new OCR engine based on LSTMs.

Related Issues:
https://github.com/Microsoft/vcpkg/issues/4604