### PR TITLE
Corrade: Drop vs2017 workaround when building HEAD for vs2019

### DIFF
--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -40,7 +40,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
-        -DDUTILITY_USE_ANSI_COLORS=ON
+        -DUTILITY_USE_ANSI_COLORS=ON
         -DBUILD_STATIC=${BUILD_STATIC}
         ${_CUSTOM_BUILD_FLAGS}
         ${_COMPONENT_FLAGS}

--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -26,13 +26,23 @@ foreach(_feature IN LISTS ALL_FEATURES)
     endif()
 endforeach()
 
+if(NOT VCPKG_CMAKE_SYSTEM_NAME)
+  # building for Windows desktop
+  if (VCPKG_PLATFORM_TOOLSET STREQUAL "v142" AND NOT VCPKG_USE_HEAD_VERSION)
+    message("**********")
+    message("WARNING: Visual Studio 2019 is not official supported by Corrade/Magnum team. Please use --head version if you intend to have upstream support.")
+    message("**********")
+    set(_CUSTOM_BUILD_FLAGS "-DCORRADE_MSVC2017_COMPATIBILITY=ON")
+  endif()
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         -DDUTILITY_USE_ANSI_COLORS=ON
         -DBUILD_STATIC=${BUILD_STATIC}
-        -DCORRADE_MSVC2017_COMPATIBILITY=ON
+        ${_CUSTOM_BUILD_FLAGS}
         ${_COMPONENT_FLAGS}
 )
 


### PR DESCRIPTION
HEAD now supports vs2019 and the workaround is not needed anymore.

Build has been tested with both vs2017 and vs2019 x64-windows, using both latest release and HEAD.

Also add a warning about current Corrade release not supporting vs2019, suggesting to use HEAD instead.

This is another attempt at https://github.com/microsoft/vcpkg/pull/7537.
@mosra
