### PR TITLE
[many ports] Add mirror

### DIFF
--- a/ports/cgicc/CONTROL
+++ b/ports/cgicc/CONTROL
@@ -1,4 +1,4 @@
 Source: cgicc
-Version: 3.2.19-3
+Version: 3.2.19-4
 Homepage: https://www.gnu.org/software/cgicc/
 Description: GNU Cgicc is an ANSI C++ compliant class library that greatly simplifies the creation of CGI applications for the World Wide Web

--- a/ports/cgicc/portfile.cmake
+++ b/ports/cgicc/portfile.cmake
@@ -1,11 +1,10 @@
-
-include(vcpkg_common_functions)
+set(CGICC_VERSION 3.2.19)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://ftp.gnu.org/gnu/cgicc/cgicc-3.2.19.tar.gz"
-    FILENAME "cgicc-3.2.19.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/cgicc/cgicc-${CGICC_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/cgicc/cgicc-${CGICC_VERSION}.tar.gz"
+    FILENAME "cgicc-${CGICC_VERSION}.tar.gz"
     SHA512 c361923cf3ac876bc3fc94dffd040d2be7cd44751d8534f4cfa3545e9f58a8ec35ebcd902a8ce6a19da0efe52db67506d8b02e5cc868188d187ce3092519abdf
 )
 

--- a/ports/gsl/CONTROL
+++ b/ports/gsl/CONTROL
@@ -1,4 +1,4 @@
 Source: gsl
-Version: 2.4-4
+Version: 2.4-5
 Homepage: https://www.gnu.org/software/gsl/
 Description: The GNU Scientific Library is a numerical library for C and C++ programmers

--- a/ports/gsl/portfile.cmake
+++ b/ports/gsl/portfile.cmake
@@ -1,8 +1,7 @@
-include(vcpkg_common_functions)
 set(GSL_VERSION 2.4)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "ftp://ftp.gnu.org/gnu/gsl/gsl-${GSL_VERSION}.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/gsl/gsl-${GSL_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gsl/gsl-${GSL_VERSION}.tar.gz"
     FILENAME "gsl-${GSL_VERSION}.tar.gz"
     SHA512 12442b023dd959e8b22a9c486646b5cedec7fdba0daf2604cda365cf96d10d99aefdec2b42e59c536cc071da1525373454e5ed6f4b15293b305ca9b1dc6db130
 )

--- a/ports/libidn2/CONTROL
+++ b/ports/libidn2/CONTROL
@@ -1,5 +1,5 @@
 Source: libidn2
-Version: 2.2.0
+Version: 2.2.0-1
 Build-Depends: libiconv
 Homepage: https://www.gnu.org/software/libidn/
 Description: GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.

--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 set(IDN2_VERSION 2.2.0)
 set(IDN2_FILENAME libidn2-${IDN2_VERSION}.tar.gz)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
+    URLS "https://ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libidn/${IDN2_FILENAME}"
     FILENAME "${IDN2_FILENAME}"
     SHA512 ccf56056a378d49a28ff67a2a23cd3d32ce51f86a78f84839b98dad709a1d0d03ac8d7c1496f0e4d3536bca00e3d09d34d76a37317b2ce87e3aa66bdf4e877b8
 )

--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,4 +1,4 @@
 Source: libmicrohttpd
-Version: 0.9.63-1
+Version: 0.9.63-2
 Homepage: https://www.gnu.org/software/libmicrohttpd/
 Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -1,10 +1,10 @@
-include(vcpkg_common_functions)
+set(MICROHTTPD_VERSION 0.9.63)
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "ftp://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.63.tar.gz"
-    FILENAME "libmicrohttpd-0.9.63.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+    FILENAME "libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
     SHA512 cb99e7af84fb6d7c0fd3894a9dc0fbff14959b35347506bd3211a65bbfad36455007b9e67493e97c9d8394834408df10eeabdc7758573e6aae0ba6f5f87afe17
 )
 

--- a/ports/libosip2/CONTROL
+++ b/ports/libosip2/CONTROL
@@ -1,4 +1,4 @@
 Source: libosip2
-Version: 5.1.0-1
+Version: 5.1.0-2
 Homepage: https://www.gnu.org/software/osip/
 Description: oSIP is an LGPL implementation of SIP. It's stable, portable, flexible and compliant! -may be more-! It is used mostly with eXosip2 stack (GPL) which provides simpler API for User-Agent implementation.

--- a/ports/libosip2/portfile.cmake
+++ b/ports/libosip2/portfile.cmake
@@ -1,13 +1,9 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(MESSAGE "${PORT} only supports Unix currently." ON_TARGET "Windows")
 
 set(LIBOSIP2_VER "5.1.0")
 
-if (VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "libosio2 only support unix currently.")
-endif()
-
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://ftp.gnu.org/gnu/osip/libosip2-${LIBOSIP2_VER}.tar.gz"
+    URLS "https://ftp.gnu.org/gnu/osip/libosip2-${LIBOSIP2_VER}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/osip/libosip2-${LIBOSIP2_VER}.tar.gz"
     FILENAME "libosip2-${LIBOSIP2_VER}.tar.gz"
     SHA512 391c9a0ea399f789d7061b0216d327eecba5bbf0429659f4f167604b9e703e1678ba6f58079aa4f84b3636a937064ecfb92e985368164fcb679e95654e43d65b
 )


### PR DESCRIPTION
Since the normal ftp.gnu.org site was not accessible for all users to acquire several GNU libraries.
I added mirror https://www.mirrorservice.org/sites to some GNU libraries to fix this issue.

Besides this, I also removed deprecated functions in some ports.

Related issue #4085
