### PR TITLE
[qt5-winextras, ecsutil, soundtouch] Fix build-depends

### DIFF
--- a/ports/ecsutil/CONTROL
+++ b/ports/ecsutil/CONTROL
@@ -1,4 +1,4 @@
 Source: ecsutil
-Version: 1.0.6.1
+Version: 1.0.6.1-1
 Description: Native Windows SDK for accessing ECS via the S3 HTTP protocol.
-Build-Depends: atlmfc
+Build-Depends: atlmfc (windows)

--- a/ports/qt5-winextras/CONTROL
+++ b/ports/qt5-winextras/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-winextras
-Version: 5.12.3
+Version: 5.12.3-1
 Description: Qt5 Windows Extras Module. Provides platform-specific APIs for Windows.
-Build-Depends: qt5-modularscripts, qt5-base, atlmfc
+Build-Depends: qt5-modularscripts, qt5-base, atlmfc (windows)

--- a/ports/soundtouch/CONTROL
+++ b/ports/soundtouch/CONTROL
@@ -1,5 +1,5 @@
 Source: soundtouch
-Version: 2.0.0-2
+Version: 2.0.0-3
 Homepage: https://www.surina.net/soundtouch
 Description: SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.
-Build-Depends: atlmfc
+Build-Depends: atlmfc (windows)


### PR DESCRIPTION
**Atlmfc** is a windows only package. So modify **atlmfc** to **atlmfc (windows)** in **CONTROL**.
Related issue: #4645