### PR TITLE
bootstrap.sh: Retry up to 3 times for transient download errors

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -100,7 +100,7 @@ vcpkgDownloadFile()
     url=$1; downloadPath=$2 sha512=$3
     vcpkgCheckRepoTool "curl"
     rm -rf "$downloadPath.part"
-    curl -L $url --create-dirs --output "$downloadPath.part" || exit 1
+    curl -L $url --create-dirs --retry 3 --output "$downloadPath.part" || exit 1
 
     vcpkgCheckEqualFileHash $url "$downloadPath.part" $sha512
     mv "$downloadPath.part" "$downloadPath"


### PR DESCRIPTION
From [curl.1 the man page](https://curl.haxx.se/docs/manpage.html#--retry):
> --retry \<num\>
> 
> If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408 or 5xx response code.