### PR TITLE
[libmodplug] use static cast for ctype

### DIFF
--- a/ports/libmodplug/003-use-static-cast-for-ctype.patch
+++ b/ports/libmodplug/003-use-static-cast-for-ctype.patch
@@ -1,0 +1,14 @@
+diff --git a/src/load_abc.cpp b/src/load_abc.cpp
+index ee79f39..874ab8f 100644
+--- a/src/load_abc.cpp
++++ b/src/load_abc.cpp
+@@ -268,7 +268,8 @@ static void setenv(const char *name, const char *value, int overwrite)
+ #endif
+ 
+ static int abc_isvalidchar(char c) {
+-	return(isalpha(c) || isdigit(c) || isspace(c) || c == '%' || c == ':');
++	unsigned char u = static_cast<unsigned char>(c);
++	return(isalpha(u) || isdigit(u) || isspace(u) || c == '%' || c == ':');
+ }
+ #if 0
+ static const char *abc_skipspace(const char *p)

--- a/ports/libmodplug/CONTROL
+++ b/ports/libmodplug/CONTROL
@@ -1,4 +1,4 @@
 Source: libmodplug
-Version: 0.8.9.0-4
+Version: 0.8.9.0-5
 Homepage: https://github.com/Konstanty/libmodplug
 Description: The ModPlug mod file playing library.

--- a/ports/libmodplug/portfile.cmake
+++ b/ports/libmodplug/portfile.cmake
@@ -11,6 +11,7 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
         PATCHES
             "001-automagically-define-modplug-static.patch"
             "002-detect_sinf.patch"
+            "003-use-static-cast-for-ctype.patch"
     )
 else()
     vcpkg_from_github(ARCHIVE
@@ -20,6 +21,7 @@ else()
         SHA512 c43bb3190b62c3a4e3636bba121b5593bbf8e6577ca9f2aa04d90b03730ea7fb590e640cdadeb565758b92e81187bc456e693fe37f1f4deace9b9f37556e3ba1
         PATCHES
             "002-detect_sinf.patch"
+            "003-use-static-cast-for-ctype.patch"
     )
 endif()
 


### PR DESCRIPTION
The original library code is correct except that it lacks a cast to `unsigned char` which in this case raises unnecessary assertions in debug mode.

References:

https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isalpha-iswalpha-isalpha-l-iswalpha-l
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isdigit-iswdigit-isdigit-l-iswdigit-l
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isspace-iswspace-isspace-l-iswspace-l
