### PR TITLE
[xeus] Fix build error with Visual Studio 2019

### DIFF
--- a/ports/xeus/CONTROL
+++ b/ports/xeus/CONTROL
@@ -1,4 +1,4 @@
 Source: xeus
-Version: 0.20.0
+Version: 0.20.0-1
 Description: C++ implementation of the Jupyter kernel protocol
 Build-Depends: cppzmq, libuuid (linux), nlohmann-json, openssl, xtl, zeromq

--- a/ports/xeus/Fix-TypeConversion.patch
+++ b/ports/xeus/Fix-TypeConversion.patch
@@ -1,0 +1,24 @@
+diff --git a/src/xkernel_configuration.cpp b/src/xkernel_configuration.cpp
+index 681b45d..b5a68eb 100644
+--- a/src/xkernel_configuration.cpp
++++ b/src/xkernel_configuration.cpp
+@@ -25,8 +25,8 @@ namespace xeus
+         ifs >> doc;
+ 
+         xconfiguration res;
+-        res.m_transport = doc["transport"];
+-        res.m_ip = doc["ip"];
++        res.m_transport = doc["transport"].get<std::string>();
++        res.m_ip = doc["ip"].get<std::string>();
+         res.m_control_port = std::to_string(doc["control_port"].get<int>());
+         res.m_shell_port = std::to_string(doc["shell_port"].get<int>());
+         res.m_stdin_port = std::to_string(doc["stdin_port"].get<int>());
+@@ -35,7 +35,7 @@ namespace xeus
+         res.m_signature_scheme = doc.value("signature_scheme", "");
+         if (res.m_signature_scheme != "")
+         {
+-            res.m_key = doc["key"];
++            res.m_key = doc["key"].get<std::string>();
+         }
+         else
+         {

--- a/ports/xeus/portfile.cmake
+++ b/ports/xeus/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO QuantStack/xeus
@@ -46,10 +44,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 # Install usage
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
-# CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME ${PORT})

--- a/ports/xeus/portfile.cmake
+++ b/ports/xeus/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 8408f237f33514610a59d19a5ff045ee70dfa02b
     SHA512 41282addbe5519b6d357e802c48483834cd951604bfeb8c99d96f02d03dec2fc66ea4c091f40ec09348bb60587e8a6efef5e6eb2bb950ba720fc8ceb7a107960
     HEAD_REF master
+    PATCHES Fix-TypeConversion.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)


### PR DESCRIPTION
Due to C++ implicit conversion failed, building xeus failed with this error:
```
xeus\src\ee70dfa02b-e9875865ca\src\xkernel_configuration.cpp(28): error C2593: 'operator =' is ambiguous
xeus\src\ee70dfa02b-e9875865ca\src\xkernel_configuration.cpp(29): error C2593: 'operator =' is ambiguous
xeus\src\ee70dfa02b-e9875865ca\src\xkernel_configuration.cpp(38): error C2593: 'operator =' is ambiguous
```
I have submit a source issue to fix it. The source issue: https://github.com/QuantStack/xeus/issues/194
There are no features of this port need to test.