### PR TITLE
[boost-modular-build-helper] Update to 1.71.

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,2 +1,2 @@
 Source: boost-modular-build-helper
-Version: 1.70.0-2
+Version: 1.71.0

--- a/ports/boost-modular-build-helper/Jamroot.jam
+++ b/ports/boost-modular-build-helper/Jamroot.jam
@@ -1,5 +1,5 @@
-constant BOOST_VERSION : 1.70.0 ;
-constant BOOST_VERSION_ABI_TAG : 1_70 ;
+constant BOOST_VERSION : 1.71.0 ;
+constant BOOST_VERSION_ABI_TAG : 1_71 ;
 constant BOOST_JAMROOT_MODULE : $(__name__) ;
 
 import boostcpp ;

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -357,7 +357,7 @@ function(boost_modular_build)
         string(REPLACE "-x64-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
         string(REPLACE "-a32-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
         string(REPLACE "-a64-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
-        string(REPLACE "-1_70" "" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake > 3.10 to locate the binaries
+        string(REPLACE "-1_71" "" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake > 3.10 to locate the binaries
         string(REPLACE "_python3-" "_python-" NEW_FILENAME ${NEW_FILENAME})
         if("${DIRECTORY_OF_LIB_FILE}/${NEW_FILENAME}" STREQUAL "${DIRECTORY_OF_LIB_FILE}/${OLD_FILENAME}")
             # nothing to do


### PR DESCRIPTION
Analog to fix 9c0b9533b0520c167595486b69d171a5fe497e92 of microsoft#6493