### PR TITLE
[vcpkg] Fix incorrect setting of FEATURE_OPTIONS

### DIFF
--- a/scripts/cmake/vcpkg_check_features.cmake
+++ b/scripts/cmake/vcpkg_check_features.cmake
@@ -94,11 +94,11 @@ function(vcpkg_check_features)
 
             if(${_vcf_FEATURE} IN_LIST FEATURES)
                 set(${_vcf_FEATURE_VAR} ON PARENT_SCOPE)
+                list(APPEND _vcf_FEATURE_OPTIONS "-D${_vcf_FEATURE_VAR}=ON")
             else()
                 set(${_vcf_FEATURE_VAR} OFF PARENT_SCOPE)
+                list(APPEND _vcf_FEATURE_OPTIONS "-D${_vcf_FEATURE_VAR}=OFF")
             endif()
-
-            list(APPEND _vcf_FEATURE_OPTIONS "-D${_vcf_FEATURE_VAR}=${${_vcf_FEATURE_VAR}}")
 
             set(_vcf_IS_FEATURE_ARG ON)
         endif()


### PR DESCRIPTION
Setting a variable in PARENT_SCOPE will not make the variable also visible in current scope, which, as a result, causes FEATURE_OPTIONS to be set incorrectly.
This is a bug introduced in https://github.com/microsoft/vcpkg/pull/6958/commits/86211997be15e412a8fbedb73b6ec68517bdbc05 .