### PR TITLE
[ecsuti] Update to v1.0.7.8

### DIFF
--- a/ports/ecsutil/CONTROL
+++ b/ports/ecsutil/CONTROL
@@ -1,4 +1,5 @@
 Source: ecsutil
-Version: 1.0.7.3
+Version: 1.0.7.8
+Homepage: https://github.com/EMCECS/ecs-object-client-windows-cpp
 Description: Native Windows SDK for accessing ECS via the S3 HTTP protocol.
 Build-Depends: atlmfc (windows)

--- a/ports/ecsutil/portfile.cmake
+++ b/ports/ecsutil/portfile.cmake
@@ -28,8 +28,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO EMCECS/ecs-object-client-windows-cpp
-    REF v1.0.7.3
-    SHA512 b678a784f26c8ac5fdac6f2be2c7fe2a2e1b0152d5cc21e629a077fce8dd9a72db46a348e4024a31273d45833f002a7823957295ec74392500ba069e8da8555d
+    REF v1.0.7.8
+    SHA512 33b15e16e8568db57a670c91e77b7624e3b70e02e18a8b337f4967b3aca4a36d3f6d87ddab60720a93fb5a4798948ec264eb273d8f31fb7e4bf4a86c1e89579a
     HEAD_REF master
 )
 


### PR DESCRIPTION
1. Ecsuti installation failed with fatal error C1083: Cannot open include file: 'typeinfo.h': No such file or directory, this is a by design issue, more detail please see [here](https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#standard-library-improvements-1).
2. This issue has been fixed in the latest release, so update version for this port.
3. This port has no additional features to test. 