### PR TITLE
[selene] Update to v0.3.

### DIFF
--- a/ports/selene/CONTROL
+++ b/ports/selene/CONTROL
@@ -1,4 +1,4 @@
 Source: selene
-Version: 0.2-1
+Version: 0.3
 Description: A C++17 image representation, processing and I/O library.
-Build-Depends: zlib, libpng, libjpeg-turbo
+Build-Depends: zlib, libpng, libjpeg-turbo, tiff

--- a/ports/selene/CONTROL
+++ b/ports/selene/CONTROL
@@ -1,4 +1,4 @@
 Source: selene
-Version: 0.3
+Version: 0.3.1
 Description: A C++17 image representation, processing and I/O library.
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff

--- a/ports/selene/portfile.cmake
+++ b/ports/selene/portfile.cmake
@@ -1,10 +1,12 @@
 include(vcpkg_common_functions)
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kmhofmann/selene
-    REF v0.3
-    SHA512 53a4a6577b4e618c5b080e0ddaa1e0e28b7c0a27e800eb9d1b1a2a6fbfaf630a6f326a3d070ad0c3f9bd8fb5e6bdd7fafbbd5a49e5f9a6f9ae79e0b50d20f741
+    REF v0.3.1
+    SHA512 7bc57ebe9e2442da2716eb5c1af11f8d610b0b09fe96e3122d1028575732b6045a987c499bbf7de53003edd627b8809d86c80ea4975fc2264a1c61d5891a46c3
     HEAD_REF master
 )
 

--- a/ports/selene/portfile.cmake
+++ b/ports/selene/portfile.cmake
@@ -1,12 +1,10 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kmhofmann/selene
-    REF v0.2
-    SHA512 9ec1c767541cbe0b349302b7db13a55869003a230669636b6bc37de01be833633be0741b80f58109140b9563b7a7f4c6a5b7ab46ecb142688170a47dba24bdc4
+    REF v0.3
+    SHA512 53a4a6577b4e618c5b080e0ddaa1e0e28b7c0a27e800eb9d1b1a2a6fbfaf630a6f326a3d070ad0c3f9bd8fb5e6bdd7fafbbd5a49e5f9a6f9ae79e0b50d20f741
     HEAD_REF master
 )
 


### PR DESCRIPTION
This PR updates the port for [Selene](https://github.com/kmhofmann/selene) to v0.3. See also the Selene [changelog](https://github.com/kmhofmann/selene/releases/tag/v0.3).

Changes to CONTROL/portfile.cmake:
* Add libtiff as a dependency.
* Update SHA512 hash for GitHub release REF.
* Remove the `vcpkg_check_linkage` call that restricted to building statically, since the relevant symbols for shared libraries should now be explicitly exported (via CMake's export header machinery).

Note that CI on macOS will fail, if compilation is run using any AppleClang release prior to version 10.0 (supplied with macOS 10.14 Mojave), due to lack of support for some C++17 features. Using AppleClang 10.0, Selene builds without warnings.