### PR TITLE
[miniz] Add new port

### DIFF
--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7dd6309..479b4af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,9 +44,17 @@ endif()
+ # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
+ # target_link_libraries(miniz_tester miniz)
+ 
+-install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
+-    ARCHIVE  DESTINATION lib
+-    LIBRARY DESTINATION lib
++install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config
++    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     )
++export(TARGETS ${PROJECT_NAME}
++    NAMESPACE miniz::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
++)
++install(EXPORT ${PROJECT_NAME}Config
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/miniz"
++    NAMESPACE miniz::
++)
+ file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+ install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
+\ No newline at end of file

--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..14a6bc9 100644
+index 7dd6309..abeadb8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -8,11 +8,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
@@ -16,7 +16,17 @@ index 7dd6309..14a6bc9 100644
  
  set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
  set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
-@@ -44,9 +43,17 @@ endif()
+@@ -41,12 +40,27 @@ if(${UNIX})
+     target_link_libraries(example6 m)
+ endif()
+ 
++target_compile_definitions(example1 PRIVATE _CRT_SECURE_NO_WARNINGS)
++target_compile_definitions(example2 PRIVATE _CRT_SECURE_NO_WARNINGS)
++target_compile_definitions(example3 PRIVATE _CRT_SECURE_NO_WARNINGS)
++target_compile_definitions(example4 PRIVATE _CRT_SECURE_NO_WARNINGS)
++target_compile_definitions(example5 PRIVATE _CRT_SECURE_NO_WARNINGS)
++target_compile_definitions(example6 PRIVATE _CRT_SECURE_NO_WARNINGS)
++
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)
  

--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..479b4af 100644
+index 7dd6309..3dc74ff 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -44,9 +44,17 @@ endif()
+@@ -8,8 +8,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
+ CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
+ endif ()
+ 
+-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+-
+ set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
+ 
+ add_library(miniz ${miniz_SOURCE})
+@@ -44,9 +42,17 @@ endif()
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)
  
@@ -22,5 +31,6 @@ index 7dd6309..479b4af 100644
 +    NAMESPACE miniz::
 +)
  file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
- install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
+-install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
 \ No newline at end of file
++install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})

--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..3dc74ff 100644
+index 7dd6309..62f6fe9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -8,8 +8,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
+@@ -8,11 +8,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
  CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
  endif ()
  
@@ -10,7 +10,11 @@ index 7dd6309..3dc74ff 100644
 -
  set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
  
- add_library(miniz ${miniz_SOURCE})
+-add_library(miniz ${miniz_SOURCE})
++add_library(miniz STATIC ${miniz_SOURCE})
+ 
+ set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
+ set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
 @@ -44,9 +42,17 @@ endif()
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)

--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..abeadb8 100644
+index 7dd6309..eaf160f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -8,11 +8,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
+@@ -8,12 +8,12 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
  CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
  endif ()
  
@@ -14,9 +14,11 @@ index 7dd6309..abeadb8 100644
 +add_library(miniz STATIC ${miniz_SOURCE})
 +target_compile_definitions(miniz PRIVATE _CRT_SECURE_NO_WARNINGS)
  
++if(FALSE)
  set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
  set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
-@@ -41,12 +40,27 @@ if(${UNIX})
+ set(EXAMPLE3_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example3.c")
+@@ -41,12 +41,28 @@ if(${UNIX})
      target_link_libraries(example6 m)
  endif()
  
@@ -29,6 +31,7 @@ index 7dd6309..abeadb8 100644
 +
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)
++endif()
  
 -install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
 -    ARCHIVE  DESTINATION lib

--- a/ports/miniz/CMakeLists-targets.patch
+++ b/ports/miniz/CMakeLists-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..62f6fe9 100644
+index 7dd6309..14a6bc9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -8,11 +8,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
+@@ -8,11 +8,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "")
  CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
  endif ()
  
@@ -12,10 +12,11 @@ index 7dd6309..62f6fe9 100644
  
 -add_library(miniz ${miniz_SOURCE})
 +add_library(miniz STATIC ${miniz_SOURCE})
++target_compile_definitions(miniz PRIVATE _CRT_SECURE_NO_WARNINGS)
  
  set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
  set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
-@@ -44,9 +42,17 @@ endif()
+@@ -44,9 +43,17 @@ endif()
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)
  

--- a/ports/miniz/CONTROL
+++ b/ports/miniz/CONTROL
@@ -1,0 +1,3 @@
+Source: miniz
+Version: 2.0.8
+Description: Single C source file zlib-replacement library

--- a/ports/miniz/portfile.cmake
+++ b/ports/miniz/portfile.cmake
@@ -1,0 +1,25 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO richgel999/miniz
+    REF 2.0.8
+    SHA512 84b480df8bff63422d8c36cef3741f9b9f3dce13babf4de6cb4d575209978ad849357cc72bcf31ee8b6c5da6853ed2e5eddbbe16fecd689afd7028e834abf7e9
+    HEAD_REF master
+    PATCHES
+    	CMakeLists-targets.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/miniz RENAME copyright)
+
+vcpkg_test_cmake(PACKAGE_NAME miniz)

--- a/ports/miniz/portfile.cmake
+++ b/ports/miniz/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+    	-DBUILD_SHARED_LIBS=False
 )
 
 vcpkg_install_cmake()

--- a/ports/miniz/portfile.cmake
+++ b/ports/miniz/portfile.cmake
@@ -13,8 +13,6 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-    	-DBUILD_SHARED_LIBS=False
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This solves #5449 by adding https://github.com/richgel999/miniz to vcpkg under `miniz`. I tried to follow best cmake practices as much as is possible, but I may have gotten something not quite right.

I did add a patch to give the miniz cmake a proper config file for easy integration. I chose to do it via a patch because the last release was in September, so even if I get something in master, it will be a very long time until another release.

