### PR TITLE
[minitrace] Add new port

### DIFF
--- a/ports/minitrace/CMakeLists.txt
+++ b/ports/minitrace/CMakeLists.txt
@@ -7,7 +7,7 @@ set(minitrace_SOURCES minitrace.c)
 add_library(minitrace ${minitrace_SOURCES})
 
 # Install headers
-install(FILES ${minitrace_HEADERS} DESTINATION include)
+install(FILES ${minitrace_HEADERS} DESTINATION include/minitrace)
 
 # Install minitrace
 install(

--- a/ports/minitrace/CMakeLists.txt
+++ b/ports/minitrace/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+project(minitrace C)
+
+set(minitrace_HEADERS minitrace.h)
+set(minitrace_SOURCES minitrace.c)
+
+add_library(minitrace ${minitrace_SOURCES})
+
+# Install headers
+install(FILES ${minitrace_HEADERS} DESTINATION include)
+
+# Install minitrace
+install(
+	TARGETS minitrace EXPORT minitraceConfig
+	RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+# Export config file for minitrace
+export(
+	TARGETS minitrace
+	NAMESPACE minitrace::
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/minitrace-config.cmake"
+)
+
+# Install config file
+install(
+	EXPORT minitraceConfig
+	DESTINATION "${CMAKE_INSTALL_PREFIX}/share/minitrace"
+	NAMESPACE minitrace::
+)

--- a/ports/minitrace/CONTROL
+++ b/ports/minitrace/CONTROL
@@ -1,0 +1,3 @@
+Source: minitrace
+Version: 2019.02.06
+Description: Simple C/C++ library for producing JSON traces suitable for Chrome's built-in trace viewer.

--- a/ports/minitrace/portfile.cmake
+++ b/ports/minitrace/portfile.cmake
@@ -1,0 +1,28 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO hrydgard/minitrace
+    REF a48215c409dd848fa0a76c5eb4dfaba4ca3bca39
+    SHA512 591fa52132b6bbe8e7e121526a43d07056deff8fe026227c1a4c26bebf95536e5d68750fa8551d23afebf048fe8b8503017b9a93650e18a992cf2e5678d46135
+    HEAD_REF master
+)
+
+file(COPY ${CURRENT_PORT_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/minitrace RENAME copyright)
+
+vcpkg_test_cmake(PACKAGE_NAME minitrace)


### PR DESCRIPTION
This adds the very small minitrace library to vcpkg. https://github.com/hrydgard/minitrace

There is no official version number, so I used the date of the last commit.

Minitrace can only be built as a static library as it doesn't have `dllimport`/`dllexport` statements.

I have provided a CMakeLists.txt to build the library. It is very simple as the library is extremely easy to build.

Locally tested all triplets except mac.