### PR TITLE
[opencv] add tesseract to fix downstream linking

### DIFF
--- a/ports/opencv3/CONTROL
+++ b/ports/opencv3/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv3
-Version: 3.4.7-1
+Version: 3.4.7-2
 Build-Depends: protobuf, zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -331,6 +331,7 @@ find_package(Ceres QUIET)
 find_package(ade QUIET)
 find_package(VTK QUIET)
 find_package(OpenMP QUIET)
+find_package(Tesseract QUIET)
 find_package(GDCM QUIET)" OPENCV_MODULES "${OPENCV_MODULES}")
 
   file(WRITE ${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules.cmake "${OPENCV_MODULES}")

--- a/ports/opencv4/CONTROL
+++ b/ports/opencv4/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv4
-Version: 4.1.1-2
+Version: 4.1.1-3
 Build-Depends: protobuf, zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -362,6 +362,7 @@ find_package(Ceres QUIET)
 find_package(ade QUIET)
 find_package(VTK QUIET)
 find_package(OpenMP QUIET)
+find_package(Tesseract QUIET)
 find_package(GDCM QUIET)" OPENCV_MODULES "${OPENCV_MODULES}")
 
   if("openmp" IN_LIST FEATURES)


### PR DESCRIPTION
when `tesseract` is installed, `opencv` detects it and uses it.
Unfortunately, it is still not managed as a feature in OpenCV, but with this fix at least downstream projects that want to link a tesseract-enabled OpenCV are able to work. 
It causes no harm when tesseract is not installed, since like many other hidden optional dependencies it is searched by CMake in `QUIET `mode.