### PR TITLE
[openblas]Disable cross-compiling to fix uwp build.

### DIFF
--- a/ports/openblas/CONTROL
+++ b/ports/openblas/CONTROL
@@ -1,3 +1,3 @@
 Source: openblas
-Version: 0.3.5-2
+Version: 0.3.5-3
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -21,6 +21,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
         message("openblas currenly only supports dynamic library linkage")
         set(VCPKG_LIBRARY_LINKAGE "dynamic")
     endif()
+    set(CMAKE_CROSSCOMPILING OFF)
 endif()
 
 vcpkg_from_github(

--- a/ports/openblas/uwp.patch
+++ b/ports/openblas/uwp.patch
@@ -1,3 +1,4 @@
+diff --git a/cmake/prebuild.cmake b/cmake/prebuild.cmake
 --- a/cmake/prebuild.cmake	2019-01-28 03:05:58.422245700 -0600
 +++ b/cmake/prebuild.cmake	2019-01-28 03:07:02.885495800 -0600
 @@ -37,6 +37,9 @@
@@ -32,3 +33,18 @@
  
    # append config data from getarch_2nd to the TARGET file and read in CMake vars
    file(APPEND ${TARGET_CONF_TEMP} ${GETARCH2_CONF_OUT})
+
+diff --git a/cmake/system.cmake b/cmake/system.cmake
+index a060d98..52ffa5a 100644
+--- a/cmake/system.cmake
++++ b/cmake/system.cmake
+@@ -13,6 +13,9 @@ if(CMAKE_CROSSCOMPILING AND NOT DEFINED TARGET)
+     set(TARGET "ARMV8")
+   elseif(ARM)
+     set(TARGET "ARMV7") # TODO: Ask compiler which arch this is
++  elseif(${HOST_OS} STREQUAL "WINDOWSSTORE")
++    set(CMAKE_CROSSCOMPILING 0)
++    add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+   else()
+     message(FATAL_ERROR "When cross compiling, a TARGET is required.")
+   endif()


### PR DESCRIPTION
When building openblas using uwp, we receive an error:
> When cross compiling, a TARGET is required.

This is because the marco **TARGET** is not set.
So I disabled cross-compiling and added marco **_CRT_SECURE_NO_WARNINGS** to fix build. (Related: [#1697](https://github.com/xianyi/OpenBLAS/pull/1697))

See #3145.