### PR TITLE
[--overlay-ports] Show location of overriden ports during install plan

### DIFF
--- a/toolsrc/include/vcpkg/dependencies.h
+++ b/toolsrc/include/vcpkg/dependencies.h
@@ -199,5 +199,7 @@ namespace vcpkg::Dependencies
                                                        const StatusParagraphs& status_db,
                                                        const CreateInstallPlanOptions& options = {});
 
-    void print_plan(const std::vector<AnyAction>& action_plan, const bool is_recursive = true);
+    void print_plan(const std::vector<AnyAction>& action_plan, 
+                    const bool is_recursive = true,
+                    const fs::path& default_ports_dir = "");
 }

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -451,7 +451,7 @@ namespace vcpkg::Commands::CI
 
             if (is_dry_run)
             {
-                Dependencies::print_plan(action_plan);
+                Dependencies::print_plan(action_plan, true, paths.ports);
             }
             else
             {

--- a/toolsrc/src/vcpkg/commands.upgrade.cpp
+++ b/toolsrc/src/vcpkg/commands.upgrade.cpp
@@ -171,7 +171,7 @@ namespace vcpkg::Commands::Upgrade
             }
         }
 
-        Dependencies::print_plan(plan, true);
+        Dependencies::print_plan(plan, true, paths.ports);
 
         if (!no_dry_run)
         {

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -129,12 +129,11 @@ namespace vcpkg::Dependencies
                                  const fs::path& install_port_path,
                                  const fs::path& default_port_path)
     {
-        const char* const from_head = options.use_head_version == Build::UseHeadVersion::YES ? " (from HEAD)" : "";
-
         if (!default_port_path.empty()
             && !Strings::case_insensitive_ascii_starts_with(install_port_path.u8string(),
                                                             default_port_path.u8string()))
         {
+            const char* const from_head = options.use_head_version == Build::UseHeadVersion::YES ? " (from HEAD)" : "";
             switch (request_type)
             {
             case RequestType::AUTO_SELECTED:  return Strings::format("  * %s%s -- %s", s, from_head, install_port_path.u8string());

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -684,7 +684,7 @@ namespace vcpkg::Install
 
         Metrics::g_metrics.lock()->track_property("installplan", specs_string);
 
-        Dependencies::print_plan(action_plan, is_recursive);
+        Dependencies::print_plan(action_plan, is_recursive, paths.ports);
 
         if (dry_run)
         {


### PR DESCRIPTION
Fixes #6991 

Sample output:
```
PS C:\src\vcpkg> ./vcpkg install sqlitecpp --dry-run --overlay-ports=C:/ports/sqlite3
The following packages will be built and installed:
  * sqlite3[core]:x86-windows -- c:\ports\sqlite3
    sqlitecpp[core]:x86-windows
Additional packages (*) will be modified to complete this operation.
```