### PR TITLE
[matroska]Fix matroska-config.cmake.in.

### DIFF
--- a/ports/matroska/CONTROL
+++ b/ports/matroska/CONTROL
@@ -1,5 +1,5 @@
 Source: matroska
-Version: 1.5.2
+Version: 1.5.2-1
 Homepage: https://github.com/Matroska-Org/libmatroska
 Description: a C++ libary to parse Matroska files (.mkv and .mka)
 Build-Depends: ebml

--- a/ports/matroska/fix-config-cmake.patch
+++ b/ports/matroska/fix-config-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/MatroskaConfig.cmake.in b/MatroskaConfig.cmake.in
+index 924fa51..88c72f5 100644
+--- a/MatroskaConfig.cmake.in
++++ b/MatroskaConfig.cmake.in
+@@ -1,7 +1,7 @@
+ @PACKAGE_INIT@
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(EBML REQUIRED)
++find_dependency(EBML CONFIG REQUIRED)
+ 
+ include(${CMAKE_CURRENT_LIST_DIR}/MatroskaTargets.cmake)
+ 

--- a/ports/matroska/portfile.cmake
+++ b/ports/matroska/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     REF release-1.5.2
     SHA512  5e819d611455efb1dd49ea26b6b124899b1f6ba07b4af93b2f3437ffe7c2c0089a922ef894a7c8612faddadeea75142d0604ee54e6c5822439dc8c65008e119b
     HEAD_REF master
+    PATCHES fix-config-cmake.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Fix `matroska-config.cmake.in` to match vcpkg.