### PR TITLE
[libusb]Fix using mismatched CRT_linkage/library_linkage issue.

### DIFF
--- a/ports/libusb/CONTROL
+++ b/ports/libusb/CONTROL
@@ -1,4 +1,4 @@
 Source: libusb
-Version: 1.0.22-3
+Version: 1.0.22-4
 Homepage: https://github.com/libusb/libusb
 Description: a cross-platform library to access USB devices

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_from_github(
         fix_c2001.patch
 )
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_TARGET_IS_WINDOWS)
   if(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
     set(MSVS_VERSION 2017)  #they are abi compatible, so it should work
   elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
@@ -29,8 +29,20 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
 
   if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
       set(LIBUSB_PROJECT_TYPE dll)
+      if (VCPKG_CRT_LINKAGE STREQUAL static)
+        file(READ "${SOURCE_PATH}/msvc/libusb_${LIBUSB_PROJECT_TYPE}_${MSVS_VERSION}.vcxproj" PROJ_FILE)
+        string(REPLACE "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>" "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" PROJ_FILE "${PROJ_FILE}")
+        string(REPLACE "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>" "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>" PROJ_FILE "${PROJ_FILE}")
+        file(WRITE "${SOURCE_PATH}/msvc/libusb_${LIBUSB_PROJECT_TYPE}_${MSVS_VERSION}.vcxproj" "${PROJ_FILE}")
+      endif()
   else()
       set(LIBUSB_PROJECT_TYPE static)
+      if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
+        file(READ "${SOURCE_PATH}/msvc/libusb_${LIBUSB_PROJECT_TYPE}_${MSVS_VERSION}.vcxproj" PROJ_FILE)
+        string(REPLACE "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>" "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>" PROJ_FILE "${PROJ_FILE}")
+        string(REPLACE "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>" "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>" PROJ_FILE "${PROJ_FILE}")
+        file(WRITE "${SOURCE_PATH}/msvc/libusb_${LIBUSB_PROJECT_TYPE}_${MSVS_VERSION}.vcxproj" "${PROJ_FILE}")
+      endif()
   endif()
 
   vcpkg_install_msbuild(


### PR DESCRIPTION
Libusb uses the msvc project so that we can't just set `VCPKG_CRT_LINKAGE`.
Fix this issue by manually editing the `vcxproj` file.

Related: #3540.