### PR TITLE
[realsense2] update to 2.30

### DIFF
--- a/ports/realsense2/CONTROL
+++ b/ports/realsense2/CONTROL
@@ -1,5 +1,5 @@
 Source: realsense2
-Version: 2.22.0-2
+Version: 2.30.0
 Homepage: https://github.com/IntelRealSense/librealsense
 Description: Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).
 

--- a/ports/realsense2/fix-dependency-glfw3.patch
+++ b/ports/realsense2/fix-dependency-glfw3.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2da00e0..09f3eba 100644
+index 16ced1b..ef1b158 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -52,7 +52,7 @@ option(BUILD_CV_KINFU_EXAMPLE "Build OpenCV KinectFusion example" OFF)
+@@ -69,7 +69,7 @@ include(CMake/install_config.cmake)
  add_subdirectory(wrappers)
  
  if (BUILD_EXAMPLES AND BUILD_GLSL_EXTENSIONS)
@@ -10,4 +10,4 @@ index 2da00e0..09f3eba 100644
 +    find_package(glfw3 CONFIG REQUIRED)
      if(NOT TARGET glfw)
          message(STATUS "GLFW 3.3 not found; using internal version")
-         set(GLFW_INSTALL ON)
+         set(GLFW_INSTALL ON CACHE BOOL "" FORCE)

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
-    REF v2.30.0
-    SHA512 b40ee0b51a4dfe8ed4470a513ba0a4f7d08083a46c85a8747f5316f47a50001448b1b762daa3c24278b10342802292df00cf417509374cad309c1af0910ba3a9
+    REF 9f99fa9a509555f85bffc15ce27531aaa6db6f7e#v2.30.0
+    SHA512 72d9e0b48a6cd0b056b6d039487431d0097e5151930a2dbb072d09a13fccee1f166ca339fe7f0ab4aae1edc5669de5e8336f0b6d87d1c4ea01ec0c5d4032c728
     HEAD_REF master
     PATCHES
         fix_openni2.patch

--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -3,9 +3,9 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
-    REF v2.22.0
-    SHA512 7595780c1955a2d4a91df5b70ab6366c672f389bc3d2dcb9f2e78a2ea1fc875c65f878103df483205e17f62dfd024ee5f7ccb15afc5d18978d3c25aa071652ab
-    HEAD_REF development
+    REF v2.30.0
+    SHA512 b40ee0b51a4dfe8ed4470a513ba0a4f7d08083a46c85a8747f5316f47a50001448b1b762daa3c24278b10342802292df00cf417509374cad309c1af0910ba3a9
+    HEAD_REF master
     PATCHES
         fix_openni2.patch
         fix-dependency-glfw3.patch


### PR DESCRIPTION
Related issue #9214.
Feature openni2 of this port triplet x86-windows install failed on master branch, and same on my branch. 