### PR TITLE
Fix how to use VULKAN_SDK under Visual Studio

### DIFF
--- a/ports/vulkan/usage
+++ b/ports/vulkan/usage
@@ -2,7 +2,7 @@ The package vulkan does not provide cmake or visual studio integration directly.
 However, it can still easily be used.
 
     Visual Studio:
-    Include ${VULKAN_SDK}/include to your include path.
+    Include $(VULKAN_SDK)/include to your include path.
 
     CMake:
     find_package(Vulkan REQUIRED)


### PR DESCRIPTION
Environment variables are referenced with brackets not curly braces. Copying and using the line will not result frustration.