### PR TITLE
[osg] Fix Applying patch failed

### DIFF
--- a/ports/osg/collada.patch
+++ b/ports/osg/collada.patch
@@ -1,23 +1,20 @@
 diff --git a/CMakeModules/FindCOLLADA.cmake b/CMakeModules/FindCOLLADA.cmake
-index 8c9c2fc33..6a8ab04ca 100644
+index 7c7d290..5b456d7 100644
 --- a/CMakeModules/FindCOLLADA.cmake
 +++ b/CMakeModules/FindCOLLADA.cmake
-@@ -25,11 +25,11 @@ ENDIF()
- 
- IF(APPLE)
-     SET(COLLADA_BUILDNAME "mac")
--  SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
-+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+@@ -29,10 +29,7 @@ IF(APPLE)
  ELSEIF(MINGW)
      SET(COLLADA_BUILDNAME "mingw")
--  SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
--ELSEIF(MSVC_VERSION EQUAL 1900 OR MSVC_VERSION EQUAL 1910 )
-+    SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
-+ELSEIF(MSVC_VERSION GREATER_EQUAL 1900 )
+     SET(COLLADA_BOOST_BUILDNAME ${COLLADA_BUILDNAME})
+-ELSEIF((MSVC_VERSION GREATER 1910) OR (MSVC_VERSION EQUAL 1910))
+-    SET(COLLADA_BUILDNAME "vc14")
+-    SET(COLLADA_BOOST_BUILDNAME "vc141")
+-ELSEIF(MSVC_VERSION EQUAL 1900)
++ELSEIF(MSVC_VERSION GREATER_EQUAL 1900)
      SET(COLLADA_BUILDNAME "vc14")
      SET(COLLADA_BOOST_BUILDNAME "vc140")
  ELSEIF(MSVC_VERSION EQUAL 1800)
-@@ -58,6 +58,7 @@ ENDIF()
+@@ -61,6 +58,7 @@ ENDIF()
  
  
  FIND_PATH(COLLADA_INCLUDE_DIR dae.h
@@ -25,7 +22,7 @@ index 8c9c2fc33..6a8ab04ca 100644
      ${COLLADA_DOM_ROOT}/include
      $ENV{COLLADA_DIR}/include
      $ENV{COLLADA_DIR}
-@@ -65,27 +66,19 @@ FIND_PATH(COLLADA_INCLUDE_DIR dae.h
+@@ -68,27 +66,19 @@ FIND_PATH(COLLADA_INCLUDE_DIR dae.h
      /Library/Frameworks
      /opt/local/Library/Frameworks #macports
      /usr/local/include
@@ -59,103 +56,58 @@ index 8c9c2fc33..6a8ab04ca 100644
  )
  
  FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY
-@@ -15,6 +15,8 @@
+@@ -116,7 +106,7 @@ FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY
+ )
  
- 
- # Check if COLLADA_DIR is set, otherwise use ACTUAL_3DPARTY_DIR:
-+include(SelectLibraryConfigurations)
-+
- SET( COLLADA_ENV_VAR_AVAILABLE $ENV{COLLADA_DIR} )
- IF ( COLLADA_ENV_VAR_AVAILABLE )
-     SET(COLLADA_DOM_ROOT "$ENV{COLLADA_DIR}/dom" CACHE PATH "Location of Collada DOM directory" FORCE)
-@@ -192,31 +194,9 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
-         ENDIF(WIN32)
-     ENDIF(LIBXML2_FOUND)
- 
--    FIND_PACKAGE(ZLIB)
--    IF (ZLIB_FOUND)
--        IF (ZLIB_LIBRARY_RELEASE)
--            SET(COLLADA_ZLIB_LIBRARY "${ZLIB_LIBRARY_RELEASE}" CACHE FILEPATH "" FORCE)
--        ELSE(ZLIB_LIBRARY_RELEASE)
--            SET(COLLADA_ZLIB_LIBRARY "${ZLIB_LIBRARY}" CACHE FILEPATH "" FORCE)
--        ENDIF(ZLIB_LIBRARY_RELEASE)
--        IF (ZLIB_LIBRARY_DEBUG)
--            SET(COLLADA_ZLIB_LIBRARY_DEBUG "${ZLIB_LIBRARY_DEBUG}" CACHE FILEPATH "" FORCE)
--        ELSE(ZLIB_LIBRARY_DEBUG)
--            SET(COLLADA_ZLIB_LIBRARY_DEBUG "${COLLADA_ZLIB_LIBRARY}" CACHE FILEPATH "" FORCE)
--        ENDIF(ZLIB_LIBRARY_DEBUG)
--    ELSE(ZLIB_FOUND)
--        IF(WIN32)
--            FIND_LIBRARY(COLLADA_ZLIB_LIBRARY
--                NAMES zlib
--                PATHS
--                ${COLLADA_DOM_ROOT}/external-libs/libxml2/win32/lib
--                ${COLLADA_DOM_ROOT}/external-libs/libxml2/mingw/lib
--                ${ACTUAL_3DPARTY_DIR}/lib
--            )
--        ENDIF(WIN32)
--    ENDIF(ZLIB_FOUND)
-+    FIND_PACKAGE(ZLIB REQUIRED)
- 
--    FIND_LIBRARY(COLLADA_PCRECPP_LIBRARY
-+    FIND_LIBRARY(COLLADA_PCRECPP_LIBRARY_RELEASE
-         NAMES pcrecpp
-         PATHS
-         ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
-@@ -233,8 +213,9 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
-         ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
-         ${ACTUAL_3DPARTY_DIR}/lib
+ FIND_LIBRARY(COLLADA_DYNAMIC_LIBRARY_DEBUG
+-    NAMES collada_dom-d collada14dom-d Collada14Dom-d libcollada14dom21-d libcollada14dom22-d  collada-dom2.5-dp-d collada-dom2.5-dp-${COLLADA_BOOST_BUILDNAME}-mt-d collada-dom2.4-dp-d collada-dom2.4-dp-${COLLADA_BOOST_BUILDNAME}-mt-d
++    NAMES collada_dom-d collada14dom-d Collada14Dom-d libcollada14dom21-d libcollada14dom22-d  collada-dom2.5-dp-d collada-dom2.5-dp-${COLLADA_BOOST_BUILDNAME}-mt-d collada-dom2.4-dp-d collada-dom2.4-dp-${COLLADA_BOOST_BUILDNAME}-mt-d collada-dom2.5-dp-${COLLADA_BOOST_BUILDNAME}-mt
+     PATHS
+     ${COLLADA_DOM_ROOT}/build/${COLLADA_BUILDNAME}-1.4-d
+     ${COLLADA_DOM_ROOT}
+@@ -279,7 +269,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
      )
-+    select_library_configurations(COLLADA_PCRECPP)
  
--    FIND_LIBRARY(COLLADA_PCRE_LIBRARY
-+    FIND_LIBRARY(COLLADA_PCRE_LIBRARY_RELEASE
-         NAMES pcre
-         PATHS
-         ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/${COLLADA_BUILDNAME}
-@@ -251,8 +232,9 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
-         ${COLLADA_DOM_ROOT}/external-libs/pcre/lib/mingw
-         ${ACTUAL_3DPARTY_DIR}/lib
-     )
-+    select_library_configurations(COLLADA_PCRE)
- 
--    FIND_LIBRARY(COLLADA_MINIZIP_LIBRARY
-+    FIND_LIBRARY(COLLADA_MINIZIP_LIBRARY_RELEASE
-         NAMES minizip
-         PATHS
-         ${COLLADA_DOM_ROOT}/external-libs/minizip/win32/lib
-@@ -267,8 +249,9 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
-         ${COLLADA_DOM_ROOT}/external-libs/minizip/mac
-         ${ACTUAL_3DPARTY_DIR}/lib
-     )
--
--    FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY
-+    select_library_configurations(COLLADA_MINIZIP)
-+    
-+    FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY_RELEASE
-         NAMES libboost_filesystem boost_filesystem boost_filesystem-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_63
+     FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY
+-        NAMES libboost_filesystem boost_filesystem boost_filesystem-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_63
++        NAMES libboost_filesystem boost_filesystem boost_filesystem-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-1_63 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt
          PATHS
          ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
-@@ -283,8 +266,9 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
          ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
-         ${ACTUAL_3DPARTY_DIR}/lib
+@@ -287,7 +277,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
      )
-+    select_library_configurations(COLLADA_BOOST_FILESYSTEM)
  
--    FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY
-+    FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY_RELEASE
-         NAMES libboost_system boost_system boost_system-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_55  libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_63
+     FIND_LIBRARY(COLLADA_BOOST_FILESYSTEM_LIBRARY_DEBUG
+-        NAMES libboost_filesystem-d boost_filesystem-d boost_filesystem-mt-d libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63
++        NAMES libboost_filesystem-d boost_filesystem-d boost_filesystem-mt-d libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63 boost_filesystem-${COLLADA_BOOST_BUILDNAME}-mt-gd
          PATHS
          ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
-@@ -299,7 +283,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
          ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
-         ${ACTUAL_3DPARTY_DIR}/lib
+@@ -295,7 +285,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
      )
--
-+    select_library_configurations(COLLADA_BOOST_SYSTEM_LIBRARY)
  
- SET(COLLADA_FOUND "NO")
- IF(COLLADA_DYNAMIC_LIBRARY OR COLLADA_STATIC_LIBRARY)
+     FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY
+-        NAMES libboost_system boost_system boost_system-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_55  libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_63
++        NAMES libboost_system boost_system boost_system-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_55  libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-1_63 boost_system-${COLLADA_BOOST_BUILDNAME}-mt
+         PATHS
+         ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+         ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+@@ -303,7 +293,7 @@ FIND_LIBRARY(COLLADA_STATIC_LIBRARY_DEBUG
+     )
+ 
+     FIND_LIBRARY(COLLADA_BOOST_SYSTEM_LIBRARY_DEBUG
+-        NAMES libboost_system-d boost_system-d boost_system-mt-d libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63
++        NAMES libboost_system-d boost_system-d boost_system-mt-d libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_54 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_55 libboost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_58 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_62 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd-1_63 boost_system-${COLLADA_BOOST_BUILDNAME}-mt-gd
+         PATHS
+         ${COLLADA_DOM_ROOT}/external-libs/boost/lib/${COLLADA_BUILDNAME}
+         ${COLLADA_DOM_ROOT}/external-libs/boost/lib/mingw
+@@ -329,5 +319,3 @@ IF(COLLADA_DYNAMIC_LIBRARY OR COLLADA_STATIC_LIBRARY)
+ 
+         ENDIF()
+ ENDIF()
+-
+-
+
 diff --git a/src/osgPlugins/dae/CMakeLists.txt b/src/osgPlugins/dae/CMakeLists.txt
 index af03fb866..7eadfc2f3 100644
 --- a/src/osgPlugins/dae/CMakeLists.txt
@@ -171,3 +123,4 @@ index af03fb866..7eadfc2f3 100644
  
  IF (COLLADA_DOM_2_4_OR_LATER)
      ADD_DEFINITIONS(-DCOLLADA_DOM_2_4_OR_LATER)
+


### PR DESCRIPTION
When I building osg[collada]:x64-windows in Visual Studio 2017, I found that I will get the following message，and the dae plugin is not compiled.
````
Building package osg[collada,core]:x64-windows...
-- Using cached D:/vcpkg/downloads/openscenegraph-OpenSceneGraph-OpenSceneGraph-3.6.4.tar.gz
-- Extracting source D:/vcpkg/downloads/openscenegraph-OpenSceneGraph-OpenSceneGraph-3.6.4.tar.gz
-- Applying patch collada.patch
-- Applying patch failed. This is expected if this patch was previously applied.
-- Using source at D:/vcpkg/buildtrees/osg/src/raph-3.6.4-31d57533f2
-- Configuring x64-windows
````
So I modified the collada.patch file to make it work properly.