### PR TITLE
[coroutine] add new port

### DIFF
--- a/ports/coroutine/CONTROL
+++ b/ports/coroutine/CONTROL
@@ -1,0 +1,4 @@
+Source: coroutine
+Version: 1.4.0
+Build-Depends: ms-gsl
+Description: C++ coroutine helper/example library

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -2,10 +2,10 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO luncliff/coroutine
-    REF be75a5dd2b2b85233b7260bc6aabeb924d8ebeb8
-    SHA512 edd8f9384ba75f10038892e55f0937edfdb8987affbee04d8f5680306fc3f72c69db4f84f31142b18edb24bb057f0c984d0b90de0adb0ca0521b0fece6dae523
-    HEAD_REF vcpkg
+    REPO            luncliff/coroutine
+    REF             1.4
+    SHA512          edd8f9384ba75f10038892e55f0937edfdb8987affbee04d8f5680306fc3f72c69db4f84f31142b18edb24bb057f0c984d0b90de0adb0ca0521b0fece6dae523
+    HEAD_REF        master
 )
 
 if(${VCPKG_TARGET_ARCHITECTURE} MATCHES x86)

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            luncliff/coroutine
     REF             1.4
-    SHA512          edd8f9384ba75f10038892e55f0937edfdb8987affbee04d8f5680306fc3f72c69db4f84f31142b18edb24bb057f0c984d0b90de0adb0ca0521b0fece6dae523
+    SHA512          981c9c728c7888995880a97e8533fa31f41085ef57e1c61e53e555f329d20d4a882d9de724d9e93e3d009dc3fe0669fe4d1af403654a9373e4aab44c933628a3
     HEAD_REF        master
 )
 
@@ -13,7 +13,7 @@ if(${VCPKG_TARGET_ARCHITECTURE} MATCHES x86)
 endif()
 
 # package: 'ms-gsl'
-message(STATUS "Using GSL with header path: ${CURRENT_INSTALLED_DIR}/include")
+message(STATUS "Using Guideline Support Library at ${CURRENT_INSTALLED_DIR}/include")
 
 set(DLL_LINKAGE false)
 if(${VCPKG_LIBRARY_LINKAGE} MATCHES dynamic)
@@ -39,7 +39,7 @@ file(
     RENAME      copyright
 )
 
-if(WIN32) # for win32, move dll files to bin
+if(WIN32 AND DLL_LINKAGE)
     file(INSTALL        ${CURRENT_PACKAGES_DIR}/debug/lib/coroutine.dll
          DESTINATION    ${CURRENT_PACKAGES_DIR}/debug/bin
     )

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -1,0 +1,29 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO luncliff/coroutine
+    REF b65dc006892e11cd4b0ada543927514b6945cfe2
+    SHA512 b3e58b024232a2c47755a50db8dce02dbabca57a107e67bc09c0829a4e4ca9c7bd652045159afc1a410ba0989e905116c17b834dd7469f21aa8731a5bb635907
+    HEAD_REF vcpkg
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        # package: 'ms-gsl'
+        -DGSL_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include
+        -DTEST_DISABLED=True
+)
+
+vcpkg_install_cmake()
+
+file(
+    INSTALL     ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/coroutine
+    RENAME      copyright
+)
+# removed duplicates in debug
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -3,10 +3,23 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO luncliff/coroutine
-    REF b65dc006892e11cd4b0ada543927514b6945cfe2
-    SHA512 b3e58b024232a2c47755a50db8dce02dbabca57a107e67bc09c0829a4e4ca9c7bd652045159afc1a410ba0989e905116c17b834dd7469f21aa8731a5bb635907
+    REF be75a5dd2b2b85233b7260bc6aabeb924d8ebeb8
+    SHA512 edd8f9384ba75f10038892e55f0937edfdb8987affbee04d8f5680306fc3f72c69db4f84f31142b18edb24bb057f0c984d0b90de0adb0ca0521b0fece6dae523
     HEAD_REF vcpkg
 )
+
+if(${VCPKG_TARGET_ARCHITECTURE} MATCHES x86)
+    message(FATAL_ERROR "This library doesn't support x86 arch. Please use x64 instead or contact maintainer")
+endif()
+
+# package: 'ms-gsl'
+message(STATUS "Using GSL with header path: ${CURRENT_INSTALLED_DIR}/include")
+
+set(DLL_LINKAGE false)
+if(${VCPKG_LIBRARY_LINKAGE} MATCHES dynamic)
+    message(STATUS "Using DLL linkage")
+    set(DLL_LINKAGE true)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -15,6 +28,7 @@ vcpkg_configure_cmake(
         # package: 'ms-gsl'
         -DGSL_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include
         -DTEST_DISABLED=True
+        -DBUILD_SHARED_LIBS=${DLL_LINKAGE}
 )
 
 vcpkg_install_cmake()
@@ -24,6 +38,21 @@ file(
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/coroutine
     RENAME      copyright
 )
+
+if(WIN32) # for win32, move dll files to bin
+    file(INSTALL        ${CURRENT_PACKAGES_DIR}/debug/lib/coroutine.dll
+         DESTINATION    ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+    file(REMOVE         ${CURRENT_PACKAGES_DIR}/debug/lib/coroutine.dll)
+
+    file(INSTALL        ${CURRENT_PACKAGES_DIR}/lib/coroutine.dll
+         DESTINATION    ${CURRENT_PACKAGES_DIR}/bin
+    )
+    file(REMOVE         ${CURRENT_PACKAGES_DIR}/lib/coroutine.dll)
+endif()
 # removed duplicates in debug
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# unset used variables
+unset(DLL_LINKAGE)


### PR DESCRIPTION
## Note
[C++ coroutine helper/example library](https://github.com/luncliff/coroutine)

### Build Type

Works both `static` and `dynamic`.

### Architecture

**`x64` only**. (`x86` is not available.)  
The purpose of this constraint is to unify supporting architecture. 

### Platform(Compiler)

In the vcpkg, the following platforms are available. 

* Windows (MSVC)
* Linux (Clang)
* Mac OS (AppleClang)

Sadly, GCC doesn't support C++ Coroutine now.  
Therefore non-msvc user have to specify their compiler to `clang` family.

```sh
export CC=clang-7 CXX=clang-7;
vcpkg install coroutine;
```

The library tests `clang-cl` build with AppVeyor CI, but it won't be a consideration until there is a request to support it.

