### PR TITLE
[Glog]Upgrades 2019.03.29

### DIFF
--- a/ports/glog/CONTROL
+++ b/ports/glog/CONTROL
@@ -1,4 +1,4 @@
 Source: glog
-Version: 0.3.5-1
+Version: 0.4.0
 Description: C++ implementation of the Google logging module
 Build-Depends: gflags

--- a/ports/glog/glog_disable_debug_postfix.patch
+++ b/ports/glog/glog_disable_debug_postfix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 808330e..de0e477 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -44,7 +44,7 @@ include (CTest)
+ include (DetermineGflagsNamespace)
+ include (GNUInstallDirs)
+ 
+-set (CMAKE_DEBUG_POSTFIX d)
++#set (CMAKE_DEBUG_POSTFIX d)
+ set (CMAKE_THREAD_PREFER_PTHREAD 1)
+ 
+ if (WITH_GFLAGS)

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/glog
     REF v0.4.0
-    SHA512 a54a3b8b4b7660d7558ba5168c659bc3c8323c30908a4f6a4bbc6f9cd899350f3243aabc720daebfdeb799b276b51ba1eaa1a0f83149c4e1a038d552ada1ed72
+    SHA512 b585f1819ade2075f6b61dc5aaca5c3f9d25601dba2bd08b6c49b96ac5f79db23c6b7f2042df003f7130497dd7241fcaa8b107d1f97385cb66ce52d3c554b176
     HEAD_REF master
     PATCHES
        glog_disable_debug_postfix.patch

--- a/ports/glog/portfile.cmake
+++ b/ports/glog/portfile.cmake
@@ -11,9 +11,11 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/glog
-    REF v0.3.5
+    REF v0.4.0
     SHA512 a54a3b8b4b7660d7558ba5168c659bc3c8323c30908a4f6a4bbc6f9cd899350f3243aabc720daebfdeb799b276b51ba1eaa1a0f83149c4e1a038d552ada1ed72
     HEAD_REF master
+    PATCHES
+       glog_disable_debug_postfix.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
In Glog latest release v0.4.0, it ‘set (CMAKE_DEBUG_POSTFIX d)’ by commit 185ba48, it generated debug\lib\glogd.lib now, It cause Cartographer, Sophus, Openmvg ports failed, since they are still trying to find debug\lib\glog.lib, so I made a patch to disable the setting.