### PR TITLE
[paho-mqtt]Fix install path.

### DIFF
--- a/ports/paho-mqtt/CONTROL
+++ b/ports/paho-mqtt/CONTROL
@@ -1,4 +1,4 @@
 Source: paho-mqtt
-Version: 1.2.1
+Version: 1.2.1-1
 Description: Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols aimed at new, existing, and emerging applications for the Internet of Things
 Build-Depends: openssl

--- a/ports/paho-mqtt/fix-install-path.patch
+++ b/ports/paho-mqtt/fix-install-path.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 418e2f2..f05aad4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,9 +62,9 @@ ENDIF()
+ ### packaging settings
+ SET(CPACK_PACKAGE_VENDOR "Eclipse Paho")
+ SET(CPACK_PACKAGE_NAME "Eclipse-Paho-MQTT-C")
+-INSTALL(FILES CONTRIBUTING.md epl-v10 edl-v10 README.md notice.html DESTINATION .)
++INSTALL(FILES CONTRIBUTING.md epl-v10 edl-v10 README.md notice.html DESTINATION share/paho-mqtt)
+ FILE(GLOB samples "src/samples/*.c")
+-INSTALL(FILES ${samples} DESTINATION samples)
++INSTALL(FILES ${samples} DESTINATION share/paho-mqtt/samples)
+ IF (WIN32)
+     SET(CPACK_GENERATOR "ZIP")
+ ELSEIF(PAHO_BUILD_DEB_PACKAGE)
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index 06e4c5d..9cf7c21 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -37,4 +37,4 @@ FOREACH(DOXYFILE_SRC DoxyfileV3ClientAPI;DoxyfileV3AsyncAPI;DoxyfileV3ClientInte
+     SET(DOXYTARGETS ${DOXYTARGETS} ${DOXYFILE_SRC}.target)
+ ENDFOREACH(DOXYFILE_SRC)
+ ADD_CUSTOM_TARGET(doc ALL DEPENDS ${DOXYTARGETS})
+-INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc DESTINATION share)
++INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc DESTINATION share/paho-mqtt)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c57185b..98c7f31 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -84,7 +84,7 @@ INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+ INSTALL(TARGETS MQTTVersion
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++    RUNTIME DESTINATION tools/paho-mqtt)
+ 
+ IF (PAHO_BUILD_STATIC)
+     ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+@@ -98,7 +98,7 @@ IF (PAHO_BUILD_STATIC)
+ ENDIF()
+ 
+ INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h
+-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/paho-mqtt)
+ 
+ IF (PAHO_WITH_SSL)
+     SET(OPENSSL_SEARCH_PATH "" CACHE PATH "Directory containing OpenSSL libraries and includes")

--- a/ports/paho-mqtt/fix-static-build.patch
+++ b/ports/paho-mqtt/fix-static-build.patch
@@ -1,0 +1,97 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 14b94b1..508c5b1 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -65,28 +65,29 @@ ENDIF()
+ ADD_LIBRARY(common_obj OBJECT ${common_src})
+ SET_PROPERTY(TARGET common_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+ 
+-ADD_EXECUTABLE(MQTTVersion MQTTVersion.c)
+-
+-ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+-ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
+-
+-TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
+-TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
+-
+-TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
+-SET_TARGET_PROPERTIES(
+-    paho-mqtt3c paho-mqtt3a PROPERTIES
+-    VERSION ${CLIENT_VERSION}
+-    SOVERSION ${PAHO_VERSION_MAJOR})
+-
+-INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
+-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-INSTALL(TARGETS MQTTVersion
+-    RUNTIME DESTINATION tools/paho-mqtt)
+-
+-IF (PAHO_BUILD_STATIC)
++IF (NOT PAHO_BUILD_STATIC)
++    ADD_EXECUTABLE(MQTTVersion MQTTVersion.c)
++    
++    ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
++    ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
++    
++    TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
++    TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
++    
++    TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
++    SET_TARGET_PROPERTIES(
++        paho-mqtt3c paho-mqtt3a PROPERTIES
++        VERSION ${CLIENT_VERSION}
++        SOVERSION ${PAHO_VERSION_MAJOR})
++    
++    INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++    INSTALL(TARGETS MQTTVersion
++        RUNTIME DESTINATION tools/paho-mqtt)
++ELSE()
++    message("Build as static library")
+     ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+     ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_obj> MQTTAsync.c)
+ 
+@@ -132,22 +133,24 @@ IF (PAHO_WITH_SSL)
+     ADD_LIBRARY(common_ssl_obj OBJECT ${common_src})
+     SET_PROPERTY(TARGET common_ssl_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+     SET_PROPERTY(TARGET common_ssl_obj PROPERTY COMPILE_DEFINITIONS "OPENSSL=1")
+-    ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
+-    ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
+-
+-    TARGET_LINK_LIBRARIES(paho-mqtt3cs ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
+-    TARGET_LINK_LIBRARIES(paho-mqtt3as ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
+-    SET_TARGET_PROPERTIES(
+-        paho-mqtt3cs paho-mqtt3as PROPERTIES
+-        VERSION ${CLIENT_VERSION}
+-        SOVERSION ${PAHO_VERSION_MAJOR}
+-        COMPILE_DEFINITIONS "OPENSSL=1")
+-    INSTALL(TARGETS paho-mqtt3cs paho-mqtt3as
+-        ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-        LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-        RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
+-
+-    IF (PAHO_BUILD_STATIC)
++    
++    IF (NOT PAHO_BUILD_STATIC)
++        ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
++        ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
++    
++        TARGET_LINK_LIBRARIES(paho-mqtt3cs ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
++        TARGET_LINK_LIBRARIES(paho-mqtt3as ${OPENSSL_LIB} ${OPENSSLCRYPTO_LIB} ${LIBS_SYSTEM})
++        SET_TARGET_PROPERTIES(
++            paho-mqtt3cs paho-mqtt3as PROPERTIES
++            VERSION ${CLIENT_VERSION}
++            SOVERSION ${PAHO_VERSION_MAJOR}
++            COMPILE_DEFINITIONS "OPENSSL=1")
++        INSTALL(TARGETS paho-mqtt3cs paho-mqtt3as
++            ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++    ELSE()
++        message("Build as static library")
+         ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
+         ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c SSLSocket.c)
+ 

--- a/ports/paho-mqtt/portfile.cmake
+++ b/ports/paho-mqtt/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
   PATCHES
          remove_compiler_options.patch
          fix-install-path.patch
+         fix-static-build.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAHO_BUILD_STATIC)

--- a/ports/paho-mqtt/portfile.cmake
+++ b/ports/paho-mqtt/portfile.cmake
@@ -6,17 +6,12 @@ vcpkg_from_github(
   REF v1.2.1
   SHA512 98828852ecd127445591df31416adaebebd30848c027361ae62af6b14b84e3cf2a4b90cab692b983148cbf93f710a9e2dd722a3da8c4fd17eb2149e4227a8860
   HEAD_REF master
+  PATCHES
+         remove_compiler_options.patch
+         fix-install-path.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAHO_BUILD_STATIC)
-
-
-vcpkg_apply_patches(
-  SOURCE_PATH ${SOURCE_PATH}
-  PATCHES
-  "${CMAKE_CURRENT_LIST_DIR}/remove_compiler_options.patch"
-)
-
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
@@ -24,62 +19,11 @@ vcpkg_configure_cmake(
   OPTIONS -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_STATIC=${PAHO_BUILD_STATIC} -DPAHO_ENABLE_TESTING=FALSE
 )
 
-
-vcpkg_build_cmake()
-
-file(GLOB DLLS
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.dll"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/Release/*.dll"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*/Release/*.dll"
-)
-file(GLOB LIBS
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/src/*.lib"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/Release/*.lib"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/*/Release/*.lib"
-)
-file(GLOB DEBUG_DLLS
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/*.dll"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/Debug/*.dll"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/*/Debug/*.dll"
-)
-file(GLOB DEBUG_LIBS
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/*.lib"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/Debug/*.lib"
-  "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/*/Debug/*.lib"
-)
-if(DLLS)
-  file(INSTALL ${DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-endif()
-if(LIBS)
-  file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-endif()
-if(DEBUG_DLLS)
-  file(INSTALL ${DEBUG_DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-endif()
-if(DEBUG_LIBS)
-  file(INSTALL ${DEBUG_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-endif()
-file(COPY ${SOURCE_PATH}/src/MQTTAsync.h ${SOURCE_PATH}/src/MQTTClient.h ${SOURCE_PATH}/src/MQTTClientPersistence.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-  foreach(libname paho-mqtt3as-static paho-mqtt3cs-static paho-mqtt3a-static paho-mqtt3c-static)
-    foreach(foldername "lib" "debug/lib")
-      string(REPLACE "-static" "" outlibname ${libname})
-      file(RENAME ${CURRENT_PACKAGES_DIR}/${foldername}/${libname}.lib  ${CURRENT_PACKAGES_DIR}/${foldername}/${outlibname}.lib)
-    endforeach()
-  endforeach()
-endif()
-
-foreach(libname paho-mqtt3a paho-mqtt3c)
-  foreach(root "${CURRENT_PACKAGES_DIR}" "${CURRENT_PACKAGES_DIR}/debug")
-    file(REMOVE
-      ${root}/lib/${libname}.lib
-      ${root}/bin/${libname}.dll
-    )
-  endforeach()
-endforeach()
-
+vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/paho-mqtt/README.md ${CURRENT_PACKAGES_DIR}/share/paho-mqtt/readme)
 file(INSTALL ${SOURCE_PATH}/about.html DESTINATION ${CURRENT_PACKAGES_DIR}/share/paho-mqtt RENAME copyright)


### PR DESCRIPTION
- Use **vcpkg_install_cmake** instead of the code in portfile.cmake
- Dynamic libraries are not built when building static libraries.

Related: #6543.