### PR TITLE
Fixed depend-info command to handle feature-level dependencies.

### DIFF
--- a/toolsrc/include/vcpkg/base/util.h
+++ b/toolsrc/include/vcpkg/base/util.h
@@ -30,6 +30,12 @@ namespace vcpkg::Util
         {
             augend->insert(augend->end(), addend.begin(), addend.end());
         }
+
+        template<class T>
+        void insert_sorted(std::vector<T>& container, const T& item)
+        {
+            container.insert(std::upper_bound(container.begin(), container.end(), item), item);
+        }
     }
 
     namespace Sets

--- a/toolsrc/include/vcpkg/dependencies.h
+++ b/toolsrc/include/vcpkg/dependencies.h
@@ -51,7 +51,7 @@ namespace vcpkg::Dependencies
                           const SourceControlFileLocation& scfl,
                           const std::set<std::string>& features,
                           const RequestType& request_type,
-                          std::vector<PackageSpec>&& dependencies);
+                          std::vector<FullPackageSpec>&& dependencies);
 
         std::string displayname() const;
 
@@ -65,7 +65,7 @@ namespace vcpkg::Dependencies
         Build::BuildPackageOptions build_options;
         std::set<std::string> feature_list;
 
-        std::vector<PackageSpec> computed_dependencies;
+        std::vector<FullPackageSpec> computed_dependencies;
     };
 
     enum class RemovePlanType
@@ -121,7 +121,7 @@ namespace vcpkg::Dependencies
         RequestType request_type;
 
         Optional<const BinaryParagraph&> core_paragraph() const;
-        std::vector<PackageSpec> dependencies(const Triplet& triplet) const;
+        std::vector<FullPackageSpec> dependencies(const Triplet& triplet) const;
 
     private:
         Optional<InstalledPackageView> m_installed_package;

--- a/toolsrc/include/vcpkg/packagespec.h
+++ b/toolsrc/include/vcpkg/packagespec.h
@@ -34,8 +34,8 @@ namespace vcpkg
 
         std::string dir() const;
 
-        std::string to_string() const;
-        void to_string(std::string& s) const;
+        std::string to_string(bool omitTriplet = false) const;
+        void to_string(std::string& s, bool omitTriplet = false) const;
 
         bool operator<(const PackageSpec& other) const
         {
@@ -65,8 +65,8 @@ namespace vcpkg
 
         const PackageSpec& spec() const { return m_spec; }
 
-        std::string to_string() const;
-        void to_string(std::string& out) const;
+        std::string to_string(bool omitTriplet = false) const;
+        void to_string(std::string& out, bool omitTriplet = false) const;
 
         static std::vector<FeatureSpec> from_strings_and_triplet(const std::vector<std::string>& depends,
                                                                  const Triplet& t);
@@ -103,6 +103,14 @@ namespace vcpkg
         PackageSpec package_spec;
         std::vector<std::string> features;
 
+        const std::string& name() const { return package_spec.name(); }
+        const Triplet& triplet() const { return package_spec.triplet(); }
+
+        const PackageSpec& spec() const { return package_spec; }
+
+        std::string to_string(bool omitTriplet = false) const;
+        void to_string(std::string& out, bool omitTriplet = false) const;
+
         static std::vector<FeatureSpec> to_feature_specs(const std::vector<FullPackageSpec>& specs);
 
         static ExpectedT<FullPackageSpec, PackageSpecParseResult> from_string(const std::string& spec_as_string,
@@ -124,6 +132,10 @@ namespace vcpkg
 
     bool operator==(const PackageSpec& left, const PackageSpec& right);
     bool operator!=(const PackageSpec& left, const PackageSpec& right);
+
+    bool operator< (const FullPackageSpec& left, const FullPackageSpec& right);
+    bool operator==(const FullPackageSpec& left, const FullPackageSpec& right);
+    bool operator!=(const FullPackageSpec& left, const FullPackageSpec& right);
 }
 
 namespace std

--- a/toolsrc/include/vcpkg/statusparagraph.h
+++ b/toolsrc/include/vcpkg/statusparagraph.h
@@ -55,7 +55,7 @@ namespace vcpkg
         }
 
         const PackageSpec& spec() const { return core->package.spec; }
-        std::vector<PackageSpec> dependencies() const;
+        std::vector<FullPackageSpec> dependencies() const;
 
         const StatusParagraph* core;
         std::vector<const StatusParagraph*> features;

--- a/toolsrc/src/vcpkg-test/plan.cpp
+++ b/toolsrc/src/vcpkg-test/plan.cpp
@@ -598,8 +598,8 @@ TEST_CASE ("install plan action dependencies", "[plan]")
     // Add a port "a" which depends on the core of "b", which was already
     // installed explicitly
     PackageSpecMap spec_map(Triplet::X64_WINDOWS);
-    auto spec_c = spec_map.emplace("c");
-    auto spec_b = spec_map.emplace("b", "c");
+    auto spec_c = FullPackageSpec{spec_map.emplace("c")};
+    auto spec_b = FullPackageSpec{spec_map.emplace("b", "c")};
     spec_map.emplace("a", "b");
 
     // Install "a" (without explicit feature specification)
@@ -613,10 +613,10 @@ TEST_CASE ("install plan action dependencies", "[plan]")
     features_check(install_plan.at(0), "c", {"core"}, Triplet::X64_WINDOWS);
 
     features_check(install_plan.at(1), "b", {"core"}, Triplet::X64_WINDOWS);
-    REQUIRE(install_plan.at(1).install_action.get()->computed_dependencies == std::vector<PackageSpec>{spec_c});
+    REQUIRE(install_plan.at(1).install_action.get()->computed_dependencies == std::vector<FullPackageSpec>{spec_c});
 
     features_check(install_plan.at(2), "a", {"core"}, Triplet::X64_WINDOWS);
-    REQUIRE(install_plan.at(2).install_action.get()->computed_dependencies == std::vector<PackageSpec>{spec_b});
+    REQUIRE(install_plan.at(2).install_action.get()->computed_dependencies == std::vector<FullPackageSpec>{spec_b});
 }
 
 TEST_CASE ("install plan action dependencies 2", "[plan]")
@@ -626,8 +626,8 @@ TEST_CASE ("install plan action dependencies 2", "[plan]")
     // Add a port "a" which depends on the core of "b", which was already
     // installed explicitly
     PackageSpecMap spec_map(Triplet::X64_WINDOWS);
-    auto spec_c = spec_map.emplace("c");
-    auto spec_b = spec_map.emplace("b", "c");
+    auto spec_c = FullPackageSpec{spec_map.emplace("c")};
+    auto spec_b = FullPackageSpec{spec_map.emplace("b", "c")};
     spec_map.emplace("a", "c, b");
 
     // Install "a" (without explicit feature specification)
@@ -641,10 +641,10 @@ TEST_CASE ("install plan action dependencies 2", "[plan]")
     features_check(install_plan.at(0), "c", {"core"}, Triplet::X64_WINDOWS);
 
     features_check(install_plan.at(1), "b", {"core"}, Triplet::X64_WINDOWS);
-    REQUIRE(install_plan.at(1).install_action.get()->computed_dependencies == std::vector<PackageSpec>{spec_c});
+    REQUIRE(install_plan.at(1).install_action.get()->computed_dependencies == std::vector<FullPackageSpec>{spec_c});
 
     features_check(install_plan.at(2), "a", {"core"}, Triplet::X64_WINDOWS);
-    REQUIRE(install_plan.at(2).install_action.get()->computed_dependencies == std::vector<PackageSpec>{spec_b, spec_c});
+    REQUIRE(install_plan.at(2).install_action.get()->computed_dependencies == std::vector<FullPackageSpec>{spec_b, spec_c});
 }
 
 TEST_CASE ("install plan action dependencies 3", "[plan]")
@@ -665,7 +665,7 @@ TEST_CASE ("install plan action dependencies 3", "[plan]")
 
     REQUIRE(install_plan.size() == 1);
     features_check(install_plan.at(0), "a", {"1", "0", "core"}, Triplet::X64_WINDOWS);
-    REQUIRE(install_plan.at(0).install_action.get()->computed_dependencies == std::vector<PackageSpec>{});
+    REQUIRE(install_plan.at(0).install_action.get()->computed_dependencies == std::vector<FullPackageSpec>{});
 }
 
 TEST_CASE ("install with default features", "[plan]")

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -262,7 +262,8 @@ namespace vcpkg::Commands::CI
                     const Build::BuildPackageConfig build_config{*scfl, triplet, build_options, p->feature_list};
 
                     auto dependency_abis =
-                        Util::fmap(p->computed_dependencies, [&](const PackageSpec& spec) -> Build::AbiEntry {
+                        Util::fmap(p->computed_dependencies, [&](const FullPackageSpec& full_spec) -> Build::AbiEntry {
+                            const auto& spec = full_spec.spec();
                             auto it = ret->abi_tag_map.find(spec);
 
                             if (it == ret->abi_tag_map.end())
@@ -313,7 +314,7 @@ namespace vcpkg::Commands::CI
                 }
                 else if (std::any_of(p->computed_dependencies.begin(),
                                      p->computed_dependencies.end(),
-                                     [&](const PackageSpec& spec) { return Util::Sets::contains(will_fail, spec); }))
+                                     [&](const FullPackageSpec& full_spec) { return Util::Sets::contains(will_fail, full_spec.spec()); }))
                 {
                     ret->known.emplace(p->spec, BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES);
                     will_fail.emplace(p->spec);

--- a/toolsrc/src/vcpkg/commands.dependinfo.cpp
+++ b/toolsrc/src/vcpkg/commands.dependinfo.cpp
@@ -36,7 +36,7 @@ namespace vcpkg::Commands::DependInfo
         constexpr std::array<CommandSetting, 2> DEPEND_SETTINGS = {
             {{OPTION_MAX_RECURSE, "Set max recursion depth, a value of -1 indicates no limit"},
              {OPTION_SORT,
-              "Set sort order for the list of dependencies, accepted values are: lexicographical, topological "
+              "Set sort order for the list of dependencies; accepted values are: lexicographical, topological "
               "(default), "
               "reverse"}}};
 
@@ -190,7 +190,10 @@ namespace vcpkg::Commands::DependInfo
                 {
                     for (auto&& dependency : info.dependencies)
                     {
-                        assign_depth_to_dependencies(dependency, depth + 1, max_depth, dependencies_map);
+                        // Extract just the package name
+                        auto dep_name = Strings::split(dependency, ":")[0];
+                        dep_name = Strings::split(dep_name, "[")[0];
+                        assign_depth_to_dependencies(dep_name, depth + 1, max_depth, dependencies_map);
                     }
                 }
             }
@@ -205,7 +208,7 @@ namespace vcpkg::Commands::DependInfo
                 const InstallPlanAction& install_action = *pia;
 
                 const std::vector<std::string> dependencies = Util::fmap(
-                    install_action.computed_dependencies, [](const PackageSpec& spec) { return spec.name(); });
+                    install_action.computed_dependencies, [](const FullPackageSpec& spec) { return spec.to_string(true /*omitTriplet*/); });
 
                 std::set<std::string> features{install_action.feature_list};
                 features.erase("core");

--- a/toolsrc/src/vcpkg/statusparagraph.cpp
+++ b/toolsrc/src/vcpkg/statusparagraph.cpp
@@ -85,7 +85,7 @@ namespace vcpkg
             default: return "error";
         }
     }
-    std::vector<PackageSpec> InstalledPackageView::dependencies() const
+    std::vector<FullPackageSpec> InstalledPackageView::dependencies() const
     {
         // accumulate all features in installed dependencies
         // Todo: make this unneeded by collapsing all package dependencies into the core package
@@ -109,8 +109,8 @@ namespace vcpkg
         // </hack>
         Util::sort_unique_erase(deps);
 
-        return Util::fmap(deps, [&](const std::string& dep) -> PackageSpec {
-            auto maybe_dependency_spec = PackageSpec::from_name_and_triplet(dep, l_spec.triplet());
+        return Util::fmap(deps, [&](const std::string& dep) -> FullPackageSpec {
+            auto maybe_dependency_spec = FullPackageSpec::from_string(dep, l_spec.triplet());
             if (auto dependency_spec = maybe_dependency_spec.get())
             {
                 return std::move(*dependency_spec);


### PR DESCRIPTION
This change fixes the depend-info command to report package dependencies at the feature level. Prior to this, for example, "vcpkg depend-info freeimage" lists "libwebp" as a dependency, but the actual dependency is "libwebp[all]".

This happens because the depend-info command relies on InstallPlanAction.computed_dependencies for the dependencies, which is a vector of PackageSpec, which does not include the feature selection. To fix this, I've converted this vector to FullPackageSpec and resolved the fallout of this change (which included needing to define operators == and < for FullPackageSpec).