### PR TITLE
Upgrade googletest to 2019-01-04 (b6cd405) version.

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,3 +1,3 @@
 Source: gtest
-Version: 1.8.1-1
+Version: 2019-01-04
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF release-1.8.1
-    SHA512 e6283c667558e1fd6e49fa96e52af0e415a3c8037afe1d28b7ff1ec4c2ef8f49beb70a9327b7fc77eb4052a58c4ccad8b5260ec90e4bceeac7a46ff59c4369d7
+    REF b6cd405286ed8635ece71c72f118e659f4ade3fb
+    SHA512 1642a9cf1923d00c52c346399941517787431dad3e6d3a5da07bc02243a231a95e30e0a9568ffd29bb9b9757f15c1c47d2d811c2bedb301f2d27cf912be0a534
     HEAD_REF master
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/0002-Fix-z7-override.patch


### PR DESCRIPTION
Compiled until Linux and Windows, and used `orc` to smoke test that packages that depend on it build too.
