### PR TITLE
[Mecab] Fix invalid cmake config and target files.

### DIFF
--- a/ports/mecab/CMakeLists.txt
+++ b/ports/mecab/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
-PROJECT(Mecab)
+PROJECT(mecab VERSION 1.0)
                           
 file(GLOB SOURCE_FILE
 	"*.cpp"
@@ -18,30 +18,50 @@ list(REMOVE_ITEM SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/mecab-system-eval.cpp)
 list(REMOVE_ITEM SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/mecab-test-gen.cpp)
 #list(REMOVE_ITEM SOURCE_FILE "mecab-cost-train.cpp" "mecab-dict-gen.cpp" "mecab-dict-index.cpp" "mecab-system-eval.cpp" "mecab-test-gen.cpp")
 
-add_library (Mecab ${SOURCE_FILE} ${HEADERS_FILE})
+add_library (mecab ${SOURCE_FILE})
+target_include_directories(mecab PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:include>)
 
 if(UNIX)
-	target_compile_definitions(Mecab PUBLIC -DHAVE_UNISTD_H -DHAVE_FCNTL_H -DHAVE_STDINT_H -DHAVE_SYS_TYPES_H -DHAVE_SYS_STAT_H -DHAVE_DIRENT_H -DDIC_VERSION=102 -DVERSION="@VERSION@" -DPACKAGE="mecab" -DMECAB_DEFAULT_RC="./mecabrc")
+	target_compile_definitions(mecab PUBLIC -DHAVE_UNISTD_H -DHAVE_FCNTL_H -DHAVE_STDINT_H -DHAVE_SYS_TYPES_H -DHAVE_SYS_STAT_H -DHAVE_DIRENT_H -DDIC_VERSION=102 -DVERSION="@VERSION@" -DPACKAGE="mecab" -DMECAB_DEFAULT_RC="./mecabrc")
 endif(UNIX)
 if(WIN32)
-	target_compile_definitions(Mecab PUBLIC -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 -DVERSION="@VERSION@" -DPACKAGE="mecab" -DUNICODE -D_UNICODE -DMECAB_DEFAULT_RC="mecabrc")
+	target_compile_definitions(mecab PUBLIC -D_CRT_SECURE_NO_DEPRECATE -DMECAB_USE_THREAD -DDLL_EXPORT -DHAVE_GETENV -DHAVE_WINDOWS_H -DDIC_VERSION=102 -DVERSION="@VERSION@" -DPACKAGE="mecab" -DUNICODE -D_UNICODE -DMECAB_DEFAULT_RC="mecabrc")
 endif(WIN32)
 
-install(TARGETS Mecab
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
-include(CMakePackageConfigHelpers)
-set(cmake_package_name Mecab)
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated" CACHE INTERNAL "")
-set(cmake_files_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${cmake_package_name}")
-set(config_file "${generated_dir}/${cmake_package_name}Config.cmake")
-configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
-"${config_file}" INSTALL_DESTINATION ${cmake_files_install_dir})
-#install(FILES ${config_file} DESTINATION ${cmake_files_install_dir} CONFIGURATIONS Release)
-install(FILES ${config_file} DESTINATION share/mecab CONFIGURATIONS Release)
-message(STATUS "ccmake_files_install_dir: ${cmake_files_install_dir}")
 
-install(FILES ${HEADERS_FILE} DESTINATION include CONFIGURATIONS Release)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+include (GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set (mecab_CMAKE_DIR share/mecab CACHE STRING "Installation dir")
+set (targets_export_name mecabTargets CACHE INTERNAL "")
+
+install(TARGETS mecab
+	EXPORT ${targets_export_name}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(FILES ${HEADERS_FILE} DESTINATION include/mecab CONFIGURATIONS Release)
+
+install(EXPORT ${targets_export_name}
+        NAMESPACE mecab::
+		DESTINATION ${mecab_CMAKE_DIR})
+
+configure_package_config_file(
+	"${PROJECT_SOURCE_DIR}/Config.cmake.in"
+	"${PROJECT_BINARY_DIR}/mecabConfig.cmake" 
+	INSTALL_DESTINATION ${mecab_CMAKE_DIR})
+
+
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/mecabConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion )
+
+install(FILES 
+	${PROJECT_BINARY_DIR}/mecabConfig.cmake 
+	${PROJECT_BINARY_DIR}/mecabConfigVersion.cmake 
+	DESTINATION ${mecab_CMAKE_DIR})

--- a/ports/mecab/CONTROL
+++ b/ports/mecab/CONTROL
@@ -1,3 +1,3 @@
 Source: mecab
-Version:0.996
+Version: 1.0
 Description: A morphological analysis engine based on CRF

--- a/ports/mecab/Config.cmake.in
+++ b/ports/mecab/Config.cmake.in
@@ -1,1 +1,4 @@
 @PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components(mecab)

--- a/ports/mecab/portfile.cmake
+++ b/ports/mecab/portfile.cmake
@@ -4,7 +4,6 @@ endif()
 
 include(vcpkg_common_functions)
 
-set(MECAB_VERSION 0.996)
 vcpkg_from_github(
 	OUT_SOURCE_PATH SOURCE_PATH
 	REPO taku910/mecab
@@ -15,21 +14,17 @@ vcpkg_from_github(
 		fix_wpath_unsigned.patch
 )
 
-message(STATUS "source path is : ${SOURCE_PATH}")
-
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/mecab/src)
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in DESTINATION ${SOURCE_PATH}/mecab/src)
 file(COPY ${SOURCE_PATH}/mecab/COPYING DESTINATION ${SOURCE_PATH}/mecab/src)
 
-message(STATUS "CURRENT_PACKAGES_DIR is : ${CURRENT_PACKAGES_DIR}")
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/mecab/src
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets()
 vcpkg_copy_pdbs()
+
 file(COPY ${SOURCE_PATH}/mecab/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/mecab)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/mecab/COPYING ${CURRENT_PACKAGES_DIR}/share/mecab/copyright)
-
-# Post-build test for cmake libraries
-# vcpkg_test_cmake(PACKAGE_NAME mecab)


### PR DESCRIPTION
The previous mecab CMakeLists.txt is incorrect for installing cmake target and config files.