### PR TITLE
[freeimage libraw] Fix case issue on Linux

### DIFF
--- a/ports/freeimage/CMakeLists.txt
+++ b/ports/freeimage/CMakeLists.txt
@@ -13,7 +13,7 @@ if(BUILD_SHARED_LIBS)
   add_definitions("-DOPENEXR_DLL")
 endif()
 
-find_package(zlib     REQUIRED)
+find_package(ZLIB     REQUIRED)
 find_package(PNG      REQUIRED)
 find_package(JPEG     REQUIRED)
 find_package(TIFF     REQUIRED)

--- a/ports/freeimage/CONTROL
+++ b/ports/freeimage/CONTROL
@@ -1,5 +1,5 @@
 Source: freeimage
-Version: 3.18.0-7
+Version: 3.18.0-8
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp[all] (!uwp), libraw, jxrlib, openexr
 Homepage: https://sourceforge.net/projects/freeimage/
 Description: Support library for graphics image formats

--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -52,8 +52,6 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-# Handle copyright
-file(COPY ${SOURCE_PATH}/license-fi.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/freeimage)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/freeimage/license-fi.txt ${CURRENT_PACKAGES_DIR}/share/freeimage/copyright)
-
 vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/license-fi.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+

--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,5 +1,5 @@
 Source: libraw
-Version: 201903-2
+Version: 201903-3
 Build-Depends: lcms, jasper
 Homepage: https://www.libraw.org
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -70,14 +70,13 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Rename cmake module into a config in order to allow more flexible lookup rules
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/FindLibRaw.cmake ${CURRENT_PACKAGES_DIR}/share/libraw/LibRaw-config.cmake)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/FindLibRaw.cmake ${CURRENT_PACKAGES_DIR}/share/libraw/libraw-config.cmake)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libraw)
 endif()
 
-# Handle copyright
-file(COPY ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/libraw)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libraw/COPYRIGHT ${CURRENT_PACKAGES_DIR}/share/libraw/copyright)
-
 vcpkg_copy_pdbs()
+
+file(INSTALL ${SOURCE_PATH}/share/libraw/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -78,5 +78,5 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/share/libraw/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 


### PR DESCRIPTION
Relate to issue https://github.com/microsoft/vcpkg/issues/9450
Freeimage depend on libraw and zlib, found 2 issues when test this port:

1. Find_package(zlib) is wrong because zlib needs to be capitalized  
2. Failed to find libraw via find_package because LibRaw-config.cmake should be lowercase

Freeimage and libraw have no feature that need to test locally.