### PR TITLE
[Poco] Add missing ipjlpapi.lib to foundation library

### DIFF
--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,5 +1,5 @@
 Source: poco
-Version: 2.0.0-pre-2
+Version: 2.0.0-pre-3
 Build-Depends: expat, libpq, pcre, sqlite3, zlib
 Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.
 Homepage: https://github.com/pocoproject/poco

--- a/ports/poco/fix_foundation_link.patch
+++ b/ports/poco/fix_foundation_link.patch
@@ -1,0 +1,26 @@
+diff --git a/Foundation/src/Environment_WIN32.cpp b/Foundation/src/Environment_WIN32.cpp
+index 3cca5c7..8ed1df2 100644
+--- a/Foundation/src/Environment_WIN32.cpp
++++ b/Foundation/src/Environment_WIN32.cpp
+@@ -23,7 +23,7 @@
+ #include <ws2ipdef.h>
+ #include <wincrypt.h>
+ #include <iphlpapi.h>
+-
++#pragma comment(lib, "IPHLPAPI.lib")
+ 
+ namespace Poco {
+ 
+diff --git a/Foundation/src/Environment_WINCE.cpp b/Foundation/src/Environment_WINCE.cpp
+index 62f19bc..d409356 100644
+--- a/Foundation/src/Environment_WINCE.cpp
++++ b/Foundation/src/Environment_WINCE.cpp
+@@ -22,7 +22,7 @@
+ #include <cstring>
+ #include <windows.h>
+ #include <iphlpapi.h>
+-
++#pragma comment(lib, "IPHLPAPI.lib")
+ 
+ namespace Poco {
+ 

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_from_github(
         unbundled_pdf.patch
         # Add the support of arm64-windows
         arm64_pcre.patch
+        fix_foundation_link.patch
 )
 
 # define Poco linkage type


### PR DESCRIPTION
Fix related issue https://github.com/microsoft/vcpkg/issues/6323, add missing ipjlpapi.lib to foundation library