### PR TITLE
[poco] Enable arm64-windows (Fix #5997)

### DIFF
--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,5 +1,5 @@
 Source: poco
-Version: 2.0.0-pre
+Version: 2.0.0-pre-1
 Build-Depends: expat, libpq, pcre, sqlite3, zlib
 Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems. (https://github.com/pocoproject/poco)
 

--- a/ports/poco/arm64_pcre.patch
+++ b/ports/poco/arm64_pcre.patch
@@ -1,0 +1,62 @@
+diff --git a/Foundation/include/Poco/Platform.h b/Foundation/include/Poco/Platform.h
+index 3f26008..d0bbd31 100644
+--- a/Foundation/include/Poco/Platform.h
++++ b/Foundation/include/Poco/Platform.h
+@@ -193,7 +193,7 @@
+ 	#else
+ 		#define POCO_ARCH_LITTLE_ENDIAN 1
+ 	#endif
+-#elif defined(__arm64__) || defined(__arm64)
++#elif defined(__arm64__) || defined(__arm64) || defined(_M_ARM64)
+ 	#define POCO_ARCH POCO_ARCH_ARM64
+ 	#if defined(__ARMEB__)
+ 		#define POCO_ARCH_BIG_ENDIAN 1
+diff --git a/Foundation/src/EventLogChannel.cpp b/Foundation/src/EventLogChannel.cpp
+index 4d655da..26567c8 100644
+--- a/Foundation/src/EventLogChannel.cpp
++++ b/Foundation/src/EventLogChannel.cpp
+@@ -11,6 +11,7 @@
+ // SPDX-License-Identifier:	BSL-1.0
+ //
+ 
++#pragma comment(lib,"advapi32.lib")
+ 
+ #include "Poco/EventLogChannel.h"
+ #include "Poco/Message.h"
+diff --git a/Foundation/src/utils.h b/Foundation/src/utils.h
+index e2b6a06..1b045c1 100644
+--- a/Foundation/src/utils.h
++++ b/Foundation/src/utils.h
+@@ -54,7 +54,7 @@
+ // disabled.)
+ // On Linux,x86 89255e-22 != Div_double(89255.0/1e22)
+ #if defined(_M_X64) || defined(__x86_64__) || \
+-    defined(__ARMEL__) || defined(_M_ARM) || defined(__arm__) || defined(__arm64__) || \
++    defined(__ARMEL__) || defined(_M_ARM) || defined(__arm__) || defined(__arm64__) || defined(_M_ARM64) || \
+     defined(__avr32__) || \
+     defined(__hppa__) || defined(__ia64__) || \
+     defined(__mips__) || \
+diff --git a/Net/src/Net.cpp b/Net/src/Net.cpp
+index e81b4b5..36ae436 100644
+--- a/Net/src/Net.cpp
++++ b/Net/src/Net.cpp
+@@ -11,6 +11,7 @@
+ // SPDX-License-Identifier:	BSL-1.0
+ //
+ 
++#pragma comment(lib,"advapi32.lib")
+ 
+ #include "Poco/Net/Net.h"
+ 
+diff --git a/Util/src/WinRegistryKey.cpp b/Util/src/WinRegistryKey.cpp
+index 4c2ad7d..cf1de17 100644
+--- a/Util/src/WinRegistryKey.cpp
++++ b/Util/src/WinRegistryKey.cpp
+@@ -11,6 +11,7 @@
+ // SPDX-License-Identifier:	BSL-1.0
+ //
+ 
++#pragma comment(lib,"advapi32.lib")
+ 
+ #include "Poco/Util/WinRegistryKey.h"
+ #include "Poco/Exception.h"

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -17,6 +17,8 @@ vcpkg_from_github(
         static_pcre.patch
         # Fix source path of PDF
         unbundled_pdf.patch
+        # Add the support of arm64-windows
+        arm64_pcre.patch
 )
 
 # define Poco linkage type


### PR DESCRIPTION
Enable poco:arm64-windows by adding the support of _M_ARM64 in utils.h and Platform.h
Fix #5997