### PR TITLE
[qt5] Modify qtdeploy to include qtquickshapes

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.5-1
+Version: 5.12.5-2
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/qtdeploy.ps1
+++ b/ports/qt5-base/qtdeploy.ps1
@@ -69,7 +69,7 @@ function deployPluginsIfQt([string]$targetBinaryDir, [string]$QtPluginsDir, [str
             }
         }
     } elseif ($targetBinaryName -match "Qt5Quickd?.dll") {
-        foreach ($a in @("Qt5QuickControls2", "Qt5QuickControls2d", "Qt5QuickTemplates2", "Qt5QuickTemplates2d"))
+        foreach ($a in @("Qt5QuickControls2", "Qt5QuickControls2d", "Qt5QuickShapes", "Qt5QuickShapesd", "Qt5QuickTemplates2", "Qt5QuickTemplates2d"))
         {
             if (Test-Path "$binDir\$a.dll")
             {


### PR DESCRIPTION
Qt 5.10 introduced the QtQuick.Shapes module. The qtdeploy tool copies the QML plugin (`qmlshapesplugin.dll`) into the build directory, but a second required dll (`Qt5QuickShapes.dll`) is not copied over.

This change adds this missing dll to  the list of QtQuick-associated dlls to deploy.