### PR TITLE
[ampl-mp] Add new port

### DIFF
--- a/ports/ampl-mp/CONTROL
+++ b/ports/ampl-mp/CONTROL
@@ -1,0 +1,3 @@
+Source: ampl-mp
+Version: 2019-02-08
+Description: An open-source library for mathematical programming

--- a/ports/ampl-mp/disable-matlab-mex.patch
+++ b/ports/ampl-mp/disable-matlab-mex.patch
@@ -1,0 +1,11 @@
+--- a/src/asl/CMakeLists.txt	2019-02-08 16:42:50.793071700 -0600
++++ b/src/asl/CMakeLists.txt	2019-02-08 16:44:04.960894500 -0600
+@@ -266,7 +266,7 @@ endif ()
+ 
+ target_link_libraries(asl ${CMAKE_DL_LIBS})
+ 
+-find_package(MATLAB)
++set(MATLAB_FOUND)
+ if (MATLAB_FOUND)
+   set(matlab_asl asl)
+   if (MSVC)

--- a/ports/ampl-mp/install-targets.patch
+++ b/ports/ampl-mp/install-targets.patch
@@ -1,0 +1,44 @@
+--- a/CMakeLists.txt	2019-02-09 04:38:25.756325900 -0600
++++ b/CMakeLists.txt	2019-02-09 04:39:55.299417600 -0600
+@@ -289,6 +289,8 @@ add_prefix(MP_SOURCES src/
+ add_mp_library(mp ${MP_HEADERS} ${MP_SOURCES} ${MP_EXPR_INFO_FILE}
+   COMPILE_DEFINITIONS MP_DATE=${MP_DATE} MP_SYSINFO="${MP_SYSINFO}"
+   INCLUDE_DIRECTORIES src OBJECT_LIBRARIES format)
++set_property(TARGET mp PROPERTY
++  INTERFACE_INCLUDE_DIRECTORIES $<INSTALL_INTERFACE:include>)
+ set_target_properties(mp PROPERTIES
+   VERSION ${MP_VERSION} SOVERSION ${MP_VERSION_MAJOR})
+ 
+@@ -385,5 +387,10 @@ if(BUILD_TESTING)
+ endif()
+ 
+ install(DIRECTORY include/mp DESTINATION include)
+-install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)
++install(TARGETS mp EXPORT unofficial-mp-targets
++  DESTINATION lib RUNTIME DESTINATION bin)
+ install(FILES LICENSE.rst DESTINATION share/mp)
++install(EXPORT unofficial-mp-targets
++  FILE unofficial-mp-config.cmake
++  NAMESPACE unofficial::mp::
++  DESTINATION share/unofficial-mp)
+--- a/src/asl/CMakeLists.txt	2019-02-09 04:38:27.196322600 -0600
++++ b/src/asl/CMakeLists.txt	2019-02-09 04:39:32.119889500 -0600
+@@ -235,6 +235,10 @@ add_mp_library(asl-extra OBJECT ${ASL_SO
+ 
+ add_mp_library(asl STATIC OBJECT_LIBRARIES asl-core asl-extra
+   LIBRARIES mp INCLUDE_DIRECTORIES ${ASL_INCLUDE_DIRS})
++set_property(TARGET asl PROPERTY
++  INTERFACE_INCLUDE_DIRECTORIES
++  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR};${PROJECT_SOURCE_DIR}/src/asl/solvers>
++  $<INSTALL_INTERFACE:include>)
+ 
+ if (NOT WIN32)
+   target_link_libraries(asl m)
+@@ -353,4 +357,6 @@ endif ()
+ install(FILES ${ASL_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/arith.h
+               solvers/opcode.hd solvers/r_opn.hd
+         DESTINATION include/asl)
+-install(TARGETS asl tableproxy DESTINATION lib RUNTIME DESTINATION bin)
++install(TARGETS tableproxy DESTINATION lib RUNTIME DESTINATION bin)
++install(TARGETS asl EXPORT unofficial-mp-targets
++        DESTINATION lib RUNTIME DESTINATION bin)

--- a/ports/ampl-mp/portfile.cmake
+++ b/ports/ampl-mp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 2c8ffd6de946a6f8ea94a8e0c00f03f67753ad99534e0d5fcaaaeb472fe76a3383324bcb628a31d8c01bc5f60254790f5508c8394096a4f05672f814dbd6fe2e
     HEAD_REF master
     PATCHES
+    disable-matlab-mex.patch
     workaround-msvc-optimizer-ice.patch
     install-targets.patch
 )

--- a/ports/ampl-mp/portfile.cmake
+++ b/ports/ampl-mp/portfile.cmake
@@ -1,0 +1,41 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ampl/mp
+    REF d305155b047b69fc5c6e5fda8630c753d7973b9a
+    SHA512 2c8ffd6de946a6f8ea94a8e0c00f03f67753ad99534e0d5fcaaaeb472fe76a3383324bcb628a31d8c01bc5f60254790f5508c8394096a4f05672f814dbd6fe2e
+    HEAD_REF master
+    PATCHES
+    workaround-msvc-optimizer-ice.patch
+    install-targets.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+    -DBUILD=asl
+    -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH share/unofficial-mp
+    TARGET_PATH share/unofficial-mp
+)
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug/bin
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
+    ${CURRENT_PACKAGES_DIR}/share/mp)
+
+configure_file(${SOURCE_PATH}/LICENSE.rst
+    ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+vcpkg_copy_pdbs()
+vcpkg_test_cmake(PACKAGE_NAME unofficial-mp)

--- a/ports/ampl-mp/workaround-msvc-optimizer-ice.patch
+++ b/ports/ampl-mp/workaround-msvc-optimizer-ice.patch
@@ -1,0 +1,14 @@
+--- a/src/asl/CMakeLists.txt	2019-02-07 22:45:15.191909400 -0600
++++ b/src/asl/CMakeLists.txt	2019-02-07 22:47:10.364936600 -0600
+@@ -216,6 +216,11 @@ add_mp_library(asl-core OBJECT ${ASL_COR
+   COMPILE_DEFINITIONS ${ASL_COMPILE_DEFINITIONS}
+   INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
+ 
++if (MSVC)
++  set_source_files_properties(solvers/avltree.c solvers/sphes.c
++    PROPERTIES COMPILE_OPTIONS /Od)
++endif ()
++
+ # Public ASL headers.
+ set(ASL_HEADERS aslbuilder.h aslexpr.h aslexpr-visitor.h
+   aslproblem.h aslinterface.h ${CMAKE_CURRENT_BINARY_DIR}/stdio1.h)


### PR DESCRIPTION
This port aims for solver development, so it does not build any existing solver modules.

The shared library build is disabled for now because it has some problem on Windows.

There is a bug on the MSVC side, I've reported it to https://developercommunity.visualstudio.com/content/problem/441193/ice-when-optimizing-c-code.html , for now I disabled code optimization on the affected files.