### PR TITLE
[zxing-cpp] Fixed renaming zxing -> zxing-cpp

### DIFF
--- a/ports/zxing-cpp/CONTROL
+++ b/ports/zxing-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: zxing-cpp
-Version: 3.3.3-3
+Version: 3.3.3-4
 Build-Depends: opencv[core]
 Description: Barcode detection and decoding library.

--- a/ports/zxing-cpp/portfile.cmake
+++ b/ports/zxing-cpp/portfile.cmake
@@ -22,13 +22,13 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/zxing/cmake" TARGET_PATH share/zxing)
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/zxing)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/zxing-cpp)
 if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/zxing.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/zxing)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/zxing.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/zxing-cpp)
 else()
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/zxing DESTINATION ${CURRENT_PACKAGES_DIR}/tools/zxing)
+    file(COPY ${CURRENT_PACKAGES_DIR}/bin/zxing DESTINATION ${CURRENT_PACKAGES_DIR}/tools/zxing-cpp)
 endif()
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/zxing)
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/zxing-cpp)
 
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)


### PR DESCRIPTION
Referenced file
  vcpkg/installed/x64-windows/tools/zxing-cpp/zxing.exe
did not exist, because it was created at
  vcpkg/installed/x64-windows/tools/zxing/zxing.exe

Closes #6616