### PR TITLE
[libpqxx] Fix lib name on Linux

### DIFF
--- a/ports/libpqxx/CMakeLists.txt
+++ b/ports/libpqxx/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
     set(SHARED_DEFINITION "")
 endif()
 
-IF(UNIX OR APPLE)
+IF(UNIX)
     set(TARGET pqxx_static)
 ENDIF()
 

--- a/ports/libpqxx/CMakeLists.txt
+++ b/ports/libpqxx/CMakeLists.txt
@@ -40,6 +40,10 @@ else()
     set(SHARED_DEFINITION "")
 endif()
 
+IF(UNIX OR APPLE)
+    set(TARGET pqxx_static)
+ENDIF()
+
 add_library(${TARGET} ${SRCS})
 target_compile_definitions(${TARGET} PRIVATE -DPQXX_INTERNAL -DNOMINMAX ${SHARED_DEFINITION})
 target_include_directories(${TARGET} PRIVATE include ${LIBPQ_FE_H} ${POSTGRES_EXT_H} ${CMAKE_BINARY_DIR})

--- a/ports/libpqxx/CONTROL
+++ b/ports/libpqxx/CONTROL
@@ -1,5 +1,5 @@
 Source: libpqxx
-Version: 6.4.5
+Version: 6.4.5-1
 Homepage: https://github.com/jtv/libpqxx
 Description: The official C++ client API for PostgreSQL
 Build-Depends: libpq


### PR DESCRIPTION
When build and generate lib on Linux, there is prefix 'lib', do not need to add 'lib' to lib name.
Related issue #9040.
No features need to test.