### PR TITLE
[corrade] Workaroud for vs 2017 is still applicable for vs 2019

### DIFF
--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DDUTILITY_USE_ANSI_COLORS=ON
         -DBUILD_STATIC=${BUILD_STATIC}
+        -DCORRADE_MSVC2017_COMPATIBILITY=ON
         ${_COMPONENT_FLAGS}
 )
 


### PR DESCRIPTION
Fixes compilation issue due to ambiguous declaration in ArrayView class.