### PR TITLE
[flann]Upgrade version to 1.9.1 and fix build error.

### DIFF
--- a/ports/flann/CONTROL
+++ b/ports/flann/CONTROL
@@ -1,4 +1,4 @@
 Source: flann
-Version: jan2019
+Version: 1.9.1
 Build-Depends: lz4
 Description: Fast Library for Approximate Nearest Neighbors

--- a/ports/flann/fix_build_error.patch
+++ b/ports/flann/fix_build_error.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f4b94d2..cfcc774 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -146,8 +146,7 @@ if (BUILD_CUDA_LIB)
+     endif(CUDA_FOUND)
+ endif(BUILD_CUDA_LIB)
+ 
+-find_package(PkgConfig REQUIRED)
+-pkg_check_modules(LZ4 REQUIRED liblz4)
++find_package(lz4 REQUIRED)
+ 
+ #set the C/C++ include path to the "include" directory
+ include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src/cpp)
+diff --git a/src/cpp/CMakeLists.txt b/src/cpp/CMakeLists.txt
+index e684e10..4196a05 100644
+--- a/src/cpp/CMakeLists.txt
++++ b/src/cpp/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ #include_directories(${CMAKE_SOURCE_DIR}/include algorithms ext util nn .)
+ 
+-add_definitions(-D_FLANN_VERSION=${FLANN_VERSION})
++add_definitions(-D_FLANN_VERSION=${FLANN_VERSION} -std=c++11)
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h)
+ 

--- a/ports/flann/fix_config_cmake.patch
+++ b/ports/flann/fix_config_cmake.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index 6b95a71..778aec4 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -3,3 +3,5 @@
+ include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+ check_required_components("flann")
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(lz4)
+\ No newline at end of file

--- a/ports/flann/fix_targets.patch
+++ b/ports/flann/fix_targets.patch
@@ -1,29 +1,5 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f4b94d2..e55195b 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -146,9 +146,6 @@ if (BUILD_CUDA_LIB)
-     endif(CUDA_FOUND)
- endif(BUILD_CUDA_LIB)
- 
--find_package(PkgConfig REQUIRED)
--pkg_check_modules(LZ4 REQUIRED liblz4)
--
- #set the C/C++ include path to the "include" directory
- include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src/cpp)
- 
-diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
-index 6b95a71..2c95b6e 100644
---- a/cmake/Config.cmake.in
-+++ b/cmake/Config.cmake.in
-@@ -3,3 +3,5 @@
- include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
- check_required_components("flann")
- 
-+include(CMakeFindDependencyMacro)
-+find_dependency(lz4)
 diff --git a/cmake/flann_utils.cmake b/cmake/flann_utils.cmake
-index afe4742..0cf8289 100644
+index afe4742..8aef8e0 100644
 --- a/cmake/flann_utils.cmake
 +++ b/cmake/flann_utils.cmake
 @@ -1,8 +1,7 @@
@@ -37,68 +13,20 @@ index afe4742..0cf8289 100644
  endmacro(GET_OS_INFO)
  
  
-@@ -27,7 +26,7 @@ macro(find_hdf5)
-     set( HDF5_IS_PARALLEL FALSE )
-     foreach( _dir ${HDF5_INCLUDE_DIRS} )
-         if( EXISTS "${_dir}/H5pubconf.h" )
--            file( STRINGS "${_dir}/H5pubconf.h" 
-+            file( STRINGS "${_dir}/H5pubconf.h"
-                 HDF5_HAVE_PARALLEL_DEFINE
-                 REGEX "HAVE_PARALLEL 1" )
-             if( HDF5_HAVE_PARALLEL_DEFINE )
-@@ -106,7 +105,7 @@ endmacro(flann_add_pyunit)
- 
- macro(flann_download_test_data _name _md5)
-     string(REPLACE "/" "_" _dataset_name dataset_${_name})
--    
-+
-     add_custom_target(${_dataset_name}
-         COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bin/download_checkmd5.py http://people.cs.ubc.ca/~mariusm/uploads/FLANN/datasets/${_name} ${TEST_OUTPUT_PATH}/${_name} ${_md5}
-         VERBATIM)
 diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
-index 3f4655a..918b94a 100644
+index 3f4655a..7bd5159 100644
 --- a/examples/CMakeLists.txt
 +++ b/examples/CMakeLists.txt
-@@ -1,9 +1,10 @@
+@@ -1,6 +1,6 @@
  add_custom_target(examples ALL)
  
+-
 +find_package(lz4 REQUIRED)
- 
  if (BUILD_C_BINDINGS)
      add_executable(flann_example_c flann_example.c)
--    target_link_libraries(flann_example_c -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
-+    target_link_libraries(flann_example_c lz4::lz4)
-     target_link_libraries(flann_example_c flann)
-     set_target_properties(flann_example_c PROPERTIES COMPILE_FLAGS -std=c99)
- 
-@@ -15,7 +16,7 @@ if (HDF5_FOUND)
-     include_directories(${HDF5_INCLUDE_DIR})
- 
-     add_executable(flann_example_cpp flann_example.cpp)
--    target_link_libraries(flann_example_cpp -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
-+    target_link_libraries(flann_example_cpp lz4::lz4)
-     target_link_libraries(flann_example_cpp ${HDF5_LIBRARIES} flann_cpp)
-     if (HDF5_IS_PARALLEL)
-         target_link_libraries(flann_example_cpp ${MPI_LIBRARIES})
-@@ -27,7 +28,7 @@ if (HDF5_FOUND)
- 
-     if (USE_MPI AND HDF5_IS_PARALLEL)
-         add_executable(flann_example_mpi flann_example_mpi.cpp)
--        target_link_libraries(flann_example_mpi -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
-+        target_link_libraries(flann_example_mpi lz4::lz4)
-         target_link_libraries(flann_example_mpi flann_cpp ${HDF5_LIBRARIES} ${MPI_LIBRARIES} ${Boost_LIBRARIES})
- 
-         add_dependencies(examples flann_example_mpi)
-@@ -36,7 +37,3 @@ if (HDF5_FOUND)
- else()
-     message("hdf5 library not found, not compiling flann_example.cpp")
- endif()
--
--
--
--
+     target_link_libraries(flann_example_c -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
 diff --git a/src/cpp/CMakeLists.txt b/src/cpp/CMakeLists.txt
-index b30f3da..1535d37 100644
+index b421abb..021d7ca 100644
 --- a/src/cpp/CMakeLists.txt
 +++ b/src/cpp/CMakeLists.txt
 @@ -8,12 +8,13 @@ file(GLOB_RECURSE C_SOURCES flann.cpp)
@@ -121,10 +49,11 @@ index b30f3da..1535d37 100644
  
  if (BUILD_CUDA_LIB)
      SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-DFLANN_USE_CUDA")
-@@ -25,48 +26,11 @@ if (BUILD_CUDA_LIB)
+@@ -24,46 +25,10 @@ if (BUILD_CUDA_LIB)
+         endif()
      else()
  	    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};" )
-     endif()
+-    endif()
 -    cuda_add_library(flann_cuda_s STATIC ${CU_SOURCES})
 -    set_property(TARGET flann_cuda_s PROPERTY COMPILE_DEFINITIONS FLANN_STATIC)
 -endif()
@@ -164,21 +93,19 @@ index b30f3da..1535d37 100644
 -       SOVERSION ${FLANN_SOVERSION}
 -       DEFINE_SYMBOL FLANN_EXPORTS
 -    )
++	endif()
 +    cuda_add_library(flann_cuda STATIC ${CU_SOURCES})
 +    set_property(TARGET flann_cuda PROPERTY COMPILE_DEFINITIONS FLANN_STATIC)
 +    set_property(TARGET flann_cpp PROPERTY COMPILE_DEFINITIONS FLANN_USE_CUDA)
  endif()
  
--
- if (USE_MPI AND HDF5_IS_PARALLEL)
-     add_executable(flann_mpi_server flann/mpi/flann_mpi_server.cpp)
-     target_link_libraries(flann_mpi_server flann_cpp ${HDF5_LIBRARIES} ${MPI_LIBRARIES} ${Boost_LIBRARIES})
-@@ -80,31 +44,9 @@ endif()
+ 
+@@ -80,31 +45,9 @@ endif()
  
  
  if (BUILD_C_BINDINGS)
 -    add_library(flann_s STATIC ${C_SOURCES})
--    target_link_libraries(flann_cpp -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
+-    target_link_libraries(flann_s -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
 -    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
 -        set_target_properties(flann_s PROPERTIES COMPILE_FLAGS -fPIC)
 -    endif()
@@ -190,7 +117,7 @@ index b30f3da..1535d37 100644
 -        target_link_libraries(flann -Wl,-whole-archive flann_s -Wl,-no-whole-archive)
 -    else()
 -        add_library(flann SHARED ${C_SOURCES})
--        target_link_libraries(flann_cpp -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
+-        target_link_libraries(flann -Wl,--push-state,--no-as-needed ${LZ4_LIBRARIES} -Wl,--pop-state)
 -
 -        if(MINGW AND OPENMP_FOUND)
 -          target_link_libraries(flann gomp)
@@ -208,36 +135,30 @@ index b30f3da..1535d37 100644
  endif()
  
  if(WIN32)
-@@ -118,9 +60,9 @@ endif(WIN32)
+@@ -118,7 +61,7 @@ endif(WIN32)
  
  
  install (
 -    TARGETS flann_cpp flann_cpp_s
-+    TARGETS flann_cpp
++	TARGETS flann_cpp
      EXPORT ${targets_export_name}
--    INCLUDES DESTINATION include
-+    INCLUDES DESTINATION ${FLANN_INCLUDE_INSTALL_DIR}
+     INCLUDES DESTINATION include
      RUNTIME DESTINATION bin
-     LIBRARY DESTINATION ${FLANN_LIB_INSTALL_DIR}
-     ARCHIVE DESTINATION ${FLANN_LIB_INSTALL_DIR}
-@@ -128,9 +70,9 @@ install (
+@@ -128,7 +71,7 @@ install (
  
  if (BUILD_CUDA_LIB)
      install (
 -        TARGETS flann_cuda flann_cuda_s
-+        TARGETS flann_cuda
++		TARGETS flann_cuda
          EXPORT ${targets_export_name}
--        INCLUDES DESTINATION include
-+        INCLUDES DESTINATION ${FLANN_INCLUDE_INSTALL_DIR}
+         INCLUDES DESTINATION include
          RUNTIME DESTINATION bin
-         LIBRARY DESTINATION ${FLANN_LIB_INSTALL_DIR}
-         ARCHIVE DESTINATION ${FLANN_LIB_INSTALL_DIR}
-@@ -139,7 +81,7 @@ endif()
+@@ -139,7 +82,7 @@ endif()
  
  if (BUILD_C_BINDINGS)
      install (
 -        TARGETS flann flann_s
-+        TARGETS flann
++		TARGETS flann
          EXPORT ${targets_export_name}
          INCLUDES DESTINATION include
          RUNTIME DESTINATION bin

--- a/ports/flann/portfile.cmake
+++ b/ports/flann/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         fix_targets.patch
         fix_build_error.patch
+        fix_config_cmake.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/flann/portfile.cmake
+++ b/ports/flann/portfile.cmake
@@ -7,11 +7,12 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mariusmuja/flann
-    REF  aa40936816f4feaa714d3a09f92a495da017d95c
-    SHA512 f6f2e75f4ce4bc4bc4cc1feab27fe683b8a5f9f5dcea35de4df5136a683b5dff5e68776008821a16ccf1a52a9807cb053c0062deba4fe121948248acd52864ef
+    REF 1d04523268c388dabf1c0865d69e1b638c8c7d9d
+    SHA512 61e322222c2daa0b9677095e5ca231cba7c305ce754ad8e659eee350111c1e04351181c3af04e45ab6e5c9edea49c7b9ec6499bb0dbc080b87af36eb11c6ef7c
     HEAD_REF master
     PATCHES
         fix_targets.patch
+        fix_build_error.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Upgrade version to 1.9.1 and fix build error.

Since the flann dependent port **lz4** has a file conflict problem(xxhash.h), this PR **needs** to wait for the #6735 merge to merge.

Related: #6618.