### PR TITLE
[libmaxminddb]fix build error in linux.

### DIFF
--- a/ports/libmaxminddb/CONTROL
+++ b/ports/libmaxminddb/CONTROL
@@ -1,3 +1,3 @@
 Source: libmaxminddb
-Version: 1.3.2-1
+Version: 1.3.2-2
 Description: C library for the MaxMind DB file format

--- a/ports/libmaxminddb/fix-linux-build.patch
+++ b/ports/libmaxminddb/fix-linux-build.patch
@@ -1,0 +1,19 @@
+diff --git a/include/maxminddb.h b/include/maxminddb.h
+index de1fdf8..1d17bc3 100644
+--- a/include/maxminddb.h
++++ b/include/maxminddb.h
+@@ -24,11 +24,12 @@ extern "C" {
+ #include <stdio.h>
+ #include <sys/types.h>
+ 
++/* libmaxminddb package version from configure */
++#define PACKAGE_VERSION "1.3.2"
++
+ #ifdef _WIN32
+ #include <winsock2.h>
+ #include <ws2tcpip.h>
+-/* libmaxminddb package version from configure */
+-#define PACKAGE_VERSION "1.3.2"
+ 
+ typedef ADDRESS_FAMILY sa_family_t;
+ 

--- a/ports/libmaxminddb/portfile.cmake
+++ b/ports/libmaxminddb/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     REF 1.3.2
     SHA512 43ff5f4e3a413772cd315412afc1070fb80280405d8845dc9d94a795265a71007c6c182dc01da8e14bf7b8ab8defe05714bec543faa956e7fb0f0a7756e7df48
     HEAD_REF master
+    PATCHES fix-linux-build.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
When libmaxminddb build fails in linux, I found the error because **PACKAGE_VERSION** was not found in _src\maxminddb.c_. By looking up this macro, I found it written in _include\maxminddb.h_ and covered under the **_WIN32** macro, so I moved this macro **out** of **_WIN32**.

Related: #5841.