### PR TITLE
[xmsh]Upgrade version to 0.5.2.

### DIFF
--- a/ports/xmsh/CONTROL
+++ b/ports/xmsh/CONTROL
@@ -1,4 +1,4 @@
 Source: xmsh
-Version: 0.4.1
+Version: 0.5.2
 Description: Reference Implementation of XMSH Library
 Build-Depends: tl-expected

--- a/ports/xmsh/portfile.cmake
+++ b/ports/xmsh/portfile.cmake
@@ -4,11 +4,15 @@ vcpkg_find_acquire_program(PYTHON3)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  REPO libxmsh/xmsh
-  REF v0.4.1
-  SHA512 7bd9fe9e565b33722fec37a7e3d9bd8b7b132692add5d26e31954367fb284b49a26a21532ddcb0e425af7f8208e755f21f2d8de81b33ed2a1149724f4ccd2c38
+  REPO nagzira/xmsh
+  REF v0.5.2
+  SHA512 f4b722e74679223f5329802ff5dd6a0ade9781246227525303a5382b744e3763aca794a49146867ef5053f06ec956a69dac06469c315bb1388fea88b3ef5c0db
   HEAD_REF master
 )
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYPATH ${PYTHON3} PATH)
+set(ENV{PATH} "$ENV{PATH};${PYPATH}")
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}

--- a/ports/xmsh/portfile.cmake
+++ b/ports/xmsh/portfile.cmake
@@ -2,9 +2,13 @@ include(vcpkg_common_functions)
 
 vcpkg_find_acquire_program(PYTHON3)
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.1")
+  message(FATAL_ERROR "Building with a gcc version less than 7.1 is not supported.")
+endif()
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  REPO nagzira/xmsh
+  REPO libxmsh/xmsh
   REF v0.5.2
   SHA512 f4b722e74679223f5329802ff5dd6a0ade9781246227525303a5382b744e3763aca794a49146867ef5053f06ec956a69dac06469c315bb1388fea88b3ef5c0db
   HEAD_REF master


### PR DESCRIPTION
Upgrade version to 0.5.2.
**NOTE**: Xmsh needs to use **gcc** with version **greater** than **7.1** under linux.

Related: #6618.