### PR TITLE
[sdformat6] Add new port 🤖

### DIFF
--- a/ports/sdformat6/CONTROL
+++ b/ports/sdformat6/CONTROL
@@ -1,4 +1,5 @@
 Source: sdformat6
 Version: 6.2.0
+Homepage: http://sdformat.org/
 Build-Depends: boost-any, boost-variant, ignition-math4, urdfdom, tinyxml
 Description: Simulation Description Format (SDF) parser and description files.

--- a/ports/sdformat6/CONTROL
+++ b/ports/sdformat6/CONTROL
@@ -1,0 +1,4 @@
+Source: sdformat6
+Version: 6.2.0
+Build-Depends: boost-any, boost-variant, ignition-math4, urdfdom, tinyxml
+Description: Simulation Description Format (SDF) parser and description files.

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -1,0 +1,55 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_bitbucket(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO osrf/sdformat
+    REF sdformat6_6.2.0
+    SHA512 3e3934010438bffbf10c1df29bd486c098e3c1bdf2b0349b69a53fb6f4d2bd3b3c8c4b4a8dfb413da13a638c0794f41c1bff4adb11a889b1552d90ba8b94c495
+    HEAD_REF sdf6
+)
+
+# Ruby is required by the sdformat build process
+vcpkg_find_acquire_program(RUBY)
+get_filename_component(RUBY_PATH ${RUBY} DIRECTORY)
+set(_path $ENV{PATH})
+vcpkg_add_to_path(${RUBY_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_TESTING=OFF
+            -DUSE_EXTERNAL_URDF=ON
+            -DUSE_EXTERNAL_TINYXML=ON
+)
+
+vcpkg_install_cmake()
+
+# Restore original path
+set(ENV{PATH} ${_path})
+
+# Move location of sdformat.dll from lib to bin
+if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/sdformat.dll)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/sdformat.dll
+                ${CURRENT_PACKAGES_DIR}/bin/sdformat.dll)
+endif()
+
+if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/sdformat.dll)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/sdformat.dll
+                ${CURRENT_PACKAGES_DIR}/debug/bin/sdformat.dll)
+endif()
+
+# Fix cmake targets location
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/sdformat")
+
+# Remove debug files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+                    ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdformat6 RENAME copyright)
+
+# Post-build test for cmake libraries
+vcpkg_test_cmake(PACKAGE_NAME SDFormat)


### PR DESCRIPTION
Add new port for the sdformat library (http://sdformat.org/).

The sdformat library is commonly used with the Ignition Robotics libraries (https://github.com/microsoft/vcpkg/pull/7781) and is a fundamental dependency of the Gazebo robotics simulator (https://github.com/microsoft/vcpkg/issues/8014).