### PR TITLE
[live555] Fix live555:x86-windows-static build failure

### DIFF
--- a/ports/live555/CMakeLists.txt
+++ b/ports/live555/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(groupsock ${GROUPSOCK_SRCS})
 
 file(GLOB LIVEMEDIA_SRCS liveMedia/*.c liveMedia/*.cpp)
 add_library(liveMedia ${LIVEMEDIA_SRCS})
+find_package(OpenSSL REQUIRED)
+target_include_directories(liveMedia PRIVATE "${OPENSSL_INCLUDE_DIR}")
 
 file(GLOB USAGE_ENVIRONMENT_SRCS UsageEnvironment/*.c UsageEnvironment/*.cpp)
 add_library(UsageEnvironment ${USAGE_ENVIRONMENT_SRCS})

--- a/ports/live555/CONTROL
+++ b/ports/live555/CONTROL
@@ -1,4 +1,5 @@
 Source: live555
-Version: latest
+Version: latest-1
 Homepage: https://www.live555.com/liveMedia
 Description: A complete RTSP server application
+Build-Depends: openssl

--- a/ports/live555/fix-RTSPClient.patch
+++ b/ports/live555/fix-RTSPClient.patch
@@ -1,0 +1,13 @@
+diff --git a/liveMedia/RTSPClient.cpp b/liveMedia/RTSPClient.cpp
+index 02c46c7..6127698 100644
+--- a/liveMedia/RTSPClient.cpp
++++ b/liveMedia/RTSPClient.cpp
+@@ -1939,7 +1939,7 @@ int RTSPClient::write(const u_int8_t* data, unsigned count) {
+       if (fTLS.isNeeded) {
+ 	return fTLS.write(data, count);
+       } else {
+-	return send(fOutputSocketNum, data, count, 0);
++	return send(fOutputSocketNum, (const char *)data, count, 0);
+       }
+ }
+ 

--- a/ports/live555/portfile.cmake
+++ b/ports/live555/portfile.cmake
@@ -1,13 +1,9 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY) 
 
 if(NOT VCPKG_USE_HEAD_VERSION)
     # Live555 only makes the latest releases available for download on their site
     message(FATAL_ERROR "Live555 does not have persistent releases. Please re-run the installation with --head.")
 endif()
-
-include(vcpkg_common_functions)
 
 set(LIVE_VERSION latest)
 
@@ -20,6 +16,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE} 
+    PATCHES
+        fix-RTSPClient.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
@@ -39,6 +37,6 @@ file(GLOB HEADERS
 )
 
 file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/live555 RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Related issue #9284.
1. Add Build-Depends: openssl
2. Fix CMakeLists.txt
3. Fix RTSPClient.cpp
4. Delete deprecated functions
5. Update deprecated functions
This port install ok on triplet x86-windows, x86-windows-static, x64-windows, x64-windows-static x64-linux.
No features need to test.