### PR TITLE
[pcre] Update download URL

### DIFF
--- a/ports/pcre/CONTROL
+++ b/ports/pcre/CONTROL
@@ -1,3 +1,3 @@
 Source: pcre
 Version: 8.41-2
-Description: Perl Compatible Regular Expresions
+Description: Perl Compatible Regular Expressions

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -10,7 +10,7 @@ set(PCRE_VERSION 8.41)
 include(vcpkg_common_functions)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/pcre-${PCRE_VERSION})
 vcpkg_download_distfile(ARCHIVE
-    URLS "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${PCRE_VERSION}.zip" 
+    URLS "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.zip" 
          "https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VERSION}/pcre-${PCRE_VERSION}.zip"
     FILENAME "pcre-${PCRE_VERSION}.zip"
     SHA512 a3fd57090a5d9ce9d608aeecd59f42f04deea5b86a5c5899bdb25b18d8ec3a89b2b52b62e325c6485a87411eb65f1421604f80c3eaa653bd7dbab05ad22795ea


### PR DESCRIPTION
- ftp.csx.cam.ac.uk is no longer available.
  Use https://ftp.pcre.org/pub/pcre/ instead
- Fix typo in Description of CONTROL file:
  Expresions -> Expressions
