### PR TITLE
[harfbuzz] Update library to 2.6.2

### DIFF
--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,5 @@
 Source: harfbuzz
-Version: 2.5.3
+Version: 2.6.0
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
 Build-Depends: freetype, ragel, gettext (osx)

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,5 @@
 Source: harfbuzz
-Version: 2.6.0
+Version: 2.6.2
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
 Build-Depends: freetype, ragel, gettext (osx)

--- a/ports/harfbuzz/glib-cmake.patch
+++ b/ports/harfbuzz/glib-cmake.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2d6e77e8..36e4b4e6 100644
+index a73754d..5d45102 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -306,22 +306,14 @@ endif ()
+@@ -237,21 +237,13 @@ endif ()
  if (HB_HAVE_GLIB)
    add_definitions(-DHAVE_GLIB)
  
@@ -15,11 +15,10 @@ index 2d6e77e8..36e4b4e6 100644
 -  find_path(GLIB_INCLUDE_DIR NAMES glib.h HINTS ${PC_GLIB_INCLUDEDIR} ${PC_GLIB_INCLUDE_DIRS} PATH_SUFFIXES glib-2.0)
 -
 -  include_directories(${GLIBCONFIG_INCLUDE_DIR} ${GLIB_INCLUDE_DIR})
-+  find_package(Threads REQUIRED)
-+  find_package(unofficial-iconv REQUIRED)
-+  find_package(unofficial-glib CONFIG REQUIRED)
++find_package(Threads REQUIRED)
++find_package(unofficial-iconv REQUIRED)
++find_package(unofficial-glib CONFIG REQUIRED)
  
-   list(APPEND project_sources ${PROJECT_SOURCE_DIR}/src/hb-glib.cc)
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-glib.h)
  
 -  list(APPEND THIRD_PARTY_LIBS ${GLIB_LIBRARIES})

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -57,6 +57,6 @@ ${_contents}
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/harfbuzz RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_test_cmake(PACKAGE_NAME harfbuzz)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -14,29 +14,12 @@ vcpkg_from_github(
         glib-cmake.patch
 )
 
-SET(HB_HAVE_ICU "OFF")
-if("icu" IN_LIST FEATURES)
-    SET(HB_HAVE_ICU "ON")
-endif()
-
-SET(HB_HAVE_GRAPHITE2 "OFF")
-if("graphite2" IN_LIST FEATURES)
-    SET(HB_HAVE_GRAPHITE2 "ON")
-endif()
-
-## Unicode callbacks
-
-# Builtin (UCDN)
-set(BUILTIN_UCDN OFF)
-if("ucdn" IN_LIST FEATURES)
-    set(BUILTIN_UCDN ON)
-endif()
-
-# Glib
-set(HAVE_GLIB OFF)
-if("glib" IN_LIST FEATURES)
-    set(HAVE_GLIB ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS(
+    "icu"           HB_HAVE_ICU
+    "graphite2"     HB_HAVE_GRAPHITE2
+    "ucdn"          BUILTIN_UCDN
+    "glib"          HAVE_GLIB
+)
 
 # At least one Unicode callback must be specified, or harfbuzz compilation fails
 if(NOT (BUILTIN_UCDN OR HAVE_GLIB))

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -58,5 +58,3 @@ endif()
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-vcpkg_test_cmake(PACKAGE_NAME harfbuzz)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF 2.6.0
-    SHA512 5a7d455f5f590521cc757487d21c1c92b5379b370410b181a6cbc03685f756fabad8af6cedd79cb82adea0e676e9b6385c2a123cb2e570be5dec2f13f3db3c33
+    REF 2.6.2
+    SHA512 0bb8398fbc17491b0f9c49aea0de49f8d9508fc92336b95daf65f1156a889166ac5a7778e79f794e8ea9b4253e5b36cb35938737f4416da418571a20ae6fcd98
     HEAD_REF master
     PATCHES
         0001-fix-cmake-export.patch

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF 2.5.3
-    SHA512 d541463b3647fc2c7ddaa29aedcea1c3bde5e26e0d529384d66d630af3aaf2a4befb3c4d47c93833f099339a0f951fb132011a02c57fc00ba543bd1b17026ffa
+    REF 2.6.0
+    SHA512 5a7d455f5f590521cc757487d21c1c92b5379b370410b181a6cbc03685f756fabad8af6cedd79cb82adea0e676e9b6385c2a123cb2e570be5dec2f13f3db3c33
     HEAD_REF master
     PATCHES
         0001-fix-cmake-export.patch
@@ -15,16 +15,6 @@ vcpkg_from_github(
         # This patch is required for propagating the full list of dependencies from glib
         glib-cmake.patch
 )
-
-file(READ ${SOURCE_PATH}/CMakeLists.txt _contents)
-
-if("${_contents}" MATCHES "include \\(FindFreetype\\)")
-    message(FATAL_ERROR "Harfbuzz's cmake must not directly include() FindFreetype.")
-endif()
-
-if("${_contents}" MATCHES "find_library\\(GLIB_LIBRARIES")
-    message(FATAL_ERROR "Harfbuzz's cmake must not directly find_library() glib.")
-endif()
 
 SET(HB_HAVE_ICU "OFF")
 if("icu" IN_LIST FEATURES)


### PR DESCRIPTION
- Update `harfbuzz` library to 2.6.2 version.
- ~~Remove `find-package-freetype-2.patch` patch.~~
-  ~~Remove `glib-cmake.patch` patch.~~