### PR TITLE
[libbson mongo-c-driver mongo-cxx-driver] upgrades to new revision

### DIFF
--- a/ports/libbson/CONTROL
+++ b/ports/libbson/CONTROL
@@ -1,3 +1,3 @@
 Source: libbson
-Version: 1.13.0
+Version: 1.14.0
 Description: libbson is a library providing useful routines related to building, parsing, and iterating BSON documents.

--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -1,10 +1,11 @@
 include(vcpkg_common_functions)
+set(BUILD_VERSION 1.14.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
-    REF 1.13.0
-    SHA512 d2f5b04b3d2dbdeba4547ec1fe8a0da7bad5214de92fff480ef0ff7d97ea45d5e6347c11c249867d4905b1dd81b76c7cfbb9094a58df586dae881955ee246907
+    REF ${BUILD_VERSION}
+    SHA512 bf2bb835543dd2a445aac6cafa7bbbf90921ec41014534779924a5eb7cbd9fd532acd8146ce81dfcf1bcac33a78d8fce22b962ed7f776449e4357eccab8d6110
     HEAD_REF master
     PATCHES fix-uwp.patch
 )
@@ -24,6 +25,7 @@ vcpkg_configure_cmake(
         -DENABLE_TESTS=OFF
         -DENABLE_EXAMPLES=OFF
         -DENABLE_STATIC=${ENABLE_STATIC}
+        -DBUILD_VERSION=${BUILD_VERSION}
 )
 
 vcpkg_install_cmake()

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-c-driver
-Version: 1.13.0
+Version: 1.14.0
 Build-Depends: libbson, openssl (uwp)
 Description: Client library written in C for MongoDB.

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: mongo-c-driver
-Version: 1.14.0
-Build-Depends: libbson, openssl (uwp)
+Version: 1.14.0-1
+Build-Depends: libbson, openssl (!windows), zlib
 Description: Client library written in C for MongoDB.

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
         -DENABLE_TESTS=OFF
         -DENABLE_EXAMPLES=OFF
         -DENABLE_SSL=${ENABLE_SSL}
+        -DENABLE_ZLIB=SYSTEM
         -DENABLE_STATIC=${ENABLE_STATIC}
         -DBUILD_VERSION=${BUILD_VERSION}
 )

--- a/ports/mongo-c-driver/portfile.cmake
+++ b/ports/mongo-c-driver/portfile.cmake
@@ -1,9 +1,11 @@
 include(vcpkg_common_functions)
+set(BUILD_VERSION 1.14.0)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-c-driver
-    REF 1.13.0
-    SHA512 d2f5b04b3d2dbdeba4547ec1fe8a0da7bad5214de92fff480ef0ff7d97ea45d5e6347c11c249867d4905b1dd81b76c7cfbb9094a58df586dae881955ee246907
+    REF ${BUILD_VERSION}
+    SHA512 bf2bb835543dd2a445aac6cafa7bbbf90921ec41014534779924a5eb7cbd9fd532acd8146ce81dfcf1bcac33a78d8fce22b962ed7f776449e4357eccab8d6110
     HEAD_REF master
     PATCHES fix-uwp.patch
 )
@@ -31,6 +33,7 @@ vcpkg_configure_cmake(
         -DENABLE_EXAMPLES=OFF
         -DENABLE_SSL=${ENABLE_SSL}
         -DENABLE_STATIC=${ENABLE_STATIC}
+        -DBUILD_VERSION=${BUILD_VERSION}
 )
 
 vcpkg_install_cmake()

--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,5 +1,5 @@
 Source: mongo-cxx-driver
-Version: 3.4.0
+Version: 3.4.0-1
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Description: MongoDB C++ Driver.
 

--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,5 +1,5 @@
 Source: mongo-cxx-driver
-Version: 3.2.0-2
+Version: 3.4.0
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Description: MongoDB C++ Driver.
 

--- a/ports/mongo-cxx-driver/disable_test_and_example.patch
+++ b/ports/mongo-cxx-driver/disable_test_and_example.patch
@@ -1,138 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c6f56e4..b250a3d 100644
+index c6f56e4..5601f90 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,70 +87,70 @@ if(NOT CMAKE_BUILD_TYPE)
-     set(CMAKE_BUILD_TYPE "Release")
- endif()
+@@ -89,6 +89,8 @@ endif()
  
--set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
--
--add_custom_target(hugo_dir
--    COMMAND ${CMAKE_COMMAND} -E make_directory hugo
--)
--
--add_custom_target(hugo
--    DEPENDS hugo_dir
--    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
--    COMMAND hugo
--    VERBATIM
--)
--
--add_custom_target(hugo-deploy
--    DEPENDS hugo
--    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--    COMMAND etc/deploy-to-ghpages.pl --hugo git@github.com:mongodb/mongo-cxx-driver
--    VERBATIM
--)
--
--add_custom_target(docs_dir_current
--    COMMAND ${CMAKE_COMMAND} -E make_directory docs/api/current
--)
--
--add_custom_target(doxygen-current
--    DEPENDS docs_dir_current
--    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--    COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
--    VERBATIM
--)
--
--add_custom_target(doxygen-all
--    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--    COMMAND etc/generate-all-apidocs.pl
--    VERBATIM
--)
--
--add_custom_target(doxygen-deploy
--    DEPENDS doxygen-all
--    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--    COMMAND etc/deploy-to-ghpages.pl --doxygen git@github.com:mongodb/mongo-cxx-driver
--    VERBATIM
--)
--
--add_custom_target(format
--    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
--    VERBATIM
--)
--
--add_custom_target(format-lint
--    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
--    VERBATIM
--)
--
--add_custom_target(docs
--    DEPENDS hugo doxygen-current
--)
--
--set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
-+# set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-+
-+# add_custom_target(hugo_dir
-+    # COMMAND ${CMAKE_COMMAND} -E make_directory hugo
-+# )
-+
-+# add_custom_target(hugo
-+    # DEPENDS hugo_dir
-+    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
-+    # COMMAND hugo
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(hugo-deploy
-+    # DEPENDS hugo
-+    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+    # COMMAND etc/deploy-to-ghpages.pl --hugo git@github.com:mongodb/mongo-cxx-driver
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(docs_dir_current
-+    # COMMAND ${CMAKE_COMMAND} -E make_directory docs/api/current
-+# )
-+
-+# add_custom_target(doxygen-current
-+    # DEPENDS docs_dir_current
-+    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+    # COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(doxygen-all
-+    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+    # COMMAND etc/generate-all-apidocs.pl
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(doxygen-deploy
-+    # DEPENDS doxygen-all
-+    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+    # COMMAND etc/deploy-to-ghpages.pl --doxygen git@github.com:mongodb/mongo-cxx-driver
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(format
-+    # python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(format-lint
-+    # python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
-+    # VERBATIM
-+# )
-+
-+# add_custom_target(docs
-+    # DEPENDS hugo doxygen-current
-+# )
-+
-+# set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
  
++if(0)
++
+ add_custom_target(hugo_dir
+     COMMAND ${CMAKE_COMMAND} -E make_directory hugo
+ )
+@@ -147,6 +149,8 @@ add_custom_target(docs
+ 
+ set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
+ 
++endif()
++
  enable_testing()
  
  add_subdirectory(src)
- 
--add_subdirectory(examples EXCLUDE_FROM_ALL)
-+# add_subdirectory(examples EXCLUDE_FROM_ALL)
- 
- add_subdirectory(benchmark EXCLUDE_FROM_ALL)
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
 index 50085d0..5966d21 100644
 --- a/src/bsoncxx/CMakeLists.txt

--- a/ports/mongo-cxx-driver/disable_test_and_example.patch
+++ b/ports/mongo-cxx-driver/disable_test_and_example.patch
@@ -1,11 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 27cf3b6b8..896eee19a 100644
+index c6f56e4..b250a3d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,68 +87,68 @@ endif()
+@@ -87,70 +87,70 @@ if(NOT CMAKE_BUILD_TYPE)
+     set(CMAKE_BUILD_TYPE "Release")
+ endif()
  
- set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
- 
+-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+-
 -add_custom_target(hugo_dir
 -    COMMAND ${CMAKE_COMMAND} -E make_directory hugo
 -)
@@ -63,60 +65,62 @@ index 27cf3b6b8..896eee19a 100644
 -)
 -
 -set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
++# set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
++
 +# add_custom_target(hugo_dir
-+#     COMMAND ${CMAKE_COMMAND} -E make_directory hugo
++    # COMMAND ${CMAKE_COMMAND} -E make_directory hugo
 +# )
 +
 +# add_custom_target(hugo
-+#     DEPENDS hugo_dir
-+#     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
-+#     COMMAND hugo
-+#     VERBATIM
++    # DEPENDS hugo_dir
++    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
++    # COMMAND hugo
++    # VERBATIM
 +# )
 +
 +# add_custom_target(hugo-deploy
-+#     DEPENDS hugo
-+#     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+#     COMMAND etc/deploy-to-ghpages.pl --hugo git@github.com:mongodb/mongo-cxx-driver
-+#     VERBATIM
++    # DEPENDS hugo
++    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    # COMMAND etc/deploy-to-ghpages.pl --hugo git@github.com:mongodb/mongo-cxx-driver
++    # VERBATIM
 +# )
 +
 +# add_custom_target(docs_dir_current
-+#     COMMAND ${CMAKE_COMMAND} -E make_directory docs/api/current
++    # COMMAND ${CMAKE_COMMAND} -E make_directory docs/api/current
 +# )
 +
 +# add_custom_target(doxygen-current
-+#     DEPENDS docs_dir_current
-+#     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+#     COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
-+#     VERBATIM
++    # DEPENDS docs_dir_current
++    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    # COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
++    # VERBATIM
 +# )
 +
 +# add_custom_target(doxygen-all
-+#     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+#     COMMAND etc/generate-all-apidocs.pl
-+#     VERBATIM
++    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    # COMMAND etc/generate-all-apidocs.pl
++    # VERBATIM
 +# )
 +
 +# add_custom_target(doxygen-deploy
-+#     DEPENDS doxygen-all
-+#     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-+#     COMMAND etc/deploy-to-ghpages.pl --doxygen git@github.com:mongodb/mongo-cxx-driver
-+#     VERBATIM
++    # DEPENDS doxygen-all
++    # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
++    # COMMAND etc/deploy-to-ghpages.pl --doxygen git@github.com:mongodb/mongo-cxx-driver
++    # VERBATIM
 +# )
 +
 +# add_custom_target(format
-+#     python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
-+#     VERBATIM
++    # python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
++    # VERBATIM
 +# )
 +
 +# add_custom_target(format-lint
-+#     python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
-+#     VERBATIM
++    # python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
++    # VERBATIM
 +# )
 +
 +# add_custom_target(docs
-+#     DEPENDS hugo doxygen-current
++    # DEPENDS hugo doxygen-current
 +# )
 +
 +# set(THIRD_PARTY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party)
@@ -126,26 +130,26 @@ index 27cf3b6b8..896eee19a 100644
  add_subdirectory(src)
  
 -add_subdirectory(examples EXCLUDE_FROM_ALL)
-+#add_subdirectory(examples EXCLUDE_FROM_ALL)
++# add_subdirectory(examples EXCLUDE_FROM_ALL)
  
  add_subdirectory(benchmark EXCLUDE_FROM_ALL)
 diff --git a/src/bsoncxx/CMakeLists.txt b/src/bsoncxx/CMakeLists.txt
-index bd6e40662..d6054b022 100644
+index 50085d0..5966d21 100644
 --- a/src/bsoncxx/CMakeLists.txt
 +++ b/src/bsoncxx/CMakeLists.txt
 @@ -249,4 +249,4 @@ install(
-   DESTINATION lib/cmake/${PKG}-${BSONCXX_VERSION}
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PKG}-${BSONCXX_VERSION}
  )
  
 -add_subdirectory(test)
-+#add_subdirectory(test)
++# add_subdirectory(test)
 diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
-index a05021228..3dd7c1224 100644
+index 3cba62d..64ff936 100644
 --- a/src/mongocxx/CMakeLists.txt
 +++ b/src/mongocxx/CMakeLists.txt
-@@ -238,4 +238,4 @@ install(
-   DESTINATION lib/cmake/${PKG}-${MONGOCXX_VERSION}
+@@ -259,4 +259,4 @@ install(
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PKG}-${MONGOCXX_VERSION}
  )
  
 -add_subdirectory(test)
-+#add_subdirectory(test)
++# add_subdirectory(test)

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -1,7 +1,7 @@
 include(vcpkg_common_functions)
 
 set(VERSION_MAJOR 3)
-set(VERSION_MINOR 2)
+set(VERSION_MINOR 4)
 set(VERSION_PATCH 0)
 set(VERSION_FULL ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 
@@ -9,7 +9,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mongodb/mongo-cxx-driver
     REF r${VERSION_FULL}
-    SHA512 cad8dd6e9fd75aa3aee15321c9b3df21d43c346f5b0b3dd75c86f9117d3376ad83fcda0c4a333c0a23d555e76d79432016623dd5f860ffef9964a6e8046e84b5
+    SHA512 28c052904f1b456b92482097166238eae1ad50c3ed207496f09366b46f2c9465c7e98c7219f4f10314e4d8fdd01c36b70a2221891bb75231adcc1edf013d43ce
     HEAD_REF master
     PATCHES
         disable_test_and_example.patch

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -12,9 +12,9 @@ vcpkg_from_github(
     SHA512 28c052904f1b456b92482097166238eae1ad50c3ed207496f09366b46f2c9465c7e98c7219f4f10314e4d8fdd01c36b70a2221891bb75231adcc1edf013d43ce
     HEAD_REF master
     PATCHES
-        disable_test_and_example.patch
         fix-uwp.patch
         disable-c2338-mongo-cxx-driver.patch
+        disable_test_and_example.patch
 )
 
 if ("mnmlstc" IN_LIST FEATURES)


### PR DESCRIPTION
1. Upgrade libbson mongo-c-driver to revision 1.14.0, and mongo-cxx-driver to 3.4.0.
2. For libbson and mongo-c-driver, I added option ' -DBUILD_VERSION=${BUILD_VERSION}' since mongo-c-driver new revision remove VERSION_CURRENT file and it failed to get the build version correctly. it's a known issue for the pkg, see https://jira.mongodb.org/browse/CDRIVER-3022, and I find the option from mongo-c-driver commit '2fe8c50'.

Related to https://github.com/microsoft/vcpkg/pull/6618