### PR TITLE
VS 2019 16.3 deprecates <experimental/filesystem>.

### DIFF
--- a/toolsrc/include/pch.h
+++ b/toolsrc/include/pch.h
@@ -37,11 +37,8 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
-#if defined(_WIN32)
-#include <filesystem>
-#else
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #include <experimental/filesystem>
-#endif
 #include <cstring>
 #include <fstream>
 #include <functional>

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -2,11 +2,8 @@
 
 #include <vcpkg/base/expected.h>
 
-#if defined(_WIN32)
-#include <filesystem>
-#else
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #include <experimental/filesystem>
-#endif
 
 namespace fs
 {


### PR DESCRIPTION
VS 2019 16.3 will contain a couple of source-breaking changes:

* `<experimental/filesystem>` will be deprecated via an impossible-to-miss preprocessor "`#error` The `<experimental/filesystem>` header providing `std::experimental::filesystem` is deprecated by Microsoft and will be REMOVED. It is superseded by the C++17 `<filesystem>` header providing `std::filesystem`. You can define `_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING` to acknowledge that you have received this warning."

* `<filesystem>` will no longer include `<experimental/filesystem>`.

In the long term, I believe that vcpkg should detect when it's being built with VS 2017 15.7 or newer, compile in C++17 mode, include `<filesystem>`, and use `std::filesystem`. (Activating this for VS 2019 16.0 or newer would also be reasonable.) Similarly for other toolsets supporting `std::filesystem`.

In the short term, this commit makes vcpkg compatible with the upcoming deprecation. First, we need to define the silencing macro before including the appropriate header. I've chosen to define it unconditionally (without checking for platform or version), since it has no effect for other platforms or versions. Second, we need to deal with `<filesystem>` no longer including `<experimental/filesystem>`. I verified that VS 2015 Update 3 contained `<experimental/filesystem>` (back then, it simply included the `<filesystem>` header, where the experimental implementation was defined; this was later reorganized). Therefore, all of vcpkg's supported MSVC toolsets have `<experimental/filesystem>`, so we can simply always include it.

I've verified that this builds with both VS 2015 Update 3 and VS 2019 16.1.3 (the current production version).