### PR TITLE
[hiredis] Support static build on Windows

### DIFF
--- a/ports/hiredis/CONTROL
+++ b/ports/hiredis/CONTROL
@@ -1,5 +1,5 @@
 Source: hiredis
-Version: 2019-11-5
+Version: 2019-11-1-1
 Homepage: https://github.com/redis/hiredis
 Description: Hiredis is a minimalistic C client library for the Redis database.
 

--- a/ports/hiredis/CONTROL
+++ b/ports/hiredis/CONTROL
@@ -9,3 +9,4 @@ Build-Depends: openssl
 
 Feature: example
 Description: Build example
+Build-Depends: glib, libevent

--- a/ports/hiredis/CONTROL
+++ b/ports/hiredis/CONTROL
@@ -1,5 +1,5 @@
 Source: hiredis
-Version: 2019-11-1
+Version: 2019-11-5
 Homepage: https://github.com/redis/hiredis
 Description: Hiredis is a minimalistic C client library for the Redis database.
 

--- a/ports/hiredis/fix-example-install.patch
+++ b/ports/hiredis/fix-example-install.patch
@@ -15,7 +15,7 @@ index dd3a313..6287794 100644
 -    LINK_DIRECTORIES(${GLIB2_LIBRARY_DIRS})
      ADD_EXECUTABLE(example-glib example-glib.c)
 -    TARGET_LINK_LIBRARIES(example-glib hiredis ${GLIB2_LIBRARIES})
-+    TARGET_LINK_LIBRARIES(example-glib PUBLIC hiredis ${GLIB2_LIBRARIES})
++    TARGET_LINK_LIBRARIES(example-glib PRIVATE hiredis ${GLIB2_LIBRARIES})
 +    if (UNIX)
 +        FIND_PACKAGE(Threads REQUIRED)
 +        TARGET_LINK_LIBRARIES(example-glib PRIVATE Threads::Threads)

--- a/ports/hiredis/fix-example-install.patch
+++ b/ports/hiredis/fix-example-install.patch
@@ -1,40 +1,36 @@
 diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
-index dd3a313..7b79b2a 100644
+index dd3a313..6287794 100644
 --- a/examples/CMakeLists.txt
 +++ b/examples/CMakeLists.txt
-@@ -1,13 +1,16 @@
+@@ -1,12 +1,17 @@
 -INCLUDE(FindPkgConfig)
  # Check for GLib
  
 -PKG_CHECK_MODULES(GLIB2 glib-2.0)
--if (GLIB2_FOUND)
--    INCLUDE_DIRECTORIES(${GLIB2_INCLUDE_DIRS})
++FIND_LIBRARY(GLIB2_LIBRARIES NAMES glib-2.0)
++FIND_PATH(GLIB2_INCLUDE_DIRS glib.h)
++SET(GLIB2_FOUND ${GLIB2_LIBRARIES})
+ if (GLIB2_FOUND)
+     INCLUDE_DIRECTORIES(${GLIB2_INCLUDE_DIRS})
 -    LINK_DIRECTORIES(${GLIB2_LIBRARY_DIRS})
--    ADD_EXECUTABLE(example-glib example-glib.c)
+     ADD_EXECUTABLE(example-glib example-glib.c)
 -    TARGET_LINK_LIBRARIES(example-glib hiredis ${GLIB2_LIBRARIES})
--ENDIF(GLIB2_FOUND)
-+IF(0)
-+    FIND_LIBRARY(GLIB_LIBRARY NAMES glib-2.0)
-+    FIND_PATH(GLIB_INCLUDE_DIR glib.h)
-+    SET(GLIB_FOUND ${GLIB_LIBRARY})
-+    IF(GLIB_FOUND)
-+        INCLUDE_DIRECTORIES(${GLIB_INCLUDE_DIR})
-+        ADD_EXECUTABLE(example-glib example-glib.c)
-+        TARGET_LINK_LIBRARIES(example-glib hiredis ${GLIB_LIBRARY})
-+        INSTALL(TARGETS example-glib RUNTIME DESTINATION tools)
-+    ENDIF()
-+ENDIF()
++    TARGET_LINK_LIBRARIES(example-glib PUBLIC hiredis ${GLIB2_LIBRARIES})
++    if (UNIX)
++        FIND_PACKAGE(Threads REQUIRED)
++        TARGET_LINK_LIBRARIES(example-glib PRIVATE Threads::Threads)
++    endif()
++    INSTALL(TARGETS example-glib RUNTIME DESTINATION tools)
+ ENDIF(GLIB2_FOUND)
  
  FIND_PATH(LIBEV ev.h
-     HINTS /usr/local /usr/opt/local
-@@ -17,30 +20,45 @@ if (LIBEV)
+@@ -17,30 +22,44 @@ if (LIBEV)
      # Just compile and link with libev
      ADD_EXECUTABLE(example-libev example-libev.c)
      TARGET_LINK_LIBRARIES(example-libev hiredis ev)
 +    INSTALL(TARGETS example-libev RUNTIME DESTINATION tools)
  ENDIF()
  
-+
 +FIND_PACKAGE(Libevent CONFIG REQUIRED)
  FIND_PATH(LIBEVENT event.h)
  if (LIBEVENT)

--- a/ports/hiredis/fix-example-install.patch
+++ b/ports/hiredis/fix-example-install.patch
@@ -1,0 +1,76 @@
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index dd3a313..7b79b2a 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -1,13 +1,16 @@
+-INCLUDE(FindPkgConfig)
+ # Check for GLib
+ 
+-PKG_CHECK_MODULES(GLIB2 glib-2.0)
+-if (GLIB2_FOUND)
+-    INCLUDE_DIRECTORIES(${GLIB2_INCLUDE_DIRS})
+-    LINK_DIRECTORIES(${GLIB2_LIBRARY_DIRS})
+-    ADD_EXECUTABLE(example-glib example-glib.c)
+-    TARGET_LINK_LIBRARIES(example-glib hiredis ${GLIB2_LIBRARIES})
+-ENDIF(GLIB2_FOUND)
++IF(0)
++    FIND_LIBRARY(GLIB_LIBRARY NAMES glib-2.0)
++    FIND_PATH(GLIB_INCLUDE_DIR glib.h)
++    SET(GLIB_FOUND ${GLIB_LIBRARY})
++    IF(GLIB_FOUND)
++        INCLUDE_DIRECTORIES(${GLIB_INCLUDE_DIR})
++        ADD_EXECUTABLE(example-glib example-glib.c)
++        TARGET_LINK_LIBRARIES(example-glib hiredis ${GLIB_LIBRARY})
++        INSTALL(TARGETS example-glib RUNTIME DESTINATION tools)
++    ENDIF()
++ENDIF()
+ 
+ FIND_PATH(LIBEV ev.h
+     HINTS /usr/local /usr/opt/local
+@@ -17,30 +20,45 @@ if (LIBEV)
+     # Just compile and link with libev
+     ADD_EXECUTABLE(example-libev example-libev.c)
+     TARGET_LINK_LIBRARIES(example-libev hiredis ev)
++    INSTALL(TARGETS example-libev RUNTIME DESTINATION tools)
+ ENDIF()
+ 
++
++FIND_PACKAGE(Libevent CONFIG REQUIRED)
+ FIND_PATH(LIBEVENT event.h)
+ if (LIBEVENT)
++    INCLUDE_DIRECTORIES(${LIBEVENT})
+     ADD_EXECUTABLE(example-libevent example-libevent)
+-    TARGET_LINK_LIBRARIES(example-libevent hiredis event)
++    if(BUILD_SHARED_LIBS)
++        TARGET_LINK_LIBRARIES(example-libevent hiredis event_shared event_core_shared event_extra_shared event_openssl_shared)
++    else()
++        TARGET_LINK_LIBRARIES(example-libevent hiredis event_static event_core_static event_extra_static event_openssl_static)
++    endif()
++    INSTALL(TARGETS example-libevent RUNTIME DESTINATION tools)
+ ENDIF()
+ 
+ FIND_PATH(LIBUV uv.h)
+ IF (LIBUV)
+     ADD_EXECUTABLE(example-libuv example-libuv.c)
+     TARGET_LINK_LIBRARIES(example-libuv hiredis uv)
++    INSTALL(TARGETS example-libuv RUNTIME DESTINATION tools)
+ ENDIF()
+ 
+ IF (APPLE)
+     FIND_LIBRARY(CF CoreFoundation)
+     ADD_EXECUTABLE(example-macosx example-macosx.c)
+     TARGET_LINK_LIBRARIES(example-macosx hiredis ${CF})
++    INSTALL(TARGETS example-macosx RUNTIME DESTINATION tools)
+ ENDIF()
+ 
+ IF (ENABLE_SSL)
+     ADD_EXECUTABLE(example-ssl example-ssl.c)
+     TARGET_LINK_LIBRARIES(example-ssl hiredis hiredis_ssl)
++    INSTALL(TARGETS example-ssl RUNTIME DESTINATION tools)
+ ENDIF()
+ 
+ ADD_EXECUTABLE(example example.c)
+ TARGET_LINK_LIBRARIES(example hiredis)
++
++#Install tools
++INSTALL(TARGETS example RUNTIME DESTINATION tools)

--- a/ports/hiredis/fix-support-windows-static.patch
+++ b/ports/hiredis/fix-support-windows-static.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e78894..62292d9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ PROJECT(hiredis VERSION "${VERSION}")
+ 
+ SET(ENABLE_EXAMPLES OFF CACHE BOOL "Enable building hiredis examples")
+ 
+-ADD_LIBRARY(hiredis SHARED
++ADD_LIBRARY(hiredis
+     async.c
+     dict.c
+     hiredis.c
+@@ -36,6 +36,8 @@ SET_TARGET_PROPERTIES(hiredis
+     VERSION "${HIREDIS_SONAME}")
+ IF(WIN32 OR MINGW)
+     TARGET_LINK_LIBRARIES(hiredis PRIVATE ws2_32)
++    INSTALL(FILES win32.h
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis) 
+ ENDIF()
+ TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC .)
+ 

--- a/ports/hiredis/fix-support-windows-static.patch
+++ b/ports/hiredis/fix-support-windows-static.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9e78894..62292d9 100644
+index 9e78894..ccd36b2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -22,7 +22,7 @@ PROJECT(hiredis VERSION "${VERSION}")
@@ -7,7 +7,7 @@ index 9e78894..62292d9 100644
  SET(ENABLE_EXAMPLES OFF CACHE BOOL "Enable building hiredis examples")
  
 -ADD_LIBRARY(hiredis SHARED
-+ADD_LIBRARY(hiredis
++ADD_LIBRARY(hiredis 
      async.c
      dict.c
      hiredis.c
@@ -16,7 +16,16 @@ index 9e78894..62292d9 100644
  IF(WIN32 OR MINGW)
      TARGET_LINK_LIBRARIES(hiredis PRIVATE ws2_32)
 +    INSTALL(FILES win32.h
-+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis) 
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
  ENDIF()
  TARGET_INCLUDE_DIRECTORIES(hiredis PUBLIC .)
  
+@@ -60,7 +62,7 @@ IF(ENABLE_SSL)
+         ENDIF()
+     ENDIF()
+     FIND_PACKAGE(OpenSSL REQUIRED)
+-    ADD_LIBRARY(hiredis_ssl SHARED
++    ADD_LIBRARY(hiredis_ssl
+         ssl.c)
+     TARGET_INCLUDE_DIRECTORIES(hiredis_ssl PRIVATE "${OPENSSL_INCLUDE_DIR}")
+     TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE ${OPENSSL_LIBRARIES})

--- a/ports/hiredis/portfile.cmake
+++ b/ports/hiredis/portfile.cmake
@@ -1,5 +1,7 @@
-if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    message(FATAL_ERROR "${PORT} currently only supports static on Windows.")
+vcpkg_fail_port_install(ON_TARGET "uwp")
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
 vcpkg_from_github(

--- a/ports/hiredis/portfile.cmake
+++ b/ports/hiredis/portfile.cmake
@@ -1,5 +1,5 @@
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    message(FATAL_ERROR "hiredis only supports static on Windows.")
+    message(FATAL_ERROR "${PORT} currently only supports static on Windows.")
 endif()
 
 vcpkg_from_github(
@@ -10,7 +10,16 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-support-windows-static.patch
+        fix-example-install.patch
 )
+
+if("ssl" IN_LIST FEATURES AND VCPKG_TARGET_IS_WINDOWS)
+   message(FATAL_ERROR "${PORT} currently doesn't support ssl feature on Windows.")
+endif()
+
+if("example" IN_LIST FEATURES AND VCPKG_TARGET_IS_WINDOWS)
+   message(FATAL_ERROR "${PORT} currently doesn't support example feature on Windows.")
+endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     ssl     ENABLE_SSL 

--- a/ports/hiredis/portfile.cmake
+++ b/ports/hiredis/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_fail_port_install(ON_TARGET "Windows")
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    message(FATAL_ERROR "hiredis only supports static on Windows.")
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -6,6 +8,8 @@ vcpkg_from_github(
     REF e777b0295eeeda89ee2ecef6ec5cb54889033d94
     SHA512 9486ce3e40580ca6a1da8a31c3e139eb8b5e17ac1b94bd0987f2435aeb2465ad271784d5e8e83dc6cbaf362f95c9e175efa5fbe80a63c56070ceb212d3d68470
     HEAD_REF master
+    PATCHES
+        fix-support-windows-static.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/hiredis/portfile.cmake
+++ b/ports/hiredis/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJIA
+    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS}
 )
 


### PR DESCRIPTION
Add windows support. 
It currently only supports static on Windows.

Related issue #8840 
Related PR #8843, #8846.
Note: All features test pass with x64-linux triplet.
All features are only supported on Unix.