### PR TITLE
[ignition-cmake0, ignition-math4] Add support for writing ports of Ignition Robotics libraries 🤖

### DIFF
--- a/ports/ignition-cmake0/CONTROL
+++ b/ports/ignition-cmake0/CONTROL
@@ -1,0 +1,7 @@
+Source: ignition-cmake0
+Version: 0.6.2
+Homepage: https://ignitionrobotics.org/libs/cmake
+Description: CMake helper functions for building robotic applications
+Build-Depends: ignition-modularscripts
+
+

--- a/ports/ignition-cmake0/do-not-compile-gtest.patch
+++ b/ports/ignition-cmake0/do-not-compile-gtest.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/IgnConfigureBuild.cmake b/cmake/IgnConfigureBuild.cmake
+--- a/cmake/IgnConfigureBuild.cmake
++++ b/cmake/IgnConfigureBuild.cmake
+@@ -109,7 +109,9 @@
+     # Add all the source code directories
+     add_subdirectory(src)
+     add_subdirectory(include)
+-    add_subdirectory(test)
++    if(BUILD_TESTING)
++      add_subdirectory(test)
++    endif()
+ 
+ 
+     #--------------------------------------

--- a/ports/ignition-cmake0/portfile.cmake
+++ b/ports/ignition-cmake0/portfile.cmake
@@ -1,0 +1,24 @@
+include(vcpkg_common_functions)
+
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+set(PACKAGE_VERSION "0.6.1")
+
+ignition_modular_library(NAME cmake
+                         VERSION ${PACKAGE_VERSION} 
+                         REF "ignition-cmake_${PACKAGE_VERSION}"
+                         SHA512 fcd3ad6b5289697c4928c71b820e2adaa758c730f52cba3f8cc714e44ca0c9f04f432ae5b98b5f258c4851c4666740b58066a25c55ff3a6de975cd8a57991b6b
+                         # Ensure that gtest is not compiled (backport of https://bitbucket.org/ignitionrobotics/ign-cmake/pull-requests/163)
+                         PATCHES do-not-compile-gtest.patch
+						 # Support for ARM64 (backport of https://bitbucket.org/ignitionrobotics/ign-cmake/pull-requests/168)
+						         support-arm64.patch
+						 )
+
+# Permit empty include folder
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+# Remove unneccessary directory, as ignition-cmake is a pure CMake package
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
+
+# Install custom usage
+configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)

--- a/ports/ignition-cmake0/support-arm64.patch
+++ b/ports/ignition-cmake0/support-arm64.patch
@@ -1,0 +1,17 @@
+diff -r 8a976a308d77 -r 1bea7874cfec cmake/IgnSetCompilerFlags.cmake
+--- a/cmake/IgnSetCompilerFlags.cmake
++++ b/cmake/IgnSetCompilerFlags.cmake
+@@ -279,13 +279,6 @@
+   # Don't pull in the Windows min/max macros
+   add_definitions(-DNOMINMAX)
+ 
+-  if (MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+-    # Not needed if a proper cmake generator (-G "...Win64") is passed
+-    # to cmake. Enable as a second measure to work around bug
+-    # http://www.cmake.org/Bug/print_bug_page.php?bug_id=11240
+-    set(CMAKE_SHARED_LINKER_FLAGS "/machine:x64")
+-  endif()
+-
+   if(USE_IGN_RECOMMENDED_FLAGS)
+ 
+     # Gy: Prevent errors caused by multiply-defined symbols

--- a/ports/ignition-cmake0/usage
+++ b/ports/ignition-cmake0/usage
@@ -1,0 +1,3 @@
+The package ignition-cmake0 provides CMake integration:
+
+    find_package(ignition-cmake0 CONFIG REQUIRED)

--- a/ports/ignition-math4/CONTROL
+++ b/ports/ignition-math4/CONTROL
@@ -1,0 +1,5 @@
+Source: ignition-math4
+Version: 4.0.0
+Homepage: https://ignitionrobotics.org/libs/math
+Build-Depends: ignition-cmake0
+Description: Math API for robotic applications

--- a/ports/ignition-math4/portfile.cmake
+++ b/ports/ignition-math4/portfile.cmake
@@ -1,0 +1,7 @@
+include(vcpkg_common_functions)
+
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME math
+                         VERSION "4.0.0"
+                         SHA512 09023b559e7e544e628131189f3a7f57a9b73868f66f81e5ce1a353092940949973e1753f18ead8f655ad88c0e1d1bf51bbf63163760694aab7a97a4c0f6d519)

--- a/ports/ignition-modularscripts/CONTROL
+++ b/ports/ignition-modularscripts/CONTROL
@@ -1,0 +1,3 @@
+Source: ignition-modularscripts
+Version: 2019-08-20
+Description: Vcpkg helpers to package ignition libraries

--- a/ports/ignition-modularscripts/ignition_modular_library.cmake
+++ b/ports/ignition-modularscripts/ignition_modular_library.cmake
@@ -1,0 +1,106 @@
+
+function(ignition_modular_build_library NAME MAJOR_VERSION SOURCE_PATH)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS -DBUILD_TESTING=OFF
+    )
+
+    vcpkg_install_cmake()
+
+    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/ignition-${NAME}${MAJOR_VERSION}")
+
+    file(GLOB_RECURSE CMAKE_RELEASE_FILES 
+                      "${CURRENT_PACKAGES_DIR}/lib/cmake/ignition-${NAME}${MAJOR_VERSION}/*")
+
+    file(COPY ${CMAKE_RELEASE_FILES} DESTINATION 
+              "${CURRENT_PACKAGES_DIR}/share/ignition-${NAME}${MAJOR_VERSION}/")
+
+    # Remove debug files
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include 
+                        ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+                        ${CURRENT_PACKAGES_DIR}/debug/share)
+
+    # Post-build test for cmake libraries 
+    vcpkg_test_cmake(PACKAGE_NAME ignition-${NAME}${MAJOR_VERSION})
+
+    # Find the relevant license file and install it
+    if(EXISTS "${SOURCE_PATH}/LICENSE")
+        set(LICENSE_PATH "${SOURCE_PATH}/LICENSE")
+    elseif(EXISTS "${SOURCE_PATH}/README.md")
+        set(LICENSE_PATH "${SOURCE_PATH}/README.md")
+    endif()
+    file(INSTALL ${LICENSE_PATH} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+endfunction()
+
+## # ignition_modular_library
+##
+## Download and build a library from the Ignition Robotics project ( https://ignitionrobotics.org/ ).
+##
+## ## Usage:
+## ```cmake
+## ignition_modular_library(NAME <name>
+##                          VERSION <version>
+##                          SHA512 <sha512>
+##                          [REF <ref>]
+##                          [HEAD_REF <head_ref>]
+##                          [PATCHES <patches>])
+## ```
+##
+## ## Parameters:
+## ### NAME
+## The name of the specific ignition library, i.e. `cmake` for `ignition-cmake0`, `math` for `ignition-math4`.
+##
+## ### VERSION
+## The complete version number.
+##
+## ### SHA512
+## The SHA512 hash that should match the downloaded  archive. This is forwarded to the `vcpkg_from_bitbucket` command.
+##
+## ### REF
+## Reference to the tag of the desired release. This is forwarded to the `vcpkg_from_bitbucket` command.
+## If not specified, defaults to `ignition-${NAME}${MAJOR_VERSION}_${VERSION}`.
+##
+## ### HEAD_REF
+## Reference (tag) to the desired release. This is forwarded to the `vcpkg_from_bitbucket` command.
+## If not specified, defaults to `ign-${NAME}${MAJOR_VERSION}`.
+##
+## ### PATCHES
+## A list of patches to be applied to the extracted sources.
+##  This is forwarded to the `vcpkg_from_bitbucket` command.
+##
+## ## Examples:
+##
+## * [ignition-cmake0](https://github.com/Microsoft/vcpkg/blob/master/ports/ignition-cmake0/portfile.cmake)
+## * [ignition-math4](https://github.com/Microsoft/vcpkg/blob/master/ports/ignition-math4/portfile.cmake)
+function(ignition_modular_library)
+    set(oneValueArgs NAME VERSION SHA512 REF HEAD_REF)
+	set(multiValueArgs PATCHES)
+    cmake_parse_arguments(IML "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    
+    string(REPLACE "." ";" IML_VERSION_LIST ${IML_VERSION})
+    list(GET IML_VERSION_LIST 0 IML_MAJOR_VERSION)
+    
+    # If the REF option is omitted, use the canonical one 
+    if(NOT DEFINED IML_REF)
+        set(IML_REF "ignition-${IML_NAME}${IML_MAJOR_VERSION}_${IML_VERSION}")
+    endif()
+    
+    # If the HEAD_REF option is omitted, use the canonical one 
+    if(NOT DEFINED IML_HEAD_REF)
+        set(IML_HEAD_REF "ign-${IML_NAME}${IML_MAJOR_VERSION}")
+    endif()
+    
+    # Download library from bitbucket, to support also the --head option
+    vcpkg_from_bitbucket(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO ignitionrobotics/ign-${IML_NAME}
+        REF ${IML_REF}
+        SHA512 ${IML_SHA512}
+        HEAD_REF ${IML_HEAD_REF}
+        PATCHES ${IML_PATCHES}
+    )
+    
+    # Build library
+    ignition_modular_build_library(${IML_NAME} ${IML_MAJOR_VERSION} ${SOURCE_PATH})
+endfunction()

--- a/ports/ignition-modularscripts/portfile.cmake
+++ b/ports/ignition-modularscripts/portfile.cmake
@@ -1,0 +1,8 @@
+file(COPY
+    ${CMAKE_CURRENT_LIST_DIR}/ignition_modular_library.cmake
+    DESTINATION
+        ${CURRENT_PACKAGES_DIR}/share/ignitionmodularscripts
+)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/ignitionmodularscripts/copyright "")
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)


### PR DESCRIPTION
The Ignition Robotics Libraries ( https://ignitionrobotics.org ) are a set of libraries that are used to develop robotics applications. In particular, they are dependencies for the widely used Gazebo simulator ( http://gazebosim.org ).

In this PR, three ports are added: 
* `ignition-modularscript` ( https://github.com/microsoft/vcpkg/commit/8fb25c18fc34249fd7c496607a01b862a6e9d9d1 )
* `ignition-cmake0` : A port for the version 0 of the ignition-cmake (https://ignitionrobotics.org/libs/cmake) library 
* `ignition-math4` : A port for the version 4 of the ignition-math (https://ignitionrobotics.org/libs/math)  library 

As most ignition libraries follow the same structure and convention, the use of `ignition-modularscript` reduces the process of writing a port of an ignition library to a few lines, unless the library has some particular features, for which custom lines can be added to the portfile.

One interesting feature of the ignition libraries  is that they different major version of the same library can be installed side-by-side in the same system. For this reason, it is quite natural to create a port for each major supported version, to enable user and downstream project to autonomously select which major version of the library they need. This is the reason why, as a first example of ports, Ignition CMake 0 and  Ignition Math 4 are added even if more recent version have been released as well, as they are the version used as dependencies for the latest stable version of the Gazebo robotic simulator. 