### PR TITLE
[libwebp] Fix cmake file install location on case sensitive filesystems

### DIFF
--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -75,7 +75,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/WebP/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/WebP)
 file(GLOB CMAKE_FILES ${CURRENT_PACKAGES_DIR}/share/${PORT}/*)
-file(COPY ${CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/webp/)
+file(COPY ${CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/WebP/)
 
 #somehow the native CMAKE_EXECUTABLE_SUFFIX does not work, so here we emulate it
 if(CMAKE_HOST_WIN32)


### PR DESCRIPTION
The libwebp port ends up installing the cmake configuration files (WebPConfig.cmake, etc.) into a folder called 'webp'. Unfortunately cmake won't look for (webp/WebPConfig.cmake), but rather (WebP/WebPConfig.cmake). If the filesystem is case sensitive then cmake won't find the configuration file. This one liner fixes the case of the install folder.