### PR TITLE
[vcpkg] fix bug in StringView::operator== 😱

### DIFF
--- a/toolsrc/src/vcpkg-test/stringview.cpp
+++ b/toolsrc/src/vcpkg-test/stringview.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch.hpp>
+
+#include <vcpkg/base/stringview.h>
+
+template <std::size_t N>
+static vcpkg::StringView sv(const char (&cstr)[N]) {
+	return cstr;
+}
+
+TEST_CASE("string view operator==", "[stringview]") {
+	// these are due to a bug in operator==
+	// see commit 782723959399a1a0725ac49
+	REQUIRE(sv("hey") != sv("heys"));
+	REQUIRE(sv("heys") != sv("hey"));
+	REQUIRE(sv("hey") == sv("hey"));
+	REQUIRE(sv("hey") != sv("hex"));
+}

--- a/toolsrc/src/vcpkg/base/stringview.cpp
+++ b/toolsrc/src/vcpkg/base/stringview.cpp
@@ -78,7 +78,7 @@ namespace vcpkg
 
     bool operator==(StringView lhs, StringView rhs) noexcept
     {
-        return lhs.size() == lhs.size() && memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+        return lhs.size() == rhs.size() && memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
     }
 
     bool operator!=(StringView lhs, StringView rhs) noexcept { return !(lhs == rhs); }


### PR DESCRIPTION
Before this change, `lhs == rhs` missed the check for
`lhs.size() == rhs.size()`, and then did a `memcmp` on the buffers up to
`lhs.size()`. This means that, if `lhs.size() < rhs.size()`, it would
allow two unequal strings to compare equal if, up to `lhs.size()` they
are the same; and if `lhs.size() > rhs.size()`, then it would read out
of bounds.