### PR TITLE
[oniguruma] Update library 6.9.3

### DIFF
--- a/ports/oniguruma/CONTROL
+++ b/ports/oniguruma/CONTROL
@@ -1,5 +1,5 @@
 Source: oniguruma
-Version: 6.9.2-3
+Version: 6.9.3
 Description: Modern and flexible regular expressions library
 Homepage: https://github.com/kkos/oniguruma
 

--- a/ports/oniguruma/portfile.cmake
+++ b/ports/oniguruma/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kkos/oniguruma
-    REF v6.9.2
-    SHA512 b5578560f469c2e123280159a23a0e59045bf2452fd3efe09393c5e99ecc6323f965d2189a4e7e6e3a108c1d02b9b041f3fe991cd8ab64f7289003a5a07b4434
+    REF v6.9.3
+    SHA512 a0f4da26ba08de516c05b5e4b803a9cf8013489c3743ecf27fbc3f66f835eef8fca81b9ed2bd68729a470fe897994046843a4fd31d44a9584ff8dabd1748df21
     HEAD_REF master
 )
 


### PR DESCRIPTION
![oniguruma-image](https://user-images.githubusercontent.com/22881814/63158100-c6a0d080-c02d-11e9-88ff-b0367f19d398.png)

Update `oniguruma` library to 6.9.3 version.