### PR TITLE
[apr-util] Fix logic error. If find_library call is used testing for …

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,4 +1,4 @@
 Source: apr-util
-Version: 1.6.0-2
+Version: 1.6.0-3
 Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
 Build-Depends: expat, apr, openssl

--- a/ports/apr-util/apr.patch
+++ b/ports/apr-util/apr.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 69e45541..19b86129 100644
+--- a/CMakeLists.txt	
++++ b/CMakeLists.txt
+@@ -35,7 +35,7 @@ IF(NOT EXISTS "${APR_INCLUDE_DIR}/apr.h")
+   MESSAGE(FATAL_ERROR "APR include directory ${APR_INCLUDE_DIR} is not correct.")
+ ENDIF()
+ FOREACH(onelib ${APR_LIBRARIES})
+-  IF(NOT EXISTS ${onelib})
++  IF(${onelib} MATCHES "NOTFOUND")
+     MESSAGE(FATAL_ERROR "APR library ${onelib} was not found.")
+   ENDIF()
+ ENDFOREACH()

--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -10,7 +10,9 @@ vcpkg_extract_source_archive(${ARCHIVE})
 
 vcpkg_apply_patches(
   SOURCE_PATH ${SOURCE_PATH}
-  PATCHES "${CMAKE_CURRENT_LIST_DIR}/use-vcpkg-expat.patch"
+  PATCHES 
+        use-vcpkg-expat.patch
+        apr.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
…existance is strange.

Especially if APR_LIBRARIES can contain a list. Testing against NOTFOUND is better.