### PR TITLE
Version number refers to the commit

### DIFF
--- a/ports/rapidjson/CONTROL
+++ b/ports/rapidjson/CONTROL
@@ -1,4 +1,4 @@
 Source: rapidjson
-Version: d87b698-1
+Version: 1.1.0 (d87b698-1)
 Description: A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>
 Homepage: http://rapidjson.org/


### PR DESCRIPTION
It is much easier when the version number from the rapidjson website is shown.

If this is annoying to maintain then never mind, I just spend some extra time to check it vcpkg was up to date vs. the actual project.

Look forward to try rapidjson out :-)