### PR TITLE
[gettext]Improve gettext on Linux.

### DIFF
--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,5 +1,5 @@
 Source: gettext
-Version: 0.19-10
+Version: 0.19-11
 Homepage: https://www.gnu.org/software/gettext/
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.
 Build-Depends: libiconv

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -1,5 +1,8 @@
 if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    if (NOT EXISTS "/usr/include/libintl.h")
+        message(FATAL_ERROR "Please use command \"sudo apt-get install gettext\" to install gettext on linux.")
+    endif()
     file(COPY ${CMAKE_CURRENT_LIST_DIR}/unofficial-gettext-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/unofficial-gettext)
     return()
 endif()


### PR DESCRIPTION
According to this [link](https://github.com/microsoft/vcpkg/commit/9f9778ccff48981a691bf34f30ecc4bf2efd5ac1#diff-ca7667cebd42a2cd66e1c878dab8a74a), gettext is not built in linux. 

Add judgment and warning to detect if gettext is installed or not.