### PR TITLE
[glew] Do not build utilities

### DIFF
--- a/ports/glew/CONTROL
+++ b/ports/glew/CONTROL
@@ -1,3 +1,3 @@
 Source: glew
-Version: 2.1.0-1
+Version: 2.1.0-2
 Description: The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -13,7 +13,9 @@ vcpkg_extract_source_archive(${ARCHIVE_FILE} ${CURRENT_BUILDTREES_DIR}/src/glew)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/build/cmake
-)
+    OPTIONS
+        -DBUILD_UTILS=OFF
+    )
 
 vcpkg_install_cmake()
 
@@ -39,11 +41,6 @@ endif()
 if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/libglew32d.lib)
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libglew32d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/glew32d.lib)
 endif()
-
-file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/glewinfo.exe)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/visualinfo.exe)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/glewinfo.exe)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/visualinfo.exe)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -3,7 +3,7 @@ include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glew/glew-2.1.0)
 
 # Don't change to vcpkg_from_github! The github-auto-generated archives are missing some files.
-# More info: https://github.com/nigels-com/glew/issues/31
+# More info: https://github.com/nigels-com/glew/issues/31 and https://github.com/nigels-com/glew/issues/13
 vcpkg_download_distfile(ARCHIVE_FILE
     URLS "https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz"
     FILENAME "glew-2.1.0.tgz"


### PR DESCRIPTION
`glew` currently builds and then deletes it's utilities. This PR prevents them from building.