### PR TITLE
[libsodium/darts-clone] remove conflicting makefile

### DIFF
--- a/ports/darts-clone/CONTROL
+++ b/ports/darts-clone/CONTROL
@@ -1,3 +1,3 @@
 Source: darts-clone
-Version:  1767ab87cffe
+Version:  1767ab87cffe-1
 Description: A static double-array trie structure

--- a/ports/darts-clone/portfile.cmake
+++ b/ports/darts-clone/portfile.cmake
@@ -23,4 +23,6 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
+file(REMOVE ${CURRENT_PACKAGES_DIR}/include/Makefile.am)
+
 file(INSTALL ${SOURCE_PATH}/COPYING.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/darts-clone RENAME copyright)

--- a/ports/libsodium/CONTROL
+++ b/ports/libsodium/CONTROL
@@ -1,3 +1,3 @@
 Source: libsodium
-Version: 1.0.17-2
+Version: 1.0.17-3
 Description: A modern and easy-to-use crypto library

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -40,6 +40,8 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include
 )
 
+file(REMOVE ${CURRENT_PACKAGES_DIR}/include/Makefile.am)
+
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string(
         ${CURRENT_PACKAGES_DIR}/include/sodium/export.h


### PR DESCRIPTION
These ports conflict with each other because of this Makefile.am.