### PR TITLE
[libics] Add libics

### DIFF
--- a/ports/libics/CONTROL
+++ b/ports/libics/CONTROL
@@ -1,0 +1,3 @@
+Source: libics
+Version: 1.6.2
+Description: Reference library for ICS (Image Cytometry Standard), an open standard for writing images of any dimensionality and data type to file, together with associated information regarding the recording equipment or recorded subject.

--- a/ports/libics/cmakelists.patch
+++ b/ports/libics/cmakelists.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -86,7 +86,8 @@
+ endif()
+ 
+ # Install
+-install(TARGETS libics libics_static DESTINATION lib)
++install(TARGETS libics DESTINATION bin)
++install(TARGETS libics_static DESTINATION lib)
+ install(FILES ${HEADERS} DESTINATION include)
+ 
+ # Unit tests

--- a/ports/libics/portfile.cmake
+++ b/ports/libics/portfile.cmake
@@ -1,0 +1,23 @@
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO svi-opensource/libics
+    REF 8d8d2dbe72450cbaf88080b6c0e24a7a4a58009e 
+    SHA512 739668b4d51ddb67d50ed1d41bd6965b90b5e4eafc7ec19e2f1d668f48af6e237f6a1872673e3fec5888efe94c2b321295c4de9502aba1f677fc6d0e0399c141
+    HEAD_REF master
+    PATCHES
+        cmakelists.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(COPY ${SOURCE_PATH}/GNU_LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libics)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libics/GNU_LICENSE ${CURRENT_PACKAGES_DIR}/share/libics/copyright)


### PR DESCRIPTION
This PR adds the libics package for reading/writing files in the image correlation spectroscopy (ics) format for scientific image data

See https://svi-opensource.github.io/libics/ for more information. 