### PR TITLE
[sfml] Declare Windows library export

### DIFF
--- a/ports/sfml/CONTROL
+++ b/ports/sfml/CONTROL
@@ -1,5 +1,5 @@
 Source: sfml
-Version: 2.5.1-4
+Version: 2.5.1-5
 Homepage: https://github.com/sfml/sfml
 Description: Simple and fast multimedia library
 Build-Depends: freetype, libflac, libogg, libvorbis, openal-soft, stb

--- a/ports/sfml/export-win-libs.patch
+++ b/ports/sfml/export-win-libs.patch
@@ -1,0 +1,26 @@
+diff --git a/src/SFML/System/CMakeLists.txt b/src/SFML/System/CMakeLists.txt
+index d1b712d..5c12801 100644
+--- a/src/SFML/System/CMakeLists.txt
++++ b/src/SFML/System/CMakeLists.txt
+@@ -96,7 +96,7 @@ endif()
+ if(SFML_OS_LINUX)
+     target_link_libraries(sfml-system PRIVATE rt)
+ elseif(SFML_OS_WINDOWS)
+-    target_link_libraries(sfml-system PRIVATE winmm)
++    target_link_libraries(sfml-system PUBLIC winmm)
+ elseif(SFML_OS_ANDROID)
+     target_link_libraries(sfml-system PRIVATE android log)
+ endif()
+diff --git a/src/SFML/Window/CMakeLists.txt b/src/SFML/Window/CMakeLists.txt
+index 98ea439..53c1ac7 100644
+--- a/src/SFML/Window/CMakeLists.txt
++++ b/src/SFML/Window/CMakeLists.txt
+@@ -276,7 +276,7 @@ if(SFML_OS_LINUX)
+     sfml_find_package(UDev INCLUDE "UDEV_INCLUDE_DIR" LINK "UDEV_LIBRARIES")
+     target_link_libraries(sfml-window PRIVATE UDev)
+ elseif(SFML_OS_WINDOWS)
+-    target_link_libraries(sfml-window PRIVATE winmm gdi32)
++    target_link_libraries(sfml-window PUBLIC winmm gdi32)
+ elseif(SFML_OS_FREEBSD)
+     target_link_libraries(sfml-window PRIVATE usbhid)
+ elseif(SFML_OS_MACOSX)

--- a/ports/sfml/portfile.cmake
+++ b/ports/sfml/portfile.cmake
@@ -1,11 +1,11 @@
-
-include(vcpkg_common_functions)
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO SFML/SFML
     REF 2.5.1
     HEAD_REF master
     SHA512 7aed2fc29d1da98e6c4d598d5c86cf536cb4eb5c2079cdc23bb8e502288833c052579dadbe0ce13ad6461792d959bf6d9660229f54c54cf90a541c88c6b03d59
-    PATCHES use-system-freetype.patch
+    PATCHES
+        use-system-freetype.patch
+        export-win-libs.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/extlibs)
@@ -54,4 +54,4 @@ endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(INSTALL ${SOURCE_PATH}/license.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/sfml RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/license.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
When using sfml, the custom project should also link to winmm.lib and gdi32.lib, so change the linking method of these two libraries to **public**.

Related: #8864.