### PR TITLE
Allow additional environment variables to be set in a clean environment

### DIFF
--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -40,3 +40,10 @@ This environment variable can be set to a triplet name which will be used for un
 #### VCPKG_FORCE_SYSTEM_BINARIES
 
 This environment variable, if set, suppresses the downloading of CMake and Ninja and forces the use of the system binaries.
+
+### VCPKG_KEEP_ENV_VARS
+
+This environment variable can be set to a list of environment variables, separated by `;`, which will be propagated to
+the build environment.
+
+Example: `FOO_SDK_DIR;BAR_SDK_DIR`

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -178,6 +178,19 @@ namespace vcpkg::System
             L"ANDROID_NDK_HOME",
         };
 
+        const Optional<std::string> keep_vars = System::get_environment_variable("VCPKG_KEEP_ENV_VARS");
+        const auto k = keep_vars.get();
+
+        if (k && !k->empty())
+        {
+            auto vars = Strings::split(*k, ";");
+
+            for (auto&& var : vars)
+            {
+                env_wstrings.push_back(Strings::to_utf16(var.c_str()));
+            }
+        }
+
         std::wstring env_cstr;
 
         for (auto&& env_wstring : env_wstrings)


### PR DESCRIPTION
Currently the user has no control of what environment variables are passed into the clean environment created by vcpkg. This is not ideal for third party triplets which may have platforms that expect certain environment variables to be set.

I'm proposing that there be an environment variable, `VCPKG_KEEP_ENV_VARS`, which contains a `;` separated list of environment variables to pass along to the clean environment.