### PR TITLE
Update SQLite to 3.26.0 because of "Magellan" vulnerability

### DIFF
--- a/ports/sqlite3/CONTROL
+++ b/ports/sqlite3/CONTROL
@@ -1,5 +1,5 @@
 Source: sqlite3
-Version: 3.25.2
+Version: 3.26.0
 Description: SQLite is a software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine.
 
 Feature: tool

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -1,7 +1,7 @@
 include(vcpkg_common_functions)
 
-set(SQLITE_VERSION 3250200)
-set(SQLITE_HASH f87b4ab405f85df85b5d63e9e28c4db76202dc2d5461e0d0c626fa7521570d89a1122403c037704859ecb58ac1747ebf4b3c8a2f3a3c3d8492e8060df92e379f)
+set(SQLITE_VERSION 3260000)
+set(SQLITE_HASH ba089abd16857a65fc6cf26558a0d3e6f20c278b8df451b357eea5154f8ccd5645c9cfdb30d0fd4fe64f19dd2f876a6cc4a28455b7b013770c2ce9a607171107)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://sqlite.org/2018/sqlite-amalgamation-${SQLITE_VERSION}.zip"


### PR DESCRIPTION
The Tencent Blade Team has recently discovered [a remote code execution vulnerability in SQLite and Chromium called "Magellan"](https://blade.tencent.com/magellan/index_en.html). Both Google and the SQLite development team have confirmed and fixed the vulnerability already.

According to them, the new SQLite release 3.26.0 fixed this issue and is no longer affected.
Therefore this PR is updating the vcpkg port sqlite3 to the new release version.