### PR TITLE
[fix][jsonnet] Improving jsonnet build

### DIFF
--- a/ports/jsonnet/CMakeLists.txt
+++ b/ports/jsonnet/CMakeLists.txt
@@ -19,31 +19,30 @@ set( jsonnet_sources
   core/static_analysis.cpp
   core/string_utils.cpp
   core/vm.cpp
+  third_party/md5/md5.cpp
 )
 
 include_directories(third_party/md5 include cpp core stdlib)
 
-add_library(md5 STATIC third_party/md5/md5.cpp)
+add_library(jsonnet ${jsonnet_sources})
+target_link_libraries(jsonnet)
 
-add_library(libjsonnet ${jsonnet_sources})
-target_link_libraries(libjsonnet md5)
-
-add_library(libjsonnet++ cpp/libjsonnet++.cpp)
-target_link_libraries(libjsonnet++ libjsonnet)
-
-add_executable(jsonnet cmd/jsonnet.cpp)
-target_link_libraries(jsonnet libjsonnet)
-
+add_library(jsonnet++ cpp/libjsonnet++.cpp)
+target_link_libraries(jsonnet++ jsonnet)
+ 
+add_executable(jsonnet-bin cmd/jsonnet.cpp)
+target_link_libraries(jsonnet-bin jsonnet)
+set_target_properties(jsonnet-bin PROPERTIES OUTPUT_NAME jsonnet)
 
 install(
-  TARGETS libjsonnet libjsonnet++
+  TARGETS jsonnet jsonnet++
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 if(NOT DISABLE_INSTALL_TOOLS)
   install (
-    TARGETS jsonnet
+    TARGETS jsonnet-bin
     RUNTIME DESTINATION tools/jsonnet
   )
 endif()

--- a/ports/jsonnet/CONTROL
+++ b/ports/jsonnet/CONTROL
@@ -1,3 +1,3 @@
 Source: jsonnet
-Version: 2018-11-01-2
+Version: 2018-11-01-3
 Description: Jsonnet - The data templating language


### PR DESCRIPTION
- linking md5.cpp into the library, like the original Makefile: https://github.com/google/jsonnet/blob/master/Makefile#L89
    - otherwise, build would always create a static `libmd5.a` that could conflict with other md5 libraries
- renaming targets so we do not end up with `liblibjsonnet.so`