### PR TITLE
[gettext] Set includes correctly in target

### DIFF
--- a/ports/gettext/CMakeLists.txt
+++ b/ports/gettext/CMakeLists.txt
@@ -3,8 +3,6 @@ project(libintl C)
 
 find_package(unofficial-iconv REQUIRED)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/config .)
-
 set(CMAKE_STATIC_LIBRARY_PREFIX)
 set(CMAKE_SHARED_LIBRARY_PREFIX)
 
@@ -23,6 +21,7 @@ else()
     set(HAVE_ASPRINTF 1)
     set(HAVE_WPRINTF 1)
     set(HAVE_NEWLOCALE 1)
+    add_definitions(-DHAVE_NEWLOCALE=1)
     add_definitions(-DHAVE_NEWLOCALE=1)
 
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
@@ -107,6 +106,12 @@ add_definitions("-DNO_XMALLOC -Dset_relocation_prefix=libintl_set_relocation_pre
 
 add_library(libintl ${SOURCES})
 target_link_libraries(libintl PRIVATE unofficial::iconv::libcharset unofficial::iconv::libiconv)
+
+target_include_directories(libintl PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/config>
+    $<INSTALL_INTERFACE:include>
+)
+
 if(APPLE)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
     target_link_libraries(libintl PRIVATE ${COREFOUNDATION_LIBRARY})
@@ -135,3 +140,8 @@ find_dependency(unofficial-iconv)
 find_dependency(Threads)
 include(\${CMAKE_CURRENT_LIST_DIR}/unofficial-gettext-targets.cmake)
 ")
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-gettext-config.cmake
+    DESTINATION share/unofficial-gettext
+)

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,4 +1,4 @@
 Source: gettext
-Version: 0.19-7
+Version: 0.19-8
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.
 Build-Depends: libiconv


### PR DESCRIPTION
This PR installs the gettext config file correctly and exports the library includes 
Fixes: #5435