### PR TITLE
[mdnsresponder] Fix build with dynamic CRT

### DIFF
--- a/ports/mdnsresponder/CONTROL
+++ b/ports/mdnsresponder/CONTROL
@@ -1,4 +1,4 @@
 Source: mdnsresponder
-Version: 765.30.11-1
+Version: 765.30.11-2
 Description: The mDNSResponder project is a component of Bonjour, Apple's ease-of-use IP networking initiative.
 Homepage: https://developer.apple.com/bonjour/

--- a/ports/mdnsresponder/portfile.cmake
+++ b/ports/mdnsresponder/portfile.cmake
@@ -21,31 +21,34 @@ ENDIF()
 
 function(FIX_VCXPROJ VCXPROJ_PATH)
   file(READ ${VCXPROJ_PATH} ORIG)
-  if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    string(REPLACE
-      "<ConfigurationType>StaticLibrary</ConfigurationType>"
-      "<ConfigurationType>DynamicLibrary</ConfigurationType>"
-      ORIG "${ORIG}")
+  if(${VCPKG_CRT_LINKAGE} STREQUAL "dynamic")
     string(REGEX REPLACE
-      "<RuntimeLibrary>*</RuntimeLibrary>"
+      "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"
       "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>"
       ORIG "${ORIG}")
     string(REGEX REPLACE
-      "<RuntimeLibrary>*</RuntimeLibrary>"
+      "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>"
       "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>"
+      ORIG "${ORIG}")
+  else()
+    string(REGEX REPLACE
+      "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>"
+      "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"
+      ORIG "${ORIG}")
+    string(REGEX REPLACE
+      "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>"
+      "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>"
+      ORIG "${ORIG}")
+  endif()
+  if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
+    string(REPLACE
+      "<ConfigurationType>StaticLibrary</ConfigurationType>"
+      "<ConfigurationType>DynamicLibrary</ConfigurationType>"
       ORIG "${ORIG}")
   else()
     string(REPLACE
       "<ConfigurationType>DynamicLibrary</ConfigurationType>"
       "<ConfigurationType>StaticLibrary</ConfigurationType>"
-      ORIG "${ORIG}")
-    string(REGEX REPLACE
-      "<RuntimeLibrary>*Debug</RuntimeLibrary>"
-      "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"
-      ORIG "${ORIG}")
-    string(REGEX REPLACE
-      "<RuntimeLibrary>*</RuntimeLibrary>"
-      "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>"
       ORIG "${ORIG}")
   endif()
   file(WRITE ${VCXPROJ_PATH} "${ORIG}")


### PR DESCRIPTION
mdnsresponder was being built with static CRT even when `VCPKG_CRT_LINKAGE` was set to `dynamic`:

```
-- Performing post-build validation
Expected Debug,Dynamic crt linkage, but the following libs had invalid crt linkage:

    C:/vcpkg/packages/mdnsresponder_x64-windows-static-md/debug/lib/dnssd.lib: Debug,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
Expected Release,Dynamic crt linkage, but the following libs had invalid crt linkage:

    C:/vcpkg/packages/mdnsresponder_x64-windows-static-md/lib/dnssd.lib: Release,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
Found 2 error(s). Please correct the portfile:
    C:\vcpkg\ports\mdnsresponder\portfile.cmake
-- Performing post-build validation done
Error: Building package mdnsresponder:x64-windows-static-md failed with: POST_BUILD_CHECKS_FAILED
```