### PR TITLE
Added instruction about libraries not available in vcpkg catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The best way to use installed libraries with CMake is via the toolchain file `sc
 
 In Visual Studio, you can create a New Project (or open an existing one). All installed libraries are immediately ready to be `#include`'d and used in your project without additional configuration.
 
-For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics. If your library is not present in vcpkg catalog, you can open an [issue on the GitHub repo](https://github.com/microsoft/vcpkg/issues) where the community and the Visual C++ team can see it and potentially create the port file for this library.
+For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics. If your library is not present in vcpkg catalog, you can open an [issue on the GitHub repo](https://github.com/microsoft/vcpkg/issues) where the dev team and the community can see it and potentially create the port file for this library.
 
 Additional notes on macOS and Linux support can be found in the [official announcement](https://blogs.msdn.microsoft.com/vcblog/2018/04/24/announcing-a-single-c-library-manager-for-linux-macos-and-windows-vcpkg/).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The best way to use installed libraries with CMake is via the toolchain file `sc
 
 In Visual Studio, you can create a New Project (or open an existing one). All installed libraries are immediately ready to be `#include`'d and used in your project without additional configuration.
 
-For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics.
+For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics. If your library is not present in vcpkg catalog, you can open an [issue on the GitHub repo](https://github.com/microsoft/vcpkg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22new+port+request+-+consider+making+a+PR%21%22) where the community and the Visual C++ team can see it and potentially create the port file for this library.
 
 Additional notes on macOS and Linux support can be found in the [official announcement](https://blogs.msdn.microsoft.com/vcblog/2018/04/24/announcing-a-single-c-library-manager-for-linux-macos-and-windows-vcpkg/).
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The best way to use installed libraries with CMake is via the toolchain file `sc
 
 In Visual Studio, you can create a New Project (or open an existing one). All installed libraries are immediately ready to be `#include`'d and used in your project without additional configuration.
 
-For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics. If your library is not present in vcpkg catalog, you can open an [issue on the GitHub repo](https://github.com/microsoft/vcpkg/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22new+port+request+-+consider+making+a+PR%21%22) where the community and the Visual C++ team can see it and potentially create the port file for this library.
+For more information, see our [using a package](docs/examples/installing-and-using-packages.md) example for the specifics. If your library is not present in vcpkg catalog, you can open an [issue on the GitHub repo](https://github.com/microsoft/vcpkg/issues) where the community and the Visual C++ team can see it and potentially create the port file for this library.
 
 Additional notes on macOS and Linux support can be found in the [official announcement](https://blogs.msdn.microsoft.com/vcblog/2018/04/24/announcing-a-single-c-library-manager-for-linux-macos-and-windows-vcpkg/).
 


### PR DESCRIPTION
It took me a while to find the information about what to do with libraries that are not available in the vcpkg catalog. I found this information in the [Visual C++ documentation](https://docs.microsoft.com/en-us/cpp/porting/porting-third-party-libraries?view=vs-2019).

I think having it in the front page would make life easier.