### PR TITLE
[icu] Prevent stale MSYS gpg-agent.exe process blocking command control

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,3 +1,3 @@
 Source: icu
-Version: 61.1-5
+Version: 61.1-6
 Description: Mature and widely used Unicode and localization library.

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -209,3 +209,9 @@ vcpkg_copy_pdbs()
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/icu/LICENSE ${CURRENT_PACKAGES_DIR}/share/icu/copyright)
+
+# Deal with a stale process created by MSYS
+vcpkg_execute_required_process(
+	COMMAND TASKKILL /F /IM gpg-agent.exe /fi "memusage gt 2"
+	WORKING_DIRECTORY ${SOURCE_PATH}
+)

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -211,7 +211,9 @@ file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/icu/LICENSE ${CURRENT_PACKAGES_DIR}/share/icu/copyright)
 
 # Deal with a stale process created by MSYS
-vcpkg_execute_required_process(
-	COMMAND TASKKILL /F /IM gpg-agent.exe /fi "memusage gt 2"
-	WORKING_DIRECTORY ${SOURCE_PATH}
-)
+if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    vcpkg_execute_required_process(
+        COMMAND TASKKILL /F /IM gpg-agent.exe /fi "memusage gt 2"
+        WORKING_DIRECTORY ${SOURCE_PATH}
+    )
+endif()


### PR DESCRIPTION
This commit fixes:
https://github.com/microsoft/vcpkg/issues/5476

The issue is that CI environments such as Appveyor's VS2017 image will wait for all processes to complete. If a stale process resides as a result, builds will hang.
There does not appear to be any good reason for gpg-agent.exe to be running once the build of icu has completed.

Without this patch builds of icu4c using CI systems will very likely hang and not in an obvious way.

Is this the _right_ solution to this problem? Probably not but it is one solution. And it degrades gracefully in that the build will not fail if gpg-agent.exe is not running. The gpg-agent.exe will not run again once MSYS has been configured, so to test this patch, a fresh install of vcpkg is required. Open the task manager and before the icu build completes, look for gpg-agent.exe just sitting there for no reason.
Might I suggest that the issue is fixed in vcpkg MSYS instead or as well?

Please don't request further from this commit.