### PR TITLE
[WIP] [gazebo10] Add new port

### DIFF
--- a/ports/gazebo10/CONTROL
+++ b/ports/gazebo10/CONTROL
@@ -1,0 +1,5 @@
+Source: gazebo10
+Version: 10.1.0
+Build-Depends: boost-asio, boost-date-time, boost-filesystem, boost-format, boost-interprocess, boost-iostreams, boost-program-options, boost-property-tree, boost-regex, boost-smart-ptr, boost-system, boost-thread, boost-uuid, bullet3, freeimage, ignition-fuel-tools1, ignition-math4, ignition-msgs1, ignition-transport4, ogre, protobuf, qt5-base, qwt, sdformat6, tbb, tinyxml, tinyxml2, zeromq
+Homepage: http://gazebosim.org/
+Description: Gazebo robot simulator

--- a/ports/gazebo10/fix-find-package-ogre.patch
+++ b/ports/gazebo10/fix-find-package-ogre.patch
@@ -1,0 +1,20 @@
+diff -r 7c4281fe1229 -r c71622e89674 cmake/SearchForStuff.cmake
+--- a/cmake/SearchForStuff.cmake
++++ b/cmake/SearchForStuff.cmake
+@@ -357,6 +357,8 @@
+   pkg_check_modules(OGRE OGRE>=${MIN_OGRE_VERSION})
+ 
+   if (NOT OGRE_FOUND)
++    # Workaround for CMake bug https://gitlab.kitware.com/cmake/cmake/issues/17135
++    unset(OGRE_FOUND CACHE)
+     # If OGRE was not found, try with the standard find_package(OGRE)
+     find_package(OGRE COMPONENTS RTShaderSystem Terrain Overlay Paging)
+     # Add each component include directories to OGRE_INCLUDE_DIRS because
+@@ -370,6 +372,7 @@
+     list(APPEND OGRE_LIBRARIES ${OGRE_Terrain_LIBRARIES})
+     list(APPEND OGRE_LIBRARIES ${OGRE_Overlay_LIBRARIES})
+     list(APPEND OGRE_LIBRARIES ${OGRE_Paging_LIBRARIES})
++    set(OGRE_PLUGINDIR ${OGRE_PLUGIN_DIR})
+   endif ()
+ 
+   if (NOT OGRE_FOUND)

--- a/ports/gazebo10/fix-link-ignition-common.patch
+++ b/ports/gazebo10/fix-link-ignition-common.patch
@@ -1,0 +1,11 @@
+diff -r 7c4281fe1229 -r 735535193dd2 gazebo/common/CMakeLists.txt
+--- a/gazebo/common/CMakeLists.txt
++++ b/gazebo/common/CMakeLists.txt
+@@ -262,6 +262,7 @@
+   ${TBB_LIBRARIES}
+   ${SDFormat_LIBRARIES}
+   ${IGNITION-FUEL_TOOLS_LIBRARIES}
++  ${IGNITION-COMMON_LIBRARIES}
+ )
+ 
+ if (UNIX)

--- a/ports/gazebo10/fix-pkg-config-msvc-workaround.patch
+++ b/ports/gazebo10/fix-pkg-config-msvc-workaround.patch
@@ -1,0 +1,29 @@
+diff -r 7c4281fe1229 -r b7e6f837cc8b cmake/SearchForStuff.cmake
+--- a/cmake/SearchForStuff.cmake
++++ b/cmake/SearchForStuff.cmake
+@@ -91,12 +91,6 @@
+ ########################################
+ # Find packages
+ 
+-# In Visual Studio we use configure.bat to trick all path cmake
+-# variables so let's consider that as a replacement for pkgconfig
+-if (MSVC)
+-  set (PKG_CONFIG_FOUND TRUE)
+-endif()
+-
+ find_package(CURL)
+ if (CURL_FOUND)
+   # FindCURL.cmake distributed with CMake exports
+@@ -109,6 +103,12 @@
+   set(CURL_INCLUDEDIR ${CURL_INCLUDE_DIRS})
+ endif ()
+ 
++# In Visual Studio we use configure.bat to trick all path cmake
++# variables so let's consider that as a replacement for pkgconfig
++if (MSVC)
++  set (PKG_CONFIG_FOUND TRUE)
++endif()
++
+ if (PKG_CONFIG_FOUND)
+   if (NOT CURL_FOUND)
+     pkg_check_modules(CURL libcurl)

--- a/ports/gazebo10/gazebo-3131.patch
+++ b/ports/gazebo10/gazebo-3131.patch
@@ -1,0 +1,14 @@
+diff -r 7c4281fe1229 -r 28fb1b2d8cc5 gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
+--- a/gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
++++ b/gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
+@@ -136,10 +136,6 @@
+   Ogre::String programName = this->baseName + "VP_" +
+                              Ogre::StringConverter::toString(_permutation);
+ 
+-#if OGRE_DEBUG_MODE
+-  Ogre::LogManager::getSingleton().getDefaultLog()->logMessage(programSource);
+-#endif
+-
+   // Create shader object
+   Ogre::HighLevelGpuProgramPtr ptrProgram =
+     Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(

--- a/ports/gazebo10/gazebo-3134.patch
+++ b/ports/gazebo10/gazebo-3134.patch
@@ -1,0 +1,14 @@
+diff -r 05048f450958 -r cc4f1a058d49 gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
+--- a/gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
++++ b/gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
+@@ -104,10 +104,6 @@
+   Ogre::String programName = this->baseName + "VP_" +
+     Ogre::StringConverter::toString(_permutation);
+ 
+-#if OGRE_DEBUG_MODE
+-  Ogre::LogManager::getSingleton().getDefaultLog()->logMessage(programSource);
+-#endif
+-
+   // Create shader object
+   Ogre::HighLevelGpuProgramPtr ptrProgram =
+     Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(

--- a/ports/gazebo10/gazebo-3135.patch
+++ b/ports/gazebo10/gazebo-3135.patch
@@ -1,0 +1,34 @@
+diff -r 783ca3ec62b8 -r ed9e0e54dc86 cmake/SearchForStuff.cmake
+--- a/cmake/SearchForStuff.cmake
++++ b/cmake/SearchForStuff.cmake
+@@ -312,13 +312,23 @@
+     message(STATUS "TBB not found, attempting to detect manually")
+     set (TBB_PKG_CONFIG "")
+ 
+-    find_library(tbb_library tbb ENV LD_LIBRARY_PATH)
+-    if (tbb_library)
+-      set(TBB_FOUND true)
+-      set(TBB_LIBRARIES ${tbb_library})
+-    else (tbb_library)
+-      BUILD_ERROR ("Missing: TBB - Threading Building Blocks")
+-    endif(tbb_library)
++    # Workaround for CMake bug https://gitlab.kitware.com/cmake/cmake/issues/17135
++    unset(TBB_FOUND CACHE)
++
++    find_package(TBB CONFIG)
++    if (TBB_FOUND)
++      set(TBB_LIBRARIES TBB::tbb)
++    endif()
++
++    if (NOT TBB_FOUND)
++      find_library(tbb_library tbb ENV LD_LIBRARY_PATH)
++      if (tbb_library)
++        set(TBB_FOUND true)
++        set(TBB_LIBRARIES ${tbb_library})
++      else (tbb_library)
++        BUILD_ERROR ("Missing: TBB - Threading Building Blocks")
++      endif(tbb_library)
++    endif (NOT TBB_FOUND)
+   endif (NOT TBB_FOUND)
+ 
+   #################################################

--- a/ports/gazebo10/gazebo-3141.patch
+++ b/ports/gazebo10/gazebo-3141.patch
@@ -1,0 +1,14 @@
+diff -r 783ca3ec62b8 -r d1dc82f1cf81 deps/opende/CMakeLists.txt
+--- a/deps/opende/CMakeLists.txt
++++ b/deps/opende/CMakeLists.txt
+@@ -269,7 +269,9 @@
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -DODE_DLL")
+ endif()
+ 
+-set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_LINK_FLAGS_${CMAKE_BUILD_TYPE}} -MF -MT -fno-strict-aliasing -DPIC ")
++if (NOT MSVC)
++  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${CMAKE_LINK_FLAGS_${CMAKE_BUILD_TYPE}} -MF -MT -fno-strict-aliasing -DPIC ")
++endif()
+ 
+ if (WIN32)
+   add_library(gazebo_ode SHARED ${sources})

--- a/ports/gazebo10/gazebo-3142.patch
+++ b/ports/gazebo10/gazebo-3142.patch
@@ -1,0 +1,27 @@
+diff -r 783ca3ec62b8 -r e94dd55a2a26 gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
+--- a/gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
++++ b/gazebo/rendering/deferred_shading/GBufferMaterialGenerator.cc
+@@ -255,9 +255,6 @@
+   Ogre::String programName = this->baseName + "FP_" +
+                              Ogre::StringConverter::toString(_permutation);
+ 
+-#if OGRE_DEBUG_MODE
+-  Ogre::LogManager::getSingleton().getDefaultLog()->logMessage(programSource);
+-#endif
+ 
+   // Create shader object
+   Ogre::HighLevelGpuProgramPtr ptrProgram =
+diff -r 783ca3ec62b8 -r e94dd55a2a26 gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
+--- a/gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
++++ b/gazebo/rendering/deferred_shading/MergeMaterialGenerator.cc
+@@ -289,10 +289,6 @@
+   Ogre::String programName = this->baseName + "FP_" +
+     Ogre::StringConverter::toString(_permutation);
+ 
+-#if OGRE_DEBUG_MODE
+-  Ogre::LogManager::getSingleton().getDefaultLog()->logMessage(programSource);
+-#endif
+-
+   // Create shader object
+   Ogre::HighLevelGpuProgramPtr ptrProgram =
+     Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(

--- a/ports/gazebo10/gazebo-3143.patch
+++ b/ports/gazebo10/gazebo-3143.patch
@@ -1,0 +1,15 @@
+diff -r 783ca3ec62b8 -r 6f45867b9258 gazebo/gui/InsertModelWidgetPrivate.hh
+--- a/gazebo/gui/InsertModelWidgetPrivate.hh
++++ b/gazebo/gui/InsertModelWidgetPrivate.hh
+@@ -25,6 +25,11 @@
+ #include <boost/thread/mutex.hpp>
+ 
+ #ifdef HAVE_IGNITION_FUEL_TOOLS
++  #ifdef _WIN32
++    // DELETE is defined in winnt.h and causes a problem with 
++    // ignition::fuel_tools::REST::DELETE
++    #undef DELETE
++  #endif
+   #include <ignition/fuel_tools/FuelClient.hh>
+   #include <ignition/fuel_tools/ModelIdentifier.hh>
+ #endif

--- a/ports/gazebo10/gazebo-3144.patch
+++ b/ports/gazebo10/gazebo-3144.patch
@@ -1,0 +1,146 @@
+diff -r 13b71990d544 -r f0c77c4ef2bb CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,7 +154,13 @@
+ # 2. In the generation of cmake/setup.sh from cmake/setup.sh.in
+ set(GAZEBO_DEFAULT_MASTER_HOST localhost)
+ set(GAZEBO_DEFAULT_MASTER_PORT 11345)
+-set(GAZEBO_PLUGIN_PATH ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/gazebo-${GAZEBO_MAJOR_VERSION}/plugins)
++set(GAZEBO_PLUGIN_LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/gazebo-${GAZEBO_MAJOR_VERSION}/plugins)
++set(GAZEBO_PLUGIN_BIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}/gazebo-${GAZEBO_MAJOR_VERSION}/plugins)
++if(WIN32)
++  set(GAZEBO_PLUGIN_PATH ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
++else()
++  set(GAZEBO_PLUGIN_PATH ${GAZEBO_PLUGIN_LIB_INSTALL_DIR})
++endif()
+ FILE(TO_NATIVE_PATH "${GAZEBO_PLUGIN_PATH}" GAZEBO_PLUGIN_PATH)
+ set(GAZEBO_MODEL_PATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/gazebo-${GAZEBO_MAJOR_VERSION}/models)
+ FILE(TO_NATIVE_PATH "${GAZEBO_MODEL_PATH}" GAZEBO_MODEL_PATH)
+diff -r 13b71990d544 -r f0c77c4ef2bb cmake/GazeboUtils.cmake
+--- a/cmake/GazeboUtils.cmake
++++ b/cmake/GazeboUtils.cmake
+@@ -115,7 +115,10 @@
+ #################################################
+ macro (gz_install_library _name)
+   set_target_properties(${_name} PROPERTIES SOVERSION ${GAZEBO_MAJOR_VERSION} VERSION ${GAZEBO_VERSION_FULL})
+-  install (TARGETS ${_name} DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib)
++  install (TARGETS ${_name}
++           LIBRARY DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib
++           ARCHIVE DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib
++           RUNTIME DESTINATION ${BIN_INSTALL_DIR} COMPONENT shlib)
+ endmacro ()
+ 
+ #################################################
+diff -r 13b71990d544 -r f0c77c4ef2bb plugins/CMakeLists.txt
+--- a/plugins/CMakeLists.txt
++++ b/plugins/CMakeLists.txt
+@@ -159,8 +159,5 @@
+   GravityCompensationPlugin
+ )
+ 
+-set(GAZEBO_PLUGIN_INSTALL_DIR
+-  ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/gazebo-${GAZEBO_MAJOR_VERSION}/plugins/
+-)
+ 
+ foreach (src ${plugins_single_header})
+@@ -179,7 +178,10 @@
+     ${ogre_libraries}
+     ${IGNITION-TRANSPORT_LIBRARIES}
+   )
+-  install (TARGETS ${src} DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++  install (TARGETS ${src}
++           LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+   gz_install_includes("plugins" ${src}.hh)
+ endforeach ()
+ 
+@@ -198,7 +200,10 @@
+     ${ogre_libraries}
+     ${IGNITION-TRANSPORT_LIBRARIES}
+   )
+-  install (TARGETS ${src} DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++  install (TARGETS ${src}
++           LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+   gz_install_includes("plugins" ${src}.hh)
+   gz_install_includes("plugins" ${src}Private.hh)
+ endforeach ()
+@@ -214,7 +219,10 @@
+                         ${Qt5Widgets_LIBRARIES}
+                         ${IGNITION-TRANSPORT_LIBRARIES}
+ )
+-  install (TARGETS ${src} DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++  install (TARGETS ${src}
++           LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++           RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+   gz_install_includes("plugins" ${src}.hh)
+ endforeach ()
+ 
+@@ -225,7 +233,10 @@
+       libgazebo
+       ${DART_LIBRARIES}
+     )
+-    install (TARGETS ${src} DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++    install (TARGETS ${src}
++             LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++             ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++             RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+     gz_install_includes("plugins" ${src}.hh)
+   endforeach ()
+ endif()
+@@ -234,7 +245,7 @@
+ # Plus, set RPATH to the directory so they can dynamically link.
+ target_link_libraries(LedPlugin FlashLightPlugin)
+ set_target_properties(
+-  LedPlugin PROPERTIES INSTALL_RPATH ${GAZEBO_PLUGIN_INSTALL_DIR})
++  LedPlugin PROPERTIES INSTALL_RPATH ${GAZEBO_PLUGIN_LIB_INSTALL_DIR})
+ 
+ add_subdirectory(events)
+ 
+diff -r 13b71990d544 -r f0c77c4ef2bb plugins/events/CMakeLists.txt
+--- a/plugins/events/CMakeLists.txt
++++ b/plugins/events/CMakeLists.txt
+@@ -46,10 +46,16 @@
+ 
+ add_library(SimEventsPlugin SHARED ${sim_event_src})
+ target_link_libraries(SimEventsPlugin gazebo_physics gazebo_msgs)
+-install (TARGETS SimEventsPlugin DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++install (TARGETS SimEventsPlugin
++         LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+ gz_install_includes("plugins/events" ${sim_event_include})
+ 
+ add_library(RegionEventBoxPlugin SHARED ${src})
+ target_link_libraries(RegionEventBoxPlugin gazebo_physics gazebo_msgs)
+-install (TARGETS RegionEventBoxPlugin DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++install (TARGETS RegionEventBoxPlugin
++         LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+ gz_install_includes("plugins/events" ${inc})
+diff -r 13b71990d544 -r f0c77c4ef2bb plugins/rest_web/CMakeLists.txt
+--- a/plugins/rest_web/CMakeLists.txt
++++ b/plugins/rest_web/CMakeLists.txt
+@@ -42,10 +42,16 @@
+ 
+ add_library(RestWebPlugin SHARED ${server_src} )
+ target_link_libraries(RestWebPlugin ${GAZEBO_libraries} gazebo_msgs)
+-install (TARGETS RestWebPlugin DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++install (TARGETS RestWebPlugin
++         LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+ gz_install_includes("plugins" ${server_inc})
+ 
+ add_library(RestUiPlugin SHARED ${client_src} ${headers_MOC})
+ target_link_libraries(RestUiPlugin ${GAZEBO_libraries} gazebo_msgs)
+-install (TARGETS RestUiPlugin DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
++install (TARGETS RestUiPlugin
++         LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
++         RUNTIME DESTINATION ${GAZEBO_PLUGIN_BIN_INSTALL_DIR})
+ gz_install_includes("plugins" ${client_inc})

--- a/ports/gazebo10/gazebo-rendering-heightmap-support-ogre-1-12.patch
+++ b/ports/gazebo10/gazebo-rendering-heightmap-support-ogre-1-12.patch
@@ -1,0 +1,163 @@
+# HG changeset patch
+# User Silvio Traversaro <silvio@traversaro.it>
+# Date 1569227706 -7200
+# Branch ogre_1_12_heightmap
+# Node ID 152a77d545b2e51cf7809760558578df36331b52
+# Parent  c28f9609823b3d7d7b1aef37fd7ebe1445e1418c
+Change HeightMap class to compile with Ogre 1.11/1.12
+
+diff --git a/gazebo/rendering/Heightmap.cc b/gazebo/rendering/Heightmap.cc
+--- a/gazebo/rendering/Heightmap.cc
++++ b/gazebo/rendering/Heightmap.cc
+@@ -53,6 +53,13 @@
+ using namespace gazebo;
+ using namespace rendering;
+ 
++#if OGRE_VERSION_MAJOR > 1 || OGRE_VERSION_MINOR >= 11
++using Ogre::TechniqueType;
++using Ogre::HIGH_LOD;
++using Ogre::RENDER_COMPOSITE_MAP;
++using Ogre::LOW_LOD;
++#endif
++
+ const double HeightmapPrivate::loadRadiusFactor = 1.0;
+ const double HeightmapPrivate::holdRadiusFactor = 1.15;
+ const boost::filesystem::path HeightmapPrivate::pagingDirname = "paging";
+@@ -1163,8 +1170,13 @@
+   Ogre::TerrainMaterialGeneratorPtr matGen =
+       this->dataPtr->terrainGlobals->getDefaultMaterialGenerator();
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
+   matProfile = static_cast<GzTerrainMatGen::SM2Profile*>(
+       matGen->getActiveProfile());
++#else
++  matProfile = static_cast<Ogre::TerrainMaterialGeneratorA::SM2Profile*>(
++      matGen->getActiveProfile());
++#endif
+   if (!matProfile)
+   {
+     // using custom material script so ignore setting shadows
+@@ -1270,6 +1282,7 @@
+   }
+   else
+   {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
+     // use default material
+     // RTSS PSSM shadows compatible terrain material
+     if (!this->dataPtr->gzMatGen)
+@@ -1279,6 +1292,16 @@
+     ptr.bind(this->dataPtr->gzMatGen);
+ 
+     this->dataPtr->terrainGlobals->setDefaultMaterialGenerator(ptr);
++#else
++    // init custom material generator
++    Ogre::TerrainMaterialGeneratorPtr terrainMaterialGenerator;
++    TerrainMaterial *terrainMaterial = OGRE_NEW TerrainMaterial("Gazebo/Grey");
++    if (this->dataPtr->splitTerrain)
++      terrainMaterial->setGridSize(this->dataPtr->numTerrainSubdivisions);
++    terrainMaterialGenerator.bind(terrainMaterial);
++    this->dataPtr->terrainGlobals->setDefaultMaterialGenerator(
++        terrainMaterialGenerator);
++#endif
+ 
+     this->SetupShadows(true);
+   }
+@@ -1296,6 +1319,7 @@
+ /////////////////////////////////////////////////
+ /////////////////////////////////////////////////
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
+ 
+ /////////////////////////////////////////////////
+ GzTerrainMatGen::GzTerrainMatGen()
+@@ -1376,10 +1400,11 @@
+     // }
+ 
+     // check SM3 features
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 8
+     this->mSM3Available =
+       Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("ps_3_0");
+-
+-#if OGRE_VERSION_MAJOR >= 1 && OGRE_VERSION_MINOR >= 8
++#endif
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 8 && OGRE_VERSION_MINOR <= 11
+     this->mSM4Available =
+       Ogre::GpuProgramManager::getSingleton().isSyntaxSupported("ps_4_0");
+ #endif
+@@ -1608,6 +1633,7 @@
+ void GzTerrainMatGen::SM2Profile::UpdateParamsForCompositeMap(
+     const Ogre::MaterialPtr &_mat, const Ogre::Terrain *_terrain)
+ {
++  // Only tested for Ogre 1.11 & 1.12
+   static_cast<GzTerrainMatGen::SM2Profile::ShaderHelperGLSL*>(
+       this->mShaderGen)->updateParams(this, _mat, _terrain, true);
+ }
+@@ -3221,6 +3247,9 @@
+   return ret;
+ }
+ 
++// #if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
++#endif
++
+ /////////////////////////////////////////////////
+ /////////////////////////////////////////////////
+ // TerrainMaterial
+diff --git a/gazebo/rendering/HeightmapPrivate.hh b/gazebo/rendering/HeightmapPrivate.hh
+--- a/gazebo/rendering/HeightmapPrivate.hh
++++ b/gazebo/rendering/HeightmapPrivate.hh
+@@ -25,6 +25,19 @@
+ 
+ #include "gazebo/rendering/RenderTypes.hh"
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++// Since OGRE 1.11, the once public Ogre::TerrainMaterialGeneratorA::SM2Profile::ShaderHelper
++// class and its descentent are now private classes of OGRE, see
++// * https://github.com/OGRECave/ogre/blob/master/Docs/1.11-Notes.md#other
++// * https://github.com/OGRECave/ogre/pull/722/commits/88d6903a0b6e3d47d477f2a18ea755804f990a2f
++//
++// As these classes are heavily used in the  Heightmap class implementation
++// (by accessing a protected Ogre class) we need to disable the definition of the custom terrain  generator,
++// and just use the Ogre default one.
++using Ogre::TechniqueType;
++#endif
++
++
+ namespace Ogre
+ {
+   class PageManager;
+@@ -43,6 +56,7 @@
+ 
+   namespace rendering
+   {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
+     /// \internal
+     /// \brief Custom terrain material generator for GLSL terrains.
+     /// A custom material generator that lets Gazebo use GLSL shaders
+@@ -184,6 +198,7 @@
+         /// Original implementation from Ogre that generates Cg shaders
+         protected: class ShaderHelperCg :
+             public Ogre::TerrainMaterialGeneratorA::SM2Profile::ShaderHelperCg
++
+         {
+           public: virtual Ogre::HighLevelGpuProgramPtr generateFragmentProgram(
+                       const SM2Profile *_prof, const Ogre::Terrain *_terrain,
+@@ -232,6 +247,8 @@
+ #endif
+       };
+     };
++// #if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
++#endif
+ 
+     /// \internal
+     /// \brief Custom terrain material generator.
+@@ -405,8 +422,10 @@
+       /// \brief The raw height values received from physics.
+       public: std::vector<float> heights;
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
+       /// \brief Pointer to the terrain material generator.
+       public: GzTerrainMatGen *gzMatGen = nullptr;
++#endif
+ 
+       /// \brief A page provider is needed to use the paging system.
+       public: DummyPageProvider dummyPageProvider;

--- a/ports/gazebo10/gazebo-rendering-support-ogre-1-12.patch
+++ b/ports/gazebo10/gazebo-rendering-support-ogre-1-12.patch
@@ -1,0 +1,723 @@
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/gui/ModelSnap.cc
+--- a/gazebo/gui/ModelSnap.cc
++++ b/gazebo/gui/ModelSnap.cc
+@@ -416,7 +416,8 @@
+         this->dataPtr->snapHighlight =
+             this->dataPtr->highlightVisual->CreateDynamicLine(
+             rendering::RENDERING_TRIANGLE_FAN);
+-        this->dataPtr->snapHighlight->setMaterial("Gazebo/RedTransparent");
++        GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->snapHighlight,
++            "Gazebo/RedTransparent");
+         this->dataPtr->snapHighlight->AddPoint(hoverTriangle[0]);
+         this->dataPtr->snapHighlight->AddPoint(hoverTriangle[1]);
+         this->dataPtr->snapHighlight->AddPoint(hoverTriangle[2]);
+@@ -480,7 +481,7 @@
+       this->dataPtr->snapLines =
+           this->dataPtr->snapVisual->CreateDynamicLine(
+           rendering::RENDERING_LINE_STRIP);
+-      this->dataPtr->snapLines->setMaterial("Gazebo/RedGlow");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->snapLines, "Gazebo/RedGlow");
+       this->dataPtr->snapLines->AddPoint(triangle[0]);
+       this->dataPtr->snapLines->AddPoint(triangle[1]);
+       this->dataPtr->snapLines->AddPoint(triangle[2]);
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/gui/model/JointMaker.cc
+--- a/gazebo/gui/model/JointMaker.cc
++++ b/gazebo/gui/model/JointMaker.cc
+@@ -506,7 +506,8 @@
+   jointData->parent = _parent;
+   jointData->line = jointLine;
+   jointData->type = this->dataPtr->jointType;
+-  jointData->line->setMaterial(this->jointMaterials[jointData->type]);
++  GZ_OGRE_SET_MATERIAL_BY_NAME(jointData->line,
++                               this->jointMaterials[jointData->type]);
+ 
+   return jointData;
+ }
+@@ -1221,7 +1222,7 @@
+   // Line
+   if (this->line)
+   {
+-    this->line->setMaterial(material);
++    GZ_OGRE_SET_MATERIAL_BY_NAME(this->line, material);
+ 
+     // Parent - child
+     if (this->child && this->jointVisual)
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/ApplyWrenchVisual.cc
+--- a/gazebo/rendering/ApplyWrenchVisual.cc
++++ b/gazebo/rendering/ApplyWrenchVisual.cc
+@@ -175,7 +175,7 @@
+   // Torque line
+   dPtr->torqueLine = dPtr->torqueVisual->
+       CreateDynamicLine(rendering::RENDERING_LINE_LIST);
+-  dPtr->torqueLine->setMaterial(dPtr->unselectedMaterial);
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->torqueLine, dPtr->unselectedMaterial);
+   dPtr->torqueLine->AddPoint(0, 0, 0);
+   dPtr->torqueLine->AddPoint(0, 0, 0.1);
+ 
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/COMVisual.cc
+--- a/gazebo/rendering/COMVisual.cc
++++ b/gazebo/rendering/COMVisual.cc
+@@ -183,7 +183,7 @@
+   p6 += dPtr->inertiaPose.Pos();
+ 
+   dPtr->crossLines = this->CreateDynamicLine(rendering::RENDERING_LINE_LIST);
+-  dPtr->crossLines->setMaterial("Gazebo/Green");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->crossLines, "Gazebo/Green");
+   dPtr->crossLines->AddPoint(p1);
+   dPtr->crossLines->AddPoint(p2);
+   dPtr->crossLines->AddPoint(p3);
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Camera.cc
+--- a/gazebo/rendering/Camera.cc
++++ b/gazebo/rendering/Camera.cc
+@@ -1793,7 +1793,11 @@
+     box.setMinimum(bbox.Min().X(), bbox.Min().Y(), bbox.Min().Z());
+     box.setMaximum(bbox.Max().X(), bbox.Max().Y(), bbox.Max().Z());
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    box.transform(_visual->GetSceneNode()->_getFullTransform());
++#else
+     box.transformAffine(_visual->GetSceneNode()->_getFullTransform());
++#endif
+ 
+     // update cam node to ensure transform is update-to-date
+     this->cameraNode->_update(false, true);
+@@ -2020,15 +2024,27 @@
+ float Camera::AvgFPS() const
+ {
+   if (this->renderTarget)
++  {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    return this->renderTarget->getStatistics().avgFPS;
++#else
+     return this->renderTarget->getAverageFPS();
++#endif
++  }
+   else
++  {
+     return 0.0f;
++  }
+ }
+ 
+ //////////////////////////////////////////////////
+ unsigned int Camera::TriangleCount() const
+ {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++  return this->renderTarget->getStatistics().triangleCount;
++#else
+   return this->renderTarget->getTriangleCount();
++#endif
+ }
+ 
+ //////////////////////////////////////////////////
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/CameraVisual.cc
+--- a/gazebo/rendering/CameraVisual.cc
++++ b/gazebo/rendering/CameraVisual.cc
+@@ -114,7 +114,7 @@
+   line->AddPoint(ignition::math::Vector3d(0, 0, 0));
+   line->AddPoint(ignition::math::Vector3d(dist, width*0.5, -height*0.5));
+ 
+-  line->setMaterial("Gazebo/WhiteGlow");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(line, "Gazebo/WhiteGlow");
+   line->setVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+   this->AttachObject(planeEnt);
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/ContactVisual.cc
+--- a/gazebo/rendering/ContactVisual.cc
++++ b/gazebo/rendering/ContactVisual.cc
+@@ -120,8 +120,8 @@
+       dPtr->points[c]->normal->SetPoint(1, (normal*normalScale));
+       dPtr->points[c]->depth->SetPoint(1, (normal*-depth*10));
+ 
+-      dPtr->points[c]->normal->setMaterial("Gazebo/LightOn");
+-      dPtr->points[c]->depth->setMaterial("Gazebo/LightOff");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->points[c]->normal, "Gazebo/LightOn");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->points[c]->depth, "Gazebo/LightOff");
+       dPtr->points[c]->depth->Update();
+       dPtr->points[c]->normal->Update();
+       c++;
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/CustomPSSMShadowCameraSetup.cc
+--- a/gazebo/rendering/CustomPSSMShadowCameraSetup.cc
++++ b/gazebo/rendering/CustomPSSMShadowCameraSetup.cc
+@@ -64,11 +64,33 @@
+ //////////////////////////////////////////////////
+ bool CustomPSSM3::resolveParameters(Ogre::RTShader::ProgramSet *_programSet)
+ {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++  Ogre::RTShader::Program* vsProgram =
++      _programSet->getCpuProgram(Ogre::GPT_VERTEX_PROGRAM);
++  Ogre::RTShader::Program* psProgram =
++      _programSet->getCpuProgram(Ogre::GPT_FRAGMENT_PROGRAM);
++#else
+   Ogre::RTShader::Program* vsProgram = _programSet->getCpuVertexProgram();
+   Ogre::RTShader::Program* psProgram = _programSet->getCpuFragmentProgram();
++#endif
+   Ogre::RTShader::Function* vsMain = vsProgram->getEntryPointFunction();
+   Ogre::RTShader::Function* psMain = psProgram->getEntryPointFunction();
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 12
++  // getParameterBySemantic was deprecated in
++  // https://github.com/OGRECave/ogre/pull/930/files
++  // All the changes for OGRE 1.12 in this file were inspired
++  // by the modifications to the OgreShaderExIntegratedPSSM3.cpp
++  // in that PR
++
++  // Get input position parameter.
++  mVSInPos = vsMain->getInputParameter(
++      Ogre::RTShader::Parameter::SPC_POSITION_OBJECT_SPACE);
++
++  // Get output position parameter.
++  mVSOutPos = vsMain->getOutputParameter(
++      Ogre::RTShader::Parameter::SPC_POSITION_PROJECTIVE_SPACE);
++#else
+   // Get input position parameter.
+   mVSInPos = vsMain->getParameterBySemantic(vsMain->getInputParameters(),
+       Ogre::RTShader::Parameter::SPS_POSITION, 0);
+@@ -76,6 +98,7 @@
+   // Get output position parameter.
+   mVSOutPos = vsMain->getParameterBySemantic(vsMain->getOutputParameters(),
+       Ogre::RTShader::Parameter::SPS_POSITION, 0);
++#endif
+ 
+   // Resolve vertex shader output depth.
+   mVSOutDepth = vsMain->resolveOutputParameter(
+@@ -90,6 +113,17 @@
+       mVSOutDepth->getContent(),
+       Ogre::GCT_FLOAT1);
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 12
++  // Get in/local diffuse parameter.
++  mPSDiffuse = psMain->getInputParameter(
++      Ogre::RTShader::Parameter::SPC_COLOR_DIFFUSE);
++
++  if (mPSDiffuse.get() == NULL)
++  {
++    mPSDiffuse = psMain->getLocalParameter(
++        Ogre::RTShader::Parameter::SPC_COLOR_DIFFUSE);
++  }
++#else
+   // Get in/local diffuse parameter.
+   mPSDiffuse = psMain->getParameterBySemantic(psMain->getInputParameters(),
+       Ogre::RTShader::Parameter::SPS_COLOR, 0);
+@@ -99,12 +133,23 @@
+         psMain->getLocalParameters(), Ogre::RTShader::Parameter::SPS_COLOR,
+         0);
+   }
++#endif
+ 
+   // Resolve output diffuse parameter.
+   mPSOutDiffuse = psMain->resolveOutputParameter(
+       Ogre::RTShader::Parameter::SPS_COLOR, 0,
+       Ogre::RTShader::Parameter::SPC_COLOR_DIFFUSE, Ogre::GCT_FLOAT4);
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 12
++  // Get in/local specular parameter.
++  mPSSpecualr = psMain->getInputParameter(
++      Ogre::RTShader::Parameter::SPC_COLOR_SPECULAR);
++  if (mPSSpecualr.get() == nullptr)
++  {
++    mPSSpecualr = psMain->getLocalParameter(
++        Ogre::RTShader::Parameter::SPC_COLOR_SPECULAR);
++  }
++#else
+   // Get in/local specular parameter.
+   mPSSpecualr = psMain->getParameterBySemantic(
+       psMain->getInputParameters(), Ogre::RTShader::Parameter::SPS_COLOR,
+@@ -115,6 +160,7 @@
+         psMain->getLocalParameters(), Ogre::RTShader::Parameter::SPS_COLOR,
+         1);
+   }
++#endif
+ 
+   // Resolve computed local shadow colour parameter.
+   mPSLocalShadowFactor = psMain->resolveLocalParameter(
+@@ -126,8 +172,13 @@
+       (Ogre::uint16)Ogre::GPV_GLOBAL, "pssm_split_points");
+ 
+   // Get derived scene colour.
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 12
++  mPSDerivedSceneColour = psProgram->resolveParameter(
++      Ogre::GpuProgramParameters::ACT_DERIVED_SCENE_COLOUR, 0);
++#else
+   mPSDerivedSceneColour = psProgram->resolveAutoParameterInt(
+       Ogre::GpuProgramParameters::ACT_DERIVED_SCENE_COLOUR, 0);
++#endif
+ 
+   auto it = mShadowTextureParamsList.begin();
+   int lightIndex = 0;
+@@ -310,7 +361,12 @@
+     // generate projection matrix if requested
+     if (_outProj != nullptr)
+     {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++// Matrix4/Affine3 changes are due to https://github.com/OGRECave/ogre/pull/661
++      *_outProj = Ogre::Matrix4(Ogre::Affine3::getScale(1, 1, -1));
++#else
+       *_outProj = Ogre::Matrix4::getScale(1, 1, -1);
++#endif
+     }
+ 
+     // set up camera if requested
+@@ -461,7 +517,11 @@
+   // return the standard shadow mapping matrix
+   if (sceneBB.isNull())
+   {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    _texCam->setCustomViewMatrix(true, Ogre::Affine3(LView));
++#else
+     _texCam->setCustomViewMatrix(true, LView);
++#endif
+     _texCam->setCustomProjectionMatrix(true, LProj);
+     return;
+   }
+@@ -475,7 +535,11 @@
+   // simply return the standard shadow mapping matrix
+   if (mPointListBodyB.getPointCount() == 0)
+   {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    _texCam->setCustomViewMatrix(true, Ogre::Affine3(LView));
++#else
+     _texCam->setCustomViewMatrix(true, LView);
++#endif
+     _texCam->setCustomProjectionMatrix(true, LProj);
+     return;
+   }
+@@ -511,8 +575,12 @@
+   // LProj = msLightSpaceToNormal * LProj;
+ 
+   // set the two custom matrices
+-  _texCam->setCustomViewMatrix(true, LView);
+-  _texCam->setCustomProjectionMatrix(true, LProj);
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    _texCam->setCustomViewMatrix(true, Ogre::Affine3(LView));
++#else
++    _texCam->setCustomViewMatrix(true, LView);
++#endif
++    _texCam->setCustomProjectionMatrix(true, LProj);
+ }
+ 
+ //////////////////////////////////////////////////
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Distortion.cc
+--- a/gazebo/rendering/Distortion.cc
++++ b/gazebo/rendering/Distortion.cc
+@@ -218,7 +218,17 @@
+   // fill the distortion map, while interpolating to fill dead pixels
+   pixelBuffer->lock(Ogre::HardwareBuffer::HBL_NORMAL);
+   const Ogre::PixelBox &pixelBox = pixelBuffer->getCurrentLock();
++
++#if OGRE_VERSION_MAJOR > 1 || OGRE_VERSION_MINOR >= 11
++  // Ogre 1.11 changed Ogre::PixelBox::data from void* to uchar*, hence
++  // reinterpret_cast is required here. static_cast is not allowed between
++  // pointers of unrelated types (see, for instance, Standard ยง 3.9.1
++  // Fundamental types)
++  float *pDest = reinterpret_cast<float *>(pixelBox.data);
++#else
+   float *pDest = static_cast<float *>(pixelBox.data);
++#endif
++
+   for (unsigned int i = 0; i < this->dataPtr->distortionTexHeight; ++i)
+   {
+     for (unsigned int j = 0; j < this->dataPtr->distortionTexWidth; ++j)
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/InertiaVisual.cc
+--- a/gazebo/rendering/InertiaVisual.cc
++++ b/gazebo/rendering/InertiaVisual.cc
+@@ -104,7 +104,7 @@
+   p6 += _pose.Pos();
+ 
+   dPtr->crossLines = this->CreateDynamicLine(rendering::RENDERING_LINE_LIST);
+-  dPtr->crossLines->setMaterial("Gazebo/Green");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->crossLines, "Gazebo/Green");
+   dPtr->crossLines->AddPoint(p1);
+   dPtr->crossLines->AddPoint(p2);
+   dPtr->crossLines->AddPoint(p3);
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/LaserVisual.cc
+--- a/gazebo/rendering/LaserVisual.cc
++++ b/gazebo/rendering/LaserVisual.cc
+@@ -132,25 +132,27 @@
+       // intersected an object.
+       dPtr->rayStrips.push_back(
+           this->CreateDynamicLine(rendering::RENDERING_TRIANGLE_STRIP));
+-      dPtr->rayStrips[j]->setMaterial("Gazebo/BlueLaser");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->rayStrips[j], "Gazebo/BlueLaser");
+ 
+       // No hit ray strips fill in-between the ray lines in areas that have
+       // not intersected an object.
+       dPtr->noHitRayStrips.push_back(
+           this->CreateDynamicLine(rendering::RENDERING_TRIANGLE_STRIP));
+-      dPtr->noHitRayStrips[j]->setMaterial("Gazebo/LightBlueLaser");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->noHitRayStrips[j],
++          "Gazebo/LightBlueLaser");
+ 
+       // Deadzone ray fans display areas that are between the sensor's origin
+       // and start of the rays.
+       dPtr->deadzoneRayFans.push_back(
+           this->CreateDynamicLine(rendering::RENDERING_TRIANGLE_FAN));
+-      dPtr->deadzoneRayFans[j]->setMaterial("Gazebo/BlackTransparent");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->deadzoneRayFans[j],
++          "Gazebo/BlackTransparent");
+       dPtr->deadzoneRayFans[j]->AddPoint(ignition::math::Vector3d(0, 0, 0));
+ 
+       // Individual ray lines
+       dPtr->rayLines.push_back(
+           this->CreateDynamicLine(rendering::RENDERING_LINE_LIST));
+-      dPtr->rayLines[j]->setMaterial("Gazebo/BlueLaser");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->rayLines[j], "Gazebo/BlueLaser");
+ 
+       this->SetVisibilityFlags(GZ_VISIBILITY_GUI);
+     }
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Light.cc
+--- a/gazebo/rendering/Light.cc
++++ b/gazebo/rendering/Light.cc
+@@ -219,7 +219,7 @@
+     this->dataPtr->line =
+         this->dataPtr->visual->CreateDynamicLine(RENDERING_LINE_LIST);
+ 
+-    this->dataPtr->line->setMaterial("Gazebo/LightOn");
++    GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->line, "Gazebo/LightOn");
+ 
+     this->dataPtr->line->setVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+@@ -400,9 +400,9 @@
+   if (this->dataPtr->light->getType() != Ogre::Light::LT_DIRECTIONAL)
+   {
+     if (_s)
+-      this->dataPtr->line->setMaterial("Gazebo/PurpleGlow");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->line, "Gazebo/PurpleGlow");
+     else
+-      this->dataPtr->line->setMaterial("Gazebo/LightOn");
++      GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->line, "Gazebo/LightOn");
+   }
+ 
+   return true;
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/LogicalCameraVisual.cc
+--- a/gazebo/rendering/LogicalCameraVisual.cc
++++ b/gazebo/rendering/LogicalCameraVisual.cc
+@@ -117,7 +117,8 @@
+   line->AddPoint(ignition::math::Vector3d(
+         _msg.far_clip(), farWidth, -farHeight));
+ 
+-  line->setMaterial("Gazebo/WhiteGlow");
++
++  GZ_OGRE_SET_MATERIAL_BY_NAME(line, "Gazebo/WhiteGlow");
+   line->setVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+   // Draw green lines from the near clipping plane to the origin
+@@ -138,7 +139,7 @@
+   sourceLine->AddPoint(ignition::math::Vector3d(
+         _msg.near_clip(), nearWidth, -nearHeight));
+ 
+-  sourceLine->setMaterial("Gazebo/PurpleGlow");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(sourceLine, "Gazebo/PurpleGlow");
+   sourceLine->setVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+   this->SetVisibilityFlags(GZ_VISIBILITY_GUI);
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/OriginVisual.cc
+--- a/gazebo/rendering/OriginVisual.cc
++++ b/gazebo/rendering/OriginVisual.cc
+@@ -54,19 +54,19 @@
+ 
+   dPtr->xLine = this->CreateDynamicLine(
+       rendering::RENDERING_LINE_LIST);
+-  dPtr->xLine->setMaterial("Gazebo/Red");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->xLine, "Gazebo/Red");
+   dPtr->xLine->AddPoint(ignition::math::Vector3d::Zero);
+   dPtr->xLine->AddPoint(ignition::math::Vector3d::UnitX*dPtr->length);
+ 
+   dPtr->yLine = this->CreateDynamicLine(
+       rendering::RENDERING_LINE_LIST);
+-  dPtr->yLine->setMaterial("Gazebo/Green");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->yLine, "Gazebo/Green");
+   dPtr->yLine->AddPoint(ignition::math::Vector3d::Zero);
+   dPtr->yLine->AddPoint(ignition::math::Vector3d::UnitY*dPtr->length);
+ 
+   dPtr->zLine = this->CreateDynamicLine(
+       rendering::RENDERING_LINE_LIST);
+-  dPtr->zLine->setMaterial("Gazebo/Blue");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->zLine, "Gazebo/Blue");
+   dPtr->zLine->AddPoint(ignition::math::Vector3d::Zero);
+   dPtr->zLine->AddPoint(ignition::math::Vector3d::UnitZ*dPtr->length);
+ 
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/RTShaderSystem.cc
+--- a/gazebo/rendering/RTShaderSystem.cc
++++ b/gazebo/rendering/RTShaderSystem.cc
+@@ -419,12 +419,19 @@
+     for (; it != itEnd; ++it)
+     {
+       struct stat st;
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++      if (stat((*it).archive->getName().c_str(), &st) == 0)
++      {
++        if ((*it).archive->getName().find("rtshaderlib") != Ogre::String::npos)
++        {
++          coreLibsPath = (*it).archive->getName() + "/";
++#else
+       if (stat((*it)->archive->getName().c_str(), &st) == 0)
+       {
+         if ((*it)->archive->getName().find("rtshaderlib") != Ogre::String::npos)
+         {
+           coreLibsPath = (*it)->archive->getName() + "/";
+-
++#endif
+           // setup patch name for rt shader cache in tmp
+           char *tmpdir;
+           char *user;
+@@ -562,7 +569,12 @@
+   // OGRE samples. They should be compared and tested.
+   // Set up caster material - this is just a standard depth/shadow map caster
+   // sceneMgr->setShadowTextureCasterMaterial("PSSM/shadow_caster");
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++  sceneMgr->setShadowTextureCasterMaterial(
++      Ogre::MaterialManager::getSingleton().getByName("Gazebo/shadow_caster"));
++#else
+   sceneMgr->setShadowTextureCasterMaterial("Gazebo/shadow_caster");
++#endif
+ 
+   // Disable fog on the caster pass.
+   //  Ogre::MaterialPtr passCaterMaterial =
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/RenderEngine.cc
+--- a/gazebo/rendering/RenderEngine.cc
++++ b/gazebo/rendering/RenderEngine.cc
+@@ -802,7 +802,13 @@
+   // int multiRenderTargetCount = capabilities->getNumMultiRenderTargets();
+ 
+   bool hasFBO =
+-    capabilities->hasCapability(Ogre::RSC_FBO);
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++  // All APIs targeted by OGRE supported this capability,
++  // see https://ogrecave.github.io/ogre/api/1.10/group___render_system.html#gga3d2965b7f378ebdcfe8a4a6cf74c3de7a8a0ececdc95122ac3063fc4f27d6402c
++  true;
++#else
++  capabilities->hasCapability(Ogre::RSC_FBO);
++#endif
+ 
+   bool hasGLSL =
+     std::find(profiles.begin(), profiles.end(), "glsl") != profiles.end();
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Scene.cc
+--- a/gazebo/rendering/Scene.cc
++++ b/gazebo/rendering/Scene.cc
+@@ -3136,8 +3136,14 @@
+ #if OGRE_VERSION_MAJOR >= 1 && OGRE_VERSION_MINOR >= 8
+     this->dataPtr->manager->setShadowTechnique(
+         Ogre::SHADOWTYPE_TEXTURE_ADDITIVE);
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    this->dataPtr->manager->setShadowTextureCasterMaterial(
++        Ogre::MaterialManager::getSingleton().getByName(
++            "DeferredRendering/Shadows/RSMCaster_Spot"));
++#else
+     this->dataPtr->manager->setShadowTextureCasterMaterial(
+         "DeferredRendering/Shadows/RSMCaster_Spot");
++#endif
+     this->dataPtr->manager->setShadowTextureCount(1);
+     this->dataPtr->manager->setShadowFarDistance(150);
+     // Use a value of "2" to use a different depth buffer pool and
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Scene.hh
+--- a/gazebo/rendering/Scene.hh
++++ b/gazebo/rendering/Scene.hh
+@@ -25,6 +25,8 @@
+ #include <boost/enable_shared_from_this.hpp>
+ #include <boost/shared_ptr.hpp>
+ 
++#include <OGRE/OgrePrerequisites.h>
++
+ #include <sdf/sdf.hh>
+ 
+ #include <ignition/math/Color.hh>
+@@ -44,16 +46,6 @@
+   class SkyX;
+ }
+ 
+-namespace Ogre
+-{
+-  class SceneManager;
+-  class Node;
+-  class Entity;
+-  class Mesh;
+-  class Vector3;
+-  class Quaternion;
+-}
+-
+ namespace gazebo
+ {
+   namespace rendering
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/SonarVisual.cc
+--- a/gazebo/rendering/SonarVisual.cc
++++ b/gazebo/rendering/SonarVisual.cc
+@@ -73,7 +73,7 @@
+       reinterpret_cast<SonarVisualPrivate *>(this->dataPtr);
+ 
+   dPtr->sonarRay = this->CreateDynamicLine(rendering::RENDERING_LINE_LIST);
+-  dPtr->sonarRay->setMaterial("Gazebo/RedGlow");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->sonarRay, "Gazebo/RedGlow");
+   dPtr->sonarRay->AddPoint(0, 0, 0);
+   dPtr->sonarRay->AddPoint(0, 0, 0);
+ 
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/TransmitterVisual.cc
+--- a/gazebo/rendering/TransmitterVisual.cc
++++ b/gazebo/rendering/TransmitterVisual.cc
+@@ -75,7 +75,7 @@
+   TransmitterVisualPrivate *dPtr =
+       reinterpret_cast<TransmitterVisualPrivate *>(this->dataPtr);
+   dPtr->points = this->CreateDynamicLine(rendering::RENDERING_POINT_LIST);
+-  dPtr->points->setMaterial("Gazebo/PointCloud");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->points, "Gazebo/PointCloud");
+ }
+ 
+ /////////////////////////////////////////////////
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/Visual.cc
+--- a/gazebo/rendering/Visual.cc
++++ b/gazebo/rendering/Visual.cc
+@@ -1092,7 +1092,8 @@
+         Ogre::SimpleRenderable *simpleRenderable =
+             dynamic_cast<Ogre::SimpleRenderable *>(obj);
+         if (simpleRenderable)
+-          simpleRenderable->setMaterial(this->dataPtr->myMaterialName);
++          GZ_OGRE_SET_MATERIAL_BY_NAME(simpleRenderable,
++              this->dataPtr->myMaterialName);
+       }
+     }
+   }
+@@ -2189,7 +2190,11 @@
+         transform[3][0] = transform[3][1] = transform[3][2] = 0;
+         transform[3][3] = 1;
+         // get oriented bounding box in object's local space
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++        bb.transform(transform);
++#else
+         bb.transformAffine(transform);
++#endif
+ 
+         min = Conversions::ConvertIgn(bb.getMinimum());
+         max = Conversions::ConvertIgn(bb.getMaximum());
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/WindowManager.cc
+--- a/gazebo/rendering/WindowManager.cc
++++ b/gazebo/rendering/WindowManager.cc
+@@ -188,9 +188,14 @@
+ 
+   if (_windowId < this->dataPtr->windows.size())
+   {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    auto stats = this->dataPtr->windows[_windowId]->getStatistics();
++    avgFPS = stats.avgFPS;
++#else
+     float lastFPS, bestFPS, worstFPS = 0;
+     this->dataPtr->windows[_windowId]->getStatistics(
+         lastFPS, avgFPS, bestFPS, worstFPS);
++#endif
+   }
+ 
+   return avgFPS;
+@@ -200,9 +205,18 @@
+ uint32_t WindowManager::TriangleCount(const uint32_t _windowId) const
+ {
+   if (_windowId < this->dataPtr->windows.size())
++  {
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    auto stats = this->dataPtr->windows[_windowId]->getStatistics();
++    return stats.triangleCount;
++#else
+     return this->dataPtr->windows[_windowId]->getTriangleCount();
++#endif
++  }
+   else
++  {
+     return 0;
++  }
+ }
+ 
+ //////////////////////////////////////////////////
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/WireBox.cc
+--- a/gazebo/rendering/WireBox.cc
++++ b/gazebo/rendering/WireBox.cc
+@@ -28,7 +28,7 @@
+ {
+   this->dataPtr->parent = _parent;
+   this->dataPtr->lines = new DynamicLines(RENDERING_LINE_LIST);
+-  this->dataPtr->lines->setMaterial("BaseWhiteNoLighting");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(this->dataPtr->lines, "BaseWhiteNoLighting");
+   this->dataPtr->parent->AttachObject(this->dataPtr->lines);
+   this->dataPtr->lines->setVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/WrenchVisual.cc
+--- a/gazebo/rendering/WrenchVisual.cc
++++ b/gazebo/rendering/WrenchVisual.cc
+@@ -150,7 +150,8 @@
+   dPtr->forceLine = dPtr->forceVisual->CreateDynamicLine(RENDERING_LINE_LIST);
+   dPtr->forceLine->AddPoint(ignition::math::Vector3d::Zero);
+   dPtr->forceLine->AddPoint(ignition::math::Vector3d(0, 0, 0.1));
+-  dPtr->forceLine->setMaterial("__GAZEBO_TRANS_PURPLE_MATERIAL__");
++  GZ_OGRE_SET_MATERIAL_BY_NAME(dPtr->forceLine,
++      "__GAZEBO_TRANS_PURPLE_MATERIAL__");
+ 
+   this->SetVisibilityFlags(GZ_VISIBILITY_GUI);
+ 
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/ogre_gazebo.h
+--- a/gazebo/rendering/ogre_gazebo.h
++++ b/gazebo/rendering/ogre_gazebo.h
+@@ -31,7 +31,6 @@
+ #include <OGRE/OgrePlugin.h>
+ #include <OGRE/OgreDataStream.h>
+ #include <OGRE/OgreLogManager.h>
+-#include <OGRE/OgreWindowEventUtilities.h>
+ #include <OGRE/OgreSceneQuery.h>
+ #include <OGRE/OgreRoot.h>
+ #include <OGRE/OgreSceneManager.h>
+@@ -83,4 +82,26 @@
+ #include <OGRE/OgreFontManager.h>
+ #endif
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR < 11
++// The  <OGRE/OgreWindowEventUtilities.h> header has always been included in
++// public headers for Gazebo <= 10, but was moved to the Bites component in
++// Ogre 1.11 (see  https://github.com/OGRECave/ogre/pull/647). As it is not
++// used at all in Gazebo, we can just include it for Ogre <= 1.10 to avoid
++// breaking transitive includes in downstream projects.
++// In Gazebo 11, this can be removed.
++#include <OGRE/OgreWindowEventUtilities.h>
+ #endif
++
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++#define GZ_OGRE_SET_MATERIAL_BY_NAME(ptr, name) \
++  (ptr)->setMaterial(Ogre::MaterialManager::getSingleton().getByName(name))
++#define GZ_OGRE_SET_MATERIAL_BY_NAME_UPPER(ptr, name) \
++  (ptr)->SetMaterial(Ogre::MaterialManager::getSingleton().getByName(name))
++#else
++#define GZ_OGRE_SET_MATERIAL_BY_NAME(ptr, name) \
++  (ptr)->setMaterial(name)
++#define GZ_OGRE_SET_MATERIAL_BY_NAME_UPPER(ptr, name) \
++  (ptr)->SetMaterial(name)
++#endif
++
++#endif
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/skyx/src/VClouds/DataManager.cpp
+--- a/gazebo/rendering/skyx/src/VClouds/DataManager.cpp
++++ b/gazebo/rendering/skyx/src/VClouds/DataManager.cpp
+@@ -682,7 +682,15 @@
+     buffer->lock(Ogre::HardwareBuffer::HBL_DISCARD);
+     const Ogre::PixelBox &pb = buffer->getCurrentLock();
+ 
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++    // Ogre 1.11 changed Ogre::PixelBox::data from void* to uchar*, hence
++    // reinterpret_cast is required here. static_cast is not allowed between
++    // pointers of unrelated types (see, for instance, Standard ง 3.9.1
++    // Fundamental types).
++    Ogre::uint32 *pbptr = reinterpret_cast < Ogre::uint32*>(pb.data);
++#else
+     Ogre::uint32 *pbptr = static_cast < Ogre::uint32*>(pb.data);
++#endif
+     size_t x, y, z;
+ 
+     for (z = pb.front; z < pb.back; z++)
+diff -r 7c4281fe1229 -r bdc1dc86f080 gazebo/rendering/skyx/src/VClouds/LightningManager.cpp
+--- a/gazebo/rendering/skyx/src/VClouds/LightningManager.cpp
++++ b/gazebo/rendering/skyx/src/VClouds/LightningManager.cpp
+@@ -283,7 +283,11 @@
+       if (k < mLightnings.size())
+       {
+         pos = mVClouds->getGeometryManager()->getSceneNode()->
++#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11
++          _getFullTransform().inverse() *
++#else
+           _getFullTransform().inverseAffine() *
++#endif
+           mSceneNodes.at(k)->_getDerivedPosition();
+ 
+         mVolCloudsLightningMaterial->

--- a/ports/gazebo10/portfile.cmake
+++ b/ports/gazebo10/portfile.cmake
@@ -1,0 +1,94 @@
+include(vcpkg_common_functions)
+ 
+vcpkg_from_bitbucket(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO osrf/gazebo
+    REF gazebo10_10.1.0
+    SHA512 7170ed87190e94e170cdcd4fad1c9e038ee2ba8979ed8187cb8e702ddd5d920f9c1a627e88ce200ecfae77a3d81fc156712beab325fe006da013386bbcd7517b
+    HEAD_REF gazebo10
+    # Ensure that pkg-config is not requirex on MSVC (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3125)
+    PATCHES fix-pkg-config-msvc-workaround.patch
+    # Fix find_package(OGRE) logic (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3126)
+            fix-find-package-ogre.patch
+    # Fix missing link of ignition-common in gazebo_common (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3127)
+            fix-link-ignition-common.patch
+    # Fix compilation of gazebo rendering with Ogre 1.12 (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3129)
+            gazebo-rendering-support-ogre-1-12.patch
+    # Fix compilation of gazebo::rendering::Heightmap with Ogre 1.12 (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3130)
+            gazebo-rendering-heightmap-support-ogre-1-12.patch
+    # Fix compilation with Ogre in debug mode, part 1 (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3131)
+            gazebo-3131.patch
+    # Fix compilation with Ogre in debug mode, part 2 (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3134)
+            gazebo-3134.patch
+    # Avoid to pass GCC style linker options to Visual Studio Linker (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3141)
+            gazebo-3141.patch
+    # Fix compilation with Ogre in debug mode, part 3 (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3142)
+            gazebo-3142.patch
+    # Add support for finding TBB via CMake config files (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3135)
+            gazebo-3135.patch
+    # Install dll in <prefix>/bin (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3144)
+            gazebo-3144.patch
+    #  Avoid conflict between winnt.h's DELETE and ignition::fuel_tools::REST::DELETE  (backport of https://bitbucket.org/osrf/gazebo/pull-requests/3143)
+            gazebo-3143.patch
+)
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA 
+    OPTIONS -DBUILD_TESTING=OFF
+)
+
+# This port needs  to generate protobuf messages with a custom plugin generator,
+# so it needs to have in Windows the relative protobuf dll available in the PATH
+set(path_backup $ENV{PATH})
+vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/bin)
+vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
+
+vcpkg_install_cmake()
+
+# Restore old path
+set(ENV{PATH} "${path_backup}")
+
+# Fix cmake targets location
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/gazebo" TARGET_PATH "share/gazebo10")
+
+# Handle executables installation
+set(GAZEBO_EXECUTABLES gz gzserver gzclient)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+  set(EXECUTABLE_SUFFIX ".exe")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+  foreach(tool ${GAZEBO_EXECUTABLES})
+    file(COPY "${CURRENT_PACKAGES_DIR}/bin/${tool}${EXECUTABLE_SUFFIX}"
+         DESTINATION ${CURRENT_PACKAGES_DIR}/tools/gazebo10/release)
+  endforeach()
+  vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/gazebo10/release)
+  foreach(tool ${GAZEBO_EXECUTABLES})
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${tool}${EXECUTABLE_SUFFIX}")
+  endforeach()
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+  foreach(tool ${GAZEBO_EXECUTABLES})
+    file(COPY "${CURRENT_PACKAGES_DIR}/debug/bin/${tool}${EXECUTABLE_SUFFIX}"
+         DESTINATION ${CURRENT_PACKAGES_DIR}/tools/gazebo10/debug)
+  endforeach()
+  vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/gazebo10/debug)
+  foreach(tool ${GAZEBO_EXECUTABLES})
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${tool}${EXECUTABLE_SUFFIX}")
+  endforeach()
+endif()
+
+# Remove debug files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include 
+                    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+                    ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/gazebo10 RENAME copyright)
+
+# Post-build test for cmake libraries
+vcpkg_test_cmake(PACKAGE_NAME gazebo)


### PR DESCRIPTION
Add new port for the Gazebo simulator and its libraries. 
Fix https://github.com/microsoft/vcpkg/issues/8014 .

Currently a WIP, as it is needs https://github.com/microsoft/vcpkg/pull/8177 and https://github.com/microsoft/vcpkg/pull/8136 to be merged before. 

Furthermore, at the moment the part of handling executables is a draft, as I am  not sure how about the following points: 
* The `gazebo` and related executables is a tool for C++ projects in the sense that is a launcher for simulations that contain C++ plugins  developed against the Gazebo C++ API . For this reason, on Windows to launch Gazebo plugins compiled in Debug, you need to have the Gazebo executables  compiled in Debug, and for plugins compiled in Release, you need the Release executables. As far as I saw, all the ports that install tools only install the release version, as they are typically tools only used for code generation or similar build duties. 
What is the correct strategy to adopt in this case? Install the tools under `tools/gazebo10/debug` ? 
Note that there is an ongoing discussion on this in https://github.com/microsoft/vcpkg/issues/7826, if the tools could be installed in `bin` and in `debug/bin` there would be no problem at all. Perhaps @seanyen you had already some plan on this for using vcpkg for generating Chocolatey packages for ROS? 
* How is `tools`/`executables` installation meant to be handled on `x64-osx` and `x64-linux` triplets? Some ports I saw identify executables by grepping all the files that end in `.exe` in the `bin` directory (see for example https://github.com/microsoft/vcpkg/blob/ecfc714b9adbdf8bf6b394dd6b46d9c56ca993ea/ports/pcl/portfile.cmake#L62) but this is not going to work on *nix triplets. 