### PR TITLE
[io2d] Fix link to target "Cairo::Cairo" error

### DIFF
--- a/ports/io2d/CONTROL
+++ b/ports/io2d/CONTROL
@@ -1,4 +1,4 @@
 Source: io2d
-Version: 2019-07-11-1
+Version: 2019-07-11-2
 Description: a lightweight, cross platform drawing library
 Build-Depends: cairo (!osx), cairo[x11] (linux), graphicsmagick (!osx)

--- a/ports/io2d/Fix-FindCairo.patch
+++ b/ports/io2d/Fix-FindCairo.patch
@@ -1,0 +1,15 @@
+diff --git a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+index d0e9176..2ac638c 100644
+--- a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
++++ b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+@@ -24,7 +24,9 @@ target_include_directories(io2d_cairo PUBLIC
+ 
+ target_compile_features(io2d_cairo PUBLIC cxx_std_17)
+ 
+-target_link_libraries(io2d_cairo PUBLIC io2d_core Cairo::Cairo unofficial::graphicsmagick::graphicsmagick)
++find_package(unofficial-cairo CONFIG REQUIRED)
++
++target_link_libraries(io2d_cairo PUBLIC io2d_core unofficial::cairo::cairo unofficial::graphicsmagick::graphicsmagick)
+ 
+ install(
+ 	TARGETS io2d_cairo EXPORT io2d_targets

--- a/ports/io2d/portfile.cmake
+++ b/ports/io2d/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/io2d/portfile.cmake
+++ b/ports/io2d/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-linux-build.patch
+        Fix-FindCairo.patch
 )
 
 if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
Fix link to target "Cairo::Cairo" error:
```
Target "hello" links to target "Cairo::Cairo" but the target was not found.
Perhaps a find_package() call is missing for an IMPORTED target, or an
ALIAS target is missing?
Call Stack (most recent call first):
CMakeLists.txt:5 (add_executable)
```
Related issue: #8865. There are no features of this port need to test.