### PR TITLE
[libudns] Add new port

### DIFF
--- a/ports/libudns/CONTROL
+++ b/ports/libudns/CONTROL
@@ -1,0 +1,4 @@
+Source: libudns
+Version: 0.4
+Homepage: https://github.com/ortclib/udns
+Description: The DNS library, udns, implements thread-safe stub DNS resolver functionality, which may be used both traditional, syncronous way and asyncronously, with application-supplied event loop.

--- a/ports/libudns/portfile.cmake
+++ b/ports/libudns/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports Linux platform" ON_TARGET "Windows" "OSX")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ortclib/udns
+    REF udns_0_4
+    SHA512 4df8def718c75872536d42a757237d6c8e0afce8a53aedd7fea73814dc5cf8b5d6c9ae8f01a8cfc76864aa8293c172f08953a6750a66749ba19a3721bb4cf2ec
+    HEAD_REF master
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_AUTO_DST
+)
+
+vcpkg_build_make()
+
+# Install
+if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL debug)
+    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/libudns.a DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+endif()
+if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL release)
+    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libudns.a DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+endif()
+
+file(INSTALL ${SOURCE_PATH}/udns.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING.LGPL DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)


### PR DESCRIPTION
The DNS library, `udns`, implements thread-safe stub DNS resolver functionality, which may be used both traditional, syncronous way and asyncronously, with application-supplied event loop.
This port currently only supports Linux platform.
Related issue #7896