### PR TITLE
[vcpkg edit] Update find_from_registry

### DIFF
--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -13,16 +13,37 @@ namespace vcpkg::Commands::Edit
         std::vector<fs::path> output;
 
 #if defined(_WIN32)
-        static const std::array<const char*, 3> REGKEYS = {
-            R"(SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1)",
-            R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1)",
-            R"(SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1)",
+        struct RegKey
+        {
+            HKEY root;
+            const char *subkey;
+        } REGKEYS[] = {
+            {
+                HKEY_LOCAL_MACHINE,
+                R"(SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{C26E74D1-022E-4238-8B9D-1E7564A36CC9}_is1)"
+            },
+            {
+                HKEY_LOCAL_MACHINE,
+                R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{1287CAD5-7C8D-410D-88B9-0D1EE4A83FF2}_is1)"
+            },
+            {
+                HKEY_LOCAL_MACHINE,
+                R"(SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{F8A2A208-72B3-4D61-95FC-8A65D340689B}_is1)"
+            },
+            {
+                HKEY_CURRENT_USER,
+                R"(Software\Microsoft\Windows\CurrentVersion\Uninstall\{771FD6B0-FA20-440A-A002-3B3BAC16DC50}_is1)"
+            },
+            {
+                HKEY_LOCAL_MACHINE,
+                R"(SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{EA457B21-F73E-494C-ACAB-524FDE069978}_is1)"
+            },
         };
 
         for (auto&& keypath : REGKEYS)
         {
             const Optional<std::string> code_installpath =
-                System::get_registry_string(HKEY_LOCAL_MACHINE, keypath, "InstallLocation");
+                System::get_registry_string(keypath.root, keypath.subkey, "InstallLocation");
             if (const auto c = code_installpath.get())
             {
                 const fs::path install_path = fs::path(*c);


### PR DESCRIPTION
I installed `VS Code` to `E:\Program Files\Microsoft VS Code`, and `vcpkg` can not find `VS Code` in this case.

I think we should take `Open with Code` shell command registry entry into consideration during the searching of `VS Code`.

![default](https://user-images.githubusercontent.com/5435649/52941989-f8015200-33a4-11e9-9572-7da3d58c1d29.png)
