### PR TITLE
[unrar] Don't use a custom struct member alignment

### DIFF
--- a/ports/unrar/CONTROL
+++ b/ports/unrar/CONTROL
@@ -1,4 +1,4 @@
 Source: unrar
-Version: 5.5.8-2
+Version: 5.5.8-3
 Homepage: https://www.rarlab.com
 Description: rarlab's unrar libary

--- a/ports/unrar/msbuild-use-default-sma.patch
+++ b/ports/unrar/msbuild-use-default-sma.patch
@@ -1,0 +1,52 @@
+diff --git a/UnRARDll.vcxproj b/UnRARDll.vcxproj
+index ec5c17b00..7d3d91bc6 100644
+--- a/UnRARDll.vcxproj
++++ b/UnRARDll.vcxproj
+@@ -138,7 +138,6 @@
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+       <PrecompiledHeader>Use</PrecompiledHeader>
+       <PrecompiledHeaderFile>rar.hpp</PrecompiledHeaderFile>
+@@ -168,7 +167,6 @@
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+       <PrecompiledHeader>Use</PrecompiledHeader>
+       <PrecompiledHeaderFile>rar.hpp</PrecompiledHeaderFile>
+@@ -198,7 +196,6 @@
+       <MinimalRebuild>false</MinimalRebuild>
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <BufferSecurityCheck>true</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+@@ -239,7 +236,6 @@
+       <MinimalRebuild>false</MinimalRebuild>
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <BufferSecurityCheck>true</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <RuntimeTypeInfo>false</RuntimeTypeInfo>
+@@ -274,7 +270,6 @@
+       <MinimalRebuild>false</MinimalRebuild>
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <BufferSecurityCheck>true</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
+@@ -315,7 +310,6 @@
+       <MinimalRebuild>false</MinimalRebuild>
+       <ExceptionHandling>Sync</ExceptionHandling>
+       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+-      <StructMemberAlignment>4Bytes</StructMemberAlignment>
+       <BufferSecurityCheck>true</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/ports/unrar/portfile.cmake
+++ b/ports/unrar/portfile.cmake
@@ -3,7 +3,6 @@ set(UNRAR_VERSION "5.5.8")
 set(UNRAR_SHA512 9eac83707fa47a03925e5f3e8adf47889064d748304b732d12a2d379ab525b441f1aa33216377d4ef445f45c4e8ad73d2cd0b560601ceac344c60571b77fd6aa)
 set(UNRAR_FILENAME unrarsrc-${UNRAR_VERSION}.tar.gz)
 set(UNRAR_URL http://www.rarlab.com/rar/${UNRAR_FILENAME})
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/unrar)
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
@@ -13,7 +12,12 @@ vcpkg_download_distfile(ARCHIVE
     FILENAME ${UNRAR_FILENAME}
     SHA512 ${UNRAR_SHA512}
 )
-vcpkg_extract_source_archive(${ARCHIVE})
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${UNRAR_VERSION}
+    PATCHES msbuild-use-default-sma.patch
+)
 
 vcpkg_build_msbuild(
     PROJECT_PATH "${SOURCE_PATH}/UnRARDll.vcxproj"


### PR DESCRIPTION
For some reason unrar's .vcxproj files specify a non-default member alignment, even though the source code already uses `pack` pragmas. With newer versions of the Windows SDK this actually breaks the build, as this build log snippet shows:

```text
[...]
                     C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\bin\HostX64\x86\CL.exe /c /Zi /nologo /W3 /WX- /diagnostics:column /O2 /Oi /Oy /D RARDLL /D UNRAR /D SILENT /D _WINDLL /D _MBCS /Gm- /EHsc /MT /Zp4 /GS /Gy /arch:IA32 /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR- /Yc"rar.hpp" /Fp"build\unrardll32\Release\obj\UnRAR.pch" /Fo"build\unrardll32\Release\obj\\" /Fd"build\unrardll32\Release\obj\vc142.pdb" /Gd /TP /wd4007 /wd4996 /analyze- /FC /errorReport:queue /MP rarpch.cpp (TaskId:40)
                     Tracking command: (TaskId:40)
                     C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\Tracker.exe /d "C:\Program Files (x86)\MSBuild\15.0\FileTracker\FileTracker32.dll" /i C:\vcpkg\buildtrees\unrar\src\unrar\build\unrardll32\Release\obj\UnRAR.tlog /r C:\VCPKG\BUILDTREES\UNRAR\SRC\UNRAR\RARPCH.CPP /b MSBuildConsole_CancelEventb780407467ca4a77a133ce5f154828e9  /c "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.22.27905\bin\HostX64\x86\CL.exe"  /c /Zi /nologo /W3 /WX- /diagnostics:column /O2 /Oi /Oy /D RARDLL /D UNRAR /D SILENT /D _WINDLL /D _MBCS /Gm- /EHsc /MT /Zp4 /GS /Gy /arch:IA32 /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR- /Yc"rar.hpp" /Fp"build\unrardll32\Release\obj\UnRAR.pch" /Fo"build\unrardll32\Release\obj\\" /Fd"build\unrardll32\Release\obj\vc142.pdb" /Gd /TP /wd4007 /wd4996 /analyze- /FC /errorReport:queue /MP rarpch.cpp (TaskId:40)
                     rarpch.cpp (TaskId:40)
14:53:55.341     1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\um\winnt.h(2482,40): error C2338:  Windows headers require the default packing option. Changing this can lead to memory corruption. This diagnostic can be disabled by building with WINDOWS_IGNORE_PACKING_MISMATCH defined. [C:\vcpkg\buildtrees\unrar\src\unrar\UnRARDll.vcxproj]
                     The command exited with code 2. (TaskId:40)
                   Done executing task "CL" -- FAILED. (TaskId:40)
[...]
```

I've added a patch for unrar that just deletes the `<StructMemberAlignment>` specifications from UnRARDll.vcxproj, which fixes the build.