### PR TITLE
[libqcow] Add new port

### DIFF
--- a/ports/libqcow/CMakeLists.txt
+++ b/ports/libqcow/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(libqcow C)
+
+find_package(OpenSSL)
+find_package(ZLIB REQUIRED)
+
+if(MSVC)
+    add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
+    add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
+add_compile_definitions(HAVE_LOCAL_LIBCAES)
+add_compile_definitions(HAVE_LOCAL_LIBCERROR)
+add_compile_definitions(HAVE_LOCAL_LIBCTHREADS)
+add_compile_definitions(HAVE_LOCAL_LIBCDATA)
+add_compile_definitions(HAVE_LOCAL_LIBCLOCALE)
+add_compile_definitions(HAVE_LOCAL_LIBCNOTIFY)
+add_compile_definitions(HAVE_LOCAL_LIBCSPLIT)
+add_compile_definitions(HAVE_LOCAL_LIBCFILE)
+add_compile_definitions(HAVE_LOCAL_LIBCPATH)
+add_compile_definitions(HAVE_LOCAL_LIBUNA)
+add_compile_definitions(HAVE_LOCAL_LIBBFIO)
+add_compile_definitions(HAVE_LOCAL_LIBFCACHE)
+add_compile_definitions(HAVE_LOCAL_LIBFDATA)
+add_compile_definitions(ZLIB_DLL)
+
+if(UNIX)
+    configure_file(common/config.h.in common/config.h)
+    add_compile_definitions(HAVE_CONFIG_H)
+    add_compile_definitions(LOCALEDIR="/usr/share/locale")
+endif()
+
+if(MSVC)
+    add_compile_definitions(LIBQCOW_DLL_EXPORT)
+    set(LIB_RC libqcow/libqcow.rc)
+endif()
+
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# Add CMake find_package() integration
+set(PROJECT_TARGET_NAME "${PROJECT_NAME}")
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_TARGET_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_TARGET_NAME}Targets")
+set(NAMESPACE "libqcow::")
+
+# Source files
+file(GLOB LIB_SRC lib*/*.c)
+
+# Headers
+file(GLOB LIB_INST_HEADERS include/libqcow/*.h)
+
+add_library(${PROJECT_NAME} ${LIB_SRC} ${LIB_RC})
+
+target_include_directories(${PROJECT_NAME} PRIVATE ./include ./common)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libbfio ./libcaes ./libcdata ./libcerror ./libcfile ./libclocale)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libcnotify ./libcpath ./libcsplit ./libcthreads)
+target_include_directories(${PROJECT_NAME} PRIVATE ./libfcache ./libfdata ./libuna)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB OpenSSL::Crypto)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${TARGETS_EXPORT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        INCLUDES DESTINATION include)
+
+install(FILES ${LIB_INST_HEADERS} DESTINATION include/libqcow)
+install(FILES include/libqcow.h DESTINATION include)
+
+
+# Generate and install libqcowConfig.cmake
+configure_package_config_file("Config.cmake.in" "${PROJECT_CONFIG}" INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}")
+install(FILES "${PROJECT_CONFIG}" DESTINATION "${CONFIG_INSTALL_DIR}")
+
+# Generate and install libqcowTargets*.cmake
+install(EXPORT ${TARGETS_EXPORT_NAME}
+        NAMESPACE ${NAMESPACE}
+        DESTINATION "${CONFIG_INSTALL_DIR}")

--- a/ports/libqcow/CONTROL
+++ b/ports/libqcow/CONTROL
@@ -1,0 +1,5 @@
+Source: libqcow
+Version: 2018-12-27
+Homepage: https://github.com/libyal/libqcow
+Build-Depends: openssl,zlib
+Description: Library and tools to access the QEMU Copy-On-Write (QCOW) image format.

--- a/ports/libqcow/Config.cmake.in
+++ b/ports/libqcow/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/ports/libqcow/portfile.cmake
+++ b/ports/libqcow/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+set(LIB_VERSION 20191221)
+set(LIB_FILENAME libqcow-alpha-${LIB_VERSION}.tar.gz)
+
+# Release distribution file contains configured sources, while the source code in the repository does not.
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/libyal/libqcow/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
+    FILENAME "${LIB_FILENAME}"
+    SHA512 de0c5cfad84bbccc9a4144b108c7e022a98d130e829385e69ff00a8750709c9de814410eebfa1c0fc89051cf8f596d87b9bbc8228d99efd8be1c3efdc2b52730
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${LIB_VERSION}
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libqcow" TARGET_PATH "share/libqcow")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# License and man
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
This port is very similar to the [*libpff* port](https://github.com/lazyhamster/vcpkg/blob/master/ports/libpff/) added in https://github.com/microsoft/vcpkg/pull/6458, which makes sense since both libraries are part of the same *libyal* collection (all written by the same author).
