### PR TITLE
[Alembic]Fix error C1803 when using headers from OpenEXR

### DIFF
--- a/ports/alembic/CONTROL
+++ b/ports/alembic/CONTROL
@@ -1,4 +1,4 @@
 Source: alembic
-Version: 1.7.10
+Version: 1.7.10-1
 Build-Depends: ilmbase, hdf5
 Description: Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications. http://alembic.io/

--- a/ports/alembic/fix-C1083.patch
+++ b/ports/alembic/fix-C1083.patch
@@ -1,0 +1,49 @@
+diff --git a/lib/Alembic/Abc/Foundation.h b/lib/Alembic/Abc/Foundation.h
+index 9760c49..fbab6a0 100644
+--- a/lib/Alembic/Abc/Foundation.h
++++ b/lib/Alembic/Abc/Foundation.h
+@@ -40,11 +40,11 @@
+ #include <Alembic/AbcCoreAbstract/All.h>
+ #include <Alembic/Util/All.h>
+ 
+-#include <ImathVec.h>
+-#include <ImathBox.h>
+-#include <ImathMatrix.h>
+-#include <ImathQuat.h>
+-#include <ImathColor.h>
++#include <OpenEXR/ImathVec.h>
++#include <OpenEXR/ImathBox.h>
++#include <OpenEXR/ImathMatrix.h>
++#include <OpenEXR/ImathQuat.h>
++#include <OpenEXR/ImathColor.h>
+ 
+ #include <iostream>
+ #include <string>
+diff --git a/lib/Alembic/AbcGeom/Foundation.h b/lib/Alembic/AbcGeom/Foundation.h
+index 301efc3..2bb0f6b 100644
+--- a/lib/Alembic/AbcGeom/Foundation.h
++++ b/lib/Alembic/AbcGeom/Foundation.h
+@@ -39,8 +39,8 @@
+ 
+ #include <Alembic/Abc/All.h>
+ 
+-#include <ImathMatrixAlgo.h>
+-#include <ImathEuler.h>
++#include <OpenEXR/ImathMatrixAlgo.h>
++#include <OpenEXR/ImathEuler.h>
+ 
+ 
+ namespace Alembic {
+diff --git a/lib/Alembic/Util/Foundation.h b/lib/Alembic/Util/Foundation.h
+index d7f40dd..a41bb97 100644
+--- a/lib/Alembic/Util/Foundation.h
++++ b/lib/Alembic/Util/Foundation.h
+@@ -63,7 +63,7 @@
+ 
+ #include <memory>
+ 
+-#include <half.h>
++#include <OpenEXR/half.h>
+ 
+ #include <iomanip>
+ #include <iostream>

--- a/ports/alembic/portfile.cmake
+++ b/ports/alembic/portfile.cmake
@@ -18,13 +18,10 @@ vcpkg_from_github(
     REF 1.7.10
     SHA512 e98ffaedb98dbc5c53fe9703d3063bb118d32c83c47e3af04c8fc96237034b02fe0fc2c628ca82bdd0e0ef17d9375f4f48e0022ce33380b9ad91970539611ced
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
-    ${CMAKE_CURRENT_LIST_DIR}/fix-hdf5link.patch
-    ${CMAKE_CURRENT_LIST_DIR}/bypass-findhdf5.patch
+        fix-hdf5link.patch
+        bypass-findhdf5.patch
+        fix-C1083.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Related issue: https://github.com/Microsoft/vcpkg/issues/5085
Issue info: Did not find headers form OpenEXR when using Alembic headers, the because we installed OpenEXR in ..\installed\\[triplets]\include\OpenEXR, so others should use it like **#include<OpenEXR/header.h>** after integrated it. 