### PR TITLE
[xtensor-blas] Add new port

### DIFF
--- a/ports/xtensor-blas/CONTROL
+++ b/ports/xtensor-blas/CONTROL
@@ -1,0 +1,4 @@
+Source: xtensor-blas
+Version: 0.15.1
+Description: BLAS extension to xtensor
+Build-Depends: xtensor

--- a/ports/xtensor-blas/portfile.cmake
+++ b/ports/xtensor-blas/portfile.cmake
@@ -1,0 +1,37 @@
+# header-only library
+
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO QuantStack/xtensor-blas
+    REF 0.15.1
+    SHA512 c80def1cc106efec1ee4c33f3724b6b63af4c826e45e2a5a8dc066d368867b3a1d909ae490e09c615c2119b3aad3ef5b739fe86925d0229a69329ddee09c3d66
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_RELEASE -DCXXBLAS_DEBUG=OFF
+    OPTIONS_DEBUG -DCXXBLAS_DEBUG=ON
+    OPTIONS
+        -DXTENSOR_USE_FLENS_BLAS=OFF
+        -DBUILD_TESTS=OFF
+        -DBUILD_BENCHMARK=OFF
+        -DDOWNLOAD_GTEST=OFF
+        -DDOWNLOAD_GBENCHMARK=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/xflens/cxxblas/netlib)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+# CMake integration test
+vcpkg_test_cmake(PACKAGE_NAME ${PORT})


### PR DESCRIPTION
This accomplishes #5140 by making the linalg namespace works.

Note that this just provides additional headers to `xtensor`; there is no new CMake targets.  Users have to find their own blas libraries to link against (as explained in `xtensor-blas` documents).  Of course, with Intel MKL auto-linking there is nothing you need to do.