### PR TITLE
[Libtomcrypt, libtommath] Add new port

### DIFF
--- a/ports/libtomcrypt/CONTROL
+++ b/ports/libtomcrypt/CONTROL
@@ -1,0 +1,4 @@
+Source: libtomcrypt
+Version: 1.18.2
+Description: LibTomCrypt is a fairly comprehensive, modular and portable cryptographic toolkit that provides developers with a vast array of well known published block ciphers, one-way hash functions, chaining modes, pseudo-random number generators, public key cryptography and a plethora of other routines. https://www.libtom.net
+Build-Depends: libtommath

--- a/ports/libtomcrypt/portfile.cmake
+++ b/ports/libtomcrypt/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtom/libtomcrypt

--- a/ports/libtomcrypt/portfile.cmake
+++ b/ports/libtomcrypt/portfile.cmake
@@ -33,7 +33,7 @@ vcpkg_execute_build_process(
 
 #Release Build
 vcpkg_execute_build_process(
-    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc EXTRALIBS="/Release" CFLAGS="/Ox /DUSE_LTM /DLTM_DESC /I${CURRENT_PACKAGES_DIR}/.."
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc CFLAGS="/Ox /DUSE_LTM /DLTM_DESC /I${CURRENT_PACKAGES_DIR}/.."
     WORKING_DIRECTORY ${SOURCE_PATH}
 )
 

--- a/ports/libtomcrypt/portfile.cmake
+++ b/ports/libtomcrypt/portfile.cmake
@@ -1,0 +1,55 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libtom/libtomcrypt
+    REF v1.18.2
+    SHA512 53accb4f92077ff1c52102bece270e77c497e599c392aa0bf4dbc173b6789e7e4f1012d8b5f257c438764197cb7bac8ba409a9d4e3a70e69bec5863b9495329e
+    HEAD_REF master
+)
+
+# Make sure we start from a clean slate
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc clean
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+#Debug Build
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc CFLAGS="/MTd /DUSE_LTM /DLTM_DESC /I${CURRENT_PACKAGES_DIR}/.."
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/tomcrypt.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/Debug/lib/
+)
+
+# Clean up necessary to rebuild without debug symbols
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc clean
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+#Release Build
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc EXTRALIBS="/Release" CFLAGS="/Ox /DUSE_LTM /DLTM_DESC /I${CURRENT_PACKAGES_DIR}/.."
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/tomcrypt.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib/
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/src/headers/
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+
+#Copy license
+file(
+    INSTALL 
+    ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/libtomcrypt/ RENAME copyright
+)

--- a/ports/libtommath/CONTROL
+++ b/ports/libtommath/CONTROL
@@ -1,0 +1,3 @@
+Source: libtommath
+Version: 1.2.0
+Description: LibTomMath is a free open source portable number theoretic multiple-precision integer library written entirely in C. https://www.libtom.net

--- a/ports/libtommath/portfile.cmake
+++ b/ports/libtommath/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtom/libtommath

--- a/ports/libtommath/portfile.cmake
+++ b/ports/libtommath/portfile.cmake
@@ -1,0 +1,52 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO libtom/libtommath
+    REF v1.2.0
+    SHA512 500bce4467d6cdb0b014e6c66d3b994a8d63b51475db6c3cd77c15c8368fbab4e3b5c458fcd5b35838b74c457a33c15b42d2356964f5ef2a0bd31fd544735c9a
+    HEAD_REF master
+)
+
+# Make sure we start from a clean slate
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc clean
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+#Debug Build
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc CFLAGS="/MTd"
+    WORKING_DIRECTORY ${SOURCE_PATH}/
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/tommath.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/Debug/lib
+)
+
+# Clean up necessary to rebuild without debug symbols
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc clean
+    WORKING_DIRECTORY ${SOURCE_PATH}
+)
+
+vcpkg_execute_build_process(
+    COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc
+    WORKING_DIRECTORY ${SOURCE_PATH}/
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/tommath.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/tommath.h
+    DESTINATION ${CURRENT_PACKAGES_DIR}/include
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/libtommath/copyright
+)


### PR DESCRIPTION
I added libtommath and libtomcrypt.

I tried updating the solution file  to be a newer version so it could be build with the `vcpkg_build_msbuild` command. However I was advised to use the existing `makefile.msvc` instead using `nmake` ( see https://github.com/libtom/libtomcrypt/pull/517 ).

I made it build by inelegantly including `${CURRENT_PACKAGES_DIR}/..` - what is the solution for elegantly including the currently built libraries?

I ran into some issues with the approach, namely building a debug version (still not sure I'm doing that right) and building for x64 (unsolved as of yet). Additionally, I'm not completely sure how to go about building for linux and filtering correctly on the triplets. 

Instead of just giving up and concluding that it's too much work to get non-cmake/msbuild packages to work with vcpkg I figured it would upload what I have now to get some feedback on how to proceed.