### PR TITLE
[Folly] Disable non-underscore posix names on windows

### DIFF
--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,5 @@
 Source: folly
-Version: 2019.05.20.00
+Version: 2019.05.20.00-1
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr

--- a/ports/folly/disable-non-underscore-posix-names.patch
+++ b/ports/folly/disable-non-underscore-posix-names.patch
@@ -1,0 +1,27 @@
+diff --git a/folly/portability/Windows.h b/folly/portability/Windows.h
+index f7990ca..b22fac5 100644
+--- a/folly/portability/Windows.h
++++ b/folly/portability/Windows.h
+@@ -26,16 +26,12 @@
+ // These have to be this way because we define our own versions
+ // of close(), because the normal Windows versions don't handle
+ // sockets at all.
+-#ifndef __STDC__
+-/* nolint */
+-#define __STDC__ 1
+-#include <direct.h> // @manual nolint
+-#include <io.h> // @manual nolint
+-#undef __STDC__
+-#else
+-#include <direct.h> // @manual nolint
+-#include <io.h> // @manual nolint
+-#endif
++#include <corecrt.h>
++#pragma push_macro("_CRT_INTERNAL_NONSTDC_NAMES")
++#define _CRT_INTERNAL_NONSTDC_NAMES 0
++#include <direct.h>
++#include <io.h>
++#pragma pop_macro("_CRT_INTERNAL_NONSTDC_NAMES")
+ 
+ #if defined(min) || defined(max)
+ #error Windows.h needs to be included by this header, or else NOMINMAX needs \

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         missing-include-atomic.patch
         boost-1.70.patch
         reorder-glog-gflags.patch
+        disable-non-underscore-posix-names.patch
 )
 
 file(COPY


### PR DESCRIPTION
Fix related issue https://github.com/microsoft/vcpkg/issues/6670.

Background:
In previous windows sdk verison 10.0.17763.0, we used to do the equivalent of checking for __STDC__ on a per-file basis with:
#define _CRT_INTERNAL_NONSTDC_NAMES                                            \
    (                                                                          \
        ( defined _CRT_DECLARE_NONSTDC_NAMES && _CRT_DECLARE_NONSTDC_NAMES) || \
        (!defined _CRT_DECLARE_NONSTDC_NAMES && !__STDC__                 )    \
)

Then in individual files, doing 
#if _CRT_INTERNAL_NONSTDC_NAMES
// define mktemp, chmod, close, etc
#endif // _CRT_INTERNAL_NONSTDC_NAMES

However, that takes advantage of non-standard preprocessor behavior, in windows sdk 10.0.18362.0  we switched to this:
#if ( defined _CRT_DECLARE_NONSTDC_NAMES && _CRT_DECLARE_NONSTDC_NAMES) || \
    (!defined _CRT_DECLARE_NONSTDC_NAMES && !__STDC__                 )
    #define _CRT_INTERNAL_NONSTDC_NAMES 1
#else
    #define _CRT_INTERNAL_NONSTDC_NAMES 0
#endif

So, we’re no longer evaluating __STDC__ on a per-file basis, but on a whole project basis.