### PR TITLE
Fix assimp linking to minizip error

### DIFF
--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
             -DASSIMP_BUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
             -DASSIMP_BUILD_ASSIMP_TOOLS=OFF
             -DASSIMP_INSTALL_PDB=OFF
+            -DASSIMP_BUILD_MINIZIP=ON
             #-DSYSTEM_IRRXML=ON # Wait for the built-in irrxml to synchronize with port irrlich, add dependencies and enable this macro
 )
 


### PR DESCRIPTION
On manjaro (not tried on another OS but should be the same), building assimp is a success but the build of our projects failes : 

```
`/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:186: undefined reference to `unzOpen'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:203: undefined reference to `unzGoToFirstFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:208: undefined reference to `unzGetCurrentFileInfo'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:214: undefined reference to `unzOpenCurrentFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:220: undefined reference to `unzReadCurrentFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:233: undefined reference to `unzCloseCurrentFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Importer/IFC/IFCLoader.cpp:247: undefined reference to `unzClose'
/usr/bin/ld: ../../../libs/vcpkg/installed/x64-linux-dyn/lib/libassimp.a(ZipArchiveIOSystem.cpp.o): in function `Assimp::ZipFileInfo::Extract(void*) const':
/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:224: undefined reference to `unzGoToFilePos'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:227: undefined reference to `unzOpenCurrentFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:232: undefined reference to `unzReadCurrentFile'
/usr/bin/ld: ../../../libs/vcpkg/installed/x64-linux-dyn/lib/libassimp.a(ZipArchiveIOSystem.cpp.o): in function `Assimp::ZipArchiveIOSystem::Implement::Implement(Assimp::IOSystem*, char const*, char const*)':
/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:342: undefined reference to `unzOpen2'
/usr/bin/ld: ../../../libs/vcpkg/installed/x64-linux-dyn/lib/libassimp.a(ZipArchiveIOSystem.cpp.o): in function `Assimp::ZipArchiveIOSystem::Implement::~Implement()':
/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:349: undefined reference to `unzClose'
/usr/bin/ld: ../../../libs/vcpkg/installed/x64-linux-dyn/lib/libassimp.a(ZipArchiveIOSystem.cpp.o): in function `Assimp::ZipArchiveIOSystem::Implement::Implement(Assimp::IOSystem*, char const*, char const*)':
/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:342: undefined reference to `unzOpen2'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:342: undefined reference to `unzOpen2'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:342: undefined reference to `unzOpen2'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:342: undefined reference to `unzOpen2'
/usr/bin/ld: ../../../libs/vcpkg/installed/x64-linux-dyn/lib/libassimp.a(ZipArchiveIOSystem.cpp.o): in function `Assimp::ZipArchiveIOSystem::Implement::MapArchive()':
/home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:362: undefined reference to `unzGoToFirstFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:377: undefined reference to `unzGoToNextFile'
/usr/bin/ld: /home/aspioupiou/Documents/imt/libs/vcpkg/buildtrees/assimp/src/v5.0.0-9e4581618e/code/Common/ZipArchiveIOSystem.cpp:370: `undefined``
```

Error comes from the build of assimp. Assimp does not build minizip and the result is undefined symbols.

All the best