### PR TITLE
[curl] Disable export of Curl::curl targets when building 'tool' feature

### DIFF
--- a/ports/curl/0007_disable_tool_export_curl_target.patch
+++ b/ports/curl/0007_disable_tool_export_curl_target.patch
@@ -1,5 +1,5 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index b376cd1..aab66cb 100644
+index b376cd1..baffe7e 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -71,8 +71,8 @@ target_link_libraries(${EXE_NAME} libcurl ${CURL_LIBS} ZLIB::ZLIB)
@@ -11,8 +11,8 @@ index b376cd1..aab66cb 100644
 -       APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
 -       NAMESPACE CURL::
 -)
-+# install(TARGETS ${EXE_NAME} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
-+# export(TARGETS ${EXE_NAME}
++install(TARGETS ${EXE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
++#export(TARGETS ${EXE_NAME}
 +#       APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
 +#       NAMESPACE CURL::
-+# )
++#)

--- a/ports/curl/0007_disable_tool_export_curl_target.patch
+++ b/ports/curl/0007_disable_tool_export_curl_target.patch
@@ -1,0 +1,18 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b376cd1..aab66cb 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -71,8 +71,8 @@ target_link_libraries(${EXE_NAME} libcurl ${CURL_LIBS} ZLIB::ZLIB)
+ 
+ #INCLUDE(ModuleInstall OPTIONAL)
+ 
+-install(TARGETS ${EXE_NAME} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+-export(TARGETS ${EXE_NAME}
+-       APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
+-       NAMESPACE CURL::
+-)
++# install(TARGETS ${EXE_NAME} EXPORT ${TARGETS_EXPORT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
++# export(TARGETS ${EXE_NAME}
++#       APPEND FILE ${PROJECT_BINARY_DIR}/curl-target.cmake
++#       NAMESPACE CURL::
++# )

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.66.0-1
+Version: 7.66.0-2
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl
 Description: A library for transferring data with URLs

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         0004_nghttp2_staticlib.patch
         0005_remove_imp_suffix.patch
         0006_fix_tool_depends.patch
+        0007_disable_tool_export_curl_target.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
Related issue https://github.com/microsoft/vcpkg/issues/8700

Curl export targets Curl:libcurl normally, and export target Curl::curl when build tool feature. The library and executable targets are inconsistent , also Curl:curl doesn’t export correctly.
we build ‘tool’ as a feature, I considered that executable targets Curl:curl doesn't need here. so I disable it here.

Failures:
CMake Error at F:/VCPKG/src/installed/x86-windows/share/curl/CURLTargets.cmake:37 (message):
  Some (but not all) targets in this export set were already defined.

  Targets Defined: CURL::libcurl
  Targets not yet defined: CURL::cur

Call Stack (most recent call first):
  F:/VCPKG/src/installed/x86-windows/share/curl/CURLConfig.cmake:35 (include)
  F:/VCPKG/src/installed/x86-windows/share/curl/vcpkg-cmake-wrapper.cmake:5 (_find_package)
  F:/VCPKG/src/scripts/buildsystems/vcpkg.cmake:218 (include)
  CMakeLists.txt:60 (find_package)

All features test pass on x86-windows.