### PR TITLE
support SKIP_CONFIGURE in vcpkg_configure_make.

### DIFF
--- a/docs/maintainers/vcpkg_configure_make.md
+++ b/docs/maintainers/vcpkg_configure_make.md
@@ -11,6 +11,7 @@ vcpkg_configure_make(
     [DISABLE_AUTO_DST]
     [GENERATOR]
     [NO_DEBUG]
+    [SKIP_CONFIGURE]
     [PROJECT_SUBPATH <${PROJ_SUBPATH}>]
     [PRERUN_SHELL <${SHELL_PATH}>]
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
@@ -31,6 +32,9 @@ Should use `GENERATOR NMake` first.
 
 ### NO_DEBUG
 This port doesn't support debug mode.
+
+### SKIP_CONFIGURE
+Skip configure process
 
 ### AUTOCONFIG
 Need to use autoconfig to generate configure file.

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -11,6 +11,7 @@
 ##     [DISABLE_AUTO_DST]
 ##     [GENERATOR]
 ##     [NO_DEBUG]
+##     [SKIP_CONFIGURE]
 ##     [PROJECT_SUBPATH <${PROJ_SUBPATH}>]
 ##     [PRERUN_SHELL <${SHELL_PATH}>]
 ##     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
@@ -31,6 +32,9 @@
 ##
 ## ### NO_DEBUG
 ## This port doesn't support debug mode.
+##
+## ### SKIP_CONFIGURE
+## Skip configure process
 ##
 ## ### AUTOCONFIG
 ## Need to use autoconfig to generate configure file.
@@ -71,7 +75,7 @@
 ## * [libosip2](https://github.com/Microsoft/vcpkg/blob/master/ports/libosip2/portfile.cmake)
 function(vcpkg_configure_make)
     cmake_parse_arguments(_csc
-        "AUTOCONFIG;DISABLE_AUTO_HOST;DISABLE_AUTO_DST;NO_DEBUG"
+        "AUTOCONFIG;DISABLE_AUTO_HOST;DISABLE_AUTO_DST;NO_DEBUG;SKIP_CONFIGURE"
         "SOURCE_PATH;PROJECT_SUBPATH;GENERATOR;PRERUN_SHELL"
         "OPTIONS;OPTIONS_DEBUG;OPTIONS_RELEASE"
         ${ARGN}
@@ -260,12 +264,14 @@ function(vcpkg_configure_make)
             )
         endif()
         
-        message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
-        vcpkg_execute_required_process(
-            COMMAND ${dbg_command}
-            WORKING_DIRECTORY ${PRJ_DIR}
-            LOGNAME config-${TARGET_TRIPLET}-dbg
-        )
+        if (NOT _csc_SKIP_CONFIGURE)
+            message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
+            vcpkg_execute_required_process(
+                COMMAND ${dbg_command}
+                WORKING_DIRECTORY ${PRJ_DIR}
+                LOGNAME config-${TARGET_TRIPLET}-dbg
+            )
+        endif()
     endif()
 
     # Configure release
@@ -325,12 +331,14 @@ function(vcpkg_configure_make)
             )
         endif()
         
-        message(STATUS "Configuring ${TAR_TRIPLET_DIR}")
-        vcpkg_execute_required_process(
-            COMMAND ${rel_command}
-            WORKING_DIRECTORY ${PRJ_DIR}
-            LOGNAME config-${TAR_TRIPLET_DIR}
-        )
+        if (NOT _csc_SKIP_CONFIGURE)
+            message(STATUS "Configuring ${TAR_TRIPLET_DIR}")
+            vcpkg_execute_required_process(
+                COMMAND ${rel_command}
+                WORKING_DIRECTORY ${PRJ_DIR}
+                LOGNAME config-${TAR_TRIPLET_DIR}
+            )
+        endif()
     endif()
     
     # Restore envs


### PR DESCRIPTION
Since some ports only provide `Makefile` without providing `configure`, add `SKIP_CONFIGURE` to vcpkg_configure_make.