### PR TITLE
[darknet] v0.2.5

### DIFF
--- a/ports/darknet/CONTROL
+++ b/ports/darknet/CONTROL
@@ -1,11 +1,11 @@
 Source: darknet
-Version: 1.0.0-2
+Version: 0.2.5
 Description: Darknet is an open source neural network framework written in C and CUDA. You only look once (YOLO) is a state-of-the-art, real-time object detection system, best example of darknet functionalities.
 Build-Depends: pthreads (windows), stb
 Default-Features: weights
 
 Feature: opencv
-Build-Depends: opencv
+Build-Depends: opencv[ffmpeg]
 Description: Build darknet with support for OpenCV
 
 Feature: cuda
@@ -16,5 +16,5 @@ Feature: weights
 Description: Download common weights from official websites, using vcpkg proxy-enabled functions
 
 Feature: opencv-cuda
-Build-Depends: opencv[cuda]
+Build-Depends: opencv[ffmpeg],opencv[cuda]
 Description: Build darknet with support for a CUDA-enabled OpenCV

--- a/ports/darknet/fix_cmakelists.patch
+++ b/ports/darknet/fix_cmakelists.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index acd6ca0..0e7de91 100644
+index 585eb0e..7515d98 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -28,8 +28,7 @@ enable_language(CXX)
@@ -7,12 +7,12 @@ index acd6ca0..0e7de91 100644
  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
  
 -set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Install prefix" FORCE)
--set(INSTALL_BIN_DIR      "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Path where exe and dll will be installed" FORCE)
+-set(INSTALL_BIN_DIR      "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Path where exe and dll will be installed")
 +set(INSTALL_BIN_DIR      "bin"                       CACHE PATH "Path where exe and dll will be installed")
  set(INSTALL_LIB_DIR      "lib"                       CACHE PATH "Path where lib will be installed")
  set(INSTALL_INCLUDE_DIR  "include"                   CACHE PATH "Path where headers will be installed")
  set(INSTALL_CMAKE_DIR    "share/darknet"             CACHE PATH "Path where cmake configs will be installed")
-@@ -79,7 +78,6 @@ if(USE_INTEGRATED_LIBS)
+@@ -88,7 +87,6 @@ if(USE_INTEGRATED_LIBS)
    set(PThreads_windows_DIR ${CMAKE_CURRENT_LIST_DIR}/3rdparty/pthreads CACHE PATH "Path where pthreads for windows can be located")
    add_definitions(-D_TIMESPEC_DEFINED)
  endif()

--- a/ports/darknet/portfile.cmake
+++ b/ports/darknet/portfile.cmake
@@ -11,8 +11,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO AlexeyAB/darknet
-  REF 1cad888641804b1ddddf03ad316aa3a6e9e679ad
-  SHA512 8d7fc673bc318fd606f7c9de04291cd0fe5c3b8f8d2076e719a6c35fe226a45c10a3f65c38be5476a72b34ac7a31c8f9e1b5ea15d061eddcdda38357bc2a8bca
+  REF 8c970498a296ed129ffef7d872ccc25d42d1afda
+  SHA512 70dda24656469b8a61a645533ac227b644d365c7d5f4dbc93077a3f46563dd45ae88c563fb1c8f8d02a2021760aba24bea35d81f0f307975d051d0f9bfe92265
   HEAD_REF master
   PATCHES
     fix_cmakelists.patch
@@ -76,7 +76,6 @@ else()
   set(EXECUTABLE_SUFFIX "")
 endif()
 
-
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/darknet${EXECUTABLE_SUFFIX})
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/uselib${EXECUTABLE_SUFFIX})
 if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/bin/uselib_track${EXECUTABLE_SUFFIX})
@@ -97,6 +96,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 vcpkg_fixup_cmake_targets()
+
+file(COPY ${SOURCE_PATH}/cmake/Modules/FindCUDNN.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/darknet)
+file(COPY ${SOURCE_PATH}/cmake/Modules/FindPThreads_windows.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/darknet)
+file(COPY ${SOURCE_PATH}/cmake/Modules/FindStb.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/darknet)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
While strange apparently, we "downgraded" the numbers in the release version so that it is more compliant with the expected one from the community. It seems that the bump inside the official CMakeLists.txt was too huge and so it was reverted.

This PR adds also dependency for opencv feature to ffmpeg and copies the CMake module inside the darknet share folder, so that it's easier for downstream projects to consume this library