### PR TITLE
[sdl2-mixer]Fix build error with feature opusfile.

### DIFF
--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -49,9 +49,11 @@ endif()
 # Opus support
 if(SDL_MIXER_ENABLE_OPUS)
     find_path(OPUS_INCLUDE_DIR opus/opusfile.h)
+    find_package(ogg CONFIG REQUIRED)
+    find_package(Opus CONFIG REQUIRED)
     find_library(OPUSFILE_LIBRARY opusfile)
     list(APPEND SDL_MIXER_INCLUDES ${OPUS_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${OPUSFILE_LIBRARY})
+    list(APPEND SDL_MIXER_LIBRARIES ${OPUSFILE_LIBRARY} Ogg::ogg Opus::opus)
     list(APPEND SDL_MIXER_DEFINES MUSIC_OPUS)
 endif()
 

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.4-2
+Version: 2.0.4-3
 Homepage: https://www.libsdl.org/projects/SDL_mixer
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2


### PR DESCRIPTION
Since the opusfile does not have a _config.cmake_ file and uses _find_library_ when it is used, add the opusfile dependency to the ports **ogg** and **opus** find/use code.

Related: #6827.