### PR TITLE
[libmariadb] Fix build library type and install path

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,4 +1,4 @@
 Source: libmariadb
-Version: 3.0.10-1
+Version: 3.0.10-2
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases

--- a/ports/libmariadb/fix-InstallPath.patch
+++ b/ports/libmariadb/fix-InstallPath.patch
@@ -1,0 +1,146 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 02757a9..b2715dd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,11 @@ IF(COMMAND CMAKE_POLICY)
+   ENDFOREACH()
+ ENDIF()
+ 
++if (BUILD_SHARED_LIBS)
++	set(DEFAULT_LINKAGE DYNAMIC)
++else()
++	set(DEFAULT_LINKAGE STATIC)
++endif()
+ 
+ PROJECT(mariadb-connector-c C)
+ 
+diff --git a/cmake/install_plugins.cmake b/cmake/install_plugins.cmake
+index cd5616c..d058a5c 100644
+--- a/cmake/install_plugins.cmake
++++ b/cmake/install_plugins.cmake
+@@ -8,7 +8,7 @@
+ # plugin installation
+ 
+ MACRO(INSTALL_PLUGIN name binary_dir)
+-  INSTALL(TARGETS ${name} COMPONENT ClientPlugins DESTINATION ${INSTALL_PLUGINDIR})
++  INSTALL(TARGETS ${name} COMPONENT ClientPlugins DESTINATION ${INSTALL_PLUGINDIR}/../../../bin/plugin)
+   IF(WIN32)
+     FILE(APPEND ${CC_BINARY_DIR}/win/packaging/plugin.conf "<File Id=\"${name}.dll\" Name=\"${name}.dll\" DiskId=\"1\" Source=\"${binary_dir}/${CMAKE_BUILD_TYPE}/${name}.dll\"/>\n")
+     FILE(APPEND ${CC_BINARY_DIR}/win/packaging/plugin.conf "<File Id=\"${name}.pdb\" Name=\"${name}.pdb\" DiskId=\"1\" Source=\"${binary_dir}/${CMAKE_BUILD_TYPE}/${name}.pdb\"/>\n")
+diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
+index a1f039e..03a3a6f 100644
+--- a/libmariadb/CMakeLists.txt
++++ b/libmariadb/CMakeLists.txt
+@@ -386,10 +386,10 @@ ADD_LIBRARY(mariadbclient STATIC  ${MARIADB_OBJECTS} ${EMPTY_FILE})
+ TARGET_LINK_LIBRARIES(mariadbclient ${SYSTEM_LIBS})
+ 
+ IF(UNIX)
+-  ADD_LIBRARY(libmariadb SHARED ${libmariadb_RC} ${MARIADB_OBJECTS} ${EMPTY_FILE})
++  ADD_LIBRARY(libmariadb ${libmariadb_RC} ${MARIADB_OBJECTS} ${EMPTY_FILE})
+   SET_TARGET_PROPERTIES(libmariadb PROPERTIES COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
+ ELSE()
+-  ADD_LIBRARY(libmariadb SHARED ${libmariadb_RC} mariadbclient.def)
++  ADD_LIBRARY(libmariadb ${libmariadb_RC} mariadbclient.def)
+   TARGET_LINK_LIBRARIES(libmariadb  mariadbclient)
+   SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
+ ENDIF()
+@@ -441,13 +441,14 @@ ENDIF()
+ 
+ INSTALL(TARGETS mariadbclient
+           COMPONENT Development
+-          DESTINATION ${INSTALL_LIBDIR})
++          LIBRARY DESTINATION lib)
+ INSTALL(TARGETS libmariadb
+           COMPONENT SharedLibraries
+-        DESTINATION ${INSTALL_LIBDIR})
++		  RUNTIME DESTINATION bin
++		  LIBRARY DESTINATION lib
++		  ARCHIVE DESTINATION lib)
+ 
+-
+-IF(WIN32)
++IF(0)
+    # On Windows, install PDB
+    INSTALL(FILES $<TARGET_PDB_FILE:libmariadb> DESTINATION "${INSTALL_LIBDIR}"
+            CONFIGURATIONS Debug RelWithDebInfo
+diff --git a/plugins/auth/CMakeLists.txt b/plugins/auth/CMakeLists.txt
+index 42f6f05..9a57146 100644
+--- a/plugins/auth/CMakeLists.txt
++++ b/plugins/auth/CMakeLists.txt
+@@ -14,7 +14,7 @@ REGISTER_PLUGIN(TARGET mysql_native_password
+ REGISTER_PLUGIN(TARGET dialog
+                 TYPE MARIADB_CLIENT_PLUGIN_AUTH
+                 CONFIGURATIONS DYNAMIC STATIC OFF
+-                DEFAULT DYNAMIC
++                DEFAULT ${DEFAULT_LINKAGE}
+                 SOURCES ${CC_SOURCE_DIR}/plugins/auth/dialog.c
+                         ${CC_SOURCE_DIR}/libmariadb/get_password.c)
+ 
+@@ -33,7 +33,7 @@ IF(WITH_SSL)
+   REGISTER_PLUGIN(TARGET caching_sha2_password
+                 TYPE MARIADB_CLIENT_PLUGIN_AUTH
+                 CONFIGURATIONS DYNAMIC STATIC OFF
+-                DEFAULT DYNAMIC
++                DEFAULT ${DEFAULT_LINKAGE}
+                 SOURCES ${CC_SOURCE_DIR}/plugins/auth/caching_sha2_pw.c 
+                         ${CRYPT_SOURCE}
+                 LIBRARIES ${CACHING_SHA2_LIBS})
+@@ -53,7 +53,7 @@ IF(GSSAPI_SOURCES)
+   REGISTER_PLUGIN(TARGET auth_gssapi_client
+                   TYPE MARIADB_CLIENT_PLUGIN_AUTH
+                   CONFIGURATIONS DYNAMIC STATIC OFF
+-                  DEFAULT DYNAMIC
++                  DEFAULT ${DEFAULT_LINKAGE}
+                   SOURCES ${GSSAPI_SOURCES}
+                   INCLUDES ${CC_SOURCE_DIR}/plugins/auth ${GSSAPI_INCS}
+                   LIBRARIES ${GSSAPI_LIBS})
+@@ -68,7 +68,7 @@ IF(${WITH_SSL} STREQUAL "OPENSSL" OR ${WITH_SSL} STREQUAL "SCHANNEL")
+   REGISTER_PLUGIN(TARGET sha256_password
+                   TYPE MARIADB_CLIENT_PLUGIN_AUTH
+                   CONFIGURATIONS DYNAMIC STATIC OFF
+-                  DEFAULT DYNAMIC
++                  DEFAULT ${DEFAULT_LINKAGE}
+                   SOURCES ${AUTH_DIR}/sha256_pw.c
+                   LIBRARIES ${SHA256_LIBS})
+ ENDIF()
+@@ -85,6 +85,6 @@ REGISTER_PLUGIN(TARGET mysql_old_password
+ REGISTER_PLUGIN(TARGET mysql_clear_password
+                 TYPE MARIADB_CLIENT_PLUGIN_AUTH
+                 CONFIGURATIONS DYNAMIC STATIC OFF
+-                DEFAULT DYNAMIC
++                DEFAULT ${DEFAULT_LINKAGE}
+                 SOURCES ${AUTH_DIR}/mariadb_cleartext.c)
+ 
+diff --git a/plugins/io/CMakeLists.txt b/plugins/io/CMakeLists.txt
+index 8c304c9..3547107 100644
+--- a/plugins/io/CMakeLists.txt
++++ b/plugins/io/CMakeLists.txt
+@@ -7,7 +7,7 @@ IF (WITH_CURL)
+     REGISTER_PLUGIN(TARGET remote_io
+                   TYPE MARIADB_CLIENT_PLUGIN_IO
+                   CONFIGURATIONS DYNAMIC STATIC OFF
+-                  DEFAULT DYNAMIC
++                  DEFAULT ${DEFAULT_LINKAGE}
+                   SOURCES ${CC_SOURCE_DIR}/plugins/io/remote_io.c
+                   INCLUDES ${CURL_INCLUDE_DIR}
+                   LIBRARIES ${CURL_LIBRARIES})
+diff --git a/plugins/pvio/CMakeLists.txt b/plugins/pvio/CMakeLists.txt
+index 76eb3ef..3601622 100644
+--- a/plugins/pvio/CMakeLists.txt
++++ b/plugins/pvio/CMakeLists.txt
+@@ -15,13 +15,13 @@ IF(WIN32)
+   REGISTER_PLUGIN(TARGET pvio_npipe
+                 TYPE MARIADB_CLIENT_PLUGIN_PVIO
+                 CONFIGURATIONS STATIC DYNAMIC DEFAULT
+-                DEFAULT DYNAMIC
++                DEFAULT ${DEFAULT_LINKAGE}
+                 SOURCES ${CC_SOURCE_DIR}/plugins/pvio/pvio_npipe.c)
+ 
+   # shared memory
+   REGISTER_PLUGIN(TARGET pvio_shmem
+                 TYPE MARIADB_CLIENT_PLUGIN_PVIO
+                 CONFIGURATIONS STATIC DYNAMIC DEFAULT
+-                DEFAULT DYNAMIC
++                DEFAULT ${DEFAULT_LINKAGE}
+                 SOURCES ${CC_SOURCE_DIR}/plugins/pvio/pvio_shmem.c)
+ ENDIF()

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
     PATCHES
             md.patch
             disable-test-build.patch
+			fix-InstallPath.patch
 )
 
 vcpkg_configure_cmake(
@@ -38,45 +39,8 @@ if(VCPKG_BUILD_TYPE STREQUAL "debug")
         ${CURRENT_PACKAGES_DIR}/include)
 endif()
 
-# fix libmariadb lib & dll directory.
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/lib/mariadb/mariadbclient.lib
-            ${CURRENT_PACKAGES_DIR}/lib/mariadbclient.lib)
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mariadb/mariadbclient.lib
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mariadbclient.lib)
-    endif()
-else()
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin)
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/lib/mariadb/libmariadb.dll
-            ${CURRENT_PACKAGES_DIR}/bin/libmariadb.dll)
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/lib/mariadb/libmariadb.lib
-            ${CURRENT_PACKAGES_DIR}/lib/libmariadb.lib)
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mariadb/libmariadb.dll
-            ${CURRENT_PACKAGES_DIR}/debug/bin/libmariadb.dll)
-        file(RENAME
-            ${CURRENT_PACKAGES_DIR}/debug/lib/mariadb/libmariadb.lib
-            ${CURRENT_PACKAGES_DIR}/debug/lib/libmariadb.lib)
-    endif()
-endif()
-
 # remove plugin folder
 file(REMOVE_RECURSE
-    ${CURRENT_PACKAGES_DIR}/lib/plugin
-    ${CURRENT_PACKAGES_DIR}/debug/lib/plugin
     ${CURRENT_PACKAGES_DIR}/lib/mariadb
     ${CURRENT_PACKAGES_DIR}/debug/lib/mariadb)
 


### PR DESCRIPTION
1. Since the build library type in the source is stable, it will generate ***.dll** in `CURRENT_PACKAGES_DIR` when building static library. So according to `BUILD_SHARED_LIBS` to set the build library type.
2. Fix install ***.lib** and ***.dll** path.

Related issue: #3624