### PR TITLE
[qt5-base] Add option to link to OpenSSL at compile-time

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.5-2
+Version: 5.12.5-3
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -1,5 +1,11 @@
 vcpkg_buildpath_length_warning(37)
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    option(QT_OPENSSL_LINK "Link against OpenSSL at compile-time." ON)
+else()
+    option(QT_OPENSSL_LINK "Link against OpenSSL at compile-time." OFF)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
@@ -74,6 +80,10 @@ list(APPEND CORE_OPTIONS
     -system-doubleconversion
     -system-sqlite
     -system-harfbuzz)
+
+if(QT_OPENSSL_LINK)
+    list(APPEND CORE_OPTIONS -openssl-linked)
+endif()
 
 find_library(ZLIB_RELEASE NAMES z zlib PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
 find_library(ZLIB_DEBUG NAMES z zlib zd zlibd PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)


### PR DESCRIPTION
By default Qt loads OpenSSL at runtime.

This pull request adds a `QT_OPENSSL_LINK` option, which specifies `-openssl-linked`. The option is enabled by default for static configurations.

From https://doc.qt.io/qt-5/ssl.html:

> By default, an SSL-enabled Qt library dynamically loads any installed OpenSSL library at run-time. However, it is possible to link against the library at compile-time by configuring Qt with the **-openssl-linked** option.

---

Fixes #2343.