### PR TITLE
[llvm]Fix build error on x64-windows.

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,4 +1,4 @@
 Source: llvm
-Version: 7.0.0-2
+Version: 7.0.0-3
 Description: The LLVM Compiler Infrastructure
 Build-Depends: atlmfc (windows)

--- a/ports/llvm/fix-build-error.patch
+++ b/ports/llvm/fix-build-error.patch
@@ -1,0 +1,16 @@
+diff --git a/tools/clang/tools/libclang/CMakeLists.txt b/tools/clang/tools/libclang/CMakeLists.txt
+index e539c83..09c1ea3 100644
+--- a/tools/clang/tools/libclang/CMakeLists.txt
++++ b/tools/clang/tools/libclang/CMakeLists.txt
+@@ -56,10 +56,7 @@ if (TARGET clangTidyPlugin)
+   endif()
+ endif ()
+ 
+-find_library(DL_LIBRARY_PATH dl)
+-if (DL_LIBRARY_PATH)
+-  list(APPEND LIBS dl)
+-endif()
++list(APPEND LIBS "${DL_LIBRARY_PATH}")
+ 
+ option(LIBCLANG_BUILD_STATIC
+   "Build libclang as a static library (in addition to a shared one)" OFF)

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -28,7 +28,9 @@ endif()
 
 vcpkg_apply_patches(
     SOURCE_PATH ${SOURCE_PATH}
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/install-cmake-modules-to-share.patch
+    PATCHES 
+            install-cmake-modules-to-share.patch
+            fix-build-error.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)


### PR DESCRIPTION
Fixed build failure in x64-windows according to @Neumann-A 's suggestion.
And this issue cannot be fixed by updating llvm version.

Related: #6584.