### PR TITLE
[live555] Update the download path

### DIFF
--- a/ports/live555/CONTROL
+++ b/ports/live555/CONTROL
@@ -1,3 +1,3 @@
 Source: live555
-Version: latest
+Version: 2019.03.06
 Description: A complete RTSP server application

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -3,41 +3,38 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(VCPKG_LIBRARY_LINKAGE "static")
 endif()
 
-if(NOT VCPKG_USE_HEAD_VERSION)
-	message(FATAL_ERROR "Live555 does not have persistent releases. Please re-run the installation with --head.")
-else()
-	# The current Live555 version from http://www.live555.com/liveMedia/public/
-	set(LIVE_VERSION latest)
+# The current Live555 version from http://www.live555.com/live.2019.03.06
+set(LIVE_VERSION 2019.03.06)
 
-	include(vcpkg_common_functions)
-	set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION}/live)
-	vcpkg_download_distfile(ARCHIVE
-		URLS "http://www.live555.com/liveMedia/public/live555-${LIVE_VERSION}.tar.gz"
-		FILENAME "live555-${LIVE_VERSION}.tar.gz"
-		SKIP_SHA512
-	)
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION}/live)
+vcpkg_download_distfile(ARCHIVE
+	URLS "http://www.live555.com/live.2019.03.06.tar.gz"
+	FILENAME "live555-${LIVE_VERSION}.tar.gz"
+	SHA512 cf3cbf57ec43d392fa82f06bd02f6d829208c9a9ec1c505d9eb6c5e2dd3393bbd8829b6216163deb8ea8356c180f30f610a639044a6941df5c9a92f29d4f1a75
+)
 
-	vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION})
+vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION})
 
-	file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-	vcpkg_configure_cmake(
-		SOURCE_PATH ${SOURCE_PATH}
-		PREFER_NINJA
-	)
+vcpkg_configure_cmake(
+	SOURCE_PATH ${SOURCE_PATH}
+	PREFER_NINJA
+)
 
-	vcpkg_install_cmake()
+vcpkg_install_cmake()
 
-	file(GLOB HEADERS
-		"${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
-		"${SOURCE_PATH}/groupsock/include/*.h*"
-		"${SOURCE_PATH}/liveMedia/include/*.h*"
-		"${SOURCE_PATH}/UsageEnvironment/include/*.h*"
-	)
+file(GLOB HEADERS
+	"${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
+	"${SOURCE_PATH}/groupsock/include/*.h*"
+	"${SOURCE_PATH}/liveMedia/include/*.h*"
+	"${SOURCE_PATH}/UsageEnvironment/include/*.h*"
+)
 
-	file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-	file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
+file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
 
-	vcpkg_copy_pdbs()
-endif()
+vcpkg_copy_pdbs()
+
 


### PR DESCRIPTION
According to the source website said: Due to the sudden, unexpected failure of our online hosting provider, we are temporarily offline. We are attempting to bring back LIVE555.COM services (web, mailing lists, etc.) as soon as possible, but some services might not be fully restored until mid-April, 2019.

Since the original source path was no longer available, updated it to the new one which provided by the website.



