### PR TITLE
[liblzma] Stop exporting HAVE_CONFIG_H

### DIFF
--- a/ports/liblzma/CMakeLists.txt
+++ b/ports/liblzma/CMakeLists.txt
@@ -142,7 +142,7 @@ if(BUILD_SHARED_LIBS)
 else()
     target_compile_definitions(LibLZMA PUBLIC -DLZMA_API_STATIC)
 endif()
-target_compile_definitions(LibLZMA PUBLIC -DHAVE_CONFIG_H)
+target_compile_definitions(LibLZMA PRIVATE -DHAVE_CONFIG_H)
 
 target_include_directories(LibLZMA PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/ports/liblzma/CONTROL
+++ b/ports/liblzma/CONTROL
@@ -1,4 +1,4 @@
 Source: liblzma
-Version: 5.2.4-2
+Version: 5.2.4-3
 Homepage: https://github.com/xz-mirror/xz
 Description: Compression library with an API similar to that of zlib.


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/issues/9136

liblzma CMakeLists.txt export definition 'HAVE_CONFIG_H' incorrectly by PUBLIC adding the definition to the project, when users link libraries via LibLZMA::LibLZMA, it will cause build failures, change it to PRIVATE to avoid this behaviors.

liblzma has no features that need test locally.