### PR TITLE
[stormlib] Add new port

### DIFF
--- a/ports/stormlib/CONTROL
+++ b/ports/stormlib/CONTROL
@@ -1,3 +1,4 @@
 Source: stormlib
 Version: 9.22
+Build-Depends: zlib, bzip2
 Description: StormLib is a library for opening and manipulating Blizzard MPQ files

--- a/ports/stormlib/CONTROL
+++ b/ports/stormlib/CONTROL
@@ -1,0 +1,3 @@
+Source: stormlib
+Version: 9.22
+Description: StormLib is a library for opening and manipulating Blizzard MPQ files

--- a/ports/stormlib/disable-building-tests.patch
+++ b/ports/stormlib/disable-building-tests.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f5211b1..4025ea1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -358,10 +358,4 @@ install(TARGETS ${LIBRARY_NAME}
+
+     INCLUDE(CPack)
+
+-if(STORM_BUILD_TESTS)
+-    target_link_libraries(storm_test ${LIBRARY_NAME})
+-    install(TARGETS storm_test DESTINATION bin)
+-endif()
+
+-add_executable(storm_test ${SRC_FILES} ${TOMCRYPT_FILES} ${TOMMATH_FILES} ${ZLIB_BZIP2_FILES} ${TEST_SRC_FILES})
+-install(TARGETS storm_test RUNTIME DESTINATION bin)

--- a/ports/stormlib/portfile.cmake
+++ b/ports/stormlib/portfile.cmake
@@ -1,0 +1,26 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ladislav-zezula/StormLib
+    REF v9.22
+    SHA512 e08571fca21be2e853d390b8feda32001df810b8f4b60d36822a9de2a877f2be9d3dadacfeec181a2eb80e00b8fed66d0dc9a0d8d9e043e2959478a41ed4d13a
+    HEAD_REF master
+)
+
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+    ${CMAKE_CURRENT_LIST_DIR}/disable-building-tests.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -STORM_BUILD_TESTS=OFF
+)
+
+vcpkg_install_cmake()
+set(STORM_BUILD_TESTS OFF)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/stormlib RENAME copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/stormlib/portfile.cmake
+++ b/ports/stormlib/portfile.cmake
@@ -17,10 +17,8 @@ vcpkg_apply_patches(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -STORM_BUILD_TESTS=OFF
 )
 
 vcpkg_install_cmake()
-set(STORM_BUILD_TESTS OFF)
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/stormlib RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
Add support for the [StormLib](https://github.com/ladislav-zezula/StormLib) library. Right now there is a patch to avoid the output of testing binaries, but this can be removed once the author finishes a new release as a fix is coming.