### PR TITLE
[openimageio]Re-fix find openexr issue.

### DIFF
--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,5 +1,5 @@
 Source: openimageio
-Version: 2019-08-08-3
+Version: 2019-08-08-4
 Homepage: https://github.com/OpenImageIO/oiio
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
 Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace

--- a/ports/openimageio/fix_find_openexr.patch
+++ b/ports/openimageio/fix_find_openexr.patch
@@ -1,8 +1,8 @@
 diff --git a/src/cmake/modules/FindOpenEXR.cmake b/src/cmake/modules/FindOpenEXR.cmake
-index babfffd..8e79925 100644
+index babfffd..3d0bee3 100644
 --- a/src/cmake/modules/FindOpenEXR.cmake
 +++ b/src/cmake/modules/FindOpenEXR.cmake
-@@ -118,24 +118,25 @@ endif ()
+@@ -118,24 +118,30 @@ endif ()
  # headers, we do two finds -- first for custom locations, then for default.
  # This is complicated because the OpenEXR libraries may or may not be
  # built with version numbers embedded.
@@ -24,24 +24,29 @@ index babfffd..8e79925 100644
 -    # One more time, with no restrictions
 -    find_library (OPENEXR_${UPPERCOMPONENT}_LIBRARY ${FULL_COMPONENT_NAME})
 -endforeach ()
++if (WIN32)
++    set(OPENEXR_DEBUG_SUFFIX "_d")
++else()
++    set(OPENEXR_DEBUG_SUFFIX "")
++endif()
 +find_library(ILMTHREAD_LIBRARY_RELEASE NAMES IlmThread-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
-+find_library(ILMTHREAD_LIBRARY_DEBUG NAMES IlmThread-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d)
++find_library(ILMTHREAD_LIBRARY_DEBUG NAMES IlmThread-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}${OPENEXR_DEBUG_SUFFIX})
 +select_library_configurations(ILMTHREAD)
 +
 +find_library(OPENEXR_ILMIMF_LIBRARY_RELEASE NAMES IlmImf-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
-+find_library(OPENEXR_ILMIMF_LIBRARY_DEBUG NAMES IlmImf-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d)
++find_library(OPENEXR_ILMIMF_LIBRARY_DEBUG NAMES IlmImf-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}${OPENEXR_DEBUG_SUFFIX})
 +select_library_configurations(OPENEXR_ILMIMF)
 +
 +find_library(OPENEXR_IMATH_LIBRARY_RELEASE NAMES Imath-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
-+find_library(OPENEXR_IMATH_LIBRARY_DEBUG NAMES Imath-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d)
++find_library(OPENEXR_IMATH_LIBRARY_DEBUG NAMES Imath-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}${OPENEXR_DEBUG_SUFFIX})
 +select_library_configurations(OPENEXR_IMATH)
 +
 +find_library(OPENEXR_IEX_LIBRARY_RELEASE NAMES Iex-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
-+find_library(OPENEXR_IEX_LIBRARY_DEBUG NAMES Iex-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d)
++find_library(OPENEXR_IEX_LIBRARY_DEBUG NAMES Iex-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}${OPENEXR_DEBUG_SUFFIX})
 +select_library_configurations(OPENEXR_IEX)
 +
 +find_library(OPENEXR_HALF_LIBRARY_RELEASE NAMES Half-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
-+find_library(OPENEXR_HALF_LIBRARY_DEBUG NAMES Half-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}_d)
++find_library(OPENEXR_HALF_LIBRARY_DEBUG NAMES Half-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}${OPENEXR_DEBUG_SUFFIX})
 +select_library_configurations(OPENEXR_HALF)
  
  # Set the FOUND, INCLUDE_DIR, and LIBRARIES variables.


### PR DESCRIPTION
The debug library generated by openexr in **windows** has the suffix `_d` and no suffix generated in linux. Fix this issue.

Related: #8049.