### PR TITLE
 [tgui] Enable static build 

### DIFF
--- a/ports/tgui/CONTROL
+++ b/ports/tgui/CONTROL
@@ -1,4 +1,4 @@
 Source: tgui
-Version: 0.8.4
+Version: 0.8.4-1
 Description: TGUI is an easy to use, cross-platform, c++ GUI for SFML.
 Build-Depends: sfml

--- a/ports/tgui/portfile.cmake
+++ b/ports/tgui/portfile.cmake
@@ -11,12 +11,17 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
+# Enable static build
+file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindSFML.cmake)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" TGUI_SHARED_LIBS)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         -DTGUI_BUILD_GUI_BUILDER=OFF
         -DTGUI_MISC_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}/share/tgui
+        -DTGUI_SHARED_LIBS=${TGUI_SHARED_LIBS}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
As @tstavrianos suggested: 
https://github.com/Microsoft/vcpkg/pull/5524#issuecomment-470040168
> 
> 
> This appears to fail for x64-windows-static.
> Adding to the portfile:
> `file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindSFML.cmake)`
> `string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" TGUI_SHARED_LIBS)`
> just before vcpkg_configure_cmake
> and adding `-DTGUI_SHARED_LIBS=${TGUI_SHARED_LIBS}` to the options in vcpkg_configure_cmake allows it to build.
