### PR TITLE
Mark overridden functions with override.

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -216,7 +216,7 @@ namespace vcpkg::Files
         {
             return fs::stdfs::copy_file(oldpath, newpath, opts, ec);
         }
-        virtual void copy_symlink(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec)
+        virtual void copy_symlink(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec) override
         {
             return fs::stdfs::copy_symlink(oldpath, newpath, ec);
         }

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -364,7 +364,7 @@ Type 'NuGet help <command>' for help on a specific command.
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {2, 7, 4}; }
 
-        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const
+        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const override
         {
 #if defined(_WIN32)
             const auto& program_files = System::get_program_files_platform_bitness();
@@ -403,7 +403,7 @@ git version 2.17.1.windows.2
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {0, 0, 0}; }
 
-        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const
+        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const override
         {
             // TODO: Uncomment later
             // const std::vector<fs::path> from_path = Files::find_from_PATH("installerbase");


### PR DESCRIPTION
clang++ warns about the missing override labels.