### PR TITLE
[fmt] Disable warning C4189 on Visual Studio 2015

### DIFF
--- a/ports/fmt/CONTROL
+++ b/ports/fmt/CONTROL
@@ -1,4 +1,4 @@
 Source: fmt
-Version: 6.0.0
+Version: 6.0.0-1
 Homepage: https://github.com/fmtlib/fmt
 Description: Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.

--- a/ports/fmt/fix-warning4189.patch
+++ b/ports/fmt/fix-warning4189.patch
@@ -1,0 +1,12 @@
+diff --git a/include/fmt/format.h b/include/fmt/format.h
+index efec5d6..9b15b48 100644
+--- a/include/fmt/format.h
++++ b/include/fmt/format.h
+@@ -33,6 +33,7 @@
+ #ifndef FMT_FORMAT_H_
+ #define FMT_FORMAT_H_
+ 
++#pragma warning(disable:4189)
+ #include <algorithm>
+ #include <cassert>
+ #include <cmath>

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -1,10 +1,10 @@
-include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fmtlib/fmt
     REF 6.0.0
     SHA512 7deb5bd843ae6b9d4b58dca9c68c1cfe7b55a41040f358247f5309655188d1ae194ff414437c068f74367f078faa214b5883e8c9e634c7623dcda50850e24766
     HEAD_REF master
+    PATCHES fix-warning4189.patch
 )
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Warning C4189 has been fixed in Visual Studio 2017 and Visual Studio 2019. Disable this warning in Visual Studio 2015.
Related issue: #9120 
There are no features of this port need to test.