### PR TITLE
[vcpkg-integrate] Improve spelling, help, and autocomplete.

### DIFF
--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -409,7 +409,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
 
         Checks::exit_with_code(VCPKG_LINE_INFO, rc);
     }
-#elif defined(__unix__)
+#else
     static void integrate_bash(const VcpkgPaths& paths)
     {
         const auto home_path = System::get_environment_variable("HOME").value_or_exit(VCPKG_LINE_INFO);
@@ -458,11 +458,12 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         "first use\n"
         "  vcpkg integrate remove          Remove user-wide integration\n"
         "  vcpkg integrate project         Generate a referencing nuget package for individual VS project use\n"
-        "  vcpkg integrate powershell      Enable PowerShell Tab-Completion\n";
+        "  vcpkg integrate powershell      Enable PowerShell tab-completion\n";
 #else
     const char* const INTEGRATE_COMMAND_HELPSTRING =
         "  vcpkg integrate install         Make installed packages available user-wide.\n"
-        "  vcpkg integrate remove          Remove user-wide integration\n";
+        "  vcpkg integrate remove          Remove user-wide integration\n"
+        "  vcpkg integrate bash            Enable bash tab-completion\n";
 #endif
 
     namespace Subcommand
@@ -476,7 +477,15 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
 
     static std::vector<std::string> valid_arguments(const VcpkgPaths&)
     {
-        return {Subcommand::INSTALL, Subcommand::REMOVE, Subcommand::PROJECT, Subcommand::POWERSHELL, Subcommand::BASH};
+        return
+        {
+            Subcommand::INSTALL, Subcommand::REMOVE,
+#if defined(_WIN32)
+                Subcommand::PROJECT, Subcommand::POWERSHELL,
+#else
+                Subcommand::BASH,
+#endif
+        };
     }
 
     const CommandStructure COMMAND_STRUCTURE = {
@@ -510,7 +519,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         {
             return integrate_powershell(paths);
         }
-#elif defined(__unix__)
+#else
         if (args.command_arguments[0] == Subcommand::BASH)
         {
             return integrate_bash(paths);


### PR DESCRIPTION
Small drive-by fixes to line up help, autocomplete, and actual execution for the `vcpkg integrate` subcommands.