### PR TITLE
Fix SQLite3 CMake targets

### DIFF
--- a/ports/sqlite3/CMakeLists.txt
+++ b/ports/sqlite3/CMakeLists.txt
@@ -7,10 +7,10 @@ if(BUILD_SHARED_LIBS)
 else()
     set(API "-DSQLITE_API=extern")
 endif()
-add_library(sqlite3 sqlite3.c)
+add_library(SQLite3 sqlite3.c)
 
 target_compile_definitions(
-    sqlite3
+    SQLite3
     PRIVATE
         $<$<CONFIG:Debug>:SQLITE_DEBUG>
         ${API}
@@ -18,20 +18,20 @@ target_compile_definitions(
         -DSQLITE_ENABLE_UNLOCK_NOTIFY
         -DSQLITE_ENABLE_COLUMN_METADATA
 )
-target_include_directories(sqlite3 INTERFACE $<INSTALL_INTERFACE:include>)
+target_include_directories(SQLite3 INTERFACE $<INSTALL_INTERFACE:include>)
 if(NOT WIN32)
     find_package(Threads REQUIRED)
-    target_link_libraries(sqlite3 PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+    target_link_libraries(SQLite3 PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
-    target_compile_definitions(sqlite3 PRIVATE -DSQLITE_OS_WINRT=1)
+    target_compile_definitions(SQLite3 PRIVATE -DSQLITE_OS_WINRT=1)
 endif()
 
 if(NOT SQLITE3_SKIP_TOOLS)
     add_executable(sqlite3-bin shell.c)
     set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME sqlite3)
-    target_link_libraries(sqlite3-bin PRIVATE sqlite3)
+    target_link_libraries(sqlite3-bin PRIVATE SQLite3)
     install(TARGETS sqlite3-bin sqlite3
       RUNTIME DESTINATION tools
       LIBRARY DESTINATION lib
@@ -40,12 +40,12 @@ if(NOT SQLITE3_SKIP_TOOLS)
 endif()
 
 install(
-    TARGETS sqlite3
-    EXPORT sqlite3
+    TARGETS SQLite3
+    EXPORT SQLite3
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
 
 install(FILES sqlite3.h sqlite3ext.h DESTINATION include CONFIGURATIONS Release)
-install(EXPORT sqlite3 FILE sqlite3-targets.cmake DESTINATION share/sqlite3)
+install(EXPORT SQLite3 NAMESPACE SQLite:: FILE sqlite3-targets.cmake DESTINATION share/sqlite3)

--- a/ports/sqlitecpp/0001-Find-external-sqlite3.patch
+++ b/ports/sqlitecpp/0001-Find-external-sqlite3.patch
@@ -16,8 +16,8 @@ index 4a3e492..f7e22a5 100644
 
  # TODO NOCOMMIT
 -#find_package(sqlite3)
-+find_package(sqlite3 CONFIG)
-+target_link_libraries(SQLiteCpp PRIVATE sqlite3)
++find_package(SQLite3 CONFIG)
++target_link_libraries(SQLiteCpp PRIVATE SQLite::SQLite3)
  #if(sqlite3_VERSION VERSION_LESS "3.19")
  #    set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-DSQLITECPP_HAS_MEM_STRUCT")
  #endif()


### PR DESCRIPTION
Upstream CMake provides a FindSQLite3 module that defines a
SQLite::SQLite3 target. When writing portable application code, the
cmake way of using SQLite3 is therefore

    find_package(SQLite3)
    target_link_libraries(mytarget PRIVATE SQLite::SQLite3)

When using the above code with vcpkg on a case-insensitive filesystem,
then the find_package call will find sqlite3-config.cmake as generated
by vcpkg. Unfortunately that wrapper will not define the same imported
targets as upstream cmake's module, hence this fix.