### PR TITLE
[cppkafka] Add new port

### DIFF
--- a/ports/cppkafka/CONTROL
+++ b/ports/cppkafka/CONTROL
@@ -1,0 +1,5 @@
+Source: cppkafka
+Version: 0.3.1
+Homepage: https://github.com/mfontanini/cppkafka
+Description: cppkafka allows C++ applications to consume and produce messages using the Apache Kafka protocol. The library is built on top of librdkafka, and provides a high level API that uses modern C++ features to make it easier to write code while keeping the wrapper's performance overhead to a minimum.
+Build-Depends: boost-program-options, librdkafka

--- a/ports/cppkafka/portfile.cmake
+++ b/ports/cppkafka/portfile.cmake
@@ -1,0 +1,21 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mfontanini/cppkafka
+    REF v0.3.1
+    SHA512 60d01ce1dd9bd9119676be939ed5ab03539abb1f945c1b31e432edfe0f06542778f7fef37696f5ff19c53024f44d5cbd8aeddbbb231c38b098e05285d3ff0cab
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/cppkafka/portfile.cmake
+++ b/ports/cppkafka/portfile.cmake
@@ -11,6 +11,9 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS 
+       -DCPPKAFKA_DISABLE_TESTS=ON
+       -DCPPKAFKA_DISABLE_EXAMPLES=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Related issue #7970.
This port depends on librdkafka. As librdkafka cannot build successfully on UWP, it doesn't currently support UWP.