### PR TITLE
[faad2] Add initial version of FAAD2

### DIFF
--- a/ports/faad2/0001-Fix-non-x86-msvc.patch
+++ b/ports/faad2/0001-Fix-non-x86-msvc.patch
@@ -1,0 +1,13 @@
+diff --git a/libfaad/common.h b/libfaad/common.h
+index 897a0f0..8b78807 100644
+--- a/libfaad/common.h
++++ b/libfaad/common.h
+@@ -313,7 +313,7 @@ char *strchr(), *strrchr();
+   }
+ 
+ 
+-  #if defined(_WIN32) && !defined(_WIN64) && !defined(__MINGW32__)
++  #if defined(_WIN32) && defined(_M_IX86) && !defined(__MINGW32__)
+     #ifndef HAVE_LRINTF
+     #define HAS_LRINTF
+     static INLINE int lrintf(float f)

--- a/ports/faad2/0002-Fix-unary-minus.patch
+++ b/ports/faad2/0002-Fix-unary-minus.patch
@@ -1,0 +1,24 @@
+diff --git a/libfaad/decoder.c b/libfaad/decoder.c
+index 4f4b011..9bed248 100644
+--- a/libfaad/decoder.c
++++ b/libfaad/decoder.c
+@@ -239,7 +239,7 @@ static int latmCheck(latm_header *latm, bitfile *ld)
+     while (ld->bytes_left)
+     {
+         bits = faad_latm_frame(latm, ld);
+-        if(bits==-1U)
++        if(bits==0xFFFFFFFF)
+             bad++;
+         else
+         {
+diff --git a/libfaad/syntax.c b/libfaad/syntax.c
+index c992543..be8c541 100644
+--- a/libfaad/syntax.c
++++ b/libfaad/syntax.c
+@@ -2644,5 +2644,5 @@ uint32_t faad_latm_frame(latm_header *latm, bitfile *ld)
+             return (len*8)-(endpos-initpos);
+         //faad_getbits(ld, initpos-endpos); //go back to initpos, but is valid a getbits(-N) ? 
+     }
+-    return -1U;
++    return 0xFFFFFFFF;
+ }

--- a/ports/faad2/0003-Initialize-pointers.patch
+++ b/ports/faad2/0003-Initialize-pointers.patch
@@ -1,0 +1,28 @@
+diff --git a/frontend/main.c b/frontend/main.c
+index e1d3c7d..25881c7 100644
+--- a/frontend/main.c
++++ b/frontend/main.c
+@@ -462,9 +462,9 @@ static int decodeAACfile(char *aacfile, char *sndfile, char *adts_fn, int to_std
+     unsigned char channels;
+     void *sample_buffer;
+ 
+-    audio_file *aufile;
++    audio_file *aufile = NULL;
+ 
+-    FILE *adtsFile;
++    FILE *adtsFile = NULL;
+     unsigned char *adtsData;
+     int adtsDataSize;
+ 
+@@ -796,9 +796,9 @@ static int decodeMP4file(char *mp4file, char *sndfile, char *adts_fn, int to_std
+ 
+     long sampleId, startSampleId;
+ 
+-    audio_file *aufile;
++    audio_file *aufile = NULL;
+ 
+-    FILE *adtsFile;
++    FILE *adtsFile = NULL;
+     unsigned char *adtsData;
+     int adtsDataSize;
+ 

--- a/ports/faad2/CMakeLists.txt
+++ b/ports/faad2/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.1)
+project (faad VERSION 2.9.1)
+
+option(FAAD_BUILD_BINARIES "Build faad2 binaries" OFF)
+
+file(GLOB_RECURSE FAAD_SOURCES "${CMAKE_CURRENT_LIST_DIR}/libfaad/*.c")
+file(GLOB_RECURSE FAAD_HEADERS "${CMAKE_CURRENT_LIST_DIR}/libfaad/*.h")
+
+if (BUILD_SHARED_LIBS)
+    list(APPEND FAAD_SOURCES "${CMAKE_CURRENT_LIST_DIR}/project/msvc/libfaad2.def")
+endif ()
+
+add_definitions(-DSTDC_HEADERS -DPACKAGE_VERSION=\"${PROJECT_VERSION}\" -D_CRT_SECURE_NO_WARNINGS -DHAVE_LRINTF)
+include_directories(
+    "${CMAKE_CURRENT_LIST_DIR}/include"
+    "${CMAKE_CURRENT_LIST_DIR}/libfaad"
+)
+add_library(faad ${FAAD_SOURCES} ${FAAD_HEADERS})
+
+if (FAAD_BUILD_BINARIES)
+    include_directories(
+        "${CMAKE_CURRENT_LIST_DIR}/frontend"
+    )
+    add_executable(faad_decoder
+        "${CMAKE_SOURCE_DIR}/frontend/audio.c"
+        "${CMAKE_SOURCE_DIR}/frontend/main.c"
+        "${CMAKE_SOURCE_DIR}/frontend/mp4read.c"
+        "${CMAKE_SOURCE_DIR}/frontend/unicode_support.c"
+    )
+    target_link_libraries(faad_decoder PRIVATE faad shell32)
+endif ()
+
+install(
+    TARGETS faad
+        ARCHIVE DESTINATION "lib"
+        LIBRARY DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+    )

--- a/ports/faad2/CONTROL
+++ b/ports/faad2/CONTROL
@@ -1,0 +1,7 @@
+Source: faad2
+Version: 2.9.1-1
+Homepage: https://sourceforge.net/projects/faac/
+Description: Freeware Advanced Audio (AAC) Decoder
+
+Feature: build_decoder
+Description: Build the embedded decoder executable

--- a/ports/faad2/portfile.cmake
+++ b/ports/faad2/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports Windows platform." ON_TARGET "Linux" "OSX")
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO knik0/faad2
+    REF 043d37b60cdded2abed7c4054f954e # 2_9_1
+    SHA512 8658256bbcb3ce641eef67c4f5d22d54b348805a06b2954718a44910861a9882371c887feb085060c524f955993ae26c211c6bb4fb8d95f9e9d1d0b5dca0ebe4
+    HEAD_REF master
+    PATCHES
+        0001-Fix-non-x86-msvc.patch    # https://github.com/knik0/faad2/pull/42
+        0002-Fix-unary-minus.patch     # https://github.com/knik0/faad2/pull/43
+        0003-Initialize-pointers.patch # https://github.com/knik0/faad2/pull/44
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    build_decoder   FAAD_BUILD_BINARIES
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/faad2 RENAME copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_copy_pdbs()


### PR DESCRIPTION
FAAD2 lists its homepage as https://sourceforge.net/projects/faac/, but
it links to https://github.com/knik0/faad2 as the place to send pull
requests. This seems good enough for Debian[0] and Arch[1], and the SF
hosts only a bit older versions, so I used the GitHub project as well.

Note that though the project is named "faad2", the library name is just
"faad"

[0] https://packages.debian.org/sid/faad
[1] https://www.archlinux.org/packages/extra/x86_64/faad2/