### PR TITLE
[DirectXTK] Fix UWP build error

### DIFF
--- a/ports/directxtk/CONTROL
+++ b/ports/directxtk/CONTROL
@@ -1,4 +1,4 @@
 Source: directxtk
-Version: apr2019
+Version: apr2019-1
 Homepage: https://github.com/Microsoft/DirectXTK
 Description: A collection of helper classes for writing DirectX 11.x code in C++.

--- a/ports/directxtk/fix-invalid-configuration.patch
+++ b/ports/directxtk/fix-invalid-configuration.patch
@@ -1,0 +1,39 @@
+diff --git a/DirectXTK_Windows10.sln b/DirectXTK_Windows10.sln
+index 8962307..9e3b8a7 100644
+--- a/DirectXTK_Windows10.sln
++++ b/DirectXTK_Windows10.sln
+@@ -15,11 +15,11 @@ Global
+ 		Debug|ARM = Debug|ARM
+ 		Debug|ARM64 = Debug|ARM64
+ 		Debug|x64 = Debug|x64
+-		Debug|x86 = Debug|x86
++		Debug|Win32 = Debug|Win32
+ 		Release|ARM = Release|ARM
+ 		Release|ARM64 = Release|ARM64
+ 		Release|x64 = Release|x64
+-		Release|x86 = Release|x86
++		Release|Win32 = Release|Win32
+ 	EndGlobalSection
+ 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|ARM.ActiveCfg = Debug|ARM
+@@ -28,16 +28,16 @@ Global
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|ARM64.Build.0 = Debug|ARM64
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|x64.ActiveCfg = Debug|x64
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|x64.Build.0 = Debug|x64
+-		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|x86.ActiveCfg = Debug|Win32
+-		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|x86.Build.0 = Debug|Win32
++		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|Win32.ActiveCfg = Debug|Win32
++		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Debug|Win32.Build.0 = Debug|Win32
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|ARM.ActiveCfg = Release|ARM
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|ARM.Build.0 = Release|ARM
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|ARM64.ActiveCfg = Release|ARM64
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|ARM64.Build.0 = Release|ARM64
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|x64.ActiveCfg = Release|x64
+ 		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|x64.Build.0 = Release|x64
+-		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|x86.ActiveCfg = Release|Win32
+-		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|x86.Build.0 = Release|Win32
++		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|Win32.ActiveCfg = Release|Win32
++		{F4776924-619C-42C7-88B2-82C947CCC9E7}.Release|Win32.Build.0 = Release|Win32
+ 	EndGlobalSection
+ 	GlobalSection(SolutionProperties) = preSolution
+ 		HideSolutionNode = FALSE

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     REF apr2019
     SHA512 811ed222c1650d34a8475e44719cca8972a85d96f9ccb10548e1501eb9d28fd8685de90832b517cdcbf21ae8c9160dea69000e8dca06fab745a15a7acc14ba98
     HEAD_REF master
+    PATCHES fix-invalid-configuration.patch
 )
 
 IF (TRIPLET_SYSTEM_ARCH MATCHES "x86")
@@ -20,33 +21,41 @@ ELSE()
     SET(BUILD_ARCH ${TRIPLET_SYSTEM_ARCH})
 ENDIF()
 
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+  set(SLN_NAME "Windows10")
+else()
+  set(SLN_NAME "Desktop_2017")
+endif()
+
 vcpkg_build_msbuild(
-    PROJECT_PATH ${SOURCE_PATH}/DirectXTK_Desktop_2017.sln
+    PROJECT_PATH ${SOURCE_PATH}/DirectXTK_${SLN_NAME}.sln
     PLATFORM ${BUILD_ARCH}
 )
 
 file(INSTALL
-    ${SOURCE_PATH}/Bin/Desktop_2017/${BUILD_ARCH}/Release/DirectXTK.lib
+    ${SOURCE_PATH}/Bin/${SLN_NAME}/${BUILD_ARCH}/Release/DirectXTK.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 
 file(INSTALL
-    ${SOURCE_PATH}/Bin/Desktop_2017/${BUILD_ARCH}/Debug/DirectXTK.lib
+    ${SOURCE_PATH}/Bin/${SLN_NAME}/${BUILD_ARCH}/Debug/DirectXTK.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 
-set(DXTK_TOOL_PATH ${CURRENT_PACKAGES_DIR}/tools/directxtk)
-file(MAKE_DIRECTORY ${DXTK_TOOL_PATH})
+if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+  set(DXTK_TOOL_PATH ${CURRENT_PACKAGES_DIR}/tools/directxtk)
+  file(MAKE_DIRECTORY ${DXTK_TOOL_PATH})
+
+  file(INSTALL
+	  ${SOURCE_PATH}/MakeSpriteFont/bin/Release/MakeSpriteFont.exe
+	  DESTINATION ${DXTK_TOOL_PATH})
+
+  file(INSTALL
+	  ${SOURCE_PATH}/XWBTool/Bin/Desktop_2017/${BUILD_ARCH}/Release/XWBTool.exe
+	  DESTINATION ${DXTK_TOOL_PATH})
+endif()
 
 file(INSTALL
-    ${SOURCE_PATH}/MakeSpriteFont/bin/Release/MakeSpriteFont.exe
-    DESTINATION ${DXTK_TOOL_PATH})
-
-file(INSTALL
-    ${SOURCE_PATH}/XWBTool/Bin/Desktop_2017/${BUILD_ARCH}/Release/XWBTool.exe
-    DESTINATION ${DXTK_TOOL_PATH})
-
-file(INSTALL
-    ${SOURCE_PATH}/Inc/
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include/DirectXTK
+	${SOURCE_PATH}/Inc/
+	DESTINATION ${CURRENT_PACKAGES_DIR}/include/DirectXTK
 )
 
 # Handle copyright


### PR DESCRIPTION
Related with issue: https://github.com/microsoft/vcpkg/issues/5011

1. The application type of DirectXTK_Windows10.vcxproj is Windows Store, so it's the corresponding project for UWP triplete.
2. The configuration of DirectXTK_Windows10.sln should be Win32 instead of x86, so add a patch for fixing this issue.