### PR TITLE
[vcpkg.cmake] Remove use of IN_LIST

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -169,6 +169,7 @@ function(add_executable name)
     _add_executable(${ARGV})
     list(FIND ARGV "IMPORTED" IMPORTED_IDX)
     list(FIND ARGV "ALIAS" ALIAS_IDX)
+    list(FIND ARGV "MACOSX_BUNDLE" MACOSX_BUNDLE_IDX)
     if(IMPORTED_IDX EQUAL -1 AND ALIAS_IDX EQUAL -1)
         if(VCPKG_APPLOCAL_DEPS)    
             if(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "windows|uwp")
@@ -179,7 +180,7 @@ function(add_executable name)
                         -OutVariable out
                 )
             elseif(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "osx")
-                if ("MACOSX_BUNDLE" IN_LIST ARGV)
+                if (NOT MACOSX_BUNDLE_IDX EQUAL -1)
                     add_custom_command(TARGET ${name} POST_BUILD
                     COMMAND python ${_VCPKG_TOOLCHAIN_DIR}/osx/applocal.py
                         $<TARGET_FILE:${name}>


### PR DESCRIPTION
Fixes regression introduced by #5681 in CMake projects with minimum version <3.3 where CMP0057 is not set to NEW
Fixes #6484