### PR TITLE
[spirv-headers] Add new port

### DIFF
--- a/ports/spirv-headers/CONTROL
+++ b/ports/spirv-headers/CONTROL
@@ -1,0 +1,3 @@
+Source: spirv-headers
+Version: 2019-03-05
+Description: Machine-readable files for the SPIR-V Registry

--- a/ports/spirv-headers/portfile.cmake
+++ b/ports/spirv-headers/portfile.cmake
@@ -1,0 +1,18 @@
+# header-only library
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KhronosGroup/SPIRV-Headers
+    REF 03a081524afabdde274d885880c2fef213e46a59
+    SHA512 27f0a4b5efbe2931c0ff5d50e5fb5bd78fe0a735ad48a08db72c8914f2de05f5d5c507134e0a090bb5a7d88e2f8c1a0bdbf51a0bc4b9fe3bf372da7000ca0b98
+    HEAD_REF master
+)
+
+# This must be spirv as other spirv packages expect it there.
+# Copy header files
+file(COPY ${SOURCE_PATH}/include/spirv/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/spirv)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spirv-headers)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/spirv-headers/LICENSE ${CURRENT_PACKAGES_DIR}/share/spirv-headers/copyright)

--- a/ports/spirv-tools/CONTROL
+++ b/ports/spirv-tools/CONTROL
@@ -1,3 +1,4 @@
 Source: spirv-tools
-Version: 2018.1-1
+Version: 2018.1-2
 Description: API and commands for processing SPIR-V modules
+Build-Depends: spirv-headers

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -10,14 +10,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SPIRV_HEADERS_PATH
-    REPO KhronosGroup/SPIRV-Headers
-    REF bd4c092be34081d88ec8342b1a4d9f77bcce4cac
-    SHA512 e0bc7b8ea73bef762eff60d83104ca93c70e06c7b6e66f73c931eb9ec51227e0b64c3169fcccbffa311acf714138300104dd5e51cdfc846ed7961debc1f9cceb
-    HEAD_REF master
-)
-
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
@@ -26,7 +18,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DSPIRV-Headers_SOURCE_DIR=${SPIRV_HEADERS_PATH}
+        -DSPIRV-Headers_SOURCE_DIR=${VCPKG_ROOT_DIR}/installed/${TARGET_TRIPLET}
         -DSPIRV_WERROR=OFF
 )
 


### PR DESCRIPTION
Resolves #5450 

This PR is two in one. First it adds the header only port `spirv-headers`. These headers were already pulled in by `spirv-tools` and then discarded. I have changed `spirv-tools` to depend on `spirv-headers` so that they don't need to download it again.

- Add port `spirv-headers`.
- Make `spirv-tools` depend on and use `spirv-headers`.