### PR TITLE
[mapbox-variant] Fix include install location due to hard-coded paths

### DIFF
--- a/ports/mapbox-variant/CONTROL
+++ b/ports/mapbox-variant/CONTROL
@@ -1,3 +1,3 @@
 Source: mapbox-variant
-Version: 1.1.6-0f734f0
+Version: 1.1.6-0f734f0-1
 Description: C++11/C++14 Variant

--- a/ports/mapbox-variant/portfile.cmake
+++ b/ports/mapbox-variant/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 )
 
 # Copy header files
-file(COPY ${SOURCE_PATH}/include/mapbox/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/mapbox-variant FILES_MATCHING PATTERN "*.hpp")
+file(COPY ${SOURCE_PATH}/include/mapbox/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/mapbox FILES_MATCHING PATTERN "*.hpp")
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/mapbox-variant)


### PR DESCRIPTION
Internally, `mapbox-variant` headers depends on being in the `mapbox` directory. Therefore we have to have them installed to `mapbox`.