### PR TITLE
[minizip, assimp] Export minizip CMake targets; Add minizip as assimp dependency

### DIFF
--- a/ports/assimp/CONTROL
+++ b/ports/assimp/CONTROL
@@ -1,5 +1,5 @@
 Source: assimp
-Version: 5.0.0-1
+Version: 5.0.0-2
 Homepage: https://github.com/assimp/assimp
 Description: The Open Asset import library
-Build-Depends: zlib, rapidjson
+Build-Depends: zlib, rapidjson, minizip

--- a/ports/assimp/fix_minizip.patch
+++ b/ports/assimp/fix_minizip.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6c3d03e..4cb6927 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -470,12 +470,12 @@ ENDIF(HUNTER_ENABLED)
+ 
+ IF( NOT IOS )
+   IF( NOT ASSIMP_BUILD_MINIZIP )
+-    use_pkgconfig(UNZIP minizip)
++    find_package(minizip CONFIG REQUIRED)
+   ENDIF( NOT ASSIMP_BUILD_MINIZIP )
+ ELSE ( NOT IOS )
+   IF( NOT BUILD_SHARED_LIBS )
+     IF( NOT ASSIMP_BUILD_MINIZIP )
+-      use_pkgconfig(UNZIP minizip)
++       find_package(minizip CONFIG REQUIRED)
+     ENDIF( NOT ASSIMP_BUILD_MINIZIP )
+   ENDIF ( NOT BUILD_SHARED_LIBS )
+ ENDIF ( NOT IOS )
+diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
+index 55538d9..30568ff 100644
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1125,7 +1125,7 @@ IF(HUNTER_ENABLED)
+       zip::zip
+   )
+ ELSE(HUNTER_ENABLED)
+-  TARGET_LINK_LIBRARIES(assimp ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES} ${IRRXML_LIBRARY} )
++  TARGET_LINK_LIBRARIES(assimp ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES} ${IRRXML_LIBRARY} minizip::minizip)
+ ENDIF(HUNTER_ENABLED)
+ 
+ if(ASSIMP_ANDROID_JNIIOSYSTEM)

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO assimp/assimp
@@ -10,6 +8,7 @@ vcpkg_from_github(
         uninitialized-variable.patch
         fix-static-build-error.patch
         cmake-policy.patch
+        fix_minizip.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake-modules/FindZLIB.cmake)
@@ -67,6 +66,4 @@ endif()
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/share/assimp/assimp-config.cmake "${ASSIMP_CONFIG}")
 
-# Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/assimp)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/assimp/LICENSE ${CURRENT_PACKAGES_DIR}/share/assimp/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -69,6 +69,7 @@ set_target_properties(miniunz_bin PROPERTIES OUTPUT_NAME miniunz)
 
 install(
   TARGETS minizip
+  EXPORT minizipTargets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/ports/minizip/CMakeLists.txt
+++ b/ports/minizip/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(minizip C)
 
+set(PROJECT_VERSION 1.2.11)
+set(PROJECT_VERSION_MAJOR 1)
+set(PROJECT_VERSION_MINOR 2)
+set(PROJECT_VERSION_PATCH 11)
+
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
 endif()
@@ -25,7 +30,6 @@ set(SRC
   ${MIN_SRC}/ioapi.c
   ${MIN_SRC}/unzip.c
   ${MIN_SRC}/zip.c
-  ${MIN_SRC}/unzip.c
   ${MIN_SRC}/mztools.c
 )
 if(WIN32)
@@ -37,7 +41,6 @@ set(HEADERS
   ${MIN_SRC}/ioapi.h
   ${MIN_SRC}/unzip.h
   ${MIN_SRC}/zip.h
-  ${MIN_SRC}/unzip.h
   ${MIN_SRC}/mztools.h
 )
 if(WIN32)
@@ -69,6 +72,25 @@ install(
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/minizipConfigVersion.cmake"
+                                    COMPATIBILITY SameMajorVersion)
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/minizipConfig.cmake.in
+                                minizipConfig.cmake
+                                INSTALL_DESTINATION share/minizip)
+
+install(FILES
+        "${PROJECT_BINARY_DIR}/minizipConfig.cmake"
+        "${PROJECT_BINARY_DIR}/minizipConfigVersion.cmake"
+        DESTINATION share/minizip
+)
+
+install(EXPORT minizipTargets
+        NAMESPACE minizip::
+        DESTINATION share/minizip
 )
 
 if(NOT DISABLE_INSTALL_TOOLS)

--- a/ports/minizip/CONTROL
+++ b/ports/minizip/CONTROL
@@ -1,5 +1,5 @@
 Source: minizip
-Version: 1.2.11-5
+Version: 1.2.11-6
 Build-Depends: zlib
 Homepage: https://github.com/madler/zlib
 Description: Zip compression library

--- a/ports/minizip/minizipConfig.cmake.in
+++ b/ports/minizip/minizipConfig.cmake.in
@@ -1,0 +1,4 @@
+#@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -1,7 +1,4 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "WindowsStore not supported")
-endif()
-
+vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -13,10 +10,9 @@ vcpkg_from_github(
     PATCHES minizip.patch # enable decrypt support for password-encrypted ZIP files
 )
 
-set(BUILD_minizip_bzip2 OFF)
-if ("bzip2" IN_LIST FEATURES)
-    set(BUILD_minizip_bzip2 ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    bzip2 ENABLE_BZIP2
+)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/minizipConfig.cmake.in  ${SOURCE_PATH}/cmake/minizipConfig.cmake.in COPYONLY)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt  ${SOURCE_PATH}/CMakeLists.txt COPYONLY)
@@ -25,7 +21,7 @@ vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         PREFER_NINJA
         OPTIONS
-            -DENABLE_BZIP2=${BUILD_minizip_bzip2}
+            ${FEATURE_OPTIONS}
         OPTIONS_DEBUG
             -DDISABLE_INSTALL_HEADERS=ON
             -DDISABLE_INSTALL_TOOLS=ON

--- a/ports/minizip/portfile.cmake
+++ b/ports/minizip/portfile.cmake
@@ -1,48 +1,48 @@
-include(vcpkg_common_functions)
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-	message(FATAL_ERROR "WindowsStore not supported")
+    message(FATAL_ERROR "WindowsStore not supported")
 endif()
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-	OUT_SOURCE_PATH SOURCE_PATH
-	REPO madler/zlib
-	REF v1.2.11
-	SHA512 104c62ed1228b5f1199bc037081861576900eb0697a226cafa62a35c4c890b5cb46622e399f9aad82ee5dfb475bae26ae75e2bd6da3d261361b1c8b996970faf
-	HEAD_REF master
-	PATCHES minizip.patch # enable decrypt support for password-encrypted ZIP files
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO madler/zlib
+    REF v1.2.11
+    SHA512 104c62ed1228b5f1199bc037081861576900eb0697a226cafa62a35c4c890b5cb46622e399f9aad82ee5dfb475bae26ae75e2bd6da3d261361b1c8b996970faf
+    HEAD_REF master
+    PATCHES minizip.patch # enable decrypt support for password-encrypted ZIP files
 )
 
 set(BUILD_minizip_bzip2 OFF)
 if ("bzip2" IN_LIST FEATURES)
-	set(BUILD_minizip_bzip2 ON)
+    set(BUILD_minizip_bzip2 ON)
 endif()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+configure_file(${CMAKE_CURRENT_LIST_DIR}/minizipConfig.cmake.in  ${SOURCE_PATH}/cmake/minizipConfig.cmake.in COPYONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt  ${SOURCE_PATH}/CMakeLists.txt COPYONLY)
 
 vcpkg_configure_cmake(
-		SOURCE_PATH ${SOURCE_PATH}
-		PREFER_NINJA
-		OPTIONS
-			-DENABLE_BZIP2=${BUILD_minizip_bzip2}
-		OPTIONS_DEBUG 
-			-DDISABLE_INSTALL_HEADERS=ON -DDISABLE_INSTALL_TOOLS=ON
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DENABLE_BZIP2=${BUILD_minizip_bzip2}
+        OPTIONS_DEBUG
+            -DDISABLE_INSTALL_HEADERS=ON
+            -DDISABLE_INSTALL_TOOLS=ON
 )
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-
+vcpkg_fixup_cmake_targets()
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/minizip)
 
 if ("bzip2" IN_LIST FEATURES)
-	file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/minizip/*.h")
-	foreach(HEADER ${HEADERS})
-		file(READ "${HEADER}" _contents)
-		string(REPLACE "#ifdef HAVE_BZIP2" "#if 1" _contents "${_contents}")
-		file(WRITE "${HEADER}" "${_contents}")
-	endforeach()
+    file(GLOB HEADERS "${CURRENT_PACKAGES_DIR}/include/minizip/*.h")
+    foreach(HEADER ${HEADERS})
+        file(READ "${HEADER}" _contents)
+        string(REPLACE "#ifdef HAVE_BZIP2" "#if 1" _contents "${_contents}")
+        file(WRITE "${HEADER}" "${_contents}")
+    endforeach()
 endif()
 
-file(INSTALL ${SOURCE_PATH}/contrib/minizip/MiniZip64_info.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/minizip RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/contrib/minizip/MiniZip64_info.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Related https://github.com/microsoft/vcpkg/pull/8642

Changes:
1. Export cmake config and and targets for minizip
2. Fix  minizip dependency to use find_package(minizip CONFIG REQUIRED) in assimp

 assimp has no features need to test locally, minizip all features test pass on x86-windows-static.