### PR TITLE
[vcpkg] QoL: add target dependent library prefix/suffix variables and enable find_library for portfiles

### DIFF
--- a/scripts/cmake/vcpkg_common_definitions.cmake
+++ b/scripts/cmake/vcpkg_common_definitions.cmake
@@ -1,3 +1,21 @@
+## # vcpkg_common_definitions
+##
+## File contains helpful variabls for portfiles which are commonly needed or used.
+##
+## ## The following variables are available:
+## ```cmake
+## VCPKG_TARGET_IS_<target>                 with <target> being one of the following: WINDOWS, UWP, LINUX, OSX, ANDROID, FREEBSD. only defined if <target>
+## VCPKG_TARGET_STATIC_LIBRARY_PREFIX       static library prefix for target (same as CMAKE_STATIC_LIBRARY_PREFIX)
+## VCPKG_TARGET_STATIC_LIBRARY_SUFFIX       static library suffix for target (same as CMAKE_STATIC_LIBRARY_SUFFIX)
+## VCPKG_TARGET_SHARED_LIBRARY_PREFIX       shared library prefix for target (same as CMAKE_SHARED_LIBRARY_PREFIX)
+## VCPKG_TARGET_SHARED_LIBRARY_SUFFIX       shared library suffix for target (same as CMAKE_SHARED_LIBRARY_SUFFIX)
+## ```
+## 
+## CMAKE_STATIC_LIBRARY_PREFIX, CMAKE_STATIC_LIBRARY_SUFFIX, CMAKE_SHARED_LIBRARY_PREFIX, CMAKE_SHARED_LIBRARY_SUFFIX are defined for the target so that 
+## portfiles are able to use find_library calls to discover dependent libraries within the current triplet for ports. 
+##
+
+#Helper variable to identify the Target system. VCPKG_TARGET_IS_<targetname>
 if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     set(VCPKG_TARGET_IS_WINDOWS 1)
     if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
@@ -12,3 +30,24 @@ elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
 elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     set(VCPKG_TARGET_IS_FREEBSD 1)
 endif()
+
+#Helper variables for libraries 
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(VCPKG_TARGET_STATIC_LIBRARY_SUFFIX ".lib")
+    set(VCPKG_TARGET_SHARED_LIBRARY_SUFFIX ".dll")
+    set(VCPKG_TARGET_STATIC_LIBRARY_PREFIX "")
+    set(VCPKG_TARGET_SHARED_LIBRARY_PREFIX "")
+else()
+    set(VCPKG_TARGET_STATIC_LIBRARY_SUFFIX ".a")
+    set(VCPKG_TARGET_SHARED_LIBRARY_SUFFIX ".so")
+    set(VCPKG_TARGET_STATIC_LIBRARY_PREFIX "lib")
+    set(VCPKG_TARGET_SHARED_LIBRARY_PREFIX "lib")
+endif()
+#Setting these variables allows find_library to work in script mode and thus in portfiles!
+#This allows us scale down on hardcoded target dependent paths in portfiles
+set(CMAKE_STATIC_LIBRARY_SUFFIX ${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+set(CMAKE_SHARED_LIBRARY_SUFFIX ${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX})
+set(CMAKE_STATIC_LIBRARY_PREFIX ${VCPKG_TARGET_STATIC_LIBRARY_PREFIX})
+set(CMAKE_SHARED_LIBRARY_PREFIX ${VCPKG_TARGET_SHARED_LIBRARY_PREFIX})
+
+


### PR DESCRIPTION
~~includes #7599; will stay in draft until #7599 is merged.~~
decoupled from #7599 

Since I am at it are there more variables which needs defining?