### PR TITLE
[argumentum] Add new port

### DIFF
--- a/ports/argumentum/CONTROL
+++ b/ports/argumentum/CONTROL
@@ -1,0 +1,3 @@
+Source: argumentum
+Version: 0.2.0
+Description: A C++17 command line argument parser inspired by Python argparse

--- a/ports/argumentum/CONTROL
+++ b/ports/argumentum/CONTROL
@@ -1,3 +1,3 @@
 Source: argumentum
-Version: 0.2.0
+Version: 0.2.1
 Description: A C++17 command line argument parser inspired by Python argparse

--- a/ports/argumentum/portfile.cmake
+++ b/ports/argumentum/portfile.cmake
@@ -1,0 +1,36 @@
+include(vcpkg_common_functions)
+
+set( VCPKG_LIBRARY_LINKAGE static )
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mmahnic/cpp-argparse
+    REF v0.2.0
+    SHA512 f2eb8c9aee8ce515d2ec3e973ceedd916458713055e1dd16e8a780cda7545b617ad0c64cd18c6356ad7584108aba3165a379ef0d3edfd89691a6343b4918e143
+    HEAD_REF master
+)
+
+# vcpkg_from_git(
+#     OUT_SOURCE_PATH SOURCE_PATH
+#     URL https://localhost/mmahnic/argumentum.git
+#     REF 310a4dd0c936f36599f76d64d4b4ec68818d8bfe
+#     HEAD_REF name_change
+# )
+
+include( GNUInstallDirs )
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+    -DARGUMENTUM_BUILD_EXAMPLES=OFF
+    -DARGUMENTUM_BUILD_TESTS=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH ${CMAKE_INSTALL_LIBDIR}/cmake/Argumentum)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/ports/argumentum/portfile.cmake
+++ b/ports/argumentum/portfile.cmake
@@ -10,13 +10,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# vcpkg_from_git(
-#     OUT_SOURCE_PATH SOURCE_PATH
-#     URL https://localhost/mmahnic/argumentum.git
-#     REF 310a4dd0c936f36599f76d64d4b4ec68818d8bfe
-#     HEAD_REF name_change
-# )
-
 include( GNUInstallDirs )
 
 vcpkg_configure_cmake(

--- a/ports/argumentum/portfile.cmake
+++ b/ports/argumentum/portfile.cmake
@@ -1,12 +1,12 @@
 include(vcpkg_common_functions)
 
-set( VCPKG_LIBRARY_LINKAGE static )
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mmahnic/cpp-argparse
-    REF v0.2.0
-    SHA512 f2eb8c9aee8ce515d2ec3e973ceedd916458713055e1dd16e8a780cda7545b617ad0c64cd18c6356ad7584108aba3165a379ef0d3edfd89691a6343b4918e143
+    REF v0.2.1
+    SHA512 26d175cf86815ed2e1f9c73e8d0eb000f3bd71eaee80ffb5d6553c21eaba6ce7617d3d95cd61fa718408f10d8c024bc171096ed0e08c4bb93bb6ac6eee2cb657
     HEAD_REF master
 )
 


### PR DESCRIPTION
Argumentum is a library for parsing command line arguments.  It can be used as a static library and as a header-only library.  A dynamic version is planned for a future release.

- What does your PR fix? It adds a new port.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Tested only on x64-linux.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I believe so.
