### PR TITLE
Fix vcpkg_from_git

### DIFF
--- a/docs/maintainers/vcpkg_from_git.md
+++ b/docs/maintainers/vcpkg_from_git.md
@@ -8,7 +8,6 @@ vcpkg_from_git(
     OUT_SOURCE_PATH <SOURCE_PATH>
     URL <https://android.googlesource.com/platform/external/fdlibm>
     REF <59f7335e4d...>
-    SHA512 <abcdef123...>
     [PATCHES <patch1.patch> <patch2.patch>...]
 )
 ```
@@ -20,17 +19,10 @@ Specifies the out-variable that will contain the extracted location.
 This should be set to `SOURCE_PATH` by convention.
 
 ### URL
-The url of the git repository.
-
-### SHA512
-The SHA512 hash that should match the archive form of the commit.
-
-This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+The url of the git repository.  Must start with `https`.
 
 ### REF
-A stable git commit-ish (ideally a tag or commit) that will not change contents. **This should not be a branch.**
-
-For repositories without official releases, this can be set to the full commit id of the current latest master.
+The git sha of the commit to download.
 
 ### PATCHES
 A list of patches to be applied to the extracted sources.
@@ -38,7 +30,7 @@ A list of patches to be applied to the extracted sources.
 Relative paths are based on the port directory.
 
 ## Notes:
-`OUT_SOURCE_PATH`, `REF`, `SHA512`, and `URL` must be specified.
+`OUT_SOURCE_PATH`, `REF`, and `URL` must be specified.
 
 ## Examples:
 

--- a/ports/fdlibm/CONTROL
+++ b/ports/fdlibm/CONTROL
@@ -1,3 +1,3 @@
 Source: fdlibm
-Version: 5.3-3
+Version: 5.3-4
 Description: FDLIBM (Freely Distributable LIBM) is a C math library for machines that support IEEE 754 floating-point arithmetic

--- a/ports/fdlibm/portfile.cmake
+++ b/ports/fdlibm/portfile.cmake
@@ -1,22 +1,9 @@
 include(vcpkg_common_functions)
 
-# vcpkg_from_git uses git archive to generate the hash, 
-# depending on what system or git settings this runs with it will result in a different hash
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(FDLIBM_HASH 825dcbbb88e3ebda6d928e1794da58d5135d37e36551c12de7eeab58a67adc4f5629c65d6afde567daeb489c287302116b2a5bbdb16693a3b068bbe16b250cf7)
-elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(FDLIBM_HASH 954c75f9f7540f4efb21b1f8de296149c648c0ba10d5e9cc99a247164b9e99b6dc37349a9ddaa04ba93dc035562457665aacf7146926d716cd406b63b97c5d44)
-else()
-    # depending on how git is configured the hash could be 
-    #  bc788c840a57716f996513980d31b203bd86ce9af1ac3656a187266bfdc2fbb22a9ddf88f79ffc91dd75f3f1f1e4fd3449a42b566ffe5e49e9384efd91a68613
-    set(FDLIBM_HASH 75c49ba2875b73e0bfe3a4595be1478ce6041236653b803b02ba00997652c969c351c9647923692af0799149da86c737467ab2954bd8845a2f75b14fde71ac29)
-endif()
-
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://android.googlesource.com/platform/external/fdlibm
     REF 59f7335e4dd8275a7dc2f8aeb4fd00758fde37ac
-    SHA512 ${FDLIBM_HASH}
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -110,7 +110,6 @@ function(vcpkg_from_git)
     file(RENAME "${TEMP_ARCHIVE}" "${ARCHIVE}")
   else()
     message(STATUS "Using cached ${ARCHIVE}")
-    test_hash("${ARCHIVE}" "cached file" "Please delete the file and retry if this file should be downloaded again.")
   endif()
 
   vcpkg_extract_source_archive_ex(

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -8,7 +8,6 @@
 ##     OUT_SOURCE_PATH <SOURCE_PATH>
 ##     URL <https://android.googlesource.com/platform/external/fdlibm>
 ##     REF <59f7335e4d...>
-##     SHA512 <abcdef123...>
 ##     [PATCHES <patch1.patch> <patch2.patch>...]
 ## )
 ## ```
@@ -20,17 +19,10 @@
 ## This should be set to `SOURCE_PATH` by convention.
 ##
 ## ### URL
-## The url of the git repository.
-##
-## ### SHA512
-## The SHA512 hash that should match the archive form of the commit.
-##
-## This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+## The url of the git repository.  Must start with `https`.
 ##
 ## ### REF
-## A stable git commit-ish (ideally a tag or commit) that will not change contents. **This should not be a branch.**
-##
-## For repositories without official releases, this can be set to the full commit id of the current latest master.
+## The git sha of the commit to download.
 ##
 ## ### PATCHES
 ## A list of patches to be applied to the extracted sources.
@@ -38,14 +30,14 @@
 ## Relative paths are based on the port directory.
 ##
 ## ## Notes:
-## `OUT_SOURCE_PATH`, `REF`, `SHA512`, and `URL` must be specified.
+## `OUT_SOURCE_PATH`, `REF`, and `URL` must be specified.
 ##
 ## ## Examples:
 ##
 ## * [fdlibm](https://github.com/Microsoft/vcpkg/blob/master/ports/fdlibm/portfile.cmake)
 
 function(vcpkg_from_git)
-  set(oneValueArgs OUT_SOURCE_PATH URL REF SHA512)
+  set(oneValueArgs OUT_SOURCE_PATH URL REF)
   set(multipleValuesArgs PATCHES)
   cmake_parse_arguments(_vdud "" "${oneValueArgs}" "${multipleValuesArgs}" ${ARGN})
 
@@ -57,12 +49,15 @@ function(vcpkg_from_git)
     message(FATAL_ERROR "The git url must be specified")
   endif()
 
-  if(NOT DEFINED _vdud_REF)
-    message(FATAL_ERROR "The git ref must be specified.")
+  if( NOT _vdud_URL MATCHES "^https:")
+    # vcpkg_from_git does not support a SHA256 parameter because hashing the git archive is
+    # not stable across all supported platforms.  The tradeoff is to require https to download
+    # and the ref to be the git sha (i.e. not things that can change like a label)
+    message(FATAL_ERROR "The git url must be https")
   endif()
 
-  if(NOT DEFINED _vdud_SHA512)
-    message(FATAL_ERROR "vcpkg_from_git requires a SHA512 argument. If you do not know the SHA512, add it as 'SHA512 0' and re-run this command.")
+  if(NOT DEFINED _vdud_REF)
+    message(FATAL_ERROR "The git ref must be specified.")
   endif()
 
   # using .tar.gz instead of .zip because the hash of the latter is affected by timezone.
@@ -70,18 +65,6 @@ function(vcpkg_from_git)
   set(TEMP_ARCHIVE "${DOWNLOADS}/temp/${PORT}-${SANITIZED_REF}.tar.gz")
   set(ARCHIVE "${DOWNLOADS}/${PORT}-${SANITIZED_REF}.tar.gz")
   set(TEMP_SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/${SANITIZED_REF}")
-
-  function(test_hash FILE_PATH FILE_KIND CUSTOM_ERROR_ADVICE)
-    file(SHA512 ${FILE_PATH} FILE_HASH)
-    if(NOT FILE_HASH STREQUAL _vdud_SHA512)
-        message(FATAL_ERROR
-            "\nFile does not have expected hash:\n"
-            "        File path: [ ${FILE_PATH} ]\n"
-            "    Expected hash: [ ${_vdud_SHA512} ]\n"
-            "      Actual hash: [ ${FILE_HASH} ]\n"
-            "${CUSTOM_ERROR_ADVICE}\n")
-    endif()
-  endfunction()
 
   if(NOT EXISTS "${ARCHIVE}")
     if(_VCPKG_NO_DOWNLOADS)
@@ -93,20 +76,35 @@ function(vcpkg_from_git)
     vcpkg_execute_required_process(
       COMMAND ${GIT} init git-tmp
       WORKING_DIRECTORY ${DOWNLOADS}
-      LOGNAME git-init
+      LOGNAME git-init-${TARGET_TRIPLET}
     )
     vcpkg_execute_required_process(
       COMMAND ${GIT} fetch ${_vdud_URL} ${_vdud_REF} --depth 1 -n
       WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
-      LOGNAME git-fetch
+      LOGNAME git-fetch-${TARGET_TRIPLET}
     )
+    execute_process(
+      COMMAND ${GIT} rev-parse FETCH_HEAD
+      OUTPUT_VARIABLE REV_PARSE_HEAD
+      ERROR_VARIABLE REV_PARSE_HEAD
+      RESULT_VARIABLE error_code
+      WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
+    )
+    if(error_code)
+        message(FATAL_ERROR "unable to determine FETCH_HEAD after fetching git repository")
+    endif()
+    string(REGEX REPLACE "\n$" "" REV_PARSE_HEAD "${REV_PARSE_HEAD}")
+    if(NOT REV_PARSE_HEAD STREQUAL ${_vdud_REF})
+        message(FATAL_ERROR "REF (${_vdud_REF}) does not match FETCH_HEAD (${REV_PARSE_HEAD})")
+    endif()
+
     file(MAKE_DIRECTORY "${DOWNLOADS}/temp")
     vcpkg_execute_required_process(
       COMMAND ${GIT} archive FETCH_HEAD -o "${TEMP_ARCHIVE}"
       WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
       LOGNAME git-archive
     )
-    test_hash("${TEMP_ARCHIVE}" "downloaded repo" "")
+
     get_filename_component(downloaded_file_dir "${ARCHIVE}" DIRECTORY)
     file(MAKE_DIRECTORY "${downloaded_file_dir}")
     file(RENAME "${TEMP_ARCHIVE}" "${ARCHIVE}")

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -94,7 +94,7 @@ function(vcpkg_from_git)
         message(FATAL_ERROR "unable to determine FETCH_HEAD after fetching git repository")
     endif()
     string(REGEX REPLACE "\n$" "" REV_PARSE_HEAD "${REV_PARSE_HEAD}")
-    if(NOT REV_PARSE_HEAD STREQUAL ${_vdud_REF})
+    if(NOT REV_PARSE_HEAD STREQUAL _vdud_REF)
         message(FATAL_ERROR "REF (${_vdud_REF}) does not match FETCH_HEAD (${REV_PARSE_HEAD})")
     endif()
 


### PR DESCRIPTION
addresses #6707 by removing the SHA256 parameter from vcpkg_from_git and instead relying on the built in sha from git.  The way it was being calculated is by hashing the output of git archive after the repository was cloned.  This was not stable because different systems/versions rely of different compression tools.

The only port using this is fdlibm so the change does not have much of an impact.