### PR TITLE
[fmt] Changed library linkage to static.

### DIFF
--- a/ports/fmt/CONTROL
+++ b/ports/fmt/CONTROL
@@ -1,3 +1,3 @@
 Source: fmt
-Version: 5.3.0
+Version: 5.3.0-1
 Description: Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -1,10 +1,4 @@
 include(vcpkg_common_functions)
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    message("fmt only supports static library linkage. Building static.")
-    set(VCPKG_LIBRARY_LINKAGE static)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fmtlib/fmt
@@ -12,7 +6,6 @@ vcpkg_from_github(
     SHA512 9ef0f3d328681253c1e1776576d54d67dec49c19fd7fc422ae63c3610b01a3f05f6e83cdf5e913dfd09bac42e52fe35c38ebe1ea91f4207d226a32aaf69eb4a8
     HEAD_REF master
 )
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -1,4 +1,10 @@
 include(vcpkg_common_functions)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    message("fmt only supports static library linkage. Building static.")
+    set(VCPKG_LIBRARY_LINKAGE static)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fmtlib/fmt
@@ -14,7 +20,6 @@ vcpkg_configure_cmake(
         -DFMT_CMAKE_DIR=share/fmt
         -DFMT_TEST=OFF
         -DFMT_DOC=OFF
-        -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
The `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` flag prevents `fmt` from being built with a `/GL` and `/LTCG` toolchain.

Tested with this:<br/><https://github.com/qis/toolchains/blob/075a467b671cc08b3f94c1f37ef503bc1627f2fe/windows.cmake>