### PR TITLE
Make "remove" accept regular expressions

### DIFF
--- a/toolsrc/src/vcpkg/remove.cpp
+++ b/toolsrc/src/vcpkg/remove.cpp
@@ -265,8 +265,6 @@ namespace vcpkg::Remove
                     std::regex arg_regex{arg};
                     for (const auto& status : status_db) 
                     {
-                        if (!status->is_installed())
-                            continue;
                         const auto& spec_name = Strings::ascii_to_lowercase(std::string(status->package.spec.name()));
                         if (spec_name == arg)
                         {
@@ -284,6 +282,11 @@ namespace vcpkg::Remove
                         specs.push_back(*exact_spec.get());
                     else
                         std::copy(regex_specs.begin(), regex_specs.end(), std::back_inserter(specs));
+                }
+                if (specs.empty())
+                {
+                    System::print2(System::Color::error, "Error: cannot find any packages that match the specified pattern.\n");
+                    Checks::exit_fail(VCPKG_LINE_INFO);
                 }
             }
             else

--- a/toolsrc/src/vcpkg/remove.cpp
+++ b/toolsrc/src/vcpkg/remove.cpp
@@ -344,7 +344,12 @@ namespace vcpkg::Remove
             Checks::exit_success(VCPKG_LINE_INFO);
         }
 
-        if (pattern && !no_dry_run)
+        const bool has_packages_to_remove =
+            Util::find_if(remove_plan, [](const RemovePlanAction& package) -> bool {
+                return package.plan_type == RemovePlanType::REMOVE;
+            }) != remove_plan.cend();
+
+        if (has_packages_to_remove && pattern && !no_dry_run)
         {
             System::print2(System::Color::warning,
                 "If you are sure you want to remove the above packages, run this command with the "


### PR DESCRIPTION
Make it possible to remove packages by using a regex as package name (see #8486).

1. Find all installed packages that match the argument(s)
2. Also find an exact name match
3. If a there is package matches exactly, remove only that package (e.g. `vcpkg remove zlib`)
4. If no exact match found, use the regex matches if found any (e.g. `vcpkg remove qt5.*`)

Because this operation may potentially be dangerous / unpredictable (e.g. user unexpectedly removes more packages than expected), I think there should be some sort of confirmation. What do you think?