### PR TITLE
[mdl] Add new port

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,5 @@
 Source: llvm
-Version: 8.0.0-3
+Version: 7.0.0
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Build-Depends: atlmfc (windows)

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -9,9 +9,9 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 endif()
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://releases.llvm.org/8.0.0/llvm-8.0.0.src.tar.xz"
-    FILENAME "llvm-8.0.0.src.tar.xz"
-    SHA512 1602343b451b964f5d8c2d6b0654d89384c80d45883498c5f0e2f4196168dd4a1ed2a4dadb752076020243df42ffe46cb31d82ffc145d8e5874163cbb9686a1f
+    URLS "http://releases.llvm.org/7.0.0/llvm-7.0.0.src.tar.xz"
+    FILENAME "llvm-7.0.0.src.tar.xz"
+    SHA512 bdc9b851c158b17e1bbeb7ac5ae49821bfb1251a3826fe8a3932cd1a43f9fb0d620c3de67150c1d9297bf0b86fa917e75978da29c3f751b277866dc90395abec
 )
 
 vcpkg_extract_source_archive_ex(
@@ -23,9 +23,9 @@ vcpkg_extract_source_archive_ex(
 )
 
 vcpkg_download_distfile(CLANG_ARCHIVE
-    URLS "http://releases.llvm.org/8.0.0/cfe-8.0.0.src.tar.xz"
-    FILENAME "cfe-8.0.0.src.tar.xz"
-    SHA512 98e540222719716985e5d8439116e47469cb01201ea91d1da7e46cb6633da099688d9352c3b65e5c5f660cbbae353b3d79bb803fc66b3be663f2b04b1feed1c3
+    URLS "http://releases.llvm.org/7.0.0/cfe-7.0.0.src.tar.xz"
+    FILENAME "cfe-7.0.0.src.tar.xz"
+    SHA512 17a658032a0160c57d4dc23cb45a1516a897e0e2ba4ebff29472e471feca04c5b68cff351cdf231b42aab0cff587b84fe11b921d1ca7194a90e6485913d62cb7
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/mdl/0001-freeimage-dependency-search.patch
+++ b/ports/mdl/0001-freeimage-dependency-search.patch
@@ -1,0 +1,55 @@
+diff --git a/cmake/find/find_freeimage_ext.cmake b/cmake/find/find_freeimage_ext.cmake
+index 5148c75..926ce6b 100644
+--- a/cmake/find/find_freeimage_ext.cmake
++++ b/cmake/find/find_freeimage_ext.cmake
+@@ -36,8 +36,8 @@ function(FIND_FREEIMAGE_EXT)
+     set(_FREEIMAGE_LIB "NOTFOUND")
+     set(_FREEIMAGE_SHARED "NOTFOUND")
+ 
+-    find_file(_FREEIMAGE_HEADER_FILE "FreeImage.h" 
+-        HINTS 
++    find_file(_FREEIMAGE_HEADER_FILE "FreeImage.h"
++        HINTS
+             ${FREEIMAGE_DIR}
+             ${FREEIMAGE_DIR}/include
+             ${FREEIMAGE_DIR}/Dist/x64
+@@ -52,16 +52,24 @@ function(FIND_FREEIMAGE_EXT)
+ 
+         if(WINDOWS)
+             # assuming that the windows (x64) binaries from http://freeimage.sourceforge.net/download.html are used
+-            find_file(_FREEIMAGE_LIB "${CMAKE_STATIC_LIBRARY_PREFIX}freeimage${CMAKE_STATIC_LIBRARY_SUFFIX}" 
+-                HINTS 
++            find_file(_FREEIMAGE_LIB
++                NAMES
++                    "${CMAKE_STATIC_LIBRARY_PREFIX}freeimage${CMAKE_STATIC_LIBRARY_SUFFIX}"
++                    "${CMAKE_STATIC_LIBRARY_PREFIX}FreeImage${CMAKE_STATIC_LIBRARY_SUFFIX}"
++                HINTS
+                     ${FREEIMAGE_DIR}
+                     ${FREEIMAGE_DIR}/Dist/x64
++                    ${FREEIMAGE_DIR}/lib
+                 )
+ 
+-            find_file(_FREEIMAGE_SHARED "${CMAKE_SHARED_LIBRARY_PREFIX}freeimage${CMAKE_SHARED_LIBRARY_SUFFIX}" 
+-                HINTS 
++            find_file(_FREEIMAGE_SHARED
++                NAMES
++                    "${CMAKE_SHARED_LIBRARY_PREFIX}freeimage${CMAKE_SHARED_LIBRARY_SUFFIX}"
++                    "${CMAKE_SHARED_LIBRARY_PREFIX}FreeImage${CMAKE_SHARED_LIBRARY_SUFFIX}"
++                HINTS
+                     ${FREEIMAGE_DIR}
+                     ${FREEIMAGE_DIR}/Dist/x64
++                    ${FREEIMAGE_DIR}/bin
+                 )
+ 
+         elseif(LINUX OR MACOSX)
+@@ -71,8 +79,9 @@ function(FIND_FREEIMAGE_EXT)
+             find_file(_FREEIMAGE_SHARED
+                 NAMES
+                     "${CMAKE_SHARED_LIBRARY_PREFIX}freeimage${CMAKE_SHARED_LIBRARY_SUFFIX}"
++                    "${CMAKE_SHARED_LIBRARY_PREFIX}FreeImage${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                     "libfreeimage.so"
+-                HINTS 
++                HINTS
+                     ${FREEIMAGE_DIR}
+                     ${FREEIMAGE_DIR}/lib64
+                     ${FREEIMAGE_DIR}/lib

--- a/ports/mdl/0002-install-rules.patch
+++ b/ports/mdl/0002-install-rules.patch
@@ -1,0 +1,253 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c91ff0a..71e2a13 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,6 +52,8 @@ option(MDL_LOG_FILE_DEPENDENCIES "Prints the list of files that is copied after
+ set(MDL_ADDITIONAL_COMPILER_DEFINES "" CACHE STRING "Additional compile defines that are passed to each of the projects")
+ set(MDL_ADDITIONAL_COMPILER_OPTIONS "" CACHE STRING "Additional compile options that are passed to each of the projects")
+ 
++include(GNUInstallDirs)
++
+ # -------------------------------------------------------------------------------------------------
+ # general setup
+ include(${MDL_BASE_FOLDER}/cmake/setup.cmake)
+@@ -199,3 +201,31 @@ foreach(_TEST_POST ${MDL_TEST_LIST_POST})
+     add_subdirectory(${_TEST_POST})
+ endforeach()
+ 
++message(STATUS "ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}")
++message(STATUS "LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}")
++message(STATUS "RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}")
++
++install(
++    TARGETS
++        core
++        sdk
++        i18n
++        mdlc
++        mdlm
++    EXPORT   mdl-targets
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++)
++
++install(
++    EXPORT       mdl-targets
++    NAMESPACE    "mdl::"
++    DESTINATION  "share/mdl"
++)
++
++export(
++    EXPORT    mdl-targets
++    NAMESPACE "mdl::"
++)
+diff --git a/cmake/utilities.cmake b/cmake/utilities.cmake
+index 745b6b2..b44d0f4 100644
+--- a/cmake/utilities.cmake
++++ b/cmake/utilities.cmake
+@@ -592,7 +592,7 @@ function(CREATE_FROM_BASE_PRESET)
+     endif()
+ 
+     # create target and alias
+-    if(CREATE_FROM_BASE_PRESET_TYPE STREQUAL "STATIC" OR CREATE_FROM_BASE_PRESET_TYPE STREQUAL "SHARED")
++    if(CREATE_FROM_BASE_PRESET_TYPE STREQUAL "STATIC" OR CREATE_FROM_BASE_PRESET_TYPE STREQUAL "SHARED" OR CREATE_FROM_BASE_PRESET_TYPE STREQUAL "MODULE")
+         add_library(${CREATE_FROM_BASE_PRESET_TARGET} ${CREATE_FROM_BASE_PRESET_TYPE} ${CREATE_FROM_BASE_PRESET_SOURCES})
+         add_library(${CREATE_FROM_BASE_PRESET_NAMESPACE}::${CREATE_FROM_BASE_PRESET_TARGET} ALIAS ${CREATE_FROM_BASE_PRESET_TARGET})
+     elseif(CREATE_FROM_BASE_PRESET_TYPE STREQUAL "EXECUTABLE")
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index ab4485d..4b493fc 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -213,7 +213,7 @@ create_from_base_preset(
+     )
+ 
+ # override position and name in the folder hierarchy
+-set_target_properties(${PROJECT_NAME} PROPERTIES 
++set_target_properties(${PROJECT_NAME} PROPERTIES
+     FOLDER          "include"               # hierarchy
+     PROJECT_LABEL   "mi"                    # project name
+     )
+@@ -223,3 +223,8 @@ source_group("base" FILES ${PROJECT_HEADERS_BASE})
+ source_group("math" FILES ${PROJECT_HEADERS_MATH})
+ source_group("mdl" FILES ${PROJECT_HEADERS_MDL})
+ source_group("neuraylib" FILES ${PROJECT_HEADERS_NEURAYLIB})
++
++install(
++    DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/mi"
++    TYPE      INCLUDE
++)
+diff --git a/src/prod/bin/i18n/CMakeLists.txt b/src/prod/bin/i18n/CMakeLists.txt
+index ea3806f..212a1c1 100644
+--- a/src/prod/bin/i18n/CMakeLists.txt
++++ b/src/prod/bin/i18n/CMakeLists.txt
+@@ -27,7 +27,7 @@
+ #*****************************************************************************
+ 
+ # name of the target and the resulting library
+-set(PROJECT_NAME prod-bin-i18n)
++set(PROJECT_NAME i18n)
+ 
+ # collect sources
+ set(PROJECT_HEADERS
+@@ -67,9 +67,11 @@ create_from_base_preset(
+     SOURCES ${PROJECT_SOURCES}
+ )
+ 
++add_executable(prod-bin-i18n ALIAS ${PROJECT_NAME})
++
+ # add mdl and other dependencies
+-target_add_dependencies(TARGET ${PROJECT_NAME} 
+-    DEPENDS 
++target_add_dependencies(TARGET ${PROJECT_NAME}
++    DEPENDS
+         boost
+         llvm
+         ${LINKER_START_GROUP}
+@@ -81,4 +83,3 @@ target_add_dependencies(TARGET ${PROJECT_NAME}
+         base-util-string_utils
+         ${LINKER_END_GROUP}
+     )
+-    
+\ No newline at end of file
+diff --git a/src/prod/bin/mdlc/CMakeLists.txt b/src/prod/bin/mdlc/CMakeLists.txt
+index 826fc83..86cf547 100644
+--- a/src/prod/bin/mdlc/CMakeLists.txt
++++ b/src/prod/bin/mdlc/CMakeLists.txt
+@@ -27,7 +27,7 @@
+ #*****************************************************************************
+ 
+ # name of the target and the resulting library
+-set(PROJECT_NAME prod-bin-mdlc)
++set(PROJECT_NAME mdlc)
+ 
+ # collect sources
+ set(PROJECT_HEADERS
+@@ -52,9 +52,11 @@ create_from_base_preset(
+     SOURCES ${PROJECT_SOURCES}
+ )
+ 
++add_executable(prod-bin-mdlc ALIAS ${PROJECT_NAME})
++
+ # add mdl and other dependencies
+-target_add_dependencies(TARGET ${PROJECT_NAME} 
+-    DEPENDS 
++target_add_dependencies(TARGET ${PROJECT_NAME}
++    DEPENDS
+         boost
+         llvm
+         ${LINKER_START_GROUP}
+@@ -70,4 +72,3 @@ target_add_dependencies(TARGET ${PROJECT_NAME}
+         mdl::base-system-version
+         ${LINKER_END_GROUP}
+     )
+-    
+\ No newline at end of file
+diff --git a/src/prod/bin/mdlm/CMakeLists.txt b/src/prod/bin/mdlm/CMakeLists.txt
+index fa2d588..30ba194 100644
+--- a/src/prod/bin/mdlm/CMakeLists.txt
++++ b/src/prod/bin/mdlm/CMakeLists.txt
+@@ -27,7 +27,7 @@
+ #*****************************************************************************
+ 
+ # name of the target and the resulting example
+-set(PROJECT_NAME prod-bin-mdlm)
++set(PROJECT_NAME mdlm)
+ 
+ # collect sources
+ set(PROJECT_HEADERS
+@@ -66,6 +66,8 @@ create_from_base_preset(
+     SOURCES ${PROJECT_SOURCES}
+ )
+ 
++add_executable(prod-bin-mdlm ALIAS ${PROJECT_NAME})
++
+ # add dependencies
+ target_add_dependencies(TARGET ${PROJECT_NAME}
+     DEPENDS
+@@ -81,7 +83,7 @@ target_add_dependencies(TARGET ${PROJECT_NAME}
+         ${LINKER_END_GROUP}
+         mdl::mdl_sdk
+     )
+-    
++
+ # creates a user settings file to setup the debugger (visual studio only, otherwise this is a no-op)
+ target_create_vs_user_settings(TARGET ${PROJECT_NAME})
+ 
+diff --git a/src/prod/lib/mdl_core/CMakeLists.txt b/src/prod/lib/mdl_core/CMakeLists.txt
+index d2378d5..14ff310 100644
+--- a/src/prod/lib/mdl_core/CMakeLists.txt
++++ b/src/prod/lib/mdl_core/CMakeLists.txt
+@@ -27,21 +27,23 @@
+ #*****************************************************************************
+ 
+ # name of the target and the resulting library
+-set(PROJECT_NAME prod-lib-mdl_core)
++set(PROJECT_NAME core)
+ 
+ # collect sources
+-set(PROJECT_SOURCES 
++set(PROJECT_SOURCES
+     "mdl_core_factory.cpp"
+     )
+ 
+ # create target from template
+ create_from_base_preset(
+     TARGET ${PROJECT_NAME}
+-    TYPE SHARED
++    TYPE MODULE
+     SOURCES ${PROJECT_SOURCES}
+     EMBED_RC "mdl_core.rc"
+     )
+ 
++add_library(prod-lib-mdl_core ALIAS ${PROJECT_NAME})
++
+ # customize name
+ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "lib")
+ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "mdl_core")
+diff --git a/src/prod/lib/mdl_sdk/CMakeLists.txt b/src/prod/lib/mdl_sdk/CMakeLists.txt
+index cf0d3d3..782a609 100644
+--- a/src/prod/lib/mdl_sdk/CMakeLists.txt
++++ b/src/prod/lib/mdl_sdk/CMakeLists.txt
+@@ -27,11 +27,11 @@
+ #*****************************************************************************
+ 
+ # name of the target and the resulting library
+-set(PROJECT_NAME prod-lib-mdl_sdk)
++set(PROJECT_NAME sdk)
+ 
+ # collect sources
+-set(PROJECT_SOURCES 
+-    "mdl_sdk_factory.cpp" 
++set(PROJECT_SOURCES
++    "mdl_sdk_factory.cpp"
+     "mdl_sdk_required_modules.cpp"
+     "mdl_sdk_stubs.cpp"
+     )
+@@ -39,11 +39,13 @@ set(PROJECT_SOURCES
+ # create target from template
+ create_from_base_preset(
+     TARGET ${PROJECT_NAME}
+-    TYPE SHARED
++    TYPE MODULE
+     SOURCES ${PROJECT_SOURCES}
+     EMBED_RC "mdl_sdk.rc"
+     )
+ 
++add_library(prod-lib-mdl_sdk ALIAS ${PROJECT_NAME})
++
+ # customize name
+ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "lib")
+ set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "mdl_sdk")
+@@ -57,8 +59,8 @@ add_library(mdl_sdk ALIAS ${PROJECT_NAME})
+ add_library(mdl::mdl_sdk ALIAS ${PROJECT_NAME})
+ 
+ # add mdl and other dependencies
+-target_add_dependencies(TARGET ${PROJECT_NAME} 
+-    DEPENDS 
++target_add_dependencies(TARGET ${PROJECT_NAME}
++    DEPENDS
+         boost
+         ${LINKER_WHOLE_ARCHIVE}
+         ${LINKER_START_GROUP}

--- a/ports/mdl/0003-disable-freeimage-faxg3.patch
+++ b/ports/mdl/0003-disable-freeimage-faxg3.patch
@@ -1,0 +1,13 @@
+diff --git a/src/shaders/plugin/freeimage/freeimage_image_plugin_impl.cpp b/src/shaders/plugin/freeimage/freeimage_image_plugin_impl.cpp
+index e649692..c616d53 100644
+--- a/src/shaders/plugin/freeimage/freeimage_image_plugin_impl.cpp
++++ b/src/shaders/plugin/freeimage/freeimage_image_plugin_impl.cpp
+@@ -257,7 +257,7 @@ Plugin_description g_plugin_list[] = {
+         Plugin_description( "fi_cut"   , FIF_CUT   ),
+         Plugin_description( "fi_dds"   , FIF_DDS   ),
+         Plugin_description( "fi_exr"   , FIF_EXR   ),
+-        Plugin_description( "fi_faxg3" , FIF_FAXG3 ),
++        // Plugin_description( "fi_faxg3" , FIF_FAXG3 ), # not supported by vcpkg
+         Plugin_description( "fi_gif"   , FIF_GIF   ),
+         Plugin_description( "fi_hdr"   , FIF_HDR   ),
+         Plugin_description( "fi_ico"   , FIF_ICO   ),

--- a/ports/mdl/0004-clang-tool-version.patch
+++ b/ports/mdl/0004-clang-tool-version.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/tools/add_clang.cmake b/cmake/tools/add_clang.cmake
+index d96162c..3f6d4dc 100644
+--- a/cmake/tools/add_clang.cmake
++++ b/cmake/tools/add_clang.cmake
+@@ -55,7 +55,7 @@ if(NOT _CLANG_VERSION_STRING)
+ else()
+     # parse version number
+     STRING(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" _CLANG_VERSION_STRING ${_CLANG_VERSION_STRING})
+-    if(${_CLANG_VERSION_STRING} VERSION_GREATER_EQUAL "3.5.0" OR ${_CLANG_VERSION_STRING} VERSION_LESS "3.4.0")
++    if(${_CLANG_VERSION_STRING} VERSION_LESS "3.4.0")
+         message(FATAL_ERROR "Clang 3.4 is required but Clang ${_CLANG_VERSION_STRING} was found instead. Please set the CMake option 'clang_PATH' that needs to point to a clang 3.4.x compiler.")
+     endif()
+-endif()
+\ No newline at end of file
++endif()

--- a/ports/mdl/0005-embedded-clang.patch
+++ b/ports/mdl/0005-embedded-clang.patch
@@ -1,0 +1,55 @@
+diff --git a/src/mdl/jit/libbsdf/CMakeLists.txt b/src/mdl/jit/libbsdf/CMakeLists.txt
+index 9f5107f..3c6916a 100644
+--- a/src/mdl/jit/libbsdf/CMakeLists.txt
++++ b/src/mdl/jit/libbsdf/CMakeLists.txt
+@@ -81,9 +81,6 @@ setup_ide(TARGET ${PROJECT_NAME} SOURCES ${PROJECT_SOURCES})
+ # CLANG Build Step
+ # -------------------------------------------------------------------------------------------------
+ 
+-# get clang
+-target_add_tool_dependency(TARGET ${PROJECT_NAME} TOOL clang)
+-
+ add_custom_command(
+     OUTPUT
+         ${_GENERATED_DIR}/libbsdf.bc
+@@ -91,15 +88,16 @@ add_custom_command(
+         ${_GENERATED_DIR}/libbsdf.ll
+     COMMAND ${CMAKE_COMMAND} -E echo "Compile libbsdf bytecode using clang ..."
+     COMMAND ${CMAKE_COMMAND} -E make_directory ${_GENERATED_DIR}
+-    COMMAND ${clang_PATH}
++    COMMAND clang
+         -emit-llvm -c -O2 -ffast-math -target x86_64-pc-win32 ${CMAKE_CURRENT_SOURCE_DIR}/libbsdf.cpp
+         -o ${_GENERATED_DIR}/libbsdf.bc -MD -MT ${_GENERATED_DIR}/libbsdf.bc -MP -MF ${_GENERATED_DIR}/libbsdf.d.tmp
+     COMMAND ${CMAKE_COMMAND} -E copy ${_GENERATED_DIR}/libbsdf.d.tmp ${_GENERATED_DIR}/libbsdf.d
+     COMMAND ${CMAKE_COMMAND} -E remove ${_GENERATED_DIR}/libbsdf.d.tmp
+-    COMMAND ${clang_PATH}
++    COMMAND clang
+         -emit-llvm -S -O2 -ffast-math -target x86_64-pc-win32 ${CMAKE_CURRENT_SOURCE_DIR}/libbsdf.cpp
+         -o ${_GENERATED_DIR}/libbsdf.ll
+     DEPENDS
+         ${PROJECT_SOURCES}
++        clang
+     VERBATIM
+     )
+diff --git a/src/mdl/jit/llvm/CMakeLists.txt b/src/mdl/jit/llvm/CMakeLists.txt
+index 8caa26b..27b04b3 100644
+--- a/src/mdl/jit/llvm/CMakeLists.txt
++++ b/src/mdl/jit/llvm/CMakeLists.txt
+@@ -112,7 +112,7 @@ option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." OFF)
+ option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." OFF)
+ option(LLVM_INCLUDE_EXAMPLES "Generate build targets for the LLVM examples" OFF)
+ option(LLVM_INCLUDE_DOCS "Generate build targets for llvm documentation." OFF)
+-option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." OFF)
++option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
+ option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." OFF)
+ option(LLVM_BUILD_UTILS "Build the LLVM tools. If OFF, just generate build targets." OFF)
+ option(LLVM_ENABLE_BINDINGS "Build bindings." OFF)
+@@ -131,6 +131,8 @@ set(PYTHON_EXECUTABLE ${python_PATH})
+ set(LLVM_CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/dist CACHE PATH "LLVM source root.")
+ set(LLVM_NATIVE_BUILD ${CMAKE_CURRENT_BINARY_DIR}/dist/NATIVE CACHE PATH "Binary root dir for LLVM tablegen.")
+ 
++set(LLVM_TOOLS_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/dist/bin" CACHE STRING "Path for binary subdirectory (defaults to 'bin')")
++
+ # speed up build is not working properly on all platforms and configurations
+ if(WINDOWS)
+     set(_ENABLE_LLVM_NATIVE_BUILD ON)   # speed up build

--- a/ports/mdl/CONTROL
+++ b/ports/mdl/CONTROL
@@ -1,0 +1,6 @@
+Source: mdl
+Version: 2019.1.1 (317500.2554)
+Description: NVIDIA Material Definition Language SDK (Open Source)
+Homepage: https://github.com/NVIDIA/MDL-SDK
+Maintainer: Andréa MACHIZAUD <andrea.machizaud@gmail.com>
+Build-Depends: freeimage, python2, boost-any, boost-algorithm, boost-bind, boost-core, boost-function, boost-functional, boost-unordered, boost-smart-ptr, boost-tokenizer

--- a/ports/mdl/fix-build-error.patch
+++ b/ports/mdl/fix-build-error.patch
@@ -1,0 +1,14 @@
+--- a/tools/libclang/CMakeLists.txt
++++ b/tools/libclang/CMakeLists.txt
+@@ -56,10 +56,7 @@ if (TARGET clangTidyPlugin)
+   endif()
+ endif ()
+ 
+-find_library(DL_LIBRARY_PATH dl)
+-if (DL_LIBRARY_PATH)
+-  list(APPEND LIBS dl)
+-endif()
++list(APPEND LIBS "${DL_LIBRARY_PATH}")
+ 
+ option(LIBCLANG_BUILD_STATIC
+   "Build libclang as a static library (in addition to a shared one)" OFF)

--- a/ports/mdl/install-clang-modules-to-share.patch
+++ b/ports/mdl/install-clang-modules-to-share.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/modules/CMakeLists.txt b/cmake/modules/CMakeLists.txt
+index be6d1d72..4749f64b 100644
+--- a/cmake/modules/CMakeLists.txt
++++ b/cmake/modules/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(CLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/clang)
++set(CLANG_INSTALL_PACKAGE_DIR share/clang)
+ set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(CLANG_EXPORTS GLOBAL PROPERTY CLANG_EXPORTS)

--- a/ports/mdl/portfile.cmake
+++ b/ports/mdl/portfile.cmake
@@ -1,0 +1,118 @@
+
+include(vcpkg_common_functions)
+include(vcpkg_common_definitions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NVIDIA/MDL-SDK
+    REF 2019.1.1
+    SHA512 20bd336bac76932271dae5c071b897f99464e53fe3f47c139a2aec777826f016ecd75f613076f0355a54344c5cfc47a48a515a857b06a97cb1692de057bcbcbe
+    HEAD_REF master
+    PATCHES
+        0001-freeimage-dependency-search.patch
+        0002-install-rules.patch
+        0003-disable-freeimage-faxg3.patch
+        0004-clang-tool-version.patch
+        0005-embedded-clang.patch
+)
+
+vcpkg_download_distfile(CLANG_ARCHIVE
+    URLS "http://releases.llvm.org/7.0.0/cfe-7.0.0.src.tar.xz"
+    FILENAME "mdl-cfe-7.0.0.src.tar.xz"
+    SHA512 17a658032a0160c57d4dc23cb45a1516a897e0e2ba4ebff29472e471feca04c5b68cff351cdf231b42aab0cff587b84fe11b921d1ca7194a90e6485913d62cb7
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH CLANG_SOURCE_PATH
+    ARCHIVE ${CLANG_ARCHIVE}
+    PATCHES
+        fix-build-error.patch
+        install-clang-modules-to-share.patch
+)
+
+set(MDL_LLVM_PATH "${SOURCE_PATH}/src/mdl/jit/llvm/dist")
+
+if(NOT EXISTS ${MDL_LLVM_PATH}/tools/clang)
+  file(RENAME ${CLANG_SOURCE_PATH} ${MDL_LLVM_PATH}/tools/clang)
+endif()
+
+vcpkg_find_acquire_program(PYTHON2)
+get_filename_component(PYTHON2_DIR ${PYTHON2} DIRECTORY)
+vcpkg_add_to_path(PREPEND ${PYTHON2_DIR})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DFREEIMAGE_DIR=${CURRENT_INSTALLED_DIR}
+        -DMDL_BUILD_SDK_EXAMPLES:BOOL=OFF
+        -DMDL_BUILD_CORE_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_CUDA_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_D3D12_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_OPENGL_EXAMPLES:BOOL=OFF
+        -DMDL_ENABLE_QT_EXAMPLES:BOOL=OFF
+)
+
+vcpkg_install_cmake()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
+    )
+
+    # HACK
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/lib/libmdl_core${CMAKE_SHARED_MODULE_SUFFIX}"
+        "${CURRENT_INSTALLED_DIR}/lib/libmdl_core${CMAKE_SHARED_MODULE_SUFFIX}"
+    )
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/lib/libmdl_sdk${CMAKE_SHARED_MODULE_SUFFIX}"
+        "${CURRENT_INSTALLED_DIR}/lib/libmdl_sdk${CMAKE_SHARED_MODULE_SUFFIX}"
+    )
+
+    # Make vcpkg believe everything is fine
+    file(TOUCH "${CURRENT_PACKAGES_DIR}/lib/libmdl_core${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    file(TOUCH "${CURRENT_PACKAGES_DIR}/lib/libmdl_sdk${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/tools")
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}"
+    )
+
+    # HACK
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/debug/lib/libmdl_core${CMAKE_SHARED_MODULE_SUFFIX}"
+        "${CURRENT_INSTALLED_DIR}/debug/lib/libmdl_core${CMAKE_SHARED_MODULE_SUFFIX}"
+    )
+    file(RENAME
+        "${CURRENT_PACKAGES_DIR}/debug/lib/libmdl_sdk${CMAKE_SHARED_MODULE_SUFFIX}"
+        "${CURRENT_INSTALLED_DIR}/debug/lib/libmdl_sdk${CMAKE_SHARED_MODULE_SUFFIX}"
+    )
+
+    # Make vcpkg believe everything is fine
+    file(TOUCH "${CURRENT_PACKAGES_DIR}/debug/lib/libmdl_core${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    file(TOUCH "${CURRENT_PACKAGES_DIR}/debug/lib/libmdl_sdk${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/debug/tools/${PORT}")
+endif()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_fixup_cmake_targets()
+
+vcpkg_copy_pdbs()
+
+file(INSTALL
+    "${SOURCE_PATH}/LICENSE.md"
+    DESTINATION
+        "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME
+        "COPYRIGHT"
+)


### PR DESCRIPTION
MDL SDK 2019.1.1

Definitely a WIP
Tweaked many times MDL SDK CMake build config to make it pass

Patch description :
- 0001-freeimage-dependency-search.patch : allow to pull freeimage from vcpkg 
- 0002-install-rules.patch : make MDL SDK install its main target
- 0003-disable-freeimage-faxg3.patch : disable image format not supported by vcpkg port
- 0004-clang-tool-version.cmake : even if restricted by current CMake build config, using newer clang seems to work

Notes:

1/ CMake MODULE installed target (at least on Windows)
vcpkg post build checks verify that after a static build no .dll exists in `lib/` directory
However CMake MODULE target only produced `.dll` file 
My hack is to directly installed them in `installed/` and produce dummy file to pass post build checks