### PR TITLE
[azure-iot-sdk-c] Update macro-utils and umock-c to differentiate master and public-preview installations

### DIFF
--- a/ports/azure-c-shared-utility/CONTROL
+++ b/ports/azure-c-shared-utility/CONTROL
@@ -1,7 +1,8 @@
 Source: azure-c-shared-utility
-Version: 2019-10-07.2
+Version: 2019-10-07.2-1
 Description: Azure C SDKs common code
 Build-Depends: curl (linux), openssl (linux), azure-macro-utils-c, umock-c
 
 Feature: public-preview
 Description: Azure C SDKs common code (public preview)
+Build-Depends: curl (linux), openssl (linux), azure-macro-utils-c[public-preview], umock-c[public-preview]

--- a/ports/azure-c-shared-utility/portfile.cmake
+++ b/ports/azure-c-shared-utility/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,11 +1,11 @@
 Source: azure-iot-sdk-c
-Version: 2019-11-21.1
+Version: 2019-11-27.1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
 
 Feature: public-preview
 Description: A version of the azure-iot-sdk-c containing public-preview features.
-Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], azure-uhttp-c[public-preview], azure-macro-utils-c, umock-c
+Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], azure-uhttp-c[public-preview], azure-macro-utils-c[public-preview], umock-c[public-preview]
 
 Feature: use_prov_client
 Description: Enables device provisioning client for DPS

--- a/ports/azure-macro-utils-c/CONTROL
+++ b/ports/azure-macro-utils-c/CONTROL
@@ -1,5 +1,7 @@
 Source: azure-macro-utils-c
-Version: 2019-10-07.2
+Version: 2019-11-27.1
 Description: A library of macros for the Azure IoT SDK Suite
 Build-Depends: 
 
+Feature: public-preview
+Description: A library of macros for the Azure IoT SDK Suite (public-preview)

--- a/ports/azure-macro-utils-c/portfile.cmake
+++ b/ports/azure-macro-utils-c/portfile.cmake
@@ -2,13 +2,23 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/azure-macro-utils-c
-    REF 7523af934fc4d9423111e358f49b19314ec9c3e3
-    SHA512 b53765096654fff9c5670004e4e107bffa81dd07e63eeac687c9e2b7e5ea2e1f26b6ae025c05c45f5c28152a457922f08c7f8d3303fa4d3b9194c34ba59533d5
-    HEAD_REF master
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-macro-utils-c
+        REF 7523af934fc4d9423111e358f49b19314ec9c3e3
+        SHA512 b53765096654fff9c5670004e4e107bffa81dd07e63eeac687c9e2b7e5ea2e1f26b6ae025c05c45f5c28152a457922f08c7f8d3303fa4d3b9194c34ba59533d5
+        HEAD_REF master
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/azure-macro-utils-c
+        REF 7523af934fc4d9423111e358f49b19314ec9c3e3
+        SHA512 b53765096654fff9c5670004e4e107bffa81dd07e63eeac687c9e2b7e5ea2e1f26b6ae025c05c45f5c28152a457922f08c7f8d3303fa4d3b9194c34ba59533d5
+        HEAD_REF master
+    )
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/azure-uamqp-c/CONTROL
+++ b/ports/azure-uamqp-c/CONTROL
@@ -1,8 +1,8 @@
 Source: azure-uamqp-c
-Version: 2019-10-07.2
+Version: 2019-11-27.1
 Build-Depends: azure-c-shared-utility, azure-macro-utils-c, umock-c
 Description: AMQP library for C
 
 Feature: public-preview
 Description: AMQP library for C (public preview)
-Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c, umock-c
+Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c[public-preview], umock-c[public-preview]

--- a/ports/azure-uhttp-c/CONTROL
+++ b/ports/azure-uhttp-c/CONTROL
@@ -1,8 +1,8 @@
 Source: azure-uhttp-c
-Version: 2019-10-07.2
+Version: 2019-11-27.1
 Build-Depends: azure-c-shared-utility, azure-macro-utils-c, umock-c
 Description: Azure HTTP Library written in C
 
 Feature: public-preview
 Description: Azure HTTP Library written in C (public preview)
-Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c, umock-c
+Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c[public-preview], umock-c[public-preview]

--- a/ports/azure-umqtt-c/CONTROL
+++ b/ports/azure-umqtt-c/CONTROL
@@ -1,8 +1,8 @@
 Source: azure-umqtt-c
-Version: 2019-10-07.2
+Version: 2019-11-27.1
 Build-Depends: azure-c-shared-utility, azure-macro-utils-c, umock-c
 Description: General purpose library for communication over the mqtt protocol
 
 Feature: public-preview
 Description: General purpose library for communication over the mqtt protocol (public preview)
-Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c, umock-c
+Build-Depends: azure-c-shared-utility[public-preview], azure-macro-utils-c[public-preview], umock-c[public-preview]

--- a/ports/umock-c/CONTROL
+++ b/ports/umock-c/CONTROL
@@ -1,5 +1,8 @@
 Source: umock-c
-Version: 2019-10-07.2
+Version: 2019-11-27.1
 Description: A pure C mocking library
 Build-Depends: azure-macro-utils-c
 
+Feature: public-preview
+Description: A pure C mocking library (public-preview)
+Build-Depends: azure-macro-utils-c[public-preview]

--- a/ports/umock-c/portfile.cmake
+++ b/ports/umock-c/portfile.cmake
@@ -2,13 +2,23 @@ include(vcpkg_common_functions)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO Azure/umock-c
-    REF 87d2214384c886a1e2406ac0756a0b3786add8da
-    SHA512 230b6c79a8346727bbc124d1aefaa14da8ecd82b2a56d68b3d2511b8efa5931872da440137a5d266835ba8c5193b83b4bc5ee85abb5242d07904a0706727926c
-    HEAD_REF master
-)
+if("public-preview" IN_LIST FEATURES)
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/umock-c
+        REF 87d2214384c886a1e2406ac0756a0b3786add8da
+        SHA512 230b6c79a8346727bbc124d1aefaa14da8ecd82b2a56d68b3d2511b8efa5931872da440137a5d266835ba8c5193b83b4bc5ee85abb5242d07904a0706727926c
+        HEAD_REF master
+    )
+else()
+    vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO Azure/umock-c
+        REF 87d2214384c886a1e2406ac0756a0b3786add8da
+        SHA512 230b6c79a8346727bbc124d1aefaa14da8ecd82b2a56d68b3d2511b8efa5931872da440137a5d266835ba8c5193b83b4bc5ee85abb5242d07904a0706727926c
+        HEAD_REF master
+    )
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
This change is necessary to keep the chain of submodule dependencies versions correct on the azure-iot-sdk-c vcpkg ports when installing using different flavors (from master or public-preview).

Note: all features test pass with following triplets:
- x86-windows
- x64-windows
- x64-windows-static
- arm64-windows
- x64-linux