### PR TITLE
[ninja issue] avoid ninja when command line might be too long

### DIFF
--- a/ports/darknet/CONTROL
+++ b/ports/darknet/CONTROL
@@ -1,5 +1,5 @@
 Source: darknet
-Version: 0.2.5-4
+Version: 0.2.5-5
 Description: Darknet is an open source neural network framework written in C and CUDA. You only look once (YOLO) is a state-of-the-art, real-time object detection system, best example of darknet functionalities.
 Build-Depends: pthreads (windows), stb
 Default-Features: weights


### PR DESCRIPTION
avoid using ninja with cuda on win32, again, almost reverting previous pr.
I ran into problems with VS2017/CUDA 10, which I can't see on another machine with VS2019 and CUDA 10.1.
Since the project is not extremely big, but is composed by many files, which have to be linked with many OpenCV and CUDA libraries, in the end ninja complains about a "Command line too long".
Which is surprising, since cmake/ninja should be very well aware of the 8191 char limit...