### PR TITLE
Fix unterminated quoted string in bootstrapping script.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -181,7 +181,7 @@ selectCXX()
     gccversion="$(extractStringBetweenDelimiters "$gccversion" "gcc version " ".")"
     if [ "$gccversion" -lt "6" ]; then
         echo "CXX ($CXX) is too old; please install a newer compiler such as g++-7."
-        echo "On Ubuntu try the following:
+        echo "On Ubuntu try the following:"
         echo "sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y"
         echo "sudo apt-get update -y"
         echo "sudo apt-get install g++-7 -y"


### PR DESCRIPTION
A recent commit introduced an unquoted string, breaking the bootstrapping shell script.