### PR TITLE
[proj4]Rename dll to proj.dll/projd.dll

### DIFF
--- a/ports/proj4/0004-CMake-fix-output-name.patch
+++ b/ports/proj4/0004-CMake-fix-output-name.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index a90cdac..b9cf21a 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -277,7 +277,7 @@ if(WIN32)
+   set_target_properties(${PROJ_CORE_TARGET}
+     PROPERTIES
+     VERSION "${${PROJECT_INTERN_NAME}_BUILD_VERSION}"
+-    OUTPUT_NAME "${PROJ_CORE_TARGET_OUTPUT_NAME}"
++    OUTPUT_NAME "${PROJ_CORE_TARGET}"
+     CLEAN_DIRECT_OUTPUT 1)
+ elseif(BUILD_FRAMEWORKS_AND_BUNDLE)
+   set_target_properties(${PROJ_CORE_TARGET}

--- a/ports/proj4/0004-CMake-fix-output-name.patch
+++ b/ports/proj4/0004-CMake-fix-output-name.patch
@@ -11,3 +11,16 @@ index a90cdac..b9cf21a 100644
      CLEAN_DIRECT_OUTPUT 1)
  elseif(BUILD_FRAMEWORKS_AND_BUNDLE)
    set_target_properties(${PROJ_CORE_TARGET}
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72b85a2..48c8602 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,7 +77,7 @@ endif ()
+ if (MSVC OR CMAKE_CONFIGURATION_TYPES)
+   # For multi-config systems and for Visual Studio, the debug version of
+   # the library has _d appended.
+-  set (CMAKE_DEBUG_POSTFIX _d)
++  set (CMAKE_DEBUG_POSTFIX d)
+ endif ()
+ 
+ option(PROJ4_TESTS "Enable build of collection of PROJ4 tests" ON)

--- a/ports/proj4/CONTROL
+++ b/ports/proj4/CONTROL
@@ -1,3 +1,3 @@
 Source: proj4
-Version: 4.9.3-1
+Version: 4.9.3-2
 Description: PROJ.4 library for cartographic projections

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -7,14 +7,14 @@ vcpkg_download_distfile(ARCHIVE
     FILENAME "proj-4.9.3.zip"
     SHA512 c9703008cd1f75fe1239b180158e560b9b88ae2ffd900b72923c716908eb86d1abbc4230647af5e3131f8c34481bdc66b03826d669620161ffcfbe67801cb631
 )
-vcpkg_extract_source_archive(${ARCHIVE})
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}/
-    PATCHES
-    ${CMAKE_CURRENT_LIST_DIR}/0001-CMake-add-detection-of-recent-visual-studio-versions.patch
-    ${CMAKE_CURRENT_LIST_DIR}/0002-CMake-fix-error-by-only-setting-properties-for-targe.patch
-    ${CMAKE_CURRENT_LIST_DIR}/0003-CMake-configurable-cmake-config-install-location.patch
+vcpkg_extract_source_archive_ex(
+    ARCHIVE ${ARCHIVE}
+    OUT_SOURCE_PATH SOURCE_PATH
+    PATCHES    
+        0001-CMake-add-detection-of-recent-visual-studio-versions.patch
+        0002-CMake-fix-error-by-only-setting-properties-for-targe.patch
+        0003-CMake-configurable-cmake-config-install-location.patch
+        0004-CMake-fix-output-name.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
@@ -40,37 +40,6 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/proj4)
-
-# Rename library and adapt cmake configuration
-if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    file(READ ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets-release.cmake _contents)
-    string(REPLACE "proj_4_9.lib" "proj.lib" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets-release.cmake "${_contents}")
-endif()
-
-if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(READ ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets-debug.cmake _contents)
-    string(REPLACE "proj_4_9_d.lib" "projd.lib" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets-debug.cmake "${_contents}")
-endif()
-
-file(READ ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets.cmake _contents)
-string(REPLACE "set(_IMPORT_PREFIX \"${CURRENT_PACKAGES_DIR}\")"
-    "set(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}\")\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)\nget_filename_component(_IMPORT_PREFIX \"\${_IMPORT_PREFIX}\" PATH)"
-    _contents "${_contents}"
-)
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets.cmake "${_contents}")
-
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/bin/proj_${PROJ4_VER}.dll ${CURRENT_PACKAGES_DIR}/bin/proj.dll)
-        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/proj_${PROJ4_VER}.lib  ${CURRENT_PACKAGES_DIR}/lib/proj.lib)
-    endif()
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/proj_${PROJ4_VER}_d.dll ${CURRENT_PACKAGES_DIR}/debug/bin/projd.dll)
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/proj_${PROJ4_VER}_d.lib  ${CURRENT_PACKAGES_DIR}/debug/lib/projd.lib)
-    endif()
-endif()
 
 # Remove duplicate headers installed from debug build
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -1,6 +1,5 @@
 include(vcpkg_common_functions)
 
-set(PROJ4_VER "4_9")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/proj-4.9.3)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/proj/proj-4.9.3.zip"

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -1,4 +1,6 @@
 include(vcpkg_common_functions)
+
+set(PROJ4_VER "4_9")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/proj-4.9.3)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/proj/proj-4.9.3.zip"
@@ -61,10 +63,12 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/share/proj4/proj4-targets.cmake "${_contents}
 
 if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/proj_4_9.lib  ${CURRENT_PACKAGES_DIR}/lib/proj.lib)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/bin/proj_${PROJ4_VER}.dll ${CURRENT_PACKAGES_DIR}/bin/proj.dll)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/proj_${PROJ4_VER}.lib  ${CURRENT_PACKAGES_DIR}/lib/proj.lib)
     endif()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/proj_4_9_d.lib  ${CURRENT_PACKAGES_DIR}/debug/lib/projd.lib)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/bin/proj_${PROJ4_VER}_d.dll ${CURRENT_PACKAGES_DIR}/debug/bin/projd.dll)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/proj_${PROJ4_VER}_d.lib  ${CURRENT_PACKAGES_DIR}/debug/lib/projd.lib)
     endif()
 endif()
 

--- a/ports/proj4/usage
+++ b/ports/proj4/usage
@@ -1,0 +1,4 @@
+The package proj4 is compatible with built-in CMake targets:
+
+    find_package(proj4 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE proj)


### PR DESCRIPTION
When using port **gdal** functions(such as **OCTTransform()**), we will received errors that cannot find proj.dll, so I rename release dll and debug dll.

See #3408.