### PR TITLE
[opencolorio] Modify find python2 to find python3

### DIFF
--- a/ports/opencolorio/CONTROL
+++ b/ports/opencolorio/CONTROL
@@ -1,5 +1,5 @@
 Source: opencolorio
-Version: 1.1.1
+Version: 1.1.1-1
 Homepage: https://opencolorio.org/
 Description: OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.
 Build-Depends: glew[core], freeglut[core], lcms[core], yaml-cpp[core], tinyxml[core]

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -1,5 +1,4 @@
 include(vcpkg_common_definitions)
-include(vcpkg_common_functions)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(_BUILD_SHARED OFF)
@@ -29,9 +28,9 @@ vcpkg_check_features(
         applications OCIO_BUILD_APPS
 )
 
-vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_PATH ${PYTHON2} DIRECTORY)
-vcpkg_add_to_path(PREPEND ${PYTHON2_PATH})
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_PATH "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path(PREPEND ${PYTHON3_PATH})
 
 # TODO(theblackunknown) build additional targets based on feature
 


### PR DESCRIPTION
Related issue: #8814 
Feature applications built failed due to it depends on openimageio[core]. Openimageio[core] built failed on Linux and windows with Visual Studio 2019.