### PR TITLE
[vcpkg] Bootstrap should use Get-CimInstance instead of Get-WmiObject.

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -339,7 +339,7 @@ if ($disableMetrics)
 
 $platform = "x86"
 $vcpkgReleaseDir = "$vcpkgSourcesPath\msbuild.x86.release"
-$architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
+$architecture=(Get-CimInstance win32_operatingsystem | Select-Object osarchitecture).osarchitecture
 if ($win64)
 {
     if (-not $architecture -like "*64*")

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -339,7 +339,14 @@ if ($disableMetrics)
 
 $platform = "x86"
 $vcpkgReleaseDir = "$vcpkgSourcesPath\msbuild.x86.release"
-$architecture=(Get-CimInstance win32_operatingsystem | Select-Object osarchitecture).osarchitecture
+if($PSVersionTable.PSVersion.Major -le 2)
+{ 
+    $architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
+}
+else
+{
+    $architecture=(Get-CimInstance win32_operatingsystem | Select-Object osarchitecture).osarchitecture
+}
 if ($win64)
 {
     if (-not $architecture -like "*64*")


### PR DESCRIPTION
This lets it work with both Powershell 5.x and Powershell Core 6.0.

It's not clear if Powershell 7.0 will remain compatible for other reasons.