### PR TITLE
[dlib] Remove patch now fixed correctly by vcpkg_fix_cmake_targets

### DIFF
--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -76,13 +76,6 @@ string(REPLACE "/* #undef ENABLE_ASSERTS */" "#if defined(_DEBUG)\n#define ENABL
 string(REPLACE "#define DLIB_DISABLE_ASSERTS" "#if !defined(_DEBUG)\n#define DLIB_DISABLE_ASSERTS\n#endif" _contents ${_contents})
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/dlib/config.h "${_contents}")
 
-file(READ ${CURRENT_PACKAGES_DIR}/share/dlib/dlib.cmake _contents)
-string(REPLACE
-    "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)"
-    "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)"
-    _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/dlib/dlib.cmake "${_contents}")
-
 # Handle copyright
 file(COPY ${SOURCE_PATH}/dlib/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/dlib)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/dlib/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/dlib/COPYRIGHT)


### PR DESCRIPTION
This PR fixes a regression in `dlib` caused by #5459. It removes the manual cmake file patching now performed correctly by `vcpkg_fixup_cmake_targets`