### PR TITLE
[vulkan] Add usage information

### DIFF
--- a/ports/vulkan/usage
+++ b/ports/vulkan/usage
@@ -1,0 +1,9 @@
+The package vulkan does not provide cmake or visual studio integration directly.
+However, it can still easily be used.
+
+    Visual Studio:
+    Include ${VULKAN_SDK}/include to your include path.
+
+    CMake:
+    find_package(Vulkan REQUIRED)
+    target_link_libraries(main PRIVATE Vulkan::Vulkan)


### PR DESCRIPTION
This resolves #5496 by adding proper information on how to use the vulkan port, as it does not follow the standard paradigms of vspkg. 