### PR TITLE
Protect #pragma comment(lib, "foo") with _WIN32 checks

### DIFF
--- a/toolsrc/src/tests.arguments.cpp
+++ b/toolsrc/src/tests.arguments.cpp
@@ -1,7 +1,9 @@
 #include "tests.pch.h"
 
+#if defined(_WIN32)
 #pragma comment(lib, "version")
 #pragma comment(lib, "winhttp")
+#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/toolsrc/src/tests.dependencies.cpp
+++ b/toolsrc/src/tests.dependencies.cpp
@@ -1,7 +1,9 @@
 #include "tests.pch.h"
 
+#if defined(_WIN32)
 #pragma comment(lib, "version")
 #pragma comment(lib, "winhttp")
+#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/toolsrc/src/tests.packagespec.cpp
+++ b/toolsrc/src/tests.packagespec.cpp
@@ -2,8 +2,10 @@
 
 #include <tests.utils.h>
 
+#if defined(_WIN32)
 #pragma comment(lib, "version")
 #pragma comment(lib, "winhttp")
+#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/toolsrc/src/tests.paragraph.cpp
+++ b/toolsrc/src/tests.paragraph.cpp
@@ -1,7 +1,9 @@
 #include "tests.pch.h"
 
+#if defined(_WIN32)
 #pragma comment(lib, "version")
 #pragma comment(lib, "winhttp")
+#endif
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -40,8 +40,10 @@
 #include <memory>
 #include <random>
 
+#if defined(_WIN32)
 #pragma comment(lib, "ole32")
 #pragma comment(lib, "shell32")
+#endif
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -16,7 +16,9 @@
 #include <sys/sysctl.h>
 #endif
 
+#if defined(_WIN32)
 #pragma comment(lib, "Advapi32")
+#endif
 
 using namespace vcpkg::System;
 

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -9,8 +9,10 @@
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.process.h>
 
+#if defined(_WIN32)
 #pragma comment(lib, "version")
 #pragma comment(lib, "winhttp")
+#endif
 
 namespace vcpkg::Metrics
 {


### PR DESCRIPTION
lld on Linux can now process #pragma comment(lib, "foo") macros which
results in build failures on Linux when lld is used. Fix this by
protecting these macros with _WIN32 checks.