### PR TITLE
[dimcli] Upgrade to version 5.0.1

### DIFF
--- a/ports/dimcli/CONTROL
+++ b/ports/dimcli/CONTROL
@@ -1,4 +1,4 @@
 Source: dimcli
-Version: 5.0.0
+Version: 5.0.1
 Homepage: https://github.com/gknowles/dimcli
 Description: C++ command line parser toolkit

--- a/ports/dimcli/fix-NameBoolean.patch
+++ b/ports/dimcli/fix-NameBoolean.patch
@@ -1,8 +1,8 @@
 diff --git a/libs/dimcli/cli.cpp b/libs/dimcli/cli.cpp
-index 9e67c12..c96bd24 100644
+index 45dac3b..6129884 100644
 --- a/libs/dimcli/cli.cpp
 +++ b/libs/dimcli/cli.cpp
-@@ -388,8 +388,8 @@ GroupConfig const & Cli::Config::findGrpOrDie(Cli const & cli) {
+@@ -392,8 +392,8 @@ GroupConfig const & Cli::Config::findGrpOrDie(Cli const & cli) {
  ***/
  
  //===========================================================================
@@ -13,7 +13,7 @@ index 9e67c12..c96bd24 100644
      , m_names{names}
  {
      // set m_fromName and assert if names is malformed
-@@ -486,12 +486,12 @@ static bool includeName(
+@@ -526,12 +526,12 @@ static bool includeName(
      OptName const & name,
      NameListType type,
      Cli::OptBase const & opt,
@@ -29,10 +29,10 @@ index 9e67c12..c96bd24 100644
              return !name.invert;
          if (type == kNameDisable)
 diff --git a/libs/dimcli/cli.h b/libs/dimcli/cli.h
-index 2c1615c..3e4f405 100644
+index d4941dc..fa8d526 100644
 --- a/libs/dimcli/cli.h
 +++ b/libs/dimcli/cli.h
-@@ -818,7 +818,7 @@ public:
+@@ -777,7 +777,7 @@ public:
      };
  
  public:
@@ -41,7 +41,7 @@ index 2c1615c..3e4f405 100644
      virtual ~OptBase() {}
  
      //-----------------------------------------------------------------------
-@@ -952,7 +952,7 @@ inline void Cli::OptBase::setValueDesc<DIMCLI_LIB_FILESYSTEM_PATH>() {
+@@ -1062,7 +1062,7 @@ std::string Cli::OptBase::toValueDesc<DIMCLI_LIB_FILESYSTEM_PATH>() const {
  template <typename A, typename T>
  class Cli::OptShim : public OptBase {
  public:
@@ -50,7 +50,7 @@ index 2c1615c..3e4f405 100644
      OptShim(OptShim const &) = delete;
      OptShim & operator=(OptShim const &) = delete;
  
-@@ -1100,8 +1100,8 @@ protected:
+@@ -1249,8 +1249,8 @@ protected:
  
  //===========================================================================
  template <typename A, typename T>
@@ -59,5 +59,5 @@ index 2c1615c..3e4f405 100644
 +Cli::OptShim<A, T>::OptShim(std::string const & keys, bool in_boolean)
 +    : OptBase(keys, in_boolean)
  {
-     setValueDesc<T>();
- }
+     if (std::is_arithmetic<T>::value)
+         this->imbue(std::locale(""));

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gknowles/dimcli
-    REF v5.0.0
-    SHA512 504e6f53e83ce17e8e4b59ecf1a610c2249c2bf48a308b1ee5db0e0e85d3cb08178d24534b5dee8bfaac83fd44c68cbbe8d300283d0023467b724a9340b56e4c
+    REF v5.0.1
+    SHA512 ff005777230f9ded5e407f11ebed7d70db2a18ec60da8c80d36644b96c9d090d2f211e3c36b7d296a446c1b54d61c359a51082034b94e2398cc2305316f33d0f
     HEAD_REF master
 	PATCHES
 		fix-NameBoolean.patch


### PR DESCRIPTION
Upgrade dimcli to version 5.0.1 and fix old patches. New version fix build error: 
```
5>F:\0814\vcpkg\buildtrees\dimcli\src\v5.0.0-89211a3afb\libs\dimcli\cli.h(1501,15): error C2220: warning treated as error - no 'object' file generated [F:\0814\vcpkg\buildtrees\dimcli\x64-windows-dbg\cli.vcxproj]
5>F:\0814\vcpkg\buildtrees\dimcli\src\v5.0.0-89211a3afb\libs\dimcli\cli.h(1501,15): warning C5055: operator '>=': deprecated between enumerations and floating-point types
```
So closed PR #7935.