### PR TITLE
[tbb] Build dll for static dependency on Windows

### DIFF
--- a/ports/tbb/CONTROL
+++ b/ports/tbb/CONTROL
@@ -1,3 +1,3 @@
 Source: tbb
-Version: 2019_U3
+Version: 2019_U3-1
 Description: Intel's Threading Building Blocks.

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -1,7 +1,10 @@
 include(vcpkg_common_functions)
 
 if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-  vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        message("tbb only supports dynamic library linkage")
+        set(VCPKG_LIBRARY_LINKAGE "dynamic")
+    endif()
 endif()
 
 vcpkg_from_github(


### PR DESCRIPTION
It's just fine (and sometimes highly desirable in practice due to potential interfering with Intel MKL binary installation) for a program with static linking to dynamic link to TBB.