### PR TITLE
[clapack] Fix clapack-targets.cmake path in clpack-config.cmake

### DIFF
--- a/ports/clapack/CONTROL
+++ b/ports/clapack/CONTROL
@@ -1,5 +1,5 @@
 Source: clapack
-Version: 3.2.1-10
+Version: 3.2.1-11
 Homepage: https://www.netlib.org/clapack
 Description: CLAPACK (f2c'ed version of LAPACK)
 Build-Depends: openblas (!osx)

--- a/ports/clapack/fix-ConfigFile.patch
+++ b/ports/clapack/fix-ConfigFile.patch
@@ -1,0 +1,7 @@
+diff --git a/clapack-config.cmake.in b/clapack-config.cmake.in
+index cd19f1d..49af4f0 100644
+--- a/clapack-config.cmake.in
++++ b/clapack-config.cmake.in
+@@ -1 +1 @@
+-include("@CLAPACK_BINARY_DIR@/clapack-targets.cmake")
++include("${CMAKE_CURRENT_LIST_DIR}/clapack-targets.cmake")

--- a/ports/clapack/portfile.cmake
+++ b/ports/clapack/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive_ex(
   ARCHIVE ${ARCHIVE}
   PATCHES
       remove_internal_blas.patch
+	  fix-ConfigFile.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
When use `find_package` to link clapack:
```
find_package(clapack CONFIG REQUIRED)
target_link_libraries(CMakeProject12 PRIVATE f2c lapack)
```
That gave this error:
```
1> CMake Error at F:/0906/vcpkg/packages/clapack_x64-windows/share/clapack/clapack-config.cmake:1 (include):
1>   include could not find load file:
1> 
1>     F:/0906/vcpkg/buildtrees/clapack/x64-windows-rel/clapack-targets.cmake
1> Call Stack (most recent call first):
1>   F:/0906/vcpkg/scripts/buildsystems/vcpkg.cmake(256): (_find_package)
1>   C:\Users\vwangli\source\repos\CMakeProject12\CMakeProject12/CMakeLists.txt(12): (find_package)
1> 
1> 
1> -- Configuring incomplete, errors occurred!
1> See also "C:/Users/vwangli/CMakeBuilds/d96af90b-0d7e-3931-b59f-9f529ce8da16/build/x64-Debug/CMakeFiles/CMakeOutput.log".
```
Related issue: #7081