### PR TITLE
[mongo-cxx-driver] Add options for C++17 polyfill selection

### DIFF
--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -2,3 +2,15 @@ Source: mongo-cxx-driver
 Version: 3.2.0-2
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Description: MongoDB C++ Driver.
+
+Feature: mnmlstc
+Description: Use MNMLSTC/core C++17 polyfill.
+
+Feature: system-mnmlstc
+Description: Use an available version of MNMLSTC on your system as C++17 polyfill.
+
+Feature: boost
+Description: Use Boost C++17 polyfill. The only option under MSVC.
+
+Feature: std-experimental
+Description: Use optional and string_view from std::experimental.

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -17,6 +17,22 @@ vcpkg_from_github(
         disable-c2338-mongo-cxx-driver.patch
 )
 
+if ("mnmlstc" IN_LIST FEATURES)
+    set(BSONCXX_POLY MNMLSTC)
+elseif ("system-mnmlstc" IN_LIST FEATURES)
+    set(BSONCXX_POLY SYSTEM_MNMLSTC)
+elseif ("boost" IN_LIST FEATURES)
+    set(BSONCXX_POLY BOOST)
+elseif("std-experimental" IN_LIST FEATURES)
+    set(BSONCXX_POLY STD_EXPERIMENTAL)
+else()
+  if (WIN32)
+    set(BSONCXX_POLY BOOST)
+  else()
+    set(BSONCXX_POLY MNMLSTC)
+  endif()
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -25,6 +41,7 @@ vcpkg_configure_cmake(
         -DLIBMONGOC_DIR=${CURRENT_INSTALLED_DIR}
         -DMONGOCXX_HEADER_INSTALL_DIR=include
         -DBSONCXX_HEADER_INSTALL_DIR=include
+        -DBSONCXX_POLY_USE_${BSONCXX_POLY}=1
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Allows explicit selecting C++17 polyfill required for `bsoncxx` (#6811).
See [mongo-cxx-driver docs](http://mongocxx.org/mongocxx-v3/installation/) (Step 2: Choose a C++17 polyfill).