### PR TITLE
[qt5]Fix build failure in linux

### DIFF
--- a/ports/qt5-3d/CONTROL
+++ b/ports/qt5-3d/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-3d
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 3d Module - Functionality for near-realtime simulation systems with support for 2D and 3D rendering
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-activeqt/CONTROL
+++ b/ports/qt5-activeqt/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-activeqt
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 ActiveQt Module - ActiveX components
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-activeqt/portfile.cmake
+++ b/ports/qt5-activeqt/portfile.cmake
@@ -1,5 +1,9 @@
 include(vcpkg_common_functions)
 
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "qt5-activeqt only support Windows.")
+endif()
+
 include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
 
 qt_modular_library(qtactiveqt 477c42653a59739aeeb17ab54bdd5cc50bc72a117250926e940c34d3f81d1b92356074056fb49f3cd811a88840377836b2d97cea8cbc62ae1d895168e7860753)

--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.3-2
+Version: 5.12.3-3
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-charts/CONTROL
+++ b/ports/qt5-charts/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-charts
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Charts Module - UI components for displaying charts, driven by static or dynamic data models
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-connectivity/CONTROL
+++ b/ports/qt5-connectivity/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-connectivity
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Connectivity module - Provides access to Bluetooth and NFC hardware
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-datavis3d/CONTROL
+++ b/ports/qt5-datavis3d/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-datavis3d
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Data Visualization 3d Module - UI Components for creating 3D data visualizations
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-declarative/CONTROL
+++ b/ports/qt5-declarative/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-declarative
-Version: 5.12.3-1
+Version: 5.12.3-2
 Description: Qt5 Declarative (Quick 2) Module. Includes QtQuick, QtQuickParticles, QtQuickWidgets, QtQml, and QtPacketProtocol.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -12,3 +12,14 @@ if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 	string(REPLACE [[QT.qmldevtools_private.libs = $$QT_MODULE_HOST_LIB_BASE]] [[QT.qmldevtools_private.libs = $$QT_MODULE_LIB_BASE]]  _contents "${_contents}")
 	file(WRITE "${qt5decpath}" "${_contents}")
 endif()
+
+# Copy qt5-declarative tools
+# This is a temporary workaround and hope to fix and remove it after the version update.
+if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (EXISTS ${CURRENT_PACKAGES_DIR}/tools/qt5-declarative/)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/tools/qt5-declarative/ ${CURRENT_PACKAGES_DIR}/tools/qt5/)
+    endif()
+    if (EXISTS ${CURRENT_PACKAGES_DIR}/lib/libQt5QmlDevTools.a)
+        file(COPY ${CURRENT_PACKAGES_DIR}/lib/libQt5QmlDevTools.a DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+    endif()
+endif()

--- a/ports/qt5-gamepad/CONTROL
+++ b/ports/qt5-gamepad/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-gamepad
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Gamepad Module - Enables Qt applications to support the use of gamepad hardware
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-graphicaleffects/CONTROL
+++ b/ports/qt5-graphicaleffects/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-graphicaleffects
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 GraphicalEffects Module.
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-imageformats/CONTROL
+++ b/ports/qt5-imageformats/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-imageformats
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Image Formats Module - Plugins for additional image formats: TIFF, MNG, TGA, WBMP
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-location/CONTROL
+++ b/ports/qt5-location/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-location
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Location Module - Displays map, navigation, and place content in a QML application.
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-macextras/CONTROL
+++ b/ports/qt5-macextras/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-macextras
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Mac Extras Module. Provides platform-specific APIs for mac.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-macextras/portfile.cmake
+++ b/ports/qt5-macextras/portfile.cmake
@@ -1,5 +1,9 @@
 include(vcpkg_common_functions)
 
+if (NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(FATAL_ERROR "qt5-macextras only support OSX.")
+endif()
+
 include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
 
 qt_modular_library(qtmacextras 56887c2a2d20c41a133af87aec8975e17c6335ffc51093f23a904e02a78f59a8117c7932827ca5dd33f538360e6fd9cfc9d0091c6f4c1e0b96528b5324c74033)

--- a/ports/qt5-modularscripts/CONTROL
+++ b/ports/qt5-modularscripts/CONTROL
@@ -1,3 +1,3 @@
 Source: qt5-modularscripts
-Version: 2019-04-30
+Version: 2019-04-30-1
 Description: Vcpkg helpers to package qt5 modules

--- a/ports/qt5-modularscripts/qt_modular_library.cmake
+++ b/ports/qt5-modularscripts/qt_modular_library.cmake
@@ -52,8 +52,12 @@ function(qt_modular_build_library SOURCE_PATH)
 
     #Configure debug+release
     vcpkg_configure_qmake(SOURCE_PATH ${SOURCE_PATH})
-
-    vcpkg_build_qmake()
+    #Build debug+release
+    if (CMAKE_HOST_WIN32)
+        vcpkg_build_qmake()
+    else()
+        vcpkg_build_qmake(SKIP_MAKEFILES)
+    endif()
 
     #Fix the cmake files if they exist
     if(EXISTS ${RELEASE_DIR}/lib/cmake)
@@ -76,11 +80,12 @@ function(qt_modular_build_library SOURCE_PATH)
     #Install the module files
     vcpkg_build_qmake(TARGETS install SKIP_MAKEFILES BUILD_LOGNAME install)
 
-    #Remove extra cmake files
+    #Install cmake files
     if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake)
         file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
         file(RENAME ${CURRENT_PACKAGES_DIR}/lib/cmake ${CURRENT_PACKAGES_DIR}/share/cmake)
     endif()
+    #Remove extra cmake files
     if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
         file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
     endif()

--- a/ports/qt5-mqtt/CONTROL
+++ b/ports/qt5-mqtt/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-mqtt
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 MQTT module.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-multimedia/CONTROL
+++ b/ports/qt5-multimedia/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-multimedia
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Multimedia Module - Classes and widgets for audio, video, radio and camera functionality
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-networkauth/CONTROL
+++ b/ports/qt5-networkauth/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-networkauth
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Network Authorization Module
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-purchasing/CONTROL
+++ b/ports/qt5-purchasing/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-purchasing
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Purchasing Module - Enables in-app purchase of products in Qt applications.
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-quickcontrols/CONTROL
+++ b/ports/qt5-quickcontrols/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-quickcontrols
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 QuickControls Module.
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-quickcontrols2/CONTROL
+++ b/ports/qt5-quickcontrols2/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-quickcontrols2
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 QuickControls2 Module.
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-remoteobjects/CONTROL
+++ b/ports/qt5-remoteobjects/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-remoteobjects
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Remoteobjects module - Provides an easy to use mechanism for sharing a QObject's API (Properties/Signals/Slots) between processes or devices.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-script/CONTROL
+++ b/ports/qt5-script/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-script
-Version: 5.12.3
+Version: 5.12.3-1
 Build-Depends: qt5-base, qt5-modularscripts
 Description:Qt5 Script Module.

--- a/ports/qt5-scxml/CONTROL
+++ b/ports/qt5-scxml/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-scxml
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 SCXML Module - Provides classes and tools for creating state machines from SCXML files and embedding them in applications
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-sensors/CONTROL
+++ b/ports/qt5-sensors/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-sensors
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Sensors module - Provides access to sensor hardware and motion gesture recognition.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-serialport/CONTROL
+++ b/ports/qt5-serialport/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-serialport
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Serial Port - provides access to hardware and virtual serial ports
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-speech/CONTROL
+++ b/ports/qt5-speech/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-speech
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Speech Module
 Build-Depends: qt5-modularscripts, qt5-base, atlmfc (windows)

--- a/ports/qt5-svg/CONTROL
+++ b/ports/qt5-svg/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-svg
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 SVG Module - provides classes for displaying the contents of SVG files
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-tools/CONTROL
+++ b/ports/qt5-tools/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-tools
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Tools Module; Includes deployment tools and helpers, Qt Designer, Assistant, and other applications
 Build-Depends: qt5-modularscripts, qt5-base, qt5-declarative

--- a/ports/qt5-virtualkeyboard/CONTROL
+++ b/ports/qt5-virtualkeyboard/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-virtualkeyboard
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Virtual Keyboard Module - A framework for implementing different input methods. Supports localized keyboard layouts and custom visual themes
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-webchannel/CONTROL
+++ b/ports/qt5-webchannel/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-webchannel
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Web Channel module - Provides access to QObject or QML objects from HTML clients for seamless integration of Qt applications with HTML/JavaScript clients.
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-websockets/CONTROL
+++ b/ports/qt5-websockets/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-websockets
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Web Sockets Module - provides WebSocket communication compliant with RFC 6455
 Build-Depends: qt5-modularscripts, qt5-base

--- a/ports/qt5-webview/CONTROL
+++ b/ports/qt5-webview/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-webview
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 WebView module - Provides a way to display web content in a QML application without necessarily including a full web browser stack by using native APIs where it makes sense.
 Build-Depends: qt5-base, qt5-modularscripts, qt5-declarative

--- a/ports/qt5-winextras/CONTROL
+++ b/ports/qt5-winextras/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-winextras
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Windows Extras Module. Provides platform-specific APIs for Windows.
 Build-Depends: qt5-modularscripts, qt5-base, atlmfc

--- a/ports/qt5-winextras/portfile.cmake
+++ b/ports/qt5-winextras/portfile.cmake
@@ -1,5 +1,9 @@
 include(vcpkg_common_functions)
 
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "qt5-winextras only support Windows.")
+endif()
+
 include(${CURRENT_INSTALLED_DIR}/share/qt5modularscripts/qt_modular_library.cmake)
 
 qt_modular_library(qtwinextras e50cb237359ce7a3bde6989ec4349fe67be3b4999092516e891bba12f0fb4acb9954de8e2f0171db0e849b7d3ef94bd80f77f81162afb239e49c6e2e0760343b)

--- a/ports/qt5-xmlpatterns/CONTROL
+++ b/ports/qt5-xmlpatterns/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-xmlpatterns
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 XML Patterns Module - Support for XPath, XQuery, XSLT and XML schema validation
 Build-Depends: qt5-modularscripts, qt5-base


### PR DESCRIPTION
Now we don't need to use `qmake_all` to build qt5 and other modules in linux, it seems to **break** the disabled parameters during the build. See [documentation](https://wiki.qt.io/Building_Qt_Documentation).

Fix the failure of qt5 module build in linux (caused by #5293):

- [x] qt5-base
- [x] qt5-3d
- [x] qt5-activeqt : only support Windows
- [x] qt5-charts
- [x] qt5-connectivity
- [x] qt5-datavis3d
- [x] qt5-declarative
- [x] qt5-gamepad
- [x] qt5-graphicaleffects
- [x] qt5-imageformats
- [x] qt5-location
- [x] qt5-macextras : only support OSX
- [x] qt5-modularscripts
- [x] qt5-mqtt
- [x] qt5-multimedia
- [x] qt5-networkauth
- [x] qt5-purchasing
- [x] qt5-quickcontrols
- [x] qt5-quickcontrols2
- [x] qt5-remoteobjects
- [x] qt5-script
- [x] qt5-scxml
- [x] qt5-sensors
- [x] qt5-serialport
- [x] qt5-speech
- [x] qt5-svg
- [x] qt5-tools
- [x] qt5-virtualkeyboard
- [x] qt5-webchannel
- [x] qt5-websockets
- [x] qt5-webview
- [x] qt5-winextras : only support Windows
- [x] qt5-xmlpatterns

Related: #6962 #5655 #5362 #3859 #3644.