### PR TITLE
[openjpeg/itk]Update openjpeg to v2.3.1 and fix conflict with ITK.

### DIFF
--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,7 +1,7 @@
 Source: itk
 Version: 4.13.0-906736bd
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
-Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp]
+Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp], openjpeg
 
 Feature: vtk
 Description: Build ITKVtkGlue module.

--- a/ports/itk/fix_conflict_with_openjp2_pc.patch
+++ b/ports/itk/fix_conflict_with_openjp2_pc.patch
@@ -1,0 +1,33 @@
+diff --git a/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt b/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
+index 6e3504d..1d641c2 100644
+--- a/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
++++ b/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
+@@ -375,7 +375,8 @@ else()
+ endif()
+ 
+ if(GDCM_USE_SYSTEM_OPENJPEG)
+-  find_package(OpenJPEG 2.0.0 REQUIRED)
++  # openjpeg version in vcpkg is already greater than 2.0.0 and openjpeg has no version.cmake file
++  find_package(OpenJPEG REQUIRED)
+   set(GDCM_OPENJPEG_LIBRARIES ${OPENJPEG_LIBRARIES})
+ else()
+   set(GDCM_OPENJPEG_LIBRARIES itkgdcmopenjp2)
+diff --git a/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt b/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt
+index 4ffe98e..a269690 100644
+--- a/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt
++++ b/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt
+@@ -347,12 +347,8 @@ endif()
+ 
+ #-----------------------------------------------------------------------------
+ # pkgconfig support
+-# enabled by default on Unix, disabled by default on other platforms
+-if(UNIX)
+-  option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" ON)
+-else()
+-  option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" OFF)
+-endif()
++# Cannot use the built-in openjp2 because the configuration path is under buildtrees
++option(BUILD_PKGCONFIG_FILES "Build and install pkg-config files" OFF)
+ if(BUILD_PKGCONFIG_FILES)
+   # install in lib and not share (see multi-arch note above)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjp2/libopenjp2.pc.cmake.in

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 906736bd453e95ccf03b318d3d07cb7884285161
     SHA512 8ac62262d46e7acbb0e5b2e964292ec17e1687bb162b8cec666e5b67acbe3449f093a0b1c03737e9951cb88248ed890805ffd57df6eae21220488620da833c57
     HEAD_REF master
+    PATCHES fix_conflict_with_openjp2_pc.patch
 )
 
 if ("vtk" IN_LIST FEATURES)
@@ -60,6 +61,7 @@ vcpkg_configure_cmake(
         -DModule_IOSTL=ON # example how to turn on a non-default module
         -DModule_MorphologicalContourInterpolation=ON # example how to turn on a remote module
         -DModule_RLEImage=ON # example how to turn on a remote module
+        -DGDCM_USE_SYSTEM_OPENJPEG=ON #Use port openjpeg instead of own third-party
         ${ADDITIONAL_OPTIONS}
 )
 

--- a/ports/openjpeg/CONTROL
+++ b/ports/openjpeg/CONTROL
@@ -1,3 +1,3 @@
 Source: openjpeg
-Version: 2.3.0
+Version: 2.3.1
 Description: JPEG 2000 image library

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -2,8 +2,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uclouvain/openjpeg
-    REF v2.3.0
-    SHA512 0a9d427be4a820b1d759fca4b50e293721b45fe4885aa61ca1ae09e099f75ed93520448090c780d62f51076d575cc03618cd6d5181bdb6b34e4fc07b4cfdd568
+    REF v2.3.1
+    SHA512 339fbc899bddf2393d214df71ed5d6070a3a76b933b1e75576c8a0ae9dfcc4adec40bdc544f599e4b8d0bc173e4e9e7352408497b5b3c9356985605830c26c03
     HEAD_REF master
 )
 


### PR DESCRIPTION
1. Update openjpeg to version **2.3.1**,
2. Since ITK's built-in openjpeg configuration file _libopenjp2.pc_ points to buildtrees, add port openjpeg to itk's dependency and disable built-in openjpeg build.