### PR TITLE
[glew] Disable the link option /nodefaultlib and /noentry

### DIFF
--- a/ports/glew/CONTROL
+++ b/ports/glew/CONTROL
@@ -1,3 +1,3 @@
 Source: glew
-Version: 2.1.0-3
+Version: 2.1.0-4
 Description: The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.

--- a/ports/glew/fix-LNK2019.patch
+++ b/ports/glew/fix-LNK2019.patch
@@ -1,0 +1,13 @@
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index 5081e0f..f76725a 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -108,7 +108,7 @@ if (MSVC)
+   target_compile_options (glew PRIVATE -GS-)
+   target_compile_options (glew_s PRIVATE -GS-)
+   # remove stdlib dependency
+-  target_link_libraries (glew LINK_PRIVATE -nodefaultlib -noentry)
++  # target_link_libraries (glew LINK_PRIVATE -nodefaultlib -noentry)
+   string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+ elseif (WIN32 AND ((CMAKE_C_COMPILER_ID MATCHES "GNU") OR (CMAKE_C_COMPILER_ID MATCHES "Clang")))
+   # remove stdlib dependency on windows with GCC and Clang (for similar reasons

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -11,6 +11,11 @@ vcpkg_download_distfile(ARCHIVE_FILE
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE} ${CURRENT_BUILDTREES_DIR}/src/glew)
 
+vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+	PATCHES fix-LNK2019.patch
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/build/cmake
     DISABLE_PARALLEL_CONFIGURE

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glew/glew-2.1.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/glew-58abdfb190)
 
 # Don't change to vcpkg_from_github! The github-auto-generated archives are missing some files.
 # More info: https://github.com/nigels-com/glew/issues/31 and https://github.com/nigels-com/glew/issues/13
@@ -9,11 +9,11 @@ vcpkg_download_distfile(ARCHIVE_FILE
     FILENAME "glew-2.1.0.tgz"
     SHA512 9a9b4d81482ccaac4b476c34ed537585ae754a82ebb51c3efa16d953c25cc3931be46ed2e49e79c730cd8afc6a1b78c97d52cd714044a339c3bc29734cd4d2ab
 )
-vcpkg_extract_source_archive(${ARCHIVE_FILE} ${CURRENT_BUILDTREES_DIR}/src/glew)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-	PATCHES fix-LNK2019.patch
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH ${SOURCE_PATH}
+    ARCHIVE ${ARCHIVE_FILE}
+    REF glew
+    PATCHES fix-LNK2019.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
1. In an internal VS version, glew installed failed with error LNK2019: unresolved external symbol memset referenced in function glewContextInit. It's due to glew didn't link with the CRT.
2. Disable the link option /nodefaultlib and /noentry to let glew link with the CRT.