### PR TITLE
[libidn2] Removed CMAKE_DEBUG_POSTFIX.

### DIFF
--- a/ports/libidn2/CMakeLists.txt
+++ b/ports/libidn2/CMakeLists.txt
@@ -4,8 +4,6 @@ project(libidn2 C)
 
 find_package(unofficial-iconv REQUIRED)
 
-set(CMAKE_DEBUG_POSTFIX "d")
-
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)

--- a/ports/libidn2/CONTROL
+++ b/ports/libidn2/CONTROL
@@ -1,4 +1,4 @@
 Source: libidn2
-Version: 2.1.1
+Version: 2.1.1-1
 Build-Depends: libiconv
 Description: GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.


### PR DESCRIPTION
Usage of the CMAKE_DEBUG_POSTFIX was not a good idea because if complicates linking for libraries that depends on this one. In initial port version I thought that it would be useful to distinguish debug and release dlls. But it creates unnecessary complications for dependent libraries.
It seems that custom CMAKE_DEBUG_POSTFIX should be avoided for libraries that require custom CMake script and do not have CMake modules.