### PR TITLE
[geographiclib]Fix usage error and cmake path in Linux.

### DIFF
--- a/ports/geographiclib/CONTROL
+++ b/ports/geographiclib/CONTROL
@@ -1,4 +1,4 @@
 Source: geographiclib
-Version: 1.47-patch1-8
+Version: 1.47-patch1-9
 Homepage: https://sourceforge.net/projects/geographiclib/
 Description: a small set of C++ classes for performing conversions between geographic, UTM, UPS, MGRS, geocentric, and local cartesian coordinates, for gravity (e.g., EGM2008), geoid height, and geomagnetic field (e.g., WMM2010) calculations, and for solving geodesic problems.

--- a/ports/geographiclib/fix-usage.patch
+++ b/ports/geographiclib/fix-usage.patch
@@ -1,0 +1,16 @@
+diff --git a/cmake/project-config-version.cmake.in b/cmake/project-config-version.cmake.in
+index 1f207b8..d469658 100644
+--- a/cmake/project-config-version.cmake.in
++++ b/cmake/project-config-version.cmake.in
+@@ -22,9 +22,9 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
+   # Reject if there's a mismatch in MSVC compiler versions
+ #  set (REASON "_MSC_VER = @MSVC_VERSION@")
+ #  set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (NOT CMAKE_CROSSCOMPILING STREQUAL "@CMAKE_CROSSCOMPILING@")
++elseif (NOT CMAKE_CROSSCOMPILING STREQUAL FALSE)
+   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}
+-  set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")
++  set (REASON "cross-compiling = FALSE")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+ elseif (CMAKE_CROSSCOMPILING AND
+     NOT (CMAKE_SYSTEM_NAME STREQUAL "@CMAKE_SYSTEM_NAME@" AND

--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
     PATCHES
            remove-tools-and-fix-version.patch
+           fix-usage.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
@@ -37,7 +38,7 @@ vcpkg_install_cmake()
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 else()
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/GeographicLib)
 endif()
 vcpkg_copy_pdbs()
 

--- a/ports/geographiclib/usage
+++ b/ports/geographiclib/usage
@@ -1,0 +1,8 @@
+The package geographiclib:x64-linux provides CMake targets:
+
+    find_package(GeographicLib CONFIG REQUIRED)
+    #dynamic
+    target_link_libraries(main PRIVATE GeographicLib GeographicLib::GeographicLib)
+    #static
+    target_link_libraries(main PRIVATE GeographicLib_STATIC GeographicLib::GeographicLib_STATIC)
+    


### PR DESCRIPTION
This PR fixed:
1. usage error.
2. cmake files path in Linux.

Related: #8104.