### PR TITLE
[botan] Fix unrecognized compile flag MT/MD

### DIFF
--- a/ports/botan/CONTROL
+++ b/ports/botan/CONTROL
@@ -1,4 +1,4 @@
 Source: botan
-Version: 2.12.1
+Version: 2.12.1-1
 Homepage: https://botan.randombit.net
 Description: A cryptography library written in C++11

--- a/ports/botan/fix-msvc-build.patch
+++ b/ports/botan/fix-msvc-build.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.py b/configure.py
+index cfec5bb..0fad6ce 100644
+--- a/configure.py
++++ b/configure.py
+@@ -2146,6 +2146,12 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch,
+ 
+         'mod_list': sorted([m.basename for m in modules])
+     }
++    
++    if cc.basename == 'msvc' and variables['cxx_abi_flags'] != '':
++        # MSVC linker doesn't support/need the ABI options,
++        # just transfer them over to just the compiler invocations
++        variables['cc_compile_flags'] = '%s %s' % (variables['cxx_abi_flags'], variables['cc_compile_flags'])
++        variables['cxx_abi_flags'] = ''
+ 
+     variables['lib_flags'] = cc.gen_lib_flags(options, variables)
+     variables['cmake_lib_flags'] = cmake_escape(variables['lib_flags'])

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF 1a6ad661ce64287ccbe26460ccc3aa4247d86ba8 # 2.12.1
     SHA512 7a774f325c85761e2d076847f1fc8bc67592d696c4ebde839928591f7c85352e2df6032c122bdcc603adf84d76f5a1897c7118aa3859d38f79e474f27bc3b588
     HEAD_REF master
-    PATCHES fix-generate-build-path.patch
+    PATCHES
+        fix-generate-build-path.patch
+        fix-msvc-build.patch # Remove this patch on next update
 )
 
 if(CMAKE_HOST_WIN32)


### PR DESCRIPTION
Use official patches([#2209](https://github.com/randombit/botan/issues/2209)) to fix build issue:
`LINK : fatal error LNK1146: no argument specified with option '/MT'`

Related: #9305.

Note: this port doesn't contain any feature.