### PR TITLE
[nonius] properly install noniusConfig.cmake

### DIFF
--- a/ports/nonius/CMakeLists.txt
+++ b/ports/nonius/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(VERSION ${CMAKE_VERSION}) # use default policies of current cmake version
+
+project(nonius)
+
+add_library(nonius INTERFACE)
+target_include_directories(nonius INTERFACE  
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> 
+    $<INSTALL_INTERFACE:include> 
+)
+
+if(NOT DISABLE_INSTALL_HEADERS)
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION include
+  )
+endif()
+
+install(TARGETS nonius
+    EXPORT noniusExport
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(
+    EXPORT noniusExport
+    FILE noniusConfig.cmake
+    NAMESPACE Nonius::
+    DESTINATION share/nonius
+)

--- a/ports/nonius/CONTROL
+++ b/ports/nonius/CONTROL
@@ -1,4 +1,4 @@
 Source: nonius
-Version: 2019-04-20
+Version: 2019-04-20-1
 Description: A C++ micro-benchmarking framework
 Build-Depends: boost-algorithm, boost-lexical-cast, boost-math

--- a/ports/nonius/portfile.cmake
+++ b/ports/nonius/portfile.cmake
@@ -10,7 +10,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
In this PR we add a CMakeLists.txt that installs / exports the nonius package config file noniusConfig.cmake to nonius/lib/share. We copy this CMakeLists.txt to the SOURCE_PATH and do a cmake configure and install step.