### PR TITLE
[embree3] Disable parallel configure due to writes to source directory

### DIFF
--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,4 +1,4 @@
 Source: embree3
-Version: 3.2.0-2
+Version: 3.2.0-3
 Description: High Performance Ray Tracing Kernels.
 Build-Depends: tbb

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -18,6 +18,7 @@ endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         -DEMBREE_ISPC_SUPPORT=OFF


### PR DESCRIPTION
The cmake build for the port performs writes to the source directory during the configure step.
Because we configure for release and debug in parallel, this causes two writes at the same time which can sometimes fail, so disable parallel configure.
