### PR TITLE
[libmediainfo] Add new port

### DIFF
--- a/ports/libmediainfo/CONTROL
+++ b/ports/libmediainfo/CONTROL
@@ -1,0 +1,5 @@
+Source: libmediainfo
+Version: 20.03
+Homepage: https://github.com/MediaArea/MediaInfoLib
+Description: Get most relevant technical and tag data from video and audio files
+Build-Depends: libzen, curl, zlib

--- a/ports/libmediainfo/portfile.cmake
+++ b/ports/libmediainfo/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO MediaArea/MediaInfoLib
+    REF v20.03
+    SHA512 c5d3444c8694ca68ee08f97f387cef3aefd9fbb23623b643a6daf9ed7d247521f1291a8a13c9088b31be9a9d594ca772d3125d6eb3d3770bee1f7c50b3b23c07
+    HEAD_REF master
+    PATCHES vcpkg_support_in_cmakelists.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/Project/CMake
+    PREFER_NINJA
+    OPTIONS -DBUILD_ZENLIB=0 -DBUILD_ZLIB=0
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/mediainfolib TARGET_PATH share/mediainfolib)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libmediainfo/vcpkg_support_in_cmakelists.patch
+++ b/ports/libmediainfo/vcpkg_support_in_cmakelists.patch
@@ -1,0 +1,64 @@
+diff --git a/Project/CMake/CMakeLists.txt b/Project/CMake/CMakeLists.txt
+index 47c4ed13..f13ff531 100644
+--- a/Project/CMake/CMakeLists.txt
++++ b/Project/CMake/CMakeLists.txt
+@@ -1,7 +1,7 @@
+-project(MediaInfoLib)
+-
+ cmake_minimum_required(VERSION 2.8.11)
+ 
++project(MediaInfoLib)
++
+ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+ 
+ set(MediaInfoLib_MAJOR_VERSION 20)
+@@ -88,7 +88,7 @@ endif()
+ find_package(TinyXML)
+ 
+ # use system curl if is present
+-find_package(CURL)
++find_package(CURL CONFIG REQUIRED)
+ 
+ include_directories(${MediaInfoLib_SOURCES_PATH})
+ include_directories(${MediaInfoLib_SOURCES_PATH}/ThirdParty/md5/)
+@@ -398,13 +398,7 @@ endif()
+ target_link_libraries(mediainfo ${ZenLib_LIBRARY} ${ZLIB_LIBRARIES})
+ 
+ if(MSVC AND BUILD_SHARED_LIBS)
+-  get_target_property(LOCATION mediainfo LOCATION_DEBUG)
+-  string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
+-  install(FILES ${LOCATION} DESTINATION ${BIN_INSTALL_DIR} CONFIGURATIONS Debug)
+-
+-  get_target_property(LOCATION mediainfo LOCATION_RELWITHDEBINFO)
+-  string(REGEX REPLACE "\\.[^.]*$" ".pdb" LOCATION "${LOCATION}")
+-  install(FILES ${LOCATION} DESTINATION ${BIN_INSTALL_DIR} CONFIGURATIONS RelWithDebInfo)
++  install(FILES $<TARGET_PDB_FILE:mediainfo> DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
+ endif()
+ 
+ if (APPLE)
+diff --git a/Source/ThirdParty/aes-gladman/aesopt.h b/Source/ThirdParty/aes-gladman/aesopt.h
+index 6ad9ca1e..a858396f 100644
+--- a/Source/ThirdParty/aes-gladman/aesopt.h
++++ b/Source/ThirdParty/aes-gladman/aesopt.h
+@@ -183,6 +183,6 @@ Issue Date: 20/12/2007
+        AES_REV_DKS must NOT be defined when such assembler files are
+        built
+ */
+-#if 1 && defined( _WIN64 ) && defined( _MSC_VER )
++#if 1 && defined( _WIN64 ) && defined( _MSC_VER ) && defined( _M_AMD64 )
+ #  define INTEL_AES_POSSIBLE
+ #endif
+diff --git a/Source/ThirdParty/aes-gladman/brg_endian.h b/Source/ThirdParty/aes-gladman/brg_endian.h
+index 4c34f2b5..fae471b9 100644
+--- a/Source/ThirdParty/aes-gladman/brg_endian.h
++++ b/Source/ThirdParty/aes-gladman/brg_endian.h
+@@ -110,7 +110,8 @@ Issue Date: 20/12/2007
+       defined( __MRC__ ) || defined( __MVS__ )   || defined( __MWERKS__ ) || \
+       defined( sparc )   || defined( __sparc)    || defined( SYMANTEC_C ) || \
+       defined( __VOS__ ) || defined( __TIGCC__ ) || defined( __TANDEM )   || \
+-      defined( THINK_C ) || defined( __VMCMS__ ) || defined( _AIX )
++      defined( THINK_C ) || defined( __VMCMS__ ) || defined( _AIX )       || \
++      defined( _M_ARM64 ) || defined ( _M_ARM )
+ #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
+ 
+ #elif 0     /* **** EDIT HERE IF NECESSARY **** */


### PR DESCRIPTION
[MediaInfoLib](https://mediaarea.net/en/MediaInfo) is a library used for retrieving technical information and other metadata about audio or video files.

Depends on:  #7004