### PR TITLE
[ampl-mp] Limit the scope of ICE workaround

### DIFF
--- a/ports/ampl-mp/CONTROL
+++ b/ports/ampl-mp/CONTROL
@@ -1,3 +1,3 @@
 Source: ampl-mp
-Version: 2019-02-08
+Version: 2019-03-21
 Description: An open-source library for mathematical programming

--- a/ports/ampl-mp/portfile.cmake
+++ b/ports/ampl-mp/portfile.cmake
@@ -2,11 +2,15 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+	message(FATAL_ERROR "Cross-compiling is not supported")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ampl/mp
-    REF d305155b047b69fc5c6e5fda8630c753d7973b9a
-    SHA512 2c8ffd6de946a6f8ea94a8e0c00f03f67753ad99534e0d5fcaaaeb472fe76a3383324bcb628a31d8c01bc5f60254790f5508c8394096a4f05672f814dbd6fe2e
+    REF 67875b71ef68511277ec2dc8224f613487cefce9
+    SHA512 fad2496c10b843ddad7c4dba1eea1b4cd22e90be12dec2ad598fbd1ed5e1c492d92c5130490c7045ea608bc9ea2af191661c39b3bee3bc5159663f306ce50950
     HEAD_REF master
     PATCHES
     disable-matlab-mex.patch

--- a/ports/ampl-mp/workaround-msvc-optimizer-ice.patch
+++ b/ports/ampl-mp/workaround-msvc-optimizer-ice.patch
@@ -1,14 +1,28 @@
---- a/src/asl/CMakeLists.txt	2019-02-07 22:45:15.191909400 -0600
-+++ b/src/asl/CMakeLists.txt	2019-02-07 22:47:10.364936600 -0600
-@@ -216,6 +216,11 @@ add_mp_library(asl-core OBJECT ${ASL_COR
-   COMPILE_DEFINITIONS ${ASL_COMPILE_DEFINITIONS}
-   INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
+diff --git a/src/asl/solvers/avltree.c b/src/asl/solvers/avltree.c
+index 7a9adaba..4dd97054 100644
+--- a/src/asl/solvers/avltree.c
++++ b/src/asl/solvers/avltree.c
+@@ -54,6 +54,9 @@ AVL_Tree {
+ 	void (*Free)(void*);
+ 	};
  
-+if (MSVC)
-+  set_source_files_properties(solvers/avltree.c solvers/sphes.c
-+    PROPERTIES COMPILE_OPTIONS /Od)
-+endif ()
-+
- # Public ASL headers.
- set(ASL_HEADERS aslbuilder.h aslexpr.h aslexpr-visitor.h
-   aslproblem.h aslinterface.h ${CMAKE_CURRENT_BINARY_DIR}/stdio1.h)
++#if defined(_MSC_VER) && _MSC_VER < 1917
++#pragma optimize("", off)
++#endif
+  AVL_Tree*
+ AVL_Tree_alloc2(void *v, AVL_Elcomp cmp, void *(*Malloc)(size_t), void (*Free)(void*))
+ {
+diff --git a/src/asl/solvers/sphes.c b/src/asl/solvers/sphes.c
+index 326d997f..ae8952ed 100644
+--- a/src/asl/solvers/sphes.c
++++ b/src/asl/solvers/sphes.c
+@@ -452,6 +452,9 @@ compar(const void *a, const void *b)
+ #undef del_mblk
+ #define del_mblk(b,c) Del_mblk_ASL(a,b,(Char*)(c))
+ 
++#if defined(_MSC_VER) && _MSC_VER < 1917
++#pragma optimize("", off)
++#endif
+  static void
+ new_Hesoprod(ASL_pfgh *asl, ograd *L, ograd *R, real coef)
+ {


### PR DESCRIPTION
Meanwhile, disable UWP early because the upstream is not taking action to support cross-compiling https://github.com/ampl/mp/issues/115 (the issue is that a binary needs to **run** on target architecture).