### PR TITLE
[decimal-for-cpp] update to 1.16

### DIFF
--- a/ports/decimal-for-cpp/CONTROL
+++ b/ports/decimal-for-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: decimal-for-cpp
-Version:1.12
+Version:1.16
 Description: Decimal data type support, for COBOL-like fixed-point operations on currency values. 
 

--- a/ports/decimal-for-cpp/portfile.cmake
+++ b/ports/decimal-for-cpp/portfile.cmake
@@ -1,29 +1,16 @@
-# Common Ambient Variables:
-#   VCPKG_ROOT_DIR = <C:\path\to\current\vcpkg>
-#   TARGET_TRIPLET is the current triplet (x86-windows, etc)
-#   PORT is the current port name (zlib, etc)
-#   CURRENT_BUILDTREES_DIR = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
-#   CURRENT_PACKAGES_DIR  = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
-#
-
 #header-only library
 
 include(vcpkg_common_functions)
 
-vcpkg_download_distfile(HEADER
-    URLS "https://raw.githubusercontent.com/vpiotr/decimal_for_cpp/98287a0f0f48aaed2cc146d7682396ae08ed0aea/include/decimal.h"
-    FILENAME "decimal.h"
-    SHA512 9de1208760c74ff1e6b1a74957dabae33981d2f5d0ec402b48f27f4dc24c950ea69219a9ee9831959a8669a9c7908093d833a227924f1955cbe444a9f43c5f3a
-)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+	REPO vpiotr/decimal_for_cpp
+	REF 375633343aa0af812a3ebf4bd06adaeff112ead4
+	SHA512 7692fbb1643ed77b0b44fee1cf9a603fa257a5cf64ea66193c571fca61d138c6465a359db21955a4e2a234677f1806d47e05811daf2954004b108e09d3c8d4fa
+	HEAD_REF master
+	)
 
-vcpkg_download_distfile(LICENSE
-    URLS "https://raw.githubusercontent.com/vpiotr/decimal_for_cpp/98287a0f0f48aaed2cc146d7682396ae08ed0aea/doc/license.txt"
-    FILENAME "decimal-for-cpp-License.txt"
-    SHA512 0b2be46b07a0536404887fae9665d6532ffd4cbfefbec42926c14e055f538c1f3a73b6e61ab7fa1584e634ad99304133d18855197df0a914cbb835674cc67677
-)
-
-
-file(COPY ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/decimal-for-cpp-License.txt ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/copyright)
+file(COPY ${SOURCE_PATH}/include/decimal.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${SOURCE_PATH}/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/license.txt ${CURRENT_PACKAGES_DIR}/share/decimal-for-cpp/copyright)
 


### PR DESCRIPTION
If there was another file previously downloaded with the name of 'decimal.h' with a different hash this port would fail.  This scenario occationally happened in the CI system.  Updated to vcpkg_from_github to avoid this issue in the future.  While here I thought I would also update to 1.16