### PR TITLE
[docs] Add vcpkg functions usage examples

### DIFF
--- a/docs/maintainers/vcpkg_add_to_path.md
+++ b/docs/maintainers/vcpkg_add_to_path.md
@@ -16,5 +16,10 @@ Prepends the directory.
 
 The default is to append.
 
+## Examples:
+* [curl][https://github.com/Microsoft/vcpkg/blob/master/ports/curl/portfile.cmake#L75]
+* [folly](https://github.com/Microsoft/vcpkg/blob/master/ports/folly/portfile.cmake#L15)
+* [z3](https://github.com/Microsoft/vcpkg/blob/master/ports/z3/portfile.cmake#L13)
+
 ## Source
 [scripts/cmake/vcpkg_add_to_path.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_add_to_path.cmake)

--- a/docs/maintainers/vcpkg_from_gitlab.md
+++ b/docs/maintainers/vcpkg_from_gitlab.md
@@ -56,6 +56,9 @@ At least one of `REF` and `HEAD_REF` must be specified, however it is preferable
 
 This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 
+## Examples:
+
+* [tiny-process-library](https://github.com/Microsoft/vcpkg/blob/master/ports/tiny-process-library/portfile.cmake#L3)
 
 ## Source
 [scripts/cmake/vcpkg_from_gitlab.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_from_gitlab.cmake)


### PR DESCRIPTION
Examples for:

* `vcpkg_add_to_path()`
* `vcpkg_from_gitlab()`