### PR TITLE
[ace] Add support for features (ssl, wchar, xml) #6372

### DIFF
--- a/ports/ace/CONTROL
+++ b/ports/ace/CONTROL
@@ -1,3 +1,13 @@
 Source: ace
 Version: 6.5.5-1
 Description: The ADAPTIVE Communication Environment
+
+Feature: wchar
+Description: Enable extra wide char functions in ACE
+
+Feature: ssl
+Description: Enable SSL/TLS features in ACE
+Build-Depends: openssl
+
+Feature: xml
+Description: Enable XML features in ACE

--- a/ports/ace/portfile.cmake
+++ b/ports/ace/portfile.cmake
@@ -2,6 +2,21 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
 
+if("wchar" IN_LIST FEATURES)
+    list(APPEND ACE_FEATURE_LIST "uses_wchar=1")
+endif()
+if("zlib" IN_LIST FEATURES)
+    list(APPEND ACE_FEATURE_LIST "zlib=1")
+else()
+    list(APPEND ACE_FEATURE_LIST "zlib=0")
+endif()
+if("ssl" IN_LIST FEATURES)
+    list(APPEND ACE_FEATURE_LIST "ssl=1")
+else()
+    list(APPEND ACE_FEATURE_LIST "ssl=0")
+endif()
+list(JOIN ACE_FEATURE_LIST "," ACE_FEATURES)
+
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
   if(NOT VCPKG_CMAKE_SYSTEM_NAME)
     set(DLL_DECORATOR s)
@@ -58,7 +73,7 @@ endif()
 
 # Invoke mwc.pl to generate the necessary solution and project files
 vcpkg_execute_required_process(
-    COMMAND ${PERL} ${ACE_ROOT}/bin/mwc.pl -type ${SOLUTION_TYPE} ace ${MPC_STATIC_FLAG}
+    COMMAND ${PERL} ${ACE_ROOT}/bin/mwc.pl -type ${SOLUTION_TYPE} -features "${ACE_FEATURES}" ace ${MPC_STATIC_FLAG}
     WORKING_DIRECTORY ${ACE_ROOT}
     LOGNAME mwc-${TARGET_TRIPLET}
 )
@@ -67,6 +82,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME)
   vcpkg_build_msbuild(
     PROJECT_PATH ${SOURCE_PATH}/ace.sln
     PLATFORM ${MSBUILD_PLATFORM}
+    USE_VCPKG_INTEGRATION
   )
 endif()
 
@@ -106,6 +122,9 @@ install_ace_headers_subdirectory(${SOURCE_PATH} "os_include/arpa")
 install_ace_headers_subdirectory(${SOURCE_PATH} "os_include/net")
 install_ace_headers_subdirectory(${SOURCE_PATH} "os_include/netinet")
 install_ace_headers_subdirectory(${SOURCE_PATH} "os_include/sys")
+if("ssl" IN_LIST FEATURES)
+    install_ace_headers_subdirectory(${SOURCE_PATH} "SSL")
+endif()
 
 # Install the libraries
 function(install_ace_library SOURCE_PATH ACE_LIBRARY)
@@ -143,6 +162,9 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME)
   install_ace_library(${ACE_ROOT} "ACE_QoS")
 endif()
 install_ace_library(${ACE_ROOT} "ACE_RLECompression")
+if("ssl" IN_LIST FEATURES)
+    install_ace_library(${ACE_ROOT} "ACE_SSL")
+endif()
 
 # Handle copyright
 file(COPY ${ACE_ROOT}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/ace)


### PR DESCRIPTION
Enable additional ACE features:
* wchar -- Additional overloads for `wchar_t`
* ssl -- creates the _ACE_SSL_ library (requires _openssl_)
* xml -- enables XML functionality (requires _xerces-c_)
