### PR TITLE
[rxqt] Remove SHA512 verification

### DIFF
--- a/ports/rxqt/CONTROL
+++ b/ports/rxqt/CONTROL
@@ -1,4 +1,4 @@
 Source: rxqt
-Version:
+Version: latest
 Description: The Reactive Extensions for Qt. <https://github.com/tetsurom/rxqt>
 Build-Depends: rxcpp

--- a/ports/rxqt/portfile.cmake
+++ b/ports/rxqt/portfile.cmake
@@ -1,20 +1,22 @@
 #header-only library
+if(NOT VCPKG_USE_HEAD_VERSION)
+    message(FATAL_ERROR "rxqt does not have persistent releases. Please re-run the installation with --head.")
+else()
+    include(vcpkg_common_functions)
 
-include(vcpkg_common_functions)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO tetsurom/rxqt
+        SKIP_SHA512
+        HEAD_REF master
+    )
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO tetsurom/rxqt
-    REF master
-    SHA512 3f25570ab98c8d3959c35b0d99d5c35486339aa8cd752d8140bb064239265ecb8c5002e3a5e2b46324bb79b558cfe0f17e23a59ad51e6d3a0764acdce493b12c
-    HEAD_REF master
-)
+    file(INSTALL
+        ${SOURCE_PATH}/include
+        DESTINATION ${CURRENT_PACKAGES_DIR}
+    )
 
-file(INSTALL
-	${SOURCE_PATH}/include
-    DESTINATION ${CURRENT_PACKAGES_DIR}
-)
-
-file(INSTALL
-	${SOURCE_PATH}/LICENSE
-	DESTINATION ${CURRENT_PACKAGES_DIR}/share/rxqt RENAME copyright)
+    file(INSTALL
+        ${SOURCE_PATH}/LICENSE
+        DESTINATION ${CURRENT_PACKAGES_DIR}/share/rxqt RENAME copyright)
+endif()


### PR DESCRIPTION
1. Rxqt installation failed with mismatched hash.
2. According to the vcpkg [doc](https://github.com/Microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_from_github.md#ref), ref should not be a branch, but this port used "master" at here.
3. Remove ref parameter and SHA512 verification.
4. Force this port install with --head and add a hint message.