### PR TITLE
[spirv-tools] Add cmake targets

### DIFF
--- a/ports/spirv-tools/CMake-targets.patch
+++ b/ports/spirv-tools/CMake-targets.patch
@@ -1,0 +1,62 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 2d7d7ca..ec6ca01 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -327,31 +327,41 @@ set_source_files_properties(
+ add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
+ spvtools_default_compile_options(${SPIRV_TOOLS})
+ target_include_directories(${SPIRV_TOOLS}
+-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
++  PUBLIC "$<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>"
+   PRIVATE ${spirv-tools_BINARY_DIR}
+   PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
+   )
+ set_property(TARGET ${SPIRV_TOOLS} PROPERTY FOLDER "SPIRV-Tools libraries")
+ spvtools_check_symbol_exports(${SPIRV_TOOLS})
+ 
+-add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
+-spvtools_default_compile_options(${SPIRV_TOOLS}-shared)
+-target_include_directories(${SPIRV_TOOLS}-shared
+-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
+-  PRIVATE ${spirv-tools_BINARY_DIR}
+-  PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
+-  )
+-set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
+-set_property(TARGET ${SPIRV_TOOLS}-shared PROPERTY FOLDER "SPIRV-Tools libraries")
+-spvtools_check_symbol_exports(${SPIRV_TOOLS}-shared)
+-target_compile_definitions(${SPIRV_TOOLS}-shared
+-  PRIVATE SPIRV_TOOLS_IMPLEMENTATION
+-  PUBLIC SPIRV_TOOLS_SHAREDLIB
+-)
++# add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
++# spvtools_default_compile_options(${SPIRV_TOOLS}-shared)
++# target_include_directories(${SPIRV_TOOLS}-shared
++#   PUBLIC ${spirv-tools_SOURCE_DIR}/include
++#   PRIVATE ${spirv-tools_BINARY_DIR}
++#   PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
++#   )
++# set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
++# set_property(TARGET ${SPIRV_TOOLS}-shared PROPERTY FOLDER "SPIRV-Tools libraries")
++# spvtools_check_symbol_exports(${SPIRV_TOOLS}-shared)
++# target_compile_definitions(${SPIRV_TOOLS}-shared
++#   PRIVATE SPIRV_TOOLS_IMPLEMENTATION
++#   PUBLIC SPIRV_TOOLS_SHAREDLIB
++# )
+ 
+ if(ENABLE_SPIRV_TOOLS_INSTALL)
+-  install(TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared
++  install(TARGETS ${SPIRV_TOOLS} EXPORT ${SPIRV_TOOLS}Config
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  export(
++    TARGETS ${SPIRV_TOOLS}
++    NAMESPACE ${SPIRV_TOOLS}::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/${SPIRV_TOOLS}-config.cmake"
++  )
++  install(
++    EXPORT ${SPIRV_TOOLS}Config
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/${SPIRV_TOOLS}"
++    NAMESPACE ${SPIRV_TOOLS}::
++  )
+ endif(ENABLE_SPIRV_TOOLS_INSTALL)

--- a/ports/spirv-tools/CMake-targets.patch
+++ b/ports/spirv-tools/CMake-targets.patch
@@ -1,5 +1,5 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index 2d7d7ca..ec6ca01 100644
+index 2d7d7ca..bf77be7 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
 @@ -327,31 +327,41 @@ set_source_files_properties(
@@ -45,18 +45,75 @@ index 2d7d7ca..ec6ca01 100644
  
  if(ENABLE_SPIRV_TOOLS_INSTALL)
 -  install(TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared
-+  install(TARGETS ${SPIRV_TOOLS} EXPORT ${SPIRV_TOOLS}Config
++  install(TARGETS ${SPIRV_TOOLS} EXPORT spirv-tools-config
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +  export(
 +    TARGETS ${SPIRV_TOOLS}
-+    NAMESPACE ${SPIRV_TOOLS}::
-+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${SPIRV_TOOLS}-config.cmake"
++    NAMESPACE spirv-tools::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-config.cmake"
 +  )
 +  install(
-+    EXPORT ${SPIRV_TOOLS}Config
-+    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/${SPIRV_TOOLS}"
-+    NAMESPACE ${SPIRV_TOOLS}::
++    EXPORT spirv-tools-config
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/spirv-tools"
++    NAMESPACE spirv-tools::
 +  )
  endif(ENABLE_SPIRV_TOOLS_INSTALL)
+diff --git a/source/link/CMakeLists.txt b/source/link/CMakeLists.txt
+index 8ca4df3..ac0aa62 100644
+--- a/source/link/CMakeLists.txt
++++ b/source/link/CMakeLists.txt
+@@ -17,7 +17,7 @@ add_library(SPIRV-Tools-link
+ 
+ spvtools_default_compile_options(SPIRV-Tools-link)
+ target_include_directories(SPIRV-Tools-link
+-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
++  PUBLIC "$<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>"
+   PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
+   PRIVATE ${spirv-tools_BINARY_DIR}
+ )
+@@ -29,8 +29,13 @@ set_property(TARGET SPIRV-Tools-link PROPERTY FOLDER "SPIRV-Tools libraries")
+ spvtools_check_symbol_exports(SPIRV-Tools-link)
+ 
+ if(ENABLE_SPIRV_TOOLS_INSTALL)
+-  install(TARGETS SPIRV-Tools-link
++  install(TARGETS SPIRV-Tools-link EXPORT spirv-tools-config
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  export(
++    TARGETS ${SPIRV_TOOLS}-link
++    NAMESPACE spirv-tools::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-link-config.cmake"
++  )
+ endif(ENABLE_SPIRV_TOOLS_INSTALL)
+diff --git a/source/opt/CMakeLists.txt b/source/opt/CMakeLists.txt
+index 854c950..fc91539 100644
+--- a/source/opt/CMakeLists.txt
++++ b/source/opt/CMakeLists.txt
+@@ -159,7 +159,7 @@ add_library(SPIRV-Tools-opt
+ 
+ spvtools_default_compile_options(SPIRV-Tools-opt)
+ target_include_directories(SPIRV-Tools-opt
+-  PUBLIC ${spirv-tools_SOURCE_DIR}/include
++  PUBLIC "$<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>"
+   PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
+   PRIVATE ${spirv-tools_BINARY_DIR}
+ )
+@@ -171,9 +171,14 @@ set_property(TARGET SPIRV-Tools-opt PROPERTY FOLDER "SPIRV-Tools libraries")
+ spvtools_check_symbol_exports(SPIRV-Tools-opt)
+ 
+ if(ENABLE_SPIRV_TOOLS_INSTALL)
+-  install(TARGETS SPIRV-Tools-opt
++  install(TARGETS SPIRV-Tools-opt EXPORT spirv-tools-config
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  export(
++    TARGETS ${SPIRV_TOOLS}-opt
++    NAMESPACE spirv-tools::
++    FILE "${CMAKE_CURRENT_BINARY_DIR}/spirv-tools-opt-config.cmake"
++  )
+ endif(ENABLE_SPIRV_TOOLS_INSTALL)
+     

--- a/ports/spirv-tools/CONTROL
+++ b/ports/spirv-tools/CONTROL
@@ -1,3 +1,3 @@
 Source: spirv-tools
-Version: 2018.1-1
+Version: 2018.1-2
 Description: API and commands for processing SPIR-V modules

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -45,4 +45,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bi
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spirv-tools)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/spirv-tools/LICENSE ${CURRENT_PACKAGES_DIR}/share/spirv-tools/copyright)
 
-vcpkg_test_cmake(PACKAGE_NAME SPIRV-Tools)
+vcpkg_test_cmake(PACKAGE_NAME spirv-tools)

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF v2018.1
     SHA512 0637c413dafd931e8222f9bf70a024f8b64116f0300c7732b86bcaff321188a0e746f79c1385ae23a7692e83194586b57692960d5be607fb2d7960731b6cd63f
     HEAD_REF master
+    PATCHES
+        CMake-targets.patch
 )
 
 vcpkg_from_github(
@@ -33,6 +35,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*${CMAKE_EXECUTABLE_SUFFIX}")
 file(COPY ${EXES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
 file(REMOVE ${EXES})
@@ -41,3 +44,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bi
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spirv-tools)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/spirv-tools/LICENSE ${CURRENT_PACKAGES_DIR}/share/spirv-tools/copyright)
+
+vcpkg_test_cmake(PACKAGE_NAME SPIRV-Tools)


### PR DESCRIPTION
This PR adds a patch to `spirv-tools` to give it cmake targets to import.

Notes:
- There was an extra shared library that was being built at the same time as the static we thought we were getting. I have disabled this for now. However, that means we could possibly reopen `spirv-tools` to being built as both a static and dynamic library through another patch, however that is outside the scope of this PR.
- Because of change I made above, it would be basically impossible to merge this into upstream as it would change their defaults in their build system and I would have to justify such a breaking change.