### PR TITLE
[msmpi] update to 10.0

### DIFF
--- a/ports/msmpi/CONTROL
+++ b/ports/msmpi/CONTROL
@@ -1,3 +1,3 @@
 Source: msmpi
-Version: 9.0
+Version: 10.0
 Description: Microsoft MPI

--- a/ports/msmpi/portfile.cmake
+++ b/ports/msmpi/portfile.cmake
@@ -1,17 +1,19 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/msmpi-8.1)
+
+set(MSMPI_VERSION "10.0.12498")
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/msmpi-${MSMPI_VERSION})
 
 vcpkg_download_distfile(SDK_ARCHIVE
-    URLS "https://download.microsoft.com/download/2/E/C/2EC96D7F-687B-4613-80F6-E10F670A2D97/msmpisdk.msi"
-    FILENAME "msmpisdk-9.0.msi"
-    SHA512 f80cc7619c42a5a0975224c5a0ab6d4085a97ab9a1480318cd72db2f600db52fb81d3959a2a9e0dbd9412b02d0814b8191dd4745bbde397110210e05960628b4
+    URLS "https://download.microsoft.com/download/A/E/0/AE002626-9D9D-448D-8197-1EA510E297CE/msmpisdk.msi"
+    FILENAME "msmpisdk-${MSMPI_VERSION}.msi"
+    SHA512 36a31b2516f45fbc26167b31d2d6419f1928aef1591033f0430d36570159205e1a3134557a4ac0462f2d879add1fc6fee87a6997032e4438b528cd42a8bbe6b1
 )
 
 macro(download_msmpi_redistributable_package)
     vcpkg_download_distfile(REDIST_ARCHIVE
-        URLS "https://download.microsoft.com/download/2/E/C/2EC96D7F-687B-4613-80F6-E10F670A2D97/msmpisetup.exe"
-        FILENAME "msmpisetup-9.0.exe"
-        SHA512 ad1cc3bc74e4c9c3c0f304395df9468e729e0acd9c77c8c6c806e88eadf4693811d29e608ffb459fcb6f4a20f61946ef4ac2e411aac49fb8f8d5aaddd10d4554
+        URLS "https://download.microsoft.com/download/A/E/0/AE002626-9D9D-448D-8197-1EA510E297CE/msmpisetup.exe"
+        FILENAME "msmpisetup-${MSMPI_VERSION}.exe"
+        SHA512 c272dc842eb1e693f25eb580e1caf0c1fdb385611a12c20cdc6a40cf592ccbdba434a1c16edb63eef14b1a2ac6e678ac1cd561ec5fd003a5d17191a0fad281ae
     )
 endmacro()
 
@@ -20,7 +22,6 @@ endmacro()
 # We always want the ProgramFiles folder even on a 64-bit machine (not the ProgramFilesx86 folder)
 vcpkg_get_program_files_platform_bitness(PROGRAM_FILES_PLATFORM_BITNESS)
 set(SYSTEM_MPIEXEC_FILEPATH "${PROGRAM_FILES_PLATFORM_BITNESS}/Microsoft MPI/Bin/mpiexec.exe")
-set(MSMPI_EXPECTED_FULL_VERSION "9.0.12497")
 
 if(EXISTS "${SYSTEM_MPIEXEC_FILEPATH}")
     set(MPIEXEC_VERSION_LOGNAME "mpiexec-version")
@@ -32,12 +33,12 @@ if(EXISTS "${SYSTEM_MPIEXEC_FILEPATH}")
     file(READ ${CURRENT_BUILDTREES_DIR}/${MPIEXEC_VERSION_LOGNAME}-out.log MPIEXEC_OUTPUT)
 
     if(MPIEXEC_OUTPUT MATCHES "\\[Version ([0-9]+\\.[0-9]+\\.[0-9]+)\\.[0-9]+\\]")
-        if(NOT CMAKE_MATCH_1 STREQUAL MSMPI_EXPECTED_FULL_VERSION)
+        if(NOT CMAKE_MATCH_1 STREQUAL MSMPI_VERSION)
             download_msmpi_redistributable_package()
 
             message(FATAL_ERROR
                 "  The version of the installed MSMPI redistributable packages does not match the version to be installed\n"
-                "    Expected version: ${MSMPI_EXPECTED_FULL_VERSION}\n"
+                "    Expected version: ${MSMPI_VERSION}\n"
                 "    Found version: ${CMAKE_MATCH_1}\n"
                 "  Please upgrade the installed version on your system.\n"
                 "  The appropriate installer for the expected version has been downloaded to:\n"
@@ -131,5 +132,6 @@ if(TRIPLET_SYSTEM_ARCH STREQUAL "x86")
 endif()
 
 # Handle copyright
-file(COPY "${SOURCE_PATH}/sdk/PFiles/Microsoft SDKs/MPI/License/license_sdk.rtf" DESTINATION ${CURRENT_PACKAGES_DIR}/share/msmpi)
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/msmpi/copyright "See the accompanying license_sdk.rtf")
+file(COPY "${SOURCE_PATH}/sdk/PFiles/Microsoft SDKs/MPI/License/MicrosoftMPI-SDK-EULA.rtf" DESTINATION ${CURRENT_PACKAGES_DIR}/share/msmpi)
+file(COPY "${SOURCE_PATH}/sdk/PFiles/Microsoft SDKs/MPI/License/MPI-SDK-TPN.txt" DESTINATION ${CURRENT_PACKAGES_DIR}/share/msmpi)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/msmpi/copyright "See the accompanying MicrosoftMPI-SDK-EULA.rtf and MPI-SDK-TPN.txt")

--- a/ports/parmetis/portfile.cmake
+++ b/ports/parmetis/portfile.cmake
@@ -7,21 +7,22 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/parmetis-4.0.3)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz"
     FILENAME "parmetis-4.0.3.tar.gz"
     SHA512 454a91921ca35c981df11c9846a11963ff8fd8407a25179453af33f8fe69493f6dd7f2a0b8feed9a7d3f121e45b715749dd7a94873eaac2bae4cad1e535ca132
 )
-vcpkg_extract_source_archive(${ARCHIVE})
 
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
     PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/fix-metis-vs14-math.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-gklib-vs14-math.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-root-cmakelist.patch
-        ${CMAKE_CURRENT_LIST_DIR}/fix-libparmetis-cmakelist.patch
+        fix-metis-vs14-math.patch
+        fix-gklib-vs14-math.patch
+        fix-root-cmakelist.patch
+        fix-libparmetis-cmakelist.patch
+        use_stdint.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/parmetis/use_stdint.patch
+++ b/ports/parmetis/use_stdint.patch
@@ -1,0 +1,22 @@
+diff --git a/metis/GKlib/ms_stdint.h b/metis/GKlib/ms_stdint.h
+index 7e200dc..0d07a7a 100644
+--- a/metis/GKlib/ms_stdint.h
++++ b/metis/GKlib/ms_stdint.h
+@@ -42,6 +42,10 @@
+ 
+ #include <limits.h>
+ 
++#if(_MSC_VER >= 1900)
++	#include <stdint.h>
++#else
++
+ // For Visual Studio 6 in C++ mode wrap <wchar.h> include with 'extern "C++" {}'
+ // or compiler give many errors like this:
+ //   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
+@@ -218,5 +222,6 @@ typedef uint64_t  uintmax_t;
+ 
+ #endif // __STDC_CONSTANT_MACROS ]
+ 
++#endif
+ 
+ #endif // _MSC_STDINT_H_ ]


### PR DESCRIPTION
Now that [MSMPI is Open Source](https://github.com/Microsoft/Microsoft-MPI/) we should also think about moving to build it appropriately (what about asking MS dev to add a `CMakeLists.txt` upstream?) instead of downloading pre-built libraries. This would fix the problem with the missing triplets and maybe some other compatibility problems