### PR TITLE
[date] Update to 2019-11-08

### DIFF
--- a/ports/date/0002-fix-cmake-3.14.patch
+++ b/ports/date/0002-fix-cmake-3.14.patch
@@ -1,0 +1,31 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index 885e424..b9e0b43 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -72,7 +72,6 @@ target_sources( date INTERFACE
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/date/julian.h>
+ )
+ # public headers will get installed:
+-set_target_properties( date PROPERTIES PUBLIC_HEADER include/date/date.h )
+ target_compile_definitions( date INTERFACE
+     #To workaround libstdc++ issue https://github.com/HowardHinnant/date/issues/388
+     ONLY_C_LOCALE=$<IF:$<BOOL:${COMPILE_WITH_C_LOCALE}>,1,0>
+@@ -112,7 +111,6 @@ if( BUILD_TZ_LIB )
+     endif( )
+     set_target_properties( tz PROPERTIES
+         POSITION_INDEPENDENT_CODE ON
+-        PUBLIC_HEADER "${TZ_HEADERS}"
+         VERSION "${PROJECT_VERSION}"
+         SOVERSION "${PROJECT_VERSION}" )
+     if( NOT MSVC )
+@@ -136,8 +134,8 @@ write_basic_package_version_file( "${version_config}"
+     COMPATIBILITY SameMajorVersion )
+ 
+ install( TARGETS date
+-    EXPORT dateConfig
+-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/date )
++    EXPORT dateConfig )
++install( FILES include/date/date.h ${TZ_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/date )
+ export( TARGETS date NAMESPACE date:: FILE dateConfig.cmake )
+ 
+ if( BUILD_TZ_LIB )

--- a/ports/date/CONTROL
+++ b/ports/date/CONTROL
@@ -1,5 +1,5 @@
 Source: date
-Version: 2019-09-09
+Version: 2019-11-08
 Homepage: https://github.com/HowardHinnant/date
 Description: A date and time library based on the C++17 <chrono> header
 

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -10,10 +10,12 @@ endif()
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO HowardHinnant/date
-  REF 44344000f0fa32e66787d6d2c9ff5ddfd3605df7
-  SHA512 1ec75a4b6310f735261c996c63df8176f0523d8f59a23edd49fd8efbdcbf1e78051ba2f36df0920f6f5e6bbc8f81ea4639f73e05bb1cb7f97a8e500bde667782
+  REF 3e376be2e9b4d32c946bd83c22601e4b7a1ce421
+  SHA512 9dad181f8544bfcff8c42200552b6673e537c53b34fbad11663d6435d4e5fd5a3ac6cabbb76312481c9784b237151d9ccd161bb1b8c54c563fa75073896f3cff
   HEAD_REF master
-  PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-fix-uwp.patch"
+  PATCHES
+    "${CMAKE_CURRENT_LIST_DIR}/0001-fix-uwp.patch"
+    "${CMAKE_CURRENT_LIST_DIR}/0002-fix-cmake-3.14.patch"
 )
 
 set(DATE_USE_SYSTEM_TZ_DB 1)
@@ -25,8 +27,8 @@ vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
   OPTIONS
+    -DBUILD_TZ_LIB=ON
     -DUSE_SYSTEM_TZ_DB=${DATE_USE_SYSTEM_TZ_DB}
-    -DENABLE_DATE_TESTING=OFF
 )
 
 vcpkg_install_cmake()
@@ -43,6 +45,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/date RENAME copyright)
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/date)
 
-# Remove the wrapper when backwards compatibility with the unofficial::date::date and unofficial::date::tz
-# targets is no longer required.
+# Remove the wrapper when backwards compatibility when the unofficial::date::date and unofficial::date::tz
+# targets are no longer required.
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/date)


### PR DESCRIPTION
This updates the `date` port to the latest version.

The https://github.com/HowardHinnant/date/commit/a5c4b4ebf8a192c6914b861b33579014a7e7d98a commit is necessary to use (not just build and install) the library in combination with a recent libc++. The later changes are not necessary, but nice to have.

Portfile changes:

- The `ENABLE_DATE_TESTING` option is off by default now, so there is no need to set it explicitly.
- The `BUILD_TZ_LIB` option is off by default now, so it has to be set explicitly.