### PR TITLE
[rocksdb]Change linkage type to static.

### DIFF
--- a/ports/rocksdb/CONTROL
+++ b/ports/rocksdb/CONTROL
@@ -1,5 +1,5 @@
 Source: rocksdb
-Version: 6.1.2
+Version: 6.1.2-1
 Homepage: https://github.com/facebook/rocksdb
 Description: A library that provides an embeddable, persistent key-value store for fast storage
 Default-Features: zlib

--- a/ports/rocksdb/portfile.cmake
+++ b/ports/rocksdb/portfile.cmake
@@ -1,5 +1,7 @@
 include(vcpkg_common_functions)
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO facebook/rocksdb


### PR DESCRIPTION
Change the link type to static for the following reasons:
1. Some functions are not exported.
2. According to the official build [documentation](https://github.com/facebook/rocksdb/wiki/Building-on-Windows), rocksdb should be built as a static library. @JoelMarcey could you confirm this?

Related: #1918 #2411.