### PR TITLE
[curl] Bump CONTROL version

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1-4
+Version: 7.61.1-5
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl


### PR DESCRIPTION
@Rastaban: Commit c2790cd23e75ee4d65772b1ac8f0e5b0f4cf8c04 did not bump the `curl` CONTROL version when merging (because the prior commit, 6240fe128b4f17d6f70c66b446d758483e622b69, already bumped it to `7.61.1-4`).