### PR TITLE
[libraw] Add wrapper for static build dependencies

### DIFF
--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,4 +1,4 @@
 Source: libraw
-Version: 0.19.0-2
+Version: 0.19.0-3
 Build-Depends: lcms, jasper
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -79,6 +79,10 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 # Rename cmake module into a config in order to allow more flexible lookup rules
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/FindLibRaw.cmake ${CURRENT_PACKAGES_DIR}/share/libraw/LibRaw-config.cmake)
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libraw)
+endif()
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/libraw)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/COPYRIGHT ${CURRENT_PACKAGES_DIR}/share/libraw/copyright)

--- a/ports/libraw/vcpkg-cmake-wrapper.cmake
+++ b/ports/libraw/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,7 @@
+_find_package(${ARGS})
+find_package(Jasper REQUIRED)
+if (Jasper_FOUND)
+   list(APPEND LibRaw_LIBRARIES ${JASPER_LIBRARIES})
+   list(APPEND LibRaw_r_LIBRARIES ${JASPER_LIBRARIES})
+endif ()
+


### PR DESCRIPTION
Libraw does not currently export it's dependency on jasper and so consuming packages fail with a static build. 

This PR explicitly exports the jasper dependency using a vcpkg-cmake-wrapper