### PR TITLE
[rabit] Add new port.

### DIFF
--- a/ports/rabit/CONTROL
+++ b/ports/rabit/CONTROL
@@ -1,0 +1,4 @@
+Source: rabit
+Version: 0.1
+Homepage: https://github.com/dmlc/rabit
+Description: rabit is a light weight library that provides a fault tolerant interface of Allreduce and Broadcast. It is designed to support easy implementations of distributed machine learning programs, many of which fall naturally under the Allreduce abstraction.

--- a/ports/rabit/portfile.cmake
+++ b/ports/rabit/portfile.cmake
@@ -1,0 +1,31 @@
+include(vcpkg_common_functions)
+
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "${PORT} does not currently support UWP.")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/rabit
+    REF v0.1
+    SHA512 145fd839898cb95eaab9a88ad3301a0ccac0c8b672419ee2b8eb6ba273cc9a26e069e5ecbc37a3078e46dc64d11efb3e5ab10e5f8fed714e7add85b9e6ac2ec7
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+


### PR DESCRIPTION
rabit is a light weight library that provides a fault tolerant interface of Allreduce and Broadcast.
It is one of  XGBoost dependencies. 
Note: This port doesn't currently support UWP.

