### PR TITLE
[mongo-cxx-driver] Do not delete the third_party include folder when building with mnmlstc

### DIFF
--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,5 +1,5 @@
 Source: mongo-cxx-driver
-Version: 3.4.0-2
+Version: 3.4.0-3
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Homepage: https://github.com/mongodb/mongo-cxx-driver
 Description: MongoDB C++ Driver.

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -83,13 +83,16 @@ set(LIBMONGOCXX_LIBRARIES optimized \${LIBMONGOCXX_LIBRARY_PATH_RELEASE} debug \
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 
+if (NOT BSONCXX_POLY STREQUAL MNMLSTC)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/bsoncxx/third_party)
+endif()
+
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/include/bsoncxx/cmake
     ${CURRENT_PACKAGES_DIR}/include/bsoncxx/config/private
     ${CURRENT_PACKAGES_DIR}/include/bsoncxx/private
     ${CURRENT_PACKAGES_DIR}/include/bsoncxx/test
     ${CURRENT_PACKAGES_DIR}/include/bsoncxx/test_util
-    ${CURRENT_PACKAGES_DIR}/include/bsoncxx/third_party
 
     ${CURRENT_PACKAGES_DIR}/include/mongocxx/cmake
     ${CURRENT_PACKAGES_DIR}/include/mongocxx/config/private


### PR DESCRIPTION
Building with the mnmlstc feature enabled, which is default for non-windows builds, will delete the third_party/mnmlstc folder which is required