### PR TITLE
[dlib] Update to v19.17 and fix static lapack linkage

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,6 +1,6 @@
 Source: dlib
-Version: 19.16-3
-Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas (!osx), clapack
+Version: 19.17
+Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas (!osx), clapack (!osx)
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
 
 Feature: cuda

--- a/ports/dlib/find_blas.patch
+++ b/ports/dlib/find_blas.patch
@@ -1,0 +1,11 @@
+--- a/dlib/cmake_utils/find_blas.cmake
++++ b/dlib/cmake_utils/find_blas.cmake
+@@ -414,7 +414,7 @@
+ if (lapack_found)
+    include(CheckFunctionExists)
+    include(CheckFortranFunctionExists)
+-   set(CMAKE_REQUIRED_LIBRARIES ${lapack_libraries})
++   set(CMAKE_REQUIRED_LIBRARIES ${lapack_libraries} ${blas_libraries})
+ 
+    check_function_exists("sgesv" LAPACK_FOUND_C_UNMANGLED)
+    check_function_exists("sgesv_" LAPACK_FOUND_C_MANGLED)

--- a/ports/dlib/force_finding_packages.patch
+++ b/ports/dlib/force_finding_packages.patch
@@ -1,8 +1,6 @@
-diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
-index d8a1362..088168c 100644
 --- a/dlib/CMakeLists.txt
 +++ b/dlib/CMakeLists.txt
-@@ -410,68 +410,9 @@ if (NOT TARGET dlib)
+@@ -430,70 +430,9 @@
        endif()
  
        if (DLIB_PNG_SUPPORT)
@@ -11,7 +9,7 @@ index d8a1362..088168c 100644
 -         # Make sure there isn't something wrong with the version of LIBPNG
 -         # installed on this system.  Also never link to anything from anaconda
 -         # since it's probably broken.
--         if (PNG_FOUND AND NOT ("${PNG_INCLUDE_DIR}" MATCHES "(.*)(Ana|ana|mini)conda(.*)"))
+-         if (PNG_FOUND AND NOT ("${PNG_INCLUDE_DIR}" MATCHES "(.*)(Ana|ana|mini)conda(.*)") AND NOT BUILDING_PYTHON_IN_MSVC)
 -            set(CMAKE_REQUIRED_LIBRARIES ${PNG_LIBRARIES})
 -            CHECK_FUNCTION_EXISTS(png_create_read_struct LIBPNG_IS_GOOD)
 -         endif()
@@ -23,6 +21,8 @@ index d8a1362..088168c 100644
 -            # If we can't find libpng then statically compile it in.
 -            include_directories(external/libpng external/zlib)
 -            set(source_files ${source_files}
+-               external/libpng/arm/arm_init.c
+-               external/libpng/arm/filter_neon_intrinsics.c
 -               external/libpng/png.c
 -               external/libpng/pngerror.c
 -               external/libpng/pngget.c
@@ -74,7 +74,7 @@ index d8a1362..088168c 100644
           set(source_files ${source_files}
              image_loader/png_loader.cpp
              image_saver/save_png.cpp
-@@ -479,68 +420,8 @@ if (NOT TARGET dlib)
+@@ -501,68 +440,8 @@
        endif()
  
        if (DLIB_JPEG_SUPPORT)
@@ -83,7 +83,7 @@ index d8a1362..088168c 100644
 -         # Make sure there isn't something wrong with the version of libjpeg 
 -         # installed on this system.  Also don't use the installed libjpeg
 -         # if this is an APPLE system because apparently it's broken (as of 2015/01/01).
--         if (JPEG_FOUND AND NOT ("${JPEG_INCLUDE_DIR}" MATCHES "(.*)(Ana|ana|mini)conda(.*)"))
+-         if (JPEG_FOUND AND NOT ("${JPEG_INCLUDE_DIR}" MATCHES "(.*)(Ana|ana|mini)conda(.*)") AND NOT BUILDING_PYTHON_IN_MSVC)
 -            set(CMAKE_REQUIRED_LIBRARIES ${JPEG_LIBRARY})
 -            CHECK_FUNCTION_EXISTS(jpeg_read_header LIBJPEG_IS_GOOD)
 -         endif()

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -5,13 +5,14 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO davisking/dlib
-    REF v19.16
-    SHA512 4e040ef88acff05e1a48e499b813c876b22ad3f989d076bdf19969d01036b62e51a0dff30b70046910ba31dfa1b1c2450a7fad41ae3142b7285ed74b8d584887
+    REF v19.17
+    SHA512 8574f48d0cc55685d494b3933079c16526fc7cfa3df85a76d51a1f13bebeccf3b6d7247981b53bd1c9e6e664e42245e518cefadf3420be1ab25b5dd6b8d55441
     HEAD_REF master
     PATCHES
         fix-mac-jpeg.patch
         fix-sqlite3-fftw-linkage.patch
         force_finding_packages.patch
+        find_blas.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/dlib/external/libjpeg)


### PR DESCRIPTION
This PR
* updates dlib to 19.17 
* fixes static linkage to lapack when openblas is statically linked (#6519)