### PR TITLE
[Exiv2] update to 0.27.1

### DIFF
--- a/ports/exiv2/CONTROL
+++ b/ports/exiv2/CONTROL
@@ -1,5 +1,5 @@
 Source: exiv2
-Version: 0.27
+Version: 0.27.1
 Build-Depends: zlib, expat, libiconv, gettext
 Description: Image metadata library and tools
 Homepage: http://www.exiv2.org

--- a/ports/exiv2/portfile.cmake
+++ b/ports/exiv2/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Exiv2/exiv2
-    REF 0.27
-    SHA512 ec605db73abcf3cc2df78c1fc3aae5335a51192f660668e39a4f20fc7f372b18c3cec9b704e1c71c356315fd75e791622de1dffe576432ee0fb12bf63a98a423
+    REF 0.27.1
+    SHA512 1b637138cee019122d98ae3c54e84416ba1a90531b3f541748697c9f1a8faee18699f10cef5a63bf60b8588e8c670925cbac3ad6c82e41160442f8a66380d407
     HEAD_REF master
     PATCHES
         iconv.patch
@@ -29,7 +29,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "share/exiv2/cmake")
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/exiv2/cmake")
 
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake
@@ -41,6 +41,7 @@ vcpkg_copy_pdbs()
 
 # Clean
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/exiv2 ${CURRENT_PACKAGES_DIR}/lib/exiv2)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)


### PR DESCRIPTION
Tested on windows and everything works like usual.

Note that there is a breaking change on cmake usage, instead of `target_link_libraries(main PRIVATE xmp exiv2lib)` now it becomes `target_link_libraries(main PRIVATE exiv2-xmp exiv2lib)`