### PR TITLE
[simpleini] Install missing code

### DIFF
--- a/ports/simpleini/CONTROL
+++ b/ports/simpleini/CONTROL
@@ -1,3 +1,4 @@
 Source: simpleini
-Version: 2018-08-31-3
+Version: 2018-08-31-4
+Homepage: https://github.com/brofield/simpleini
 Description: Cross-platform C++ library providing a simple API to read and write INI-style configuration files

--- a/ports/simpleini/portfile.cmake
+++ b/ports/simpleini/portfile.cmake
@@ -7,6 +7,14 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/SimpleIni.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+# Install codes
+set(SIMPLEINI_SOURCE ${SOURCE_PATH}/SimpleIni.h
+                     ${SOURCE_PATH}/ConvertUTF.h
+                     ${SOURCE_PATH}/ConvertUTF.c
+)
+
+file(INSTALL ${SIMPLEINI_SOURCE} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+# Install sample
+file(INSTALL ${SOURCE_PATH}/snippets.cpp DESTINATION ${CURRENT_PACKAGES_DIR}/share/sample)
 
 file(INSTALL ${SOURCE_PATH}/LICENCE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
- Install missing code files `ConvertUTF.h` and `ConvertUTF.c`.
- Install sample code.

Related: #9320.

Note: no feature needs to be tested.