### PR TITLE
Add googleapis proto libraries port.

### DIFF
--- a/ports/googleapis/CONTROL
+++ b/ports/googleapis/CONTROL
@@ -1,0 +1,4 @@
+Source: googleapis
+Version: 0.1.1
+Build-Depends: grpc, protobuf
+Description: C++ Proto Libraries for Google APIs.

--- a/ports/googleapis/portfile.cmake
+++ b/ports/googleapis/portfile.cmake
@@ -1,0 +1,28 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO googleapis/cpp-cmakefiles
+    REF v0.1.1
+    SHA512 e23af2d0d36d4e13da761473b78b958326b9c7fd4aaf0c4b6742ae498b65aafe73976f7c858365b041aa667f280c10eca6df7e87644c260fc022ec4eee7a7bc6
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/googleapis RENAME copyright)
+
+vcpkg_copy_pdbs()
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/googleapis/usage
+++ b/ports/googleapis/usage
@@ -1,0 +1,6 @@
+The package googleapis is compatible with built-in CMake targets:
+
+    find_package(googleapis CONFIG REQUIRED)
+
+    # Then link against the proto libraries that you want to use, for example:
+    target_link_libraries(main PRIVATE googleapis-c++::bigtable_protos gRPC::grpc gRPC::grpc++)


### PR DESCRIPTION
Compile protos from github.com/googleapis/googleapis into C++ libraries.
