### PR TITLE
[sdl2-mixer]Remove useless dependency link libraries.

### DIFF
--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -10,53 +10,6 @@ set(SDL_MIXER_LIBRARIES SDL2::SDL2)
 # builtin formats
 set(SDL_MIXER_DEFINES MUSIC_WAV)
 
-# MP3 support
-if(SDL_MIXER_ENABLE_MP3)
-    find_path(MPG123_INCLUDE_DIR mpg123.h)
-    find_library(MPG123_LIBRARY NAMES libmpg123 mpg123)
-    list(APPEND SDL_MIXER_INCLUDES ${MPG123_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${MPG123_LIBRARY})
-    list(APPEND SDL_MIXER_DEFINES MUSIC_MP3_MPG123)
-endif()
-
-# FLAC support
-if(SDL_MIXER_ENABLE_FLAC)
-    find_path(FLAC_INCLUDE_DIR FLAC/all.h)
-    find_library(FLAC_LIBRARY FLAC)
-    list(APPEND SDL_MIXER_INCLUDES ${FLAC_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${FLAC_LIBRARY})
-    list(APPEND SDL_MIXER_DEFINES MUSIC_FLAC)
-endif()
-
-# MOD support
-if(SDL_MIXER_ENABLE_MOD)
-    find_path(MODPLUG_INCLUDE_DIR libmodplug/modplug.h)
-    find_library(MODPLUG_LIBRARY modplug)
-    list(APPEND SDL_MIXER_INCLUDES ${MODPLUG_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${MODPLUG_LIBRARY})
-    list(APPEND SDL_MIXER_DEFINES MUSIC_MOD_MODPLUG)
-endif()
-
-# Ogg-Vorbis support
-if(SDL_MIXER_ENABLE_OGGVORBIS)
-    find_path(VORBIS_INCLUDE_DIR vorbis/codec.h)
-    find_library(VORBISFILE_LIBRARY vorbisfile)
-    list(APPEND SDL_MIXER_INCLUDES ${VORBIS_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${VORBISFILE_LIBRARY})
-    list(APPEND SDL_MIXER_DEFINES MUSIC_OGG)
-endif()
-
-# Opus support
-if(SDL_MIXER_ENABLE_OPUS)
-    find_path(OPUS_INCLUDE_DIR opus/opusfile.h)
-    find_package(ogg CONFIG REQUIRED)
-    find_package(Opus CONFIG REQUIRED)
-    find_library(OPUSFILE_LIBRARY opusfile)
-    list(APPEND SDL_MIXER_INCLUDES ${OPUS_INCLUDE_DIR})
-    list(APPEND SDL_MIXER_LIBRARIES ${OPUSFILE_LIBRARY} Ogg::ogg Opus::opus)
-    list(APPEND SDL_MIXER_DEFINES MUSIC_OPUS)
-endif()
-
 add_library(SDL2_mixer
     effect_position.c
     effect_stereoreverse.c

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.4-3
+Version: 2.0.4-4
 Homepage: https://www.libsdl.org/projects/SDL_mixer
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2

--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -13,40 +13,9 @@ vcpkg_extract_source_archive_ex(
 )
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-set(USE_MP3 OFF)
-if("mpg123" IN_LIST FEATURES)
-    set(USE_MP3 ON)
-endif()
-
-set(USE_FLAC OFF)
-if("libflac" IN_LIST FEATURES)
-    set(USE_FLAC ON)
-endif()
-
-set(USE_MOD OFF)
-if("libmodplug" IN_LIST FEATURES)
-    set(USE_MOD ON)
-endif()
-
-set(USE_OGGVORBIS OFF)
-if("libvorbis" IN_LIST FEATURES)
-    set(USE_OGGVORBIS ON)
-endif()
-
-set(USE_OPUS OFF)
-if("opusfile" IN_LIST FEATURES)
-    set(USE_OPUS ON)
-endif()
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-        -DSDL_MIXER_ENABLE_MP3=${USE_MP3}             # mpg123
-        -DSDL_MIXER_ENABLE_FLAC=${USE_FLAC}           # libflac
-        -DSDL_MIXER_ENABLE_MOD=${USE_MOD}             # libmodplug
-        -DSDL_MIXER_ENABLE_OGGVORBIS=${USE_OGGVORBIS} # libvorbis
-        -DSDL_MIXER_ENABLE_OPUS=${USE_OPUS}           # opusfile
     OPTIONS_DEBUG
         -DSDL_MIXER_SKIP_HEADERS=ON
 )


### PR DESCRIPTION
Since the library method using features in sdl2-mixer is dynamically loaded (using the function `SDL_LoadFunction`), remove all links that depend on the feature library.

Related: #7356.