### PR TITLE
Including config file openssl.cnf in installation.

### DIFF
--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,3 +1,3 @@
 Source: openssl-windows
-Version: 1.0.2s-1
+Version: 1.0.2s-2
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl-windows/portfile.cmake
+++ b/ports/openssl-windows/portfile.cmake
@@ -171,11 +171,11 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE
     ${CURRENT_PACKAGES_DIR}/debug/bin/openssl.exe
     ${CURRENT_PACKAGES_DIR}/debug/openssl.cnf
-    ${CURRENT_PACKAGES_DIR}/openssl.cnf
 )
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/openssl/)
 file(RENAME ${CURRENT_PACKAGES_DIR}/bin/openssl.exe ${CURRENT_PACKAGES_DIR}/tools/openssl/openssl.exe)
+file(RENAME ${CURRENT_PACKAGES_DIR}/openssl.cnf ${CURRENT_PACKAGES_DIR}/tools/openssl/openssl.cnf)
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/openssl)
 


### PR DESCRIPTION
The original cmake script after the build delete the openssl.cnf files,
but if there is no config file in the environment the openssl.exe
warnings and fails in some commands.

This commit instead of deleting one of the openssl.cnf file it renames
(moves) to the installation dir tools/openssl, the same openssl.exe
final destination.