### PR TITLE
[gtest/pmdk] Upgrade to new version

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,4 +1,4 @@
 Source: gtest
-Version: 2019-08-14-2
+Version: 2019-10-09
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF 90a443f9c2437ca8a682a1ac625eba64e1d74a8a
-    SHA512 fc874a7977f11be58dc63993b520b4ae6ca43654fb5250c8b56df62a21f4dca8fcbdc81dfa106374b2bb7c59bc88952fbfc0e3ae4c7d63fdb502afbaeb39c822
+    REF cd17fa2abda2a2e4111cdabd62a87aea16835014 #version 1.10.0 commit on 2019.10.09
+    SHA512 0899ebc21821e1978e8831ac89698fc88bf98ec7e22b9dd4f9eea0459396f6834ef35f6ee2afd1b8ca9432722e561c30905f8d87614d012bb711d295ebc1d833
     HEAD_REF master
     PATCHES
         0002-Fix-z7-override.patch

--- a/ports/pmdk/CONTROL
+++ b/ports/pmdk/CONTROL
@@ -1,3 +1,4 @@
 Source: pmdk
-Version: 1.6-3
+Version: 2019-10-10
+Homepage: https://github.com/pmem/pmdk
 Description: Persistent Memory Development Kit

--- a/ports/pmdk/portfile.cmake
+++ b/ports/pmdk/portfile.cmake
@@ -8,13 +8,13 @@ elseif (TRIPLET_SYSTEM_ARCH MATCHES "x86")
     message(FATAL_ERROR "x86 is not supported. Please use pmdk:x64-windows instead.")
 endif()
 
-set(PMDK_VERSION "1.6")
+set(PMDK_VERSION "1.7")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pmem/pmdk
-    REF ${PMDK_VERSION}
-    SHA512 f66e4edf1937d51abfa7c087b65a64109cd3d2a8d9587d6c4fc28a1003d67ec1f35a0011c9a9d0bfe76ad7227be83e86582f8405c988eac828d8ae5d0a399483
+    REF d2f6f5b0032eb5678ec6c5c3dff03509caa4b817 #version 1.7 commit on 2019.10.10
+    SHA512 8ac50f9ea03e140eeb5fcd25ea34591b38cb76cfaa2a8622155d54b90c1cadb9fe046deeaa422163e2cd82a993a9b736523e932d66cb458ff1d2111649587e8a
     HEAD_REF master
 )
 


### PR DESCRIPTION
Gtest: Upgrade to version 1.10.0. Related issue: #8452
Pmdk: Upgrade to version 1.7. Related issue: #8526