### PR TITLE
[cppfs] Add new port

### DIFF
--- a/ports/cppfs/CONTROL
+++ b/ports/cppfs/CONTROL
@@ -1,0 +1,7 @@
+Source: cppfs
+Version: 1.2.0
+Description: Cross-platform C++ file system library supporting multiple backends
+
+Feature: ssh
+Description: SSH backend for cppfs
+Build-Depends: libssh2,openssl,zlib

--- a/ports/cppfs/LibCrypto-fix.patch
+++ b/ports/cppfs/LibCrypto-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/source/cppfs/CMakeLists.txt b/source/cppfs/CMakeLists.txt
-index aa37eda..08c7190 100644
+index aa37eda..d29176a 100644
 --- a/source/cppfs/CMakeLists.txt
 +++ b/source/cppfs/CMakeLists.txt
 @@ -4,18 +4,18 @@
@@ -24,13 +24,17 @@ index aa37eda..08c7190 100644
  endif()
  
  
-@@ -208,8 +208,7 @@ if (OPTION_BUILD_SSH_BACKEND)
+@@ -207,10 +207,9 @@ target_link_libraries(${target}
+ if (OPTION_BUILD_SSH_BACKEND)
      target_link_libraries(${target}
          PRIVATE
-         ${OPENSSL_LIBRARIES}
+-        ${OPENSSL_LIBRARIES}
 -        ${LIBSSH2_LIBRARY}
 -        ${LIBCRYPTO_LIBRARY}
+-        ${ZLIB_LIBRARY}
++        Libssh2::libssh2
 +        OpenSSL::SSL OpenSSL::Crypto
-         ${ZLIB_LIBRARY}
++        ZLIB::ZLIB
      )
  
+     if("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")

--- a/ports/cppfs/LibCrypto-fix.patch
+++ b/ports/cppfs/LibCrypto-fix.patch
@@ -1,0 +1,36 @@
+diff --git a/source/cppfs/CMakeLists.txt b/source/cppfs/CMakeLists.txt
+index aa37eda..08c7190 100644
+--- a/source/cppfs/CMakeLists.txt
++++ b/source/cppfs/CMakeLists.txt
+@@ -4,18 +4,18 @@
+ #
+ 
+ find_package(LibSSH2)
+-find_package(LibCrypto)
++# find_package(LibCrypto)
+ find_package(ZLIB)
+ find_package(OpenSSL)
+ 
+-if (LibSSH2_FOUND AND LibCrypto_FOUND AND ZLIB_FOUND AND OpenSSL_FOUND)
++if (LibSSH2_FOUND AND ZLIB_FOUND AND OpenSSL_FOUND)
+     set(SSH_DEPS_MET TRUE)
+ else()
+     set(SSH_DEPS_MET FALSE)
+ endif()
+ 
+ if (OPTION_BUILD_SSH_BACKEND AND NOT SSH_DEPS_MET)
+-    message(FATAL_ERROR "Requested to build ssh module but not all dependencies are found! LibSSH2: ${LibSSH2_FOUND}, LibCrypto: ${LibCrypto_FOUND}, ZLIB: ${ZLIB_FOUND}, OpenSSL: ${OpenSSL_FOUND}")
++    message(FATAL_ERROR "Requested to build ssh module but not all dependencies are found! LibSSH2: ${LibSSH2_FOUND}, ZLIB: ${ZLIB_FOUND}, OpenSSL: ${OpenSSL_FOUND}")
+ endif()
+ 
+ 
+@@ -208,8 +208,7 @@ if (OPTION_BUILD_SSH_BACKEND)
+     target_link_libraries(${target}
+         PRIVATE
+         ${OPENSSL_LIBRARIES}
+-        ${LIBSSH2_LIBRARY}
+-        ${LIBCRYPTO_LIBRARY}
++        OpenSSL::SSL OpenSSL::Crypto
+         ${ZLIB_LIBRARY}
+     )
+ 

--- a/ports/cppfs/LibCrypto-fix.patch
+++ b/ports/cppfs/LibCrypto-fix.patch
@@ -1,3 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea9fd15..af63d1e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+ 
+ # Include cmake modules
+-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
++# list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ 
+ include(GenerateExportHeader)
+ 
 diff --git a/source/cppfs/CMakeLists.txt b/source/cppfs/CMakeLists.txt
 index aa37eda..d29176a 100644
 --- a/source/cppfs/CMakeLists.txt

--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -10,6 +10,10 @@ vcpkg_from_github(
     	LibCrypto-fix.patch
 )
 
+if(${TARGET_TRIPLET} MATCHES "uwp")
+	message(FATAL_ERROR "cppfs does not support uwp")
+endif()
+
 set(SHARED_LIBS Off)
 if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
 	set(SHARED_LIBS On)
@@ -18,6 +22,9 @@ endif()
 set(SSH_BACKEND OFF)
 if("ssh" IN_LIST FEATURES)
     set(SSH_BACKEND ON)
+    if("${VCPKG_TARGET_ARCHITECTURE}" STREQUAL "arm64")
+		message(FATAL_ERROR "SSH backend of cppfs does not support arm64.")
+	endif()
 endif()
 
 vcpkg_configure_cmake(

--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v1.2.0
     SHA512 2e831978dd87bd40d14e5b6f5089f3a962481d41959bfd62db543339d05e306315a1167c3bc06b372517357cc314f7d06ac19605f9a2d5b4edddc9a1f3fa8d03
     HEAD_REF master
+    PATCHES
+    	LibCrypto-fix.patch
 )
 
 set(SHARED_LIBS Off)

--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -1,0 +1,38 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cginternals/cppfs
+    REF v1.2.0
+    SHA512 2e831978dd87bd40d14e5b6f5089f3a962481d41959bfd62db543339d05e306315a1167c3bc06b372517357cc314f7d06ac19605f9a2d5b4edddc9a1f3fa8d03
+    HEAD_REF master
+)
+
+set(SHARED_LIBS Off)
+if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
+	set(SHARED_LIBS On)
+endif()
+
+set(SSH_BACKEND OFF)
+if("ssh" IN_LIST FEATURES)
+    set(SSH_BACKEND ON)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DOPTION_BUILD_SSH_BACKEND=${SSH_BACKEND}
+        -DOPTION_BUILD_TESTS=Off
+        -DBUILD_SHARED_LIBS=${SHARED_LIBS}
+        -DOPTION_FORCE_SYSTEM_DIR_INSTALL=On
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cppfs RENAME copyright)
+
+vcpkg_test_cmake(PACKAGE_NAME cppfs)

--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -7,24 +7,24 @@ vcpkg_from_github(
     SHA512 2e831978dd87bd40d14e5b6f5089f3a962481d41959bfd62db543339d05e306315a1167c3bc06b372517357cc314f7d06ac19605f9a2d5b4edddc9a1f3fa8d03
     HEAD_REF master
     PATCHES
-    	LibCrypto-fix.patch
+        LibCrypto-fix.patch
 )
 
 if(${TARGET_TRIPLET} MATCHES "uwp")
-	message(FATAL_ERROR "cppfs does not support uwp")
+    message(FATAL_ERROR "cppfs does not support uwp")
 endif()
 
 set(SHARED_LIBS Off)
 if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
-	set(SHARED_LIBS On)
+    set(SHARED_LIBS On)
 endif()
 
 set(SSH_BACKEND OFF)
 if("ssh" IN_LIST FEATURES)
     set(SSH_BACKEND ON)
     if("${VCPKG_TARGET_ARCHITECTURE}" STREQUAL "arm64")
-		message(FATAL_ERROR "SSH backend of cppfs does not support arm64.")
-	endif()
+        message(FATAL_ERROR "SSH backend of cppfs does not support arm64.")
+    endif()
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This adds the C++ filesystem library cppfs to vcpkg. https://github.com/cginternals/cppfs/tree/v1.2.0

Some notes: 

- cppfs does not support uwp and cannot be fixed in a trivial way.
- It has an ssh backend that can be selectively enabled through a feature. This backend cannot support arm64 because OpenSSL doesn't support arm64.

Results from my machines:

|       triple       |      core     |      ssh      |
|:------------------:|:-------------:|:-------------:|
| x86-windows        | passes        | passes        |
| x64-windows        | passes        | passes        |
| arm-windows        | passes        | passes        |
| arm64-windows      | passes        | not supported |
| x86-windows-static | passes        | passes        |
| x64-windows-static | passes        | passes        |
| x64-osx            | untested      | untested      |
| x64-linux          | passes        | passes        |
| x86-uwp            | not supported | not supported |
| x64-uwp            | not supported | not supported |
| arm-uwp            | not supported | not supported |
| arm64-uwp          | not supported | not supported |