### PR TITLE
[sqlpp11] fixed ddl2cpp path

### DIFF
--- a/ports/sqlpp11/CONTROL
+++ b/ports/sqlpp11/CONTROL
@@ -1,4 +1,4 @@
 Source: sqlpp11
-Version: 0.58-2
+Version: 0.58-3
 Description: A type safe embedded domain specific language for SQL queries and results in C++.
 Build-Depends: date

--- a/ports/sqlpp11/ddl2cpp_path.patch
+++ b/ports/sqlpp11/ddl2cpp_path.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/Sqlpp11Config.cmake b/cmake/Sqlpp11Config.cmake
+index 720fef2..d8f93b8 100644
+--- a/cmake/Sqlpp11Config.cmake
++++ b/cmake/Sqlpp11Config.cmake
+@@ -34,7 +34,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp11Targets.cmake")
+ if(TARGET sqlpp11::ddl2cpp)
+   message(FATAL_ERROR "Target sqlpp11::ddl2cpp already defined")
+ endif()
+-get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
++get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../scripts/sqlpp11-ddl2cpp" REALPATH)
+ if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
+   message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
+ endif()

--- a/ports/sqlpp11/portfile.cmake
+++ b/ports/sqlpp11/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 0.58
     SHA512 c391e72638a748e0e25b53176dc371ba468bc14bdcb6dda2f2418c4ab4d620ebc5507ee284ff81c3104888d0d959703c6c91b55ccd69a8641b07dcb20cd56209
     HEAD_REF master
+    PATCHES ddl2cpp_path.patch
 )
 
 # Use sqlpp11's own build process, skipping tests
@@ -19,7 +20,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 # Move CMake config files to the right place
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Sqlpp11 TARGET_PATH share/sqlpp11)
+
 
 # Delete redundant and unnecessary directories
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)


### PR DESCRIPTION
Need that to get new port compiled, sqlpp11-connector-postgresql. There are two dependencies for sqlpp11: sqlpp11-connector-mysql and sqlpp11-connector-sqlite3 and they build fine after patch.