### PR TITLE
[libtheora] Remove double build. 

### DIFF
--- a/ports/libtheora/CONTROL
+++ b/ports/libtheora/CONTROL
@@ -1,4 +1,4 @@
 Source: libtheora
-Version: 1.2.0alpha1-20170719~vcpkg1-1
+Version: 1.2.0alpha1-20170719~vcpkg1-2
 Description: Theora is a free and open video compression format from the Xiph.org Foundation.
 Build-Depends: libogg

--- a/ports/libtheora/portfile.cmake
+++ b/ports/libtheora/portfile.cmake
@@ -31,7 +31,6 @@ vcpkg_configure_cmake(
         -DUSE_X86=${THEORA_X86_OPT}
 )
 
-vcpkg_build_cmake()
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
the log always shows 4 build steps. This PR intends to remove the two extra.