### PR TITLE
[libogg] Add package config module

### DIFF
--- a/ports/libogg/0001-Install-CMake-package-config-module.patch
+++ b/ports/libogg/0001-Install-CMake-package-config-module.patch
@@ -1,0 +1,97 @@
+From 0d3c307cee6e8135c84f3f7755bbc10dfd26e02b Mon Sep 17 00:00:00 2001
+From: evpobr <evpobr@gmail.com>
+Date: Sat, 16 Feb 2019 11:50:16 +0500
+Subject: [PATCH] Install CMake package config module
+
+---
+ CMakeLists.txt | 40 ++++++++++++++++++++++++++++++++++------
+ 1 file changed, 34 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ab14a2..9f5ee5a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,9 +1,10 @@
+-cmake_minimum_required(VERSION 2.8.7)
++cmake_minimum_required(VERSION 2.8.12)
+ project(libogg)
+ 
+ # Required modules
+ include(GNUInstallDirs)
+ include(CheckIncludeFiles)
++include(CMakePackageConfigHelpers)
+ 
+ # Build options
+ option(BUILD_SHARED_LIBS "Build shared library" OFF)
+@@ -80,18 +81,24 @@ if(BUILD_FRAMEWORK)
+     set(BUILD_SHARED_LIBS TRUE)
+ endif()
+ 
+-include_directories(include ${CMAKE_CURRENT_BINARY_DIR}/include)
+-add_library(ogg ${OGG_HEADERS} ${OGG_SOURCES})
++add_library(Ogg ${OGG_HEADERS} ${OGG_SOURCES})
++
++target_include_directories(Ogg
++    PUBLIC
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++)
+ 
+ get_version_info(OGG_VERSION_INFO "LIB_CURRENT" "LIB_AGE" "LIB_REVISION")
+ set_target_properties(
+-    ogg PROPERTIES
++    Ogg PROPERTIES
+     SOVERSION ${OGG_VERSION_INFO}
+     PUBLIC_HEADER "${OGG_HEADERS}"
+ )
+ 
+ if(BUILD_FRAMEWORK)
+-    set_target_properties(ogg PROPERTIES
++    set_target_properties(Ogg PROPERTIES
+         FRAMEWORK TRUE
+         FRAMEWORK_VERSION ${PROJECT_VERSION}
+         MACOSX_FRAMEWORK_IDENTIFIER org.xiph.ogg
+@@ -100,17 +107,38 @@ if(BUILD_FRAMEWORK)
+         XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+         OUTPUT_NAME Ogg
+     )
++else()
++    set_target_properties(Ogg PROPERTIES OUTPUT_NAME ogg)
+ endif()
+ 
+ configure_pkg_config_file(ogg.pc.in)
+ 
+-install(TARGETS ogg
++set(CMAKE_INSTALL_PACKAGEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Ogg)
++
++install(TARGETS Ogg
++    EXPORT OggConfig
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     FRAMEWORK DESTINATION ${CMAKE_INSTALL_PREFIX}
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ogg
+ )
++install(EXPORT OggConfig
++    NAMESPACE Ogg::
++    DESTINATION ${CMAKE_INSTALL_PACKAGEDIR}
++)
++
++if(CMAKE_VERSION VERSION_LESS 3.11)
++    write_basic_package_version_file(OggConfigVersion.cmake COMPATIBILITY SameMajorVersion)
++else()
++    write_basic_package_version_file(OggConfigVersion.cmake COMPATIBILITY SameMinorVersion)
++endif()
++
++install(
++    FILES ${CMAKE_CURRENT_BINARY_DIR}/OggConfigVersion.cmake
++    DESTINATION	${CMAKE_INSTALL_PACKAGEDIR}
++)
++
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ogg.pc
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+ )
+-- 
+2.20.1.windows.1
+

--- a/ports/libogg/CONTROL
+++ b/ports/libogg/CONTROL
@@ -1,3 +1,3 @@
 Source: libogg
-Version: 1.3.3
+Version: 1.3.3-1
 Description: Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.

--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     REF v1.3.3
     SHA512 0bd6095d647530d4cb1f509eb5e99965a25cc3dd9b8125b93abd6b248255c890cf20710154bdec40568478eb5c4cde724abfb2eff1f3a04e63acef0fbbc9799b
     HEAD_REF master
+    PATCHES 0001-Install-CMake-package-config-module.patch
 )
 
 vcpkg_configure_cmake(
@@ -15,6 +16,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Ogg TARGET_PATH share/Ogg)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
```
PS D:\vcpkg> vcpkg install libogg
The following packages will be built and installed:
    libogg[core]:x64-windows
Starting package 1/1: libogg:x64-windows
Building package libogg[core]:x64-windows...
-- Using cached D:/vcpkg/downloads/xiph-ogg-v1.3.3.tar.gz
-- Using source at D:/vcpkg/buildtrees/libogg/src/v1.3.3-8dc28d69e8
-- Configuring x64-windows
-- Building x64-windows-dbg
-- Building x64-windows-rel
-- Installing: D:/vcpkg/packages/libogg_x64-windows/share/libogg/copyright
-- Performing post-build validation
-- Performing post-build validation done
Building package libogg[core]:x64-windows... done
Installing package libogg[core]:x64-windows...
Installing package libogg[core]:x64-windows... done
Elapsed time for package libogg:x64-windows: 16.34 s

Total elapsed time: 16.34 s

The package libogg:x64-windows provides CMake targets:

    find_package(Ogg CONFIG REQUIRED)
    target_link_libraries(main PRIVATE Ogg::Ogg)
```