### PR TITLE
azure-iot-sdk-c master and public-preview 2019_01_31 changes

### DIFF
--- a/ports/azure-c-shared-utility/CONTROL
+++ b/ports/azure-c-shared-utility/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-c-shared-utility
-Version: 1.1.11-3
+Version: 1.1.11-4
 Description: Azure C SDKs common code
 Build-Depends: curl (linux), openssl (linux)
 

--- a/ports/azure-c-shared-utility/portfile.cmake
+++ b/ports/azure-c-shared-utility/portfile.cmake
@@ -6,17 +6,17 @@ if("public-preview" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-c-shared-utility
-        REF e885482ce32f1f77d29e85f7b8d35d74ffc69c74
-        SHA512 329101cb2ff499aa16e1df736285e2fdd8c34549d4790eaafa1df763950c2b4a5927f52e93dbf22192b240fe0445050ad99133df0405227ffe9857ff2b25014d
-        HEAD_REF public-preview
+        REF 773980d7882e4d5f1e7c9be2a0797d61fbc19da1
+        SHA512 fa374db336f5d186bcfd6ba70660167fdc87a1847376579cee894af3d2810aba097b3468e75c0b4213b68423cc07215032eeae6ee07590378237606112286ac4
+        HEAD_REF master
         PATCHES no-double-expand-cmake.patch
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-c-shared-utility
-        REF 1d622902d7842f94193fc394987f2b4e978bb700
-        SHA512 e7b3671955aeefe8e748bc68dd9f914fbb86c9cf325606691efc332cffa0d80b61f87d5f5c1026676c35fd1c5e88f22ca60f2e811c351aeba659f810fdc52e84
+        REF 773980d7882e4d5f1e7c9be2a0797d61fbc19da1
+        SHA512 fa374db336f5d186bcfd6ba70660167fdc87a1847376579cee894af3d2810aba097b3468e75c0b4213b68423cc07215032eeae6ee07590378237606112286ac4
         HEAD_REF master
         PATCHES no-double-expand-cmake.patch
     )

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-iot-sdk-c
-Version: 1.2.12-1
+Version: 1.2.13-1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
 

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -6,8 +6,8 @@ if("public-preview" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-iot-sdk-c
-        REF 74b03316ec90f1602c20ebeab67a3b4a61065d8e
-        SHA512 78ab8d7cd6e25886e41f98500cb8cd9609ca677426a882ed0364a908e5267ec6191bb15fd65fb2c420a108df41f52a8ba6d5e6d626874bbfae4f56e8af5ca428
+        REF 6633c5b18710febf1af7713cf1a336fd38f623ed
+        SHA512 17787aa4ef52d4cf39f939fee05555fcef85cde63620036f6715b699902fd3fd766250c26ea6065f5f36572ac2b9d5293e79ba17ea9d8f4cbce267322269e7e4
         HEAD_REF public-preview
         PATCHES improve-external-deps.patch
     )
@@ -15,8 +15,8 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-iot-sdk-c
-        REF 350b51f5abaedc975dae5419ad1fa4add7635fd2
-        SHA512 7559768f7d1c67f6b28d16871c3c783e9f88d9dc4f9051a7a3c0329311d39821301edf64fcbde15a8e904c6d5a6326feee25be8e46cb657c21455ae920b266eb
+        REF 738f160116a689566f6f20e0200a0c3c86e85dee
+        SHA512 e697fcefaae938c66e6cca5b35b6924bff76f6b147afeffe45acff63aa6e6ed99da53450fc2a1e80700f44928ce3cd3a3e6d3ce72f96a1b22a74557828be1cbc
         HEAD_REF master
         PATCHES improve-external-deps.patch
     )

--- a/ports/azure-uamqp-c/CONTROL
+++ b/ports/azure-uamqp-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-uamqp-c
-Version: 1.2.11-2
+Version: 1.2.11-3
 Build-Depends: azure-c-shared-utility
 Description: AMQP library for C
 

--- a/ports/azure-uamqp-c/portfile.cmake
+++ b/ports/azure-uamqp-c/portfile.cmake
@@ -6,16 +6,16 @@ if("public-preview" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-uamqp-c
-        REF bd7b85d0830634e3157da2411a6d060bf28f266e
-        SHA512 cbc2aa2765242ebe1a5e194e126f419cbd26edda5c1f72ffe9219a6c38b80aa91ef823a4fd8f78ac5d7ae0d9d471b50e5b8c4684e77c71b31e7cf35802e0cc17
-        HEAD_REF public-preview
+        REF 195f2480f31e0a9492e3ff3a7a1eed4a69205ddd
+        SHA512 fa2cab67d119018b7e28dd002641bc3e87ac2d45ecddeddb867135bac6e5eda02588f84c26283947bdc47789c90a3f9e04dab16e5eb9be8a384ef5c9bcf39572
+        HEAD_REF master
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-uamqp-c
-        REF f29401ab5eb3853390d5f573d8fb37c0c96dba16
-        SHA512 8fdee32e2a85218257ee91754873f9f8ae5e16cd2b7b10c88ab6d4115fe4378a2b08f211d8307346b0bd7688c4c896c25a4de34e9231c2506819a97bbf46dd73
+        REF 195f2480f31e0a9492e3ff3a7a1eed4a69205ddd
+        SHA512 fa2cab67d119018b7e28dd002641bc3e87ac2d45ecddeddb867135bac6e5eda02588f84c26283947bdc47789c90a3f9e04dab16e5eb9be8a384ef5c9bcf39572
         HEAD_REF master
     )
 endif()

--- a/ports/azure-uhttp-c/CONTROL
+++ b/ports/azure-uhttp-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-uhttp-c
-Version: 1.1.11-2
+Version: 1.1.11-3
 Build-Depends: azure-c-shared-utility
 Description: Azure HTTP Library written in C
 

--- a/ports/azure-uhttp-c/portfile.cmake
+++ b/ports/azure-uhttp-c/portfile.cmake
@@ -6,16 +6,16 @@ if("public-preview" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-uhttp-c
-        REF e459385a811ce075f42aa7202db96ba1d1f55ac1
-        SHA512 b96382184893b49f30ad75d4c19eeb48f7a7823e9d48f2896ee4760be20f2f5b5ee3e78e39f10ae26363165360e5871c3ba82aa9edf3943b9f0ef9c0e3036ea6
-        HEAD_REF public-preview
+        REF 3a81e598caf2bd37077b7cd20bb45aaa9e694df7
+        SHA512 6f12efdd2f02adb2414e10daa0604f5351f7731b997d69a9ca2923b6246c7a628bd859c6dca2503e51eeece851421b7739ffbf31a3f3d34dca4dcbadb54411d2
+        HEAD_REF master
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-uhttp-c
-        REF 647ec7cc75961cd7ff7cbb7eca30e1de819802ed
-        SHA512 1768ea978ab7fa328b74444573c3d1eb2a5fae1e36dbe1dcc186df3e2ab2a0a3b1ba8a434934462184582525b3a1850fc04ca2927f95f0df0ae483f8a1673e30
+        REF 3a81e598caf2bd37077b7cd20bb45aaa9e694df7
+        SHA512 6f12efdd2f02adb2414e10daa0604f5351f7731b997d69a9ca2923b6246c7a628bd859c6dca2503e51eeece851421b7739ffbf31a3f3d34dca4dcbadb54411d2
         HEAD_REF master
     )
 endif()

--- a/ports/azure-umqtt-c/CONTROL
+++ b/ports/azure-umqtt-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-umqtt-c
-Version: 1.1.11-2
+Version: 1.1.11-3
 Build-Depends: azure-c-shared-utility
 Description: General purpose library for communication over the mqtt protocol
 

--- a/ports/azure-umqtt-c/portfile.cmake
+++ b/ports/azure-umqtt-c/portfile.cmake
@@ -6,16 +6,16 @@ if("public-preview" IN_LIST FEATURES)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-umqtt-c
-        REF 1b3a25f4f7f0edbe068e261e8a808d7bc394a358
-        SHA512 00ff90eccfbb4febded7e819baa6303e97d3e7d6f6f8f1a28ebf353d7ad7ac5ec7f479e66456f395c7ece7fd6d612f3948ac656420bc0bc75566bdbb65fb88c3
-        HEAD_REF public-preview
+        REF f68e8d535d18028e3e6ed4d806ce8994037a49fa
+        SHA512 9bea4c3dbd26f5221c4da782954a4e8b4d372aca75b71a9eb63b818f31f153e4be534a20960c007c3aa184766f2a826c5ba11e780e23098707419ab39f055cc1
+        HEAD_REF master
     )
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO Azure/azure-umqtt-c
-        REF 3205eb26401e9c6639100934e8fb75b75275760d
-        SHA512 002c0d4f0373faeb7171465afce268f18b52d80ec057af36c81dd807de8ccf2bf1a46ef00c7f8e8fcdbef8d7f5c36616a304007c98ea5700c5f662b4c8868c2c
+        REF f68e8d535d18028e3e6ed4d806ce8994037a49fa
+        SHA512 9bea4c3dbd26f5221c4da782954a4e8b4d372aca75b71a9eb63b818f31f153e4be534a20960c007c3aa184766f2a826c5ba11e780e23098707419ab39f055cc1
         HEAD_REF master
     )
 endif()


### PR DESCRIPTION
This PR bumps the release version for the azure-iot-sdk-c vcpkg
Version: 1.2.13-1