### PR TITLE
[redis-plus-plus] Add new port

### DIFF
--- a/ports/redis-plus-plus/CONTROL
+++ b/ports/redis-plus-plus/CONTROL
@@ -1,0 +1,5 @@
+Source: redis-plus-plus
+Version: 1.1.1
+Homepage: https://github.com/sewenew/redis-plus-plus
+Description: This is a C++ client for Redis. It's based on hiredis, and written in C++ 11.
+Build-Depends: hiredis

--- a/ports/redis-plus-plus/disable-build-test.patch
+++ b/ports/redis-plus-plus/disable-build-test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fb160b5..6235d89 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,7 +34,7 @@ set_target_properties(${SHARED_LIB} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+ set_target_properties(${STATIC_LIB} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+ set_target_properties(${SHARED_LIB} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+ 
+-add_subdirectory(test)
++#add_subdirectory(test)
+ 
+ # Install static lib.
+ install(TARGETS ${STATIC_LIB}

--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_fail_port_install(ON_TARGET "Windows")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO sewenew/redis-plus-plus
+    REF d35267580568517f09bdf70cb582e5284c25401a 
+    SHA512 f065b97d438772300e30485a7550bc0fff00005f1056cf9c23216ea388fa088303869ccf2eaa70ee8b06cc0fc2406c9c6faddd5ad08759ee2d0665ac91761914
+    HEAD_REF master
+    PATCHES disable-build-test.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJIA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright )


### PR DESCRIPTION
This is a C++ client for Redis. It's based on hiredis, and written in C++ 11.
It depends on hiredis, the related PR #8845. 
Since  hiredis only supports dynamic build on Unix. 
redis-plus-plus only supports Unix too.

When building test, it needs `find_library(HIREDIS_STATIC_LIB libhiredis.a)`, so I disable test now.

Related issue #8840.

Note: this port doesn't contain any feature.