### PR TITLE
[tensorflow-cc]Fix build error and add warning message.

### DIFF
--- a/ports/tensorflow-cc/CONTROL
+++ b/ports/tensorflow-cc/CONTROL
@@ -1,4 +1,4 @@
 Source: tensorflow-cc
-Version: 1.14
+Version: 1.14-1
 Description: Library for computation using data flow graphs for scalable machine learning
 Build-Depends: c-ares

--- a/ports/tensorflow-cc/fix-build-error.patch
+++ b/ports/tensorflow-cc/fix-build-error.patch
@@ -7,13 +7,13 @@ index 99dd6de..3cbe8ed 100644
  
  #define _TF_LOG_INFO \
 -  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
-+  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::INFO)
  #define _TF_LOG_WARNING \
 -  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
-+  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::WARNING)
  #define _TF_LOG_ERROR \
 -  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
-+  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, tensorflow::ERROR)
  #define _TF_LOG_FATAL \
 -  ::tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)
 +  tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)

--- a/ports/tensorflow-cc/fix-build-error.patch
+++ b/ports/tensorflow-cc/fix-build-error.patch
@@ -1,0 +1,22 @@
+diff --git a/tensorflow/core/platform/default/logging.h b/tensorflow/core/platform/default/logging.h
+index 99dd6de..3cbe8ed 100644
+--- a/tensorflow/core/platform/default/logging.h
++++ b/tensorflow/core/platform/default/logging.h
+@@ -82,13 +82,13 @@ class LogMessageFatal : public LogMessage {
+ };
+ 
+ #define _TF_LOG_INFO \
+-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::INFO)
+ #define _TF_LOG_WARNING \
+-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::WARNING)
+ #define _TF_LOG_ERROR \
+-  ::tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
++  tensorflow::internal::LogMessage(__FILE__, __LINE__, ::tensorflow::ERROR)
+ #define _TF_LOG_FATAL \
+-  ::tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)
++  tensorflow::internal::LogMessageFatal(__FILE__, __LINE__)
+ 
+ #define _TF_LOG_QFATAL _TF_LOG_FATAL
+ 

--- a/ports/tensorflow-cc/portfile.cmake
+++ b/ports/tensorflow-cc/portfile.cmake
@@ -2,6 +2,10 @@ include(vcpkg_common_functions)
 
 message(WARNING "This tensorflow port currently is experimental on Windows and Linux platforms.")
 
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+    message(FATAL_ERROR "TensorFlow does not support 32bit system.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tensorflow/tensorflow
@@ -10,6 +14,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         file-exists.patch # required or otherwise it cant find python lib path on windows
+        fix-build-error.patch # Fix namespace error
 )
 
 # due to https://github.com/bazelbuild/bazel/issues/8028, bazel must be version 25.0 or higher


### PR DESCRIPTION
1. Fix unrecognized namespace tag `::`.
2. Tensorflow does not support 32-bit systems, adding error messages.

Related: #7995.