### PR TITLE
[cpd] Add new port

### DIFF
--- a/ports/cpd/CONTROL
+++ b/ports/cpd/CONTROL
@@ -1,0 +1,5 @@
+Source: cpd
+Version: 2019-03-26
+Homepage: https://github.com/gadomski/cpd
+Description: Coherent Point Drift (CPD) is a point-set registration algorithm, originally developed by Andriy Myronenko et al. This is a C++ library that runs CPD.
+Build-Depends: eigen3

--- a/ports/cpd/Fix-FindJsoncpp.patch
+++ b/ports/cpd/Fix-FindJsoncpp.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ab282f4..5319d17 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -118,6 +118,5 @@ endif()
+ find_package(jsoncpp QUIET)
+ option(WITH_JSONCPP "Build with jsoncpp" ${jsoncpp_FOUND})
+ if(WITH_JSONCPP)
+-    find_package(jsoncpp REQUIRED)
+-    add_subdirectory(components/jsoncpp)
++    find_package(jsoncpp CONFIG REQUIRED)
+ endif()

--- a/ports/cpd/portfile.cmake
+++ b/ports/cpd/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(ON_LIBRARY_LINKAGE "dynamic")
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/cpd/portfile.cmake
+++ b/ports/cpd/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_fail_port_install(ON_LIBRARY_LINKAGE "dynamic")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gadomski/cpd
+    REF 1f3637e96f755957eab529c7eb15334f04fb6d19 #version 0.5.1 commit on 2019.03.26
+    SHA512 349edb7995a8790736465b0b56c5e7bd3167b7cd54ac8f07e62a238e2638f43c30c0a11aae289dac005a2840c8440158c1f2bda10b14e2fbaee82dfaf34525ae
+    HEAD_REF master
+    PATCHES 
+        Fix-FindJsoncpp.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+    


### PR DESCRIPTION
Due to there are no `dllexport` in source code, port cpd only support build static library.
There are no features of this port need to test.