### PR TITLE
[asio] Add cmake target

### DIFF
--- a/ports/asio/CMakeLists.txt
+++ b/ports/asio/CMakeLists.txt
@@ -16,8 +16,7 @@ install(TARGETS asio
 
 install(EXPORT asio
     DESTINATION "share/asio"
-    FILE asio-config.cmake
-    NAMESPACE asio::
+    FILE asio-targets.cmake
 )
 
 install(DIRECTORY

--- a/ports/asio/CMakeLists.txt
+++ b/ports/asio/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(asio)
+
+add_library(asio INTERFACE)
+
+# Always use "ASIO_STANDALONE" to avoid boost dependency
+file(READ "asio/include/asio/detail/config.hpp" _contents)
+string(REPLACE "defined(ASIO_STANDALONE)" "!defined(VCPKG_DISABLE_ASIO_STANDALONE)" _contents "${_contents}")
+file(WRITE "asio/include/asio/detail/config.hpp" "${_contents}")
+
+# Export target
+install(TARGETS asio
+    EXPORT asio
+    INCLUDES DESTINATION include/
+)
+
+install(EXPORT asio
+    DESTINATION "share/asio"
+    FILE asio-config.cmake
+    NAMESPACE asio::
+)
+
+install(DIRECTORY
+    asio/include/asio
+    DESTINATION include/
+    FILES_MATCHING
+        PATTERN "*.hpp"
+        PATTERN "*.ipp"
+)
+
+install(FILES
+    asio/include/asio.hpp
+    DESTINATION include/
+)

--- a/ports/asio/CONTROL
+++ b/ports/asio/CONTROL
@@ -1,3 +1,3 @@
 Source: asio
-Version: 1.12.2
+Version: 1.12.2-1
 Description: Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.

--- a/ports/asio/asio-config.cmake
+++ b/ports/asio/asio-config.cmake
@@ -1,0 +1,3 @@
+include ("${CMAKE_CURRENT_LIST_DIR}/asio-targets.cmake")
+add_library(asio::asio INTERFACE IMPORTED)
+target_link_libraries(asio::asio INTERFACE asio)

--- a/ports/asio/asio-config.cmake
+++ b/ports/asio/asio-config.cmake
@@ -1,3 +1,6 @@
 include ("${CMAKE_CURRENT_LIST_DIR}/asio-targets.cmake")
 add_library(asio::asio INTERFACE IMPORTED)
 target_link_libraries(asio::asio INTERFACE asio)
+
+get_target_property(_ASIO_INCLUDE_DIR asio INTERFACE_INCLUDE_DIRECTORIES)
+set(ASIO_INCLUDE_DIR "${_ASIO_INCLUDE_DIR}")

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -9,13 +9,16 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# CMake install
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH "share/asio")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/asio/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
-# Copy the asio header files
-file(INSTALL ${SOURCE_PATH}/asio/include DESTINATION ${CURRENT_PACKAGES_DIR} FILES_MATCHING PATTERN "*.hpp" PATTERN "*.ipp")
-
-# Always use "ASIO_STANDALONE" to avoid boost dependency
-file(READ "${CURRENT_PACKAGES_DIR}/include/asio/detail/config.hpp" _contents)
-string(REPLACE "defined(ASIO_STANDALONE)" "!defined(VCPKG_DISABLE_ASIO_STANDALONE)" _contents "${_contents}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/include/asio/detail/config.hpp" "${_contents}")

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -16,7 +16,12 @@ vcpkg_configure_cmake(
     PREFER_NINJA
 )
 vcpkg_install_cmake()
+
 vcpkg_fixup_cmake_targets(CONFIG_PATH "share/asio")
+file(INSTALL
+    ${CMAKE_CURRENT_LIST_DIR}/asio-config.cmake
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/asio/
+)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright


### PR DESCRIPTION
Adds a exported cmake target for asio such that the library can be used with:

```
find_package(asio CONFIG REQUIRED)
target_link_libraries(main PUBLIC asio::asio)
```

EDIT: perfect example of why cmake targets are useful. `fastrtps` was trusting on a include directory variable being defined and valid.
A bit weird was that there were no error messages in the output logs