### PR TITLE
[Tweeny] Added Tweeny port

### DIFF
--- a/ports/tweeny/CONTROL
+++ b/ports/tweeny/CONTROL
@@ -1,0 +1,4 @@
+Source: tweeny
+Version: 3.0
+Description: A modern C++ tweening library
+Homepage: https://github.com/mobius3/tweeny

--- a/ports/tweeny/portfile.cmake
+++ b/ports/tweeny/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -15,9 +14,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(GLOB TWEENY_CMAKE_FILES
-		"${CURRENT_PACKAGES_DIR}/lib/cmake/Tweeny/Tweeny*")
-file(COPY ${TWEENY_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/tweeny/cmake)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "/lib/cmake/Tweeny/")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake/Tweeny)

--- a/ports/tweeny/portfile.cmake
+++ b/ports/tweeny/portfile.cmake
@@ -1,0 +1,25 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mobius3/tweeny
+    REF v3
+    SHA512 41f2562a0e55b0fd2c219fab384bf46f70432abb47953b5ac768a29b2ea7b790c6aa56fd44c1fef583f6fa2011010d7dd7e637bcd2d8a9be5c9638a7f2ce7436
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(GLOB TWEENY_CMAKE_FILES
+		"${CURRENT_PACKAGES_DIR}/lib/cmake/Tweeny/Tweeny*")
+file(COPY ${TWEENY_CMAKE_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/tweeny/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake/Tweeny)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/tweeny RENAME copyright)


### PR DESCRIPTION
This PR adds a port for the header only library, [Tweeny](https://github.com/mobius3/tweeny).

This is my first port. Let me know if there's anything that i forgot to add and I'll be sure to make the changes. 

### Installation

`vcpkg install tweeny`