### PR TITLE
[libarchive] Fix libxml2 feature not taking effect

### DIFF
--- a/ports/libarchive/CONTROL
+++ b/ports/libarchive/CONTROL
@@ -1,5 +1,5 @@
 Source: libarchive
-Version: 3.3.3-2
+Version: 3.3.3-3
 Description: Library for reading and writing streaming archives
 Build-Depends: zlib
 Default-Features: bzip2, libxml2, lz4, lzma, lzo, openssl

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -26,7 +26,6 @@ set(BUILD_libarchive_libxml2 OFF)
 if("libxml2" IN_LIST FEATURES)
   set(BUILD_libarchive_libxml2 ON)
 endif()
-set(BUILD_libarchive_libxml2 OFF)
 
 set(BUILD_libarchive_lz4 OFF)
 if("lz4" IN_LIST FEATURES)


### PR DESCRIPTION
I would sign your CLA but [your site](https://cla.opensource.microsoft.com/) doesn't work currently. The "sign in" link just refreshes the page with no change. I tried on multiple browsers across multiple operating systems.

If it's enough, I verbally agree to it. Otherwise, ping me when it is working again.