### PR TITLE
[corrade] Fix build of magnum on MSVC 2019

### DIFF
--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -32,7 +32,6 @@ vcpkg_configure_cmake(
     OPTIONS
         -DUTILITY_USE_ANSI_COLORS=ON
         -DBUILD_STATIC=${BUILD_STATIC}
-        -DCORRADE_MSVC2017_COMPATIBILITY=ON
         ${_COMPONENT_FLAGS}
 )
 

--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -30,7 +30,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
-        -DDUTILITY_USE_ANSI_COLORS=ON
+        -DUTILITY_USE_ANSI_COLORS=ON
         -DBUILD_STATIC=${BUILD_STATIC}
         -DCORRADE_MSVC2017_COMPATIBILITY=ON
         ${_COMPONENT_FLAGS}


### PR DESCRIPTION
*(I'm the author of these libraries.)*

In 71214e6a2940efba0a996eb08f1864a6ae88e9ca (PR #7025) a flag was added to make corrade build on MSVC 2019. This was done on Jun 25 (merged on Jul 7), however *real* MSVC 2019 support in corrade sources was introduced soon after (on Jul 5). Until then, MSVC 2019 wasn't officially supported by these libraries.

Setting this flag unconditionally unfortunately breaks the build of Magnum (an error about an unknown `_deg` literal in `GenerateNormals.cpp`, a regression of MSVC 2019 compared to 2017) and besides that causes some code parts to be overly pessimistic about C++ standard support, leading to a reduced feature set. So I removed it, together with one additional fix for a typo in a flag.

Note that `v2019.01` doesn't work with MSVC 2019, the next release (`v2019.09`, scheduled to go out in September, https://github.com/mosra/magnum/issues/340) will. I hope that's not a problem for your CIs.

- - -

By the way there's a [fixC2666.patch](https://github.com/microsoft/vcpkg/blob/master/ports/corrade/fixC2666.patch), is it still needed? I'm not aware of any crash related to `/permissive-` *not* being present, rather the opposite. I asked on https://github.com/microsoft/vcpkg/pull/5126 but never got a reply.