### PR TITLE
[giflib] Changed library linkage to static.

### DIFF
--- a/ports/giflib/CMakeLists.txt
+++ b/ports/giflib/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-project(giflib)
+project(giflib C)
 
 set(GIFLIB_HEADERS
     lib/gif_lib.h
@@ -18,9 +18,6 @@ set(GIFLIB_SOURCES
 )
 
 add_library(gif ${GIFLIB_SOURCES})
-if (BUILD_SHARED_LIBS)
-    set_property(TARGET gif PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif ()
 
 if (NOT GIFLIB_SKIP_HEADERS)
     install(FILES ${GIFLIB_HEADERS} DESTINATION include)

--- a/ports/giflib/CONTROL
+++ b/ports/giflib/CONTROL
@@ -1,3 +1,3 @@
 Source: giflib
-Version: 5.1.4-1
+Version: 5.1.4-2
 Description: A library for reading and writing gif images.

--- a/ports/giflib/CONTROL
+++ b/ports/giflib/CONTROL
@@ -1,3 +1,3 @@
 Source: giflib
-Version: 5.1.4-2
+Version: 5.1.4-3
 Description: A library for reading and writing gif images.

--- a/ports/giflib/portfile.cmake
+++ b/ports/giflib/portfile.cmake
@@ -2,22 +2,21 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/giflib-5.1.4)
+set(GIFLIB_VERSION 5.1.4)
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://downloads.sourceforge.net/sourceforge/giflib/giflib-5.1.4.tar.bz2"
-    FILENAME "giflib-5.1.4.tar.bz2"
+    URLS "http://downloads.sourceforge.net/sourceforge/giflib/giflib-${GIFLIB_VERSION}.tar.bz2"
+    FILENAME "giflib-${GIFLIB_VERSION}.tar.bz2"
     SHA512 32b5e342056c210e6478e9cb3b6ceec9594dcfaf34feea1eb4dad633a081ed4465bceee578c19165907cb47cb83912ac359ceea666a8e07dbbb5420f9928f96d
 )
 
-vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${GIFLIB_VERSION}
+    PATCHES msvc-guard-unistd-h.patch
+)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/msvc-guard-unistd-h.patch
-)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/giflib/portfile.cmake
+++ b/ports/giflib/portfile.cmake
@@ -1,11 +1,16 @@
 include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/giflib-5.1.4)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://downloads.sourceforge.net/sourceforge/giflib/giflib-5.1.4.tar.bz2"
     FILENAME "giflib-5.1.4.tar.bz2"
     SHA512 32b5e342056c210e6478e9cb3b6ceec9594dcfaf34feea1eb4dad633a081ed4465bceee578c19165907cb47cb83912ac359ceea666a8e07dbbb5420f9928f96d
 )
+
 vcpkg_extract_source_archive(${ARCHIVE})
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_apply_patches(


### PR DESCRIPTION
The `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` flag prevents `giflib` from being built with a `/GL` and `/LTCG` toolchain.

Tested with this:<br/>https://github.com/qis/toolchains/blob/075a467b671cc08b3f94c1f37ef503bc1627f2fe/windows.cmake

Please note that the `portfile.cmake` file does not explicitly set `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`, but it is set in `giflib-5.1.4/CMakeLists.txt` line 22 when `BUILD_SHARED_LIBS` is enabled.

I have found no other support for shared libraries on Windows in the `giflib` port. All functions are hard-coded as `extern` or don't have any linkage specifier at all.