### PR TITLE
[monkeys-audio] Update library to 4.8.3

### DIFF
--- a/ports/monkeys-audio/CONTROL
+++ b/ports/monkeys-audio/CONTROL
@@ -1,5 +1,5 @@
 Source: monkeys-audio
-Version: 4.3.3-1
+Version: 4.8.3
 Homepage: https://monkeysaudio.com
 Description: Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.
   Audio files compressed with it ends with .ape extension.

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -6,17 +6,17 @@ endif()
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY ONLY_STATIC_CRT)
 
-if(EXISTS ${CURRENT_BUILDTREES_DIR}/src/MAC_SDK_433.zip.extracted)
+if(EXISTS ${CURRENT_BUILDTREES_DIR}/src/MAC_SDK_483.zip.extracted)
     file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src)
 endif()
 
 set(VERSION 4.7)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/433)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/483)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://monkeysaudio.com/files/MAC_SDK_433.zip"
-    FILENAME "MAC_SDK_433.zip"
-    SHA512 957ba262da29a8542ab82dc828328b19bf80ecf0d09165db935924b390cb6a3a2d9303a2e07b86b28ecf4210a66dd5c4be840205a9f09518189101033f1a13c8
+    URLS "http://monkeysaudio.com/files/MAC_SDK_483.zip"
+    FILENAME "MAC_SDK_483.zip"
+    SHA512 c080aa87997def3b970050f6bd334b6908884cc521f192abc02d774a8b3067207781dcab30f052015d4ae891fc6390c6f0b33ed319d9d7fd0850dab6fcded8f0
 )
 
 vcpkg_extract_source_archive(${ARCHIVE} ${SOURCE_PATH})
@@ -29,7 +29,7 @@ file(REMOVE
 
 vcpkg_install_msbuild(
     SOURCE_PATH ${SOURCE_PATH}
-    PROJECT_SUBPATH Source/Projects/VS2017/Console/Console.vcxproj
+    PROJECT_SUBPATH Source/Projects/VS2019/Console/Console.vcxproj
 )
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include)


### PR DESCRIPTION
Happened to notice that the current link returns a 404 http://monkeysaudio.com/files/MAC_SDK_433.zip