### PR TITLE
[breakpad] Fix build failed with Visual Studio 2019

### DIFF
--- a/ports/breakpad/CONTROL
+++ b/ports/breakpad/CONTROL
@@ -1,5 +1,5 @@
 Source: breakpad
-Version: 2019-07-11
+Version: 2019-07-11-1
 Build-Depends: libdisasm
 Homepage: https://github.com/google/breakpad
 Description: a set of client and server components which implement a crash-reporting system.

--- a/ports/breakpad/fix-unique_ptr.patch
+++ b/ports/breakpad/fix-unique_ptr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/windows/pe_util.cc b/src/common/windows/pe_util.cc
+index 9f9e8fa..d912635 100644
+--- a/src/common/windows/pe_util.cc
++++ b/src/common/windows/pe_util.cc
+@@ -28,7 +28,7 @@
+ // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include "pe_util.h"
+-
++#include <memory>
+ #include <windows.h>
+ #include <winnt.h>
+ #include <atlbase.h>

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF c46151db0ffd1a8dae914e45f1212ef427f61ed3
     SHA512 bd9f247851a3caa6f36574c8a243c2a01cb1cf23c2266b6f6786b85c7418dba5937363c00184e26cda24225f96bb7aaeb08efd13d6a269a3b78c357c2eda7e14
     HEAD_REF master
+	PATCHES
+		fix-unique_ptr.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
Fix build error:
```
F:\0814\vcpkg\buildtrees\breakpad\src\f427f61ed3-5c9c1c4794\src\common\windows\pe_util.cc(122): error C2039: 'unique_ptr': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.22.27905\include\functional(23): note: see declaration of 'std'
F:\0814\vcpkg\buildtrees\breakpad\src\f427f61ed3-5c9c1c4794\src\common\windows\pe_util.cc(122): error C2873: 'unique_ptr': symbol cannot be used in a using-declaration
```