### PR TITLE
[c-ares] Change to 0/1 instead of OFF/ON

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -13,11 +13,11 @@ vcpkg_from_github(
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(CARES_STATIC ON)
-    set(CARES_SHARED OFF)
+    set(CARES_STATIC 1)
+    set(CARES_SHARED 0)
 else()
-    set(CARES_STATIC OFF)
-    set(CARES_SHARED ON)
+    set(CARES_STATIC 0)
+    set(CARES_SHARED 1)
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
On newer CMake's, the following errors are reported:

```
CMake Warning (dev) at .... /vcpkg/installed/x64-osx/share/c-ares/c-ares-config.cmake:32 (if):
  if given arguments:

    "ON"

  An argument named "ON" appears in a conditional statement.  Policy CMP0012
  is not set: if() recognizes numbers and boolean constants.  Run "cmake
  --help-policy CMP0012" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
```

Which corresponds to the following configured code:

```
if(ON)
    set(c-ares_STATIC_LIBRARY c-ares::cares_static)
endif()
```