### PR TITLE
[eastl] Upgrade to 3.14

### DIFF
--- a/ports/eastl/CONTROL
+++ b/ports/eastl/CONTROL
@@ -1,5 +1,5 @@
 Source: eastl
-Version: 3.13.05-1
+Version: 3.14.00
 Homepage: https://github.com/electronicarts/EASTL
 Description: Electronic Arts Standard Template Library.
   It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.

--- a/ports/eastl/fix_cmake_install.patch
+++ b/ports/eastl/fix_cmake_install.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b8171cd..c771e77 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,7 @@ add_definitions(-DEASTL_OPENSOURCE=1)
+ #-------------------------------------------------------------------------------------------
+ # Include dirs
+ #-------------------------------------------------------------------------------------------
++include_directories(APPEND test/packages)
+ target_include_directories(EASTL PUBLIC include)
+ 
+ #-------------------------------------------------------------------------------------------
+@@ -48,3 +49,6 @@ target_include_directories(EASTL PUBLIC include)
+ #-------------------------------------------------------------------------------------------
+ target_link_libraries(EASTL EABase)
+ 
++install(TARGETS EASTL DESTINATION lib)
++install(DIRECTORY include/EASTL DESTINATION include)
++install(DIRECTORY test/packages/EABase DESTINATION include)

--- a/ports/eastl/fix_uwp.patch
+++ b/ports/eastl/fix_uwp.patch
@@ -1,0 +1,13 @@
+diff --git a/include/Common/EABase/config/eaplatform.h b/include/Common/EABase/config/eaplatform.h
+index 8b16146..54079ab 100644
+--- a/include/Common/EABase/config/eaplatform.h
++++ b/include/Common/EABase/config/eaplatform.h
+@@ -125,7 +125,7 @@
+ 	#endif
+ 
+ 
+-#elif defined(EA_PLATFORM_XBOXONE) || defined(_DURANGO) || defined(EA_PLATFORM_CAPILANO) || (defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES || WINAPI_FAMILY == WINAPI_FAMILY_TV_TITLE))
++#elif defined(EA_PLATFORM_XBOXONE) || defined(_DURANGO) || defined(EA_PLATFORM_CAPILANO) || (defined(WINAPI_FAMILY) && WINAPI_FAMILY && (WINAPI_FAMILY == WINAPI_FAMILY_GAMES || WINAPI_FAMILY == WINAPI_FAMILY_TV_TITLE))
+ 	// XBox One
+ 	// Durango was Microsoft's code-name for the platform, which is now obsolete.
+ 	// Microsoft uses _DURANGO instead of some variation of _XBOX, though it's not natively defined by the compiler.

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -2,19 +2,37 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/eastl)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO electronicarts/EABase
+    REF 6f27a2f7aa21f2d71ae8c6bc1d889d0119677a56
+    SHA512 9176fb2d508cf023c3c16c61a511196a2f6af36172145544bba44062a00ca7591e54e4fc16ac13562ef0e2d629b626f398bff3669b4cdb7ba0068548d6a53883
+    HEAD_REF master
+    PATCHES
+    fix_uwp.patch
+)
+
+set(EABASE_PATH  ${SOURCE_PATH})
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO electronicarts/EASTL
-    REF 3.13.05
-    SHA512 2364554339203c972f10d58ebe8f14fb221a40451f4cd2c3c5acd6891e8580c1a0a5d4ba592c91349d3feca50d9880648bb37358820a1c9552dde3f7af400a82
+    REF dcd2b838d52de13691999aff8faeaa8f284928ac
+    SHA512 9756ee47a30447f17ceb45fb5143d6e80905636cf709c171059a83f74094fb25391c896de0ea5e063cdad4e7334c5f963c75b1c34ad539fd24175983a2054159
     HEAD_REF master
-    PATCHES fixchar8_t.patch # can be removed after electronicarts/EASTL#274 is resolved
+    PATCHES 
+    fixchar8_t.patch # can be removed after electronicarts/EASTL#274 is resolved
+    fix_cmake_install.patch
 )
+
+file(COPY ${EABASE_PATH}/include/Common/EABase/ DESTINATION ${SOURCE_PATH}/test/packages/EABase)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+    -DEASTL_BUILD_TESTS=OFF
+    -DEASTL_BUILD_BENCHMARK=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/7217
1. Upgrade EASTL to revision 3.14.00
2. In latest revision EASTL migration tests as its submodule, however its source file still rely on header from  submodule EABase, so added it and copy it to folder test\packages\EABase.
3. Add patch to fix errors when build with uwp