### PR TITLE
kinectsdk2: fix missing header files

### DIFF
--- a/ports/kinectsdk2/CONTROL
+++ b/ports/kinectsdk2/CONTROL
@@ -1,3 +1,3 @@
 Source: kinectsdk2
-Version: 2.0
+Version: 2.0-1
 Description: Kinect for Windows SDK for Kinect v2 sensor.

--- a/ports/kinectsdk2/portfile.cmake
+++ b/ports/kinectsdk2/portfile.cmake
@@ -43,7 +43,7 @@ set(KINECTSDK20_DIR "${CURRENT_BUILDTREES_DIR}/src/installer/msi/Microsoft SDKs/
 
 file(
     INSTALL
-        "${KINECTSDK20_DIR}/inc/Kinect.h"
+        "${KINECTSDK20_DIR}/inc/"
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/include
 )


### PR DESCRIPTION
The Kinect sdk is missing crucial headers like `Kinect.INPC.h`.