### PR TITLE
[libpng] Replace find_library() with a simple set() for linking libm on UNIX

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,5 +1,5 @@
 Source: libpng
-Version: 1.6.37-3
+Version: 1.6.37-4
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/fix-libm-unix.patch
+++ b/ports/libpng/fix-libm-unix.patch
@@ -1,0 +1,12 @@
+diff -ur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2019-04-14 20:10:32.000000000 +0200
++++ b/CMakeLists.txt	2019-09-06 14:14:39.425498139 +0200
+@@ -44,7 +44,7 @@
+ endif()
+ 
+ if(UNIX AND NOT APPLE AND NOT BEOS AND NOT HAIKU)
+-  find_library(M_LIBRARY m)
++  set(M_LIBRARY m)
+ else()
+   # libm is not needed and/or not available
+   set(M_LIBRARY "")

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         use-abort-on-all-platforms.patch
+        fix-libm-unix.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
Similar issue as with Pull Request #7989, but different and more generic fix. Linking libm will work with the default x64-linux triplet, but fail if cross compiling (with a user-specific x86-linux triplet for example), with or without emscripten. As libm is part of the standard library, it can just be linked with its name.

This issue was also present [in the Conan package manager](https://github.com/bincrafters/community/issues/884) and fixed the same way.