### PR TITLE
[args] Export official targets

### DIFF
--- a/ports/args/CONTROL
+++ b/ports/args/CONTROL
@@ -1,3 +1,3 @@
 Source: args
-Version: 2019-03-29
+Version: 2019-05-01
 Description: A simple header-only C++ argument parser library.

--- a/ports/args/portfile.cmake
+++ b/ports/args/portfile.cmake
@@ -4,23 +4,26 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Taywee/args
-    REF 6cd243def4b335efa5a83acb4d29aee482970d2e
-    SHA512 112b98d37d0a3f5bd2993e0e7fb64545391a368e43a87d56e0129cc8f6edc9158d6bd105dc33e3263ff1c48a584ef2dc0fadcd1e8d810b06c716d703c5a1079f
+    REF 623e52cb128cfc572ad4e79de8d5f8861d13d017
+    SHA512 b951caed125fd937549db6702de8615eac0f380026ea4de5937721143b0929f5aa47ecc8068b7d9689822d303b25d6350f00a8e6346a53d51a0ea40872488533
     HEAD_REF master
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+    -DARGS_BUILD_UNITTESTS=OFF
+    -DARGS_BUILD_EXAMPLE=OFF
 )
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
 
 # Put the licence file where vcpkg expects it
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/args)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/args/LICENSE ${CURRENT_PACKAGES_DIR}/share/args/copyright)
 
-# Copy the args header files
-file(INSTALL ${SOURCE_PATH}/ DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN "*.hxx")
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/examples ${CURRENT_PACKAGES_DIR}/include/test)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Meanwhile, install the header with `vcpkg_install_cmake`.