### PR TITLE
[sdl2-mixer]Re-fix dynamic call.

### DIFF
--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -13,38 +13,46 @@ set(SDL_MIXER_DEFINES MUSIC_WAV)
 # MP3 support
 if(SDL_MIXER_ENABLE_MP3)
     find_path(MPG123_INCLUDE_DIR mpg123.h)
+    find_library(MPG123_LIBRARY NAMES libmpg123 mpg123)
     list(APPEND SDL_MIXER_INCLUDES ${MPG123_INCLUDE_DIR})
     list(APPEND SDL_MIXER_DEFINES MUSIC_MP3_MPG123)
+    list(APPEND SDL_MIXER_LOAD_DEFINES -DMPG123_DYNAMIC="${MPG123_LIBRARY}")
 endif()
 
 # FLAC support
 if(SDL_MIXER_ENABLE_FLAC)
     find_path(FLAC_INCLUDE_DIR FLAC/all.h)
+    find_library(FLAC_LIBRARY FLAC)
     list(APPEND SDL_MIXER_INCLUDES ${FLAC_INCLUDE_DIR})
     list(APPEND SDL_MIXER_DEFINES MUSIC_FLAC)
+    list(APPEND SDL_MIXER_LOAD_DEFINES -DFLAC_DYNAMIC="${FLAC_LIBRARY}")
 endif()
 
 # MOD support
 if(SDL_MIXER_ENABLE_MOD)
     find_path(MODPLUG_INCLUDE_DIR libmodplug/modplug.h)
+    find_library(MODPLUG_LIBRARY modplug)
     list(APPEND SDL_MIXER_INCLUDES ${MODPLUG_INCLUDE_DIR})
     list(APPEND SDL_MIXER_DEFINES MUSIC_MOD_MODPLUG)
+    list(APPEND SDL_MIXER_LOAD_DEFINES -DMODPLUG_DYNAMIC="${MODPLUG_LIBRARY}")
 endif()
 
 # Ogg-Vorbis support
 if(SDL_MIXER_ENABLE_OGGVORBIS)
     find_path(VORBIS_INCLUDE_DIR vorbis/codec.h)
+    find_library(VORBISFILE_LIBRARY vorbisfile)
     list(APPEND SDL_MIXER_INCLUDES ${VORBIS_INCLUDE_DIR})
     list(APPEND SDL_MIXER_DEFINES MUSIC_OGG)
+    list(APPEND SDL_MIXER_LOAD_DEFINES -DOGG_DYNAMIC="${VORBISFILE_LIBRARY}")
 endif()
 
 # Opus support
 if(SDL_MIXER_ENABLE_OPUS)
     find_path(OPUS_INCLUDE_DIR opus/opusfile.h)
-    find_package(ogg CONFIG REQUIRED)
-    find_package(Opus CONFIG REQUIRED)
+    find_library(OPUSFILE_LIBRARY opusfile)
     list(APPEND SDL_MIXER_INCLUDES ${OPUS_INCLUDE_DIR})
     list(APPEND SDL_MIXER_DEFINES MUSIC_OPUS)
+    list(APPEND SDL_MIXER_LOAD_DEFINES -DOPUS_DYNAMIC="${OPUSFILE_LIBRARY}")
 endif()
 
 add_library(SDL2_mixer
@@ -75,7 +83,7 @@ if(WIN32)
 endif()
 
 set_target_properties(SDL2_mixer PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)
-target_compile_definitions(SDL2_mixer PRIVATE ${SDL_MIXER_DEFINES})
+target_compile_definitions(SDL2_mixer PRIVATE ${SDL_MIXER_DEFINES} ${SDL_MIXER_LOAD_DEFINES})
 target_include_directories(SDL2_mixer PRIVATE ${SDL_MIXER_INCLUDES} ./native_midi)
 
 install(TARGETS SDL2_mixer

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.4-5
+Version: 2.0.4-6
 Homepage: https://www.libsdl.org/projects/SDL_mixer
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2


### PR DESCRIPTION
Define `-D${PORT}="${PORT_LIBRARY}"` to use dynamic call in sdl2-mixer.

Related: #8208.