### PR TITLE
[vcpkg] Fix `depend-info` command arguments arity

### DIFF
--- a/toolsrc/src/vcpkg/commands.dependinfo.cpp
+++ b/toolsrc/src/vcpkg/commands.dependinfo.cpp
@@ -228,8 +228,8 @@ namespace vcpkg::Commands::DependInfo
 
     const CommandStructure COMMAND_STRUCTURE = {
         Help::create_example_string("depend-info sqlite3"),
-        0,
-        SIZE_MAX,
+        1,
+        1,
         {DEPEND_SWITCHES, DEPEND_SETTINGS},
         nullptr,
     };


### PR DESCRIPTION
Added minimum and maximum arity to the `depend-info` command.

If `depend-info` is used with an incorrect number of arguments a usage message is printed.

Fix #8130 