### PR TITLE
[sfml] Fix system package dependencies on Ubuntu

### DIFF
--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -16,7 +16,7 @@ file(WRITE ${SOURCE_PATH}/extlibs/libs/x "")
 file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/Modules/FindFreetype.cmake)
 
 if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message("SFML currently requires the following libraries from the system package manager:\n    libudev\n    libx11\n    libxrandr\n    opengl\n\nThese can be installed on Ubuntu systems via apt-get install libx11-dev libxrandr-dev libxi-dev libudev-dev mesa-common-dev")
+    message("SFML currently requires the following libraries from the system package manager:\n    libudev\n    libx11\n    libxrandr\n    opengl\n\nThese can be installed on Ubuntu systems via apt-get install libx11-dev libxrandr-dev libxi-dev libudev-dev libgl1-mesa-dev")
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Cmake doesn't find opengl on Ubuntu (tried 18.04, 19.04) even after installing the required system dependencies.
    
`libgl1-mesa-dev` works instead of `mesa-common-dev`, as noted here: https://stackoverflow.com/a/47926071/6597851.
