### PR TITLE
[libmodplug] Always use the upstream repository

### DIFF
--- a/ports/libmodplug/portfile.cmake
+++ b/ports/libmodplug/portfile.cmake
@@ -15,7 +15,7 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
 else()
     vcpkg_from_github(ARCHIVE
         OUT_SOURCE_PATH SOURCE_PATH
-        REPO JackBister/libmodplug
+        REPO Konstanty/libmodplug
         REF ${MODPLUG_HASH}
         SHA512 c43bb3190b62c3a4e3636bba121b5593bbf8e6577ca9f2aa04d90b03730ea7fb590e640cdadeb565758b92e81187bc456e693fe37f1f4deace9b9f37556e3ba1
         PATCHES


### PR DESCRIPTION
Hello folks, it seems like there was a mistake made when libmodplug was fixed to build on Linux (PR #5397). The portfile ends up sometimes using my fork of libmodplug instead of the upstream one, but uses a commit that is present in both repos so there isn't much of a point in using my fork. I have updated the portfile to always use the upstream version since it's likely that my fork will be deleted before the upstream repo.

