### PR TITLE
[clapack]fix missing library and tools.

### DIFF
--- a/ports/clapack/CONTROL
+++ b/ports/clapack/CONTROL
@@ -1,4 +1,4 @@
 Source: clapack
-Version: 3.2.1-1
+Version: 3.2.1-2
 Description: CLAPACK (f2c'ed version of LAPACK)
 Build-Depends: openblas

--- a/ports/clapack/fix-lack-library.patch
+++ b/ports/clapack/fix-lack-library.patch
@@ -1,0 +1,19 @@
+diff --git a/F2CLIBS/libf2c/CMakeLists.txt b/F2CLIBS/libf2c/CMakeLists.txt
+index 2bdbd05..e77b3a3 100644
+--- a/F2CLIBS/libf2c/CMakeLists.txt
++++ b/F2CLIBS/libf2c/CMakeLists.txt
+@@ -60,3 +60,13 @@ include_directories(${CLAPACK_SOURCE_DIR}/F2CLIBS/libf2c)
+ include_directories(${CLAPACK_BINARY_DIR}/F2CLIBS/libf2c)
+ add_library(f2c STATIC ${OFILES} ${CMAKE_CURRENT_BINARY_DIR}/arith.h)
+ set_property(TARGET f2c PROPERTY PREFIX lib)
++
++install(TARGETS f2c 
++        RUNTIME DESTINATION bin
++        LIBRARY DESTINATION lib
++        ARCHIVE DESTINATION lib)
++        
++install(TARGETS arithchk 
++        RUNTIME DESTINATION tools
++        LIBRARY DESTINATION lib
++        ARCHIVE DESTINATION lib)
+\ No newline at end of file

--- a/ports/clapack/portfile.cmake
+++ b/ports/clapack/portfile.cmake
@@ -29,7 +29,9 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/lapack.def DESTINATION ${SOURCE_PATH}/SRC)
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/use-other-blas-and-install-include.patch"
+    PATCHES
+        use-other-blas-and-install-include.patch
+        fix-lack-library.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
In clapack, libf2c is not archived, so I added these codes to archive its library and exe.
See #3268.