### PR TITLE
[xerces-c]Replace the macro DLL_EXPORT with the macro XERCES_DLL_EXPORT

### DIFF
--- a/ports/xerces-c/CONTROL
+++ b/ports/xerces-c/CONTROL
@@ -1,5 +1,5 @@
 Source: xerces-c
-Version: 3.2.2-9
+Version: 3.2.2-10
 Homepage: https://github.com/apache/xerces-c
 Description: Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.
 

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -48,6 +48,16 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfigInternal.cmake "${
 file(READ ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfig.cmake _contents)
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfig.cmake "include(CMakeFindDependencyMacro)\nfind_dependency(Threads)\n${_contents}")
 
+# Disable defining DLL_EXPORT to avoid affecting other ports
+file(READ ${CURRENT_PACKAGES_DIR}/include/xercesc/util/Xerces_autoconf_config.hpp _contents)
+string(REPLACE
+    "#  define DLL_EXPORT"
+    "//#  define DLL_EXPORT"
+    _contents
+    "${_contents}"
+)
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/xercesc/util/Xerces_autoconf_config.hpp "${_contents}")
+
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake
     ${CURRENT_PACKAGES_DIR}/share/xercesc

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF Xerces-C_3_2_2
     SHA512 66f60fe9194376ac0ca99d13ea5bce23ada86e0261dde30686c21ceb5499e754dab8eb0a98adadd83522bda62709377715501f6dac49763e3a686f9171cc63ea
     HEAD_REF trunk
-    PATCHES disable-tests.patch
+    PATCHES
+        disable-tests.patch
+        remove-dll-export-macro.patch
 )
 
 set(DISABLE_ICU ON)
@@ -47,16 +49,6 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfigInternal.cmake "${
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfig.cmake _contents)
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/xercesc/XercesCConfig.cmake "include(CMakeFindDependencyMacro)\nfind_dependency(Threads)\n${_contents}")
-
-# Disable defining DLL_EXPORT to avoid affecting other ports
-file(READ ${CURRENT_PACKAGES_DIR}/include/xercesc/util/Xerces_autoconf_config.hpp _contents)
-string(REPLACE
-    "#  define DLL_EXPORT"
-    "//#  define DLL_EXPORT"
-    _contents
-    "${_contents}"
-)
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/xercesc/util/Xerces_autoconf_config.hpp "${_contents}")
 
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake

--- a/ports/xerces-c/remove-dll-export-macro.patch
+++ b/ports/xerces-c/remove-dll-export-macro.patch
@@ -1,0 +1,27 @@
+diff --git a/src/xercesc/util/XercesDefs.hpp b/src/xercesc/util/XercesDefs.hpp
+index 8071260..cd6bd68 100644
+--- a/src/xercesc/util/XercesDefs.hpp
++++ b/src/xercesc/util/XercesDefs.hpp
+@@ -133,7 +133,7 @@ typedef XMLUInt32           UCS4Ch;
+ // The DLL_EXPORT flag should be defined on the command line during the build of a DLL
+ // configure conspires to make this happen.
+ 
+-#if defined(DLL_EXPORT)
++#if defined(XERCES_DLL_EXPORT)
+   #if defined(XERCES_BUILDING_LIBRARY)
+     #define XMLUTIL_EXPORT XERCES_PLATFORM_EXPORT
+     #define XMLPARSER_EXPORT XERCES_PLATFORM_EXPORT
+diff --git a/src/xercesc/util/Xerces_autoconf_config.hpp.cmake.in b/src/xercesc/util/Xerces_autoconf_config.hpp.cmake.in
+index e849e08..69fe3bf 100644
+--- a/src/xercesc/util/Xerces_autoconf_config.hpp.cmake.in
++++ b/src/xercesc/util/Xerces_autoconf_config.hpp.cmake.in
+@@ -85,9 +85,6 @@
+ #define XERCES_PLATFORM_EXPORT @XERCES_PLATFORM_EXPORT@
+ #define XERCES_PLATFORM_IMPORT @XERCES_PLATFORM_IMPORT@
+ #define XERCES_TEMPLATE_EXTERN @XERCES_TEMPLATE_EXTERN@
+-#ifdef XERCES_DLL_EXPORT
+-#  define DLL_EXPORT
+-#endif
+ 
+ // ---------------------------------------------------------------------------
+ //  Include standard headers, if available, that we may rely on below.


### PR DESCRIPTION
Replace the macro `DLL_EXPORT` with the macro `XERCES_DLL_EXPORT` to avoid affecting other ports.

Related: #4899.