### PR TITLE
[angle] Add option /bigobj to compiler

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 endif()
 
 if(MSVC)
-    add_compile_options(/d2guard4 /Wv:18 /guard:cf /permissive)
+    add_compile_options(/d2guard4 /Wv:18 /guard:cf /permissive /bigobj)
 else()
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/ports/angle/CONTROL
+++ b/ports/angle/CONTROL
@@ -1,5 +1,5 @@
 Source: angle
-Version: 2019-07-19-2
+Version: 2019-07-19-3
 Homepage: https://github.com/google/angle
 Description: A conformant OpenGL ES implementation for Windows, Mac and Linux.
   The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support.


### PR DESCRIPTION
Add option /bigobj to compiler. Related issue: #8775
There are no features of this port need to test.