### PR TITLE
[check] Fix library cannot be found

### DIFF
--- a/ports/check/CONTROL
+++ b/ports/check/CONTROL
@@ -1,3 +1,4 @@
 Source: check
-Version: 0.13.0
+Version: 0.13.0-1
+Homepage: https://github.com/libcheck/check
 Description: A unit testing framework for C

--- a/ports/check/portfile.cmake
+++ b/ports/check/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcheck/check
@@ -14,7 +13,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/check)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)


### PR DESCRIPTION
Since `check-config.cmake` is installed to _share/check/check_ directory, which leads to that `check `cannot be found successfully.
I fixed this issue by adding `check `to `vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/check)`.

Related issue #9262.
Note: No features need to test.