### PR TITLE
[libmspack] Fix several missing imports

### DIFF
--- a/ports/libmspack/CMakeLists.txt
+++ b/ports/libmspack/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(libmspack C)
 
-set(CMAKE_DEBUG_POSTFIX "d")
-
 add_definitions(-DHAVE_CONFIG_H)
 
 if(MSVC)

--- a/ports/libmspack/CONTROL
+++ b/ports/libmspack/CONTROL
@@ -1,5 +1,4 @@
 Source: libmspack
 Version: 0.10.1-3
-Build-Depends:
 Homepage: https://www.cabextract.org.uk/libmspack
 Description: libmspack is a portable library for some loosely related Microsoft compression formats.

--- a/ports/libmspack/CONTROL
+++ b/ports/libmspack/CONTROL
@@ -1,5 +1,5 @@
 Source: libmspack
-Version: 0.10.1-2
+Version: 0.10.1-3
 Build-Depends:
 Homepage: https://www.cabextract.org.uk/libmspack
 Description: libmspack is a portable library for some loosely related Microsoft compression formats.

--- a/ports/libmspack/config.h
+++ b/ports/libmspack/config.h
@@ -1,8 +1,4 @@
 #define HAVE_LIMITS_H 1
 #define HAVE_INTTYPES_H 1
-#define HAVE_STRING_H 1
-#define HAVE_CTYPE_H 1
 
-#define HAVE_MEMCMP 1
 #define HAVE_TOWLOWER 1
-#define HAVE_TOLOWER 1

--- a/ports/libmspack/libmspack.def
+++ b/ports/libmspack/libmspack.def
@@ -30,3 +30,6 @@ mspack_destroy_kwaj_compressor
 mspack_destroy_kwaj_decompressor
 mspack_destroy_oab_compressor
 mspack_destroy_oab_decompressor
+
+mspack_sys_selftest_internal
+mspack_version


### PR DESCRIPTION
- Added 2 missing export for the library.
- Removed CMAKE_DEBUG_POSTFIX which is proven to be a bad idea.
- Removed several obsolete defines in config.h.