### PR TITLE
[duktape/open62541] Update the SHA512 of distfile

### DIFF
--- a/ports/duktape/CONTROL
+++ b/ports/duktape/CONTROL
@@ -1,4 +1,4 @@
 Source: duktape
-Version: 2.0.3-5
+Version: 2.0.3-6
 Description: Embeddable Javascript engine with a focus on portability and compact footprint.
 Build-Depends:

--- a/ports/duktape/portfile.cmake
+++ b/ports/duktape/portfile.cmake
@@ -28,7 +28,7 @@ if(NOT EXISTS ${PYTHON2_DIR}/easy_install${EXECUTABLE_SUFFIX})
         vcpkg_download_distfile(GET_PIP
             URLS "https://bootstrap.pypa.io/get-pip.py"
             FILENAME "tools/python/python2/get-pip.py"
-            SHA512 fdbcef1037dca7cc914e2304af657ebd08239cd18c3e79786dc25c8ea39957674e012d7ea8ae2c99006e4b61d3a5e24669ac5771dc186697fd9fdb40b6cc07ae
+            SHA512 99520d223819708b8f6e4b839d1fa215e4e8adc7fcd0db6c25a0399cf2fa10034b35673cf450609303646d12497f301ef53b7e7cc65c78e7bce4af0c673555ad
         )
         execute_process(COMMAND ${PYTHON2_DIR}/python${EXECUTABLE_SUFFIX} ${PYTHON2_DIR}/get-pip.py)
     endif()

--- a/ports/open62541/CONTROL
+++ b/ports/open62541/CONTROL
@@ -1,3 +1,3 @@
 Source: open62541
-Version: 0.3.0
+Version: 0.3.0-1
 Description: open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -37,7 +37,7 @@ if(NOT EXISTS ${PYTHON3_DIR}/easy_install${EXECUTABLE_SUFFIX})
         vcpkg_download_distfile(GET_PIP
             URLS "https://bootstrap.pypa.io/get-pip.py"
             FILENAME "tools/python/python3/get-pip.py"
-            SHA512 fdbcef1037dca7cc914e2304af657ebd08239cd18c3e79786dc25c8ea39957674e012d7ea8ae2c99006e4b61d3a5e24669ac5771dc186697fd9fdb40b6cc07ae
+            SHA512 99520d223819708b8f6e4b839d1fa215e4e8adc7fcd0db6c25a0399cf2fa10034b35673cf450609303646d12497f301ef53b7e7cc65c78e7bce4af0c673555ad
         )
         execute_process(COMMAND ${PYTHON3_DIR}/python${EXECUTABLE_SUFFIX} ${PYTHON3_DIR}/get-pip.py)
     endif()


### PR DESCRIPTION
Duktape and open62541 failed due to the SHA512 mismatch when download the distfile: https://bootstrap.pypa.io/get-pip.py , so update it. 