### PR TITLE
[libwebm] Fix no-postfix in debug for dll/lib/pdb

### DIFF
--- a/ports/libwebm/CONTROL
+++ b/ports/libwebm/CONTROL
@@ -1,3 +1,3 @@
 Source: libwebm
-Version: 1.0.0.27-3
+Version: 1.0.0.27-4
 Description: WebM File Parser

--- a/ports/libwebm/portfile.cmake
+++ b/ports/libwebm/portfile.cmake
@@ -24,7 +24,17 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+if((NOT VCPKG_CMAKE_SYSTEM_NAME) AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/libwebm.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libwebmd.dll)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/webm.lib ${CURRENT_PACKAGES_DIR}/debug/lib/webmd.lib)
+endif()
+
 vcpkg_copy_pdbs()
+
+if((NOT VCPKG_CMAKE_SYSTEM_NAME) AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/libwebm.pdb ${CURRENT_PACKAGES_DIR}/debug/bin/libwebmd.pdb)
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
Issue related with: **https://github.com/Microsoft/vcpkg/issues/4878**, all debug libraries should have some postfix "d"