### PR TITLE
[simpleini] Fix build failure on travis CI

### DIFF
--- a/ports/simpleini/CONTROL
+++ b/ports/simpleini/CONTROL
@@ -1,3 +1,3 @@
 Source: simpleini
-Version: 2018-08-31-2
+Version: 2018-08-31-3
 Description: Cross-platform C++ library providing a simple API to read and write INI-style configuration files

--- a/ports/simpleini/portfile.cmake
+++ b/ports/simpleini/portfile.cmake
@@ -1,6 +1,4 @@
 # header-only library
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO brofield/simpleini
@@ -9,6 +7,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/Simpleini.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${SOURCE_PATH}/SimpleIni.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-file(INSTALL ${SOURCE_PATH}/LICENCE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/simpleini RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENCE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1533,7 +1533,6 @@ shogun:x86-windows        = skip
 simdjson:arm64-windows=fail
 simdjson:arm-uwp=fail
 simdjson:x86-windows=fail
-simpleini:x64-linux=fail
 simpleini:x64-osx=fail
 slikenet:arm-uwp=fail
 slikenet:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1533,7 +1533,6 @@ shogun:x86-windows        = skip
 simdjson:arm64-windows=fail
 simdjson:arm-uwp=fail
 simdjson:x86-windows=fail
-simpleini:x64-osx=fail
 slikenet:arm-uwp=fail
 slikenet:x64-uwp=fail
 smpeg2:arm-uwp=fail


### PR DESCRIPTION
Related issue #9320.

1. Fix Simpleini.h to SimpleIni.h
2. Update the versions
3. Delete deprecated functions
4. Update deprecated functions

This port install ok on triplet x86-windows, x64-windows, x64-linux.
No features need to test.