### PR TITLE
[imgui] Updated to 1.74 and added features for sdl2 and vulkan

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -44,7 +44,7 @@ if (IMGUI_INCLUDE_IMPL_VULKAN)
     target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
 endif()
 
-if (IMGUI_INCLUDE_IMPL_VULKAN)
+if (IMGUI_INCLUDE_IMPL_SDL2)
     target_link_libraries(${PROJECT_NAME} PUBLIC SDL2::SDL2main SDL2::SDL2-static)
 endif()
 

--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -19,13 +19,38 @@ set(IMGUI_SOURCES
     imgui_widgets.cpp
 )
 
+if (IMGUI_INCLUDE_IMPL_VULKAN)
+    find_package(vulkan)
+
+    list (APPEND IMGUI_INCLUDES_PUBLIC examples/imgui_impl_vulkan.h)
+    list (APPEND IMGUI_SOURCES examples/imgui_impl_vulkan.cpp)
+endif()
+
+if (IMGUI_INCLUDE_IMPL_SDL2)
+    find_package(SDL2 CONFIG REQUIRED)
+
+    list (APPEND IMGUI_INCLUDES_PUBLIC examples/imgui_impl_sdl.h)
+    list (APPEND IMGUI_SOURCES examples/imgui_impl_sdl.cpp)
+endif()
+
+
 add_library(${PROJECT_NAME}
     ${IMGUI_INCLUDES_PUBLIC}
     ${IMGUI_INCLUDES_PRIVATE}
     ${IMGUI_SOURCES}
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
+if (IMGUI_INCLUDE_IMPL_VULKAN)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
+endif()
+
+if (IMGUI_INCLUDE_IMPL_VULKAN)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL2::SDL2main SDL2::SDL2-static)
+endif()
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
 
 install(TARGETS ${PROJECT_NAME}
     EXPORT IMGUIExport

--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -20,7 +20,7 @@ set(IMGUI_SOURCES
 )
 
 if (IMGUI_INCLUDE_IMPL_VULKAN)
-    find_package(vulkan)
+    find_package(vulkan REQUIRED)
 
     list (APPEND IMGUI_INCLUDES_PUBLIC examples/imgui_impl_vulkan.h)
     list (APPEND IMGUI_SOURCES examples/imgui_impl_vulkan.cpp)

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,5 +1,5 @@
 Source: imgui
-Version: 1.73-1
+Version: 1.74
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
@@ -12,5 +12,5 @@ Description: sdl2 implementation for imgui
 Build-Depends: sdl2
 
 Feature: example
-Description: build with examples
+Description: build with all examples
 Build-Depends: glfw3, freeglut, opengl, sdl1

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -3,6 +3,14 @@ Version: 1.73-1
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
+Feature: vulkan
+Description: vulkan implementation for imgui
+Build-Depends: vulkan
+
+Feature: sdl2
+Description: sdl2 implementation for imgui
+Build-Depends: sdl2
+
 Feature: example
 Description: build with examples
 Build-Depends: glfw3, freeglut, opengl, sdl1

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -4,11 +4,11 @@ Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
 Feature: vulkan
-Description: vulkan implementation for imgui
+Description: imgui developer renderer bindings implementation for vulkan
 Build-Depends: vulkan
 
 Feature: sdl2
-Description: sdl2 implementation for imgui
+Description: imgui developer platform bindings implementation for sdl2
 Build-Depends: sdl2
 
 Feature: example

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     example IMGUI_COMPILE_ALL_EXAMPLES
 )
 
-if ("example" IN_LIST FEATURES AND ("sdl2" IN_LIST FEATURES OR "vulkan" IN_LIST ))
+if ("example" IN_LIST FEATURES AND ("sdl2" IN_LIST FEATURES OR "vulkan" IN_LIST FEATURES))
     message (FATAL_ERROR "example feature uses includes whole examples folder, do not use it with other features")
 endif()
 

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -12,15 +12,23 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    vulkan IMGUI_INCLUDE_IMPL_VULKAN
+    sdl2 IMGUI_INCLUDE_IMPL_SDL2
+    example IMGUI_COMPILE_ALL_EXAMPLES
+)
+
+if ("example" IN_LIST FEATURES AND ("sdl2" IN_LIST FEATURES OR "vulkan" IN_LIST ))
+    message (FATAL_ERROR "example feature uses includes whole examples folder, do not use it with other features")
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DIMGUI_INCLUDE_IMPL_VULKAN=ON
-        -DIMGUI_INCLUDE_IMPL_SDL2=ON
+        ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
-        
 )
 
 vcpkg_install_cmake()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v1.73
-    SHA512 1d67b7cc3f06ea77a2484e62034104386f42106fefe9b6eb62ee8a31fe949c9cda0cc095fbead9269e9da2a5d6199604d34c095eefd630655725265ac0fc4d92
+    REF v1.74
+    SHA512 e49e5cbe55899c0d0abc9b66c4e6e3e9941542af542d0ed3304bd3bde34c769baa2367355b77b91acb7fca56f9bcfd233dfc99881cfc8f5f6a2e2e6839990832
     HEAD_REF master
 )
 

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -29,8 +29,6 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
-        -DIMGUI_INCLUDE_IMPL_VULKAN=ON
-        -DIMGUI_INCLUDE_IMPL_SDL2=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -17,6 +17,8 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
+        -DIMGUI_INCLUDE_IMPL_VULKAN=ON
+        -DIMGUI_INCLUDE_IMPL_SDL2=ON
 )
 
 vcpkg_install_cmake()
@@ -29,11 +31,11 @@ if ("example" IN_LIST FEATURES)
         USE_VCPKG_INTEGRATION
         PROJECT_PATH ${SOURCE_PATH}/examples/imgui_examples.sln
     )
-    
+
     # Install headers
     file(GLOB IMGUI_EXAMPLE_INCLUDES ${SOURCE_PATH}/examples/*.h)
     file(INSTALL ${IMGUI_EXAMPLE_INCLUDES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-    
+
     # Install tools
     file(GLOB_RECURSE IMGUI_EXAMPLE_BINARIES ${SOURCE_PATH}/examples/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
     file(INSTALL ${IMGUI_EXAMPLE_BINARIES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -15,8 +15,12 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DIMGUI_INCLUDE_IMPL_VULKAN=ON
+        -DIMGUI_INCLUDE_IMPL_SDL2=ON
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
+        
 )
 
 vcpkg_install_cmake()
@@ -29,11 +33,11 @@ if ("example" IN_LIST FEATURES)
         USE_VCPKG_INTEGRATION
         PROJECT_PATH ${SOURCE_PATH}/examples/imgui_examples.sln
     )
-    
+
     # Install headers
     file(GLOB IMGUI_EXAMPLE_INCLUDES ${SOURCE_PATH}/examples/*.h)
     file(INSTALL ${IMGUI_EXAMPLE_INCLUDES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-    
+
     # Install tools
     file(GLOB_RECURSE IMGUI_EXAMPLE_BINARIES ${SOURCE_PATH}/examples/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
     file(INSTALL ${IMGUI_EXAMPLE_BINARIES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)


### PR DESCRIPTION
I updated library to latest 1.74 and added separate features for sdl2 and Vulkan.
To not break old functionality I added check for not using feature "extra" with sdl2 and vulkan. Extra is windows only feature (sln solution for a lot of stuff in extras folder, including content in these two other features), where as sdl2 and vulkan are just implementation example bindings made by library developers.