### PR TITLE
[capnproto] Add Capnproto package

### DIFF
--- a/ports/capnproto/0001-fix-capnpc-extension-handling-on-Windows.patch
+++ b/ports/capnproto/0001-fix-capnpc-extension-handling-on-Windows.patch
@@ -1,0 +1,39 @@
+From 6e142f270524d78689a119737660050561cf853e Mon Sep 17 00:00:00 2001
+From: Thomas Arcila <thomas.arcila@gmail.com>
+Date: Sat, 9 Mar 2019 19:00:24 -0500
+Subject: [PATCH] fix capnpc extension handling on Windows
+
+---
+ c++/src/capnp/CMakeLists.txt     | 2 +-
+ c++/src/capnp/compiler/capnp.c++ | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/c++/src/capnp/CMakeLists.txt b/c++/src/capnp/CMakeLists.txt
+index 11cbf5af..20b99ed3 100644
+--- a/c++/src/capnp/CMakeLists.txt
++++ b/c++/src/capnp/CMakeLists.txt
+@@ -182,7 +182,7 @@ if(NOT CAPNP_LITE)
+   install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+   # Symlink capnpc -> capnp
+-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc\")")
++  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
+ endif()  # NOT CAPNP_LITE
+ 
+ # Tests ========================================================================
+diff --git a/c++/src/capnp/compiler/capnp.c++ b/c++/src/capnp/compiler/capnp.c++
+index 8e8c459b..d252fb12 100644
+--- a/c++/src/capnp/compiler/capnp.c++
++++ b/c++/src/capnp/compiler/capnp.c++
+@@ -78,7 +78,7 @@ public:
+       : context(context), disk(kj::newDiskFilesystem()), loader(*this) {}
+ 
+   kj::MainFunc getMain() {
+-    if (context.getProgramName().endsWith("capnpc")) {
++    if (context.getProgramName().endsWith("capnpc") || context.getProgramName().endsWith("capnpc.exe")) {
+       kj::MainBuilder builder(context, VERSION_STRING,
+             "Compiles Cap'n Proto schema files and generates corresponding source code in one or "
+             "more languages.");
+-- 
+2.19.1
+

--- a/ports/capnproto/CONTROL
+++ b/ports/capnproto/CONTROL
@@ -1,0 +1,4 @@
+Source: capnproto
+Version: 0.7.0
+Description: Data interchange format and capability-based RPC system https://capnproto.org/
+Build-Depends: zlib

--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -1,5 +1,10 @@
-if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
     message(FATAL_ERROR "Error: UWP build is not supported.")
+endif()
+
+if(DEFINED VCPKG_CMAKE_SYSTEM_NAME)
+    # Undefined VCPKG_CMAKE_SYSTEM_NAME means Windows
+    message(FATAL_ERROR "Error: CapnProto only build on Windows for now. See #5630 and #5635")
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -36,4 +41,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/capnproto)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/capnproto/LICENSE ${CURRENT_PACKAGES_DIR}/share/capnproto/copyright)
 
-vcpkg_test_cmake(PACKAGE_NAME CapnProto)
+# Disabled for now, see #5630 and #5635
+# vcpkg_test_cmake(PACKAGE_NAME CapnProto)

--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -14,10 +14,6 @@ vcpkg_from_github(
     REF v0.7.0
     SHA512 a3ea278ded6a866759c0517d16b99bd38ffea1c163ce63a3604b752d8bdaafbc38a600de94afe12db35e7f7f06e29cc94c911dc2e0ecec6fe1185452df2a2bd3
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-	SOURCE_PATH ${SOURCE_PATH}
 	PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-capnpc-extension-handling-on-Windows.patch"
 )
 
@@ -28,7 +24,7 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/CapnProto")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
-file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/CapnProto")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/capnproto")
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/capnproto)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
@@ -40,3 +36,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/capnproto)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/capnproto/LICENSE ${CURRENT_PACKAGES_DIR}/share/capnproto/copyright)
 
+vcpkg_test_cmake(PACKAGE_NAME CapnProto)

--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -1,0 +1,42 @@
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
+    message(FATAL_ERROR "Error: UWP build is not supported.")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    message("Building DLLs not supported. Building static instead.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO capnproto/capnproto
+    REF v0.7.0
+    SHA512 a3ea278ded6a866759c0517d16b99bd38ffea1c163ce63a3604b752d8bdaafbc38a600de94afe12db35e7f7f06e29cc94c911dc2e0ecec6fe1185452df2a2bd3
+    HEAD_REF master
+)
+
+vcpkg_apply_patches(
+	SOURCE_PATH ${SOURCE_PATH}
+	PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-capnpc-extension-handling-on-Windows.patch"
+)
+
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/CapnProto")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/CapnProto")
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/capnproto)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/capnproto)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/capnproto/LICENSE ${CURRENT_PACKAGES_DIR}/share/capnproto/copyright)
+


### PR DESCRIPTION
Add a new CapnProto package. Tested on Windows and Linux (Ubuntu 18.10).
The embedded patch as also been submitted upstream (https://github.com/capnproto/capnproto/pull/804)