### PR TITLE
[cppfs] Only build static library

### DIFF
--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -1,5 +1,7 @@
 include(vcpkg_common_functions)
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cginternals/cppfs


### PR DESCRIPTION
No `__dllimport`/`__dllexport` statements, so it needs to be static.