### PR TITLE
[openexr] Fix static linkage issues on Linux

### DIFF
--- a/ports/openexr/fix_linux_static_library_names.patch
+++ b/ports/openexr/fix_linux_static_library_names.patch
@@ -1,0 +1,109 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b06d97e..ad360f8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,10 +53,13 @@ endif()
+ if (WIN32 AND OPENEXR_BUILD_ILMBASE AND OPENEXR_BUILD_OPENEXR AND OPENEXR_BUILD_SHARED)
+     # necessary for building dwa lookup tables, and b44log tables on windows
+     set(BUILD_ILMBASE_STATIC ON)
++    set(OPENEXR_STATIC_SUFFIX "_s")
+ elseif (OPENEXR_BUILD_ILMBASE AND OPENEXR_BUILD_STATIC)
+     set(BUILD_ILMBASE_STATIC ON)
++    set(OPENEXR_STATIC_SUFFIX "")
+ else()
+     set(BUILD_ILMBASE_STATIC OFF)
++    set(OPENEXR_STATIC_SUFFIX "")
+ endif()
+ 
+ if (NOT OPENEXR_BUILD_SHARED)
+diff --git a/IlmBase/Half/CMakeLists.txt b/IlmBase/Half/CMakeLists.txt
+index 3d24cd7..d92aa67 100644
+--- a/IlmBase/Half/CMakeLists.txt
++++ b/IlmBase/Half/CMakeLists.txt
+@@ -60,7 +60,7 @@ IF (BUILD_ILMBASE_STATIC)
+   SET_TARGET_PROPERTIES ( Half_static
+     PROPERTIES
+     VERSION ${ILMBASE_VERSION_MAJOR}.${ILMBASE_VERSION_MINOR}.${ILMBASE_VERSION_PATCH}
+-    OUTPUT_NAME "Half${ILMBASE_LIBSUFFIX}_s"
++    OUTPUT_NAME "Half${ILMBASE_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ 
+   ADD_DEPENDENCIES ( Half_static toFloat eLut )
+diff --git a/IlmBase/Iex/CMakeLists.txt b/IlmBase/Iex/CMakeLists.txt
+index 847518c..9425430 100644
+--- a/IlmBase/Iex/CMakeLists.txt
++++ b/IlmBase/Iex/CMakeLists.txt
+@@ -34,7 +34,7 @@ IF (BUILD_ILMBASE_STATIC)
+   SET_TARGET_PROPERTIES ( Iex_static
+     PROPERTIES
+     VERSION ${ILMBASE_VERSION_MAJOR}.${ILMBASE_VERSION_MINOR}.${ILMBASE_VERSION_PATCH}
+-    OUTPUT_NAME "Iex${ILMBASE_LIBSUFFIX}_s"
++    OUTPUT_NAME "Iex${ILMBASE_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ ENDIF()
+ 
+diff --git a/IlmBase/IexMath/CMakeLists.txt b/IlmBase/IexMath/CMakeLists.txt
+index 472fd33..1427fa8 100644
+--- a/IlmBase/IexMath/CMakeLists.txt
++++ b/IlmBase/IexMath/CMakeLists.txt
+@@ -36,7 +36,7 @@ IF (BUILD_ILMBASE_STATIC)
+   SET_TARGET_PROPERTIES ( IexMath_static
+     PROPERTIES
+     VERSION ${ILMBASE_VERSION_MAJOR}.${ILMBASE_VERSION_MINOR}.${ILMBASE_VERSION_PATCH}
+-    OUTPUT_NAME "IexMath${ILMBASE_LIBSUFFIX}_s"
++    OUTPUT_NAME "IexMath${ILMBASE_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ ENDIF( )
+ 
+diff --git a/IlmBase/IlmThread/CMakeLists.txt b/IlmBase/IlmThread/CMakeLists.txt
+index 3a24823..b281916 100644
+--- a/IlmBase/IlmThread/CMakeLists.txt
++++ b/IlmBase/IlmThread/CMakeLists.txt
+@@ -49,7 +49,7 @@ IF (BUILD_ILMBASE_STATIC)
+   SET_TARGET_PROPERTIES ( IlmThread_static
+     PROPERTIES
+     VERSION ${ILMBASE_VERSION_MAJOR}.${ILMBASE_VERSION_MINOR}.${ILMBASE_VERSION_PATCH}
+-    OUTPUT_NAME "IlmThread${ILMBASE_LIBSUFFIX}_s"
++    OUTPUT_NAME "IlmThread${ILMBASE_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ ENDIF ()
+ 
+diff --git a/IlmBase/Imath/CMakeLists.txt b/IlmBase/Imath/CMakeLists.txt
+index 8faa97a..bf29000 100644
+--- a/IlmBase/Imath/CMakeLists.txt
++++ b/IlmBase/Imath/CMakeLists.txt
+@@ -37,7 +37,7 @@ IF (BUILD_ILMBASE_STATIC)
+   SET_TARGET_PROPERTIES ( Imath_static
+     PROPERTIES
+     VERSION ${ILMBASE_VERSION_MAJOR}.${ILMBASE_VERSION_MINOR}.${ILMBASE_VERSION_PATCH}
+-    OUTPUT_NAME "Imath${ILMBASE_LIBSUFFIX}_s"
++    OUTPUT_NAME "Imath${ILMBASE_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ ENDIF ()
+ 
+diff --git a/OpenEXR/IlmImf/CMakeLists.txt b/OpenEXR/IlmImf/CMakeLists.txt
+index d31cf68..52c2b6e 100644
+--- a/OpenEXR/IlmImf/CMakeLists.txt
++++ b/OpenEXR/IlmImf/CMakeLists.txt
+@@ -226,7 +226,7 @@ IF (OPENEXR_BUILD_STATIC)
+   SET_TARGET_PROPERTIES ( IlmImf_static
+     PROPERTIES
+     VERSION ${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR}.${OPENEXR_VERSION_PATCH}
+-    OUTPUT_NAME "IlmImf${OPENEXR_LIBSUFFIX}_s"
++    OUTPUT_NAME "IlmImf${OPENEXR_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+     SET_ILMBASE_INCLUDE_DIRS(IlmImf_static)
+ 
+diff --git a/OpenEXR/IlmImfUtil/CMakeLists.txt b/OpenEXR/IlmImfUtil/CMakeLists.txt
+index 4cc53de..26df90e 100644
+--- a/OpenEXR/IlmImfUtil/CMakeLists.txt
++++ b/OpenEXR/IlmImfUtil/CMakeLists.txt
+@@ -60,7 +60,7 @@ IF ( OPENEXR_BUILD_STATIC )
+     PROPERTIES
+     VERSION ${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR}.${OPENEXR_VERSION_PATCH}
+     SOVERSION ${OPENEXR_SOVERSION}
+-    OUTPUT_NAME "IlmImfUtil${OPENEXR_LIBSUFFIX}_s"
++    OUTPUT_NAME "IlmImfUtil${OPENEXR_LIBSUFFIX}${OPENEXR_STATIC_SUFFIX}"
+     )
+ ENDIF()
+ 

--- a/ports/openexr/portfile.cmake
+++ b/ports/openexr/portfile.cmake
@@ -16,12 +16,18 @@ vcpkg_from_github(
   PATCHES
     fix_clang_not_setting_modern_cplusplus.patch
     fix_install_ilmimf.patch
+    fix_linux_static_library_names.patch
 )
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" OPENEXR_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" OPENEXR_BUILD_SHARED)
 
 vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
   OPTIONS
     -DOPENEXR_BUILD_PYTHON_LIBS:BOOL=FALSE
+    -DOPENEXR_BUILD_STATIC=${OPENEXR_BUILD_STATIC}
+    -DOPENEXR_BUILD_SHARED=${OPENEXR_BUILD_SHARED}
   OPTIONS_DEBUG
     -DILMBASE_PACKAGE_PREFIX=${CURRENT_INSTALLED_DIR}/debug
   OPTIONS_RELEASE
@@ -58,7 +64,7 @@ vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/openexr)
 
 vcpkg_copy_pdbs()
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if (VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_LIBRARY_LINKAGE STREQUAL static)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 


### PR DESCRIPTION
From issue #8668, this:

- Correctly sets `OPENEXR_BUILD_[STATIC/DYNAMIC]`, using `VCPKG_LIBRARY_LINKAGE`
- Deletes the empty `bin` directories, to fix dynamic linkage build on Linux
- Allows the current `FindOpenEXR.cmake` to find the static libraries
  - Done by removing the `_s` suffix, as suggested in the issue comments
  - `OPENEXR_STATIC_SUFFIX` added to allow dynamic builds on Windows to compile the built-in tools, which use the static library