### PR TITLE
[casclib] Update library to 1.50b

### DIFF
--- a/ports/casclib/CONTROL
+++ b/ports/casclib/CONTROL
@@ -1,4 +1,4 @@
 Source: casclib
-Version: 1.50-1
+Version: 1.50b-1
 Build-Depends: zlib
 Description: An open-source implementation of library for reading CASC storage from Blizzard games since 2014

--- a/ports/casclib/ctype_for_mac.patch
+++ b/ports/casclib/ctype_for_mac.patch
@@ -1,16 +1,11 @@
 diff --git a/src/CascPort.h b/src/CascPort.h
-index 87a2f2f..da74aef 100644
+index 3bd08d4..201f7dd 100644
 --- a/src/CascPort.h
 +++ b/src/CascPort.h
-@@ -79,14 +79,19 @@
-   #include <sys/types.h>
-   #include <sys/stat.h>
-   #include <sys/mman.h>
--  #include <unistd.h>
-   #include <fcntl.h>
--  #include <stdlib.h>
+@@ -85,10 +85,17 @@
+   #include <stdlib.h>
    #include <dirent.h>
--  #include <errno.h>
+   #include <errno.h>
 +  #include <unistd.h>
    #include <stddef.h>
 +  #include <stdint.h>
@@ -18,7 +13,7 @@ index 87a2f2f..da74aef 100644
 +  #include <stdio.h>
 +  #include <stdarg.h>
    #include <string.h>
-+  #include <ctype.h>
+   #include <ctype.h>
 +  #include <wchar.h>
    #include <cassert>
 +  #include <errno.h>

--- a/ports/casclib/portfile.cmake
+++ b/ports/casclib/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ladislav-zezula/CascLib
-    REF 1.50
-    SHA512 7e95e314f09e504566e6fa2b1742f986d17526fb0283af8ffb77681338c9a852d369cbd863512a20ddd3a277d10a9bf701d745f500a717826dd08e201eb6d80e
+    REF 1.50b
+    SHA512 f32cc592f454db4815c0dfd18a9c0076d85b1582e6974d241d1d4094269c42a978fa42186504988ced2c8f4a0b598f41e3ec8a95ddc3c0551af997e37708b1f5
     HEAD_REF master
     PATCHES
         ctype_for_mac.patch


### PR DESCRIPTION
- Update `casclib` library to 1.50b version.
- Fix `ctype_for_mac.patch` patch file.