### PR TITLE
[ptext] Fix library cannot be found by find_package()

### DIFF
--- a/ports/ptex/CONTROL
+++ b/ports/ptex/CONTROL
@@ -1,5 +1,5 @@
 Source: ptex
-Version: 2.3.2
+Version: 2.3.2-1
 Homepage: https://github.com/wdas/ptex
 Description: Per-Face Texture Mapping for Production Rendering.
 Build-Depends: zlib

--- a/ports/ptex/fix-config.cmake.patch
+++ b/ports/ptex/fix-config.cmake.patch
@@ -1,0 +1,18 @@
+diff --git a/src/build/ptex-config.cmake b/src/build/ptex-config.cmake
+index f95df9e..2d3f58f 100644
+--- a/src/build/ptex-config.cmake
++++ b/src/build/ptex-config.cmake
+@@ -1,11 +1,11 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
+ include("${CMAKE_CURRENT_LIST_DIR}/ptex-version.cmake")
+ include("${CMAKE_CURRENT_LIST_DIR}/ptex-exports.cmake")
+ 
+ # Provide PkgConfig::ZLIB to downstream dependents
+-find_package(PkgConfig REQUIRED)
+-pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
++find_dependency(ZLIB REQUIRED)
+ 
+ set_and_check(Ptex_DIR @PACKAGE_CMAKE_INSTALL_PREFIX@)
+ set_and_check(Ptex_LIBRARY_DIRS @PACKAGE_CMAKE_INSTALL_LIBDIR@)

--- a/ports/ptex/portfile.cmake
+++ b/ports/ptex/portfile.cmake
@@ -1,8 +1,4 @@
-include(vcpkg_common_functions)
-
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "UWP build not supported")
-endif()
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 set(PTEX_VER 2.3.2)
 
@@ -12,7 +8,9 @@ vcpkg_from_github(
     REF 1b8bc985a71143317ae9e4969fa08e164da7c2e5
     SHA512 37f2df9ec195f3d69d9526d0dea6a93ef49d69287bfae6ccd9671477491502ea760ed14e3b206b4f488831ab728dc749847b7d176c9b8439fb58b0a0466fe6c5
     HEAD_REF master
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/fix-build.patch
+    PATCHES 
+        fix-build.patch
+        fix-config.cmake.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
@@ -47,5 +45,5 @@ foreach(HEADER PtexHalf.h Ptexture.h)
 endforeach()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-file(COPY ${SOURCE_PATH}/src/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ptex)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/ptex/license.txt ${CURRENT_PACKAGES_DIR}/share/ptex/copyright)
+#Handle copyright
+file(INSTALL ${SOURCE_PATH}/src/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ptex RENAME copyright)

--- a/ports/ptex/portfile.cmake
+++ b/ports/ptex/portfile.cmake
@@ -45,5 +45,5 @@ foreach(HEADER PtexHalf.h Ptexture.h)
 endforeach()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-#Handle copyright
-file(INSTALL ${SOURCE_PATH}/src/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ptex RENAME copyright)
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/src/doc/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
In `ptex-config.cmake` file, find its dependency by 
```
find_package(PkgConfig REQUIRED)
pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
```
It will post the error:

` Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
` 

So I modify this as :
```
include(CMakeFindDependencyMacro)
find_dependency(ZLIB REQUIRED)
```

Related issue: #9454
Note: No features need to test.
