### PR TITLE
[proj4] Update to version 6.2.0

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,8 +1,8 @@
 Source: gdal
-Version: 2.4.1-8
+Version: 2.4.1-9
 Homepage: https://gdal.org/
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
-Build-Depends: proj, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma, netcdf-c, hdf5, zlib
+Build-Depends: proj4, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma, netcdf-c, hdf5, zlib
 
 Feature: mysql-libmariadb
 Build-Depends: libmariadb

--- a/ports/proj4/CONTROL
+++ b/ports/proj4/CONTROL
@@ -1,5 +1,5 @@
 Source: proj4
-Version: 6.1.1-1
+Version: 6.2.0-1
 Homepage: https://github.com/OSGeo/PROJ
 Description: PROJ.4 library for cartographic projections
 Build-Depends: sqlite3[core]

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
-    REF 6.1.1
-    SHA512 d7c13eec5bc75ace132b7a35118b0e254b9e766cad7bfe23f8d1ec52c32e388607b4f04e9befceef8185e25b98c678c492a6319d19a5e62d074a6d23474b68fa
+    REF 6.2.0
+    SHA512 035c138e1a7794760652906daaf3c8a42cb6431ad9062a42ec2f8d721ead25394407fdd52560c5f1fc8668a0167459fdbe47c6392de23c1474304ea26b8a3a33
     HEAD_REF master
     PATCHES
         fix-sqlite3-bin.patch


### PR DESCRIPTION
This PR updates `proj4` from 4.9 to 6.2.

This newer version, however, introduces some breaking changes:

* The use of `proj_api.h` has now been deprecated. Using it will result in a compile-time error, unless `ACCEPT_USE_OF_DEPRECATED_PROJ_API_H` has been defined. The following ports have been updated as well to accommodate this change:
  - ~~`libgeotiff`~~
  - ~~`libspatialite`~~
* The private internal header file `projects.h` has been removed. The `vtk` package was using it. A [future release will address this issue](https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status). ~~In the meantime, the port has been adjusted to use [this patch](https://gitlab.kitware.com/vtk/vtk/issues/17554)~~.

**_Edit: These breaking changes were addressed in #7917._**


Additionally, this PR changes `gdal`'s `CONTROL` file to depend on `proj4`, not on `proj`.