### PR TITLE
[vcpkg] Fix powershell font corruption bug

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -114,7 +114,7 @@
         <sha512>56a55ae9a6b5dfad4f28f9fe9b8114f1475c999d2f07fff7efa7375f987e74b498e9b63c41fc6c577756f15f3a1459c6d5d367902de3bedebdf9a9fd49089a86</sha512>
         <archiveName>ninja-freebsd-1.8.2.zip</archiveName>
     </tool>
-    <tool name="powershell" os="windows">
+    <tool name="powershell-core" os="windows">
         <version>6.2.1</version>
         <exeRelativePath>pwsh.exe</exeRelativePath>
         <url>https://github.com/PowerShell/PowerShell/releases/download/v6.2.1/PowerShell-6.2.1-win-x86.zip</url>

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -114,4 +114,11 @@
         <sha512>56a55ae9a6b5dfad4f28f9fe9b8114f1475c999d2f07fff7efa7375f987e74b498e9b63c41fc6c577756f15f3a1459c6d5d367902de3bedebdf9a9fd49089a86</sha512>
         <archiveName>ninja-freebsd-1.8.2.zip</archiveName>
     </tool>
+    <tool name="powershell" os="windows">
+        <version>6.2.1</version>
+        <exeRelativePath>pwsh.exe</exeRelativePath>
+        <url>https://github.com/PowerShell/PowerShell/releases/download/v6.2.1/PowerShell-6.2.1-win-x86.zip</url>
+        <sha512>ab1effc926b000a6adc12198a1886514ec203621a53b0cd7ec1cd9a8225dccda7e857feaabcfba4004bea73129b986abaad777c4573f44e0af70411226ce08b0</sha512>
+        <archiveName>PowerShell-6.2.1-win-x86.zip</archiveName>
+    </tool>
 </tools>

--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -31,7 +31,8 @@ namespace vcpkg::System
     };
 
     int cmd_execute_clean(const ZStringView cmd_line,
-                          const std::unordered_map<std::string, std::string>& extra_env = {});
+                          const std::unordered_map<std::string, std::string>& extra_env = {},
+                          const std::string& prepend_to_path = {});
 
     int cmd_execute(const ZStringView cmd_line);
 

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -188,12 +188,17 @@ namespace vcpkg
     }
 
 #if defined(_WIN32)
-    static std::wstring compute_clean_environment(const std::unordered_map<std::string, std::string>& extra_env)
+    static std::wstring compute_clean_environment(const std::unordered_map<std::string, std::string>& extra_env,
+                                                  const std::string& prepend_to_path)
     {
         static const std::string SYSTEM_ROOT = get_environment_variable("SystemRoot").value_or_exit(VCPKG_LINE_INFO);
         static const std::string SYSTEM_32 = SYSTEM_ROOT + R"(\system32)";
-        std::string new_path = Strings::format(
-            R"(Path=%s;%s;%s\Wbem;%s\WindowsPowerShell\v1.0\)", SYSTEM_32, SYSTEM_ROOT, SYSTEM_32, SYSTEM_32);
+        std::string new_path = Strings::format(R"(Path=%s%s;%s;%s\Wbem;%s\WindowsPowerShell\v1.0\)",
+                                               prepend_to_path,
+                                               SYSTEM_32,
+                                               SYSTEM_ROOT,
+                                               SYSTEM_32,
+                                               SYSTEM_32);
 
         std::vector<std::wstring> env_wstrings = {
             L"ALLUSERSPROFILE",
@@ -348,7 +353,8 @@ namespace vcpkg
 #endif
 
     int System::cmd_execute_clean(const ZStringView cmd_line,
-                                  const std::unordered_map<std::string, std::string>& extra_env)
+                                  const std::unordered_map<std::string, std::string>& extra_env,
+                                  const std::string& prepend_to_path)
     {
         auto timer = Chrono::ElapsedTimer::create_started();
 #if defined(_WIN32)
@@ -357,7 +363,7 @@ namespace vcpkg
         memset(&process_info, 0, sizeof(PROCESS_INFORMATION));
 
         g_ctrl_c_state.transition_to_spawn_process();
-        auto clean_env = compute_clean_environment(extra_env);
+        auto clean_env = compute_clean_environment(extra_env, prepend_to_path);
         windows_create_process(cmd_line, clean_env.data(), process_info, NULL);
 
         CloseHandle(process_info.hThread);
@@ -608,10 +614,7 @@ namespace vcpkg
     void System::register_console_ctrl_handler() {}
 #endif
 
-    int System::get_num_logical_cores()
-    {
-        return std::thread::hardware_concurrency();
-    }
+    int System::get_num_logical_cores() { return std::thread::hardware_concurrency(); }
 }
 
 namespace vcpkg::Debug

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -363,13 +363,11 @@ namespace vcpkg::Build
         const Triplet& triplet = spec.triplet();
         const auto& triplet_file_path = paths.get_triplet_file_path(spec.triplet()).u8string();
 
-        if (!Strings::case_insensitive_ascii_starts_with(triplet_file_path, 
-                                                         paths.triplets.u8string()))
+        if (!Strings::case_insensitive_ascii_starts_with(triplet_file_path, paths.triplets.u8string()))
         {
             System::printf("-- Loading triplet configuration from: %s\n", triplet_file_path);
         }
-        if (!Strings::case_insensitive_ascii_starts_with(config.port_dir.u8string(),
-                                                         paths.ports.u8string()))
+        if (!Strings::case_insensitive_ascii_starts_with(config.port_dir.u8string(), paths.ports.u8string()))
         {
             System::printf("-- Installing port from location: %s\n", config.port_dir.u8string());
         }
@@ -382,6 +380,13 @@ namespace vcpkg::Build
 
         const fs::path& cmake_exe_path = paths.get_tool_exe(Tools::CMAKE);
         const fs::path& git_exe_path = paths.get_tool_exe(Tools::GIT);
+#if defined(_WIN32)
+        const fs::path& powershell_exe_path = paths.get_tool_exe("powershell");
+        if (!fs.exists(powershell_exe_path.parent_path() / "powershell.exe"))
+        {
+            fs.copy(powershell_exe_path, powershell_exe_path.parent_path() / "powershell.exe", fs::copy_options::none);
+        }
+#endif
 
         std::string all_features;
         for (auto& feature : config.scf.feature_paragraphs)
@@ -425,8 +430,14 @@ namespace vcpkg::Build
         }
         command.append(cmd_launch_cmake);
         const auto timer = Chrono::ElapsedTimer::create_started();
-
-        const int return_code = System::cmd_execute_clean(command);
+        const int return_code = System::cmd_execute_clean(
+            command,
+            {}
+#ifdef _WIN32
+            ,
+            powershell_exe_path.parent_path().u8string() + ";"
+#endif
+        );
         const auto buildtimeus = timer.microseconds();
         const auto spec_string = spec.to_string();
 

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -381,7 +381,7 @@ namespace vcpkg::Build
         const fs::path& cmake_exe_path = paths.get_tool_exe(Tools::CMAKE);
         const fs::path& git_exe_path = paths.get_tool_exe(Tools::GIT);
 #if defined(_WIN32)
-        const fs::path& powershell_exe_path = paths.get_tool_exe("powershell");
+        const fs::path& powershell_exe_path = paths.get_tool_exe("powershell-core");
         if (!fs.exists(powershell_exe_path.parent_path() / "powershell.exe"))
         {
             fs.copy(powershell_exe_path, powershell_exe_path.parent_path() / "powershell.exe", fs::copy_options::none);

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -380,17 +380,10 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         static constexpr StringLiteral TITLE = "PowerShell Tab-Completion";
         const fs::path script_path = paths.scripts / "addPoshVcpkgToPowershellProfile.ps1";
 
-        // Console font corruption workaround
-        SetConsoleCP(437);
-        SetConsoleOutputCP(437);
-
+        const auto& ps = paths.get_tool_exe("powershell");
         const std::string cmd = Strings::format(
-            R"(powershell -NoProfile -ExecutionPolicy Bypass -Command "& {& '%s' %s}")", script_path.u8string(), "");
+            R"("%s" -NoProfile -ExecutionPolicy Bypass -Command "& {& '%s' }")", ps.u8string(), script_path.u8string());
         const int rc = System::cmd_execute(cmd);
-
-        SetConsoleCP(CP_UTF8);
-        SetConsoleOutputCP(CP_UTF8);
-
         if (rc)
         {
             System::printf(System::Color::error,

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -380,7 +380,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         static constexpr StringLiteral TITLE = "PowerShell Tab-Completion";
         const fs::path script_path = paths.scripts / "addPoshVcpkgToPowershellProfile.ps1";
 
-        const auto& ps = paths.get_tool_exe("powershell");
+        const auto& ps = paths.get_tool_exe("powershell-core");
         const std::string cmd = Strings::format(
             R"("%s" -NoProfile -ExecutionPolicy Bypass -Command "& {& '%s' }")", ps.u8string(), script_path.u8string());
         const int rc = System::cmd_execute(cmd);

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj
@@ -161,8 +161,14 @@
     <ClInclude Include="..\include\vcpkg\base\stringliteral.h" />
     <ClInclude Include="..\include\vcpkg\base\stringrange.h" />
     <ClInclude Include="..\include\vcpkg\base\strings.h" />
+    <ClInclude Include="..\include\vcpkg\base\stringview.h" />
+    <ClInclude Include="..\include\vcpkg\base\system.debug.h" />
     <ClInclude Include="..\include\vcpkg\base\system.h" />
+    <ClInclude Include="..\include\vcpkg\base\system.print.h" />
+    <ClInclude Include="..\include\vcpkg\base\system.process.h" />
     <ClInclude Include="..\include\vcpkg\base\util.h" />
+    <ClInclude Include="..\include\vcpkg\base\view.h" />
+    <ClInclude Include="..\include\vcpkg\base\zstringview.h" />
     <ClInclude Include="..\include\vcpkg\binaryparagraph.h" />
     <ClInclude Include="..\include\vcpkg\build.h" />
     <ClInclude Include="..\include\vcpkg\commands.h" />

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj.filters
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj.filters
@@ -383,5 +383,23 @@
     <ClInclude Include="..\include\vcpkg\base\downloads.h">
       <Filter>Header Files\vcpkg\base</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\stringview.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\system.debug.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\system.print.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\system.process.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\view.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\vcpkg\base\zstringview.h">
+      <Filter>Header Files\vcpkg\base</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
All in-box versions of powershell in Windows 7 through Windows 10 will corrupt the console font in certain (common) circumstances[1]. The best way to fix this is to always use the new powershell core, which has removed this "feature".

As an added bonus, it means any powershell scripts inside vcpkg can rely on having a modern version of powershell and don't need to worry about version skew across legacy Windows versions (Note: does not apply to bootstrap.ps1 and applocal.ps1 because these run outside vcpkg).

[1] https://github.com/PowerShell/PowerShell/commit/46cdd7ec13eb6f29f0984b0278ef1f58bfb853bc#diff-38052b6d0f2182bf2d4debed33df29f6L2665