### PR TITLE
[minizip] Fix BZip2 Dependency on Linux

### DIFF
--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 find_package(ZLIB REQUIRED)
 
-find_package(Bzip2 REQUIRED)
+find_package(BZip2 REQUIRED)
 
 set(MIN_SRC contrib/minizip)
 


### PR DESCRIPTION
It was spelled `Bzip2` when the dependency was `BZip2`.

Fixes #3310.