### PR TITLE
Remove constructor for type that was using aggregate initialization

### DIFF
--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -657,8 +657,6 @@ namespace vcpkg::PostBuildLint
     {
         fs::path file;
         OutdatedDynamicCrt outdated_crt;
-
-        OutdatedDynamicCrtAndFile() = delete;
     };
 
     static LintStatus check_outdated_crt_linkage_of_dlls(const std::vector<fs::path>& dlls,


### PR DESCRIPTION
as in C++20 any user declared constructor means a type is no longer an aggregate.

(Without this change `bootstrap_vcpkg.exe` fails on preview releases of Visual C++'s compiler)