### PR TITLE
[eastl]Add option(/Zc:char8_t-) to fix compile issue 

### DIFF
--- a/ports/eastl/CONTROL
+++ b/ports/eastl/CONTROL
@@ -1,4 +1,4 @@
 Source: eastl
-Version: 3.13.05
+Version: 3.13.05-01
 Description: Electronic Arts Standard Template Library.
   It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.

--- a/ports/eastl/CONTROL
+++ b/ports/eastl/CONTROL
@@ -1,4 +1,4 @@
 Source: eastl
-Version: 3.13.05-01
+Version: 3.13.05-1
 Description: Electronic Arts Standard Template Library.
   It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.

--- a/ports/eastl/fixchar8_t.patch
+++ b/ports/eastl/fixchar8_t.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/CMake/CommonCppFlags.cmake b/scripts/CMake/CommonCppFlags.cmake
+index 566fbee..4fcca61 100644
+--- a/scripts/CMake/CommonCppFlags.cmake
++++ b/scripts/CMake/CommonCppFlags.cmake
+@@ -54,7 +54,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+         message(FATAL_ERROR "Building with a gcc version less than 4.7.3 is not supported.")
+     endif()
+ elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W4 /permissive-")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest /W4 /permissive- /Zc:char8_t-")
+ endif()
+ 
+ 

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REF 3.13.05
     SHA512 2364554339203c972f10d58ebe8f14fb221a40451f4cd2c3c5acd6891e8580c1a0a5d4ba592c91349d3feca50d9880648bb37358820a1c9552dde3f7af400a82
     HEAD_REF master
+    PATCHES fixchar8_t.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     REF 3.13.05
     SHA512 2364554339203c972f10d58ebe8f14fb221a40451f4cd2c3c5acd6891e8580c1a0a5d4ba592c91349d3feca50d9880648bb37358820a1c9552dde3f7af400a82
     HEAD_REF master
-    PATCHES fixchar8_t.patch
+    PATCHES fixchar8_t.patch # can be removed after electronicarts/EASTL#274 is resolved
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This issue was reported in electronicarts/EASTL#274 by Casey. Currently we should add /Zc:char8_t- as a workaround until this issue fixed in EASTL. 
