### PR TITLE
[poco] Fix the release libraries are linked to debug pcred.dll

### DIFF
--- a/ports/poco/find_pcre.patch
+++ b/ports/poco/find_pcre.patch
@@ -1,13 +1,17 @@
 diff --git a/cmake/FindPCRE.cmake b/cmake/FindPCRE.cmake
-index 41a99cb..77f3a42 100644
+index 41a99cb57..3236b97e8 100644
 --- a/cmake/FindPCRE.cmake
 +++ b/cmake/FindPCRE.cmake
-@@ -14,7 +14,7 @@ ENDIF (PCRE_INCLUDE_DIRS)
+@@ -14,7 +14,11 @@ ENDIF (PCRE_INCLUDE_DIRS)
  
  FIND_PATH(PCRE_INCLUDE_DIR pcre.h)
  
 -SET(PCRE_NAMES pcre)
-+SET(PCRE_NAMES pcred pcre)
++if(CMAKE_BUILD_TYPE STREQUAL Debug)
++  SET(PCRE_NAMES pcre${CMAKE_DEBUG_POSTFIX})
++else()
++  SET(PCRE_NAMES pcre)
++endif()
  FIND_LIBRARY(PCRE_LIBRARY NAMES ${PCRE_NAMES} )
  
  # handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if

--- a/ports/poco/find_pcre.patch
+++ b/ports/poco/find_pcre.patch
@@ -8,9 +8,9 @@ index 41a99cb57..3236b97e8 100644
  
 -SET(PCRE_NAMES pcre)
 +if(CMAKE_BUILD_TYPE STREQUAL Debug)
-+  SET(PCRE_NAMES pcre${CMAKE_DEBUG_POSTFIX})
++  SET(PCRE_NAMES pcred pcre)
 +else()
-+  SET(PCRE_NAMES pcre)
++  SET(PCRE_NAMES pcre pcred)
 +endif()
  FIND_LIBRARY(PCRE_LIBRARY NAMES ${PCRE_NAMES} )
  


### PR DESCRIPTION
This merge fixies #6349 but adhoc way.

This is a modified version of PR #5994 to support non-windows platforms.

Note:  this find_pcre.patch will be breaked by POCO's upstream modification  https://github.com/pocoproject/poco/commit/bd98f5cedf298148a053bf2f7142847351f64fb9
So we will need to remake find_pcre.patch when bump up ports/poco/portfile.cmake.

Usually, this problem should be solved by POCO or PCRE itself by providing FindPCRE.cmake.
In the meantime, I would like to apply this patch to keep the correct POCO build on vcpkg.

Initially, #5543 considered to include #5994 but finally excluded. because it looks a special kind of butterfly between #304 and #5994.  I hope this fixes these butterfly issue too.
