### PR TITLE
[libplist,libusbmuxd] Set ONLY_DYNAMIC_LIBRARY instead of ONLY_STATIC_LIBRARY

### DIFF
--- a/ports/libplist/portfile.cmake
+++ b/ports/libplist/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY ONLY_DYNAMIC_CRT)
+vcpkg_check_linkage(ONLY_DYNAMIC_CRT ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/libplist/portfile.cmake
+++ b/ports/libplist/portfile.cmake
@@ -14,6 +14,10 @@ vcpkg_from_github(
 set(ENV{_CL_} "$ENV{_CL_} /GL-")
 set(ENV{_LINK_} "$ENV{_LINK_} /LTCG:OFF")
 
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    set(ENV{_LINK_} "$ENV{_LINK_} /APPCONTAINER")
+endif()
+
 vcpkg_install_msbuild(
     SOURCE_PATH ${SOURCE_PATH}
     PROJECT_SUBPATH libplist.sln

--- a/ports/libusbmuxd/portfile.cmake
+++ b/ports/libusbmuxd/portfile.cmake
@@ -1,6 +1,6 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY ONLY_DYNAMIC_CRT)
+vcpkg_check_linkage(ONLY_DYNAMIC_CRT ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
libplist appears to always build as a dynamic library and the previous
ONLY_STATIC_LIBRARY option was causing the DLLs to not be installed.

Signed-off-by: Andrew Gunnerson <andrewgunnerson@gmail.com>