### PR TITLE
[blosc] enable dependent ports to use debug builds

### DIFF
--- a/ports/blosc/0001-find-deps.patch
+++ b/ports/blosc/0001-find-deps.patch
@@ -1,0 +1,107 @@
+diff --git a/blosc/CMakeLists.txt b/blosc/CMakeLists.txt
+index 1d1bebe..3a7a51c 100644
+--- a/blosc/CMakeLists.txt
++++ b/blosc/CMakeLists.txt
+@@ -109,7 +109,7 @@ endif(NOT DEACTIVATE_ZLIB)
+ 
+ if (NOT DEACTIVATE_ZSTD)
+     if (ZSTD_FOUND)
+-        set(LIBS ${LIBS} ${ZSTD_LIBRARY})
++        set(LIBS ${LIBS} ${ZSTD_LIBRARIES})
+     else (ZSTD_FOUND)
+       file(GLOB ZSTD_FILES
+         ${ZSTD_LOCAL_DIR}/common/*.c
+diff --git a/cmake/FindLZ4.cmake b/cmake/FindLZ4.cmake
+index e581a80..8ce17c5 100644
+--- a/cmake/FindLZ4.cmake
++++ b/cmake/FindLZ4.cmake
+@@ -1,10 +1,13 @@
+-find_path(LZ4_INCLUDE_DIR lz4.h)
++find_path(LZ4_INCLUDE_DIRS NAMES lz4.h)
+ 
+-find_library(LZ4_LIBRARY NAMES lz4)
++find_library(LZ4_LIBRARY_DEBUG NAMES lz4d)
++find_library(LZ4_LIBRARY_RELEASE NAMES lz4)
+ 
+-if (LZ4_INCLUDE_DIR AND LZ4_LIBRARY)
+-    set(LZ4_FOUND TRUE)
+-    message(STATUS "Found LZ4 library: ${LZ4_LIBRARY}")
+-else ()
+-    message(STATUS "No LZ4 library found.  Using internal sources.")
+-endif ()
++include(SelectLibraryConfigurations)
++select_library_configurations(LZ4)
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(
++    LZ4
++    REQUIRED_VARS LZ4_LIBRARIES LZ4_INCLUDE_DIRS
++)
+diff --git a/cmake/FindSnappy.cmake b/cmake/FindSnappy.cmake
+index 688d4d5..c8b9a05 100644
+--- a/cmake/FindSnappy.cmake
++++ b/cmake/FindSnappy.cmake
+@@ -1,10 +1,13 @@
+-find_path(SNAPPY_INCLUDE_DIR snappy-c.h)
++find_path(SNAPPY_INCLUDE_DIR snappy.h)
+ 
+-find_library(SNAPPY_LIBRARY NAMES snappy)
++find_library(SNAPPY_LIBRARY_DEBUG NAMES snappyd)
++find_library(SNAPPY_LIBRARY_RELEASE NAMES snappy)
+ 
+-if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARY)
+-    set(SNAPPY_FOUND TRUE)
+-    message(STATUS "Found SNAPPY library: ${SNAPPY_LIBRARY}")
+-else ()
+-    message(STATUS "No snappy found.  Using internal sources.")
+-endif ()
++include(SelectLibraryConfigurations)
++select_library_configurations(SNAPPY)
++
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(
++    SNAPPY DEFAULT_MSG
++    SNAPPY_LIBRARY SNAPPY_INCLUDE_DIR
++)
+diff --git a/cmake/FindZstd.cmake b/cmake/FindZstd.cmake
+index 7db4bb9..ba20ba6 100644
+--- a/cmake/FindZstd.cmake
++++ b/cmake/FindZstd.cmake
+@@ -1,10 +1,30 @@
++include(FindPackageHandleStandardArgs)
++
+ find_path(ZSTD_INCLUDE_DIR zstd.h)
+ 
+-find_library(ZSTD_LIBRARY NAMES zstd)
++get_filename_component(_prefix_path ${ZSTD_INCLUDE_DIR} PATH)
++
++find_library(
++    ZSTD_LIBRARY_DEBUG
++    NAMES zstdd
++    PATHS ${_prefix_path}/debug/lib
++    NO_DEFAULT_PATH
++)
++
++find_library(
++    ZSTD_LIBRARY_RELEASE
++    NAMES zstd
++    PATHS ${_prefix_path}/lib
++    NO_DEFAULT_PATH
++)
++
++unset(_prefix_path)
++
++include(SelectLibraryConfigurations)
++select_library_configurations(ZSTD)
+ 
+-if (ZSTD_INCLUDE_DIR AND ZSTD_LIBRARY)
+-    set(ZSTD_FOUND TRUE)
+-    message(STATUS "Found Zstd library: ${ZSTD_LIBRARY}")
+-else ()
+-    message(STATUS "No Zstd library found.  Using internal sources.")
+-endif ()
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(
++    ZSTD
++    REQUIRED_VARS ZSTD_LIBRARIES ZSTD_INCLUDE_DIR
++)

--- a/ports/blosc/CONTROL
+++ b/ports/blosc/CONTROL
@@ -1,5 +1,5 @@
 Source: blosc
-Version: 1.17.0
+Version: 1.17.0-1
 Build-Depends: lz4, snappy, zlib, zstd
 Homepage: https://github.com/Blosc/c-blosc
 Description: A blocking, shuffling and loss-less compression library that can be faster than `memcpy()`

--- a/ports/blosc/FindBlosc.cmake
+++ b/ports/blosc/FindBlosc.cmake
@@ -1,0 +1,33 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(
+  BLOSC_INCLUDE_DIRS
+  blosc.h
+)
+
+get_filename_component(_prefix_path ${BLOSC_INCLUDE_DIRS} PATH)
+
+find_library(
+    BLOSC_LIBRARY_DEBUG
+    NAMES blosc
+    PATHS ${_prefix_path}/debug/lib
+    NO_DEFAULT_PATH
+)
+
+find_library(
+    SNAPPY_LIBRARY_RELEASE
+    NAMES blosc
+    PATHS ${_prefix_path}/lib
+    NO_DEFAULT_PATH
+)
+
+unset(_prefix_path)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(blosc)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    blosc
+    REQUIRED_VARS BLOSC_LIBRARIES BLOSC_INCLUDE_DIRS
+)

--- a/ports/blosc/portfile.cmake
+++ b/ports/blosc/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v1.17.0
     SHA512 7fe517e9d050a36839ddf963e718881533cc10a7c8963222b3167fd48ec84455614206c1cc2c248f52042a019262fa0419c4c1a828eb1ae64294c55bbaf56f6e
     HEAD_REF master
+    PATCHES
+      0001-find-deps.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
@@ -51,3 +53,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSES/BLOSC.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/blosc RENAME copyright)
 
+file(COPY
+    "${CMAKE_CURRENT_LIST_DIR}/FindBlosc.cmake"
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+)


### PR DESCRIPTION
refs: https://github.com/Microsoft/vcpkg/issues/3601

The bulk of this work is to utilize the standard vcpkg find_package code to find the correct binaries in both Release and Debug modes.

When attempting to perform a debug build on an application that depends on `openvdb` the result was a run time failure. This is due to `blosc` not providing a mechanism to select its debug build and no way for it to find debug builds of its dependencies.

![image](https://user-images.githubusercontent.com/46673/62838637-05044d00-bc34-11e9-98d7-1ec3d969278e.png)

(you can ignore the issue with `Half-2_3.dll` as that is being worked on in #7636)
