### PR TITLE
[ports.cmake] Fixup capitalization inconsistencies of Windows drive letter

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -18,6 +18,9 @@ else()
     ]])
 endif()
 
+# fixup Windows drive letter to uppercase.
+get_filename_component(VCPKG_ROOT_DIR_CANDIDATE ${VCPKG_ROOT_DIR_CANDIDATE} ABSOLUTE)
+
 # Validate VCPKG_ROOT_DIR_CANDIDATE
 if (NOT EXISTS "${VCPKG_ROOT_DIR_CANDIDATE}/.vcpkg-root")
     message(FATAL_ERROR "Could not find .vcpkg-root")


### PR DESCRIPTION
This PR make VCPKG_ROOT_DIR never contain lower case drive letter.

CMAKE_CURRENT_LIST_DIR reflect current directory. Thus It can be lowercase drive letter.
The lowercase drive letter cause #8237 issue.
Fixup drive letter to uppercase by using get_filename_component().