### PR TITLE
[libtins]Upgrade version to 4.2 and adds dependent ports to new version.

### DIFF
--- a/ports/libtins/CONTROL
+++ b/ports/libtins/CONTROL
@@ -1,4 +1,4 @@
 Source: libtins
-Version: 4.0-2
+Version: 4.2
 Description: High-level, multiplatform C++ network packet sniffing and crafting library
-Build-Depends: winpcap (windows)
+Build-Depends: winpcap (windows), boost-icl, boost-any

--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mfontanini/libtins
-    REF v4.0
-    SHA512 8a497617ca68f4bad331452778b92c51ce87e42d1ceae493ecd6799cabbe71609214ca962c4a8c83d205f76277f2a82f92d3d17341984caa1592cf237eb3cf3b
+    REF v4.2
+    SHA512 46d07712604c780e418135c996f195046fd85a9e1411962c9bcee3c8d0fc64f494aa50164236ffd1e77ff8a398e9617bbf040b3e01a5771c5621c0faa1ce312f
     HEAD_REF master
 )
 

--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -24,7 +24,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH CMake TARGET_PATH share/libtins)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/libtins/copyright COPYONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libtins RENAME copyright)
 
 # Post-build test for cmake libraries
 vcpkg_test_cmake(PACKAGE_NAME libtins)

--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -19,7 +19,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH CMake TARGET_PATH share/libtins)
+if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "windows" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore") #Windows
+    vcpkg_fixup_cmake_targets(CONFIG_PATH CMake TARGET_PATH share/libtins)
+else() #Linux/Unix/Darwin
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libtins TARGET_PATH share/libtins)
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
Upgrade version to 4.2 and adds dependent ports to new version.
Added dependent ports:
- boost-icl
- boost-any

Related: #6618.