### PR TITLE
Update SDL2 from 2.0.9 -> 2.0.10

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.9-4
+Version: 2.0.10
 Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -3,14 +3,14 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SDL-Mirror/SDL
-    REF release-2.0.9
-    SHA512 444c906c0baa720c86ca72d1b4cd66fdf6f516d5d2a9836169081a2997a5aebaaf9caa687ec060fa02292d79cfa4a62442333e00f90a0239edd1601529f6b056
+    REF release-2.0.10
+    SHA512 c5fe59eed7ba9c6a82cceaf513623480793727fceec84b01d819e7cbefc8229a84be93067d7539f12d5811c49d3d54fd407272786aef3e419f439d0105c34b21
     HEAD_REF master
     PATCHES
         export-symbols-only-in-shared-build.patch
         fix-x86-windows.patch
         enable-winrt-cmake.patch
-        SDL-2.0.9-bug-4391-fix.patch # See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391 # Can be removed once SDL 2.0.10 is released
+        #SDL-2.0.9-bug-4391-fix.patch # See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391 # Can be removed once SDL 2.0.10 is released
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)


### PR DESCRIPTION
Patch to update SDL2 -> 2.0.10. Verified SHA512 key, and commented out line 13 in PATCHES, since the comment states it can be safely removed at this point.

=============
**CHANGELOG:**
=============
**PORTFILE.cmake**
> ln6: Change 2.0.9 -> 2.0.10
> ln7: Update SHA512 for SDL-release-2.0.10.tar.gz
> ln13: Commented out, but left in just in case, a fixup patch for previous SDL2 version.

**CONTROL**
> ln2: Changed version string -> 2.0.10

- Built and linked on my own end with several projects and there does not appear to be any conflict.