### PR TITLE
[minizip] Make BZip2 an optional feature

### DIFF
--- a/ports/libkml/CONTROL
+++ b/ports/libkml/CONTROL
@@ -2,4 +2,4 @@ Source: libkml
 Version: 1.3.0-3
 Homepage: https://github.com/libkml/libkml
 Description: Reference implementation of OGC KML 2.2
-Build-Depends: zlib, expat, minizip, uriparser, boost-smart-ptr
+Build-Depends: zlib, expat, minizip[bzip2], uriparser, boost-smart-ptr

--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -6,12 +6,20 @@ if(MSVC)
 endif()
 
 find_package(ZLIB REQUIRED)
-
-find_package(BZip2)
-
 set(MIN_SRC contrib/minizip)
 
 include_directories(${MIN_SRC} ${ZLIB_INCLUDE_DIRS})
+
+set(MINIZIP_LIBRARIES ZLIB::ZLIB)
+if(ENABLE_BZIP2)
+  message(STATUS "Building with bzip2 support")
+  find_package(BZip2)
+
+  include_directories(${BZIP2_INCLUDE_DIR})
+  set(MINIZIP_LIBRARIES ${MINIZIP_LIBRARIES} ${BZIP2_LIBRARIES})
+else()
+  message(STATUS "Building without bzip2 support")
+endif()
 
 set(SRC
   ${MIN_SRC}/ioapi.c
@@ -41,19 +49,16 @@ add_library(minizip ${SRC})
 target_link_libraries(minizip PRIVATE ZLIB::ZLIB)
 target_compile_definitions(minizip PRIVATE -D_ZLIB_H)
 
-if(BZip2_FOUND)
-  include_directories(${BZIP2_INCLUDE_DIR})
+if(ENABLE_BZIP2)
   target_link_libraries(minizip PRIVATE ${BZIP2_LIBRARIES})
   target_compile_definitions(minizip PRIVATE -DHAVE_BZIP2=1)
-else()
-  set(BZIP2_LIBRARIES "")
 endif()
 
-add_executable(minizip_bin  ${MIN_SRC}/minizip.c)
-add_executable(miniunz_bin  ${MIN_SRC}/miniunz.c)
+add_executable(minizip_bin ${MIN_SRC}/minizip.c)
+add_executable(miniunz_bin ${MIN_SRC}/miniunz.c)
 
-target_link_libraries(minizip_bin minizip ${BZIP2_LIBRARIES} ZLIB::ZLIB)
-target_link_libraries(miniunz_bin minizip ${BZIP2_LIBRARIES} ZLIB::ZLIB)
+target_link_libraries(minizip_bin minizip ${MINIZIP_LIBRARIES})
+target_link_libraries(miniunz_bin minizip ${MINIZIP_LIBRARIES})
 
 set_target_properties(minizip_bin PROPERTIES OUTPUT_NAME minizip)
 set_target_properties(miniunz_bin PROPERTIES OUTPUT_NAME miniunz)

--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -7,11 +7,11 @@ endif()
 
 find_package(ZLIB REQUIRED)
 
-find_package(BZip2 REQUIRED)
+find_package(BZip2)
 
 set(MIN_SRC contrib/minizip)
 
-include_directories(${MIN_SRC} ${ZLIB_INCLUDE_DIRS} ${BZIP2_INCLUDE_DIR})
+include_directories(${MIN_SRC} ${ZLIB_INCLUDE_DIRS})
 
 set(SRC
   ${MIN_SRC}/ioapi.c
@@ -41,8 +41,13 @@ add_library(minizip ${SRC})
 target_link_libraries(minizip PRIVATE ZLIB::ZLIB)
 target_compile_definitions(minizip PRIVATE -D_ZLIB_H)
 
-target_link_libraries(minizip PRIVATE ${BZIP2_LIBRARIES})
-target_compile_definitions(minizip PRIVATE -DHAVE_BZIP2=1)
+if(BZip2_FOUND)
+  include_directories(${BZIP2_INCLUDE_DIR})
+  target_link_libraries(minizip PRIVATE ${BZIP2_LIBRARIES})
+  target_compile_definitions(minizip PRIVATE -DHAVE_BZIP2=1)
+else()
+  set(BZIP2_LIBRARIES "")
+endif()
 
 add_executable(minizip_bin  ${MIN_SRC}/minizip.c)
 add_executable(miniunz_bin  ${MIN_SRC}/miniunz.c)

--- a/ports/minizip/CONTROL
+++ b/ports/minizip/CONTROL
@@ -2,4 +2,8 @@ Source: minizip
 Version: 1.2.11-4
 Homepage: https://github.com/madler/zlib
 Description: Zip compression library
-Build-Depends: bzip2, zlib
+Build-Depends: zlib
+
+Feature: bzip2support
+Description: Support compression using bzip2 library
+Build-Depends: bzip2

--- a/ports/minizip/CONTROL
+++ b/ports/minizip/CONTROL
@@ -1,9 +1,9 @@
 Source: minizip
-Version: 1.2.11-4
+Version: 1.2.11-5
+Build-Depends: zlib
 Homepage: https://github.com/madler/zlib
 Description: Zip compression library
-Build-Depends: zlib
 
-Feature: bzip2support
-Description: Support compression using bzip2 library
+Feature: bzip2
 Build-Depends: bzip2
+Description: Support compression using bzip2 library

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -1,37 +1,48 @@
 include(vcpkg_common_functions)
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-  message(FATAL_ERROR "WindowsStore not supported")
+	message(FATAL_ERROR "WindowsStore not supported")
 endif()
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO madler/zlib
-  REF v1.2.11
-  SHA512 104c62ed1228b5f1199bc037081861576900eb0697a226cafa62a35c4c890b5cb46622e399f9aad82ee5dfb475bae26ae75e2bd6da3d261361b1c8b996970faf
-  HEAD_REF master
-  PATCHES minizip.patch # enable decrypt support for password-encrypted ZIP files
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO madler/zlib
+	REF v1.2.11
+	SHA512 104c62ed1228b5f1199bc037081861576900eb0697a226cafa62a35c4c890b5cb46622e399f9aad82ee5dfb475bae26ae75e2bd6da3d261361b1c8b996970faf
+	HEAD_REF master
+	PATCHES minizip.patch # enable decrypt support for password-encrypted ZIP files
 )
+
+set(BUILD_minizip_bzip2 OFF)
+if ("bzip2" IN_LIST FEATURES)
+	set(BUILD_minizip_bzip2 ON)
+endif()
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON -DDISABLE_INSTALL_TOOLS=ON
+		SOURCE_PATH ${SOURCE_PATH}
+		PREFER_NINJA
+		OPTIONS
+			-DENABLE_BZIP2=${BUILD_minizip_bzip2}
+		OPTIONS_DEBUG 
+			-DDISABLE_INSTALL_HEADERS=ON -DDISABLE_INSTALL_TOOLS=ON
 )
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/minizip)
-file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/minizip/*.h")
-foreach(HEADER ${HEADERS})
-  file(READ "${HEADER}" _contents)
-  string(REPLACE "#ifdef HAVE_BZIP2" "#if 1" _contents "${_contents}")
-  file(WRITE "${HEADER}" "${_contents}")
-endforeach()
+
+if ("bzip2" IN_LIST FEATURES)
+	file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/minizip/*.h")
+	foreach(HEADER ${HEADERS})
+		file(READ "${HEADER}" _contents)
+		string(REPLACE "#ifdef HAVE_BZIP2" "#if 1" _contents "${_contents}")
+		file(WRITE "${HEADER}" "${_contents}")
+	endforeach()
+endif()
 
 file(INSTALL ${SOURCE_PATH}/contrib/minizip/MiniZip64_info.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/minizip RENAME copyright)


### PR DESCRIPTION
If the BZip2 package has not been found, ensure that the library does
not assume it is. This would stop any build on targets where bzip2 is
not installed. This can either be the bzip2 package provided by vcpkg
or locally on the system.

Feature:
- Allow optionally to enable bzip2 supprt