### PR TITLE
[irrlicht] Reorder link libraries

### DIFF
--- a/ports/irrlicht/CMakeLists.txt
+++ b/ports/irrlicht/CMakeLists.txt
@@ -79,9 +79,9 @@ else()
 endif()
 
 target_link_libraries(Irrlicht PRIVATE 
-    ${ZLIB_LIBRARY} 
     ${PNG_LIBRARY} 
     ${JPEG_LIBRARY} 
+    ${ZLIB_LIBRARY}
     ${BZIP2_LIBRARY}
     )
 

--- a/ports/irrlicht/CONTROL
+++ b/ports/irrlicht/CONTROL
@@ -1,5 +1,5 @@
 Source: irrlicht
-Version: 1.8.4-2
+Version: 1.8.4-3
 Homepage: http://irrlicht.sourceforge.net
 Description: Irrlicht lightning fast 3d engine
 Build-Depends: zlib, libpng, bzip2, libjpeg-turbo


### PR DESCRIPTION
Since libpng depends on zlib it needs to be linked before so that the needed zlib symbols are found