### PR TITLE
[glslang,pthreads,shaderc,spirv-tools,nlohmann-json] Various fixes/improvements

### DIFF
--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -13,6 +13,15 @@ vcpkg_from_github(
     CMakeLists-windows.patch
 )
 
+file(READ ${SOURCE_PATH}/glslang/CMakeLists.txt glsl_cmake_lists)
+string(REPLACE [[target_link_libraries(glslang OGLCompiler OSDependent)]]
+    [[
+target_link_libraries(glslang OGLCompiler OSDependent)
+target_include_directories(glslang PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    ]] 
+glsl_cmake_lists "${glsl_cmake_lists}")
+file(WRITE ${SOURCE_PATH}/glslang/CMakeLists.txt "${glsl_cmake_lists}")
+
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -21,6 +21,15 @@ download_src(nlohmann_json.natvis 9bce6758db0e54777394a4e718e60a281952b15f0c6dc6
 download_src(cmake/config.cmake.in 7caab6166baa891f77f5b632ac4a920e548610ec41777b885ec51fe68d3665ffe91984dd2881caf22298b5392dfbd84b526fda252467bb66de9eb90e6e6ade5a)
 download_src(single_include/nlohmann/json.hpp 1a12ea9e54a19e398a4d7aa3be1759ce3666a1b479bd553fe11bc63897a8055f11f42871eee6c801756dde038d860c48043cc50df753835c9a9691a1876a159e)
 
+# fifo_map
+vcpkg_download_distfile(FIFO_MAP
+    URLS "https://raw.githubusercontent.com/nlohmann/fifo_map/0dfbf5dacbb15a32c43f912a7e66a54aae39d0f9/src/fifo_map.hpp"
+    FILENAME "nlohmann-json-v${SOURCE_VERSION}/fifo_map.hpp"
+    SHA512 dc6acfa8cc8317f0f98b4af35125df330052a6de8f4752d61efb3f80a4b01570d5ced2360dcbdf5d59cb5742b25f373f9b18f758994bccaa29959c6f6b875cb4
+)
+get_filename_component(SUBPATH_DIR "${SOURCE_PATH}/single_include/nlohmann/json.hpp" DIRECTORY)
+file(COPY ${FIFO_MAP} DESTINATION ${SUBPATH_DIR})
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/pthreads/vcpkg-cmake-wrapper.cmake
+++ b/ports/pthreads/vcpkg-cmake-wrapper.cmake
@@ -74,8 +74,8 @@ endif()
 find_package_handle_standard_args(PThreads4W DEFAULT_MSG PThreads4W_LIBRARY PThreads4W_CXXEXC_LIBRARY PThreads4W_STRUCTEXC_LIBRARY PThreads4W_INCLUDE_DIR)
 mark_as_advanced(PThreads4W_INCLUDE_DIR PThreads4W_LIBRARY PThreads4W_CXXEXC_LIBRARY PThreads4W_STRUCTEXC_LIBRARY)
 
-set(PThreads4W_DLL_DIR ${PThreads4W_INCLUDE_DIR})
-list(TRANSFORM PThreads4W_DLL_DIR APPEND "/../bin")
+set(PThreads4W_DLL_DIR "${PThreads4W_INCLUDE_DIR}/../bin")
+list(APPEND PThreads4W_DLL_DIR "${PThreads4W_INCLUDE_DIR}/../debug/bin")
 message(STATUS "PThreads4W_DLL_DIR: ${PThreads4W_DLL_DIR}")
 
 find_file(PThreads4W_LIBRARY_RELEASE_DLL NAMES pthreadVC${PThreads4W_MAJOR_VERSION}.dll PATHS ${PThreads4W_DLL_DIR})

--- a/ports/shaderc/CONTROL
+++ b/ports/shaderc/CONTROL
@@ -3,3 +3,6 @@ Version: 2019-06-26-1
 Homepage: https://github.com/google/shaderc
 Description: A collection of tools, libraries and tests for shader compilation.
 Build-Depends: glslang, spirv-tools
+
+Feature: combine
+Description: build target shaderc::shaderc_combined (static all-in-one gigantic lib)

--- a/ports/shaderc/export-target-config.patch
+++ b/ports/shaderc/export-target-config.patch
@@ -1,0 +1,234 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dc5f1a9..4e4d813 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,7 +70,10 @@ endif(MSVC)
+ 
+ # Configure subdirectories.
+ # We depend on these for later projects, so they should come first.
+-add_subdirectory(third_party)
++# add_subdirectory(third_party)
++
++find_package(glslang CONFIG REQUIRED)
++find_package(spirv-tools CONFIG REQUIRED)
+ 
+ if(SHADERC_ENABLE_SPVC)
+ add_subdirectory(libshaderc_spvc)
+diff --git a/glslc/CMakeLists.txt b/glslc/CMakeLists.txt
+index d0df7db..c4113fc 100644
+--- a/glslc/CMakeLists.txt
++++ b/glslc/CMakeLists.txt
+@@ -15,15 +15,16 @@ add_library(glslc STATIC
+   src/dependency_info.h
+ )
+ 
++get_target_property(glslang_SOURCE_DIR spirv-tools::SPIRV-Tools-opt INTERFACE_INCLUDE_DIRECTORIES)
++
+ shaderc_default_compile_options(glslc)
+-target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
+-target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
+-  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
++target_link_libraries(glslc PRIVATE glslang::glslang glslang::OSDependent glslang::OGLCompiler
++  glslang::HLSL glslang::SPIRV ${CMAKE_THREAD_LIBS_INIT})
+ target_link_libraries(glslc PRIVATE shaderc_util shaderc)
+ 
+ add_executable(glslc_exe src/main.cc)
+ shaderc_default_compile_options(glslc_exe)
+-target_include_directories(glslc_exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/.. ${spirv-tools_SOURCE_DIR}/include)
++target_include_directories(glslc_exe PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/.. ${glslang_SOURCE_DIR})
+ set_target_properties(glslc_exe PROPERTIES OUTPUT_NAME glslc)
+ target_link_libraries(glslc_exe PRIVATE glslc shaderc_util shaderc)
+ 
+diff --git a/libshaderc/CMakeLists.txt b/libshaderc/CMakeLists.txt
+index 0ffa06f..7f7ac59 100644
+--- a/libshaderc/CMakeLists.txt
++++ b/libshaderc/CMakeLists.txt
+@@ -12,17 +12,28 @@ set(SHADERC_SOURCES
+ 
+ add_library(shaderc STATIC ${SHADERC_SOURCES})
+ shaderc_default_compile_options(shaderc)
+-target_include_directories(shaderc PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
++target_include_directories(shaderc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ add_library(shaderc_shared SHARED ${SHADERC_SOURCES})
+ shaderc_default_compile_options(shaderc_shared)
+-target_include_directories(shaderc_shared PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
++target_include_directories(shaderc_shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ target_compile_definitions(shaderc_shared
+     PRIVATE SHADERC_IMPLEMENTATION
+     PUBLIC SHADERC_SHAREDLIB
+ )
+ set_target_properties(shaderc_shared PROPERTIES SOVERSION 1)
+ 
++find_package(Threads)
++set(SHADERC_LIBS
++  glslang::glslang glslang::OSDependent glslang::OGLCompiler ${CMAKE_THREAD_LIBS_INIT}
++  shaderc_util
++  glslang::SPIRV # from glslang
++  spirv-tools::SPIRV-Tools
++)
++
++target_link_libraries(shaderc PUBLIC ${SHADERC_LIBS})
++target_link_libraries(shaderc_shared PUBLIC ${SHADERC_LIBS})
++
+ if(SHADERC_ENABLE_INSTALL)
+   install(
+     FILES
+@@ -34,22 +45,20 @@ if(SHADERC_ENABLE_INSTALL)
+     DESTINATION
+       ${CMAKE_INSTALL_INCLUDEDIR}/shaderc)
+ 
+-  install(TARGETS shaderc shaderc_shared
++  install(TARGETS shaderc EXPORT shadercConfig
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++
++install(
++    EXPORT shadercConfig
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/shaderc"
++    NAMESPACE shaderc::
++    )
++    
+ endif(SHADERC_ENABLE_INSTALL)
+ 
+-find_package(Threads)
+-set(SHADERC_LIBS
+-  glslang OSDependent OGLCompiler glslang ${CMAKE_THREAD_LIBS_INIT}
+-  shaderc_util
+-  SPIRV # from glslang
+-  SPIRV-Tools
+-)
+ 
+-target_link_libraries(shaderc PRIVATE ${SHADERC_LIBS})
+-target_link_libraries(shaderc_shared PRIVATE ${SHADERC_LIBS})
+ 
+ shaderc_add_tests(
+   TEST_PREFIX shaderc
+@@ -71,33 +80,37 @@ shaderc_add_tests(
+     shaderc_cpp
+     shaderc_private)
+ 
+-shaderc_combine_static_lib(shaderc_combined shaderc)
++if (SHADERC_ENABLE_COMBINE)
++    shaderc_combine_static_lib(shaderc_combined shaderc)
+ 
+-if(SHADERC_ENABLE_INSTALL)
+-  # Since shaderc_combined is defined as an imported library, we cannot use the
+-  # install() directive to install it. Install it like a normal file.
+-  get_target_property(generated_location shaderc_combined LOCATION)
+-  string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
+-  if (NOT "${vs_generator}" STREQUAL "")
+-    # With Visual Studio generators, the LOCATION property is not properly
+-    # expanded according to the current build configuration. We need to work
+-    # around this problem by manually substitution.
+-    string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
+-      install_location "${generated_location}")
+-    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  else()
+-    install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  endif()
+-endif(SHADERC_ENABLE_INSTALL)
++    if(SHADERC_ENABLE_INSTALL)
++      # Since shaderc_combined is defined as an imported library, we cannot use the
++      # install() directive to install it. Install it like a normal file.
++      get_target_property(generated_location shaderc_combined LOCATION)
++         
++      string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
++      if (NOT "${vs_generator}" STREQUAL "")
++        # With Visual Studio generators, the LOCATION property is not properly
++        # expanded according to the current build configuration. We need to work
++        # around this problem by manually substitution.
++        string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
++          install_location "${generated_location}")
++        install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++      else()
++        install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++      endif()
++    endif(SHADERC_ENABLE_INSTALL)
++
++    shaderc_add_tests(
++      TEST_PREFIX shaderc_combined
++      LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
++      INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${glslang_SOURCE_DIR}
++                   ${spirv-tools_SOURCE_DIR}/include
++      TEST_NAMES
++        shaderc
++        shaderc_cpp)
++endif (SHADERC_ENABLE_COMBINE)
+ 
+-shaderc_add_tests(
+-  TEST_PREFIX shaderc_combined
+-  LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
+-  INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${glslang_SOURCE_DIR}
+-               ${spirv-tools_SOURCE_DIR}/include
+-  TEST_NAMES
+-    shaderc
+-    shaderc_cpp)
+ 
+ if(${SHADERC_ENABLE_TESTS})
+   add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)
+diff --git a/libshaderc_util/CMakeLists.txt b/libshaderc_util/CMakeLists.txt
+index ec0e8fb..9c95586 100644
+--- a/libshaderc_util/CMakeLists.txt
++++ b/libshaderc_util/CMakeLists.txt
+@@ -23,13 +23,45 @@ add_library(shaderc_util STATIC
+ )
+ 
+ shaderc_default_compile_options(shaderc_util)
+-target_include_directories(shaderc_util
+-  PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
++target_include_directories(shaderc_util PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ find_package(Threads)
+-target_link_libraries(shaderc_util PRIVATE
+-  glslang OSDependent OGLCompiler HLSL glslang SPIRV
+-  SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
++target_link_libraries(shaderc_util PUBLIC
++  glslang::glslang glslang::OSDependent glslang::OGLCompiler glslang::HLSL glslang::SPIRV spirv-tools::SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
++
++if(SHADERC_ENABLE_INSTALL)
++  install(
++    FILES
++      include/libshaderc_util/compiler.h
++      include/libshaderc_util/counting_includer.h
++      include/libshaderc_util/exceptions.h
++      include/libshaderc_util/file_finder.h
++      include/libshaderc_util/format.h
++      include/libshaderc_util/io.h
++      include/libshaderc_util/message.h
++      include/libshaderc_util/mutex.h
++      include/libshaderc_util/resources.h
++      include/libshaderc_util/resources.inc
++      include/libshaderc_util/shader_stage.h
++      include/libshaderc_util/spirv_tools_wrapper.h
++      include/libshaderc_util/string_piece.h
++      include/libshaderc_util/universal_unistd.h
++      include/libshaderc_util/version_profile.h
++    DESTINATION
++      ${CMAKE_INSTALL_INCLUDEDIR}/libshaderc_util)
++
++  install(TARGETS shaderc_util EXPORT shadercConfig
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++
++install(
++    EXPORT shadercConfig
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/shaderc"
++    NAMESPACE shaderc::
++    )
++    
++endif(SHADERC_ENABLE_INSTALL)
+ 
+ shaderc_add_tests(
+   TEST_PREFIX shaderc_util
+@@ -44,6 +76,8 @@ shaderc_add_tests(
+     mutex
+     version_profile)
+ 
++get_target_property(glslang_SOURCE_DIR spirv-tools::SPIRV-Tools-opt INTERFACE_INCLUDE_DIRECTORIES)
++
+ if(${SHADERC_ENABLE_TESTS})
+   target_include_directories(shaderc_util_counting_includer_test
+     PRIVATE ${glslang_SOURCE_DIR})

--- a/ports/shaderc/export-target-config.patch
+++ b/ports/shaderc/export-target-config.patch
@@ -7,8 +7,8 @@ index dc5f1a9..4e4d813 100644
  # Configure subdirectories.
  # We depend on these for later projects, so they should come first.
 -add_subdirectory(third_party)
-+# add_subdirectory(third_party)
-+
++set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 +find_package(glslang CONFIG REQUIRED)
 +find_package(spirv-tools CONFIG REQUIRED)
  

--- a/ports/shaderc/export-target-config.patch
+++ b/ports/shaderc/export-target-config.patch
@@ -1,24 +1,42 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dc5f1a9..4e4d813 100644
+index dc5f1a9..42d4864 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -70,7 +70,10 @@ endif(MSVC)
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.1.3)
+ project(shaderc)
+ enable_testing()
+ 
+@@ -70,7 +70,17 @@ endif(MSVC)
  
  # Configure subdirectories.
  # We depend on these for later projects, so they should come first.
 -add_subdirectory(third_party)
++# add_subdirectory(third_party)
 +set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 +set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++
++find_package(Threads)
++if (Threads_FOUND)
++set(THREADS_LIB Threads::Threads)
++endif()
++
 +find_package(glslang CONFIG REQUIRED)
 +find_package(spirv-tools CONFIG REQUIRED)
  
  if(SHADERC_ENABLE_SPVC)
  add_subdirectory(libshaderc_spvc)
 diff --git a/glslc/CMakeLists.txt b/glslc/CMakeLists.txt
-index d0df7db..c4113fc 100644
+index d0df7db..f8bcca2 100644
 --- a/glslc/CMakeLists.txt
 +++ b/glslc/CMakeLists.txt
-@@ -15,15 +15,16 @@ add_library(glslc STATIC
+@@ -1,4 +1,3 @@
+-find_package(Threads)
+ 
+ add_library(glslc STATIC
+   src/file_compiler.cc
+@@ -15,15 +14,16 @@ add_library(glslc STATIC
    src/dependency_info.h
  )
  
@@ -29,7 +47,7 @@ index d0df7db..c4113fc 100644
 -target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
 -  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
 +target_link_libraries(glslc PRIVATE glslang::glslang glslang::OSDependent glslang::OGLCompiler
-+  glslang::HLSL glslang::SPIRV ${CMAKE_THREAD_LIBS_INIT})
++  glslang::HLSL glslang::SPIRV ${THREADS_LIB})
  target_link_libraries(glslc PRIVATE shaderc_util shaderc)
  
  add_executable(glslc_exe src/main.cc)
@@ -40,10 +58,10 @@ index d0df7db..c4113fc 100644
  target_link_libraries(glslc_exe PRIVATE glslc shaderc_util shaderc)
  
 diff --git a/libshaderc/CMakeLists.txt b/libshaderc/CMakeLists.txt
-index 0ffa06f..7f7ac59 100644
+index 0ffa06f..1b877a9 100644
 --- a/libshaderc/CMakeLists.txt
 +++ b/libshaderc/CMakeLists.txt
-@@ -12,17 +12,28 @@ set(SHADERC_SOURCES
+@@ -12,17 +12,27 @@ set(SHADERC_SOURCES
  
  add_library(shaderc STATIC ${SHADERC_SOURCES})
  shaderc_default_compile_options(shaderc)
@@ -60,9 +78,8 @@ index 0ffa06f..7f7ac59 100644
  )
  set_target_properties(shaderc_shared PROPERTIES SOVERSION 1)
  
-+find_package(Threads)
 +set(SHADERC_LIBS
-+  glslang::glslang glslang::OSDependent glslang::OGLCompiler ${CMAKE_THREAD_LIBS_INIT}
++  glslang::glslang glslang::OSDependent glslang::OGLCompiler ${THREADS_LIB}
 +  shaderc_util
 +  glslang::SPIRV # from glslang
 +  spirv-tools::SPIRV-Tools
@@ -74,7 +91,7 @@ index 0ffa06f..7f7ac59 100644
  if(SHADERC_ENABLE_INSTALL)
    install(
      FILES
-@@ -34,22 +45,20 @@ if(SHADERC_ENABLE_INSTALL)
+@@ -34,22 +44,20 @@ if(SHADERC_ENABLE_INSTALL)
      DESTINATION
        ${CMAKE_INSTALL_INCLUDEDIR}/shaderc)
  
@@ -105,7 +122,7 @@ index 0ffa06f..7f7ac59 100644
  
  shaderc_add_tests(
    TEST_PREFIX shaderc
-@@ -71,33 +80,37 @@ shaderc_add_tests(
+@@ -71,33 +79,37 @@ shaderc_add_tests(
      shaderc_cpp
      shaderc_private)
  
@@ -149,7 +166,7 @@ index 0ffa06f..7f7ac59 100644
 +
 +    shaderc_add_tests(
 +      TEST_PREFIX shaderc_combined
-+      LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
++      LINK_LIBS shaderc_combined ${THREADS_LIB}
 +      INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${glslang_SOURCE_DIR}
 +                   ${spirv-tools_SOURCE_DIR}/include
 +      TEST_NAMES
@@ -168,11 +185,161 @@ index 0ffa06f..7f7ac59 100644
  
  if(${SHADERC_ENABLE_TESTS})
    add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)
+diff --git a/libshaderc_spvc/CMakeLists.txt b/libshaderc_spvc/CMakeLists.txt
+index b503e70..458b877 100644
+--- a/libshaderc_spvc/CMakeLists.txt
++++ b/libshaderc_spvc/CMakeLists.txt
+@@ -1,5 +1,7 @@
+ project(libshaderc)
+ 
++#potential feature depending on spirv-cross
++
+ # Even though shaderc.hpp is a headers-only library, adding
+ # a dependency here will force clients of the library to rebuild
+ # when it changes.
+@@ -11,11 +13,11 @@ set(SPVC_SOURCES
+ 
+ add_library(shaderc_spvc STATIC ${SPVC_SOURCES})
+ shaderc_default_compile_options(shaderc_spvc)
+-target_include_directories(shaderc_spvc PUBLIC include PRIVATE ${shaderc_SOURCE_DIR}/libshaderc/include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${spirv-tools_SOURCE_DIR}/include ${SPIRV-Cross_SOURCE_DIR}/..)
++target_include_directories(shaderc_spvc PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> PRIVATE $<BUILD_INTERFACE:${shaderc_SOURCE_DIR}/libshaderc/include ${shaderc_SOURCE_DIR}/libshaderc_util/include>)
+ 
+ add_library(shaderc_spvc_shared SHARED ${SPVC_SOURCES})
+ shaderc_default_compile_options(shaderc_spvc_shared)
+-target_include_directories(shaderc_spvc_shared PUBLIC include PRIVATE ${shaderc_SOURCE_DIR}/libshaderc/include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${spirv-tools_SOURCE_DIR}/include ${SPIRV-Cross_SOURCE_DIR}/..)
++target_include_directories(shaderc_spvc PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> PRIVATE $<BUILD_INTERFACE:${shaderc_SOURCE_DIR}/libshaderc/include ${shaderc_SOURCE_DIR}/libshaderc_util/include>)
+ 
+ target_compile_definitions(shaderc_spvc_shared
+     PRIVATE SHADERC_IMPLEMENTATION
+@@ -29,6 +31,17 @@ endif (DISABLE_EXCEPTIONS)
+ 
+ set_target_properties(shaderc_spvc_shared PROPERTIES SOVERSION 1)
+ 
++set(SPVC_LIBS
++  ${THREADS_LIB}
++  spirv-tools::SPIRV-Tools
++  spirv-cross-glsl
++  spirv-cross-hlsl
++  spirv-cross-msl
++)
++
++target_link_libraries(shaderc_spvc PUBLIC ${SPVC_LIBS})
++target_link_libraries(shaderc_spvc_shared PUBLIC ${SPVC_LIBS})
++
+ if(SHADERC_ENABLE_INSTALL)
+   install(
+     FILES
+@@ -37,28 +50,22 @@ if(SHADERC_ENABLE_INSTALL)
+     DESTINATION
+       ${CMAKE_INSTALL_INCLUDEDIR}/shaderc)
+ 
+-  install(TARGETS shaderc_spvc shaderc_spvc_shared
++  install(TARGETS shaderc_spvc shaderc_spvc_shared EXPORT shadercConfig
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    
++  install(
++    EXPORT shadercConfig
++    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/shaderc"
++    NAMESPACE shaderc::
++    )
+ endif(SHADERC_ENABLE_INSTALL)
+ 
+-find_package(Threads)
+-set(SPVC_LIBS
+-  ${CMAKE_THREAD_LIBS_INIT}
+-  SPIRV-Tools
+-  spirv-cross-glsl
+-  spirv-cross-hlsl
+-  spirv-cross-msl
+-)
+-
+-target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})
+-target_link_libraries(shaderc_spvc_shared PRIVATE ${SPVC_LIBS})
+-
+ shaderc_add_tests(
+   TEST_PREFIX shaderc
+   LINK_LIBS shaderc_spvc
+-  INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
++  INCLUDE_DIRS ${shaderc_SOURCE_DIR}/libshaderc/include 
+   TEST_NAMES
+     spvc
+     spvc_cpp)
+@@ -66,37 +73,41 @@ shaderc_add_tests(
+ shaderc_add_tests(
+   TEST_PREFIX shaderc_shared
+   LINK_LIBS shaderc_spvc_shared SPIRV-Tools
+-  INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
++  INCLUDE_DIRS ${shaderc_SOURCE_DIR}/libshaderc/include 
+   TEST_NAMES
+     spvc
+     spvc_cpp)
+ 
+-shaderc_combine_static_lib(shaderc_spvc_combined shaderc_spvc)
+-
+-if(SHADERC_ENABLE_INSTALL)
+-  # Since shaderc_combined is defined as an imported library, we cannot use the
+-  # install() directive to install it. Install it like a normal file.
+-  get_target_property(generated_location shaderc_spvc_combined LOCATION)
+-  string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
+-  if (NOT "${vs_generator}" STREQUAL "")
+-    # With Visual Studio generators, the LOCATION property is not properly
+-    # expanded according to the current build configuration. We need to work
+-    # around this problem by manually substitution.
+-    string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
+-      install_location "${generated_location}")
+-    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  else()
+-    install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  endif()
+-endif(SHADERC_ENABLE_INSTALL)
+-
+-shaderc_add_tests(
+-  TEST_PREFIX shaderc_spvc_combined
+-  LINK_LIBS shaderc_spvc_combined ${CMAKE_THREAD_LIBS_INIT} shaderc_util
+-  INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include
+-  TEST_NAMES
+-    spvc
+-    spvc_cpp)
++if (SHADERC_ENABLE_SPVC_COMBINE)
++
++    shaderc_combine_static_lib(shaderc_spvc_combined shaderc_spvc)
++
++    if(SHADERC_ENABLE_INSTALL)
++      # Since shaderc_combined is defined as an imported library, we cannot use the
++      # install() directive to install it. Install it like a normal file.
++      get_target_property(generated_location shaderc_spvc_combined LOCATION)
++      string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
++      if (NOT "${vs_generator}" STREQUAL "")
++        # With Visual Studio generators, the LOCATION property is not properly
++        # expanded according to the current build configuration. We need to work
++        # around this problem by manually substitution.
++        string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
++          install_location "${generated_location}")
++        install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++      else()
++        install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
++      endif()
++    endif(SHADERC_ENABLE_INSTALL)
++
++    shaderc_add_tests(
++      TEST_PREFIX shaderc_spvc_combined
++      LINK_LIBS shaderc_spvc_combined ${THREADS_LIB} shaderc_util
++      INCLUDE_DIRS ${shaderc_SOURCE_DIR}/libshaderc/include
++      TEST_NAMES
++        spvc
++        spvc_cpp)
++
++endif (SHADERC_ENABLE_SPVC_COMBINE)
+ 
+ if(${SHADERC_ENABLE_TESTS})
+   add_executable(spvc_c_smoke_test ./src/spvc_c_smoke_test.c)
 diff --git a/libshaderc_util/CMakeLists.txt b/libshaderc_util/CMakeLists.txt
-index ec0e8fb..9c95586 100644
+index ec0e8fb..53ba66e 100644
 --- a/libshaderc_util/CMakeLists.txt
 +++ b/libshaderc_util/CMakeLists.txt
-@@ -23,13 +23,45 @@ add_library(shaderc_util STATIC
+@@ -23,13 +23,44 @@ add_library(shaderc_util STATIC
  )
  
  shaderc_default_compile_options(shaderc_util)
@@ -180,12 +347,12 @@ index ec0e8fb..9c95586 100644
 -  PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
 +target_include_directories(shaderc_util PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
  
- find_package(Threads)
+-find_package(Threads)
 -target_link_libraries(shaderc_util PRIVATE
 -  glslang OSDependent OGLCompiler HLSL glslang SPIRV
 -  SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
 +target_link_libraries(shaderc_util PUBLIC
-+  glslang::glslang glslang::OSDependent glslang::OGLCompiler glslang::HLSL glslang::SPIRV spirv-tools::SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
++  glslang::glslang glslang::OSDependent glslang::OGLCompiler glslang::HLSL glslang::SPIRV spirv-tools::SPIRV-Tools-opt ${THREADS_LIB})
 +
 +if(SHADERC_ENABLE_INSTALL)
 +  install(
@@ -223,7 +390,7 @@ index ec0e8fb..9c95586 100644
  
  shaderc_add_tests(
    TEST_PREFIX shaderc_util
-@@ -44,6 +76,8 @@ shaderc_add_tests(
+@@ -44,6 +75,8 @@ shaderc_add_tests(
      mutex
      version_profile)
  
@@ -232,3 +399,23 @@ index ec0e8fb..9c95586 100644
  if(${SHADERC_ENABLE_TESTS})
    target_include_directories(shaderc_util_counting_includer_test
      PRIVATE ${glslang_SOURCE_DIR})
+@@ -56,7 +89,6 @@ shaderc_add_tests(
+   LINK_LIBS shaderc_util
+   INCLUDE_DIRS
+     ${glslang_SOURCE_DIR}
+-    ${spirv-tools_SOURCE_DIR}/include
+   TEST_NAMES
+     compiler)
+ 
+diff --git a/spvc/CMakeLists.txt b/spvc/CMakeLists.txt
+index 76f8c2e..b283ee2 100644
+--- a/spvc/CMakeLists.txt
++++ b/spvc/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ add_executable(spvc_exe src/main.cc)
+ shaderc_default_compile_options(spvc_exe)
+-target_include_directories(spvc_exe PRIVATE ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include)
++target_include_directories(spvc_exe PRIVATE ${shaderc_SOURCE_DIR}/libshaderc/include)
+ set_target_properties(spvc_exe PROPERTIES OUTPUT_NAME spvc)
+ target_link_libraries(spvc_exe PRIVATE shaderc_spvc shaderc_util)
+ 

--- a/ports/spirv-tools/CMake-targets.patch
+++ b/ports/spirv-tools/CMake-targets.patch
@@ -1,16 +1,19 @@
 diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
-index 1f96018..c9a3758 100644
+index 1f96018..7212467 100644
 --- a/source/CMakeLists.txt
 +++ b/source/CMakeLists.txt
-@@ -337,7 +337,7 @@ spvtools_pch(SPIRV_SOURCES pch_source)
+@@ -337,9 +337,9 @@ spvtools_pch(SPIRV_SOURCES pch_source)
  add_library(${SPIRV_TOOLS} ${SPIRV_SOURCES})
  spvtools_default_compile_options(${SPIRV_TOOLS})
  target_include_directories(${SPIRV_TOOLS}
 -  PUBLIC ${spirv-tools_SOURCE_DIR}/include
 +  PUBLIC "$<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>"
    PRIVATE ${spirv-tools_BINARY_DIR}
-   PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
+-  PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
++  PUBLIC ${SPIRV_HEADER_INCLUDE_DIR}
    )
+ set_property(TARGET ${SPIRV_TOOLS} PROPERTY FOLDER "SPIRV-Tools libraries")
+ spvtools_check_symbol_exports(${SPIRV_TOOLS})
 @@ -370,10 +370,20 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
  endif()
  

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/spirv-tools)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)


### PR DESCRIPTION
glslang: added include dir to target config file;
pthreads: added path to debug version of dll;
shaderc: export target config file, make shaderc::combined optional as a feature;
spirv-tools: vcpkg_fixup_cmake_targets, added INTERFACE_INCLUDE_DIRECTORIES for target spirv-tools::SPIRV-Tools;
nlohmann-json: added fifo_map.hpp (fifo_map.hpp helps preserve the insertion order of object elements);