### PR TITLE
[asio] fix flaky build

### DIFF
--- a/ports/asio/CMakeLists.txt
+++ b/ports/asio/CMakeLists.txt
@@ -3,11 +3,6 @@ project(asio)
 
 add_library(asio INTERFACE)
 
-# Always use "ASIO_STANDALONE" to avoid boost dependency
-file(READ "asio/include/asio/detail/config.hpp" _contents)
-string(REPLACE "defined(ASIO_STANDALONE)" "!defined(VCPKG_DISABLE_ASIO_STANDALONE)" _contents "${_contents}")
-file(WRITE "asio/include/asio/detail/config.hpp" "${_contents}")
-
 # Export target
 install(TARGETS asio
     EXPORT asio

--- a/ports/asio/CONTROL
+++ b/ports/asio/CONTROL
@@ -1,4 +1,4 @@
 Source: asio
-Version: 1.12.2-1
+Version: 1.12.2-2
 Homepage: https://github.com/chriskohlhoff/asio
 Description: Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -9,6 +9,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Always use "ASIO_STANDALONE" to avoid boost dependency
+file(READ "${SOURCE_PATH}/asio/include/asio/detail/config.hpp" _contents)
+string(REPLACE "defined(ASIO_STANDALONE)" "!defined(VCPKG_DISABLE_ASIO_STANDALONE)" _contents "${_contents}")
+file(WRITE "${SOURCE_PATH}/asio/include/asio/detail/config.hpp" "${_contents}")
+
 # CMake install
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 vcpkg_configure_cmake(


### PR DESCRIPTION
because debug/release cmake config is run at the same time it sometimes caused issues when both were trying to write to the same file.  The 'patch' is better off in the portfile anyway so move it there.