### PR TITLE
[qt5-tools] change control file so activeqt isn't a dependency on non windows

### DIFF
--- a/ports/qt5-tools/CONTROL
+++ b/ports/qt5-tools/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-tools
 Version: 5.12.5-2
 Description: Qt5 Tools Module; Includes deployment tools and helpers, Qt Designer, Assistant, and other applications
-Build-Depends:  qt5-base, qt5-declarative, qt5-activeqt(windows)
+Build-Depends:  qt5-base, qt5-declarative, qt5-activeqt (windows)

--- a/ports/qt5-tools/CONTROL
+++ b/ports/qt5-tools/CONTROL
@@ -1,4 +1,4 @@
 Source: qt5-tools
-Version: 5.12.5-1
+Version: 5.12.5-2
 Description: Qt5 Tools Module; Includes deployment tools and helpers, Qt Designer, Assistant, and other applications
-Build-Depends:  qt5-base, qt5-declarative, qt5-activeqt
+Build-Depends:  qt5-base, qt5-declarative, qt5-activeqt(windows)


### PR DESCRIPTION
Active Qt can only be built on Windows