### PR TITLE
[openblas]Enable x86 build and fix usage errors.

### DIFF
--- a/ports/openblas/CONTROL
+++ b/ports/openblas/CONTROL
@@ -1,5 +1,5 @@
 Source: openblas
-Version: 0.3.6-5
+Version: 0.3.6-6
 Homepage: https://github.com/xianyi/OpenBLAS
 Build-Depends: pthread (linux)
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.

--- a/ports/openblas/fix-redefinition-function.patch
+++ b/ports/openblas/fix-redefinition-function.patch
@@ -16,7 +16,7 @@ index 52dd49d..239219d 100644
    #define openblas_complex_xdouble_imag(z)           (cimag(z))
 +  #endif
  #else
-+  #ifned OPENBLAS_COMPLEX_STRUCT
++  #ifndef OPENBLAS_COMPLEX_STRUCT
    #define OPENBLAS_COMPLEX_STRUCT
    typedef struct { float real, imag; } openblas_complex_float;
    typedef struct { double real, imag; } openblas_complex_double;

--- a/ports/openblas/fix-redefinition-function.patch
+++ b/ports/openblas/fix-redefinition-function.patch
@@ -1,0 +1,28 @@
+diff --git a/openblas_config_template.h b/openblas_config_template.h
+index 52dd49d..239219d 100644
+--- a/openblas_config_template.h
++++ b/openblas_config_template.h
+@@ -64,6 +64,7 @@ typedef int blasint;
+ #ifndef __cplusplus
+   #include <complex.h>
+ #endif
++  #ifndef OPENBLAS_COMPLEX_STRUCT
+   typedef float _Complex openblas_complex_float;
+   typedef double _Complex openblas_complex_double;
+   typedef xdouble _Complex openblas_complex_xdouble;
+@@ -76,7 +77,9 @@ typedef int blasint;
+   #define openblas_complex_double_imag(z)            (cimag(z))
+   #define openblas_complex_xdouble_real(z)           (creal(z))
+   #define openblas_complex_xdouble_imag(z)           (cimag(z))
++  #endif
+ #else
++  #ifned OPENBLAS_COMPLEX_STRUCT
+   #define OPENBLAS_COMPLEX_STRUCT
+   typedef struct { float real, imag; } openblas_complex_float;
+   typedef struct { double real, imag; } openblas_complex_double;
+@@ -90,4 +93,5 @@ typedef int blasint;
+   #define openblas_complex_double_imag(z)            ((z).imag)
+   #define openblas_complex_xdouble_real(z)           ((z).real)
+   #define openblas_complex_xdouble_imag(z)           ((z).imag)
++  #endif
+ #endif

--- a/ports/openblas/openblas_common.h
+++ b/ports/openblas/openblas_common.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "openblas_config.h"
+#include "openblas/openblas_config.h"
 
 #if defined(OPENBLAS_OS_WINNT) || defined(OPENBLAS_OS_CYGWIN_NT) || defined(OPENBLAS_OS_INTERIX)
 #define OPENBLAS_WINDOWS_ABI

--- a/ports/openblas/openblas_common.h
+++ b/ports/openblas/openblas_common.h
@@ -57,6 +57,7 @@ typedef int blasint;
    predefined macros with some compilers (e.g. GCC 4.7 on Linux).  This occurs
    as a side effect of including either <features.h> or <stdc-predef.h>. */
 #include <stdio.h>
+#ifndef OPENBLAS_COMPLEX_STRUCT
 #define OPENBLAS_COMPLEX_STRUCT
 typedef struct { float real, imag; } openblas_complex_float;
 typedef struct { double real, imag; } openblas_complex_double;
@@ -70,3 +71,4 @@ typedef struct { xdouble real, imag; } openblas_complex_xdouble;
 #define openblas_complex_double_imag(z)            ((z).imag)
 #define openblas_complex_xdouble_real(z)           ((z).real)
 #define openblas_complex_xdouble_imag(z)           ((z).imag)
+#endif

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,9 +1,5 @@
 include(vcpkg_common_functions)
 
-if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    message(FATAL_ERROR "openblas can only be built for x64 currently")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         uwp.patch
         fix-space-path.patch
+        fix-redefinition-function.patch
 )
 
 find_program(GIT NAMES git git.cmd)


### PR DESCRIPTION
1. Enable openblas:x86-windows build.
2. Fix **openblas_config.h** include path in **openblas_common.h**
3. Fix **OPENBLAS_COMPLEX_STRUCT** redefinition errors.