### PR TITLE
[spdlog] fix cmake targets path

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,5 +1,5 @@
 Source: spdlog
-Version: 1.3.1-1
+Version: 1.3.1-2
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -27,7 +27,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/spdlog)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/${PORT}/cmake")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/${PORT}/cmake)
+endif()
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION

Fix related issue https://github.com/microsoft/vcpkg/issues/6794

In spdlog latest release version 1.3.1, it install cmake targets to 
${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}

From https://github.com/gabime/spdlog/blob/v1.x/CMakeLists.txt#L151 in dev branch, it install 
${CMAKE_INSTALL_LIBDIR}/spdlog/cmake

So vcpkg_fixup_cmake_targets failed when build with --head option.