### PR TITLE
[speexdsp] update to 1.2.0

### DIFF
--- a/ports/speexdsp/CMakeLists.txt
+++ b/ports/speexdsp/CMakeLists.txt
@@ -5,10 +5,7 @@ option(USE_SSE       "Use SSE")
 project (libspeexdsp)
 
 file(GLOB_RECURSE LIBSPEEXDSP_SOURCES "${SOURCE_PATH}/libspeexdsp/*.c")
-list(REMOVE_ITEM LIBSPEEXDSP_SOURCES "${SOURCE_PATH}/libspeexdsp/testdenoise.c"
-                                     "${SOURCE_PATH}/libspeexdsp/testecho.c"
-                                     "${SOURCE_PATH}/libspeexdsp/testjitter.c"
-                                     "${SOURCE_PATH}/libspeexdsp/testresample.c")
+list(FILTER LIBSPEEXDSP_SOURCES EXCLUDE REGEX "${SOURCE_PATH}/libspeexdsp/test.*\\.c")
 file(GLOB_RECURSE LIBSPEEXDSP_HEADERS "${SOURCE_PATH}/libspeexdsp/*.h")
 file(GLOB_RECURSE LIBSPEEXDSP_HEADERS_PUBLIC "${SOURCE_PATH}/include/**/*.h")
 

--- a/ports/speexdsp/CONTROL
+++ b/ports/speexdsp/CONTROL
@@ -1,5 +1,5 @@
 Source: speexdsp
-Version: 1.2rc3-3
+Version: 1.2.0
 Homepage: https://ftp.osuosl.org/pub/xiph/releases/speex/
 Description: A patent-free, Open Source/Free Software DSP library.
 Build-Depends:

--- a/ports/speexdsp/portfile.cmake
+++ b/ports/speexdsp/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/speexdsp-1.2rc3)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/speexdsp-1.2.0)
 set(CMAKE_PATH ${CMAKE_CURRENT_LIST_DIR})
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "http://downloads.xiph.org/releases/speex/speexdsp-1.2rc3.tar.gz"
-    FILENAME "speexdsp-1.2rc3.tar.xz"
-    SHA512 29dfa8345df025eeb076561648a9b5c0485692be699b6da3c2a3734b4329187a1c2eb181252f4df12b21f1309ecdf59797437dfb123d160fd723491ab216e858
+    URLS "http://downloads.xiph.org/releases/speex/speexdsp-1.2.0.tar.gz"
+    FILENAME "speexdsp-1.2.0.tar.gz"
+    SHA512 e357cd5377415ea66c862302c7cf8bf6a10063cacd903f0846478975b87974cf5bdf00e2c6759d8f4f453c4c869cf284e9dc948a84a83d7b2ab96bd5405c05ec
 )
 vcpkg_extract_source_archive(${ARCHIVE_FILE})
 


### PR DESCRIPTION
The update added another test file. Changed the CMake instruction to exclude the specific test files to catch any source file with the test file naming convention to handle this and any future test file changes.