### PR TITLE
[wangle]Fix config.cmake

### DIFF
--- a/ports/wangle/CONTROL
+++ b/ports/wangle/CONTROL
@@ -1,4 +1,4 @@
 Source: wangle
-Version: 2019.07.08.00
+Version: 2019.07.08.00-1
 Build-Depends: fizz, folly, openssl, glog, libevent, double-conversion, boost-system, boost-thread, boost-filesystem, boost-regex, boost-context
 Description: Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.

--- a/ports/wangle/fix-config-cmake.patch
+++ b/ports/wangle/fix-config-cmake.patch
@@ -9,11 +9,11 @@ index e50af54..a16cdbb 100644
 -set_and_check(WANGLE_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_DIR@")
 +set_and_check(WANGLE_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/share/wangle")
 +
-+find_package(folly REQUIRED)
-+find_package(fizz REQUIRED)
++find_package(folly CONFIG REQUIRED)
++find_package(fizz CONFIG REQUIRED)
 +find_package(glog REQUIRED)
-+find_package(threads REQUIRED)
-+find_package(libevent REQUIRED)
++find_package(Threads REQUIRED)
++find_package(Libevent CONFIG REQUIRED)
  
  if (NOT TARGET wangle::wangle)
    include("${WANGLE_CMAKE_DIR}/wangle-targets.cmake")


### PR DESCRIPTION
Re-fix `fizz-config.cmake.in` to match vcpkg.

Related: #8766.