### PR TITLE
[vcpkg] Fix RealFilesystem::remove_all

### DIFF
--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -31,7 +31,7 @@ namespace fs
         struct symlink_status_t
         {
             file_status operator()(const path& p, std::error_code& ec) const noexcept;
-            file_status operator()(const path& p, vcpkg::LineInfo li) const noexcept;
+            file_status operator()(vcpkg::LineInfo li, const path& p) const noexcept;
         };
         struct is_symlink_t
         {

--- a/toolsrc/include/vcpkg/base/work_queue.h
+++ b/toolsrc/include/vcpkg/base/work_queue.h
@@ -12,17 +12,23 @@ namespace vcpkg
     namespace detail
     {
         // for SFINAE purposes, keep out of the class
-        template<class Action, class ThreadLocalData>
-        auto call_moved_action(Action& action,
+        // also this sfinae is so weird because Backwards Compatibility with VS2015
+        template<class Action,
+                 class ThreadLocalData,
+                 class = decltype(std::declval<Action>()(std::declval<ThreadLocalData&>(),
+                                                         std::declval<const WorkQueue<Action, ThreadLocalData>&>()))>
+        void call_moved_action(Action& action,
                                const WorkQueue<Action, ThreadLocalData>& work_queue,
-                               ThreadLocalData& tld) -> decltype(static_cast<void>(std::move(action)(tld, work_queue)))
+                               ThreadLocalData& tld)
         {
             std::move(action)(tld, work_queue);
         }
 
-        template<class Action, class ThreadLocalData>
-        auto call_moved_action(Action& action, const WorkQueue<Action, ThreadLocalData>&, ThreadLocalData& tld)
-            -> decltype(static_cast<void>(std::move(action)(tld)))
+        template<class Action,
+                 class ThreadLocalData,
+                 class = decltype(std::declval<Action>()(std::declval<ThreadLocalData&>())),
+                 class = void>
+        void call_moved_action(Action& action, const WorkQueue<Action, ThreadLocalData>&, ThreadLocalData& tld)
         {
             std::move(action)(tld);
         }

--- a/toolsrc/include/vcpkg/base/work_queue.h
+++ b/toolsrc/include/vcpkg/base/work_queue.h
@@ -32,7 +32,7 @@ namespace vcpkg
     struct WorkQueue
     {
         template<class F>
-        WorkQueue(std::uint16_t num_threads, LineInfo li, const F& tld_init) noexcept
+        WorkQueue(LineInfo li, std::uint16_t num_threads, const F& tld_init) noexcept
         {
             m_line_info = li;
 

--- a/toolsrc/src/vcpkg-test/files.cpp
+++ b/toolsrc/src/vcpkg-test/files.cpp
@@ -115,7 +115,9 @@ TEST_CASE ("remove all", "[files]")
 
     fs::path fp;
     fs.remove_all(temp_dir, ec, fp);
-    REQUIRE_FALSE(ec);
+    if (ec) {
+        FAIL("remove_all failure on file: " << fp);
+    }
 
     REQUIRE_FALSE(fs.exists(temp_dir));
 }

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -28,16 +28,9 @@ namespace fs::detail
 #if defined(_WIN32)
         static_cast<void>(ec);
 
-        /*
-            do not find the permissions of the file -- it's unnecessary for the
-            things that vcpkg does.
-            if one were to add support for this in the future, one should look
-            into GetFileSecurityW
-        */
-        perms permissions = perms::unknown;
-
         WIN32_FILE_ATTRIBUTE_DATA file_attributes;
         file_type ft = file_type::unknown;
+        perms permissions = perms::unknown;
         if (!GetFileAttributesExW(p.c_str(), GetFileExInfoStandard, &file_attributes))
         {
             ft = file_type::not_found;
@@ -64,7 +57,7 @@ namespace fs::detail
 #endif
     }
 
-    file_status symlink_status_t::operator()(const path& p, vcpkg::LineInfo li) const noexcept
+    file_status symlink_status_t::operator()(vcpkg::LineInfo li, const path& p) const noexcept
     {
         std::error_code ec;
         auto result = symlink_status(p, ec);
@@ -77,6 +70,28 @@ namespace fs::detail
 namespace vcpkg::Files
 {
     static const std::regex FILESYSTEM_INVALID_CHARACTERS_REGEX = std::regex(R"([\/:*?"<>|])");
+
+    namespace {
+        // does _not_ follow symlinks
+        void set_writeable(const fs::path& path, std::error_code& ec) noexcept {
+#if defined(_WIN32)
+            auto const file_name = path.c_str();
+            WIN32_FILE_ATTRIBUTE_DATA attributes;
+            if (!GetFileAttributesExW(file_name, GetFileExInfoStandard, &attributes)) {
+                ec = std::error_code(GetLastError(), std::system_category());
+                return;
+            }
+
+            auto dw_attributes = attributes.dwFileAttributes;
+            dw_attributes &= ~FILE_ATTRIBUTE_READONLY;
+            if (!SetFileAttributesW(file_name, dw_attributes)) {
+                ec = std::error_code(GetLastError(), std::system_category());
+            }
+#else
+            fs::stdfs::permissions(path, perms::add_perms | perms::owner_write, ec);
+#endif
+        }
+    }
 
     std::string Filesystem::read_contents(const fs::path& path, LineInfo linfo) const
     {
@@ -384,6 +399,9 @@ namespace vcpkg::Files
                             }
                         }
 
+                        set_writeable(current_path, ec);
+                        if (check_ec(ec, info, queue, current_path)) return;
+
                         if (fs::stdfs::remove(current_path, ec))
                         {
                             info.files_deleted.fetch_add(1, std::memory_order_relaxed);
@@ -447,7 +465,7 @@ namespace vcpkg::Files
                     return remove::tld{path, index, files_deleted, ec_mutex, ec, failure_point};
                 };
 
-                remove::queue queue{4, VCPKG_LINE_INFO, tld_gen};
+                remove::queue queue{VCPKG_LINE_INFO, 4, tld_gen};
 
                 // note: we don't actually start the queue running until the
                 // `join()`. This allows us to rename all the top-level files in

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -85,10 +85,9 @@ namespace vcpkg::Files
             auto dw_attributes = attributes.dwFileAttributes;
             dw_attributes &= ~FILE_ATTRIBUTE_READONLY;
             if (!SetFileAttributesW(file_name, dw_attributes)) {
-                ec = std::error_code(GetLastError(), std::system_category());
+                ec.assign(GetLastError(), std::system_category());
             }
 #else
-            // I hate C
             struct stat s;
             if (lstat(path.c_str(), &s)) {
                 ec.assign(errno, std::system_category());

--- a/toolsrc/vcpkgtest/vcpkgtest.vcxproj
+++ b/toolsrc/vcpkgtest/vcpkgtest.vcxproj
@@ -19,19 +19,19 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\vcpkg-tests\arguments.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\catch.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\chrono.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\dependencies.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\files.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\paragraph.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\plan.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\specifier.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\statusparagraphs.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\strings.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\supports.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\update.cpp" />
-    <ClCompile Include="..\src\vcpkg-tests\util.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\arguments.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\catch.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\chrono.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\dependencies.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\files.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\paragraph.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\plan.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\specifier.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\statusparagraphs.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\strings.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\supports.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\update.cpp" />
+    <ClCompile Include="..\src\vcpkg-test\util.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\vcpkglib\vcpkglib.vcxproj">
@@ -39,8 +39,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\include\vcpkg-tests\catch.h" />
-    <ClInclude Include="..\include\vcpkg-tests\util.h" />
+    <ClInclude Include="..\include\vcpkg-test\catch.h" />
+    <ClInclude Include="..\include\vcpkg-test\util.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F27B8DB0-1279-4AF8-A2E3-1D49C4F0220D}</ProjectGuid>

--- a/toolsrc/vcpkgtest/vcpkgtest.vcxproj.filters
+++ b/toolsrc/vcpkgtest/vcpkgtest.vcxproj.filters
@@ -15,43 +15,43 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\vcpkg-tests\arguments.cpp">
+    <ClCompile Include="..\src\vcpkg-test\arguments.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\catch.cpp">
+    <ClCompile Include="..\src\vcpkg-test\catch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\chrono.cpp">
+    <ClCompile Include="..\src\vcpkg-test\chrono.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\dependencies.cpp">
+    <ClCompile Include="..\src\vcpkg-test\dependencies.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\paragraph.cpp">
+    <ClCompile Include="..\src\vcpkg-test\paragraph.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\plan.cpp">
+    <ClCompile Include="..\src\vcpkg-test\plan.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\specifier.cpp">
+    <ClCompile Include="..\src\vcpkg-test\specifier.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\statusparagraphs.cpp">
+    <ClCompile Include="..\src\vcpkg-test\statusparagraphs.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\supports.cpp">
+    <ClCompile Include="..\src\vcpkg-test\supports.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\update.cpp">
+    <ClCompile Include="..\src\vcpkg-test\update.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\vcpkg-tests\util.cpp">
+    <ClCompile Include="..\src\vcpkg-test\util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\tests.files.cpp">
+    <ClCompile Include="..\src\vcpkg-test\files.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\tests.strings.cpp">
+    <ClCompile Include="..\src\vcpkg-test\strings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
we were attempting to remove READONLY files before this, and so set them to non-READONLY

TODO: add readonly to some files in the tests

Fixes #7405