### PR TITLE
magnum: Fix KHR/khrplatform.h not found on vcpkg in VS

### DIFF
--- a/ports/magnum/004-khrplatform-include.patch
+++ b/ports/magnum/004-khrplatform-include.patch
@@ -1,0 +1,13 @@
+diff --git a/src/MagnumExternal/OpenGL/GL/flextGL.h b/src/MagnumExternal/OpenGL/GL/flextGL.h
+index 7d36f26e3..69cc8c82f 100644
+--- a/src/MagnumExternal/OpenGL/GL/flextGL.h
++++ b/src/MagnumExternal/OpenGL/GL/flextGL.h
+@@ -118,7 +118,7 @@ void flextGLInit(Magnum::GL::Context& context);
+
+ /* Data types */
+
+-#include <KHR/khrplatform.h>
++#include "MagnumExternal/OpenGL/KHR/khrplatform.h"
+ typedef unsigned int GLenum;
+ typedef unsigned char GLboolean;
+ typedef unsigned int GLbitfield;

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_apply_patches(
         ${CMAKE_CURRENT_LIST_DIR}/001-sdl-includes.patch
         ${CMAKE_CURRENT_LIST_DIR}/002-tools-path.patch
         ${CMAKE_CURRENT_LIST_DIR}/003-glfw-find-module.patch
+        ${CMAKE_CURRENT_LIST_DIR}/004-khrplatform-include.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)


### PR DESCRIPTION
Hi all!

The following diff fixes an include not found when using vcpkg in VS instead of through cmake.
@mosra will formally approve this PR in a few minutes.

Cheers, Jonathan.