### PR TITLE
[devicenameresolver] Add missing <string>

### DIFF
--- a/ports/devicenameresolver/CONTROL
+++ b/ports/devicenameresolver/CONTROL
@@ -1,3 +1,3 @@
 Source: devicenameresolver
-Version: 2016-06-26-0850d88fa6
+Version: 2016-06-26-0850d88fa6-1
 Description: a little library that resolves a path from a (virtual) device name.

--- a/ports/devicenameresolver/add-string-headfile.patch
+++ b/ports/devicenameresolver/add-string-headfile.patch
@@ -1,0 +1,12 @@
+diff --git a/NativeWinApi.h b/NativeWinApi.h
+index 63fced1..582306b 100644
+--- a/NativeWinApi.h
++++ b/NativeWinApi.h
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <windows.h>
++#include <string>
+ 
+ #define STATUS_INFO_LENGTH_MISMATCH ((NTSTATUS)0xC0000004L)
+ #define STATUS_SUCCESS   ((NTSTATUS)0x00000000L)

--- a/ports/devicenameresolver/portfile.cmake
+++ b/ports/devicenameresolver/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_bitbucket(
     REF 0850d88fa6a759d79b3c859933870d9aa602aa79
     SHA512 9161411d3c8c17f49f5ff9482a007a6608872c948ef856aa7076a45c246e8d777e4cd6b54169d9c1b9e99e7b383436e1a084e168fafff1ca5f2b28260bac1452
     HEAD_REF master
+    PATCHES add-string-headfile.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
1. Port failed in VS2019, it's due to \<vector> no longer includes \<string>.
2. Add \<string> into the source file.