### PR TITLE
sdl1 x64-windows-static... ok

### DIFF
--- a/ports/sdl1/portfile.cmake
+++ b/ports/sdl1/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+# vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/sdl1/portfile.cmake
+++ b/ports/sdl1/portfile.cmake
@@ -2,6 +2,11 @@ include(vcpkg_common_functions)
 
 # vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+    message(STATUS "Static CRT linkage is not supported")
+    set(VCPKG_CRT_LINKAGE dynamic)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SDL-Mirror/SDL


### PR DESCRIPTION

[sdl1.zip](https://github.com/Microsoft/vcpkg/files/3026246/sdl1.zip)

Starting package 1/33: sdl1:x64-windows-static
Building package sdl1[core]:x64-windows-static...
-- Using cached E:/tools/vcpkg/downloads/SDL-Mirror-SDL-release-1.2.15.tar.gz
-- Using source at E:/tools/vcpkg/buildtrees/sdl1/src/ase-1.2.15-2ca6426de6
-- Building VisualC/SDL1_2017.sln for Release
-- Building VisualC/SDL1_2017.sln for Debug
-- Installing: E:/tools/vcpkg/packages/sdl1_x64-windows-static/share/sdl1/copyright
-- Performing post-build validation
-- Performing post-build validation done
Building package sdl1[core]:x64-windows-static... done
Installing package sdl1[core]:x64-windows-static...