### PR TITLE
[libwebp] Fixed build error ARM64 Windows 10

### DIFF
--- a/ports/libwebp/0007-fix-arm-build.patch
+++ b/ports/libwebp/0007-fix-arm-build.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/cpu.cmake b/cmake/cpu.cmake
+index da9a42a4..ce7a69f3 100644
+--- a/cmake/cpu.cmake
++++ b/cmake/cpu.cmake
+@@ -73,7 +73,7 @@ foreach(I_SIMD RANGE ${WEBP_SIMD_FLAGS_RANGE})
+     set(CMAKE_REQUIRED_FLAGS ${SIMD_COMPILE_FLAG})
+     webp_check_compiler_flag(${WEBP_SIMD_FLAG} ${WEBP_ENABLE_SIMD})
+   else()
+-    if(MSVC)
++    if(MSVC AND NOT (CMAKE_GENERATOR_PLATFORM MATCHES "^ARM"))
+       list(GET SIMD_ENABLE_FLAGS ${I_SIMD} SIMD_COMPILE_FLAG)
+     else()
+       set(SIMD_COMPILE_FLAG " ")

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -2,8 +2,7 @@ Source: libwebp
 Version: 1.0.2-7
 Homepage: https://github.com/webmproject/libwebp
 Description: Lossy compression of digital photographic images.
-Build-Depends: opengl
 
 Feature: all
 Description: enable all webp features
-Build-Depends: giflib, libjpeg-turbo, zlib, libpng, tiff, freeglut (!osx), sdl1 (windows)
+Build-Depends: giflib, libjpeg-turbo, zlib, libpng, tiff, freeglut (!osx), sdl1 (windows), opengl

--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebp
-Version: 1.0.2-7
+Version: 1.0.2-8
 Homepage: https://github.com/webmproject/libwebp
 Description: Lossy compression of digital photographic images.
 

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     0004-add-missing-linked-library.patch
     0005-fix-static-build.patch
     0006-fix-dependecies-platform.patch
+    0007-fix-arm-build.patch
 )
 
 set(WEBP_BUILD_ANIM_UTILS OFF)


### PR DESCRIPTION
`libwebp[core]` does not require `opengl` dependency. Only the extra `vwebp` app requires `opengl`.