### PR TITLE
Find default for text/plain on Linux and Windows (#567)

### DIFF
--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -174,6 +174,22 @@ namespace vcpkg::Commands::Edit
 #elif defined(__linux__)
         candidate_paths.push_back(fs::path{"/usr/share/code/bin/code"});
         candidate_paths.push_back(fs::path{"/usr/bin/code"});
+
+        if(System::cmd_execute("command -v xdg-mime") == 0)
+        {
+            auto mime_qry = Strings::format(R"(xdg-mime query default text/plain)");
+            auto execute_result = System::cmd_execute_and_capture_output(mime_qry);
+            if(execute_result.exit_code == 0 && !execute_result.output.empty())
+            {
+                mime_qry = Strings::format(R"(command -v %s)", execute_result.output.substr(0, execute_result.output.find('.')));
+                execute_result = System::cmd_execute_and_capture_output(mime_qry);
+                if(execute_result.exit_code == 0 && !execute_result.output.empty())
+                {
+                    execute_result.output.erase(std::remove(std::begin(execute_result.output), std::end(execute_result.output), '\n'), std::end(execute_result.output));
+                    candidate_paths.push_back(fs::path{execute_result.output});
+                }
+            }
+        }
 #endif
 
         const auto it = Util::find_if(candidate_paths, [&](const fs::path& p) { return fs.exists(p); });


### PR DESCRIPTION
Related issue #567

This finds the default program for text/plain for any system with xdg-utils (namely xdg-mime).

Addionally finds default on Windows using registry entry at HKEY_CLASSES_ROOT\.txt\ShellNew ItemName. Covers unicode case.