### PR TITLE
[libmicrohttpd] Fix CONTROL version

### DIFF
--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,3 +1,3 @@
 Source: libmicrohttpd
-Version: 0.9.55-2
+Version: 0.9.63
 Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application


### PR DESCRIPTION
Port was updated to version 0.9.63 in PR #6464 but the CONTROL file wasn't updated to reflect this change.