### PR TITLE
[openvdb] Fix openvdb[tools] build failures

### DIFF
--- a/ports/openvdb/0001-fix-cmake-modules.patch
+++ b/ports/openvdb/0001-fix-cmake-modules.patch
@@ -67,6 +67,15 @@ index cea0b86..07ea09e 100644
  
  FIND_PACKAGE_HANDLE_STANDARD_ARGS ( GLFW3
    REQUIRED_VARS GLFW3_LOCATION
+@@ -59,7 +59,7 @@ IF (GLFW3_FOUND)
+ 	  NO_CMAKE_SYSTEM_PATH
+ 	  )
+   ELSE (GLFW3_USE_STATIC_LIBS)
+-    FIND_LIBRARY ( GLFW3_glfw_LIBRARY  glfw
++    FIND_LIBRARY ( GLFW3_glfw_LIBRARY  glfw3dll
+       PATHS ${GLFW3_LOCATION}/lib
+       PATH_SUFFIXES ${GLFW3_PATH_SUFFIXES}
+ 	  NO_DEFAULT_PATH
 diff --git a/cmake/FindILMBase.cmake b/cmake/FindILMBase.cmake
 index 664affd..5197110 100644
 --- a/cmake/FindILMBase.cmake

--- a/ports/openvdb/0003-build-only-necessary-targets.patch
+++ b/ports/openvdb/0003-build-only-necessary-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/openvdb/CMakeLists.txt b/openvdb/CMakeLists.txt
-index 9404dbc..b4129e3 100644
+index 9404dbc..94daf8c 100644
 --- a/openvdb/CMakeLists.txt
 +++ b/openvdb/CMakeLists.txt
-@@ -29,12 +29,13 @@ PROJECT ( OpenVDBCore )
+@@ -29,28 +29,31 @@ PROJECT ( OpenVDBCore )
  
  set(CMAKE_CXX_STANDARD 11)
  
@@ -11,21 +11,25 @@ index 9404dbc..b4129e3 100644
    FIND_PACKAGE ( GLFW3 REQUIRED )
    SET ( OPENVDB_USE_GLFW_FLAG "-DOPENVDB_USE_GLFW_3" )
    IF ( UNIX AND NOT APPLE )
-     SET ( GLFW_DEPENDENT_LIBRARIES "X11;Xi;Xrandr;Xinerama;Xcursor;Xxf86vm" )
+-    SET ( GLFW_DEPENDENT_LIBRARIES "X11;Xi;Xrandr;Xinerama;Xcursor;Xxf86vm" )
 -  ENDIF ( UNIX AND NOT APPLE )
++	SET ( GLFW_DEPENDENT_LIBRARIES "X11;Xi;Xrandr;Xinerama;Xcursor;Xxf86vm" )
 +  ENDIF ()
    SET ( GLFW_LINK_LIBRARY ${GLFW3_glfw_LIBRARY} )
    SET ( GLFW_INCLUDE_DIRECTORY  ${GLFW3_INCLUDE_DIR} CACHE STRING "GLFW3 include directory")
  ELSE ()
-@@ -45,12 +46,14 @@ ELSE ()
+   FIND_PACKAGE ( GLFW REQUIRED )
+   IF ( UNIX AND NOT APPLE )
+-    SET ( GLFW_DEPENDENT_LIBRARIES "X11;Xi;Xrandr;Xinerama;Xcursor;Xxf86vm" )
++	SET ( GLFW_DEPENDENT_LIBRARIES "X11;Xi;Xrandr;Xinerama;Xcursor;Xxf86vm" )
+   ENDIF ()
    SET ( GLFW_LINK_LIBRARY ${GLFW_glfw_LIBRARY} )
    SET ( GLFW_INCLUDE_DIRECTORY  ${GLFW_INCLUDE_DIR} CACHE STRING "GLFW include directory")
  ENDIF ()
 +ENDIF ()
  
--IF (WIN32)
 +IF ( OPENVDB_BUILD_TOOLS )
-+IF ( WIN32 )
+ IF (WIN32)
    FIND_PACKAGE ( GLEW REQUIRED )
 -ELSE ()
 -  FIND_PACKAGE ( Threads REQUIRED )
@@ -57,7 +61,8 @@ index 9404dbc..b4129e3 100644
 -  COMPILE_FLAGS "-DOPENVDB_PRIVATE -DOPENVDB_USE_BLOSC ${OPENVDB_USE_GLFW_FLAG}"
 +  COMPILE_FLAGS "-DOPENVDB_PRIVATE -DOPENVDB_USE_BLOSC ${OPENVDB_USE_GLFW_FLAG} $<$<CXX_COMPILER_ID:MSVC>:/bigobj>"
    )
- 
+-
++  
 +IF ( OPENVDB_STATIC )
  ADD_LIBRARY ( openvdb_static STATIC
    ${OPENVDB_LIBRARY_SOURCE_FILES}
@@ -121,7 +126,19 @@ index 9404dbc..b4129e3 100644
  ADD_EXECUTABLE ( vdb_print
    ${VDB_PRINT_SOURCE_FILES}
    )
-@@ -236,7 +257,7 @@ TARGET_LINK_LIBRARIES ( vdb_print
+@@ -229,14 +250,19 @@ TARGET_LINK_LIBRARIES ( vdb_print
+   openvdb_shared
+   ${CMAKE_THREAD_LIBS_INIT}
+   ${BLOSC_blosc_LIBRARY}
++  )
++  
++IF (NOT WIN32)
++TARGET_LINK_LIBRARIES ( vdb_print
+   m
+   stdc++
+   )
++ENDIF ()
+ 
  SET ( VDB_RENDER_SOURCE_FILES cmd/openvdb_render/main.cc )
  SET_SOURCE_FILES_PROPERTIES ( ${VDB_RENDER_SOURCE_FILES}
    PROPERTIES
@@ -130,56 +147,81 @@ index 9404dbc..b4129e3 100644
    )
  ADD_EXECUTABLE ( vdb_render
    ${VDB_RENDER_SOURCE_FILES}
-@@ -263,31 +284,40 @@ SET ( VDB_VIEW_SOURCE_FILES
+@@ -249,9 +275,14 @@ TARGET_LINK_LIBRARIES ( vdb_render
+   ${Openexr_ILMIMF_LIBRARY}
+   ${Ilmbase_ILMTHREAD_LIBRARY}
+   ${Ilmbase_IEX_LIBRARY}
++  )
++
++IF (NOT WIN32)
++TARGET_LINK_LIBRARIES ( vdb_render
+   m
+   stdc++
+   )
++ENDIF () 
+ 
+ SET ( VDB_VIEW_SOURCE_FILES
+   cmd/openvdb_view/main.cc
+@@ -263,29 +294,38 @@ SET ( VDB_VIEW_SOURCE_FILES
    )
  SET_SOURCE_FILES_PROPERTIES ( ${VDB_VIEW_SOURCE_FILES}
    PROPERTIES
 -  COMPILE_FLAGS "-DOPENVDB_USE_BLOSC ${OPENVDB_USE_GLFW_FLAG} -DGL_GLEXT_PROTOTYPES=1"
 +  COMPILE_FLAGS "-DOPENVDB_USE_BLOSC ${OPENVDB_USE_GLFW_FLAG} -DGL_GLEXT_PROTOTYPES=1 $<$<CXX_COMPILER_ID:MSVC>:/bigobj>"
++  )
++
++ADD_EXECUTABLE ( vdb_view
++  ${VDB_VIEW_SOURCE_FILES}
    )
 -IF (NOT WIN32)
-+
-   ADD_EXECUTABLE ( vdb_view
-     ${VDB_VIEW_SOURCE_FILES}
-     )
--  
-+
-   target_include_directories ( vdb_view SYSTEM PRIVATE ${Boost_INCLUDE_DIR} )
+-  ADD_EXECUTABLE ( vdb_view
+-    ${VDB_VIEW_SOURCE_FILES}
+-    )
+   
+-  target_include_directories ( vdb_view SYSTEM PRIVATE ${Boost_INCLUDE_DIR} )
++target_include_directories ( vdb_view SYSTEM PRIVATE ${Boost_INCLUDE_DIR} )
  
-   TARGET_LINK_LIBRARIES ( vdb_view
-     openvdb_shared
+-  TARGET_LINK_LIBRARIES ( vdb_view
+-    openvdb_shared
 -    ${Boost_THREAD_LIBRARY}
-+    ${Boost_LIBRARIES}
-     ${OPENGL_gl_LIBRARY}
-     ${OPENGL_glu_LIBRARY}
+-    ${OPENGL_gl_LIBRARY}
+-    ${OPENGL_glu_LIBRARY}
 -    ${COCOA_LIBRARY}
 -    ${IOKIT_LIBRARY}
 -    ${COREVIDEO_LIBRARY}
-     ${GLFW_LINK_LIBRARY}
-     ${GLFW_DEPENDENT_LIBRARIES}
-     ${GLEW_GLEW_LIBRARY}
-+    )
-+  IF (APPLE)
-+  TARGET_LINK_LIBRARIES ( vdb_view
-+    ${COCOA_LIBRARY}
-+    ${IOKIT_LIBRARY}
-+    ${COREVIDEO_LIBRARY}
-+  )
-+  ENDIF ()
-+  IF (NOT WIN32)
-+  TARGET_LINK_LIBRARIES ( vdb_view
-     m
-     stdc++
+-    ${GLFW_LINK_LIBRARY}
+-    ${GLFW_DEPENDENT_LIBRARIES}
+-    ${GLEW_GLEW_LIBRARY}
+-    m
+-    stdc++
 -    )
++TARGET_LINK_LIBRARIES ( vdb_view
++  openvdb_shared
++  ${Boost_LIBRARIES}
++  ${OPENGL_gl_LIBRARY}
++  ${OPENGL_glu_LIBRARY}
++  ${GLFW_LINK_LIBRARY}
++  ${GLFW_DEPENDENT_LIBRARIES}
++  ${GLEW_GLEW_LIBRARY}
++   )
++IF (APPLE)
++TARGET_LINK_LIBRARIES ( vdb_view
++  ${COCOA_LIBRARY}
++  ${IOKIT_LIBRARY}
++  ${COREVIDEO_LIBRARY}
++)
++ENDIF ()
++IF (NOT WIN32)
++TARGET_LINK_LIBRARIES ( vdb_view
++  m
++  stdc++
 +  )
-+  ENDIF ()
++ 
++ENDIF ()
  ENDIF ()
  
-+
  SET ( UNITTEST_SOURCE_FILES
-   unittest/main.cc
-   unittest/TestAttributeArray.cc
-@@ -398,7 +428,7 @@ IF ( OPENVDB_BUILD_UNITTESTS )
+@@ -398,7 +438,7 @@ IF ( OPENVDB_BUILD_UNITTESTS )
  
    ADD_TEST ( vdb_unit_test vdb_test )
  
@@ -188,7 +230,7 @@ index 9404dbc..b4129e3 100644
  
  # Doxygen docmentation
  IF (OPENVDB_BUILD_DOCS)
-@@ -419,26 +449,29 @@ IF (OPENVDB_BUILD_DOCS)
+@@ -419,26 +459,29 @@ IF (OPENVDB_BUILD_DOCS)
  ENDIF ()
  
  # Installation
@@ -199,28 +241,38 @@ index 9404dbc..b4129e3 100644
      DESTINATION
      bin
      )
--ENDIF ()
- INSTALL ( TARGETS
-   vdb_print
-   vdb_render
-   DESTINATION
-   bin
-   )
-+ENDIF ()
++  INSTALL ( TARGETS
++    vdb_print
++    vdb_render
++    DESTINATION
++    bin
++    )
+ ENDIF ()
+-INSTALL ( TARGETS
+-  vdb_print
+-  vdb_render
+-  DESTINATION
+-  bin
+-  )
  
+-INSTALL ( TARGETS
+-  openvdb_static
+-  DESTINATION
+-  lib
+-  )
 +IF ( OPENVDB_STATIC)
- INSTALL ( TARGETS
-   openvdb_static
-   DESTINATION
-   lib
-   )
++  INSTALL ( TARGETS
++    openvdb_static
++    DESTINATION
++    lib
++    )
 +ENDIF ()
  
 +IF ( OPENVDB_SHARED )
  IF (WIN32)
    INSTALL ( TARGETS
  	openvdb_shared
-@@ -452,6 +485,7 @@ ELSE()
+@@ -452,6 +495,7 @@ ELSE()
  	lib
  	)
  ENDIF ()

--- a/ports/openvdb/0004-add-necessary-head.patch
+++ b/ports/openvdb/0004-add-necessary-head.patch
@@ -1,0 +1,59 @@
+diff --git a/openvdb/viewer/ClipBox.h b/openvdb/viewer/ClipBox.h
+index ad62d39..c68c5be 100644
+--- a/openvdb/viewer/ClipBox.h
++++ b/openvdb/viewer/ClipBox.h
+@@ -37,6 +37,7 @@
+ #include <OpenGL/gl.h>
+ #include <OpenGL/glu.h>
+ #else
++#include <windows.h>
+ #include <GL/gl.h>
+ #include <GL/glu.h>
+ #endif
+diff --git a/openvdb/viewer/Font.h b/openvdb/viewer/Font.h
+index da62993..b341165 100644
+--- a/openvdb/viewer/Font.h
++++ b/openvdb/viewer/Font.h
+@@ -37,6 +37,7 @@
+ #include <OpenGL/gl.h>
+ #include <OpenGL/glu.h>
+ #else
++#include <windows.h>
+ #include <GL/gl.h>
+ #include <GL/glu.h>
+ #endif
+diff --git a/openvdb/viewer/RenderModules.h b/openvdb/viewer/RenderModules.h
+index b9fa5b1..fd38a50 100644
+--- a/openvdb/viewer/RenderModules.h
++++ b/openvdb/viewer/RenderModules.h
+@@ -31,6 +31,7 @@
+ #ifndef OPENVDB_VIEWER_RENDERMODULES_HAS_BEEN_INCLUDED
+ #define OPENVDB_VIEWER_RENDERMODULES_HAS_BEEN_INCLUDED
+ 
++#include <GL/glew.h>
+ #include <openvdb/openvdb.h>
+ #include <openvdb/tools/VolumeToMesh.h>
+ #include <openvdb/tools/MeshToVolume.h>
+@@ -41,6 +42,7 @@
+ #include <vector>
+ 
+ #if defined(__APPLE__) || defined(MACOSX)
++#include <windows.h>
+ #include <OpenGL/gl.h>
+ #include <OpenGL/glu.h>
+ #else
+diff --git a/openvdb/viewer/Viewer.cc b/openvdb/viewer/Viewer.cc
+index 31bb7a4..88bd308 100644
+--- a/openvdb/viewer/Viewer.cc
++++ b/openvdb/viewer/Viewer.cc
+@@ -31,9 +31,9 @@
+ #include "Viewer.h"
+ 
+ #include "Camera.h"
++#include "RenderModules.h"
+ #include "ClipBox.h"
+ #include "Font.h"
+-#include "RenderModules.h"
+ #include <openvdb/util/Formats.h> // for formattedInt()
+ #include <openvdb/util/logging.h>
+ #include <openvdb/points/PointDataGrid.h>

--- a/ports/openvdb/CONTROL
+++ b/ports/openvdb/CONTROL
@@ -1,5 +1,5 @@
 Source: openvdb
-Version: 6.0.0
+Version: 6.0.0-1
 Build-Depends: boost-ptr-container, openexr, tbb, blosc, boost-iostreams, boost-system, boost-thread, boost-date-time, boost-any, boost-uuid, boost-interprocess
 Description: Sparse volume data structure and tools
 

--- a/ports/openvdb/portfile.cmake
+++ b/ports/openvdb/portfile.cmake
@@ -7,9 +7,10 @@ vcpkg_from_github(
     SHA512 6b9e267fff46647b39e1e6faa12059442196c1858df1fda1515cfc375e25bc3033e2828c80e63a652509cfba386376e022cebf81ec85aaccece421b0c721529b
     HEAD_REF master
     PATCHES
-      ${CMAKE_CURRENT_LIST_DIR}/0001-fix-cmake-modules.patch
-      ${CMAKE_CURRENT_LIST_DIR}/0002-add-custom-options.patch
-      ${CMAKE_CURRENT_LIST_DIR}/0003-build-only-necessary-targets.patch
+        0001-fix-cmake-modules.patch
+        0002-add-custom-options.patch
+        0003-build-only-necessary-targets.patch
+        0004-add-necessary-head.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)


### PR DESCRIPTION
Related with issue https://github.com/Microsoft/vcpkg/issues/5473

1. About the config failure, since glfw3's library file named glfw3dll.lib instead of glfw.lib, cmake failed with sentense:  FIND_LIBRARY ( GLFW3_glfw_LIBRARY  glfw ...), so changed the name from glfw to glfw3dll.
2. Port build failed with compile error, this because the source missed header files #include<windows.h> and #include<GL/glew.h> , so added them.
