### PR TITLE
handle properly response file with Windows line endings

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -202,6 +202,10 @@ namespace vcpkg::Files
             std::string line;
             while (std::getline(file_stream, line))
             {
+                // Remove the trailing \r to accomodate Windows line endings.
+                if ((!line.empty()) && (line.back() == '\r'))
+                    line.pop_back();
+
                 output.push_back(line);
             }
             file_stream.close();

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -389,7 +389,7 @@ namespace vcpkg
             System::printf(System::Color::error, "Unknown option(s) for command '%s':\n", this->command);
             for (auto&& option : options_copy)
             {
-                System::print2("    ", option.first, "\n");
+                System::print2("    '", option.first, "'\n");
             }
             System::print2("\n");
             failed = true;


### PR DESCRIPTION
 - remove trailing \r when parsing response file that might have Windows line endings;

 - when an option is not recognized (perhaps because it has trailing whitespace characters), print it out enclosed with single quote to delimit and highlight potenatial not printable characters.