### PR TITLE
Removes string replacement on Abseil headers

### DIFF
--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -23,14 +23,6 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-abseil TARGET_PATH share/unofficial-abseil)
 
-file(GLOB_RECURSE HEADERS ${CURRENT_PACKAGES_DIR}/include/*)
-foreach(FILE ${HEADERS})
-    file(READ "${FILE}" _contents)
-    string(REPLACE "std::min(" "(std::min)(" _contents "${_contents}")
-    string(REPLACE "std::max(" "(std::max)(" _contents "${_contents}")
-    file(WRITE "${FILE}" "${_contents}")
-endforeach()
-
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/abseil RENAME copyright)


### PR DESCRIPTION
Abseil now has all uses of min and max wrapped in parens to prevent macro expansion. This will continue to be the case going forward, so these replacements are no longer needed.

Also, the Github web UI is forcing an extra change that updates the return character to the proper Windows CR+LF