### PR TITLE
[wt] Fix XML file installation path

### DIFF
--- a/ports/wt/0005-XML_file_path.patch
+++ b/ports/wt/0005-XML_file_path.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca19b30..4765632 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,7 +197,11 @@ SET(CMAKE_INSTALL_DIR "${LIB_INSTALL_DIR}/cmake" CACHE STRING
+ 
+ IF(WIN32)
+ 
+-  SET(RUNDIR "c:/witty") # Does not apply to win32
++  if (NOT INSTALL_CONFIG_FILE_PATH)
++    SET(RUNDIR "c:/witty") # Does not apply to win32
++  else()
++    SET(RUNDIR ${INSTALL_CONFIG_FILE_PATH}) # Does not apply to win32
++  endif()
+ 
+   IF(NOT DEFINED CONFIGDIR)
+     SET(CONFIGDIR ${RUNDIR} CACHE STRING "Path for the configuration files")

--- a/ports/wt/CONTROL
+++ b/ports/wt/CONTROL
@@ -1,5 +1,5 @@
 Source: wt
-Version: 4.0.5
+Version: 4.0.5-1
 Homepage: https://github.com/emweb/wt
 Description: Wt is a C++ library for developing web applications
 Build-Depends: openssl, sqlite3, libpq, pango, glew, boost-date-time, boost-regex, boost-program-options, boost-signals, boost-system, boost-filesystem, boost-thread, boost-random, boost-multi-index, boost-signals2, boost-asio, boost-ublas, boost-conversion, boost-array, boost-smart-ptr, boost-tuple, boost-algorithm, boost-logic, boost-interprocess

--- a/ports/wt/portfile.cmake
+++ b/ports/wt/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0002-link-glew.patch
         0003-disable-boost-autolink.patch
         0004-link-ssl.patch
+		0005-XML_file_path.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED_LIBS)
@@ -18,6 +19,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+		-DINSTALL_CONFIG_FILE_PATH="${DOWNLOADS}/wt"
         -DSHARED_LIBS=${SHARED_LIBS}
         -DBOOST_DYNAMIC=ON
         -DDISABLE_BOOST_AUTOLINK=ON


### PR DESCRIPTION
The file **wt_config.xml** was installed in the _c:/witty_, change the installation path to _vcpkg/downloads_. Code in CMakeLists.txt:
```
IF(WIN32)
  SET(RUNDIR "c:/witty") # Does not apply to win32
```
From log:
```
Process failed because: Das System kann die angegebene Datei nicht finden

for command: mkdir -p c:/witty 

Process failed because: Das System kann die angegebene Datei nicht finden

for command: chown apache:apache c:/witty 
```
Related issue: #6908 