### PR TITLE
[libpng] Fix find_package() in CONFIG mode (#7968)

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,5 +1,5 @@
 Source: libpng
-Version: 1.6.37-2
+Version: 1.6.37-3
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/libpngConfig.cmake
+++ b/ports/libpng/libpngConfig.cmake
@@ -1,6 +1,6 @@
-# The upstream CMake exports its targets to a file named libpng.cmake
-# however, find_package(libpng CONFIG) doesn't work with that name.
+# The upstream CMakeLists.txt exports libpng's targets to a file named `libpng16.cmake`.
+# However, `find_package(libpng CONFIG)` expects a file named `libpngConfig.cmake` to exist instead.
 #
-# By includeing `libpng.cmake` form this file, find_package() will be 
-# able to find the exports `libpngConfig.cmake`.
-include(libpng16)
+# By including `libpng.cmake` from this file, `find_package(libpng CONFIG)` will work.
+get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include("${_DIR}/libpng16.cmake")

--- a/ports/libpng/libpngConfig.cmake
+++ b/ports/libpng/libpngConfig.cmake
@@ -1,0 +1,6 @@
+# The upstream CMake exports its targets to a file named libpng.cmake
+# however, find_package(libpng CONFIG) doesn't work with that name.
+#
+# By includeing `libpng.cmake` form this file, find_package() will be 
+# able to find the exports `libpngConfig.cmake`.
+include(libpng16)

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -46,6 +46,7 @@ endif()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/libpng)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share/)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/libpngConfig.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpng)
 
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpng)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libpng/LICENSE ${CURRENT_PACKAGES_DIR}/share/libpng/copyright)


### PR DESCRIPTION
Fix #7968

The upstream `CMakeLists.txt` for **libpng** exports targets to a file named `libpng16.cmake`.  
However, `find_package(libpng CONFIG)` expects a file named `libpngConfig.cmake` to exist instead.

In order for `find_package(libpng CONFIG)` to work, we create a file with the proper name (`libpngConfig.cmake`) that includes the one generated by the build (`libpng16.cmake`).

**Note: CMake provides a module to find `libpng` by calling `find_package(PNG)`.**
