### PR TITLE
[vtk] fix finding glew issue

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-5
+Version: 8.2.0-6
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, atlmfc (windows), eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -51,12 +51,9 @@ vcpkg_from_github(
         hdf5_static.patch
 )
 
-# Remove the FindGLEW.cmake and FindPythonLibs.cmake that are distributed with VTK,
-# since they do not detect the debug libraries correctly.
 # The default files distributed with CMake (>= 3.9) should be superior by all means.
 # For GDAL, the one distributed with CMake does not detect the debug libraries correctly,
 # so we provide an own one.
-file(REMOVE ${SOURCE_PATH}/CMake/FindGLEW.cmake)
 file(REMOVE ${SOURCE_PATH}/CMake/FindPythonLibs.cmake)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/FindGDAL.cmake DESTINATION ${SOURCE_PATH}/CMake)


### PR DESCRIPTION
Glew find failed when CMake upgrade to 3.15.2, since FindGLEW.cmake changed in CMake 3.15.2, related issue https://github.com/microsoft/vcpkg/issues/7519

VTK has CMake/FindGLEW.cmake, but it removed by [616cfb0ef](https://github.com/microsoft/vcpkg/commit/616cfb0eff834d5311f064db218ffb8e5e3a52ab#diff-b26c0e14460d9ce49a576b1d015dd879) due to VTK debug was build linked against the release glew library, however this issue fixed in VTK, so I think we should add that back instead of adding others function.

I checked that glew debug library correctly linked in vtk now.