### PR TITLE
[fribidi]Fix static library suffix in windows-static

### DIFF
--- a/ports/fribidi/CONTROL
+++ b/ports/fribidi/CONTROL
@@ -1,3 +1,3 @@
 Source: fribidi
-Version: 58c6cb3
+Version: 2019-02-04-1
 Description: GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)

--- a/ports/fribidi/fix-win-static-suffix.patch
+++ b/ports/fribidi/fix-win-static-suffix.patch
@@ -1,0 +1,39 @@
+diff --git a/lib/meson.build b/lib/meson.build
+index 573d47f..c9b249e 100644
+--- a/lib/meson.build
++++ b/lib/meson.build
+@@ -71,14 +71,26 @@ fribidi_sources = [
+   'fribidi-shape.c',
+ ]
+ 
+-libfribidi = library('fribidi',
+-  fribidi_sources, fribidi_unicode_version_h, fribidi_config_h,
+-  generated_tab_include_files, config_h,
+-  include_directories: incs,
+-  c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+-  version: libversion,
+-  soversion: soversion,
+-  install: true)
++if host_machine.system() == 'windows' and get_option('default_library') == 'static'
++    libfribidi = library('fribidi',
++    fribidi_sources, fribidi_unicode_version_h, fribidi_config_h,
++    generated_tab_include_files, config_h,
++    include_directories: incs,
++    c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
++    version: libversion,
++    soversion: soversion,
++    install: true,
++    name_suffix: 'lib')
++else
++    libfribidi = library('fribidi',
++    fribidi_sources, fribidi_unicode_version_h, fribidi_config_h,
++    generated_tab_include_files, config_h,
++    include_directories: incs,
++    c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
++    version: libversion,
++    soversion: soversion,
++    install: true)
++endif
+ 
+ libfribidi_dep = declare_dependency(link_with: libfribidi,
+   include_directories: incs,

--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 58c6cb390a9a18c98b2cbaac555d8ea9352a9e4f
     SHA512 1ec9c19faa87886786ce1589e2c66cab173b48e34d0e43487becc8606001f21f6ed17d0abd1c322fbbcaeb96a47ed882cad228be2e9beb019020ca2a475fc298
     HEAD_REF master
+    PATCHES fix-win-static-suffix.patch
 )
 
 vcpkg_configure_meson(


### PR DESCRIPTION
Meason will set the default static library suffix to `.a`.

Related: #6789.