### PR TITLE
Export paho-mqtt cmake targets, fix paho-mqttpp3 dependency.

### DIFF
--- a/ports/paho-mqtt/CONTROL
+++ b/ports/paho-mqtt/CONTROL
@@ -1,5 +1,5 @@
 Source: paho-mqtt
-Version: 1.3.0
+Version: 1.3.0-1
 Homepage: https://github.com/eclipse/paho.mqtt.c
 Description: Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols aimed at new, existing, and emerging applications for the Internet of Things
 Build-Depends: openssl

--- a/ports/paho-mqtt/export-cmake-targets.patch
+++ b/ports/paho-mqtt/export-cmake-targets.patch
@@ -1,0 +1,101 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4fdafef..dc8fd8a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -19,10 +19,6 @@
+ # Note: on OS X you should install XCode and the associated command-line tools
+ 
+ ## compilation/linkage settings
+-INCLUDE_DIRECTORIES(
+-    .
+-    ${CMAKE_BINARY_DIR}
+-    )
+ 
+ CONFIGURE_FILE(VersionInfo.h.in
+     ${CMAKE_BINARY_DIR}/VersionInfo.h
+@@ -84,8 +80,17 @@ IF (NOT PAHO_BUILD_STATIC)
+         paho-mqtt3c paho-mqtt3a PROPERTIES
+         VERSION ${CLIENT_VERSION}
+         SOVERSION ${PAHO_VERSION_MAJOR})
++    FOREACH(TARGET paho-mqtt3c paho-mqtt3a)
++    TARGET_INCLUDE_DIRECTORIES(${TARGET}
++        PUBLIC
++            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++        PRIVATE
++            ${CMAKE_BINARY_DIR})
++    ENDFOREACH()
+     
+     INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
++        EXPORT eclipse-paho-mqtt-cTargets
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+@@ -98,7 +103,14 @@ ELSE()
+ 
+     TARGET_LINK_LIBRARIES(paho-mqtt3c-static ${LIBS_SYSTEM})
+     TARGET_LINK_LIBRARIES(paho-mqtt3a-static ${LIBS_SYSTEM})
+-
++    FOREACH(TARGET paho-mqtt3c-static paho-mqtt3a-static)
++        TARGET_INCLUDE_DIRECTORIES(${TARGET}
++            PUBLIC
++                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++            PRIVATE
++                ${CMAKE_BINARY_DIR})
++    ENDFOREACH()
+     INSTALL(TARGETS paho-mqtt3c-static paho-mqtt3a-static
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ ENDIF()
+@@ -159,7 +171,16 @@ IF (PAHO_WITH_SSL)
+             VERSION ${CLIENT_VERSION}
+             SOVERSION ${PAHO_VERSION_MAJOR}
+             COMPILE_DEFINITIONS "OPENSSL=1")
++        FOREACH(TARGET paho-mqtt3cs paho-mqtt3as)
++            TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                PUBLIC
++                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                PRIVATE
++                    ${CMAKE_BINARY_DIR})
++        ENDFOREACH()
+         INSTALL(TARGETS paho-mqtt3cs paho-mqtt3as
++            EXPORT eclipse-paho-mqtt-cTargets
+             ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+             LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+             RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
+@@ -175,12 +196,33 @@ IF (PAHO_WITH_SSL)
+         VERSION ${CLIENT_VERSION}
+         SOVERSION ${PAHO_VERSION_MAJOR}
+         COMPILE_DEFINITIONS "OPENSSL=1")
+-
++        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3as-static)
++            TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                PUBLIC
++                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                PRIVATE
++                    ${CMAKE_BINARY_DIR})
++        ENDFOREACH()
+         INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
++            EXPORT eclipse-paho-mqtt-cTargets
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+     ENDIF()
+ ENDIF()
+ 
++INSTALL(EXPORT eclipse-paho-mqtt-cTargets
++    FILE eclipse-paho-mqtt-cConfig.cmake
++    NAMESPACE eclipse-paho-mqtt-c::
++    DESTINATION share/eclipse-paho-mqtt-c)
++
++INCLUDE(CMakePackageConfigHelpers)
++WRITE_BASIC_PACKAGE_VERSION_FILE("eclipse-paho-mqtt-cConfigVersion.cmake"
++    VERSION ${CLIENT_VERSION}
++    COMPATIBILITY SameMajorVersion)
++INSTALL(FILES
++    "${CMAKE_CURRENT_BINARY_DIR}/eclipse-paho-mqtt-cConfigVersion.cmake"
++    DESTINATION share/eclipse-paho-mqtt-c)
++    
+ # Base64 test
+ ADD_EXECUTABLE( Base64Test EXCLUDE_FROM_ALL Base64.c Base64.h )
+ TARGET_COMPILE_DEFINITIONS( Base64Test PUBLIC "-DBASE64_TEST" )

--- a/ports/paho-mqtt/portfile.cmake
+++ b/ports/paho-mqtt/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
          fix-install-path.patch
          fix-static-build.patch
          fix-unresolvedsymbol-arm.patch
+         export-cmake-targets.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAHO_BUILD_STATIC)
@@ -22,6 +23,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/eclipse-paho-mqtt-c TARGET_PATH share/eclipse-paho-mqtt-c)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/paho-mqttpp3/CONTROL
+++ b/ports/paho-mqttpp3/CONTROL
@@ -1,5 +1,5 @@
 Source: paho-mqttpp3
-Version: 1.0.1-2
+Version: 1.0.1-3
 Description: Paho project provides open-source C++ wrapper for Paho C library
 Build-Depends: paho-mqtt
 Default-Features: ssl

--- a/ports/paho-mqttpp3/fix-dependency.patch
+++ b/ports/paho-mqttpp3/fix-dependency.patch
@@ -1,0 +1,54 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index a9f8908..5c98f3f 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -17,6 +17,5 @@ install(EXPORT ${package_name} DESTINATION lib/cmake/${package_name}
+ 
+ install(FILES
+     "${CMAKE_CURRENT_BINARY_DIR}/${package_name}Config.cmake"
+-    FindPahoMqttC.cmake
+     "${CMAKE_CURRENT_BINARY_DIR}/${package_name}ConfigVersion.cmake"
+     DESTINATION lib/cmake/${package_name})
+diff --git a/cmake/PahoMqttCppConfig.cmake.in b/cmake/PahoMqttCppConfig.cmake.in
+index e06dc68..df1cfa6 100644
+--- a/cmake/PahoMqttCppConfig.cmake.in
++++ b/cmake/PahoMqttCppConfig.cmake.in
+@@ -1,6 +1,6 @@
+ include(CMakeFindDependencyMacro)
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+-find_dependency(PahoMqttC REQUIRED)
++find_dependency(eclipse-paho-mqtt-c REQUIRED)
+ list(REMOVE_AT CMAKE_MODULE_PATH -1)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/@package_name@Targets.cmake")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index bfcf6bb..089e35a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -23,7 +23,7 @@
+ #     Frank Pagliughi - made the shared library optional
+ #*******************************************************************************/
+ 
+-find_package(PahoMqttC REQUIRED)
++find_package(eclipse-paho-mqtt-c CONFIG REQUIRED)
+ 
+ # --- The headers ---
+ 
+@@ -91,7 +91,7 @@ if(PAHO_BUILD_SHARED)
+     ## add dependencies to the shared library
+     target_link_libraries(paho-mqttpp3
+         PRIVATE ${LIBS_SYSTEM}
+-        PUBLIC PahoMqttC::PahoMqttC)
++        PUBLIC eclipse-paho-mqtt-c::paho-mqtt3a eclipse-paho-mqtt-c::paho-mqtt3c eclipse-paho-mqtt-c::paho-mqtt3as eclipse-paho-mqtt-c::paho-mqtt3cs)
+ 
+     # It would be nice to exort the include paths from the obj lib, but we
+     # get an export error. Perhaps in a future version?
+@@ -129,7 +129,7 @@ if(PAHO_BUILD_STATIC)
+     ## add dependencies to the shared library
+     target_link_libraries(paho-mqttpp3-static
+         PRIVATE ${LIBS_SYSTEM}
+-        PUBLIC PahoMqttC::PahoMqttC)
++        PUBLIC eclipse-paho-mqtt-c::paho-mqtt3as-static eclipse-paho-mqtt-c::paho-mqtt3cs-static)
+ 
+     target_include_directories(paho-mqttpp3-static PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/ports/paho-mqttpp3/portfile.cmake
+++ b/ports/paho-mqttpp3/portfile.cmake
@@ -8,7 +8,8 @@ vcpkg_from_github(
   SHA512 be612197fae387b9f1d8f10944d451ec9e7ebec6045beed365e642089c0a5fde882ed5c734f2b46a5008f98b8445a51114492f0f36fdc684b8a8fe4b71fe31a4
   HEAD_REF master
   PATCHES
-    fix-include-path.patch  
+    fix-include-path.patch
+    fix-dependency.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS 
@@ -67,4 +68,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Add copyright
-file(INSTALL ${SOURCE_PATH}/about.html DESTINATION ${CURRENT_PACKAGES_DIR}/share/paho-mqttpp3 RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/about.html DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
1. Use [#636](https://github.com/eclipse/paho.mqtt.c/pull/636) changes to export `paho-mqtt` cmake targes.
2. fix `paho-mqttpp3` dependency `paho-mqtt`.

Related: #8481.