### PR TITLE
Testing for --overlay-ports and --overlay-triplets args

### DIFF
--- a/toolsrc/src/tests.arguments.cpp
+++ b/toolsrc/src/tests.arguments.cpp
@@ -15,24 +15,60 @@ namespace UnitTest1
     {
         TEST_METHOD(create_from_arg_sequence_options_lower)
         {
-            std::vector<std::string> t = {"--vcpkg-root", "C:\\vcpkg", "--scripts-root", "C:\\scripts", "--debug", "--sendmetrics", "--printmetrics"};
+            std::vector<std::string> t = {
+                "--vcpkg-root", "C:\\vcpkg", 
+                "--scripts-root=C:\\scripts", 
+                "--debug", 
+                "--sendmetrics", 
+                "--printmetrics",
+                "--overlay-ports=C:\\ports1",
+                "--overlay-ports=C:\\ports2",
+                "--overlay-triplets=C:\\tripletsA",
+                "--overlay-triplets=C:\\tripletsB"
+            };
             auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
             Assert::AreEqual("C:\\vcpkg", v.vcpkg_root_dir.get()->c_str());
             Assert::AreEqual("C:\\scripts", v.scripts_root_dir.get()->c_str());
             Assert::IsTrue(v.debug && *v.debug.get());
             Assert::IsTrue(v.sendmetrics && v.sendmetrics.get());
             Assert::IsTrue(v.printmetrics && *v.printmetrics.get());
+            
+            Assert::IsTrue(v.overlay_ports.get()->size() == 2);
+            Assert::AreEqual("C:\\ports1", v.overlay_ports.get()->at(0).c_str());
+            Assert::AreEqual("C:\\ports2", v.overlay_ports.get()->at(1).c_str());
+
+            Assert::IsTrue(v.overlay_triplets.get()->size() == 2);
+            Assert::AreEqual("C:\\tripletsA", v.overlay_triplets.get()->at(0).c_str());
+            Assert::AreEqual("C:\\tripletsB", v.overlay_triplets.get()->at(1).c_str());
         }
 
         TEST_METHOD(create_from_arg_sequence_options_upper)
         {
-            std::vector<std::string> t = {"--VCPKG-ROOT", "C:\\vcpkg", "--SCRIPTS-ROOT", "C:\\scripts", "--DEBUG", "--SENDMETRICS", "--PRINTMETRICS"};
+            std::vector<std::string> t = {
+                "--VCPKG-ROOT", "C:\\vcpkg", 
+                "--SCRIPTS-ROOT=C:\\scripts", 
+                "--DEBUG", 
+                "--SENDMETRICS", 
+                "--PRINTMETRICS",
+                "--OVERLAY-PORTS=C:\\ports1",
+                "--OVERLAY-PORTS=C:\\ports2",
+                "--OVERLAY-TRIPLETS=C:\\tripletsA",
+                "--OVERLAY-TRIPLETS=C:\\tripletsB"
+            };
             auto v = VcpkgCmdArguments::create_from_arg_sequence(t.data(), t.data() + t.size());
             Assert::AreEqual("C:\\vcpkg", v.vcpkg_root_dir.get()->c_str());
             Assert::AreEqual("C:\\scripts", v.scripts_root_dir.get()->c_str());
             Assert::IsTrue(v.debug && *v.debug.get());
             Assert::IsTrue(v.sendmetrics && v.sendmetrics.get());
             Assert::IsTrue(v.printmetrics && *v.printmetrics.get());
+
+            Assert::IsTrue(v.overlay_ports.get()->size() == 2);
+            Assert::AreEqual("C:\\ports1", v.overlay_ports.get()->at(0).c_str());
+            Assert::AreEqual("C:\\ports2", v.overlay_ports.get()->at(1).c_str());
+
+            Assert::IsTrue(v.overlay_triplets.get()->size() == 2);
+            Assert::AreEqual("C:\\tripletsA", v.overlay_triplets.get()->at(0).c_str());
+            Assert::AreEqual("C:\\tripletsB", v.overlay_triplets.get()->at(1).c_str());
         }
 
         TEST_METHOD(create_from_arg_sequence_valued_options)

--- a/toolsrc/src/tests.plan.cpp
+++ b/toolsrc/src/tests.plan.cpp
@@ -89,14 +89,15 @@ namespace UnitTest1
                             const std::vector<std::pair<const char*, const char*>>& features = {},
                             const std::vector<const char*>& default_features = {})
         {
-            return emplace(std::move(*make_control_file(name, depends, features, default_features)));
+            auto scfl = SourceControlFileLocation { make_control_file(name, depends, features, default_features), "" };
+            return emplace(std::move(scfl));
         }
-        PackageSpec emplace(vcpkg::SourceControlFile&& scf)
+
+        PackageSpec emplace(vcpkg::SourceControlFileLocation&& scfl)
         {
-            auto spec = PackageSpec::from_name_and_triplet(scf.core_paragraph->name, triplet);
+            auto spec = PackageSpec::from_name_and_triplet(scfl.source_control_file->core_paragraph->name, triplet);
             Assert::IsTrue(spec.has_value());
-            map.emplace(scf.core_paragraph->name,
-                        SourceControlFileLocation{std::unique_ptr<SourceControlFile>(std::move(&scf)), ""});
+            map.emplace(scfl.source_control_file->core_paragraph->name, std::move(scfl));
             return PackageSpec{*spec.get()};
         }
     };


### PR DESCRIPTION
Fixes test failures introduced by `--overlay-ports` and adds new testing.