### PR TITLE
[folly/gdcm2] Update version to fix compile issue

### DIFF
--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,5 @@
 Source: folly
-Version: 2019.01.28.00-4
+Version: 2019.05.06.00
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread
 Default-Features: zlib

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -14,8 +14,8 @@ vcpkg_add_to_path("${PYTHON3_DIR}")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebook/folly
-    REF v2019.01.28.00
-    SHA512 cdd32d863bd98b31332fbcb25a548407857ffd8e611fb5d243821f43fcf240cb796fb4520dddec5537f398c10492e1ecb03de22f7ec0384b98411e9906f40d09
+    REF v2019.05.06.00
+    SHA512 4e1327d9e4d18525de8a3e6017786c29f2231d462accc686418922c0f83e1c9a6ef646f5bb6553bd33036815c3dcfea259233b84ea5de6f200caaa219c791bbd
     HEAD_REF master
     PATCHES
         find-gflags.patch

--- a/ports/gdcm2/CONTROL
+++ b/ports/gdcm2/CONTROL
@@ -1,4 +1,4 @@
 Source: gdcm2
-Version: 2.8.9
+Version: 3.0.0
 Description: Grassroots DICOM library
 Build-Depends: zlib, expat, openjpeg

--- a/ports/gdcm2/portfile.cmake
+++ b/ports/gdcm2/portfile.cmake
@@ -2,8 +2,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO malaterre/GDCM
-    REF v2.8.9
-    SHA512 3c80503de6df8fe2589849ae9334d11e3cb033701450e1d7ea2781d122d1c8c1fc205fefc358d0ad1b9c5199c838e1c7c1bb34949da1c73cc8ae174b72e7e70c
+    REF v3.0.0
+    SHA512 2ac076dd49011234f4431ffe67fcba84a1ca9042ec5fc4dfc8aed2ed16bec5f499fa7aa666e5630796afc266ce76741d931cca333534b55fdc477e25a9189d33
     HEAD_REF master
     PATCHES find-openjpeg.patch
 )
@@ -29,7 +29,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/gdcm-2.8 TARGET_PATH share/gdcm)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/gdcm-3.0 TARGET_PATH share/gdcm)
 
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include


### PR DESCRIPTION
[folly] Since implementing support for char8_t under /std:c++latest in the development version of Visual C++, folly build failed with error C2664, this issue has been fixed in the latest release of folly, so update it.

[gdcm2] Gdcm2 build failed with error C3848 in the internal develop branch. This issue has been fixed by Billy's commit: https://github.com/malaterre/GDCM/commit/b9232933da42016fc882e590764d34b8673b3111, and this commit has been released in the latest version, so update it.
