### PR TITLE
[magic-enum] Update to v0.6.0

### DIFF
--- a/ports/magic-enum/CONTROL
+++ b/ports/magic-enum/CONTROL
@@ -1,3 +1,3 @@
 Source: magic-enum
-Version: 2019-06-07
+Version: 0.6.0
 Description: Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.

--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO "Neargye/magic_enum"
-    REF 4dfaa4b7b4814c2cf85b08ad3084fc28c8b129c6
-    SHA512 924e5a134f4200652fdc3f3d676b49efa8c30b5577d638f60134ce81092b23f7976a494ce50b58b25ed7bce0653a7e29206acf9e512408c4701ec6822ab2d176
+    REF v0.6.0
+    SHA512 3079155509f0141e9a50b2a773e33e3ebda1a4c1a7d0b78f093e2d0e8a4b78ef108876e63ef986a55c03bb712a494943b7c4c37bcbe08d932035106f4afe3bd2
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
https://github.com/Neargye/magic_enum/releases/tag/v0.6.0