### PR TITLE
[opencv]Fix build error with feature gdcm: cannot find openjp2.

### DIFF
--- a/ports/opencv/0006-fix-missing-openjp2.patch
+++ b/ports/opencv/0006-fix-missing-openjp2.patch
@@ -1,0 +1,16 @@
+diff --git a/modules/imgcodecs/CMakeLists.txt b/modules/imgcodecs/CMakeLists.txt
+index 434278c..0d8f4d8 100644
+--- a/modules/imgcodecs/CMakeLists.txt
++++ b/modules/imgcodecs/CMakeLists.txt
+@@ -36,6 +36,11 @@ if(HAVE_PNG)
+ endif()
+ 
+ if(HAVE_GDCM)
++  if (CMAKE_BUILD_TYPE STREQUAL "Release")
++    link_directories("${CURRENT_INSTALLED_DIR}/lib")
++  else()
++    link_directories("${CURRENT_INSTALLED_DIR}/debug/lib")
++  endif()
+   ocv_include_directories(${GDCM_INCLUDE_DIRS})
+   list(APPEND GRFMT_LIBS ${GDCM_LIBRARIES})
+ endif()

--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv
-Version: 3.4.3-8
+Version: 3.4.3-9
 Build-Depends: zlib
 Description: computer vision library
 Default-Features: opengl, jpeg, png, tiff, eigen, flann

--- a/ports/opencv/portfile.cmake
+++ b/ports/opencv/portfile.cmake
@@ -9,11 +9,12 @@ vcpkg_from_github(
     SHA512 d653a58eb5e3939b9fdb7438ac35f77cf4385cf72d5d22bfd21722a109e1b3283dbb9407985061b7548114f0d05c9395aac9bb62b4d2bc1f68da770a49987fef
     HEAD_REF master
     PATCHES
-      "${CMAKE_CURRENT_LIST_DIR}/0001-winrt-fixes.patch"
-      "${CMAKE_CURRENT_LIST_DIR}/0002-install-options.patch"
-      "${CMAKE_CURRENT_LIST_DIR}/0003-disable-downloading.patch"
-      "${CMAKE_CURRENT_LIST_DIR}/0004-use-find-package-required.patch"
-      "${CMAKE_CURRENT_LIST_DIR}/0005-remove-custom-protobuf-find-package.patch"
+      0001-winrt-fixes.patch
+      0002-install-options.patch
+      0003-disable-downloading.patch
+      0004-use-find-package-required.patch
+      0005-remove-custom-protobuf-find-package.patch
+      0006-fix-missing-openjp2.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_WITH_STATIC_CRT)
@@ -321,6 +322,7 @@ vcpkg_configure_cmake(
         -DWITH_VTK=${WITH_VTK}
         -DWITH_WEBP=${WITH_WEBP}
         -DWITH_ZLIB=${WITH_ZLIB}
+        -DCURRENT_INSTALLED_DIR=${CURRENT_INSTALLED_DIR}
     OPTIONS_DEBUG
         -DINSTALL_HEADERS=OFF
         -DINSTALL_OTHER=OFF


### PR DESCRIPTION
Since the gdcm dependent library openjpeg path is not set, add the default library path.

Related: #6863.