### PR TITLE
[osgearth]Fix osgearth rocksdb plugin build falied

### DIFF
--- a/ports/osgearth/CONTROL
+++ b/ports/osgearth/CONTROL
@@ -1,4 +1,4 @@
 Source: osgearth
-Version: 2.10.1
+Version: 2.10.2
 Description:  osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.
 Build-Depends: osg

--- a/ports/osgearth/RocksDB.patch
+++ b/ports/osgearth/RocksDB.patch
@@ -1,0 +1,84 @@
+diff --git a/CMakeModules/FindRocksDB.cmake b/CMakeModules/FindRocksDB.cmake
+index 109b383..8382ed9 100644
+--- a/CMakeModules/FindRocksDB.cmake
++++ b/CMakeModules/FindRocksDB.cmake
+@@ -40,5 +40,49 @@ find_package_handle_standard_args(ROCKSDB
+       "Could NOT find ROCKSDB"
+ )
+ 
++if(ROCKSDB_FOUND)
++	FIND_PACKAGE(ZLIB REQUIRED)
++
++	include(SelectLibraryConfigurations)
++	# Find Snappy library
++	find_library(SNAPPY_LIBRARY_DEBUG NAMES snappyd)
++	find_library(SNAPPY_LIBRARY_RELEASE NAMES snappy)
++	select_library_configurations(SNAPPY)
++	find_package_handle_standard_args(SNAPPY
++		FOUND_VAR
++		  SNAPPY_FOUND
++		REQUIRED_VARS
++		  SNAPPY_LIBRARY
++		FAIL_MESSAGE
++		  "Could NOT find SNAPPY"
++	)
++
++	# Find LZ4 library
++	find_library(LZ4_LIBRARY_DEBUG NAMES lz4d)
++	find_library(LZ4_LIBRARY_RELEASE NAMES lz4)
++	select_library_configurations(LZ4)
++	find_package_handle_standard_args(LZ4
++		FOUND_VAR
++		  LZ4_FOUND
++		REQUIRED_VARS
++		  LZ4_LIBRARY
++		FAIL_MESSAGE
++		  "Could NOT find LZ4"
++	)
++
++	# Find ZSTD library
++	find_library(ZSTD_LIBRARY_DEBUG NAMES zstdd)
++	find_library(ZSTD_LIBRARY_RELEASE NAMES zstd)
++	select_library_configurations(ZSTD)
++	find_package_handle_standard_args(ZSTD
++		FOUND_VAR
++		  ZSTD_FOUND
++		REQUIRED_VARS
++		  ZSTD_LIBRARY
++		FAIL_MESSAGE
++		  "Could NOT find ZSTD_"
++	)
++endif(ROCKSDB_FOUND)
++
+ set(ROCKSDB_INCLUDE_DIRS ${ROCKSDB_INCLUDE_DIR} )
+ set(ROCKSDB_LIBRARIES ${ROCKSDB_LIBRARY})
+-
+-
+
+diff --git a/src/osgEarthDrivers/cache_rocksdb/CMakeLists.txt b/src/osgEarthDrivers/cache_rocksdb/CMakeLists.txt
+index 68ad85d..86bb18a 100644
+--- a/src/osgEarthDrivers/cache_rocksdb/CMakeLists.txt
++++ b/src/osgEarthDrivers/cache_rocksdb/CMakeLists.txt
+@@ -16,7 +16,19 @@ SET(TARGET_SRC
+     RocksDBCacheDriver.cpp
+ )
+ 
+-SET(TARGET_LIBRARIES_VARS ROCKSDB_LIBRARY ZLIB_LIBRARY)
++if(SNAPPY_FOUND)
++	SET(ROCKSDB_DEPENDENT_LIBRARY ${ROCKSDB_DEPENDENT_LIBRARY} ${SNAPPY_LIBRARY})
++endif(SNAPPY_FOUND)
++
++if(LZ4_FOUND)
++	SET(ROCKSDB_DEPENDENT_LIBRARY ${ROCKSDB_DEPENDENT_LIBRARY} ${LZ4_LIBRARY})
++endif(LZ4_FOUND)
++
++if(ZSTD_FOUND)
++	SET(ROCKSDB_DEPENDENT_LIBRARY ${ROCKSDB_DEPENDENT_LIBRARY} ${ZSTD_LIBRARY})
++endif(ZSTD_FOUND)
++
++SET(TARGET_LIBRARIES_VARS ROCKSDB_LIBRARY ZLIB_LIBRARY ROCKSDB_DEPENDENT_LIBRARY)
+ 
+ IF(MSVC)
+     SET(TARGET_EXTERNAL_LIBRARIES ws2_32 winmm rpcrt4 shlwapi)
+-
+-

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -9,20 +9,14 @@ if(NOT OSG_PLUGINS_SUBDIR_LENGTH EQUAL 1)
 endif()
 string(REPLACE "${CURRENT_INSTALLED_DIR}/tools/osg/" "" OSG_PLUGINS_SUBDIR "${OSG_PLUGINS_SUBDIR}")
 
-vcpkg_download_distfile(
-    VS2017PATCH
-    URLS "https://github.com/remoe/osgearth/commit/f7081cc4f9991c955c6a0ef7b7b50e48360d14fd.diff"
-    FILENAME "osgearth-f7081cc4f9991c955c6a0ef7b7b50e48360d14fd.patch"
-    SHA512 eadb47a5713c00c05add8627e5cad22844db041da34081d59104151a1a1e2d5ac9552909d67171bfc0449a3e4d2930dd3a7914d3ec7ef7ff1015574e9c9a6105
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gwaldron/osgearth
-    REF osgearth-2.10.1
-    SHA512 a74e6922ae29f85b4227b23a83dbccba92e08b7880533c281ceb244703c38b51a02823fdee3199c975c969db963b35ebad0e3bfed3c1e218a36d130b20a48e5b
+    REF osgearth-2.10.2
+    SHA512 fa306a82374716dafae9d834ed0fb07a7369ae0961696de36b6e2af45bc150040295985d9b9781ab713fd0707691451a6a8f173b34253749ab22764f51e60045
     HEAD_REF master
-    PATCHES ${VS2017PATCH}
+    PATCHES 
+		RocksDB.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
When I building rocksdb[lz4,snappy,zlib,tbb,zstd]:x64-windows osgearth:x64-windows in Visual Studio 2017, osgearth failed to compile.
```
Microsoft (R) Incremental Linker Version 14.16.27032.1
Copyright (C) Microsoft Corporation.  All rights reserved.

[233/662] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2017\COMMUN~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe  src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCache.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheBin.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheDriver.cpp.obj  /out:lib\osgdb_osgearth_cache_rocksdbd.dll /implib:lib\osgdb_osgearth_cache_rocksdbd.lib /pdb:lib\osgdb_osgearth_cache_rocksdbd.pdb /dll /version:0.0 /machine:x64 /debug /INCREMENTAL -LIBPATH:D:\vcpkg\buildtrees\osgearth\x64-windows-dbg\lib lib\osgEarthd.lib D:\vcpkg\installed\x64-windows\debug\lib\rocksdbd.lib ws2_32.lib winmm.lib rpcrt4.lib shlwapi.lib wldap32.lib psapi.lib D:\vcpkg\installed\x64-windows\debug\lib\osgd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgUtild.lib D:\vcpkg\installed\x64-windows\debug\lib\osgSimd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTerraind.lib D:\vcpkg\installed\x64-windows\debug\lib\osgDBd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgFXd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgViewerd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTextd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgGAd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgShadowd.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."
FAILED: lib/osgdb_osgearth_cache_rocksdbd.dll 
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2017\COMMUN~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe  src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCache.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheBin.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheDriver.cpp.obj  /out:lib\osgdb_osgearth_cache_rocksdbd.dll /implib:lib\osgdb_osgearth_cache_rocksdbd.lib /pdb:lib\osgdb_osgearth_cache_rocksdbd.pdb /dll /version:0.0 /machine:x64 /debug /INCREMENTAL -LIBPATH:D:\vcpkg\buildtrees\osgearth\x64-windows-dbg\lib lib\osgEarthd.lib D:\vcpkg\installed\x64-windows\debug\lib\rocksdbd.lib ws2_32.lib winmm.lib rpcrt4.lib shlwapi.lib wldap32.lib psapi.lib D:\vcpkg\installed\x64-windows\debug\lib\osgd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgUtild.lib D:\vcpkg\installed\x64-windows\debug\lib\osgSimd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTerraind.lib D:\vcpkg\installed\x64-windows\debug\lib\osgDBd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgFXd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgViewerd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTextd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgGAd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgShadowd.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."
LINK Pass 1: command "C:\PROGRA~2\MICROS~1\2017\COMMUN~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCache.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheBin.cpp.obj src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir\RocksDBCacheDriver.cpp.obj /out:lib\osgdb_osgearth_cache_rocksdbd.dll /implib:lib\osgdb_osgearth_cache_rocksdbd.lib /pdb:lib\osgdb_osgearth_cache_rocksdbd.pdb /dll /version:0.0 /machine:x64 /debug /INCREMENTAL -LIBPATH:D:\vcpkg\buildtrees\osgearth\x64-windows-dbg\lib lib\osgEarthd.lib D:\vcpkg\installed\x64-windows\debug\lib\rocksdbd.lib ws2_32.lib winmm.lib rpcrt4.lib shlwapi.lib wldap32.lib psapi.lib D:\vcpkg\installed\x64-windows\debug\lib\osgd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgUtild.lib D:\vcpkg\installed\x64-windows\debug\lib\osgSimd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTerraind.lib D:\vcpkg\installed\x64-windows\debug\lib\osgDBd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgFXd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgViewerd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTextd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgGAd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgShadowd.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib opengl32.lib glu32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir/intermediate.manifest src\osgEarthDrivers\cache_rocksdb\CMakeFiles\osgdb_osgearth_cache_rocksdb.dir/manifest.res" failed (exit code 1120) with the following output:
Microsoft (R) Incremental Linker Version 14.16.27032.1
Copyright (C) Microsoft Corporation.  All rights reserved.

rocksdbd.lib(options_helper.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_versionNumber referenced in function "bool __cdecl rocksdb::ZSTD_Supported(void)" (?ZSTD_Supported@rocksdb@@YA_NXZ)
rocksdbd.lib(column_family.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_versionNumber
rocksdbd.lib(db_impl.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_versionNumber
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_versionNumber
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol "void __cdecl snappy::RawCompress(char const *,unsigned __int64,char *,unsigned __int64 *)" (?RawCompress@snappy@@YAXPEBD_KPEADPEA_K@Z) referenced in function "bool __cdecl rocksdb::Snappy_Compress(class rocksdb::CompressionInfo const &,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Snappy_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@PEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol "unsigned __int64 __cdecl snappy::MaxCompressedLength(unsigned __int64)" (?MaxCompressedLength@snappy@@YA_K_K@Z) referenced in function "bool __cdecl rocksdb::Snappy_Compress(class rocksdb::CompressionInfo const &,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Snappy_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@PEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol deflate referenced in function "bool __cdecl rocksdb::Zlib_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Zlib_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol deflateEnd referenced in function "bool __cdecl rocksdb::Zlib_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Zlib_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol deflateSetDictionary referenced in function "bool __cdecl rocksdb::Zlib_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Zlib_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol deflateInit2_ referenced in function "bool __cdecl rocksdb::Zlib_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?Zlib_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_compressBound referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_createStream referenced in function "bool __cdecl rocksdb::LZ4_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_freeStream referenced in function "bool __cdecl rocksdb::LZ4_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_loadDict referenced in function "bool __cdecl rocksdb::LZ4_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_compress_fast_continue referenced in function "bool __cdecl rocksdb::LZ4_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_createStreamHC referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_freeStreamHC referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_loadDictHC referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_compress_HC_continue referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_resetStreamHC referenced in function "bool __cdecl rocksdb::LZ4HC_Compress(class rocksdb::CompressionInfo const &,unsigned int,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?LZ4HC_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@IPEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_compressBound referenced in function "bool __cdecl rocksdb::ZSTD_Compress(class rocksdb::CompressionInfo const &,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?ZSTD_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@PEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_createCCtx referenced in function "private: void __cdecl rocksdb::CompressionContext::CreateNativeContext(enum rocksdb::CompressionType)" (?CreateNativeContext@CompressionContext@rocksdb@@AEAAXW4CompressionType@2@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_freeCCtx referenced in function "private: void __cdecl rocksdb::CompressionContext::DestroyNativeContext(void)" (?DestroyNativeContext@CompressionContext@rocksdb@@AEAAXXZ)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_freeDCtx referenced in function "public: __cdecl rocksdb::ZSTDUncompressCachedData::~ZSTDUncompressCachedData(void)" (??1ZSTDUncompressCachedData@rocksdb@@QEAA@XZ)
rocksdbd.lib(block_based_table_reader.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_freeDCtx
rocksdbd.lib(compression_context_cache.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_freeDCtx
rocksdbd.lib(block_fetcher.cc.obj) : error LNK2001: unresolved external symbol __imp_ZSTD_freeDCtx
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_compress_usingDict referenced in function "bool __cdecl rocksdb::ZSTD_Compress(class rocksdb::CompressionInfo const &,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?ZSTD_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@PEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_createCDict referenced in function "public: __cdecl rocksdb::CompressionDict::CompressionDict(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,enum rocksdb::CompressionType,int)" (??0CompressionDict@rocksdb@@QEAA@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4CompressionType@1@H@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_freeCDict referenced in function "public: __cdecl rocksdb::CompressionDict::~CompressionDict(void)" (??1CompressionDict@rocksdb@@QEAA@XZ)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_compress_usingCDict referenced in function "bool __cdecl rocksdb::ZSTD_Compress(class rocksdb::CompressionInfo const &,char const *,unsigned __int64,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > *)" (?ZSTD_Compress@rocksdb@@YA_NAEBVCompressionInfo@1@PEBD_KPEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZDICT_trainFromBuffer referenced in function "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl rocksdb::ZSTD_TrainDictionary(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::vector<unsigned __int64,class std::allocator<unsigned __int64> > const &,unsigned __int64)" (?ZSTD_TrainDictionary@rocksdb@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@AEBV?$vector@_KV?$allocator@_K@std@@@3@_K@Z)
rocksdbd.lib(block_based_table_builder.cc.obj) : error LNK2019: unresolved external symbol __imp_ZDICT_isError referenced in function "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl rocksdb::ZSTD_TrainDictionary(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::vector<unsigned __int64,class std::allocator<unsigned __int64> > const &,unsigned __int64)" (?ZSTD_TrainDictionary@rocksdb@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBV23@AEBV?$vector@_KV?$allocator@_K@std@@@3@_K@Z)
rocksdbd.lib(compression_context_cache.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_createDCtx referenced in function "public: void __cdecl rocksdb::ZSTDUncompressCachedData::CreateIfNeeded(void)" (?CreateIfNeeded@ZSTDUncompressCachedData@rocksdb@@QEAAXXZ)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol "bool __cdecl snappy::RawUncompress(char const *,unsigned __int64,char *)" (?RawUncompress@snappy@@YA_NPEBD_KPEAD@Z) referenced in function "bool __cdecl rocksdb::Snappy_Uncompress(char const *,unsigned __int64,char *)" (?Snappy_Uncompress@rocksdb@@YA_NPEBD_KPEAD@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol "bool __cdecl snappy::GetUncompressedLength(char const *,unsigned __int64,unsigned __int64 *)" (?GetUncompressedLength@snappy@@YA_NPEBD_KPEA_K@Z) referenced in function "bool __cdecl rocksdb::Snappy_GetUncompressedLength(char const *,unsigned __int64,unsigned __int64 *)" (?Snappy_GetUncompressedLength@rocksdb@@YA_NPEBD_KPEA_K@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol inflate referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::Zlib_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *,int)" (?Zlib_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@H@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol inflateEnd referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::Zlib_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *,int)" (?Zlib_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@H@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol inflateSetDictionary referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::Zlib_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *,int)" (?Zlib_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@H@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol inflateInit2_ referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::Zlib_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *,int)" (?Zlib_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@H@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_createStreamDecode referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::LZ4_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *)" (?LZ4_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_freeStreamDecode referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::LZ4_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *)" (?LZ4_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_setStreamDecode referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::LZ4_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *)" (?LZ4_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol __imp_LZ4_decompress_safe_continue referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::LZ4_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,unsigned int,class rocksdb::MemoryAllocator *)" (?LZ4_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHIPEAVMemoryAllocator@1@@Z)
rocksdbd.lib(format.cc.obj) : error LNK2019: unresolved external symbol __imp_ZSTD_decompress_usingDict referenced in function "class std::unique_ptr<char [0],struct rocksdb::CustomDeleter> __cdecl rocksdb::ZSTD_Uncompress(class rocksdb::UncompressionInfo const &,char const *,unsigned __int64,int *,class rocksdb::MemoryAllocator *)" (?ZSTD_Uncompress@rocksdb@@YA?AV?$unique_ptr@$$BY0A@DUCustomDeleter@rocksdb@@@std@@AEBVUncompressionInfo@1@PEBD_KPEAHPEAVMemoryAllocator@1@@Z)
lib\osgdb_osgearth_cache_rocksdbd.dll : fatal error LNK1120: 39 unresolved externals
[234/662] cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --intdir=src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2017\COMMUN~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe  src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\AltitudeSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\BBoxSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\BillboardResource.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\BillboardSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Color.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\CoverageSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\CssUtils.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Expression.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\ExtrusionSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Fill.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Geometry.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\GeometryFactory.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\GEOS.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\GeometryRasterizer.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\IconResource.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\IconSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\InstanceResource.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\InstanceSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\LineSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\MeshConsolidator.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\MeshFlattener.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\MeshSubdivider.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\ModelResource.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\ModelSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\PointSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\PolygonSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Query.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\RenderSymbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Resource.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\ResourceCache.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\ResourceLibrary.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Skins.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Stroke.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Style.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\StyleSelector.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\StyleSheet.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\Symbol.cpp.obj src\osgEarthSymbology\CMakeFiles\osgEarthSymbology.dir\TextSymbol.cpp.obj  /out:lib\osgEarthSymbologyd.dll /implib:lib\osgEarthSymbologyd.lib /pdb:lib\osgEarthSymbologyd.pdb /dll /version:2.10 /machine:x64 /debug /INCREMENTAL -LIBPATH:D:\vcpkg\buildtrees\osgearth\x64-windows-dbg\lib lib\osgEarthd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgWidgetd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgUtild.lib D:\vcpkg\installed\x64-windows\debug\lib\osgSimd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTerraind.lib D:\vcpkg\installed\x64-windows\debug\lib\osgDBd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgFXd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgViewerd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTextd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgGAd.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib D:\vcpkg\installed\x64-windows\debug\lib\geosd.lib opengl32.lib glu32.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib ws2_32.lib winmm.lib wldap32.lib psapi.lib D:\vcpkg\installed\x64-windows\debug\lib\osgd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgShadowd.lib D:\vcpkg\installed\x64-windows\debug\lib\libcurl-d.lib D:\vcpkg\installed\x64-windows\lib\gdal.lib D:\vcpkg\installed\x64-windows\debug\lib\osgManipulatord.lib D:\vcpkg\installed\x64-windows\debug\lib\osgUtild.lib D:\vcpkg\installed\x64-windows\debug\lib\osgSimd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTerraind.lib D:\vcpkg\installed\x64-windows\debug\lib\osgDBd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgFXd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgViewerd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgTextd.lib D:\vcpkg\installed\x64-windows\debug\lib\osgGAd.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib opengl32.lib glu32.lib D:\vcpkg\installed\x64-windows\debug\lib\OpenThreadsd.lib opengl32.lib glu32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."
```
Because rocksdb can only be compiled into a static library in vcpkg. The rocksdb dependent library is not specified in osgearth, So the error happened.
I added RocksDB.patch to fix this problem. 
VS2017PATCH has expired，Because osgearth has merged this patch, So I deleted it.
By the way, I will upgrade osgearth from 2.10.1 to 2.10.2.