### PR TITLE
[libxslt]Using vcpkg_install_nmake in Windows, support unix.

### DIFF
--- a/docs/maintainers/vcpkg_build_nmake.md
+++ b/docs/maintainers/vcpkg_build_nmake.md
@@ -9,6 +9,9 @@ vcpkg_build_nmake(
     [NO_DEBUG]
     PROJECT_SUBPATH <${SUBPATH}>
     PROJECT_NAME <${MAKEFILE_NAME}>
+    [PRERUN_SHELL <${SHELL_PATH}>]
+    [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
+    [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
@@ -32,6 +35,15 @@ This port doesn't support debug mode.
 
 ### ENABLE_INSTALL
 Install binaries after build.
+
+### PRERUN_SHELL
+Script that needs to be called before build
+
+### PRERUN_SHELL_DEBUG
+Script that needs to be called before debug build
+
+### PRERUN_SHELL_RELEASE
+Script that needs to be called before release build
 
 ### OPTIONS
 Additional options passed to generate during the generation.

--- a/docs/maintainers/vcpkg_install_nmake.md
+++ b/docs/maintainers/vcpkg_install_nmake.md
@@ -9,6 +9,9 @@ vcpkg_install_nmake(
     [NO_DEBUG]
     PROJECT_SUBPATH <${SUBPATH}>
     PROJECT_NAME <${MAKEFILE_NAME}>
+    [PRERUN_SHELL <${SHELL_PATH}>]
+    [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
+    [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
@@ -28,6 +31,15 @@ Default is makefile.vc
 
 ### NO_DEBUG
 This port doesn't support debug mode.
+
+### PRERUN_SHELL
+Script that needs to be called before build
+
+### PRERUN_SHELL_DEBUG
+Script that needs to be called before debug build
+
+### PRERUN_SHELL_RELEASE
+Script that needs to be called before release build
 
 ### OPTIONS
 Additional options passed to generate during the generation.

--- a/ports/libxslt/CONTROL
+++ b/ports/libxslt/CONTROL
@@ -1,5 +1,5 @@
 Source: libxslt
-Version: 1.1.33-3
+Version: 1.1.33-4
 Homepage: https://github.com/GNOME/libxslt
 Description: Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT
 Build-Depends: libxml2, liblzma

--- a/ports/libxslt/CONTROL
+++ b/ports/libxslt/CONTROL
@@ -1,5 +1,5 @@
 Source: libxslt
-Version: 1.1.33-2
-Homepage: http://xmlsoft.org/XSLT/
+Version: 1.1.33-3
+Homepage: https://github.com/GNOME/libxslt
 Description: Libxslt is a XSLT library implemented in C for XSLT 1.0 and most of EXSLT
 Build-Depends: libxml2, liblzma

--- a/ports/libxslt/portfile.cmake
+++ b/ports/libxslt/portfile.cmake
@@ -11,114 +11,115 @@ vcpkg_from_github(
         0002-Fix-lzma.patch
 )
 
-find_program(NMAKE nmake)
-
-set(SCRIPTS_DIR ${SOURCE_PATH}/win32)
-
-set(CONFIGURE_COMMAND_TEMPLATE cscript configure.js
-    cruntime=@CRUNTIME@
-    debug=@DEBUGMODE@
-    prefix=@INSTALL_DIR@
-    include=@INCLUDE_DIR@
-    lib=@LIB_DIR@
-    bindir=$(PREFIX)\\tools\\
-    sodir=$(PREFIX)\\bin\\
-)
-
-# Create some directories ourselves, because the makefile doesn't
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin)
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
-
-#
-# Release
-#
-
-message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
-
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(CRUNTIME /MD)
+if (VCPKG_TARGET_IS_WINDOWS)
+    # Create some directories ourselves, because the makefile doesn't
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/bin)
+    file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/bin)
+    set(CONFIGURE_COMMAND_TEMPLATE
+        cruntime=@CRUNTIME@
+        debug=@DEBUGMODE@
+        prefix=@INSTALL_DIR@
+        include=@INCLUDE_DIR@
+        lib=@LIB_DIR@
+        bindir=$(PREFIX)\\tools\\
+        sodir=$(PREFIX)\\bin\\
+    )
+    # Debug params
+    if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+        set(CRUNTIME /MD)
+    else()
+        set(CRUNTIME /MT)
+    endif()
+    set(DEBUGMODE no)
+    set(LIB_DIR ${CURRENT_INSTALLED_DIR}/lib)
+    set(INCLUDE_DIR ${CURRENT_INSTALLED_DIR}/include)
+    set(INSTALL_DIR ${CURRENT_PACKAGES_DIR})
+    file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
+    file(TO_NATIVE_PATH "${INCLUDE_DIR}" INCLUDE_DIR)
+    file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
+    string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND_REL)
+    # Release params
+    if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+        set(CRUNTIME /MDd)
+    else()
+        set(CRUNTIME /MTd)
+    endif()
+    set(DEBUGMODE yes)
+    set(LIB_DIR ${CURRENT_INSTALLED_DIR}/debug/lib)
+    set(INSTALL_DIR ${CURRENT_PACKAGES_DIR}/debug)
+    file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
+    file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
+    string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND_DBG)
+    
+    vcpkg_install_nmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PROJECT_SUBPATH win32
+        PROJECT_NAME Makefile.msvc
+        PRERUN_SHELL_DEBUG cscript configure.js ${CONFIGURE_COMMAND_DBG}
+        PRERUN_SHELL_RELEASE cscript configure.js ${CONFIGURE_COMMAND_REL}
+        OPTIONS rebuild
+    )
+    
+    # The makefile builds both static and dynamic libraries, so remove the ones we don't want
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/lib/libexslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+    else()
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/lib/libexslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+        # Rename the libs to match the dynamic lib names
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libxslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/lib/libxslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libexslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/lib/libexslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt_a${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX})
+    endif()
 else()
-    set(CRUNTIME /MT)
+    vcpkg_find_acquire_program(PYTHON2)
+    get_filename_component(PYTHON2_DIR ${PYTHON2} DIRECTORY)
+    
+    find_library(LibXml2_DEBUG_LIBRARIES libxml2 PATHS ${CURRENT_INSTALLED_DIR}/debug/lib REQUIRED)
+    find_library(LibXml2_RELEASE_LIBRARIES libxml2 PATHS ${CURRENT_INSTALLED_DIR}/lib REQUIRED)
+    
+    vcpkg_configure_make(
+        SOURCE_PATH ${SOURCE_PATH}
+        AUTOCONFIG
+        OPTIONS
+            --with-crypto
+            --with-plugins
+            --with-libxml-include-prefix=${CURRENT_INSTALLED_DIR}/include
+            --with-python=${PYTHON2_DIR}
+        OPTIONS_DEBUG
+            --with-mem-debug
+            --with-debug
+            --with-debugger
+            --with-libxml-libs-prefix="${CURRENT_INSTALLED_DIR}/debug/lib -lxml2 -lz -llzmad"
+            --with-html-dir=${CURRENT_INSTALLED_DIR}/debug/tools
+            --with-html-subdir=${CURRENT_INSTALLED_DIR}/debug/tools
+        OPTIONS_RELEASE
+            --with-libxml-libs-prefix="${CURRENT_INSTALLED_DIR}/lib -lxml2 -lz -llzma"
+            --with-html-dir=${CURRENT_INSTALLED_DIR}/tools
+            --with-html-subdir=${CURRENT_INSTALLED_DIR}/tools
+    )
+    
+    vcpkg_install_make()
+    
+    if (EXISTS ${CURRENT_PACKAGES_DIR}/bin/xslt-config)
+        file(COPY ${CURRENT_PACKAGES_DIR}/bin/xslt-config DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/xslt-config)
+    endif()
+    if (EXISTS ${CURRENT_PACKAGES_DIR}/bin/xsltproc)
+        file(COPY ${CURRENT_PACKAGES_DIR}/bin/xsltproc DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/xslt-config)
+    endif()
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        file(COPY ${CURRENT_PACKAGES_DIR}/lib/libxslt.so ${CURRENT_PACKAGES_DIR}/bin/)
+    else()
+        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libxslt-plugins ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt-plugins)
+    endif()
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxslt.so)
 endif()
-set(DEBUGMODE no)
-set(LIB_DIR ${CURRENT_INSTALLED_DIR}/lib)
-set(INCLUDE_DIR ${CURRENT_INSTALLED_DIR}/include)
-set(INSTALL_DIR ${CURRENT_PACKAGES_DIR})
-file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
-file(TO_NATIVE_PATH "${INCLUDE_DIR}" INCLUDE_DIR)
-file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
-string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND)
-vcpkg_execute_required_process(
-    COMMAND ${CONFIGURE_COMMAND}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME config-${TARGET_TRIPLET}-rel
-)
-# Handle build output directory
-file(TO_NATIVE_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel" OUTDIR)
-file(MAKE_DIRECTORY "${OUTDIR}")
-message(STATUS "Configuring ${TARGET_TRIPLET}-rel done")
-
-message(STATUS "Building ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${NMAKE} /f Makefile.msvc rebuild OUTDIR=${OUTDIR}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME build-${TARGET_TRIPLET}-rel
-)
-message(STATUS "Building ${TARGET_TRIPLET}-rel done")
-
-message(STATUS "Installing ${TARGET_TRIPLET}-rel")
-vcpkg_execute_required_process(
-    COMMAND ${NMAKE} /f Makefile.msvc install OUTDIR=${OUTDIR}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME install-${TARGET_TRIPLET}-rel
-)
-message(STATUS "Installing ${TARGET_TRIPLET}-rel done")
-
-
-#
-# Debug
-#
-
-message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
-
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(CRUNTIME /MDd)
-else()
-    set(CRUNTIME /MTd)
-endif()
-set(DEBUGMODE yes)
-set(LIB_DIR ${CURRENT_INSTALLED_DIR}/debug/lib)
-set(INSTALL_DIR ${CURRENT_PACKAGES_DIR}/debug)
-file(TO_NATIVE_PATH "${LIB_DIR}" LIB_DIR)
-file(TO_NATIVE_PATH "${INSTALL_DIR}" INSTALL_DIR)
-string(CONFIGURE "${CONFIGURE_COMMAND_TEMPLATE}" CONFIGURE_COMMAND)
-
-vcpkg_execute_required_process(
-    COMMAND ${CONFIGURE_COMMAND}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME config-${TARGET_TRIPLET}-dbg
-)
-# Handle build output directory
-file(TO_NATIVE_PATH "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg" OUTDIR)
-file(MAKE_DIRECTORY "${OUTDIR}")
-message(STATUS "Configuring ${TARGET_TRIPLET}-dbg done")
-
-message(STATUS "Building ${TARGET_TRIPLET}-dbg")
-vcpkg_execute_required_process(
-    COMMAND ${NMAKE} /f Makefile.msvc rebuild OUTDIR=${OUTDIR}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME build-${TARGET_TRIPLET}-dbg
-)
-message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
-
-message(STATUS "Installing ${TARGET_TRIPLET}-dbg")
-vcpkg_execute_required_process(
-    COMMAND ${NMAKE} /f Makefile.msvc install OUTDIR=${OUTDIR}
-    WORKING_DIRECTORY ${SCRIPTS_DIR}
-    LOGNAME install-${TARGET_TRIPLET}-dbg
-)
-message(STATUS "Installing ${TARGET_TRIPLET}-dbg done")
-
 #
 # Cleanup
 #
@@ -144,21 +145,7 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/include/libexslt/exsltexports.h "${EXSLTEXPOR
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/tools)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-# The makefile builds both static and dynamic libraries, so remove the ones we don't want
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxslt_a.lib ${CURRENT_PACKAGES_DIR}/lib/libexslt_a.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt_a.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt_a.lib)
-else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libxslt.lib ${CURRENT_PACKAGES_DIR}/lib/libexslt.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt.lib)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    # Rename the libs to match the dynamic lib names
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libxslt_a.lib ${CURRENT_PACKAGES_DIR}/lib/libxslt.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libexslt_a.lib ${CURRENT_PACKAGES_DIR}/lib/libexslt.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt_a.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libxslt.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt_a.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libexslt.lib)
-endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 vcpkg_copy_pdbs()
 

--- a/scripts/cmake/vcpkg_build_nmake.cmake
+++ b/scripts/cmake/vcpkg_build_nmake.cmake
@@ -7,8 +7,11 @@
 ## vcpkg_build_nmake(
 ##     SOURCE_PATH <${SOURCE_PATH}>
 ##     [NO_DEBUG]
-##     PROJECT_SUBPATH <${SUBPATH}>
-##     PROJECT_NAME <${MAKEFILE_NAME}>
+##     [PROJECT_SUBPATH <${SUBPATH}>]
+##     [PROJECT_NAME <${MAKEFILE_NAME}>]
+##     [PRERUN_SHELL <${SHELL_PATH}>]
+##     [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
+##     [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
 ##     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
 ##     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
 ##     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
@@ -32,6 +35,15 @@
 ##
 ## ### ENABLE_INSTALL
 ## Install binaries after build.
+##
+## ### PRERUN_SHELL
+## Script that needs to be called before build
+##
+## ### PRERUN_SHELL_DEBUG
+## Script that needs to be called before debug build
+##
+## ### PRERUN_SHELL_RELEASE
+## Script that needs to be called before release build
 ##
 ## ### OPTIONS
 ## Additional options passed to generate during the generation.
@@ -62,7 +74,7 @@ function(vcpkg_build_nmake)
     cmake_parse_arguments(_bn
         "ADD_BIN_TO_PATH;ENABLE_INSTALL;NO_DEBUG"
         "SOURCE_PATH;PROJECT_SUBPATH;PROJECT_NAME;LOGFILE_ROOT"
-        "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG"
+        "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;PRERUN_SHELL;PRERUN_SHELL_DEBUG;PRERUN_SHELL_RELEASE"
         ${ARGN}
     )
     
@@ -164,6 +176,31 @@ function(vcpkg_build_nmake)
                 string(REPLACE "${_bn_SOURCE_PATH}" "${OBJ_DIR}" DST_DIR "${DST_DIR}")
                 file(COPY ${ONE_SOUCRCE_FILE} DESTINATION ${DST_DIR})
             endforeach()
+            
+            if (_bn_PRERUN_SHELL)
+                message("Prerunning ${CURRENT_TRIPLET_NAME}")
+                vcpkg_execute_required_process(
+                    COMMAND ${_bn_PRERUN_SHELL}
+                    WORKING_DIRECTORY ${OBJ_DIR}${_bn_PROJECT_SUBPATH}
+                    LOGNAME "$prerun-${CURRENT_TRIPLET_NAME}"
+                )
+            endif()
+            if (BUILDTYPE STREQUAL "debug" AND _bn_PRERUN_SHELL_DEBUG)
+                message("Prerunning ${CURRENT_TRIPLET_NAME}")
+                vcpkg_execute_required_process(
+                    COMMAND "${_bn_PRERUN_SHELL_DEBUG}"
+                    WORKING_DIRECTORY ${OBJ_DIR}${_bn_PROJECT_SUBPATH}
+                    LOGNAME "prerun-${CURRENT_TRIPLET_NAME}-dbg"
+                )
+            endif()
+            if (BUILDTYPE STREQUAL "release" AND _bn_PRERUN_SHELL_RELEASE)
+                message("Prerunning ${CURRENT_TRIPLET_NAME}")
+                vcpkg_execute_required_process(
+                    COMMAND ${_bn_PRERUN_SHELL_RELEASE}
+                    WORKING_DIRECTORY ${OBJ_DIR}${_bn_PROJECT_SUBPATH}
+                    LOGNAME "prerun-${CURRENT_TRIPLET_NAME}-dbg"
+                )
+            endif()
 
             if (NOT _bn_ENABLE_INSTALL)
                 message(STATUS "Building ${CURRENT_TRIPLET_NAME}")

--- a/scripts/cmake/vcpkg_install_nmake.cmake
+++ b/scripts/cmake/vcpkg_install_nmake.cmake
@@ -9,6 +9,9 @@
 ##     [NO_DEBUG]
 ##     PROJECT_SUBPATH <${SUBPATH}>
 ##     PROJECT_NAME <${MAKEFILE_NAME}>
+##     [PRERUN_SHELL <${SHELL_PATH}>]
+##     [PRERUN_SHELL_DEBUG <${SHELL_PATH}>]
+##     [PRERUN_SHELL_RELEASE <${SHELL_PATH}>]
 ##     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
 ##     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
 ##     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
@@ -28,6 +31,15 @@
 ##
 ## ### NO_DEBUG
 ## This port doesn't support debug mode.
+##
+## ### PRERUN_SHELL
+## Script that needs to be called before build
+##
+## ### PRERUN_SHELL_DEBUG
+## Script that needs to be called before debug build
+##
+## ### PRERUN_SHELL_RELEASE
+## Script that needs to be called before release build
 ##
 ## ### OPTIONS
 ## Additional options passed to generate during the generation.
@@ -53,7 +65,7 @@ function(vcpkg_install_nmake)
     cmake_parse_arguments(_in
         "NO_DEBUG"
         "SOURCE_PATH;PROJECT_SUBPATH;PROJECT_NAME"
-        "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG"
+        "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;PRERUN_SHELL;PRERUN_SHELL_DEBUG;PRERUN_SHELL_RELEASE"
         ${ARGN}
     )
     
@@ -68,6 +80,7 @@ function(vcpkg_install_nmake)
     vcpkg_build_nmake(LOGFILE_ROOT ENABLE_INSTALL
         ${NO_DEBUG}
         SOURCE_PATH ${_in_SOURCE_PATH} PROJECT_SUBPATH ${_in_PROJECT_SUBPATH} PROJECT_NAME ${_in_PROJECT_NAME}
+        PRERUN_SHELL ${_in_PRERUN_SHELL} PRERUN_SHELL_DEBUG ${_in_PRERUN_SHELL_DEBUG} PRERUN_SHELL_RELEASE ${_in_PRERUN_SHELL_RELEASE}
         OPTIONS ${_in_OPTIONS} OPTIONS_RELEASE ${_in_OPTIONS_RELEASE} OPTIONS_DEBUG ${_in_OPTIONS_DEBUG}
     )
 endfunction()


### PR DESCRIPTION
- `vcpkg_build_nmake`/`vcpkg_install_nmake` support options `PRERUN_SHELL`/`PRERUN_SHELL_DEBUG`/`PRERUN_SHELL_RELEASE`
- Using `vcpkg_install_nmake` in Windows
- Support UNIX.

Related: #8556.