### PR TITLE
Added OIS port

### DIFF
--- a/ports/ois/CONTROL
+++ b/ports/ois/CONTROL
@@ -1,0 +1,4 @@
+Source: ois
+Version: 1.5
+Description: Cross Platform Object Oriented Input Lib System. Meant to be very robust and compatiable with many systems and operating systems.
+Homepage: https://wgois.github.io/OIS/

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -1,0 +1,26 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wgois/OIS
+    REF v1.5
+    SHA512 5ab1dda7c25c1959ccbbb758ea3fda36bd62ad65f46e2c6b418317a5eb39e0bace52a44ae079dfb69fc58c90df54f8e50d589daae1100ec615325363c9d77513
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+# vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+
+# Include files should not be duplicated into the /debug/include directory
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+# CMake integration test
+vcpkg_test_cmake(PACKAGE_NAME ${PORT})

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -1,3 +1,6 @@
+# Automatically fail port install for UWP and ARM. Unsure if it is
+# supported by library. See here: https://github.com/wgois/OIS/issues/57
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -11,10 +14,6 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
 )
-
-# Automatically fail port install for UWP and ARM. Unsure if it is
-# supported by library. See here: https://github.com/wgois/OIS/issues/57
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 
 vcpkg_install_cmake()
 

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -22,7 +22,7 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 # CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME ${PORT})
+# vcpkg_test_cmake(PACKAGE_NAME ${PORT})

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -14,7 +14,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+	file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
 
 # Include files should not be duplicated into the /debug/include directory
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -12,6 +12,10 @@ vcpkg_configure_cmake(
     PREFER_NINJA
 )
 
+# Automatically fail port install for UWP and ARM. Unsure if it is
+# supported by library. See here: https://github.com/wgois/OIS/issues/57
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
+
 vcpkg_install_cmake()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)


### PR DESCRIPTION
Created OIS Port. I wasn't sure if `vcpkg_fixup_cmake_targets` should be used here. When it's uncommented, it returned ` 'C:/vcpkg/packages/ois_x86-windows/debug/lib/cmake/ois'                                         does not exist` so i figured it wasn't necessary here.

#8451
