### PR TITLE
[simpleamqpclient] Add new port

### DIFF
--- a/ports/simpleamqpclient/CONTROL
+++ b/ports/simpleamqpclient/CONTROL
@@ -1,0 +1,5 @@
+Source: simpleamqpclient
+Version: 2019-4-19
+Homepage: https://github.com/alanxz/SimpleAmqpClient
+Description: SimpleAmqpClient is an easy-to-use C++ wrapper around the rabbitmq-c C library
+Build-Depends: librabbitmq, boost-chrono, boost-system, boost-smart-ptr, boost-lexical-cast, boost-variant, boost-math, boost-foreach, boost-algorithm

--- a/ports/simpleamqpclient/Fix-BuildError.patch
+++ b/ports/simpleamqpclient/Fix-BuildError.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Channel.cpp b/src/Channel.cpp
+index 0d08453..b3eb39b 100644
+--- a/src/Channel.cpp
++++ b/src/Channel.cpp
+@@ -73,7 +73,7 @@ Channel::ptr_t Channel::CreateFromUri(const std::string &uri, int frame_max) {
+   amqp_default_connection_info(&info);
+ 
+   boost::shared_ptr<char> uri_dup =
+-      boost::shared_ptr<char>(strdup(uri.c_str()), free);
++      boost::shared_ptr<char>(_strdup(uri.c_str()), free);
+ 
+   if (0 != amqp_parse_url(uri_dup.get(), &info)) {
+     throw BadUriException();
+@@ -92,7 +92,7 @@ Channel::ptr_t Channel::CreateSecureFromUri(
+   amqp_default_connection_info(&info);
+ 
+   boost::shared_ptr<char> uri_dup =
+-      boost::shared_ptr<char>(strdup(uri.c_str()), free);
++      boost::shared_ptr<char>(_strdup(uri.c_str()), free);
+ 
+   if (0 != amqp_parse_url(uri_dup.get(), &info)) {
+     throw BadUriException();

--- a/ports/simpleamqpclient/Fix-FindLibrabbitmq.patch
+++ b/ports/simpleamqpclient/Fix-FindLibrabbitmq.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 340f732..fb6aa6f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,8 +37,13 @@ INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIRS})
+ LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
+ 
+ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
+-FIND_PACKAGE(Rabbitmqc REQUIRED)
+-INCLUDE_DIRECTORIES(SYSTEM ${Rabbitmqc_INCLUDE_DIRS})
++if (WIN32)
++    set(Rabbitmqc_LIB_SUFFIX .4)
++endif()
++FIND_LIBRARY(Rabbitmqc_LIBRARY rabbitmq${Rabbitmqc_LIB_SUFFIX} REQUIRED)
++FIND_PATH(Rabbitmqc_INCLUDE_DIRS amqp.h)
++INCLUDE_DIRECTORIES(${Rabbitmqc_INCLUDE_DIRS})
++LINK_LIBRARIES(${Rabbitmqc_LIBRARY})
+ 
+ option(ENABLE_SSL_SUPPORT "Enable SSL support." ${Rabbitmqc_SSL_ENABLED})
+ 

--- a/ports/simpleamqpclient/portfile.cmake
+++ b/ports/simpleamqpclient/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_fail_port_install(ON_LIBRARY_LINKAGE "static")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO alanxz/SimpleAmqpClient
+    REF eefabcdb25b6adf841dcc226abfdce94c27a4446 #version 2.4 commit on 2019.4.19
+    SHA512 3f4fe7c20e0e557af03a98a5489efe5ebd65e8331dca4305eef9c9be0c8f728be18bef3973baeae401be4f321fdd6372f53b83e79d685d48bd8c918b6a9c907a
+    HEAD_REF master
+    PATCHES
+        Fix-FindLibrabbitmq.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=ON
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/simpleamqpclient/portfile.cmake
+++ b/ports/simpleamqpclient/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         Fix-FindLibrabbitmq.patch
+        Fix-BuildError.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This port doesn't support build static library for now. The source description: https://github.com/alanxz/SimpleAmqpClient/issues/113

Related issue: #8038
There are no features of this port need to test.