### PR TITLE
[issue template] Add 'good first issue' label to request-a-new-port template

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-a-new-port.md
+++ b/.github/ISSUE_TEMPLATE/request-a-new-port.md
@@ -2,7 +2,7 @@
 name: Request a new port
 about: Request a new port/library that vcpkg should support
 title: "[New Port Request] <library name here>"
-labels: new port request - consider making a PR!
+labels: new port request - consider making a PR!, good first issue
 assignees: ''
 
 ---


### PR DESCRIPTION
Add 'good first issue' label to request-a-new-port issue template, then new port request issue will be created with 'good first issue' label by default.