### PR TITLE
[xerces-c] Add libraries required on osx to target using wrapper

### DIFF
--- a/ports/xerces-c/CONTROL
+++ b/ports/xerces-c/CONTROL
@@ -1,5 +1,5 @@
 Source: xerces-c
-Version: 3.2.2-7
+Version: 3.2.2-8
 Description: Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.
 
 Feature: icu

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -45,6 +45,12 @@ string(REPLACE
 )
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfigInternal.cmake "${_contents}")
 
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake
+    ${CURRENT_PACKAGES_DIR}/share/xercesc
+    @ONLY
+)
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/xerces-c/vcpkg-cmake-wrapper.cmake
+++ b/ports/xerces-c/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,9 @@
+_find_package(${ARGS})
+
+if (APPLE)
+   if (TARGET XercesC::XercesC)
+      set_property(TARGET XercesC::XercesC APPEND PROPERTY INTERFACE_LINK_LIBRARIES  "-framework CoreServices" "-framework CoreFoundation" curl)  
+      list(APPEND XercesC_LIBRARIES "-framework CoreServices" "-framework CoreFoundation" curl)
+   endif()
+endif()
+


### PR DESCRIPTION
`xerces-c` build successfully on `osx`, however it does not correctly export it's required dependencies. 
This PR adds the required dependencies to the target using a wrapper file