### PR TITLE
[rabit] Fix cmake files path

### DIFF
--- a/ports/rabit/CONTROL
+++ b/ports/rabit/CONTROL
@@ -1,5 +1,5 @@
 Source: rabit
-Version: 0.1-1
+Version: 0.1-2
 Homepage: https://github.com/dmlc/rabit
 Description: rabit is a light weight library that provides a fault tolerant interface of Allreduce and Broadcast. It is designed to support easy implementations of distributed machine learning programs, many of which fall naturally under the Allreduce abstraction.
 Build-Depends: dmlc

--- a/ports/rabit/portfile.cmake
+++ b/ports/rabit/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
Currently the files such as `rabitConfig.cmake rabitConfigVersion.cmake` in `cmake` directory have been moved to `share/rabit/rabit` directorty. So when we use `find_package(rabit CONFIG REQUIRED)`, this port cannot be found successfully.
Use` vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})` to fix this issue.