### PR TITLE
Fix for #6152: Broken release build of SDL2-image

### DIFF
--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -65,7 +65,12 @@ endforeach(FORMAT)
 
 # SDL
 find_path(SDL_INCLUDE_DIR SDL2/SDL.h)
-find_library(SDL_LIBRARY NAMES SDL2d SDL2)
+find_library(SDL_LIBRARY_RELEASE NAMES SDL2)
+find_library(SDL_LIBRARY_DEBUG NAMES SDL2d)
+SET(SDL_LIBRARY
+  debug ${SDL_LIBRARY_DEBUG}
+  optimized ${SDL_LIBRARY_RELEASE}
+  )
 
 include_directories(${SDL_INCLUDE_DIR})
 include_directories(${SDL_INCLUDE_DIR}/SDL2)

--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-image
-Version: 2.0.4-1
+Version: 2.0.4-2
 Build-Depends: sdl2, libpng
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV
 


### PR DESCRIPTION
#6152: The release build of SDL2-image depends on the debug build of SDL2

Add logic to use the right SDL2 build flavor (debug/release). This only fixes SDL2-image, although as noted in #6152 other ports are likely affected by the same issue.
