### PR TITLE
[sdl2] Updated to 2.0.10

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.9-4
+Version: 2.0.10-1
 Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/ports/sdl2/enable-winrt-cmake.patch
+++ b/ports/sdl2/enable-winrt-cmake.patch
@@ -4,7 +4,7 @@ index 0128c7a..bd534e4 100644
 +++ b/CMakeLists.txt
 @@ -5,6 +5,18 @@ endif()
  cmake_minimum_required(VERSION 2.8.11)
- project(SDL2 C)
+ project(SDL2 C CXX)
  
 +if(WINDOWS_STORE)
 +  enable_language(CXX)
@@ -21,7 +21,7 @@ index 0128c7a..bd534e4 100644
  # !!! FIXME: this should probably do "MACOSX_RPATH ON" as a target property
  # !!! FIXME:  for the SDL2 shared library (so you get an
  # !!! FIXME:  install_name ("soname") of "@rpath/libSDL-whatever.dylib"
-@@ -1166,6 +1178,11 @@ elseif(WINDOWS)
+@@ -1209,6 +1221,11 @@ elseif(WINDOWS)
    file(GLOB CORE_SOURCES ${SDL2_SOURCE_DIR}/src/core/windows/*.c)
    set(SOURCE_FILES ${SOURCE_FILES} ${CORE_SOURCES})
  
@@ -33,7 +33,7 @@ index 0128c7a..bd534e4 100644
    if(MSVC)
      # Prevent codegen that would use the VC runtime libraries.
      set_property(DIRECTORY . APPEND PROPERTY COMPILE_OPTIONS "/GS-")
-@@ -1211,6 +1228,9 @@ elseif(WINDOWS)
+@@ -1254,6 +1271,9 @@ elseif(WINDOWS)
      check_include_file(ddraw.h HAVE_DDRAW_H)
      check_include_file(dsound.h HAVE_DSOUND_H)
      check_include_file(dinput.h HAVE_DINPUT_H)
@@ -43,7 +43,7 @@ index 0128c7a..bd534e4 100644
      check_include_file(dxgi.h HAVE_DXGI_H)
      if(HAVE_D3D_H OR HAVE_D3D11_H OR HAVE_DDRAW_H OR HAVE_DSOUND_H OR HAVE_DINPUT_H)
        set(HAVE_DIRECTX TRUE)
-@@ -1229,18 +1249,20 @@ elseif(WINDOWS)
+@@ -1272,18 +1292,20 @@ elseif(WINDOWS)
    check_include_file(endpointvolume.h HAVE_ENDPOINTVOLUME_H)
  
    if(SDL_AUDIO)
@@ -66,7 +66,7 @@ index 0128c7a..bd534e4 100644
        set(SDL_AUDIO_DRIVER_WASAPI 1)
        file(GLOB WASAPI_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/wasapi/*.c)
        set(SOURCE_FILES ${SOURCE_FILES} ${WASAPI_AUDIO_SOURCES})
-@@ -1252,11 +1274,20 @@ elseif(WINDOWS)
+@@ -1295,11 +1317,20 @@ elseif(WINDOWS)
      if(NOT SDL_LOADSO)
        message_error("SDL_VIDEO requires SDL_LOADSO, which is not enabled")
      endif()
@@ -88,7 +88,7 @@ index 0128c7a..bd534e4 100644
        set(SDL_VIDEO_RENDER_D3D 1)
        set(HAVE_RENDER_D3D TRUE)
      endif()
-@@ -1279,20 +1310,31 @@ elseif(WINDOWS)
+@@ -1322,20 +1353,31 @@ elseif(WINDOWS)
    endif()
  
    if(SDL_POWER)
@@ -115,12 +115,12 @@ index 0128c7a..bd534e4 100644
  
    # Libraries for Win32 native and MinGW
 +  if(NOT WINDOWS_STORE)
-   list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32)
+   list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 setupapi shell32)
 +  endif()
  
-   # TODO: in configure.in the check for timers is set on
+   # TODO: in configure.ac the check for timers is set on
    # cygwin | mingw32* - does this include mingw32CE?
-@@ -1314,7 +1356,7 @@ elseif(WINDOWS)
+@@ -1357,7 +1399,7 @@ elseif(WINDOWS)
    set(SOURCE_FILES ${SOURCE_FILES} ${CORE_SOURCES})
  
    if(SDL_VIDEO)
@@ -129,7 +129,7 @@ index 0128c7a..bd534e4 100644
        set(SDL_VIDEO_OPENGL 1)
        set(SDL_VIDEO_OPENGL_WGL 1)
        set(SDL_VIDEO_RENDER_OGL 1)
-@@ -1731,12 +1773,14 @@ endif()
+@@ -1788,12 +1830,14 @@ endif()
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
  
  # Always build SDLmain
@@ -148,7 +148,7 @@ diff --git a/include/SDL_config.h.cmake b/include/SDL_config.h.cmake
 index 48dd2d4..0c4fa28 100644
 --- a/include/SDL_config.h.cmake
 +++ b/include/SDL_config.h.cmake
-@@ -324,6 +324,7 @@
+@@ -326,6 +326,7 @@
  #cmakedefine SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC @SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC@
  #cmakedefine SDL_VIDEO_DRIVER_DUMMY @SDL_VIDEO_DRIVER_DUMMY@
  #cmakedefine SDL_VIDEO_DRIVER_WINDOWS @SDL_VIDEO_DRIVER_WINDOWS@
@@ -156,7 +156,7 @@ index 48dd2d4..0c4fa28 100644
  #cmakedefine SDL_VIDEO_DRIVER_WAYLAND @SDL_VIDEO_DRIVER_WAYLAND@
  #cmakedefine SDL_VIDEO_DRIVER_RPI @SDL_VIDEO_DRIVER_RPI@
  #cmakedefine SDL_VIDEO_DRIVER_VIVANTE @SDL_VIDEO_DRIVER_VIVANTE@
-@@ -392,6 +393,7 @@
+@@ -391,6 +392,7 @@
  #cmakedefine SDL_POWER_ANDROID @SDL_POWER_ANDROID@
  #cmakedefine SDL_POWER_LINUX @SDL_POWER_LINUX@
  #cmakedefine SDL_POWER_WINDOWS @SDL_POWER_WINDOWS@
@@ -164,7 +164,7 @@ index 48dd2d4..0c4fa28 100644
  #cmakedefine SDL_POWER_MACOSX @SDL_POWER_MACOSX@
  #cmakedefine SDL_POWER_HAIKU @SDL_POWER_HAIKU@
  #cmakedefine SDL_POWER_EMSCRIPTEN @SDL_POWER_EMSCRIPTEN@
-@@ -414,7 +416,7 @@
+@@ -413,7 +415,7 @@
  #cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@
  
  /* Platform specific definitions */

--- a/ports/sdl2/fix-arm64-headers.patch
+++ b/ports/sdl2/fix-arm64-headers.patch
@@ -1,0 +1,14 @@
+--- a/include/SDL_cpuinfo.h	Tue Jul 23 21:41:00 2019 -0400
++++ b/include/SDL_cpuinfo.h	Tue Aug 13 20:26:27 2019 -0700
+@@ -73,8 +73,8 @@
+ #      define __ARM_NEON 1 /* Set __ARM_NEON so that it can be used elsewhere, at compile time */
+ #    endif
+ #    if defined (_M_ARM64)
+-#      include <armintr.h>
+-#      include <arm_neon.h>
++#      include <arm64intr.h>
++#      include <arm64_neon.h>
+ #      define __ARM_NEON 1 /* Set __ARM_NEON so that it can be used elsewhere, at compile time */
+ #    endif
+ #  endif
+ 

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -3,14 +3,13 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SDL-Mirror/SDL
-    REF release-2.0.9
-    SHA512 444c906c0baa720c86ca72d1b4cd66fdf6f516d5d2a9836169081a2997a5aebaaf9caa687ec060fa02292d79cfa4a62442333e00f90a0239edd1601529f6b056
+    REF release-2.0.10
+    SHA512 c5fe59eed7ba9c6a82cceaf513623480793727fceec84b01d819e7cbefc8229a84be93067d7539f12d5811c49d3d54fd407272786aef3e419f439d0105c34b21
     HEAD_REF master
     PATCHES
         export-symbols-only-in-shared-build.patch
-        fix-x86-windows.patch
         enable-winrt-cmake.patch
-        SDL-2.0.9-bug-4391-fix.patch # See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391 # Can be removed once SDL 2.0.10 is released
+        fix-arm64-headers.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)


### PR DESCRIPTION
Despite having updated the previous patches carefully, this new SDL2 version can't be build on x64-uwp, and arm-uwp platforms. Any help to fix that would be appreciated.

Many thanks to past-due for informing me about the existence of a patch for the arm64 platform (https://github.com/microsoft/vcpkg/pull/7503#issuecomment-520868541) .