### PR TITLE
[glib] Install msvc_recommended_pragmas.h to <vcpkg>/installed/include

### DIFF
--- a/ports/glib/CMakeLists.txt
+++ b/ports/glib/CMakeLists.txt
@@ -109,6 +109,7 @@ else()
     add_definitions("-DGIO_MODULE_DIR=\"gio/modules\"")
 endif()
 install(FILES ${CMAKE_BINARY_DIR}/config/config.h DESTINATION include/glib)
+install(FILES ${CMAKE_SOURCE_DIR}/msvc_recommended_pragmas.h DESTINATION include)
 
 include_directories(${CMAKE_BINARY_DIR}/config ${CMAKE_BINARY_DIR}/config/glib ${CMAKE_BINARY_DIR}/config/gio ${CMAKE_BINARY_DIR}/config/gmodule)
 include_directories(. glib)

--- a/ports/glib/CONTROL
+++ b/ports/glib/CONTROL
@@ -1,5 +1,5 @@
 Source: glib
-Version: 2.52.3-14-4
+Version: 2.52.3-14-5
 Homepage: https://developer.gnome.org/glib/
 Description: Portable, general-purpose utility library.
 Build-Depends: zlib, pcre, libffi, gettext, libiconv

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -1,13 +1,9 @@
-include(vcpkg_common_functions)
-
 # Glib uses winapi functions not available in WindowsStore
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "Error: UWP builds are currently not supported.")
-endif()
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 # Glib relies on DllMain on Windows
-if (NOT VCPKG_CMAKE_SYSTEM_NAME)
-    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 endif()
 
 set(GLIB_VERSION 2.52.3)


### PR DESCRIPTION
Related issue: #6523 
Feature test pass with following triplets:
- x86-windows (Pass)
- x64-windows (Pass)
- x64-windows-static (Glib does not support static library)
- arm64-windows (Selinux due to dependency build failure)
- arm64-uwp (Glib does not support triplet uwp)
- x64-linux (Selinux build failure on master)