### PR TITLE
[pdal] Add plugin features

### DIFF
--- a/ports/pdal/CONTROL
+++ b/ports/pdal/CONTROL
@@ -1,5 +1,5 @@
 Source: pdal
-Version: 1.7.1-6
+Version: 1.7.1-7
 Description: PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.
 Build-Depends: gdal, geos, jsoncpp, libgeotiff, laszip
 

--- a/ports/pdal/CONTROL
+++ b/ports/pdal/CONTROL
@@ -2,3 +2,47 @@ Source: pdal
 Version: 1.7.1-6
 Description: PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.
 Build-Depends: gdal, geos, jsoncpp, libgeotiff, laszip
+
+Feature: i3s
+Description: Indexed 3d Scene Layer (I3S) plugin
+Build-Depends: zlib
+
+Feature: cpd
+Description: Coherent Point Drift (CPD) plugin
+Build-Depends: cpd
+
+Feature: geowave
+Description: GeoWave plugin
+
+Feature: icebridge
+Description: Icebridge plugin
+Build-Depends: hdf5
+
+Feature: mbio
+Description: MBIO plugin
+
+Feature: mrsid
+Description: MrSID plugin
+
+Feature: pgpointcloud
+Description: PgPointCloud plugin
+
+Feature: openscenegraph
+Description: OpenScenGraph plugin
+Build-Depends: osg
+
+Feature: rdb
+Description: RDB plugin
+
+Feature: sqlite
+Description: SQLite plugin
+Build-Depends: sqlite3
+
+Feature: fbx
+Description: FBX plugin
+
+Feature: tiledb
+Description: TileDB plugin
+
+Feature: e57
+Description: E57 plugin

--- a/ports/pdal/FindGEOS.cmake
+++ b/ports/pdal/FindGEOS.cmake
@@ -1,7 +1,12 @@
 find_path(GEOS_INCLUDE_DIR geos_c.h)
 
-find_library(GEOS_LIBRARY_DEBUG NAMES geos_cd)
-find_library(GEOS_LIBRARY_RELEASE NAMES geos_c)
+if(BUILD_SHARED_LIBS)
+    find_library(GEOS_LIBRARY_DEBUG NAMES geos_cd)
+    find_library(GEOS_LIBRARY_RELEASE NAMES geos_c)
+else()
+    find_library(GEOS_LIBRARY_DEBUG NAMES libgeos_cd)
+    find_library(GEOS_LIBRARY_RELEASE NAMES libgeos_c)
+endif()
 
 include(SelectLibraryConfigurations)
 select_library_configurations(GEOS)

--- a/ports/pdal/fix-FindDependency.patch
+++ b/ports/pdal/fix-FindDependency.patch
@@ -1,0 +1,38 @@
+diff --git a/plugins/icebridge/CMakeLists.txt b/plugins/icebridge/CMakeLists.txt
+index aebfa70..f9ccd31 100644
+--- a/plugins/icebridge/CMakeLists.txt
++++ b/plugins/icebridge/CMakeLists.txt
+@@ -2,8 +2,7 @@
+ # Icebridge plugin CMake configuration
+ #
+ 
+-include (${PDAL_CMAKE_DIR}/hdf5.cmake)
+-
++find_package(hdf5 CONFIG REQUIRED)
+ 
+ if (NOT PDAL_HAVE_HDF5)
+     message(FATAL "HDF5 not found but is required for Icebridge.")
+@@ -16,7 +15,8 @@ else()
+     target_include_directories(${libname}
+         PRIVATE
+             ${ROOT_DIR}
+-            ${LIBXML2_INCLUDE_DIR})
++            ${LIBXML2_INCLUDE_DIR}
++            ${HDF5_INCLUDE_DIRS})
+ 
+     if (WITH_TESTS)
+         PDAL_ADD_TEST(icetest
+diff --git a/plugins/sqlite/CMakeLists.txt b/plugins/sqlite/CMakeLists.txt
+index 7699310..3d26c6b 100644
+--- a/plugins/sqlite/CMakeLists.txt
++++ b/plugins/sqlite/CMakeLists.txt
+@@ -2,8 +2,7 @@
+ # SQLite plugin CMake configuration
+ #
+ 
+-include (${PDAL_CMAKE_DIR}/sqlite.cmake)
+-include (${PDAL_CMAKE_DIR}/spatialite.cmake)
++find_package(sqlite3 CONFIG REQUIRED)
+ 
+ # SQLite Reader
+ #

--- a/ports/pdal/fix-osgFunction.patch
+++ b/ports/pdal/fix-osgFunction.patch
@@ -1,0 +1,15 @@
+//The new version of OSG removed redudent bool parameter from TriangleFunctor::operator(Vec3, Vec3, Vec3, bool) so it's now simply TriangleFunctor::operator(Vec3, Vec3, Vec3) as the bool was always false in recently OSG versions.
+
+diff --git a/plugins/openscenegraph/io/OSGReader.cpp b/plugins/openscenegraph/io/OSGReader.cpp
+index 4b1a916..c35aa5e 100644
+--- a/plugins/openscenegraph/io/OSGReader.cpp
++++ b/plugins/openscenegraph/io/OSGReader.cpp
+@@ -51,7 +51,7 @@ struct CollectTriangles
+         verts = new osg::Vec3Array();
+     }
+ #ifdef OSG_VERSION_GREATER_THAN
+-#if OSG_VERSION_GREATER_THAN(3,2,0)
++#if 0
+     inline void operator () (const osg::Vec3& v1, const osg::Vec3& v2, const osg::Vec3& v3, bool treatVertexDataAsTemporary)
+ #else
+     inline void operator () (const osg::Vec3& v1, const osg::Vec3& v2, const osg::Vec3& v3)

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -16,6 +16,8 @@ vcpkg_extract_source_archive_ex(
         0002-no-source-dir-writes.patch
         0003-fix-copy-vendor.patch
         PDALConfig.patch
+        fix-osgFunction.patch
+        fix-FindDependency.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/pdal/gitsha.cpp")
@@ -39,6 +41,26 @@ else()
   set(VCPKG_BUILD_STATIC_LIBS ON)
 endif()
 
+vcpkg_find_acquire_program(PYTHON2)
+get_filename_component(PYPATH ${PYTHON2} PATH)
+vcpkg_add_to_path("${PYPATH}")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    i3s BUILD_PLUGIN_I3S
+    cpd BUILD_PLUGIN_CPD  # Only support build static library.
+    geowave BUILD_PLUGIN_GEOWAVE
+    icebridge BUILD_PLUGIN_ICEBRIDGE
+    mbio BUILD_PLUGIN_MBIO
+    mrsid BUILD_PLUGIN_MRSID
+    pgpointcloud BUILD_PLUGIN_PGPOINTCLOUD
+    openscenegraph BUILD_PLUGIN_OPENSCENEGRAPH
+    rdb BUILD_PLUGIN_RDBLIB
+    sqlite BUILD_PLUGIN_SQLITE
+    fbx BUILD_PLUGIN_FBX
+    tiledb BUILD_PLUGIN_TILEDB
+    e57 BUILD_PLUGIN_E57
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -46,6 +68,7 @@ vcpkg_configure_cmake(
         -DPDAL_BUILD_STATIC:BOOL=${VCPKG_BUILD_STATIC_LIBS}
         -DWITH_TESTS:BOOL=OFF
         -DWITH_COMPLETION:BOOL=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)


### PR DESCRIPTION
Add plugin features for pdal. Related issue: #8478. Plugins list:

- i3s
- cpd (Need add new port: cpd, related PR: #8827. Port cpd only support build static library.)
- geowave
- icebridge
- mbio
- mrsid
- pgpointcloud
- openscenegraph
- rdb
- sqlite
- fbx
- tiledb
- e57