### PR TITLE
[vcpkg] fix #7616

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -78,7 +78,7 @@ namespace fs::detail
 #else
         auto result = symlink ? stdfs::symlink_status(p, ec) : stdfs::status(p, ec);
         // libstdc++ doesn't correctly not-set ec on nonexistent paths
-        if (ec.value() == ENOENT)
+        if (ec.value() == ENOENT || ec.value() == ENOTDIR)
         {
             ec.clear();
             result = file_status(file_type::not_found, perms::unknown);


### PR DESCRIPTION
There's a bug in `std::experimental::filesystem::status` on
libstdc++ -- it incorrectly sets its `error_code` when a file
doesn't exist, or when a path doesn't exist. In order to get
around this, `error_code` was cleared when the file doesn't exist,
but it was not cleared when the path didn't exist.

Note: in this case, I say "the file doesn't exist" when, if you
look up "a/b/c", "a/b" exists but "c" doesn't. I say "the path
doesn't exist" when, if you look up "a/b/c", either "a" or "a/b"
doesn't exist.