### PR TITLE
[opencv] Expose all features from `opencv4` in meta-package

### DIFF
--- a/ports/opencv/CONTROL
+++ b/ports/opencv/CONTROL
@@ -1,17 +1,101 @@
 Source: opencv
-Version: 1
+Version: 4.1.1
 Homepage: https://github.com/opencv/opencv
 Description: Computer vision library
-Build-Depends: opencv4[core]
+Build-Depends: opencv4
+
+Feature: nonfree
+Build-Depends: opencv4[nonfree]
+Description: opencv nonfree module
+
+Feature: ade
+Build-Depends: opencv4[ade]
+Description: graph api
 
 Feature: contrib
-Description: opencv_contrib module
 Build-Depends: opencv4[contrib]
+Description: opencv_contrib module
 
 Feature: cuda
-Description: Enable CUDA support in OpenCV
 Build-Depends: opencv4[cuda]
+Description: CUDA support for opencv
+
+Feature: dnn
+Build-Depends: opencv4[dnn]
+Description: Enable dnn module
+
+Feature: eigen
+Build-Depends: opencv4[eigen]
+Description: Eigen support for opencv
 
 Feature: ffmpeg
-Description: Enable ffmpeg support in OpenCV
 Build-Depends: opencv4[ffmpeg]
+Description: ffmpeg support for opencv
+
+Feature: gdcm
+Build-Depends: opencv4[gdcm]
+Description: GDCM support for opencv
+
+Feature: ipp
+Build-Depends: opencv4[ipp]
+Description: Enable Intel Integrated Performance Primitives
+
+Feature: jasper
+Build-Depends: opencv4[jasper]
+Description: JPEG 2000 support for opencv
+
+Feature: jpeg
+Build-Depends: opencv4[jpeg]
+Description: JPEG support for opencv
+
+Feature: openexr
+Build-Depends: opencv4[openexr]
+Description: OpenEXR support for opencv
+
+Feature: opengl
+Build-Depends: opencv4[opengl]
+Description: opengl support for opencv
+
+Feature: openmp
+Build-Depends: opencv4[openmp]
+Description: Enable openmp support for opencv
+
+Feature: ovis
+Build-Depends: opencv4[ovis]
+Description: opencv_ovis module
+
+Feature: png
+Build-Depends: opencv4[png]
+Description: PNG support for opencv
+
+Feature: qt
+Build-Depends: opencv4[qt]
+Description: Qt GUI support for opencv
+
+Feature: sfm
+Build-Depends: opencv4[sfm]
+Description: opencv_sfm module
+
+Feature: tbb
+Build-Depends: opencv4[tbb]
+Description: Enable Intel Threading Building Blocks
+
+Feature: tiff
+Build-Depends: opencv4[tiff]
+Description: TIFF support for opencv
+
+Feature: vtk
+Build-Depends: opencv4[vtk]
+Description: vtk support for opencv
+
+Feature: webp
+Build-Depends: opencv4[webp]
+Description: WebP support for opencv
+
+Feature: halide
+Build-Depends: opencv4[halide]
+Description: Halide support for opencv
+
+Feature: world
+Build-Depends: opencv4[world]
+Description: Compile to a single package support for opencv


### PR DESCRIPTION
Adds missing features to the meta-package.

Forwarding was tested with the experimental [`vcpkg depend-info`](#7643).

```
PS D:\src\viromer\vcpkg> vcpkg depend-info opencv[*] --max-recurse=1 --sort=reverse
opencv[ade, contrib, cuda, dnn, eigen, ffmpeg, gdcm, halide, ipp, jasper, jpeg, nonfree, openexr, opengl, openmp, ovis, png, qt, sfm, tbb, tiff, vtk, webp, world]: opencv4
opencv4[ade, contrib, cuda, dnn, eigen, ffmpeg, gdcm, halide, ipp, jasper, jpeg, nonfree, openexr, opengl, openmp, ovis, png, qt, sfm, tbb, tiff, vtk, webp, world]: ade, ceres, cuda, eigen3, ffmpeg, gdcm, gflags, glog, halide, hdf5, jasper, libjpeg-turbo, libpng, libwebp, ogre, openexr, opengl, protobuf, qt5, tbb, tiff, vtk, zlib
```