### PR TITLE
[FFmpeg] Add support for VP8/VP9 codecs

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.1-5
+Version: 4.1-6
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.
 
@@ -26,6 +26,10 @@ Description: lzma support in ffmpeg
 Feature: bzip2
 Build-Depends: bzip2
 Description: bzip2 support in ffmpeg
+
+Feature: vpx
+Build-Depends: libvpx
+Description: WebM VP8/VP9 support in ffmpeg
 
 Feature: x264
 Build-Depends: x264, ffmpeg[gpl]

--- a/ports/ffmpeg/fix_libvpx_windows_linking.patch
+++ b/ports/ffmpeg/fix_libvpx_windows_linking.patch
@@ -1,0 +1,55 @@
+diff --git "a/configure" "b/configure"
+index c8be177..2fef830 100644
+--- "a/configure"
++++ "b/configure"
+@@ -5098,6 +5098,8 @@ case "$arch" in
+     ;;
+ esac
+ 
++libvpx_name=vpx
++
+ # OS specific
+ case $target_os in
+     aix)
+@@ -5269,6 +5271,15 @@ case $target_os in
+         enabled x86_64 && objformat="win64" || objformat="win32"
+         ranlib=:
+         enable dos_paths
++        if [ -z "${extra_cflags##*-MDd*}" ]; then
++            libvpx_name=vpxmdd
++        elif [ -z "${extra_cflags##*-MD*}" ]; then
++            libvpx_name=vpxmd
++        elif [ -z "${extra_cflags##*-MTd*}" ]; then
++            libvpx_name=vpxmtd
++        elif [ -z "${extra_cflags##*-MT*}" ]; then
++            libvpx_name=vpxmt
++        fi
+         ;;
+     cygwin*)
+         target_os=cygwin
+@@ -6153,21 +6164,21 @@ enabled libvorbis         && require_pkg_config libvorbis vorbis vorbis/codec.h
+ enabled libvpx            && {
+     enabled libvpx_vp8_decoder && {
+         check_pkg_config libvpx_vp8_decoder "vpx >= 1.4.0" "vpx/vpx_decoder.h vpx/vp8dx.h" vpx_codec_vp8_dx ||
+-            check_lib libvpx_vp8_decoder "vpx/vpx_decoder.h vpx/vp8dx.h" "vpx_codec_dec_init_ver VPX_IMG_FMT_HIGHBITDEPTH" -lvpx ||
++            check_lib libvpx_vp8_decoder "vpx/vpx_decoder.h vpx/vp8dx.h" "vpx_codec_dec_init_ver VPX_IMG_FMT_HIGHBITDEPTH" -l$libvpx_name ||
+                 die "ERROR: libvpx decoder version must be >=1.4.0";
+     }
+     enabled libvpx_vp8_encoder && {
+         check_pkg_config libvpx_vp8_encoder "vpx >= 1.4.0" "vpx/vpx_encoder.h vpx/vp8cx.h" vpx_codec_vp8_cx ||
+-            check_lib libvpx_vp8_encoder "vpx/vpx_encoder.h vpx/vp8cx.h" "vpx_codec_enc_init_ver VPX_IMG_FMT_HIGHBITDEPTH" -lvpx ||
++            check_lib libvpx_vp8_encoder "vpx/vpx_encoder.h vpx/vp8cx.h" "vpx_codec_enc_init_ver VPX_IMG_FMT_HIGHBITDEPTH" -l$libvpx_name ||
+                 die "ERROR: libvpx encoder version must be >=1.4.0";
+     }
+     enabled libvpx_vp9_decoder && {
+         check_pkg_config libvpx_vp9_decoder "vpx >= 1.4.0" "vpx/vpx_decoder.h vpx/vp8dx.h" vpx_codec_vp9_dx ||
+-            check_lib libvpx_vp9_decoder "vpx/vpx_decoder.h vpx/vp8dx.h" "vpx_codec_vp9_dx VPX_IMG_FMT_HIGHBITDEPTH" "-lvpx $libm_extralibs"
++            check_lib libvpx_vp9_decoder "vpx/vpx_decoder.h vpx/vp8dx.h" "vpx_codec_vp9_dx VPX_IMG_FMT_HIGHBITDEPTH" "-l$libvpx_name $libm_extralibs"
+     }
+     enabled libvpx_vp9_encoder && {
+         check_pkg_config libvpx_vp9_encoder "vpx >= 1.4.0" "vpx/vpx_encoder.h vpx/vp8cx.h" vpx_codec_vp9_cx ||
+-            check_lib libvpx_vp9_encoder "vpx/vpx_encoder.h vpx/vp8cx.h" "vpx_codec_vp9_cx VPX_IMG_FMT_HIGHBITDEPTH" "-lvpx $libm_extralibs"
++            check_lib libvpx_vp9_encoder "vpx/vpx_encoder.h vpx/vp8cx.h" "vpx_codec_vp9_cx VPX_IMG_FMT_HIGHBITDEPTH" "-l$libvpx_name $libm_extralibs"
+     }
+     if disabled_all libvpx_vp8_decoder libvpx_vp9_decoder libvpx_vp8_encoder libvpx_vp9_encoder; then
+         die "libvpx enabled but no supported decoders found"

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive_ex(
         configure_opencv.patch
         fix_windowsinclude-in-ffmpegexe-1.patch
         fix_windowsinclude-in-ffmpegexe-2.patch
+        fix_libvpx_windows_linking.patch
 )
 
 if (${SOURCE_PATH} MATCHES " ")
@@ -92,6 +93,12 @@ if("ffprobe" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-ffprobe")
 else()
     set(OPTIONS "${OPTIONS} --disable-ffprobe")
+endif()
+
+if("vpx" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-libvpx")
+else()
+    set(OPTIONS "${OPTIONS} --disable-libvpx")
 endif()
 
 if("x264" IN_LIST FEATURES)


### PR DESCRIPTION
Added ```vpx``` feature to ```ffmpeg``` to support WebM VP8/VP9  codecs.

Resolves #6449.