### PR TITLE
[json-spirit] Fix link error C1128

### DIFF
--- a/ports/json-spirit/CONTROL
+++ b/ports/json-spirit/CONTROL
@@ -1,4 +1,4 @@
 Source: json-spirit
-Version: 4.1.0
+Version: 4.1.0-1
 Description: json parser using boost library
 Build-Depends: boost-config, boost-integer, boost-smart-ptr, boost-variant, boost-spirit

--- a/ports/json-spirit/Fix-link-error-C1128.patch
+++ b/ports/json-spirit/Fix-link-error-C1128.patch
@@ -2,12 +2,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 24b1caf..2aac0b0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -60,7 +60,7 @@ endif()
+@@ -60,7 +60,9 @@ endif()
  
  message(${CMAKE_INSTALL_INCLUDEDIR})
  
 -
-+set(CMAKE_CXX_FLAGS "/bigobj")
++if(MSVC)
++add_definitions(/bigobj)
++endif()
  set(CPACK_PACKAGE_VERSION_MAJOR 4)
  set(CPACK_PACKAGE_VERSION_MINOR 0)
  set(CPACK_PACKAGE_VERSION_PATCH 8)

--- a/ports/json-spirit/Fix-link-error-C1128.patch
+++ b/ports/json-spirit/Fix-link-error-C1128.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 24b1caf..2aac0b0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ endif()
+ 
+ message(${CMAKE_INSTALL_INCLUDEDIR})
+ 
+-
++set(CMAKE_CXX_FLAGS "/bigobj")
+ set(CPACK_PACKAGE_VERSION_MAJOR 4)
+ set(CPACK_PACKAGE_VERSION_MINOR 0)
+ set(CPACK_PACKAGE_VERSION_PATCH 8)

--- a/ports/json-spirit/portfile.cmake
+++ b/ports/json-spirit/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
     PATCHES ${CMAKE_CURRENT_LIST_DIR}/dll-wins.patch
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/Fix-link-error-C1128.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/json-spirit/portfile.cmake
+++ b/ports/json-spirit/portfile.cmake
@@ -6,12 +6,9 @@ vcpkg_from_github(
     REF 5e16cca59b31d8beda0f07e3917ce11dcd43b3db
     SHA512 6ac0f15726391c9003e516213535c8d30e98b6c33bca0b03e9bf38e7085824bfc6cfaab267b1dfccbfcc567638d26f722d7e331f4e3b60d3acd5c717cb1fafcc
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/dll-wins.patch
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/Fix-link-error-C1128.patch
+    PATCHES
+        dll-wins.patch
+        Fix-link-error-C1128.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
json-spirit failed with “fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj”, it casued the /Z7 option. it is by-design issue here.
Without using /Z7 nor /Zi, the compiler won’t generate any .debug$* section, and therefore the number of sections won’t exceed the limit allowed by COFF.  With /Z7 or /Zi, extra .debug$* sections make the total number of sections exceeding the COFF limit, so we need to add /bigobj so that the compiler will produce OBJ in extended COFF (COFFEX) format which allows much more sections to exist in an OBJ file.