### PR TITLE
[readerwriterqueue] Change include path to not polute main directory

### DIFF
--- a/ports/readerwriterqueue/CONTROL
+++ b/ports/readerwriterqueue/CONTROL
@@ -1,3 +1,3 @@
 Source: readerwriterqueue
-Version: 1.0.0
+Version: 1.0.0-1
 Description: A single-producer, single-consumer lock-free queue

--- a/ports/readerwriterqueue/portfile.cmake
+++ b/ports/readerwriterqueue/portfile.cmake
@@ -12,4 +12,4 @@ vcpkg_from_github(
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/readerwriterqueue RENAME copyright)
 
 file(GLOB HEADER_FILES ${SOURCE_PATH}/*.h)
-file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/readerwriterqueue)


### PR DESCRIPTION
It feels wrong to me to drop the include files for the readerwriterqueue in the main include folder without prefixing it with a folder specifically for the package. Yes the names aren't particularly common, but it seems like good practice.

Because of the versioning #5535 should probably merge _after_ this one.