### PR TITLE
[libpopt]Fix linux build.

### DIFF
--- a/ports/libpopt/CMakeLists.txt
+++ b/ports/libpopt/CMakeLists.txt
@@ -46,7 +46,9 @@ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 include_directories(${CMAKE_BINARY_DIR})
 
 add_library(popt ${SOURCES})
-set_target_properties(popt PROPERTIES COMPILE_FLAGS "/wd4996")
+if (MSVC)
+    target_compile_options(popt PRIVATE /wd4996)
+endif()
 
 install(TARGETS popt
   RUNTIME DESTINATION bin

--- a/ports/libpopt/CONTROL
+++ b/ports/libpopt/CONTROL
@@ -1,3 +1,3 @@
 Source: libpopt
-Version: 1.16-11
+Version: 1.16-12
 Description: Library for parsing command line parameters


### PR DESCRIPTION
Only use `/wd4996` on `MSVC`.