### PR TITLE
[json-spirit] fix post-validation

### DIFF
--- a/ports/json-spirit/portfile.cmake
+++ b/ports/json-spirit/portfile.cmake
@@ -21,4 +21,7 @@ vcpkg_install_cmake()
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/json-spirit RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
 vcpkg_copy_pdbs()


### PR DESCRIPTION
I was trying to build json-spirit with `static` (vcpkg install json-spirit:x86-windows-static) build, however in the end I got error 

`There should be no bin\ directory in a static build, but c:\work\vcpkg\packages\json-spirit_x86-windows-static\bin is present.
There should be no debug\bin\ directory in a static build, but D:\work\vcpkg\packages\json-spirit_x86-windows-static\debug\bin is present.
If the creation of bin\ and/or debug\bin\ cannot be disabled, use this in the portfile to remove them

    if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
    endif()`