### PR TITLE
[gtk] Build using msbuild on Windows

### DIFF
--- a/ports/gtk/CONTROL
+++ b/ports/gtk/CONTROL
@@ -1,5 +1,5 @@
 Source: gtk
-Version: 3.22.19-3
+Version: 3.22.19-4
 Homepage: https://www.gtk.org/
 Description: Portable library for creating graphical user interfaces.
 Build-Depends: glib, atk, gdk-pixbuf, pango, cairo, libepoxy, gettext

--- a/ports/gtk/fix-win-build.patch
+++ b/ports/gtk/fix-win-build.patch
@@ -1,0 +1,136 @@
+diff --git a/build/win32/vs15/gtk-3.vcxproj b/build/win32/vs15/gtk-3.vcxproj
+index cacde98..c23c705 100644
+--- a/build/win32/vs15/gtk-3.vcxproj
++++ b/build/win32/vs15/gtk-3.vcxproj
+@@ -163,20 +163,6 @@
+     </Link>
+   </ItemDefinitionGroup>
+   <ItemGroup>
+-    <CustomBuild Include="..\..\..\gtk\gtkdbusinterfaces.xml">
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating GTK+ DBus Sources...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GenerateGtkDbusBuiltSources)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\gtk\gtkdbusgenerated.c;..\..\..\gtk\gtkdbusgenerated.h;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating GTK+ DBus Sources...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GenerateGtkDbusBuiltSourcesX64)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\..\..\gtk\gtkdbusgenerated.c;..\..\..\gtk\gtkdbusgenerated.h;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating GTK+ DBus Sources...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GenerateGtkDbusBuiltSources)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\gtk\gtkdbusgenerated.c;..\..\..\gtk\gtkdbusgenerated.h;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating GTK+ DBus Sources...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GenerateGtkDbusBuiltSourcesX64)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\..\..\gtk\gtkdbusgenerated.c;..\..\..\gtk\gtkdbusgenerated.h;%(Outputs)</Outputs>
+-    </CustomBuild>
+     <CustomBuild Include="..\..\..\gtk\gtk-win32.rc.body">
+       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Copying GTK+ Win32 Version Resource...</Message>
+       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(CopyGtkWin32RC)</Command>
+@@ -191,20 +177,6 @@
+       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(CopyGtkWin32RC)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\..\..\gtk\gtk-win32.rc;%(Outputs)</Outputs>
+     </CustomBuild>
+-    <CustomBuild Include="..\..\..\gtk\libgtk3.manifest.in">
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating GTK+ Win32 Manifest...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GenerateGtkWin32Manifest)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\..\..\gtk\libgtk3.manifest;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating GTK+ Win32 Manifest...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GenerateGtkWin32Manifest)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\..\..\gtk\libgtk3.manifest;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating GTK+ Win32 Manifest...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GenerateGtkWin32Manifest)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\..\..\gtk\libgtk3.manifest;%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating GTK+ Win32 Manifest...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GenerateGtkWin32Manifest)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\..\..\gtk\libgtk3.manifest;%(Outputs)</Outputs>
+-    </CustomBuild>
+   </ItemGroup>
+   <ItemGroup>
+     <ResourceCompile Include="..\..\..\gtk\gtk-win32.rc" />
+diff --git a/build/win32/vs15/gtk3-build-defines.props b/build/win32/vs15/gtk3-build-defines.props
+index d695642..34661ea 100644
+--- a/build/win32/vs15/gtk3-build-defines.props
++++ b/build/win32/vs15/gtk3-build-defines.props
+@@ -29,7 +29,8 @@
+       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
+     </ClCompile>
+     <Link>
+-      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;epoxy.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32' Or '$(Configuration)|$(Platform)'=='Release|x64'">pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;epoxy.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' Or '$(Configuration)|$(Platform)'=='Debug|x64'">pangocairo-1.0.lib;cairod.lib;cairo-gobjectd.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;epoxy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+     </Link>
+   </ItemDefinitionGroup>
+diff --git a/build/win32/vs15/gtk3-install.vcxproj b/build/win32/vs15/gtk3-install.vcxproj
+index 3a4d947..e8ca0a5 100644
+--- a/build/win32/vs15/gtk3-install.vcxproj
++++ b/build/win32/vs15/gtk3-install.vcxproj
+@@ -158,63 +158,37 @@
+     <CustomBuild Include="..\..\..\config.h.win32">
+       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GtkDoInstallBin)$(GtkDoInstall)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GtkDoInstallBin)$(GtkDoInstall)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">blah;%(Outputs)</Outputs>
+       <Message Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">Installing Build Results...</Message>
+       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">$(GtkPCFiles)</AdditionalInputs>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)$(GtkPostInstall)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">$(GtkDoInstallBin)$(GtkDoInstall)$(GtkDoInstallBroadwayHeaders)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">blah;%(Outputs)</Outputs>
+     </CustomBuild>
+-    <CustomBuild Include="..\gtkpc.py">
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GenerateGtkPC)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">$(GenerateGtkPC) --broadway</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|Win32'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GenerateGtkPCX64)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">$(GenerateGtkPCX64) --broadway</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug_Broadway|x64'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GenerateGtkPC)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">$(GenerateGtkPC) --broadway</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|Win32'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GenerateGtkPCX64)</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(GtkPCFiles);%(Outputs)</Outputs>
+-      <Message Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">Generating .pc files...</Message>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">$(GenerateGtkPCX64) --broadway</Command>
+-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release_Broadway|x64'">$(GtkPCFiles);%(Outputs)</Outputs>
+-    </CustomBuild>
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="gdk-3.vcxproj">

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -1,5 +1,3 @@
-
-include(vcpkg_common_functions)
 set(GTK_VERSION 3.22.19)
 
 vcpkg_download_distfile(ARCHIVE
@@ -11,32 +9,174 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES fix-win-build.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake DESTINATION ${SOURCE_PATH})
-
-# generate sources using python script installed with glib
-if(NOT EXISTS ${SOURCE_PATH}/gtk/gtkdbusgenerated.h OR NOT EXISTS ${SOURCE_PATH}/gtk/gtkdbusgenerated.c)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+    
     vcpkg_find_acquire_program(PYTHON3)
+    
+    set(GTK_PROPS_FILE ${SOURCE_PATH}/build/win32/vs15/gtk3-version-paths.props)
+    set(GTK_PROPS_FILE_BAK ${SOURCE_PATH}/build/win32/vs15/gtk3-version-paths.props.bak)
+    # Bakup prop file
+    if (NOT EXISTS ${GTK_PROPS_FILE_BAK})
+        configure_file(${GTK_PROPS_FILE} ${GTK_PROPS_FILE_BAK} COPYONLY)
+    endif()
+    # Set install path
+    configure_file(${GTK_PROPS_FILE_BAK} ${GTK_PROPS_FILE} COPYONLY)
+    file(READ ${GTK_PROPS_FILE} GTK_PROPS)
+    file(TO_NATIVE_PATH ${CURRENT_PACKAGES_DIR} NATIVE_PATH_REL)
+    file(TO_NATIVE_PATH ${CURRENT_PACKAGES_DIR}/debug NATIVE_PATH_DBG)
+    string(REPLACE "<CopyDir>..\\..\\..\\..\\vs$(VSVer)\\$(Platform)<\/CopyDir>"
+                "<CopyDir Condition=\"\'$(Configuration)|$(Platform)\'==\'Release|Win32\' Or \'$(Configuration)|$(Platform)\'==\'Release|x64\'\">${NATIVE_PATH_REL}<\/CopyDir>\r\n    <CopyDir Condition=\"\'$(Configuration)|$(Platform)\'==\'Debug|Win32\' Or \'$(Configuration)|$(Platform)\'==\'Debug|x64\'\">${NATIVE_PATH_DBG}<\/CopyDir>"
+                GTK_PROPS "${GTK_PROPS}"
+    )
+    file(WRITE ${GTK_PROPS_FILE} "${GTK_PROPS}")
+    
+    # generate sources using python script installed with glib
     set(GLIB_TOOL_DIR ${CURRENT_INSTALLED_DIR}/tools/glib)
-
+    message("Generating GTK+ DBus Sources...")
     vcpkg_execute_required_process(
         COMMAND ${PYTHON3} ${GLIB_TOOL_DIR}/gdbus-codegen --interface-prefix org.Gtk. --c-namespace _Gtk --generate-c-code gtkdbusgenerated ./gtkdbusinterfaces.xml
         WORKING_DIRECTORY ${SOURCE_PATH}/gtk
-        LOGNAME source-gen)
+        LOGNAME source-gen
+    )
+    
+    # generate manifest
+    message("Generating GTK+ Win32 Manifest...")
+    vcpkg_execute_required_process(
+        COMMAND ${PYTHON3} ../replace.py --action=replace-var --input=../../../gtk/libgtk3.manifest.in --output=../../../gtk/libgtk3.manifest --var=EXE_MANIFEST_ARCHITECTURE --outstring=*
+        WORKING_DIRECTORY ${SOURCE_PATH}/build/win32/vs15
+        LOGNAME manifest-gen
+    )
+    
+    if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+        set(BUILD_ARCH "Win32")
+    elseif (VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
+        set(BUILD_ARCH "x64")
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+    endif()
+    
+    vcpkg_build_msbuild(
+        PROJECT_PATH ${SOURCE_PATH}/build/win32/vs15/gtk+.sln
+        PLATFORM ${BUILD_ARCH}
+        USE_VCPKG_INTEGRATION
+    )
+
+    message("Compiling gsettings XML Files...")
+    # Since glib-compile-schemas.exe requires link dependencies, these dlls are temporarily needs to copy.
+    set(TEMP_USE_DLL ${CURRENT_INSTALLED_DIR}/bin/libintl.dll
+                     ${CURRENT_INSTALLED_DIR}/bin/gdk_pixbuf-2.dll
+                     ${CURRENT_INSTALLED_DIR}/bin/glib-2.dll
+                     ${CURRENT_INSTALLED_DIR}/bin/pcre.dll
+                     ${CURRENT_INSTALLED_DIR}/bin/libiconv.dll
+                     ${CURRENT_INSTALLED_DIR}/bin/libcharset.dll
+    )
+    file(COPY ${TEMP_USE_DLL} ${CURRENT_INSTALLED_DIR}/tools/glib/glib-compile-schemas.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tmp/tools)
+    vcpkg_execute_required_process(
+        COMMAND ${CURRENT_PACKAGES_DIR}/tmp/tools/glib-compile-schemas.exe ${CURRENT_PACKAGES_DIR}/share/glib-2.0/schemas
+        WORKING_DIRECTORY ${SOURCE_PATH}/build/win32/vs15
+        LOGNAME xml-gen
+    )
+    # Remove these dependencies
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tmp)
+    
+    message("Generating icon cache......")
+    # temporarily copy these dependencies.
+    list(APPEND TEMP_USE_DLL ${CURRENT_INSTALLED_DIR}/bin/gio-2.dll
+                             ${CURRENT_INSTALLED_DIR}/bin/gmodule-2.dll
+                             ${CURRENT_INSTALLED_DIR}/bin/gobject-2.dll
+                             ${CURRENT_INSTALLED_DIR}/bin/libpng16.dll
+                             ${CURRENT_INSTALLED_DIR}/bin/zlib1.dll
+    )
+    file(COPY ${TEMP_USE_DLL} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    vcpkg_execute_required_process(
+        COMMAND ${CURRENT_PACKAGES_DIR}/bin/gtk-update-icon-cache.exe --ignore-theme-index --force "${CURRENT_PACKAGES_DIR}/share/icons/hicolor"
+        WORKING_DIRECTORY ${SOURCE_PATH}/build/win32/vs15
+        LOGNAME icno-gen
+    )
+    # Remove these dependencies
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libintl.dll
+                ${CURRENT_PACKAGES_DIR}/bin/gdk_pixbuf-2.dll
+                ${CURRENT_PACKAGES_DIR}/bin/glib-2.dll
+                ${CURRENT_PACKAGES_DIR}/bin/pcre.dll
+                ${CURRENT_PACKAGES_DIR}/bin/libiconv.dll
+                ${CURRENT_PACKAGES_DIR}/bin/libcharset.dll
+                ${CURRENT_PACKAGES_DIR}/bin/gio-2.dll
+                ${CURRENT_PACKAGES_DIR}/bin/gmodule-2.dll
+                ${CURRENT_PACKAGES_DIR}/bin/gobject-2.dll
+                ${CURRENT_PACKAGES_DIR}/bin/libpng16.dll
+                ${CURRENT_PACKAGES_DIR}/bin/zlib1.dll
+    )
+    
+    message("Generating .pc files...")
+    if (VCPKG_PLATFORM_TOOLSET STREQUAL v140)
+        set(VS_VER 15)
+    elseif (VCPKG_PLATFORM_TOOLSET STREQUAL v141)
+        set(VS_VER 17)
+    elseif (VCPKG_PLATFORM_TOOLSET STREQUAL v142)
+        set(VS_VER 19)
+    else()
+        set(VS_VER unknow)
+    endif()
+    vcpkg_execute_required_process(
+        COMMAND ${PYTHON3} ../gtkpc.py --prefix=${CURRENT_PACKAGES_DIR} --version=${GTK_VERSION} --host=i686-pc-vs${VS_VER}
+        WORKING_DIRECTORY ${SOURCE_PATH}/build/win32/vs15
+        LOGNAME pc-gen
+    )
+    
+    # Install tools
+    if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL release)
+        file(GLOB_RECURSE GTK_TOOLS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
+        foreach (GTK_TOOL ${GTK_TOOLS})
+            get_filename_component(TOOL_NAME ${GTK_TOOL} NAME_WE)
+            file(INSTALL ${GTK_TOOL} ${CURRENT_PACKAGES_DIR}/bin/${TOOL_NAME}.pdb DESTINATION ${CURRENT_PACKAGES_DIR}/tools/gtk)
+            file(REMOVE ${GTK_TOOL} ${CURRENT_PACKAGES_DIR}/bin/${TOOL_NAME}.pdb)
+        endforeach()
+    endif()
+    if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL debug)
+        file(GLOB_RECURSE GTK_TOOLS ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
+        foreach (GTK_TOOL ${GTK_TOOLS})
+            get_filename_component(TOOL_NAME ${GTK_TOOL} NAME_WE)
+            file(INSTALL ${GTK_TOOL} ${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL_NAME}.pdb DESTINATION ${CURRENT_PACKAGES_DIR}/debug/tools/gtk)
+            file(REMOVE ${GTK_TOOL} ${CURRENT_PACKAGES_DIR}/debug/bin/${TOOL_NAME}.pdb)
+        endforeach()
+    endif()
+    
+    # Install pkgconfig
+    file(INSTALL ${SOURCE_PATH}/build/win32/gdk-3.0.pc DESTINATION ${CURRENT_PACKAGES_DIR}/lib/pkgconfig RENAME gdk-win32-3.0.pc)
+    file(INSTALL ${SOURCE_PATH}/build/win32/gdk-3.0.pc DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig RENAME gdk-win32-3.0.pc)
+    file(INSTALL ${SOURCE_PATH}/build/win32/gtk+-3.0.pc DESTINATION ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+    file(INSTALL ${SOURCE_PATH}/build/win32/gtk+-3.0.pc DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
+else()
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/cmake DESTINATION ${SOURCE_PATH})
+    
+    # generate sources using python script installed with glib
+    if(NOT EXISTS ${SOURCE_PATH}/gtk/gtkdbusgenerated.h OR NOT EXISTS ${SOURCE_PATH}/gtk/gtkdbusgenerated.c)
+        vcpkg_find_acquire_program(PYTHON3)
+        set(GLIB_TOOL_DIR ${CURRENT_INSTALLED_DIR}/tools/glib)
+    
+        vcpkg_execute_required_process(
+            COMMAND ${PYTHON3} ${GLIB_TOOL_DIR}/gdbus-codegen --interface-prefix org.Gtk. --c-namespace _Gtk --generate-c-code gtkdbusgenerated ./gtkdbusinterfaces.xml
+            WORKING_DIRECTORY ${SOURCE_PATH}/gtk
+            LOGNAME source-gen)
+    endif()
+    
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DGTK_VERSION=${GTK_VERSION}
+        OPTIONS_DEBUG
+            -DGTK_SKIP_HEADERS=ON)
+    
+    vcpkg_install_cmake()
+    vcpkg_copy_pdbs()
 endif()
+    
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DGTK_VERSION=${GTK_VERSION}
-    OPTIONS_DEBUG
-        -DGTK_SKIP_HEADERS=ON)
-
-vcpkg_install_cmake()
-vcpkg_copy_pdbs()
-
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/gtk)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/gtk/COPYING ${CURRENT_PACKAGES_DIR}/share/gtk/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Building gtk with CMakeLists.txt is missing too much functionality, replacing the build form to msvc..

Related: #6554.

Note: this PR is experimental.