### PR TITLE
[libmorton] Update library to 0.2

### DIFF
--- a/ports/libmorton/CONTROL
+++ b/ports/libmorton/CONTROL
@@ -1,3 +1,3 @@
 Source: libmorton
-Version: 2018-19-07
+Version: 0.2
 Description: header-only library for encoding/decoding Morton codes in/from 2D/3D coordinates

--- a/ports/libmorton/portfile.cmake
+++ b/ports/libmorton/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Forceflow/libmorton
-    REF 797ea736dca49553a56089f143ee6d1effdd318e
-    SHA512 ee9632f5c873462842d18014d4fd2d461e9fe767659e7426a7dec90fcc06cb974fb064229db5622c38ad0af9509004edea87e0f1d57ad09d8d1d236a5b9579a0
+    REF v0.2
+    SHA512 04cf8332a1cee52eebfb25a46ac64517900704f62fe53ccf1d6a74c535ccac5af4e3ce2e0a5ce94ee850fadb429fe0d88d5a66901f16e4308341a621e599d33d
     HEAD_REF master
 )
 


### PR DESCRIPTION
![libmorton-image](https://user-images.githubusercontent.com/22881814/63213810-ed423280-c125-11e9-8aa0-7dbe22e34432.png)

Update `libmorton` library to 0.2 version.