### PR TITLE
[embree3]Fix generated cmake files path.

### DIFF
--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,5 +1,5 @@
 Source: embree3
-Version: 3.5.2-2
+Version: 3.5.2-3
 Homepage: https://github.com/embree/embree
 Description: High Performance Ray Tracing Kernels.
 Build-Depends: tbb

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -43,12 +43,12 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/embree3)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/embree3 TARGET_PATH share/embree)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/${PORT}/doc)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/embree/doc)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
We often use `find_package(embree 3 CONFIG REQUIRED)` to use embree3, so fix _embree-config.cmake_ path.

Related: #8607.