### PR TITLE
[rtmidi] Update to version 4.0.0

### DIFF
--- a/ports/rtmidi/CONTROL
+++ b/ports/rtmidi/CONTROL
@@ -1,3 +1,3 @@
 Source: rtmidi
-Version: 2.1.1-2
+Version: 4.0.0
 Description: A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)

--- a/ports/rtmidi/fix-POSIXname.patch
+++ b/ports/rtmidi/fix-POSIXname.patch
@@ -1,13 +1,17 @@
 diff --git a/rtmidi_c.cpp b/rtmidi_c.cpp
-index 248c9e5..91da34e 100644
+index 248c9e5..ec1dd38 100644
 --- a/rtmidi_c.cpp
 +++ b/rtmidi_c.cpp
-@@ -136,7 +136,7 @@ const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
+@@ -136,7 +136,11 @@ const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
  {
      try {
          std::string name = ((RtMidi*) device->ptr)->getPortName (portNumber);
 -        return strdup (name.c_str ());
-+        return _strdup (name.c_str ());
++#if defined(_WIN) || defined(WINAPI_FAMILY) //Windows platform
++			return _strdup (name.c_str ());
++#else // Unix platform
++			return strdup (name.c_str ());
++#endif
      
      } catch (const RtMidiError & err) {
          device->ok  = false;

--- a/ports/rtmidi/fix-POSIXname.patch
+++ b/ports/rtmidi/fix-POSIXname.patch
@@ -1,0 +1,13 @@
+diff --git a/rtmidi_c.cpp b/rtmidi_c.cpp
+index 248c9e5..91da34e 100644
+--- a/rtmidi_c.cpp
++++ b/rtmidi_c.cpp
+@@ -136,7 +136,7 @@ const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
+ {
+     try {
+         std::string name = ((RtMidi*) device->ptr)->getPortName (portNumber);
+-        return strdup (name.c_str ());
++        return _strdup (name.c_str ());
+     
+     } catch (const RtMidiError & err) {
+         device->ok  = false;

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -3,9 +3,11 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thestk/rtmidi
-    REF  2.1.1
-    SHA512 4d378720dd0f7c0e1a87741c088756839878ed56465b053040f70a1e039828fe221a6b1669b77b2fdd146cb192934c5719cc934c2c6a6304f44dbee2972c68e8
+    REF  4.0.0
+    SHA512 39383f121320c9471b31f8b9d283167bfadf4c7328b6664d1d54a4c52e3dd9b76362875258d90363c6044e87fcee31ccce80e19435dc620c88e6d60fc82d0f9d
     HEAD_REF master
+	PATCHES
+		fix-POSIXname.patch
 )
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
@@ -17,4 +19,4 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(INSTALL ${SOURCE_PATH}/readme DESTINATION ${CURRENT_PACKAGES_DIR}/share/rtmidi RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/rtmidi RENAME copyright)


### PR DESCRIPTION
Related issue: #6632 
Replace `strdup` with `_strdup`. Beacuse of `The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup.`.