### PR TITLE
[basisu] update from upstream repository, add support for pvrtc2

### DIFF
--- a/ports/basisu/CONTROL
+++ b/ports/basisu/CONTROL
@@ -1,5 +1,5 @@
 Source: basisu
-Version: 1.11-2
+Version: 1.11-3
 Homepage: https://github.com/BinomialLLC/basis_universal
 Description: Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats. 
 Build-Depends: lodepng

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jherico/basis_universal
@@ -24,9 +22,8 @@ else()
     set(TOOL_NAME basisu_tool)
 endif()
 
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/basisu)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(COPY ${CURRENT_PACKAGES_DIR}/bin/${TOOL_NAME} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/basisu)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/basisu/LICENSE ${CURRENT_PACKAGES_DIR}/share/basisu/copyright)
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/basisu)
 

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jherico/basis_universal
-    REF b0ec54562c215b2f9ed6d54dcaaca9d762d4aff3
-    SHA512 27ceb6076c79991639c16bd56a1f81f03fad6d6b4b0184f3f3b594bb163509525e03a7d5f1ba068d186f9cbba677e52972e0b364f4369eadf507fca6e6c60820
+    REF 497875f756ed0e3eb62e0ff08d55c62242f4be74
+    SHA512 2293b78620a7ed510dbecf48bcae5f4b8524fe9020f864c8e79cf94ea9d95d51dddf83a5b4ea29cc95db19f87137bfef1cb68b7fbc6387e08bb42898d81c9303
     HEAD_REF master
 )
 


### PR DESCRIPTION
The existing basis universal library in vcpkg is a [fork](https://github.com/jherico/basis_universal) of the [primary repository](https://github.com/BinomialLLC/basis_universal) based on a refactoring of the source code to make it more inline with modern CMake practices.

However, the fork hadn't been updated since mid September, and the upstream repository has made some significant updates, including support for the pvrtc2 compressed texture format.  As of today the fork is now consistent with the tip of master upstream, and this PR updates vcpkg to point at the most recent commit on the fork, which incorporates all upstream changes to date.

Unfortunately the upstream repository doesn't seem to follow any kind of rigorous versioning scheme, so we're forced to simply increment a "dash value"
