### PR TITLE
[pango/gtk]Fix build error C2001.

### DIFF
--- a/ports/gtk/CMakeLists.txt
+++ b/ports/gtk/CMakeLists.txt
@@ -12,6 +12,11 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
     set(CAIRO_LIB_SUFFIX d)
 endif()
 
+if (WIN32)
+  # Set utf-8 charset to avoid compile error C2001
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
+endif()
+
 # find dependencies
 # glib
 find_path(GLIB_INCLUDE_DIR glib.h)

--- a/ports/gtk/CONTROL
+++ b/ports/gtk/CONTROL
@@ -1,4 +1,4 @@
 Source: gtk
-Version: 3.22.19-2
+Version: 3.22.19-3
 Description: Portable library for creating graphical user interfaces.
 Build-Depends: glib, atk, gdk-pixbuf, pango, cairo, libepoxy, gettext

--- a/ports/pango/CMakeLists.txt
+++ b/ports/pango/CMakeLists.txt
@@ -11,6 +11,11 @@ else()
   configure_file(./config.h.unix ${CMAKE_CURRENT_BINARY_DIR}/config.h COPYONLY)
 endif()
 
+if (WIN32)
+  # Set utf-8 charset to avoid compile error C2001
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
+endif()
+
 add_definitions(-DHAVE_CONFIG_H)
 include_directories(. ./pango ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/ports/pango/CONTROL
+++ b/ports/pango/CONTROL
@@ -1,4 +1,4 @@
 Source: pango
-Version: 1.40.11-3
+Version: 1.40.11-4
 Description: Text and font handling library.
 Build-Depends: glib, gettext, cairo, fontconfig, freetype, harfbuzz[glib] (!windows-static)


### PR DESCRIPTION
I encountered some errors when building **pango** / **gtk** on **Windows10-zh_CN** / **Visual Studio 2017-zh_CN**:
`error C2001: newline in constant`

This is because we deleted the cmake flag "**/utf-8**" in _scripts/toolchains/windows.cmake_ (PR: #5924).
Due to the problem caused by **special characters** in the source code, I think we should treat these ports **specially**, rather than unified processing. So I added it to each **CMakeLists.txt**.

Related: #6622.