### PR TITLE
[xmsh]Upgrade version to 0.5.2 and fix build failure.

### DIFF
--- a/ports/xmsh/CONTROL
+++ b/ports/xmsh/CONTROL
@@ -1,4 +1,4 @@
 Source: xmsh
-Version: 0.4.1
+Version: 0.5.2
 Description: Reference Implementation of XMSH Library
 Build-Depends: tl-expected

--- a/ports/xmsh/CONTROL
+++ b/ports/xmsh/CONTROL
@@ -1,4 +1,4 @@
 Source: xmsh
 Version: 0.5.2
 Description: Reference Implementation of XMSH Library
-Build-Depends: tl-expected
+Build-Depends: tl-expected, nlohmann-json

--- a/ports/xmsh/portfile.cmake
+++ b/ports/xmsh/portfile.cmake
@@ -36,4 +36,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
+file(INSTALL ${SOURCE_PATH}/copyright.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/xmsh RENAME copyright)
+
 vcpkg_copy_pdbs()

--- a/ports/xmsh/portfile.cmake
+++ b/ports/xmsh/portfile.cmake
@@ -2,16 +2,17 @@ include(vcpkg_common_functions)
 
 vcpkg_find_acquire_program(PYTHON3)
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.1")
-  message(FATAL_ERROR "Building with a gcc version less than 7.1 is not supported.")
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    message("Building with a gcc version less than 7.1.0 is not supported.")
+else()
+    message(FATAL_ERROR "xmsh only support Linux/OSX.")
 endif()
-
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO libxmsh/xmsh
-  REF v0.5.2
-  SHA512 f4b722e74679223f5329802ff5dd6a0ade9781246227525303a5382b744e3763aca794a49146867ef5053f06ec956a69dac06469c315bb1388fea88b3ef5c0db
+  REF e1900845b796ef977db70519b2ac08eebd788236 #v0.5.2
+  SHA512 643c6c94956de9b6fae635b6528e8ba756f4a2bc38de71613c2dd8d47f4a043aee7b6e7fec1870b306be3bea9f5c0c81d1d343bfc27883b3fba986fbc5b15406
   HEAD_REF master
 )
 

--- a/ports/xmsh/portfile.cmake
+++ b/ports/xmsh/portfile.cmake
@@ -2,11 +2,16 @@ include(vcpkg_common_functions)
 
 vcpkg_find_acquire_program(PYTHON3)
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7.1")
+  message(FATAL_ERROR "Building with a gcc version less than 7.1 is not supported.")
+endif()
+
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO libxmsh/xmsh
-  REF v0.4.1
-  SHA512 7bd9fe9e565b33722fec37a7e3d9bd8b7b132692add5d26e31954367fb284b49a26a21532ddcb0e425af7f8208e755f21f2d8de81b33ed2a1149724f4ccd2c38
+  REF v0.5.2
+  SHA512 f4b722e74679223f5329802ff5dd6a0ade9781246227525303a5382b744e3763aca794a49146867ef5053f06ec956a69dac06469c315bb1388fea88b3ef5c0db
   HEAD_REF master
 )
 
@@ -16,6 +21,10 @@ vcpkg_configure_cmake(
   OPTIONS
     -DPYTHON3_EXECUTABLE=${PYTHON3}
 )
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYPATH ${PYTHON3} PATH)
+set(ENV{PATH} "$ENV{PATH};${PYPATH}")
 
 vcpkg_install_cmake()
 


### PR DESCRIPTION
Upgrade version to 0.5.2.
**NOTE**: Xmsh needs to use **gcc** with version **greater** than **7.1** under linux.

Related: #6618.

Note: this port doesn't contain any feature.