### PR TITLE
[pcre2/caffe2] Fix space issue

### DIFF
--- a/ports/caffe2/CONTROL
+++ b/ports/caffe2/CONTROL
@@ -1,4 +1,4 @@
 Source: caffe2
-Version: 0.8.1-1
+Version: 0.8.1-2
 Build-Depends: lmdb, gflags, glog, eigen3, protobuf
 Description: Caffe2 is a lightweight, modular, and scalable deep learning framework.

--- a/ports/caffe2/fix-space.patch
+++ b/ports/caffe2/fix-space.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Utils.cmake b/cmake/Utils.cmake
+index e082298..25186e4 100644
+--- a/cmake/Utils.cmake
++++ b/cmake/Utils.cmake
+@@ -386,7 +386,7 @@ function(caffe_add_whole_archive_flag lib output_var)
+     set(${output_var} -Wl,-force_load,$<TARGET_FILE:${lib}> PARENT_SCOPE)
+   elseif(MSVC)
+     # In MSVC, we will add whole archive in default.
+-    set(${output_var} -WHOLEARCHIVE:$<TARGET_FILE:${lib}> PARENT_SCOPE)
++    set(${output_var} -WHOLEARCHIVE:"$<TARGET_FILE:${lib}>" PARENT_SCOPE)
+   else()
+     # Assume everything else is like gcc
+     set(${output_var} -Wl,--whole-archive ${lib} -Wl,--no-whole-archive PARENT_SCOPE)

--- a/ports/caffe2/portfile.cmake
+++ b/ports/caffe2/portfile.cmake
@@ -16,7 +16,8 @@ vcpkg_from_github(
     SHA512 505a8540b0c28329c4e2ce443ac8e198c1ee613eb6b932927ee9d04c8afdc95081f3c4581408b7097d567840427b31f6d7626ea80f27e56532f2f2e6acd87023
     HEAD_REF master
     PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/msvc-fixes.patch
+        msvc-fixes.patch
+        fix-space.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)

--- a/ports/pcre2/CONTROL
+++ b/ports/pcre2/CONTROL
@@ -1,3 +1,3 @@
 Source: pcre2
-Version: 10.30-2
+Version: 10.30-3
 Description: PCRE2 is a re-working of the original Perl Compatible Regular Expressions library

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -8,6 +8,9 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 
+vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
+    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-space.patch)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -19,9 +22,6 @@ vcpkg_configure_cmake(
         -DPCRE2_SUPPORT_UNICODE=ON
         -DPCRE2_BUILD_TESTS=OFF
         -DPCRE2_BUILD_PCRE2GREP=OFF)
-
-vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-space.patch)
 
 vcpkg_install_cmake()
 

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -6,10 +6,11 @@ vcpkg_download_distfile(ARCHIVE
     FILENAME "pcre2-${PCRE2_VERSION}.zip"
     SHA512 03e570b946ac29498a114b27e715a0fcf25702bfc9623f9fc085ee8a3214ab3c303baccb9c0af55da6916e8ce40d931d97f1ee9628690563041a943f0aa2bc54)
 
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-space.patch)
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    PATCHES fix-space.patch
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -1,6 +1,6 @@
 set(PCRE2_VERSION 10.30)
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pcre2-${PCRE2_VERSION})
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.pcre.org/pub/pcre/pcre2-${PCRE2_VERSION}.zip" "https://sourceforge.net/projects/pcre/files/pcre2/${PCRE2_VERSION}/pcre2-${PCRE2_VERSION}.zip/download"
     FILENAME "pcre2-${PCRE2_VERSION}.zip"


### PR DESCRIPTION
These 2 ports failed with space path when installing in our testing.
[pcre2] There was a patch for the space issue previously, but put the patch to the wrong place in portfile.camke. It should be patched after extract source. Updates!
[caffe2]Failed with link error lNK1104 when linking lib files.  Add "" to fix this issue.