### PR TITLE
[fribidi] Update Version to support static build

### DIFF
--- a/ports/fribidi/CONTROL
+++ b/ports/fribidi/CONTROL
@@ -1,3 +1,3 @@
 Source: fribidi
-Version: 1.0.5
+Version: 58c6cb3
 Description: GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)

--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fribidi/fribidi
-    REF v1.0.5
-    SHA512 c51b67cc3e7610bef9a66f2456f7602fe010164c2c01e7d91026cefa4a08fdce5165b6eb3814e76cd89e766356fb71adc08bf75d9b2f5802f71c18b5d0476887
+    REF 58c6cb390a9a18c98b2cbaac555d8ea9352a9e4f
+    SHA512 1ec9c19faa87886786ce1589e2c66cab173b48e34d0e43487becc8606001f21f6ed17d0abd1c322fbbcaeb96a47ed882cad228be2e9beb019020ca2a475fc298
 HEAD_REF master)
 
 vcpkg_configure_meson(SOURCE_PATH ${SOURCE_PATH}
@@ -21,6 +21,10 @@ file(GLOB EXE_FILES
 )
 if (EXE_FILES)
     file(REMOVE ${EXE_FILES})
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
 # Handle copyright


### PR DESCRIPTION
Related issue https://github.com/Microsoft/vcpkg/issues/5199, It will cause LINK error when building static arch. 
Port owner has supported static build for windows, but no release version published. Use latest commit as the REF to fix this issue.