### PR TITLE
[curl]Add the dependency of the curl feature [ssh] to solve the lnk2019 error.

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1-2
+Version: 7.61.1-3
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl
@@ -19,7 +19,7 @@ Build-Depends: curl[openssl] (!windows), curl[winssl] (windows)
 Description: Default SSL backend
 
 Feature: ssh
-Build-Depends: libssh2, curl[non-http]
+Build-Depends: curl[openssl], libssh2, curl[non-http]
 Description: SSH support via libssh2
 
 # SSL backends


### PR DESCRIPTION
See #5200.