### PR TITLE
[openxr-loader] Update to 1.0.2

### DIFF
--- a/ports/openxr-loader/CONTROL
+++ b/ports/openxr-loader/CONTROL
@@ -1,5 +1,5 @@
 Source: openxr-loader
-Version: 1.0.0-2
+Version: 1.0.2-0
 Description: Khronos API for abstracting VR/MR/AR hardware
 
 Feature: vulkan

--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -12,8 +12,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/OpenXR-SDK
-    REF release-1.0.0
-    SHA512 423079b841a01f3b51283839c565cfa1b8ff38348c3f3d6f62e9120569d4ad540d8d6bfe8010e74d9bbb76aeaedcf273e5e3b1717bb0b424898793fb4712aa58
+    REF release-1.0.2
+    SHA512 a3eb61d76e5b6658376870633cf067ddf43d68758d8eaa29dce97fe25d1959f7166f31840dffdae6f1c2f9ef6546e0e90f26b2c84afede6dc702e16a23d0676e
     HEAD_REF master
 )
 
@@ -44,29 +44,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-function(COPY_BINARIES SOURCE DEST)
-    # hack, because CMAKE_SHARED_LIBRARY_SUFFIX seems to be unpopulated
-    if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        set(SHARED_LIB_SUFFIX ".dll")
-    else()
-        set(SHARED_LIB_SUFFIX ".so")
-    endif()
-    file(MAKE_DIRECTORY ${DEST})
-    file(GLOB_RECURSE SHARED_BINARIES ${SOURCE}/*${SHARED_LIB_SUFFIX})
-    file(COPY ${SHARED_BINARIES} DESTINATION ${DEST})
-    file(REMOVE_RECURSE ${SHARED_BINARIES})
-endfunction()
-
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 # No CMake files are contained in /share only docs
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/openxr-loader RENAME copyright)
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    COPY_BINARIES(${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/bin)
-    COPY_BINARIES(${CURRENT_PACKAGES_DIR}/debug/lib ${CURRENT_PACKAGES_DIR}/debug/bin)
-endif()
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
[1.0.2](https://github.com/KhronosGroup/OpenXR-SDK/releases/tag/release-1.0.2) contains a security fix.  Users are advised to update ASAP.