### PR TITLE
[msix] Update to 1.7

### DIFF
--- a/ports/msix/CONTROL
+++ b/ports/msix/CONTROL
@@ -1,5 +1,5 @@
 Source: msix
-Version: MsixCoreInstaller-preview-1
-Build-Depends: xerces-c, zlib, openssl (!uwp&!windows)
+Version: 1.7
+Build-Depends: xerces-c, zlib, openssl (!uwp&!windows), catch2
 Description: The MSIX Packaging SDK project is an effort to enable developers on a variety of platforms to pack and unpack packages for the purposes of distribution from either the Microsoft Store, or their own content distribution networks.
   The MSIX Packaging APIs that a client app would use to interact with .msix/.appx packages are a subset of those documented here. See sample/ExtractContentsSample/ExtractContentsSample.cpp for additional details.

--- a/ports/msix/fix-dependency-catch2.patch
+++ b/ports/msix/fix-dependency-catch2.patch
@@ -1,0 +1,22 @@
+diff --git a/src/test/msixtest/CMakeLists.txt b/src/test/msixtest/CMakeLists.txt
+index e991231..e5c43ed 100644
+--- a/src/test/msixtest/CMakeLists.txt
++++ b/src/test/msixtest/CMakeLists.txt
+@@ -5,6 +5,8 @@
+ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+ project (msixtest)
+ 
++find_package(Catch2 CONFIG REQUIRED)
++
+ if(WIN32)
+     set(DESCRIPTION "msixtest manifest")
+     configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_TEST_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+@@ -91,7 +93,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
+ )
+ 
+ add_dependencies(${PROJECT_NAME} msix)
+-target_link_libraries(${PROJECT_NAME} msix)
++target_link_libraries(${PROJECT_NAME} msix Catch2::Catch2)
+ 
+ # For windows copy the library
+ if(WIN32)

--- a/ports/msix/install-cmake.patch
+++ b/ports/msix/install-cmake.patch
@@ -1,19 +1,20 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8ee0443..8c0a868 100644
+index 20098bf..38c3c95 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -266,3 +266,5 @@ message(STATUS "sample processed")
- add_subdirectory(test)
- message(STATUS "tests processed")
+@@ -190,3 +190,5 @@ message(STATUS "src processed")
+ add_subdirectory(sample)
+ message(STATUS "sample processed")
  message(STATUS "DONE!")
 +
 +install(TARGETS msix)
+\ No newline at end of file
 diff --git a/src/msix/CMakeLists.txt b/src/msix/CMakeLists.txt
-index 817040b..6b16b69 100644
+index 296eda4..cf87993 100644
 --- a/src/msix/CMakeLists.txt
 +++ b/src/msix/CMakeLists.txt
-@@ -164,9 +164,9 @@ message(STATUS "PAL: Compression     = ${CompressionObject}")
- include(msix_resources)
+@@ -87,9 +87,9 @@ endif()
+ include(msix_resources) # Handles all the certificates and schemas we are going to use.
  
  set(LIB_PUBLIC_HEADERS
 -    ../inc/AppxPackaging.hpp
@@ -24,4 +25,13 @@ index 817040b..6b16b69 100644
 +    ${CMAKE_CURRENT_SOURCE_DIR}/../inc/MsixErrors.hpp
  )
  
- # Bundle specific files
+ set(MsixSrc) # list with all the files we are going to use
+@@ -260,7 +260,7 @@ if(WIN32)
+             "/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")
+     string(REPLACE ";" " " DELAYFLAGS "${DELAYFLAGS}")
+     set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS "${DELAYFLAGS} /LTCG")
+-    set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /DEF:windowsexports.def")
++    set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /DEF:${CMAKE_CURRENT_BINARY_DIR}/windowsexports.def")
+     if(USE_STATIC_MSVC)
+         if(CMAKE_BUILD_TYPE MATCHES Debug)
+             set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /NODEFAULTLIB:MSVCRTD")

--- a/ports/msix/portfile.cmake
+++ b/ports/msix/portfile.cmake
@@ -1,27 +1,27 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/msix-packaging
-    REF MsixCoreInstaller-preview
-    SHA512 b034559da8e4d5fedc79b3ef65b6f8e9bca69c92f3d85096e7ea84a0e394fa04a92f84079524437ceebd6c006a12dac9cc2e46197154257bbf7449ded031d3e8
+    REF ab322965d64baf1448548cbe18139e8872d686f2 # v1.7
+    SHA512 d64767c84d5933bf3d1e0e62e9dc21fa13e02b8cf31776ccbe2e7066e514798d8ff758dc2b6fd64f6eabcf3deb83ef0eaa03e1a7d407307f347a045e8a75d3dd
     HEAD_REF master
-    PATCHES install-cmake.patch
+    PATCHES
+        install-cmake.patch
+        fix-dependency-catch2.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/lib)
 file(MAKE_DIRECTORY ${SOURCE_PATH}/lib)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/lib)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt ${SOURCE_PATH}/lib/CMakeLists.txt)
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_TARGET_IS_WINDOWS)
     set(PLATFORM WIN32)
     set(CRYPTO_LIB crypt32)
-elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+elseif(VCPKG_TARGET_IS_LINUX)
     set(PLATFORM LINUX)
     set(CRYPTO_LIB openssl)
-elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif(VCPKG_TARGET_IS_OSX)
     set(PLATFORM MACOS)
     set(CRYPTO_LIB openssl)
 else()
@@ -45,8 +45,5 @@ vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL
-    ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/msix RENAME copyright)
-
 vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/8792
Changes: 
1.  Upgrade version to 1.7
2.  Update patch install-cmake.patch
3. Add new patch fix-dependency-catch2.patch for fixing catch2 dependency issue.

msix has no feature that need to test locally.