### PR TITLE
[moos-ui] Fix install path

### DIFF
--- a/ports/moos-ui/CONTROL
+++ b/ports/moos-ui/CONTROL
@@ -1,7 +1,5 @@
 Source: moos-ui
-Version: 10.0.1-1
+Version: 10.0.1-2
 Description: set of user interface tools to use and leverage the MOOS project.
 Homepage: https://sites.google.com/site/moossoftware/
 Build-Depends: moos-core
-
-

--- a/ports/moos-ui/portfile.cmake
+++ b/ports/moos-ui/portfile.cmake
@@ -19,9 +19,13 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/MOOS)
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke.exe)
-file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite.exe)
-
+if (VCPKG_TARGET_IS_WINDOWS)
+	file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke.exe)
+	file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite.exe)
+else()
+	file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke)
+	file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite)
+endif()
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/MOOS) 
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug)

--- a/ports/moos-ui/portfile.cmake
+++ b/ports/moos-ui/portfile.cmake
@@ -19,19 +19,12 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/MOOS)
-if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/uPoke")
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite)
-endif()
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPoke.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/uPoke.exe)
+file(RENAME ${CURRENT_PACKAGES_DIR}/bin/iRemoteLite.exe ${CURRENT_PACKAGES_DIR}/tools/MOOS/iRemoteLite.exe)
 
-#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uMS ${CURRENT_PACKAGES_DIR}/tools/uMS)
-#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/uPlayback ${CURRENT_PACKAGES_DIR}/tools/uPlayback)
-#    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/pShare ${CURRENT_PACKAGES_DIR}/tools/pShare)
-#endif()
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/MOOS) 
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug)
-endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug)
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/fake_header_ui.h "// fake header to pass vcpkg post install check \n")
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright "see moos-core for copyright\n" )


### PR DESCRIPTION
Fix build error:
```
The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    E:/v-wangli/4/vcpkg/packages/moos-ui_x64-windows/bin/iRemoteLite.exe
    E:/v-wangli/4/vcpkg/packages/moos-ui_x64-windows/bin/uPoke.exe

The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    E:/v-wangli/4/vcpkg/packages/moos-ui_x64-windows/debug/bin/iRemoteLite.exe
    E:/v-wangli/4/vcpkg/packages/moos-ui_x64-windows/debug/bin/uPoke.exe

There should be no empty directories in E:\v-wangli\4\vcpkg\packages\moos-ui_x64-windows
The following empty directories were found:

    E:/v-wangli/4/vcpkg/packages/moos-ui_x64-windows/tools/MOOS
```