### PR TITLE
[darknet/yolo] new port

### DIFF
--- a/ports/darknet/CONTROL
+++ b/ports/darknet/CONTROL
@@ -1,0 +1,20 @@
+Source: darknet
+Version: 1.0.0
+Description: Darknet is an open source neural network framework written in C and CUDA. You only look once (YOLO) is a state-of-the-art, real-time object detection system, best example of darknet functionalities.
+Build-Depends: pthreads (windows)
+Default-Features: weights
+
+Feature: opencv
+Build-Depends: opencv
+Description: Build darknet with support for OpenCV
+
+Feature: cuda
+Build-Depends: cuda
+Description: Build darknet with support for CUDA
+
+Feature: weights
+Description: Download common weights from official websites, using vcpkg proxy-enabled functions
+
+Feature: opencv-cuda
+Build-Depends: darknet[cuda], opencv[cuda]
+Description: Build darknet with support for a CUDA-enabled OpenCV

--- a/ports/darknet/CONTROL
+++ b/ports/darknet/CONTROL
@@ -1,7 +1,7 @@
 Source: darknet
 Version: 1.0.0
 Description: Darknet is an open source neural network framework written in C and CUDA. You only look once (YOLO) is a state-of-the-art, real-time object detection system, best example of darknet functionalities.
-Build-Depends: pthreads (windows)
+Build-Depends: pthreads (windows), stb
 Default-Features: weights
 
 Feature: opencv

--- a/ports/darknet/dont_use_integrated_stb_lib.patch
+++ b/ports/darknet/dont_use_integrated_stb_lib.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a5385ae..41514af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,7 +75,10 @@ if(USE_INTEGRATED_LIBS)
+   include_directories(${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
+   set(PThreads_windows_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
+   set(PThreads_windows_LIBRARY ${CMAKE_CURRENT_LIST_DIR}/3rdparty/lib/x64/pthreadVC2.lib)
++  set(STB_INCLUDE_PATH ${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
+   add_definitions(-D_TIMESPEC_DEFINED)
++else()
++  find_path(STB_INCLUDE_PATH NAMES stb.h "The directory where stb.h resides")
+ endif()
+ 
+ set(CMAKE_DEBUG_POSTFIX d)
+@@ -240,7 +243,7 @@ if(OpenCV_VERSION VERSION_GREATER "3.0" AND NOT SKIP_USELIB_TRACK)
+   add_executable(uselib_track ${CMAKE_CURRENT_LIST_DIR}/src/yolo_console_dll.cpp)
+   target_compile_definitions(uselib_track PRIVATE TRACK_OPTFLOW=1)
+   set_target_properties(uselib_track PROPERTIES LINKER_LANGUAGE CXX)
+-  target_include_directories(uselib_track PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
++  target_include_directories(uselib_track PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${STB_INCLUDE_PATH}>)
+   target_link_libraries(uselib_track PRIVATE ${OpenCV_LIBS})
+ endif()
+ 
+@@ -251,9 +254,9 @@ add_executable(darknet ${CMAKE_CURRENT_LIST_DIR}/src/darknet.c ${sources} ${head
+ set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/src/darknet.c PROPERTIES LANGUAGE CXX)
+ set_target_properties(darknet PROPERTIES LINKER_LANGUAGE CXX)
+ 
+-target_include_directories(darknet PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+-target_include_directories(darklib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+-target_include_directories(uselib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
++target_include_directories(darknet PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${STB_INCLUDE_PATH}>)
++target_include_directories(darklib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${STB_INCLUDE_PATH}>)
++target_include_directories(uselib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${STB_INCLUDE_PATH}>)
+ 
+ if(CUDNN_FOUND)
+   target_link_libraries(darknet PRIVATE CuDNN::CuDNN)

--- a/ports/darknet/enable_standard_installation.patch
+++ b/ports/darknet/enable_standard_installation.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 26c0ad7..9f425ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,8 +25,7 @@ enable_language(CXX)
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
+ 
+-set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Install prefix" FORCE)
+-set(INSTALL_BIN_DIR      "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Path where exe and dll will be installed" FORCE)
++set(INSTALL_BIN_DIR      "bin"                       CACHE PATH "Path where exe and dll will be installed")
+ set(INSTALL_LIB_DIR      "lib"                       CACHE PATH "Path where lib will be installed")
+ set(INSTALL_INCLUDE_DIR  "include"                   CACHE PATH "Path where headers will be installed")
+ set(INSTALL_CMAKE_DIR    "share/darknet"             CACHE PATH "Path where cmake configs will be installed")

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -1,0 +1,98 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO cenit/darknet
+  REF 7a8574ec5fb5d2ac98bcc90426f5c4ca21230b45
+  SHA512 244066cee9ca34168058bb49df9d6be7d9915e43513f522c605c33d682e3187329ad76945ea604be90290bd99ad54e98717e2b14712d14d9a1d5e908efdee89b
+  HEAD_REF dev/cenit/cmakeConfig
+  PATCHES
+    enable_standard_installation.patch
+)
+
+set(ENABLE_CUDA OFF)
+if("cuda" IN_LIST FEATURES)
+  set(ENABLE_CUDA ON)
+endif()
+
+set(ENABLE_OPENCV OFF)
+if("opencv" IN_LIST FEATURES)
+  set(ENABLE_OPENCV ON)
+endif()
+
+if("weights" IN_LIST FEATURES)
+  vcpkg_download_distfile(YOLOV3_WEIGHTS
+    URLS "https://pjreddie.com/media/files/yolov3.weights"
+    FILENAME "darknet-cache/yolov3.weights"
+    SHA512 293c70e404ff0250d7c04ca1e5e053fc21a78547e69b5b329d34f25981613e59b982d93fff2c352915ef7531d6c3b02a9b0b38346d05c51d6636878d8883f2c1
+  )
+  vcpkg_download_distfile(YOLOV2_WEIGHTS
+    URLS "https://pjreddie.com/media/files/yolov2.weights"
+    FILENAME "darknet-cache/yolov2.weights"
+    SHA512 5271da2dd2da915172ddd034c8e894877e7066051f105ae82e25e185a2b4e4157d2b9514653c23780e87346f2b20df6363018b7e688aba422e2dacf1d2fbf6ab
+  )
+  vcpkg_download_distfile(YOLOV3-TINY_WEIGHTS
+    URLS "https://pjreddie.com/media/files/yolov3-tiny.weights"
+    FILENAME "darknet-cache/yolov3-tiny.weights"
+    SHA512 981a56459515f727bb7b3d3341b95f4117499b6726eab2798e1c3e524de1ee8ed0d954c11b27bbbb926da2cc955526a194eddf69c55d65923994ab2e8af07042
+  )
+  vcpkg_download_distfile(YOLOV2-TINY_WEIGHTS
+    URLS "https://pjreddie.com/media/files/yolov2-tiny.weights"
+    FILENAME "darknet-cache/yolov2-tiny.weights"
+    SHA512 f0857a7a02cf4322354d288c9afa0b87321b23082b719bc84ea64e2f3556cc1fafeb836ee5bf9fb6dcf448839061b93623a067dfde7afa1338636865ea88989a
+  )
+endif()
+
+
+vcpkg_configure_cmake(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+    -DENABLE_CUDA=${ENABLE_CUDA}
+    -DENABLE_OPENCV=${ENABLE_OPENCV}
+)
+
+vcpkg_install_cmake()
+
+#somehow the native CMAKE_EXECUTABLE_SUFFIX does not work, so here we emulate it
+if(CMAKE_HOST_WIN32)
+  set(EXECUTABLE_SUFFIX ".exe")
+else()
+  set(EXECUTABLE_SUFFIX "")
+endif()
+
+
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/darknet${EXECUTABLE_SUFFIX})
+file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/uselib${EXECUTABLE_SUFFIX})
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/darknet/)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/darknet${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/darknet${EXECUTABLE_SUFFIX})
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uselib${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/uselib${EXECUTABLE_SUFFIX})
+file(COPY ${SOURCE_PATH}/cfg DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+file(COPY ${SOURCE_PATH}/data DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/darknet)
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/uselib_track${EXECUTABLE_SUFFIX})
+  file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/uselib_track${EXECUTABLE_SUFFIX})
+endif()
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/uselib_track${EXECUTABLE_SUFFIX})
+  file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uselib_track${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/uselib_track${EXECUTABLE_SUFFIX})
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+file(RENAME ${CURRENT_PACKAGES_DIR}/debug/share/darknet/DarknetTargets.cmake ${CURRENT_PACKAGES_DIR}/share/darknet/DarknetTargets.cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/darknet RENAME copyright)
+
+if("weights" IN_LIST FEATURES)
+  file(COPY ${VCPKG_ROOT_DIR}/downloads/darknet-cache/yolov3.weights DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+  file(COPY ${VCPKG_ROOT_DIR}/downloads/darknet-cache/yolov2.weights DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+  file(COPY ${VCPKG_ROOT_DIR}/downloads/darknet-cache/yolov3-tiny.weights DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+  file(COPY ${VCPKG_ROOT_DIR}/downloads/darknet-cache/yolov2-tiny.weights DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+endif()

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -5,9 +5,10 @@ vcpkg_from_github(
   REPO AlexeyAB/darknet
   REF dd27d67f58f563bb6bb2af7bb6374f8a59cebcde
   SHA512 6821ba9cd5dc185759492deaa2d20ac1ce60778a8aec9c372c96887d9650f9a97a3b7a3a5860b70078f483e62224772ef1078ecb9c03b1b3bed230569cc7b919
-  HEAD_REF dev/cenit/cmakeConfig
+  HEAD_REF master
   PATCHES
     enable_standard_installation.patch
+    dont_use_integrated_stb_lib.patch
 )
 
 set(ENABLE_CUDA OFF)
@@ -43,6 +44,8 @@ if("weights" IN_LIST FEATURES)
   )
 endif()
 
+file(REMOVE ${SOURCE_PATH}/src/stb_image.h)
+file(REMOVE ${SOURCE_PATH}/src/stb_image_write.h)
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -1,3 +1,11 @@
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+  message(FATAL_ERROR "darknet does not support ARM")
+endif()
+
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+  message(FATAL_ERROR "darknet does not support UWP")
+endif()
+
 include(vcpkg_common_functions)
 
 vcpkg_from_github(

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -2,9 +2,9 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  REPO cenit/darknet
-  REF 7a8574ec5fb5d2ac98bcc90426f5c4ca21230b45
-  SHA512 244066cee9ca34168058bb49df9d6be7d9915e43513f522c605c33d682e3187329ad76945ea604be90290bd99ad54e98717e2b14712d14d9a1d5e908efdee89b
+  REPO AlexeyAB/darknet
+  REF dd27d67f58f563bb6bb2af7bb6374f8a59cebcde
+  SHA512 6821ba9cd5dc185759492deaa2d20ac1ce60778a8aec9c372c96887d9650f9a97a3b7a3a5860b70078f483e62224772ef1078ecb9c03b1b3bed230569cc7b919
   HEAD_REF dev/cenit/cmakeConfig
   PATCHES
     enable_standard_installation.patch
@@ -64,27 +64,26 @@ endif()
 
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/darknet${EXECUTABLE_SUFFIX})
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/uselib${EXECUTABLE_SUFFIX})
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/darknet/)
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/darknet${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/darknet${EXECUTABLE_SUFFIX})
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uselib${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/uselib${EXECUTABLE_SUFFIX})
-file(COPY ${SOURCE_PATH}/cfg DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
-file(COPY ${SOURCE_PATH}/data DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
-
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/darknet)
-
 if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/uselib_track${EXECUTABLE_SUFFIX})
   file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/uselib_track${EXECUTABLE_SUFFIX})
 endif()
-
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/darknet/)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/darknet${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/darknet${EXECUTABLE_SUFFIX})
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uselib${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/uselib${EXECUTABLE_SUFFIX})
 if(EXISTS ${CURRENT_PACKAGES_DIR}/bin/uselib_track${EXECUTABLE_SUFFIX})
   file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uselib_track${EXECUTABLE_SUFFIX} ${CURRENT_PACKAGES_DIR}/tools/darknet/uselib_track${EXECUTABLE_SUFFIX})
 endif()
+file(COPY ${SOURCE_PATH}/cfg DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+file(COPY ${SOURCE_PATH}/data DESTINATION ${CURRENT_PACKAGES_DIR}/tools/darknet)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/darknet)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
+#use vcpkg_fixup_cmake_targets()?
 file(RENAME ${CURRENT_PACKAGES_DIR}/debug/share/darknet/DarknetTargets.cmake ${CURRENT_PACKAGES_DIR}/share/darknet/DarknetTargets.cmake)
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
We finished a big rework of darknet to make it more easily buildable on windows. It is possible now to build it with vcpkg without any big effort. 
The port is still very much untested, but we can iterate quickly on it also from the repository point of view, not just on this portfile.
Any suggestion is really appreciated and any issue will be taken into consideration