### PR TITLE
[SDL2_xxx]: Add CMake targets for SDL2 addons

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
         -DFT_WITH_BZIP2=ON
         -DFT_WITH_PNG=ON
         -DFT_WITH_HARFBUZZ=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE
 )
 
 vcpkg_install_cmake()

--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -48,6 +48,15 @@ add_library(SDL2_image
     version.rc
     )
 
+if (APPLE)
+    target_sources(SDL2_image PRIVATE
+        IMG_ImageIO.m
+    )
+    target_compile_options(SDL2_image BEFORE PRIVATE
+        "-x" "objective-c"
+    )
+endif()
+
 set_target_properties(SDL2_image PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 
 foreach(FORMAT ${SUPPORTED_FORMATS})

--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -94,11 +94,18 @@ endif()
 
 
 install(TARGETS SDL2_image
+    EXPORT SDL2_image
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)
 
 install(FILES SDL_image.h DESTINATION include/SDL2 CONFIGURATIONS Release)
+
+install(EXPORT SDL2_image
+    DESTINATION share/sdl2-image/
+    FILE sdl2-image-config.cmake
+    NAMESPACE SDL2::
+)
 
 
 message(STATUS "Link-time dependencies:")

--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-image
-Version: 2.0.4
+Version: 2.0.4-1
 Build-Depends: sdl2, libpng
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV
 

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -44,6 +44,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH "share/sdl2-image")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 # Handle copyright
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-image)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-image/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2-image/copyright)

--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -78,17 +78,24 @@ add_library(SDL2_mixer
 if(WIN32)
     list(APPEND SDL_MIXER_DEFINES MUSIC_MID_NATIVE)
     target_sources(SDL2_mixer PRIVATE music_nativemidi.c native_midi/native_midi_common.c native_midi/native_midi_win32.c)
+    target_link_libraries(SDL2_mixer ${SDL_MIXER_LIBRARIES} Winmm)
 endif()
 
 set_target_properties(SDL2_mixer PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_compile_definitions(SDL2_mixer PRIVATE ${SDL_MIXER_DEFINES})
 target_include_directories(SDL2_mixer PRIVATE ${SDL_MIXER_INCLUDES} ./native_midi)
-target_link_libraries(SDL2_mixer ${SDL_MIXER_LIBRARIES} Winmm)
 
 install(TARGETS SDL2_mixer
+    EXPORT SDL2_mixer
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)
+
+install(EXPORT SDL2_mixer
+    DESTINATION share/sdl2-mixer/
+    FILE sdl2-mixer-config.cmake
+    NAMESPACE SDL2::
+)
 
 if(NOT SDL_MIXER_SKIP_HEADERS)
     install(FILES SDL_mixer.h DESTINATION include/SDL2)

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.4
+Version: 2.0.4-1
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2
 

--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -54,5 +54,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH "share/sdl2-mixer")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-mixer)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-mixer/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2-mixer/copyright)

--- a/ports/sdl2-net/CMakeLists.txt
+++ b/ports/sdl2-net/CMakeLists.txt
@@ -13,12 +13,22 @@ add_library(SDL2_net SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c version.rc)
 set_target_properties(SDL2_net PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_compile_definitions(SDL2_net PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)
 target_include_directories(SDL2_net PRIVATE ${SDL_INCLUDE_DIR}/SDL2)
-target_link_libraries(SDL2_net ${SDL_LIBRARY} ws2_32 iphlpapi)
+
+if (WIN32)
+    target_link_libraries(SDL2_net ${SDL_LIBRARY} ws2_32 iphlpapi)
+endif()
 
 install(TARGETS SDL2_net
+    EXPORT SDL2_net
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)
+
+install(EXPORT SDL2_net
+    DESTINATION "share/sdl2-net"
+    FILE sdl2-net-config.cmake
+    NAMESPACE SDL2::
+)
 
 if(NOT DEFINED SDL_NET_SKIP_HEADERS)
     install(FILES SDL_net.h DESTINATION include/SDL2)

--- a/ports/sdl2-net/CONTROL
+++ b/ports/sdl2-net/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-net
-Version: 2.0.1-4
+Version: 2.0.1-5
 Description: Networking library for SDL
 Build-Depends: sdl2

--- a/ports/sdl2-net/portfile.cmake
+++ b/ports/sdl2-net/portfile.cmake
@@ -18,5 +18,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH "share/sdl2-net")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-net)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-net/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2-net/copyright)

--- a/ports/sdl2-ttf/CMakeLists.txt
+++ b/ports/sdl2-ttf/CMakeLists.txt
@@ -9,12 +9,19 @@ add_library(SDL2_ttf SDL_ttf.c version.rc)
 
 set_target_properties(SDL2_ttf PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
 target_include_directories(SDL2_ttf PRIVATE ${SDL_INCLUDE_DIR}/SDL2 ${FREETYPE_INCLUDE_DIR_ft2build})
-target_link_libraries(SDL2_ttf ${SDL_LIBRARY} ${FREETYPE_LIBRARY})
+target_link_libraries(SDL2_ttf ${SDL_LIBRARY} ${FREETYPE_LIBRARIES})
 
 install(TARGETS SDL2_ttf
+    EXPORT SDL2_ttf
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib)
+
+INSTALL(EXPORT SDL2_ttf
+    DESTINATION "share/sdl2-ttf"
+    FILE sdl2-ttf-config.cmake
+    NAMESPACE SDL2::
+)
 
 if(NOT DEFINED SDL_TTF_SKIP_HEADERS)
     install(FILES SDL_ttf.h DESTINATION include/SDL2)
@@ -22,4 +29,4 @@ endif()
 
 message(STATUS "Link-time dependencies:")
 message(STATUS "  " ${SDL_LIBRARY})
-message(STATUS "  " ${FREETYPE_LIBRARY})
+message(STATUS "  " ${FREETYPE_LIBRARIES})

--- a/ports/sdl2-ttf/CMakeLists.txt
+++ b/ports/sdl2-ttf/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(Freetype REQUIRED)
 add_library(SDL2_ttf SDL_ttf.c version.rc)
 
 set_target_properties(SDL2_ttf PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
-target_include_directories(SDL2_ttf PRIVATE ${SDL_INCLUDE_DIR}/SDL2 ${FREETYPE_INCLUDE_DIR_ft2build})
+target_include_directories(SDL2_ttf PRIVATE ${SDL_INCLUDE_DIR}/SDL2 ${FREETYPE_INCLUDE_DIRS})
 target_link_libraries(SDL2_ttf ${SDL_LIBRARY} ${FREETYPE_LIBRARIES})
 
 install(TARGETS SDL2_ttf

--- a/ports/sdl2-ttf/CONTROL
+++ b/ports/sdl2-ttf/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl2-ttf
-Version: 2.0.15
+Version: 2.0.15-1
 Description: A library for rendering TrueType fonts with SDL
 Build-Depends: sdl2, freetype

--- a/ports/sdl2-ttf/portfile.cmake
+++ b/ports/sdl2-ttf/portfile.cmake
@@ -25,5 +25,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH "share/sdl2-ttf")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
 file(COPY ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2-ttf/copyright)


### PR DESCRIPTION
At the current state one has many difficulties trying to add the SDL2 addons as dependencies (from my own experience on Windows as well as on Linux). I have added CMake targets to link against to have a consistent way to add SDL_image, SDL_Mixer, SDL_ttf and SDL_net to a minimal project in the form:

```
find_package(SDL2 CONFIG REQUIRED)
find_package(SDL2-ttf CONFIG REQUIRED)
find_package(SDL2-image CONFIG REQUIRED)
find_package(SDL2-mixer CONFIG REQUIRED)
find_package(SDL2-net CONFIG REQUIRED)

target_link_libraries(test PRIVATE
    SDL2::SDL2
    SDL2::SDL2_ttf
    SDL2::SDL2_image
    SDL2::SDL2_mixer
    SDL2::SDL2_net
)
```

Most of them only required an CMake export target in their CMakeLists.txt and the removal of some Windows-specific line. For SDL2_ttf the wrong variable to link against freetype was used, causing the freetype dependencies (libpng, zlib, bzip2) to not be linked against.

I have compiled a minimal project to test these changes: https://github.com/Helco/vcpkg-test-sdl2-addons.

Testing was done on:

- [x] Linux
- [x] Windows -  ~(will do shortly)~ tested
- [x] MacOS - ~(help would be appreciated)~ tested