### PR TITLE
[proj4] Allow consumers to use a different MSVC version from the one used to compile proj4

### DIFF
--- a/ports/proj4/0004-CMake-skip-msvc-check.patch
+++ b/ports/proj4/0004-CMake-skip-msvc-check.patch
@@ -1,0 +1,15 @@
+diff --git a/project-config-version.cmake.in b/project-config-version.cmake.in
+index ce2820c..f90706c 100644
+--- a/project-config-version.cmake.in
++++ b/project-config-version.cmake.in
+@@ -18,10 +18,6 @@ elseif (NOT (APPLE OR (NOT DEFINED CMAKE_SIZEOF_VOID_P) OR
+   # since a multi-architecture library is built for that platform).
+   set (REASON "sizeof(*void) =  @CMAKE_SIZEOF_VOID_P@")
+   set (PACKAGE_VERSION_UNSUITABLE TRUE)
+-elseif (MSVC AND NOT MSVC_VERSION STREQUAL "@MSVC_VERSION@")
+-  # Reject if there's a mismatch in MSVC compiler versions
+-  set (REASON "_MSC_VER = @MSVC_VERSION@")
+-  set (PACKAGE_VERSION_UNSUITABLE TRUE)
+ elseif (NOT CMAKE_CROSSCOMPILING STREQUAL "@CMAKE_CROSSCOMPILING@")
+   # Reject if there's a mismatch in ${CMAKE_CROSSCOMPILING}
+   set (REASON "cross-compiling = @CMAKE_CROSSCOMPILING@")

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive_ex(
         0001-CMake-add-detection-of-recent-visual-studio-versions.patch
         0002-CMake-fix-error-by-only-setting-properties-for-targe.patch
         0003-CMake-configurable-cmake-config-install-location.patch
+        0004-CMake-skip-msvc-check.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")


### PR DESCRIPTION
After upgrading our machines to VS2019 we found that anything that had proj4 as a dependency and needed to be rebuilt was failing as a result of a MSVC compiler consistency check in proj4. This specifically was affecting pdal.