### PR TITLE
[qt-base] Use opengl dynamic configuration

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-base
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/install_qt.cmake
+++ b/ports/qt5-base/install_qt.cmake
@@ -25,7 +25,25 @@ function(install_qt)
     endif()
     vcpkg_find_acquire_program(PYTHON3)
     get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
+    vcpkg_find_acquire_program(FLEX)
+    get_filename_component(FLEX_EXE_PATH ${FLEX} DIRECTORY)
+    #    vcpkg_find_acquire_program(BISON)
+    #get_filename_component(BISON_EXE_PATH ${BISON} DIRECTORY)
+
+    file(COPY ${FLEX} DESTINATION "${FLEX_EXE_PATH}/bin" )
+    file(COPY "${FLEX_EXE_PATH}/win_bison.exe" DESTINATION "${FLEX_EXE_PATH}/bin" )
+    file(RENAME "${FLEX_EXE_PATH}/bin/win_bison.exe" "${FLEX_EXE_PATH}/bin/bison.exe")
+    file(RENAME "${FLEX_EXE_PATH}/bin/win_flex.exe" "${FLEX_EXE_PATH}/bin/flex.exe")
+    file(COPY "${FLEX_EXE_PATH}/bin/flex.exe" DESTINATION "${FLEX_EXE_PATH}" )
+    file(COPY "${FLEX_EXE_PATH}/bin/bison.exe" DESTINATION "${FLEX_EXE_PATH}" )
+    vcpkg_add_to_path("${FLEX_EXE_PATH}")
+
     vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
+
+
+    message(STATUS "PATH: $ENV{PATH}")
+
+
     set(_path "$ENV{PATH}")
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")

--- a/ports/qt5-base/install_qt.cmake
+++ b/ports/qt5-base/install_qt.cmake
@@ -25,22 +25,21 @@ function(install_qt)
     endif()
     vcpkg_find_acquire_program(PYTHON3)
     get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
-    vcpkg_find_acquire_program(FLEX)
-    get_filename_component(FLEX_EXE_PATH ${FLEX} DIRECTORY)
-    #    vcpkg_find_acquire_program(BISON)
-    #get_filename_component(BISON_EXE_PATH ${BISON} DIRECTORY)
-
-    file(COPY ${FLEX} DESTINATION "${FLEX_EXE_PATH}/bin" )
-    file(COPY "${FLEX_EXE_PATH}/win_bison.exe" DESTINATION "${FLEX_EXE_PATH}/bin" )
-    file(RENAME "${FLEX_EXE_PATH}/bin/win_bison.exe" "${FLEX_EXE_PATH}/bin/bison.exe")
-    file(RENAME "${FLEX_EXE_PATH}/bin/win_flex.exe" "${FLEX_EXE_PATH}/bin/flex.exe")
-    file(COPY "${FLEX_EXE_PATH}/bin/flex.exe" DESTINATION "${FLEX_EXE_PATH}" )
-    file(COPY "${FLEX_EXE_PATH}/bin/bison.exe" DESTINATION "${FLEX_EXE_PATH}" )
-    vcpkg_add_to_path("${FLEX_EXE_PATH}")
-
     vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
 
-    set(_path "$ENV{PATH}")
+    # flex and bison for ANGLE library
+    vcpkg_find_acquire_program(FLEX)
+    get_filename_component(FLEX_EXE_PATH ${FLEX} DIRECTORY)
+    get_filename_component(FLEX_DIR ${FLEX_EXE_PATH} NAME)
+
+    file(COPY ${FLEX_EXE_PATH} DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools" )
+    set(FLEX_TEMP "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools/${FLEX_DIR}")
+    message(STATUS "FLEX_TEMP: ${FLEX_TEMP}")
+    file(RENAME "${FLEX_TEMP}/win_bison.exe" "${FLEX_TEMP}/bison.exe")
+    file(RENAME "${FLEX_TEMP}/win_flex.exe" "${FLEX_TEMP}/flex.exe")
+    vcpkg_add_to_path("${FLEX_TEMP}")
+
+   set(_path "$ENV{PATH}")
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         message(STATUS "Package ${TARGET_TRIPLET}-dbg")

--- a/ports/qt5-base/install_qt.cmake
+++ b/ports/qt5-base/install_qt.cmake
@@ -34,7 +34,6 @@ function(install_qt)
 
     file(COPY ${FLEX_EXE_PATH} DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools" )
     set(FLEX_TEMP "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools/${FLEX_DIR}")
-    message(STATUS "FLEX_TEMP: ${FLEX_TEMP}")
     file(RENAME "${FLEX_TEMP}/win_bison.exe" "${FLEX_TEMP}/bison.exe")
     file(RENAME "${FLEX_TEMP}/win_flex.exe" "${FLEX_TEMP}/flex.exe")
     vcpkg_add_to_path("${FLEX_TEMP}")

--- a/ports/qt5-base/install_qt.cmake
+++ b/ports/qt5-base/install_qt.cmake
@@ -27,16 +27,18 @@ function(install_qt)
     get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
     vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
 
-    # flex and bison for ANGLE library
-    vcpkg_find_acquire_program(FLEX)
-    get_filename_component(FLEX_EXE_PATH ${FLEX} DIRECTORY)
-    get_filename_component(FLEX_DIR ${FLEX_EXE_PATH} NAME)
+    if (CMAKE_HOST_WIN32)
+	# flex and bison for ANGLE library
+	vcpkg_find_acquire_program(FLEX)
+	get_filename_component(FLEX_EXE_PATH ${FLEX} DIRECTORY)
+	get_filename_component(FLEX_DIR ${FLEX_EXE_PATH} NAME)
 
-    file(COPY ${FLEX_EXE_PATH} DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools" )
-    set(FLEX_TEMP "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools/${FLEX_DIR}")
-    file(RENAME "${FLEX_TEMP}/win_bison.exe" "${FLEX_TEMP}/bison.exe")
-    file(RENAME "${FLEX_TEMP}/win_flex.exe" "${FLEX_TEMP}/flex.exe")
-    vcpkg_add_to_path("${FLEX_TEMP}")
+	file(COPY ${FLEX_EXE_PATH} DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools" )
+	set(FLEX_TEMP "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-tools/${FLEX_DIR}")
+	file(RENAME "${FLEX_TEMP}/win_bison.exe" "${FLEX_TEMP}/bison.exe")
+	file(RENAME "${FLEX_TEMP}/win_flex.exe" "${FLEX_TEMP}/flex.exe")
+	vcpkg_add_to_path("${FLEX_TEMP}")
+   endif()
 
    set(_path "$ENV{PATH}")
 

--- a/ports/qt5-base/install_qt.cmake
+++ b/ports/qt5-base/install_qt.cmake
@@ -40,10 +40,6 @@ function(install_qt)
 
     vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
 
-
-    message(STATUS "PATH: $ENV{PATH}")
-
-
     set(_path "$ENV{PATH}")
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -69,7 +69,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
         OPTIONS
             ${CORE_OPTIONS}
             -mp
-            -opengl desktop # other options are "-no-opengl", "-opengl angle", and "-opengl desktop"
+            -opengl dynamic # other options are "-no-opengl", "-opengl angle", and "-opengl desktop"
         OPTIONS_RELEASE
             LIBJPEG_LIBS="-ljpeg"
             ZLIB_LIBS="-lzlib"


### PR DESCRIPTION
This setting lets Qt use the ANGLE library and makes rendering on DirectX / Direct3D possible. OpenGL backends are switchable at runtime.