### PR TITLE
[Openxr-loader] Fix fatal error C1189

### DIFF
--- a/ports/openxr-loader/0004-fix-fatal-errorC1189.patch
+++ b/ports/openxr-loader/0004-fix-fatal-errorC1189.patch
@@ -1,0 +1,13 @@
+diff --git a/src/loader/CMakeLists.txt b/src/loader/CMakeLists.txt
+index 92985a5..b265091 100644
+--- a/src/loader/CMakeLists.txt
++++ b/src/loader/CMakeLists.txt
+@@ -134,7 +134,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+     endforeach()
+ 
+     target_link_libraries(${LOADER_NAME} shlwapi)
+-    target_compile_options(${LOADER_NAME} PRIVATE)
++    target_compile_options(${LOADER_NAME} PRIVATE /std:c++17)
+     generate_export_header(${LOADER_NAME})
+     # set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS false)
+ 

--- a/ports/openxr-loader/CONTROL
+++ b/ports/openxr-loader/CONTROL
@@ -1,5 +1,5 @@
 Source: openxr-loader
-Version: 0.90.1
+Version: 0.90.1-1
 Description: Khronos API for abstracting VR/MR/AR hardware
 
 Feature: vulkan

--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_from_github(
         0002-fix-linux-pkgconfig-dependency.patch
         # Python < 3.6 doesn't allow a WindowsPath object to act as a pathlike in os.path functions
         0003-windows-path-python-fix.patch
+        0004-fix-fatal-errorC1189.patch
 )
 
 # Weird behavior inside the OpenXR loader.  On Windows they force shared libraries to use static crt, and


### PR DESCRIPTION
Openxr-loader compile filed with a fatal error C1189 in an internal version of VS, this issue could be fixed by adding the compile option /std:c++17.