### PR TITLE
Removed umock-c:64-windows-static result in baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1665,7 +1665,6 @@ torch-th:x64-uwp=fail
 torch-th:x64-windows-static=fail
 tre:x64-osx=fail
 treehopper:x64-windows-static=fail
-umock-c:x64-windows-static=fail
 unicorn:arm64-windows=fail
 unicorn:arm-uwp=fail
 unicorn:x64-linux=fail


### PR DESCRIPTION
`umock-c:64-windows-static` can build successfully now, so remove it. 
```
|x64-windows-static|result|features|notes
|------------------|----|--------|-----
|umock-c           |Pass|core|Test fails in baseline but now passes.  Update ci.baseline.txt with 'umock-c:x64-windows-static=pass'
```
This problem has recently appeared in the CI test of related PRs.