### PR TITLE
[SDL2] Add patch for SDL2 hid_enumerate bug 4391

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.9-1
+Version: 2.0.9-2
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 
 Feature: vulkan

--- a/ports/sdl2/SDL-2.0.9-bug-4391-fix.patch
+++ b/ports/sdl2/SDL-2.0.9-bug-4391-fix.patch
@@ -1,0 +1,75 @@
+# HG changeset patch
+# User Sam Lantinga <slouken@libsdl.org>
+# Date 1542691020 28800
+# Node ID 9091b20040cf04cdc348d290ca22373b36364c39
+# Parent  144400e4630d885d2eb0761b7174433b4c0d90bb
+Fixed bug 4391 - hid_enumerate() sometimes causes game to freeze for a few seconds
+
+Daniel Gibson
+
+Even though my game (dhewm3) doesn't use SDL_INIT_JOYSTICK, SDL_PumpEvent() calls SDL_JoystickUpdate() which ends up calling hid_enumerate() every three seconds, and sometimes on my Win7 box hid_enumerate() takes about 5 seconds, which causes the whole game to freeze for that time.
+
+diff -r 144400e4630d -r 9091b20040cf include/SDL_bits.h
+--- a/include/SDL_bits.h	Sun Nov 18 19:28:20 2018 +0300
++++ b/include/SDL_bits.h	Mon Nov 19 21:17:00 2018 -0800
+@@ -101,6 +101,15 @@
+ #endif
+ }
+ 
++SDL_FORCE_INLINE SDL_bool
++SDL_HasExactlyOneBitSet32(Uint32 x)
++{
++    if (x && !(x & (x - 1))) {
++        return SDL_TRUE;
++    }
++    return SDL_FALSE;
++}
++
+ /* Ends C function definitions when using C++ */
+ #ifdef __cplusplus
+ }
+diff -r 144400e4630d -r 9091b20040cf src/SDL.c
+--- a/src/SDL.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/SDL.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -348,6 +348,12 @@
+     int num_subsystems = SDL_arraysize(SDL_SubsystemRefCount);
+     Uint32 initialized = 0;
+ 
++    /* Fast path for checking one flag */
++    if (SDL_HasExactlyOneBitSet32(flags)) {
++        int subsystem_index = SDL_MostSignificantBitIndex32(flags);
++        return SDL_SubsystemRefCount[subsystem_index] ? flags : 0;
++    }
++
+     if (!flags) {
+         flags = SDL_INIT_EVERYTHING;
+     }
+diff -r 144400e4630d -r 9091b20040cf src/joystick/SDL_joystick.c
+--- a/src/joystick/SDL_joystick.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/joystick/SDL_joystick.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -1016,6 +1016,10 @@
+     int i;
+     SDL_Joystick *joystick;
+ 
++    if (!SDL_WasInit(SDL_INIT_JOYSTICK)) {
++        return;
++    }
++
+     SDL_LockJoysticks();
+ 
+     if (SDL_updating_joystick) {
+diff -r 144400e4630d -r 9091b20040cf src/sensor/SDL_sensor.c
+--- a/src/sensor/SDL_sensor.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/sensor/SDL_sensor.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -505,6 +505,10 @@
+     int i;
+     SDL_Sensor *sensor;
+ 
++    if (!SDL_WasInit(SDL_INIT_SENSOR)) {
++        return;
++    }
++
+     SDL_LockSensors();
+ 
+     if (SDL_updating_sensor) {
+

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         export-symbols-only-in-shared-build.patch
         fix-x86-windows.patch
         enable-winrt-cmake.patch
+        SDL-2.0.9-bug-4391-fix.patch # See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391 # Can be removed once SDL 2.0.10 is released
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)


### PR DESCRIPTION
Applies patch for SDL 2.0.9 bug 4391: "hid_enumerate() sometimes causes game to freeze for a few seconds"

See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391