### PR TITLE
[Curl] Upgrades 2019.05.08

### DIFF
--- a/ports/cpr/002_cpr_fixcase.patch
+++ b/ports/cpr/002_cpr_fixcase.patch
@@ -1,0 +1,13 @@
+diff --git a/cpr/error.cpp b/cpr/error.cpp
+index 713cb10..4143f93 100644
+--- a/cpr/error.cpp
++++ b/cpr/error.cpp
+@@ -38,8 +38,6 @@ ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
+             return ErrorCode::SSL_LOCAL_CERTIFICATE_ERROR;
+         case CURLE_SSL_CIPHER:
+             return ErrorCode::GENERIC_SSL_ERROR;
+-        case CURLE_SSL_CACERT:
+-            return ErrorCode::SSL_CACERT_ERROR;
+         case CURLE_USE_SSL_FAILED:
+             return ErrorCode::GENERIC_SSL_ERROR;
+         case CURLE_SSL_ENGINE_INITFAILED:

--- a/ports/cpr/CONTROL
+++ b/ports/cpr/CONTROL
@@ -1,4 +1,4 @@
 Source: cpr
-Version: 1.3.0-6
+Version: 1.3.0-7
 Description: C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.
 Build-Depends: curl[core]

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         001-cpr-config.patch
+        002_cpr_fixcase.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/curl/0001_cmake.patch
+++ b/ports/curl/0001_cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMake/FindLibSSH2.cmake b/CMake/FindLibSSH2.cmake
-index 84822dba7..0d6219425 100644
+index 84822db..0d62194 100644
 --- a/CMake/FindLibSSH2.cmake
 +++ b/CMake/FindLibSSH2.cmake
 @@ -12,7 +12,7 @@ endif()
@@ -11,18 +11,3 @@ index 84822dba7..0d6219425 100644
  )
  
  if(LIBSSH2_INCLUDE_DIR)
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e6dbb73f1..1e2ff138e 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1144,7 +1144,9 @@ function(TRANSFORM_MAKEFILE_INC INPUT_FILE OUTPUT_FILE)
- 
- endfunction()
- 
--if(WIN32 AND NOT CYGWIN)
-+if(MSVC)
-+  set(CURL_INSTALL_CMAKE_DIR share/curl)
-+elseif(WIN32 AND NOT CYGWIN)
-   set(CURL_INSTALL_CMAKE_DIR CMake)
- else()
-   set(CURL_INSTALL_CMAKE_DIR lib/cmake/curl)

--- a/ports/curl/0002_fix_uwp.patch
+++ b/ports/curl/0002_fix_uwp.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index edb1cec..e7b4c68 100644
+index 38b7b7d..5b3d33e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -894,7 +894,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
+@@ -897,7 +897,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
  check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
  
  # symbol exists in win32, but function does not.
@@ -38,19 +38,21 @@ index 8337c72..41867b2 100644
    }
    else {
 diff --git a/lib/curl_ntlm_core.c b/lib/curl_ntlm_core.c
-index e7060eb..55e3738 100644
+index e7060eb..9cd76f7 100644
 --- a/lib/curl_ntlm_core.c
 +++ b/lib/curl_ntlm_core.c
-@@ -726,10 +726,10 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
+@@ -726,10 +726,11 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
  
    /* Calculate the timestamp */
  #ifdef DEBUGBUILD
 -  char *force_timestamp = getenv("CURL_FORCETIME");
+-  if(force_timestamp)
 +  char *force_timestamp = curl_getenv("CURL_FORCETIME");
-   if(force_timestamp)
++  if(force_timestamp) {
      tw = CURL_OFF_T_C(11644473600) * 10000000;
 -  else
 +    free(force_timestamp);
++  }
  #endif
      tw = ((curl_off_t)time(NULL) + CURL_OFF_T_C(11644473600)) * 10000000;
  

--- a/ports/curl/0002_fix_uwp.patch
+++ b/ports/curl/0002_fix_uwp.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7b73b98..72f6171 100644
+index 38b7b7d..5b3d33e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -882,7 +882,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
+@@ -897,7 +897,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
  check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
  
  # symbol exists in win32, but function does not.
@@ -38,10 +38,10 @@ index 8337c72..41867b2 100644
    }
    else {
 diff --git a/lib/curl_ntlm_core.c b/lib/curl_ntlm_core.c
-index e896276..268f0ea 100644
+index e7060eb..614ed61 100644
 --- a/lib/curl_ntlm_core.c
 +++ b/lib/curl_ntlm_core.c
-@@ -743,9 +743,12 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
+@@ -726,9 +726,10 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
  
    /* Calculate the timestamp */
  #ifdef DEBUGBUILD
@@ -49,28 +49,26 @@ index e896276..268f0ea 100644
 -  if(force_timestamp)
 +  char *force_timestamp = curl_getenv("CURL_FORCETIME");
 +  if (force_timestamp)
-+  {
      tw = CURL_OFF_T_C(11644473600) * 10000000;
 +    free(force_timestamp);
-+  }
    else
  #endif
      tw = ((curl_off_t)time(NULL) + CURL_OFF_T_C(11644473600)) * 10000000;
 diff --git a/lib/ftp.c b/lib/ftp.c
-index 8042edf..3442df7 100644
+index 825aaaa..3b96670 100644
 --- a/lib/ftp.c
 +++ b/lib/ftp.c
-@@ -4260,7 +4260,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
+@@ -4262,7 +4262,7 @@ CURLcode ftp_parse_url_path(struct connectdata *conn)
      /* prevpath is "raw" so we convert the input path before we compare the
         strings */
      size_t dlen;
 -    char *path;
 +    char *path = NULL;
      CURLcode result =
-       Curl_urldecode(conn->data, data->state.path, 0, &path, &dlen, TRUE);
+       Curl_urldecode(conn->data, ftp->path, 0, &path, &dlen, TRUE);
      if(result) {
 diff --git a/lib/rand.c b/lib/rand.c
-index 2670af9..0d18d37 100644
+index 6ee45fe..b2d712d 100644
 --- a/lib/rand.c
 +++ b/lib/rand.c
 @@ -44,7 +44,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)

--- a/ports/curl/0002_fix_uwp.patch
+++ b/ports/curl/0002_fix_uwp.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 38b7b7d..5b3d33e 100644
+index edb1cec..e7b4c68 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -897,7 +897,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
+@@ -894,7 +894,9 @@ check_symbol_exists(setsockopt     "${CURL_INCLUDES}" HAVE_SETSOCKOPT)
  check_function_exists(mach_absolute_time HAVE_MACH_ABSOLUTE_TIME)
  
  # symbol exists in win32, but function does not.
@@ -38,22 +38,22 @@ index 8337c72..41867b2 100644
    }
    else {
 diff --git a/lib/curl_ntlm_core.c b/lib/curl_ntlm_core.c
-index e7060eb..614ed61 100644
+index e7060eb..55e3738 100644
 --- a/lib/curl_ntlm_core.c
 +++ b/lib/curl_ntlm_core.c
-@@ -726,9 +726,10 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
+@@ -726,10 +726,10 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
  
    /* Calculate the timestamp */
  #ifdef DEBUGBUILD
 -  char *force_timestamp = getenv("CURL_FORCETIME");
--  if(force_timestamp)
 +  char *force_timestamp = curl_getenv("CURL_FORCETIME");
-+  if (force_timestamp)
+   if(force_timestamp)
      tw = CURL_OFF_T_C(11644473600) * 10000000;
+-  else
 +    free(force_timestamp);
-   else
  #endif
      tw = ((curl_off_t)time(NULL) + CURL_OFF_T_C(11644473600)) * 10000000;
+ 
 diff --git a/lib/ftp.c b/lib/ftp.c
 index 825aaaa..3b96670 100644
 --- a/lib/ftp.c

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -15,7 +15,7 @@ Build-Depends: nghttp2, curl[ssl]
 Description: HTTP2 support
 
 Feature: ssl
-Build-Depends: curl[openssl] (!windows&!osx), curl[winssl] (windows), curl[darwinssl] (osx)
+Build-Depends: curl[openssl] (!windows&!osx), curl[winssl] (windows), curl[sectransp] (osx)
 Description: Default SSL backend
 
 Feature: ssh
@@ -34,5 +34,5 @@ Feature: mbedtls
 Build-Depends: mbedtls
 Description: SSL support (mbedTLS)
 
-Feature: darwinssl
-Description: SSL support (darwinssl)
+Feature: sectransp
+Description: SSL support (sectransp)

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.64.1
+Version: 7.65.0
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.61.1-7
+Version: 7.64.1
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
-    REF curl-7_64_1
-    SHA512 bfaed8c65e82cb27a68e259516c8395cf10a67b62bb7e9d44803bde450f6017116fb3da8db716a172e140324831a63b4046a355810d86ba6577ebda3883a3625
+    REF curl-7_65_0
+    SHA512 436b6b42654c1db2b3f69df410a7f28401a50faf18e74f328a93585c147541e697664b0e9e7df03239fd76c797c1bb4f435f4c668a6b0ad28bdd67e17f786491
     HEAD_REF master
     PATCHES
         0001_cmake.patch
@@ -83,10 +83,6 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     )
 endif()
 
-vcpkg_find_acquire_program(PERL)
-get_filename_component(PERL_PATH ${PERL} DIRECTORY)
-vcpkg_add_to_path(${PERL_PATH})
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -104,6 +100,7 @@ vcpkg_configure_cmake(
         -DCMAKE_USE_DARWINSSL=${USE_DARWINSSL}
         -DCMAKE_USE_LIBSSH2=${USE_LIBSSH2}
         -DHTTP_ONLY=${USE_HTTP_ONLY}
+        -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON
     OPTIONS_RELEASE
         -DBUILD_CURL_EXE=${BUILD_CURL_EXE}
     OPTIONS_DEBUG

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -40,14 +40,14 @@ if("mbedtls" IN_LIST FEATURES)
     set(USE_MBEDTLS ON)
 endif()
 
-set(USE_DARWINSSL OFF)
-set(DARWINSSL_OPTIONS)
-if("darwinssl" IN_LIST FEATURES)
+set(USE_SECTRANSP OFF)
+set(SECTRANSP_OPTIONS)
+if("sectransp" IN_LIST FEATURES)
     if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        message(FATAL_ERROR "darwinssl is not supported on non-Apple platforms")
+        message(FATAL_ERROR "sectransp is not supported on non-Apple platforms")
     endif()
-    set(USE_DARWINSSL ON)
-    set(DARWINSSL_OPTIONS
+    set(USE_SECTRANSP ON)
+    set(SECTRANSP_OPTIONS
         -DCURL_CA_PATH=none
     )
 endif()
@@ -97,7 +97,7 @@ vcpkg_configure_cmake(
         -DCMAKE_USE_OPENSSL=${USE_OPENSSL}
         -DCMAKE_USE_WINSSL=${USE_WINSSL}
         -DCMAKE_USE_MBEDTLS=${USE_MBEDTLS}
-        -DCMAKE_USE_DARWINSSL=${USE_DARWINSSL}
+        -DCMAKE_USE_SECTRANSP=${USE_SECTRANSP}
         -DCMAKE_USE_LIBSSH2=${USE_LIBSSH2}
         -DHTTP_ONLY=${USE_HTTP_ONLY}
         -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -113,8 +113,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/curl)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/curl)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/CURL)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/CURL)
 elseif(EXISTS ${CURRENT_PACKAGES_DIR}/share/curl)
     vcpkg_fixup_cmake_targets(CONFIG_PATH share/curl)
 endif()

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
-    REF curl-7_61_1
-    SHA512 09fa3c87f8d516eabe3241247a5094c32ee0481961cf85bf78ecb13acdf23bb2ec82f113d2660271d22742c79e76d73fb122730fa28e34c7f5477c05a4a6534c
+    REF curl-7_64_1
+    SHA512 bfaed8c65e82cb27a68e259516c8395cf10a67b62bb7e9d44803bde450f6017116fb3da8db716a172e140324831a63b4046a355810d86ba6577ebda3883a3625
     HEAD_REF master
     PATCHES
         0001_cmake.patch
@@ -113,8 +113,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/curl)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/curl)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/CURL)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/CURL)
 elseif(EXISTS ${CURRENT_PACKAGES_DIR}/share/curl)
     vcpkg_fixup_cmake_targets(CONFIG_PATH share/curl)
 else()

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -43,7 +43,7 @@ endif()
 set(USE_SECTRANSP OFF)
 set(SECTRANSP_OPTIONS)
 if("sectransp" IN_LIST FEATURES)
-    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    if(NOT VCPKG_CMAKE_SYSTEM_NAME OR (VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
         message(FATAL_ERROR "sectransp is not supported on non-Apple platforms")
     endif()
     set(USE_SECTRANSP ON)
@@ -88,7 +88,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         ${UWP_OPTIONS}
-        ${DARWINSSL_OPTIONS}
+        ${SECTRANSP_OPTIONS}
         ${HTTP2_OPTIONS}
         -DBUILD_TESTING=OFF
         -DBUILD_CURL_EXE=${BUILD_CURL_EXE}

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -141,36 +141,14 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/curl${EXECUTABLE_SUFFIX}")
     endif()
 endif()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    # Drop debug suffix, as FindCURL.cmake does not look for it
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
-        # Fixup libcurl-target-debug.cmake to match
-        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-debug.cmake" DEBUG_MODULE)
-        string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/libcurl-d.lib" "\${_IMPORT_PREFIX}/debug/lib/libcurl.lib" DEBUG_MODULE "${DEBUG_MODULE}")
-        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-debug.cmake" "${DEBUG_MODULE}")
-    endif()
-else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl-config ${CURRENT_PACKAGES_DIR}/debug/bin/curl-config)
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libcurl_imp.lib ${CURRENT_PACKAGES_DIR}/lib/libcurl.lib)
-        # Fixup libcurl-target-release.cmake to match
-        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-release.cmake" RELEASE_MODULE)
-        string(REPLACE "\${_IMPORT_PREFIX}/lib/libcurl_imp.lib" "\${_IMPORT_PREFIX}/lib/libcurl.lib" RELEASE_MODULE "${RELEASE_MODULE}")
-        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-release.cmake" "${RELEASE_MODULE}")
-    endif()
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib")
-        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl-d_imp.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libcurl.lib)
-        # Fixup libcurl-target-debug.cmake to match
-        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-debug.cmake" DEBUG_MODULE)
-        string(REPLACE "\${_IMPORT_PREFIX}/debug/lib/libcurl-d_imp.lib" "\${_IMPORT_PREFIX}/debug/lib/libcurl.lib" DEBUG_MODULE "${DEBUG_MODULE}")
-        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-debug.cmake" "${DEBUG_MODULE}")
-    endif()
-endif()
-
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+else()
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl-config ${CURRENT_PACKAGES_DIR}/debug/bin/curl-config)
+endif()
 
 file(READ ${CURRENT_PACKAGES_DIR}/include/curl/curl.h CURL_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
-    REF curl-7_64_1
-    SHA512 bfaed8c65e82cb27a68e259516c8395cf10a67b62bb7e9d44803bde450f6017116fb3da8db716a172e140324831a63b4046a355810d86ba6577ebda3883a3625
+    REF curl-7_61_1
+    SHA512 09fa3c87f8d516eabe3241247a5094c32ee0481961cf85bf78ecb13acdf23bb2ec82f113d2660271d22742c79e76d73fb122730fa28e34c7f5477c05a4a6534c
     HEAD_REF master
     PATCHES
         0001_cmake.patch
@@ -113,10 +113,12 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/CURL)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/CURL)
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/curl)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/curl)
 elseif(EXISTS ${CURRENT_PACKAGES_DIR}/share/curl)
     vcpkg_fixup_cmake_targets(CONFIG_PATH share/curl)
+else()
+    message(FATAL_ERROR "Could not locate the curl config files")
 endif()
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/curl RENAME copyright)
@@ -135,9 +137,9 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/curl${EXECUTABLE_SUFFIX}")
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/curl)
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-release.cmake" RELEASE_MODULE)
+        file(READ "${CURRENT_PACKAGES_DIR}/share/curl/curl-target-release.cmake" RELEASE_MODULE)
         string(REPLACE "\${_IMPORT_PREFIX}/bin/curl${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/curl/curl${EXECUTABLE_SUFFIX}" RELEASE_MODULE "${RELEASE_MODULE}")
-        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/CURLTargets-release.cmake" "${RELEASE_MODULE}")
+        file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/curl-target-release.cmake" "${RELEASE_MODULE}")
     endif()
 endif()
 


### PR DESCRIPTION
Related PR https://github.com/microsoft/vcpkg/pull/6382
1. Update the patch 
2. Update the name of share/curl/curl-target-release.cmake to share/curl/CURLTargets-release.cmake
3. Case sensitive in Linux, the name(curl -> CURL) changed in curl by commit 6932849.
4. Fix same case value issue in cpr.

The new upgrade in Curl, it moved deprecated #define CURLE_SSL_CACERT CURLE_PEER_FAILED_VERIFICATION to ifndef block in commit 0fd4427f, we didn’t define CURL_NO_OLDIES, so the following code enabled:
#define CURLE_SSL_CACERT CURLE_PEER_FAILED_VERIFICATION

In cpr\error.cpp reference 2 cases that both have same case value, so it failed with ‘error C2196: case value '60' already used’.

case CURLE_PEER_FAILED_VERIFICATION:
            return ErrorCode::SSL_REMOTE_CERTIFICATE_ERROR;
case CURLE_SSL_CACERT:
           return ErrorCode::SSL_CACERT_ERROR;

So I removed one of them to fix it.