### PR TITLE
Workaround Powershell 6.2/7.0 breaking compatibility with Get-ChildItem

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -226,8 +226,9 @@ function getWindowsSDK( [Parameter(Mandatory=$False)][switch]$DisableWin10SDK = 
         $win10sdkVersions = @(Get-ChildItem $folder | Where-Object {$_.Name -match "^10"} | Sort-Object)
         [array]::Reverse($win10sdkVersions) # Newest SDK first
 
-        foreach ($win10sdkV in $win10sdkVersions)
+        foreach ($win10sdk in $win10sdkVersions)
         {
+            $win10sdkV = $win10sdk.Name
             $windowsheader = "$folder\$win10sdkV\um\windows.h"
             if (!(Test-Path $windowsheader))
             {


### PR DESCRIPTION
Powershell 6.2/7.0 in infinite wisdom decided to change the value of
what `Get-ChildItem` (and anything dealing with FileInfo/DirectoryInfo)
returns from relative to absolute path.

The only way to work around this for both existing versions and future
versions is to explicitly request the `Name`. Hopefully this doesn't
get changed again.

NOTE: This PS change breaks a lot of scripts, including many
of Microsoft's own first-party scripts. No workarounds were pushed
for any that I could see in the year+ since the issue was first
reported.