### PR TITLE
[freeimage] fixup dependencies

### DIFF
--- a/ports/freeimage/CONTROL
+++ b/ports/freeimage/CONTROL
@@ -1,4 +1,4 @@
 Source: freeimage
-Version: 3.18.0-4
-Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp, libraw, jxrlib, openexr
+Version: 3.18.0-5
+Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp[all], libraw, jxrlib, openexr
 Description: Support library for graphics image formats


### PR DESCRIPTION
freeimage has a dependency on webp/mux.h which is not installed in libwebp[core]