### PR TITLE
[draco]Fix build error on x86-uwp.

### DIFF
--- a/ports/draco/CONTROL
+++ b/ports/draco/CONTROL
@@ -1,4 +1,4 @@
 Source: draco
-Version: 1.3.3
+Version: 1.3.3-1
 Description: A library for compressing and decompressing 3D geometric meshes and point clouds. It is intended to improve the storage and transmission of 3D graphics.
 Build-Depends:

--- a/ports/draco/fix-compile-error-uwp.patch
+++ b/ports/draco/fix-compile-error-uwp.patch
@@ -1,0 +1,30 @@
+diff --git a/src/draco/core/symbol_coding_utils.h b/src/draco/core/symbol_coding_utils.h
+index be2183d..eaaca00 100644
+--- a/src/draco/core/symbol_coding_utils.h
++++ b/src/draco/core/symbol_coding_utils.h
+@@ -41,7 +41,9 @@ typename std::make_unsigned<IntTypeT>::type ConvertSignedIntToSymbol(
+   if (val >= 0) {
+     return static_cast<UnsignedType>(val) << 1;
+   }
+-  val = -(val + 1);  // Map -1 to 0, -2 to -1, etc..
++  // Map -1 to 0, -2 to -1, etc..
++  val += 1;
++  val *= -1;
+   UnsignedType ret = static_cast<UnsignedType>(val);
+   ret <<= 1;
+   ret |= 1;
+diff --git a/src/draco/io/parser_utils.cc b/src/draco/io/parser_utils.cc
+index 1aa52cc..cfbbdbd 100644
+--- a/src/draco/io/parser_utils.cc
++++ b/src/draco/io/parser_utils.cc
+@@ -150,7 +150,9 @@ bool ParseSignedInt(DecoderBuffer *buffer, int32_t *value) {
+   uint32_t v;
+   if (!ParseUnsignedInt(buffer, &v))
+     return false;
+-  *value = (sign < 0) ? -v : v;
++  if (sign < 0)
++    v *= -1;
++  *value = v;
+   return true;
+ }
+ 

--- a/ports/draco/portfile.cmake
+++ b/ports/draco/portfile.cmake
@@ -23,6 +23,8 @@ vcpkg_from_github(
     REF 1.3.3
     SHA512 80ed5a623046822f5bb26b2454c8ee8cc93ffe9eb3012e8461cefdfc577b26d69a92ea0f0c5e14f5f48c1ef99f9a7263b01710df376792e74358ae14e49c3897
     HEAD_REF master
+    PATCHES
+        fix-compile-error-uwp.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
When draco compiles x86-uwp, an error occurs:
>error C4146: unary minus operator applied to unsigned type, result still unsigned.

normally, we can add theses code to avoid the error:
```
#pragma warning(disable:4146)
#import "c:\Program Files\common files\system\ado\msado20.tlb" no_namespace rename("EOF","adoEOF")
```

but another error appears:
>error C2813: #import is not supported with /MP

So, I modified some code to solve this problem.

See #3276.