### PR TITLE
#5248 make vcpkg buildable as  'system' user

### DIFF
--- a/scripts/cleanEnvironmentHelper.ps1
+++ b/scripts/cleanEnvironmentHelper.ps1
@@ -1,6 +1,6 @@
 # Capture environment variables for the System and User. Also add some special/built-in variables.
 # These will be used to synthesize a clean environment
-$specialEnvironmentMap = @{ "SystemDrive"=$env:SystemDrive; "SystemRoot"=$env:SystemRoot; "UserProfile"=$env:UserProfile } # These are built-in and not set in the registry
+$specialEnvironmentMap = @{ "SystemDrive"=$env:SystemDrive; "SystemRoot"=$env:SystemRoot; "UserProfile"=$env:UserProfile; "TMP"=$env:TMP } # These are built-in and not set in the registry
 $machineEnvironmentMap = [Environment]::GetEnvironmentVariables('Machine') # HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment
 $userEnvironmentMap = [Environment]::GetEnvironmentVariables('User') # HKEY_CURRENT_USER\Environment
 


### PR DESCRIPTION
If we keep TMP, when run as 'system' user it is using Windows\Temp and under normal domain user it is using default temp.