### PR TITLE
Add missing dependency for static Qt builds on Windows

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-base
-Version: 5.12.1-3
+Version: 5.12.1-4
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/vcpkg-cmake-wrapper.cmake
+++ b/ports/qt5-base/vcpkg-cmake-wrapper.cmake
@@ -35,7 +35,7 @@ if("${_target_type}" STREQUAL "STATIC_LIBRARY")
 
     if(MSVC)
        set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES 
-           Netapi32.lib Ws2_32.lib Mincore.lib Winmm.lib Iphlpapi.lib Wtsapi32.lib Dwmapi.lib)
+           Netapi32.lib Ws2_32.lib Mincore.lib Winmm.lib Iphlpapi.lib Wtsapi32.lib Dwmapi.lib Imm32.lib)
 
       add_qt_library(Qt5::Core Qt5WindowsUIAutomationSupport qwindows qdirect2d)
 


### PR DESCRIPTION
This fixes #5993 by linking `Imm32.lib` to static Qt builds on Windows.