### PR TITLE
[irrlicht] do not build exisiting dependencies

### DIFF
--- a/ports/irrlicht/CMakeLists.txt
+++ b/ports/irrlicht/CMakeLists.txt
@@ -137,6 +137,14 @@ if(NOT ${IRR_SHARED_LIB})
     target_compile_definitions(Irrlicht PUBLIC _IRR_STATIC_LIB_)
 endif()
 
+# Disable Irrlicht building already provided dependencies
+target_compile_definitions(Irrlicht
+    PRIVATE NO_IRR_USE_NON_SYSTEM_ZLIB_
+    PRIVATE NO_IRR_USE_NON_SYSTEM_LIB_PNG_
+    PRIVATE NO_IRR_USE_NON_SYSTEM_BZLIB_
+    PRIVATE NO_IRR_USE_NON_SYSTEM_JPEG_LIB_
+    )
+
 # Per platform config
 # -------------------------------------------------------------------------------------------------
 

--- a/ports/irrlicht/CONTROL
+++ b/ports/irrlicht/CONTROL
@@ -1,5 +1,5 @@
 Source: irrlicht
-Version: 1.8.4-3
+Version: 1.8.4-4
 Homepage: http://irrlicht.sourceforge.net
 Description: Irrlicht lightning fast 3d engine
 Build-Depends: zlib, libpng, bzip2, libjpeg-turbo


### PR DESCRIPTION
Since libjpeg, libpng, zlib and bzlib are provided as dependencies
through vcpkg, we disable building them in irrlicht. This fixes a
runtime error steming from a version mismatch between the libjpeg
versions provided by irrlicht and vcpkg respectively