### PR TITLE
[mapbox-variant] Add new port

### DIFF
--- a/ports/mapbox-variant/CONTROL
+++ b/ports/mapbox-variant/CONTROL
@@ -1,0 +1,3 @@
+Source: mapbox-variant
+Version: 1.1.6-trunk
+Description: C++11/C++14 Variant

--- a/ports/mapbox-variant/CONTROL
+++ b/ports/mapbox-variant/CONTROL
@@ -1,3 +1,3 @@
 Source: mapbox-variant
-Version: 1.1.6-trunk
+Version: 1.1.6-0f734f0
 Description: C++11/C++14 Variant

--- a/ports/mapbox-variant/portfile.cmake
+++ b/ports/mapbox-variant/portfile.cmake
@@ -1,0 +1,17 @@
+# header-only
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mapbox/variant
+    REF 0f734f01e685a298e3756d30044a4164786c58c5
+    SHA512 36b842ffbaa7d466c26b4783d68dff17b0079927aca876bd021f439591a4ee5f184c71a60ca59857c35675b2e27cf650bedea7a3cdf9c3fc959c3c0ec3b135eb
+    HEAD_REF master
+)
+
+# Copy header files
+file(COPY ${SOURCE_PATH}/include/mapbox/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/mapbox-variant FILES_MATCHING PATTERN "*.hpp")
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/mapbox-variant)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mapbox-variant/LICENSE ${CURRENT_PACKAGES_DIR}/share/mapbox-variant/copyright)


### PR DESCRIPTION
This adds https://github.com/mapbox/variant to vcpkg. It's header only, so just some copying files.

There hasn't been a release in over 2 years, with some critical bug fixes happening after the last release, so I bumped the version number by 1 from `1.1.5` to `1.1.6-trunk`.