### PR TITLE
Fix libyaml CMake package and CMake targets

### DIFF
--- a/ports/libyaml/CONTROL
+++ b/ports/libyaml/CONTROL
@@ -1,3 +1,3 @@
 Source: libyaml
-Version: 0.2.2-1
+Version: 0.2.2-2
 Description: A C library for parsing and emitting YAML.

--- a/ports/libyaml/portfile.cmake
+++ b/ports/libyaml/portfile.cmake
@@ -15,12 +15,14 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DINSTALL_CMAKE_DIR="share/yaml"
 )
 
 vcpkg_install_cmake()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/include/config.h)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/yaml TARGET_PATH share/yaml)
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/include/config.h ${CURRENT_PACKAGES_DIR}/debug/share)
+
 
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/libyaml/copyright COPYONLY)

--- a/ports/libyaml/portfile.cmake
+++ b/ports/libyaml/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DINSTALL_CMAKE_DIR="share/yaml"
+        -DINSTALL_CMAKE_DIR=share/yaml
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
The CMake exported targets and CMake package of libyaml were broken for the following reasons:
* The CMake package of the port is called yaml, but the config files were installed in share/libyaml,
  so it was not possible for CMake's find_package command to find them
* The CMake config file for the library is custom, so vcpkg_fixup_cmake_targets was not properly handling
  the change of CMake conf file directory from cmake to share/yaml. Use of the project's INSTALL_CMAKE_DIR
  option permitted to change easily also the custom part of the config file.