### PR TITLE
[freetype] use config and the correct alias

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,5 @@
 Source: freetype
-Version: 2.10.1-1
+Version: 2.10.1-2
 Build-Depends: zlib, bzip2, libpng
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -72,7 +72,6 @@ file(COPY
     ${SOURCE_PATH}/docs/LICENSE.TXT
     ${SOURCE_PATH}/docs/FTL.TXT
     ${SOURCE_PATH}/docs/GPLv2.TXT
-    ${CMAKE_CURRENT_LIST_DIR}/usage
     DESTINATION ${CURRENT_PACKAGES_DIR}/share/freetype
 )
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/freetype/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/freetype/copyright)

--- a/ports/freetype/usage
+++ b/ports/freetype/usage
@@ -1,4 +1,4 @@
 The package freetype is compatible with built-in CMake targets:
 
-    find_package(Freetype REQUIRED)
-    target_link_libraries(main PRIVATE Freetype::Freetype)
+    find_package(freetype CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE freetype)

--- a/ports/freetype/usage
+++ b/ports/freetype/usage
@@ -1,4 +1,0 @@
-The package freetype is compatible with built-in CMake targets:
-
-    find_package(freetype CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE freetype)


### PR DESCRIPTION
Neumann-A figured out that `add_library(Freetype::Freetype ALIAS freetype)` is defined so instead of Freetype::Freetype use freetype. qis Also pointed out that freetype uses a cmake config file. Thats why CONFIG parameter is required.

**Describe the pull request**

- What does your PR fix? Fixes issue #
The usage file from freetype library.
- Which triplets are supported/not supported? Have you updated the CI baseline?
All should be supported. They should not have been changed. No.
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.