### PR TITLE
[cppfs] Fix debug exports

### DIFF
--- a/ports/cppfs/cmake-export-fix.patch
+++ b/ports/cppfs/cmake-export-fix.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea9fd15..c62c6fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -124,7 +124,7 @@ endif()
+ if((UNIX AND SYSTEM_DIR_INSTALL) OR OPTION_FORCE_SYSTEM_DIR_INSTALL)
+     # Install into the system (/usr/bin or /usr/local/bin)
+     set(INSTALL_ROOT      "share/${project}")       # /usr/[local]/share/<project>
+-    set(INSTALL_CMAKE     "share/${project}/cmake") # /usr/[local]/share/<project>/cmake
++    set(INSTALL_CMAKE     "share/${project}")       # /usr/[local]/share/<project>
+     set(INSTALL_EXAMPLES  "share/${project}")       # /usr/[local]/share/<project>
+     set(INSTALL_DATA      "share/${project}")       # /usr/[local]/share/<project>
+     set(INSTALL_BIN       "bin")                    # /usr/[local]/bin
+@@ -183,7 +183,7 @@ add_subdirectory(deploy)
+ install(FILES "${PROJECT_BINARY_DIR}/VERSION" DESTINATION ${INSTALL_ROOT} COMPONENT runtime)
+ 
+ # Install cmake find script for the project
+-install(FILES ${META_PROJECT_NAME}-config.cmake DESTINATION ${INSTALL_ROOT} COMPONENT dev)
++# install(FILES ${META_PROJECT_NAME}-config.cmake DESTINATION ${INSTALL_ROOT} COMPONENT dev)
+ 
+ # Install the project meta files
+ install(FILES AUTHORS   DESTINATION ${INSTALL_ROOT} COMPONENT runtime)
+diff --git a/source/cppfs/CMakeLists.txt b/source/cppfs/CMakeLists.txt
+index aa37eda..e8a59e0 100644
+--- a/source/cppfs/CMakeLists.txt
++++ b/source/cppfs/CMakeLists.txt
+@@ -283,7 +283,7 @@ perform_health_checks(
+ 
+ # Library
+ install(TARGETS ${target}
+-    EXPORT  "${target}-export"            COMPONENT dev
++    EXPORT  "${target}-config"            COMPONENT dev
+     RUNTIME DESTINATION ${INSTALL_BIN}    COMPONENT runtime
+     LIBRARY DESTINATION ${INSTALL_SHARED} COMPONENT runtime
+     ARCHIVE DESTINATION ${INSTALL_LIB}    COMPONENT dev
+@@ -302,8 +302,8 @@ install(DIRECTORY
+ )
+ 
+ # CMake config
+-install(EXPORT ${target}-export
++install(EXPORT ${target}-config
+     NAMESPACE   ${META_PROJECT_NAME}::
+-    DESTINATION ${INSTALL_CMAKE}/${target}
++    DESTINATION ${INSTALL_CMAKE}
+     COMPONENT   dev
+ )

--- a/ports/cppfs/portfile.cmake
+++ b/ports/cppfs/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         LibCrypto-fix.patch
+        cmake-export-fix.patch
 )
 
 if(${TARGET_TRIPLET} MATCHES "uwp")
@@ -39,6 +40,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
+
+vcpkg_fixup_cmake_targets()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)


### PR DESCRIPTION
`cppfs` gets in the way of the default cmake exports. This disables that and fixes various path issues within their cmake through the use of a patch. This is not viable to be upstreamed as they use a special cmake format for all of their projects so they can mesh together. Changing this would violate that.

Follows up #5707 without disabling static builds.