### PR TITLE
[realsense2] fix dependency glfw3 and mismatching number of debug and release binaries

### DIFF
--- a/ports/realsense2/CONTROL
+++ b/ports/realsense2/CONTROL
@@ -1,10 +1,10 @@
 Source: realsense2
-Version: 2.22.0-1
+Version: 2.22.0-2
 Homepage: https://github.com/IntelRealSense/librealsense
 Description: Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).
 
 Feature: tools
-Build-Depends: opengl
+Build-Depends: opengl, glfw3
 Description: Build Intel® RealSense™ examples and tools
 
 Feature: openni2

--- a/ports/realsense2/fix-dependency-glfw3.patch
+++ b/ports/realsense2/fix-dependency-glfw3.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2da00e0..09f3eba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,7 +52,7 @@ option(BUILD_CV_KINFU_EXAMPLE "Build OpenCV KinectFusion example" OFF)
+ add_subdirectory(wrappers)
+ 
+ if (BUILD_EXAMPLES AND BUILD_GLSL_EXTENSIONS)
+-    find_package(glfw3 3.3 QUIET)
++    find_package(glfw3 CONFIG REQUIRED)
+     if(NOT TARGET glfw)
+         message(STATUS "GLFW 3.3 not found; using internal version")
+         set(GLFW_INSTALL ON)

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -7,7 +7,8 @@ vcpkg_from_github(
     SHA512 7595780c1955a2d4a91df5b70ab6366c672f389bc3d2dcb9f2e78a2ea1fc875c65f878103df483205e17f62dfd024ee5f7ccb15afc5d18978d3c25aa071652ab
     HEAD_REF development
     PATCHES
-      "fix_openni2.patch"
+        fix_openni2.patch
+        fix-dependency-glfw3.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_CRT_LINKAGE)
@@ -68,6 +69,11 @@ if(BUILD_TOOLS)
     if(NOT BINS)
         file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
     endif()
+    
+    # Issue#7109, remove mismatched dlls and libs when build with tools, this workaround should be removed when the post-build checks related feature implemented.
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/realsense2-gl.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/realsense2-gl.dll)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/realsense2-gl.pdb)
 endif()
 
 
@@ -76,5 +82,4 @@ if(BUILD_OPENNI2_BINDINGS)
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/openni2/OpenNI2/Drivers)
 endif()
 
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/realsense2)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/realsense2/LICENSE ${CURRENT_PACKAGES_DIR}/share/realsense2/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Changes: 
1. Update realsense2 to depend on glfw3 instead.
2. Add a workaround for fixing 'mismatching number of debug and release binaries' in post-build validation when build with feature tools, related issue https://github.com/microsoft/vcpkg/issues/7109 and https://github.com/microsoft/vcpkg/issues/8246