### PR TITLE
[libpqxx]Update to version 6.4.3

### DIFF
--- a/ports/libpqxx/CMakeLists.txt
+++ b/ports/libpqxx/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(libpqxx VERSION 6.0.0 LANGUAGES CXX)
+project(libpqxx VERSION 6.4.3 LANGUAGES CXX)
 
 set(CMAKE_DEBUG_POSTFIX "d")
 set(CMAKE_CXX_STANDARD 14)

--- a/ports/libpqxx/CONTROL
+++ b/ports/libpqxx/CONTROL
@@ -1,4 +1,4 @@
 Source: libpqxx
-Version: 6.0.0-1
+Version: 6.4.3
 Description: The official C++ client API for PostgreSQL
 Build-Depends: libpq

--- a/ports/libpqxx/fix-deprecated-bug.patch
+++ b/ports/libpqxx/fix-deprecated-bug.patch
@@ -1,0 +1,40 @@
+diff --git a/include/pqxx/tablereader.hxx b/include/pqxx/tablereader.hxx
+index f5300cb..0cc0e43 100644
+--- a/include/pqxx/tablereader.hxx
++++ b/include/pqxx/tablereader.hxx
+@@ -34,13 +34,13 @@ public:
+ 	const std::string &Name,
+ 	const std::string &Null=std::string{});
+   template<typename ITER>
+-  PQXX_DEPRECATED tablereader(
++  tablereader(
+ 	transaction_base &,
+ 	const std::string &Name,
+ 	ITER begincolumns,
+ 	ITER endcolumns);
+   template<typename ITER>
+-  PQXX_DEPRECATED tablereader(
++  tablereader(
+ 	transaction_base &,
+ 	const std::string &Name,
+ 	ITER begincolumns,
+diff --git a/include/pqxx/tablewriter.hxx b/include/pqxx/tablewriter.hxx
+index 32e7a98..a25b356 100644
+--- a/include/pqxx/tablewriter.hxx
++++ b/include/pqxx/tablewriter.hxx
+@@ -36,13 +36,13 @@ public:
+ 	const std::string &WName,
+ 	const std::string &Null=std::string{});
+   template<typename ITER>
+-        PQXX_DEPRECATED tablewriter(
++        tablewriter(
+ 	transaction_base &,
+ 	const std::string &WName,
+ 	ITER begincolumns,
+ 	ITER endcolumns);
+   template<typename ITER>
+-        PQXX_DEPRECATED tablewriter(
++        tablewriter(
+ 	transaction_base &T,
+ 	const std::string &WName,
+ 	ITER begincolumns,

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -3,9 +3,11 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jtv/libpqxx
-    REF 6.0.0
-    SHA512  f237cc03c01a8262eee44a9428206c1cc11b6034dddf540afef145f58eee5c32b880d84832563480d73d834c24311170e2ef6789e100793afbe0b6e393bd4169
+    REF 6.4.3
+    SHA512  d2d54adf4f498cba0ec20bb37b7a32d18b25e298d81b1884aecb3edec99beca6a10683478e6ca02953ace0b20d335a87b926bf77cbe3cb40822cf12649ea65c5
     HEAD_REF master
+	PATCHES
+		fix-deprecated-bug.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
Related issue: #5899 

We blocked by a known VS bug about adding template \<typename T\> before [[deprecated]]. This bug has been fixed in VS2019 when updating version to 6.4.3. See bug here: https://developercommunity.visualstudio.com/content/problem/139521/compilation-error-on-deprecated-template-construct.html, so remove [[deprecated]] temporarily as a workaround to update to the latest source version.