### PR TITLE
[Thrift] Make Thrift static again

### DIFF
--- a/ports/thrift/CONTROL
+++ b/ports/thrift/CONTROL
@@ -1,5 +1,5 @@
 Source: thrift
-Version: 2019-05-07-2
+Version: 2019-05-07-3
 Build-Depends: zlib, libevent, openssl, boost-range, boost-smart-ptr, boost-date-time, boost-locale, boost-scope-exit
 Homepage: https://github.com/apache/thrift
 Description: Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -1,7 +1,5 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(BISON)
 
@@ -18,8 +16,6 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     NO_CHARSET_FLAG
     OPTIONS
-        -DWITH_SHARED_LIB=OFF
-        -DWITH_STATIC_LIB=ON
         -DWITH_STDTHREADS=ON
         -DBUILD_TESTING=off
         -DBUILD_JAVA=off
@@ -40,14 +36,18 @@ file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/th
 # Move CMake config files to the right place
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/thrift)
 
-file(GLOB COMPILER "${CURRENT_PACKAGES_DIR}/bin/thrift*")
+file(GLOB COMPILER "${CURRENT_PACKAGES_DIR}/bin/thrift" "${CURRENT_PACKAGES_DIR}/bin/thrift.exe")
 if(COMPILER)
     file(COPY ${COMPILER} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/thrift)
     file(REMOVE ${COMPILER})
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/thrift)
 endif()
 
+file(GLOB COMPILERD "${CURRENT_PACKAGES_DIR}/debug/bin/thrift" "${CURRENT_PACKAGES_DIR}/debug/bin/thrift.exe")
+if(COMPILERD)
+    file(REMOVE ${COMPILERD})
+endif()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+
 vcpkg_copy_pdbs()

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -50,4 +50,9 @@ endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
+if ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+endif()
+
 vcpkg_copy_pdbs()

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -1,8 +1,10 @@
 include(vcpkg_common_functions)
 
 # We currently insist on static only because:
-# - Thrift doesn't yet support building as a DLL on Windows.
-# - x64-linux only builds static anyway
+# - Thrift doesn't yet support building as a DLL on Windows,
+# - x64-linux only builds static anyway.
+# From https://github.com/apache/thrift/blob/master/CHANGES.md
+# it looks like it will be supported in v0.13.
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_find_acquire_program(FLEX)

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -24,7 +24,7 @@ vcpkg_configure_cmake(
     NO_CHARSET_FLAG
     OPTIONS
         -DWITH_SHARED_LIB=off
-        -DWITH_STATIC_LIB=on # these are marked as deprecated but 
+        -DWITH_STATIC_LIB=on
         -DWITH_STDTHREADS=ON
         -DBUILD_TESTING=off
         -DBUILD_JAVA=off

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -18,6 +18,8 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     NO_CHARSET_FLAG
     OPTIONS
+        -DWITH_SHARED_LIB=OFF
+        -DWITH_STATIC_LIB=ON
         -DWITH_STDTHREADS=ON
         -DBUILD_TESTING=off
         -DBUILD_JAVA=off

--- a/ports/thrift/portfile.cmake
+++ b/ports/thrift/portfile.cmake
@@ -1,5 +1,10 @@
 include(vcpkg_common_functions)
 
+# We currently insist on static only because:
+# - Thrift doesn't yet support building as a DLL on Windows.
+# - x64-linux only builds static anyway
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(BISON)
 
@@ -11,11 +16,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# note we specify values for WITH_STATIC_LIB and WITH_SHARED_LIB because even though
+# they're marked as deprecated, Thrift incorrectly hard-codes a value for BUILD_SHARED_LIBS.
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     NO_CHARSET_FLAG
     OPTIONS
+        -DWITH_SHARED_LIB=off
+        -DWITH_STATIC_LIB=on # these are marked as deprecated but 
         -DWITH_STDTHREADS=ON
         -DBUILD_TESTING=off
         -DBUILD_JAVA=off


### PR DESCRIPTION
Master seems to be building Thrift as a shared library. Reviewing the history shows we've lost the flags which build Thrift statically.