### PR TITLE
[stlab] update to v1.4.1

### DIFF
--- a/ports/stlab/CONTROL
+++ b/ports/stlab/CONTROL
@@ -1,5 +1,5 @@
 Source: stlab
-Version: 1.3.3
+Version: 1.4.1
 Description: 
   stlab is the ongoing work of what was Adobe’s Software Technology Lab.
   The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures.

--- a/ports/stlab/CONTROL
+++ b/ports/stlab/CONTROL
@@ -3,3 +3,4 @@ Version: 1.4.1
 Description: 
   stlab is the ongoing work of what was Adobe’s Software Technology Lab.
   The Concurrency library provides futures and channels, high level constructs for implementing algorithms that eases the use of multiple CPU cores while minimizing contention. This library solves several problems of the C++11 and C++17 TS futures.
+Build-Depends: boost-variant (osx)

--- a/ports/stlab/dont-require-testing.patch
+++ b/ports/stlab/dont-require-testing.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d058bbe..260d940 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,8 +123,7 @@ if ( stlab.testing OR stlab.boost_variant OR stlab.boost_optional )
+     endif()
+   endif()
+ 
+-
+-  if(NOT TARGET Boost::unit_test_framework)
++  if (stlab.testing AND NOT TARGET Boost::unit_test_framework)
+     message(FATAL_ERROR "Could not find Boost unit test framework.")
+   endif()
+   

--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -5,7 +5,8 @@ vcpkg_from_github(
     REPO stlab/libraries
     REF v1.4.1
     SHA512 e9da6f2c570397842f5e73a681f49c5a77977fda430ec730eed6f19d04161172829b7f1adcafd416f0a3f35ea8717ca14e9b935b5ec8fa423e4951c3ba961c7a
-    HEAD_REF develop
+    HEAD_REF develop    
+    PATCHES dont-require-testing.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/stlab/portfile.cmake
+++ b/ports/stlab/portfile.cmake
@@ -3,9 +3,9 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stlab/libraries
-    REF v1.3.3
-    SHA512 2c0eec5638b40f8285cc3b0d756df619b53ba44421c47713aaf45196100765a31a6aea3c5bedba4fcc44494b74e3f0a919271601e717e7f274fe15beb93f8889
-    HEAD_REF master
+    REF v1.4.1
+    SHA512 e9da6f2c570397842f5e73a681f49c5a77977fda430ec730eed6f19d04161172829b7f1adcafd416f0a3f35ea8717ca14e9b935b5ec8fa423e4951c3ba961c7a
+    HEAD_REF develop
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
- update [stlab](http://stlab.cc/) from `1.3.3` to `1.4.1`
- update head reference to `develop` - the active development branch