### PR TITLE
[open62541] Fix flakiness/bugginess

### DIFF
--- a/ports/open62541/CONTROL
+++ b/ports/open62541/CONTROL
@@ -1,3 +1,3 @@
 Source: open62541
-Version: 0.3.0-2
+Version: 0.3.0-3
 Description: open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(NOT CMAKE_HOST_WIN32)
     message("${PORT} currently requires the following tools from the system package manager:\n    python-six\n\nThis can be installed on Ubuntu systems via apt-get install python-six python3-six (depending on your current python default interpreter)")
 endif()
 
@@ -31,21 +31,24 @@ endif()
 
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-get_filename_component(PYTHON3_DIR_NAME "${PYTHON3_DIR}" NAME)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
-if(NOT EXISTS ${PYTHON3_DIR}/easy_install${EXECUTABLE_SUFFIX})
-    if(NOT EXISTS ${PYTHON3_DIR}/Scripts/pip${EXECUTABLE_SUFFIX})
-        vcpkg_download_distfile(GET_PIP
-            URLS "https://bootstrap.pypa.io/get-pip.py"
-            FILENAME "tools/python/${PYTHON3_DIR_NAME}/get-pip.py"
-            SHA512 99520d223819708b8f6e4b839d1fa215e4e8adc7fcd0db6c25a0399cf2fa10034b35673cf450609303646d12497f301ef53b7e7cc65c78e7bce4af0c673555ad
-        )
-        execute_process(COMMAND ${PYTHON3_DIR}/python${EXECUTABLE_SUFFIX} ${PYTHON3_DIR}/get-pip.py)
+if(CMAKE_HOST_WIN32)
+    # Must not modify system copy of python3 -- on CMAKE_HOST_WIN32, we have our own private copy
+    if(NOT EXISTS ${PYTHON3_DIR}/easy_install.exe)
+        if(NOT EXISTS ${PYTHON3_DIR}/Scripts/pip.exe)
+            get_filename_component(PYTHON3_DIR_NAME "${PYTHON3_DIR}" NAME)
+            vcpkg_download_distfile(GET_PIP
+                URLS "https://bootstrap.pypa.io/3.3/get-pip.py"
+                FILENAME "tools/python/${PYTHON3_DIR_NAME}/get-pip.py"
+                SHA512 92e68525830bb23955a31cb19ebc3021ef16b6337eab83d5db2961b791283d2867207545faf83635f6027f2f7b7f8fee2c85f2cfd8e8267df25406474571c741
+            )
+            execute_process(COMMAND ${PYTHON3_DIR}/python.exe ${GET_PIP})
+        endif()
+        execute_process(COMMAND ${PYTHON3_DIR}/Scripts/pip.exe install six)
+    else()
+        execute_process(COMMAND ${PYTHON3_DIR}/easy_install.exe six)
     endif()
-    execute_process(COMMAND ${PYTHON3_DIR}/Scripts/pip${EXECUTABLE_SUFFIX} install six)
-else()
-    execute_process(COMMAND ${PYTHON3_DIR}/easy_install${EXECUTABLE_SUFFIX} six)
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
  - We used to `get-pip` on all non-Linux systems; we should be
    downloading and running it only on Windows.
  - `get-pip`'s download link was volatile, and the SHA would change. We
    now download it from a versioned link, which should not change

As part of these, we bumped the number from 0.30.0-2 to 0.30.0-3