### PR TITLE
[openimageio] Upgrade to version 2.0.8

### DIFF
--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,8 +1,8 @@
 Source: openimageio
-Version: 1.8.16
+Version: 2.0.8
 Homepage: https://github.com/OpenImageIO/oiio
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
-Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map
+Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace
 
 Feature: libraw
 Build-Depends: libraw

--- a/ports/openimageio/fix_libraw.patch
+++ b/ports/openimageio/fix_libraw.patch
@@ -1,8 +1,8 @@
 diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
-index 5eeb7d3..3e8bfcb 100644
+index 2692bb0..f2709d0 100644
 --- a/src/cmake/externalpackages.cmake
 +++ b/src/cmake/externalpackages.cmake
-@@ -336,7 +336,7 @@ if (USE_LIBRAW)
+@@ -380,7 +380,7 @@ if (USE_LIBRAW)
          message (STATUS "Looking for LibRaw with ${LIBRAW_PATH}")
      endif ()
      find_package (LibRaw)
@@ -11,7 +11,7 @@ index 5eeb7d3..3e8bfcb 100644
          set (LIBRAW_FOUND TRUE)
          include_directories (${LibRaw_INCLUDE_DIR})
          if (NOT LibRaw_FIND_QUIETLY)
-@@ -350,7 +350,7 @@ if (USE_LIBRAW)
+@@ -394,7 +394,7 @@ if (USE_LIBRAW)
      if (LINKSTATIC)
          find_package (Jasper)
          find_library (LCMS2_LIBRARIES NAMES lcms2)
@@ -20,11 +20,6 @@ index 5eeb7d3..3e8bfcb 100644
      endif ()
  else ()
      message (STATUS "Not using LibRaw")
-@@ -494,4 +494,3 @@ if (USE_DICOM)
- endif()
- # end DCMTK setup
- ###########################################################################
--
 diff --git a/src/raw.imageio/CMakeLists.txt b/src/raw.imageio/CMakeLists.txt
 index e3608a2..f503035 100644
 --- a/src/raw.imageio/CMakeLists.txt

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OpenImageIO/oiio
-    REF Release-1.8.16
-    SHA512 a919341df7d9625a869cad266d8434881b63a47f3da8daccf4bbab6675d45bd121ff780dd911a7447450fee44cd7bdd42d73aec59a99b667d6d98e79682db2c7
+    REF Release-2.0.8
+    SHA512 412d240916780b784b89d9eeb36b5b9451e8448100fce494c0d95f0b274506d2946cae0eb929dbe8118b8b04a8bd2a926270a971aad7d0542abcff5f35404953
     HEAD_REF master
     PATCHES
         fix_libraw.patch
@@ -72,5 +72,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/openimageio)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/openimageio/LICENSE ${CURRENT_PACKAGES_DIR}/share/openimageio/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/openimageio)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/openimageio/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/openimageio/copyright)

--- a/ports/openimageio/remove_wrong_dependency.patch
+++ b/ports/openimageio/remove_wrong_dependency.patch
@@ -1,23 +1,15 @@
 diff --git a/src/libOpenImageIO/CMakeLists.txt b/src/libOpenImageIO/CMakeLists.txt
-index c528adc..bc133b6 100644
+index 61ed97b..4435426 100644
 --- a/src/libOpenImageIO/CMakeLists.txt
 +++ b/src/libOpenImageIO/CMakeLists.txt
-@@ -162,9 +162,6 @@ if (WIN32)
+@@ -164,10 +164,6 @@ if (WIN32)
      target_link_libraries (OpenImageIO psapi.lib)
  endif ()
  
 -if (VISIBILITY_MAP_FILE)
 -    add_dependencies (OpenImageIO "${VISIBILITY_MAP_FILE}")
 -endif ()
- 
+-
  if (USE_EXTERNAL_PUGIXML)
      target_link_libraries (OpenImageIO ${PUGIXML_LIBRARIES})
-@@ -230,7 +227,7 @@ if (OIIO_BUILD_TESTS)
-     set_target_properties (imagespec_test PROPERTIES FOLDER "Unit Tests")
-     target_link_libraries (imagespec_test OpenImageIO ${Boost_LIBRARIES})
-     add_test (unit_imagespec imagespec_test)
--    
-+
-     add_executable (imagespeed_test imagespeed_test.cpp)
-     set_target_properties (imagespeed_test PROPERTIES FOLDER "Unit Tests")
-     target_link_libraries (imagespeed_test OpenImageIO ${Boost_LIBRARIES})
+ endif ()

--- a/ports/openimageio/use-webp.patch
+++ b/ports/openimageio/use-webp.patch
@@ -1,34 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index abd4e23..12a7f54 100644
+index 7f43455..393af70 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -87,6 +87,7 @@ option (USE_FREETYPE "Use Freetype if found" ON)
- option (USE_GIF "Use GIF if found" ON)
+@@ -96,6 +96,7 @@ option (USE_GIF "Use GIF if found" ON)
  option (USE_PTEX "Use PTex if found" ON)
+ option (USE_WEBP "Use WebP if found" ON)
  option (USE_LIBRAW "Use LibRaw if found" ON)
 +option (USE_WEBP "Use WebP if found" ON)
  set (LIBRAW_PATH "" CACHE STRING "Custom LibRaw path")
  option (OIIO_THREAD_ALLOW_DCLP "OIIO threads may use DCLP for speed" ON)
  option (USE_NUKE "Build Nuke plugins, if Nuke is found" ON)
 diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
-index 7dde986..66da94d 100644
+index f2709d0..3a95da6 100644
 --- a/src/cmake/externalpackages.cmake
 +++ b/src/cmake/externalpackages.cmake
-@@ -366,6 +366,7 @@ endif()
- if (NOT WEBP_FIND_QUIETLY)
-     message (STATUS "WEBP_HOME=${WEBP_HOME}")
+@@ -411,6 +411,7 @@ if (USE_WEBP)
+     if (NOT WEBP_FIND_QUIETLY)
+         message (STATUS "WEBP_HOME=${WEBP_HOME}")
+     endif ()
++    if(USE_WEBP)
+     find_path (WEBP_INCLUDE_DIR webp/encode.h
+                "${PROJECT_SOURCE_DIR}/src/include"
+                "${WEBP_HOME}")
+@@ -427,6 +428,9 @@ if (USE_WEBP)
+         set (WEBP_FOUND FALSE)
+         message (STATUS "WebP library not found")
+     endif()
++    else()
++        set (WEBP_FOUND FALSE)
++    endif()
+ else ()
+     message (STATUS "Not using WebP")
  endif ()
-+if(USE_WEBP)
- find_path (WEBP_INCLUDE_DIR webp/encode.h
-            "${PROJECT_SOURCE_DIR}/src/include"
-            "${WEBP_HOME}")
-@@ -382,6 +383,9 @@ else()
-     set (WEBP_FOUND FALSE)
-     message (STATUS "WebP library not found")
- endif()
-+else()
-+    set (WEBP_FOUND FALSE)
-+endif()
- # end Webp setup
- ###########################################################################
- 


### PR DESCRIPTION
1. Upgrade to version 2.0.8.
2. Fix old patches.
3. Add port **boost-stacktrace** to build-depends.

Related issue: #7163 