### PR TITLE
[cgl] Fix cgl cannot be found

### DIFF
--- a/ports/cgl/CMakeLists.txt
+++ b/ports/cgl/CMakeLists.txt
@@ -23,24 +23,9 @@ foreach(p LIB BIN INCLUDE CMAKE)
   endif()
 endforeach()
 
-if(MSVC)
-  set(
-    CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} /bigobj /MP /wd4996 /wd4819 /wd4251 /wd4267 /wd4244 /wd4275"
-    )
-endif()
-
-if(APPLE)
-  set(
-    CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override -Wno-unused-command-line-argument -Wno-unused-result -Wno-exceptions"
-    )
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9"
-      CACHE STRING "Minimum OS X deployment version")
-endif()
-
 find_package(CoinUtils REQUIRED)
 find_package(Osi REQUIRED)
+find_package(Clp REQUIRED)
 
 file(GLOB CGL_SOURCES
           Cgl/src/CglConfig.h
@@ -100,13 +85,10 @@ target_include_directories(${PROJECT_NAME}
                            $<INSTALL_INTERFACE:${RELATIVE_INSTALL_INCLUDE_DIR}>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Cgl/src/>)
 
-if(MSVC)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
-endif()
 target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_CMATH)
 target_compile_definitions(${PROJECT_NAME} PUBLIC COIN_HAS_CLP)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Coin::CoinUtils Coin::Osi)
+target_link_libraries(${PROJECT_NAME} PRIVATE Coin::CoinUtils Coin::Osi Coin::Clp)
 
 install(DIRECTORY Cgl/src/
         DESTINATION ${INSTALL_INCLUDE_DIR}

--- a/ports/cgl/CONTROL
+++ b/ports/cgl/CONTROL
@@ -1,5 +1,5 @@
 Source: cgl
-Version: 0.60.2-1
+Version: 0.60.2-2
 Homepage: https://github.com/coin-or/Cgl
 Description: The COIN-OR Cut Generation Library (Cgl) is a collection of cut generators that can be used with other COIN-OR packages that make use of cuts, such as, among others, the linear solver Clp or the mixed integer linear programming solvers Cbc or BCP.
 Build-Depends: coinutils, osi, clp

--- a/ports/cgl/portfile.cmake
+++ b/ports/cgl/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO coin-or/Cgl
-    REF releases/0.60.2
-    SHA512 86db94638d586d2fb64cb55f72197f847731c710351168189647686c5229555c79bc411044ab1cc789a520577de2be3c2e8611221d743f9dbaabb71544d0fa66
+    REF 6377b88754fafacf24baac28bb27c0623cc14457
+    SHA512 7579a89f945fd3b88cc1f0dd95906c385b5c730b58bd620ea8b820926096256f9083f50dd4e70f71d69432e4d0ffc60b4ec8fa517893a549621d8373f944a1bb
     PATCHES fix-c1083-error.patch
 )
 
@@ -19,6 +17,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets()
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
When building cbc, we found that cgl cannot be found.

```
CMake Error at C:/vsts/_work/1/s/installed/x64-uwp/share/cgl/CglTargets.cmake:74 (message):
The imported target "Coin::Cgl" references the file

 "C:/vsts/_work/1/s/packages/cgl_x64-uwp/lib/Cgl.lib"
```
Fix #7850
No feature need to test.