### PR TITLE
[leptonica] Upgrade to 1.78.0

### DIFF
--- a/ports/leptonica/CONTROL
+++ b/ports/leptonica/CONTROL
@@ -1,5 +1,5 @@
 Source: leptonica
-Version: 1.76.0-1
+Version: 1.78.0
 Homepage: https://github.com/DanBloomberg/leptonica
 Description: An open source library containing software that is broadly useful for image processing and image analysis applications
 Build-Depends: libjpeg-turbo, zlib, libpng, tiff, giflib

--- a/ports/leptonica/portfile.cmake
+++ b/ports/leptonica/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DanBloomberg/leptonica
-    REF 1.76.0
-    SHA512 0d7575dc38d1e656a228ef30412a2cbb908b9c7c8636e4e96f4a7dc0429c04709316b8ad04893285ab430c1b2063d71537fc5b989a0f9dbdbec488713e1bab1f
+    REF 87b8219360bca3c9929a5705c3d9c50c42c34bca
+    SHA512 b7bfa9437be7e3d9276acacf8f62ccda1cd8f88741ada5106ef0232d4965617be2c5d0b8a6b4462896a1a0b6b44d9ecefd6e6b8d0e50d4fb881bdf5e821703a4
     HEAD_REF master
     PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/fix-cmakelists.patch

--- a/ports/leptonica/use-tiff-libraries.patch
+++ b/ports/leptonica/use-tiff-libraries.patch
@@ -1,8 +1,8 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 3af7e30..55e17da 100644
+index 6daad98..5119895 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -44,7 +44,7 @@ if (PNG_LIBRARY)
+@@ -48,7 +48,7 @@ if (PNG_LIBRARY)
  endif()
  if (TIFF_LIBRARY)
      target_include_directories  (leptonica PUBLIC ${TIFF_INCLUDE_DIR})
@@ -10,4 +10,4 @@ index 3af7e30..55e17da 100644
 +    target_link_libraries       (leptonica ${TIFF_LIBRARIES})
  endif()
  if (WEBP_FOUND)
-     target_include_directories  (leptonica PUBLIC ${WEBP_INCLUDE_DIR})
+     target_include_directories  (leptonica PUBLIC ${WEBP_INCLUDE_DIRS})


### PR DESCRIPTION
Upgrade leptonica to 1.78.0, related to PR https://github.com/microsoft/vcpkg/pull/7217