### PR TITLE
Mixed release and debug build in libarchive

### DIFF
--- a/ports/libarchive/CONTROL
+++ b/ports/libarchive/CONTROL
@@ -1,5 +1,5 @@
 Source: libarchive
-Version: 3.4.0
+Version: 3.4.0-1
 Homepage: https://github.com/libarchive/libarchive
 Description: Library for reading and writing streaming archives
 Build-Depends: zlib

--- a/ports/libarchive/fix-zstd.patch
+++ b/ports/libarchive/fix-zstd.patch
@@ -1,0 +1,28 @@
+From 9397ed51eddf43481d5710eb80441ce4a64356ea Mon Sep 17 00:00:00 2001
+From: Julian Scholle <julian.scholle@iff.fraunhofer.de>
+Date: Fri, 11 Oct 2019 16:46:06 +0200
+Subject: [PATCH] test
+
+---
+ CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 13da432..911ae5b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -588,7 +588,10 @@ IF(ENABLE_ZSTD)
+   ENDIF (ZSTD_INCLUDE_DIR)
+ 
+   FIND_PATH(ZSTD_INCLUDE_DIR zstd.h)
+-  FIND_LIBRARY(ZSTD_LIBRARY NAMES zstd libzstd)
++  FIND_LIBRARY(ZSTD_LIBRARY_DEBUG NAMES zstdd libzstdd)
++  FIND_LIBRARY(ZSTD_LIBRARY_RELEASE NAMES zstd libzstd)
++  INCLUDE(SelectLibraryConfigurations)
++  SELECT_LIBRARY_CONFIGURATIONS(ZSTD)
+   INCLUDE(FindPackageHandleStandardArgs)
+   FIND_PACKAGE_HANDLE_STANDARD_ARGS(ZSTD DEFAULT_MSG ZSTD_LIBRARY ZSTD_INCLUDE_DIR)
+ ELSE(ENABLE_ZSTD)
+-- 
+2.16.1.windows.1
+

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         fix-buildsystem.patch
         fix-dependencies.patch
         fix-lz4.patch
+        fix-zstd.patch
 )
 
 set(BUILD_libarchive_bzip2 OFF)


### PR DESCRIPTION
Fixes mixed release and debug build in libarchive (was always using zstd release)