### PR TITLE
[metis][suitesparse] add metisConfig.cmake

### DIFF
--- a/ports/metis/CONTROL
+++ b/ports/metis/CONTROL
@@ -1,4 +1,4 @@
 Source: metis
-Version: 5.1.0-5
+Version: 5.1.0-6
 Homepage: https://glaros.dtc.umn.edu/gkhome/metis/metis/overview
 Description: Serial Graph Partitioning and Fill-reducing Matrix Ordering

--- a/ports/metis/install-metisConfig.patch
+++ b/ports/metis/install-metisConfig.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9613a7..e43ffee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,3 +22,23 @@ include_directories(include)
+ add_subdirectory("include")
+ add_subdirectory("libmetis")
+ # add_subdirectory("programs")
++
++if(METIS_INSTALL)
++  set(PRJ_NAME metis)
++  set(PRJ_VER 5.1.0)
++  install(EXPORT metisTargets 
++    FILE ${PRJ_NAME}Targets.cmake
++    DESTINATION lib/cmake/${PRJ_NAME})
++  include(CMakePackageConfigHelpers)
++  write_basic_package_version_file(
++    ${CMAKE_CURRENT_BINARY_DIR}/${PRJ_NAME}ConfigVersion.cmake
++    VERSION ${PRJ_VER}
++    COMPATIBILITY SameMajorVersion)
++  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PRJ_NAME}Config.cmake
++    "include(\${CMAKE_CURRENT_LIST_DIR}/${PRJ_NAME}Targets.cmake)")
++  install(FILES 
++    ${CMAKE_CURRENT_BINARY_DIR}/${PRJ_NAME}ConfigVersion.cmake
++    ${CMAKE_CURRENT_BINARY_DIR}/${PRJ_NAME}Config.cmake
++    DESTINATION lib/cmake/${PRJ_NAME})
++endif()
++
+diff --git a/libmetis/CMakeLists.txt b/libmetis/CMakeLists.txt
+index 7a5fc74..5a68cf0 100644
+--- a/libmetis/CMakeLists.txt
++++ b/libmetis/CMakeLists.txt
+@@ -9,8 +9,9 @@ if(UNIX)
+ endif()
+ 
+ if(METIS_INSTALL)
+-  install(TARGETS metis
++  install(TARGETS metis EXPORT metisTargets
+     LIBRARY DESTINATION lib
+     RUNTIME DESTINATION bin
+-    ARCHIVE DESTINATION lib)
++    ARCHIVE DESTINATION lib
++    INCLUDES DESTINATION include)
+ endif()

--- a/ports/metis/portfile.cmake
+++ b/ports/metis/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_extract_source_archive_ex(
         fix-metis-vs14-math.patch
         fix-gklib-vs14-math.patch
         fix-linux-build-error.patch
+        install-metisConfig.patch
 )
 
 vcpkg_configure_cmake(
@@ -32,6 +33,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/metis)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/suitesparse/CONTROL
+++ b/ports/suitesparse/CONTROL
@@ -1,5 +1,5 @@
 Source: suitesparse
-Version: 5.4.0-3
+Version: 5.4.0-4
 Build-Depends: clapack (!osx)
 Homepage: http://faculty.cse.tamu.edu/davis/SuiteSparse
 Description: algebra library

--- a/ports/suitesparse/add-find-package-metis.patch
+++ b/ports/suitesparse/add-find-package-metis.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b8c2e63..d443390 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -199,12 +199,15 @@ if(LAPACK_FOUND AND BLAS_FOUND)
+ endif() # LAPACK is not found
+ 
+ IF(BUILD_METIS OR USE_VCPKG_METIS)
++	find_package(metis REQUIRED)
+ 	set(SuiteSparse_LINKER_METIS_LIBS "metis")
+ 	## namespaced library target for config
+-	set(SuiteSparse_EXPORTED_METIS_LIBS "SuiteSparse::metis")
++	set(SuiteSparse_EXPORTED_METIS_LIBS "metis")
++	set(SuiteSparse_FIND_PACKAGE_METIS "find_package(metis REQUIRED)")
+ else()
+ 	set(SuiteSparse_LINKER_METIS_LIBS "")
+ 	set(SuiteSparse_EXPORTED_METIS_LIBS "")
++	set(SuiteSparse_FIND_PACKAGE_METIS "")
+ ENDIF()
+ 
+ add_subdirectory(SuiteSparse)
+diff --git a/SuiteSparse/CMakeLists.txt b/SuiteSparse/CMakeLists.txt
+index 5ef08a6..6c7abfd 100644
+--- a/SuiteSparse/CMakeLists.txt
++++ b/SuiteSparse/CMakeLists.txt
+@@ -13,7 +13,7 @@ ENDIF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+ 
+ # Global flags:
+ IF (BUILD_METIS OR USE_VCPKG_METIS)
+-	INCLUDE_DIRECTORIES("${METIS_SOURCE_DIR}/include")
++	#INCLUDE_DIRECTORIES("${METIS_SOURCE_DIR}/include")
+ ELSE ()
+ 	ADD_DEFINITIONS(-DNPARTITION)
+ ENDIF ()
+diff --git a/cmake/SuiteSparse-config-install.cmake.in b/cmake/SuiteSparse-config-install.cmake.in
+index 49387b8..553d9c7 100644
+--- a/cmake/SuiteSparse-config-install.cmake.in
++++ b/cmake/SuiteSparse-config-install.cmake.in
+@@ -5,6 +5,7 @@ get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
+ get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
+ 
+ find_package(LAPACK REQUIRED)
++@SuiteSparse_FIND_PACKAGE_METIS@
+ 
+ # Load targets from the install tree.
+ include(${_SuiteSparse_SELF_DIR}/suitesparse-targets.cmake)

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         suitesparse.patch
+        add-find-package-metis.patch
 )
 
 # Copy suitesparse sources.


### PR DESCRIPTION
Related to #8336 , fix build failure on
```
vcpkg install suitesparse[metis]:x64-windows
vcpkg install ceres[suitesparse]:x64-windows
```

 - make metis to install metisConfig.cmake
 - make suitesparse to use find_package(metis)