### PR TITLE
Update various SDL2-based libraries

### DIFF
--- a/ports/sdl2-gfx/CONTROL
+++ b/ports/sdl2-gfx/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-gfx
-Version: 1.0.3-3
+Version: 1.0.4
 Build-Depends: sdl2
 Description: Graphics primitives (line, circle, rectangle etc.) with AA support, rotozoomer and other drawing related support functions wrapped up in a C based add-on library for the Simple Direct Media (SDL) cross-platform API layer.

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -1,9 +1,9 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_gfx-1.0.3)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_gfx-1.0.4)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-1.0.3.zip"
-    FILENAME "SDL2_gfx-1.0.3.zip"
-    SHA512 f68485f71acf979aba68f3575f260fbc95a59496a9639498bcff80ffbfdb157c82a44bb5a0b0e3b1e157376ea4ff2f196f50466e6f24d850f94cfe7c24b1a497
+    URLS "http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-1.0.4.zip"
+    FILENAME "SDL2_gfx-1.0.4.zip"
+    SHA512 213b481469ba2161bd8558a7a5427b129420193b1c3895923d515f69f87991ed2c99bbc44349c60b4bcbb7d7d2255c1f15ee8a3523c26502070cfaacccaa5242
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -1,11 +1,19 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_gfx-1.0.4)
+
+set(VERSION 1.0.4)
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-1.0.4.zip"
-    FILENAME "SDL2_gfx-1.0.4.zip"
+    URLS "http://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-${VERSION}.zip"
+    FILENAME "SDL2_gfx-${VERSION}.zip"
     SHA512 213b481469ba2161bd8558a7a5427b129420193b1c3895923d515f69f87991ed2c99bbc44349c60b4bcbb7d7d2255c1f15ee8a3523c26502070cfaacccaa5242
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH 
+    ARCHIVE ${ARCHIVE}
+    REF ${VERSION}
+)
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(

--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(SDL2_image
     IMG_xpm.c
     IMG_xv.c
     IMG_xxx.c
+    IMG_WIC.c
     version.rc
     )
 

--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-image
-Version: 2.0.2-3
+Version: 2.0.4
 Build-Depends: sdl2, libpng
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV
 

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -1,12 +1,18 @@
 include(vcpkg_common_functions)
+
 set(SDL2_IMAGE_VERSION "2.0.4")
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_image-${SDL2_IMAGE_VERSION})
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${SDL2_IMAGE_VERSION}.zip"
     FILENAME "SDL2_image-${SDL2_IMAGE_VERSION}.zip"
     SHA512 b26ef2546718754481385ddad800ee61c84c58a9e141127c0a12215362d41c23603bfb21d556803396c0cb17bd7f48a45dd1b2e66573a1b2e32f590cc3fa48d0
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${SDL2_IMAGE_VERSION}    
+)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
-set(SDL2_IMAGE_VERSION "2.0.2")
+set(SDL2_IMAGE_VERSION "2.0.4")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_image-${SDL2_IMAGE_VERSION})
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${SDL2_IMAGE_VERSION}.zip"
     FILENAME "SDL2_image-${SDL2_IMAGE_VERSION}.zip"
-    SHA512 bf143bdbd3cb7cfad61b8dcc35950584304deac802bad6c0c8144e914401a5ddef01f674d2dc1214371d0f371f76e87a45873e2655947e8e1da83fb44d8285f4
+    SHA512 b26ef2546718754481385ddad800ee61c84c58a9e141127c0a12215362d41c23603bfb21d556803396c0cb17bd7f48a45dd1b2e66573a1b2e32f590cc3fa48d0
 )
 vcpkg_extract_source_archive(${ARCHIVE})
 

--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -45,6 +45,15 @@ if(SDL_MIXER_ENABLE_OGGVORBIS)
     list(APPEND SDL_MIXER_DEFINES MUSIC_OGG)
 endif()
 
+# Opus support
+if(SDL_MIXER_ENABLE_OPUS)
+    find_path(OPUS_INCLUDE_DIR opus/opusfile.h)
+    find_library(OPUSFILE_LIBRARY opusfile)
+    list(APPEND SDL_MIXER_INCLUDES ${OPUS_INCLUDE_DIR})
+    list(APPEND SDL_MIXER_LIBRARIES ${OPUSFILE_LIBRARY})
+    list(APPEND SDL_MIXER_DEFINES MUSIC_OPUS)
+endif()
+
 add_library(SDL2_mixer
     effect_position.c
     effect_stereoreverse.c
@@ -61,7 +70,7 @@ add_library(SDL2_mixer
     music_modplug.c
     music_mpg123.c
     music_ogg.c
-    music_smpeg.c
+    music_opus.c
     music_timidity.c
     music_wav.c
     version.rc)

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.2-6
+Version: 2.0.4
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2
 
@@ -18,3 +18,7 @@ Build-Depends: libmodplug
 Feature: libvorbis
 Description: Support for OGG Vorbis audio format.
 Build-Depends: libvorbis
+
+Feature: opusfile
+Description: Support for Opus audio format.
+Build-Depends: opusfile

--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -1,9 +1,9 @@
 include(vcpkg_common_functions)
-set(SDL2_MIXER_VERSION 2.0.2)
+set(SDL2_MIXER_VERSION 2.0.4)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${SDL2_MIXER_VERSION}.zip"
     FILENAME "SDL2_mixer-${SDL2_MIXER_VERSION}.zip"
-    SHA512 da0c27c560a153d57d69a1b6c58a288f017762afc654749957072900a904d3dac19a0efcb68516cb166546d29ff570462385016e0041dae6f393ccb4bbd2ffbc
+    SHA512 359b4f9877804f9c4b3cb608ca6082aab684f07a20a816ab71c8cdf85d26f76d67eeb5aee44daf52b7935d82aa3b45941f8f53f07ca3dd5150d6c58ed99e1492
 )
 
 vcpkg_extract_source_archive_ex(
@@ -33,6 +33,11 @@ if("libvorbis" IN_LIST FEATURES)
     set(USE_OGGVORBIS ON)
 endif()
 
+set(USE_OPUS OFF)
+if("opusfile" IN_LIST FEATURES)
+    set(USE_OPUS ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -40,7 +45,8 @@ vcpkg_configure_cmake(
         -DSDL_MIXER_ENABLE_MP3=${USE_MP3}             # mpg123
         -DSDL_MIXER_ENABLE_FLAC=${USE_FLAC}           # libflac
         -DSDL_MIXER_ENABLE_MOD=${USE_MOD}             # libmodplug
-        -DSDL_MIXER_ENABLE_OGGVORBIS=${USE_OGGVORBIS} # libvorbis 
+        -DSDL_MIXER_ENABLE_OGGVORBIS=${USE_OGGVORBIS} # libvorbis
+        -DSDL_MIXER_ENABLE_OPUS=${USE_OPUS}           # opusfile
     OPTIONS_DEBUG
         -DSDL_MIXER_SKIP_HEADERS=ON
 )

--- a/ports/sdl2-ttf/CONTROL
+++ b/ports/sdl2-ttf/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-ttf
-Version: 2.0.14-4
+Version: 2.0.15
 Description: A library for rendering TrueType fonts with SDL
 Build-Depends: sdl2, freetype

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -1,12 +1,18 @@
-
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_ttf-2.0.15)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz"
-    FILENAME "SDL2_ttf-2.0.15.tar.gz"
-    SHA512 30d685932c3dd6f2c94e2778357a5c502f0421374293d7102a64d92f9c7861229bf36bedf51c1a698b296a58c858ca442d97afb908b7df1592fc8d4f8ae8ddfd)
 
-vcpkg_extract_source_archive(${ARCHIVE})
+set(VERSION 2.0.15)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-${VERSION}.tar.gz"
+    FILENAME "SDL2_ttf-${VERSION}.tar.gz"
+    SHA512 30d685932c3dd6f2c94e2778357a5c502f0421374293d7102a64d92f9c7861229bf36bedf51c1a698b296a58c858ca442d97afb908b7df1592fc8d4f8ae8ddfd
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${VERSION}
+)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -1,11 +1,11 @@
 
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_ttf-2.0.14)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/SDL2_ttf-2.0.15)
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14.tar.gz"
-    FILENAME "SDL2_ttf-2.0.14.tar.gz"
-    SHA512 4db817573fd216e26180f4c401cc869ce407589a461032fd7167dc612d35e038cca1ab67be7909b6b49c741581a68125ab46362ad8e3c0a2cdd39624ad847099)
-	
+    URLS "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz"
+    FILENAME "SDL2_ttf-2.0.15.tar.gz"
+    SHA512 30d685932c3dd6f2c94e2778357a5c502f0421374293d7102a64d92f9c7861229bf36bedf51c1a698b296a58c858ca442d97afb908b7df1592fc8d4f8ae8ddfd)
+
 vcpkg_extract_source_archive(${ARCHIVE})
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
Updates SDL2-gfx, SDL2-mixer (#4934), SDL2-image and SDL2-ttf to latest upstream versions.