### PR TITLE
[qt5-modularscripts]make fixcmake.py support unix

### DIFF
--- a/ports/qt5-modularscripts/fixcmake.py
+++ b/ports/qt5-modularscripts/fixcmake.py
@@ -13,11 +13,11 @@ tooldir="/tools/"+port+"/"
 for f in files:
     openedfile = open(f, "r")
     builder = ""
-    dllpattern = re.compile("_install_prefix}/bin/Qt5.*d.dll")
-    libpattern = re.compile("_install_prefix}/lib/Qt5.*d.lib")
-    exepattern = re.compile("_install_prefix}/bin/[a-z]+.exe")
-    toolexepattern = re.compile("_install_prefix}/tools/qt5/[a-z]+.exe")
-    tooldllpattern = re.compile("_install_prefix}/tools/qt5/Qt5.*d.dll")
+    dllpattern = re.compile("_install_prefix}/bin/Qt5.*d+(.dll|.so)")
+    libpattern = re.compile("_install_prefix}/lib/Qt5.*d+(.lib|.a)")
+    exepattern = re.compile("_install_prefix}/bin/[a-z]+(.exe|)")
+    toolexepattern = re.compile("_install_prefix}/tools/qt5/[a-z]+(.exe|)")
+    tooldllpattern = re.compile("_install_prefix}/tools/qt5/Qt5.*d+(.dll|.so)")
     for line in openedfile:
         if "_install_prefix}/tools/qt5/${LIB_LOCATION}" in line:
             builder += "    if (${Configuration} STREQUAL \"RELEASE\")"


### PR DESCRIPTION
fix Qt5LinguistToolsConfig Can't find "x64-linux/tools/qt5/lrelease" under linux #7771
Fixcmake.py Modify the tools/qt5 in the cmake file of the qt tool to the tools/${port} directory, but it only considers the file suffix of windows. Add the suffix of linux and osx to the regular expression to fix the issue.