### PR TITLE
[libmysql] Fix issue #5046

### DIFF
--- a/ports/libmysql/linux_libmysql.patch
+++ b/ports/libmysql/linux_libmysql.patch
@@ -1,0 +1,16 @@
+--- a/buildtrees/libmysql/src/ysql-8.0.4-6271934d70/configure.cmake
++++ b/buildtrees/libmysql/src/ysql-8.0.4-6271934d70/configure.cmake
+@@ -456,7 +456,11 @@
+ ENDIF()
+ 
+ IF(NOT CMAKE_CROSSCOMPILING AND NOT MSVC)
+-  STRING(TOLOWER ${CMAKE_SYSTEM_PROCESSOR}  processor)
++  IF(${CMAKE_SYSTEM_PROCESSOR})
++    STRING(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} processor)
++  ELSE()
++    STRING(TOLOWER ${CMAKE_HOST_SYSTEM_PROCESSOR} processor)
++  ENDIF()
+   IF(processor MATCHES "86" OR processor MATCHES "amd64" OR processor MATCHES "x64")
+     IF(NOT CMAKE_SYSTEM_NAME MATCHES "SunOS")
+       # The loader in some Solaris versions has a bug due to which it refuses to
+

--- a/ports/libmysql/linux_libmysql.patch
+++ b/ports/libmysql/linux_libmysql.patch
@@ -1,5 +1,5 @@
---- a/buildtrees/libmysql/src/ysql-8.0.4-6271934d70/configure.cmake
-+++ b/buildtrees/libmysql/src/ysql-8.0.4-6271934d70/configure.cmake
+--- a/configure.cmake
++++ b/configure.cmake
 @@ -456,7 +456,11 @@
  ENDIF()
  

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_apply_patches(
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/ignore-boost-version.patch
         ${CMAKE_CURRENT_LIST_DIR}/system-libs.patch
+        ${CMAKE_CURRENT_LIST_DIR}/linux_libmysql.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/include/boost_1_65_0)


### PR DESCRIPTION
libmysql installed failed on Linux, ${CMAKE_SYSTEM_PROCESSOR} didn’t get the value here, apply the patch for fix this issue.

The error message likes:
  CMAKE_REQUIRED_LIBRARIES is set to:
    m;crypt;dl;-lpthread;rt;atomic
  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  configure.cmake:188 (CHECK_INCLUDE_FILES)
  CMakeLists.txt:653 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at configure.cmake:459 (STRING):
  STRING no output variable specified
Call Stack (most recent call first):
  CMakeLists.txt:653 (INCLUDE)
