### PR TITLE
[ignition-common1] Add new port 🤖

### DIFF
--- a/ports/ignition-common1/CONTROL
+++ b/ports/ignition-common1/CONTROL
@@ -1,0 +1,4 @@
+Source: ignition-common1
+Version: 1.1.1
+Build-Depends: dlfcn-win32 (windows|uwp), ffmpeg (!windows&!uwp), freeimage (!windows&!uwp), gts (!windows&!uwp), ignition-cmake0, ignition-math4, tinyxml2 (!windows&!uwp)
+Description: Common libraries for robotics applications

--- a/ports/ignition-common1/portfile.cmake
+++ b/ports/ignition-common1/portfile.cmake
@@ -1,0 +1,8 @@
+include(vcpkg_common_functions)
+
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME common
+                         VERSION "1.1.1"
+                         REF ignition-common_1.1.1
+                         SHA512 8453e1cf2337898b81b313aeffd1a7b683fd03184edfae74c81aa861b28036f6b9094fcab36f7a0f68b4204956d7116bd03073c7bdf2e769e47dffcdaad454d6)


### PR DESCRIPTION
Add port for the ignition-common 1 library ( https://www.ignitionrobotics.org/libs/common ). 
Dependency for the Gazebo simulator (see https://github.com/microsoft/vcpkg/issues/8014).