### PR TITLE
[visit-struct] Add new port

### DIFF
--- a/ports/visit-struct/CMakeLists.txt
+++ b/ports/visit-struct/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.11)
+project(visit_struct)
+
+add_library(visit_struct INTERFACE)
+
+install(TARGETS visit_struct
+    EXPORT visit_struct-targets
+    INCLUDES DESTINATION include)
+
+install(EXPORT visit_struct-targets
+    FILE visit_struct-config.cmake
+    NAMESPACE visit_struct::
+    DESTINATION share/visit_struct)
+
+install(DIRECTORY
+    include/visit_struct
+    DESTINATION include)

--- a/ports/visit-struct/CONTROL
+++ b/ports/visit-struct/CONTROL
@@ -1,0 +1,3 @@
+Source: visit-struct
+Version: 1.0
+Description: A header-only library providing structure visitors for C++11 and C++14

--- a/ports/visit-struct/portfile.cmake
+++ b/ports/visit-struct/portfile.cmake
@@ -1,0 +1,30 @@
+#header-only library
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cbeck88/visit_struct
+    REF v1.0
+    SHA512 1396d0d4c4d37f48434361d1e0ab4cb02c397aff1134678b26de713a27a4fcfa1c352890845502be645ba01e20314bf67731893fc6410b93e4521c1261d63c06
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH share/visit_struct
+    TARGET_PATH TARGET_PATH share/visit_struct
+)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+     RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/README.md
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
  https://github.com/cbeck88/visit_struct

The motivation for this port is that we do not have to lock ourselves
with Boost.Fusion, or Boost.Hana, and can benefit from some downstream
projects such as Configuru at the same time.

PS: I think it's okay to export targets with underscores in names?  I feel
that it makes sense to match the include directory name.