### PR TITLE
[libsodium]Change build mode to vcpkg_configure_make/vcpkg_install_make in Linux.

### DIFF
--- a/ports/libsodium/CONTROL
+++ b/ports/libsodium/CONTROL
@@ -1,4 +1,4 @@
 Source: libsodium
-Version: 1.0.18-1
+Version: 1.0.18-2
 Description: A modern and easy-to-use crypto library
 Homepage: https://github.com/jedisct1/libsodium

--- a/ports/libsodium/portfile.cmake
+++ b/ports/libsodium/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jedisct1/libsodium
@@ -8,47 +6,59 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-configure_file(
-    ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
-    ${SOURCE_PATH}/CMakeLists.txt
-    COPYONLY
-)
-
-configure_file(
-    ${CMAKE_CURRENT_LIST_DIR}/sodiumConfig.cmake.in
-    ${SOURCE_PATH}/sodiumConfig.cmake.in
-    COPYONLY
-)
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DBUILD_TESTING=OFF
-)
-
-vcpkg_install_cmake()
-
-vcpkg_copy_pdbs()
-
-vcpkg_fixup_cmake_targets(
-    CONFIG_PATH lib/cmake/unofficial-sodium
-    TARGET_PATH share/unofficial-sodium
-)
+if (VCPKG_TARGET_IS_WINDOWS)
+    configure_file(
+        ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+        ${SOURCE_PATH}/CMakeLists.txt
+        COPYONLY
+    )
+    
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DBUILD_TESTING=OFF
+    )
+    
+    vcpkg_install_cmake()
+    
+    vcpkg_copy_pdbs()
+    
+    vcpkg_fixup_cmake_targets(
+        CONFIG_PATH lib/cmake/unofficial-sodium
+        TARGET_PATH share/unofficial-sodium
+    )
+    
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        vcpkg_replace_string(
+            ${CURRENT_PACKAGES_DIR}/include/sodium/export.h
+            "#ifdef SODIUM_STATIC"
+            "#if 1 //#ifdef SODIUM_STATIC"
+        )
+    endif ()
+else()
+    set(EXTRA_OPTS )
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dymaic)
+        set(EXTRA_OPTS ${EXTRA_OPTS} --enable-shared)
+    else()
+        set(EXTRA_OPTS ${EXTRA_OPTS} --enable-static)
+    endif()
+    
+    vcpkg_configure_make(
+        SOURCE_PATH ${SOURCE_PATH}
+        AUTOCONFIG
+        OPTIONS ${EXTRA_OPTS}
+        OPTIONS_DEBUG --enable-debug 
+    )
+    
+    vcpkg_install_make()
+endif()
 
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include
 )
 
 file(REMOVE ${CURRENT_PACKAGES_DIR}/include/Makefile.am)
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string(
-        ${CURRENT_PACKAGES_DIR}/include/sodium/export.h
-        "#ifdef SODIUM_STATIC"
-        "#if 1 //#ifdef SODIUM_STATIC"
-    )
-endif ()
 
 configure_file(
     ${SOURCE_PATH}/LICENSE


### PR DESCRIPTION
Since Linux build has some problem, change build mode to vcpkg_configure_make/vcpkg_install_make.

Related: #8956.

Note: this port does not contain any feature.