### PR TITLE
[xalan-c] Bump version number

### DIFF
--- a/ports/xalan-c/CONTROL
+++ b/ports/xalan-c/CONTROL
@@ -1,5 +1,5 @@
 Source: xalan-c
-Version: 1.11-5
+Version: 1.11-6
 Homepage: https://www-us.apache.org/dist/xalan/xalan-c/
 Description: Xalan is an XSLT processor for transforming XML documents into HTML, text, or other XML document types
 Build-Depends: xerces-c


### PR DESCRIPTION
#7126 didn't bump the version number. Bump the version number to ensure users get the update when they use `vcpkg upgrade`