### PR TITLE
[opencv] Fixed OpenCV versioning using wrong commit

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv
-Version: 3.4.3-8
+Version: 3.4.3-9
 Build-Depends: zlib
 Description: computer vision library
 Default-Features: opengl, jpeg, png, tiff, eigen, flann

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -1,6 +1,7 @@
 include(vcpkg_common_functions)
 
 set(OPENCV_PORT_VERSION "3.4.3")
+set(OPENCV_VCSVERSION b38c50b3)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -294,6 +295,7 @@ vcpkg_configure_cmake(
         -DINSTALL_FORCE_UNIX_PATHS=ON
         -DINSTALL_LICENSE=OFF
         # OPENCV
+        -DOPENCV_VCSVERSION=vcpkg-${OPENCV_VCSVERSION}
         -DOPENCV_CONFIG_INSTALL_PATH=share/opencv
         "-DOPENCV_DOWNLOAD_PATH=${DOWNLOADS}/opencv-cache"
         ${BUILD_WITH_CONTRIB_FLAG}

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -1,7 +1,6 @@
 include(vcpkg_common_functions)
 
 set(OPENCV_PORT_VERSION "3.4.3")
-set(OPENCV_VCSVERSION b38c50b3)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -285,6 +284,7 @@ vcpkg_configure_cmake(
         -DPROTOBUF_UPDATE_FILES=${PROTOBUF_UPDATE_FILES}
         -DUPDATE_PROTO_FILES=${UPDATE_PROTO_FILES}
         # CMAKE
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_JNI=ON
         "-DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}"
         # ENABLE
@@ -295,7 +295,6 @@ vcpkg_configure_cmake(
         -DINSTALL_FORCE_UNIX_PATHS=ON
         -DINSTALL_LICENSE=OFF
         # OPENCV
-        -DOPENCV_VCSVERSION=vcpkg-${OPENCV_VCSVERSION}
         -DOPENCV_CONFIG_INSTALL_PATH=share/opencv
         "-DOPENCV_DOWNLOAD_PATH=${DOWNLOADS}/opencv-cache"
         ${BUILD_WITH_CONTRIB_FLAG}


### PR DESCRIPTION
As there is no OpenCV repository, the hash is wrongly determined

Closes #6708

Open point: https://github.com/microsoft/vcpkg/issues/6708#issuecomment-499666717
> Unfortunately, there is no similar way to workaround `opencv_contrib` git hashes (they are not collected from the git-"rooted" path in general, so proposed above workaround doesn't work at all even without vcpkg):
> 
>     * turn off information about them completely via `BUILD_INFO_SKIP_EXTRA_MODULES=ON`
> 
>     * or disable "find_package(Git)" via CMake's: `CMAKE_DISABLE_FIND_PACKAGE_Git=ON` (should work if it is new "CMake" process)