### PR TITLE
Fix LLVM cmake modules

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,4 +1,4 @@
 Source: llvm
-Version: 7.0.0
+Version: 7.0.0-1
 Description: The LLVM Compiler Infrastructure
 Build-Depends: atlmfc (windows)

--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,4 +1,4 @@
 Source: llvm
-Version: 7.0.0-1
+Version: 7.0.0-2
 Description: The LLVM Compiler Infrastructure
 Build-Depends: atlmfc (windows)

--- a/ports/llvm/install-cmake-modules-to-share.patch
+++ b/ports/llvm/install-cmake-modules-to-share.patch
@@ -1,10 +1,26 @@
-diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
-index ac4b0b7..13a271d 100644
---- a/cmake/modules/CMakeLists.txt
-+++ b/cmake/modules/CMakeLists.txt
+diff -urN llvm-7.0.0.src-orig/cmake/modules/CMakeLists.txt llvm-7.0.0.src/cmake/modules/CMakeLists.txt
+--- llvm-7.0.0.src-orig/cmake/modules/CMakeLists.txt	2018-07-27 13:57:51.000000000 +0300
++++ llvm-7.0.0.src/cmake/modules/CMakeLists.txt	2019-03-26 14:56:34.645434190 +0200
 @@ -1,4 +1,4 @@
 -set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
 +set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
  set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
  
  # First for users who use an installed LLVM, create the LLVMExports.cmake file.
+diff -urN llvm-7.0.0.src-orig/tools/clang/cmake/modules/CMakeLists.txt llvm-7.0.0.src/tools/clang/cmake/modules/CMakeLists.txt
+--- llvm-7.0.0.src-orig/tools/clang/cmake/modules/CMakeLists.txt	2018-01-24 21:26:50.000000000 +0200
++++ llvm-7.0.0.src/tools/clang/cmake/modules/CMakeLists.txt	2019-03-26 14:57:07.173362736 +0200
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(CLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/clang)
++set(CLANG_INSTALL_PACKAGE_DIR share/clang)
+ set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(CLANG_EXPORTS GLOBAL PROPERTY CLANG_EXPORTS)

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_configure_cmake(
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
         -DLLVM_TOOLS_INSTALL_DIR=tools/llvm
+        -DLLVM_PARALLEL_LINK_JOBS=1
 )
 
 vcpkg_install_cmake()

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -63,9 +63,29 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     file(REMOVE ${DEBUG_EXE})
 endif()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/clang TARGET_PATH share/clang)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/clang TARGET_PATH share/clang)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/llvm)
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/llvm)
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(READ ${CURRENT_PACKAGES_DIR}/share/clang/ClangTargets-release.cmake RELEASE_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}/bin" "\${_IMPORT_PREFIX}/tools/llvm" RELEASE_MODULE "${RELEASE_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/clang/ClangTargets-release.cmake "${RELEASE_MODULE}")
+
+    file(READ ${CURRENT_PACKAGES_DIR}/share/llvm/LLVMExports-release.cmake RELEASE_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}/bin" "\${_IMPORT_PREFIX}/tools/llvm" RELEASE_MODULE "${RELEASE_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/llvm/LLVMExports-release.cmake "${RELEASE_MODULE}")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(READ ${CURRENT_PACKAGES_DIR}/share/clang/ClangTargets-debug.cmake DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin" "\${_IMPORT_PREFIX}/tools/llvm" DEBUG_MODULE "${DEBUG_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/clang/ClangTargets-debug.cmake "${DEBUG_MODULE}")
+
+    file(READ ${CURRENT_PACKAGES_DIR}/share/llvm/LLVMExports-debug.cmake DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin" "\${_IMPORT_PREFIX}/tools/llvm" DEBUG_MODULE "${DEBUG_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/llvm/LLVMExports-debug.cmake "${DEBUG_MODULE}")
+endif()
 
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include


### PR DESCRIPTION
- Fix wrong paths in LLVM/Clang cmake modules
- Reduce build-time memory usage (at the expense of some build-time slow down)
