### PR TITLE
[glfw3]Add more information about installing dependencies.

### DIFF
--- a/ports/glfw3/CONTROL
+++ b/ports/glfw3/CONTROL
@@ -1,4 +1,4 @@
 Source: glfw3
-Version: 3.3-1
+Version: 3.3-2
 Homepage: https://github.com/glfw/glfw
 Description: GLFW is a free, Open Source, multi-platform library for OpenGL, OpenGL ES and Vulkan application development. It provides a simple, platform-independent API for creating windows, contexts and surfaces, reading input, handling events, etc.

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -9,13 +9,15 @@ vcpkg_from_github(
     PATCHES move-cmake-min-req.patch
 )
 
-if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(
 "GLFW3 currently requires the following libraries from the system package manager:
     xinerama
     xcursor
+    xorg
+    libglu1-mesa
 
-These can be installed on Ubuntu systems via sudo apt install libxinerama-dev libxcursor-dev")
+These can be installed on Ubuntu systems via sudo apt install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev")
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Building glfw3 requires installing xorg-dev and libglu1-mesa-dev.
So add them to the prompt message.

Related: #7187. 