### PR TITLE
Fix error C2169

### DIFF
--- a/ports/libmupdf/CONTROL
+++ b/ports/libmupdf/CONTROL
@@ -1,4 +1,4 @@
 Source: libmupdf
-Version: 1.12.0
+Version: 1.12.0-1
 Build-Depends: freetype, libjpeg-turbo, harfbuzz, zlib, curl, glfw3, openjpeg, jbig2dec
 Description: a lightweight PDF, XPS, and E-book library

--- a/ports/libmupdf/Fix-error-C2169.patch
+++ b/ports/libmupdf/Fix-error-C2169.patch
@@ -1,0 +1,12 @@
+diff --git a/include/mupdf/fitz/system.h b/include/mupdf/fitz/system.h
+index 0552771..42fd037 100644
+--- a/include/mupdf/fitz/system.h
++++ b/include/mupdf/fitz/system.h
+@@ -117,7 +117,6 @@ static __inline int signbit(double x)
+ #define isinf(x) (!_finite(x))
+ #endif
+ 
+-#define hypotf _hypotf
+ #define atoll _atoi64
+ 
+ char *fz_utf8_from_wchar(const wchar_t *s);

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 1.12.0
     SHA512 893a1958e34355acf73624e9c47f4a97adf13d5fe33604ac384df9ac22a56ef7c18e02143eaffc3c2a08f460e4c71fee00c094b6d6696f8446977bb18f65e3da
     HEAD_REF master
+	PATCHES
+        "${CURRENT_PORT_DIR}/Fix-error-C2169.patch"
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
**Error info**: C:\Program Files (x86)\Windows Kits\10\include\10.0.17134.0\ucrt\corecrt_math.h(702): error C2169: '_hypotf': intrinsic function, cannot be defined.
This above error is because this port has a macro that messes with this in include/mupdf/fitz/system.h.
Remove the impacted line and installed this port successfully！Adding this patch as our workaround here!