### PR TITLE
[qt5-base] Fix hardcoded and wrong absolute paths in Qt5Core.dll

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-base
-Version: 5.12.1
+Version: 5.12.1-1
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/configure_qt.cmake
+++ b/ports/qt5-base/configure_qt.cmake
@@ -32,11 +32,11 @@ function(configure_qt)
             -debug
             -prefix ${CURRENT_INSTALLED_DIR}/debug
             -extprefix ${CURRENT_PACKAGES_DIR}/debug
-            -hostbindir ${CURRENT_PACKAGES_DIR}/debug/tools/qt5
-            -archdatadir ${CURRENT_PACKAGES_DIR}/share/qt5/debug
-            -datadir ${CURRENT_PACKAGES_DIR}/share/qt5/debug
-            -plugindir ${CURRENT_PACKAGES_DIR}/debug/plugins
-            -qmldir ${CURRENT_PACKAGES_DIR}/debug/qml
+            -hostbindir ${CURRENT_INSTALLED_DIR}/debug/tools/qt5
+            -archdatadir ${CURRENT_INSTALLED_DIR}/share/qt5/debug
+            -datadir ${CURRENT_INSTALLED_DIR}/share/qt5/debug
+            -plugindir ${CURRENT_INSTALLED_DIR}/debug/plugins
+            -qmldir ${CURRENT_INSTALLED_DIR}/debug/qml
             -headerdir ${CURRENT_PACKAGES_DIR}/include
             -I ${CURRENT_INSTALLED_DIR}/include
             -L ${CURRENT_INSTALLED_DIR}/debug/lib
@@ -53,11 +53,11 @@ function(configure_qt)
             -release
             -prefix ${CURRENT_INSTALLED_DIR}
             -extprefix ${CURRENT_PACKAGES_DIR}
-            -hostbindir ${CURRENT_PACKAGES_DIR}/tools/qt5
-            -archdatadir ${CURRENT_PACKAGES_DIR}/share/qt5
-            -datadir ${CURRENT_PACKAGES_DIR}/share/qt5
-            -plugindir ${CURRENT_PACKAGES_DIR}/plugins
-            -qmldir ${CURRENT_PACKAGES_DIR}/qml
+            -hostbindir ${CURRENT_INSTALLED_DIR}/tools/qt5
+            -archdatadir ${CURRENT_INSTALLED_DIR}/share/qt5
+            -datadir ${CURRENT_INSTALLED_DIR}/share/qt5
+            -plugindir ${CURRENT_INSTALLED_DIR}/plugins
+            -qmldir ${CURRENT_INSTALLED_DIR}/qml
             -I ${CURRENT_INSTALLED_DIR}/include
             -L ${CURRENT_INSTALLED_DIR}/lib
             -platform ${_csc_PLATFORM}


### PR DESCRIPTION
This PR changes the configuration parameters for the `qt5-base` port in order to fix #5455.

This reverts the reverting commit https://github.com/Microsoft/vcpkg/commit/473d63c#diff-ae2ab5cd22202159887c7d80ea952a4e as described in #5455.

Fixes #5455