### PR TITLE
[mongo-c-driver]Solve the problem of dll name and lib name mismatch, set to "libmongoc-1.0"

### DIFF
--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-c-driver
-Version: 1.9.5-3
+Version: 1.9.5-4
 Build-Depends: libbson, openssl (uwp)
 Description: Client library written in C for MongoDB.

--- a/ports/mongo-c-driver/fix-lib-name.patch
+++ b/ports/mongo-c-driver/fix-lib-name.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6938cb8..fdd3f65 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -641,7 +641,7 @@ target_compile_definitions (mongoc_shared PUBLIC MONGOC_COMPILATION ${BSON_DEFIN
+ # https://cmake.org/pipermail/cmake/2007-September/016501.html
+ # This hack sets up standard symlink, libmongoc-1.0.so -> libmongoc-1.0.0.so
+ set_target_properties(mongoc_shared PROPERTIES VERSION 0 SOVERSION ${MONGOC_MAJOR_VERSION})
+-set_target_properties(mongoc_shared PROPERTIES OUTPUT_NAME "mongoc-${MONGOC_API_VERSION}" PREFIX "lib")
++set_target_properties(mongoc_shared PROPERTIES OUTPUT_NAME "libmongoc-${MONGOC_API_VERSION}")
+ endif ()
+ 
+ if (MONGOC_ENABLE_STATIC)
+@@ -650,7 +650,7 @@ if (MONGOC_ENABLE_STATIC)
+    target_include_directories (mongoc_static BEFORE PUBLIC ${BSON_STATIC_INCLUDE_DIRS} ${MONGOC_INTERNAL_INCLUDE_DIRS})
+    target_compile_definitions (mongoc_static PUBLIC MONGOC_COMPILATION MONGOC_STATIC ${BSON_STATIC_DEFINITIONS})
+    set_target_properties(mongoc_static PROPERTIES VERSION ${MONGOC_VERSION})
+-   set_target_properties(mongoc_static PROPERTIES OUTPUT_NAME "mongoc-static-${MONGOC_API_VERSION}")
++   set_target_properties(mongoc_static PROPERTIES OUTPUT_NAME "libmongoc-static-${MONGOC_API_VERSION}")
+ endif ()
+ 
+ function(mongoc_add_test test use_shared)

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -5,7 +5,9 @@ vcpkg_from_github(
     REF 1.9.5
     SHA512 bee584c83bb317802eb855fececc98f2013d7c3134f063c3146521ab535c8a89c2dfe89ccfa6ebbe2d7c64edec0e53105ead361da83b885c7778b40e4801de62
     HEAD_REF master
-    PATCHES fix-uwp.patch
+    PATCHES
+        fix-uwp.patch
+        fix-lib-name.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -59,11 +61,11 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
             ${CURRENT_PACKAGES_DIR}/debug/lib/libmongoc-1.0.a)
     else()
         file(RENAME
-            ${CURRENT_PACKAGES_DIR}/lib/mongoc-static-1.0.lib
-            ${CURRENT_PACKAGES_DIR}/lib/mongoc-1.0.lib)
+            ${CURRENT_PACKAGES_DIR}/lib/libmongoc-static-1.0.lib
+            ${CURRENT_PACKAGES_DIR}/lib/libmongoc-1.0.lib)
         file(RENAME
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mongoc-static-1.0.lib
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mongoc-1.0.lib)
+            ${CURRENT_PACKAGES_DIR}/debug/lib/libmongoc-static-1.0.lib
+            ${CURRENT_PACKAGES_DIR}/debug/lib/libmongoc-1.0.lib)
     endif()
 
     # drop the __declspec(dllimport) when building static


### PR DESCRIPTION
Fix #3226 .