### PR TITLE
Add more detailed error message for v142 + MSBuild

### DIFF
--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -109,7 +109,20 @@ function(vcpkg_configure_cmake)
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" AND VCPKG_PLATFORM_TOOLSET MATCHES "v141")
         set(GENERATOR "Visual Studio 15 2017")
         set(ARCH "ARM64")
+    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
+        if(NOT VCPKG_CMAKE_SYSTEM_NAME)
+            set(VCPKG_CMAKE_SYSTEM_NAME Windows)
+        endif()
+        message(FATAL_ERROR
+"Unable to determine appropriate CMake MSBuild generator for: ${VCPKG_CMAKE_SYSTEM_NAME}-${VCPKG_TARGET_ARCHITECTURE}-${VCPKG_PLATFORM_TOOLSET}.
+This is because CMake 3.12.4 does not currently have a 'Visual Studio 16 2019' option.
+This can be worked around by either:
+  1. Install Visual Studio 2017 Stable
+")
     else()
+        if(NOT VCPKG_CMAKE_SYSTEM_NAME)
+            set(VCPKG_CMAKE_SYSTEM_NAME Windows)
+        endif()
         message(FATAL_ERROR "Unable to determine appropriate generator for: ${VCPKG_CMAKE_SYSTEM_NAME}-${VCPKG_TARGET_ARCHITECTURE}-${VCPKG_PLATFORM_TOOLSET}")
     endif()
 


### PR DESCRIPTION
This PR adds a more descriptive error message when the user would try to use the v142 toolset in cmake via the MSBuild generator. In our current CMake version (3.12.4) this will fail.

Eventually updating to CMake 3.14[1] will remove this error case, however it will already require modification to the file (so this PR will not add an additional file to be modified upon updating cmake).

[1] https://cmake.org/cmake/help/v3.14/release/3.14.html
