### PR TITLE
[fftw3]Changed library linkage to static.

### DIFF
--- a/ports/fftw3/CONTROL
+++ b/ports/fftw3/CONTROL
@@ -1,5 +1,5 @@
 Source: fftw3
-Version: 3.3.8-3
+Version: 3.3.8-4
 Description: FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST).
 
 Feature: openmp

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -1,6 +1,8 @@
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/fftw-3.3.8)
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 # This can be removed in the next source code update
 if(EXISTS "${SOURCE_PATH}/CMakeLists.txt")
     file(READ "${SOURCE_PATH}/CMakeLists.txt" _contents)


### PR DESCRIPTION
Because many functions are not declared as exportable in fftw3, we can only build them as static libraries now.
The following are these functions(prefix with X in the declaration):

- imax
- mksolver_ct_hook
- mksolver_hc2hc_hook
- mksolver
- mkplan_d
- mkplan_dft
- mkplan_rdft
- mkplan_rdft2
- mktensor_1d
- mktensor_2d
- mkproblem_dft
- mkproblem_dft_d
- mkproblem_rdft
- mkproblem_rdft_d
- mkproblem_rdft2
- solvtab_exec
- dft_solve
- ops_zero
- ops_add2
- tensor_tornk1
- plan_destroy_internal
- choose_radix
- ct_applicable
- tensor_copy
- tensor_destroy
- solver_register
- pickdim
- rdft_solve
- hc2hc_applicable
- rdft2_solve
- rdft2_inplace_strides
- rdft2_strides
- set_planner_hooks

Relate: #6056.