### PR TITLE
[gdk-pixbuf] Fix Linux compilation.

### DIFF
--- a/ports/gdk-pixbuf/CMakeLists.txt
+++ b/ports/gdk-pixbuf/CMakeLists.txt
@@ -9,20 +9,19 @@ set(GLIB_LIB_VERSION 2.0)
 find_package(ZLIB REQUIRED)
 find_package(PNG REQUIRED)
 
+find_package(unofficial-glib CONFIG REQUIRED)
 find_path(GLIB_INCLUDE_DIR glib.h)
-find_library(GLIB_GLIB_LIBRARY glib-${GLIB_LIB_VERSION})
-find_library(GLIB_GIO_LIBRARY gio-${GLIB_LIB_VERSION})
-find_library(GLIB_GOBJECT_LIBRARY gobject-${GLIB_LIB_VERSION})
-find_library(GLIB_GMODULE_LIBRARY gmodule-${GLIB_LIB_VERSION})
-set(GLIB_LIBRARIES ${GLIB_GLIB_LIBRARY} ${GLIB_GOBJECT_LIBRARY} ${GLIB_GMODULE_LIBRARY} ${GLIB_GIO_LIBRARY})
 
-find_path(LIBINTL_INCLUDE_DIR libintl.h)
-find_library(LIBINTL_LIBRARY NAMES libintl intl)
-
-configure_file(./config.h.win32 ${CMAKE_SOURCE_DIR}/config.h COPYONLY)
+if(WIN32)
+    find_package(unofficial-gettext CONFIG REQUIRED)
+    find_path(LIBINTL_INCLUDE_DIR libintl.h)
+    configure_file(${CMAKE_SOURCE_DIR}/config.h.win32 ${CMAKE_SOURCE_DIR}/config.h COPYONLY)
+else()
+    configure_file(${CMAKE_SOURCE_DIR}/config.h.linux ${CMAKE_SOURCE_DIR}/config.h COPYONLY)
+endif()
 include_directories(. ./gdk-pixbuf)
 
-add_library(gdk-pixbuf
+set(SOURCES
     gdk-pixbuf/gdk-pixbuf.c
     gdk-pixbuf/gdk-pixbuf-animation.c
     gdk-pixbuf/gdk-pixbuf-data.c
@@ -46,6 +45,9 @@ add_library(gdk-pixbuf
     gdk-pixbuf/io-xpm.c
     gdk-pixbuf/io-xbm.c
     gdk-pixbuf/pixops/pixops.c
+)
+if(WIN32)
+    list(APPEND SOURCES
     gdk-pixbuf/io-gdip-animation.c
     gdk-pixbuf/io-gdip-bmp.c
     gdk-pixbuf/io-gdip-emf.c
@@ -54,7 +56,10 @@ add_library(gdk-pixbuf
     gdk-pixbuf/io-gdip-jpeg.c
     gdk-pixbuf/io-gdip-tiff.c
     gdk-pixbuf/io-gdip-utils.c
-    gdk-pixbuf/io-gdip-wmf.c)
+    gdk-pixbuf/io-gdip-wmf.c
+)
+endif()
+add_library(gdk-pixbuf ${SOURCES})
 
 target_include_directories(gdk-pixbuf PRIVATE 
     ${GLIB_INCLUDE_DIR} 
@@ -62,14 +67,20 @@ target_include_directories(gdk-pixbuf PRIVATE
     ${ZLIB_INCLUDE_DIRS}
     ${LIBINTL_INCLUDE_DIR})
 
-target_link_libraries(gdk-pixbuf 
-    ${GLIB_LIBRARIES} 
+set(LIBS 
+    unofficial::glib::gio unofficial::glib::glib unofficial::glib::gmodule unofficial::glib::gobject 
     ${ZLIB_LIBRARIES} 
     ${PNG_LIBRARIES} 
-    ${LIBINTL_LIBRARY}
-    Gdiplus)
+)
+if(WIN32)
+    list(APPEND LIBS Gdiplus unofficial::gettext::libintl)
+else()
+    list(APPEND LIBS m)
+endif()
 
-target_compile_definitions(gdk-pixbuf PRIVATE
+target_link_libraries(gdk-pixbuf ${LIBS})
+
+set(DEFS
     HAVE_CONFIG_H
     GDK_PIXBUF_COMPILATION
     GDK_PIXBUF_ENABLE_BACKEND
@@ -85,9 +96,12 @@ target_compile_definitions(gdk-pixbuf PRIVATE
     INCLUDE_pnm
     INCLUDE_icns
     INCLUDE_xpm
-    INCLUDE_gdiplus
     G_DISABLE_SINGLE_INCLUDES
     GDK_PIXBUF_DISABLE_SINGLE_INCLUDES)
+if(WIN32)
+    list(APPEND DEFS INCLUDE_gdiplus)
+endif()
+target_compile_definitions(gdk-pixbuf PRIVATE ${DEFS})
 
 set_target_properties(gdk-pixbuf PROPERTIES 
     OUTPUT_NAME gdk_pixbuf-${GDK_PIXBUF_DLL_SUFFIX}

--- a/ports/gdk-pixbuf/CONTROL
+++ b/ports/gdk-pixbuf/CONTROL
@@ -1,4 +1,4 @@
 Source: gdk-pixbuf
-Version: 2.36.9-2
+Version: 2.36.9-3
 Description: Image loading library.
 Build-Depends: gettext, zlib, libpng, glib

--- a/ports/gdk-pixbuf/config.h.linux
+++ b/ports/gdk-pixbuf/config.h.linux
@@ -1,0 +1,158 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+#define ENABLE_NLS 1
+
+/* Define to 1 to replace the build-time prefix in modules */
+/* #undef GDK_PIXBUF_RELOCATABLE */
+
+/* Define if gio can sniff image data */
+#define GDK_PIXBUF_USE_GIO_MIME 1
+
+/* The prefix for our gettext translation domains. */
+#define GETTEXT_PACKAGE "gdk-pixbuf"
+
+/* Define to 1 if you have the `bind_textdomain_codeset' function. */
+#define HAVE_BIND_TEXTDOMAIN_CODESET 1
+
+/* Define to 1 if you have the Mac OS X function CFLocaleCopyCurrent in the
+   CoreFoundation framework. */
+/* #undef HAVE_CFLOCALECOPYCURRENT */
+
+/* Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+/* #undef HAVE_CFPREFERENCESCOPYAPPVALUE */
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+#define HAVE_DCGETTEXT 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+#define HAVE_GETTEXT 1
+
+/* Define if you have the iconv() function and it works. */
+/* #undef HAVE_ICONV */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if libm has lrint */
+#define HAVE_LRINT 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 is libjpeg supports progressive JPEG */
+#define HAVE_PROGRESSIVE_JPEG 1
+
+/* Define to 1 if libm has round */
+#define HAVE_ROUND 1
+
+/* Define to 1 if you have the `setrlimit' function. */
+#define HAVE_SETRLIMIT 1
+
+/* Define to 1 if sigsetjmp is available */
+#define HAVE_SIGSETJMP 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#define HAVE_SYS_RESOURCE_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if sys/sysinfo.h is available */
+#define HAVE_SYS_SYSINFO_H 1
+
+/* Define to 1 if sys/systeminfo.h is available */
+/* #undef HAVE_SYS_SYSTEMINFO_H */
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+/* #undef NO_MINUS_C_MINUS_O */
+
+/* Define to 1 if it's a darwin platform */
+/* #undef OS_DARWIN */
+
+/* Define to 1 if it's a Linux platform */
+#define OS_LINUX 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://bugzilla.gnome.org/enter_bug.cgi?product=gdk-pixbuf"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "gdk-pixbuf"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "gdk-pixbuf 2.36.9"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "gdk-pixbuf"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.36.9"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if gmodule works and should be used */
+#define USE_GMODULE 1
+
+/* Whether to load modules via .la files rather than directly */
+/* #undef USE_LA_MODULES */
+
+/* Define to 1 if medialib is available and should be used */
+/* #undef USE_MEDIALIB */
+
+/* Define to 1 if medialib 2.5 is available */
+/* #undef USE_MEDIALIB25 */
+
+/* Define to 1 if MMX is available and should be used */
+/* #undef USE_MMX */
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* defines how to decorate public symbols while building */
+#define _GDK_PIXBUF_EXTERN __attribute__((visibility("default"))) extern
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive(${ARCHIVE})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.linux ${SOURCE_PATH}/config.h.linux)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/glib/CMakeLists.txt
+++ b/ports/glib/CMakeLists.txt
@@ -330,8 +330,8 @@ install(
     DESTINATION share/unofficial-glib
 )
 configure_file(
-    cmake/unofficial-glib-config.in.cmake
-    cmake/unofficial-glib-config.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/unofficial-glib-config.in.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/unofficial-glib-config.cmake
     @ONLY
 )
 install(

--- a/ports/glib/CONTROL
+++ b/ports/glib/CONTROL
@@ -1,4 +1,4 @@
 Source: glib
-Version: 2.52.3-14-1
+Version: 2.52.3-14-2
 Description: Portable, general-purpose utility library.
 Build-Depends: zlib, pcre, libffi, gettext, libiconv

--- a/ports/glib/cmake/unofficial-glib-config.in.cmake
+++ b/ports/glib/cmake/unofficial-glib-config.in.cmake
@@ -1,7 +1,7 @@
-if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
-    include(CMakeFindDependencyMacro)
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-iconv)
+if(NOT WIN32)
     find_dependency(Threads)
-    find_dependency(unofficial-iconv)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/unofficial-glib-targets.cmake")

--- a/ports/libcroco/CMakeLists.txt
+++ b/ports/libcroco/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.11)
 project(libcroco C)
 
+find_package(unofficial-iconv REQUIRED)
+find_package(unofficial-gettext CONFIG REQUIRED)
 find_package(unofficial-glib CONFIG REQUIRED)
 find_package(LibXml2 REQUIRED)
 if(NOT WIN32)
     find_package(Threads REQUIRED)
-    find_package(unofficial-iconv REQUIRED)
 endif()
 find_path(GLIB_INCLUDE_DIR glib.h)
 
@@ -67,10 +68,10 @@ file(GLOB SOURCES
 
 set(CMAKE_DEBUG_POSTFIX "d")
 
-add_library(libcroco ${SOURCES})
+add_library(croco-0.6 ${SOURCES})
 
-target_include_directories(libcroco PRIVATE ${GLIB_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
-target_link_libraries(libcroco PRIVATE 
+target_include_directories(croco-0.6 PRIVATE ${GLIB_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
+target_link_libraries(croco-0.6 PRIVATE 
     unofficial::glib::gio
     unofficial::glib::glib
     unofficial::glib::gmodule
@@ -78,7 +79,7 @@ target_link_libraries(libcroco PRIVATE
     ${LIBXML2_LIBRARIES}
 )
 
-install(TARGETS libcroco
+install(TARGETS croco-0.6
     EXPORT libcroco-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
@@ -126,11 +127,12 @@ install(
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/unofficial-libcroco-config.cmake "
 include(CMakeFindDependencyMacro)
+find_dependency(unofficial-gettext)
+find_dependency(unofficial-iconv CONFIG)
 find_dependency(unofficial-glib CONFIG)
 find_dependency(LibXml2)
 if(NOT WIN32)
     find_dependency(Threads)
-    find_dependency(unofficial-iconv)
 endif()
 include(\${CMAKE_CURRENT_LIST_DIR}/unofficial-libcroco-targets.cmake)
 ")

--- a/ports/libcroco/CONTROL
+++ b/ports/libcroco/CONTROL
@@ -1,4 +1,4 @@
 Source: libcroco
-Version: 0.6.13
+Version: 0.6.13-1
 Description: A standalone css2 parsing and manipulation library
 Build-Depends: glib, libxml2

--- a/ports/libcroco/portfile.cmake
+++ b/ports/libcroco/portfile.cmake
@@ -30,5 +30,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libcroco RENAME copyright)
 
+vcpkg_copy_pdbs()
+
 # Post-build test for cmake libraries
  vcpkg_test_cmake(PACKAGE_NAME libcroco)

--- a/ports/libcroco/portfile.cmake
+++ b/ports/libcroco/portfile.cmake
@@ -24,8 +24,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-libcroco TARGET_PATH share/unofficial-libcroco)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libcroco RENAME copyright)
@@ -33,4 +33,4 @@ file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/li
 vcpkg_copy_pdbs()
 
 # Post-build test for cmake libraries
- vcpkg_test_cmake(PACKAGE_NAME libcroco)
+vcpkg_test_cmake(PACKAGE_NAME libcroco)


### PR DESCRIPTION
Unlike #6625 this version contains the minimal changes required
to keep other dependencies as untouched as possible.