### PR TITLE
Add public-preview version of azure-iot-sdk-c

### DIFF
--- a/ports/azure-c-shared-utility/CONTROL
+++ b/ports/azure-c-shared-utility/CONTROL
@@ -2,3 +2,7 @@ Source: azure-c-shared-utility
 Version: 1.1.11-3
 Description: Azure C SDKs common code
 Build-Depends: curl (linux), openssl (linux)
+
+Feature: public-preview
+Description: Azure C SDKs common code (public preview)
+Build-Depends: curl (linux), openssl (linux)

--- a/ports/azure-c-shared-utility/CONTROL
+++ b/ports/azure-c-shared-utility/CONTROL
@@ -5,4 +5,3 @@ Build-Depends: curl (linux), openssl (linux)
 
 Feature: public-preview
 Description: Azure C SDKs common code (public preview)
-Build-Depends: curl (linux), openssl (linux)

--- a/ports/azure-c-shared-utility/portfile.cmake
+++ b/ports/azure-c-shared-utility/portfile.cmake
@@ -2,14 +2,25 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-c-shared-utility
-    REF 1d622902d7842f94193fc394987f2b4e978bb700
-    SHA512 e7b3671955aeefe8e748bc68dd9f914fbb86c9cf325606691efc332cffa0d80b61f87d5f5c1026676c35fd1c5e88f22ca60f2e811c351aeba659f810fdc52e84
-    HEAD_REF master
-    PATCHES no-double-expand-cmake.patch
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-c-shared-utility
+        REF e885482ce32f1f77d29e85f7b8d35d74ffc69c74
+        SHA512 329101cb2ff499aa16e1df736285e2fdd8c34549d4790eaafa1df763950c2b4a5927f52e93dbf22192b240fe0445050ad99133df0405227ffe9857ff2b25014d
+        HEAD_REF public-preview
+        PATCHES no-double-expand-cmake.patch
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-c-shared-utility
+        REF 1d622902d7842f94193fc394987f2b4e978bb700
+        SHA512 e7b3671955aeefe8e748bc68dd9f914fbb86c9cf325606691efc332cffa0d80b61f87d5f5c1026676c35fd1c5e88f22ca60f2e811c351aeba659f810fdc52e84
+        HEAD_REF master
+        PATCHES no-double-expand-cmake.patch
+    )
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -5,4 +5,4 @@ Description: A C99 SDK for connecting devices to Microsoft Azure IoT services
 
 Feature: public-preview
 Description: A version of the azure-iot-sdk-c containing public-preview features.
-Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], parson
+Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview]

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -2,3 +2,7 @@ Source: azure-iot-sdk-c
 Version: 1.2.12-1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
+
+Feature: public-preview
+Description: A version of the azure-iot-sdk-c containing public-preview features.
+Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], parson

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -2,14 +2,25 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-iot-sdk-c
-    REF 350b51f5abaedc975dae5419ad1fa4add7635fd2
-    SHA512 7559768f7d1c67f6b28d16871c3c783e9f88d9dc4f9051a7a3c0329311d39821301edf64fcbde15a8e904c6d5a6326feee25be8e46cb657c21455ae920b266eb
-    HEAD_REF master
-    PATCHES improve-external-deps.patch
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-iot-sdk-c
+        REF 74b03316ec90f1602c20ebeab67a3b4a61065d8e
+        SHA512 78ab8d7cd6e25886e41f98500cb8cd9609ca677426a882ed0364a908e5267ec6191bb15fd65fb2c420a108df41f52a8ba6d5e6d626874bbfae4f56e8af5ca428
+        HEAD_REF public-preview
+        PATCHES improve-external-deps.patch
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-iot-sdk-c
+        REF 350b51f5abaedc975dae5419ad1fa4add7635fd2
+        SHA512 7559768f7d1c67f6b28d16871c3c783e9f88d9dc4f9051a7a3c0329311d39821301edf64fcbde15a8e904c6d5a6326feee25be8e46cb657c21455ae920b266eb
+        HEAD_REF master
+        PATCHES improve-external-deps.patch
+    )
+endif()
 
 file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/azure-c-shared-utility/configs/)
 

--- a/ports/azure-uamqp-c/CONTROL
+++ b/ports/azure-uamqp-c/CONTROL
@@ -2,3 +2,7 @@ Source: azure-uamqp-c
 Version: 1.2.11-2
 Build-Depends: azure-c-shared-utility
 Description: AMQP library for C
+
+Feature: public-preview
+Description: AMQP library for C (public preview)
+Build-Depends: azure-c-shared-utility[public-preview]

--- a/ports/azure-uamqp-c/portfile.cmake
+++ b/ports/azure-uamqp-c/portfile.cmake
@@ -2,13 +2,23 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-uamqp-c
-    REF f29401ab5eb3853390d5f573d8fb37c0c96dba16
-    SHA512 8fdee32e2a85218257ee91754873f9f8ae5e16cd2b7b10c88ab6d4115fe4378a2b08f211d8307346b0bd7688c4c896c25a4de34e9231c2506819a97bbf46dd73
-    HEAD_REF master
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-uamqp-c
+        REF bd7b85d0830634e3157da2411a6d060bf28f266e
+        SHA512 cbc2aa2765242ebe1a5e194e126f419cbd26edda5c1f72ffe9219a6c38b80aa91ef823a4fd8f78ac5d7ae0d9d471b50e5b8c4684e77c71b31e7cf35802e0cc17
+        HEAD_REF public-preview
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-uamqp-c
+        REF f29401ab5eb3853390d5f573d8fb37c0c96dba16
+        SHA512 8fdee32e2a85218257ee91754873f9f8ae5e16cd2b7b10c88ab6d4115fe4378a2b08f211d8307346b0bd7688c4c896c25a4de34e9231c2506819a97bbf46dd73
+        HEAD_REF master
+    )
+endif()
 
 file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/azure-c-shared-utility/configs/)
 

--- a/ports/azure-uhttp-c/CONTROL
+++ b/ports/azure-uhttp-c/CONTROL
@@ -2,3 +2,7 @@ Source: azure-uhttp-c
 Version: 1.1.11-2
 Build-Depends: azure-c-shared-utility
 Description: Azure HTTP Library written in C
+
+Feature: public-preview
+Description: Azure HTTP Library written in C (public preview)
+Build-Depends: azure-c-shared-utility[public-preview]

--- a/ports/azure-uhttp-c/portfile.cmake
+++ b/ports/azure-uhttp-c/portfile.cmake
@@ -2,13 +2,23 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-uhttp-c
-    REF 647ec7cc75961cd7ff7cbb7eca30e1de819802ed
-    SHA512 1768ea978ab7fa328b74444573c3d1eb2a5fae1e36dbe1dcc186df3e2ab2a0a3b1ba8a434934462184582525b3a1850fc04ca2927f95f0df0ae483f8a1673e30
-    HEAD_REF master
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-uhttp-c
+        REF e459385a811ce075f42aa7202db96ba1d1f55ac1
+        SHA512 b96382184893b49f30ad75d4c19eeb48f7a7823e9d48f2896ee4760be20f2f5b5ee3e78e39f10ae26363165360e5871c3ba82aa9edf3943b9f0ef9c0e3036ea6
+        HEAD_REF public-preview
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-uhttp-c
+        REF 647ec7cc75961cd7ff7cbb7eca30e1de819802ed
+        SHA512 1768ea978ab7fa328b74444573c3d1eb2a5fae1e36dbe1dcc186df3e2ab2a0a3b1ba8a434934462184582525b3a1850fc04ca2927f95f0df0ae483f8a1673e30
+        HEAD_REF master
+    )
+endif()
 
 file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/c-utility/configs/)
 

--- a/ports/azure-umqtt-c/CONTROL
+++ b/ports/azure-umqtt-c/CONTROL
@@ -2,3 +2,7 @@ Source: azure-umqtt-c
 Version: 1.1.11-2
 Build-Depends: azure-c-shared-utility
 Description: General purpose library for communication over the mqtt protocol
+
+Feature: public-preview
+Description: General purpose library for communication over the mqtt protocol (public preview)
+Build-Depends: azure-c-shared-utility[public-preview]

--- a/ports/azure-umqtt-c/portfile.cmake
+++ b/ports/azure-umqtt-c/portfile.cmake
@@ -2,13 +2,23 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-umqtt-c
-    REF 3205eb26401e9c6639100934e8fb75b75275760d
-    SHA512 002c0d4f0373faeb7171465afce268f18b52d80ec057af36c81dd807de8ccf2bf1a46ef00c7f8e8fcdbef8d7f5c36616a304007c98ea5700c5f662b4c8868c2c
-    HEAD_REF master
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-umqtt-c
+        REF 1b3a25f4f7f0edbe068e261e8a808d7bc394a358
+        SHA512 00ff90eccfbb4febded7e819baa6303e97d3e7d6f6f8f1a28ebf353d7ad7ac5ec7f479e66456f395c7ece7fd6d612f3948ac656420bc0bc75566bdbb65fb88c3
+        HEAD_REF public-preview
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-umqtt-c
+        REF 3205eb26401e9c6639100934e8fb75b75275760d
+        SHA512 002c0d4f0373faeb7171465afce268f18b52d80ec057af36c81dd807de8ccf2bf1a46ef00c7f8e8fcdbef8d7f5c36616a304007c98ea5700c5f662b4c8868c2c
+        HEAD_REF master
+    )
+endif()
 
 file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/c-utility/configs/)
 


### PR DESCRIPTION
This is a new port of https://github.com/Azure/azure-iot-sdk-c/tree/public-preview

This port will expose all azure-iot-sdk-c features currently ready for public preview.