### PR TITLE
[botan] Fix build error C2039 with Visual Studio 2019 and C++17

### DIFF
--- a/ports/botan/CONTROL
+++ b/ports/botan/CONTROL
@@ -1,4 +1,4 @@
 Source: botan
-Version: 2.9.0-1
+Version: 2.9.0-2
 Homepage: https://botan.randombit.net
 Description: A cryptography library written in C++11

--- a/ports/botan/fix-build_error.patch
+++ b/ports/botan/fix-build_error.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lib/utils/filesystem.cpp b/src/lib/utils/filesystem.cpp
+index 053c91e..8e0a271 100644
+--- a/src/lib/utils/filesystem.cpp
++++ b/src/lib/utils/filesystem.cpp
+@@ -9,8 +9,10 @@
+ #include <botan/internal/filesystem.h>
+ #include <algorithm>
+ 
++#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
++
+ #if defined(BOTAN_TARGET_OS_HAS_STL_FILESYSTEM_MSVC) && defined(BOTAN_BUILD_COMPILER_IS_MSVC)
+-  #include <filesystem>
++  #include <experimental/filesystem>
+ #elif defined(BOTAN_HAS_BOOST_FILESYSTEM)
+   #include <boost/filesystem.hpp>
+ #elif defined(BOTAN_TARGET_OS_HAS_POSIX1)
+@@ -38,7 +40,7 @@ std::vector<std::string> impl_stl_filesystem(const std::string& dir)
+ #if (_MSVC_LANG >= 201703L)
+    using namespace std::filesystem;
+ #else
+-   using namespace std::tr2::sys;
++   using namespace std::experimental::filesystem;
+ #endif
+ 
+    std::vector<std::string> out;

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF 0129d3172ec419beb90a2b3487f6385a35da0742
     SHA512 a8328df5ad2693a96935d1d2202ddd6678a5ba9c63a8159acbe56f1c884fa5faaa71339e8f56284cfd00574a9b4f91bdb1fb22c36c8e899d9b4cbe881f4867d3
     HEAD_REF master
+	PATCHES
+		fix-build_error.patch
 )
 
 if(CMAKE_HOST_WIN32)


### PR DESCRIPTION
Fix build error:
```
/botan/src/5a35da0742-04e84f84a0/src/lib/utils/filesystem.cpp(41): error C2039: 'tr2': is not a member of 'std'
/botan/src/5a35da0742-04e84f84a0/src/lib/utils/filesystem.cpp(41): error C3083: 'tr2': the symbol to the left of a '::' must be a type
/botan/src/5a35da0742-04e84f84a0/src/lib/utils/filesystem.cpp(41): error C2039: 'sys': is not a member of 'std'
/botan/src/5a35da0742-04e84f84a0/src/lib/utils/filesystem.cpp(41): error C2871: 'sys': a namespace with this name does not exist
/botan/src/5a35da0742-04e84f84a0/src/lib/utils/filesystem.cpp(46): error C2065: 'path': undeclared identifier
```