### PR TITLE
Fix debug format patch for gtest.

### DIFF
--- a/ports/gtest/0002-Fix-z7-override.patch
+++ b/ports/gtest/0002-Fix-z7-override.patch
@@ -1,13 +1,13 @@
 diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
-index 777b91e..75a13c9 100644
+index 99725b7..3c25b0a 100644
 --- a/googletest/cmake/internal_utils.cmake
 +++ b/googletest/cmake/internal_utils.cmake
-@@ -55,7 +55,7 @@ macro(config_compiler_and_linker)
+@@ -66,7 +66,7 @@ macro(config_compiler_and_linker)
    if (MSVC)
      # Newlines inside flags variables break CMake's NMake generator.
      # TODO(vladl@google.com): Add -RTCs and -RTCu to debug builds.
 -    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J -Zi")
 +    set(cxx_base_flags "-GS -W4 -WX -wd4251 -wd4275 -nologo -J")
-     if (MSVC_VERSION LESS 1400)  # 1400 is Visual Studio 2005
-       # Suppress spurious warnings MSVC 7.1 sometimes issues.
-       # Forcing value to bool.
+     set(cxx_base_flags "${cxx_base_flags} -D_UNICODE -DUNICODE -DWIN32 -D_WIN32")
+     set(cxx_base_flags "${cxx_base_flags} -DSTRICT -DWIN32_LEAN_AND_MEAN")
+     set(cxx_exception_flags "-EHsc -D_HAS_EXCEPTIONS=1")

--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,3 +1,3 @@
 Source: gtest
-Version: 2019-01-04
+Version: 2019-01-04-1
 Description: GoogleTest and GoogleMock testing frameworks.


### PR DESCRIPTION
The previous patch no longer applied. It's been revised to reflect the upstream changes.