### PR TITLE
[proj4] Update to version 6.2.1; disable exporting symbols for static libraries

### DIFF
--- a/ports/proj4/CONTROL
+++ b/ports/proj4/CONTROL
@@ -1,5 +1,5 @@
 Source: proj4
-Version: 6.2.0-1
+Version: 6.2.1-1
 Homepage: https://github.com/OSGeo/PROJ
 Description: PROJ.4 library for cartographic projections
 Build-Depends: sqlite3[core]

--- a/ports/proj4/disable-export-for-static-lib.patch
+++ b/ports/proj4/disable-export-for-static-lib.patch
@@ -1,0 +1,26 @@
+diff --git a/src/geodesic.h b/src/geodesic.h
+index 11484ec7..479a9462 100644
+--- a/src/geodesic.h
++++ b/src/geodesic.h
+@@ -158,7 +158,7 @@
+                       GEODESIC_VERSION_PATCH)
+ 
+ #ifndef GEOD_DLL
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) && defined(PROJ_MSVC_DLL_EXPORT)
+ #define GEOD_DLL __declspec(dllexport)
+ #elif defined(__GNUC__)
+ #define GEOD_DLL __attribute__ ((visibility("default")))
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index bad60324..2e90f98f 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -443,7 +443,7 @@ endif()
+ include_directories(${SQLITE3_INCLUDE_DIR})
+ target_link_libraries(${PROJ_CORE_TARGET} ${SQLITE3_LIBRARY})
+ 
+-if(MSVC)
++if(MSVC AND BUILD_LIBPROJ_SHARED)
+   target_compile_definitions(${PROJ_CORE_TARGET}
+     PRIVATE PROJ_MSVC_DLL_EXPORT=1)
+ endif()

--- a/ports/proj4/fix-sqlite-dependency-export.patch
+++ b/ports/proj4/fix-sqlite-dependency-export.patch
@@ -1,13 +1,13 @@
 diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
-index 5a0a807..f7bfffd 100644
+index 2e90f98f..dc171e91 100644
 --- a/src/lib_proj.cmake
 +++ b/src/lib_proj.cmake
-@@ -439,7 +439,7 @@ if(USE_THREAD AND Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
+@@ -441,7 +441,7 @@ if(USE_THREAD AND Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
  endif()
  
  include_directories(${SQLITE3_INCLUDE_DIR})
 -target_link_libraries(${PROJ_CORE_TARGET} ${SQLITE3_LIBRARY})
 +target_link_libraries(${PROJ_CORE_TARGET} PUBLIC ${SQLITE3_LIBRARY})
  
- if(MSVC)
+ if(MSVC AND BUILD_LIBPROJ_SHARED)
    target_compile_definitions(${PROJ_CORE_TARGET}

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
@@ -72,4 +70,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/proj4)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/proj4 RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -3,11 +3,13 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
-    REF 6.2.0
-    SHA512 035c138e1a7794760652906daaf3c8a42cb6431ad9062a42ec2f8d721ead25394407fdd52560c5f1fc8668a0167459fdbe47c6392de23c1474304ea26b8a3a33
+    REF 6.2.1
+    SHA512 43f0356a1f4df871e09a738fb8ac386c0fbe543b35c3c1b9c9685469ca7a2a540427edb9b17d4c010c06a4818d17d0421dfcdca9af9d091854da71690fddfbf3
     HEAD_REF master
     PATCHES
         fix-sqlite3-bin.patch
+        disable-export-namespace.patch
+        disable-export-for-static-lib.patch
         disable-projdb-with-arm-uwp.patch
         fix-win-output-name.patch
         fix-sqlite-dependency-export.patch


### PR DESCRIPTION
Updates proj4 to version 6.2.1.

New patch: disable-export-for-static-lib.patch - this has been submitted upstream to PROJ (https://github.com/OSGeo/PROJ/pull/1773) and will hopefully be accepted for the next version.

disable-export-namespace.patch was added in the previous proj4 commit but was never added to the portfile, which seemed to be an oversight.