### PR TITLE
[lz4]Fix conflict file xxhash.h

### DIFF
--- a/ports/lz4/CMakeLists.txt
+++ b/ports/lz4/CMakeLists.txt
@@ -36,6 +36,7 @@ install(TARGETS lz4
 )
 
 FILE(GLOB lz4h "${CMAKE_CURRENT_LIST_DIR}/lib/*.h")
+list(REMOVE_ITEM lz4h "${CMAKE_CURRENT_LIST_DIR}/lib/xxhash.h")
 INSTALL(FILES ${lz4h} DESTINATION "${INSTALL_INCLUDE_DIR}")
 
 install(EXPORT lz4Config

--- a/ports/lz4/CONTROL
+++ b/ports/lz4/CONTROL
@@ -1,3 +1,4 @@
 Source: lz4
 Version: 1.9.1-2
 Description: Lossless compression algorithm, providing compression speed at 400 MB/s per core.
+Build-Depends: xxhash

--- a/ports/lz4/CONTROL
+++ b/ports/lz4/CONTROL
@@ -1,3 +1,3 @@
 Source: lz4
-Version: 1.9.1-1
+Version: 1.9.1-2
 Description: Lossless compression algorithm, providing compression speed at 400 MB/s per core.

--- a/ports/lz4/portfile.cmake
+++ b/ports/lz4/portfile.cmake
@@ -34,6 +34,11 @@ vcpkg_fixup_cmake_targets()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
+if (NOT EXISTS "${CURRENT_INSTALLED_DIR}/include/xxhash.h")
+  message(STATUS "xxhash.h not found. installing xxhash.h.")
+  file(INSTALL ${SOURCE_PATH}/lib/xxhash.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+endif()
+
 file(COPY ${SOURCE_PATH}/lib/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/lz4)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/lz4/LICENSE ${CURRENT_PACKAGES_DIR}/share/lz4/copyright)
 

--- a/ports/lz4/portfile.cmake
+++ b/ports/lz4/portfile.cmake
@@ -34,11 +34,6 @@ vcpkg_fixup_cmake_targets()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-if (NOT EXISTS "${CURRENT_INSTALLED_DIR}/include/xxhash.h")
-  message(STATUS "xxhash.h not found. installing xxhash.h.")
-  file(INSTALL ${SOURCE_PATH}/lib/xxhash.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-endif()
-
 file(COPY ${SOURCE_PATH}/lib/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/lz4)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/lz4/LICENSE ${CURRENT_PACKAGES_DIR}/share/lz4/copyright)
 


### PR DESCRIPTION
Lz4 conflicts with xxhash file xxhash.h, I modified to install xxhash.h when xxhash.h is not installed.

Related: #6532.