### PR TITLE
[apr-util]Fix static library usage bug.

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,4 +1,4 @@
 Source: apr-util
-Version: 1.6.0-1
+Version: 1.6.0-2
 Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
 Build-Depends: expat, apr, openssl

--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -13,15 +13,23 @@ vcpkg_apply_patches(
   PATCHES "${CMAKE_CURRENT_LIST_DIR}/use-vcpkg-expat.patch"
 )
 
-
-vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
-  OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
-)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_configure_cmake(
+      SOURCE_PATH ${SOURCE_PATH}
+      PREFER_NINJA
+      OPTIONS -DAPU_DECLARE_EXPORT=ON
+      OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+    )
+else()
+    vcpkg_configure_cmake(
+      SOURCE_PATH ${SOURCE_PATH}
+      PREFER_NINJA
+      OPTIONS -DAPU_DECLARE_EXPORT=ON
+      OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+    )
+endif()
 
 vcpkg_install_cmake()
-
 
 file(READ ${CURRENT_PACKAGES_DIR}/include/apu.h  APU_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -24,7 +24,7 @@ else()
     vcpkg_configure_cmake(
       SOURCE_PATH ${SOURCE_PATH}
       PREFER_NINJA
-      OPTIONS -DAPU_DECLARE_EXPORT=ON
+      OPTIONS -DAPU_DECLARE_STATIC=ON
       OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
     )
 endif()


### PR DESCRIPTION
In _CMakelists.txt_, there are two macros(**APU_DECLARE_EXPORT** and **APU_DECLARE_STATIC**) to judge whether to select the compiled library as _static_ or _dynamic_.
Without macros, link problems occur when we use static libraries.

Additionally, we need to import **ws2_32.lib** and **rpcrt4.lib** to solve other link errors.
See #3462