### PR TITLE
[libpff] Initial port.

### DIFF
--- a/ports/libpff/CMakeLists.txt
+++ b/ports/libpff/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(libpff C)
+
+find_package(zlib REQUIRED)
+
+if(MSVC)
+    add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
+    add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
+add_compile_definitions(HAVE_LOCAL_LIBCERROR)
+add_compile_definitions(HAVE_LOCAL_LIBCTHREADS)
+add_compile_definitions(HAVE_LOCAL_LIBCDATA)
+add_compile_definitions(HAVE_LOCAL_LIBCLOCALE)
+add_compile_definitions(HAVE_LOCAL_LIBCNOTIFY)
+add_compile_definitions(HAVE_LOCAL_LIBCSPLIT)
+add_compile_definitions(HAVE_LOCAL_LIBCFILE)
+add_compile_definitions(HAVE_LOCAL_LIBCPATH)
+add_compile_definitions(HAVE_LOCAL_LIBUNA)
+add_compile_definitions(HAVE_LOCAL_LIBBFIO)
+add_compile_definitions(HAVE_LOCAL_LIBFCACHE)
+add_compile_definitions(HAVE_LOCAL_LIBFDATA)
+add_compile_definitions(HAVE_LOCAL_LIBFDATETIME)
+add_compile_definitions(HAVE_LOCAL_LIBFGUID)
+add_compile_definitions(HAVE_LOCAL_LIBFWNT)
+add_compile_definitions(HAVE_LOCAL_LIBFMAPI)
+add_compile_definitions(HAVE_LOCAL_LIBFVALUE)
+add_compile_definitions(ZLIB_DLL)
+
+add_compile_definitions(LIBPFF_DLL_EXPORT)
+
+if(MSVC)
+    set(LIB_RC libpff/libpff.rc)
+endif()
+
+# Source files
+file(GLOB LIB_SRC lib*/*.c)
+
+# Headers
+file(GLOB LIB_INST_HEADERS include/libpff/*.h)
+
+add_library(${PROJECT_NAME} ${LIB_SRC} ${LIB_RC})
+
+target_include_directories(${PROJECT_NAME} PRIVATE ./include ./common)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libbfio ./libcdata ./libcerror ./libcfile ./libclocale ./libcnotify)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libcpath ./libcsplit ./libcthreads ./libfcache ./libfdata ./libfdatetime)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libfguid ./libfmapi ./libfvalue ./libfwnt ./libuna)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
+
+install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(FILES ${LIB_INST_HEADERS} DESTINATION include/libpff)
+install(FILES include/libpff.h DESTINATION include)

--- a/ports/libpff/CMakeLists.txt
+++ b/ports/libpff/CMakeLists.txt
@@ -34,6 +34,17 @@ if(MSVC)
     set(LIB_RC libpff/libpff.rc)
 endif()
 
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# Add CMake find_package() integration
+set(PROJECT_TARGET_NAME "unofficial-${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_TARGET_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_TARGET_NAME}Targets")
+set(NAMESPACE "unofficial-libpff::")
+
 # Source files
 file(GLOB LIB_SRC lib*/*.c)
 
@@ -50,9 +61,21 @@ target_include_directories(${PROJECT_NAME} PRIVATE ./libfguid ./libfmapi ./libfv
 target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
 
 install(TARGETS ${PROJECT_NAME}
+        EXPORT ${TARGETS_EXPORT_NAME}
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        ARCHIVE DESTINATION lib
+        INCLUDES DESTINATION include)
 
 install(FILES ${LIB_INST_HEADERS} DESTINATION include/libpff)
 install(FILES include/libpff.h DESTINATION include)
+
+
+# Generate and install unofficial-libpffConfig.cmake
+configure_package_config_file("Config.cmake.in" "${PROJECT_CONFIG}" INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}")
+install(FILES "${PROJECT_CONFIG}" DESTINATION "${CONFIG_INSTALL_DIR}")
+
+# Generate and install unofficial-libpffTargets*.cmake
+install(EXPORT ${TARGETS_EXPORT_NAME}
+        NAMESPACE ${NAMESPACE}
+        DESTINATION "${CONFIG_INSTALL_DIR}")

--- a/ports/libpff/CONTROL
+++ b/ports/libpff/CONTROL
@@ -1,0 +1,4 @@
+Source: libpff
+Version: 2018-07-14
+Build-Depends: zlib
+Description: Library and tools to access the Personal Folder File (PFF) and the Offline Folder File (OFF) format.

--- a/ports/libpff/Config.cmake.in
+++ b/ports/libpff/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/ports/libpff/portfile.cmake
+++ b/ports/libpff/portfile.cmake
@@ -1,0 +1,39 @@
+include(vcpkg_common_functions)
+
+set(LIB_NAME libpff)
+set(LIB_VERSION 20180714)
+
+set(LIB_FILENAME libpff-experimental-${LIB_VERSION}.tar.gz)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    message("Current version of libpff is not intended to be used as a static library")
+    set(VCPKG_LIBRARY_LINKAGE "dynamic")
+endif()
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/libyal/libpff/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
+    FILENAME "${LIB_FILENAME}"
+    SHA512 7207ba87607ea2fd4609a081c2f4b061344a783e188605e88df99fd473f2a8da1269b065e57b054f4622888d40aa8f2b8272dc4748334ddfe358b28d443d6ad1
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${LIB_VERSION}
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# License and man
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${LIB_NAME} RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/libpff/portfile.cmake
+++ b/ports/libpff/portfile.cmake
@@ -1,39 +1,39 @@
 include(vcpkg_common_functions)
 
-set(LIB_NAME libpff)
-set(LIB_VERSION 20180714)
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+set(LIB_VERSION 20180714)
 set(LIB_FILENAME libpff-experimental-${LIB_VERSION}.tar.gz)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    message("Current version of libpff is not intended to be used as a static library")
-    set(VCPKG_LIBRARY_LINKAGE "dynamic")
-endif()
-
+# Release distribution file contains configured sources, while the source code in the repository does not.
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libyal/libpff/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
     SHA512 7207ba87607ea2fd4609a081c2f4b061344a783e188605e88df99fd473f2a8da1269b065e57b054f4622888d40aa8f2b8272dc4748334ddfe358b28d443d6ad1
 )
 
-vcpkg_extract_source_archive_ex(
+ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF ${LIB_VERSION}
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
 )
 
 vcpkg_install_cmake()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libpff" TARGET_PATH "share/unofficial-libpff")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # License and man
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${LIB_NAME} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libpff" RENAME copyright)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Initial port of libpff (https://github.com/libyal/libpff).
Only dynamic version is enabled because it doesn't seem like author intended it to be used as static library.