### PR TITLE
[metis] Fix linux build error.

### DIFF
--- a/ports/metis/CONTROL
+++ b/ports/metis/CONTROL
@@ -1,4 +1,4 @@
 Source: metis
-Version: 5.1.0-3
+Version: 5.1.0-4
 Homepage: https://glaros.dtc.umn.edu/gkhome/metis/metis/overview
 Description: Serial Graph Partitioning and Fill-reducing Matrix Ordering

--- a/ports/metis/fix-linux-build-error.patch
+++ b/ports/metis/fix-linux-build-error.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e94f050..b9613a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,8 @@
+ cmake_minimum_required(VERSION 2.8)
+ project(METIS)
+ 
+-set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")
++set(GKLIB_PATH "${CMAKE_SOURCE_DIR}/GKlib" CACHE PATH "path to GKlib")
++
+ set(SHARED FALSE CACHE BOOL "build a shared library")
+ 
+ set(METIS_INSTALL TRUE)

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_extract_source_archive_ex(
         fix-runtime-install-destination.patch
         fix-metis-vs14-math.patch
         fix-gklib-vs14-math.patch
+        fix-linux-build-error.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
As `GKLIB_PATH` is a relative path, the files in GKlib directory cannot be found successfully.
So I change it as an absolute path.
Related issue #3422.