### PR TITLE
Add support for edge modules

### DIFF
--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,8 +1,8 @@
 Source: azure-iot-sdk-c
-Version: 1.2.13-1
-Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson
+Version: 1.2.13-2
+Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
 
 Feature: public-preview
 Description: A version of the azure-iot-sdk-c containing public-preview features.
-Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview]
+Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], azure-uhttp-c[public-preview]

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
         -Duse_installed_dependencies=ON
         -Duse_default_uuid=ON
         -Dbuild_as_dynamic=OFF
+        -Duse_edge_modules=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Added Edge CMake flags and dependency on uhttp

Validated using pasting and building edge sample [from this issue](https://github.com/Azure/azure-iot-sdk-c/issues/779) successfully by replacing the contents of the [iothub_ll_telemetry_sample source file](https://github.com/Azure/azure-iot-sdk-c/blob/master/iothub_client/samples/iothub_ll_telemetry_sample/iothub_ll_telemetry_sample.c) in windows project [at this location](https://github.com/Azure/azure-iot-sdk-c/tree/master/iothub_client/samples/iothub_ll_telemetry_sample/windows)