### PR TITLE
Triplets Overlay Implementation

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -32,7 +32,7 @@ endif()
 
 
 if(CMD MATCHES "^BUILD$")
-    set(CMAKE_TRIPLET_FILE ${VCPKG_ROOT_DIR}/triplets/${TARGET_TRIPLET}.cmake)
+    set(CMAKE_TRIPLET_FILE ${TARGET_TRIPLET_FILE})
     if(NOT EXISTS ${CMAKE_TRIPLET_FILE})
         message(FATAL_ERROR "Unsupported target triplet. Triplet file does not exist: ${CMAKE_TRIPLET_FILE}")
     endif()

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -88,6 +88,7 @@ namespace vcpkg
         std::unique_ptr<std::string> vcpkg_root_dir;
         std::unique_ptr<std::string> triplet;
         std::unique_ptr<std::vector<std::string>> overlay_ports;
+        std::unique_ptr<std::vector<std::string>> overlay_triplets;
         Optional<bool> debug = nullopt;
         Optional<bool> sendmetrics = nullopt;
         Optional<bool> printmetrics = nullopt;

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -47,7 +47,9 @@ namespace vcpkg
 
     struct VcpkgPaths
     {
-        static Expected<VcpkgPaths> create(const fs::path& vcpkg_root_dir, const std::string& default_vs_path);
+        static Expected<VcpkgPaths> create(const fs::path& vcpkg_root_dir, 
+                                           const std::string& default_vs_path,
+                                           const std::vector<std::string>* triplets_dirs);
 
         fs::path package_dir(const PackageSpec& spec) const;
         fs::path build_info_file_path(const PackageSpec& spec) const;
@@ -62,7 +64,6 @@ namespace vcpkg
         fs::path downloads;
         fs::path ports;
         fs::path installed;
-        fs::path triplets;
         fs::path scripts;
 
         fs::path tools;
@@ -75,6 +76,9 @@ namespace vcpkg
         fs::path vcpkg_dir_updates;
 
         fs::path ports_cmake;
+
+        const fs::path get_triplet_file_path(const Triplet& triplet) const;
+        const std::vector<fs::path>& get_triplets_dirs() const;
 
         const fs::path& get_tool_exe(const std::string& tool) const;
         const std::string& get_tool_version(const std::string& tool) const;
@@ -93,6 +97,7 @@ namespace vcpkg
         Lazy<std::vector<Toolset>> toolsets_vs2013;
 
         fs::path default_vs_path;
+        std::vector<fs::path> triplets_dirs;
 
         mutable std::unique_ptr<ToolCache> m_tool_cache;
     };

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -54,9 +54,10 @@ namespace vcpkg
         fs::path package_dir(const PackageSpec& spec) const;
         fs::path build_info_file_path(const PackageSpec& spec) const;
         fs::path listfile_path(const BinaryParagraph& pgh) const;
-
-        const std::vector<std::string>& get_available_triplets() const;
+        
         bool is_valid_triplet(const Triplet& t) const;
+        const std::vector<std::string>& get_available_triplets() const;
+        const fs::path get_triplet_file_path(const Triplet& triplet) const;
 
         fs::path root;
         fs::path packages;
@@ -64,6 +65,7 @@ namespace vcpkg
         fs::path downloads;
         fs::path ports;
         fs::path installed;
+        fs::path triplets;
         fs::path scripts;
 
         fs::path tools;
@@ -76,9 +78,6 @@ namespace vcpkg
         fs::path vcpkg_dir_updates;
 
         fs::path ports_cmake;
-
-        const fs::path get_triplet_file_path(const Triplet& triplet) const;
-        const std::vector<fs::path>& get_triplets_dirs() const;
 
         const fs::path& get_tool_exe(const std::string& tool) const;
         const std::string& get_tool_version(const std::string& tool) const;
@@ -100,5 +99,6 @@ namespace vcpkg
         std::vector<fs::path> triplets_dirs;
 
         mutable std::unique_ptr<ToolCache> m_tool_cache;
+        mutable vcpkg::Cache<std::string, fs::path> m_triplets_cache;
     };
 }

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -99,6 +99,6 @@ namespace vcpkg
         std::vector<fs::path> triplets_dirs;
 
         mutable std::unique_ptr<ToolCache> m_tool_cache;
-        mutable vcpkg::Cache<std::string, fs::path> m_triplets_cache;
+        mutable vcpkg::Cache<Triplet, fs::path> m_triplets_cache;
     };
 }

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -118,7 +118,9 @@ static void inner(const VcpkgCmdArguments& args)
 
     auto default_vs_path = System::get_environment_variable("VCPKG_VISUAL_STUDIO_PATH").value_or("");
 
-    const Expected<VcpkgPaths> expected_paths = VcpkgPaths::create(vcpkg_root_dir, default_vs_path);
+    const Expected<VcpkgPaths> expected_paths = VcpkgPaths::create(vcpkg_root_dir, 
+                                                                   default_vs_path, 
+                                                                   args.overlay_triplets.get());
     Checks::check_exit(VCPKG_LINE_INFO,
                        !expected_paths.error(),
                        "Error: Invalid vcpkg root directory %s: %s",

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -390,6 +390,7 @@ namespace vcpkg::Build
             {"PORT", config.scf.core_paragraph->name},
             {"CURRENT_PORT_DIR", config.port_dir},
             {"TARGET_TRIPLET", spec.triplet().canonical_name()},
+            {"TARGET_TRIPLET_FILE", paths.get_triplet_file_path(spec.triplet()).u8string()},
             {"VCPKG_PLATFORM_TOOLSET", toolset.version.c_str()},
             {"VCPKG_USE_HEAD_VERSION", Util::Enum::to_bool(config.build_package_options.use_head_version) ? "1" : "0"},
             {"DOWNLOADS", paths.downloads},
@@ -890,7 +891,7 @@ namespace vcpkg::Build
 
         const fs::path& cmake_exe_path = paths.get_tool_exe(Tools::CMAKE);
         const fs::path ports_cmake_script_path = paths.scripts / "get_triplet_environment.cmake";
-        const fs::path triplet_file_path = paths.triplets / (triplet.canonical_name() + ".cmake");
+        const fs::path triplet_file_path = paths.get_triplet_file_path(triplet);
 
         const auto cmd_launch_cmake = System::make_cmake_cmd(cmake_exe_path,
                                                              ports_cmake_script_path,

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -361,9 +361,15 @@ namespace vcpkg::Build
     {
         auto& fs = paths.get_filesystem();
         const Triplet& triplet = spec.triplet();
+        const auto& triplet_file_path = paths.get_triplet_file_path(spec.triplet()).u8string();
 
-        if (!Strings::starts_with(Strings::ascii_to_lowercase(config.port_dir.u8string()),
-                                  Strings::ascii_to_lowercase(paths.ports.u8string())))
+        if (!Strings::case_insensitive_ascii_starts_with(triplet_file_path, 
+                                                         paths.triplets.u8string()))
+        {
+            System::printf("-- Loading triplet configuration from: %s\n", triplet_file_path);
+        }
+        if (!Strings::case_insensitive_ascii_starts_with(config.port_dir.u8string(),
+                                                         paths.ports.u8string()))
         {
             System::printf("-- Installing port from location: %s\n", config.port_dir.u8string());
         }
@@ -390,7 +396,7 @@ namespace vcpkg::Build
             {"PORT", config.scf.core_paragraph->name},
             {"CURRENT_PORT_DIR", config.port_dir},
             {"TARGET_TRIPLET", spec.triplet().canonical_name()},
-            {"TARGET_TRIPLET_FILE", paths.get_triplet_file_path(spec.triplet()).u8string()},
+            {"TARGET_TRIPLET_FILE", triplet_file_path},
             {"VCPKG_PLATFORM_TOOLSET", toolset.version.c_str()},
             {"VCPKG_USE_HEAD_VERSION", Util::Enum::to_bool(config.build_package_options.use_head_version) ? "1" : "0"},
             {"DOWNLOADS", paths.downloads},

--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -117,6 +117,8 @@ namespace vcpkg::Help
                        "\n"
                        "  --overlay-ports=<path>          Specify directories to be used when searching for ports\n"
                        "\n"
+                       "  --overlay-triplets=<path>       Specify directories containing triplets files\n"
+                       "\n"
                        "  --vcpkg-root <path>             Specify the vcpkg root "
                        "directory\n"
                        "                                  (default: " ENVVAR(VCPKG_ROOT) //

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -163,6 +163,13 @@ namespace vcpkg
                                               args.overlay_ports);
                     continue;
                 }
+                if (Strings::starts_with(arg, "--overlay-triplets="))
+                {
+                    parse_cojoined_multivalue(arg.substr(sizeof("--overlay-triplets=") - 1),
+                                              "--overlay-triplets",
+                                              args.overlay_triplets);
+                    continue;
+                }
                 if (arg == "--debug")
                 {
                     parse_switch(true, "debug", args.debug);
@@ -418,6 +425,9 @@ namespace vcpkg
         System::printf("    %-40s %s\n", 
                        "--overlay-ports=<path>", 
                        "Specify directories to be used when searching for ports");
+        System::printf("    %-40s %s\n",
+                       "--overlay-triplets=<path>",
+                       "Specify directories containing triplets files");
         System::printf("    %-40s %s\n",
                        "--vcpkg-root <path>",
                        "Specify the vcpkg directory to use instead of current directory or tool directory");

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -45,26 +45,6 @@ namespace vcpkg
         option_field = new_setting;
     }
 
-    static void parse_multivalue(const std::string* arg_begin,
-                                 const std::string* arg_end,
-                                 const std::string& option_name,
-                                 std::unique_ptr<std::vector<std::string>>& option_field)
-    {
-        if (arg_begin == arg_end)
-        {
-            System::print2(System::Color::error, "Error: expected value after ", option_name, '\n');
-            Metrics::g_metrics.lock()->track_property("error", "error option name");
-            Help::print_usage();
-            Checks::exit_fail(VCPKG_LINE_INFO);
-        }
-
-        if (!option_field)
-        {
-            option_field = std::make_unique<std::vector<std::string>>();
-        }
-        option_field->emplace_back(*arg_begin);
-    }
-
     static void parse_cojoined_multivalue(std::string new_value,
                                           const std::string& option_name,
                                           std::unique_ptr<std::vector<std::string>>& option_field)

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -133,7 +133,7 @@ namespace vcpkg
 
     const fs::path VcpkgPaths::get_triplet_file_path(const Triplet& triplet) const
     {
-        return m_triplets_cache.get_lazy(triplet.canonical_name(), [&]()-> auto {
+        return m_triplets_cache.get_lazy(triplet, [&]()-> auto {
             for (auto&& triplet_dir : triplets_dirs)
             {
                 auto&& path = triplet_dir / (triplet.canonical_name() + ".cmake");
@@ -146,7 +146,6 @@ namespace vcpkg
             Checks::exit_with_message(VCPKG_LINE_INFO,
                                       "Error: Triplet file %s.cmake not found",
                                       triplet.canonical_name());
-            return fs::u8path("");
         });
         
     }


### PR DESCRIPTION
Add command `--overlay-triplets` which let's the user specify directories containing triplet files.