### PR TITLE
[sfml]Add usage.

### DIFF
--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,5 +1,5 @@
 Source: sfml
-Version: 2.5.1-3
+Version: 2.5.1-4
 Homepage: https://github.com/sfml/sfml
 Description: Simple and fast multimedia library
 Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb

--- a/ports/sfml/usage
+++ b/ports/sfml/usage
@@ -1,0 +1,7 @@
+The package sfml provides CMake targets:
+
+    find_package(SFML COMPONENTS system window graphics CONFIG REQUIRED)
+    # Windows
+    target_link_libraries(main PRIVATE FLAC OpenAL OpenGL Vorbis)
+    # Linux/MacOS
+    target_link_libraries(main PRIVATE X11 FLAC UDev OpenAL)


### PR DESCRIPTION
Since calling `find_package(sfml CONFIG)` requires adding `COMPONENTS`, add usage info.

Related: #8503.