### PR TITLE
Adding #elif macros for ARM and ARM64

### DIFF
--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -74,6 +74,10 @@ namespace vcpkg::System
         return CPUArchitecture::X64;
 #elif defined(__x86__) || defined(_M_X86)
         return CPUArchitecture::X86;
+#elif defined(__arm__) || defined(_M_ARM)
+        return CPUArchitecture::ARM;
+#elif defined(__aarch64__) || defined(_M_ARM64)
+        return CPUArchitecture::ARM64;
 #else
 #error "Unknown host architecture"
 #endif


### PR DESCRIPTION
However the results of `./vcpkg search libXYZ` or `./vcpkg install libXYZ` are still looking for x64 architecture. This PR is only for fixing compiling errors on ARM.