### PR TITLE
[vcpkg] Fix warning on Apple

### DIFF
--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -30,7 +30,7 @@ namespace vcpkg::System
         static constexpr const uint32_t buff_size = 1024 * 32;
         uint32_t size = buff_size;
         char buf[buff_size] = {};
-        bool result = _NSGetExecutablePath(buf, &size);
+        int result = _NSGetExecutablePath(buf, &size);
         Checks::check_exit(VCPKG_LINE_INFO, result != -1, "Could not determine current executable path.");
         std::unique_ptr<char> canonicalPath(realpath(buf, NULL));
         Checks::check_exit(VCPKG_LINE_INFO, result != -1, "Could not determine current executable path.");


### PR DESCRIPTION
This patch addresses a warning when compiling on OSX (I used LLVM Clang 7.0). The warning is as follows:

```
[12/64] Building CXX object CMakeFiles/vcpkg.dir/src/vcpkg/base/system.cpp.o
../src/vcpkg/base/system.cpp:34:52: warning: result of comparison of constant -1 with expression of type 'bool' is always true [-Wtautological-constant-out-of-range-compare]
        Checks::check_exit(VCPKG_LINE_INFO, result != -1, "Could not determine current executable path.");
                                            ~~~~~~ ^  ~~
../src/vcpkg/base/system.cpp:36:52: warning: result of comparison of constant -1 with expression of type 'bool' is always true [-Wtautological-constant-out-of-range-compare]
        Checks::check_exit(VCPKG_LINE_INFO, result != -1, "Could not determine current executable path.");
                                            ~~~~~~ ^  ~~
2 warnings generated.
```

The warning is the result of using bool as the return type of ```_NSGetExecutablePath```, when the documentation states it is an int [1]:

```
bool result = _NSGetExecutablePath(buf, &size);
```
The patch sets result to match the return type of the function. It was tested using LLVM Clang 7.0 and compiles cleanly.

[1] https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dyld.3.html