### PR TITLE
[rxcpp] Change to new repository

### DIFF
--- a/ports/rxcpp/CONTROL
+++ b/ports/rxcpp/CONTROL
@@ -1,4 +1,4 @@
 Source: rxcpp
 Version: 4.1.0
-Homepage: https://github.com/Reactive-Extensions/RxCpp
+Homepage: https://github.com/ReactiveX/RxCpp
 Description: Reactive Extensions for C++

--- a/ports/rxcpp/portfile.cmake
+++ b/ports/rxcpp/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
     REF v4.1.0
     SHA512 a92e817ecbdf6f235cae724ada2615af9fa0c243249625d0f2c2f09ff5dd7f53fdabd03a0278fe2995fe27528c5511d71f87b7a6b3d54f73b49b65aef56e32fd
     HEAD_REF master
-    PATCHES "${CMAKE_CURRENT_LIST_DIR}/support_find_package.patch"
+    PATCHES support_find_package.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/rxcpp/portfile.cmake
+++ b/ports/rxcpp/portfile.cmake
@@ -1,25 +1,26 @@
 #header-only library
 include(vcpkg_common_functions)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/RxCpp-4.0.0)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/RxCpp-4.1.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO Reactive-Extensions/RxCpp
+    REPO ReactiveX/RxCpp
     REF v4.1.0
     SHA512 a92e817ecbdf6f235cae724ada2615af9fa0c243249625d0f2c2f09ff5dd7f53fdabd03a0278fe2995fe27528c5511d71f87b7a6b3d54f73b49b65aef56e32fd
     HEAD_REF master
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/support_find_package.patch"
 )
 
-file(INSTALL
-	${SOURCE_PATH}/Rx/v2/src/rxcpp
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTS=OFF
 )
 
-file(INSTALL
-	${SOURCE_PATH}/Ix/CPP/src/cpplinq
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include
-)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT}/cmake/)
 
-file(INSTALL
-	${SOURCE_PATH}/license.md
-	DESTINATION ${CURRENT_PACKAGES_DIR}/share/rxcpp RENAME copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(COPY ${SOURCE_PATH}/license.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/license.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)

--- a/ports/rxcpp/support_find_package.patch
+++ b/ports/rxcpp/support_find_package.patch
@@ -1,0 +1,32 @@
+diff --git a/projects/CMake/CMakeLists.txt b/projects/CMake/CMakeLists.txt
+index 3d0744740..293f187c5 100644
+--- a/projects/CMake/CMakeLists.txt
++++ b/projects/CMake/CMakeLists.txt
+@@ -146,3 +146,27 @@ set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE CACHE BOOL "Don't require all project
+ 
+ install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
+         FILES_MATCHING PATTERN "*.hpp")
++
++# Here we are exporting TARGETS so that other projects can import rxcpp
++# just with find_package(rxcpp CONFIG) after rxcpp is installed into system by "make install". 
++add_library(rxcpp INTERFACE)
++
++target_include_directories(rxcpp INTERFACE
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<INSTALL_INTERFACE:include/rxcpp>
++)
++
++install(TARGETS rxcpp EXPORT rxcppConfig)
++install(EXPORT rxcppConfig DESTINATION share/rxcpp/cmake)
++
++# When find_package(rxcpp SOME_VERSION REQUIRED) will be used in third party project
++# where SOME_VERSION is any version incompatible with ${PROJECT_VERSION} then cmake will generate the error.
++# It means you don't need track versions manually.
++include(CMakePackageConfigHelpers)
++write_basic_package_version_file("${PROJECT_BINARY_DIR}/rxcppConfigVersion.cmake"
++    VERSION
++        ${PROJECT_VERSION}
++    COMPATIBILITY
++        AnyNewerVersion
++)
++install(FILES "${PROJECT_BINARY_DIR}/rxcppConfigVersion.cmake" DESTINATION share/rxcpp/cmake)


### PR DESCRIPTION
This changes the source repository but not the version.  I also added an upstream patch that allows for `find_package(rxcpp CONFIG)` to work properly.  This will be in their next release and can be dropped at that point, but for any prior releases it will need to be applied.  I can remove that part of the PR if this is not acceptable. 