### PR TITLE
Bootstrap: Refining PreferredToolArchitecture

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -359,7 +359,7 @@ $arguments = (
 "/p:Platform=$platform",
 "/p:PlatformToolset=$platformToolset",
 "/p:TargetPlatformVersion=$windowsSDK",
-"/p:PreferredToolArchitecture=x64",
+"/p:PreferredToolArchitecture=$platform",
 "/verbosity:minimal",
 "/m",
 "/nologo",

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -339,10 +339,9 @@ if ($disableMetrics)
 
 $platform = "x86"
 $vcpkgReleaseDir = "$vcpkgSourcesPath\msbuild.x86.release"
-
+$architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
 if ($win64)
 {
-    $architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
     if (-not $architecture -like "*64*")
     {
         throw "Cannot build 64-bit on non-64-bit system"
@@ -352,6 +351,15 @@ if ($win64)
     $vcpkgReleaseDir = "$vcpkgSourcesPath\msbuild.x64.release"
 }
 
+if ($architecture -like "*64*")
+{
+    $PreferredToolArchitecture = "x64"
+}
+else
+{
+    $PreferredToolArchitecture = "x86"
+}
+
 $arguments = (
 "`"/p:VCPKG_VERSION=-nohash`"",
 "`"/p:DISABLE_METRICS=$disableMetricsValue`"",
@@ -359,7 +367,7 @@ $arguments = (
 "/p:Platform=$platform",
 "/p:PlatformToolset=$platformToolset",
 "/p:TargetPlatformVersion=$windowsSDK",
-"/p:PreferredToolArchitecture=$platform",
+"/p:PreferredToolArchitecture=$PreferredToolArchitecture",
 "/verbosity:minimal",
 "/m",
 "/nologo",


### PR DESCRIPTION
Trying to run `bootstrap-vcpkg.bat` in a 32-bit Windows7 VM with VS2017 ran into an error. Running with `-verbose` revealed that the culprit was a command-line option `/p:PreferredToolArchitecture=x64` introduced with commit e8371c179d1e138b4c79b24fce7b3fce154cf031.

I have changed the offending line in `scripts\bootstrap.ps1` to use `$platform` instead of hardcoded `x64`, so bootstrapping works on `x86` platforms as well.
