### PR TITLE
Fix MSYS hanging of PowerShell

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,3 +1,3 @@
 Source: icu
-Version: 61.1-6
+Version: 61.1-7
 Description: Mature and widely used Unicode and localization library.

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -209,11 +209,3 @@ vcpkg_copy_pdbs()
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/icu)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/icu/LICENSE ${CURRENT_PACKAGES_DIR}/share/icu/copyright)
-
-# Deal with a stale process created by MSYS
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    vcpkg_execute_required_process(
-        COMMAND TASKKILL /F /IM gpg-agent.exe /fi "memusage gt 2"
-        WORKING_DIRECTORY ${SOURCE_PATH}
-    )
-endif()

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -113,5 +113,13 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     message(STATUS "Acquiring MSYS Packages... OK")
   endif()
 
+  # Deal with a stale process created by MSYS
+  if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+      vcpkg_execute_required_process(
+          COMMAND TASKKILL /F /IM gpg-agent.exe /fi "memusage gt 2"
+          WORKING_DIRECTORY ${SOURCE_PATH}
+      )
+  endif()
+
   set(${PATH_TO_ROOT_OUT} ${PATH_TO_ROOT} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Fixes #6688.

I moved gpg-agent.exe termination code from #6407 into vcpkg_acquire_msys so that none of the ports using MSYS would block build automation tools.