### PR TITLE
[cccapstone]Fix include file <capstone.h> path.

### DIFF
--- a/ports/cccapstone/CONTROL
+++ b/ports/cccapstone/CONTROL
@@ -1,4 +1,4 @@
 Source: cccapstone
-Version: 9b4128ee1153e78288a1b5433e2c06a0d47a4c4e
+Version: 9b4128ee1153e78288a1b5433e2c06a0d47a4c4e-1
 Description: c++ bindings for capstone disasembly framework
 Build-Depends: capstone

--- a/ports/cccapstone/fix-include-path.patch
+++ b/ports/cccapstone/fix-include-path.patch
@@ -1,0 +1,24 @@
+diff --git a/cppbindings/CsCapstoneHelper.hh b/cppbindings/CsCapstoneHelper.hh
+index daf7a73..8ed5194 100644
+--- a/cppbindings/CsCapstoneHelper.hh
++++ b/cppbindings/CsCapstoneHelper.hh
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ #include <memory>
+ 
+ struct CS_HANDLE :
+diff --git a/cppbindings/CsIns.hpp b/cppbindings/CsIns.hpp
+index 6e8ba71..c723be9 100644
+--- a/cppbindings/CsIns.hpp
++++ b/cppbindings/CsIns.hpp
+@@ -1,6 +1,6 @@
+ #pragma once
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ #include "CsCapstoneHelper.hh"
+ 
+ //x86_insn_group, x86_reg, x86_op_type, x86_insn

--- a/ports/cccapstone/portfile.cmake
+++ b/ports/cccapstone/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     REPO zer0mem/cccapstone
     SHA512 d0023586281f921314dbba501fa2c06d822b1adba0a0c32f30b78628ee935e5822caebe3881a5d1cc4cc696b82a7e348044d887a7f652303359d2853d2ee45fb
     HEAD_REF master
+    PATCHES fix-include-path.patch
 )
 
 file(INSTALL ${SOURCE_PATH}/cppbindings/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/cccapstone/cppbindings)


### PR DESCRIPTION
Since the port capstone header file is installed under _include/capstone_ **instead** of _include_, the reference path for **capstone.h** in cccapstone needs to be changed to _capstone/capstone.h_

Related: #6495.