### PR TITLE
[libwebp]Fix two dependent windows library link conditions.

### DIFF
--- a/ports/libwebp/0006-fix-dependecies-platform.patch
+++ b/ports/libwebp/0006-fix-dependecies-platform.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 83edb3a..f634094 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -540,7 +540,10 @@ if(WEBP_BUILD_EXTRAS)
+   find_package(SDL)
+   if(SDL_FOUND)
+     add_executable(vwebp_sdl ${VWEBP_SDL_SRCS})
+-    target_link_libraries(vwebp_sdl ${SDL_LIBRARY} imageioutil webp dxguid winmm)
++    target_link_libraries(vwebp_sdl ${SDL_LIBRARY} imageioutil webp)
++    if (MSVC)
++        target_link_libraries(vwebp_sdl dxguid winmm)
++    endif()
+     target_include_directories(vwebp_sdl
+                                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                        ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebp
-Version: 1.0.2-6
+Version: 1.0.2-7
 Homepage: https://github.com/webmproject/libwebp
 Description: Lossy compression of digital photographic images.
 Build-Depends: opengl

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     0003-remove-missing-symbol.patch
     0004-add-missing-linked-library.patch
     0005-fix-static-build.patch
+    0006-fix-dependecies-platform.patch
 )
 
 set(WEBP_BUILD_ANIM_UTILS OFF)


### PR DESCRIPTION
dxguid.lib and winmm.lib shouldn't be linked to libwebp:x64-linux.

Related: #7842.