### PR TITLE
[pegtl-2] Update library to 2.8.1

### DIFF
--- a/ports/pegtl-2/CONTROL
+++ b/ports/pegtl-2/CONTROL
@@ -1,3 +1,3 @@
 Source: pegtl-2
-Version: 2.8.0
+Version: 2.8.1
 Description: The Parsing Expression Grammar Template Library (PEGTL) is a zero-dependency C++ header-only parser combinator library for creating parsers according to a Parsing Expression Grammar (PEG). This version maintains compatibility with C++11.

--- a/ports/pegtl-2/portfile.cmake
+++ b/ports/pegtl-2/portfile.cmake
@@ -2,8 +2,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taocpp/pegtl
-    REF 2.8.0
-    SHA512 1652b0061cd4cbd0e687855ee2e61e97d020606c54329de8769c3a3f411002323900c11eaf0da28e107c17e269025f577f9205b7500c5bbb16502687be8ee77b
+    REF 2.8.1
+    SHA512 7a8f6829123fbbd5a0ef1c8ef2c72bdae48576ef94056a1dff7914e4bb85caac1df02839131ea5cfb4131c8902addeca92df48fe7dd5815bdf5cb35759dace49
     HEAD_REF master
 )
 


### PR DESCRIPTION
![pegtl-2-image](https://user-images.githubusercontent.com/22881814/63153565-d87d7600-c023-11e9-8a2b-5196f269efe8.png)

Update `pegtl-2` library to 2.8.1 version.