### PR TITLE
[gdcm/libtorrent] Upgrade to new version

### DIFF
--- a/ports/gdcm/CONTROL
+++ b/ports/gdcm/CONTROL
@@ -1,4 +1,4 @@
 Source: gdcm
-Version: 3.0.0-5
+Version: 3.0.3
 Description: Grassroots DICOM library
 Build-Depends: zlib, expat, openjpeg

--- a/ports/gdcm/portfile.cmake
+++ b/ports/gdcm/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO malaterre/GDCM
-    REF v3.0.0
-    SHA512 2ac076dd49011234f4431ffe67fcba84a1ca9042ec5fc4dfc8aed2ed16bec5f499fa7aa666e5630796afc266ce76741d931cca333534b55fdc477e25a9189d33
+    REF v3.0.3
+    SHA512 d1b95ec342341f026f03ead569c20d4482611b6ba1616fab2aaeec617675c678db7e7d9d14820364231b1319ece284f0cd3c35f356b20ef22f7e8ccf8a3fbc21
     HEAD_REF master
     PATCHES
         use-openjpeg-config.patch

--- a/ports/libtorrent/CONTROL
+++ b/ports/libtorrent/CONTROL
@@ -1,5 +1,5 @@
 Source: libtorrent
-Version: 1.2.1-bcb26fd6
+Version: 1.2.2
 Homepage: https://github.com/arvidn/libtorrent
 Description: An efficient feature complete C++ BitTorrent implementation 
 Build-Depends: openssl, boost-system, boost-date-time, boost-chrono, boost-random, boost-asio, boost-crc, boost-config, boost-iterator, boost-scope-exit, boost-multiprecision

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arvidn/libtorrent
-    REF bcb26fd638bd8c543cd3cc42837b120ff86d44b1
-    SHA512 af897d2daca6e67efe777724147b1047624df9df938222fe967d380263d88ccb3c081e1a24a6c790bf1b35f46385ef08b46d8e46d0922f945cd28c59dd0d35a7
+    REF libtorrent-1_2_2
+    SHA512 34dcf5421dfccbba78bdd30890b9c18b92fdee1a2e1693ada9b55b79a167730093862017581b9251a654b5517011dbe4c46b520b03b78aa86a909457f7edcf2c
     HEAD_REF master
     PATCHES
         add-datetime-to-boost-libs.patch


### PR DESCRIPTION
Gdcm: Upgrade to version 3.0.3. Related issue: #8449 
Libtorrent: Upgrade to version 1.2.2. Related issue: #8448