### PR TITLE
[parallelstl] Add new port

### DIFF
--- a/ports/parallelstl/CONTROL
+++ b/ports/parallelstl/CONTROL
@@ -1,0 +1,5 @@
+Source: parallelstl
+Version: 20190522-1
+Homepage: https://github.com/intel/parallelstl
+Description: Parallel STL is an implementation of the C++ standard library algorithms with support for execution policies, as specified in ISO/IEC 14882:2017 standard, commonly called C++17.
+Build-Depends: tbb

--- a/ports/parallelstl/fix-install-header.patch
+++ b/ports/parallelstl/fix-install-header.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c20a5c3..1ba8583 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,3 +74,6 @@ configure_file(
+ 
+ export(TARGETS ParallelSTL NAMESPACE pstl:: FILE ParallelSTLTargets.cmake)
+ export(PACKAGE ParallelSTL)
++
++#Install headers
++install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION include)
+\ No newline at end of file

--- a/ports/parallelstl/portfile.cmake
+++ b/ports/parallelstl/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/parallelstl
+    REF  20190522
+    SHA512 ad1b820ff4c2ce45ea3d6069dc8d5219449baca44d0bce86482aca247db7a4191e2bce10ab8365056ca278322809fdbb096519436e850cf95f2bb98fa7bc1ab1
+    HEAD_REF master
+    PATCHES fix-install-header.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+      -DPARALLELSTL_USE_PARALLEL_POLICIES=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)


### PR DESCRIPTION
This port seems to be a header-only library. It needs to depend on tbb.
Related issue #5793.