### PR TITLE
Update baseline with 'leptonica:arm-uwp=fail'

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -684,6 +684,7 @@ laszip:x64-uwp=fail
 lcm:x64-linux=fail
 lcm:x64-osx=fail
 leptonica:x64-uwp=fail
+leptonica:arm-uwp=fail
 leveldb:arm-uwp=fail
 leveldb:x64-uwp=fail
 libaiff:x64-linux=fail


### PR DESCRIPTION
Since `leptonica `failed on `arm-uwp` triplet.
```
|arm-uwp  |result|features|notes
|---------|----|--------|-----
|leptonica|Fail|core|Test passes in baseline but fails in current run. If expected update ci.baseline.txt with 'leptonica:arm-uwp=fail'

```
I add `leptonica:arm-uwp=fail` to ci.baseline.txt.

Related: #9300.
