### PR TITLE
nlohmann-json : change the destination of the copyright file

### DIFF
--- a/ports/nlohmann-json/CONTROL
+++ b/ports/nlohmann-json/CONTROL
@@ -1,3 +1,3 @@
 Source: nlohmann-json
-Version: 3.6.1
+Version: 3.6.1-1
 Description: JSON for Modern C++

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -50,4 +50,4 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/nlohmann_json.natvis)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/nlohmann-json RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/nlohmann_json RENAME copyright)


### PR DESCRIPTION
#6103 
Change the destination of the copyright file so it is next to the other port files.