### PR TITLE
[libcroco] Initial port files for libcroco

### DIFF
--- a/ports/libcroco/CMakeLists.txt
+++ b/ports/libcroco/CMakeLists.txt
@@ -3,6 +3,10 @@ project(libcroco C)
 
 find_package(unofficial-glib CONFIG REQUIRED)
 find_package(LibXml2 REQUIRED)
+if(NOT WIN32)
+    find_package(Threads REQUIRED)
+    find_package(unofficial-iconv REQUIRED)
+endif()
 find_path(GLIB_INCLUDE_DIR glib.h)
 
 file(GLOB SOURCES
@@ -124,7 +128,10 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libcroco-config.cmake "
 include(CMakeFindDependencyMacro)
 find_dependency(unofficial-glib CONFIG)
 find_dependency(LibXml2)
-
+if(NOT WIN32)
+    find_dependency(Threads)
+    find_dependency(unofficial-iconv)
+endif()
 include(\${CMAKE_CURRENT_LIST_DIR}/unofficial-libcroco-targets.cmake)
 ")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libcroco-config.cmake DESTINATION share/unofficial-libcroco)

--- a/ports/libcroco/CMakeLists.txt
+++ b/ports/libcroco/CMakeLists.txt
@@ -1,0 +1,130 @@
+cmake_minimum_required(VERSION 3.11)
+project(libcroco C)
+
+find_package(unofficial-glib CONFIG REQUIRED)
+find_package(LibXml2 REQUIRED)
+find_path(GLIB_INCLUDE_DIR glib.h)
+
+file(GLOB SOURCES
+	src/cr-utils.c
+	src/cr-utils.h
+	src/cr-input.c
+	src/cr-input.h
+	src/cr-enc-handler.c
+	src/cr-enc-handler.h
+	src/cr-num.c
+	src/cr-num.h
+	src/cr-rgb.c
+	src/cr-rgb.h
+	src/cr-token.c
+	src/cr-token.h
+	src/cr-tknzr.c
+	src/cr-tknzr.h
+	src/cr-term.c
+	src/cr-term.h
+	src/cr-attr-sel.c
+	src/cr-attr-sel.h
+	src/cr-pseudo.c
+	src/cr-pseudo.h
+	src/cr-additional-sel.c
+	src/cr-additional-sel.h
+	src/cr-simple-sel.c
+	src/cr-simple-sel.h
+	src/cr-selector.c
+	src/cr-selector.h
+	src/cr-doc-handler.c
+	src/cr-doc-handler.h
+	src/cr-parser.c
+	src/cr-parser.h
+	src/cr-declaration.c
+	src/cr-declaration.h
+	src/cr-statement.c
+	src/cr-statement.h
+	src/cr-stylesheet.c
+	src/cr-stylesheet.h
+	src/cr-cascade.c
+	src/cr-cascade.h
+	src/cr-om-parser.c
+	src/cr-om-parser.h
+	src/cr-style.c
+	src/cr-style.h
+	src/cr-sel-eng.c
+	src/cr-sel-eng.h
+	src/cr-fonts.c
+	src/cr-fonts.h
+	src/cr-prop-list.c
+	src/cr-prop-list.h
+	src/cr-parsing-location.c
+	src/cr-parsing-location.h
+	src/cr-string.c
+	src/cr-string.h
+	src/libcroco.def
+)
+
+set(CMAKE_DEBUG_POSTFIX "d")
+
+add_library(libcroco ${SOURCES})
+
+target_include_directories(libcroco PRIVATE ${GLIB_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
+target_link_libraries(libcroco PRIVATE 
+    unofficial::glib::gio
+    unofficial::glib::glib
+    unofficial::glib::gmodule
+    unofficial::glib::gobject
+    ${LIBXML2_LIBRARIES}
+)
+
+install(TARGETS libcroco
+    EXPORT libcroco-targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(FILES
+	src/libcroco.h
+	src/cr-additional-sel.h
+	src/cr-attr-sel.h
+	src/cr-cascade.h
+	src/cr-declaration.h
+	src/cr-doc-handler.h
+	src/cr-enc-handler.h
+	src/cr-input.h
+	src/cr-num.h
+	src/cr-om-parser.h
+	src/cr-parser.h
+	src/cr-pseudo.h
+	src/cr-rgb.h
+	src/cr-selector.h
+	src/cr-simple-sel.h
+	src/cr-statement.h
+	src/cr-stylesheet.h
+	src/cr-term.h
+	src/cr-tknzr.h
+	src/cr-token.h
+	src/cr-utils.h
+	src/cr-fonts.h
+	src/cr-sel-eng.h
+	src/cr-style.h
+	src/cr-prop-list.h
+	src/cr-parsing-location.h
+	src/cr-string.h
+	src/libcroco-config.h
+    DESTINATION include/libcroco
+)
+
+install(
+    EXPORT libcroco-targets
+    NAMESPACE unofficial::libcroco::
+    FILE unofficial-libcroco-targets.cmake
+    DESTINATION share/unofficial-libcroco
+)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libcroco-config.cmake "
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-glib CONFIG)
+find_dependency(LibXml2)
+
+include(\${CMAKE_CURRENT_LIST_DIR}/unofficial-libcroco-targets.cmake)
+")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libcroco-config.cmake DESTINATION share/unofficial-libcroco)

--- a/ports/libcroco/CONTROL
+++ b/ports/libcroco/CONTROL
@@ -1,0 +1,4 @@
+Source: libcroco
+Version: 0.6.13
+Description: A standalone css2 parsing and manipulation library
+Build-Depends: glib, libxml2

--- a/ports/libcroco/portfile.cmake
+++ b/ports/libcroco/portfile.cmake
@@ -1,0 +1,34 @@
+include(vcpkg_common_functions)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/libcroco/0.6/libcroco-0.6.13.tar.xz"
+    FILENAME "libcroco-0.6.13.tar.xz"
+    SHA512 038a3ac9d160a8cf86a8a88c34367e154ef26ede289c93349332b7bc449a5199b51ea3611cebf3a2416ae23b9e45ecf8f9c6b24ea6d16a5519b796d3c7e272d4
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+configure_file(${SOURCE_PATH}/config.h.win32 ${SOURCE_PATH}/src/config.h COPYONLY)
+file(READ "${SOURCE_PATH}/src/libcroco.symbols" SYMBOLS)
+string(REGEX REPLACE ";[^\n]*\n" "" DEF "EXPORTS\n${SYMBOLS}")
+file(WRITE "${SOURCE_PATH}/src/libcroco.def" "${DEF}")
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libcroco RENAME copyright)
+
+# Post-build test for cmake libraries
+ vcpkg_test_cmake(PACKAGE_NAME libcroco)


### PR DESCRIPTION
From the libcroco readme file:

Libcroco is a standalone css2 parsing and manipulation library.
The parser provides a low level event driven SAC like api
and a css object model like api.
Libcroco provides a CSS2 selection engine and an experimental
xml/css rendering engine.

libcroco is part of the GNOME project.