### PR TITLE
[loguru] Update to 2.1.0 and extend to generate proper binary on non-windows

### DIFF
--- a/ports/loguru/CMakeLists.txt
+++ b/ports/loguru/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(loguru PUBLIC
 if(UNIX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
-    target_link_libraries(loguru PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+    target_link_libraries(loguru PUBLIC Threads::Threads ${CMAKE_DL_LIBS})
 endif()
 
 set(LOGURU_INCLUDE_INSTALL_DIR include/loguru CACHE PATH "Install directory for headers")

--- a/ports/loguru/CMakeLists.txt
+++ b/ports/loguru/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.12)
 
 project(loguru CXX)
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_LINK_FLAGS -lpthread -ldl)
+set(CMAKE_CXX_LINK_FLAGS ${CMAKE_CXX_LINK_FLAGS} -lpthread -ldl)
 
 option(INSTALL_HEADERS "Install header files" ON)
 

--- a/ports/loguru/CMakeLists.txt
+++ b/ports/loguru/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(loguru C CXX)
+option(INSTALL_HEADERS "Install header files" ON)
+
+set(loguru_headers
+  loguru.hpp
+)
+
+set(loguru_sources
+  loguru.cpp
+)
+
+add_library(loguru ${loguru_sources})
+target_include_directories(loguru PUBLIC 
+                               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                               $<INSTALL_INTERFACE:include/loguru>)
+
+set(LOGURU_INCLUDE_INSTALL_DIR include/loguru CACHE PATH "Install directory for headers")
+if(INSTALL_HEADERS)
+  install(FILES ${loguru_headers} DESTINATION ${LOGURU_INCLUDE_INSTALL_DIR})
+endif()
+
+set(INCLUDE_INSTALL_DIR ${LOGURU_INCLUDE_INSTALL_DIR})
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(loguruConfig.cmake.in
+              ${CMAKE_CURRENT_BINARY_DIR}/loguruConfig.cmake
+              INSTALL_DESTINATION share/loguru
+              NO_CHECK_REQUIRED_COMPONENTS_MACRO
+              PATH_VARS INCLUDE_INSTALL_DIR)
+
+install(TARGETS loguru
+  EXPORT loguruTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/loguruConfig.cmake DESTINATION share/loguru)
+install(EXPORT loguruTargets DESTINATION share/loguru)
+
+

--- a/ports/loguru/CMakeLists.txt
+++ b/ports/loguru/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(loguru C CXX)
+project(loguru CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_LINK_FLAGS -lpthread -ldl)
+
 option(INSTALL_HEADERS "Install header files" ON)
 
 set(loguru_headers

--- a/ports/loguru/CMakeLists.txt
+++ b/ports/loguru/CMakeLists.txt
@@ -1,16 +1,13 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(loguru CXX)
-
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_LINK_FLAGS ${CMAKE_CXX_LINK_FLAGS} -lpthread -ldl)
 
 option(INSTALL_HEADERS "Install header files" ON)
 
 set(loguru_headers
   loguru.hpp
 )
-
 set(loguru_sources
   loguru.cpp
 )
@@ -19,6 +16,12 @@ add_library(loguru ${loguru_sources})
 target_include_directories(loguru PUBLIC 
                                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                $<INSTALL_INTERFACE:include/loguru>)
+
+if(UNIX)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(loguru PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+endif()
 
 set(LOGURU_INCLUDE_INSTALL_DIR include/loguru CACHE PATH "Install directory for headers")
 if(INSTALL_HEADERS)
@@ -43,5 +46,3 @@ install(TARGETS loguru
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/loguruConfig.cmake DESTINATION share/loguru)
 install(EXPORT loguruTargets DESTINATION share/loguru)
-
-

--- a/ports/loguru/CONTROL
+++ b/ports/loguru/CONTROL
@@ -1,4 +1,4 @@
 Source: loguru
-Version: v2.0.0
+Version: v2.1.0
+Homepage: https://github.com/emilk/loguru
 Description: A lightweight and flexible C++ logging library
-Build-Depends:

--- a/ports/loguru/loguruConfig.cmake.in
+++ b/ports/loguru/loguruConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
-set_and_check(loguru_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+if(UNIX)
+    include(CMakeFindDependencyMacro)
+    find_dependency(Threads)
+endif()
 
+set_and_check(loguru_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 include("${CMAKE_CURRENT_LIST_DIR}/loguruTargets.cmake")

--- a/ports/loguru/loguruConfig.cmake.in
+++ b/ports/loguru/loguruConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+set_and_check(loguru_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/loguruTargets.cmake")

--- a/ports/loguru/portfile.cmake
+++ b/ports/loguru/portfile.cmake
@@ -1,12 +1,29 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emilk/loguru
-    REF v2.0.0
-    SHA512 d6358f843689d10a44dc7bf590305cbfb89727e26d971ca4fe439e5468cdb7bcee2aa858368250e9654fb5ecebf63bca9742451881dae78068fecb18f279d988
+    REF 9c2fea0d4530657f23259be4132f8101c98b579e  #v2.1.0
+    SHA512 49eebf8648f9d29273af76dca0a4e49155daa3664e98979df005e64eb0fa9f4eeb4228245327d469772c51076571acbe39a644eba531444d8676d9709a7e3914
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/loguru.hpp  DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
-file(COPY ${CURRENT_PORT_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/loguru)
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(INSTALL ${SOURCE_PATH}/loguru.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
+endif()
+
+if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt ${SOURCE_PATH}/CMakeLists.txt COPYONLY)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/loguruConfig.cmake.in  ${SOURCE_PATH}/loguruConfig.cmake.in COPYONLY)
+
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS_DEBUG
+            -DINSTALL_HEADERS=OFF
+     )
+
+    vcpkg_install_cmake()
+    vcpkg_fixup_cmake_targets()
+    vcpkg_copy_pdbs()
+endif()
+
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/issues/8158

Loguru is not a header-only library any more, however, the source doesn't export to the lib on windows, so only install header on windows.

loguru has no feature that need to test locally.