### PR TITLE
[vcpkg-msbuild-integration] Extending logic that decides between 'Release' and 'Debug' libraries by referring to $(UseDebugLibraries)

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -85,11 +85,11 @@
     <WriteLinesToFile
     File="$(TLogLocation)$(ProjectName).write.1u.tlog"
     Lines="^$(TargetPath);$([System.IO.Path]::Combine($(ProjectDir),$(IntDir)))vcpkg.applocal.log" Encoding="Unicode"/>
-    <Exec Condition="$(VcpkgConfiguration.StartsWith('Debug'))"
+    <Exec Condition="'$(VcpkgNormalizedConfiguration)' == 'Debug'"
       Command="$(SystemRoot)\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -noprofile -File %22$(MSBuildThisFileDirectory)applocal.ps1%22 %22$(TargetPath)%22 %22$(VcpkgRoot)debug\bin%22 %22$(TLogLocation)$(ProjectName).write.1u.tlog%22 %22$(IntDir)vcpkg.applocal.log%22"
       StandardOutputImportance="Normal">
     </Exec>
-    <Exec Condition="$(VcpkgConfiguration.StartsWith('Release'))"
+    <Exec Condition="'$(VcpkgNormalizedConfiguration)' == 'Release'"
       Command="$(SystemRoot)\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -noprofile -File %22$(MSBuildThisFileDirectory)applocal.ps1%22 %22$(TargetPath)%22 %22$(VcpkgRoot)bin%22 %22$(TLogLocation)$(ProjectName).write.1u.tlog%22 %22$(IntDir)vcpkg.applocal.log%22"
       StandardOutputImportance="Normal">
     </Exec>

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -51,8 +51,10 @@
 
   <PropertyGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <VcpkgConfiguration Condition="'$(VcpkgConfiguration)' == ''">$(Configuration)</VcpkgConfiguration>
-    <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Debug'))">Debug</VcpkgNormalizedConfiguration>
-    <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Release')) or '$(VcpkgConfiguration)' == 'RelWithDebInfo' or '$(VcpkgConfiguration)' == 'MinSizeRel'">Release</VcpkgNormalizedConfiguration>
+    <VcpkgNormalizedConfiguration Condition="'$(UseDebugLibraries)' == 'true'">Debug</VcpkgNormalizedConfiguration>
+    <VcpkgNormalizedConfiguration Condition="'$(UseDebugLibraries)' == 'false'">Release</VcpkgNormalizedConfiguration>
+    <VcpkgNormalizedConfiguration Condition="'$(VcpkgNormalizedConfiguration)' == '' and $(VcpkgConfiguration.StartsWith('Debug'))">Debug</VcpkgNormalizedConfiguration>
+    <VcpkgNormalizedConfiguration Condition="'$(VcpkgNormalizedConfiguration)' == '' and ($(VcpkgConfiguration.StartsWith('Release')) or '$(VcpkgConfiguration)' == 'RelWithDebInfo' or '$(VcpkgConfiguration)' == 'MinSizeRel')">Release</VcpkgNormalizedConfiguration>
     <VcpkgRoot Condition="'$(VcpkgRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .vcpkg-root))\installed\$(VcpkgTriplet)\</VcpkgRoot>
     <VcpkgApplocalDeps Condition="'$(VcpkgApplocalDeps)' == ''">true</VcpkgApplocalDeps>
     <!-- Deactivate Autolinking if lld is used as a linker. (Until a better way to solve the problem is found!). 


### PR DESCRIPTION
- Fixes #9495

_scripts/buildsystems/msbuild/vcpkg.targets_ should be extended to determine the build configuration in the following way:

```xml
<VcpkgNormalizedConfiguration Condition="'$(UseDebugLibraries)' == 'true'">Debug</VcpkgNormalizedConfiguration>
<VcpkgNormalizedConfiguration Condition="'$(UseDebugLibraries)' == 'false'">Release</VcpkgNormalizedConfiguration>
<VcpkgNormalizedConfiguration Condition="'$(VcpkgNormalizedConfiguration)' == '' and $(VcpkgConfiguration.StartsWith('Debug'))">Debug</VcpkgNormalizedConfiguration>
<VcpkgNormalizedConfiguration Condition="'$(VcpkgNormalizedConfiguration)' == '' and ($(VcpkgConfiguration.StartsWith('Release')) or '$(VcpkgConfiguration)' == 'RelWithDebInfo' or '$(VcpkgConfiguration)' == 'MinSizeRel')">Release</VcpkgNormalizedConfiguration>
```