### PR TITLE
[entt] Upgrade library to 3.2.2

### DIFF
--- a/ports/entt/CONTROL
+++ b/ports/entt/CONTROL
@@ -1,4 +1,4 @@
 Source: entt
-Version: 3.1.1
+Version: 3.2.2
 Description: Gaming meets modern C++ - a fast and reliable entity-component system and much more.
 Homepage: https://github.com/skypjack/entt

--- a/ports/entt/portfile.cmake
+++ b/ports/entt/portfile.cmake
@@ -4,8 +4,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO skypjack/entt
-    REF v3.1.1
-    SHA512 eec6dfa82c0290d4c9da2dda5eb31b8fca9de7378aa1560bea78512fa358da34b64efa7cb6c70b7d6fed0ea8dd041d44c6348d847f14b071a61f3258a4f720c1
+    REF v3.2.2
+    SHA512 231bd3c4300dbc6aaee31364e5e8a769f2c3ccd70bfbcc1315d782c21332e1d1f12367b14833cdfe4d90fc8e4ecd2424136ee29f4db36ebcebf1d41bb07bb250
     HEAD_REF master
 )
 


### PR DESCRIPTION
**Describe the pull request** Upgrade entt library to version 3.2.2

- What does your PR fix? Fixes issue #9407

- Which triplets are supported/not supported? Have you updated the CI baseline? All already supported tripplets should still be supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
