### PR TITLE
[openexr] Fix IlmImf.dll installed to the wrong location

### DIFF
--- a/ports/openexr/fix_install_ilmimf.patch
+++ b/ports/openexr/fix_install_ilmimf.patch
@@ -1,0 +1,19 @@
+diff --git a/OpenEXR/IlmImf/CMakeLists.txt b/OpenEXR/IlmImf/CMakeLists.txt
+index e1a8740..d31cf68 100644
+--- a/OpenEXR/IlmImf/CMakeLists.txt
++++ b/OpenEXR/IlmImf/CMakeLists.txt
+@@ -2,14 +2,6 @@
+ 
+ SET(CMAKE_INCLUDE_CURRENT_DIR 1)
+ 
+-IF (WIN32)
+-  SET(RUNTIME_DIR ${OPENEXR_PACKAGE_PREFIX}/bin)
+-  SET(WORKING_DIR ${RUNTIME_DIR})
+-ELSE ()
+-  SET(RUNTIME_DIR ${OPENEXR_PACKAGE_PREFIX}/lib)
+-  SET(WORKING_DIR .)
+-ENDIF ()
+-
+ SET(BUILD_B44EXPLOGTABLE OFF)
+ IF (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h")
+   SET(BUILD_B44EXPLOGTABLE ON)

--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
   REF v${OPENEXR_VERSION}
   SHA512 ${OPENEXR_HASH}
   HEAD_REF master
+  PATCHES "fix_install_ilmimf.patch"
 )
 
 vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
One of the CMakeLists.txt files sets RUNTIME_DIR redundantly, and the target IlmImf gets installed to the bin folder inside the root folder of that partition. This patch fixes that. (It is probably better for this to be fixed by the upstream.)