### PR TITLE
[freetype]Re-fixed the issue of exporting symbols when building dynamic library.

### DIFF
--- a/ports/freetype/0005-Fix-DLL-EXPORTS.patch
+++ b/ports/freetype/0005-Fix-DLL-EXPORTS.patch
@@ -1,13 +1,14 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dd8a878..75f9ab7 100644
+index ede5daf..46c1e55 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -141,7 +141,7 @@ set(VERSION_PATCH "1")
- #     Increment REVISION.
- set(LIBRARY_VERSION "6.16.0")
- set(LIBRARY_SOVERSION "6")
--
-+ADD_DEFINITIONS(-DDLL_EXPORT)
- # These options mean "require x and complain if not found". They'll get
+@@ -151,6 +151,9 @@ set(LIBRARY_SOVERSION "6")
  # optionally found anyway. Use `-DCMAKE_DISABLE_FIND_PACKAGE_x=TRUE` to disable
  # searching for a packge entirely (x is the CMake package name, so "BZip2"
+ # instead of "BZIP2").
++if (ENABLE_DLL_EXPORT)
++  ADD_DEFINITIONS(-DDLL_EXPORT)
++endif()
+ option(FT_WITH_ZLIB "Use system zlib instead of internal library." OFF)
+ option(FT_WITH_BZIP2 "Support bzip2 compressed fonts." OFF)
+ option(FT_WITH_PNG "Support PNG compressed OpenType embedded bitmaps." OFF)

--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,5 @@
 Source: freetype
-Version: 2.10.0
+Version: 2.10.0-1
 Build-Depends: zlib, bzip2, libpng
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -7,27 +7,20 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 dfad66f419ea9577f09932e0730c0c887bdcbdbc8152fa7477a0c39d69a5b68476761deed6864ddcc5cf18d100a7a3f728049768e24afcb04b1a74b25b6acf7e
 )
 
+vcpkg_extract_source_archive_ex(
+OUT_SOURCE_PATH SOURCE_PATH
+ARCHIVE ${ARCHIVE}
+REF ${FT_VERSION}
+PATCHES
+    0001-Fix-install-command.patch
+    0002-Add-CONFIG_INSTALL_PATH-option.patch
+    0003-Fix-UWP.patch
+)
+    
 if(NOT ${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
-    vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${FT_VERSION}
-    PATCHES
-        0001-Fix-install-command.patch
-        0002-Add-CONFIG_INSTALL_PATH-option.patch
-        0003-Fix-UWP.patch
-    )
+  set(ENABLE_DLL_EXPORT OFF)
 else()
-    vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${FT_VERSION}
-    PATCHES
-        0001-Fix-install-command.patch
-        0002-Add-CONFIG_INSTALL_PATH-option.patch
-        0003-Fix-UWP.patch
-        0005-Fix-DLL-EXPORTS.patch
-    )
+  set(ENABLE_DLL_EXPORT ON)
 endif()
 
 vcpkg_configure_cmake(
@@ -40,6 +33,7 @@ vcpkg_configure_cmake(
         -DFT_WITH_PNG=ON
         -DFT_WITH_HARFBUZZ=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE
+        -DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
 )
 
 vcpkg_install_cmake()

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -15,6 +15,7 @@ PATCHES
     0001-Fix-install-command.patch
     0002-Add-CONFIG_INSTALL_PATH-option.patch
     0003-Fix-UWP.patch
+    0005-Fix-DLL-EXPORTS.patch
 )
     
 if(NOT ${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")


### PR DESCRIPTION
When we have built a dynamic library, since there is already a **source cache**, the patch will **not** be applied.

It is **unreasonable** to use the condition to determine whether to apply the patch.

Related: #5853.