### PR TITLE
[rttr] Add dependency rapidjson

### DIFF
--- a/ports/rttr/CONTROL
+++ b/ports/rttr/CONTROL
@@ -1,4 +1,5 @@
 Source: rttr
-Version: 0.9.6-1
+Version: 0.9.6-2
 Homepage: https://github.com/rttrorg/rttr
 Description: an easy and intuitive way to use reflection in C++
+Build-Depends: rapidjson

--- a/ports/rttr/Fix-depends.patch
+++ b/ports/rttr/Fix-depends.patch
@@ -1,0 +1,14 @@
+diff --git a/CMake/3rd_party_libs.cmake b/CMake/3rd_party_libs.cmake
+index dca5071..4dd4471 100644
+--- a/CMake/3rd_party_libs.cmake
++++ b/CMake/3rd_party_libs.cmake
+@@ -51,7 +51,8 @@ if (BUILD_BENCHMARKS)
+     find_package(Threads REQUIRED)
+ endif()
+ 
+-set(RAPID_JSON_DIR ${RTTR_3RD_PARTY_DIR}/rapidjson-1.1.0)
++find_package(RapidJSON CONFIG REQUIRED)
++set(RAPID_JSON_DIR ${RAPIDJSON_INCLUDE_DIRS})
+ set(NONIUS_DIR ${RTTR_3RD_PARTY_DIR}/nonius-1.1.2)
+ 
+ # Prepare "Catch" library for other executables

--- a/ports/rttr/portfile.cmake
+++ b/ports/rttr/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rttrorg/rttr
@@ -44,8 +42,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 #Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/rttr)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/rttr/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/rttr/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include
     ${CURRENT_PACKAGES_DIR}/debug/share

--- a/ports/rttr/portfile.cmake
+++ b/ports/rttr/portfile.cmake
@@ -8,7 +8,8 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-directory-output.patch
-        remove-owner-read-perms.patch		
+        Fix-depends.patch
+        remove-owner-read-perms.patch
 )
 
 #Handle static lib

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1463,7 +1463,6 @@ rpclib:x64-uwp=fail
 rpclib:x64-windows=ignore
 rpclib:x86-windows=ignore
 rpclib:x64-windows-static=ignore
-rttr:arm64-windows=fail
 rttr:arm-uwp=fail
 rttr:x64-uwp=fail
 scintilla:arm64-windows=fail


### PR DESCRIPTION
Add dependency rapidjson instead of source code for port rttr. Fix build error:
```
rttr\src\v0.9.6-eb280525cd\3rd_party\rapidjson-1.1.0\rapidjson/document.h(102): error C2220: the following warning is treated as an error
rttr\src\v0.9.6-eb280525cd\3rd_party\rapidjson-1.1.0\rapidjson/document.h(102): warning C4996: 'std::iterator<std::random_access_iterator_tag,rapidjson::GenericMember<Encoding,Allocator>,ptrdiff_t,rapidjson::GenericMember<Encoding,Allocator> *,rapidjson::GenericMember<Encoding,Allocator> &>': warning STL4015: The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17. (The <iterator> header is NOT deprecated.) The C++ Standard has never required user-defined iterators to derive from std::iterator. To fix this warning, stop deriving from std::iterator and start providing publicly accessible typedefs named iterator_category, value_type, difference_type, pointer, and reference. Note that value_type is required to be non-const, even for constant iterators. You can define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning.
```
There are no features of this port need to test.