### PR TITLE
Remove vtk:x64-linux result in baseline

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-9
+Version: 8.2.0-10
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1713,7 +1713,6 @@ vlpp:arm64-windows=fail
 vlpp:arm-uwp=fail
 vlpp:x64-osx=fail
 vlpp:x64-uwp=fail
-vtk:x64-linux=fail
 vulkan:arm64-windows=fail
 vulkan:arm-uwp=fail
 vulkan:x64-linux=fail


### PR DESCRIPTION
Since vtk:x64-linux build passed, remove it from baseline.

Related: #9311.