### PR TITLE
[stb] Fix copy operation

### DIFF
--- a/ports/stb/portfile.cmake
+++ b/ports/stb/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
 )
 
 # Put the licence file where vcpkg expects it
-file(COPY ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/stb/README.md)
+file(COPY ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/stb)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/stb/README.md ${CURRENT_PACKAGES_DIR}/share/stb/copyright)
 
 # Copy the stb header files


### PR DESCRIPTION
Copy README.md to `share/stb/` instead of `share/stb/README.md/`