### PR TITLE
[dimcli] Fix build failed with Visual Studio 2019

### DIFF
--- a/ports/dimcli/CONTROL
+++ b/ports/dimcli/CONTROL
@@ -1,4 +1,4 @@
 Source: dimcli
-Version: 5.0.0
+Version: 5.0.0-1
 Homepage: https://github.com/gknowles/dimcli
 Description: C++ command line parser toolkit

--- a/ports/dimcli/fix-NameBoolean.patch
+++ b/ports/dimcli/fix-NameBoolean.patch
@@ -1,8 +1,8 @@
 diff --git a/libs/dimcli/cli.cpp b/libs/dimcli/cli.cpp
-index 9e67c12..c96bd24 100644
+index 45dac3b..6129884 100644
 --- a/libs/dimcli/cli.cpp
 +++ b/libs/dimcli/cli.cpp
-@@ -388,8 +388,8 @@ GroupConfig const & Cli::Config::findGrpOrDie(Cli const & cli) {
+@@ -392,8 +392,8 @@ GroupConfig const & Cli::Config::findGrpOrDie(Cli const & cli) {
  ***/
  
  //===========================================================================
@@ -13,7 +13,7 @@ index 9e67c12..c96bd24 100644
      , m_names{names}
  {
      // set m_fromName and assert if names is malformed
-@@ -486,12 +486,12 @@ static bool includeName(
+@@ -526,12 +526,12 @@ static bool includeName(
      OptName const & name,
      NameListType type,
      Cli::OptBase const & opt,
@@ -29,10 +29,10 @@ index 9e67c12..c96bd24 100644
              return !name.invert;
          if (type == kNameDisable)
 diff --git a/libs/dimcli/cli.h b/libs/dimcli/cli.h
-index 2c1615c..3e4f405 100644
+index d4941dc..fa8d526 100644
 --- a/libs/dimcli/cli.h
 +++ b/libs/dimcli/cli.h
-@@ -818,7 +818,7 @@ public:
+@@ -777,7 +777,7 @@ public:
      };
  
  public:
@@ -41,7 +41,7 @@ index 2c1615c..3e4f405 100644
      virtual ~OptBase() {}
  
      //-----------------------------------------------------------------------
-@@ -952,7 +952,7 @@ inline void Cli::OptBase::setValueDesc<DIMCLI_LIB_FILESYSTEM_PATH>() {
+@@ -1062,7 +1062,7 @@ std::string Cli::OptBase::toValueDesc<DIMCLI_LIB_FILESYSTEM_PATH>() const {
  template <typename A, typename T>
  class Cli::OptShim : public OptBase {
  public:
@@ -50,7 +50,7 @@ index 2c1615c..3e4f405 100644
      OptShim(OptShim const &) = delete;
      OptShim & operator=(OptShim const &) = delete;
  
-@@ -1100,8 +1100,8 @@ protected:
+@@ -1249,8 +1249,8 @@ protected:
  
  //===========================================================================
  template <typename A, typename T>
@@ -59,5 +59,5 @@ index 2c1615c..3e4f405 100644
 +Cli::OptShim<A, T>::OptShim(std::string const & keys, bool in_boolean)
 +    : OptBase(keys, in_boolean)
  {
-     setValueDesc<T>();
- }
+     if (std::is_arithmetic<T>::value)
+         this->imbue(std::locale(""));

--- a/ports/dimcli/fix-VS2019_BuildError.patch
+++ b/ports/dimcli/fix-VS2019_BuildError.patch
@@ -1,0 +1,32 @@
+diff --git a/libs/dimcli/cli.h b/libs/dimcli/cli.h
+index fa8d526..8ae4134 100644
+--- a/libs/dimcli/cli.h
++++ b/libs/dimcli/cli.h
+@@ -1234,7 +1234,7 @@ protected:
+     // those limits badRange() is called, otherwise returns true.
+     template <typename U>
+     auto checkLimits(Cli & cli, std::string const & val, U const & x, int)
+-    -> decltype(std::declval<T&>() > x);
++    -> decltype((long double) std::declval<T&>() > (long double) x);
+     template <typename U>
+     bool checkLimits(Cli & cli, std::string const & val, U const & x, long);
+ 
+@@ -1492,14 +1492,15 @@ auto Cli::OptShim<A, T>::checkLimits(
+     std::string const & val,
+     U const & x,
+     int
+-) -> decltype(std::declval<T&>() > x)
++) -> decltype((long double) std::declval<T&>() > (long double) x)
+ {
+     constexpr auto low = std::numeric_limits<T>::min();
+     constexpr auto high = std::numeric_limits<T>::max();
+     if (!std::is_arithmetic<T>::value)
+         return true;
+-    return (x >= low && x <= high)
+-        || cli.badRange(*this, val, low, high);
++    return (long double) x >= (long double) low
++            && (long double) x <= (long double) high
++		|| cli.badRange(*this, val, low, high);
+ }
+ 
+ //===========================================================================

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
 	PATCHES
 		fix-NameBoolean.patch
+		fix-VS2019_BuildError.patch
 )
 set(staticCrt OFF)
 if(VCPKG_CRT_LINKAGE STREQUAL "static")


### PR DESCRIPTION
Fix old patch and build error:
```
5>F:\0814\vcpkg\buildtrees\dimcli\src\v5.0.0-89211a3afb\libs\dimcli\cli.h(1501,15): error C2220: warning treated as error - no 'object' file generated [F:\0814\vcpkg\buildtrees\dimcli\x64-windows-dbg\cli.vcxproj]
5>F:\0814\vcpkg\buildtrees\dimcli\src\v5.0.0-89211a3afb\libs\dimcli\cli.h(1501,15): warning C5055: operator '>=': deprecated between enumerations and floating-point types
```
This error will be merged in new version 5.0.1. Related source issue: https://github.com/gknowles/dimcli/issues/15