### PR TITLE
[liblzma] Add missing pthreads link

### DIFF
--- a/ports/liblzma/CMakeLists.txt
+++ b/ports/liblzma/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 if(WIN32)
     include_directories(windows/vs2017)
 else()
+    find_package(Threads REQUIRED)
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/config.h
     """
@@ -144,6 +145,9 @@ add_library(lzma
     src/liblzma/simple/simple_encoder.c
     src/liblzma/simple/sparc.c
     src/liblzma/simple/x86.c)
+if(CMAKE_USE_PTHREADS_INIT)
+    target_link_libraries(lzma PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 install(TARGETS lzma
     RUNTIME DESTINATION bin

--- a/ports/liblzma/CONTROL
+++ b/ports/liblzma/CONTROL
@@ -1,3 +1,3 @@
 Source: liblzma
-Version: 5.2.4-1
+Version: 5.2.4-2
 Description: Compression library with an API similar to that of zlib.


### PR DESCRIPTION
It is required to link liblzma to pthreads because FindLibLZMA checks for symbol presence with compilation test, which fails when limlzma is build as a shared library due to missing pthreads link.