### PR TITLE
[vcpkg] Avoid duplication of targets in the CMake message

### DIFF
--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -531,7 +531,9 @@ namespace vcpkg::Install
                         while (next != last)
                         {
                             auto match = *next;
-                            library_targets[find_package_name].push_back(match[1]);
+                            auto& targets = library_targets[find_package_name];
+                            if (std::find(targets.cbegin(), targets.cend(), match[1]) == targets.cend())
+                                targets.push_back(match[1]);
                             ++next;
                         }
                     }


### PR DESCRIPTION
>vcpkg install octomap:x86-windows

Before:
```
The package octomap:x86-windows provides CMake targets:

    find_package(octomap CONFIG REQUIRED)
    # Note: 2 target(s) were omitted.
    target_link_libraries(main PRIVATE octomap octomap octomath octomath)
```
After:
```
The package octomap:x86-windows provides CMake targets:

    find_package(octomap CONFIG REQUIRED)
    target_link_libraries(main PRIVATE octomap octomath octomap-static octomath-static)
```