### PR TITLE
[libmupdf] Enable the old patch for fixing C2169

### DIFF
--- a/ports/libmupdf/CONTROL
+++ b/ports/libmupdf/CONTROL
@@ -1,5 +1,5 @@
 Source: libmupdf
-Version: 1.15.0
+Version: 1.15.0-1
 Build-Depends: freetype, libjpeg-turbo, harfbuzz, zlib, curl, glfw3, openjpeg, jbig2dec
 Homepage: https://github.com/ArtifexSoftware/mupdf
 Description: a lightweight PDF, XPS, and E-book library

--- a/ports/libmupdf/Fix-error-C2169.patch
+++ b/ports/libmupdf/Fix-error-C2169.patch
@@ -2,11 +2,11 @@ diff --git a/include/mupdf/fitz/system.h b/include/mupdf/fitz/system.h
 index 0552771..42fd037 100644
 --- a/include/mupdf/fitz/system.h
 +++ b/include/mupdf/fitz/system.h
-@@ -117,7 +117,6 @@ static __inline int signbit(double x)
+@@ -131,7 +131,6 @@ #define isnan(x) _isnan(x)
  #define isinf(x) (!_finite(x))
  #endif
  
 -#define hypotf _hypotf
  #define atoll _atoi64
  
- char *fz_utf8_from_wchar(const wchar_t *s);
+ #endif


### PR DESCRIPTION
Since the last source update, the patch Fix-error-C2169.patch became invalid, then the error C2169 appeared again.
Modify the patch file for fixing C2169.