### PR TITLE
[openal-soft] Fixes windows arm/arm64 build on vs2019

### DIFF
--- a/ports/openal-soft/CONTROL
+++ b/ports/openal-soft/CONTROL
@@ -1,3 +1,3 @@
 Source: openal-soft
-Version: 1.19.1-1
+Version: 1.19.1-2
 Description: OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.

--- a/ports/openal-soft/fix-arm-builds.patch
+++ b/ports/openal-soft/fix-arm-builds.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39b80250..e2a1ed76 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1409,6 +1409,7 @@ ELSE()
+         ELSEIF(CMAKE_COMPILER_IS_GNUCC)
+             SET(SUBSYS_FLAG ${SUBSYS_FLAG} "-mwindows")
+         ENDIF()
++        SET(COMMON_LIB ${COMMON_LIB} shell32 ole32)
+     ENDIF()
+ 
+     IF(WIN32 AND ALSOFT_BUILD_ROUTER)
+diff --git a/native-tools/CMakeLists.txt b/native-tools/CMakeLists.txt
+index 5e816bba..16f3be12 100644
+--- a/native-tools/CMakeLists.txt
++++ b/native-tools/CMakeLists.txt
+@@ -24,6 +24,11 @@ set_target_properties(bsincgen PROPERTIES OUTPUT_NAME bsincgen)
+ set_target_properties(bsincgen PROPERTIES RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}")
+ set_target_properties(bsincgen PROPERTIES RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}")
+ target_compile_definitions(bsincgen PRIVATE ${CPP_DEFS})
++set(BSINCGEN_LIB )
+ if(HAVE_LIBM)
+-    target_link_libraries(bsincgen m)
++    set(BSINCGEN_LIB ${BSINCGEN_LIB} m)
+ endif(HAVE_LIBM)
++if(WIN32)
++    set(BSINCGEN_LIB ${BSINCGEN_LIB} shell32)
++endif()
++target_link_libraries(bsincgen ${BSINCGEN_LIB})
+\ No newline at end of file

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     PATCHES
         dont-export-symbols-in-static-build.patch
         cmake-3-11.patch
+        fix-arm-builds.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -30,7 +31,6 @@ endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DLIBTYPE=${OPENAL_LIBTYPE}
         -DALSOFT_UTILS=OFF
@@ -54,6 +54,7 @@ vcpkg_configure_cmake(
         -DALSOFT_REQUIRE_WINMM=${ALSOFT_REQUIRE_WINDOWS}
         -DALSOFT_REQUIRE_DSOUND=${ALSOFT_REQUIRE_WINDOWS}
         -DALSOFT_REQUIRE_MMDEVAPI=${ALSOFT_REQUIRE_WINDOWS}
+        -DALSOFT_CPUEXT_NEON=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Should fix https://github.com/Microsoft/vcpkg/issues/5731.

Changed from ninja to msbuild (since it seems to be impossible to separate native-tools and openal-soft itself and use different toolchain with ninja), it might be a breaking change.

Tested on VS2019 16.0.1, with Spectre libraries installed.