### PR TITLE
[openssl-windows] Bump version number

### DIFF
--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl-windows
-Version: 1.0.2q-1
+Version: 1.0.2q-2
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.


### PR DESCRIPTION
Merged `openssl-windows` port update #6030 without bumping version number.