### PR TITLE
[civetweb] Upgrade and enable feature websocket

### DIFF
--- a/ports/civetweb/CONTROL
+++ b/ports/civetweb/CONTROL
@@ -1,3 +1,3 @@
 Source: civetweb
-Version: 1.11-1
+Version: 2019-07-05
 Description: Easy to use, powerful, C/C++ embeddable web server.

--- a/ports/civetweb/portfile.cmake
+++ b/ports/civetweb/portfile.cmake
@@ -9,8 +9,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO civetweb/civetweb
-    REF v1.11
-    SHA512 e1520fd2f4a54b6ab4838f4da2ce3f0956e9884059467d196078935a3fce61dad619f3bb1bc2b4c6a757e1a8abfed0e83cba38957c7c52fff235676e9dd1d428
+    REF 2c1caa6e690bfe3b435a10c372ab2dcd14b872e8
+    SHA512 bfd37906f85c10649108f83e755f28f058c0c27b0d597e6eb82f097db7fa043f6014984f1735c904d0e01c8a5e0dc45f1c57c1fb45b08bce78f42539e19160d6
     HEAD_REF master
 )
 
@@ -24,13 +24,16 @@ vcpkg_configure_cmake(
         -DCIVETWEB_ENABLE_IPV6=ON
         -DCIVETWEB_ENABLE_SERVER_EXECUTABLE=OFF
         -DCIVETWEB_ENABLE_SSL=OFF
+        -DCIVETWEB_ENABLE_WEBSOCKETS=ON
 )
 
 vcpkg_install_cmake()
 
-vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/civetweb)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/civetweb/copyright COPYONLY)
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Fix issue https://github.com/microsoft/vcpkg/issues/6108

1. Upgrade to civetweb to the commit https://github.com/civetweb/civetweb/commit/2c1caa6e690bfe3b435a10c372ab2dcd14b872e8 that export cmake targets. It has no new revision released by now. The latest commit break the build, so use the clean commits here.
2. Enable websocket in default.