### PR TITLE
[lest] Add lest v1.34.1 (was: v1.34.0)

### DIFF
--- a/ports/lest/CONTROL
+++ b/ports/lest/CONTROL
@@ -1,0 +1,3 @@
+Source: lest
+Version: 1.34.0
+Description: A modern, C++11-native, single-file header-only, tiny framework for unit-tests, TDD and BDD (includes C++98 variant)

--- a/ports/lest/CONTROL
+++ b/ports/lest/CONTROL
@@ -1,3 +1,3 @@
 Source: lest
-Version: 1.34.0
+Version: 1.34.1
 Description: A modern, C++11-native, single-file header-only, tiny framework for unit-tests, TDD and BDD (includes C++98 variant)

--- a/ports/lest/portfile.cmake
+++ b/ports/lest/portfile.cmake
@@ -1,0 +1,11 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO martinmoene/lest
+    REF v1.34.0
+    SHA512 aca8a13915ecb2542c0401e17e4d1395ddc9d6299b6cc6521ccb0477aec8dbfe9e7e4e9838fcc2ef15a83cdf8161fa2ed3beeac5fdc825e1b86936f219e9a62d
+)
+
+file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/lest RENAME copyright)

--- a/ports/lest/portfile.cmake
+++ b/ports/lest/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/lest
     REF v1.34.1
-    SHA512 e2e2764f4095ff95b9faab01c2cb4bd2b527d3e582eba10a699d8e44d194c90409eabbc842cf7627fd6f1f1eaa4c45cf314959e79aea858346fb844962009f92
+    SHA512 7f4b0e49c1cf4c55d21752259ee45f9265aba254b9c15f84e77f9ae3e5ef3443abcb43fafe8e16d84bbdffee72dae842de0ed661c2caeb9607fcb188eb3ec7d1
 )
 
 file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/lest/portfile.cmake
+++ b/ports/lest/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/lest
-    REF v1.34.0
-    SHA512 aca8a13915ecb2542c0401e17e4d1395ddc9d6299b6cc6521ccb0477aec8dbfe9e7e4e9838fcc2ef15a83cdf8161fa2ed3beeac5fdc825e1b86936f219e9a62d
+    REF v1.34.1
+    SHA512 e2e2764f4095ff95b9faab01c2cb4bd2b527d3e582eba10a699d8e44d194c90409eabbc842cf7627fd6f1f1eaa4c45cf314959e79aea858346fb844962009f92
 )
 
 file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)


### PR DESCRIPTION
First version of lest C++ tiny test framework.

See also issue #1489.