### PR TITLE
[qt5-declarative]Fix error when building release-only.

### DIFF
--- a/ports/qt5-declarative/CONTROL
+++ b/ports/qt5-declarative/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-declarative
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Declarative (Quick 2) Module. Includes QtQuick, QtQuickParticles, QtQuickWidgets, QtQml, and QtPacketProtocol.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -6,7 +6,9 @@ qt_modular_library(qtdeclarative 0caddcfee36cbf52bacd3a400d304511255715e2b5a58c1
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools/qt5-declarative/plugins/platforminputcontexts)
 
-set(qt5decpath ${CURRENT_PACKAGES_DIR}/share/qt5/debug/mkspecs/modules/qt_lib_qmldevtools_private.pri)
-file(READ "${qt5decpath}" _contents)
-string(REPLACE [[QT.qmldevtools_private.libs = $$QT_MODULE_HOST_LIB_BASE]] [[QT.qmldevtools_private.libs = $$QT_MODULE_LIB_BASE]]  _contents "${_contents}")
-file(WRITE "${qt5decpath}" "${_contents}")
+if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+	set(qt5decpath ${CURRENT_PACKAGES_DIR}/share/qt5/debug/mkspecs/modules/qt_lib_qmldevtools_private.pri)
+	file(READ "${qt5decpath}" _contents)
+	string(REPLACE [[QT.qmldevtools_private.libs = $$QT_MODULE_HOST_LIB_BASE]] [[QT.qmldevtools_private.libs = $$QT_MODULE_LIB_BASE]]  _contents "${_contents}")
+	file(WRITE "${qt5decpath}" "${_contents}")
+endif()


### PR DESCRIPTION
When the release-only is built, the debug directory does not exist, so I added the conditions for handling the debug directory.


Related: #6857.