### PR TITLE
[libpq] fix error at link time on linux

### DIFF
--- a/ports/libpq/CMakeLists.txt
+++ b/ports/libpq/CMakeLists.txt
@@ -66,6 +66,9 @@ if(WIN32)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND pg_port_src
         src/port/strlcpy.c
+        src/port/inet_aton.c
+        src/port/inet_net_ntop.c
+        src/port/getpeereid.c
     )
 endif()
 
@@ -130,7 +133,12 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_DEBUG_POSTFIX "d")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
+
 target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY -DUSE_OPENSSL -D_CRT_SECURE_NO_WARNINGS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(libpq PRIVATE -D_GNU_SOURCE)
+endif()
+
 target_link_libraries(libpq PRIVATE OpenSSL::SSL)
 if(WIN32)
     target_link_libraries(libpq PRIVATE ws2_32 secur32 advapi32 shell32)

--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,4 +1,4 @@
 Source: libpq
-Version: 9.6.1-5
+Version: 9.6.1-6
 Description: The official database access API of postgresql
 Build-Depends: openssl, zlib (linux)


### PR DESCRIPTION
A fix for this issue https://github.com/Microsoft/vcpkg/issues/5884 
It is observed when we try to link libpq with executable on linux.