### PR TITLE
[libcrafter] Add new port

### DIFF
--- a/ports/libcrafter/CONTROL
+++ b/ports/libcrafter/CONTROL
@@ -1,0 +1,5 @@
+Source: libcrafter
+Version: 0.3
+Homepage: https://github.com/pellegre/libcrafter
+Description: Libcrafter is a high level library for C++ designed to create and decode network packets.
+Build-Depends: libpcap

--- a/ports/libcrafter/fix-build-error.patch
+++ b/ports/libcrafter/fix-build-error.patch
@@ -1,0 +1,20 @@
+diff --git a/libcrafter/configure.ac b/libcrafter/configure.ac
+index 860d98b..b04ccce 100644
+--- a/libcrafter/configure.ac
++++ b/libcrafter/configure.ac
+@@ -35,14 +35,13 @@ AC_ARG_WITH(libpcap,
+ 	PCAPINC="-I$withval -I$withval/bpf"
+ 	PCAPLIB="-L$withval -lpcap"
+      elif test -f $withval/include/pcap.h -a \
+-	       -f $withval/include/net/bpf.h -a \
+ 	       -f $withval/lib/libpcap.a; then
+ 	owd=`pwd`
+ 	if cd $withval; then withval=`pwd`; cd $owd; fi
+ 	PCAPINC="-I$withval/include"
+ 	PCAPLIB="-L$withval/lib -lpcap"
+      else
+-        AC_ERROR(pcap.h, net/bpf.h, or libpcap.a not found in $withval)
++        AC_ERROR(pcap.h, or libpcap.a not found in $withval)
+      fi
+      ;;
+   esac ],

--- a/ports/libcrafter/portfile.cmake
+++ b/ports/libcrafter/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports Linux platforms" ON_TARGET "Windows" "OSX")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pellegre/libcrafter
+    REF version-0.3
+    SHA512 7c396ba942b304dddfaa569adb44697f75568d3ef2ed48dda758e281f3b7c172439309033bbf5498069a4a61a952f93e41af99b129ce874ce76b5ec08da58116
+    HEAD_REF master
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    AUTOCONFIG
+    PROJECT_SUBPATH libcrafter
+    OPTIONS
+        --with-libpcap=${CURRENT_INSTALLED_DIR}
+)
+
+vcpkg_install_make()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/libcrafter/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)

--- a/ports/libcrafter/portfile.cmake
+++ b/ports/libcrafter/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF version-0.3
     SHA512 7c396ba942b304dddfaa569adb44697f75568d3ef2ed48dda758e281f3b7c172439309033bbf5498069a4a61a952f93e41af99b129ce874ce76b5ec08da58116
     HEAD_REF master
+    PATCHES fix-build-error.patch
 )
 
 vcpkg_configure_make(


### PR DESCRIPTION
`Libcrafter `is a high level library for C++ designed to create and decode network packets.
It currently only supports Linux platform.
Depends on `libpcap`.
Related issue #7580