### PR TITLE
Create a feature package for building libssh with zlib

### DIFF
--- a/ports/libssh/CONTROL
+++ b/ports/libssh/CONTROL
@@ -1,4 +1,8 @@
 Source: libssh
 Version: 0.7.6
 Description: libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side
-Build-Depends: zlib, openssl
+Build-Depends: openssl
+
+Feature: zlib
+Description: libssh with zlib
+Build-Depends: zlib

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -30,6 +30,12 @@ vcpkg_extract_source_archive_ex(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" WITH_STATIC_LIB)
 
+if(zlib IN_LIST FEATURES)
+	set(WITH_ZLIB ON)
+else()
+	set(WITH_ZLIB OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -39,6 +45,7 @@ vcpkg_configure_cmake(
         -DWITH_TESTING=OFF
         -DWITH_NACL=OFF
         -DWITH_GSSAPI=OFF
+        -DWITH_ZLIB=${WITH_ZLIB}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This adds a feature package for libssh, so that it is not necessary to always build libssh with zlib. It would maybe be better to have building libssh with zlib as a default, and building it without that dependency as an option, but that does not seem to be possible with feature packages.