### PR TITLE
[libgeotiff] Debug version gets incorrectly linked with release version of PROJ4

### DIFF
--- a/ports/libgeotiff/CONTROL
+++ b/ports/libgeotiff/CONTROL
@@ -1,4 +1,4 @@
 Source: libgeotiff
-Version: 1.4.2-6
+Version: 1.4.2-7
 Description: Libgeotiff is an open source library normally hosted on top of ​libtiff for reading, and writing GeoTIFF information tags.
 Build-Depends: tiff, proj4, zlib, libjpeg-turbo

--- a/ports/libgeotiff/portfile.cmake
+++ b/ports/libgeotiff/portfile.cmake
@@ -21,6 +21,9 @@ vcpkg_extract_source_archive_ex(
         0006-Fix-utility-link-error.patch
 )
 
+# Delete FindPROJ4.cmake
+file(REMOVE ${SOURCE_PATH}/cmake/FindPROJ4.cmake)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA


### PR DESCRIPTION
The GeoTIFF library ships with its own FindPROJ4.cmake module. This file interferes with the cmake files that are installed by vcpkg for the PROJ4 package. As a result, the debug version of libgeotiff gets incorrectly linked to the release version of PROJ4. By removing FindPROJ4.cmake from the source directory, the vcpkg's .cmake files are used instead, allowing CMake to find the debug version of PROJ4 when building the debug version of libgeotiff.