### PR TITLE
[libusb] fix error c2001

### DIFF
--- a/ports/libusb/CONTROL
+++ b/ports/libusb/CONTROL
@@ -1,3 +1,3 @@
 Source: libusb
-Version: 1.0.22-1
+Version: 1.0.22-2
 Description: a cross-platform library to access USB devices

--- a/ports/libusb/fix_c2001.patch
+++ b/ports/libusb/fix_c2001.patch
@@ -1,0 +1,92 @@
+diff --git a/msvc/libusb_dll_2015.vcxproj b/msvc/libusb_dll_2015.vcxproj
+index ce562f1..e5a19fd 100644
+--- a/msvc/libusb_dll_2015.vcxproj
++++ b/msvc/libusb_dll_2015.vcxproj
+@@ -53,10 +53,18 @@
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <Optimization>Disabled</Optimization>
+       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <ClCompile Condition="'$(Configuration)'=='Release'">
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <Link>
+       <EmbedManagedResourceFile>libusb-1.0.rc;%(EmbedManagedResourceFile)</EmbedManagedResourceFile>
+diff --git a/msvc/libusb_dll_2017.vcxproj b/msvc/libusb_dll_2017.vcxproj
+index 8311300..f635aed 100644
+--- a/msvc/libusb_dll_2017.vcxproj
++++ b/msvc/libusb_dll_2017.vcxproj
+@@ -53,10 +53,18 @@
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <Optimization>Disabled</Optimization>
+       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <ClCompile Condition="'$(Configuration)'=='Release'">
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <Link>
+       <EmbedManagedResourceFile>libusb-1.0.rc;%(EmbedManagedResourceFile)</EmbedManagedResourceFile>
+diff --git a/msvc/libusb_static_2015.vcxproj b/msvc/libusb_static_2015.vcxproj
+index a182171..ce4cc66 100644
+--- a/msvc/libusb_static_2015.vcxproj
++++ b/msvc/libusb_static_2015.vcxproj
+@@ -54,10 +54,18 @@
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <Optimization>Disabled</Optimization>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <ClCompile Condition="'$(Configuration)'=='Release'">
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <Lib>
+       <OutputFile>$(OutDir)libusb-1.0.lib</OutputFile>
+diff --git a/msvc/libusb_static_2017.vcxproj b/msvc/libusb_static_2017.vcxproj
+index 1341693..8908450 100644
+--- a/msvc/libusb_static_2017.vcxproj
++++ b/msvc/libusb_static_2017.vcxproj
+@@ -54,10 +54,18 @@
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <Optimization>Disabled</Optimization>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <ClCompile Condition="'$(Configuration)'=='Release'">
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <Lib>
+       <OutputFile>$(OutDir)libusb-1.0.lib</OutputFile>

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_from_github(
     REF v1.0.22
     SHA512 b1fed66aafa82490889ee488832c6884a95d38ce7b28fb7c3234b9bce1f749455d7b91cde397a0abc25101410edb13ab2f9832c59aa7b0ea8c19ba2cf4c63b00
     HEAD_REF master
+    PATCHES
+      "${CMAKE_CURRENT_LIST_DIR}/fix_c2001.patch"
 )
 
 if(VCPKG_PLATFORM_TOOLSET MATCHES "v141")


### PR DESCRIPTION
Fix error c2001 by specify <code>/source-charset:utf-8</code>.
That error seems to occur on multi-byte character locale such as Japanese.  (for details https://github.com/libusb/libusb/issues/207)