### PR TITLE
[libwebp]Fix static build.

### DIFF
--- a/ports/libwebp/0005-fix-static-build.patch
+++ b/ports/libwebp/0005-fix-static-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7585fac..83edb3a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -540,7 +540,7 @@ if(WEBP_BUILD_EXTRAS)
+   find_package(SDL)
+   if(SDL_FOUND)
+     add_executable(vwebp_sdl ${VWEBP_SDL_SRCS})
+-    target_link_libraries(vwebp_sdl ${SDL_LIBRARY} imageioutil webp)
++    target_link_libraries(vwebp_sdl ${SDL_LIBRARY} imageioutil webp dxguid winmm)
+     target_include_directories(vwebp_sdl
+                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebp
-Version: 1.0.2-3
+Version: 1.0.2-4
 Description: Lossy compression of digital photographic images.
 Build-Depends: opengl
 

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     0002-cmake-config-add-backwards-compatibility.patch
     0003-remove-missing-symbol.patch
     0004-add-missing-linked-library.patch
+    0005-fix-static-build.patch
 )
 
 set(WEBP_BUILD_ANIM_UTILS OFF)


### PR DESCRIPTION
When I installed libwebp:x86-windows-static, the following link error occurred:
```
SDL.lib(SDL_systimer.obj) : error LNK2019: unresolved external symbol __imp__timeSetEvent@20 referenced in function _SDL_SYS_TimerInit
SDL.lib(SDL_systimer.obj) : error LNK2019: unresolved external symbol __imp__timeKillEvent@4 referenced in function _SDL_SYS_TimerQuit
SDL.lib(SDL_systimer.obj) : error LNK2019: unresolved external symbol __imp__timeGetTime@0 referenced in function _SDL_GetTicks
SDL.lib(SDL_systimer.obj) : error LNK2019: unresolved external symbol __imp__timeBeginPeriod@4 referenced in function _SDL_SYS_TimerInit
SDL.lib(SDL_systimer.obj) : error LNK2019: unresolved external symbol __imp__timeEndPeriod@4 referenced in function _SDL_SYS_TimerQuit
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_XAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_YAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_ZAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_RxAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_RyAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_RzAxis
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_Slider
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_Key
SDL.lib(SDL_dx5video.obj) : error LNK2001: unresolved external symbol _GUID_POV
```

It shows that we lack to add dependent libraries **dxguid** **winmm**, so I added them.

Related: #6646.