### PR TITLE
[ixwebsocket] update to 6.1.0 to fix Windows problem

### DIFF
--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,5 +1,5 @@
 Source: ixwebsocket
-Version: 5.0.4
+Version: 5.0.6
 Build-Depends: zlib
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server
 Default-Features: ssl

--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,5 +1,5 @@
 Source: ixwebsocket
-Version: 5.0.6
+Version: 6.1.0
 Build-Depends: zlib
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server
 Default-Features: ssl

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF v5.0.6
-    SHA512 8e908fd836ac2d6721bb72c21763f4e07175d5b19767ae86bc042415d702d288b16c7e272c7b116790666d459bb2eb06cad28c97547a5df802de78202fbd9644
+    REF v6.1.0
+    SHA512 5f19f2b220b87f9300a1d67e527ee2ee26d459e185357c2c121a2ce359fc8e5f04bd714c225b0f309ebcb6e416d7ca15ca93a88409fa09f88f065dec0a37bbe2
 )
 
 vcpkg_configure_cmake(

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF v5.0.4
-    SHA512 8e8f0050251ba71fa3bba01adbf6fd1a797518115ac8207481b89aebcadc310b98451cc141f3c8f69a0b8397f35b6e0fe51c65fbdc3d7d5e2a4271472f422b13
+    REF v5.0.6
+    SHA512 8e908fd836ac2d6721bb72c21763f4e07175d5b19767ae86bc042415d702d288b16c7e272c7b116790666d459bb2eb06cad28c97547a5df802de78202fbd9644
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Some test started to fail on Windows in the 5.0 branch.
```
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
ERROR: Unable to connect to echo.websocket.org on port 80, error: Connect error: No error
```
We figured it out and fixed it. This issue has more details. https://github.com/machinezone/IXWebSocket/issues/103