### PR TITLE
[freealut] Add new port

### DIFF
--- a/ports/freealut/CONTROL
+++ b/ports/freealut/CONTROL
@@ -1,0 +1,11 @@
+Source: freealut
+Version: 2019-11-15
+Homepage: https://github.com/vancegroup/freealut
+Description: freealut is a free implementation of OpenAL's ALUT standard.
+Build-Depends: openal-soft
+
+Feature: test
+Description:Build test
+
+Feature: example
+Description: Build example

--- a/ports/freealut/fix-build-error.patch
+++ b/ports/freealut/fix-build-error.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 963c530..c8e2094 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,8 +40,7 @@ option(BUILD_USE_WERROR "enable fail on all warning" OFF)
+ ###
+ # Dependencies
+ ###
+-find_package(OpenAL REQUIRED)
+-include_directories(${OPENAL_INCLUDE_DIR})
++find_package(OpenAL CONFIG REQUIRED)
+ 
+ ###
+ # Checking for types
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b72d1a1..0c2e799 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -44,7 +44,7 @@ if(BUILD_STATIC)
+ 	# we can't create a static library with the same name
+ 	# as the shared one, so we copy it over after creation
+ 	add_library(alut_static STATIC ${ALUT_SOURCES} ${ALUT_INTERNAL_HEADERS} ${ALUT_HEADERS})
+-	target_link_libraries(alut_static ${OPENAL_LIBRARY} ${ADD_LIBS})
++	target_link_libraries(alut_static OpenAL::OpenAL ${ADD_LIBS})
+ 	if(UNIX)
+ 		target_link_libraries(alut_static m)
+ 	endif()	
+@@ -79,7 +79,7 @@ set_target_properties(alut
+ 	${MAJOR_VERSION}
+ 	SOVERSION
+ 	${MAJOR_VERSION})
+-target_link_libraries(alut ${OPENAL_LIBRARY})
++target_link_libraries(alut OpenAL::OpenAL)
+ if(UNIX)
+ 	target_link_libraries(alut m)
+ endif()	

--- a/ports/freealut/portfile.cmake
+++ b/ports/freealut/portfile.cmake
@@ -1,0 +1,42 @@
+vcpkg_fail_port_install(MESSAGE "${PORT} currently doesn't support uwp." ON_TARGET "uwp")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO vancegroup/freealut
+    REF fc814e316c2bfa6e05b723b8cc9cb276da141aae
+    SHA512 046990cc13822ca6eea0b8e412aa95a994b881429e0b15cefee379f08bd9636d4a4598292a8d46b30c3cd06814bfaeae3298e8ef4087a46eede344f3880e9fed
+    HEAD_REF master
+    PATCHES
+        fix-build-error.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    test BUILD_TESTS
+    example BUILD_EXAMPLES
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(BUILD_STATIC ON)
+else()
+    set(BUILD_STATIC OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA 
+    OPTIONS ${FEATURE_OPTIONS}
+        -DBUILD_STATIC=${BUILD_STATIC}
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
`freealut `is a free implementation of OpenAL's ALUT standard.
This port currently doesn't support uwp due to it needs to depend on `openal-soft`.

Related issue #9009

Note: All features test pass with the following triplets:

- x86-windows

- x64-windows-static

- arm64-windows

- x64-linux