### PR TITLE
[vcpkg] Fix the build on VS2015 debug

### DIFF
--- a/toolsrc/include/vcpkg/base/strings.h
+++ b/toolsrc/include/vcpkg/base/strings.h
@@ -1,10 +1,12 @@
 #pragma once
 
+
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringliteral.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/view.h>
+#include <vcpkg/pragmas.h>
 
 #include <vector>
 

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -202,6 +202,12 @@ namespace vcpkg::Install
 
         struct intersection_compare
         {
+            // The VS2015 standard library requires comparison operators of T and U
+            // to also support comparison of T and T, and of U and U, due to debug checks.
+#if _MSC_VER < 1910
+            bool operator()(const std::string& lhs, const std::string& rhs) { return lhs < rhs; }
+            bool operator()(const file_pack& lhs, const file_pack& rhs) { return lhs.first < rhs.first; }
+#endif
             bool operator()(const std::string& lhs, const file_pack& rhs) { return lhs < rhs.first; }
             bool operator()(const file_pack& lhs, const std::string& rhs) { return lhs.first < rhs; }
         };


### PR DESCRIPTION
The VS2015 standard library requires, in debug mode, a comparison
operator on `T × U` and `U × T` to also be a comparison operator on
`T × T` and on `U × U`, and so in
`vcpkg::Install::install_package::intersection_compare`, I've added two
new `operator()` overloads which take those respectively, on VS2015.

Also, `[[nodiscard]]` was added to somewhere in `vcpkg/base/strings.h`,
which gives a warning in VS2015 -- thus, I added the `vcpkg/pragmas.h`
include, since that fixes the warning.