### PR TITLE
[glslang] Export CMake package files

### DIFF
--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -8,7 +8,7 @@ index 5bb3f0ee..1e248b55 100644
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OGLCompiler
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS OGLCompiler EXPORT OGLCompilerConfig
++    install(TARGETS OGLCompiler EXPORT glslangConfig
 +            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
@@ -17,7 +17,7 @@ index 5bb3f0ee..1e248b55 100644
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OGLCompiler-config.cmake"
 +    )
 +    install(
-+        EXPORT OGLCompilerConfig
++        EXPORT glslangConfig
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
@@ -58,7 +58,7 @@ index 1bf49e12..bd02ca1e 100644
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OSDependent
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS OSDependent EXPORT OSDependentConfig
++    install(TARGETS OSDependent EXPORT glslangConfig
 +            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
@@ -67,7 +67,7 @@ index 1bf49e12..bd02ca1e 100644
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
 +    install(
-+        EXPORT OSDependentConfig
++        EXPORT glslangConfig
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
@@ -82,7 +82,7 @@ index f257418a..ed2d208d 100644
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OSDependent
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS OSDependent EXPORT OSDependentConfig
++    install(TARGETS OSDependent EXPORT glslangConfig
 +            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
@@ -91,7 +91,7 @@ index f257418a..ed2d208d 100644
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
 +    install(
-+        EXPORT OSDependentConfig
++        EXPORT glslangConfig
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
@@ -106,7 +106,7 @@ index 98dfad7c..1fe4a5cb 100755
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS HLSL
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS HLSL EXPORT HLSLConfig
++    install(TARGETS HLSL EXPORT glslangConfig
 +            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
@@ -115,7 +115,7 @@ index 98dfad7c..1fe4a5cb 100755
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/HLSL-config.cmake"
 +    )
 +    install(
-+        EXPORT HLSLConfig
++        EXPORT glslangConfig
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,3 +1,13 @@
+diff --git a/ChooseMSVCCRT.cmake b/ChooseMSVCCRT.cmake
+index 2097881..f0cddd7 100644
+--- a/ChooseMSVCCRT.cmake
++++ b/ChooseMSVCCRT.cmake
+@@ -102,4 +102,4 @@ set(MSVC_CRT
+   MT
+   MTd)
+ 
+-choose_msvc_crt(MSVC_CRT)
++# choose_msvc_crt(MSVC_CRT)
 diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
 index 5bb3f0ee..1e248b55 100644
 --- a/OGLCompilersDLL/CMakeLists.txt

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,17 +1,3 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0d453cc6..ae4713b7 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -45,9 +45,6 @@ endif(ENABLE_HLSL)
-
- if(WIN32)
-     set(CMAKE_DEBUG_POSTFIX "d")
--    if(MSVC)
--        include(ChooseMSVCCRT.cmake)
--    endif(MSVC)
-     add_definitions(-DGLSLANG_OSINCLUDE_WIN32)
- elseif(UNIX)
-     add_definitions(-DGLSLANG_OSINCLUDE_UNIX)
 diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
 index 5bb3f0ee..1e248b55 100644
 --- a/OGLCompilersDLL/CMakeLists.txt

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -119,4 +119,4 @@ index 98dfad7c..1fe4a5cb 100755
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
-endif(ENABLE_GLSLANG_INSTALL)
+ endif(ENABLE_GLSLANG_INSTALL)

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,120 +1,122 @@
 diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
-index 5bb3f0ee..cc938722 100644
+index 5bb3f0ee..1e248b55 100644
 --- a/OGLCompilersDLL/CMakeLists.txt
 +++ b/OGLCompilersDLL/CMakeLists.txt
-@@ -9,6 +9,16 @@ if(WIN32)
+@@ -9,6 +9,17 @@ if(WIN32)
  endif(WIN32)
-
+ 
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OGLCompiler
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +    install(TARGETS OGLCompiler EXPORT OGLCompilerConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
 +    export(TARGETS OGLCompiler
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/OGLCompiler-config.cmake"
++           NAMESPACE glslang::
++           FILE "${CMAKE_CURRENT_BINARY_DIR}/OGLCompiler-config.cmake"
 +    )
-+    install(EXPORT OGLCompilerConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OGLCompiler"
-+        NAMESPACE glslang::
-+    )
- endif(ENABLE_GLSLANG_INSTALL)
-diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
-index 7a50ab67..bfa4840c 100644
---- a/glslang/CMakeLists.txt
-+++ b/glslang/CMakeLists.txt
-@@ -97,8 +97,18 @@ if(WIN32)
- endif(WIN32)
-
- if(ENABLE_GLSLANG_INSTALL)
--    install(TARGETS glslang
--            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS glslang EXPORT glslangConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    )
-+    export(TARGETS glslang
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
-+    )
-+    install(EXPORT glslangConfig
++    install(
++        EXPORT OGLCompilerConfig
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
  endif(ENABLE_GLSLANG_INSTALL)
-
+diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
+index 7a50ab67..b70345ea 100644
+--- a/glslang/CMakeLists.txt
++++ b/glslang/CMakeLists.txt
+@@ -97,8 +97,19 @@ if(WIN32)
+ endif(WIN32)
+ 
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS glslang
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS glslang EXPORT glslangConfig
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS glslang
++           NAMESPACE glslang::
++           FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
++    )
++    install(
++        EXPORT glslangConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
++        NAMESPACE glslang::
++    )
+ endif(ENABLE_GLSLANG_INSTALL)
+ 
  if(ENABLE_GLSLANG_INSTALL)
 diff --git a/glslang/OSDependent/Unix/CMakeLists.txt b/glslang/OSDependent/Unix/CMakeLists.txt
-index 1bf49e12..eda00efe 100644
+index 1bf49e12..bd02ca1e 100644
 --- a/glslang/OSDependent/Unix/CMakeLists.txt
 +++ b/glslang/OSDependent/Unix/CMakeLists.txt
-@@ -3,6 +3,16 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
+@@ -3,6 +3,17 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
  set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
-
+ 
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OSDependent
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +    install(TARGETS OSDependent EXPORT OSDependentConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
 +    export(TARGETS OSDependent
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
++           NAMESPACE glslang::
++           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
-+    install(EXPORT OSDependentConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OSDependent"
++    install(
++        EXPORT OSDependentConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
  endif(ENABLE_GLSLANG_INSTALL)
 diff --git a/glslang/OSDependent/Windows/CMakeLists.txt b/glslang/OSDependent/Windows/CMakeLists.txt
-index f257418a..1a392ad7 100644
+index f257418a..ed2d208d 100644
 --- a/glslang/OSDependent/Windows/CMakeLists.txt
 +++ b/glslang/OSDependent/Windows/CMakeLists.txt
-@@ -15,6 +15,16 @@ if(WIN32)
+@@ -15,6 +15,17 @@ if(WIN32)
  endif(WIN32)
-
+ 
  if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS OSDependent
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +    install(TARGETS OSDependent EXPORT OSDependentConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
 +    export(TARGETS OSDependent
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
++           NAMESPACE glslang::
++           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
-+    install(EXPORT OSDependentConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OSDependent"
++    install(
++        EXPORT OSDependentConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
  endif(ENABLE_GLSLANG_INSTALL)
 diff --git a/hlsl/CMakeLists.txt b/hlsl/CMakeLists.txt
-index 98dfad7c..1def8811 100755
+index 98dfad7c..1fe4a5cb 100755
 --- a/hlsl/CMakeLists.txt
 +++ b/hlsl/CMakeLists.txt
-@@ -25,7 +25,17 @@ if(WIN32)
-     source_group("Source" FILES ${SOURCES} ${HEADERS})
+@@ -26,6 +26,17 @@ if(WIN32)
  endif(WIN32)
-
--if(ENABLE_GLSLANG_INSTALL)
+ 
+ if(ENABLE_GLSLANG_INSTALL)
 -    install(TARGETS HLSL
 -            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
--endif(ENABLE_GLSLANG_INSTALL)
-+if(ENABLE_HLSL_INSTALL)
 +    install(TARGETS HLSL EXPORT HLSLConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
 +    export(TARGETS HLSL
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/HLSL-config.cmake"
++           NAMESPACE glslang::
++           FILE "${CMAKE_CURRENT_BINARY_DIR}/HLSL-config.cmake"
 +    )
-+    install(EXPORT HLSLConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/HLSL"
++    install(
++        EXPORT HLSLConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
-+endif(ENABLE_HLSL_INSTALL)
+endif(ENABLE_GLSLANG_INSTALL)

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,3 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d453cc6..ae4713b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,9 +45,6 @@ endif(ENABLE_HLSL)
+
+ if(WIN32)
+     set(CMAKE_DEBUG_POSTFIX "d")
+-    if(MSVC)
+-        include(ChooseMSVCCRT.cmake)
+-    endif(MSVC)
+     add_definitions(-DGLSLANG_OSINCLUDE_WIN32)
+ elseif(UNIX)
+     add_definitions(-DGLSLANG_OSINCLUDE_UNIX)
 diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
 index 5bb3f0ee..1e248b55 100644
 --- a/OGLCompilersDLL/CMakeLists.txt
@@ -119,4 +133,29 @@ index 98dfad7c..1fe4a5cb 100755
 +        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
 +        NAMESPACE glslang::
 +    )
+ endif(ENABLE_GLSLANG_INSTALL)
+diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
+index b6824192..f01d0f3b 100755
+--- a/SPIRV/CMakeLists.txt
++++ b/SPIRV/CMakeLists.txt
+@@ -64,8 +64,18 @@ if(WIN32)
+ endif(WIN32)
+
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS SPIRV SPVRemapper
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS SPIRV EXPORT glslangConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS SPIRV
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
++    )
++    install(EXPORT glslangConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
++        NAMESPACE glslang::
++    )
+
+     install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SPIRV/)
  endif(ENABLE_GLSLANG_INSTALL)

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,22 +1,120 @@
+diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
+index 5bb3f0ee..cc938722 100644
+--- a/OGLCompilersDLL/CMakeLists.txt
++++ b/OGLCompilersDLL/CMakeLists.txt
+@@ -9,6 +9,16 @@ if(WIN32)
+ endif(WIN32)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7dd6309..eaf160f 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -121,18 +121,18 @@        install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/${dir})
-    endforeach()
-endif(ENABLE_GLSLANG_INSTALL)
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS OGLCompiler
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS OGLCompiler EXPORT OGLCompilerConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS OGLCompiler
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/OGLCompiler-config.cmake"
++    )
++    install(EXPORT OGLCompilerConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OGLCompiler"
++        NAMESPACE glslang::
++    )
+ endif(ENABLE_GLSLANG_INSTALL)
+diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
+index 7a50ab67..bfa4840c 100644
+--- a/glslang/CMakeLists.txt
++++ b/glslang/CMakeLists.txt
+@@ -97,8 +97,18 @@ if(WIN32)
+ endif(WIN32)
 
-+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config
-+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+     )
-+export(TARGETS ${PROJECT_NAME}
-+    NAMESPACE glslang::
-+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-+)
-+install(EXPORT ${PROJECT_NAME}Config
-+    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+    NAMESPACE glslang::
-+)
-+install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS glslang
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS glslang EXPORT glslangConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS glslang
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
++    )
++    install(EXPORT glslangConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
++        NAMESPACE glslang::
++    )
+ endif(ENABLE_GLSLANG_INSTALL)
+
+ if(ENABLE_GLSLANG_INSTALL)
+diff --git a/glslang/OSDependent/Unix/CMakeLists.txt b/glslang/OSDependent/Unix/CMakeLists.txt
+index 1bf49e12..eda00efe 100644
+--- a/glslang/OSDependent/Unix/CMakeLists.txt
++++ b/glslang/OSDependent/Unix/CMakeLists.txt
+@@ -3,6 +3,16 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
+ set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS OSDependent
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS OSDependent EXPORT OSDependentConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS OSDependent
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
++    )
++    install(EXPORT OSDependentConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OSDependent"
++        NAMESPACE glslang::
++    )
+ endif(ENABLE_GLSLANG_INSTALL)
+diff --git a/glslang/OSDependent/Windows/CMakeLists.txt b/glslang/OSDependent/Windows/CMakeLists.txt
+index f257418a..1a392ad7 100644
+--- a/glslang/OSDependent/Windows/CMakeLists.txt
++++ b/glslang/OSDependent/Windows/CMakeLists.txt
+@@ -15,6 +15,16 @@ if(WIN32)
+ endif(WIN32)
+
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS OSDependent
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS OSDependent EXPORT OSDependentConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS OSDependent
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
++    )
++    install(EXPORT OSDependentConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/OSDependent"
++        NAMESPACE glslang::
++    )
+ endif(ENABLE_GLSLANG_INSTALL)
+diff --git a/hlsl/CMakeLists.txt b/hlsl/CMakeLists.txt
+index 98dfad7c..1def8811 100755
+--- a/hlsl/CMakeLists.txt
++++ b/hlsl/CMakeLists.txt
+@@ -25,7 +25,17 @@ if(WIN32)
+     source_group("Source" FILES ${SOURCES} ${HEADERS})
+ endif(WIN32)
+
+-if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS HLSL
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-endif(ENABLE_GLSLANG_INSTALL)
++if(ENABLE_HLSL_INSTALL)
++    install(TARGETS HLSL EXPORT HLSLConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    )
++    export(TARGETS HLSL
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/HLSL-config.cmake"
++    )
++    install(EXPORT HLSLConfig
++        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/HLSL"
++        NAMESPACE glslang::
++    )
++endif(ENABLE_HLSL_INSTALL)

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -9,10 +9,10 @@ index 2097881..f0cddd7 100644
 -choose_msvc_crt(MSVC_CRT)
 +# choose_msvc_crt(MSVC_CRT)
 diff --git a/OGLCompilersDLL/CMakeLists.txt b/OGLCompilersDLL/CMakeLists.txt
-index 5bb3f0ee..1e248b55 100644
+index 5bb3f0e..e7be6e6 100644
 --- a/OGLCompilersDLL/CMakeLists.txt
 +++ b/OGLCompilersDLL/CMakeLists.txt
-@@ -9,6 +9,17 @@ if(WIN32)
+@@ -9,6 +9,12 @@ if(WIN32)
  endif(WIN32)
  
  if(ENABLE_GLSLANG_INSTALL)
@@ -26,14 +26,30 @@ index 5bb3f0ee..1e248b55 100644
 +           NAMESPACE glslang::
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OGLCompiler-config.cmake"
 +    )
-+    install(
-+        EXPORT glslangConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+        NAMESPACE glslang::
+ endif(ENABLE_GLSLANG_INSTALL)
+diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
+index b682419..3a10f1a 100755
+--- a/SPIRV/CMakeLists.txt
++++ b/SPIRV/CMakeLists.txt
+@@ -64,8 +64,14 @@ if(WIN32)
+ endif(WIN32)
+ 
+ if(ENABLE_GLSLANG_INSTALL)
+-    install(TARGETS SPIRV SPVRemapper
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    install(TARGETS SPIRV EXPORT glslangConfig
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    )
++    export(TARGETS SPIRV
++        NAMESPACE glslang::
++        FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
++    )
+ 
+     install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SPIRV/)
  endif(ENABLE_GLSLANG_INSTALL)
 diff --git a/glslang/CMakeLists.txt b/glslang/CMakeLists.txt
-index 7a50ab67..b70345ea 100644
+index 7a50ab6..b70345e 100644
 --- a/glslang/CMakeLists.txt
 +++ b/glslang/CMakeLists.txt
 @@ -97,8 +97,19 @@ if(WIN32)
@@ -59,10 +75,10 @@ index 7a50ab67..b70345ea 100644
  
  if(ENABLE_GLSLANG_INSTALL)
 diff --git a/glslang/OSDependent/Unix/CMakeLists.txt b/glslang/OSDependent/Unix/CMakeLists.txt
-index 1bf49e12..bd02ca1e 100644
+index 1bf49e1..edd733c 100644
 --- a/glslang/OSDependent/Unix/CMakeLists.txt
 +++ b/glslang/OSDependent/Unix/CMakeLists.txt
-@@ -3,6 +3,17 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
+@@ -3,6 +3,12 @@ set_property(TARGET OSDependent PROPERTY FOLDER glslang)
  set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
  
  if(ENABLE_GLSLANG_INSTALL)
@@ -76,17 +92,12 @@ index 1bf49e12..bd02ca1e 100644
 +           NAMESPACE glslang::
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
-+    install(
-+        EXPORT glslangConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+        NAMESPACE glslang::
-+    )
  endif(ENABLE_GLSLANG_INSTALL)
 diff --git a/glslang/OSDependent/Windows/CMakeLists.txt b/glslang/OSDependent/Windows/CMakeLists.txt
-index f257418a..ed2d208d 100644
+index f257418..cadd70d 100644
 --- a/glslang/OSDependent/Windows/CMakeLists.txt
 +++ b/glslang/OSDependent/Windows/CMakeLists.txt
-@@ -15,6 +15,17 @@ if(WIN32)
+@@ -15,6 +15,12 @@ if(WIN32)
  endif(WIN32)
  
  if(ENABLE_GLSLANG_INSTALL)
@@ -100,17 +111,12 @@ index f257418a..ed2d208d 100644
 +           NAMESPACE glslang::
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/OSDependent-config.cmake"
 +    )
-+    install(
-+        EXPORT glslangConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+        NAMESPACE glslang::
-+    )
  endif(ENABLE_GLSLANG_INSTALL)
 diff --git a/hlsl/CMakeLists.txt b/hlsl/CMakeLists.txt
-index 98dfad7c..1fe4a5cb 100755
+index 98dfad7..94d96a0 100755
 --- a/hlsl/CMakeLists.txt
 +++ b/hlsl/CMakeLists.txt
-@@ -26,6 +26,17 @@ if(WIN32)
+@@ -26,6 +26,12 @@ if(WIN32)
  endif(WIN32)
  
  if(ENABLE_GLSLANG_INSTALL)
@@ -124,34 +130,4 @@ index 98dfad7c..1fe4a5cb 100755
 +           NAMESPACE glslang::
 +           FILE "${CMAKE_CURRENT_BINARY_DIR}/HLSL-config.cmake"
 +    )
-+    install(
-+        EXPORT glslangConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+        NAMESPACE glslang::
-+    )
- endif(ENABLE_GLSLANG_INSTALL)
-diff --git a/SPIRV/CMakeLists.txt b/SPIRV/CMakeLists.txt
-index b6824192..f01d0f3b 100755
---- a/SPIRV/CMakeLists.txt
-+++ b/SPIRV/CMakeLists.txt
-@@ -64,8 +64,18 @@ if(WIN32)
- endif(WIN32)
-
- if(ENABLE_GLSLANG_INSTALL)
--    install(TARGETS SPIRV SPVRemapper
--            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+    install(TARGETS SPIRV EXPORT glslangConfig
-+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    )
-+    export(TARGETS SPIRV
-+        NAMESPACE glslang::
-+        FILE "${CMAKE_CURRENT_BINARY_DIR}/glslang-config.cmake"
-+    )
-+    install(EXPORT glslangConfig
-+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
-+        NAMESPACE glslang::
-+    )
-
-     install(FILES ${HEADERS} ${SPVREMAP_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SPIRV/)
  endif(ENABLE_GLSLANG_INSTALL)

--- a/ports/glslang/CMakeLists-targets.patch
+++ b/ports/glslang/CMakeLists-targets.patch
@@ -1,0 +1,22 @@
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7dd6309..eaf160f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -121,18 +121,18 @@        install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/glslang/${dir})
+    endforeach()
+endif(ENABLE_GLSLANG_INSTALL)
+
++install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config
++    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++     )
++export(TARGETS ${PROJECT_NAME}
++    NAMESPACE glslang::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
++)
++install(EXPORT ${PROJECT_NAME}Config
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/glslang"
++    NAMESPACE glslang::
++)
++install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -27,3 +27,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/glslang)
+
+vcpkg_test_cmake(PACKAGE_NAME glslang)

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/glslang)

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -8,12 +8,14 @@ vcpkg_from_github(
   REF b5b5f918c6b72d7cf2ee73641cc6c6ddb211ca70
   SHA512 ec0f7a23fa60457a481c7b3acf4c127c3bf898d23655d346aeafb304f74e798d632c83d676873f2c764d241de6dc4392cff8d6ce0ee509a4b74ee2233b01c008
   HEAD_REF master
+  PATCHES
+    CMakeLists-targets.patch
 )
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
-  OPTIONS -DCMAKE_DEBUG_POSTFIX=d
+  OPTIONS -DCMAKE_DEBUG_POSTFIX=d -DSKIP_GLSLANG_INSTALL=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
I've added a file to patch `glslang`'s CMake files so that `glslang` can be used as a CMake package and can be used in a project with the `find_package` command