### PR TITLE
[nano-signal-slot] Enable UWP and dynamic builds

### DIFF
--- a/ports/nano-signal-slot/CONTROL
+++ b/ports/nano-signal-slot/CONTROL
@@ -1,3 +1,3 @@
 Source: nano-signal-slot
-Version: commit-25aa2aa90d450d3c7550c535c7993a9e2ed0764a
+Version: commit-25aa2aa90d450d3c7550c535c7993a9e2ed0764a-1
 Description: Pure C++17 Signals and Slots

--- a/ports/nano-signal-slot/CONTROL
+++ b/ports/nano-signal-slot/CONTROL
@@ -1,3 +1,3 @@
 Source: nano-signal-slot
-Version: 2019-08-25-1
+Version: 2018-08-25-1
 Description: Pure C++17 Signals and Slots

--- a/ports/nano-signal-slot/CONTROL
+++ b/ports/nano-signal-slot/CONTROL
@@ -1,3 +1,3 @@
 Source: nano-signal-slot
-Version: commit-25aa2aa90d450d3c7550c535c7993a9e2ed0764a-1
+Version: 2019-08-25-1
 Description: Pure C++17 Signals and Slots

--- a/ports/nano-signal-slot/portfile.cmake
+++ b/ports/nano-signal-slot/portfile.cmake
@@ -1,13 +1,5 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(
-	ONLY_STATIC_LIBRARY
-)
-
-if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "Error: UWP builds not supported yet.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NoAvailableAlias/nano-signal-slot


### PR DESCRIPTION
It was one of the first port I made, when I was only caring about windows static builds and was disabling anything else to avoid problems with other platforms or configuration. I'm fixing that with this library which is fully cross-platform and can be build in dynamic linkage configuration as it is header only.