### PR TITLE
[curlpp] Restore installing vcpkg-cmake-wrapper script

### DIFF
--- a/ports/curlpp/CONTROL
+++ b/ports/curlpp/CONTROL
@@ -1,4 +1,4 @@
 Source: curlpp
-Version: 2018-06-15-1
+Version: 2018-06-15-2
 Description: C++ wrapper around libcURL
 Build-Depends: curl

--- a/ports/curlpp/portfile.cmake
+++ b/ports/curlpp/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jpbarrette/curlpp
@@ -17,10 +15,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(
-    CONFIG_PATH lib/cmake/${PORT}
-    TARGET_PATH share/unofficial-${PORT}
-)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT} TARGET_PATH share/unofficial-${PORT})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
@@ -31,11 +26,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     )
 endif()
 
-# Handle copyright
-configure_file(${SOURCE_PATH}/doc/LICENSE
-    ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-
 vcpkg_copy_pdbs()
+vcpkg_test_cmake(PACKAGE_NAME unofficial-${PORT})
 
-# CMake integration test
-#vcpkg_test_cmake(PACKAGE_NAME ${PORT})
+file(INSTALL ${SOURCE_PATH}/doc/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT})
+


### PR DESCRIPTION
The wrapper was deleted by #7331, restored in the port folder by #8532 but still not installed.
This PR is meant to finally fix this long-standing bug which required a manual copy of the file to the proper destination