### PR TITLE
[tiff] Changed library linkage to static.

### DIFF
--- a/ports/tiff/CONTROL
+++ b/ports/tiff/CONTROL
@@ -1,4 +1,4 @@
 Source: tiff
-Version: 4.0.10-3
+Version: 4.0.10-4
 Build-Depends: zlib, libjpeg-turbo, liblzma (!uwp)
 Description: A library that supports the manipulation of TIFF image files

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -2,6 +2,8 @@ include(vcpkg_common_functions)
 
 set(LIBTIFF_VERSION 4.0.10)
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz"
     FILENAME "tiff-${LIBTIFF_VERSION}.tar.gz"


### PR DESCRIPTION
The `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` flag prevents `tiff` from being built with a `/GL` and `/LTCG` toolchain.

Tested with this:<br/>https://github.com/qis/toolchains/blob/075a467b671cc08b3f94c1f37ef503bc1627f2fe/windows.cmake

Please note that the `portfile.cmake` file does not explicitly set `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`, but it is set in `libtiff/CMakeLists.txt` line 149 when C++ support is enabled (on by default).

I have found no other support for shared libraries on Windows in the `tiff` port. All functions are hard-coded as `extern`.