### PR TITLE
[vcpkg] Continue on malformed paths in PATH

### DIFF
--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -123,7 +123,7 @@ namespace vcpkg::Files
         virtual void remove_all(const fs::path& path, std::error_code& ec, fs::path& failure_point) = 0;
         void remove_all(const fs::path& path, LineInfo li);
         bool exists(const fs::path& path, std::error_code& ec) const;
-        bool exists(LineInfo li, const fs::path& path) const;
+        bool exists(LineInfo li, const fs::path& path, bool ignore = false) const;
         // this should probably not exist, but would require a pass through of
         // existing code to fix
         bool exists(const fs::path& path) const;

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -123,7 +123,7 @@ namespace vcpkg::Files
         virtual void remove_all(const fs::path& path, std::error_code& ec, fs::path& failure_point) = 0;
         void remove_all(const fs::path& path, LineInfo li);
         bool exists(const fs::path& path, std::error_code& ec) const;
-        bool exists(LineInfo li, const fs::path& path, bool ignore = false) const;
+        bool exists(LineInfo li, const fs::path& path) const;
         // this should probably not exist, but would require a pass through of
         // existing code to fix
         bool exists(const fs::path& path) const;

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -178,13 +178,14 @@ namespace vcpkg::Files
         return fs::exists(this->symlink_status(path, ec));
     }
 
-    bool Filesystem::exists(LineInfo li, const fs::path& path, bool ignore) const
+    bool Filesystem::exists(LineInfo li, const fs::path& path) const
     {
         std::error_code ec;
         auto result = this->exists(path, ec);
-        if (ec && !ignore) Checks::exit_with_message(li, "error checking existence of file %s: %s", path.u8string(), ec.message());
+        if (ec) Checks::exit_with_message(li, "error checking existence of file %s: %s", path.u8string(), ec.message());
         return result;
     }
+    
     bool Filesystem::exists(const fs::path& path) const
     {
         std::error_code ec;
@@ -667,13 +668,14 @@ namespace vcpkg::Files
             auto paths = Strings::split(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO), ";");
 
             std::vector<fs::path> ret;
+            std::error_code ec;
             for (auto&& path : paths)
             {
                 auto base = path + "/" + name;
                 for (auto&& ext : EXTS)
                 {
                     auto p = fs::u8path(base + ext.c_str());
-                    if (Util::find(ret, p) == ret.end() && this->exists(VCPKG_LINE_INFO, p, true))
+                    if (Util::find(ret, p) == ret.end() && this->exists(p, ec))
                     {
                         ret.push_back(p);
                         Debug::print("Found path: ", p.u8string(), '\n');

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -178,11 +178,11 @@ namespace vcpkg::Files
         return fs::exists(this->symlink_status(path, ec));
     }
 
-    bool Filesystem::exists(LineInfo li, const fs::path& path) const
+    bool Filesystem::exists(LineInfo li, const fs::path& path, bool ignore) const
     {
         std::error_code ec;
         auto result = this->exists(path, ec);
-        if (ec) Checks::exit_with_message(li, "error checking existence of file %s: %s", path.u8string(), ec.message());
+        if (ec && !ignore) Checks::exit_with_message(li, "error checking existence of file %s: %s", path.u8string(), ec.message());
         return result;
     }
     bool Filesystem::exists(const fs::path& path) const
@@ -673,7 +673,7 @@ namespace vcpkg::Files
                 for (auto&& ext : EXTS)
                 {
                     auto p = fs::u8path(base + ext.c_str());
-                    if (Util::find(ret, p) == ret.end() && this->exists(VCPKG_LINE_INFO, p))
+                    if (Util::find(ret, p) == ret.end() && this->exists(VCPKG_LINE_INFO, p, true))
                     {
                         ret.push_back(p);
                         Debug::print("Found path: ", p.u8string(), '\n');


### PR DESCRIPTION
For issue https://github.com/microsoft/vcpkg/issues/8116, when add ;; to PATH, it consider it’s a path and add quota to it( change to “;;” in PATH);  In vcpkg, it use ; to split the PATH, so it will split “;;”  to  “ ,  empty  , “ , 
So the base value  becomes  “\cmake.bat, it’s illegal path, and exit in  this->exists(VCPKG_LINE_INFO, p).

In this case I think we shouldn’t exit when environment variable ‘PATH’ contains illegal path(eg ;;).