### PR TITLE
[msmpi] Fix /MD for static libs.

### DIFF
--- a/ports/msmpi/CONTROL
+++ b/ports/msmpi/CONTROL
@@ -1,3 +1,3 @@
 Source: msmpi
-Version: 10.0
+Version: 10.0-1
 Description: Microsoft MPI

--- a/ports/msmpi/CONTROL
+++ b/ports/msmpi/CONTROL
@@ -1,3 +1,3 @@
 Source: msmpi
-Version: 10.0-1
+Version: 10.0-2
 Description: Microsoft MPI

--- a/ports/msmpi/portfile.cmake
+++ b/ports/msmpi/portfile.cmake
@@ -1,9 +1,5 @@
 include(vcpkg_common_functions)
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static AND VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    message(STATUS "Warning: Static library with dynamic CRT is not supported. Building static linkage to crt.")
-    set(VCPKG_CRT_LINKAGE static)
-endif()
-   
+
 set(MSMPI_VERSION "10.0.12498")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/msmpi-${MSMPI_VERSION})
 
@@ -99,40 +95,28 @@ file(INSTALL
         ${CURRENT_PACKAGES_DIR}/include
 )
 
-# Install release libraries
-file(INSTALL
-        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpi.lib"
-        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifec.lib"
-        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifmc.lib"
-    DESTINATION
-        ${CURRENT_PACKAGES_DIR}/lib
-)
-if(TRIPLET_SYSTEM_ARCH STREQUAL "x86")
-    file(INSTALL
-            "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifes.lib"
-            "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifms.lib"
-        DESTINATION
-            ${CURRENT_PACKAGES_DIR}/lib
-    )
-endif()
-
-# Install debug libraries
-# NOTE: since the binary distribution does not include any debug libraries we simply install the release libraries
+# NOTE: since the binary distribution does not include any debug libraries we always install the release libraries
 SET(VCPKG_POLICY_ONLY_RELEASE_CRT enabled)
+
+file(GLOB STATIC_LIBS
+    ${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifec.lib
+    ${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifmc.lib
+    ${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifes.lib
+    ${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifms.lib
+)
+
 file(INSTALL
         "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpi.lib"
-        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifec.lib"
-        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifmc.lib"
-    DESTINATION
-        ${CURRENT_PACKAGES_DIR}/debug/lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
 )
-if(TRIPLET_SYSTEM_ARCH STREQUAL "x86")
-    file(INSTALL
-            "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifes.lib"
-            "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpifms.lib"
-        DESTINATION
-            ${CURRENT_PACKAGES_DIR}/debug/lib
-    )
+file(INSTALL
+        "${SOURCE_LIB_PATH}/${TRIPLET_SYSTEM_ARCH}/msmpi.lib"
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+)
+
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+    file(INSTALL ${STATIC_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(INSTALL ${STATIC_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 endif()
 
 # Handle copyright

--- a/ports/msmpi/portfile.cmake
+++ b/ports/msmpi/portfile.cmake
@@ -1,5 +1,9 @@
 include(vcpkg_common_functions)
-
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static AND VCPKG_CRT_LINKAGE STREQUAL dynamic)
+    message(STATUS "Warning: Static library with dynamic CRT is not supported. Building static linkage to crt.")
+    set(VCPKG_CRT_LINKAGE static)
+endif()
+   
 set(MSMPI_VERSION "10.0.12498")
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/msmpi-${MSMPI_VERSION})
 


### PR DESCRIPTION
When building static library with dynamic CRT, it failed with:
```
Expected Release,Dynamic crt linkage, but the following libs had invalid crt linkage:

    F:/vcpkgissue/vcpkg/packages/msmpi_x64-windows/lib/msmpifec.lib: Release,Static
    F:/vcpkgissue/vcpkg/packages/msmpi_x64-windows/lib/msmpifmc.lib: Release,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
```
So I added set(VCPKG_CRT_LINKAGE static) to fix it.
Related issue #2059.