### PR TITLE
[qt-advanced-docking-system] Add new port

### DIFF
--- a/ports/qt-advanced-docking-system/CONTROL
+++ b/ports/qt-advanced-docking-system/CONTROL
@@ -1,0 +1,4 @@
+Source: qt-advanced-docking-system
+Version: 2019-08-09
+Build-Depends: zlib, bzip2
+Description: Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio

--- a/ports/qt-advanced-docking-system/CONTROL
+++ b/ports/qt-advanced-docking-system/CONTROL
@@ -1,4 +1,4 @@
 Source: qt-advanced-docking-system
 Version: 2019-08-09
 Build-Depends: qt5-base
-Description: Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio
+Description: Create highly customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio

--- a/ports/qt-advanced-docking-system/CONTROL
+++ b/ports/qt-advanced-docking-system/CONTROL
@@ -1,4 +1,4 @@
 Source: qt-advanced-docking-system
 Version: 2019-08-09
-Build-Depends: zlib, bzip2
+Build-Depends: qt5-base
 Description: Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio

--- a/ports/qt-advanced-docking-system/CONTROL
+++ b/ports/qt-advanced-docking-system/CONTROL
@@ -1,4 +1,4 @@
 Source: qt-advanced-docking-system
-Version: 2019-08-09
-Build-Depends: qt5-base
-Description: Create highly customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio
+Version: 2019-08-14
+Build-Depends: qt5-base, zlib, bzip2
+Description: Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio

--- a/ports/qt-advanced-docking-system/config_changes.patch
+++ b/ports/qt-advanced-docking-system/config_changes.patch
@@ -1,7 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 289e108..c907c90 100644
 --- a/CMakeLists.txt
-+++ b/CMakeLists.txt 
++++ b/CMakeLists.txt
 @@ -79,8 +79,8 @@ install(FILES
      DESTINATION license 
      COMPONENT license

--- a/ports/qt-advanced-docking-system/config_changes.patch
+++ b/ports/qt-advanced-docking-system/config_changes.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 289e108..c907c90 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt 
+@@ -79,8 +79,8 @@ install(FILES
+     DESTINATION license 
+     COMPONENT license
+ )
+-install(TARGETS qtadvanceddocking
+-    EXPORT adsBinary
++install(TARGETS qtadvanceddocking 
++    EXPORT qt-advanced-docking-systemConfig
+     RUNTIME DESTINATION bin COMPONENT library
+     LIBRARY DESTINATION lib COMPONENT library
+     ARCHIVE DESTINATION lib COMPONENT library
+@@ -93,7 +93,6 @@ target_link_libraries(qtadvanceddocking PUBLIC ${ads_LIBS})
+ target_compile_definitions(qtadvanceddocking PRIVATE ${ads_COMPILE_DEFINE})
+ set_target_properties(qtadvanceddocking PROPERTIES 
+     VERSION ${ads_VERSION}
+-    EXPORT_NAME "Qt Advanced Docking System"
+     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
+     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
+     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+@@ -103,3 +102,5 @@ if(BUILD_EXAMPLES)
+     add_subdirectory(demo)
+ endif()
+ 
++
++install(EXPORT qt-advanced-docking-systemConfig NAMESPACE qt-advanced-docking-system:: DESTINATION share/qt-advanced-docking-system)
+\ No newline at end of file

--- a/ports/qt-advanced-docking-system/config_changes.patch
+++ b/ports/qt-advanced-docking-system/config_changes.patch
@@ -1,14 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 289e108..c907c90 100644
+index 8a9f919..9c2b8ad 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -79,8 +79,8 @@ install(FILES
-     DESTINATION license 
+@@ -62,7 +62,7 @@ if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+ else()
+     set(ads_PlatformDir "x64")
+ endif()
+-if(BUILD_STATIC)
++if(NOT BUILD_SHARED_LIBS)
+     add_library(qtadvanceddocking STATIC ${ads_SRCS})
+     set(ads_COMPILE_DEFINE ${ads_COMPILE_DEFINE} ADS_STATIC)
+ else()
+@@ -80,7 +80,7 @@ install(FILES
      COMPONENT license
  )
--install(TARGETS qtadvanceddocking
+ install(TARGETS qtadvanceddocking
 -    EXPORT adsBinary
-+install(TARGETS qtadvanceddocking 
 +    EXPORT qt-advanced-docking-systemConfig
      RUNTIME DESTINATION bin COMPONENT library
      LIBRARY DESTINATION lib COMPONENT library
@@ -21,10 +28,9 @@ index 289e108..c907c90 100644
      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
-@@ -103,3 +102,5 @@ if(BUILD_EXAMPLES)
+@@ -103,3 +102,4 @@ if(BUILD_EXAMPLES)
      add_subdirectory(demo)
  endif()
  
-+
 +install(EXPORT qt-advanced-docking-systemConfig NAMESPACE qt-advanced-docking-system:: DESTINATION share/qt-advanced-docking-system)
 \ No newline at end of file

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,0 +1,24 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO githubuser0xFFFF/Qt-Advanced-Docking-System
+    REF 6cc7d7983201596a3f579adbe09417fe8c73c409
+    SHA512 fc508ffb69a265ac52a9be72854140717e7c61925c7275e44fd2f76d0df03637b8d7fd61b7ce86e03fa1e9bf0a0e4a9c2ed9477b9d758a3b0e4760839288e431
+    HEAD_REF master
+    PATCHES
+        config_changes.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/qt-advanced-docking-system RENAME copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/license)
+vcpkg_fixup_cmake_targets()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS -DBUILD_EXAMPLES=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
-    REF 6cc7d7983201596a3f579adbe09417fe8c73c409
-    SHA512 fc508ffb69a265ac52a9be72854140717e7c61925c7275e44fd2f76d0df03637b8d7fd61b7ce86e03fa1e9bf0a0e4a9c2ed9477b9d758a3b0e4760839288e431
+    REF a2b07fd97f0fac63fd7a0ed7b1eb0692b3efab71
+    SHA512 a44babd6100f299aea7fcf2d730874e204151ce363e1f58a2be938f70d28b07f3cb39adfbf46527fdacc3b12a630e7d97851e4a6fcd04e750a007ee06d06d3b5
     HEAD_REF master
     PATCHES
         config_changes.patch


### PR DESCRIPTION
This is a new port for the [qt advanced docking system](https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System)
I wasn't sure about the name as they use qt-advanced-docking-system as the repository name, qtadvanceddocking in the cmake file and ads as a namespace/general shortcut.

This library supports Windows and Linux. If Mac OS compiles then that is a fortunate extra since the library maintainers don't actively maintain a Mac OS version.