### PR TITLE
[shaderc] install executable files on linux and macos

### DIFF
--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -36,7 +36,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}")
 file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
 
 #Safe to remove as libs are static


### PR DESCRIPTION
The linux and macos version of this port fail to install the generated executables into the tools directory because of the hard coded windows executable extension. This patch uses the CMAKE_EXECUTABLE_SUFFIX variable to make this work on linux and macos. I don't have ready access to a windows machine to test this, but it should be a no-op on that platform.