### PR TITLE
new port: sqlpp11-connector-postgresql

### DIFF
--- a/ports/sqlpp11-connector-postgresql/CONTROL
+++ b/ports/sqlpp11-connector-postgresql/CONTROL
@@ -1,0 +1,4 @@
+Source: sqlpp11-connector-postgresql
+Version: 0.54
+Description: A C++ wrapper for PostgreSQL meant to be used in combination with sqlpp11.
+Build-Depends: libpqxx, sqlpp11

--- a/ports/sqlpp11-connector-postgresql/portfile.cmake
+++ b/ports/sqlpp11-connector-postgresql/portfile.cmake
@@ -1,0 +1,28 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO matthijs/sqlpp11-connector-postgresql
+    REF v0.54
+    SHA512 0d26dc80e6e7d9f13e95c6aaf9b7550aa86298010e4ddd35af6cc43eed315da78eb343034691117583140be393da7af6e7c53b4e429db37023171159d79dcb7c
+    HEAD_REF master
+)
+
+# Use sqlpp11-connector-postgresql's own build process, skipping tests
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DENABLE_TESTS:BOOL=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/sqlpp-connector-postgresql")
+
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sqlpp11-connector-postgresql RENAME copyright)

--- a/ports/sqlpp11/ddl2cpp_path.patch
+++ b/ports/sqlpp11/ddl2cpp_path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Sqlpp11Config.cmake b/cmake/Sqlpp11Config.cmake
+index 720fef2..d8f93b8 100644
+--- a/cmake/Sqlpp11Config.cmake
++++ b/cmake/Sqlpp11Config.cmake
+@@ -34,7 +34,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp11Targets.cmake")
+ if(TARGET sqlpp11::ddl2cpp)
+   message(FATAL_ERROR "Target sqlpp11::ddl2cpp already defined")
+ endif()
+-get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
++get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp11-ddl2cpp" REALPATH)
+ if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
+   message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
+ endif()

--- a/ports/sqlpp11/portfile.cmake
+++ b/ports/sqlpp11/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 0.58
     SHA512 c391e72638a748e0e25b53176dc371ba468bc14bdcb6dda2f2418c4ab4d620ebc5507ee284ff81c3104888d0d959703c6c91b55ccd69a8641b07dcb20cd56209
     HEAD_REF master
+    PATCHES ddl2cpp_path.patch
 )
 
 # Use sqlpp11's own build process, skipping tests

--- a/ports/sqlpp11/portfile.cmake
+++ b/ports/sqlpp11/portfile.cmake
@@ -19,7 +19,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 # Move CMake config files to the right place
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Sqlpp11 TARGET_PATH share/sqlpp11)
+
 
 # Delete redundant and unnecessary directories
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)


### PR DESCRIPTION
A C++ wrapper for PostgreSQL meant to be used in combination with sqlpp11. Plus a fix to sqlpp11 port.
