### PR TITLE
[genann] Add new port.

### DIFF
--- a/ports/genann/CMakeLists.txt
+++ b/ports/genann/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.11)
+project(genann)
+
+set(SRC_FILES
+genann.c
+)
+
+add_library(genann ${SRC_FILES})
+
+target_include_directories(genann PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include/genann>
+)
+
+# Install targets
+install(TARGETS genann
+	RUNTIME DESTINATION bin 
+	LIBRARY DESTINATION lib 
+	ARCHIVE DESTINATION lib 
+)
+
+# Install headers
+if (INSTALL_HEADERS)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/genann.h DESTINATION include/genann)
+endif() 

--- a/ports/genann/CONTROL
+++ b/ports/genann/CONTROL
@@ -1,0 +1,4 @@
+Source: genann
+Version: 122243f
+Homepage: https://github.com/codeplea/genann
+Description: Genann is a minimal, well-tested library for training and using feedforward artificial neural networks (ANN) in C.

--- a/ports/genann/CONTROL
+++ b/ports/genann/CONTROL
@@ -1,4 +1,4 @@
 Source: genann
-Version: 122243f
+Version: 2019-07-10
 Homepage: https://github.com/codeplea/genann
 Description: Genann is a minimal, well-tested library for training and using feedforward artificial neural networks (ANN) in C.

--- a/ports/genann/portfile.cmake
+++ b/ports/genann/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO codeplea/genann
+    REF 122243f9449b3e33a4e11450b70c10576d4559d7
+    SHA512 d70cb8bc678d80ed3e790866f6060850cf9309eefe90d3ca4d77e28538639a927333d49c4d1af3e81123b8e88224f2f51b74ec41ca22639a276359568652ed15
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_RELEASE -DINSTALL_HEADERS=ON
+    OPTIONS_DEBUG -DINSTALL_HEADERS=OFF
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/genann)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/genann/LICENSE ${CURRENT_PACKAGES_DIR}/share/genann/copyright)
+


### PR DESCRIPTION
Brief: Genann is a minimal, well-tested library for training and using feedforward artificial neural networks (ANN) in C. Its primary focus is on being simple, fast, reliable, and hackable. It achieves this by providing only the necessary functions and little extra.
Related issue #7023.