### PR TITLE
[jsonnet] Fix space path issue.

### DIFF
--- a/ports/jsonnet/CONTROL
+++ b/ports/jsonnet/CONTROL
@@ -1,3 +1,3 @@
 Source: jsonnet
-Version: 2018-11-01-1
+Version: 2018-11-01-2
 Description: Jsonnet - The data templating language

--- a/ports/jsonnet/portfile.cmake
+++ b/ports/jsonnet/portfile.cmake
@@ -10,14 +10,14 @@ vcpkg_from_github(
 
 if (WIN32)
   vcpkg_execute_required_process(
-    COMMAND Powershell -Command "((Get-Content -Encoding Byte ${SOURCE_PATH}/stdlib/std.jsonnet) -join ',') + ',0' > ${SOURCE_PATH}/core/std.jsonnet.h"
-    WORKING_DIRECTORY ${SOURCE_PATH}
+    COMMAND Powershell -Command "((Get-Content -Encoding Byte \"${SOURCE_PATH}/stdlib/std.jsonnet\") -join ',') + ',0' > \"${SOURCE_PATH}/core/std.jsonnet.h\""
+    WORKING_DIRECTORY "${SOURCE_PATH}"
     LOGNAME "std.jsonnet"
   )
 else()
   vcpkg_execute_required_process(
-    COMMAND bash -c "((od -v -Anone -t u1 ${SOURCE_PATH}/stdlib/std.jsonnet | tr ' ' '\\n' | grep -v '^$' | tr '\\n' ',' ) && echo '0') > ${SOURCE_PATH}/core/std.jsonnet.h"
-    WORKING_DIRECTORY ${SOURCE_PATH}
+    COMMAND bash -c "((od -v -Anone -t u1 \"${SOURCE_PATH}/stdlib/std.jsonnet\" | tr ' ' '\\n' | grep -v '^$' | tr '\\n' ',' ) && echo '0') > \"${SOURCE_PATH}/core/std.jsonnet.h\""
+    WORKING_DIRECTORY "${SOURCE_PATH}"
     LOGNAME "std.jsonnet"
   )
 endif()


### PR DESCRIPTION
Description:
When installing jsonnet, it failed if the path contains space. The errors like this:
Unexpected token 'spaces/vcpkg/buildtrees/jsonnet/src/0617772bb0-75cfbe40ed/core/std.jsonnet.h' in expression or 
statement.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnexpectedToken
Solution:
Add "" to fix this issue.