### PR TITLE
[libunibreak] add missing source files and headers to the package

### DIFF
--- a/ports/libunibreak/CMakeLists.txt
+++ b/ports/libunibreak/CMakeLists.txt
@@ -5,6 +5,7 @@ project(libunibreak)
 set(libunibreak_srcs
   src/linebreakdata.c
   src/linebreakdef.c
+  src/linebreak.c
   src/wordbreak.c
   src/graphemebreak.c
   src/unibreakbase.c
@@ -30,6 +31,8 @@ if(NOT DISABLE_INSTALL_HEADERS)
     src/linebreakdef.h
     src/wordbreak.h
     src/wordbreakdef.h
+    src/unibreakbase.h
+    src/unibreakdef.h
     DESTINATION include
   )
 endif()


### PR DESCRIPTION
The build file for this project is missing some files that are normally part of this package. This patch adds the missing source file and installs a couple of missing public headers.