### PR TITLE
Better error message when VCPKG_ROOT is independently defined

### DIFF
--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -143,7 +143,7 @@ static void inner(const VcpkgCmdArguments& args)
 #else
     const int exit_code = chdir(paths.root.c_str());
 #endif
-    Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Changing the working dir failed");
+    Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Changing the working directory to the vcpkg root directory failed. Did you incorrectly define the VCPKG_ROOT environment variable, or did you mistakenly create a file named .vcpkg-root somewhere?");
 
     if (args.command == "install" || args.command == "remove" || args.command == "export" || args.command == "update")
     {


### PR DESCRIPTION
If the VCPKG_ROOT environment variable is defined incorrectly - i.e., does not point to the 'vcpkg' root directory - the current error message provides no insight into the real cause of the problem.

I just lost 10 hours debugging this issue.  It *does* make sense for end-users to define an environment variable called 'VCPKG_ROOT' independently of actually running vcpkg, as I did - to indicate to my downstream application the location of the 'include' path created for a 3rd-party library when vcpkg installed it (which happens to be located inside the vkpkg root directory by default - in the <vcpkg>/installed/.../include directory).

Unfortunately, defining the 'VCPKG_ROOT' independently, as I did, caused complete failure of vcpkg to run, giving the current useless error "Changing the working dir failed".  (...The path <vcpkg/installed/.../include> is not the root directory of vcpkg, and in fact does not even exist when the vcpkg repository is cloned.)

It would be immensely helpful to receive a proper error message alerting a programmer to the real likely cause of this error - i.e., alerting the programmer to the fact that the VCPKG_ROOT environment variable is reserved for use by 'vcpkg' itself, and should not be used by end-users for alternate purposes.  (I have also included the other potential error condition - an improperly created '.vcpkg-root' file - for completeness, though it seems less likely this would be the issue.)

The current error message addresses this issue, and I hope will be accepted into the library to save some other poor soul such as myself an entire lost day should they mistakenly create an environment variable called 'VCPKG_ROOT' pointing to the install target location inside the actual vkpkg root directory.