### PR TITLE
Fix CMAKE_TRY_COMPILE_PLATFORM_VARIABLES

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -283,7 +283,7 @@ if(NOT _CMAKE_IN_TRY_COMPILE)
             "set(_VCPKG_ROOT_DIR \"${_root_dir}\" CACHE STRING \"\")\n"
         )
     else()
-        set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+        list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES 
             VCPKG_TARGET_TRIPLET
             VCPKG_APPLOCAL_DEPS
             VCPKG_CHAINLOAD_TOOLCHAIN_FILE

--- a/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
+++ b/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
@@ -179,4 +179,4 @@ function(vcpkg_fixup_cmake_targets)
     endforeach()
 endfunction()
 
-
+ 


### PR DESCRIPTION
to respect already set values
closes #8506

should I force a full rebuild or do you want to make it manually?