### PR TITLE
Update egl-registry to 2019-08-08 and opengl-registry to 2019-08-22.

### DIFF
--- a/ports/egl-registry/CONTROL
+++ b/ports/egl-registry/CONTROL
@@ -1,3 +1,3 @@
 Source: egl-registry
-Version: 2018-06-30-1
+Version: 2019-08-08
 Description: the EGL API and Extension Registry

--- a/ports/egl-registry/portfile.cmake
+++ b/ports/egl-registry/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/EGL-Registry
-  REF e2562a9e7f567b837cdf96cf8b12e7fc0d88cc30
-  SHA512 8c380c26f6afc0ce2ab2dd2fe834daae0d0dbe9e2bd55ab30c80f8dfa5e234f1902e5735c4d8acf016f03924a46431b9bb794bb77f1f091c56905a98c38f5d04
+  REF 598f20e3b7b7eec3e8d8a83e64b9592a21c55bb6
+  SHA512 360aa2399fec12ad23c5e4bce7e9287a9b1b1d98ba6c326dde2b1bc1c32735bc6933ca8e5c626ba421cda5aac216bc7c268e064cf0dd67605a23151e29ba1f36
   HEAD_REF master
 )
 

--- a/ports/opengl-registry/CONTROL
+++ b/ports/opengl-registry/CONTROL
@@ -1,4 +1,4 @@
 Source: opengl-registry
-Version: 2018-06-30-1
+Version: 2019-08-22
 Build-Depends: egl-registry
 Description: the API and Extension registries for the OpenGL family APIs

--- a/ports/opengl-registry/portfile.cmake
+++ b/ports/opengl-registry/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KhronosGroup/OpenGL-Registry
-  REF e18e52a14e902a9ee29c5bf87478ac2ca21bb06b
-  SHA512 3b883115e138178984a751ee314b0589a7a20db3bc7cff96fa0b886be1779c24031ce65847386aa2d4f42823b1597edccc5a9afc0aef42fea8611a44d2ca5df6
+  REF 3c9ab309994c2baeb5572aa0befd5f405166a275
+  SHA512 f53018fe6dfb926dd6c1ce64ffde19b650a9071a1f6fa0c7a1596237e4ff84c3ff0092fb80811c4fea9b533c4b8607ed51f328d683d8f4aac18f0616f58b56a4
   HEAD_REF master
 )
 


### PR DESCRIPTION
Since the registries are still active, these should probably get updated more often, but this is about a year's worth of updates, at any rate.