### PR TITLE
[glib] Fix install config.h

### DIFF
--- a/ports/glib/CMakeLists.txt
+++ b/ports/glib/CMakeLists.txt
@@ -102,6 +102,7 @@ else()
     endif()
     add_definitions("-DGIO_MODULE_DIR=\"gio/modules\"")
 endif()
+install(FILES ${CMAKE_BINARY_DIR}/config/config.h DESTINATION include)
 
 include_directories(${CMAKE_BINARY_DIR}/config ${CMAKE_BINARY_DIR}/config/glib ${CMAKE_BINARY_DIR}/config/gio ${CMAKE_BINARY_DIR}/config/gmodule)
 include_directories(. glib)

--- a/ports/glib/CMakeLists.txt
+++ b/ports/glib/CMakeLists.txt
@@ -102,7 +102,7 @@ else()
     endif()
     add_definitions("-DGIO_MODULE_DIR=\"gio/modules\"")
 endif()
-install(FILES ${CMAKE_BINARY_DIR}/config/config.h DESTINATION include)
+install(FILES ${CMAKE_BINARY_DIR}/config/config.h DESTINATION include/glib)
 
 include_directories(${CMAKE_BINARY_DIR}/config ${CMAKE_BINARY_DIR}/config/glib ${CMAKE_BINARY_DIR}/config/gio ${CMAKE_BINARY_DIR}/config/gmodule)
 include_directories(. glib)

--- a/ports/glib/CONTROL
+++ b/ports/glib/CONTROL
@@ -1,5 +1,5 @@
 Source: glib
-Version: 2.52.3-14-2
+Version: 2.52.3-14-3
 Homepage: https://developer.gnome.org/glib/
 Description: Portable, general-purpose utility library.
 Build-Depends: zlib, pcre, libffi, gettext, libiconv

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -48,5 +48,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-glib TARGET_PATH share/un
 vcpkg_copy_pdbs()
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/glib)
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
 file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/glib)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/glib/COPYING ${CURRENT_PACKAGES_DIR}/share/glib/copyright)


### PR DESCRIPTION
New port libgpod depends on glib, its source file use glib's **config.h**. So add `install(FILES ${CMAKE_BINARY_DIR}/config/config.h DESTINATION include)` to glib's CMakeLists.txt.