### PR TITLE
Add homepage for zxing-cpp

### DIFF
--- a/ports/zxing-cpp/CONTROL
+++ b/ports/zxing-cpp/CONTROL
@@ -1,4 +1,5 @@
 Source: zxing-cpp
 Version: 3.3.3-6
+Homepage: https://github.com/glassechidna/zxing-cpp
 Build-Depends: opencv
 Description: Barcode detection and decoding library.


### PR DESCRIPTION
This is be useful for Repology (and probably vcpkg users) to distinguish this project from https://github.com/nu-book/zxing-cpp, unrelated project with similar name.