### PR TITLE
[openblas] Enable static build on windows

### DIFF
--- a/ports/openblas/CONTROL
+++ b/ports/openblas/CONTROL
@@ -1,3 +1,3 @@
 Source: openblas
-Version: 0.3.6
+Version: 0.3.6-1
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -16,11 +16,6 @@ if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     message(FATAL_ERROR "openblas can only be built for x64 currently")
 endif()
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-    set(CMAKE_CROSSCOMPILING OFF)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS


### PR DESCRIPTION
The latest version of openblas supports static builds on windows. This PR removes the enforced dynamic build on windows