### PR TITLE
[dlib]Fix build error in linux

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,5 +1,5 @@
 Source: dlib
-Version: 19.16-2
+Version: 19.16-3
 Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas (!osx), clapack
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
 

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -76,5 +76,5 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/include/dlib/config.h "${_contents}")
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/dlib/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/dlib)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/dlib/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/dlib/COPYRIGHT)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/dlib/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/dlib/copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)


### PR DESCRIPTION
The copyright check in linux failed with the following details:
> The software license must be available at ${CURRENT_PACKAGES_DIR}/share/dlib/copyright

This is because of case sensitivity in linux, so I fixed it in **lowercase**.

Ref: #6167.