### PR TITLE
[liblas] link with laszip to support .laz (compressed .las) files.

### DIFF
--- a/ports/liblas/CONTROL
+++ b/ports/liblas/CONTROL
@@ -1,6 +1,6 @@
 Source: liblas
-Version: 1.8.1-3
-Build-Depends: boost, boost-thread, boost-system, boost-iostreams, boost-filesystem, libgeotiff
+Version: 1.8.1-4
+Build-Depends: boost, boost-thread, boost-system, boost-iostreams, boost-filesystem, libgeotiff, laszip
 Description: A C/C++ library for reading and writing the very common LAS LiDAR format.
 
 Feature: jpeg

--- a/ports/liblas/portfile.cmake
+++ b/ports/liblas/portfile.cmake
@@ -17,6 +17,13 @@ vcpkg_extract_source_archive_ex(
 
 file(REMOVE ${SOURCE_PATH}/cmake/modules/FindPROJ4.cmake)
 file(REMOVE ${SOURCE_PATH}/cmake/modules/FindGeoTIFF.cmake)
+file(REMOVE ${SOURCE_PATH}/cmake/modules/FindLASzip.cmake)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  set(WITH_STATIC_LASZIP TRUE)
+else()
+  set(WITH_STATIC_LASZIP FALSE)
+endif()
 
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
@@ -26,6 +33,8 @@ vcpkg_configure_cmake(
 	-DBUILD_OSGEO4W=OFF # Disable osgeo4w
 	-DWITH_TESTS=OFF
 	-DWITH_UTILITIES=OFF
+	-DWITH_LASZIP=ON
+	-DWITH_STATIC_LASZIP=${WITH_STATIC_LASZIP}
 	-DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=${CMAKE_DISABLE_FIND_PACKAGE_ZLIB}
 	-DCMAKE_DISABLE_FIND_PACKAGE_JPEG=${CMAKE_DISABLE_FIND_PACKAGE_JPEG}
 )


### PR DESCRIPTION
By linking liblas with laszip, it gains support for compressed .laz files.
I have only just read that liblas is being replaced by pdal, but we are still using liblas to get read ability for las and laz in osg.
Regards, Laurens.
