### PR TITLE
[netcdf-c] Fix link error.

### DIFF
--- a/ports/netcdf-c/CONTROL
+++ b/ports/netcdf-c/CONTROL
@@ -1,5 +1,5 @@
 Source: netcdf-c
-Version: 4.7.0-2
+Version: 4.7.0-3
 Build-Depends: hdf5, curl
 Homepage: https://github.com/Unidata/netcdf-c
 Description: a set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.

--- a/ports/netcdf-c/hdf5_3.patch
+++ b/ports/netcdf-c/hdf5_3.patch
@@ -1,0 +1,12 @@
+diff --git a/libhdf5/CMakeLists.txt b/libhdf5/CMakeLists.txt
+index f3c7bbc..34fc2ab 100644
+--- a/libhdf5/CMakeLists.txt
++++ b/libhdf5/CMakeLists.txt
+@@ -20,3 +20,7 @@ add_library(netcdfhdf5 OBJECT ${libnchdf5_SOURCES})
+ 
+ # Remember to package this file for CMake builds.
+ ADD_EXTRA_DIST(${libnchdf5_SOURCES} CMakeLists.txt)
++
++if(BUILD_SHARED_LIBS)
++target_link_libraries(netcdfhdf5 PRIVATE hdf5::hdf5-shared hdf5::hdf5-static hdf5::hdf5_hl-shared hdf5::hdf5_hl-static)
++endif()

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         hdf5.patch
         hdf5_2.patch
         fix-build-error-on-linux.patch
+        hdf5_3.patch
 )
 
 #Remove outdated find modules


### PR DESCRIPTION
When building this port on x64-windows or x86-windows, it failed with some error LNK2001, like this:
```
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5T_IEEE_F32BE_g
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5T_IEEE_F32LE_g
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5T_IEEE_F64BE_g
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5T_IEEE_F64LE_g
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5T_STD_I8BE_g
...
nc4hdf.c.obj : error LNK2001: unresolved external symbol H5P_CLS_GROUP_CREATE_ID_g
hdf5create.c.obj : error LNK2001: unresolved external symbol H5P_CLS_FILE_CREATE_ID_g
hdf5create.c.obj : error LNK2001: unresolved external symbol H5P_CLS_FILE_ACCESS_ID_g
hdf5open.c.obj : error LNK2001: unresolved external symbol H5P_CLS_FILE_ACCESS_ID_g
nc4memcb.c.obj : error LNK2001: unresolved external symbol H5P_CLS_FILE_ACCESS_ID_g
hdf5var.c.obj : error LNK2001: unresolved external symbol H5P_CLS_DATASET_XFER_ID_g
liblib\netcdf.dll : fatal error LNK1120: 37 unresolved externals
```
As hdf5 doesn't link correctly, I added target_link_libraries() to fix it.

