### PR TITLE
[sdl1]Fix sdl1 conflict with sdl2

### DIFF
--- a/ports/sdl1-net/CMakeLists.txt
+++ b/ports/sdl1-net/CMakeLists.txt
@@ -5,8 +5,7 @@ if (MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244 /wd4996")
 endif()
 
-find_path(SDL_INCLUDE_DIR SDL.h)
-find_library(SDL_LIBRARY NAMES SDLd SDL)
+find_package(SDL)
 
 add_library(SDL_net SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c version.rc)
 

--- a/ports/sdl1-net/CONTROL
+++ b/ports/sdl1-net/CONTROL
@@ -1,4 +1,4 @@
 Source: sdl1-net
-Version: 1.2.8-2
+Version: 1.2.8-3
 Description: Networking library for SDL
 Build-Depends: sdl1

--- a/ports/sdl1/CONTROL
+++ b/ports/sdl1/CONTROL
@@ -1,3 +1,3 @@
 Source: sdl1
-Version: 1.2.15-4
+Version: 1.2.15-5
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl1/portfile.cmake
+++ b/ports/sdl1/portfile.cmake
@@ -34,7 +34,13 @@ vcpkg_install_msbuild(
     ALLOW_ROOT_INCLUDES
 )
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/doxyfile)
+#Take all the fils into include/SDL to sovle conflict with SDL2 port
+file(GLOB files ${CURRENT_PACKAGES_DIR}/include/*)
+foreach(file ${files})
+        file(COPY ${file} DESTINATION ${CURRENT_PACKAGES_DIR}/include/SDL)
+        file(REMOVE ${file})
+endforeach()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/SDL/doxyfile)
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)


### PR DESCRIPTION
Relate issue https://github.com/Microsoft/vcpkg/issues/5474, https://github.com/Microsoft/vcpkg/issues/5982. 

1. ogre and sdl2-image ports failed after sdl1 and sdl2 were installed, this because sdl1 did not own a separate include folder, then caused compiler errors for some conflicts with sdl2. So take all headers into include/SDL/* to fix the conflict.
2. [sdl1-net]: use find_package(SDL) to get ${SDL_INCLUDE_DIR}