### PR TITLE
[vtk] Fix vtk[python] build failure

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-6
+Version: 8.2.0-7
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, atlmfc (windows), eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -73,6 +73,7 @@ if(VTK_WITH_QT)
 endif()
 
 if(VTK_WITH_PYTHON)
+    vcpkg_find_acquire_program(PYTHON3)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_WRAP_PYTHON=ON
         -DVTK_PYTHON_VERSION=3
@@ -128,6 +129,7 @@ vcpkg_configure_cmake(
         -DModule_vtkGUISupportMFC=${Module_vtkGUISupportMFC}
         -DModule_vtkRenderingOpenVR=${Module_vtkRenderingOpenVR}
         -DVTK_Group_MPI=${VTK_Group_MPI}
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 
         ${ADDITIONAL_OPTIONS}
 )


### PR DESCRIPTION
Fix vtk[python] build failure. Due to this:
```
CMake Error at D:/Repository/vcpkg/tools/cmake-3.14.0-windows/cmake-3.14.0-win32-x86/share/cmake-3.14/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE)
Call Stack (most recent call first):
```
Related issue #8330.