### PR TITLE
[tesseract[training_tools]] Fix build error

### DIFF
--- a/ports/tesseract/CONTROL
+++ b/ports/tesseract/CONTROL
@@ -1,12 +1,12 @@
 Source: tesseract
-Version: 4.1.0
+Version: 4.1.0-1
 Homepage: https://github.com/tesseract-ocr/tesseract
 Description: An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.
 Build-Depends: leptonica
 
 Feature: training_tools
 Description: build training tools
-Build-Depends: icu
+Build-Depends: icu, pango, cairo, fontconfig
 
 Feature: cpu_independed
 Description: build on any cpu extension commands support

--- a/ports/tesseract/fix-text2image.patch
+++ b/ports/tesseract/fix-text2image.patch
@@ -1,0 +1,64 @@
+diff --git a/src/training/CMakeLists.txt b/src/training/CMakeLists.txt
+index 8fd96a9..ef258e1 100644
+--- a/src/training/CMakeLists.txt
++++ b/src/training/CMakeLists.txt
+@@ -253,7 +253,7 @@ if (NOT CPPAN_BUILD)
+ find_package(PkgConfig)
+ endif()
+ 
+-if (PKG_CONFIG_FOUND OR CPPAN_BUILD)
++if (1)
+ 
+ if (PKG_CONFIG_FOUND)
+ pkg_check_modules(Pango REQUIRED pango)
+@@ -261,8 +261,35 @@ pkg_check_modules(Cairo REQUIRED cairo)
+ pkg_check_modules(PangoFt2 REQUIRED pangoft2)
+ pkg_check_modules(PangoCairo REQUIRED pangocairo)
+ pkg_check_modules(FontConfig REQUIRED fontconfig)
+-endif()
++else()
++find_library(Glib_LIBRARY_RELEASE NAMES glib-2.0)
++find_library(Glib_LIBRARY_DEBUG NAMES glib-2.0)
++select_library_configurations(Glib)
++
++find_library(GObject_LIBRARY_RELEASE NAMES gobject-2.0)
++find_library(GObject_LIBRARY_DEBUG NAMES gobject-2.0)
++select_library_configurations(GObject)
++
++find_library(Pango_LIBRARY_RELEASE NAMES pango-1.0)
++find_library(Pango_LIBRARY_DEBUG NAMES pango-1.0)
++select_library_configurations(Pango)
++
++find_library(Cairo_LIBRARY_RELEASE NAMES cairo)
++find_library(Cairo_LIBRARY_DEBUG NAMES cairod)
++select_library_configurations(Cairo)
+ 
++find_library(FontConfig_LIBRARY_RELEASE NAMES fontconfig)
++find_library(FontConfig_LIBRARY_DEBUG NAMES fontconfig)
++select_library_configurations(FontConfig)
++
++find_library(PangoFt2_LIBRARY_RELEASE NAMES pangoft2-1.0)
++find_library(PangoFt2_LIBRARY_DEBUG NAMES pangoft2-1.0)
++select_library_configurations(PangoFt2)
++
++find_library(PangoCairo_LIBRARY_RELEASE NAMES pangocairo-1.0)
++find_library(PangoCairo_LIBRARY_DEBUG NAMES pangocairo-1.0)
++select_library_configurations(PangoCairo)
++endif()
+ set(text2image_src
+     text2image.cpp
+     boxchar.cpp
+@@ -285,10 +312,12 @@ set(text2image_src
+ 
+ add_executable              (text2image ${text2image_src})
+ target_link_libraries       (text2image unicharset_training)
+-if (PKG_CONFIG_FOUND)
++if (1)
+ target_include_directories  (text2image BEFORE PRIVATE ${Cairo_INCLUDE_DIRS} ${Pango_INCLUDE_DIRS})
+ target_compile_definitions  (text2image PRIVATE -DPANGO_ENABLE_ENGINE)
+ target_link_libraries       (text2image
++	${GObject_LIBRARIES}
++	${Glib_LIBRARIES}
+     ${Pango_LIBRARIES}
+     ${Cairo_LIBRARIES}
+     ${PangoCairo_LIBRARIES}

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 d617f5c5b826640b2871dbe3d7973bcc5e66fafd837921a20e009d683806ed50f0f258aa455019d99fc54f5cb65c2fa0380e3a3c92b39ab0684b8799c730b09d
     PATCHES
         fix-tiff-linkage.patch
+		fix-text2image.patch
 )
 
 # The built-in cmake FindICU is better


### PR DESCRIPTION
Due to `glib, gobject, pango, cairo, pangocairo, pangoft2, fontconfig` don't have ***config.cmake** in PACKAGES_DIR, so use `find_library` to find them.

Related issue: #7343 