### PR TITLE
make meson not download things

### DIFF
--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -26,7 +26,7 @@ function(vcpkg_configure_meson)
     set(MESON_RELEASE_LDFLAGS "${MESON_RELEASE_LDFLAGS} /INCREMENTAL:NO /OPT:REF /OPT:ICF")
     
     # select meson cmd-line options
-    list(APPEND _vcm_OPTIONS --buildtype plain --backend ninja)
+    list(APPEND _vcm_OPTIONS --buildtype plain --backend ninja --wrap-mode nodownload)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         list(APPEND _vcm_OPTIONS --default-library shared)
     else()


### PR DESCRIPTION
by default meson will fallback to it's "wrap" system to download dependencies. It's a good idea for packagers to disable that (this may break ports, but afaict very few ports actually use meson)