### PR TITLE
[google-cloud-cpp] Fix libcurl linkage

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1-3
+Version: 7.61.1-4
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -118,14 +118,26 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     # Drop debug suffix, as FindCURL.cmake does not look for it
     if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib")
         file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+        # Fixup libcurl-target-debug.cmake to match
+        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-debug.cmake" DEBUG_MODULE)
+        string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/libcurl-d.lib" "\${_IMPORT_PREFIX}/debug/lib/libcurl.lib" DEBUG_MODULE "${DEBUG_MODULE}")
+        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-debug.cmake" "${DEBUG_MODULE}")
     endif()
 else()
     file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl-config ${CURRENT_PACKAGES_DIR}/debug/bin/curl-config)
     if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib")
         file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib ${CURRENT_PACKAGES_DIR}/lib/libcurl.lib)
+        # Fixup libcurl-target-release.cmake to match
+        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-release.cmake" RELEASE_MODULE)
+        string(REPLACE "\${_IMPORT_PREFIX}/lib/libcurl_imp.lib" "\${_IMPORT_PREFIX}/lib/libcurl.lib" RELEASE_MODULE "${RELEASE_MODULE}")
+        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-release.cmake" "${RELEASE_MODULE}")
     endif()
     if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib")
         file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
+        # Fixup libcurl-target-debug.cmake to match
+        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-debug.cmake" DEBUG_MODULE)
+        string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/libcurl-d_imp.lib" "\${_IMPORT_PREFIX}/debug/lib/libcurl.lib" DEBUG_MODULE "${DEBUG_MODULE}")
+        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/libcurl-target-debug.cmake" "${DEBUG_MODULE}")
     endif()
 endif()
 

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: google-cloud-cpp
-Version: 0.8.0
-Build-Depends: grpc, curl, crc32c
+Version: 0.8.0-1
+Build-Depends: grpc, curl[ssl], crc32c
 Description: C++ Client Libraries for Google Cloud Platform APIs.

--- a/ports/google-cloud-cpp/cmake-libcurl-find-config.patch
+++ b/ports/google-cloud-cpp/cmake-libcurl-find-config.patch
@@ -1,0 +1,142 @@
+diff --git a/cmake/IncludeCurl.cmake b/cmake/IncludeCurl.cmake
+index 6ea7ca3e6..3c2db6b28 100644
+--- a/cmake/IncludeCurl.cmake
++++ b/cmake/IncludeCurl.cmake
+@@ -34,49 +34,57 @@ set_property(CACHE GOOGLE_CLOUD_CPP_CURL_PROVIDER
+ if ("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "external")
+     include(external/curl)
+ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
+-    # Search for libcurl, in CMake 3.5 this does not define a target, but it
+-    # will in 3.12 (see https://cmake.org/cmake/help/git-
+-    # stage/module/FindCURL.html for details).  Until then, define the target
+-    # ourselves if it is missing.
+-    find_package(CURL REQUIRED)
+-    if (NOT TARGET CURL::libcurl)
+-        add_library(CURL::libcurl UNKNOWN IMPORTED)
+-        set_property(TARGET CURL::libcurl
+-                     APPEND
+-                     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+-                              "${CURL_INCLUDE_DIR}")
+-        set_property(TARGET CURL::libcurl
+-                     APPEND
+-                     PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+-    endif ()
+-    # If the library is static, we need to explicitly link its dependencies.
+-    # However, we should not do so for shared libraries, because the version of
+-    # OpenSSL (for example) found by find_package() may be newer than the
+-    # version linked against libcurl.
+-    if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+-        find_package(OpenSSL REQUIRED)
+-        find_package(ZLIB REQUIRED)
+-        set_property(TARGET CURL::libcurl
+-                     APPEND
+-                     PROPERTY INTERFACE_LINK_LIBRARIES
+-                              OpenSSL::SSL
+-                              OpenSSL::Crypto
+-                              ZLIB::ZLIB)
+-        message(STATUS "CURL linkage will be static")
+-        if (WIN32)
++    # Search for libcurl, first using CONFIG mode, and retrying
++    # using MODULE mode if that fails
++    find_package(CURL CONFIG QUIET) # Deliberately quiet, so we can handle the result
++    if(CURL_FOUND)
++        message(STATUS "CURL library found via CONFIG mode")
++    else()
++        # CONFIG mode failed - fallback to MODULE mode
++        # In CMake 3.5 this does not define a target, but it
++        # will in 3.12 (see https://cmake.org/cmake/help/git-
++        # stage/module/FindCURL.html for details).  Until then, define the target
++        # ourselves if it is missing.
++        find_package(CURL MODULE REQUIRED) # Use REQUIRED the second time to fail out
++        if (NOT TARGET CURL::libcurl)
++            add_library(CURL::libcurl UNKNOWN IMPORTED)
+             set_property(TARGET CURL::libcurl
+                          APPEND
+-                         PROPERTY INTERFACE_LINK_LIBRARIES
+-                                  crypt32
+-                                  wsock32
+-                                  ws2_32)
++                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES
++                                  "${CURL_INCLUDE_DIR}")
++            set_property(TARGET CURL::libcurl
++                         APPEND
++                         PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+         endif ()
+-        if (APPLE)
++        # If the library is static, we need to explicitly link its dependencies.
++        # However, we should not do so for shared libraries, because the version of
++        # OpenSSL (for example) found by find_package() may be newer than the
++        # version linked against libcurl.
++        if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
++            find_package(OpenSSL REQUIRED)
++            find_package(ZLIB REQUIRED)
+             set_property(TARGET CURL::libcurl
+                          APPEND
+-                         PROPERTY INTERFACE_LINK_LIBRARIES ldap)
++                         PROPERTY INTERFACE_LINK_LIBRARIES
++                                  OpenSSL::SSL
++                                  OpenSSL::Crypto
++                                  ZLIB::ZLIB)
++            message(STATUS "CURL linkage will be static")
++            if (WIN32)
++                set_property(TARGET CURL::libcurl
++                             APPEND
++                             PROPERTY INTERFACE_LINK_LIBRARIES
++                                      crypt32
++                                      wsock32
++                                      ws2_32)
++            endif ()
++            if (APPLE)
++                set_property(TARGET CURL::libcurl
++                             APPEND
++                             PROPERTY INTERFACE_LINK_LIBRARIES ldap)
++            endif ()
++        else()
++            message(STATUS "CURL linkage will be non-static")
+         endif ()
+-    else()
+-        message(STATUS "CURL linkage will be non-static")
+     endif ()
+ endif ()
+diff --git a/google/cloud/storage/config.cmake.in b/google/cloud/storage/config.cmake.in
+index a4d261815..640089e09 100644
+--- a/google/cloud/storage/config.cmake.in
++++ b/google/cloud/storage/config.cmake.in
+@@ -13,21 +13,25 @@
+ # limitations under the License.
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(CURL)
++# Search for libcurl, first using CONFIG mode, and retrying
++# using MODULE mode if that fails
++find_package(CURL CONFIG QUIET) # find_package so we can explicitly specify QUIET
++if(NOT CURL_FOUND)
++    find_dependency(CURL MODULE)
++    # Some versions of FindCURL do not define CURL::libcurl, so we define it ourselves.
++    if (NOT TARGET CURL::libcurl)
++        add_library(CURL::libcurl UNKNOWN IMPORTED)
++        set_property(TARGET CURL::libcurl
++                     APPEND
++                     PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
++        set_property(TARGET CURL::libcurl
++                     APPEND
++                     PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
++    endif ()
++endif()
+ find_dependency(Crc32c)
+ find_dependency(google_cloud_cpp_common)
+ find_dependency(OpenSSL)
+ find_dependency(ZLIB)
+ 
+-# Some versions of FindCURL do not define CURL::libcurl, so we define it ourselves.
+-if (NOT TARGET CURL::libcurl)
+-    add_library(CURL::libcurl UNKNOWN IMPORTED)
+-    set_property(TARGET CURL::libcurl
+-                 APPEND
+-                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
+-    set_property(TARGET CURL::libcurl
+-                 APPEND
+-                 PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+-endif ()
+-
+ include("${CMAKE_CURRENT_LIST_DIR}/storage-targets.cmake")

--- a/ports/google-cloud-cpp/cmake-libcurl-target.patch
+++ b/ports/google-cloud-cpp/cmake-libcurl-target.patch
@@ -1,0 +1,144 @@
+diff --git a/cmake/IncludeCurl.cmake b/cmake/IncludeCurl.cmake
+index d3323e3b8..6ea7ca3e6 100644
+--- a/cmake/IncludeCurl.cmake
++++ b/cmake/IncludeCurl.cmake
+@@ -39,13 +39,13 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
+     # stage/module/FindCURL.html for details).  Until then, define the target
+     # ourselves if it is missing.
+     find_package(CURL REQUIRED)
+-    if (NOT TARGET CURL::CURL)
+-        add_library(CURL::CURL UNKNOWN IMPORTED)
+-        set_property(TARGET CURL::CURL
++    if (NOT TARGET CURL::libcurl)
++        add_library(CURL::libcurl UNKNOWN IMPORTED)
++        set_property(TARGET CURL::libcurl
+                      APPEND
+                      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                               "${CURL_INCLUDE_DIR}")
+-        set_property(TARGET CURL::CURL
++        set_property(TARGET CURL::libcurl
+                      APPEND
+                      PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+     endif ()
+@@ -56,7 +56,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
+     if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+         find_package(OpenSSL REQUIRED)
+         find_package(ZLIB REQUIRED)
+-        set_property(TARGET CURL::CURL
++        set_property(TARGET CURL::libcurl
+                      APPEND
+                      PROPERTY INTERFACE_LINK_LIBRARIES
+                               OpenSSL::SSL
+@@ -64,7 +64,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
+                               ZLIB::ZLIB)
+         message(STATUS "CURL linkage will be static")
+         if (WIN32)
+-            set_property(TARGET CURL::CURL
++            set_property(TARGET CURL::libcurl
+                          APPEND
+                          PROPERTY INTERFACE_LINK_LIBRARIES
+                                   crypt32
+@@ -72,7 +72,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
+                                   ws2_32)
+         endif ()
+         if (APPLE)
+-            set_property(TARGET CURL::CURL
++            set_property(TARGET CURL::libcurl
+                          APPEND
+                          PROPERTY INTERFACE_LINK_LIBRARIES ldap)
+         endif ()
+diff --git a/cmake/external/curl.cmake b/cmake/external/curl.cmake
+index 54753ada9..2a83e19df 100644
+--- a/cmake/external/curl.cmake
++++ b/cmake/external/curl.cmake
+@@ -88,10 +88,10 @@ if (NOT TARGET curl_project)
+     endif ()
+ 
+     include(ExternalProjectHelper)
+-    add_library(CURL::CURL INTERFACE IMPORTED)
+-    add_dependencies(CURL::CURL curl_project)
+-    set_library_properties_for_external_project(CURL::CURL curl)
+-    set_property(TARGET CURL::CURL
++    add_library(CURL::libcurl INTERFACE IMPORTED)
++    add_dependencies(CURL::libcurl curl_project)
++    set_library_properties_for_external_project(CURL::libcurl curl)
++    set_property(TARGET CURL::libcurl
+                  APPEND
+                  PROPERTY INTERFACE_LINK_LIBRARIES
+                           c-ares::cares
+@@ -99,7 +99,7 @@ if (NOT TARGET curl_project)
+                           OpenSSL::Crypto
+                           ZLIB::ZLIB)
+     if (WIN32)
+-        set_property(TARGET CURL::CURL
++        set_property(TARGET CURL::libcurl
+                      APPEND
+                      PROPERTY INTERFACE_LINK_LIBRARIES
+                               crypt32
+@@ -107,7 +107,7 @@ if (NOT TARGET curl_project)
+                               ws2_32)
+     endif ()
+     if (APPLE)
+-        set_property(TARGET CURL::CURL
++        set_property(TARGET CURL::libcurl
+                      APPEND
+                      PROPERTY INTERFACE_LINK_LIBRARIES ldap)
+     endif ()
+diff --git a/google/cloud/storage/CMakeLists.txt b/google/cloud/storage/CMakeLists.txt
+index 1e750af8a..a0a04caab 100644
+--- a/google/cloud/storage/CMakeLists.txt
++++ b/google/cloud/storage/CMakeLists.txt
+@@ -226,7 +226,7 @@ target_link_libraries(storage_client
+                       PUBLIC google_cloud_cpp_common
+                              nlohmann_json
+                              Crc32c::crc32c
+-                             CURL::CURL
++                             CURL::libcurl
+                              Threads::Threads
+                              OpenSSL::SSL
+                              OpenSSL::Crypto
+@@ -396,7 +396,7 @@ if (BUILD_TESTING)
+                                           GTest::gmock_main
+                                           GTest::gmock
+                                           GTest::gtest
+-                                          CURL::CURL
++                                          CURL::libcurl
+                                           storage_common_options
+                                           nlohmann_json)
+             if (MSVC)
+diff --git a/google/cloud/storage/config.cmake.in b/google/cloud/storage/config.cmake.in
+index 660829ae4..a4d261815 100644
+--- a/google/cloud/storage/config.cmake.in
++++ b/google/cloud/storage/config.cmake.in
+@@ -19,13 +19,13 @@ find_dependency(google_cloud_cpp_common)
+ find_dependency(OpenSSL)
+ find_dependency(ZLIB)
+ 
+-# Some versions of FindCURL do not define CURL::CURL, so we define it ourselves.
+-if (NOT TARGET CURL::CURL)
+-    add_library(CURL::CURL UNKNOWN IMPORTED)
+-    set_property(TARGET CURL::CURL
++# Some versions of FindCURL do not define CURL::libcurl, so we define it ourselves.
++if (NOT TARGET CURL::libcurl)
++    add_library(CURL::libcurl UNKNOWN IMPORTED)
++    set_property(TARGET CURL::libcurl
+                  APPEND
+                  PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
+-    set_property(TARGET CURL::CURL
++    set_property(TARGET CURL::libcurl
+                  APPEND
+                  PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+ endif ()
+diff --git a/google/cloud/storage/tests/CMakeLists.txt b/google/cloud/storage/tests/CMakeLists.txt
+index 9e5fb663d..987958396 100644
+--- a/google/cloud/storage/tests/CMakeLists.txt
++++ b/google/cloud/storage/tests/CMakeLists.txt
+@@ -50,7 +50,7 @@ foreach (fname ${storage_client_integration_tests})
+                                   GTest::gmock_main
+                                   GTest::gmock
+                                   GTest::gtest
+-                                  CURL::CURL
++                                  CURL::libcurl
+                                   Threads::Threads
+                                   nlohmann_json
+                                   storage_common_options)

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,6 +8,9 @@ vcpkg_from_github(
     REF v0.8.0
     SHA512 cdb527169c7badab395eb38ba554022a364a99b9cb32705bf69a9613cee74acc1e2402e00ffdcb740467e85603e617f73b01e557afeb1f2786872f8d60f3a75a
     HEAD_REF master
+	PATCHES
+		cmake-libcurl-target.patch # Not needed _after_ v0.8.0
+		cmake-libcurl-find-config.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This fixes two issues with `google-cloud-cpp` that are the cause of the breakage in #5824

1. `google-cloud-cpp` uses the `CURL::CURL` target, when it should be using `CURL::libcurl`
2. To properly detect & use the vcpkg-exported CMake config for `curl`, `google-cloud-cpp` must first attempt `find_package(CURL CONFIG QUIET)` before using the default `find_package` "MODULE" mode.

With these two patches, `google-cloud-cpp` will detect and use the vcpkg-exported CMake config for the `CURL::libcurl` target, which includes all necessary `INTERFACE_LINK_LIBRARIES` (including those required for a non-OpenSSL SSL library, fixing the current breakage in #5824).