### PR TITLE
[libraw] Fix build release only issue

### DIFF
--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,4 +1,4 @@
 Source: libraw
-Version: 0.19.0-1
+Version: 0.19.0-2
 Build-Depends: lcms, jasper
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -52,13 +52,17 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     # because otherwise libraries that build on top of libraw have to choose.
     file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/raw.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
     file(RENAME ${CURRENT_PACKAGES_DIR}/lib/raw_r.lib ${CURRENT_PACKAGES_DIR}/lib/raw.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/raw_rd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
+    if(NOT VCPKG_BUILD_TYPE STREQUAL "release")
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/raw_rd.lib ${CURRENT_PACKAGES_DIR}/debug/lib/rawd.lib)
+    endif()
 
     # Cleanup
     file(GLOB RELEASE_EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/*.exe)
     file(REMOVE ${RELEASE_EXECUTABLES})
-    file(GLOB DEBUG_EXECUTABLES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-    file(REMOVE ${DEBUG_EXECUTABLES})
+    if(NOT VCPKG_BUILD_TYPE STREQUAL "release")
+        file(GLOB DEBUG_EXECUTABLES ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+        file(REMOVE ${DEBUG_EXECUTABLES})
+    endif()
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)


### PR DESCRIPTION
Issue in https://github.com/Microsoft/vcpkg/issues/3561. Build libraw for release only (VCPKG_BUILD_TYPE set to release in triplets), it failed with renaming files in debug folder.  