### PR TITLE
Update baseline to skip ogre conflicts

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1153,6 +1153,15 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
+# Conflicts with ogre-next
+ogre:arm64-windows      = skip
+ogre:arm-uwp            = skip
+ogre:x64-osx            = skip
+ogre:x64-linux          = skip
+ogre:x64-uwp            = skip
+ogre:x64-windows        = skip
+ogre:x64-windows-static = skip
+ogre:x86-windows        = skip
 ois:arm64-windows=fail
 ois:arm-uwp=fail
 ois:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1153,15 +1153,15 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
-# Conflicts with ogre-next
-ogre:arm64-windows      = skip
-ogre:arm-uwp            = skip
-ogre:x64-osx            = skip
-ogre:x64-linux          = skip
-ogre:x64-uwp            = skip
-ogre:x64-windows        = skip
-ogre:x64-windows-static = skip
-ogre:x86-windows        = skip
+# Conflicts with ogre
+ogre-next:arm64-windows      = skip
+ogre-next:arm-uwp            = skip
+ogre-next:x64-osx            = skip
+ogre-next:x64-linux          = skip
+ogre-next:x64-uwp            = skip
+ogre-next:x64-windows        = skip
+ogre-next:x64-windows-static = skip
+ogre-next:x86-windows        = skip
 ois:arm64-windows=fail
 ois:arm-uwp=fail
 ois:x64-uwp=fail


### PR DESCRIPTION
Since  there are some file conflicts between `ogre` and `ogre-next`, set all triplets of ogre-next to **skip**.

As some ports depend on ogre, set all triplets results of `ogre-next` to skip in the baseline.

Related: #9255 #9301.