### PR TITLE
[suitesparse]Fix build error in linux

### DIFF
--- a/ports/suitesparse/CONTROL
+++ b/ports/suitesparse/CONTROL
@@ -1,5 +1,5 @@
 Source: suitesparse
-Version: 5.1.2-1
+Version: 5.1.2-2
 Build-Depends: clapack (!osx)
 Description: algebra library
 

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 set(SUITESPARSE_VER SuiteSparse-5.1.2)  #if you change the version, becarefull of changing the SHA512 checksum accordingly
 set(SUITESPARSEWIN_VER 1.4.0)
 set(SUITESPARSEWIN_PATH ${CURRENT_BUILDTREES_DIR}/src/suitesparse-metis-for-windows-${SUITESPARSEWIN_VER})
-set(SUITESPARSE_PATH ${SUITESPARSEWIN_PATH}/Suitesparse)
+set(SUITESPARSE_PATH ${SUITESPARSEWIN_PATH}/SuiteSparse)
 
 #download suitesparse libary
 vcpkg_download_distfile(SUITESPARSE


### PR DESCRIPTION
The LICENSE.txt cannot find in linux with the following details:

>  file COPY cannot find
  "/home/vwangli/Lily/vcpkg/buildtrees/suitesparse/src/suitesparse-metis-for-windows-1.4.0/Suitesparse/LICENSE.txt".

This is because of case sensitivity in linux, so I modified the name of the directory according to the source.
Related issue: #6395