### PR TITLE
[libwebp] do not include all feature by default

### DIFF
--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebp
-Version: 1.0.2-1
+Version: 1.0.2-2
 Description: Lossy compression of digital photographic images.
 Build-Depends: opengl
 

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -2,7 +2,6 @@ Source: libwebp
 Version: 1.0.2-1
 Description: Lossy compression of digital photographic images.
 Build-Depends: opengl
-Default-Features: all
 
 Feature: all
 Description: enable all webp features


### PR DESCRIPTION
Currently `vcpkg install libwebp` will try to install these packages:
```
  * freeglut[core]:x64-windows
  * giflib[core]:x64-windows
  * libjpeg-turbo[core]:x64-windows
  * liblzma[core]:x64-windows
  * libpng[core]:x64-windows
    libwebp[all,core]:x64-windows
  * opengl[core]:x64-windows
  * sdl1[core]:x64-windows
  * tiff[core]:x64-windows
  * zlib[core]:x64-windows
```

I dont think that a reasonable default.  If a user really wants everything, he should install `libwebp[all]`.