### PR TITLE
Fix typo of the port name(milerius-sfml-imgui) in port.camke

### DIFF
--- a/ports/milerius-sfml-imgui/CONTROL
+++ b/ports/milerius-sfml-imgui/CONTROL
@@ -1,4 +1,4 @@
 Source: milerius-sfml-imgui
-Version: 1.1
+Version: 1.1-1
 Description: imgui dll for sfml usage
 Build-Depends: sfml (windows), imgui

--- a/ports/milerius-sfml-imgui/portfile.cmake
+++ b/ports/milerius-sfml-imgui/portfile.cmake
@@ -20,5 +20,5 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sfml-imgui)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sfml-imgui)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/sfml-imgui/LICENSE ${CURRENT_PACKAGES_DIR}/share/sfml-imgui/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/milerius-sfml-imgui)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/milerius-sfml-imgui/LICENSE ${CURRENT_PACKAGES_DIR}/share/milerius-sfml-imgui/copyright)


### PR DESCRIPTION
This was a typo for source "milerius-sfml-imgui", after modified the "sfml-imgui" to "milerius-sfml-imgui" in portfile.cmake: line 23 and 24, it installed successfully.