### PR TITLE
[mpfr] Update mpfr to 4.0.1 and fix compilation under gcc 7

### DIFF
--- a/ports/mpfr/CMakeLists.txt
+++ b/ports/mpfr/CMakeLists.txt
@@ -255,6 +255,11 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(mpfr PRIVATE __GMP_LIBGMP_DLL)
 endif()
 
+try_compile(I_HAVE_STDARG ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR}/test_stdarg.c)
+if (I_HAVE_STDARG)
+    target_compile_definitions(mpfr PRIVATE HAVE_STDARG)
+endif (I_HAVE_STDARG)
+
 target_link_libraries(mpfr ${GMP_LIBRARIES})
 
 target_include_directories(mpfr PUBLIC ${GMP_INCLUDE_DIRS})

--- a/ports/mpfr/CMakeLists.txt
+++ b/ports/mpfr/CMakeLists.txt
@@ -11,237 +11,240 @@ set(GMP_INCLUDE_DIRS ${GMP_INCLUDE_DIR})
 
 # Sources
 set(SRCS
-  src/gmp_printf.c
-  src/mpfr.h
-  src/mpf2mpfr.h
-  src/mpfr-gmp.h
-  src/mpfr-impl.h
-  src/mpfr-intmax.h
-  src/mpfr-longlong.h
-  src/mpfr-thread.h
-  src/exceptions.c
-  src/extract.c
-  src/uceil_exp2.c
-  src/uceil_log2.c
-  src/ufloor_log2.c
+  src/abort_prec_max.c
+  src/acos.c
+  src/acosh.c
   src/add.c
   src/add1.c
+  src/add1sp.c
+  src/add_d.c
   src/add_ui.c
   src/agm.c
+  src/ai.c
+  src/asin.c
+  src/asinh.c
+  src/atan.c
+  src/atan2.c
+  src/atanh.c
+  src/bernoulli.c
+  src/beta.c
+  src/buildopt.c
+  src/cache.c
+  src/cbrt.c
+  src/check.c
   src/clear.c
+  src/clears.c
   src/cmp.c
+  src/cmp2.c
   src/cmp_abs.c
+  src/cmp_d.c
+  src/cmp_ld.c
   src/cmp_si.c
   src/cmp_ui.c
   src/comparisons.c
-  src/div_2exp.c
-  src/div_2si.c	
-  src/div_2ui.c
+  src/constant.c
+  src/const_catalan.c
+  src/const_euler.c
+  src/const_log2.c
+  src/const_pi.c
+  src/copysign.c
+  src/cos.c
+  src/cosh.c
+  src/cot.c
+  src/coth.c
+  src/csc.c
+  src/csch.c
+  src/digamma.c
+  src/dim.c
   src/div.c
+  src/div_2exp.c
+  src/div_2si.c
+  src/div_2ui.c
+  src/div_d.c
   src/div_ui.c
   src/dump.c
+  src/d_div.c
+  src/d_sub.c
+  src/eint.c
   src/eq.c
+  src/erandom.c
+  src/erf.c
+  src/erfc.c
+  src/exceptions.c
+  src/exp.c
   src/exp10.c
   src/exp2.c
   src/exp3.c
-  src/exp.c
+  src/expm1.c
+  src/exp_2.c
+  src/extract.c
+  src/factorial.c
+  src/fits_intmax.c
+  src/fits_sint.c
+  src/fits_slong.c
+  src/fits_sshort.c
+  src/fits_uint.c
+  src/fits_uintmax.c
+  src/fits_ulong.c
+  src/fits_ushort.c
+  src/fma.c
+  src/fmma.c
+  src/fms.c
   src/frac.c
+  src/free_cache.c
   src/frexp.c
+  src/gamma.c
+  src/gammaonethird.c
+  src/gamma_inc.c
   src/get_d.c
+  src/get_d64.c
   src/get_exp.c
+  src/get_f.c
+  src/get_float128.c
+  src/get_flt.c
+  src/get_ld.c
+  src/get_patches.c
+  src/get_q.c
+  src/get_si.c
+  src/get_sj.c
   src/get_str.c
+  src/get_ui.c
+  src/get_uj.c
+  src/get_z.c
+  src/get_z_exp.c
+  src/gmp_op.c
+  src/grandom.c
+  src/hypot.c
   src/init.c
+  src/init2.c
+  src/inits.c
+  src/inits2.c
   src/inp_str.c
-  src/isinteger.c
+  src/int_ceil_log2.c
   src/isinf.c
+  src/isinteger.c
   src/isnan.c
   src/isnum.c
-  src/const_log2.c
+  src/isqrt.c
+  src/isregular.c
+  src/iszero.c
+  src/jn.c
+  src/li2.c
+  src/lngamma.c
   src/log.c
+  src/log10.c
+  src/log1p.c
+  src/log2.c
+  src/logging.c
+  src/log_ui.c
+  src/minmax.c
+  src/min_prec.c
   src/modf.c
+  src/mpfr-gmp.c
+  src/mpfr-mini-gmp.c
+  src/mpn_exp.c
+  src/mp_clz_tab.c
+  src/mul.c
+  src/mulders.c
   src/mul_2exp.c
   src/mul_2si.c
   src/mul_2ui.c
-  src/mul.c
+  src/mul_d.c
   src/mul_ui.c
   src/neg.c
   src/next.c
+  src/nrandom.c
+  src/odd_p.c
   src/out_str.c
-  src/printf.c
-  src/vasprintf.c
-  src/const_pi.c
+  src/pool.c
   src/pow.c
+  src/powerof2.c
   src/pow_si.c
   src/pow_ui.c
+  src/pow_z.c
+  src/printf.c
   src/print_raw.c
-  src/print_rnd_mode.c	
+  src/print_rnd_mode.c
+  src/random_deviate.c
+  src/rec_sqrt.c
   src/reldiff.c
+  src/rem1.c
+  src/rint.c
+  src/rndna.c
+  src/root.c
+  src/round_near_x.c
+  src/round_p.c
   src/round_prec.c
+  src/scale2.c
+  src/sec.c
+  src/sech.c
   src/set.c
   src/setmax.c
   src/setmin.c
+  src/setsign.c
   src/set_d.c
+  src/set_d64.c
   src/set_dfl_prec.c
   src/set_exp.c
-  src/set_rnd.c
   src/set_f.c
+  src/set_float128.c
+  src/set_flt.c
+  src/set_inf.c
+  src/set_ld.c
+  src/set_nan.c
   src/set_prc_raw.c
   src/set_prec.c
   src/set_q.c
+  src/set_rnd.c
   src/set_si.c
+  src/set_si_2exp.c
+  src/set_sj.c
   src/set_str.c
   src/set_str_raw.c
   src/set_ui.c
+  src/set_ui_2exp.c
+  src/set_uj.c
   src/set_z.c
+  src/set_zero.c
+  src/set_z_exp.c
+  src/sgn.c
+  src/signbit.c
+  src/sin.c
+  src/sinh.c
+  src/sinh_cosh.c
+  src/sin_cos.c
+  src/si_op.c
+  src/sqr.c
   src/sqrt.c
   src/sqrt_ui.c
+  src/stack_interface.c
+  src/strtofr.c
   src/sub.c
   src/sub1.c
+  src/sub1sp.c
+  src/subnormal.c
+  src/sub_d.c
   src/sub_ui.c
-  src/rint.c
+  src/sum.c
+  src/swap.c
+  src/tan.c
+  src/tanh.c
+  src/ubf.c
+  src/uceil_exp2.c
+  src/uceil_log2.c
+  src/ufloor_log2.c
   src/ui_div.c
+  src/ui_pow.c
+  src/ui_pow_ui.c
   src/ui_sub.c
   src/urandom.c
   src/urandomb.c
-  src/get_z_exp.c
-  src/swap.c
-  src/factorial.c
-  src/cosh.c
-  src/sinh.c
-  src/tanh.c
-  src/sinh_cosh.c
-  src/acosh.c
-  src/asinh.c
-  src/atanh.c
-  src/atan.c
-  src/cmp2.c
-  src/exp_2.c
-  src/asin.c
-  src/const_euler.c
-  src/cos.c
-  src/sin.c
-  src/tan.c
-  src/fma.c
-  src/fms.c
-  src/hypot.c
-  src/log1p.c
-  src/expm1.c
-  src/log2.c
-  src/log10.c
-  src/ui_pow.c	
-  src/ui_pow_ui.c
-  src/minmax.c
-  src/dim.c
-  src/signbit.c
-  src/copysign.c
-  src/setsign.c
-  src/gmp_op.c
-  src/init2.c
-  src/acos.c
-  src/sin_cos.c
-  src/set_nan.c
-  src/set_inf.c
-  src/set_zero.c
-  src/powerof2.c
-  src/gamma.c
-  src/set_ld.c
-  src/get_ld.c
-  src/cbrt.c
-  src/volatile.c
-  src/fits_s.h
-  src/fits_sshort.c
-  src/fits_sint.c
-  src/fits_slong.c
-  src/fits_u.h
-  src/fits_ushort.c
-  src/fits_uint.c	
-  src/fits_ulong.c
-  src/fits_uintmax.c
-  src/fits_intmax.c
-  src/get_si.c
-  src/get_ui.c
-  src/zeta.c
-  src/cmp_d.c
-  src/erf.c
-  src/inits.c
-  src/inits2.c
-  src/clears.c
-  src/sgn.c
-  src/check.c
-  src/sub1sp.c	
+  src/vasprintf.c
   src/version.c
-  src/mpn_exp.c
-  src/mpfr-gmp.c
-  src/mp_clz_tab.c
-  src/sum.c
-  src/add1sp.c	
-  src/free_cache.c
-  src/si_op.c
-  src/cmp_ld.c
-  src/set_ui_2exp.c
-  src/set_si_2exp.c
-  src/set_uj.c
-  src/set_sj.c
-  src/get_sj.c
-  src/get_uj.c
-  src/get_z.c
-  src/iszero.c
-  src/cache.c
-  src/sqr.c	
-  src/int_ceil_log2.c
-  src/isqrt.c
-  src/strtofr.c
-  src/pow_z.c
-  src/logging.c
-  src/mulders.c
-  src/get_f.c
-  src/round_p.c
-  src/erfc.c
-  src/atan2.c
-  src/subnormal.c
-  src/const_catalan.c
-  src/root.c	
-  src/gen_inverse.h
-  src/sec.c
-  src/csc.c
-  src/cot.c
-  src/eint.c
-  src/sech.c
-  src/csch.c
-  src/coth.c	
-  src/round_near_x.c
-  src/constant.c
-  src/abort_prec_max.c
-  src/stack_interface.c
-  src/lngamma.c
-  src/zeta_ui.c
-  src/set_d64.c
-  src/get_d64.c
-  src/jn.c
+  src/volatile.c
   src/yn.c
-  src/rem1.c
-  src/get_patches.c
-  src/add_d.c
-  src/sub_d.c
-  src/d_sub.c
-  src/mul_d.c
-  src/div_d.c
-  src/d_div.c
-  src/li2.c
-  src/rec_sqrt.c
-  src/min_prec.c
-  src/buildopt.c
-  src/digamma.c
-  src/bernoulli.c
-  src/isregular.c
-  src/set_flt.c
-  src/get_flt.c
-  src/scale2.c
-  src/set_z_exp.c
-  src/ai.c
-  src/gammaonethird.c
-  src/ieee_floats.h		
-  src/grandom.c)
+  src/zeta.c
+  src/zeta_ui.c)
 
 configure_file("src/mparam_h.in" "mparam.h")
 

--- a/ports/mpfr/CONTROL
+++ b/ports/mpfr/CONTROL
@@ -1,4 +1,4 @@
 Source: mpfr
-Version: 3.1.6-3
+Version: 4.0.1
 Description: The MPFR library is a C library for multiple-precision floating-point computations with correct rounding
 Build-Depends: mpir

--- a/ports/mpfr/CONTROL
+++ b/ports/mpfr/CONTROL
@@ -1,4 +1,4 @@
 Source: mpfr
-Version: 3.1.6-2
+Version: 3.1.6-3
 Description: The MPFR library is a C library for multiple-precision floating-point computations with correct rounding
 Build-Depends: mpir

--- a/ports/mpfr/gmp_printf.c
+++ b/ports/mpfr/gmp_printf.c
@@ -1,6 +1,0 @@
-#include <stdio.h>
-#include <stdarg.h>
-
-extern int __gmpfr_fprintf(const char *fmt, va_list argp) {
-    return fprintf(stderr, fmt, argp);
-}

--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -9,7 +9,6 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive(${ARCHIVE})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/test_stdarg.c DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/gmp_printf.c DESTINATION ${SOURCE_PATH}/src)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -1,13 +1,14 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mpfr-3.1.6)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/mpfr-4.0.1)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.mpfr.org/mpfr-3.1.6/mpfr-3.1.6.tar.xz"
-    FILENAME "mpfr-3.1.6.tar.xz"
-    SHA512 746ee74d5026f267f74ab352d850ed30ff627d530aa840c71b24793e44875f8503946bd7399905dea2b2dd5744326254d7889337fe94cfe58d03c4066e9d8054
+    URLS "http://www.mpfr.org/mpfr-4.0.1/mpfr-4.0.1.tar.xz"
+    FILENAME "mpfr-4.0.1.tar.xz"
+    SHA512 137ad68bc1e33a155edc1247fcdba27f999cf48ed526773136584090ddf2cfdfc9ea79fbf74ea1943b835b4b1ff29b05087114738c6ad3b485848540f30cac4f
 )
 
 vcpkg_extract_source_archive(${ARCHIVE})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/test_stdarg.c DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/gmp_printf.c DESTINATION ${SOURCE_PATH}/src)
 
 vcpkg_configure_cmake(

--- a/ports/mpfr/test_stdarg.c
+++ b/ports/mpfr/test_stdarg.c
@@ -1,0 +1,6 @@
+# include <stdarg.h>
+
+int main(int argc, char *argv) {
+    return 0;
+}
+


### PR DESCRIPTION
gcc 7 deprecates the use of varargs.h in favour of stdarg.h.
mpfr already fixes it, but the fix is enabled if stdarg is available.
This patch adds the test on CMakeLists.txt and enables the fix if
needed.