### PR TITLE
[fix][ffmpeg] changing $PATH separator for Linux

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.1-2
+Version: 4.1-3
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.
 

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -21,22 +21,21 @@ vcpkg_apply_patches(
 
 vcpkg_find_acquire_program(YASM)
 get_filename_component(YASM_EXE_PATH ${YASM} DIRECTORY)
-set(ENV{PATH} "$ENV{PATH};${YASM_EXE_PATH}")
 
 if (WIN32)
+    set(ENV{PATH} "$ENV{PATH};${YASM_EXE_PATH}")
+    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
+    set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\\build.sh)
+
     if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
         vcpkg_acquire_msys(MSYS_ROOT PACKAGES perl gcc diffutils make)
     else()
         vcpkg_acquire_msys(MSYS_ROOT PACKAGES diffutils make)
     endif()
-endif()
-
-if (WIN32)
-  set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
-  set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\\build.sh)
 else()
-  set(BASH bash)
-  set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/build_linux.sh)
+    set(ENV{PATH} "$ENV{PATH}:${YASM_EXE_PATH}")
+    set(BASH /bin/bash)
+    set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/build_linux.sh)
 endif()
 
 set(ENV{INCLUDE} "${CURRENT_INSTALLED_DIR}/include;$ENV{INCLUDE}")

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -24,7 +24,6 @@ get_filename_component(YASM_EXE_PATH ${YASM} DIRECTORY)
 
 if (WIN32)
     set(ENV{PATH} "$ENV{PATH};${YASM_EXE_PATH}")
-    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
     set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\\build.sh)
 
     if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
@@ -32,6 +31,8 @@ if (WIN32)
     else()
         vcpkg_acquire_msys(MSYS_ROOT PACKAGES diffutils make)
     endif()
+    
+    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
 else()
     set(ENV{PATH} "$ENV{PATH}:${YASM_EXE_PATH}")
     set(BASH /bin/bash)


### PR DESCRIPTION
Using a semicolon in $PATH might break on some flavors of Linux, eg Docker based on Ubuntu 18.04.