### PR TITLE
Fix compile error in Visual Studio 2017 15.1

### DIFF
--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -204,7 +204,7 @@ namespace vcpkg::Install
         {
             // The VS2015 standard library requires comparison operators of T and U
             // to also support comparison of T and T, and of U and U, due to debug checks.
-#if _MSC_VER < 1910
+#if _MSC_VER <= 1910
             bool operator()(const std::string& lhs, const std::string& rhs) { return lhs < rhs; }
             bool operator()(const file_pack& lhs, const file_pack& rhs) { return lhs.first < rhs.first; }
 #endif


### PR DESCRIPTION
This fixed a compile error for me in Visual Studio 2017 version 15.1 26403.7 with v141 toolset [I just tried building vcpkg on an old computer that I have from 2017].