### PR TITLE
[grppi] Add new port

### DIFF
--- a/ports/grppi/CONTROL
+++ b/ports/grppi/CONTROL
@@ -1,4 +1,4 @@
 Source: grppi
-Version: 0.4.0-1
+Version: 0.4.0
 Homepage: https://github.com/arcosuc3m/grppi
 Description: GrPPI is an open source generic and reusable parallel pattern programming interface developed at University Carlos III of Madrid.  

--- a/ports/grppi/CONTROL
+++ b/ports/grppi/CONTROL
@@ -1,0 +1,4 @@
+Source: grppi
+Version: 0.4.0-1
+Homepage: https://github.com/arcosuc3m/grppi
+Description: GrPPI is an open source generic and reusable parallel pattern programming interface developed at University Carlos III of Madrid.  

--- a/ports/grppi/fix-build-error.patch
+++ b/ports/grppi/fix-build-error.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 09f1f9b..9ef62e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,7 @@ message(STATUS "CMAKE_CXX_COMPILER_ID: " ${CMAKE_CXX_COMPILER_ID} )
+ 
+ set(CMAKE_CXX_STANDARD 14)
+ 
+-add_compile_options(-Wall -Werror -pedantic -pedantic-errors -Wextra -Weffc++)
++add_compile_options(-Wall -Werror -pedantic -pedantic-errors -Wextra)
+ 
+ # Set specific options depending on compiler
+ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )

--- a/ports/grppi/fix-support-other-compilers.patch
+++ b/ports/grppi/fix-support-other-compilers.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 09f1f9b..e7b562b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,22 +20,19 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
+   if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 3.9.0))
+     message(FATAL_ERROR "Clang version " ${CMAKE_CXX_COMPILER_VERSION} 
+        " not supported. Upgrade to 3.9 or above.")
+-  else()
+-    message( STATUS "C++ Compiler is Clang" )
+   endif()
+ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+   if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 6.0))
+     message(FATAL_ERROR "g++ version " ${CMAKE_CXX_COMPILER_VERSION} 
+         " not supported. Upgrade to 6.0 or above.")
+   else()
+-    message( STATUS "C++ Compiler is GNU")
+     if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 7.0)
+       #g++ 7 warns in non C++17 for over-aligned new otherwise
+       add_compile_options(-faligned-new)
+     endif()
+   endif()
+ elseif ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" )
+-  message(FATAL_ERROR "Intel compiler is not currently supported")   
++  message(WARNING "Intel compiler is not currently supported")   
+ # if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 16.0))
+ #   message( FATAL_ERROR "Intel version " ${CMAKE_CXX_COMPILER_VERSION} 
+ #       " not supported. Upgrade to 16.0 or above.")
+@@ -43,12 +40,11 @@ elseif ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel" )
+ #   message( STATUS "C++ Compiler is Intel" )
+ #   message( WARNING "WARNING: GrPPI has not been fully tested with Intel compiler." )
+ # endif()
+-else()
+-  message( FATAL_ERROR "Unsupported compiler: " 
+-      ${CMAKE_CXX_COMPILER_ID} 
+-      ${CMAKE_CXX_COMPILER_VERSION})
+ endif()
+ 
++message(STATUS "C++ Compiler is " ${CMAKE_CXX_COMPILER_ID}
++        " version " ${CMAKE_CXX_COMPILER_VERSION})
++        
+ # GrPPI library
+ include_directories("${CMAKE_SOURCE_DIR}/include")
+ 

--- a/ports/grppi/portfile.cmake
+++ b/ports/grppi/portfile.cmake
@@ -1,0 +1,27 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO arcosuc3m/grppi
+	REF  v0.4.0
+	SHA512 f8235af6832958de420a68d4465a6c63701ab4385f3430d32f77c1d5e8212001262aad1a8aae04261ba889d592798cd3963843b190d325bddc1fe7dcc4aebd7d 
+    HEAD_REF master 
+    PATCHES 
+        fix-build-error.patch
+        fix-support-other-compilers.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+      -DGRPPI_DOXY_ENABLE=OFF
+      -DGRPPI_EXAMPLE_APPLICATIONS_ENABLE=OFF
+      -DGRPPI_UNIT_TEST_ENABLE=OFF
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
GrPPI is a header-only library. It doesn't currently support Intel compiler.
I try to add test as feature at first and find that there are many problems when building test.
Especially on Windows, except for some unsupported commands,` experimental/optional` cannot be found in many files. Even though I have updated them as `optional`, it will cause many other issues.
So I disable test now.
