### PR TITLE
[ms-gsl] update to support clang-cl

### DIFF
--- a/ports/ms-gsl/CONTROL
+++ b/ports/ms-gsl/CONTROL
@@ -1,3 +1,3 @@
 Source: ms-gsl
-Version: 2018-12-14
+Version: 2019-01-15
 Description: Microsoft implementation of the Guidelines Support Library

--- a/ports/ms-gsl/portfile.cmake
+++ b/ports/ms-gsl/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/GSL
-    REF 0f68d133fa6fd2973951b8aaab481e34bbfd2cf4
-    SHA512 1aa8116a75dd6ffd3a879dcf52f804e1d67e03bac3788559441ddebe2db6fd43a362bfa5ddac36954848555ba1e7fccb2d26b6060a9e171a04497ea551402b42
+    REF 6418b5f4de2204cd5a335b00d2f8754301b8b382
+    SHA512 d585ce18ff190e681f55c53978bd8d84dd0f8ebf0f572a49a38be07c44bd97b6d99c46b9f5fff2455dbd934e242be4a2d6d3ca2ba193358cafa14272d7a6fba8
     HEAD_REF master
 )
 


### PR DESCRIPTION
Support for LLVM/clang-cl has been merged.

Clang-cl is the cl.exe compatible Clang compiler implementation on Windows.