### PR TITLE
[tiff] Disable libwebp support.

### DIFF
--- a/ports/tiff/CONTROL
+++ b/ports/tiff/CONTROL
@@ -1,4 +1,4 @@
 Source: tiff
-Version: 4.0.10-1
+Version: 4.0.10-2
 Build-Depends: zlib, libjpeg-turbo, liblzma (!uwp)
 Description: A library that supports the manipulation of TIFF image files

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
         -DBUILD_TESTS=OFF
         -Djbig=OFF # This is disabled by default due to GPL/Proprietary licensing.
         -Djpeg12=OFF
+        -Dwebp=OFF
         -Dzstd=OFF
         ${TIFF_CXX_TARGET}
 )


### PR DESCRIPTION
Since version 4.0.10, libtiff supports optional compression modes using
either libweb or zstd.
When libtiff is built, and libwebp and/or zstd are found anywhere on the
system, these modes will be enabled. However, the respective libraries
are not added as link targets, so this will result in linker errors for
any unsuspecting project using libtiff.

Since zstd support was already disabled by a previous commit, I have
also simply disabled libwebp support to fix this issue.

A more proper fix might be to add both libwebp and zstd as required
libtiff dependencies, and to patch libtiff's CMakeLists.txt, such that
these libraries are properly linked to. However, it is currently very
unlikely to encounter TIFF images in the wild compressed using either
of these methods, so the effect of disabling support may not be
noticeable at all.