### PR TITLE
[ffmpeg] Add NVIDIA Codec support for Windows and Linux x64

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -50,3 +50,7 @@ Description: allow GPL licensed libraries
 
 Feature: avresample
 Description: Libav audio resampling library support in ffmpeg
+
+Feature: nvcodec
+Build-Depends: ffnvcodec, cuda
+Description: Hardware accelerated codecs

--- a/ports/ffmpeg/build_linux.sh
+++ b/ports/ffmpeg/build_linux.sh
@@ -16,6 +16,7 @@ PATH_TO_PACKAGE_DIR=$3
 
 cd "$PATH_TO_BUILD_DIR"
 echo "=== CONFIGURING ==="
+chmod a+x "$PATH_TO_SRC_DIR/configure"
 "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" $4
 echo "=== BUILDING ==="
 make -j6

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
@@ -185,7 +183,7 @@ set(ENV{PKG_CONFIG_PATH} "${CURRENT_PACKAGES_DIR}/../ffnvcodec_${TARGET_TRIPLET}
 
 message(STATUS "Building Options: ${OPTIONS}")
 
-# Relase build
+# Release build
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL release)
     message(STATUS "Building Release Options: ${OPTIONS_RELEASE}")
     set(ENV{${LIB_PATH_VAR}} "${CURRENT_INSTALLED_DIR}/lib${SEP}${ENV_LIB_PATH}")

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -129,6 +129,12 @@ if("avresample" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-avresample")
 endif()
 
+if("nvcodec" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-cuda --enable-nvenc --enable-cuvid --disable-libnpp")
+else()
+    set(OPTIONS "${OPTIONS} --disable-cuda --disable-nvenc --disable-cuvid --disable-libnpp")
+endif()
+
 set(OPTIONS_CROSS "")
 
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
@@ -175,12 +181,13 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 set(ENV_LIB_PATH "$ENV{${LIB_PATH_VAR}}")
+set(ENV{PKG_CONFIG_PATH} "${CURRENT_PACKAGES_DIR}/../ffnvcodec_${TARGET_TRIPLET}/lib/pkgconfig")
 
 message(STATUS "Building Options: ${OPTIONS}")
 
 # Relase build
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL release)
-    message(STATUS "Building Relase Options: ${OPTIONS_RELEASE}")
+    message(STATUS "Building Release Options: ${OPTIONS_RELEASE}")
     set(ENV{${LIB_PATH_VAR}} "${CURRENT_INSTALLED_DIR}/lib${SEP}${ENV_LIB_PATH}")
     set(ENV{CFLAGS} "${VCPKG_C_FLAGS} ${VCPKG_C_FLAGS_RELEASE}")
     set(ENV{LDFLAGS} "${VCPKG_LINKER_FLAGS}")

--- a/ports/ffnvcodec/CONTROL
+++ b/ports/ffnvcodec/CONTROL
@@ -1,4 +1,4 @@
 Source: ffnvcodec
-Version: 9.1.23.0
+Version: 9.0.18.1
 Homepage: https://github.com/FFmpeg/nv-codec-headers
 Description: FFmpeg version of Nvidia Codec SDK headers.

--- a/ports/ffnvcodec/build.sh
+++ b/ports/ffnvcodec/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+set -e
+export PATH=/usr/bin:$PATH
+
+#SOURCE_PATH="`cygpath "$1"`"
+#CURRENT_PACKAGES_DIR="`cygpath "$2"`"
+SOURCE_PATH="$1"
+CURRENT_PACKAGES_DIR="$2"
+
+echo "CURRENT_PACKAGES_DIR=${CURRENT_PACKAGES_DIR}"
+
+pushd ${SOURCE_PATH}
+make PREFIX=${CURRENT_PACKAGES_DIR}
+make install PREFIX=${CURRENT_PACKAGES_DIR}
+mkdir -p /usr/lib/pkgconfig
+cp ${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ffnvcodec.pc /usr/lib/pkgconfig
+popd

--- a/ports/ffnvcodec/copyright
+++ b/ports/ffnvcodec/copyright
@@ -1,0 +1,26 @@
+/*
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2019 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/ports/ffnvcodec/portfile.cmake
+++ b/ports/ffnvcodec/portfile.cmake
@@ -1,13 +1,59 @@
-# Header-only-library
+include(vcpkg_common_functions)
+
+
+# Get nvcodec
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FFmpeg/nv-codec-headers
-    REF n9.1.23.0 
-    SHA512 d9cb1ad496d971da31165e643c6c4f433561a856050503783051604f24ea5f9997859b05695632ea94ce9659966915789e6d7f7d536764804c9f673d1c8c63e4
+    REF n9.0.18.1
+    SHA512 4306ee3c6e72e9e3172b28c5e6166ec3fb9dfdc32578aebda0588afc682f56286dd6f616284c9892907cd413f57770be3662572207a36d6ac65c75a03d381f6f
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+# ====================================================
+# Install the pkgconfig info the `nccodec` package
+# ====================================================
+if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\build.sh)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES make pkg-config)
+    set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
 
-#Handle copyright
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+    message(STATUS "Building ${_csc_PROJECT_PATH} for Release")
+    file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})
+
+    # Build script parameters:
+    # source root
+    # msys root
+    vcpkg_execute_required_process(
+        COMMAND ${BASH} --noprofile --norc "${BUILD_SCRIPT}"
+            "${SOURCE_PATH}" # SOURCE DIR
+            "${CURRENT_PACKAGES_DIR}" # PACKAGE DIR
+        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}
+        LOGNAME build-${TARGET_TRIPLET}
+    )
+
+else()
+    FIND_PROGRAM(MAKE make)
+    IF (NOT MAKE)
+        MESSAGE(FATAL_ERROR "MAKE not found")
+    ENDIF ()
+    
+
+    vcpkg_execute_required_process(
+        COMMAND make PREFIX=$${CURRENT_PACKAGES_DIR}
+        WORKING_DIRECTORY ${SOURCE_PATH}
+        LOGNAME make-${TARGET_TRIPLET}
+    )
+    file(INSTALL ${SOURCE_PATH}/ffnvcodec.pc DESTINATION ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+endif()
+
+# == Windows ========================
+# Run make in the msys environment so FFmpeg can find it there
+# A. Get msys
+# B. Run a bash script that will run make and install the headers in the msys environment
+# (In Windows we may  need to create a dummy location to avoid conflicts with other include directories)
+
+
+# Install the files to their generic location regardless
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${CURRENT_PORT_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/ffnvcodec)

--- a/ports/ffnvcodec/portfile.cmake
+++ b/ports/ffnvcodec/portfile.cmake
@@ -8,10 +8,10 @@ vcpkg_from_github(
 )
 
 # ====================================================
-# Install the pkgconfig info the `nccodec` package
+# Install the pkgconfig info for the the `nvcodec` package
 # ====================================================
 if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\build.sh)
+    set(BUILD_SCRIPT ${CMAKE_CURRENT_LIST_DIR}\\build.sh)
     vcpkg_acquire_msys(MSYS_ROOT PACKAGES make pkg-config)
     set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
 
@@ -20,7 +20,7 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
 
     # Build script parameters:
     # source root
-    # msys root
+    # root of where the package would be installed on a linux system (here this is the package dir)
     vcpkg_execute_required_process(
         COMMAND ${BASH} --noprofile --norc "${BUILD_SCRIPT}"
             "${SOURCE_PATH}" # SOURCE DIR
@@ -35,22 +35,16 @@ else()
         MESSAGE(FATAL_ERROR "MAKE not found")
     ENDIF ()
     
-
     vcpkg_execute_required_process(
         COMMAND make PREFIX=$${CURRENT_PACKAGES_DIR}
         WORKING_DIRECTORY ${SOURCE_PATH}
         LOGNAME make-${TARGET_TRIPLET}
     )
+
+    # Deploy a copy of the ffnvcodec.pc file where ffmpeg's pkgconfig call expects to find it
     file(INSTALL ${SOURCE_PATH}/ffnvcodec.pc DESTINATION ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
 endif()
 
-# == Windows ========================
-# Run make in the msys environment so FFmpeg can find it there
-# A. Get msys
-# B. Run a bash script that will run make and install the headers in the msys environment
-# (In Windows we may  need to create a dummy location to avoid conflicts with other include directories)
-
-
-# Install the files to their generic location regardless
+# Install the files to their generic location as well
 file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
 file(INSTALL ${CURRENT_PORT_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/ffnvcodec)

--- a/ports/ffnvcodec/portfile.cmake
+++ b/ports/ffnvcodec/portfile.cmake
@@ -1,6 +1,3 @@
-include(vcpkg_common_functions)
-
-
 # Get nvcodec
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
Expose FFmpeg options to enable NVIDIA's hardware codecs.
`./vcpkg install ffmpeg[nvcodec]`

- Created a new feature for `ffmpeg` called `nvcodec`
- Force the `configure` script to be executable
- Roll back ffnvcodec headers version - My Linux machine complained that 9.1 was too new for my GTX1060.
- Make ffnvcode visible to pkgconfig, used by ffmpeg to find the headers.

This is my first vcpkg pull request, I'm very receptive to feedback on how I can do this better!