### PR TITLE
[vcpkg create] Update create command template and docs on patching

### DIFF
--- a/docs/examples/patching.md
+++ b/docs/examples/patching.md
@@ -147,11 +147,11 @@ Finally, we need to apply the patch after extracting the source.
 ```cmake
 # ports\libpng\portfile.cmake
 ...
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libpng-1.6.24
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/use-abort-on-all-platforms.patch"
+vcpkg_extract_source_archive_ex(
+  OUT_SOURCE_PATH SOURCE_PATH
+  ARCHIVE ${ARCHIVE}
+  PATCHES 
+    "use-abort-on-all-platforms.patch"
 )
 
 vcpkg_configure_cmake(

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -11,13 +11,24 @@
 #
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/@ROOT_NAME@)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "@URL@"
     FILENAME "@FILENAME@"
     SHA512 @SHA512@
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+    # (Optional) A friendly name to use instead of the filename of the archive (e.g.: a version number or tag).
+    # REF 1.0.0
+    # (Optional) Read the docs for how to generate patches at: 
+    # https://github.com/Microsoft/vcpkg/blob/master/docs/examples/patching.md
+    # PATCHES
+    #   001_port_fixes.patch
+    #   002_more_port_fixes.patch
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
* Update the template generated by the `vcpkg create ...` command to use `vcpkg_extract_source_archive_ex()`.

* Update documentation on how to apply patches to use the `PATCHES` parameter in `vcpkg_extract_source_archive_ex()`.
