### PR TITLE
[libffi] Add libffiConfigVersion.cmake file

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -132,7 +132,14 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
      "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
      INSTALL_DESTINATION share/${PROJECT_NAME})
+# Disable check for same 32/64bit-ness in libffiConfigVersion.cmake by setting CMAKE_SIZEOF_VOID_P
+set (CMAKE_SIZEOF_VOID_P "")
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${VERSION}
+    COMPATIBILITY AnyNewerVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
     DESTINATION share/${PROJECT_NAME})
 install(EXPORT ${PROJECT_NAME}Targets
     DESTINATION share/${PROJECT_NAME})

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,4 +1,4 @@
 Source: libffi
-Version: 3.1-6
+Version: 3.1-7
 Homepage: https://github.com/libffi/libffi
 Description: Portable, high level programming interface to various calling conventions


### PR DESCRIPTION
Use `write_basic_package_version_file()` to create the
**`libffiConfigVersion.cmake`** file.
This allows detection of the libffi version using cmake.
An example, where this is relevant is e.g. glib 2.62, with the
following code in **`meson.build`**:
  `libffi_dep = dependency('libffi', version : '>= 3.0.0',`
  `fallback : ['libffi', 'ffi_dep'])`

When the **`libffiConfigVersion.cmake`** file is present, the following output
can be found in the meson-build.log:
```console  
Run-time dependency libffi found: YES 3.1
```
