### PR TITLE
fix over-planning of features

### DIFF
--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -443,18 +443,6 @@ namespace vcpkg::Dependencies
                     Checks::check_exit(VCPKG_LINE_INFO, res == MarkPlusResult::SUCCESS);
                 }
 
-                if (!cluster.installed.get() && !Util::Sets::contains(prevent_default_features, cluster.spec.name()))
-                {
-                    // Add the default features of this package if it was not previously installed and it isn't being
-                    // suppressed.
-                    auto res = mark_plus("", cluster, graph, graph_plan, prevent_default_features);
-
-                    Checks::check_exit(VCPKG_LINE_INFO,
-                                       res == MarkPlusResult::SUCCESS,
-                                       "Error: Unable to satisfy default dependencies of %s",
-                                       cluster.spec);
-                }
-
                 for (auto&& depend : it_build_edges->second)
                 {
                     auto& depend_cluster = graph.get(depend.spec());


### PR DESCRIPTION
As far as I can tell this code was not needed in any case, default features are already added to plan (when needed) by the mark_plus function.
However, it was breaking Build-Depends feature selection (see #5887) by forcing default features even when inappropriate.

Fixes #5887.