### PR TITLE
[milerius-sfml-imgui] Fix find_package issue

### DIFF
--- a/ports/milerius-sfml-imgui/CONTROL
+++ b/ports/milerius-sfml-imgui/CONTROL
@@ -1,4 +1,4 @@
 Source: milerius-sfml-imgui
-Version: 1.1-1
+Version: 1.1-2
 Description: imgui dll for sfml usage
 Build-Depends: sfml (windows), imgui

--- a/ports/milerius-sfml-imgui/FixFindPackageIssue.patch
+++ b/ports/milerius-sfml-imgui/FixFindPackageIssue.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27b8bd8..33fe623 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@ if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+     message(FATAL_ERROR "Prevented in-tree built. Please create a build directory outside of the source code and call cmake from there")
+ endif ()
+ 
+-project(sfml-imgui)
++project(milerius-sfml-imgui)
+ cmake_minimum_required(VERSION 3.9)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+@@ -26,7 +26,7 @@ include(CMakePackageConfigHelpers)
+ 
+ install(TARGETS
+         ${PROJECT_NAME}
+-        EXPORT sfml-imgui-targets
++        EXPORT milerius-sfml-imgui-targets
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -39,7 +39,7 @@ install(EXPORT ${PROJECT_NAME}-targets
+         )
+ 
+ configure_package_config_file(
+-        "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in"
++        "${PROJECT_SOURCE_DIR}/cmake/sfml-imgui-config.cmake.in"
+         "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+         INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+ )
+@@ -51,6 +51,6 @@ install(FILES
+ install(DIRECTORY
+         ${CMAKE_CURRENT_SOURCE_DIR}/sfml-imgui
+         DESTINATION
+-        ${CMAKE_INSTALL_INCLUDEDIR}/sfml-imgui
++        ${CMAKE_INSTALL_INCLUDEDIR}/
+         FILES_MATCHING PATTERN "*.h*"
+         )
+diff --git a/cmake/sfml-imgui-config.cmake.in b/cmake/sfml-imgui-config.cmake.in
+index cd790be..e1bdd77 100644
+--- a/cmake/sfml-imgui-config.cmake.in
++++ b/cmake/sfml-imgui-config.cmake.in
+@@ -2,5 +2,5 @@
+ find_package(SFML CONFIG REQUIRED graphics)
+ find_package(imgui CONFIG REQUIRED)
+ find_package(OpenGL REQUIRED)
+-include("${CMAKE_CURRENT_LIST_DIR}/sfml-imgui-targets.cmake")
+-check_required_components("sfml-imgui")
+\ No newline at end of file
++include("${CMAKE_CURRENT_LIST_DIR}/milerius-sfml-imgui-targets.cmake")
++check_required_components("milerius-sfml-imgui")
+\ No newline at end of file

--- a/ports/milerius-sfml-imgui/portfile.cmake
+++ b/ports/milerius-sfml-imgui/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     REF 1.1
     SHA512 191184f7b302f643bd7c241b69d9f9edc0d03c6f5a0b3a49f57ac84f3828202f8065291fb17993073a2c07f1237ba491de677c47e2f8160dc70ea77f20eb1946
     HEAD_REF master
+    PATCHES FixFindPackageIssue.patch
 )
 
 vcpkg_configure_cmake(
@@ -16,7 +17,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sfml-imgui)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/milerius-sfml-imgui)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
1. Since the port name(milerius-sfml-imgui) doesn't match the source name(sfml-imgui), find_package(milerius-sfml-imgui CONFIG REQUIRED) will failed due to the the cmake file named sfml-imgui-config.cmake.
2. Add a patch to modify the source name in the cmake file of the source.
3. After verification, Find_package(milerius-sfml-imgui CONFIG REQUIRED) now works fine.
4. Fix the issue https://github.com/Microsoft/vcpkg/issues/5879.
