### PR TITLE
[uvw] Fix uvw.hpp not being installed

### DIFF
--- a/ports/uvw/CONTROL
+++ b/ports/uvw/CONTROL
@@ -1,3 +1,3 @@
 Source: uvw
-Version: 1.11.2
+Version: 1.11.3
 Description: Header-only, event based, tiny and easy to use libuv wrapper in modern C++. <https://github.com/skypjack/uvw>

--- a/ports/uvw/portfile.cmake
+++ b/ports/uvw/portfile.cmake
@@ -13,6 +13,11 @@ file(INSTALL
     DESTINATION ${CURRENT_PACKAGES_DIR}/include
 )
 
+file(INSTALL
+    ${SOURCE_PATH}/src/uvw.hpp
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+
 # Handle copyright/readme/package files
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/uvw RENAME copyright)
 file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/uvw)


### PR DESCRIPTION
In the uvw package the central header `uvw.hpp` is not being installed.
The version I had to increase as to make vcpkg upgrade old versions.