### PR TITLE
[paho-mqttpp3] Fix missing reference to C library headers

### DIFF
--- a/ports/paho-mqttpp3/CONTROL
+++ b/ports/paho-mqttpp3/CONTROL
@@ -1,5 +1,5 @@
 Source: paho-mqttpp3
-Version: 1.0.1-1
+Version: 1.0.1-2
 Description: Paho project provides open-source C++ wrapper for Paho C library
 Build-Depends: paho-mqtt
 Default-Features: ssl

--- a/ports/paho-mqttpp3/fix-include-path.patch
+++ b/ports/paho-mqttpp3/fix-include-path.patch
@@ -1,0 +1,182 @@
+diff --git a/src/mqtt/async_client.h b/src/mqtt/async_client.h
+index 2754690..019c81b 100644
+--- a/src/mqtt/async_client.h
++++ b/src/mqtt/async_client.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_async_client_h
+ #define __mqtt_async_client_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include "mqtt/token.h"
+ #include "mqtt/string_collection.h"
+diff --git a/src/mqtt/callback.h b/src/mqtt/callback.h
+index 6cac442..13585de 100644
+--- a/src/mqtt/callback.h
++++ b/src/mqtt/callback.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_callback_h
+ #define __mqtt_callback_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/delivery_token.h"
+ #include "mqtt/types.h"
+ #include <vector>
+diff --git a/src/mqtt/connect_options.h b/src/mqtt/connect_options.h
+index a7cdf56..adb52fb 100644
+--- a/src/mqtt/connect_options.h
++++ b/src/mqtt/connect_options.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_connect_options_h
+ #define __mqtt_connect_options_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include "mqtt/message.h"
+ #include "mqtt/topic.h"
+diff --git a/src/mqtt/delivery_token.h b/src/mqtt/delivery_token.h
+index 3ecf70b..16c47bb 100644
+--- a/src/mqtt/delivery_token.h
++++ b/src/mqtt/delivery_token.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_delivery_token_h
+ #define __mqtt_delivery_token_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/token.h"
+ #include "mqtt/message.h"
+ #include <memory>
+diff --git a/src/mqtt/disconnect_options.h b/src/mqtt/disconnect_options.h
+index 81b74ad..2f8c824 100644
+--- a/src/mqtt/disconnect_options.h
++++ b/src/mqtt/disconnect_options.h
+@@ -23,7 +23,7 @@
+ #ifndef __mqtt_disconnect_options_h
+ #define __mqtt_disconnect_options_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/token.h"
+ #include <chrono>
+ 
+diff --git a/src/mqtt/exception.h b/src/mqtt/exception.h
+index 775589f..77f4821 100644
+--- a/src/mqtt/exception.h
++++ b/src/mqtt/exception.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_exception_h
+ #define __mqtt_exception_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include <vector>
+ #include <memory>
+diff --git a/src/mqtt/iaction_listener.h b/src/mqtt/iaction_listener.h
+index 1e34577..2af8c1b 100644
+--- a/src/mqtt/iaction_listener.h
++++ b/src/mqtt/iaction_listener.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_iaction_listener_h
+ #define __mqtt_iaction_listener_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include <vector>
+ 
+diff --git a/src/mqtt/iclient_persistence.h b/src/mqtt/iclient_persistence.h
+index 852ec8e..aa721bc 100644
+--- a/src/mqtt/iclient_persistence.h
++++ b/src/mqtt/iclient_persistence.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_iclient_persistence_h
+ #define __mqtt_iclient_persistence_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include "mqtt/buffer_view.h"
+ #include "mqtt/string_collection.h"
+diff --git a/src/mqtt/message.h b/src/mqtt/message.h
+index feb3b97..bdab5d8 100644
+--- a/src/mqtt/message.h
++++ b/src/mqtt/message.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_message_h
+ #define __mqtt_message_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/buffer_ref.h"
+ #include "mqtt/exception.h"
+ #include <memory>
+diff --git a/src/mqtt/response_options.h b/src/mqtt/response_options.h
+index 6fc727f..dca2013 100644
+--- a/src/mqtt/response_options.h
++++ b/src/mqtt/response_options.h
+@@ -7,7 +7,7 @@
+ #ifndef __mqtt_response_options_h
+ #define __mqtt_response_options_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/token.h"
+ #include "mqtt/delivery_token.h"
+ 
+diff --git a/src/mqtt/ssl_options.h b/src/mqtt/ssl_options.h
+index ca2f847..64a3afc 100644
+--- a/src/mqtt/ssl_options.h
++++ b/src/mqtt/ssl_options.h
+@@ -25,7 +25,7 @@
+ #ifndef __mqtt_ssl_options_h
+ #define __mqtt_ssl_options_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/message.h"
+ #include "mqtt/topic.h"
+ #include "mqtt/types.h"
+diff --git a/src/mqtt/token.h b/src/mqtt/token.h
+index 0db8196..e4fe10e 100644
+--- a/src/mqtt/token.h
++++ b/src/mqtt/token.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_token_h
+ #define __mqtt_token_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/iaction_listener.h"
+ #include "mqtt/exception.h"
+ #include "mqtt/types.h"
+diff --git a/src/mqtt/topic.h b/src/mqtt/topic.h
+index f68005a..61e53f0 100644
+--- a/src/mqtt/topic.h
++++ b/src/mqtt/topic.h
+@@ -24,7 +24,7 @@
+ #ifndef __mqtt_topic_h
+ #define __mqtt_topic_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/delivery_token.h"
+ #include "mqtt/message.h"
+ #include "mqtt/types.h"
+diff --git a/src/mqtt/will_options.h b/src/mqtt/will_options.h
+index bffb9e0..d7eca10 100644
+--- a/src/mqtt/will_options.h
++++ b/src/mqtt/will_options.h
+@@ -25,7 +25,7 @@
+ #ifndef __mqtt_will_options_h
+ #define __mqtt_will_options_h
+ 
+-#include "MQTTAsync.h"
++#include "paho-mqtt/MQTTAsync.h"
+ #include "mqtt/types.h"
+ #include "mqtt/message.h"
+ #include "mqtt/topic.h"

--- a/ports/paho-mqttpp3/portfile.cmake
+++ b/ports/paho-mqttpp3/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
   REF v1.0.1
   SHA512 be612197fae387b9f1d8f10944d451ec9e7ebec6045beed365e642089c0a5fde882ed5c734f2b46a5008f98b8445a51114492f0f36fdc684b8a8fe4b71fe31a4
   HEAD_REF master
+  PATCHES
+    fix-include-path.patch  
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS 
@@ -24,7 +26,7 @@ else()
 endif()
 
 # Setting the include path where MqttClient.h is present
-set(PAHO_C_INC "${CURRENT_INSTALLED_DIR}/include/paho-mqtt")
+set(PAHO_C_INC "${CURRENT_INSTALLED_DIR}/include")
 
 # Set the generator to Ninja
 set(PAHO_CMAKE_GENERATOR "Ninja")


### PR DESCRIPTION
  When to build, set the include directory  paho-mqtt, is ok. But when user use  C++ library headers, not set the include directory paho-mqtt, so cannot open include file: 'MQTTAsync.h'. The solution is to delete the  directory paho-mqtt in portfile.cmake, add paho-mqtt directory in 14 header files. Relate: #7725