### PR TITLE
[plplot] Avoid naming nonstandard <ymath.h> to retrieve a NaN constant

### DIFF
--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive_ex(
       "${CMAKE_CURRENT_LIST_DIR}/0001-findwxwidgets-fixes.patch"
       "${CMAKE_CURRENT_LIST_DIR}/0002-wxwidgets-dev-fixes.patch"
       "${CMAKE_CURRENT_LIST_DIR}/install-interface-include-directories.patch"
+      "${CMAKE_CURRENT_LIST_DIR}/use-math-h-nan.patch"
 )
 
 set(BUILD_with_wxwidgets OFF)

--- a/ports/plplot/use-math-h-nan.patch
+++ b/ports/plplot/use-math-h-nan.patch
@@ -1,0 +1,28 @@
+diff --git "a/lib/csa/nan.h" "b/lib/csa/nan.h"
+index 29fd3d2f..7f16e8c8 100644
+--- "a/lib/csa/nan.h"
++++ "b/lib/csa/nan.h"
+@@ -19,6 +19,16 @@
+ #if !defined ( _NAN_H )
+ #define _NAN_H
+
++// Try to use the implementation-provided NAN constant:
++
++#include <math.h>
++
++#if defined(NAN)
++
++#define NaN ((double)NAN)
++
++#else // ^^^ implementation provides NAN // implementation does not provide NAN vvv
++
+ #if ( defined ( __GNUC__ ) && !defined ( __ICC ) ) || defined ( __BORLANDC__ )
+
+ static const double NaN = 0.0 / 0.0;
+@@ -63,4 +73,6 @@ static const long long lNaN = ( (unsigned long long) 1 << 63 ) - 1;
+
+ #endif
+
++#endif // defined(NAN)
++
+ #endif


### PR DESCRIPTION
The header <ymath.h> is an implementation detail of the STL, and changes were made to it in development branches that prevent including it from C.