### PR TITLE
Add netcdf and hdf5 dependencies

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,7 +1,7 @@
 Source: gdal
 Version: 2.4.0
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
-Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma
+Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma, netcdf-c, hdf5
 
 Feature: mysql-libmariadb
 Build-Depends: libmariadb


### PR DESCRIPTION
Netcdf and HDF are important _formats_ in the scientific domains (lots of satellite data come in nc or hdf) so having them by default in GDAL seems the most natural.