### PR TITLE
[libkml] Fix install path

### DIFF
--- a/ports/libkml/CONTROL
+++ b/ports/libkml/CONTROL
@@ -1,5 +1,5 @@
 Source: libkml
-Version: 1.3.0-2
+Version: 1.3.0-3
 Homepage: https://github.com/libkml/libkml
 Description: Reference implementation of OGC KML 2.2
 Build-Depends: zlib, expat, minizip, uriparser, boost-smart-ptr

--- a/ports/libkml/portfile.cmake
+++ b/ports/libkml/portfile.cmake
@@ -23,6 +23,13 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+elseif (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libkml)
+elseif (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libkml)
+endif()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libkml RENAME copyright)


### PR DESCRIPTION
Fix build error on Linux:
```
CMake Error at scripts/cmake/vcpkg_fixup_cmake_targets.cmake:53 (message):
  '/home/vwangli/Lily/vcpkg/packages/libkml_x64-linux/debug/cmake' does not
  exist.
Call Stack (most recent call first):
  ports/libkml/portfile.cmake:26 (vcpkg_fixup_cmake_targets)
  scripts/ports.cmake:73 (include)
```

Related issue: #7193 