### PR TITLE
[gettext] fixes arm64-windows build

### DIFF
--- a/ports/gettext/0001-Fix-macro-definitions.patch
+++ b/ports/gettext/0001-Fix-macro-definitions.patch
@@ -1,18 +1,3 @@
-diff --git a/gettext-runtime/intl/printf-parse.c b/gettext-runtime/intl/printf-parse.c
-index 0e2d2c7..e1dc39b 100644
---- a/gettext-runtime/intl/printf-parse.c
-+++ b/gettext-runtime/intl/printf-parse.c
-@@ -48,7 +48,9 @@
- #include <stddef.h>
- 
- /* Get intmax_t.  */
--#if defined IN_LIBINTL || defined IN_LIBASPRINTF
-+#if defined _MSC_VER
-+# define intmax_t long int
-+#elif defined IN_LIBINTL || defined IN_LIBASPRINTF
- # if HAVE_STDINT_H_WITH_UINTMAX
- #  include <stdint.h>
- # endif
 diff --git a/gettext-runtime/intl/xsize.h b/gettext-runtime/intl/xsize.h
 index c256665..7400ea1 100644
 --- a/gettext-runtime/intl/xsize.h

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,4 +1,4 @@
 Source: gettext
-Version: 0.19-9
+Version: 0.19-10
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.
 Build-Depends: libiconv

--- a/ports/gettext/config.win32.h
+++ b/ports/gettext/config.win32.h
@@ -229,7 +229,7 @@
 /* #undef HAVE_INCLUDE_NEXT */
 
 /* Define if you have the 'intmax_t' type in <stdint.h> or <inttypes.h>. */
-/* #undef HAVE_INTMAX_T */
+#define HAVE_INTMAX_T 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 /* #undef HAVE_INTTYPES_H */
@@ -330,11 +330,11 @@
 #define HAVE_STDDEF_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
-/* #undef HAVE_STDINT_H */
+#define HAVE_STDINT_H 1
 
 /* Define if <stdint.h> exists, doesn't clash with <sys/types.h>, and declares
    uintmax_t. */
-/* #undef HAVE_STDINT_H_WITH_UINTMAX */
+#define HAVE_STDINT_H_WITH_UINTMAX 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -382,7 +382,7 @@
 /* #undef HAVE_TSEARCH */
 
 /* Define if you have the 'uintmax_t' type in <stdint.h> or <inttypes.h>. */
-/* #undef HAVE_UINTMAX_T */
+#define HAVE_UINTMAX_T 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
 /* #undef HAVE_UNISTD_H */
@@ -624,11 +624,12 @@
 
 /* Define to unsigned long or unsigned long long if <stdint.h> and
    <inttypes.h> don't define. */
-#ifdef _WIN64
+/* #ifdef _WIN64
 #define uintmax_t unsigned __int64
 #elif _WIN32
 #define uintmax_t unsigned __int32
 #endif
+*/
 
 #define __libc_lock_t                   gl_lock_t
 #define __libc_lock_define              gl_lock_define

--- a/ports/gettext/config.win32.h
+++ b/ports/gettext/config.win32.h
@@ -624,12 +624,7 @@
 
 /* Define to unsigned long or unsigned long long if <stdint.h> and
    <inttypes.h> don't define. */
-/* #ifdef _WIN64
-#define uintmax_t unsigned __int64
-#elif _WIN32
-#define uintmax_t unsigned __int32
-#endif
-*/
+/* #undef uintmax_t */
 
 #define __libc_lock_t                   gl_lock_t
 #define __libc_lock_define              gl_lock_define


### PR DESCRIPTION
This fixes a type collision in uintmax_t and intmax_t (which seems to be already defined in stdint.h since VS2015).