### PR TITLE
[zziplib] Fix autotool generated includes

### DIFF
--- a/ports/zziplib/CMakeLists.txt
+++ b/ports/zziplib/CMakeLists.txt
@@ -23,10 +23,18 @@ if(UNIX)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
   message(STATUS "Autotools should have finished their job")
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/x86_64-pc-linux-gnu/zzip)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/x86_64-pc-linux-gnu)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/x86_64-apple-darwin18.2.0/zzip)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/x86_64-apple-darwin18.2.0)
+
+  # Find autotools output
+  set(ZZLIB_AUTOOLS_INCLUDE_DIRS)
+  file(GLOB CHILDREN RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*")
+  foreach(CHILD ${CHILDREN})
+    string(REGEX MATCH "x86_64*" ZZLIB_AUTOOLS_OUTPUT_FOLDER "${CHILD}")
+    if (ZZLIB_AUTOOLS_OUTPUT_FOLDER)
+      set(ZZLIB_AUTOOLS_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/${CHILD})
+      include_directories(${ZZLIB_AUTOOLS_INCLUDE_DIRS})
+      include_directories(${ZZLIB_AUTOOLS_INCLUDE_DIRS}/zzip)
+    endif()
+  endforeach()
 endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
@@ -55,9 +63,7 @@ set(HEADERS zzip/__debug.h
             zzip/zzip.h
 )
 if(UNIX)
-  file(GLOB OTHER_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/x86_64-pc-linux-gnu/zzip/*.h)
-  list(APPEND HEADERS ${OTHER_HEADERS})
-  file(GLOB OTHER_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/x86_64-apple-darwin18.2.0/zzip/*.h)
+  file(GLOB OTHER_HEADERS ${ZZLIB_AUTOOLS_INCLUDE_DIRS}/zzip/*.h)
   list(APPEND HEADERS ${OTHER_HEADERS})
 else()
   list(APPEND HEADERS zzip/_msvc.h)

--- a/ports/zziplib/CMakeLists.txt
+++ b/ports/zziplib/CMakeLists.txt
@@ -16,14 +16,6 @@ if(MSVC)
 endif()
 
 if(UNIX)
-  message(STATUS "Running ${SHELL_EXECUTABLE} ./configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/")
-  add_custom_target(
-    zziplib_autotools
-    ${SHELL_EXECUTABLE} ./configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  )
-  message(STATUS "Autotools should have finished their job")
-
   # Find autotools output
   set(ZZLIB_AUTOOLS_INCLUDE_DIRS)
   file(GLOB CHILDREN RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*")
@@ -81,9 +73,6 @@ set(SRCS zzip/dir.c
 )
 
 add_library(zziplib ${SRCS} ${HEADERS})
-if(UNIX)
-  add_dependencies(zziplib zziplib_autotools)
-endif()
 
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(zziplib PRIVATE -DZZIPLIB_EXPORTS)

--- a/ports/zziplib/CONTROL
+++ b/ports/zziplib/CONTROL
@@ -1,4 +1,4 @@
 Source: zziplib
-Version: 0.13.69-1
+Version: 0.13.69-2
 Build-Depends: zlib
 Description: library providing read access on ZIP-archives

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -1,4 +1,5 @@
 include(vcpkg_common_functions)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gdraheim/zziplib

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -7,6 +7,16 @@ vcpkg_from_github(
     SHA512 ade026289737f43ca92a8746818d87dd7618d473dbce159546ce9071c9e4cbe164a6b1c9efff16efb7aa0327b2ec6b34f3256c6bda19cd6e325703fffc810ef0
 )
 
+# Run configure
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(STATUS "Configuring zziplib")
+    vcpkg_execute_required_process(
+        COMMAND "./configure"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "autotools-config-${TARGET_TRIPLET}"
+    )
+endif()
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Fix include directories produced by configuring `zziplib`.
This PR removes the hard-coded version number on Mac OS X introduced in PR #6188 .

~~**HOWEVER**, this is a flaky solution.~~

~~Sometimes the search finishes before the output folders have been generated, in which case, running `vcpkg install zziplib` a second time will succeed.~~ Moved call to configure script to portfile to avoid this issue.

Tested only in 64-bit machines, the regex probably has to change to accommodate 32-bit machines.