### PR TITLE
glfw3: Adds patch for fixing GLFW_TRANSPARENT_FRAMEBUFFER bug on Win32.

### DIFF
--- a/ports/glfw3/fix-transparency.patch
+++ b/ports/glfw3/fix-transparency.patch
@@ -1,0 +1,14 @@
+diff --git a/src/win32_window.c b/src/win32_window.c
+index 4506c8a7..8f3e60f3 100644
+--- a/src/win32_window.c
++++ b/src/win32_window.c
+@@ -339,8 +339,7 @@ static void updateFramebufferTransparency(const _GLFWwindow* window)
+             // Using a color key not equal to black to fix the trailing
+             // issue.  When set to black, something is making the hit test
+             // not resize with the window frame.
+-            SetLayeredWindowAttributes(window->win32.handle,
+-                                       RGB(0, 193, 48), 255, LWA_COLORKEY);
++            SetLayeredWindowAttributes(window->win32.handle, 0, 254, LWA_ALPHA);
+         }
+ 
+         DeleteObject(region);

--- a/ports/glfw3/portfile.cmake
+++ b/ports/glfw3/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         move-cmake-min-req.patch
         fix-config.patch
+        fix-transparency.patch
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)


### PR DESCRIPTION
This patch, fix the transparency issues on Win32,
was proposed in https://github.com/glfw/glfw/issues/1237
but wasn't merged yet.
