### PR TITLE
appleclang 10.01 does not have <filesystem> support

### DIFF
--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
     if(NOT VCPKG_ALLOW_APPLE_CLANG)
         message(FATAL_ERROR
 "Building the vcpkg tool requires support for the C++ Filesystem TS.
-Apple clang versions 9 and below do not have support for it.
+Apple clang versions 10.01 and below do not have support for it.
 Please install gcc6 or newer from homebrew (brew install gcc6).
 If you would like to try anyway, pass --allowAppleClang to bootstrap.sh.")
     else()


### PR DESCRIPTION
build failure using appleclang compiler on macos mentions 'appleclang 9 or less', while also 'appleclang 10.01' does not have support for <filesystem> nor for <experimental/filesystem>