### PR TITLE
[ogdf] Update source link

### DIFF
--- a/ports/ogdf/CONTROL
+++ b/ports/ogdf/CONTROL
@@ -1,3 +1,4 @@
 Source: ogdf
-Version: 2018-03-28-2
+Version: 2019-08-23
+Homepage: https://github.com/ogdf/ogdf
 Description: Open Graph Drawing Framework

--- a/ports/ogdf/portfile.cmake
+++ b/ports/ogdf/portfile.cmake
@@ -1,11 +1,12 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/2018-03-28/OGDF-snapshot)
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.ogdf.net/lib/exe/fetch.php/tech%3aogdf-snapshot-2018-03-28.zip"
-    FILENAME "ogdf-2018-03-28.zip"
-    SHA512 a6ddb33bc51dca4d59fcac65ff66459043b11ce5303e9d40e4fc1756adf84a0af7d0ac7debab670111e7a145dcdd9373c0e350d5b7e831b169811f246b6e19b6
+
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO ogdf/ogdf
+	REF  8a103cf3a7dfff87fe8b7534575604bc53c0870c
+	SHA512 264e8586be7a18640f253eb7b289dd99f1f2fc42c4d2304ab12f7c6aa9c5754b710642e7296038aea0cd9368d732d0106501fefed800743b403adafff7e3f0b2
+    HEAD_REF master
 )
-vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/src/2018-03-28)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Fix build error:
```
.\vcpkg.exe install ogdf
The following packages will be built and installed:
    ogdf[core]:x86-windows
Starting package 1/1: ogdf:x86-windows
Building package ogdf[core]:x86-windows...
-- Downloading http://www.ogdf.net/lib/exe/fetch.php/tech%3aogdf-snapshot-2018-03-28.zip...
-- Downloading http://www.ogdf.net/lib/exe/fetch.php/tech%3aogdf-snapshot-2018-03-28.zip... Failed. Status: 6;"Couldn't resolve host name"
CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:172 (message):

      Failed to download file.
      If you use a proxy, please set the HTTPS_PROXY and HTTP_PROXY environment
      variables to "https://user:password@your-proxy-ip-address:port/".
      Otherwise, please submit an issue at https://github.com/Microsoft/vcpkg/issues

Call Stack (most recent call first):
  ports/ogdf/portfile.cmake:3 (vcpkg_download_distfile)
  scripts/ports.cmake:85 (include)
```
Related issue: #7841 