### PR TITLE
Removed unused template function.

### DIFF
--- a/toolsrc/include/vcpkg/base/util.h
+++ b/toolsrc/include/vcpkg/base/util.h
@@ -11,14 +11,6 @@
 
 namespace vcpkg::Util
 {
-    template<class T>
-    constexpr std::add_const_t<T>& as_const(T& t) noexcept
-    {
-        return t;
-    }
-    template<class T>
-    void as_const(const T&&) = delete;
-
     template<class Container>
     using ElementT =
         std::remove_reference_t<decltype(*std::declval<typename std::remove_reference_t<Container>::iterator>())>;


### PR DESCRIPTION
Hi all,

I'm using vcpkg repo to get myself familiar with MSCS 2019 (after moving from Linux dev environment to Windos). Just by chance bumped into this function an got very interested where/how it is used, but unfortunately I failed to find where it is used in the project. Thus I removed it, recompiled and thought it is worth removing it.