### PR TITLE
[openssl-windows] Make sure ninja is available on our path

### DIFF
--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl-windows
-Version: 1.0.2q
+Version: 1.0.2q-1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl-windows/portfile.cmake
+++ b/ports/openssl-windows/portfile.cmake
@@ -168,4 +168,7 @@ vcpkg_copy_pdbs()
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(INSTALL ${MASTER_COPY_SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
+vcpkg_find_acquire_program(NINJA)
+get_filename_component(NINJA_PATH ${NINJA} DIRECTORY)
+set(ENV{PATH} "$ENV{PATH};${NINJA_PATH}")
 vcpkg_test_cmake(PACKAGE_NAME OpenSSL MODULE)


### PR DESCRIPTION
vcpkg_test_cmake uses ninja by default, make sure we install it and have it on our path, fixes #5713. Normally ninja would be installed by vcpkg_configure_cmake but openssl doesn't use cmake for compilation of itself