### PR TITLE
[grpc] Fix ARM/ARM64 on Windows Build

### DIFF
--- a/ports/grpc/00001-fix-uwp.patch
+++ b/ports/grpc/00001-fix-uwp.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e1013dc561..b02d07ccba 100644
+index 8ba68c4a13..258a1609f6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -90,6 +90,9 @@ if(UNIX)
@@ -33,7 +33,7 @@ index e1013dc561..b02d07ccba 100644
    if(NOT ARGN)
      message(SEND_ERROR "Error: PROTOBUF_GENERATE_GRPC_CPP() called without any proto files")
      return()
-@@ -211,6 +221,7 @@ function(protobuf_generate_grpc_cpp)
+@@ -218,6 +228,7 @@ function(protobuf_generate_grpc_cpp)
    endforeach()
  endfunction()
  
@@ -41,7 +41,7 @@ index e1013dc561..b02d07ccba 100644
  add_custom_target(plugins
    DEPENDS
    grpc_cpp_plugin
-@@ -240,6 +251,8 @@ add_custom_target(tools_cxx
+@@ -247,6 +258,8 @@ add_custom_target(tools_cxx
  add_custom_target(tools
    DEPENDS tools_c tools_cxx)
  
@@ -50,60 +50,60 @@ index e1013dc561..b02d07ccba 100644
  if (gRPC_BUILD_TESTS)
  add_custom_target(buildtests_c)
  add_dependencies(buildtests_c algorithm_test)
-@@ -3795,7 +3808,6 @@ foreach(_hdr
+@@ -4029,7 +4042,6 @@ foreach(_hdr
      DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
    )
  endforeach()
 -endif (gRPC_BUILD_CODEGEN)
  
+ if (gRPC_BUILD_CODEGEN)
  
- if (gRPC_INSTALL)
-@@ -3805,6 +3817,7 @@ if (gRPC_INSTALL)
+@@ -4040,6 +4052,7 @@ if (gRPC_INSTALL)
      ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
    )
  endif()
 +endif (gRPC_BUILD_CODEGEN)
  
+ endif (gRPC_BUILD_CODEGEN)
  if (gRPC_BUILD_TESTS)
- 
-@@ -3925,7 +3938,7 @@ foreach(_hdr
+@@ -4163,7 +4176,7 @@ foreach(_hdr
      DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
    )
  endforeach()
 -endif (gRPC_BUILD_CODEGEN)
 +
  
+ if (gRPC_BUILD_CODEGEN)
  
- if (gRPC_INSTALL)
-@@ -3935,6 +3948,7 @@ if (gRPC_INSTALL)
+@@ -4174,6 +4187,7 @@ if (gRPC_INSTALL)
      ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
    )
  endif()
 +endif (gRPC_BUILD_CODEGEN)
  
+ endif (gRPC_BUILD_CODEGEN)
  if (gRPC_BUILD_TESTS)
- 
-@@ -4926,7 +4940,6 @@ foreach(_hdr
+@@ -5196,7 +5210,6 @@ foreach(_hdr
      DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
    )
  endforeach()
 -endif (gRPC_BUILD_CODEGEN)
  
+ if (gRPC_BUILD_CODEGEN)
  
- if (gRPC_INSTALL)
-@@ -4936,6 +4949,7 @@ if (gRPC_INSTALL)
+@@ -5207,6 +5220,7 @@ if (gRPC_INSTALL)
      ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
    )
  endif()
 +endif (gRPC_BUILD_CODEGEN)
  
+ endif (gRPC_BUILD_CODEGEN)
  if (gRPC_BUILD_TESTS)
- 
 diff --git a/src/core/lib/iomgr/resource_quota.cc b/src/core/lib/iomgr/resource_quota.cc
-index 61c366098e..aac2ce0a9f 100644
+index dffac348c5..a59becb046 100644
 --- a/src/core/lib/iomgr/resource_quota.cc
 +++ b/src/core/lib/iomgr/resource_quota.cc
-@@ -937,7 +937,7 @@ void grpc_resource_user_alloc(grpc_resource_user* resource_user, size_t size,
+@@ -940,7 +940,7 @@ void grpc_resource_user_alloc(grpc_resource_user* resource_user, size_t size,
  void grpc_resource_user_free(grpc_resource_user* resource_user, size_t size) {
    gpr_mu_lock(&resource_user->mu);
    grpc_resource_quota* resource_quota = resource_user->resource_quota;
@@ -113,7 +113,7 @@ index 61c366098e..aac2ce0a9f 100644
    bool was_zero_or_negative = resource_user->free_pool <= 0;
    resource_user->free_pool += static_cast<int64_t>(size);
 diff --git a/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc b/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
-index 55efe0e..f538f26 100644
+index 55efe0e9dd..f538f26edf 100644
 --- a/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
 +++ b/src/core/lib/security/credentials/alts/check_gcp_environment_windows.cc
 @@ -60,6 +60,8 @@ bool check_bios_data(const char* bios_data_file) {

--- a/ports/grpc/00002-static-linking-in-linux.patch
+++ b/ports/grpc/00002-static-linking-in-linux.patch
@@ -6,7 +6,7 @@ index 3839e22..91720a9 100644
  
  add_definitions(-DPB_FIELD_32BIT)
  
-+if (gRPC_STATIC_LINKING)
++if (gRPC_STATIC_LINKING AND NOT _gRPC_PLATFORM_WINDOWS)
 +  # Force to static link
 +  set(CMAKE_EXE_LINKER_FLAGS "-Bstatic")
 +endif()

--- a/ports/grpc/00003-undef-base64-macro.patch
+++ b/ports/grpc/00003-undef-base64-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/lib/transport/transport.cc b/src/core/lib/transport/transport.cc
+index 09306110c6..eb0ad96a7a 100644
+--- a/src/core/lib/transport/transport.cc
++++ b/src/core/lib/transport/transport.cc
+@@ -134,6 +134,8 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
+   refcount->slice_refcount.sub_refcount = &refcount->slice_refcount;
+ }
+ 
++#undef move64
++
+ static void move64(uint64_t* from, uint64_t* to) {
+   *to += *from;
+   *from = 0;

--- a/ports/grpc/00004-link-gdi32-on-windows.patch
+++ b/ports/grpc/00004-link-gdi32-on-windows.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e820737201..3eb4795660 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -158,7 +158,7 @@ elseif(UNIX)
+ endif()
+ 
+ if(WIN32 AND MSVC)
+-  set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32)
++  set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32 gdi32)
+ endif()
+ 
+ # Create directory for generated .proto files

--- a/ports/grpc/CONTROL
+++ b/ports/grpc/CONTROL
@@ -1,4 +1,4 @@
 Source: grpc
-Version: 1.19.1-1
+Version: 1.20.1
 Build-Depends: zlib, openssl, protobuf, c-ares (!uwp)
 Description: An RPC library and framework

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -11,15 +11,17 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO grpc/grpc
-    REF v1.19.1
-    SHA512 4bb127d946fc16887fd4cf75215f0bc9f6d17dbd36fc4f1b191a64914f96c49dddb41f1b6c72fd24ea0a40f242b4398248f32fcb1fe9a764367be1c2edda9142
+    REF v1.20.1
+    SHA512 e0dd0318d2b4ec07e0eafffa218938d91b1440c5053a557460ea7fceaab3d76f0cccc1d595abe7de9fa79f068b71cfbc5a28a3b688bc9c1e2737086928149583
     HEAD_REF master
     PATCHES 
         00001-fix-uwp.patch
         00002-static-linking-in-linux.patch
+        00003-undef-base64-macro.patch
+        00004-link-gdi32-on-windows.patch
 )
 
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
     set(gRPC_BUILD_CODEGEN OFF)
 else()
     set(gRPC_BUILD_CODEGEN ON)


### PR DESCRIPTION
This PR is for #6485 and includes the following changes that were required to get `VcPkg` to build `gRPC` for `ARM/ARM64` on Windows
1) Updated to v1.20.1
2) Disables Codegen Build for ARM/ARM64 builds
3) Rebased the "Fix UWP" patch so that it will apply properly
4) Fixed the "Static Linking in Linux" patch because it specified an invalid option on Windows builds
5) Added patch to "#undef" a macro name collision
6) Added GDI32.lib to the list of standard libraries linked to Windows

---
Also:  **Thank you 🙏🙏🙏 so much for `vcpkg`!**  It has literally saved me an immeasurable amount of time and saved me from copious amounts of stress.