### PR TITLE
[ffmpeg] install correct copyright file and enable (L)GPLv3 builds

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -48,5 +48,8 @@ Description: allow nonfree and unredistributable libraries
 Feature: gpl
 Description: allow GPL licensed libraries
 
+Feature: version3
+Description: upgrade (L)GPL to version 3
+
 Feature: avresample
 Description: Libav audio resampling library support in ffmpeg

--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.2-1
+Version: 4.2-2
 Build-Depends: zlib
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -276,7 +276,6 @@ elseif(${LICENSE_STRING} STREQUAL "License: nonfree and unredistributable")
 else()
     message(FATAL_ERROR "Failed to identify license (${LICENSE_STRING})")
 endif()
-message(STATUS ${LICENSE_STRING})
 file(INSTALL ${SOURCE_PATH}/${LICENSE_FILE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/FindFFMPEG.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/FindFFMPEG.cmake @ONLY)

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -67,6 +67,10 @@ if("gpl" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-gpl")
 endif()
 
+if("version3" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-version3")
+endif()
+
 if("openssl" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-openssl")
 else()

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -261,8 +261,23 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR
 vcpkg_copy_pdbs()
 
 # Handle copyright
-# TODO: Examine build log and confirm that this license matches the build output
-file(INSTALL ${SOURCE_PATH}/COPYING.LGPLv2.1 DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(STRINGS ${CURRENT_BUILDTREES_DIR}/build-${TARGET_TRIPLET}-rel-out.log LICENSE_STRING REGEX "License: .*" LIMIT_COUNT 1)
+if(${LICENSE_STRING} STREQUAL "License: LGPL version 2.1 or later")
+    set(LICENSE_FILE "COPYING.LGPLv2.1")
+elseif(${LICENSE_STRING} STREQUAL "License: LGPL version 3 or later")
+    set(LICENSE_FILE "COPYING.LGPLv3")
+elseif(${LICENSE_STRING} STREQUAL "License: GPL version 2 or later")
+    set(LICENSE_FILE "COPYING.GPLv2")
+elseif(${LICENSE_STRING} STREQUAL "License: GPL version 3 or later")
+    set(LICENSE_FILE "COPYING.GPLv3")
+elseif(${LICENSE_STRING} STREQUAL "License: nonfree and unredistributable")
+    set(LICENSE_FILE "COPYING.NONFREE")
+    file(WRITE ${SOURCE_PATH}/${LICENSE_FILE} ${LICENSE_STRING})
+else()
+    message(FATAL_ERROR "Failed to identify license (${LICENSE_STRING})")
+endif()
+message(STATUS ${LICENSE_STRING})
+file(INSTALL ${SOURCE_PATH}/${LICENSE_FILE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/FindFFMPEG.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/FindFFMPEG.cmake @ONLY)
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
This patch adds a new "version3" feature to allow (L)GPLv3 builds. It also inspects the log files to ensure that the correct license file is installed.