### PR TITLE
[pcl]Fix Build failure in linux

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.9.1-5
+Version: 1.9.1-6
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
@@ -23,3 +23,6 @@ Build-Depends: boost-accumulators
 Feature: cuda
 Description: CUDA support for PCL
 Build-Depends: cuda
+
+Feature: opengl
+Description: CUDA support for OpenGL

--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -25,4 +25,4 @@ Description: CUDA support for PCL
 Build-Depends: cuda
 
 Feature: opengl
-Description: CUDA support for OpenGL
+Description: OpenGL support for PCL

--- a/ports/pcl/boost-1.70.patch
+++ b/ports/pcl/boost-1.70.patch
@@ -12,14 +12,16 @@ index 05e6002..99e3a07 100644
        typedef boost::ptr_list<SupervoxelHelper> HelperListT;
        HelperListT supervoxel_helpers_;
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 68cc438..a9d7732 100644
+index 68cc438..8cfa1c6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -416,6 +416,7 @@ endif()
+@@ -416,6 +416,9 @@ endif()
  
  # Boost (required)
  include("${PCL_SOURCE_DIR}/cmake/pcl_find_boost.cmake")
-+add_definitions(-fext-numeric-literals)
++if (NOT APPLE)
++    add_definitions(-fext-numeric-literals)
++endif()
  
  ### ---[ Create the config.h file
  set(pcl_config_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pcl_config.h.in")

--- a/ports/pcl/boost-1.70.patch
+++ b/ports/pcl/boost-1.70.patch
@@ -11,3 +11,15 @@ index 05e6002..99e3a07 100644
  
        typedef boost::ptr_list<SupervoxelHelper> HelperListT;
        HelperListT supervoxel_helpers_;
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68cc438..a9d7732 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -416,6 +416,7 @@ endif()
+ 
+ # Boost (required)
+ include("${PCL_SOURCE_DIR}/cmake/pcl_find_boost.cmake")
++add_definitions(-fext-numeric-literals)
+ 
+ ### ---[ Create the config.h file
+ set(pcl_config_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pcl_config.h.in")

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -43,6 +43,11 @@ if("tools" IN_LIST FEATURES)
     set(BUILD_TOOLS ON)
 endif()
 
+set(WITH_OPENGL OFF)
+if ("opengl" IN_LIST FEATURES)
+    set(WITH_OPENGL ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -66,6 +71,7 @@ vcpkg_configure_cmake(
         -DWITH_QHULL=ON
         -DWITH_QT=${WITH_QT}
         -DWITH_VTK=ON
+        -DWITH_OPENGL=${WITH_OPENGL}
 )
 
 vcpkg_install_cmake()

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -18,35 +18,14 @@ file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindFLANN.cmake)
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PCL_SHARED_LIBS)
 
-set(WITH_OPENNI2 OFF)
-if("openni2" IN_LIST FEATURES)
-    set(WITH_OPENNI2 ON)
-endif()
-
-set(WITH_QT OFF)
-if("qt" IN_LIST FEATURES)
-    set(WITH_QT ON)
-endif()
-
-set(WITH_PCAP OFF)
-if("pcap" IN_LIST FEATURES)
-    set(WITH_PCAP ON)
-endif()
-
-set(WITH_CUDA OFF)
-if("cuda" IN_LIST FEATURES)
-    set(WITH_CUDA ON)
-endif()
-
-set(BUILD_TOOLS OFF)
-if("tools" IN_LIST FEATURES)
-    set(BUILD_TOOLS ON)
-endif()
-
-set(WITH_OPENGL OFF)
-if ("opengl" IN_LIST FEATURES)
-    set(WITH_OPENGL ON)
-endif()
+vcpkg_check_features(
+    openni2 WITH_OPENNI2
+    qt WITH_QT
+    pcap WITH_PCAP
+    cuda WITH_CUDA
+    tools BUILD_TOOLS
+    opengl WITH_OPENGL
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
1. Set opengl as a port feature.
2. Fix boost build issues.
3. Since opengl no longer supports `libGL.a`, this feature is disabled in Linux.

Related: #3466.