### PR TITLE
[fruit] fix wchar.h import issue under Catalina

### DIFF
--- a/ports/fruit/CONTROL
+++ b/ports/fruit/CONTROL
@@ -1,4 +1,4 @@
 Source: fruit
 Version: 3.4.0-2
+Homepage: https://github.com/google/fruit
 Description: Fruit, a dependency injection framework for C++ by Google
-

--- a/ports/fruit/CONTROL
+++ b/ports/fruit/CONTROL
@@ -1,4 +1,4 @@
 Source: fruit
-Version: 3.4.0-1
+Version: 3.4.0-2
 Description: Fruit, a dependency injection framework for C++ by Google
 

--- a/ports/fruit/portfile.cmake
+++ b/ports/fruit/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DFRUIT_USES_BOOST=False
+        -DFRUIT_TESTS_USE_PRECOMPILED_HEADERS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/fruit/portfile.cmake
+++ b/ports/fruit/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/fruit
@@ -20,4 +20,4 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/fruit/copyright COPYONLY)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Under MacOS sdk 10.5, the use of `import_next wchar.h` in the precompiled header file in `tests/test_macros.h` caused the error `wchar.h:119:15: fatal error: 'wchar.h' file not found` on Catalina, as there is no additional `wchar.h` file in import path to fallback to.  There is a build option provided by fruit cmake to skip uses precompiled headers on the test branch of project, which fixes above error.

- What does your PR fix? Fixes issue #9444

- Which triplets are supported/not supported? Have you updated the CI baseline?

The option is a build optimisation related to tests on posix platforms.  It is a header only library.  
All triplets are supported with this change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes
