### PR TITLE
[blend2d] add port

### DIFF
--- a/ports/blend2d/CONTROL
+++ b/ports/blend2d/CONTROL
@@ -1,0 +1,10 @@
+Source: blend2d
+Version: beta_2019-04-30
+Description: Beta 2D Vector Graphics Powered by a JIT Compiler
+Default-Features: jit, logging
+
+Feature: jit
+Description: asmjit is used to jit compile pipelines
+
+Feature: logging
+Description: enables logging


### PR DESCRIPTION
 Fixes #6051 
 - port version `beta_2019-04-22`
 - same versioning as in asmjit package with the addition of `beta_` prefix

The decision to [download and copy](https://github.com/maximilian578/vcpkg/blob/np_blend2d/ports/blend2d/portfile.cmake#L11:L23) another library to source is questionable but:
 - This library depends on `next-wip` branch of [asmjit](https://github.com/asmjit/asmjit/tree/next-wip) and only  asmjit `master` branch package is available at the moment.
 - This library depends on CmakeLists.txt from asmjit