### PR TITLE
[dimcli] Fix build error C2220

### DIFF
--- a/ports/dimcli/CONTROL
+++ b/ports/dimcli/CONTROL
@@ -1,4 +1,4 @@
 Source: dimcli
-Version: 4.1.0
+Version: 4.1.0-1
 Homepage: https://github.com/gknowles/dimcli
 Description: C++ command line parser toolkit

--- a/ports/dimcli/fix-NameBoolean.patch
+++ b/ports/dimcli/fix-NameBoolean.patch
@@ -1,0 +1,63 @@
+diff --git a/libs/dimcli/cli.cpp b/libs/dimcli/cli.cpp
+index 9e67c12..c96bd24 100644
+--- a/libs/dimcli/cli.cpp
++++ b/libs/dimcli/cli.cpp
+@@ -388,8 +388,8 @@ GroupConfig const & Cli::Config::findGrpOrDie(Cli const & cli) {
+ ***/
+ 
+ //===========================================================================
+-Cli::OptBase::OptBase(string const & names, bool boolean)
+-    : m_bool{boolean}
++Cli::OptBase::OptBase(string const & names, bool in_boolean)
++    : m_bool{in_boolean}
+     , m_names{names}
+ {
+     // set m_fromName and assert if names is malformed
+@@ -486,12 +486,12 @@ static bool includeName(
+     OptName const & name,
+     NameListType type,
+     Cli::OptBase const & opt,
+-    bool boolean,
++    bool in_boolean,
+     bool inverted
+ ) {
+     if (name.opt != &opt)
+         return false;
+-    if (boolean) {
++    if (in_boolean) {
+         if (type == kNameEnable)
+             return !name.invert;
+         if (type == kNameDisable)
+diff --git a/libs/dimcli/cli.h b/libs/dimcli/cli.h
+index 2c1615c..3e4f405 100644
+--- a/libs/dimcli/cli.h
++++ b/libs/dimcli/cli.h
+@@ -818,7 +818,7 @@ public:
+     };
+ 
+ public:
+-    OptBase(std::string const & keys, bool boolean);
++    OptBase(std::string const & keys, bool in_boolean);
+     virtual ~OptBase() {}
+ 
+     //-----------------------------------------------------------------------
+@@ -952,7 +952,7 @@ inline void Cli::OptBase::setValueDesc<DIMCLI_LIB_FILESYSTEM_PATH>() {
+ template <typename A, typename T>
+ class Cli::OptShim : public OptBase {
+ public:
+-    OptShim(std::string const & keys, bool boolean);
++    OptShim(std::string const & keys, bool in_boolean);
+     OptShim(OptShim const &) = delete;
+     OptShim & operator=(OptShim const &) = delete;
+ 
+@@ -1100,8 +1100,8 @@ protected:
+ 
+ //===========================================================================
+ template <typename A, typename T>
+-Cli::OptShim<A, T>::OptShim(std::string const & keys, bool boolean)
+-    : OptBase(keys, boolean)
++Cli::OptShim<A, T>::OptShim(std::string const & keys, bool in_boolean)
++    : OptBase(keys, in_boolean)
+ {
+     setValueDesc<T>();
+ }

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v4.1.0
     SHA512 5de010b5abfda9e6996bba8c621e03ae0cf81dbc2f69cd859e2ebf7b1706c451f7f8e142299784646d89ca3c3e5803e8711215680b8bdb8eb663158bff3b4f3d
     HEAD_REF master
+	PATCHES
+		fix-NameBoolean.patch
 )
 set(staticCrt OFF)
 if(VCPKG_CRT_LINKAGE STREQUAL "static")


### PR DESCRIPTION
Building dimcli:x64-windows failed in an internal version of Visual Studio. This issue could be fixed by modifying `boolean` to `in_boolean`.
```
F:\v-8-12\vcpkg\buildtrees\dimcli\src\v4.1.0-4b0780b74d\libs\dimcli\cli.cpp(391): error C2220: the following warning is treated as an error [F:\v-8-12\vcpkg\buildtrees\dimcli\x64-windows-dbg\dimcli.vcxproj]
F:\v-8-12\vcpkg\buildtrees\dimcli\src\v4.1.0-4b0780b74d\libs\dimcli\cli.cpp(391): warning C4459: declaration of 'boolean' hides global declaration [F:\v-8-12\vcpkg\buildtrees\dimcli\x64-windows-dbg\dimcli.vcxproj]
```