### PR TITLE
[rocksdb] Supported static linking in Linux

### DIFF
--- a/ports/rocksdb/0005-static-linking-in-linux.patch
+++ b/ports/rocksdb/0005-static-linking-in-linux.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0303186..2b09591 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -741,7 +741,12 @@ if(WIN32)
+   set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+ else()
+   set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
+-  set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
++  
++  if(ROCKSDB_DISABLE_INSTALL_SHARED_LIB)
++    set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
++  else()
++    set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
++  endif()
+ 
+   add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
+   target_link_libraries(${ROCKSDB_SHARED_LIB}

--- a/ports/rocksdb/CONTROL
+++ b/ports/rocksdb/CONTROL
@@ -1,5 +1,5 @@
 Source: rocksdb
-Version: 5.18.3
+Version: 5.18.3-1
 Description: A library that provides an embeddable, persistent key-value store for fast storage
 Default-Features: zlib
 

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     0002-only-build-one-flavor.patch
     0003-zlib-findpackage.patch
     0004-use-find-package.patch
+    0005-static-linking-in-linux.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/cmake/modules/Findzlib.cmake")


### PR DESCRIPTION
Fixed Issue #6134 

CMake targets defined in `rocksdb/tools` depend on shared library of rocksdb, but we want static linking, which cause linking error:
```
attempted static link of dynamic object `librocksdbd.so.5.15.10'
```