### PR TITLE
[SDL2] fix arm-windows build

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.9-2
+Version: 2.0.9-3
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 
 Feature: vulkan

--- a/ports/sdl2/enable-winrt-cmake.patch
+++ b/ports/sdl2/enable-winrt-cmake.patch
@@ -37,7 +37,7 @@ index 0128c7a..bd534e4 100644
      check_include_file(ddraw.h HAVE_DDRAW_H)
      check_include_file(dsound.h HAVE_DSOUND_H)
      check_include_file(dinput.h HAVE_DINPUT_H)
-+    if(WINDOWS_STORE)
++    if(WINDOWS_STORE OR VCPKG_TARGET_TRIPLET MATCHES "arm-windows")
 +      set(HAVE_DINPUT_H 0)
 +    endif()
      check_include_file(dxgi.h HAVE_DXGI_H)


### PR DESCRIPTION
Disabled DirectInput for arm-windows due to lack of components.