### PR TITLE
[reproc] Enabled C++ target for version 6.0.0.

### DIFF
--- a/ports/reproc/CONTROL
+++ b/ports/reproc/CONTROL
@@ -1,3 +1,3 @@
 Source: reproc
-Version: 6.0.0
+Version: 6.0.0-1
 Description: Cross-platform library that simplifies working with external CLI applications from C and C++ 

--- a/ports/reproc/portfile.cmake
+++ b/ports/reproc/portfile.cmake
@@ -12,14 +12,17 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DREPROC_BUILD_CXX_WRAPPER=ON
+        -DREPROC++=ON
+        -DREPROC++_INSTALL=ON
         -DREPROC_INSTALL=ON
 )
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/reproc)
+file(GLOB REPROC_CMAKE_FILES ${CURRENT_PACKAGES_DIR}/lib/cmake/reproc++/*)
+file(COPY ${REPROC_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/lib/cmake/reproc)
 
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/reproc)
 
 # Debug
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
After the upgrade to version 6.0.0 the C++ target is neither built nor installed.

This PR fixes the build and install part, but leaves the usasge message alone since the cmake scripts are generated using a broken library (cddm) and don't work.

The library (both, `reproc` and `reproc++`) can still be used when linking manually.