### PR TITLE
Fix CMake checks for Apple Clang 11.0 on macOS 10.15

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -244,7 +244,7 @@ else
 fi
 if [ "$os" = "osx" ]; then
     if [ "$vcpkgAllowAppleClang" = "true" ] ; then
-        CXX=clang
+        CXX=clang++
     else
         selectCXX CXX || exit 1
     fi

--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -23,7 +23,11 @@ endif()
 if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(GCC 1)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-    if(NOT VCPKG_ALLOW_APPLE_CLANG)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
+        set(CLANG 1)
+        # Disable linking with libc++fs because this features are added in libc++ library
+        set(NO_LIBCXXFS 1)
+    elseif(NOT VCPKG_ALLOW_APPLE_CLANG)
         message(FATAL_ERROR
 "Building the vcpkg tool requires support for the C++ Filesystem TS.
 Apple clang versions 10.01 and below do not have support for it.
@@ -58,7 +62,7 @@ endif()
 
 if(GCC OR (CLANG AND USES_LIBSTDCXX))
     link_libraries(stdc++fs)
-elseif(CLANG AND NOT MSVC)
+elseif(CLANG AND NOT MSVC AND NOT NO_LIBCXXFS)
     link_libraries(c++fs)
 endif()
 


### PR DESCRIPTION
Fix CMake checks for Apple Clang 11.0 on macOS 10.15

Related #8490 