### PR TITLE
[libmariadb]Disable test build.

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,3 +1,3 @@
 Source: libmariadb
-Version: 3.0.10
+Version: 3.0.10-1
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases

--- a/ports/libmariadb/disable-test-build.patch
+++ b/ports/libmariadb/disable-test-build.patch
@@ -1,0 +1,34 @@
+diff --git a/unittest/libmariadb/CMakeLists.txt b/unittest/libmariadb/CMakeLists.txt
+index 9cea916..a39ba94 100644
+--- a/unittest/libmariadb/CMakeLists.txt
++++ b/unittest/libmariadb/CMakeLists.txt
+@@ -58,16 +58,16 @@ ENDIF()
+ 
+ ADD_LIBRARY(ma_getopt ma_getopt.c)
+ 
+-FOREACH(API_TEST ${API_TESTS})
+-  IF (NOT TARGET ${API_TEST})
+-    ADD_EXECUTABLE(${API_TEST} ${API_TEST}.c)
+-  ENDIF()
+-  TARGET_LINK_LIBRARIES(${API_TEST} cctap ma_getopt mariadbclient)
+-  ADD_TEST(${API_TEST} ${EXECUTABLE_OUTPUT_PATH}/${API_TEST})
+-  SET_TESTS_PROPERTIES(${API_TEST} PROPERTIES TIMEOUT 180)
+-ENDFOREACH(API_TEST)
+-
+-FOREACH(API_TEST ${MANUAL_TESTS})
+-  ADD_EXECUTABLE(${API_TEST} ${API_TEST}.c)
+-  TARGET_LINK_LIBRARIES(${API_TEST} cctap ma_getopt mariadbclient)
+-ENDFOREACH()
++#FOREACH(API_TEST ${API_TESTS})
++#  IF (NOT TARGET ${API_TEST})
++#    ADD_EXECUTABLE(${API_TEST} ${API_TEST}.c)
++#  ENDIF()
++#  TARGET_LINK_LIBRARIES(${API_TEST} cctap ma_getopt mariadbclient)
++#  ADD_TEST(${API_TEST} ${EXECUTABLE_OUTPUT_PATH}/${API_TEST})
++#  SET_TESTS_PROPERTIES(${API_TEST} PROPERTIES TIMEOUT 180)
++#ENDFOREACH(API_TEST)
++#
++#FOREACH(API_TEST ${MANUAL_TESTS})
++#  ADD_EXECUTABLE(${API_TEST} ${API_TEST}.c)
++#  TARGET_LINK_LIBRARIES(${API_TEST} cctap ma_getopt mariadbclient)
++#ENDFOREACH()

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -11,7 +11,9 @@ vcpkg_from_github(
     REF v3.0.10
     SHA512 43f89ead531d1b2f6ede943486bf39f606124762309c294b0f3e185937aef7439cb345103fc065e7940ed64c01ca1bf16940cd2fb0d80da60f39009c3b5a910b
     HEAD_REF master
-    PATCHES md.patch
+    PATCHES
+            md.patch
+            disable-test-build.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
The **test** project build relies on **cctap.lib** and the library is **not found**(LNK1104).
Although we can fix it, we don't need it. So I **disabled** the test project.

Related: #6562.