### PR TITLE
Fix double-conversion issue in ITK

### DIFF
--- a/ports/hdf5/CONTROL
+++ b/ports/hdf5/CONTROL
@@ -1,5 +1,5 @@
 Source: hdf5
-Version: 1.10.5-2
+Version: 1.10.5-3
 Description: HDF5 is a data model, library, and file format for storing and managing data
 Build-Depends: zlib, szip
 

--- a/ports/hdf5/CONTROL
+++ b/ports/hdf5/CONTROL
@@ -1,5 +1,5 @@
 Source: hdf5
-Version: 1.10.5-1
+Version: 1.10.5-2
 Description: HDF5 is a data model, library, and file format for storing and managing data
 Build-Depends: zlib, szip
 

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -7,7 +7,7 @@ include(vcpkg_common_functions)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/CMake-hdf5-1.10.5.tar.gz"
     FILENAME "CMake-hdf5-1.10.5.tar.gz"
-    SHA512  a25ea28d7a511f9184d97b5b8cd4c6d52dcdcad2bffd670e24a1c9a6f98b03108014a853553fa2b00d4be7523128b5fd6a4454545e3b17ff8c66fea16a09e962
+    SHA512 a25ea28d7a511f9184d97b5b8cd4c6d52dcdcad2bffd670e24a1c9a6f98b03108014a853553fa2b00d4be7523128b5fd6a4454545e3b17ff8c66fea16a09e962
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
@@ -37,6 +37,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,7 +1,7 @@
 Source: itk
-Version: 4.13.0-b288412
+Version: 4.13.0-906736bd
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
-Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, hdf5[cpp]
+Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp]
 
 Feature: vtk
 Description: Build ITKVtkGlue module.

--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,5 +1,5 @@
 Source: itk
-Version: 4.13.0-2
+Version: 4.13.0-b288412
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
 Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, hdf5[cpp]
 

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -9,9 +9,9 @@ vcpkg_from_github(
 )
 
 if ("vtk" IN_LIST FEATURES)
-    set(ITKVtkGlue                     ON )
+    set(ITKVtkGlue ON)
 else()
-    set(ITKVtkGlue                     OFF )
+    set(ITKVtkGlue OFF)
 endif()
 
 # directory path length needs to be shorter than 50 characters
@@ -54,8 +54,8 @@ vcpkg_configure_cmake(
         #-DITK_WRAP_PYTHON=ON
         #-DITK_PYTHON_VERSION=3
 
-        -DITK_USE_SYSTEM_HDF5=ON
-        -DModule_ITKVtkGlue=${ITKVtkGlue}
+        -DITK_USE_SYSTEM_HDF5=ON # HDF5 was problematic in the past
+        -DModule_ITKVtkGlue=${ITKVtkGlue} # optional feature
 
         -DModule_IOSTL=ON # example how to turn on a non-default module
         -DModule_MorphologicalContourInterpolation=ON # example how to turn on a remote module

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO InsightSoftwareConsortium/ITK
-    REF b2884129bf6db53cb102137d81e7176e893c5e5f
-    SHA512 5d66d3c1a09b4f62b7bba6395a473c30c7e1d0f61d07eb96a6c2e35837409c0dd71d5a64e45772ad90c112c3997ad8acdfdbb60b1e01c9245b8bb1793ff8e134
+    REF 906736bd453e95ccf03b318d3d07cb7884285161
+    SHA512 8ac62262d46e7acbb0e5b2e964292ec17e1687bb162b8cec666e5b67acbe3449f093a0b1c03737e9951cb88248ed890805ffd57df6eae21220488620da833c57
     HEAD_REF master
 )
 
@@ -68,8 +68,11 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_cmake_targets() # combines release and debug build configurations
 
+file(RENAME ${CURRENT_PACKAGES_DIR}/vcl_compiler_detection.h ${CURRENT_PACKAGES_DIR}/include/ITK-5.0/vcl_compiler_detection.h)
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/vcl_compiler_detection.h)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/itk)

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO InsightSoftwareConsortium/ITK
-    REF 14b74af735aee8bfbe9d6a222835e1c2db1d8d88
-    SHA512 b826a4966b8dfe9532b1f1f719bb91afd7bf1baf6fabe7a846aba361564069dcc01c19d601a6bef500680370582169d7b764e9425c72766462493328ee6345d9
+    REF b2884129bf6db53cb102137d81e7176e893c5e5f
+    SHA512 5d66d3c1a09b4f62b7bba6395a473c30c7e1d0f61d07eb96a6c2e35837409c0dd71d5a64e45772ad90c112c3997ad8acdfdbb60b1e01c9245b8bb1793ff8e134
     HEAD_REF master
 )
 

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -3,10 +3,9 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO InsightSoftwareConsortium/ITK
-    REF d92873e33e8a54e933e445b92151191f02feab42
-    SHA512 0e3ebd27571543e1c497377dd9576a9bb0711129be12131109fe9b3c8413655ad14ce4d9ac6e281bac83c57e6032b614bc9ff53ed357d831544ca52f41513b62
+    REF 14b74af735aee8bfbe9d6a222835e1c2db1d8d88
+    SHA512 b826a4966b8dfe9532b1f1f719bb91afd7bf1baf6fabe7a846aba361564069dcc01c19d601a6bef500680370582169d7b764e9425c72766462493328ee6345d9
     HEAD_REF master
-    PATCHES hdf5_config_mode_find_package.patch
 )
 
 if ("vtk" IN_LIST FEATURES)
@@ -45,6 +44,7 @@ vcpkg_configure_cmake(
         -DITK_USE_SYSTEM_PNG=ON
         -DITK_USE_SYSTEM_TIFF=ON
         -DITK_USE_SYSTEM_ZLIB=ON
+        -DITK_USE_SYSTEM_EIGEN=ON
         # This should be turned on some day, however for now ITK does download specific versions so it shouldn't spontaneously break
         -DITK_FORBID_DOWNLOADS=OFF
 
@@ -55,7 +55,7 @@ vcpkg_configure_cmake(
         #-DITK_PYTHON_VERSION=3
 
         -DITK_USE_SYSTEM_HDF5=ON
-        -DModule_ITKVtkGlue=${ITKVtkGlue} # this option requires VTK to be a dependency in CONTROL file. VTK depends on HDF5!
+        -DModule_ITKVtkGlue=${ITKVtkGlue}
 
         -DModule_IOSTL=ON # example how to turn on a non-default module
         -DModule_MorphologicalContourInterpolation=ON # example how to turn on a remote module

--- a/ports/netcdf-c/CONTROL
+++ b/ports/netcdf-c/CONTROL
@@ -1,4 +1,4 @@
 Source: netcdf-c
-Version: 4.6.2
+Version: 4.6.2-1
 Build-Depends: hdf5, curl
 Description: a set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -1,22 +1,11 @@
-# Common Ambient Variables:
-#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
-#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
-#   PORT is the current port name (zlib, etc)
-#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#
-
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/netcdf-c-4.6.2)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/Unidata/netcdf-c/archive/v4.6.2.tar.gz"
-    FILENAME "netcdf-c-v4.6.2.tar.gz"
-    SHA512 7c7084e80cf2fb86cd05101f5be7b74797ee96bf49afadfae6ab32ceed6cd9a049bfa90175e7cc0742806bcd2f61156e33fe7930c7b646661d9c89be6b20dea3
-)
-vcpkg_extract_source_archive(${ARCHIVE})
 
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Unidata/netcdf-c
+    REF v4.6.2
+    SHA512 7c7084e80cf2fb86cd05101f5be7b74797ee96bf49afadfae6ab32ceed6cd9a049bfa90175e7cc0742806bcd2f61156e33fe7930c7b646661d9c89be6b20dea3
+    HEAD_REF master
     PATCHES
         no-install-deps.patch
         config-pkg-location.patch
@@ -26,7 +15,8 @@ vcpkg_apply_patches(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    DISABLE_PARALLEL_CONFIGURE
+    PREFER_NINJA
     OPTIONS
         -DBUILD_UTILITIES=OFF
         -DBUILD_TESTING=OFF
@@ -36,9 +26,6 @@ vcpkg_configure_cmake(
         -DENABLE_DAP_REMOTE_TESTS=OFF
         -DDISABLE_INSTALL_DEPENDENCIES=ON
         -DConfigPackageLocation=share/netcdf
-
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Fixed by InsightSoftwareConsortium/ITK/pull/366. Closes google/double-conversion#85. Closes #4334. ITK is still not properly compiling [due](https://github.com/Microsoft/vcpkg/issues/5116) to an out-of-date version of HDF5.