### PR TITLE
Update vcpkg create template

### DIFF
--- a/scripts/templates/CONTROL.in
+++ b/scripts/templates/CONTROL.in
@@ -1,3 +1,4 @@
 Source: @PORT@
 Version:
+Homepage: 
 Description:

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -32,6 +32,14 @@ vcpkg_extract_source_archive_ex(
     #   002_more_port_fixes.patch
 )
 
+# # Check if one or more features are a part of a package installation.
+# vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+#   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
+#     tbb   WITH_TBB
+#   INVERTED_FEATURES
+#     tbb   ROCKSDB_IGNORE_PACKAGE_TBB
+# )
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
@@ -42,8 +50,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# #  
-#vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
+# # Moves all .cmake files from /debug/share/@PORT@/ to /share/@PORT@/
+# # See /docs/maintainers/vcpkg_fixup_cmake_targets.md for more details
+# vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
 
 # # Handle copyright
 # file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/@PORT@ RENAME copyright)

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -33,6 +33,7 @@ vcpkg_extract_source_archive_ex(
 )
 
 # # Check if one or more features are a part of a package installation.
+# # See /docs/maintainers/vcpkg_check_features.md for more details
 # vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 #   FEATURES # <- Keyword FEATURES is required because INVERTED_FEATURES are being used
 #     tbb   WITH_TBB

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -9,8 +9,10 @@
 #   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
 #   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
 #
+# 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md 
 
-include(vcpkg_common_functions)
+# # Specifies if the port install should fail immediately given a condition
+# vcpkg_fail_port_install(MESSAGE "@PORT@ currently only supports Linux and Mac platforms" ON_TARGET "Windows")
 
 vcpkg_download_distfile(ARCHIVE
     URLS "@URL@"
@@ -40,8 +42,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# Handle copyright
+# #  
+#vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
+
+# # Handle copyright
 # file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/@PORT@ RENAME copyright)
 
-# Post-build test for cmake libraries
+# # Post-build test for cmake libraries
 # vcpkg_test_cmake(PACKAGE_NAME @PORT@)


### PR DESCRIPTION
Pull request in response to issue #8363 

Changes to the template that `vcpkg create` creates

- [x] Added example `vcpkg_fail_port_install
- [x] Removed `include(vcpkg_common_functions)`
- [x] Added hint to see `vcpkg_common_definitions` for more variables
- [x] Added `vcpkg_fixup_cmake_targets` example to template
- [x] Added `vcpkg_check_features` example to template

Let me know if anyone can think of any other additions that would be helpful. 
I left the new additions commented out because i don't believe they would apply to every port file (Except maybe vcpkg_fixup_cmake_targets maybe?)  