### PR TITLE
[Thrift] Updates 2019.03.29

### DIFF
--- a/ports/thrift/CONTROL
+++ b/ports/thrift/CONTROL
@@ -1,4 +1,4 @@
 Source: thrift
-Version: 2019-01-30
+Version: 2019-03-29
 Build-Depends: zlib, libevent, openssl, boost-range, boost-smart-ptr, boost-date-time, boost-locale, boost-scope-exit
 Description: Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible. Originally developed at Facebook, Thrift was open sourced in April 2007 and entered the Apache Incubator in May, 2008. Thrift became an Apache TLP in October, 2010.

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_find_acquire_program(BISON)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/thrift
-    REF 2ec93c8a2da2531755078ab6d5a65a96e26cf4c2
-    SHA512 6e6787e04ec963516be669511a18e128e5aff19bf33c70b37d9488b4abf42c20de75c8e72d60a81e679dea2faa8abe526deb71a6fc8ef7ba27216990be07c22c
+    REF 7b94dd422117ffb6c646d1217c643efb80a8cf45
+    SHA512 56b1810031b26ccc921cc39a2511fbee9af165c618b5ecb72d8f3dbdf9ae1d05b8adfe59e6f7ece8be837ca69a58e279997dd76c93e28c96607f18e2badcfbd1
     HEAD_REF master
 )
 
@@ -41,6 +41,9 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/thrift RENAME copyright)
+
+# Move CMake config files to the right place
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/thrift")
 
 file(GLOB COMPILER "${CURRENT_PACKAGES_DIR}/bin/thrift*")
 if(COMPILER)

--- a/scripts/toolchains/windows.cmake
+++ b/scripts/toolchains/windows.cmake
@@ -9,7 +9,6 @@ if(NOT _CMAKE_IN_TRY_COMPILE)
         message(FATAL_ERROR "Invalid setting for VCPKG_CRT_LINKAGE: \"${VCPKG_CRT_LINKAGE}\". It must be \"static\" or \"dynamic\"")
     endif()
 
-    set(CHARSET_FLAG "/utf-8")
     if(VCPKG_PLATFORM_TOOLSET MATCHES "v120")
         # VS 2013 does not support /utf-8
         set(CHARSET_FLAG)


### PR DESCRIPTION
This commit fix 2 issues when upgrade thrift:

Issue 1: Failed with cl : Command line error D8016 : '/utf-8' and '/source-charset:utf-8' command-line options are incompatible
Fix: The thrift latest changes added ‘/source-charset:utf-8' and ‘/execution-charset:utf-8’ by commit ‘a6a3a78’. And VCPKG  added options ‘/utf-8' in .\scripts\toolchains\windows.cmake.

So the fix should remove the one of the options, I removed ‘/utf-8' in .\scripts\toolchains\windows.cmake, I think VCPKG doesn't need add /utf-8 to the pkg, it should added by the pkg itself.

Issue 2: Failed when performing post-build validation
Fix: Add ‘vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/thrift")’ in thrift portfile to help copy the cmake targets to install directory.

