### PR TITLE
[mongoose] Add new port

### DIFF
--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(mongoose C)
+
+include(GNUInstallDirs)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+option(MONGOOSE_INSTALL_HEADERS "Install header files" ON)
+
+add_library(mongoose STATIC mongoose.c)
+
+if(MONGOOSE_INSTALL_HEADERS)
+    install(
+        FILES ${CMAKE_CURRENT_LIST_DIR}/mongoose.h
+        DESTINATION include
+    )
+endif()
+
+install(
+    TARGETS mongoose
+    EXPORT unofficial-mongoose-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    EXPORT unofficial-mongoose-config
+    FILE unofficial-mongoose-config.cmake
+    NAMESPACE unofficial::mongoose::
+    DESTINATION share/cmake/unofficial-mongoose
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)

--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 
 project(mongoose C)
 
@@ -6,30 +6,15 @@ include(GNUInstallDirs)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-option(MONGOOSE_INSTALL_HEADERS "Install header files" ON)
+add_library(mongoose mongoose.c)
+target_include_directories(mongoose PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(mongoose PROPERTIES PUBLIC_HEADER mongoose.h)
 
-add_library(mongoose STATIC mongoose.c)
-
-if(MONGOOSE_INSTALL_HEADERS)
-    install(
-        FILES ${CMAKE_CURRENT_LIST_DIR}/mongoose.h
-        DESTINATION include
-    )
-endif()
-
-install(
-    TARGETS mongoose
-    EXPORT unofficial-mongoose-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+install(TARGETS mongoose EXPORT unofficial-mongoose-config)
 
 install(
     EXPORT unofficial-mongoose-config
-    FILE unofficial-mongoose-config.cmake
     NAMESPACE unofficial::mongoose::
-    DESTINATION share/cmake/unofficial-mongoose
+    DESTINATION share/unofficial-mongoose
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
 )

--- a/ports/mongoose/CONTROL
+++ b/ports/mongoose/CONTROL
@@ -1,4 +1,4 @@
 Source: mongoose
-Version: 6.15
+Version: 6.15-1
 Description: Embedded web server / embedded networking library
 Homepage: https://cesanta.com/

--- a/ports/mongoose/CONTROL
+++ b/ports/mongoose/CONTROL
@@ -1,0 +1,4 @@
+Source: mongoose
+Version: 6.15
+Description: Embedded web server / embedded networking library
+Homepage: https://cesanta.com/

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -1,5 +1,9 @@
 include(vcpkg_common_functions)
 
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "${PORT} does not currently support UWP")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cesanta/mongoose

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO cesanta/mongoose
+    REF 6.15
+    SHA512 d736aeb9ccb7a67fb8180ed324d3fa26e005bfc2ede1db00d73349976bfcfb45489ce3efb178817937fae3cd9f6a6e9c4b620af8517e3ace9c53b9541539bdde
+    HEAD_REF master
+)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_DEBUG
+        -DMONGOOSE_INSTALL_HEADERS=OFF
+    OPTIONS_RELEASE
+        -DMONGOOSE_INSTALL_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+# CMake integration test
+vcpkg_test_cmake(PACKAGE_NAME unofficial-${PORT})

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -4,6 +4,8 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cesanta/mongoose
@@ -12,22 +14,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS_DEBUG
-        -DMONGOOSE_INSTALL_HEADERS=OFF
-    OPTIONS_RELEASE
-        -DMONGOOSE_INSTALL_HEADERS=ON
 )
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
https://github.com/cesanta/mongoose

There is also a Javascript project named `mongoose`: https://github.com/Automattic/mongoose
From https://repology.org/projects/?search=mongoose, we see that some use `mongoose` as the lib name, and some use `libmongoose`.

`Cesanta` also provides a web server application named `mongoose` which can be downloaded from the homepage.
