### PR TITLE
[polyhook2] Add new port

### DIFF
--- a/ports/polyhook2/CONTROL
+++ b/ports/polyhook2/CONTROL
@@ -1,0 +1,4 @@
+Source: polyhook2
+Version: 2019-10-22
+Description: C++17, x86/x64 Hooking Libary v2.0
+Build-Depends: capstone

--- a/ports/polyhook2/CONTROL
+++ b/ports/polyhook2/CONTROL
@@ -1,4 +1,8 @@
 Source: polyhook2
-Version: 2019-10-22
+Version: 2019-10-24
+Homepage: https://github.com/stevemk14ebr/PolyHook_2_0
 Description: C++17, x86/x64 Hooking Libary v2.0
 Build-Depends: capstone
+
+Feature: tool
+Description: Build tests

--- a/ports/polyhook2/fix-build-error.patch
+++ b/ports/polyhook2/fix-build-error.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 62dbdba..55a3068 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -217,8 +217,10 @@ if(NOT ${CAPSTONE_FULL})
+ 	set(CAPSTONE_EVM_SUPPORT OFF CACHE BOOL "EVM support")
+ endif()
+ 
+-add_subdirectory(capstone)
+-target_link_libraries(${PROJECT_NAME} capstone-static)
++find_library(CAPSTONE_LIBRARY NAMES capstone_dll capstone)
++find_path(CAPSTONE_INCLUDE_DIR NAMES capstone/capstone.h)
++target_link_libraries(${PROJECT_NAME} ${CAPSTONE_LIBRARY})
++target_include_directories(${PROJECT_NAME} PRIVATE ${CAPSTONE_INCLUDE_DIR})
+ 
+ # ASMJIT
+ if(DEP_ASMJIT_NEED MATCHES ON)
+@@ -230,3 +232,13 @@ if(DEP_ASMJIT_NEED MATCHES ON)
+ 	add_subdirectory(${ASMJIT_DIR}) # build it
+ 	target_link_libraries(${PROJECT_NAME} asmjit)
+ endif()
++
++#Install targets
++install(TARGETS ${PROJECT_NAME}
++  RUNTIME DESTINATION bin
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)
++
++#Install headers
++install(FILES ${HEADER_FILES} DESTINATION include)
+diff --git a/headers/CapstoneDisassembler.hpp b/headers/CapstoneDisassembler.hpp
+index 2c31bfe..5f3a8ee 100644
+--- a/headers/CapstoneDisassembler.hpp
++++ b/headers/CapstoneDisassembler.hpp
+@@ -7,7 +7,7 @@
+ 
+ #include "headers/ADisassembler.hpp"
+ 
+-#include <capstone/include/capstone/capstone.h>
++#include <capstone/capstone.h>
+ 
+ #include <string.h>
+ #include <iostream> //for debug printing

--- a/ports/polyhook2/fix-build-tests-error.patch
+++ b/ports/polyhook2/fix-build-tests-error.patch
@@ -1,0 +1,92 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 55a3068..c45f7bf 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,6 +12,7 @@ option(FEATURE_PE "Implement all win pe hooking functionality" ON)
+ option(BUILD_DLL "Build dll & lib instead of tests" OFF)
+ option(BUILD_STATIC "If BUILD_DLL is set, create the type that can be statically linked" ON)
+ option(CAPSTONE_FULL "Build all features of capstone." OFF)
++option(BUILD_TOOLS "Build tests" OFF)
+ 
+ # Calculate inclusion of necessary dependencies based on features
+ 
+@@ -38,7 +39,7 @@ set(HEADER_IMP_SOURCES
+ 		${PROJECT_SOURCE_DIR}/sources/PageAllocator.cpp)
+ 
+ # only build tests if making exe
+-if(BUILD_DLL MATCHES OFF)	
++if(BUILD_TOOLS)	
+ 	set(UNIT_TEST_SOURCES 
+ 			${PROJECT_SOURCE_DIR}/MainTests.cpp
+ 			${PROJECT_SOURCE_DIR}/UnitTests/TestDisassembler.cpp
+@@ -62,7 +63,7 @@ if(FEATURE_DETOURS MATCHES ON)
+ 	set(HEADER_IMP_SOURCES ${HEADER_IMP_SOURCES} ${DETOUR_IMP_SOURCES})
+ 
+ 	# only build tests if making exe
+-	if(BUILD_DLL MATCHES OFF)
++	if(BUILD_TOOLS)
+ 		if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 			# 64 bits
+ 			set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} 
+@@ -90,7 +91,7 @@ if(FEATURE_EXCEPTION MATCHES ON)
+ 	set(HEADER_IMP_SOURCES ${HEADER_IMP_SOURCES} ${EXCEPTION_IMP_SOURCES})
+ 
+ 	# only build tests if making exe
+-	if(BUILD_DLL MATCHES OFF)
++	if(BUILD_TOOLS)
+ 		set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} 
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestBreakpointHook.cpp
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestHWBreakpointHook.cpp)
+@@ -110,7 +111,7 @@ if(FEATURE_VIRTUALS MATCHES ON)
+ 	set(HEADER_IMP_SOURCES ${HEADER_IMP_SOURCES} ${VIRTUAL_IMP_SOURCES})
+ 
+ 	# only build tests if making exe
+-	if(BUILD_DLL MATCHES OFF)
++	if(BUILD_TOOLS)
+ 		set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES} 
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestVTableSwapHook.cpp
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestVFuncSwapHook.cpp)
+@@ -131,7 +132,7 @@ if(FEATURE_PE MATCHES ON)
+ 	set(HEADER_IMP_SOURCES ${HEADER_IMP_SOURCES} ${PE_IMP_SOURCES})
+ 
+ 	# only build tests if making exe
+-	if(BUILD_DLL MATCHES OFF)
++	if(BUILD_TOOLS)
+ 		set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES}
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestEatHook.cpp
+ 				${PROJECT_SOURCE_DIR}/UnitTests/TestIatHook.cpp)
+@@ -149,7 +150,7 @@ if(FEATURE_INLINENTD MATCHES ON)
+ 	set(HEADER_IMP_SOURCES ${HEADER_IMP_SOURCES} ${NTD_SOURCES})
+ 
+ 	# only build tests if making exe
+-	if(BUILD_DLL MATCHES OFF)
++	if(BUILD_TOOLS)
+ 		if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 			# 64 bits
+ 			set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES}
+@@ -172,8 +173,10 @@ if(BUILD_DLL MATCHES ON)
+ 	else()
+ 	    add_library(PolyHook_2 SHARED ${SOURCE_FILES_PLH})
+ 	endif()
+-else()
+-    add_executable(PolyHook_2 ${SOURCE_FILES_PLH})
++endif()
++
++if(BUILD_TOOLS)
++    add_executable(PolyHook2_tool ${SOURCE_FILES_PLH})
+ endif()
+ 
+ # add WALL + PDB flags
+@@ -222,6 +225,12 @@ find_path(CAPSTONE_INCLUDE_DIR NAMES capstone/capstone.h)
+ target_link_libraries(${PROJECT_NAME} ${CAPSTONE_LIBRARY})
+ target_include_directories(${PROJECT_NAME} PRIVATE ${CAPSTONE_INCLUDE_DIR})
+ 
++if(BUILD_TOOLS)
++    target_link_libraries(PolyHook2_tool ${CAPSTONE_LIBRARY})
++    target_include_directories(PolyHook2_tool PRIVATE ${CAPSTONE_INCLUDE_DIR})
++    install(TARGETS PolyHook2_tool DESTINATION tool)
++endif()
++
+ # ASMJIT
+ if(DEP_ASMJIT_NEED MATCHES ON)
+ 	# AsmJit is a dep iff inlinetd is on

--- a/ports/polyhook2/portfile.cmake
+++ b/ports/polyhook2/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "Linux" "OSX" "UWP")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO stevemk14ebr/PolyHook_2_0
+    REF  00709c8621af8a6f9e91200088178e6d9f751097
+    SHA512 c6fe9ef9e21de440556cbeb8269e13ef0daafcbc760b04a06e1689d181b6a097c4de9a0f364f7e10f8b0b2f3e419e0ede62aaf4a2a9b16eb2fb57d24eb1b9b5c
+    HEAD_REF master
+    PATCHES fix-build-error.patch
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    set(BUILD_DLL ON)
+    set(BUILD_STATIC OFF)
+else()
+    set(BUILD_DLL OFF)
+    set(BUILD_STATIC ON)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA  
+    OPTIONS
+      -DFEATURE_INLINENTD=OFF
+      -DBUILD_DLL=${BUILD_DLL}
+      -DBUILD_STATIC=${BUILD_STATIC}
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_copy_pdbs()
+
+file(GLOB EXE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+file(GLOB DEBUG_EXE ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+if(EXE OR DEBUG_EXE)
+    file(COPY ${EXE} ${DEBUG_EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools )
+    file(REMOVE ${EXE} ${DEBUG_EXE})
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+    
+endif()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/polyhook2/portfile.cmake
+++ b/ports/polyhook2/portfile.cmake
@@ -6,23 +6,27 @@ vcpkg_from_github(
     REF  00709c8621af8a6f9e91200088178e6d9f751097
     SHA512 c6fe9ef9e21de440556cbeb8269e13ef0daafcbc760b04a06e1689d181b6a097c4de9a0f364f7e10f8b0b2f3e419e0ede62aaf4a2a9b16eb2fb57d24eb1b9b5c
     HEAD_REF master
-    PATCHES fix-build-error.patch
+    PATCHES 
+        fix-build-error.patch
+        fix-build-tests-error.patch
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(BUILD_DLL ON)
-    set(BUILD_STATIC OFF)
-else()
-    set(BUILD_DLL OFF)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    tool BUILD_TOOLS
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     set(BUILD_STATIC ON)
+else()
+    set(BUILD_STATIC OFF)
 endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA  
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
       -DFEATURE_INLINENTD=OFF
-      -DBUILD_DLL=${BUILD_DLL}
+      -DBUILD_DLL=ON
       -DBUILD_STATIC=${BUILD_STATIC}
 )
 
@@ -32,17 +36,8 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_copy_pdbs()
 
-file(GLOB EXE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
-file(GLOB DEBUG_EXE ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-if(EXE OR DEBUG_EXE)
-    file(COPY ${EXE} ${DEBUG_EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools )
-    file(REMOVE ${EXE} ${DEBUG_EXE})
-endif()
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-    
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)    
 endif()
 
 # Handle copyright


### PR DESCRIPTION
`polyhook2` is C++17, x86/x64 Hooking Libary v2.0.
It currently doesn't support Linux and Mac platforms. 
It only supports x86, x64, x86-windows-static and x64-windows-static triplets on Windows.

Related issue #4984.

