### PR TITLE
ITK portfile support legacy user code by default

### DIFF
--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,5 +1,5 @@
 Source: itk
-Version: 5.0.0-2
+Version: 5.0.0-3
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
 Homepage: https://github.com/InsightSoftwareConsortium/ITK
 Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp], openjpeg

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -35,8 +35,6 @@ vcpkg_configure_cmake(
         -DITK_INSTALL_DATA_DIR=share/itk/data
         -DITK_INSTALL_DOC_DIR=share/itk/doc
         -DITK_INSTALL_PACKAGE_DIR=share/itk
-        -DITK_LEGACY_REMOVE=ON
-        -DITK_FUTURE_LEGACY_REMOVE=ON
         -DITK_USE_64BITS_IDS=ON
         -DITK_USE_CONCEPT_CHECKING=ON
         #-DITK_USE_SYSTEM_LIBRARIES=ON # enables USE_SYSTEM for all third party libraries, some of which do not have vcpkg ports such as CastXML, SWIG, MINC etc


### PR DESCRIPTION
No longer specify `ITK_LEGACY_REMOVE` and `ITK_FUTURE_LEGACY_REMOVE`
options for `vcpkg_configure_cmake`. By default, these two flags are
`OFF`, for ITK 5.0.0:
https://github.com/InsightSoftwareConsortium/ITK/blob/v5.0.0/CMakeLists.txt#L261

This commit will allow legacy ITK user code to build with vcpkg, and it
will ease adding vcpkg support to https://github.com/SuperElastix/elastix

Dženan Zukić @dzenanz suggested this change:
https://discourse.itk.org/t/how-to-avoid-rebuilding-itk-by-azure-ci-at-the-github-of-another-project-elastix/2002/7

CONTROL version bumped as requested by Phil Christensen @Rastaban