### PR TITLE
[abseil] fix cmake config issue

### DIFF
--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -1,5 +1,5 @@
 Source: abseil
-Version: 2019-05-08
+Version: 2019-05-08-1
 Homepage: https://github.com/abseil/abseil-cpp
 Description: an open-source collection designed to augment the C++ standard library.
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.

--- a/ports/abseil/fix-config.patch
+++ b/ports/abseil/fix-config.patch
@@ -1,0 +1,26 @@
+diff --git a/CMake/abslConfig.cmake.in b/CMake/abslConfig.cmake.in
+index 60847fa..4641d44 100644
+--- a/CMake/abslConfig.cmake.in
++++ b/CMake/abslConfig.cmake.in
+@@ -4,4 +4,8 @@ include(FindThreads)
+ 
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++
++set_and_check(absl_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
++
+ include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+\ No newline at end of file
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e7587f7..3079534 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -132,6 +132,7 @@ if(ABSL_ENABLE_INSTALL)
+     CMake/abslConfig.cmake.in
+     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+     INSTALL_DESTINATION "${ABSL_INSTALL_CONFIGDIR}"
++    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+   )
+   install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+     DESTINATION "${ABSL_INSTALL_CONFIGDIR}"

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -12,7 +12,9 @@ vcpkg_from_github(
     REF aa468ad75539619b47979911297efbb629c52e44
     SHA512 4254d8599103d8f06b03f60a0386eba07f314184217d0bca404d41fc0bd0a8df287fe6d07158d10cde096af3097aff2ecc1a5e8f7c3046ecf956b5fde709ad1d
     HEAD_REF master
-    PATCHES fix-usage-lnk-error.patch
+    PATCHES 
+        fix-usage-lnk-error.patch
+        fix-config.patch
 )
 
 vcpkg_configure_cmake(
@@ -21,7 +23,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/absl)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/absl TARGET_PATH share/absl)
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
Fix issue https://github.com/microsoft/vcpkg/issues/7706

1. abseil cmake config file name is abslConfig.cmake, however it says to find_package by 'abseil' in vcpkg. so it can't find abseilConfig.cmake or abseil-config.cmake.
Considering the project libraries name are 'absl' in its source https://github.com/abseil/abseil-cpp/blob/master/CMakeLists.txt, so install the config file to share/absl, then  find abseil by find_package(absl CONFIG REQUIRED).

    The package abseil:x64-windows provides CMake targets:
         find_package(abseil CONFIG REQUIRED)
         # Note: 74 target(s) were omitted.
          target_link_libraries(main PRIVATE absl::any absl::base absl::bits absl::city))

2. Fix issue that can't not find abseil include files.