### PR TITLE
[aws-checksums]Fix build error with arm-uwp.

### DIFF
--- a/ports/aws-checksums/CONTROL
+++ b/ports/aws-checksums/CONTROL
@@ -1,3 +1,3 @@
 Source: aws-checksums
-Version: 0.1.2
+Version: 0.1.2-1
 Description: Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient SW implementations.

--- a/ports/aws-checksums/fix-arm-build.patch
+++ b/ports/aws-checksums/fix-arm-build.patch
@@ -1,0 +1,77 @@
+diff --git a/source/arm/crc32c_arm.c b/source/arm/crc32c_arm.c
+new file mode 100644
+index 0000000..7ed1d8c
+--- /dev/null
++++ b/source/arm/crc32c_arm.c
+@@ -0,0 +1,25 @@
++/*
++ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License").
++ * You may not use this file except in compliance with the License.
++ * A copy of the License is located at
++ *
++ *  http://aws.amazon.com/apache2.0
++ *
++ * or in the "license" file accompanying this file. This file is distributed
++ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
++ * express or implied. See the License for the specific language governing
++ * permissions and limitations under the License.
++ */
++
++/* for the moment, fallback to SW on ARM until MSFT adds intrensics for ARM v8.1+ */
++#if (defined(_M_ARM) || defined(__arm__) || defined(__ARM_ARCH_ISA_A64)) && !(defined(__GNUC__) && defined(DEBUG_BUILD))
++
++#    include <aws/checksums/private/crc_priv.h>
++
++uint32_t aws_checksums_crc32c_hw(const uint8_t *data, int length, uint32_t previousCrc32) {
++    aws_checksums_crc32c_sw(data, length, previousCrc32);
++}
++
++#endif
+\ No newline at end of file
+diff --git a/source/visualc/visualc_crc32c_sse42.c b/source/visualc/visualc_crc32c_sse42.c
+index 05ad5cf..bc80771 100644
+--- a/source/visualc/visualc_crc32c_sse42.c
++++ b/source/visualc/visualc_crc32c_sse42.c
+@@ -16,13 +16,15 @@
+ #include <aws/checksums/private/crc_priv.h>
+ #include <intrin.h>
+ 
+-#if defined(_M_X64)
++#if defined(_M_X64) || defined(_M_IX86)
++
++#    if defined(_M_X64)
+ typedef uint64_t *slice_ptr_type;
+ typedef uint64_t slice_ptr_int_type;
+-#else
++#    else
+ typedef uint32_t *slice_ptr_type;
+ typedef uint32_t slice_ptr_int_type;
+-#endif
++#    endif
+ 
+ /**
+  * This implements crc32c via the intel sse 4.2 instructions.
+@@ -62,11 +64,11 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *data, int length, uint32_t previ
+     uint32_t remainder = length_to_process % sizeof(temp);
+ 
+     while (slices--) {
+-#if defined(_M_X64)
++#    if defined(_M_X64)
+         crc = (uint32_t)_mm_crc32_u64(crc, *temp++);
+-#else
++#    else
+         crc = _mm_crc32_u32(crc, *temp++);
+-#endif
++#    endif
+     }
+ 
+     /* process the remaining parts that can't be done on the slice size. */
+@@ -78,3 +80,5 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *data, int length, uint32_t previ
+ 
+     return ~crc;
+ }
++
++#endif /* x64 || x86 */
+\ No newline at end of file

--- a/ports/aws-checksums/portfile.cmake
+++ b/ports/aws-checksums/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF v0.1.2
     SHA512 d924918fce5179e2f42c0aeb86cb3bfda22f92bf3950e179f248a8d3e72c05a4f1015982970fd4075bb687a0a6e03120eee2134c0f017ec8ef69ae066881aa0d
     HEAD_REF master
+    PATCHES fix-arm-build.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Fix arm-uwp build error according to official [method](https://github.com/awslabs/aws-checksums/pull/18).

Related: #4910.