### PR TITLE
[nvtt] install extra libraries used by OSG.

### DIFF
--- a/ports/nvtt/CONTROL
+++ b/ports/nvtt/CONTROL
@@ -1,3 +1,3 @@
 Source: nvtt
-Version: 2.1.0-2
+Version: 2.1.0-3
 Description: Texture processing tools with support for Direct3D 10 and 11 formats.

--- a/ports/nvtt/bc6h.patch
+++ b/ports/nvtt/bc6h.patch
@@ -1,0 +1,14 @@
+diff --git a/src/bc6h/CMakeLists.txt b/src/bc6h/CMakeLists.txt
+index 635e0f3a..f758df43 100644
+--- a/src/bc6h/CMakeLists.txt	
++++ b/src/bc6h/CMakeLists.txt
+@@ -20,3 +20,8 @@ IF(NOT WIN32)
+         SET_TARGET_PROPERTIES(bc6h PROPERTIES COMPILE_FLAGS -fPIC)
+     ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+ ENDIF(NOT WIN32)
++
++INSTALL(TARGETS bc6h 
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib/static)
+\ No newline at end of file

--- a/ports/nvtt/bc7.patch
+++ b/ports/nvtt/bc7.patch
@@ -1,0 +1,14 @@
+diff --git a/src/bc7/CMakeLists.txt b/src/bc7/CMakeLists.txt
+index 2eb01c06..0c36895b 100644
+--- a/src/bc7/CMakeLists.txt	
++++ b/src/bc7/CMakeLists.txt
+@@ -28,3 +28,8 @@ IF(NOT WIN32)
+         SET_TARGET_PROPERTIES(bc7 PROPERTIES COMPILE_FLAGS -fPIC)
+     ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+ ENDIF(NOT WIN32)
++
++INSTALL(TARGETS bc7 
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib/static)
+\ No newline at end of file

--- a/ports/nvtt/portfile.cmake
+++ b/ports/nvtt/portfile.cmake
@@ -9,7 +9,10 @@ vcpkg_from_github(
     SHA512 6c5c9588af57023fc384de080cbe5c5ccd8707d04a9533384c606efd09730d780cb21bcf2d3576102a3facd2f281cacb2625958d74575e71550fd98da92e38b6
     HEAD_REF master
     PATCHES
-        "001-define-value-for-HAVE_UNISTD_H-in-mac-os.patch"
+        001-define-value-for-HAVE_UNISTD_H-in-mac-os.patch
+        bc6h.patch
+        bc7.patch
+        squish.patch
 )
 
 vcpkg_configure_cmake(
@@ -17,6 +20,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DNVTT_SHARED=0
+        -DCMAKE_DEBUG_POSTFIX=_d # required by OSG
 )
 
 vcpkg_install_cmake()

--- a/ports/nvtt/squish.patch
+++ b/ports/nvtt/squish.patch
@@ -1,0 +1,13 @@
+diff --git a/src/nvtt/squish/CMakeLists.txt b/src/nvtt/squish/CMakeLists.txt
+index 832013e1..76824137 100644
+--- a/src/nvtt/squish/CMakeLists.txt	
++++ b/src/nvtt/squish/CMakeLists.txt
+@@ -33,3 +33,7 @@ IF(NOT WIN32)
+     ENDIF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+ ENDIF(NOT WIN32)
+ 
++INSTALL(TARGETS squish 
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib/static)
+\ No newline at end of file


### PR DESCRIPTION
At least my config logs of #5543 were telling me that OSG is searching for these and were unable to find them because they did not get installed.