### PR TITLE
[libzip] Fix patch not applying

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,5 +1,5 @@
 Source: libzip
-Version: rel-1-5-3
+Version: rel-1-5-2--1
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
 Default-Features: openssl, bzip2

--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,5 +1,5 @@
 Source: libzip
-Version: rel-1-5-2
+Version: rel-1-5-3
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
 Default-Features: openssl, bzip2

--- a/ports/libzip/avoid_computation_on_void_pointer.patch
+++ b/ports/libzip/avoid_computation_on_void_pointer.patch
@@ -1,13 +1,13 @@
 diff --git a/lib/zip_source_winzip_aes_encode.c b/lib/zip_source_winzip_aes_encode.c
-
+index c428c9a..4e5f753 100644
 --- a/lib/zip_source_winzip_aes_encode.c
 +++ b/lib/zip_source_winzip_aes_encode.c
 @@ -163,7 +163,7 @@ winzip_aes_encrypt(zip_source_t *src, void *ud, void *data, zip_uint64_t length,
-                /* TODO: return partial read? */
-                return -1;
-            }
--           buffer_n += _zip_buffer_read(ctx->buffer, data + ret, length - (zip_uint64_t)ret);
-+           buffer_n += _zip_buffer_read(ctx->buffer, (zip_uint8_t *)data + ret, length - (zip_uint64_t)ret);
-        }
+ 		/* TODO: return partial read? */
+ 		return -1;
+ 	    }
+-	    buffer_n += _zip_buffer_read(ctx->buffer, data + ret, length - (zip_uint64_t)ret);
++	    buffer_n += _zip_buffer_read(ctx->buffer, (zip_uint8_t *)data + ret, length - (zip_uint64_t)ret);
+ 	}
  
-        return (zip_int64_t)(buffer_n + (zip_uint64_t)ret);
+ 	return (zip_int64_t)(buffer_n + (zip_uint64_t)ret);

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nih-at/libzip
@@ -33,6 +32,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_copy_pdbs()
 
 # Remove include directories from lib
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libzip ${CURRENT_PACKAGES_DIR}/debug/lib/libzip)
@@ -41,6 +41,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/libzip ${CURRENT_PACKAGES_DIR}/d
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Copy copright information
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libzip RENAME copyright)
-
-vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Error:
```
error: git diff header lacks filename information when removing 1 leading pathname component (line 2)
```

Update patch to avoid this situation.

Related: #8896.