### PR TITLE
[cairo] Fix linker errors on Linux and MacOS

### DIFF
--- a/ports/cairo/CMakeLists.txt
+++ b/ports/cairo/CMakeLists.txt
@@ -167,9 +167,6 @@ find_package(Freetype REQUIRED)
 find_package(unofficial-glib CONFIG REQUIRED)
 find_package(unofficial-fontconfig CONFIG REQUIRED)
 find_package(unofficial-pixman CONFIG REQUIRED)
-if(APPLE)
-  find_package(Threads REQUIRED)
-endif()
 
 # Cairo needs to be told which features of FreeType are availible
 add_definitions(
@@ -193,7 +190,11 @@ endif()
 
 add_library(cairo ${SOURCES})
 
-target_link_libraries(cairo PRIVATE gdi32 msimg32 user32 ZLIB::ZLIB PNG::PNG Freetype::Freetype unofficial::pixman::pixman-1 unofficial::fontconfig::fontconfig)
+target_link_libraries(cairo PRIVATE ZLIB::ZLIB PNG::PNG Freetype::Freetype unofficial::pixman::pixman-1 unofficial::fontconfig::fontconfig)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_link_libraries(cairo PRIVATE gdi32 msimg32 user32)
+endif()
 
 # GObject support module
 

--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,4 +1,4 @@
 Source: cairo
-Version: 1.16.0
+Version: 1.16.0-1
 Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
 Build-Depends: zlib, libpng, pixman, glib, freetype, fontconfig

--- a/ports/cairo/cairo-features.h
+++ b/ports/cairo/cairo-features.h
@@ -5,8 +5,10 @@
 */
 
 /* Always for Win32 */
+#ifdef _WIN32
 #define CAIRO_HAS_WIN32_SURFACE 1
 #define CAIRO_HAS_WIN32_FONT 1
+#endif
 
 /* Require libpng */
 #define CAIRO_HAS_PNG_FUNCTIONS 1


### PR DESCRIPTION
On Linux and MacOS, the cairo port was attempting to link to some Windows-only libraries.