### PR TITLE
[gdal/pmdk]Update to new version

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,5 +1,5 @@
 Source: gdal
-Version: 2.4.0-2
+Version: 2.4.1
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
 Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma, netcdf-c, hdf5
 

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -1,10 +1,10 @@
 # vcpkg portfile.cmake for GDAL
 #
 # NOTE: update the version and checksum for new GDAL release
-set(GDAL_VERSION_STR "2.4.0")
-set(GDAL_VERSION_PKG "240")
+set(GDAL_VERSION_STR "2.4.1")
+set(GDAL_VERSION_PKG "241")
 set(GDAL_VERSION_LIB "204")
-set(GDAL_PACKAGE_SUM "a8543425d7bdbb5ab94638a490fe5b62e37983fbb89e1eea98b0e31d5fa76b7568e7b633c90ac429c87a6c9e8d9e1358b48428f3885aac8d574d1f01e9631f7f")
+set(GDAL_PACKAGE_SUM "edb9679ee6788334cf18971c803615ac9b1c72bc0c96af8fd4852cb7e8f58e9c4f3d9cb66406bc8654419612e1a7e9d0e62f361712215f4a50120f646bb0a738")
 
 if (TRIPLET_SYSTEM_ARCH MATCHES "arm")
     message(FATAL_ERROR "ARM is currently not supported.")

--- a/ports/pmdk/CONTROL
+++ b/ports/pmdk/CONTROL
@@ -1,3 +1,3 @@
 Source: pmdk
-Version: 1.4.2
+Version: 1.6
 Description: Persistent Memory Development Kit

--- a/ports/pmdk/portfile.cmake
+++ b/ports/pmdk/portfile.cmake
@@ -18,8 +18,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pmem/pmdk
-    REF 1.4.2
-    SHA512 87aa226487046aba14f3a0b51d066f4498a6021580fd203df45f0900fc0c0c5cdb192156a4c730a5a7dc5826e204d688531e5680145161750057803cb24d088d
+    REF 1.6
+    SHA512 f66e4edf1937d51abfa7c087b65a64109cd3d2a8d9587d6c4fc28a1003d67ec1f35a0011c9a9d0bfe76ad7227be83e86582f8405c988eac828d8ae5d0a399483
     HEAD_REF master
     PATCHES
         "${CMAKE_CURRENT_LIST_DIR}/addPowerShellExecutionPolicy.patch"
@@ -32,7 +32,7 @@ string(REPLACE "pmdk-" "" PMDK_VERSION "${PMDK_VERSION}")
 # Build only the selected projects
 vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/src/PMDK.sln
-    TARGET "Solution Items\\libpmem,Solution Items\\libpmemlog,Solution Items\\libpmemblk,Solution Items\\libpmemobj,Solution Items\\libpmemcto,Solution Items\\libpmempool,Solution Items\\libvmem,Solution Items\\Tools\\pmempool"
+    TARGET "Solution Items\\libpmem,Solution Items\\libpmemlog,Solution Items\\libpmemblk,Solution Items\\libpmemobj,Solution Items\\libpmempool,Solution Items\\libvmem,Solution Items\\Tools\\pmempool"
     OPTIONS /p:SRCVERSION=${PMDK_VERSION}
 )
 
@@ -44,29 +44,27 @@ file(GLOB HEADER_FILES ${SOURCE_PATH}/src/include/*.h)
 file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 file(GLOB HEADER_FILES ${SOURCE_PATH}/src/include/libpmemobj/*.h)
 file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/libpmemobj)
-file(GLOB HEADER_FILES ${SOURCE_PATH}/src/include/libpmemobj++/*.hpp)
-file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/libpmemobj++)
 
 # Remove unneeded header files
 file(REMOVE ${CURRENT_PACKAGES_DIR}/include/libvmmalloc.h)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/include/librpmem.h)
 
 # Install libraries (debug)
-file(GLOB LIB_DEBUG_FILES ${DEBUG_ARTIFACTS_PATH}/lib[pv]mem*.lib ${DEBUG_ARTIFACTS_PATH}/lib[pv]mem*.exp)
+file(GLOB LIB_DEBUG_FILES ${DEBUG_ARTIFACTS_PATH}/libs/libpmem*.lib)
 file(INSTALL ${LIB_DEBUG_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libpmemcommon.lib)
-file(GLOB LIB_DEBUG_FILES ${DEBUG_ARTIFACTS_PATH}/lib[pv]mem*.dll)
+file(GLOB LIB_DEBUG_FILES ${DEBUG_ARTIFACTS_PATH}/libs/libpmem*.dll)
 file(INSTALL ${LIB_DEBUG_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
 
 # Install libraries (release)
-file(GLOB LIB_RELEASE_FILES ${RELEASE_ARTIFACTS_PATH}/lib[pv]mem*.lib ${RELEASE_ARTIFACTS_PATH}/lib[pv]mem*.exp)
+file(GLOB LIB_RELEASE_FILES ${RELEASE_ARTIFACTS_PATH}/libs/libpmem*.lib)
 file(INSTALL ${LIB_RELEASE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libpmemcommon.lib)
-file(GLOB LIB_RELEASE_FILES ${RELEASE_ARTIFACTS_PATH}/lib[pv]mem*.dll)
+file(GLOB LIB_RELEASE_FILES ${RELEASE_ARTIFACTS_PATH}/libs/libpmem*.dll)
 file(INSTALL ${LIB_RELEASE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
 
 # Install tools (release only)
-file(INSTALL ${RELEASE_ARTIFACTS_PATH}/pmempool.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pmdk)
+file(INSTALL ${RELEASE_ARTIFACTS_PATH}/libs/pmempool.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/pmdk)
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/pmdk)
 


### PR DESCRIPTION
[gdal] Update to version 2.4.1, related issue #6074.

[pmdk]

1. Update to version 1.6, related issue #4683.

2. Since `Solution Items\\libpmemcto` didn't exist in the source, removed this item.

3. Since the source changed, modified the operation of the header files and the directory of `pmempool.exe`.
