### PR TITLE
[eastl]Add option(/Zc:char8_t-) to fix compile issue

### DIFF
--- a/ports/eastl/CONTROL
+++ b/ports/eastl/CONTROL
@@ -1,4 +1,4 @@
 Source: eastl
-Version: 3.13.04-1
+Version: 3.13.04-2
 Description: Electronic Arts Standard Template Library.
   It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.

--- a/ports/eastl/fixchar8_t.patch
+++ b/ports/eastl/fixchar8_t.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/CMake/CommonCppFlags.cmake b/scripts/CMake/CommonCppFlags.cmake
+index 566fbee..4fcca61 100644
+--- a/scripts/CMake/CommonCppFlags.cmake
++++ b/scripts/CMake/CommonCppFlags.cmake
+@@ -54,7 +54,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+         message(FATAL_ERROR "Building with a gcc version less than 4.7.3 is not supported.")
+     endif()
+ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W4 /permissive-")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W4 /permissive- /Zc:char8_t-")
+ endif()
+ 
+ 

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REF 3.13.04
     SHA512 4baa3dcf9fceac44f0c515db8bf50b7040afd5091162199c78bf9a1ab13ae19b4e55bb0bafe56da83a7b375ca0c15ba9c19d003de321ec6e40b489b2fe2561d5
     HEAD_REF master
+    PATCHES fixchar8_t.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This issue was reported in https://github.com/electronicarts/EASTL/issues/274 by Casey. Currently we should add  /Zc:char8_t- as a workaround until this issue fixed in EASTL