### PR TITLE
[curl] Fix `tool` feature

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1-3
+Version: 7.61.1-4
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl


### PR DESCRIPTION
- Use appropriate EXECUTABLE_SUFFIX to support non-Windows platforms
- Fixup `curl-target-release.cmake` to point to the new executable location (fixing the `CURL::curl` exported target config)