### PR TITLE
[Live555]Update version to 'latest'

### DIFF
--- a/ports/live555/CONTROL
+++ b/ports/live555/CONTROL
@@ -1,3 +1,3 @@
 Source: live555
-Version: 2019.03.06
+Version: latest
 Description: A complete RTSP server application

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -4,38 +4,42 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 endif()
 
 if(NOT VCPKG_USE_HEAD_VERSION)
-	message(FATAL_ERROR "Live555 does not have persistent releases. Please re-run the installation with --head.")
-else()
-    # The current Live555 version from http://www.live555.com/liveMedia/public/
-    set(LIVE_VERSION latest)
-    include(vcpkg_common_functions)
-    set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION}/live)
-    vcpkg_download_distfile(ARCHIVE
-	    URLS "http://www.live555.com/liveMedia/public/live555-${LIVE_VERSION}.tar.gz"
-	    FILENAME "live555-${LIVE_VERSION}.tar.gz"
-	    SKIP_SHA512
-    )
-
-    vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION})
-
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-
-    vcpkg_configure_cmake(
-	    SOURCE_PATH ${SOURCE_PATH}
-	    PREFER_NINJA
-    )
-
-    vcpkg_install_cmake()
-
-    file(GLOB HEADERS
-	    "${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
-	    "${SOURCE_PATH}/groupsock/include/*.h*"
-	    "${SOURCE_PATH}/liveMedia/include/*.h*"
-	    "${SOURCE_PATH}/UsageEnvironment/include/*.h*"
-    )
-
-    file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-    file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
-
-    vcpkg_copy_pdbs()
+    # Live555 only makes the latest releases available for download on their site
+    message(FATAL_ERROR "Live555 does not have persistent releases. Please re-run the installation with --head.")
 endif()
+
+include(vcpkg_common_functions)
+
+set(LIVE_VERSION latest)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.live555.com/liveMedia/public/live555-${LIVE_VERSION}.tar.gz"
+    FILENAME "live555-${LIVE_VERSION}.tar.gz"
+    SKIP_SHA512
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(GLOB HEADERS
+    "${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
+    "${SOURCE_PATH}/groupsock/include/*.h*"
+    "${SOURCE_PATH}/liveMedia/include/*.h*"
+    "${SOURCE_PATH}/UsageEnvironment/include/*.h*"
+)
+
+file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -3,38 +3,39 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(VCPKG_LIBRARY_LINKAGE "static")
 endif()
 
-# The current Live555 version from http://www.live555.com/liveMedia/public/live.2019.03.06
-set(LIVE_VERSION 2019.03.06)
+if(NOT VCPKG_USE_HEAD_VERSION)
+	message(FATAL_ERROR "Live555 does not have persistent releases. Please re-run the installation with --head.")
+else()
+    # The current Live555 version from http://www.live555.com/liveMedia/public/
+    set(LIVE_VERSION latest)
+    include(vcpkg_common_functions)
+    set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION}/live)
+    vcpkg_download_distfile(ARCHIVE
+	    URLS "http://www.live555.com/liveMedia/public/live555-${LIVE_VERSION}.tar.gz"
+	    FILENAME "live555-${LIVE_VERSION}.tar.gz"
+	    SKIP_SHA512
+    )
 
-include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION}/live)
-vcpkg_download_distfile(ARCHIVE
-	URLS "http://www.live555.com/liveMedia/public/live.${LIVE_VERSION}.tar.gz"
-	FILENAME "live555-${LIVE_VERSION}.tar.gz"
-	SHA512 cf3cbf57ec43d392fa82f06bd02f6d829208c9a9ec1c505d9eb6c5e2dd3393bbd8829b6216163deb8ea8356c180f30f610a639044a6941df5c9a92f29d4f1a75
-)
+    vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION})
 
-vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/${LIVE_VERSION})
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+    vcpkg_configure_cmake(
+	    SOURCE_PATH ${SOURCE_PATH}
+	    PREFER_NINJA
+    )
 
-vcpkg_configure_cmake(
-	SOURCE_PATH ${SOURCE_PATH}
-	PREFER_NINJA
-)
+    vcpkg_install_cmake()
 
-vcpkg_install_cmake()
+    file(GLOB HEADERS
+	    "${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
+	    "${SOURCE_PATH}/groupsock/include/*.h*"
+	    "${SOURCE_PATH}/liveMedia/include/*.h*"
+	    "${SOURCE_PATH}/UsageEnvironment/include/*.h*"
+    )
 
-file(GLOB HEADERS
-	"${SOURCE_PATH}/BasicUsageEnvironment/include/*.h*"
-	"${SOURCE_PATH}/groupsock/include/*.h*"
-	"${SOURCE_PATH}/liveMedia/include/*.h*"
-	"${SOURCE_PATH}/UsageEnvironment/include/*.h*"
-)
+    file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+    file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
 
-file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
-
-vcpkg_copy_pdbs()
-
-
+    vcpkg_copy_pdbs()
+endif()


### PR DESCRIPTION
[live555] Update to latest version and disable SHA512 when downloading source form 'latest'. Then it will not block when source updated in the future.