### PR TITLE
Add a more correct port for libass

### DIFF
--- a/ports/libass/CMakeLists.txt
+++ b/ports/libass/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.9)
+project(libass C CXX)
+
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/config.h.in config.h)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+# This is Windows-specific. Other acceptable values on different platforms should be
+#    macOS - CONFIG_CORETEXT
+#    linux - CONFIG_FONTCONFIG
+add_compile_definitions(CONFIG_DIRECTWRITE)
+
+file (GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libass/*.c)
+
+list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
+list(FILTER SOURCES EXCLUDE REGEX ".*ass_fontconfig.c$")
+
+find_package(Freetype REQUIRED)
+
+find_path(FRIBIDI_INCLUDE_DIR
+          NAMES fribidi.h
+          PATH_SUFFIXES fribidi)
+
+find_library(FRIBIDI_LIBRARY NAMES fribidi)
+
+add_library(ass STATIC ${SOURCES})
+
+target_include_directories(ass PRIVATE ${FRIBIDI_INCLUDE_DIR})
+
+target_link_libraries(ass PRIVATE Freetype::Freetype)
+
+install(TARGETS ass
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+

--- a/ports/libass/CONTROL
+++ b/ports/libass/CONTROL
@@ -1,3 +1,4 @@
 Source: libass
 Version: 0.14.0
+Build-Depends: freetype, fribidi, harfbuzz, dirent (windows)
 Description: libass is a portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format.

--- a/ports/libass/ConstantValues.patch
+++ b/ports/libass/ConstantValues.patch
@@ -1,0 +1,43 @@
+---
+ libass/ass_outline.c | 4 ++--
+ libass/ass_render.c  | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libass/ass_outline.c b/libass/ass_outline.c
+index 1b9afe9..527403e 100644
+--- a/libass/ass_outline.c
++++ b/libass/ass_outline.c
+@@ -518,7 +518,7 @@ static bool draw_arc(StrokerState *str, ASS_Vector pt,
+                      ASS_DVector normal0, ASS_DVector normal1, double c, int dir)
+ {
+     const int max_subdiv = 15;
+-    double mul[max_subdiv + 1];
++    double mul[16];
+ 
+     ASS_DVector center;
+     bool small_angle = true;
+@@ -554,7 +554,7 @@ static bool draw_arc(StrokerState *str, ASS_Vector pt,
+ static bool draw_circle(StrokerState *str, ASS_Vector pt, int dir)
+ {
+     const int max_subdiv = 15;
+-    double mul[max_subdiv + 1], c = 0;
++    double mul[16], c = 0;
+ 
+     int pos = max_subdiv;
+     while (c < str->split_cos && pos) {
+diff --git a/libass/ass_render.c b/libass/ass_render.c
+index 69c4439..f6fa85c 100644
+--- a/libass/ass_render.c
++++ b/libass/ass_render.c
+@@ -1235,7 +1235,7 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info)
+     }
+ 
+     const int n_outlines = 3;
+-    ASS_Outline outline[n_outlines];
++    ASS_Outline outline[3];
+     outline_copy(&outline[0], info->outline);
+     outline_copy(&outline[1], info->border[0]);
+     outline_copy(&outline[2], info->border[1]);
+-- 
+2.18.0.windows.1
+

--- a/ports/libass/portfile.cmake
+++ b/ports/libass/portfile.cmake
@@ -1,5 +1,7 @@
-#header-only library
+
 include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -7,9 +9,22 @@ vcpkg_from_github(
     REF 98727c3b78f44cb3bbc955fcf5d977ebd911d5ca
     SHA512 d466108180cea598b817f89aa21a1021ed2a763580d9aad51b054aa120186af48ab4264907e49ddcb38479a28d87d5431751a28afee9cb83ad7623f002d99c57
     HEAD_REF master
+    PATCHES ConstantValues.patch
 )
 
-file(INSTALL ${SOURCE_PATH}/libass/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/config.h.in DESTINATION ${SOURCE_PATH})
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libass RENAME copyright)
+
+# Since libass uses automake, make and configure, we use a custom CMake file
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+file(COPY ${SOURCE_PATH}/libass/ass.h ${SOURCE_PATH}/libass/ass_types.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/ass)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()


### PR DESCRIPTION
This port currently only works on Windows because the dependencies of the port (fribidi in particular) don't build on non-Windows platforms.

I made patch modifications to the source code because the Visual C compiler does not allow for non-constant-expression array indices to be used to declare a static array.

I've verified that this (1) builds on Windows and (2) works with a sample test that's included in the libass github repo.