### PR TITLE
[nlohmann-json] update version to 3.6.1

### DIFF
--- a/ports/nlohmann-json/CONTROL
+++ b/ports/nlohmann-json/CONTROL
@@ -1,3 +1,3 @@
 Source: nlohmann-json
-Version: 3.6.0
+Version: 3.6.1
 Description: JSON for Modern C++

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-set(SOURCE_VERSION 3.6.0)
+set(SOURCE_VERSION 3.6.1)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/nlohmann-json-v${SOURCE_VERSION})
 
 file(MAKE_DIRECTORY ${SOURCE_PATH})
@@ -15,11 +15,11 @@ function(download_src SUBPATH SHA512)
     file(COPY ${FILE} DESTINATION ${SUBPATH_DIR})
 endfunction()
 
-download_src(CMakeLists.txt f6b6576790a47d9b07b25abbcf2638fb0eb2bfeb780dc8c6d65b97da94ac0e13eeb751fbbc2cfbfbdaa4246704b703d00818ebd7dc844d7079886e5e7ce287f3)
+download_src(CMakeLists.txt ea5775c8eca3f387d152e6adadeb5e5454b7bce2bb45b305019248def2714b85b959196cb97f25b175ebebd044f179bcffa5ec62b0373bee3a8ca135f2988054)
 download_src(LICENSE.MIT 44e6d9510dd66195211aa8ce3e6eef55be524e82c5864f3bfb85f2ac1215529c8ca370c8746de61ad5739e5af1633a5985085dacd1ffe220cd21d06433936801)
 download_src(nlohmann_json.natvis 9bce6758db0e54777394a4e718e60a281952b15f0c6dc6a6ad4a6d023c958b5515b2d39b7d4c66c03f0d3fdfdc1d6c23afb8b8419f1345c9d44d7b9a9ee2582b)
 download_src(cmake/config.cmake.in 7caab6166baa891f77f5b632ac4a920e548610ec41777b885ec51fe68d3665ffe91984dd2881caf22298b5392dfbd84b526fda252467bb66de9eb90e6e6ade5a)
-download_src(single_include/nlohmann/json.hpp 732fde576437ac02144a9e7a88b20600f786e97f5c5d59d78eb849d50bb61ee3633114f910913378c23497838fbd90c3c67704f0921ebba4d5e4ad5070fcd071)
+download_src(single_include/nlohmann/json.hpp 17ad2911f054235002e273a34087f91122586de475792e9a41b8fa5cd0df3341867a976d702e2bb99459583d393afaabb481823700260bc19fb64eae544fc0bd)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Fixes regressions and bugs in 3.6.0 release. Details: https://github.com/nlohmann/json/releases/tag/v3.6.1