### PR TITLE
GENERATOR "MinGW Makefiles"

### DIFF
--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -50,6 +50,8 @@ function(vcpkg_build_cmake)
         set(PARALLEL_ARG "/m")
     elseif(_VCPKG_CMAKE_GENERATOR MATCHES "NMake")
         # No options are currently added for nmake builds
+    elseif(_VCPKG_CMAKE_GENERATOR MATCHES "MinGW Makefiles")
+        # Options?
     else()
         message(FATAL_ERROR "Unrecognized GENERATOR setting from vcpkg_configure_cmake(). Valid generators are: Ninja, Visual Studio, and NMake Makefiles")
     endif()


### PR DESCRIPTION
tested sqlite3 - PREFER_NINJA + GENERATOR "MinGW Makefiles"

```
vcpkg_configure_cmake(
    SOURCE_PATH ${SOURCE_PATH}
    PREFER_NINJA
    #DISABLE_PARALLEL_CONFIGURE
    GENERATOR "MinGW Makefiles"
    OPTIONS
        -DSQLITE3_SKIP_TOOLS=${SQLITE3_SKIP_TOOLS}
    OPTIONS_DEBUG
        -DSQLITE3_SKIP_TOOLS=ON
)
```

edit `CMakeMinGWFindMake.cmake` in the locations `mingw32-make.exe`

C:\Program Files (x86)\CMake\share\cmake-3.12\Modules\CMakeMinGWFindMake.cmake

```
find_program(CMAKE_MAKE_PROGRAM mingw32-make.exe 
	PATHS
	"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\MinGW;InstallLocation]/bin"
	"[HKEY_CURRENT_USER\\Software\\CodeBlocks;Path]/MinGW/bin"
	I:/msys2/mingw64 /mingw64/bin
  )
```

build ok