### PR TITLE
[libsodium] Fix Linux build error.

### DIFF
--- a/ports/libsodium/CMakeLists.txt
+++ b/ports/libsodium/CMakeLists.txt
@@ -152,24 +152,24 @@ else ()
             -Wbad-function-cast
             -Wcast-qual
             #-Wdiv-by-zero
-            -Wduplicated-branches
-            -Wduplicated-cond
+            #-Wduplicated-branches
+            #-Wduplicated-cond
             -Wfloat-equal
             -Wformat=2
             -Wlogical-op
             -Wmaybe-uninitialized
-            -Wmisleading-indentation
+            #-Wmisleading-indentation
             -Wmissing-declarations
             -Wmissing-prototypes
             -Wnested-externs
             #-Wno-type-limits
             #-Wno-unknown-pragmas
             -Wnormalized=id
-            -Wnull-dereference
+            #-Wnull-dereference
             -Wold-style-declaration
             -Wpointer-arith
             -Wredundant-decls
-            -Wrestrict
+            #-Wrestrict
             #-Wsometimes-uninitialized
             -Wstrict-prototypes
             -Wswitch-enum

--- a/ports/libsodium/CONTROL
+++ b/ports/libsodium/CONTROL
@@ -1,4 +1,4 @@
 Source: libsodium
-Version: 1.0.18
+Version: 1.0.18-1
 Description: A modern and easy-to-use crypto library
 Homepage: https://github.com/jedisct1/libsodium


### PR DESCRIPTION
When building on Linux, there are some errors like this:

> cc: error: unrecognized command option ‘-Wduplicated-branches’
> cc: error: unrecognized command line option ‘-Wduplicated-cond’
> cc: error: unrecognized command line option ‘-Wmisleading-indentation’
> cc: error: unrecognized command line option ‘-Wnull-dereference’
> cc: error: unrecognized command line option ‘-Wrestrict’

So I fix it by removing these command options in CMakeLists.txt.