### PR TITLE
[ignition-msgs1, ignition-transport4] Add new ports 🤖

### DIFF
--- a/ports/ignition-cmake0/portfile.cmake
+++ b/ports/ignition-cmake0/portfile.cmake
@@ -12,6 +12,8 @@ ignition_modular_library(NAME cmake
                          PATCHES do-not-compile-gtest.patch
 						 # Support for ARM64 (backport of https://bitbucket.org/ignitionrobotics/ign-cmake/pull-requests/168)
 						         support-arm64.patch
+                         # Do not depend on pkg-config installed to find uuid 
+                                 uuid-do-not-require-pkg-config.patch
 						 )
 
 # Permit empty include folder

--- a/ports/ignition-cmake0/uuid-do-not-require-pkg-config.patch
+++ b/ports/ignition-cmake0/uuid-do-not-require-pkg-config.patch
@@ -1,0 +1,30 @@
+diff --git a/cmake/FindUUID.cmake b/cmake/FindUUID.cmake
+index bf055d4..15be822 100644
+--- a/cmake/FindUUID.cmake
++++ b/cmake/FindUUID.cmake
+@@ -18,4 +18,25 @@
+ if (UNIX)
+   include(IgnPkgConfig)
+   ign_pkg_check_modules(UUID uuid)
++
++  # If pkg-config is not available in the system,
++  # it is neccessary to manually find uuid
++  if(NOT TARGET UUID::UUID)
++    find_path(UUID_INCLUDE_DIRS NAMES uuid.h PATH_SUFFIXES uuid)
++    mark_as_advanced(UUID_INCLUDE_DIRS)
++
++    find_library(UUID_LIBRARIES NAMES uuid libuuid)
++    mark_as_advanced(UUID_LIBRARIES)
++
++    if(NOT UUID_INCLUDE_DIRS OR NOT UUID_LIBRARIES)
++      set(UUID_FOUND false)
++    else()
++      set(UUID_FOUND true)
++    endif()
++
++    if(UUID_FOUND)
++      include(IgnImportTarget)
++      ign_import_target(UUID)
++    endif()
++  endif()
+ endif()

--- a/ports/ignition-msgs1/CONTROL
+++ b/ports/ignition-msgs1/CONTROL
@@ -1,0 +1,4 @@
+Source: ignition-msgs1
+Version: 1.0.0
+Build-Depends: ignition-cmake0, ignition-math4, protobuf
+Description: Middleware protobuf messages for robotics

--- a/ports/ignition-msgs1/fix-protobuf-static-link-order.patch
+++ b/ports/ignition-msgs1/fix-protobuf-static-link-order.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -2,8 +2,8 @@
+ # Build a custom protoc plugin
+ ign_add_executable(ign_msgs_gen Generator.cc generator_main.cc)
+ target_link_libraries(ign_msgs_gen
+-  protobuf::libprotobuf 
+-  protobuf::libprotoc)
++  protobuf::libprotoc
++  protobuf::libprotobuf)
+ target_include_directories(ign_msgs_gen PRIVATE ${PROTOBUF_INCLUDE_DIR})
+ target_compile_features(ign_msgs_gen PRIVATE ${IGN_CXX_11_FEATURES})
+ 

--- a/ports/ignition-msgs1/portfile.cmake
+++ b/ports/ignition-msgs1/portfile.cmake
@@ -1,0 +1,35 @@
+include(vcpkg_common_functions)
+
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+# Explicitly disable cross-compilation until the upstream discussion
+# https://bitbucket.org/ignitionrobotics/ign-msgs/issues/34/add-support-for-cross-compilation is solved
+if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+    set(ignition_msgs_CROSSCOMPILING ON)
+elseif(CMAKE_HOST_WIN32 AND VCPKG_CMAKE_SYSTEM_NAME)
+    set(ignition_msgs_CROSSCOMPILING ON)
+else()
+    set(ignition_msgs_CROSSCOMPILING OFF)
+endif()
+
+if(ignition_msgs_CROSSCOMPILING)
+    message(FATAL_ERROR "This port does not currently support triplets that require cross-compilation.")
+endif()
+
+# This port needs  to generate protobuf messages with a custom plugin generator,
+# so it needs to have in Windows the relative protobuf dll available in the PATH
+set(path_backup $ENV{PATH})
+vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/bin)
+vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
+
+ignition_modular_library(NAME msgs
+                         VERSION "1.0.0"
+                         # See https://bitbucket.org/ignitionrobotics/ign-msgs/issues/33/the-ignition-msgs1_100-tag-does-not-match
+                         REF ignition-msgs_1.0.0
+                         SHA512 15261d9c82c05952b1b7dfc50346e73ab041bf6e2e5a63698e17bfa36b2d261aad2777f770f6dccd0d58eb9c90979fe89a7371dc2ec6050149bf63cafc4f6779
+                         # Fix linking order of protobuf libraries (backport of https://bitbucket.org/ignitionrobotics/ign-msgs/pull-requests/151)
+                         PATCHES fix-protobuf-static-link-order.patch)
+
+
+# Restore old path
+set(ENV{PATH} ${path_backup})

--- a/ports/ignition-transport4/CONTROL
+++ b/ports/ignition-transport4/CONTROL
@@ -1,0 +1,4 @@
+Source: ignition-transport4
+Version: 4.0.0
+Build-Depends: cppzmq, ignition-cmake0, ignition-msgs1, libuuid (!windows&!uwp), protobuf, zeromq
+Description: Transport middleware for robotics

--- a/ports/ignition-transport4/portfile.cmake
+++ b/ports/ignition-transport4/portfile.cmake
@@ -1,0 +1,7 @@
+include(vcpkg_common_functions)
+
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME transport
+                         VERSION "4.0.0"
+                         SHA512 4f8d947e046653fafb27063de3cd97a66c169d53ef48ee5f06b0c0c3a40d7ad0f58028b615a0321aa46ed56aef2acbeeb46a48b2ff3a3d1050df89a3688877c6)


### PR DESCRIPTION
Write new ports using the ignition-modularscript port added in https://github.com/microsoft/vcpkg/pull/7781 .
The ports are for the ignition-msgs ( https://ignitionrobotics.org/libs/msgs ) and ignition-transport ( https://ignitionrobotics.org/libs/transport ) libraries for robotics applications. 

Related issue: https://github.com/microsoft/vcpkg/issues/8014 .

