### PR TITLE
[python3] Fix CONTROL Version

### DIFF
--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -1,5 +1,5 @@
 Source: python3
-Version: 3.7.4
+Version: 3.7.3
 Homepage: https://github.com/python/cpython
 Description: The Python programming language as an embeddable library
 Build-Depends: libffi, openssl


### PR DESCRIPTION
Related issue #9164.
	
CONTROL file version is 3.7.4, portfile.cmake version is 3.7.3, change CONTROL file version to 3.7.3. The two should be consistent.

No features need to test.