### PR TITLE
[nanodbc] Set NANODBC_ENABLE_UNICODE to OFF

### DIFF
--- a/ports/nanodbc/CONTROL
+++ b/ports/nanodbc/CONTROL
@@ -1,4 +1,4 @@
 Source: nanodbc
-Version: 2.12.4-4
+Version: 2.12.4-5
 Homepage: https://github.com/lexicalunit/nanodbc
 Description: A small C++ wrapper for the native C ODBC API.

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 # Only static libraries are supported.
 # See https://github.com/nanodbc/nanodbc/issues/13
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
@@ -23,7 +21,7 @@ vcpkg_configure_cmake(
 # /Legacy
         -DNANODBC_DISABLE_EXAMPLES=ON
         -DNANODBC_DISABLE_TESTS=ON
-        -DNANODBC_ENABLE_UNICODE=ON
+        -DNANODBC_ENABLE_UNICODE=OFF
 )
 
 vcpkg_install_cmake()
@@ -33,4 +31,4 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/cmake)
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nanodbc RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fix build error: 
```
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "public: __cdecl nanodbc::connection::connection(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,long)" (??0connection@nanodbc@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@J@Z) referenced in function "void __cdecl run_test(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?run_test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "public: class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl nanodbc::connection::driver_name(void)const " (?driver_name@connection@nanodbc@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ) referenced in function "void __cdecl run_test(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?run_test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "public: class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl nanodbc::result::column_name(short)const " (?column_name@result@nanodbc@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@F@Z) referenced in function "void __cdecl show(class nanodbc::result &)" (?show@@YAXAEAVresult@nanodbc@@@Z)
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "class nanodbc::result __cdecl nanodbc::execute(class nanodbc::connection &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,long,long)" (?execute@nanodbc@@YA?AVresult@1@AEAVconnection@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@JJ@Z) referenced in function "void __cdecl run_test(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?run_test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "void __cdecl nanodbc::prepare(class nanodbc::statement &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,long)" (?prepare@nanodbc@@YAXAEAVstatement@1@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@J@Z) referenced in function "void __cdecl run_test(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?run_test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
1>ConsoleApplication2.obj : error LNK2019: unresolved external symbol "public: int __cdecl nanodbc::result::get<int>(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)const " (??$get@H@result@nanodbc@@QEBAHAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z) referenced in function "void __cdecl run_test(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?run_test@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
1>C:\source\repos\ConsoleApplication2\x64\Debug\ConsoleApplication2.exe : fatal error LNK1120: 6 unresolved externals
```
Visual C++ with `NANODBC_USE_UNICODE ... row.get<std::wstring>(1)` causes this link error. Modify `NANODBC_ENABLE_UNICODE` to OFF to fix this error. Related source description: https://github.com/nanodbc/nanodbc/issues/110
There are no features of this port need to test. Related issue: #9128