### PR TITLE
Run bootstrap-vcpkg.bat when bootstrapped from git-bash

### DIFF
--- a/bootstrap-vcpkg.sh
+++ b/bootstrap-vcpkg.sh
@@ -1,10 +1,4 @@
 #!/bin/sh -e
 
 vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
-unixName=$(uname -s)
-if [[ $unixName == MINGW*_NT* ]]; then
-  vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
-  cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat"
-else
-  . "$vcpkgRootDir/scripts/bootstrap.sh"
-fi
+. "$vcpkgRootDir/scripts/bootstrap.sh"

--- a/bootstrap-vcpkg.sh
+++ b/bootstrap-vcpkg.sh
@@ -1,4 +1,10 @@
 #!/bin/sh -e
 
 vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
-. "$vcpkgRootDir/scripts/bootstrap.sh"
+unixName=$(uname -s)
+if [[ $unixName == MINGW*_NT* ]]; then
+  vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
+  cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat"
+else
+  . "$vcpkgRootDir/scripts/bootstrap.sh"
+fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+# Find .vcpkg-root, which indicates the root of this repo
+vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
+while [ "$vcpkgRootDir" != "/" ] && ! [ -e "$vcpkgRootDir/.vcpkg-root" ]; do
+    vcpkgRootDir="$(dirname "$vcpkgRootDir")"
+done
+
+# Enable using this entry point on windows from git bash by redirecting to the .bat file.
+unixName=$(uname -s | sed 's/MINGW.*_NT.*/MINGW_NT/')
+if [ "$unixName" = "MINGW_NT" ]; then
+  vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
+  cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat" || exit 1
+  exit 0
+fi
+
+# Argument parsing
 vcpkgDisableMetrics="OFF"
 vcpkgUseSystem=false
 vcpkgAllowAppleClang=OFF
@@ -24,12 +39,6 @@ do
         echo "Unknown argument $var. Use '-help' for help."
         exit 1
     fi
-done
-
-# Find vcpkg-root
-vcpkgRootDir=$(X= cd -- "$(dirname -- "$0")" && pwd -P)
-while [ "$vcpkgRootDir" != "/" ] && ! [ -e "$vcpkgRootDir/.vcpkg-root" ]; do
-    vcpkgRootDir="$(dirname "$vcpkgRootDir")"
 done
 
 if [ -z ${VCPKG_DOWNLOADS+x} ]; then


### PR DESCRIPTION
When calling `bootstrap-vcpkg.sh` from within a git-bash script it fails
with the error message `Unknown uname: MINGW64_NT-10.0`.

This change delegates bootstrapping to `bootstrap-vcpkg.bat` by
executing it in a `cmd` session when the result of `uname -s` matches
the pattern `MINGW*_NT*`.