### PR TITLE
[apr activemq-cpp] Fix fatal error building activemq-cpp windows-static

### DIFF
--- a/ports/activemq-cpp/CONTROL
+++ b/ports/activemq-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: activemq-cpp
-Version: 3.9.5-1
+Version: 3.9.5-2
 Build-Depends: apr
 Description: Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server.

--- a/ports/activemq-cpp/portfile.cmake
+++ b/ports/activemq-cpp/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
@@ -43,9 +41,7 @@ vcpkg_build_msbuild(
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/activemq-cpp)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/activemq-cpp/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/activemq-cpp/copyright)
-
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 file(
     COPY
@@ -81,3 +77,7 @@ file(
 file(COPY ${SOURCE_PATH}/src/main/activemq DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.h)
 file(COPY ${SOURCE_PATH}/src/main/cms      DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.h)
 file(COPY ${SOURCE_PATH}/src/main/decaf    DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.h)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()

--- a/ports/apr/CONTROL
+++ b/ports/apr/CONTROL
@@ -1,5 +1,5 @@
 Source: apr
-Version: 1.6.5-3
+Version: 1.6.5-4
 Homepage: https://apr.apache.org/
 Description: The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.
 

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -2,8 +2,6 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
 
-include(vcpkg_common_functions)
-
 set(VERSION 1.6.5)
 
 vcpkg_download_distfile(ARCHIVE
@@ -31,9 +29,6 @@ vcpkg_configure_cmake(
         -DMIN_WINDOWS_VER=Windows7
         -DAPR_HAVE_IPV6=ON
         -DAPR_INSTALL_PRIVATE_H=${INSTALL_PRIVATE_H}
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
 vcpkg_install_cmake()
@@ -48,15 +43,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
                 ${CURRENT_PACKAGES_DIR}/debug/lib/apr-1.lib
                 ${CURRENT_PACKAGES_DIR}/debug/lib/aprapp-1.lib)
 else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libapr-1.lib
-                ${CURRENT_PACKAGES_DIR}/lib/libaprapp-1.lib
-                ${CURRENT_PACKAGES_DIR}/debug/lib/libapr-1.lib
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libaprapp-1.lib
                 ${CURRENT_PACKAGES_DIR}/debug/lib/libaprapp-1.lib)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/apr)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/apr/LICENSE ${CURRENT_PACKAGES_DIR}/share/apr/copyright)
-
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Related issue: #9138.
1.apr do not delete libapr-1.lib,  activemq-cpp REMOVE folder bin when VCPKG_LIBRARY_LINKAGE is static. 
2.Delete deprecated functions.

Note: apr feature test with following triplets:
x86-windows (Pass)
x64-windows (Pass)
x64-windows-static (Pass)
arm64-windows (Skip due to not supported)
arm64-uwp (Skip due to not supported)
x64-linux (Skip due to not supported)