### PR TITLE
[gtest] Fix install src/gtest-matchers.cc

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,3 +1,3 @@
 Source: gtest
-Version: 2019-01-04-1
+Version: 2019-01-04-2
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -37,6 +37,7 @@ file(
         "${SOURCE_PATH}/googletest/src/gtest-death-test.cc"
         "${SOURCE_PATH}/googletest/src/gtest-filepath.cc"
         "${SOURCE_PATH}/googletest/src/gtest-internal-inl.h"
+        "${SOURCE_PATH}/googletest/src/gtest-matchers.cc"
         "${SOURCE_PATH}/googletest/src/gtest-port.cc"
         "${SOURCE_PATH}/googletest/src/gtest-printers.cc"
         "${SOURCE_PATH}/googletest/src/gtest-test-part.cc"


### PR DESCRIPTION
Fix install src/gtest-matchers.cc.
It is included in googletest since Nov 21, 2018.