### PR TITLE
[osg] fix non-windows builds

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,5 +1,5 @@
 Source: osg
-Version: 3.6.4
+Version: 3.6.4-1
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
@@ -19,38 +17,27 @@ else()
 endif()
 file(REMOVE ${SOURCE_PATH}/CMakeModules/FindSDL2.cmake)
 if(VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} OPTIONS -DOSG_USE_UTF8_FILENAME=ON)
+  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} OPTIONS -DBUILD_OSG_APPLICATIONS=OFF -DOSG_USE_UTF8_FILENAME=ON)
 else()
-  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} OPTIONS -DBUILD_OSG_APPLICATIONS=OFF)
 endif()
 
 vcpkg_install_cmake()
 
-# handle osg tools and plugins
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-set(OSG_TOOL_PATH ${CURRENT_PACKAGES_DIR}/tools/osg)
-file(MAKE_DIRECTORY ${OSG_TOOL_PATH})
-
-file(GLOB OSG_TOOLS ${CURRENT_PACKAGES_DIR}/bin/*.exe)
-file(COPY ${OSG_TOOLS} DESTINATION ${OSG_TOOL_PATH})
-file(REMOVE_RECURSE ${OSG_TOOLS})
-file(GLOB OSG_TOOLS_DBG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-file(REMOVE_RECURSE ${OSG_TOOLS_DBG})
-
-file(GLOB OSG_PLUGINS_DBG ${CURRENT_PACKAGES_DIR}/debug/bin/osgPlugins-3.6.4/*.dll)
+# handle plugins
+file(GLOB OSG_PLUGINS_DBG ${CURRENT_PACKAGES_DIR}/debug/bin/osgPlugins-3.6.4/*${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX})
 file(COPY ${OSG_PLUGINS_DBG} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/tools/osg/osgPlugins-3.6.4)
-file(GLOB OSG_PLUGINS_REL ${CURRENT_PACKAGES_DIR}/bin/osgPlugins-3.6.4/*.dll)
+file(GLOB OSG_PLUGINS_REL ${CURRENT_PACKAGES_DIR}/bin/osgPlugins-3.6.4/*${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX})
 file(COPY ${OSG_PLUGINS_REL} DESTINATION ${OSG_TOOL_PATH}/osgPlugins-3.6.4)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/osgPlugins-3.6.4/)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/osgPlugins-3.6.4/)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/osg)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/osg/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/osg/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 #Cleanup
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -18,11 +18,11 @@ else()
     set(OSG_DYNAMIC ON)
 endif()
 file(REMOVE ${SOURCE_PATH}/CMakeModules/FindSDL2.cmake)
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-        -DOSG_USE_UTF8_FILENAME=ON
-)
+if(VCPKG_TARGET_IS_WINDOWS)
+  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} OPTIONS -DOSG_USE_UTF8_FILENAME=ON)
+else()
+  vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+endif()
 
 vcpkg_install_cmake()
 


### PR DESCRIPTION
Enabling OSG_USE_UTF8_FILENAME on any platform other than windows causes the build to fail.  This is because it substitutes fopen for _wfopen, which is only on windows.

Related: #9449.