### PR TITLE
[urdfdom] Fix linux build

### DIFF
--- a/ports/console-bridge/portfile.cmake
+++ b/ports/console-bridge/portfile.cmake
@@ -25,6 +25,8 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
     vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/console_bridge)
 else()
     vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/console_bridge/cmake" TARGET_PATH share/console_bridge)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/console_bridge)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/console_bridge)
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/urdfdom-headers/portfile.cmake
+++ b/ports/urdfdom-headers/portfile.cmake
@@ -15,10 +15,18 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake")
+if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/urdfdom_headers)
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/urdfdom_headers/cmake" TARGET_PATH share/urdfdom_headers)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/urdfdom_headers)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/urdfdom_headers)
+endif()
 
 # The config files for this project use underscore
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/urdfdom-headers ${CURRENT_PACKAGES_DIR}/share/urdfdom_headers)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/share/urdfdom-headers)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/share/urdfdom-headers ${CURRENT_PACKAGES_DIR}/share/urdfdom_headers)
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/)
 

--- a/ports/urdfdom/portfile.cmake
+++ b/ports/urdfdom/portfile.cmake
@@ -28,7 +28,13 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake")
+if(EXISTS ${CURRENT_PACKAGES_DIR}/CMake)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "CMake" TARGET_PATH share/urdfdom)
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/urdfdom/cmake" TARGET_PATH share/urdfdom)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/urdfdom)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/urdfdom)
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)


### PR DESCRIPTION
Remove empty directories and set correct cmake target path

Machine setup: ubuntu 18.10 x64 gcc version 8.2.0
The steps to reproduce: ./vcpkg install urdfdom:x64-linux