### PR TITLE
[mgnlibs] Add new port

### DIFF
--- a/ports/mgnlibs/CONTROL
+++ b/ports/mgnlibs/CONTROL
@@ -1,0 +1,4 @@
+Source: mgnlibs
+Version: 2019-09-29
+Homepage: https://github.com/mattiasgustavsson/libs
+Description: Single-file public domain libraries for C/C++

--- a/ports/mgnlibs/portfile.cmake
+++ b/ports/mgnlibs/portfile.cmake
@@ -1,0 +1,17 @@
+#header-only library
+include(vcpkg_common_functions)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mattiasgustavsson/libs
+    REF 9a6e7205caecbe336e41aebdc9c79a5c47daa5ec
+    SHA512 87493f883f0752a334bbcec69228e325d9e1f36a99d313be9243f4e6e14876bcd5a976682d3fd7e3e285e426ac69587d35ba3378b2124450b9a8ed6127f110a5
+    HEAD_REF master
+)
+
+# Put the licence file where vcpkg expects it
+file(COPY ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/mgnlibs/README.md)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/mgnlibs/README.md ${CURRENT_PACKAGES_DIR}/share/mgnlibs/copyright)
+
+# Copy the header files
+file(GLOB HEADER_FILES ${SOURCE_PATH}/*.h)
+file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/mgnlibs)


### PR DESCRIPTION
This is a redo of #7657

Now copies header files to `include/mgnlibs` instead of `include`