### PR TITLE
[libevent] Add thread as default feature

### DIFF
--- a/ports/libevent/CONTROL
+++ b/ports/libevent/CONTROL
@@ -1,8 +1,9 @@
 Source: libevent
-Version: 2.1.11-1
+Version: 2.1.11-2
 Build-Depends: openssl
 Homepage: https://github.com/libevent/libevent
 Description: An event notification library
+Default-Features: thread
 
 Feature: openssl
 Description: Support for openssl

--- a/ports/libevent/portfile.cmake
+++ b/ports/libevent/portfile.cmake
@@ -1,8 +1,4 @@
-include(vcpkg_common_functions)
-
-if(VCPKG_CMAKE_SYSTEM_NAME MATCHES "WindowsStore")
-    message(FATAL_ERROR "${PORT} does not currently support UWP")
-endif()
+vcpkg_fail_port_install(MESSAGE "${PORT} does not currently support UWP" ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -57,5 +53,5 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libevent)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libevent/LICENSE ${CURRENT_PACKAGES_DIR}/share/libevent/copyright)
+#Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
When we disable support `thread` for this port, it will cause some [errors](https://github.com/bitcoin/bitcoin/issues/17586) in Bitcoin Core msvc build.
So I add `thread `as the default feature of `libevent`.

I also updated the deprecated functions.


Related PR #8349.

All features test pass with the following triplets:

- x86-windows

- x64-windows-static

- arm64-windows

- x64-linux

- x64-uwp (not supported)