### PR TITLE
[ixwebsocket] update to 7.6.3

### DIFF
--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,5 +1,5 @@
 Source: ixwebsocket
-Version: 7.6.3
+Version: 7.9.2
 Build-Depends: zlib
 Homepage: https://github.com/machinezone/IXWebSocket
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server

--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,5 +1,5 @@
 Source: ixwebsocket
-Version: 7.4.0
+Version: 7.6.3
 Build-Depends: zlib
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server
 Default-Features: ssl

--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,6 +1,7 @@
 Source: ixwebsocket
 Version: 7.6.3
 Build-Depends: zlib
+Homepage: https://github.com/machinezone/IXWebSocket
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server
 Default-Features: ssl
 

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF v7.4.0
-    SHA512 ea78f42a8cf1dfaafe7bf3a849e62a8e039e10cc8d93add7bf2d5283f53311dac449f86c5f22496b55ad6e22597b2842cba85936170d2d0e720389a88d87268c
+    REF v7.6.3
+    SHA512 429fc95b4e5bf36a6baf679ff168b327cd768f3d97e7d2356b4751812fe8c17ed3378ffa74f4a4c9a22f38edb763da45f5d280234dada03c330e037ef41ed350
 )
 
 vcpkg_configure_cmake(

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF v7.6.3
-    SHA512 429fc95b4e5bf36a6baf679ff168b327cd768f3d97e7d2356b4751812fe8c17ed3378ffa74f4a4c9a22f38edb763da45f5d280234dada03c330e037ef41ed350
+    REF v7.9.2
+    SHA512 478aca334cc9e3244f403b88ec4d33fff2f6815b44ecd846d3c58cd763768e4bad50fec0c4ae570ade9aa8450315c3e70df76ed99de76bc93af705f882fefad1
 )
 
 vcpkg_configure_cmake(

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
@@ -18,7 +16,7 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ixwebsocket RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 # Post-build test for cmake libraries
 # vcpkg_test_cmake(PACKAGE_NAME ixwebsocket)


### PR DESCRIPTION
Update to the latest version, which improve SSL support on Windows.

(cf https://github.com/machinezone/IXWebSocket/issues/135)