### PR TITLE
[qt5-base]Add a print message to inform the user to install the dependency package.

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.3-1
+Version: 5.12.3-2
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -87,11 +87,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     )
 
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(STATUS "Installing libgl1-mesa-dev")
-    execute_process(COMMAND sudo apt-get install libgl1-mesa-dev -f -y)
-    
-    message(STATUS "Installing libglu1-mesa-dev")
-    execute_process(COMMAND sudo apt-get install libglu1-mesa-dev -f -y)
+    message("qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use command: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\" to install them.")
 
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -87,7 +87,8 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     )
 
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message("qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use command: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\" to install them.")
+    message("qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use your distribution's package manager to install them.")
+    message("Example: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\"")
 
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -87,6 +87,12 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     )
 
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(STATUS "Installing libgl1-mesa-dev")
+    execute_process(COMMAND sudo apt-get install libgl1-mesa-dev -f -y)
+    
+    message(STATUS "Installing libglu1-mesa-dev")
+    execute_process(COMMAND sudo apt-get install libglu1-mesa-dev -f -y)
+
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}
         PLATFORM "linux-g++"

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -87,8 +87,9 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     )
 
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message("qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use your distribution's package manager to install them.")
-    message("Example: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\"")
+    if (NOT EXISTS "/usr/include/GL/glu.h")
+        message(FATAL_ERROR "qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use your distribution's package manager to install them.\nExample: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\"")
+    endif()
 
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -87,8 +87,8 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
     )
 
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message("qt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use your distribution's package manager to install them.")
-    message("Example: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\"")
+    message("\nqt5 requires libgl1-mesa-dev and libglu1-mesa-dev, please use your distribution's package manager to install them.")
+    message("Example: \"apt-get install libgl1-mesa-dev\" and \"apt-get install libglu1-mesa-dev\"\n")
 
     configure_qt(
         SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
When qt5 is installed in Linux, we need two packages:
- libgl1-mesa-dev
- libglu1-mesa-dev

And users may not have installed them, so I added a print message to inform to install them.