### PR TITLE
[spdlog]Update  to 1.4.2

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,5 +1,5 @@
 Source: spdlog
-Version: 1.3.1-2
+Version: 1.4.2
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/disable-master-project-check.patch
+++ b/ports/spdlog/disable-master-project-check.patch
@@ -1,17 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e1d9656..f8cb60c 100644
+index 12320fb..70f611b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -46,9 +46,9 @@ add_library(spdlog::spdlog ALIAS spdlog)
+@@ -33,13 +33,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ # Set SPDLOG_MASTER_PROJECT to ON if we are building spdlog
+ #---------------------------------------------------------------------------------------
+ # Check if spdlog is being used directly or via add_subdirectory, but allow overriding
+-if (NOT DEFINED SPDLOG_MASTER_PROJECT)
+-    if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+-        set(SPDLOG_MASTER_PROJECT ON)
+-    else()
+-        set(SPDLOG_MASTER_PROJECT OFF)
+-    endif()
+-endif ()
++set(SPDLOG_MASTER_PROJECT OFF)
  
- # Check if spdlog is being used directly or via add_subdirectory
- set(SPDLOG_MASTER_PROJECT OFF)
--if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
--  set(SPDLOG_MASTER_PROJECT ON)
--endif()
-+#if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-+#  set(SPDLOG_MASTER_PROJECT ON)
-+#endif()
- 
- option(SPDLOG_BUILD_EXAMPLES "Build examples" ${SPDLOG_MASTER_PROJECT})
- option(SPDLOG_BUILD_BENCH "Build benchmarks" ${SPDLOG_MASTER_PROJECT})
+ # build shared option
+ if(NOT WIN32)

--- a/ports/spdlog/fix-error-4275.patch
+++ b/ports/spdlog/fix-error-4275.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cd17178..c9910e1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -126,6 +126,10 @@ if(SPDLOG_FMT_EXTERNAL)
+ 
+     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)
+     target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
++    
++    if (MSVC)
++        add_compile_options(/wd4275)
++    endif()
+ 
+     set(PKG_CONFIG_REQUIRES fmt) # add dependecy to pkg-config
+ endif()

--- a/ports/spdlog/fix-error-4275.patch
+++ b/ports/spdlog/fix-error-4275.patch
@@ -8,7 +8,7 @@ index cd17178..c9910e1 100644
      target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
 +    
 +    if (WIN32)
-+        add_compile_options(/wd4275)
++        target_compile_options(spdlog PRIVATE /wd4275)
 +    endif()
  
      set(PKG_CONFIG_REQUIRES fmt) # add dependecy to pkg-config

--- a/ports/spdlog/fix-error-4275.patch
+++ b/ports/spdlog/fix-error-4275.patch
@@ -7,7 +7,7 @@ index cd17178..c9910e1 100644
      target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)
      target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
 +    
-+    if (MSVC)
++    if (WIN32)
 +        add_compile_options(/wd4275)
 +    endif()
  

--- a/ports/spdlog/fix-feature-export.patch
+++ b/ports/spdlog/fix-feature-export.patch
@@ -1,9 +1,9 @@
 diff --git a/bench/CMakeLists.txt b/bench/CMakeLists.txt
-index 3c4a3f9..3bc3813 100644
+index d087cf6..86483db 100644
 --- a/bench/CMakeLists.txt
 +++ b/bench/CMakeLists.txt
-@@ -46,3 +46,8 @@ add_executable(formatter-bench formatter-bench.cpp)
- target_link_libraries(formatter-bench PRIVATE benchmark::benchmark spdlog::spdlog Threads::Threads)
+@@ -26,3 +26,8 @@ add_executable(formatter-bench formatter-bench.cpp)
+ target_link_libraries(formatter-bench PRIVATE benchmark::benchmark spdlog::spdlog)
  
  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
 +

--- a/ports/spdlog/fix-uwp.patch
+++ b/ports/spdlog/fix-uwp.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 35425db..28c555a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -128,7 +128,7 @@ if(SPDLOG_FMT_EXTERNAL)
+     target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
+     
+     if (WIN32)
+-        target_compile_options(spdlog PRIVATE /wd4275)
++        target_compile_options(spdlog PRIVATE /wd4275 /wd4100)
+     endif()
+ 
+     set(PKG_CONFIG_REQUIRES fmt) # add dependecy to pkg-config
+diff --git a/include/spdlog/details/os-inl.h b/include/spdlog/details/os-inl.h
+index f436b0d..82f3510 100644
+--- a/include/spdlog/details/os-inl.h
++++ b/include/spdlog/details/os-inl.h
+@@ -128,7 +128,7 @@ SPDLOG_INLINE void prevent_child_fd(FILE *f)
+ {
+ 
+ #ifdef _WIN32
+-#if !defined(__cplusplus_winrt)
++#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+     auto file_handle = reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(f)));
+     if (!::SetHandleInformation(file_handle, HANDLE_FLAG_INHERIT, 0))
+         SPDLOG_THROW(spdlog_ex("SetHandleInformation failed", errno));

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -1,6 +1,3 @@
-#header-only library
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog
@@ -36,9 +33,6 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
-
 # use vcpkg-provided fmt library (see also option SPDLOG_FMT_EXTERNAL above)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/bundled)
 
@@ -52,7 +46,9 @@ vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/ostr.h
     "#if 0 // !defined(SPDLOG_FMT_EXTERNAL)"
 )
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/spdlog
+                    ${CURRENT_PACKAGES_DIR}/debug/lib/spdlog
+                    ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spdlog)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/spdlog/LICENSE ${CURRENT_PACKAGES_DIR}/share/spdlog/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         disable-master-project-check.patch
         fix-feature-export.patch
+        fix-error-4275.patch
 )
 
 set(SPDLOG_USE_BENCHMARK OFF)

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog
-    REF v1.3.1
-    SHA512 a851a44b6384f493dd312ae0a611d068af46bbfe8daf1c2f61f13d8836a3801f41b339074fbe8da8e428131c82fa5c4a9e3320a55cbdd4b7aff8bb349dfff7dd
+    REF 1549ff12f1aa61ffc4d9a8727c519034724392a0 #v1.4.2
+    SHA512 c159aea475baecad0a5a9eef965856203c96aa855b0480e82d751bcc050c6e08bb0aa458544da061f5d744e17dcd27bd9b6e31a62d502834f02d3591f29febec
     HEAD_REF v1.x
     PATCHES
         disable-master-project-check.patch
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DSPDLOG_FMT_EXTERNAL=ON
         -DSPDLOG_BUILD_BENCH=${SPDLOG_USE_BENCHMARK}
+        -DSPDLOG_INSTALL=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "UWP")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog
@@ -10,6 +8,7 @@ vcpkg_from_github(
         disable-master-project-check.patch
         fix-feature-export.patch
         fix-error-4275.patch
+        fix-uwp.patch
 )
 
 set(SPDLOG_USE_BENCHMARK OFF)


### PR DESCRIPTION
Related to spdlog [homepage](https://github.com/gabime/spdlog):
> Very fast, header-only/compiled, C++ logging library.

It can be a compiled or header only.

Since spdlog uses the function `SetHandleInformation`, this feature can only be used in desktop applications[1], so I think spdlog no longer supports uwp.

Related: #8786.

Note: all features test pass with following triplets:
- x86-windows
- x64-windows
- x64-windows-static

[1]. MSDN [documentation](https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-sethandleinformation).