### PR TITLE
[curl] fix linkage type control

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.65.0-1
+Version: 7.65.0-2
 Build-Depends: zlib
 Description: A library for transferring data with URLs
 Default-Features: ssl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
         0004_nghttp2_staticlib.patch
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
 # Support HTTP2 TLS Download https://curl.haxx.se/ca/cacert.pem rename to curl-ca-bundle.crt, copy it to libcurl.dll location.
 set(HTTP2_OPTIONS)
@@ -93,7 +93,7 @@ vcpkg_configure_cmake(
         -DBUILD_TESTING=OFF
         -DBUILD_CURL_EXE=${BUILD_CURL_EXE}
         -DENABLE_MANUAL=OFF
-        -DCURL_STATICLIB=${CURL_STATICLIB}
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED}
         -DCMAKE_USE_OPENSSL=${USE_OPENSSL}
         -DCMAKE_USE_WINSSL=${USE_WINSSL}
         -DCMAKE_USE_MBEDTLS=${USE_MBEDTLS}
@@ -143,19 +143,7 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/curl-config ${CURRENT_PACKAGES_DIR}/debug/bin/curl-config)
-endif()
-
-file(READ ${CURRENT_PACKAGES_DIR}/include/curl/curl.h CURL_H)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    string(REPLACE "#ifdef CURL_STATICLIB" "#if 1" CURL_H "${CURL_H}")
-else()
-    string(REPLACE "#ifdef CURL_STATICLIB" "#if 0" CURL_H "${CURL_H}")
-endif()
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/curl/curl.h "${CURL_H}")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
There are at least five variables to control linkage type in curl `CMakeLists`. 
`BUILD_SHARED_LIBS` is an option and depending on its value each of `CURL_STATICLIB`, `ENABLE_SHARED`, `ENABLE_STATIC`, `CPPFLAG_CURL_STATICLIB` are set in different files.

The portfile tries to control the linkage type with cmake options but it sets `CURL_STATICLIB` rather than `BUILD_SHARED_LIBS`. `CURL_STATICLIB` is then overwritten by curl cmakes. However vcpkg doesn’t know anything about it and changes `curl.h` header file directly, setting wrong linkage type:
https://github.com/microsoft/vcpkg/blob/b03f62e0ebc1b5515bc8a1f41f3bfe9eca6589d4/ports/curl/portfile.cmake#L152

This leads to crushes of programs which use curl in certain build configurations.