### PR TITLE
use latest librtmp

### DIFF
--- a/ports/librtmp/hide_netstackdump.patch
+++ b/ports/librtmp/hide_netstackdump.patch
@@ -1,8 +1,8 @@
 diff --git a/librtmp/rtmp.c b/librtmp/rtmp.c
-index 5ef3ae9..7c6a010 100644
+index 0865689..b00710e 100644
 --- a/librtmp/rtmp.c
 +++ b/librtmp/rtmp.c
-@@ -129,7 +129,7 @@ static int clk_tck;
+@@ -155,7 +155,7 @@ static int clk_tck;
  uint32_t
  RTMP_GetTime()
  {
@@ -11,7 +11,7 @@ index 5ef3ae9..7c6a010 100644
    return 0;
  #elif defined(_WIN32)
    return timeGetTime();
-@@ -1256,7 +1256,7 @@ RTMP_ClientPacket(RTMP *r, RTMPPacket *packet)
+@@ -1381,7 +1381,7 @@ RTMP_ClientPacket(RTMP *r, RTMPPacket *packet)
    return bHasMediaPacket;
  }
  
@@ -20,8 +20,8 @@ index 5ef3ae9..7c6a010 100644
  extern FILE *netstackdump;
  extern FILE *netstackdump_read;
  #endif
-@@ -1333,7 +1333,7 @@ ReadN(RTMP *r, char *buffer, int n)
- 	    SendBytesReceived(r);
+@@ -1469,7 +1469,7 @@ ReadN(RTMP *r, char *buffer, int n)
+ 	        return FALSE;
  	}
        /*RTMP_Log(RTMP_LOGDEBUG, "%s: %d bytes\n", __FUNCTION__, nBytes); */
 -#ifdef _DEBUG
@@ -29,16 +29,16 @@ index 5ef3ae9..7c6a010 100644
        fwrite(ptr, 1, nBytes, netstackdump_read);
  #endif
  
-@@ -3064,7 +3064,7 @@ HandShake(RTMP *r, int FP9HandShake)
+@@ -3757,7 +3757,7 @@ HandShake(RTMP *r, int FP9HandShake)
  
    memset(&clientsig[4], 0, 4);
  
 -#ifdef _DEBUG
-+#if defined(_DEBUG) && !defined(LIBRTMP_ONLY)
++#if defined(_DEBUG) && !defined(LIBRTMP_ONLY)s
    for (i = 8; i < RTMP_SIG_SIZE; i++)
      clientsig[i] = 0xff;
  #else
-@@ -3136,7 +3136,7 @@ SHandShake(RTMP *r)
+@@ -3829,7 +3829,7 @@ SHandShake(RTMP *r)
    memcpy(serversig, &uptime, 4);
  
    memset(&serversig[4], 0, 4);
@@ -47,7 +47,7 @@ index 5ef3ae9..7c6a010 100644
    for (i = 8; i < RTMP_SIG_SIZE; i++)
      serversig[i] = 0xff;
  #else
-@@ -3553,7 +3553,7 @@ RTMPSockBuf_Send(RTMPSockBuf *sb, const char *buf, int len)
+@@ -4298,7 +4298,7 @@ RTMPSockBuf_Send(RTMPSockBuf *sb, const char *buf, int len)
  {
    int rc;
  

--- a/ports/librtmp/portfile.cmake
+++ b/ports/librtmp/portfile.cmake
@@ -1,17 +1,11 @@
 include(vcpkg_common_functions)
 
-set(RTMPDUMP_VERSION 2.4)
-set(RTMPDUMP_FILENAME rtmpdump-${RTMPDUMP_VERSION}.tar.gz)
+set(RTMPDUMP_REVISION c5f04a58fc2aeea6296ca7c44ee4734c18401aa3)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://rtmpdump.mplayerhq.hu/download/${RTMPDUMP_FILENAME}"
-    FILENAME "${RTMPDUMP_FILENAME}"
-    SHA512 a6253af95492739366dce620a2a6cc6f4f18d7f12f9ef2c747240259066ca135beeb02091d0f3dd8380c0c294a30d3f702ad3fad1dee1db4e70473078fb81609
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    URL https://git.ffmpeg.org/rtmpdump
+    REF ${RTMPDUMP_REVISION}
     PATCHES
         fix_strncasecmp.patch
         hide_netstackdump.patch


### PR DESCRIPTION
as stated there: http://rtmpdump.mplayerhq.hu/ we should use the git repository, as the sources tar ball are very outdated