### PR TITLE
Update bootstrap.ps1 for Visual Studio 2019 detection.

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -72,7 +72,7 @@ function getVisualStudioInstances()
     $vswhereExe = "$programFiles\Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vswhereExe)
     {
-        $output = & $vswhereExe -prerelease -legacy -products * -format xml
+        $output = & $vswhereExe -prerelease -all -legacy -products * -format xml
         [xml]$asXml = $output
 
         foreach ($instance in $asXml.instances.instance)


### PR DESCRIPTION
Despite using the `-prerelease` argument, `build` script does not detect VS 2019 and fails building `vcpkg`. Adding `-all` fixes this.