### PR TITLE
[detours] Fix to build with debug/release and static/dynamic crt, and cmake target

### DIFF
--- a/ports/detours/CMakeLists.txt
+++ b/ports/detours/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+project(detours CXX)
+
+add_library(detours INTERFACE)
+
+target_link_libraries(detours INTERFACE debug \${_IMPORT_PREFIX}/debug/lib/detours.lib optimized \${_IMPORT_PREFIX}/lib/detours.lib)
+target_include_directories(detours INTERFACE $<INSTALL_INTERFACE:include>)
+
+install(TARGETS detours
+    EXPORT detours
+)
+install(EXPORT detours FILE unofficial-detours-targets.cmake NAMESPACE unofficial::detours:: DESTINATION share/unofficial-detours)

--- a/ports/detours/CONTROL
+++ b/ports/detours/CONTROL
@@ -1,3 +1,3 @@
 Source: detours
-Version: 4.0.1-1
+Version: 4.0.1-2
 Description: Detours is a software package for monitoring and instrumenting API calls on Windows.

--- a/ports/detours/compiler-flags.patch
+++ b/ports/detours/compiler-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile b/src/Makefile
+index 320f3b786..47f04058c 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -16,7 +16,7 @@ DETOURS_SOURCE_BROWSING = 0
+ 
+ #######################/#######################################################
+ ##
+-CFLAGS=/W4 /WX /Zi /MT /Gy /Gm- /Zl /Od
++CFLAGS=/WX /Gy /Gm- /Zl
+ 
+ !IF $(DETOURS_SOURCE_BROWSING)==1
+ CFLAGS=$(CFLAGS) /FR

--- a/ports/detours/portfile.cmake
+++ b/ports/detours/portfile.cmake
@@ -10,6 +10,24 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         find-jmp-bounds-arm64.patch
+        compiler-flags.patch
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-detours TARGET_PATH share/unofficial-detours)
+vcpkg_copy_pdbs()
+
+configure_file(
+    ${CMAKE_CURRENT_LIST_DIR}/unofficial-detours-config.in.cmake
+    ${CURRENT_PACKAGES_DIR}/share/unofficial-detours/unofficial-detours-config.cmake
+    @ONLY
 )
 
 vcpkg_build_nmake(
@@ -17,11 +35,10 @@ vcpkg_build_nmake(
     PROJECT_SUBPATH "src"
     PROJECT_NAME "Makefile"
     OPTIONS "PROCESSOR_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}"
-    NO_DEBUG
 )
 
-file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}/lib.${VCPKG_TARGET_ARCHITECTURE}/ DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}/lib.${VCPKG_TARGET_ARCHITECTURE}/ DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME detours)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib.${VCPKG_TARGET_ARCHITECTURE}/ DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib.${VCPKG_TARGET_ARCHITECTURE}/ DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/include DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME detours)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/detours/unofficial-detours-config.in.cmake
+++ b/ports/detours/unofficial-detours-config.in.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/unofficial-detours-targets.cmake)


### PR DESCRIPTION
allow build detours with debug/release config, use static/dynamic crt linkage.
add cmake target for detours.