### PR TITLE
[sdl2-image] Updated to 2.0.5

### DIFF
--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-image
-Version: 2.0.4-3
+Version: 2.0.5
 Build-Depends: sdl2, libpng
 Homepage: https://www.libsdl.org/projects/SDL_image
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV

--- a/ports/sdl2-image/portfile.cmake
+++ b/ports/sdl2-image/portfile.cmake
@@ -1,11 +1,11 @@
 include(vcpkg_common_functions)
 
-set(SDL2_IMAGE_VERSION "2.0.4")
+set(SDL2_IMAGE_VERSION "2.0.5")
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${SDL2_IMAGE_VERSION}.zip"
     FILENAME "SDL2_image-${SDL2_IMAGE_VERSION}.zip"
-    SHA512 b26ef2546718754481385ddad800ee61c84c58a9e141127c0a12215362d41c23603bfb21d556803396c0cb17bd7f48a45dd1b2e66573a1b2e32f590cc3fa48d0
+    SHA512 c10e28a0d50fb7a6c985ffe8904370ab4faeb9bbed6f2ffbc81536422e8f8bb66eddbf69b12423082216c2bcfcb617cba4c5970f63fe75bfacccd9f99f02a6a2
 )
 
 vcpkg_extract_source_archive_ex(


### PR DESCRIPTION
I generated the hash by running CertUtil on the official release zip. Hope that's the proper way to get it.