### PR TITLE
[imgui] Add feature internal to add imgui_internal.h

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -12,6 +12,17 @@ set(IMGUI_INCLUDES_PRIVATE
     imgui_internal.h
 )
 
+set(IMGUI_INCLUDES_ALL
+    ${IMGUI_INCLUDES_PUBLIC}
+)
+
+IF (ENABLE_INTERNAL)
+    set(IMGUI_INCLUDES_ALL
+    ${IMGUI_INCLUDES_PUBLIC}
+    ${IMGUI_INCLUDES_PRIVATE}
+)  
+ENDIF (ENABLE_INTERNAL)
+
 set(IMGUI_SOURCES
     imgui.cpp
     imgui_demo.cpp
@@ -38,7 +49,7 @@ install(EXPORT IMGUIExport FILE ${PROJECT_NAME}Config.cmake NAMESPACE ${PROJECT_
 
 if(NOT IMGUI_SKIP_HEADERS)
     install(
-        FILES ${IMGUI_INCLUDES_PUBLIC}
+        FILES ${IMGUI_INCLUDES_ALL}
         DESTINATION include
     )
 endif()

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,8 +1,11 @@
 Source: imgui
-Version: 1.73-1
+Version: 1.73-2
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
 Feature: example
 Description: build with examples
 Build-Depends: glfw3, freeglut, opengl, sdl1
+
+Feature: internal
+Description: using the imgui_internal.h header

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -12,11 +12,18 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    internal   ENABLE_INTERNAL
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
+        ${FEATURE_OPTIONS}
+    OPTIONS_RELEASE	
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -21,8 +21,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
-        ${FEATURE_OPTIONS}
-    OPTIONS_RELEASE	
+    OPTIONS
         ${FEATURE_OPTIONS}
 )
 


### PR DESCRIPTION
Related issue: #6665.
1. Add feature internal to use the imgui_internal.h header.
2. Feature example of this port triplet x86-windows install failed on master branch, and same on my branch.