### PR TITLE
[stxxl] compilation fix

### DIFF
--- a/ports/stxxl/0001-fix-visual-studio.patch
+++ b/ports/stxxl/0001-fix-visual-studio.patch
@@ -1,0 +1,272 @@
+diff --git a/include/stxxl/bits/algo/ksort.h b/include/stxxl/bits/algo/ksort.h
+index 33ec8cf..4079a57 100644
+--- a/include/stxxl/bits/algo/ksort.h
++++ b/include/stxxl/bits/algo/ksort.h
+@@ -299,11 +299,7 @@ create_runs(
+ template <typename BlockType,
+           typename prefetcher_type,
+           typename KeyExtractor>
+-struct run_cursor2_cmp : public std::binary_function<
+-                             run_cursor2<BlockType, prefetcher_type>,
+-                             run_cursor2<BlockType, prefetcher_type>,
+-                             bool
+-                             >
++struct run_cursor2_cmp
+ {
+     typedef run_cursor2<BlockType, prefetcher_type> cursor_type;
+     KeyExtractor keyobj;
+@@ -327,7 +323,7 @@ private:
+ };
+ 
+ template <typename RecordType, typename KeyExtractor>
+-class key_comparison : public std::binary_function<RecordType, RecordType, bool>
++class key_comparison
+ {
+     KeyExtractor ke;
+ 
+diff --git a/include/stxxl/bits/algo/sort_helper.h b/include/stxxl/bits/algo/sort_helper.h
+index 524e40d..69234c4 100644
+--- a/include/stxxl/bits/algo/sort_helper.h
++++ b/include/stxxl/bits/algo/sort_helper.h
+@@ -51,7 +51,6 @@ struct trigger_entry
+ 
+ template <typename TriggerEntryType, typename ValueCmp>
+ struct trigger_entry_cmp
+-    : public std::binary_function<TriggerEntryType, TriggerEntryType, bool>
+ {
+     typedef TriggerEntryType trigger_entry_type;
+     ValueCmp cmp;
+@@ -67,11 +66,6 @@ template <typename BlockType,
+           typename PrefetcherType,
+           typename ValueCmp>
+ struct run_cursor2_cmp
+-    : public std::binary_function<
+-          run_cursor2<BlockType, PrefetcherType>,
+-          run_cursor2<BlockType, PrefetcherType>,
+-          bool
+-          >
+ {
+     typedef BlockType block_type;
+     typedef PrefetcherType prefetcher_type;
+diff --git a/include/stxxl/bits/compat/unique_ptr.h b/include/stxxl/bits/compat/unique_ptr.h
+index 9df12ff..7110246 100644
+--- a/include/stxxl/bits/compat/unique_ptr.h
++++ b/include/stxxl/bits/compat/unique_ptr.h
+@@ -22,12 +22,7 @@ STXXL_BEGIN_NAMESPACE
+ 
+ template <class Type>
+ struct compat_unique_ptr {
+-#if __cplusplus >= 201103L && ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) >= 40400)
+     typedef std::unique_ptr<Type> result;
+-#else
+-    // auto_ptr is inherently broken and is deprecated by unique_ptr in c++0x
+-    typedef std::auto_ptr<Type> result;
+-#endif
+ };
+ 
+ STXXL_END_NAMESPACE
+diff --git a/include/stxxl/bits/containers/btree/leaf.h b/include/stxxl/bits/containers/btree/leaf.h
+index d7c619f..c6b2fcc 100644
+--- a/include/stxxl/bits/containers/btree/leaf.h
++++ b/include/stxxl/bits/containers/btree/leaf.h
+@@ -66,7 +66,7 @@ public:
+     typedef node_cache<normal_leaf, btree_type> leaf_cache_type;
+ 
+ public:
+-    struct value_compare : public std::binary_function<value_type, value_type, bool>
++    struct value_compare
+     {
+         key_compare comp;
+ 
+diff --git a/include/stxxl/bits/containers/btree/node.h b/include/stxxl/bits/containers/btree/node.h
+index 13dec7b..a4c47d8 100644
+--- a/include/stxxl/bits/containers/btree/node.h
++++ b/include/stxxl/bits/containers/btree/node.h
+@@ -71,7 +71,7 @@ public:
+     typedef node_cache<normal_node, btree_type> node_cache_type;
+ 
+ private:
+-    struct value_compare : public std::binary_function<value_type, value_type, bool>
++    struct value_compare
+     {
+         key_compare comp;
+ 
+diff --git a/include/stxxl/bits/containers/hash_map/hash_map.h b/include/stxxl/bits/containers/hash_map/hash_map.h
+index 0759bd2..ecf19cd 100644
+--- a/include/stxxl/bits/containers/hash_map/hash_map.h
++++ b/include/stxxl/bits/containers/hash_map/hash_map.h
+@@ -1258,10 +1258,7 @@ protected:
+      * lexicographically by <hash-value, key> Note: the hash-value has already
+      * been computed.
+      */
+-    struct Cmp : public std::binary_function<
+-                     std::pair<internal_size_type, value_type>,
+-                     std::pair<internal_size_type, value_type>, bool
+-                     >
++    struct Cmp
+     {
+         self_type& map_;
+         Cmp(self_type& map) : map_(map) { }
+@@ -1520,7 +1517,7 @@ protected:
+ 
+ public:
+     //! Construct an equality predicate from the comparison operator
+-    struct equal_to : public std::binary_function<key_type, key_type, bool>
++    struct equal_to
+     {
+         //! reference to hash_map
+         const self_type& m_map;
+diff --git a/include/stxxl/bits/io/wbtl_file.h b/include/stxxl/bits/io/wbtl_file.h
+index 933a216..30828a0 100644
+--- a/include/stxxl/bits/io/wbtl_file.h
++++ b/include/stxxl/bits/io/wbtl_file.h
+@@ -65,7 +65,7 @@ class wbtl_file : public disk_queued_file
+     size_type curpos;
+     request_ptr backend_request;
+ 
+-    struct FirstFit : public std::binary_function<place, offset_type, bool>
++    struct FirstFit
+     {
+         bool operator () (
+             const place& entry,
+diff --git a/include/stxxl/bits/mng/block_alloc.h b/include/stxxl/bits/mng/block_alloc.h
+index 19ade8b..887f0e6 100644
+--- a/include/stxxl/bits/mng/block_alloc.h
++++ b/include/stxxl/bits/mng/block_alloc.h
+@@ -138,7 +138,7 @@ private:
+             perm[i] = i;
+ 
+         stxxl::random_number<random_uniform_fast> rnd;
+-        std::random_shuffle(perm.begin(), perm.end(), rnd _STXXL_FORCE_SEQUENTIAL);
++        std::shuffle(perm.begin(), perm.end(), std::mt19937(std::random_device()()));
+     }
+ 
+ public:
+diff --git a/include/stxxl/bits/mng/block_alloc_interleaved.h b/include/stxxl/bits/mng/block_alloc_interleaved.h
+index a82ee34..5aba23a 100644
+--- a/include/stxxl/bits/mng/block_alloc_interleaved.h
++++ b/include/stxxl/bits/mng/block_alloc_interleaved.h
+@@ -93,7 +93,7 @@ struct interleaved_RC : public interleaved_striping
+                 perms[i][j] = j;
+ 
+             random_number<random_uniform_fast> rnd;
+-            std::random_shuffle(perms[i].begin(), perms[i].end(), rnd _STXXL_FORCE_SEQUENTIAL);
++            std::shuffle(perms[i].begin(), perms[i].end(), std::mt19937(std::random_device()()));
+         }
+     }
+ 
+diff --git a/include/stxxl/bits/mng/disk_allocator.h b/include/stxxl/bits/mng/disk_allocator.h
+index 59ad085..c1e0f83 100644
+--- a/include/stxxl/bits/mng/disk_allocator.h
++++ b/include/stxxl/bits/mng/disk_allocator.h
+@@ -44,7 +44,7 @@ class disk_allocator : private noncopyable
+ {
+     typedef std::pair<stxxl::int64, stxxl::int64> place;
+ 
+-    struct first_fit : public std::binary_function<place, stxxl::int64, bool>
++    struct first_fit
+     {
+         bool operator () (
+             const place& entry,
+@@ -189,7 +189,7 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
+ 
+     sortseq::iterator space;
+     space = std::find_if(free_space.begin(), free_space.end(),
+-                         bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
++                         std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
+ 
+     if (space == free_space.end() && requested_size == BlockSize)
+     {
+@@ -207,7 +207,7 @@ void disk_allocator::new_blocks(BID<BlockSize>* begin, BID<BlockSize>* end)
+         grow_file(BlockSize);
+ 
+         space = std::find_if(free_space.begin(), free_space.end(),
+-                             bind2nd(first_fit(), requested_size) _STXXL_FORCE_SEQUENTIAL);
++                             std::bind(first_fit(), std::placeholders::_1, requested_size) _STXXL_FORCE_SEQUENTIAL);
+     }
+ 
+     if (space != free_space.end())
+diff --git a/include/stxxl/bits/parallel.h b/include/stxxl/bits/parallel.h
+index d973861..c858d87 100644
+--- a/include/stxxl/bits/parallel.h
++++ b/include/stxxl/bits/parallel.h
+@@ -121,7 +121,6 @@ using __gnu_parallel::random_shuffle;
+ #elif STXXL_PARALLEL
+ 
+ using std::sort;
+-using std::random_shuffle;
+ 
+ #else
+ 
+diff --git a/include/stxxl/bits/parallel/base.h b/include/stxxl/bits/parallel/base.h
+index 141d515..7dae74f 100644
+--- a/include/stxxl/bits/parallel/base.h
++++ b/include/stxxl/bits/parallel/base.h
+@@ -33,7 +33,6 @@ namespace parallel {
+  */
+ template <class Predicate, typename first_argument_type, typename second_argument_type>
+ class binary_negate
+-    : public std::binary_function<first_argument_type, second_argument_type, bool>
+ {
+ protected:
+     Predicate pred;
+@@ -80,7 +79,7 @@ static inline void decode2(lcas_t x, int& a, int& b)
+  * Constructs predicate for equality from strict weak ordering predicate
+  */
+ template <class Comparator, typename T1, typename T2>
+-class equal_from_less : public std::binary_function<T1, T2, bool>
++class equal_from_less
+ {
+ private:
+     Comparator& comp;
+@@ -126,7 +125,7 @@ median_of_three_iterators(RandomAccessIterator a, RandomAccessIterator b,
+ 
+ /** Similar to std::equal_to, but allows two different types. */
+ template <typename T1, typename T2>
+-struct equal_to : std::binary_function<T1, T2, bool>
++struct equal_to
+ {
+     bool operator () (const T1& t1, const T2& t2) const
+     {
+@@ -136,7 +135,7 @@ struct equal_to : std::binary_function<T1, T2, bool>
+ 
+ /** Similar to std::less, but allows two different types. */
+ template <typename T1, typename T2>
+-struct less : std::binary_function<T1, T2, bool>
++struct less
+ {
+     bool operator () (const T1& t1, const T2& t2) const
+     {
+diff --git a/include/stxxl/bits/parallel/multiseq_selection.h b/include/stxxl/bits/parallel/multiseq_selection.h
+index 57e7599..f41d9aa 100644
+--- a/include/stxxl/bits/parallel/multiseq_selection.h
++++ b/include/stxxl/bits/parallel/multiseq_selection.h
+@@ -35,7 +35,6 @@ namespace parallel {
+ //! Compare a pair of types lexcigraphically, ascending.
+ template <typename T1, typename T2, typename Comparator>
+ class lexicographic
+-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool>
+ {
+ protected:
+     Comparator& m_comp;
+@@ -60,7 +59,6 @@ public:
+ //! Compare a pair of types lexcigraphically, descending.
+ template <typename T1, typename T2, typename Comparator>
+ class lexicographic_rev
+-    : public std::binary_function<std::pair<T1, T2>, std::pair<T1, T2>, bool>
+ {
+ protected:
+     Comparator& m_comp;
+diff --git a/lib/io/wbtl_file.cpp b/lib/io/wbtl_file.cpp
+index 310d76a..6d52e2e 100644
+--- a/lib/io/wbtl_file.cpp
++++ b/lib/io/wbtl_file.cpp
+@@ -304,7 +304,7 @@ wbtl_file::offset_type wbtl_file::get_next_write_block()
+     // mapping_lock has to be aquired by caller
+     sortseq::iterator space =
+         std::find_if(free_space.begin(), free_space.end(),
+-                     bind2nd(FirstFit(), write_block_size) _STXXL_FORCE_SEQUENTIAL);
++                     std::bind(FirstFit(), std::placeholders::_1, write_block_size) _STXXL_FORCE_SEQUENTIAL);
+ 
+     if (space != free_space.end())
+     {

--- a/ports/stxxl/CONTROL
+++ b/ports/stxxl/CONTROL
@@ -1,3 +1,3 @@
 Source: stxxl
-Version: 2018-11-15-1
+Version: 2018-11-15-2
 Description: Standard Template Library for Extra Large Data Sets

--- a/ports/stxxl/portfile.cmake
+++ b/ports/stxxl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         # This patch can be removed when stxxl/stxxl/#95 is accepted
         fix-include-dir.patch
+        0001-fix-visual-studio.patch
 )
 
 vcpkg_configure_cmake(
@@ -31,7 +32,7 @@ vcpkg_configure_cmake(
     OPTIONS_DEBUG
         -DSTXXL_DEBUG_ASSERTIONS=ON
     OPTIONS_RELEASE
-        -DSTXXL_DEBUG_ASSERTIONS=OFF    
+        -DSTXXL_DEBUG_ASSERTIONS=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
I did some fix on stxxl library. I had many problems on building it with the new standard C++17, due to removed `std::random_shuffle` and `std::binary_function`. I've simply removed that and using code that will be accepted by these standards:

- C++11
- C++14
- C++17

I've also solved some issue with `__cplusplus` that in Visual Studio 2019 with CMake is not set to `201704L` even if `/Zc:__cplusplus` flag added in CMakeLists.txt. Now it build following project, that creates three executables with same source and different standard:

CMakeLists.txt:

```
cmake_minimum_required (VERSION 3.10.0)

set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/lib)
set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/lib)
set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/bin)
set (CONNECTION_PLUGIN_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/connections)
set (TEST_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/tests)
set (DOC_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build/${CMAKE_BUILD_TYPE}/doc)
set (THIRDPARTY_DIRECTORY ${CMAKE_SOURCE_DIR}/thirdparty)

project (test)

message (STATUS "Building project ${PROJECT_NAME}")

find_package(stxxl CONFIG REQUIRED)

include_directories (${CMAKE_CURRENT_SOURCE_DIR})

set (PROJECT_SRC
  main.cpp
  )


add_executable (${PROJECT_NAME}11 ${PROJECT_SRC} )
add_executable (${PROJECT_NAME}14 ${PROJECT_SRC} )
add_executable (${PROJECT_NAME}17 ${PROJECT_SRC} )
target_compile_features(${PROJECT_NAME}11 PRIVATE cxx_std_11)
target_compile_features(${PROJECT_NAME}14 PRIVATE cxx_std_14)
target_compile_features(${PROJECT_NAME}17 PRIVATE cxx_std_17)

target_link_libraries(${PROJECT_NAME}11 stxxl)
target_link_libraries(${PROJECT_NAME}14 stxxl)
target_link_libraries(${PROJECT_NAME}17 stxxl)
```

main.cpp

```{.cpp}
/***************************************************************************
 *  examples/algo/copy_and_sort_file.cpp
 *
 *  Part of the STXXL. See http://stxxl.sourceforge.net
 *
 *  Copyright (C) 2010 Andreas Beckmann <beckmann@cs.uni-frankfurt.de>
 *
 *  Distributed under the Boost Software License, Version 1.0.
 *  (See accompanying file LICENSE_1_0.txt or copy at
 *  http://www.boost.org/LICENSE_1_0.txt)
 **************************************************************************/

 //! \example algo/copy_and_sort_file.cpp
 //! This example imports a file into an \c stxxl::vector without copying its
 //! content and then sorts it using \c stxxl::stream::sort while writing the
 //! sorted output to a different file.

#include <algorithm>
#include <iostream>
#include <limits>
#include <vector>
#include <stxxl/io>
#include <stxxl/vector>
#include <stxxl/stream>

struct my_type
{
  typedef unsigned key_type;

  key_type m_key;
  char m_data[128 - sizeof(key_type)];

  my_type() { }
  my_type(key_type k) : m_key(k) { }

  static my_type min_value()
  {
    return my_type(std::numeric_limits<key_type>::min());
  }
  static my_type max_value()
  {
    return my_type(std::numeric_limits<key_type>::max());
  }
};

inline bool operator < (const my_type& a, const my_type& b)
{
  return a.m_key < b.m_key;
}

inline bool operator == (const my_type& a, const my_type& b)
{
  return a.m_key == b.m_key;
}

struct Cmp
{
  typedef my_type first_argument_type;
  typedef my_type second_argument_type;
  typedef bool result_type;
  bool operator () (const my_type& a, const my_type& b) const
  {
    return a < b;
  }
  static my_type min_value()
  {
    return my_type::min_value();
  }
  static my_type max_value()
  {
    return my_type::max_value();
  }
};

std::ostream& operator << (std::ostream& o, const my_type& obj)
{
  o << obj.m_key;
  return o;
}

int main(int argc, char** argv)
{
  if (argc < 3)
  {
    std::cout << "Usage: " << argv[0] << " infile outfile" << std::endl;
    return -1;
  }

  const stxxl::internal_size_type memory_to_use = 512 * 1024 * 1024;
  const stxxl::internal_size_type block_size = sizeof(my_type) * 4096;

  typedef stxxl::vector<my_type, 1, stxxl::lru_pager<2>, block_size> vector_type;

  stxxl::syscall_file in_file(argv[1], stxxl::file::DIRECT | stxxl::file::RDONLY);
  stxxl::syscall_file out_file(argv[2], stxxl::file::DIRECT | stxxl::file::RDWR | stxxl::file::CREAT);
  vector_type input(&in_file);
  vector_type output(&out_file);
  output.resize(input.size());

  typedef stxxl::stream::streamify_traits<vector_type::iterator>::stream_type input_stream_type;
  input_stream_type input_stream = stxxl::stream::streamify(input.begin(), input.end());

  typedef Cmp comparator_type;
  typedef stxxl::stream::sort<input_stream_type, comparator_type, block_size> sort_stream_type;
  sort_stream_type sort_stream(input_stream, comparator_type(), memory_to_use);

  vector_type::iterator o = stxxl::stream::materialize(sort_stream, output.begin(), output.end());
  STXXL_ASSERT(o == output.end());

  if (1) {
    STXXL_MSG("Checking order...");
    STXXL_MSG((stxxl::is_sorted(output.begin(), output.end(), comparator_type()) ? "OK" : "WRONG"));
  }

  return 0;
}

// vim: et:ts=4:sw=4
```

I've also tried some other example in `stxxl` examples folder, and everything seems to work. I've tested it only in windows with Visual Studio 2019.
