### PR TITLE
[robin-hood-hashing] Update library to 3.4.0

### DIFF
--- a/ports/robin-hood-hashing/CONTROL
+++ b/ports/robin-hood-hashing/CONTROL
@@ -1,3 +1,3 @@
 Source: robin-hood-hashing
-Version: 3.2.13
+Version: 3.4.0
 Description: Fast & memory efficient hashtable based on robin hood hashing for C++14

--- a/ports/robin-hood-hashing/portfile.cmake
+++ b/ports/robin-hood-hashing/portfile.cmake
@@ -5,8 +5,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinus/robin-hood-hashing
-    REF 3.2.13
-    SHA512 5c508a1f43d2ca86c89b9aac3b17493a23b8ee3c7485438afc8e5eb4e697d663588e1945001ba3ba95dd1480b3c1b846079fadec5972e5ac4462117379052433
+    REF 3.4.0
+    SHA512 7985d64063af7d28b9404639df48645d2d72b0bc752fde23c7e3bf431adbd8eb4ffbc439e5a8513a39eb54481ce875fb044fafc86c36046995e3193284a594dd
     HEAD_REF master
 )
 


### PR DESCRIPTION
![robin-hood-hashing-image](https://user-images.githubusercontent.com/22881814/63159258-5ba4c900-c030-11e9-8acd-b96545054370.png)

Update `robin-hood-hashing` library to 3.4.0 version.