### PR TITLE
[vtk] fix VTKConfig.cmake path

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-9
+Version: 8.2.0-10
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/fix-VTKConfig-cmake.patch
+++ b/ports/vtk/fix-VTKConfig-cmake.patch
@@ -1,0 +1,29 @@
+diff --git a/CMake/VTKConfig.cmake.in b/CMake/VTKConfig.cmake.in
+index 13e4db42..d28e0cc2 100644
+--- a/CMake/VTKConfig.cmake.in
++++ b/CMake/VTKConfig.cmake.in
+@@ -66,19 +66,11 @@ set(VTK_USE_FILE "${VTK_CMAKE_DIR}/UseVTK.cmake")
+ # The rendering backend VTK was configured to use.
+ set(VTK_RENDERING_BACKEND "@VTK_RENDERING_BACKEND@")
+ 
+-if (__vtk_install_tree)
+-  if (WIN32)
+-    set (VTK_RUNTIME_DIRS "@CMAKE_INSTALL_PREFIX@/@VTK_INSTALL_RUNTIME_DIR@")
+-  else ()
+-    set (VTK_RUNTIME_DIRS "@CMAKE_INSTALL_PREFIX@/@VTK_INSTALL_LIBRARY_DIR@")
+-  endif ()
+-else()
+-  if (WIN32)
+-    set (VTK_RUNTIME_DIRS "@CMAKE_BINARY_DIR@/bin")
+-  else ()
+-    set (VTK_RUNTIME_DIRS "@CMAKE_BINARY_DIR@/lib")
+-  endif ()
+-endif()
++if (WIN32)
++  set (VTK_RUNTIME_DIRS "@CMAKE_INSTALL_PREFIX@/@VTK_INSTALL_RUNTIME_DIR@")
++else ()
++  set (VTK_RUNTIME_DIRS "@CMAKE_INSTALL_PREFIX@/@VTK_INSTALL_LIBRARY_DIR@")
++endif ()
+ 
+ # Setup VTK-m if it was enabled
+ set(VTK_HAS_VTKM @VTK_HAS_VTKM@)

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -34,6 +34,7 @@ vcpkg_from_github(
         hdf5_static.patch
         fix-find-lzma.patch
         fix-proj4.patch
+        fix-VTKConfig-cmake.patch
 )
 
 # Remove the FindGLEW.cmake and FindPythonLibs.cmake that are distributed with VTK,


### PR DESCRIPTION
Related issue #9200.
Feature mpi of this port triplet x86-windows install failed on master branch, and same on my branch. 