### PR TITLE
[poco]Upgrade version to 1.9.2 release.

### DIFF
--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,6 +1,6 @@
 Source: poco
-Version: 2.0.0-pre-3
-Build-Depends: expat, libpq, pcre, sqlite3, zlib
+Version: 1.9.2
+Build-Depends: expat, libpq, pcre, sqlite3, zlib, libpng
 Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.
 Homepage: https://github.com/pocoproject/poco
 

--- a/ports/poco/find_pcre.patch
+++ b/ports/poco/find_pcre.patch
@@ -1,13 +1,22 @@
 diff --git a/cmake/FindPCRE.cmake b/cmake/FindPCRE.cmake
-index 41a99cb..77f3a42 100644
+index 41a99cb..b1acb32 100644
 --- a/cmake/FindPCRE.cmake
 +++ b/cmake/FindPCRE.cmake
-@@ -14,7 +14,7 @@ ENDIF (PCRE_INCLUDE_DIRS)
+@@ -14,9 +14,15 @@ ENDIF (PCRE_INCLUDE_DIRS)
  
  FIND_PATH(PCRE_INCLUDE_DIR pcre.h)
  
 -SET(PCRE_NAMES pcre)
++if (WIN32)
++include(SelectLibraryConfigurations)
++find_library(PCRE_LIBRARY_RELEASE NAMES pcre)
++find_library(PCRE_LIBRARY_DEBUG NAMES pcred)
++select_library_configurations(PCRE)
++else()
 +SET(PCRE_NAMES pcred pcre)
  FIND_LIBRARY(PCRE_LIBRARY NAMES ${PCRE_NAMES} )
- 
+-
++endif()
  # handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if
+ # all listed variables are TRUE
+ INCLUDE(FindPackageHandleStandardArgs)

--- a/ports/poco/fix_foundation_link.patch
+++ b/ports/poco/fix_foundation_link.patch
@@ -1,25 +1,23 @@
 diff --git a/Foundation/src/Environment_WIN32.cpp b/Foundation/src/Environment_WIN32.cpp
-index 3cca5c7..8ed1df2 100644
+index 62845fa..edcf6fe 100644
 --- a/Foundation/src/Environment_WIN32.cpp
 +++ b/Foundation/src/Environment_WIN32.cpp
-@@ -23,7 +23,7 @@
+@@ -22,6 +22,7 @@
  #include <ws2ipdef.h>
- #include <wincrypt.h>
  #include <iphlpapi.h>
--
+ 
 +#pragma comment(lib, "IPHLPAPI.lib")
  
  namespace Poco {
  
 diff --git a/Foundation/src/Environment_WINCE.cpp b/Foundation/src/Environment_WINCE.cpp
-index 62f19bc..d409356 100644
+index afa59b6..c43767b 100644
 --- a/Foundation/src/Environment_WINCE.cpp
 +++ b/Foundation/src/Environment_WINCE.cpp
-@@ -22,7 +22,7 @@
- #include <cstring>
+@@ -23,6 +23,7 @@
  #include <windows.h>
  #include <iphlpapi.h>
--
+ 
 +#pragma comment(lib, "IPHLPAPI.lib")
  
  namespace Poco {

--- a/ports/poco/include_pcre.patch
+++ b/ports/poco/include_pcre.patch
@@ -1,12 +1,12 @@
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index 5b7df96..4fedfd5 100644
+index 26a2365..0b8f7bc 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
-@@ -101,6 +101,7 @@ target_link_libraries(Foundation PUBLIC ${PCRE_LIBRARIES} ${ZLIB_LIBRARIES})
- target_include_directories(Foundation
+@@ -168,6 +168,7 @@ target_link_libraries( "${LIBNAME}" ${SYSLIBS})
+ target_include_directories( "${LIBNAME}"
  	PUBLIC
  		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-+		$<BUILD_INTERFACE:${PCRE_INCLUDE_DIRS}>
++        $<BUILD_INTERFACE:${PCRE_INCLUDE_DIRS}>
  		$<INSTALL_INTERFACE:include>
  	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
  	)

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,13 +1,11 @@
 include(vcpkg_common_functions)
 
-# Poco 2.0.0 (pre)
-# commit 46e00c8
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF 46e00c8d6f6d03864397c3e517a165e82f9efd5e
-    SHA512 2c2f5048b7bfbbfe47ac303ed79213197c97f3d90362dd2d7629c8b353a6c8bd303b1bcf477e3493cc6c984645822ca043dd0a77e9186e001e6808dc2d17a5b4
-    HEAD_REF develop
+    REF 8a127d6f16795d914cadc342d3f4f3b9b7999e3b #1.9.2
+    SHA512 282097ee2118ac55320ebdde05bb53ed27d68af49c201b0b26027706ef935ae08f8090abb8aab1cafe84c72520ea73b01263b439d32bd2d0bd55319b0634b168
+    HEAD_REF master
     PATCHES
         # Find pcre in debug
         find_pcre.patch
@@ -52,37 +50,34 @@ vcpkg_configure_cmake(
         -DPOCO_STATIC=${POCO_STATIC}
         -DPOCO_MT=${POCO_MT}
         # Set to OFF|ON (default is OFF) to control build of POCO tests
-        -DPOCO_ENABLE_TESTS=OFF
+        -DENABLE_TESTS=OFF
         # Set to OFF|ON (default is OFF) to control build of POCO samples
-        -DPOCO_ENABLE_SAMPLES=OFF
+        -DENABLE_SAMPLES=OFF
         # Allow enabling and disabling components
         # POCO_ENABLE_SQL_ODBC, POCO_ENABLE_SQL_MYSQL and POCO_ENABLE_SQL_POSTGRESQL are
         # defined on the fly if the required librairies are present
-        -DPOCO_ENABLE_ENCODINGS=ON
-        -DPOCO_ENABLE_ENCODINGS_COMPILER=ON
-        -DPOCO_ENABLE_XML=ON
-        -DPOCO_ENABLE_JSON=ON
-        -DPOCO_ENABLE_MONGODB=ON
-        -DPOCO_ENABLE_SQL_SQLITE=ON
-        -DPOCO_ENABLE_REDIS=ON
-        -DPOCO_ENABLE_PDF=ON
-        -DPOCO_ENABLE_UTIL=ON
-        -DPOCO_ENABLE_NET=ON
-        -DPOCO_ENABLE_SEVENZIP=ON
-        -DPOCO_ENABLE_ZIP=ON
-        -DPOCO_ENABLE_CPPPARSER=ON
-        -DPOCO_ENABLE_POCODOC=ON
-        -DPOCO_ENABLE_PAGECOMPILER=ON
-        -DPOCO_ENABLE_PAGECOMPILER_FILE2PAGE=ON
-        -DPOCO_ENABLE_WSTRING=ON
-        -DPOCO_ENABLE_FPENVIRONMENT=ON
-        -DPOCO_ENABLE_CPPUNIT=ON
+        -DENABLE_ENCODINGS=ON
+        -DENABLE_ENCODINGS_COMPILER=ON
+        -DENABLE_XML=ON
+        -DENABLE_JSON=ON
+        -DENABLE_MONGODB=ON
+        # -DPOCO_ENABLE_SQL_SQLITE=ON # SQLITE are not supported.
+        -DENABLE_REDIS=ON
+        -DENABLE_PDF=ON
+        -DENABLE_UTIL=ON
+        -DENABLE_NET=ON
+        -DENABLE_SEVENZIP=ON
+        -DENABLE_ZIP=ON
+        -DENABLE_CPPPARSER=ON
+        -DENABLE_POCODOC=ON
+        -DENABLE_PAGECOMPILER=ON
+        -DENABLE_PAGECOMPILER_FILE2PAGE=ON
         #
         -DMYSQL_INCLUDE_DIR=${MYSQL_INCLUDE_DIR}
     OPTIONS_RELEASE
-        -DMYSQL_LIBRARY=${MYSQL_LIBRARY}
+        -DMYSQL_LIB=${MYSQL_LIBRARY}
     OPTIONS_DEBUG
-        -DMYSQL_LIBRARY=${MYSQL_LIBRARY_DEBUG}
+        -DMYSQL_LIB=${MYSQL_LIBRARY_DEBUG}
 )
 
 vcpkg_install_cmake()
@@ -154,7 +149,7 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # copy license
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/poco)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/poco/LICENSE ${CURRENT_PACKAGES_DIR}/share/poco/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/poco/static_pcre.patch
+++ b/ports/poco/static_pcre.patch
@@ -1,27 +1,26 @@
 diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
-index 4fedfd5..741313b 100644
+index 0b8f7bc..c362890 100644
 --- a/Foundation/CMakeLists.txt
 +++ b/Foundation/CMakeLists.txt
-@@ -35,6 +35,22 @@ if (POCO_UNBUNDLED)
- 	find_package(PCRE REQUIRED)
- 	find_package(ZLIB REQUIRED)
+@@ -53,6 +53,21 @@ if (POCO_UNBUNDLED)
+ 	include_directories(${ZLIB_INCLUDE_DIRS})
  
-+	add_definitions(
-+		-D_pcre_utf8_table1=_poco_pcre_utf8_table1
-+		-D_pcre_utf8_table1_size=_poco_pcre_utf8_table1_size
-+		-D_pcre_utf8_table2=_poco_pcre_utf8_table2
-+		-D_pcre_utf8_table3=_poco_pcre_utf8_table3
-+		-D_pcre_utf8_table4=_poco_pcre_utf8_table4
-+		-D_pcre_utt_names=_poco_pcre_utt_names
-+		-D_pcre_utt=_poco_pcre_utt
-+		-D_pcre_utt_size=_poco_pcre_utt_size
-+		-D_pcre_OP_lengths=_poco_pcre_OP_lengths
-+		-D_pcre_hspace_list=_poco_pcre_hspace_list
-+		-D_pcre_vspace_list=_poco_pcre_vspace_list
-+		-D_pcre_ucp_gentype=_poco_pcre_ucp_gentype
-+		-D_pcre_ucp_gbtable=_poco_pcre_ucp_gbtable
-+	)
-+
- 	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
- 	POCO_SOURCES( SRCS RegExp
- 		src/pcre_ucd.c
+ 	add_definitions(-DPOCO_UNBUNDLED)
++    add_definitions(
++        -D_pcre_utf8_table1=_poco_pcre_utf8_table1
++        -D_pcre_utf8_table1_size=_poco_pcre_utf8_table1_size
++        -D_pcre_utf8_table2=_poco_pcre_utf8_table2
++        -D_pcre_utf8_table3=_poco_pcre_utf8_table3
++        -D_pcre_utf8_table4=_poco_pcre_utf8_table4
++        -D_pcre_utt_names=_poco_pcre_utt_names
++        -D_pcre_utt=_poco_pcre_utt
++        -D_pcre_utt_size=_poco_pcre_utt_size
++        -D_pcre_OP_lengths=_poco_pcre_OP_lengths
++        -D_pcre_hspace_list=_poco_pcre_hspace_list
++        -D_pcre_vspace_list=_poco_pcre_vspace_list
++        -D_pcre_ucp_gentype=_poco_pcre_ucp_gentype
++        -D_pcre_ucp_gbtable=_poco_pcre_ucp_gbtable
++    )
+ 
+ else()
+ 	# pcre

--- a/ports/poco/unbundled_pdf.patch
+++ b/ports/poco/unbundled_pdf.patch
@@ -6,7 +6,7 @@ index 3e44906..ae8fe6e 100644
  
  # TODO: Currently only bundled is supported, in future this should also be possible
  # with an unbundled version of libpng
-+find_package(png REQUIRED)
++find_package(PNG REQUIRED)
 +if (0)
  POCO_SOURCES( SRCS libpng
      src/png.c

--- a/ports/poco/unbundled_pdf.patch
+++ b/ports/poco/unbundled_pdf.patch
@@ -1,17 +1,30 @@
 diff --git a/PDF/CMakeLists.txt b/PDF/CMakeLists.txt
-index b377035..9cfbd32 100644
+index 3e44906..ae8fe6e 100644
 --- a/PDF/CMakeLists.txt
 +++ b/PDF/CMakeLists.txt
-@@ -31,6 +31,12 @@ endif (POCO_UNBUNDLED)
+@@ -97,6 +97,8 @@ POCO_SOURCES(SRCS hpdf
+ 
  # TODO: Currently only bundled is supported, in future this should also be possible
- # with an unbundled version of hpdf
- # hpdf
-+if (POCO_UNBUNDLED)
-+    POCO_SOURCES( SRCS hpdf
-+        src/bmpread.c
-+    )
-+endif (POCO_UNBUNDLED)
-+
- POCO_SOURCES(SRCS hpdf
-     src/hpdf_3dmeasure.c
-     src/hpdf_annotation.c
+ # with an unbundled version of libpng
++find_package(png REQUIRED)
++if (0)
+ POCO_SOURCES( SRCS libpng
+     src/png.c
+     src/pngerror.c
+@@ -117,6 +119,7 @@ POCO_SOURCES( SRCS libpng
+     src/pngwtran.c
+     src/pngwutil.c
+ )
++endif(0)
+ 
+ # Version Resource
+ if(MSVC AND NOT POCO_STATIC)
+@@ -136,7 +139,7 @@ set_target_properties( "${LIBNAME}"
+     DEFINE_SYMBOL PDF_EXPORTS
+     )
+ 
+-target_link_libraries( "${LIBNAME}" ${SYSLIBS} XML Util Foundation )
++target_link_libraries( "${LIBNAME}" ${SYSLIBS} XML Util Foundation ${PNG_LIBRARIES})
+ target_include_directories( "${LIBNAME}"
+     PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
1. Upgrade version to 1.9.2 release(from preview).
2. Fix library using `pcre`.

Feature `mysql` needs official to fix(issue [#2744](https://github.com/pocoproject/poco/issues/2744)).

Related: #6349 #7555.