### PR TITLE
[libodb] Assorted fixes to get ODB v2.4 libraries to compile on x64 Linux

### DIFF
--- a/ports/libodb-boost/CMakeLists.txt
+++ b/ports/libodb-boost/CMakeLists.txt
@@ -40,6 +40,7 @@ install(DIRECTORY odb DESTINATION include/
         PATTERN "*.hxx"
         PATTERN "*.ixx"
         PATTERN "*.txx"
+        PATTERN "*.options"
 )
 endif()
 install(EXPORT odb_boostConfig NAMESPACE odb:: COMPONENT boost DESTINATION share/odb)

--- a/ports/libodb-boost/CMakeLists.txt
+++ b/ports/libodb-boost/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.0)
+project(libodb-boost VERSION 2.4.0 LANGUAGES CXX)
+find_package(odb 2.4.0 REQUIRED COMPONENTS libodb)
+configure_file(config.unix.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/odb/boost/details/config.h COPYONLY)
+
+# FIXME: should we require boost? which packages?
+# find_package(PostgreSQL REQUIRED)
+set(LIBODB_INSTALL_HEADERS ON CACHE BOOL "Install the header files (a debug install)")
+file(GLOB_RECURSE libodb_src LIST_DIRECTORIES False
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    *.cxx)
+add_library(libodb-boost ${libodb_src})
+target_include_directories(libodb-boost
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+
+)
+
+target_link_libraries(libodb-boost PRIVATE odb::libodb)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(libodb-boost PRIVATE
+        -DLIBODB_BOOST_DYNAMIC_LIB)
+else()
+    target_compile_definitions(libodb-boost PRIVATE
+        -DLIBODB_BOOST_STATIC_LIB)
+endif()
+install(TARGETS libodb-boost EXPORT odb_boostConfig
+    COMPONENT boost
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+if(LIBODB_INSTALL_HEADERS)
+install(DIRECTORY odb DESTINATION include/
+        COMPONENT sqlite
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hxx"
+        PATTERN "*.ixx"
+        PATTERN "*.txx"
+)
+endif()
+install(EXPORT odb_boostConfig NAMESPACE odb:: COMPONENT boost DESTINATION share/odb)
+export(TARGETS libodb-boost NAMESPACE odb:: FILE odb_boostConfig.cmake)

--- a/ports/libodb-boost/CONTROL
+++ b/ports/libodb-boost/CONTROL
@@ -1,0 +1,4 @@
+Source: libodb-boost
+Version: 2.4.0-1
+Description: Description: Boost support for the ODB ORM library
+Build-Depends: libodb

--- a/ports/libodb-boost/config.unix.h.in
+++ b/ports/libodb-boost/config.unix.h.in
@@ -1,0 +1,14 @@
+/* odb/boost/details/config.h.  Generated from config.h.in by configure.  */
+/* file      : odb/boost/details/config.h.in
+ * copyright : Copyright (c) 2009-2015 Code Synthesis Tools CC
+ * license   : GNU GPL v2; see accompanying LICENSE file
+ */
+
+/* This file is automatically processed by configure. */
+
+#ifndef ODB_BOOST_DETAILS_CONFIG_H
+#define ODB_BOOST_DETAILS_CONFIG_H
+
+/* #undef LIBODB_BOOST_STATIC_LIB */
+
+#endif /* ODB_BOOST_DETAILS_CONFIG_H */

--- a/ports/libodb-boost/portfile.cmake
+++ b/ports/libodb-boost/portfile.cmake
@@ -1,0 +1,29 @@
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libodb-boost-2.4.0)
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.codesynthesis.com/download/odb/2.4/libodb-boost-2.4.0.tar.gz"
+    FILENAME "libodb-boost-2.4.0.tar.gz"
+    SHA512 af716b0385cf4ea18b20dcd5880c69c43cfc195eec4ff196a8e438833306489c39ab06a494e5d60cd08ba0d94caa05bd07e5f3fa836d835bad15c8a2ad7de306
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+file(COPY
+  ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+  ${CMAKE_CURRENT_LIST_DIR}/config.unix.h.in
+  DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS_DEBUG
+        -DLIBODB_INSTALL_HEADERS=OFF
+)
+vcpkg_build_cmake()
+vcpkg_install_cmake()
+
+file(READ ${CURRENT_PACKAGES_DIR}/debug/share/odb/odb_boostConfig-debug.cmake LIBODB_DEBUG_TARGETS)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" LIBODB_DEBUG_TARGETS "${LIBODB_DEBUG_TARGETS}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/odb/odb_boostConfig-debug.cmake "${LIBODB_DEBUG_TARGETS}")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libodb-boost)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libodb-boost/LICENSE ${CURRENT_PACKAGES_DIR}/share/libodb-boost/copyright)
+vcpkg_copy_pdbs()

--- a/ports/libodb-mysql/CMakeLists.txt
+++ b/ports/libodb-mysql/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(libodb-mysql VERSION 2.4.0 LANGUAGES CXX)
 find_package(odb 2.4.0 REQUIRED COMPONENTS libodb)
+configure_file(config.unix.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/odb/mysql/details/config.h COPYONLY)
+
 INCLUDE_DIRECTORIES(${MYSQL_INCLUDE_DIR})
 set(LIBODB_INSTALL_HEADERS ON CACHE BOOL "Install the header files (a debug install)")
 file(GLOB_RECURSE libodb_src

--- a/ports/libodb-mysql/config.unix.h.in
+++ b/ports/libodb-mysql/config.unix.h.in
@@ -1,0 +1,19 @@
+/* odb/mysql/details/config.h.  Generated from config.h.in by configure.  */
+/* file      : odb/mysql/details/config.h.in
+ * copyright : Copyright (c) 2009-2015 Code Synthesis Tools CC
+ * license   : GNU GPL v2; see accompanying LICENSE file
+ */
+
+/* This file is automatically processed by configure. */
+
+#ifndef ODB_MYSQL_DETAILS_CONFIG_H
+#define ODB_MYSQL_DETAILS_CONFIG_H
+
+/* #undef LIBODB_MYSQL_STATIC_LIB */
+
+/* #undef LIBODB_MYSQL_INCLUDE_SHORT */
+#define LIBODB_MYSQL_INCLUDE_LONG 1
+
+/* #undef LIBODB_MYSQL_THR_KEY_VISIBLE */
+
+#endif /* ODB_MYSQL_DETAILS_CONFIG_H */

--- a/ports/libodb-mysql/portfile.cmake
+++ b/ports/libodb-mysql/portfile.cmake
@@ -25,7 +25,11 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/adapter_mysql_8.0.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY
+  ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+  ${CMAKE_CURRENT_LIST_DIR}/config.unix.h.in
+  DESTINATION ${SOURCE_PATH})
+
 set(MYSQL_INCLUDE_DIR "${CURRENT_INSTALLED_DIR}/include/mysql")
 set(MYSQL_LIB "${CURRENT_INSTALLED_DIR}/lib/libmysql.lib")
 set(MYSQL_LIB_DEBUG "${CURRENT_INSTALLED_DIR}/debug/lib/libmysql.lib")

--- a/ports/libodb-pgsql/CMakeLists.txt
+++ b/ports/libodb-pgsql/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 project(libodb-pgsql VERSION 2.4.0 LANGUAGES CXX)
 find_package(odb 2.4.0 REQUIRED COMPONENTS libodb)
 find_package(PostgreSQL REQUIRED)
+configure_file(config.unix.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/odb/pgsql/details/config.h COPYONLY)
+
 set(LIBODB_INSTALL_HEADERS ON CACHE BOOL "Install the header files (a debug install)")
 file(GLOB_RECURSE libodb_src LIST_DIRECTORIES False
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ports/libodb-pgsql/config.unix.h.in
+++ b/ports/libodb-pgsql/config.unix.h.in
@@ -1,0 +1,14 @@
+/* odb/pgsql/details/config.h.  Generated from config.h.in by configure.  */
+/* file      : odb/pgsql/details/config.h.in
+ * copyright : Copyright (c) 2009-2015 Code Synthesis Tools CC
+ * license   : GNU GPL v2; see accompanying LICENSE file
+ */
+
+/* This file is automatically processed by configure. */
+
+#ifndef ODB_PGSQL_DETAILS_CONFIG_H
+#define ODB_PGSQL_DETAILS_CONFIG_H
+
+/* #undef LIBODB_PGSQL_STATIC_LIB */
+
+#endif /* ODB_PGSQL_DETAILS_CONFIG_H */

--- a/ports/libodb-pgsql/portfile.cmake
+++ b/ports/libodb-pgsql/portfile.cmake
@@ -7,7 +7,11 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY
+  ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+  ${CMAKE_CURRENT_LIST_DIR}/config.unix.h.in
+  DESTINATION ${SOURCE_PATH})
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS_DEBUG

--- a/ports/libodb-sqlite/CMakeLists.txt
+++ b/ports/libodb-sqlite/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 project(libodb-sqlite VERSION 2.4.0 LANGUAGES CXX)
 find_package(odb 2.4.0 REQUIRED COMPONENTS libodb)
 find_package(sqlite3 REQUIRED)
+configure_file(config.unix.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/odb/sqlite/details/config.h COPYONLY)
+
 set(LIBODB_INSTALL_HEADERS ON CACHE BOOL "Install the header files (a debug install)")
 file(GLOB_RECURSE libodb_src LIST_DIRECTORIES False
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ports/libodb-sqlite/config.unix.h.in
+++ b/ports/libodb-sqlite/config.unix.h.in
@@ -1,0 +1,15 @@
+/* odb/sqlite/details/config.h.  Generated from config.h.in by configure.  */
+/* file      : odb/sqlite/details/config.h.in
+ * copyright : Copyright (c) 2009-2015 Code Synthesis Tools CC
+ * license   : GNU GPL v2; see accompanying LICENSE file
+ */
+
+/* This file is automatically processed by configure. */
+
+#ifndef ODB_SQLITE_DETAILS_CONFIG_H
+#define ODB_SQLITE_DETAILS_CONFIG_H
+
+/* #undef LIBODB_SQLITE_STATIC_LIB */
+#define LIBODB_SQLITE_HAVE_UNLOCK_NOTIFY 1
+
+#endif /* ODB_SQLITE_DETAILS_CONFIG_H */

--- a/ports/libodb-sqlite/portfile.cmake
+++ b/ports/libodb-sqlite/portfile.cmake
@@ -15,7 +15,11 @@ vcpkg_download_distfile(ARCHIVE
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY
+  ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+  ${CMAKE_CURRENT_LIST_DIR}/config.unix.h.in
+  DESTINATION ${SOURCE_PATH})
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS_DEBUG

--- a/ports/libodb/CMakeLists.txt
+++ b/ports/libodb/CMakeLists.txt
@@ -1,13 +1,21 @@
 cmake_minimum_required(VERSION 3.0)
 project(libodb VERSION 2.4.0 LANGUAGES CXX)
 set(LIBODB_INSTALL_HEADERS ON CACHE BOOL "Install the header files (a debug install)")
+configure_file(config.unix.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/odb/details/config.h COPYONLY)
+
 file(GLOB_RECURSE libodb_src LIST_DIRECTORIES False
     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     *.cxx)
-list(FILTER libodb_src EXCLUDE REGEX /posix/.*)
+if (WIN32)
+  list(FILTER libodb_src EXCLUDE REGEX /posix/.*)
+elseif (UNIX)
+  list(FILTER libodb_src EXCLUDE REGEX /win32/.*)
+endif()
+
 add_library(libodb ${libodb_src})
 target_include_directories(libodb
-    PUBLIC 
+    PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 

--- a/ports/libodb/config.unix.h.in
+++ b/ports/libodb/config.unix.h.in
@@ -1,0 +1,20 @@
+/* odb/details/config.h.  Generated from config.h.in by configure.  */
+/* file      : odb/details/config.h.in
+ * copyright : Copyright (c) 2009-2015 Code Synthesis Tools CC
+ * license   : GNU GPL v2; see accompanying LICENSE file
+ */
+
+/* This file is automatically processed by configure. */
+
+#ifndef ODB_DETAILS_CONFIG_H
+#define ODB_DETAILS_CONFIG_H
+
+/* #undef ODB_THREADS_NONE */
+#define ODB_THREADS_POSIX 1
+/* #undef ODB_THREADS_WIN32 */
+#define ODB_THREADS_TLS_KEYWORD 1
+/* #undef ODB_THREADS_TLS_DECLSPEC */
+
+/* #undef LIBODB_STATIC_LIB */
+
+#endif /* ODB_DETAILS_CONFIG_H */

--- a/ports/libodb/portfile.cmake
+++ b/ports/libodb/portfile.cmake
@@ -15,7 +15,11 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 f1311458634695eb6ba307ebfd492e3b260e7beb06db1c5c46df58c339756be4006322cdc4e42d055bf5b2ad14ce4656ddcafcc4e16c282034db8a77d255c3eb
 )
 vcpkg_extract_source_archive(${ARCHIVE})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY
+  ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+  ${CMAKE_CURRENT_LIST_DIR}/config.unix.h.in
+  DESTINATION ${SOURCE_PATH})
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS_DEBUG


### PR DESCRIPTION
This PR gets libodb and associated libs to compile and install on Linux x64. Notes:

- The underlying problems were discussed as part of issue https://github.com/Microsoft/vcpkg/issues/4428. See the ticket for more details. The TL;DR is that there are missing files on Linux, resulting on compilation errors.
- OSX and Windows were not tested. Windows is not believed to be broken by these changes.
- All libraries except ```libodb-mysql``` compiled and installed. MySQL failed to compile due to https://github.com/Microsoft/vcpkg/issues/5046.
- The approach taken is not the cleanest as it hard-codes the config files. However, its an improvement on the present state.
- The second commit adds the ```*.options``` files for the boost profile, which are required in order to get the ODB compiler to generate code for boost. That is, they are not needed to compile the generated code, but the code generator will not emit code for this profile in the absence of these files. Thus it seems wise to include them.