### PR TITLE
[podofo] Change auto_ptr to unique_ptr.

### DIFF
--- a/ports/podofo/CONTROL
+++ b/ports/podofo/CONTROL
@@ -1,5 +1,5 @@
 Source: podofo
-Version: 0.9.6-2
+Version: 0.9.6-3
 Description: PoDoFo is a library to work with the PDF file format
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openssl (!windows&!uwp), freetype
 

--- a/ports/podofo/CONTROL
+++ b/ports/podofo/CONTROL
@@ -1,5 +1,5 @@
 Source: podofo
-Version: 0.9.6-1
+Version: 0.9.6-2
 Description: PoDoFo is a library to work with the PDF file format
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openssl (!windows&!uwp), freetype
 

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -10,10 +10,7 @@ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF ${PODOFO_VERSION}
-)
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/unique_ptr.patch
+    PATCHES unique_ptr.patch
 )
 
 set(PODOFO_NO_FONTMANAGER ON)

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -11,6 +11,10 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
     REF ${PODOFO_VERSION}
 )
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/unique_ptr.patch
+)
 
 set(PODOFO_NO_FONTMANAGER ON)
 if("fontconfig" IN_LIST FEATURES)

--- a/ports/podofo/unique_ptr.patch
+++ b/ports/podofo/unique_ptr.patch
@@ -1,0 +1,198 @@
+diff -ruNp a/src/base/PdfFilter.cpp b/src/base/PdfFilter.cpp
+--- a/src/base/PdfFilter.cpp	2016-11-18 20:08:56.000000000 +0100
++++ b/src/base/PdfFilter.cpp	2019-01-16 10:25:22.934430500 +0100
+@@ -131,7 +131,7 @@ class PdfFilteredEncodeStream : public P
+ 
+ private:
+     PdfOutputStream*         m_pOutputStream;
+-    std::auto_ptr<PdfFilter> m_filter;
++    std::unique_ptr<PdfFilter> m_filter;
+ };
+ 
+ /** Create a filter that is a PdfOutputStream.
+@@ -206,7 +206,7 @@ class PdfFilteredDecodeStream : public P
+ 
+ private:
+     PdfOutputStream*         m_pOutputStream;
+-    std::auto_ptr<PdfFilter> m_filter;
++    std::unique_ptr<PdfFilter> m_filter;
+     bool                     m_bFilterFailed;
+ };
+ 
+@@ -264,7 +264,7 @@ PdfFilterFactory::PdfFilterFactory()
+ {
+ }
+ 
+-std::auto_ptr<PdfFilter> PdfFilterFactory::Create( const EPdfFilter eFilter ) 
++std::unique_ptr<PdfFilter> PdfFilterFactory::Create( const EPdfFilter eFilter ) 
+ {
+     PdfFilter* pFilter = NULL;
+     switch( eFilter )
+@@ -316,7 +316,7 @@ std::auto_ptr<PdfFilter> PdfFilterFactor
+             break;
+     }
+ 
+-    return std::auto_ptr<PdfFilter>(pFilter);
++    return std::unique_ptr<PdfFilter>(pFilter);
+ }
+ 
+ PdfOutputStream* PdfFilterFactory::CreateEncodeStream( const TVecFilters & filters, PdfOutputStream* pStream ) 
+diff -ruNp a/src/base/PdfFilter.h b/src/base/PdfFilter.h
+--- a/src/base/PdfFilter.h	2016-11-18 20:08:56.000000000 +0100
++++ b/src/base/PdfFilter.h	2019-01-16 10:25:22.981323900 +0100
+@@ -454,7 +454,7 @@ class PODOFO_API PdfFilterFactory {
+  public:
+     /** Create a filter from an enum.
+      *
+-     *  Ownership is transferred to the caller, who should let the auto_ptr
++     *  Ownership is transferred to the caller, who should let the unique_ptr
+      *  the filter is returned in take care of freeing it when they're done
+      *  with it.
+      *
+@@ -463,7 +463,7 @@ class PODOFO_API PdfFilterFactory {
+      *  \returns a new PdfFilter allocated using new, or NULL if no
+      *           filter is available for this type.
+      */
+-    static std::auto_ptr<PdfFilter> Create( const EPdfFilter eFilter );
++    static std::unique_ptr<PdfFilter> Create( const EPdfFilter eFilter );
+ 
+     /** Create a PdfOutputStream that applies a list of filters 
+      *  on all data written to it.
+diff -ruNp a/src/base/PdfMemStream.cpp b/src/base/PdfMemStream.cpp
+--- a/src/base/PdfMemStream.cpp	2016-11-18 20:08:56.000000000 +0100
++++ b/src/base/PdfMemStream.cpp	2019-01-16 10:25:23.479681200 +0100
+@@ -245,7 +245,7 @@ void PdfMemStream::FlateCompressStreamDa
+     if( !m_lLength )
+         return;
+ 
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_FlateDecode );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_FlateDecode );
+     if( pFilter.get() )
+     {
+         pFilter->Encode( m_buffer.GetBuffer(), m_buffer.GetSize(), &pBuffer, &lLen );
+diff -ruNp a/src/base/PdfStream.cpp b/src/base/PdfStream.cpp
+--- a/src/base/PdfStream.cpp	2016-11-18 20:08:56.000000000 +0100
++++ b/src/base/PdfStream.cpp	2019-01-16 10:25:24.387075400 +0100
+@@ -91,9 +91,9 @@ void PdfStream::GetFilteredCopy( char**
+     PdfMemoryOutputStream  stream;
+     if( vecFilters.size() )
+     {
+-        // Use std::auto_ptr so that pDecodeStream is deleted 
++        // Use std::unique_ptr so that pDecodeStream is deleted 
+         // even in the case of an exception 
+-        std::auto_ptr<PdfOutputStream> pDecodeStream( PdfFilterFactory::CreateDecodeStream( vecFilters, &stream, 
++        std::unique_ptr<PdfOutputStream> pDecodeStream( PdfFilterFactory::CreateDecodeStream( vecFilters, &stream, 
+                                                                                             m_pParent ? 
+                                                                                             &(m_pParent->GetDictionary()) : NULL  ) );
+ 
+diff -ruNp a/src/base/PdfString.cpp b/src/base/PdfString.cpp
+--- a/src/base/PdfString.cpp	2018-03-10 17:30:53.000000000 +0100
++++ b/src/base/PdfString.cpp	2019-01-16 10:25:24.480799400 +0100
+@@ -673,7 +673,7 @@ PdfString PdfString::HexEncode() const
+         return *this;
+     else
+     {
+-        std::auto_ptr<PdfFilter> pFilter;
++        std::unique_ptr<PdfFilter> pFilter;
+ 
+         pdf_long                  lLen  = (m_buffer.GetSize() - 1) << 1;
+         PdfString             str;
+@@ -702,7 +702,7 @@ PdfString PdfString::HexDecode() const
+         return *this;
+     else
+     {
+-        std::auto_ptr<PdfFilter> pFilter;
++        std::unique_ptr<PdfFilter> pFilter;
+ 
+         pdf_long                  lLen = m_buffer.GetSize() >> 1;
+         PdfString             str;
+diff -ruNp a/src/doc/PdfFont.cpp b/src/doc/PdfFont.cpp
+--- a/src/doc/PdfFont.cpp	2016-05-13 16:04:34.000000000 +0200
++++ b/src/doc/PdfFont.cpp	2019-01-16 10:25:26.372048300 +0100
+@@ -145,7 +145,7 @@ void PdfFont::WriteStringToStream( const
+     pdf_long  lLen    = 0;
+     char* pBuffer = NULL;
+ 
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );    
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );    
+     pFilter->Encode( buffer.GetBuffer(), buffer.GetSize(), &pBuffer, &lLen );
+ 
+     pStream->Append( "<", 1 );
+diff -ruNp a/src/doc/PdfPainter.cpp b/src/doc/PdfPainter.cpp
+--- a/src/doc/PdfPainter.cpp	2018-03-06 15:04:03.000000000 +0100
++++ b/src/doc/PdfPainter.cpp	2019-01-16 10:25:28.512159900 +0100
+@@ -829,7 +829,7 @@ void PdfPainter::DrawText( double dX, do
+ 
+     /*
+     char* pBuffer;
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
+     pFilter->Encode( sString.GetString(), sString.GetLength(), &pBuffer, &lLen );
+ 
+     m_pCanvas->Append( pBuffer, lLen );
+diff -ruNp a/test/CreationTest/CreationTest.cpp b/test/CreationTest/CreationTest.cpp
+--- a/test/CreationTest/CreationTest.cpp	2018-02-25 12:48:38.000000000 +0100
++++ b/test/CreationTest/CreationTest.cpp	2019-01-16 10:25:29.605315700 +0100
+@@ -37,7 +37,7 @@ void WriteStringToStream( const PdfStrin
+     pdf_long  lLen    = 0;
+     char* pBuffer = NULL;
+ 
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
+     pFilter->Encode( buffer.GetBuffer(), buffer.GetSize(), &pBuffer, &lLen );
+ 
+     oss << "<";
+diff -ruNp a/test/FilterTest/FilterTest.cpp b/test/FilterTest/FilterTest.cpp
+--- a/test/FilterTest/FilterTest.cpp	2018-03-10 15:06:27.000000000 +0100
++++ b/test/FilterTest/FilterTest.cpp	2019-01-16 10:25:29.777214800 +0100
+@@ -57,7 +57,7 @@ void test_filter( EPdfFilter eFilter, co
+     pdf_long   lEncoded;
+     pdf_long   lDecoded;
+ 
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( eFilter );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( eFilter );
+     if( !pFilter.get() )
+     {
+         printf("!!! Filter %i not implemented.\n", eFilter);
+@@ -256,7 +256,7 @@ int main()
+     char*    pLargeBuffer2 = static_cast<char*>(malloc( strlen(pszInputAscii85Lzw) * 6 ));
+ 
+     try {
+-        std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCII85Decode );
++        std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCII85Decode );
+         pFilter->Decode( pszInputAscii85Lzw, strlen(pszInputAscii85Lzw),
+                          &pLargeBuffer1, &lLargeBufer1 );
+         pFilter->Encode( pLargeBuffer1, lLargeBufer1,
+diff -ruNp a/test/VariantTest/VariantTest.cpp b/test/VariantTest/VariantTest.cpp
+--- a/test/VariantTest/VariantTest.cpp	2010-10-21 19:09:00.000000000 +0200
++++ b/test/VariantTest/VariantTest.cpp	2019-01-16 10:25:32.418465600 +0100
+@@ -124,7 +124,7 @@ int main()
+     printf("This test tests the PdfVariant class.\n");
+     printf("---\n");
+ 
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_ASCIIHexDecode );
+ 
+     // testing strings
+     TEST_SAFE_OP( Test( "(Hallo Welt!)", ePdfDataType_String ) );
+diff -ruNp a/test/unit/FilterTest.cpp b/test/unit/FilterTest.cpp
+--- a/test/unit/FilterTest.cpp	2016-05-12 22:25:45.000000000 +0200
++++ b/test/unit/FilterTest.cpp	2019-01-16 10:25:31.464162600 +0100
+@@ -59,7 +59,7 @@ void FilterTest::TestFilter( EPdfFilter
+     pdf_long   lEncoded;
+     pdf_long   lDecoded;
+    
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( eFilter );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( eFilter );
+     if( !pFilter.get() )
+     {
+         printf("!!! Filter %i not implemented.\n", eFilter);
+@@ -123,7 +123,7 @@ void FilterTest::testFilters()
+ 
+ void FilterTest::testCCITT()
+ {
+-    std::auto_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_CCITTFaxDecode );
++    std::unique_ptr<PdfFilter> pFilter = PdfFilterFactory::Create( ePdfFilter_CCITTFaxDecode );
+     if( !pFilter.get() )
+     {
+         printf("!!! ePdfFilter_CCITTFaxDecode not implemented skipping test!\n");


### PR DESCRIPTION
This change makes it possible to compile and use PoDoFo in C++17 mode.

It may be better to implement this as a feature and this PR is incompatible with https://github.com/Microsoft/vcpkg/pull/5181.