### PR TITLE
[netcdf-c]Fix build error on linux.

### DIFF
--- a/ports/netcdf-c/CONTROL
+++ b/ports/netcdf-c/CONTROL
@@ -1,4 +1,4 @@
 Source: netcdf-c
-Version: 4.7.0-1
+Version: 4.7.0-2
 Build-Depends: hdf5, curl
 Description: a set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.

--- a/ports/netcdf-c/fix-build-error-on-linux.patch
+++ b/ports/netcdf-c/fix-build-error-on-linux.patch
@@ -1,0 +1,28 @@
+diff --git a/include/ncconfigure.h b/include/ncconfigure.h
+index 2c5b2c8..d397790 100644
+--- a/include/ncconfigure.h
++++ b/include/ncconfigure.h
+@@ -25,20 +25,20 @@ missing functions should be
+ defined and missing types defined.
+ */
+ 
+-#ifndef HAVE_STRDUP
++#ifndef strdup
+ extern char* strdup(const char*);
+ #endif
+ 
+ /* handle null arguments */
+ #ifndef nulldup
+-#ifdef HAVE_STRDUP
++#ifdef strdup
+ #define nulldup(s) ((s)==NULL?NULL:strdup(s))
+ #else
+ char *nulldup(const char* s);
+ #endif
+ #endif
+ 
+-#ifdef _MSC_VER
++#ifdef _WIN32
+ #ifndef HAVE_SSIZE_T
+ #include <basetsd.h>
+ typedef SSIZE_T ssize_t;

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         transitive-hdf5.patch
         hdf5.patch
         hdf5_2.patch
+        fix-build-error-on-linux.patch
 )
 
 #Remove outdated find modules


### PR DESCRIPTION
Use the official patch([#1408](https://github.com/Unidata/netcdf-c/issues/1408)) to resolve build errors in Linux.

Related: #6585.