### PR TITLE
[libpq] Fix version mismatch between CONTROL and portfile

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 9.6.1-8
+Version: 9.6.3
 Homepage: https://www.postgresql.org/
 Description: The official database access API of postgresql
 Build-Depends: openssl, zlib (linux)

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} currently only supports being built for desktop")
 endif()

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -1,4 +1,4 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_TARGET_IS_UWP)
     message(FATAL_ERROR "${PORT} currently only supports being built for desktop")
 endif()
 
@@ -27,4 +27,4 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/libpq RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Related issue #9235.
1. Update the CONTROL version
2. Delete deprecated functions
3. Update deprecated functions

No features need to test.