### PR TITLE
[libspatialindex]Add new port 

### DIFF
--- a/ports/libspatialindex/CONTROL
+++ b/ports/libspatialindex/CONTROL
@@ -1,0 +1,6 @@
+Source: libspatialindex
+Version: 1.9.0
+Homepage: http://libspatialindex.github.com
+Description: C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.
+Build-Depends: zlib
+

--- a/ports/libspatialindex/portfile.cmake
+++ b/ports/libspatialindex/portfile.cmake
@@ -1,5 +1,7 @@
 include(vcpkg_common_functions)
 
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libspatialindex/libspatialindex

--- a/ports/libspatialindex/portfile.cmake
+++ b/ports/libspatialindex/portfile.cmake
@@ -1,18 +1,18 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libspatialindex/libspatialindex
     REF 1.9.0
     SHA512   368537e9bfe52db96486a1febfabe035f9f7714fd1cb50450e3ab89d51c5ffffb0e2ea219e08bee34f772ba9813a3a7f9e63d8b8946887ce83811ef68d17d1cc
     HEAD_REF master
+	PATCHES
+        static.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-	OPTIONS -DCMAKE_DEBUG_POSTFIX=d
+	OPTIONS -DCMAKE_DEBUG_POSTFIX=d -DSIDX_BUILD_TESTS:BOOL=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/libspatialindex/portfile.cmake
+++ b/ports/libspatialindex/portfile.cmake
@@ -1,0 +1,25 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libspatialindex/libspatialindex
+    REF 1.9.0
+    SHA512   368537e9bfe52db96486a1febfabe035f9f7714fd1cb50450e3ab89d51c5ffffb0e2ea219e08bee34f772ba9813a3a7f9e63d8b8946887ce83811ef68d17d1cc
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS -DCMAKE_DEBUG_POSTFIX=d
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+#Debug
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libspatialindex)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libspatialindex/COPYING ${CURRENT_PACKAGES_DIR}/share/libspatialindex/copyright)

--- a/ports/libspatialindex/static.patch
+++ b/ports/libspatialindex/static.patch
@@ -1,0 +1,21 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e6b733bd..8f227ab0 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -194,9 +194,13 @@ if (NOT WITH_STATIC_LASZIP)
+ endif()
+ endif()
+ 
+-add_library(${SIDX_LIB_NAME} SHARED ${SIDX_SOURCES})
+-
+-add_library(${SIDX_C_LIB_NAME} SHARED ${SIDX_CAPI_CPP})
++if(BUILD_SHARED_LIBS)
++	add_library(${SIDX_LIB_NAME} SHARED ${SIDX_SOURCES})
++	add_library(${SIDX_C_LIB_NAME} SHARED ${SIDX_CAPI_CPP})
++else(BUILD_SHARED_LIBS)
++	add_library(${SIDX_LIB_NAME} STATIC ${SIDX_SOURCES})
++	add_library(${SIDX_C_LIB_NAME} STATIC ${SIDX_CAPI_CPP})
++endif(BUILD_SHARED_LIBS)
+ 
+ target_link_libraries(${SIDX_C_LIB_NAME}
+   ${SIDX_LIB_NAME}


### PR DESCRIPTION
libspatialindex is a C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API.
This library is dependent on qgis.
for issues #7761