### PR TITLE
[OpenEXR] add missing underscore for OpenEXR_IEXMATH_LIBRARY_DEBUG NAMES

### DIFF
--- a/ports/alembic/CONTROL
+++ b/ports/alembic/CONTROL
@@ -1,5 +1,5 @@
 Source: alembic
-Version: 1.7.11-5
+Version: 1.7.11-6
 Build-Depends: ilmbase, hdf5
 Description: Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications.
 Homepage: https://alembic.io/

--- a/ports/alembic/fix-find-openexr-ilmbase.patch
+++ b/ports/alembic/fix-find-openexr-ilmbase.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/AlembicIlmBase.cmake b/cmake/AlembicIlmBase.cmake
-index cd00d70..a73c8db 100644
+index cd00d70..0e50512 100644
 --- a/cmake/AlembicIlmBase.cmake
 +++ b/cmake/AlembicIlmBase.cmake
 @@ -33,11 +33,25 @@
@@ -30,6 +30,18 @@ index cd00d70..a73c8db 100644
      SET(ALEMBIC_ILMBASE_LIBS
          ${ALEMBIC_ILMBASE_IMATH_LIB}
          ${ALEMBIC_ILMBASE_ILMTHREAD_LIB}
+@@ -45,9 +59,9 @@ IF (ILMBASE_FOUND)
+         ${ALEMBIC_ILMBASE_HALF_LIB}
+     )
+ 
+-    if (${ALEMBIC_ILMBASE_IEXMATH_LIB})
++    if (ALEMBIC_ILMBASE_IEXMATH_LIB)
+         SET(ALEMBIC_ILMBASE_LIBS ${ALEMBIC_ILMBASE_LIBS} ${ALEMBIC_ILMBASE_IEXMATH_LIB})
+-    endif (${ALEMBIC_ILMBASE_IEXMATH_LIB})
++    endif (ALEMBIC_ILMBASE_IEXMATH_LIB)
+ 
+ ELSE()
+     SET(ALEMBIC_ILMBASE_FOUND 0 CACHE STRING "Set to 1 if IlmBase is found, 0 otherwise")
 diff --git a/cmake/AlembicOpenEXR.cmake b/cmake/AlembicOpenEXR.cmake
 index 0833b32..a9180cd 100644
 --- a/cmake/AlembicOpenEXR.cmake

--- a/ports/openexr/CONTROL
+++ b/ports/openexr/CONTROL
@@ -1,5 +1,5 @@
 Source: openexr
-Version: 2.3.0-4
+Version: 2.3.0-5
 Homepage: https://www.openexr.com/
 Description: OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications
 Build-Depends: zlib

--- a/ports/openexr/FindOpenEXR.cmake
+++ b/ports/openexr/FindOpenEXR.cmake
@@ -49,7 +49,7 @@ endif()
 
 if(NOT OpenEXR_IEXMATH_LIBRARY)
   find_library(OpenEXR_IEXMATH_LIBRARY_RELEASE NAMES IexMath-${OpenEXR_LIB_SUFFIX})
-  find_library(OpenEXR_IEXMATH_LIBRARY_DEBUG NAMES IexMath-${OpenEXR_LIB_SUFFIX}d)
+  find_library(OpenEXR_IEXMATH_LIBRARY_DEBUG NAMES IexMath-${OpenEXR_LIB_SUFFIX}_d)
   select_library_configurations(OpenEXR_IEXMATH)
 endif()
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1153,6 +1153,15 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
+# Conflicts with ogre-next
+ogre:arm64-windows      = skip
+ogre:arm-uwp            = skip
+ogre:x64-osx            = skip
+ogre:x64-linux          = skip
+ogre:x64-uwp            = skip
+ogre:x64-windows        = skip
+ogre:x64-windows-static = skip
+ogre:x86-windows        = skip
 ois:arm64-windows=fail
 ois:arm-uwp=fail
 ois:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1153,15 +1153,15 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
-# Conflicts with ogre-next
-ogre:arm64-windows      = skip
-ogre:arm-uwp            = skip
-ogre:x64-osx            = skip
-ogre:x64-linux          = skip
-ogre:x64-uwp            = skip
-ogre:x64-windows        = skip
-ogre:x64-windows-static = skip
-ogre:x86-windows        = skip
+# Conflicts with ogre
+ogre-next:arm64-windows      = skip
+ogre-next:arm-uwp            = skip
+ogre-next:x64-osx            = skip
+ogre-next:x64-linux          = skip
+ogre-next:x64-uwp            = skip
+ogre-next:x64-windows        = skip
+ogre-next:x64-windows-static = skip
+ogre-next:x86-windows        = skip
 ois:arm64-windows=fail
 ois:arm-uwp=fail
 ois:x64-uwp=fail


### PR DESCRIPTION
fix missing underscore causing the debug library not to be found.
Laurens.