### PR TITLE
Update some ports version

### DIFF
--- a/ports/ade/CONTROL
+++ b/ports/ade/CONTROL
@@ -1,3 +1,3 @@
 Source: ade
-Version: 0.1.1d
+Version: 0.1.1e
 Description: ADE Framework is a graph construction, manipulation, and processing framework. ADE Framework is suitable for organizing data flow processing and execution.

--- a/ports/ade/portfile.cmake
+++ b/ports/ade/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO opencv/ade
-    REF v0.1.1d
-    SHA512 c493cb57e59ba859ca0cbf5d48bae4233f22104dfb4a96864d07e9422bb700c27af2d53a602f2230d68b7bcc598920d0652c3d9fdf8fad94a7e5b4d21664a44e
+    REF v0.1.1e
+    SHA512 6271b3a6d23b155757a47b21f70cb169b0469501bd1a7c99aa91a76117387840e02b4c70dc4069b7c50408f760b9a7ea77527a30b4691048a1ee55dd94988dd5
     HEAD_REF master
 )
 

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,5 @@
 Source: harfbuzz
-Version: 2.5.1-1
+Version: 2.5.3
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
 Build-Depends: freetype, ragel, gettext (osx)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF 2.5.1
-    SHA512 e8b4b98e65d809579456551e4dd70bdd847d02cbfa80df479f6f544eff2bdbfaa7502f22e5f4e5217f063badc8874f6e568d49e9c40ab752b233fafa9e74aeab
+    REF 2.5.3
+    SHA512 d541463b3647fc2c7ddaa29aedcea1c3bde5e26e0d529384d66d630af3aaf2a4befb3c4d47c93833f099339a0f951fb132011a02c57fc00ba543bd1b17026ffa
     HEAD_REF master
     PATCHES
         0001-fix-cmake-export.patch

--- a/ports/libpmemobj-cpp/CONTROL
+++ b/ports/libpmemobj-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: libpmemobj-cpp
-Version: 1.6-1
+Version: 1.7
 #Build-Depends: pmdk
 Description: C++ bindings for libpmemobj (https://github.com/pmem/pmdk).

--- a/ports/libpmemobj-cpp/portfile.cmake
+++ b/ports/libpmemobj-cpp/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pmem/libpmemobj-cpp
-    REF 1.6
-    SHA512 c9a90ebc6e3231b9fcc86c9c55cc8dc219b663b39828680fb58ad7229dba1d60428c34824445f627350013bf32b83e5f0f9c2d4c17054f2321d5200832e6fea0
+    REF 1.7
+    SHA512 1caea1227baa0f36190a108cbf7150fd7022175a138d81167bb25d4b1c5dba14a5c16c37477f8895b5c4f9fd460c7c43560ceeccc4ad088f94b50de18637173b
     HEAD_REF master
 )
 

--- a/ports/msgpack/CONTROL
+++ b/ports/msgpack/CONTROL
@@ -1,4 +1,4 @@
 Source: msgpack
-Version: 3.1.1
+Version: 3.2.0
 Homepage: https://github.com/msgpack/msgpack-c
 Description: MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.

--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -2,8 +2,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c
-    REF cpp-3.1.1
-    SHA512 2d1607f482160d8860b07d7597af760bfefcb3afa4e82602df43487d15950ab235e7efeabd7e08996807935de71d4dcdab424c91bff806279419db2ec9500227
+    REF cpp-3.2.0
+    SHA512 698fcdd5b427373997d0c89ff2cd09c44cf3b165defd381ff3cd9e14ecb83841064754a42aab99441a3b17aa26e3daec8f83e40d6d482c4b443b21b313278d14
     HEAD_REF master)
 
 vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH}

--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.8.0-1
+Version: 3.9.0
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/protobuf
-    REF v3.8.0
-    SHA512 ba27c64e5193cd4a144bf0c9dc0d195fbbe6e580aaca01960362f0f185074588ca40046d3bcea76e1deae7508b722f6c5be484ea957122ae8e98229c7c3a4ad2
+    REF v3.9.0
+    SHA512 eebfea7758b924939edaf44d0f51e341f4778dcf943c9e399da57cb5f52e875bda1e37e40841798232dea52082b5d59c20de69a15ddeaf00220c432f05ca0e6e
     HEAD_REF master
     PATCHES
         fix-uwp.patch

--- a/ports/string-theory/CONTROL
+++ b/ports/string-theory/CONTROL
@@ -1,4 +1,4 @@
 Source: string-theory
-Version: 2.1-1
+Version: 2.2
 Homepage: https://github.com/zrax/string_theory
 Description: Flexible C++11 string library with type-safe formatting.

--- a/ports/string-theory/portfile.cmake
+++ b/ports/string-theory/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zrax/string_theory
-    REF 2.1
-    SHA512 c20f481ba1bd3f1add2d7ee085db7dfa387e3675df5551e64bf294a96f4902551635e83faf2580fb0d6a55fd5ed1c906510d6cb39580a07234e5638e6c747fe0
+    REF 2.2
+    SHA512 84b0eb645fdb302f233c162afbcea1b1b201546a60d81448a86437fe599c4184d7abe3d6ea8bd1743bdffab75bcd4e4ab296ce1fffb7da8ae6aab880d0bbda2d
     HEAD_REF master
 )
 


### PR DESCRIPTION
Related to: #7495 

- Update `ade` library to 0.1.1e version.
- Update `libpmemobj-cpp` library to 1.7 version.
- Update `msgpack` library to 3.2.0 version.
- Update `protobuf` library to 3.9.0 version.
- Update `string-theory` library to 2.2 version.
- Update `harfbuzz` library to 2.5.3 version.