### PR TITLE
[Qt5] Fix libpq linkage in wrapper

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.3-3
+Version: 5.12.3-4
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/vcpkg-cmake-wrapper.cmake
+++ b/ports/qt5-base/vcpkg-cmake-wrapper.cmake
@@ -23,11 +23,12 @@ if("${_target_type}" STREQUAL "STATIC_LIBRARY")
 
     set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES
         ZLIB::ZLIB JPEG::JPEG PNG::PNG Freetype::Freetype sqlite3 harfbuzz::harfbuzz
-        ${PostgreSQL_LIBRARY} double-conversion::double-conversion OpenSSL::SSL OpenSSL::Crypto
+        double-conversion::double-conversion OpenSSL::SSL OpenSSL::Crypto
     )
 
     add_qt_library(Qt5::Core
         pcre2-16
+        libpq
         Qt5ThemeSupport
         Qt5EventDispatcherSupport
         Qt5PlatformCompositorSupport


### PR DESCRIPTION
PostgreSQL_LIBRARY will contain optimized/debug keywords which will not work in INTERFACE_LINK_LIBRARIES. So i moved it into add_qt_library