### PR TITLE
[vcpkg] Move do_build_package_and_clean_buildtrees() above generating vcpkg_abi_info.txt so it will be included in the package.

### DIFF
--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -872,13 +872,13 @@ namespace vcpkg::Build
             System::printf("Could not locate cached archive: %s\n", archive_path.u8string());
         }
 
+        ExtendedBuildResult result = do_build_package_and_clean_buildtrees(
+            paths, pre_build_info, spec, pre_build_info.public_abi_override.value_or(abi_tag_and_file->tag), config);
+
         fs.create_directories(abi_package_dir, ec);
         Checks::check_exit(VCPKG_LINE_INFO, !ec, "Coud not create directory %s", abi_package_dir.u8string());
         fs.copy_file(abi_tag_and_file->tag_file, abi_file_in_package, fs::stdfs::copy_options::none, ec);
         Checks::check_exit(VCPKG_LINE_INFO, !ec, "Could not copy into file: %s", abi_file_in_package.u8string());
-
-        ExtendedBuildResult result = do_build_package_and_clean_buildtrees(
-            paths, pre_build_info, spec, pre_build_info.public_abi_override.value_or(abi_tag_and_file->tag), config);
 
         if (config.build_package_options.binary_caching == BinaryCaching::YES && result.code == BuildResult::SUCCEEDED)
         {


### PR DESCRIPTION
This reverts the movement:

https://github.com/microsoft/vcpkg/commit/0c7d8f414669c6e025794c374f2837e5fa24d02b#diff-7c78ff08e66ca1729315028943b36e19R860-R872

This PR will:
1. Restore `vcpkg_abi_info.txt` being included inside binary packages.
2. Fix a crash due to `copy_options::none` if a previous version of vcpkg was used previously and placed a file in the location.