### PR TITLE
[vxl] move problematic feature to optional one

### DIFF
--- a/ports/vxl/CONTROL
+++ b/ports/vxl/CONTROL
@@ -1,5 +1,8 @@
 Source: vxl
-Version: v1.18.0-3
-Build-Depends: bzip2, libgeotiff, libjpeg-turbo, libpng, tiff, zlib, expat, shapelib
-# Build-Depends: bzip2, dcmtk, libgeotiff, libjpeg-turbo, openjpeg, libpng, tiff, zlib
+Version: v1.18.0-4
+Build-Depends: bzip2, expat, libgeotiff, libjpeg-turbo, libpng, shapelib, tiff, zlib
+# Build-Depends: bzip2, dcmtk, expat, libgeotiff, libjpeg-turbo, openjpeg, libpng, shapelib, tiff, zlib
 Description: A multi-platform collection of C++ software libraries for Computer Vision and Image Understanding.
+
+Feature: core_imaging
+Description: core_imaging support for vxl

--- a/ports/vxl/fix_dependency.patch
+++ b/ports/vxl/fix_dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index b6af7c2..7ca75d3 100644
+--- a/core/CMakeLists.txt
++++ b/core/CMakeLists.txt
+@@ -100,7 +100,7 @@ endif()
+ 
+ 
+ # coordinate systems
+-if(BUILD_CORE_GEOMETRY AND BUILD_CORE_NUMERICS)
++if(BUILD_CORE_GEOMETRY AND BUILD_CORE_NUMERICS AND BUILD_CORE_IMAGING)
+   add_subdirectory(vcsl)
+   add_subdirectory(vpgl)
+ endif()

--- a/ports/vxl/portfile.cmake
+++ b/ports/vxl/portfile.cmake
@@ -1,7 +1,12 @@
 include(vcpkg_common_functions)
 
-if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openjpeg.h")
-    message(FATAL_ERROR "Can't build VXL with non built-in OpenJpeg in current version. Please remove OpenJpeg, and try install VXL again.")
+set(BUILD_CORE_IMAGING OFF)
+if("core_imaging" IN_LIST FEATURES)
+  set(BUILD_CORE_IMAGING ON)
+  if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openjpeg.h")
+    set(BUILD_CORE_IMAGING OFF)
+    message(WARNING "Can't build VXL CORE_IMAGING features with non built-in OpenJpeg. Please remove OpenJpeg, and try install VXL again if you need them.")
+  endif()
 endif()
 
 vcpkg_from_github(
@@ -10,6 +15,8 @@ vcpkg_from_github(
     REF v1.18.0
     SHA512 6666d647b2e7010b91cb0b05016b5f49ae46d198f6bd160fe13fc09bc674eff5b937331fa11d81a8496473968b63452d950eee4fc2512152af57304a14bed63f
     HEAD_REF master
+    PATCHES
+        fix_dependency.patch
 )
 
 set(USE_WIN_WCHAR_T OFF)
@@ -23,6 +30,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_TESTING=OFF
+        -DBUILD_CORE_IMAGING=${BUILD_CORE_IMAGING}
         -DVXL_FORCE_V3P_BZLIB2=OFF
         -DVXL_USING_NATIVE_BZLIB2=TRUE # for disable build built-in bzip2 (v3p/bzlib/CMakeLists.txt#L10-L26)
         -DVXL_FORCE_V3P_CLIPPER=ON # TODO : need add clipper port to turn off


### PR DESCRIPTION
follow up of #6636, second part of the vxl fixup (not the last one, I hope to be able to fix vxl with latest OpenJPEG2 API).
This time I just moved problematic parts to an optional vcpkg feature, so that CI is at least happy again very easily. This should not impact also anyone, people requiring it are just a feature away, with a much nicer message welcoming them :)