### PR TITLE
[asio]Upgrade to v1.14.0

### DIFF
--- a/ports/asio/CONTROL
+++ b/ports/asio/CONTROL
@@ -1,4 +1,4 @@
 Source: asio
-Version: 1.12.2-2
+Version: 1.14.0
 Homepage: https://github.com/chriskohlhoff/asio
 Description: Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -1,11 +1,9 @@
 #header-only library
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO chriskohlhoff/asio
-    REF asio-1-12-2
-    SHA512 7c2e213ff154bb2e5776b37906d437a62206f973316c94706e6d42e3c2f0866e7d97f3e40225ab5f28bf2c4a33fa0b38a4b75421aef86ddf9f2da0811caa2d00
+    REF 8d4c8c3ce43c866f609d2eda9a43fe5b334620be # asio-1-14-0
+    SHA512 ab79d68a4c77758d47c7bda510edc054d72086926967ea9773a7ff2005add94e2efa2eedd9f90b2dba55ef81e510dcd6b7326bcd5b27a18f364b6283b199e559
     HEAD_REF master
 )
 
@@ -25,7 +23,7 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH "share/asio")
 file(INSTALL
     ${CMAKE_CURRENT_LIST_DIR}/asio-config.cmake
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/asio/
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/asio
 )
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 


### PR DESCRIPTION
Due to asio upgrade to 1.14.0, some functions are deprecated, this cause some ports build failure.