### PR TITLE
[thor] Fix error on Linux.

### DIFF
--- a/ports/thor/CONTROL
+++ b/ports/thor/CONTROL
@@ -1,5 +1,4 @@
 Source: thor
-Version: 2.0-2
-Homepage: https://github.com/Bromeon/Thor
+Version: 2.0-3
 Description: Extends the multimedia library SFML with higher-level features
 Build-Depends: sfml, aurora

--- a/ports/thor/portfile.cmake
+++ b/ports/thor/portfile.cmake
@@ -49,6 +49,9 @@ endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/Aurora)
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+endif()
 
 file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/thor RENAME copyright)
 


### PR DESCRIPTION
When building on Linux, there is /debug/share directory. It should't exist. So I remove this directory.
Related issue #4523.