### PR TITLE
[dlib] fix mac, windows-static build

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,5 +1,5 @@
 Source: dlib
-Version: 19.16
+Version: 19.16-1
 Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas, clapack
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
 

--- a/ports/dlib/fix-mac-jpeg.patch
+++ b/ports/dlib/fix-mac-jpeg.patch
@@ -1,0 +1,12 @@
+diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
+--- a/dlib/CMakeLists.txt
++++ b/dlib/CMakeLists.txt
+@@ -480,7 +480,7 @@
+             set(CMAKE_REQUIRED_LIBRARIES ${JPEG_LIBRARY})
+             CHECK_FUNCTION_EXISTS(jpeg_read_header LIBJPEG_IS_GOOD)
+          endif()
+-         if (JPEG_FOUND AND LIBJPEG_IS_GOOD AND NOT APPLE)
++         if (JPEG_FOUND AND LIBJPEG_IS_GOOD)
+             include_directories(${JPEG_INCLUDE_DIR})
+             set (dlib_needed_libraries ${dlib_needed_libraries} ${JPEG_LIBRARY})
+          else()

--- a/ports/dlib/fix-sqlite3-fftw-linkage.patch
+++ b/ports/dlib/fix-sqlite3-fftw-linkage.patch
@@ -1,0 +1,57 @@
+diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
+--- a/dlib/CMakeLists.txt
++++ b/dlib/CMakeLists.txt
+@@ -747,32 +750,15 @@
+ 
+ 
+       if (DLIB_LINK_WITH_SQLITE3)
+-         find_library(sqlite sqlite3)
+-         # make sure sqlite3.h is in the include path
+-         find_path(sqlite_path sqlite3.h)
+-         if (sqlite AND sqlite_path)
+-            set(dlib_needed_includes ${dlib_needed_includes} ${sqlite_path})
+-            set(dlib_needed_libraries ${dlib_needed_libraries} ${sqlite} )
+-         else()
+-            set(DLIB_LINK_WITH_SQLITE3 OFF CACHE STRING ${DLIB_LINK_WITH_SQLITE3_STR} FORCE )
+-         endif()
+-         mark_as_advanced(sqlite sqlite_path)
++         find_package(sqlite3 CONFIG)
++         set(dlib_needed_libraries ${dlib_needed_libraries} sqlite3 )
+       endif()
+ 
+ 
+ 
+       if (DLIB_USE_FFTW)
+-         find_library(fftw fftw3)
+-         # make sure fftw3.h is in the include path
+-         find_path(fftw_path fftw3.h)
+-         if (fftw AND fftw_path)
+-            set(dlib_needed_includes ${dlib_needed_includes} ${fftw_path})
+-            set(dlib_needed_libraries ${dlib_needed_libraries} ${fftw} )
+-         else()
+-            set(DLIB_USE_FFTW OFF CACHE STRING ${DLIB_USE_FFTW_STR} FORCE )
+-            toggle_preprocessor_switch(DLIB_USE_FFTW)
+-         endif()
+-         mark_as_advanced(fftw fftw_path)
++         find_package(FFTW3 CONFIG)
++         set(dlib_needed_libraries ${dlib_needed_libraries} FFTW3::fftw3)
+       endif()
+ 
+ 
+--- a/dlib/cmake_utils/dlibConfig.cmake.in
++++ b/dlib/cmake_utils/dlibConfig.cmake.in
+@@ -28,6 +28,14 @@
+    include("${dlib_CMAKE_DIR}/dlib.cmake")
+ endif()
+ 
++include(CMakeFindDependencyMacro)
++if("@DLIB_USE_FFTW@")
++   find_dependency(FFTW3 CONFIG)
++endif()
++if("@DLIB_LINK_WITH_SQLITE3@")
++   find_dependency(sqlite3 CONFIG)
++endif()
++
+ set(dlib_LIBRARIES dlib::dlib)
+ set(dlib_LIBS      dlib::dlib)
+ set(dlib_INCLUDE_DIRS "@CMAKE_INSTALL_FULL_INCLUDEDIR@" "@dlib_needed_includes@")

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -11,6 +11,9 @@ vcpkg_from_github(
     REF v19.16
     SHA512 4e040ef88acff05e1a48e499b813c876b22ad3f989d076bdf19969d01036b62e51a0dff30b70046910ba31dfa1b1c2450a7fad41ae3142b7285ed74b8d584887
     HEAD_REF master
+    PATCHES
+        fix-mac-jpeg.patch
+        fix-sqlite3-fftw-linkage.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/dlib/external/libjpeg)
@@ -40,6 +43,7 @@ vcpkg_configure_cmake(
         -DDLIB_USE_CUDA=${WITH_CUDA}
         -DDLIB_GIF_SUPPORT=OFF
         -DDLIB_USE_MKL_FFT=OFF
+        -DCMAKE_DEBUG_POSTFIX=d	
     OPTIONS_DEBUG
         -DDLIB_ENABLE_ASSERTS=ON
         #-DDLIB_ENABLE_STACK_TRACE=ON


### PR DESCRIPTION
This PR 
- Fixes dlib build on mac (remove apple-specific check for jpeg library - now uses dlib build)
- Fixes linkage of consuming projects to dependencies fftw and sqlite3 with a static build on windows