### PR TITLE
[restclient-cpp]: correct the way to remove debug/include

### DIFF
--- a/ports/restclient-cpp/CONTROL
+++ b/ports/restclient-cpp/CONTROL
@@ -1,4 +1,4 @@
 Source: restclient-cpp
-Version: 0.5.1-2
+Version: 0.5.1-3
 Build-Depends: curl
 Description: Binn is a binary data serialization format designed to be compact, fast and easy to use.

--- a/ports/restclient-cpp/portfile.cmake
+++ b/ports/restclient-cpp/portfile.cmake
@@ -1,4 +1,6 @@
-include(vcpkg_common_functions)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -22,12 +24,9 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/restclient-cpp)
 
-# Remove includes in debug
+vcpkg_copy_pdbs()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/restclient-cpp)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/restclient-cpp/LICENSE ${CURRENT_PACKAGES_DIR}/share/restclient-cpp/copyright)
-
-# Copy pdb files
-vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/restclient-cpp/portfile.cmake
+++ b/ports/restclient-cpp/portfile.cmake
@@ -23,7 +23,7 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/restclient-cpp)
 
 # Remove includes in debug
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/restclient-cpp)


### PR DESCRIPTION
Just need removing `${CURRENT_PACKAGES_DIR}/debug/include`, not `${CURRENT_PACKAGES_DIR}/lib` and `${CURRENT_PACKAGES_DIR}/bin`.