### PR TITLE
[libevent] add features

### DIFF
--- a/ports/evpp/CONTROL
+++ b/ports/evpp/CONTROL
@@ -1,5 +1,5 @@
 Source: evpp
-Version: 0.7.0-1
+Version: 0.7.0-2
 Homepage: https://github.com/Qihoo360/evpp
 Description: A modern C++ network library based on libevent for developing high performance network services in TCP/UDP/HTTP protocols.
 Build-Depends: glog, libevent (windows), libevent[openssl] (!windows), rapidjson, concurrentqueue (!windows), boost-lockfree (!windows)

--- a/ports/evpp/CONTROL
+++ b/ports/evpp/CONTROL
@@ -2,4 +2,4 @@ Source: evpp
 Version: 0.7.0-1
 Homepage: https://github.com/Qihoo360/evpp
 Description: A modern C++ network library based on libevent for developing high performance network services in TCP/UDP/HTTP protocols.
-Build-Depends: glog, libevent, rapidjson, concurrentqueue (!windows), boost-lockfree (!windows)
+Build-Depends: glog, libevent (windows), libevent[openssl] (!windows), rapidjson, concurrentqueue (!windows), boost-lockfree (!windows)

--- a/ports/libevent/CONTROL
+++ b/ports/libevent/CONTROL
@@ -1,5 +1,5 @@
 Source: libevent
-Version: 2.1.11
+Version: 2.1.11-1
 Build-Depends: openssl
 Homepage: https://github.com/libevent/libevent
 Description: An event notification library

--- a/ports/libevent/CONTROL
+++ b/ports/libevent/CONTROL
@@ -3,3 +3,10 @@ Version: 2.1.11
 Build-Depends: openssl
 Homepage: https://github.com/libevent/libevent
 Description: An event notification library
+
+Feature: openssl
+Description: Support for openssl
+Build-Depends: openssl
+
+Feature: thread
+Description: Support for thread

--- a/ports/libevent/portfile.cmake
+++ b/ports/libevent/portfile.cmake
@@ -14,6 +14,12 @@ vcpkg_from_github(
         fix-crt_linkage.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    INVERTED_FEATURES
+    openssl EVENT__DISABLE_OPENSSL
+    thread  EVENT__DISABLE_THREAD_SUPPORT
+)
+
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(LIBEVENT_LIB_TYPE SHARED)
 else()
@@ -23,7 +29,7 @@ endif()
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DEVENT_INSTALL_CMAKE_DIR:PATH=share/libevent
         -DEVENT__LIBRARY_TYPE=${LIBEVENT_LIB_TYPE}
         -DVCPKG_CRT_LINKAGE=${VCPKG_CRT_LINKAGE}


### PR DESCRIPTION
Add `openssl `and `thread `features for `libevent`.
 `libevhtp` needs to depend on this two features.
Related issue #4793.