### PR TITLE
[openMVG] Disable AVX[2] usage 

### DIFF
--- a/ports/openmvg/CONTROL
+++ b/ports/openmvg/CONTROL
@@ -1,5 +1,5 @@
 Source: openmvg
-Version: 1.5
+Version: 1.5-1
 Description: open Multiple View Geometry library. Basis for 3D computer vision and Structure from Motion.
 Build-Depends: coinutils, clp, osi, liblemon, flann, eigen3, ceres, cereal, libjpeg-turbo, tiff, libpng, zlib, suitesparse
 

--- a/ports/openmvg/portfile.cmake
+++ b/ports/openmvg/portfile.cmake
@@ -60,6 +60,7 @@ vcpkg_configure_cmake(
         -DOpenMVG_USE_INTERNAL_CERES=OFF
         -DOpenMVG_USE_INTERNAL_FLANN=OFF
         -DOpenMVG_USE_INTERNAL_LEMON=OFF
+        -DTARGET_ARCHITECTURE=none
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
The default value for TARGET_ARCHITECTURE is 'auto' which works as 'march=native' i.e. it uses all instruction sets available on the build node, including AVX and AVX2.  Setting it to 'none' makes "SSE 4.1" the highest instruction set used.