### PR TITLE
[capnproto] Enable Linux and OSX support

### DIFF
--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -2,10 +2,6 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
     message(FATAL_ERROR "Error: UWP build is not supported.")
 endif()
 
-if(DEFINED VCPKG_CMAKE_SYSTEM_NAME)
-    message(FATAL_ERROR "Error: CapnProto only build on Windows for now. See #5630 and #5635")
-endif()
-
 include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)


### PR DESCRIPTION
Now that #5630 is fix, this package is fully supported on both Linux
and Mac OS X.