### PR TITLE
[libharu] Remove symbols also exported from tiff (as a default feature)

### DIFF
--- a/ports/libharu/CONTROL
+++ b/ports/libharu/CONTROL
@@ -1,5 +1,10 @@
 Source: libharu
-Version: 2017-08-15-8
+Version: 2017-08-15-9
 Homepage: https://github.com/libharu/libharu
 Description: libharu - free PDF library
 Build-Depends: zlib, libpng
+Default-Features: notiffsymbols
+
+Feature: notiffsymbols
+Description: disable symbols also defined by the tiff port
+Build-Depends: tiff

--- a/ports/libharu/portfile.cmake
+++ b/ports/libharu/portfile.cmake
@@ -1,5 +1,6 @@
-include(vcpkg_common_functions)
-
+if("notiffsymbols" IN_LIST FEATURES)
+    set(DISABLETIFF tiff.patch)
+endif()
 vcpkg_download_distfile(SHADING_PR
     URLS "https://github.com/libharu/libharu/pull/157.diff"
     FILENAME "libharu-shading-pr-157.patch"
@@ -17,6 +18,7 @@ vcpkg_from_github(
         add-boolean-typedef.patch
         # This patch adds shading support which is required for VTK. If desired, this could be moved into an on-by-default feature.
         ${SHADING_PR}
+        ${DISABLETIFF}
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/libharu/portfile.cmake
+++ b/ports/libharu/portfile.cmake
@@ -1,5 +1,7 @@
 if("notiffsymbols" IN_LIST FEATURES)
-    set(DISABLETIFF tiff.patch)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        set(DISABLETIFF tiff.patch)
+    endif()
 endif()
 vcpkg_download_distfile(SHADING_PR
     URLS "https://github.com/libharu/libharu/pull/157.diff"

--- a/ports/libharu/tiff.patch
+++ b/ports/libharu/tiff.patch
@@ -10,3 +10,16 @@ index 2937fc90d..a1a35d0ed 100644
  #include "t4.h"
  
  typedef unsigned int uint32;
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 354ca7526..ee301d9af 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -99,6 +99,8 @@ if(PNG_FOUND)
+   set(ADDITIONAL_LIBRARIES ${ADDITIONAL_LIBRARIES} ${PNG_LIBRARIES})
+ endif(PNG_FOUND)
+ 
++find_package(TIFF REQUIRED)
++list(APPEND ADDITIONAL_LIBRARIES TIFF::TIFF)
+ 
+ # =======================================================================
+ # configure header files, add compiler flags

--- a/ports/libharu/tiff.patch
+++ b/ports/libharu/tiff.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hpdf_image_ccitt.c b/src/hpdf_image_ccitt.c
+index 2937fc90d..a1a35d0ed 100644
+--- a/src/hpdf_image_ccitt.c
++++ b/src/hpdf_image_ccitt.c
+@@ -21,7 +21,6 @@
+ #include <memory.h>
+ #include <assert.h>
+ 
+-#define	G3CODES
+ #include "t4.h"
+ 
+ typedef unsigned int uint32;


### PR DESCRIPTION
closes #9250