### PR TITLE
[tiny-process-library] Add new port

### DIFF
--- a/ports/tiny-process-library/CONTROL
+++ b/ports/tiny-process-library/CONTROL
@@ -1,0 +1,3 @@
+Source: tiny-process-library
+Version: 2018-12-06
+Description: A small platform independent library

--- a/ports/tiny-process-library/fix-cmake.patch
+++ b/ports/tiny-process-library/fix-cmake.patch
@@ -1,0 +1,40 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ace2879..15c7f44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
+ project(tiny-process-library)
+ 
+ if(MSVC)
++  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+   add_definitions(/D_CRT_SECURE_NO_WARNINGS)
+ else()
+   add_compile_options(-std=c++11 -Wall -Wextra)
+@@ -23,7 +24,7 @@ endif()
+ find_package(Threads REQUIRED)
+ 
+ target_link_libraries(tiny-process-library ${CMAKE_THREAD_LIBS_INIT})
+-target_include_directories(tiny-process-library PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
++target_include_directories(tiny-process-library PUBLIC $<INSTALL_INTERFACE:include>)
+ 
+ option(BUILD_TESTING OFF)
+ 
+@@ -34,7 +35,17 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+   
+   set(BUILD_TESTING ON)
+   
+-  install(TARGETS tiny-process-library DESTINATION lib)
++  install(TARGETS tiny-process-library
++    EXPORT ${PROJECT_NAME}-config
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  )
++  install(EXPORT ${PROJECT_NAME}-config
++    FILE unofficial-${PROJECT_NAME}-config.cmake
++    NAMESPACE unofficial::${PROJECT_NAME}::
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unofficial-${PROJECT_NAME}
++  )
+   install(FILES process.hpp DESTINATION include)
+ endif()
+ 

--- a/ports/tiny-process-library/portfile.cmake
+++ b/ports/tiny-process-library/portfile.cmake
@@ -1,0 +1,39 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.com
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO eidheim/tiny-process-library
+    REF 273270d0f9d0cf4a8282fadd589060a7b0eab425
+    SHA512 f99e586ee6fa9b7c0a3633b59e0e099becba48e2ef375268eeecd9099a233e3b528ba373edc74983d49934ff10f99884fdeb594ff546054fc91d1341d0e86c0a
+    HEAD_REF master
+    PATCHES
+        fix-cmake.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH lib/cmake/unofficial-${PORT}
+    TARGET_PATH share/unofficial-${PORT}
+)
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
+)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+# CMake integration test
+#vcpkg_test_cmake(PACKAGE_NAME ${PORT})


### PR DESCRIPTION
Tested with:

* [x] x86-windows
* [x] x86-windows-static
* [x] x64-windows
* [x] x64-windows-static
* [x] x64-linux

Test project: https://github.com/myd7349/Ongoing-Study/tree/master/cpp/CMake/vcpkg/tiny_process_library_example

These triplets are not supported:

* x86-uwp
* x64-uwp

Other triplets are not tested.