### PR TITLE
[protobuf] Update protobuf to 3.10.0

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.9.1
+Version: 3.10.0
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/fix-uwp.patch
+++ b/ports/protobuf/fix-uwp.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 3afe376..1a0b6a7 100644
+index f87b0928e..5102a10e3 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -151,6 +151,7 @@ if (MSVC)
+@@ -190,6 +190,7 @@ if (MSVC)
      /wd4506 # no definition for inline function 'function'
      /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
      /wd4996 # The compiler encountered a deprecated declaration.

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.9.1
-    SHA512 9accb56c1aadef83bf27280e15a99809a3561cbd4b39d6605dec730cc112bf4fd2e9f1ac39127b32a1b87253e712be4b4f12afe4061a8f7be76266b3f4bca314
+    REF v3.10.0
+    SHA512 0dcba6d21486fdc162f57119754b47b4a2fb605af878d5b96a32df55895321535cffb5b804566fd90ee7c36e20106d0cd4f5d9f3c652dc9c4dfca96be41a1977
     HEAD_REF master
     PATCHES
         fix-uwp.patch


### PR DESCRIPTION
Update protobuf to release [3.10.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.10.0)