### PR TITLE
fix: Invalid character ('(') in a variable name: 'PROGRAMFILES'

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -130,7 +130,8 @@ else() #Release build: Put Release paths before Debug paths. Debug Paths are req
 endif()
 
 file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)
-file(TO_CMAKE_PATH "$ENV{PROGRAMFILES(x86)}" _programfiles_x86)
+set(_PROGRAMFILESX86 "PROGRAMFILES(x86)")
+file(TO_CMAKE_PATH "$ENV{${_PROGRAMFILESX86}}" _programfiles_x86)
 set(CMAKE_SYSTEM_IGNORE_PATH
     "${_programfiles}/OpenSSL"
     "${_programfiles}/OpenSSL-Win32"


### PR DESCRIPTION
CMake Warning (dev) at ..../vcpkg/scripts/buildsystems/vcpkg.cmake:133 (file):
  Policy CMP0053 is not set: Simplify variable reference and escape sequence
  evaluation.  Run "cmake --help-policy CMP0053" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  For input:

    '$ENV{PROGRAMFILES(x86)}'

  the old evaluation rules produce:

    'C:\Program Files (x86)'

  but the new evaluation rules produce an error:

    Syntax error in cmake code at
      ..../vcpkg/scripts/buildsystems/vcpkg.cmake:133
    when parsing string
      $ENV{PROGRAMFILES(x86)}
    Invalid character ('(') in a variable name: 'PROGRAMFILES'

  Using the old result for compatibility since the policy is not set.