### PR TITLE
[openscap]Add new port.

### DIFF
--- a/ports/openscap/CONTROL
+++ b/ports/openscap/CONTROL
@@ -1,0 +1,17 @@
+Source: openscap
+Version: 1.3.1
+Homepage: https://github.com/OpenSCAP/openscap
+Description: The oscap program is a command line tool that allows users to load, scan, validate, edit, and export SCAP documents.
+Build-Depends: libxslt, libxml2, libzip, curl, pcre2, libpopt, pthread, glib, openssl
+
+Feature: docs
+Description: install docs
+
+Feature: tests
+Description: build with tests
+
+Feature: util
+Description: build available utils
+
+Feature: python
+Description: build with python3

--- a/ports/openscap/CONTROL
+++ b/ports/openscap/CONTROL
@@ -12,6 +12,7 @@ Description: build with tests
 
 Feature: util
 Description: build available utils
+Build-Depends: getopt-win32 (windows)
 
 Feature: python
 Description: build with python3

--- a/ports/openscap/CONTROL
+++ b/ports/openscap/CONTROL
@@ -2,7 +2,7 @@ Source: openscap
 Version: 1.3.1
 Homepage: https://github.com/OpenSCAP/openscap
 Description: The oscap program is a command line tool that allows users to load, scan, validate, edit, and export SCAP documents.
-Build-Depends: libxslt, libxml2, libzip, curl, pcre2, libpopt, pthread, glib, openssl
+Build-Depends: libxslt, libxml2, libzip, curl, pcre2, libpopt, pthread, glib, openssl, zlib
 
 Feature: docs
 Description: install docs

--- a/ports/openscap/fix-build.patch
+++ b/ports/openscap/fix-build.patch
@@ -1,0 +1,105 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4de5b57..e390e34 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -140,16 +140,23 @@ find_package(SWIG)
+ find_package(LibXml2 REQUIRED)
+ find_package(LibXslt REQUIRED)
+ find_package(BZip2)
++find_package(OpenSSL REQUIRED)
+ 
+ # PThread
+-set(CMAKE_THREAD_PREFER_PTHREAD)
+-set(THREADS_PREFER_PTHREAD_FLAG)
+-set(THREADS_USE_PTHREADS_WIN32 true)
+-find_package(Threads REQUIRED)
+-check_library_exists(pthread pthread_timedjoin_np "" HAVE_PTHREAD_TIMEDJOIN_NP)
+-check_library_exists(pthread pthread_setname_np "" HAVE_PTHREAD_SETNAME_NP)
+-check_library_exists(pthread pthread_getname_np "" HAVE_PTHREAD_GETNAME_NP)
+-
++if (WIN32)
++    set(CMAKE_THREAD_PREFER_PTHREAD)
++    set(THREADS_PREFER_PTHREAD_FLAG)
++    set(THREADS_USE_PTHREADS_WIN32 true)
++    find_package(pthread CONFIG REQUIRED)
++    set(CMAKE_THREAD_LIBS_INIT ${PThreads4W_LIBRARY})
++    check_library_exists(pthread pthread_timedjoin_np "" HAVE_PTHREAD_TIMEDJOIN_NP)
++    check_library_exists(pthread pthread_setname_np "" HAVE_PTHREAD_SETNAME_NP)
++    check_library_exists(pthread pthread_getname_np "" HAVE_PTHREAD_GETNAME_NP)
++else()
++    set(THREADS_USE_PTHREADS_WIN32 -pthread)
++endif()
++# OpenSSL
++link_libraries(OpenSSL::SSL OpenSSL::Crypto)
+ # WITH_CRYPTO
+ set(WITH_CRYPTO "gcrypt" CACHE STRING "gcrypt|nss3")
+ if(NOT (${WITH_CRYPTO} EQUAL "nss3"))
+@@ -378,13 +385,13 @@ if(WIN32)
+ 	# The install path can be changed by user in Windows installer.
+ 	# We will use relative names - "schemas", "xsl" and "cpe"
+ 	# directories will be located in the same directory as oscap.exe.
+-	set(OSCAP_DEFAULT_SCHEMA_PATH "schemas")
+-	set(OSCAP_DEFAULT_XSLT_PATH "xsl")
+-	set(OSCAP_DEFAULT_CPE_PATH "cpe")
++	set(OSCAP_DEFAULT_SCHEMA_PATH share/openscap/schemas)
++	set(OSCAP_DEFAULT_XSLT_PATH share/openscap/xsl)
++	set(OSCAP_DEFAULT_CPE_PATH share/openscap/cpe)
+ else()
+-	set(OSCAP_DEFAULT_SCHEMA_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/schemas")
+-	set(OSCAP_DEFAULT_XSLT_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/xsl")
+-	set(OSCAP_DEFAULT_CPE_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/cpe")
++	set(OSCAP_DEFAULT_SCHEMA_PATH share/openscap/schemas)
++	set(OSCAP_DEFAULT_XSLT_PATH share/openscap/xsl)
++	set(OSCAP_DEFAULT_CPE_PATH share/openscap/cpe)
+ endif()
+ set(OSCAP_TEMP_DIR "/tmp" CACHE STRING "use different temporary directory to execute sce scripts (default=/tmp)")
+ 
+diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
+index 2a3f373..bd0e12c 100644
+--- a/utils/CMakeLists.txt
++++ b/utils/CMakeLists.txt
+@@ -6,27 +6,20 @@ if(ENABLE_OSCAP_UTIL)
+ 	add_executable(oscap ${UTILS_SOURCES})
+ 	target_link_libraries(oscap openscap)
+ 	if(WIN32)
+-		set(OSCAP_UTIL_DESTINATION ".")
++		set(OSCAP_UTIL_DESTINATION tools)
+ 		# Install the 'oscap' utility
+ 		install(TARGETS "oscap"
+ 			DESTINATION ${OSCAP_UTIL_DESTINATION}
+ 		)
+-		# Install all recursively dependent DLLs for oscap.exe
+-		set(APPS "\${CMAKE_INSTALL_PREFIX}/oscap.exe") # the \ before $ is required by BundleUtilities
+-		set(VCPKG_DLL_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin")
+-		install(CODE "
+-			include(BundleUtilities)
+-			fixup_bundle(\"${APPS}\" \"\" \"${VCPKG_DLL_DIR}\")
+-		")
+ 	else()
+-		set(OSCAP_UTIL_DESTINATION ${CMAKE_INSTALL_BINDIR})
++		set(OSCAP_UTIL_DESTINATION tools)
+ 		# Install the 'oscap' utility
+ 		install(TARGETS "oscap"
+ 			DESTINATION ${OSCAP_UTIL_DESTINATION}
+ 		)
+ 		# Install manual page
+ 		install(FILES "oscap.8"
+-			DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
++			DESTINATION "share/openscap/man8"
+ 		)
+ 	endif()
+ endif()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9e18613..e84a21f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -125,4 +125,8 @@ else()
+ 	set(OPENSCAP_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+-install(TARGETS openscap DESTINATION ${OPENSCAP_INSTALL_DESTINATION})
++install(TARGETS openscap
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)

--- a/ports/openscap/fix-build.patch
+++ b/ports/openscap/fix-build.patch
@@ -59,14 +59,26 @@ index 4de5b57..5f483a3 100644
  
  # ---------- RPATHS for linking
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
-index 2a3f373..bd0e12c 100644
+index 2a3f373..781d05a 100644
 --- a/utils/CMakeLists.txt
 +++ b/utils/CMakeLists.txt
-@@ -6,27 +6,20 @@ if(ENABLE_OSCAP_UTIL)
+@@ -6,27 +6,32 @@ if(ENABLE_OSCAP_UTIL)
  	add_executable(oscap ${UTILS_SOURCES})
  	target_link_libraries(oscap openscap)
  	if(WIN32)
 -		set(OSCAP_UTIL_DESTINATION ".")
++        find_path(GETOPT_INCLUDE_DIR getopt.h)
++        include(SelectLibraryConfigurations)
++        find_library(GETOPT_LIBRARY_RELEASE NAMES getopt)
++        find_library(GETOPT_LIBRARY_DEBUG NAMES getopt PATH_SUFFIXES debug/lib)
++        select_library_configurations(GETOPT)
++        
++        message("GETOPT_INCLUDE_DIR: ${GETOPT_INCLUDE_DIR}")
++        message("GETOPT_LIBRARY: ${GETOPT_LIBRARY}")
++        
++        target_include_directories(oscap PRIVATE ${GETOPT_INCLUDE_DIR})
++        target_link_libraries(oscap PRIVATE ${GETOPT_LIBRARY})
++        
 +		set(OSCAP_UTIL_DESTINATION tools)
  		# Install the 'oscap' utility
  		install(TARGETS "oscap"
@@ -89,7 +101,7 @@ index 2a3f373..bd0e12c 100644
  		# Install manual page
  		install(FILES "oscap.8"
 -			DESTINATION "${CMAKE_INSTALL_MANDIR}/man8"
-+			DESTINATION "share/openscap/man8"
++			DESTINATION share/openscap/man8
  		)
  	endif()
  endif()

--- a/ports/openscap/fix-build.patch
+++ b/ports/openscap/fix-build.patch
@@ -1,12 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4de5b57..e390e34 100644
+index 4de5b57..5f483a3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -140,16 +140,23 @@ find_package(SWIG)
+@@ -140,15 +140,25 @@ find_package(SWIG)
  find_package(LibXml2 REQUIRED)
  find_package(LibXslt REQUIRED)
  find_package(BZip2)
 +find_package(OpenSSL REQUIRED)
++find_package(ZLIB REQUIRED)
  
  # PThread
 -set(CMAKE_THREAD_PREFER_PTHREAD)
@@ -16,7 +17,6 @@ index 4de5b57..e390e34 100644
 -check_library_exists(pthread pthread_timedjoin_np "" HAVE_PTHREAD_TIMEDJOIN_NP)
 -check_library_exists(pthread pthread_setname_np "" HAVE_PTHREAD_SETNAME_NP)
 -check_library_exists(pthread pthread_getname_np "" HAVE_PTHREAD_GETNAME_NP)
--
 +if (WIN32)
 +    set(CMAKE_THREAD_PREFER_PTHREAD)
 +    set(THREADS_PREFER_PTHREAD_FLAG)
@@ -29,31 +29,35 @@ index 4de5b57..e390e34 100644
 +else()
 +    set(THREADS_USE_PTHREADS_WIN32 -pthread)
 +endif()
++
 +# OpenSSL
 +link_libraries(OpenSSL::SSL OpenSSL::Crypto)
+ 
  # WITH_CRYPTO
  set(WITH_CRYPTO "gcrypt" CACHE STRING "gcrypt|nss3")
- if(NOT (${WITH_CRYPTO} EQUAL "nss3"))
-@@ -378,13 +385,13 @@ if(WIN32)
- 	# The install path can be changed by user in Windows installer.
- 	# We will use relative names - "schemas", "xsl" and "cpe"
- 	# directories will be located in the same directory as oscap.exe.
+@@ -373,19 +383,9 @@ message(STATUS "asciidoc: ${ASCIIDOC_EXECUTABLE}")
+ 
+ # ---------- PATHS
+ 
+-if(WIN32)
+-	# Windows installer does not allow full paths.
+-	# The install path can be changed by user in Windows installer.
+-	# We will use relative names - "schemas", "xsl" and "cpe"
+-	# directories will be located in the same directory as oscap.exe.
 -	set(OSCAP_DEFAULT_SCHEMA_PATH "schemas")
 -	set(OSCAP_DEFAULT_XSLT_PATH "xsl")
 -	set(OSCAP_DEFAULT_CPE_PATH "cpe")
-+	set(OSCAP_DEFAULT_SCHEMA_PATH share/openscap/schemas)
-+	set(OSCAP_DEFAULT_XSLT_PATH share/openscap/xsl)
-+	set(OSCAP_DEFAULT_CPE_PATH share/openscap/cpe)
- else()
+-else()
 -	set(OSCAP_DEFAULT_SCHEMA_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/schemas")
 -	set(OSCAP_DEFAULT_XSLT_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/xsl")
 -	set(OSCAP_DEFAULT_CPE_PATH "${CMAKE_INSTALL_FULL_DATADIR}/openscap/cpe")
-+	set(OSCAP_DEFAULT_SCHEMA_PATH share/openscap/schemas)
-+	set(OSCAP_DEFAULT_XSLT_PATH share/openscap/xsl)
-+	set(OSCAP_DEFAULT_CPE_PATH share/openscap/cpe)
- endif()
+-endif()
++set(OSCAP_DEFAULT_SCHEMA_PATH share/openscap/schemas)
++set(OSCAP_DEFAULT_XSLT_PATH share/openscap/xsl)
++set(OSCAP_DEFAULT_CPE_PATH share/openscap/cpe)
  set(OSCAP_TEMP_DIR "/tmp" CACHE STRING "use different temporary directory to execute sce scripts (default=/tmp)")
  
+ # ---------- RPATHS for linking
 diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
 index 2a3f373..bd0e12c 100644
 --- a/utils/CMakeLists.txt

--- a/ports/openscap/portfile.cmake
+++ b/ports/openscap/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO OpenSCAP/openscap
+    REF 3a4c635691380fa990a226acc8558db35d7ebabc #1.3.1
+    SHA512 12681d43b2ce067c5a5c4eb47e14d91d6e9362b1f98f1d35b05d79ad84c7ee8c29f438eaae8e8465033155e500bb0f936eb79af46fab15e4a07e03c6be8b655d
+    HEAD_REF dev
+    PATCHES
+        fix-build.patch
+)
+
+if ("python" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PYTHON3)
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    docs ENABLE_DOCS
+    tests ENABLE_TESTS
+    util ENABLE_OSCAP_UTIL
+    python ENABLE_PYTHON3
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS ${FEATURE_OPTIONS}
+        -DPYTHON_EXECUTABLE=${PYTHON3}
+        -DENABLE_PERL=OFF
+        -DENABLE_MITRE=OFF
+        -DENABLE_VALGRIND=OFF
+        -DENABLE_OSCAP_UTIL_DOCKER=OFF
+        -DENABLE_OSCAP_UTIL_AS_RPM=OFF
+        -DENABLE_OSCAP_UTIL_SSH=OFF
+        -DENABLE_OSCAP_UTIL_VM=OFF
+        -DENABLE_OSCAP_UTIL_PODMAN=OFF
+        -DENABLE_OSCAP_UTIL_CHROOT=OFF
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+
+vcpkg_copy_pdbs()
+
+#Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Since openscap dependency port `glib`(#8653) and `libpopt`(#8652) are not fixed, check windows build only.

Related: #6169.