### PR TITLE
[irrlicht] use unicode path on windows

### DIFF
--- a/ports/irrlicht/CMakeLists.txt
+++ b/ports/irrlicht/CMakeLists.txt
@@ -85,6 +85,13 @@ target_link_libraries(Irrlicht PRIVATE
     ${BZIP2_LIBRARY}
     )
 
+target_compile_definitions(Irrlicht PRIVATE
+    NO_IRR_USE_NON_SYSTEM_ZLIB_
+    NO_IRR_USE_NON_SYSTEM_LIB_PNG_
+    NO_IRR_USE_NON_SYSTEM_JPEG_LIB_
+    NO_IRR_USE_NON_SYSTEM_BZLIB_
+    )
+
 if(IRR_BUILD_TOOLS)
     add_executable(FileToHeader         ${IRR_TOOL_FILES_FILE_TO_HEADER})
 

--- a/ports/irrlicht/CMakeLists.txt
+++ b/ports/irrlicht/CMakeLists.txt
@@ -144,6 +144,9 @@ endif()
 target_compile_definitions(Irrlicht PRIVATE IRRLICHT_EXPORTS)
 
 if(WIN32)
+    # Unicode
+    target_compile_definitions(Irrlicht PRIVATE UNICODE _UNICODE)
+
     # Import the symbols of bzip2
     target_compile_definitions(Irrlicht PRIVATE BZ_IMPORT)
 

--- a/ports/irrlicht/CONTROL
+++ b/ports/irrlicht/CONTROL
@@ -1,5 +1,5 @@
 Source: irrlicht
-Version: 1.8.4-1
+Version: 1.8.4-2
 Description: Irrlicht lightning fast 3d engine
 Build-Depends: zlib, libpng, bzip2, libjpeg-turbo
 

--- a/ports/irrlicht/portfile.cmake
+++ b/ports/irrlicht/portfile.cmake
@@ -22,6 +22,8 @@ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF "1.8.4"
+    PATCHES
+        "support-unicode-on-windows.patch"
     # [NO_REMOVE_ONE_LEVEL]
     # [WORKING_DIRECTORY <${CURRENT_BUILDTREES_DIR}/src>]
     # [PATCHES <a.patch>...]

--- a/ports/irrlicht/support-unicode-on-windows.patch
+++ b/ports/irrlicht/support-unicode-on-windows.patch
@@ -1,0 +1,28 @@
+diff --git a/include/IrrCompileConfig.h b/include/IrrCompileConfig.h
+index c2c5d12..7c44f0c 100644
+--- a/include/IrrCompileConfig.h
++++ b/include/IrrCompileConfig.h
+@@ -233,7 +233,9 @@ you will not be able to use anything provided by the GUI Environment, including
+ disable this feature, the engine behave as before (ansi). This is currently only supported
+ for Windows based systems. You also have to set #define UNICODE for this to compile.
+ */
+-//#define _IRR_WCHAR_FILESYSTEM
++#if defined(_IRR_WINDOWS_) && (defined(_UNICODE) || defined(UNICODE))
++#define _IRR_WCHAR_FILESYSTEM
++#endif
+ #ifdef NO_IRR_WCHAR_FILESYSTEM
+ #undef _IRR_WCHAR_FILESYSTEM
+ #endif
+diff --git a/include/Keycodes.h b/include/Keycodes.h
+index e56eca1..57ab312 100644
+--- a/include/Keycodes.h
++++ b/include/Keycodes.h
+@@ -89,7 +89,7 @@ namespace irr
+ 		KEY_KEY_X            = 0x58,  // X key
+ 		KEY_KEY_Y            = 0x59,  // Y key
+ 		KEY_KEY_Z            = 0x5A,  // Z key
+-		KEY_LWIN             = 0x5B,  // Left Windows key (Microsoft® Natural® keyboard)
++		KEY_LWIN             = 0x5B,  // Left Windows key (MicrosoftÂ® NaturalÂ® keyboard)
+ 		KEY_RWIN             = 0x5C,  // Right Windows key (Natural keyboard)
+ 		KEY_APPS             = 0x5D,  // Applications key (Natural keyboard)
+ 		KEY_SLEEP            = 0x5F,  // Computer Sleep key


### PR DESCRIPTION
use unicode path on windows
also patch `/include/Keycodes.h` to utf-8 encoding