### PR TITLE
[mongoose] Add feature ssl

### DIFF
--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(mongoose PROPERTIES PUBLIC_HEADER mongoose.h)
 
 if (ENABLE_SSL)
     find_package(OpenSSL REQUIRED)
-    target_compile_options(mongoose PRIVATE MG_ENABLE_SSL)
+    target_compile_options(mongoose PRIVATE -DMG_ENABLE_SSL)
     target_link_libraries(mongoose PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 endif()
 

--- a/ports/mongoose/CMakeLists.txt
+++ b/ports/mongoose/CMakeLists.txt
@@ -4,11 +4,19 @@ project(mongoose C)
 
 include(GNUInstallDirs)
 
+option(ENABLE_SSL "Build with openssl support" OFF)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_library(mongoose mongoose.c)
 target_include_directories(mongoose PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 set_target_properties(mongoose PROPERTIES PUBLIC_HEADER mongoose.h)
+
+if (ENABLE_SSL)
+    find_package(OpenSSL REQUIRED)
+    target_compile_options(mongoose PRIVATE MG_ENABLE_SSL)
+    target_link_libraries(mongoose PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
 
 install(TARGETS mongoose EXPORT unofficial-mongoose-config)
 

--- a/ports/mongoose/CONTROL
+++ b/ports/mongoose/CONTROL
@@ -1,4 +1,8 @@
 Source: mongoose
-Version: 6.15-1
+Version: 6.15-2
 Description: Embedded web server / embedded networking library
 Homepage: https://cesanta.com/
+
+Feature: ssl
+Build-Depends: openssl
+Description: Build with openssl

--- a/ports/mongoose/portfile.cmake
+++ b/ports/mongoose/portfile.cmake
@@ -1,8 +1,4 @@
-include(vcpkg_common_functions)
-
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "${PORT} does not currently support UWP")
-endif()
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -16,9 +12,14 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    ssl ENABLE_SSL
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
@@ -28,7 +29,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-
-# CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME unofficial-${PORT})
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Add feature `ssl` to enable build option `MG_ENABLE_SSL`.

Related: #9197.

Note: all features test pass with following triplets:

- x86-windows (Pass)
- x64-windows (Pass)
- x64-windows-static (Pass)
- arm64-windows (Pass)
- arm64-uwp (Skip due to not supported)
- x64-linux (Pass)