### PR TITLE
[pixman] Fix build on x86-linux

### DIFF
--- a/ports/pixman/CMakeLists.txt
+++ b/ports/pixman/CMakeLists.txt
@@ -56,6 +56,10 @@ target_compile_definitions(pixman-1
         USE_SSE2
 )
 
+if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+    target_compile_options(pixman-1 PRIVATE -msse2)
+endif()
+
 # pixman produces a lot of warnings which are disabled here because they otherwise fill up the log files
 if(MSVC)
     target_compile_options(pixman-1 PRIVATE "/wd4244" "/wd4146" "/wd4996") #  PUBLIC "/D_CRT_SECURE_NO_WARNINGS"

--- a/ports/pixman/CONTROL
+++ b/ports/pixman/CONTROL
@@ -1,3 +1,3 @@
 Source: pixman
-Version: 0.38.0
+Version: 0.38.0-1
 Description: Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.


### PR DESCRIPTION
Changes to build pixman on x86-linux target. The following triplet file has been used for the build:

```
set(VCPKG_TARGET_ARCHITECTURE x86)
set(VCPKG_CRT_LINKAGE dynamic)
set(VCPKG_LIBRARY_LINKAGE static)

set(VCPKG_CMAKE_SYSTEM_NAME Linux)

set(VCPKG_C_FLAGS "-m32")
set(VCPKG_CXX_FLAGS "-m32")
set(VCPKG_LINKER_FLAGS "-m32")
```