### PR TITLE
[poco] fix pcre linking against pcred on release

### DIFF
--- a/ports/poco/find_pcre.patch
+++ b/ports/poco/find_pcre.patch
@@ -2,12 +2,16 @@ diff --git a/cmake/FindPCRE.cmake b/cmake/FindPCRE.cmake
 index 41a99cb..77f3a42 100644
 --- a/cmake/FindPCRE.cmake
 +++ b/cmake/FindPCRE.cmake
-@@ -14,7 +14,7 @@ ENDIF (PCRE_INCLUDE_DIRS)
+@@ -14,7 +14,11 @@ ENDIF (PCRE_INCLUDE_DIRS)
  
  FIND_PATH(PCRE_INCLUDE_DIR pcre.h)
  
 -SET(PCRE_NAMES pcre)
-+SET(PCRE_NAMES pcred pcre)
++if(CMAKE_BUILD_TYPE MATCHES Debug)
++    SET(PCRE_NAMES pcred)
++else()
++    SET(PCRE_NAMES pcre)
++endif()
  FIND_LIBRARY(PCRE_LIBRARY NAMES ${PCRE_NAMES} )
  
  # handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if


### PR DESCRIPTION
Latest version of poco was linking on releas against the debug binary of pcre.
So, PocoFoundation.dll was looking for pcred.dll.