### PR TITLE
[exiv2] Update exiv2 to 0.27 release, optionally support unicode on windows

### DIFF
--- a/ports/exiv2/CONTROL
+++ b/ports/exiv2/CONTROL
@@ -1,4 +1,7 @@
 Source: exiv2
-Version: 2018-11-08
-Build-Depends: zlib, expat, libiconv
+Version: 0.27
+Build-Depends: zlib, expat, libiconv, gettext
 Description: Image metadata library and tools http://www.exiv2.org
+
+Feature: unicode
+Description: Compile with unicode support on windows

--- a/ports/exiv2/iconv.patch
+++ b/ports/exiv2/iconv.patch
@@ -12,7 +12,7 @@ diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 91469b6..4c51068 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -208,14 +208,11 @@
+@@ -208,14 +208,14 @@
  endif()
  
  if( EXIV2_ENABLE_NLS )
@@ -26,6 +26,9 @@ index 91469b6..4c51068 100644
 -if( ICONV_FOUND )
 -    target_link_libraries( exiv2lib PRIVATE Iconv::Iconv )
 -endif()
++if(NOT TARGET unofficial::iconv::libiconv)
++    find_package(unofficial-iconv CONFIG)
++endif()
 +target_link_libraries( exiv2lib PRIVATE unofficial::iconv::libiconv )
  
  

--- a/ports/exiv2/iconv.patch
+++ b/ports/exiv2/iconv.patch
@@ -1,28 +1,33 @@
-diff --git a/cmake/findDependencies.cmake b/cmake/findDependencies.cmake
-index e220e2f..992b887 100644
 --- a/cmake/findDependencies.cmake
 +++ b/cmake/findDependencies.cmake
-@@ -50,7 +50,7 @@ if( EXIV2_ENABLE_NLS )
-     # the manual check in cmake/generateConfigFile.cmake
+@@ -36,5 +36,5 @@
+ 
+ 
+ if (EXIV2_ENABLE_NLS)
+-    find_package(Intl REQUIRED)
++    find_package(unofficial-gettext CONFIG)
  endif( )
  
--find_package(Iconv)
-+find_package(unofficial-iconv CONFIG REQUIRED)
- if( ICONV_FOUND )
-     message ( "-- ICONV_INCLUDE_DIR : " ${Iconv_INCLUDE_DIR} )
-     message ( "-- ICONV_LIBRARIES : " ${Iconv_LIBRARY} )
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 index 91469b6..4c51068 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -274,8 +274,8 @@ if( EXIV2_ENABLE_NLS )
-     target_link_libraries( exiv2lib PRIVATE  ${LIBINTL_LIBRARIES} )
+@@ -208,14 +208,11 @@
+ endif()
+ 
+ if( EXIV2_ENABLE_NLS )
+-    target_link_libraries(exiv2lib PRIVATE ${Intl_LIBRARIES})
+-    target_include_directories(exiv2lib PRIVATE ${Intl_INCLUDE_DIRS})
++    target_link_libraries(exiv2lib PRIVATE unofficial::gettext::libintl)
+     # Definition needed for translations
+     target_compile_definitions(exiv2lib PUBLIC EXV_LOCALEDIR="/../${CMAKE_INSTALL_LOCALEDIR}")
  endif()
  
 -if( ICONV_FOUND )
 -    target_link_libraries( exiv2lib PRIVATE Iconv::Iconv )
-+if( ICONV_FOUND OR 1 )
-+    target_link_libraries( exiv2lib PRIVATE unofficial::iconv::libiconv )
- endif()
+-endif()
++target_link_libraries( exiv2lib PRIVATE unofficial::iconv::libiconv )
  
+ 
+
  

--- a/ports/exiv2/portfile.cmake
+++ b/ports/exiv2/portfile.cmake
@@ -3,26 +3,44 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Exiv2/exiv2
-    REF 274ef04f7ebbff567135e732434c9c8353265d6c
-    SHA512 8e8d32a4c51da2a61026a4541885da72df88c3e30452944c5e2d2d8e6d8d03dcdea72c4e3bfe9673554453ddc547651d160cfba2bfab1450a1770f4af2be740a
+    REF 0.27
+    SHA512 ec605db73abcf3cc2df78c1fc3aae5335a51192f660668e39a4f20fc7f372b18c3cec9b704e1c71c356315fd75e791622de1dffe576432ee0fb12bf63a98a423
     HEAD_REF master
-    PATCHES iconv.patch
+    PATCHES
+        iconv.patch
 )
+
+if(WIN32 AND ("unicode" IN_LIST FEATURES))
+    set(enable_win_unicode TRUE)
+elseif()
+    set(enable_win_unicode FALSE)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DEXIV2_ENABLE_WIN_UNICODE:BOOL=${enable_win_unicode}
+        -DEXIV2_BUILD_EXIV2_COMMAND:BOOL=FALSE
+        -DEXIV2_BUILD_UNIT_TESTS:BOOL=FALSE
+        -DEXIV2_BUILD_SAMPLES:BOOL=FALSE
+#        -DEXIV2_ENABLE_NLS:BOOL=OFF
 )
 
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "share/exiv2/cmake")
 
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake
+    ${CURRENT_PACKAGES_DIR}/share/exiv2
+    @ONLY
+)
+
 vcpkg_copy_pdbs()
 
 # Clean
-file(GLOB EXE ${CURRENT_PACKAGES_DIR}/bin/*.exe ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share ${EXE} ${DEBUG_EXE})
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)

--- a/ports/exiv2/vcpkg-cmake-wrapper.cmake
+++ b/ports/exiv2/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,11 @@
+_find_package(${ARGS})
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+    find_package(unofficial-iconv CONFIG REQUIRED)
+    find_package(unofficial-gettext CONFIG REQUIRED)
+    if(TARGET exiv2lib)
+        set_property(TARGET exiv2lib APPEND PROPERTY INTERFACE_LINK_LIBRARIES 
+            unofficial::iconv::libiconv 
+            unofficial::gettext::libintl)
+    endif()
+endif()


### PR DESCRIPTION
This PR

* Updates exiv2 to the latest release, 0.27
* Optionally allows user to enable unicode support on windows using feature `unicode` - this is implemented as an option as exiv2 supports either ASCII or unicode paths but not both
* Adds a wrapper to allow consuming libraries to correctly locate iconv when build statically