### PR TITLE
[angle] Fixed build with /permissive- MSVC toolchain and clang on Linux

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -19,9 +19,11 @@ else()
 endif()
 
 if(WINDOWS_ANY)
-    add_compile_options(/d2guard4 /Wv:18 /guard:cf)
+    add_compile_options(/d2guard4 /Wv:18 /guard:cf /permissive)
 else()
-    add_compile_options(-std=c++17 -fPIC)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if (APPLE)

--- a/ports/angle/CONTROL
+++ b/ports/angle/CONTROL
@@ -1,5 +1,5 @@
 Source: angle
-Version: 2019-03-13-c2ee2cc
+Version: 2019-03-13-c2ee2cc-1
 Description: A conformant OpenGL ES implementation for Windows, Mac and Linux.
   The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support.
 Build-Depends: egl-registry


### PR DESCRIPTION
The first change is to fix builds with MSVC toolchains that set `/permissive-` since ANGLE requires the old behavior.

The biggest offender is the macro `NOTREACHED` (`src\common\third_party\base\anglebaselogging.h` line 23).

I see no harm in forcing `/permissive` as it should not have any effect on builds with the default toolchain.

The second change is switching from hard-coded compile options to CMake properties, otherwise the port cannot be built with clang since the `clang(1)` executable does not support the `-std=c++...` command line options.

The [CMAKE_CXX_STANDARD 17](https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html) property is supported since CMake version 3.8.2.
The [CMAKE_POSITION_INDEPENDENT_CODE](https://cmake.org/cmake/help/v3.12/variable/CMAKE_POSITION_INDEPENDENT_CODE.html) property improves `try_compile` support.