### PR TITLE
[vcpkg] Avoid RENAME usage to prevent cross-device link problems (#4245)

### DIFF
--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -75,11 +75,14 @@ function(vcpkg_download_distfile VAR)
 
     # Works around issue #3399
     if(IS_DIRECTORY "${DOWNLOADS}/temp")
+        # Delete "temp0" directory created by the old version of vcpkg
         file(REMOVE_RECURSE "${DOWNLOADS}/temp0")
-        file(RENAME "${DOWNLOADS}/temp" "${DOWNLOADS}/temp0")
-        file(REMOVE_RECURSE "${DOWNLOADS}/temp0")
+
+        file(GLOB temp_files "${DOWNLOADS}/temp")
+        file(REMOVE_RECURSE ${temp_files})
+    else()
+      file(MAKE_DIRECTORY "${DOWNLOADS}/temp")
     endif()
-    file(MAKE_DIRECTORY "${DOWNLOADS}/temp")
 
     function(test_hash FILE_PATH FILE_KIND CUSTOM_ERROR_ADVICE)
         if(_VCPKG_INTERNAL_NO_HASH_CHECK)


### PR DESCRIPTION
In `vcpkg_download_distfile.cmake` vcpkg was using `file(RENAME)` to prevent error creating directory `downloads/temp` on Windows (see #3399).

Anyway, in some case `file(RENAME)` fails, which interrupt package installation.
The observed error messages are:
`No such file or directory` (#4245), `Invalid cross-device link` (#7079, #7997).

This PR proposes `temp` directory cleanup mechanism without `file(RENAME)`.
We create `temp` once and remove all its contents when we need.

Here is the Dockerfile I built to test my changes.
```Dockerfile
FROM gcc:latest
RUN apt-get update && apt-get install -y git curl unzip tar
RUN git clone https://github.com/Pospelove/vcpkg.git && cd vcpkg && git reset --hard 32fa8b4c226129a98a3f62e92d17f47fe2122e55 && chmod 777 bootstrap-vcpkg.sh && ./bootstrap-vcpkg.sh
RUN cd vcpkg && ./vcpkg install cpp-httplib
RUN cd vcpkg && ./vcpkg install nlohmann-json
```