### PR TITLE
[cryptopp] fix build by disabling assembly on osx

### DIFF
--- a/ports/cryptopp/CONTROL
+++ b/ports/cryptopp/CONTROL
@@ -1,3 +1,3 @@
 Source: cryptopp
-Version: 8.1.0
+Version: 8.1.0-1
 Description: Crypto++ is a free C++ class library of cryptographic schemes.

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -26,6 +26,14 @@ vcpkg_from_github(
 file(COPY ${CMAKE_SOURCE_PATH}/cryptopp-config.cmake DESTINATION ${SOURCE_PATH})
 file(COPY ${CMAKE_SOURCE_PATH}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+# disable assembly on OSX to fix broken build
+if(APPLE)
+    set(CRYPTOPP_DISABLE_ASM "ON")
+else()
+    set(CRYPTOPP_DISABLE_ASM "OFF")
+endif()
+
+
 # Dynamic linking should be avoided for Crypto++ to reduce the attack surface,
 # so generate a static lib for both dynamic and static vcpkg targets.
 # See also:
@@ -40,6 +48,7 @@ vcpkg_configure_cmake(
         -DBUILD_STATIC=ON
         -DBUILD_TESTING=OFF
         -DBUILD_DOCUMENTATION=OFF
+        -DDISABLE_ASM=${CRYPTOPP_DISABLE_ASM}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This port fails to build on osx (see #5953). The cmake files seem designed to test for the needed compiler support but it isn't working for some reason. This patch just disables all assembly on mac to get the port to build. Not tested on windows because I don't have access, but linux is still ok.