### PR TITLE
[libnice]Fix build error in windows.

### DIFF
--- a/ports/libnice/CONTROL
+++ b/ports/libnice/CONTROL
@@ -1,4 +1,4 @@
 Source: libnice
-Version: 0.1.13-1
+Version: 0.1.13-2
 Description: Libnice is an implementation of the IETF's Interactive Connectivity Establishment (ICE) standard (RFC 5245) and the Session Traversal Utilities for NAT (STUN) standard (RFC 5389).
 Build-Depends: glib

--- a/ports/libnice/fix-build_in_windows.patch
+++ b/ports/libnice/fix-build_in_windows.patch
@@ -1,0 +1,13 @@
+diff --git a/stun/usages/bind.c b/stun/usages/bind.c
+index c5b09ab..58ef882 100644
+--- a/stun/usages/bind.c
++++ b/stun/usages/bind.c
+@@ -340,7 +340,7 @@ static void stun_trans_deinit (StunTransport *tr)
+ 
+ static int stun_err_dequeue (int fd)
+ {
+-#ifdef MSG_ERRQUEUE
++#if (defined(MSG_ERRQUEUE) && !defined(_WIN32))
+   struct msghdr hdr;
+   int saved_errno = errno, ret;
+ 

--- a/ports/libnice/portfile.cmake
+++ b/ports/libnice/portfile.cmake
@@ -8,6 +8,11 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 c9bb81e8cd0b4e3673dba07ce08a16dd8821831339b44f1006510cdc09f9ae4c6eb7d43230711a2509867acb8d7df71821c411830dbf71c5a5d7e802f14a32c1
 )
 vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/fix-build_in_windows.patch
+)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 

--- a/ports/libnice/portfile.cmake
+++ b/ports/libnice/portfile.cmake
@@ -1,18 +1,17 @@
 include(vcpkg_common_functions)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/libnice-0.1.13)
-
-vcpkg_download_distfile(ARCHIVE
+vcpkg_download_distfile(
+    ARCHIVE
     URLS "https://nice.freedesktop.org/releases/libnice-0.1.13.tar.gz"
     FILENAME "libnice-0.1.13.tar.gz"
     SHA512 c9bb81e8cd0b4e3673dba07ce08a16dd8821831339b44f1006510cdc09f9ae4c6eb7d43230711a2509867acb8d7df71821c411830dbf71c5a5d7e802f14a32c1
 )
-vcpkg_extract_source_archive(${ARCHIVE})
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_extract_source_archive_ex(
+    ARCHIVE ${ARCHIVE}
+    OUT_SOURCE_PATH SOURCE_PATH
     PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/fix-build_in_windows.patch
-)
+        fix-build_in_windows.patch
+   )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 


### PR DESCRIPTION
When libnice is built in windows, the following error occurred:
>      4>...\bind.c(344): error C2079: 'hdr' uses undefined struct 'msghdr' [...\libnice.vcxproj]
This is because this structure is used in linux. So I modified one macro to avoid it.

See #3571