### PR TITLE
[argagg] Update library to 0.4.6

### DIFF
--- a/ports/argagg/CONTROL
+++ b/ports/argagg/CONTROL
@@ -1,3 +1,3 @@
 Source: argagg
-Version: 2019-01-25
+Version: 0.4.6
 Description: A simple C++11 command line argument parser

--- a/ports/argagg/portfile.cmake
+++ b/ports/argagg/portfile.cmake
@@ -5,8 +5,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO vietjtnguyen/argagg
-    REF e678cebf90d8f132f5e54f19c6b95b75e655226c
-    SHA512 10085caaf9bfb507ae7117b61bfe6174dc2af91c347393c3cbb994fe5b824d4b439e1e0d2e2580dc34568d8046529acc211f76863be047d05d3845e9ff19ccbf
+    REF 0.4.6
+    SHA512 7d8cf04a7c679518f01120830637c68719dd67a765457789eb4afedbead7be9efadc6bcdf640999329aaaf8659a5e5d1896f66587068cc668a7c49703aca3070
     HEAD_REF master
 )
 


### PR DESCRIPTION
Update `argagg` library to 0.4.6 version.