### PR TITLE
[opencv] Add feature for building with TBB as parallel framework

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -37,6 +37,10 @@ Description: prebuilt ffmpeg support for opencv
 Feature: ipp
 Description: Enable Intel Integrated Performance Primitives
 
+Feature: tbb
+Build-Depends: tbb
+Description: Enable Intel Threading Building Blocks
+
 Feature: qt
 Build-Depends: qt5
 Description: Qt GUI support for opencv

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -145,6 +145,11 @@ if("ipp" IN_LIST FEATURES)
   endif()
 endif()
 
+set(WITH_TBB OFF)
+if("tbb" IN_LIST FEATURES)
+  set(WITH_TBB ON)
+endif()
+
 set(WITH_QT OFF)
 if("qt" IN_LIST FEATURES)
   set(WITH_QT ON)
@@ -299,6 +304,7 @@ vcpkg_configure_cmake(
         -DWITH_PNG=${WITH_PNG}
         -DWITH_PROTOBUF=${WITH_PROTOBUF}
         -DWITH_QT=${WITH_QT}
+        -DWITH_TBB=${WITH_TBB}
         -DWITH_TIFF=${WITH_TIFF}
         -DWITH_VTK=${WITH_VTK}
         -DWITH_WEBP=${WITH_WEBP}


### PR DESCRIPTION
Adds support for building OpenCV with TBB as the parallel framework.
Tested on x64-windows with: opencv[tbb] and opencv[core,dnn,jpeg,ffmpeg,flann,ipp,opengl,png,tbb].