### PR TITLE
Updated libc++fs link for libc++ 8.0

### DIFF
--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 if(GCC OR (CLANG AND USES_LIBSTDCXX))
     target_link_libraries(vcpkg PRIVATE stdc++fs)
 elseif(CLANG)
-    target_link_libraries(vcpkg PRIVATE c++experimental)
+    target_link_libraries(vcpkg PRIVATE c++fs)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
This is on par with the libc++ documentation there :
http://releases.llvm.org/8.0.0/projects/libcxx/docs/UsingLibcxx.html#using-filesystem-and-libc-fs

Tested on linux and macos.