### PR TITLE
[sol2] Use the single header release

### DIFF
--- a/ports/sol2/CONTROL
+++ b/ports/sol2/CONTROL
@@ -1,5 +1,5 @@
 Source: sol2
-Version: 3.0.3-1
+Version: 3.0.3-2
 Homepage: https://github.com/ThePhD/sol2
 Description: Sol v2.0 - a C++ <-> Lua API wrapper with advanced features and top notch performance - is here, and it's great
 Build-Depends: lua (windows)

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -6,18 +6,8 @@ vcpkg_from_github(
     REF v3.0.3
     SHA512 8c8f36eaedb76863106ecd24543b82c76a2fac15e86bfaf0e724b726e89d4238adf9eea8abefe0add5ee17e45b1a73ee24496f691b79c15dca85e2cfde8762b4
     HEAD_REF develop
-    PATCHES fix-namespace.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-)
+file(INSTALL ${SOURCE_PATH}/single/include/sol DESTINATION ${CURRENT_PACKAGES_DIR}/include/)
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sol2)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
-
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sol2 RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -19,8 +19,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sol2)
 
 file(
     REMOVE_RECURSE
-        ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib
-        ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/include
+        ${CURRENT_PACKAGES_DIR}/debug
+        ${CURRENT_PACKAGES_DIR}/lib
+        ${CURRENT_PACKAGES_DIR}/include
 )
 
 file(INSTALL ${SOURCE_PATH}/single/include/sol DESTINATION ${CURRENT_PACKAGES_DIR}/include/)

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -6,6 +6,21 @@ vcpkg_from_github(
     REF v3.0.3
     SHA512 8c8f36eaedb76863106ecd24543b82c76a2fac15e86bfaf0e724b726e89d4238adf9eea8abefe0add5ee17e45b1a73ee24496f691b79c15dca85e2cfde8762b4
     HEAD_REF develop
+    PATCHES fix-namespace.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sol2)
+
+file(
+    REMOVE_RECURSE
+        ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib
+        ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/include
 )
 
 file(INSTALL ${SOURCE_PATH}/single/include/sol DESTINATION ${CURRENT_PACKAGES_DIR}/include/)


### PR DESCRIPTION
Using the single header release of sol2 is easier, faster to 'build', and is recommended by the documentation. It also fix the duplicated include folder issue of the previous port : <sol/sol/sol.hpp> can now be replaced with <sol/sol.hpp> as it should be.

Is there any drawback about using the single header release that I am not seing?