### PR TITLE
Fix freetype cmake config files

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,4 +1,4 @@
 Source: freetype
-Version: 2.9.1-1
+Version: 2.9.1-2
 Build-Depends: zlib, bzip2, libpng
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 else() #if(VCPKG_BUILD_TYPE STREQUAL "release")
     file(READ ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-config.cmake CONFIG_MODULE)
 endif()
-string(REPLACE "\${_IMPORT_PREFIX}/include/freetype2" "\${_IMPORT_PREFIX}/include/freetype" CONFIG_MODULE "${CONFIG_MODULE}")
+string(REPLACE "\${_IMPORT_PREFIX}/include/freetype2" "\${_IMPORT_PREFIX}/include;\${_IMPORT_PREFIX}/include/freetype" CONFIG_MODULE "${CONFIG_MODULE}")
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-config.cmake "${CONFIG_MODULE}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)


### PR DESCRIPTION
The way of including freetype headers is by using

    #include <ft2build.h>
    #include FT_FREETYPE_H

along with $root/include/freetype which has $root/include/freetype/ft2build.h
and then the rest of the headers under $root/include/freetype/freetype2/*.h.

The portfile.cmake moves the headers one directory up into $root/include
so that there's $root/include/ft2build.h and the rest of the headers
under $root/include/freetype/.

This in turn means that the above way of including header files requires
$root/include to be in the include search path. That's not the case by
default and the generated freetype-config.cmake also doesn't include
that.

Therefore the freetype config approach results in failing builds when
applications wants to use it. This is easy to reproduce using

    find_package(Freetype CONFIG REQUIRED)
    ...
    target_link_libraries(foo PRIVATE freetype)

As a remedy, this patch fixes the freetype-config.cmake file to add
$root/include in the include search path.