### PR TITLE
[check/gettimeofday] Move static libraries to manual-link

### DIFF
--- a/ports/check/CONTROL
+++ b/ports/check/CONTROL
@@ -1,4 +1,4 @@
 Source: check
-Version: 0.13.0-1
+Version: 0.13.0-2
 Homepage: https://github.com/libcheck/check
 Description: A unit testing framework for C

--- a/ports/check/fix-lib-path.patch
+++ b/ports/check/fix-lib-path.patch
@@ -1,0 +1,43 @@
+diff --git a/doc/example/src/CMakeLists.txt b/doc/example/src/CMakeLists.txt
+index b5e211e..2a92a1a 100644
+--- a/doc/example/src/CMakeLists.txt
++++ b/doc/example/src/CMakeLists.txt
+@@ -18,7 +18,7 @@ target_link_libraries(main money)
+ 
+ install(TARGETS money
+   RUNTIME DESTINATION bin
+-  LIBRARY DESTINATION lib
+-  ARCHIVE DESTINATION lib)
++  LIBRARY DESTINATION lib/manual-link
++  ARCHIVE DESTINATION lib/manual-link)
+ 
+ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/money.h DESTINATION include)
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index e6346dd..8f5762a 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -70,3 +70,8 @@ set(HEADERS libcompat.h)
+ 
+ add_library(compat STATIC ${SOURCES} ${HEADERS})
+ 
++install(TARGETS compat
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib/manual-link
++    ARCHIVE DESTINATION lib/manual-link
++)
+\ No newline at end of file
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 37fcaf8..334fc9c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -180,8 +180,8 @@ target_include_directories(checkShared
+ 
+ install(TARGETS check checkShared
+   EXPORT check-targets
+-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/manual-link
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/manual-link
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )

--- a/ports/check/portfile.cmake
+++ b/ports/check/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 0.13.0
     SHA512 7943021c5bc3b5ca7bc552f6fe1287e384724d69e5bb128d58256692e810b194e506fc1b65ea4fed27d065e2176e7371483e918beb48125abfe3b6f1ca68eb8f
     HEAD_REF master
+    PATCHES fix-lib-path.patch
 )
 
 vcpkg_configure_cmake(
@@ -15,6 +16,8 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/check)
 
+vcpkg_copy_pdbs()
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
@@ -23,6 +26,4 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING.LESSER DESTINATION ${CURRENT_PACKAGES_DIR}/share/check RENAME copyright)
-
-vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/COPYING.LESSER DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/gettimeofday/CMakeLists.txt
+++ b/ports/gettimeofday/CMakeLists.txt
@@ -5,8 +5,8 @@ add_library(gettimeofday gettimeofday.c gettimeofday.def)
 
 install(TARGETS gettimeofday
     RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib/manual-link
+    LIBRARY DESTINATION lib/manual-link
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/ports/gettimeofday/CONTROL
+++ b/ports/gettimeofday/CONTROL
@@ -1,3 +1,3 @@
 Source: gettimeofday
-Version: 2017-10-14-2
+Version: 2017-10-14-3
 Description: An implementation of gettimeofday for WIN32

--- a/ports/gettimeofday/portfile.cmake
+++ b/ports/gettimeofday/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${CMAKE_CURRENT_LIST_DIR}
     PREFER_NINJA
@@ -8,4 +6,4 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/gettimeofday RENAME copyright)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Ports check and gettimeofday contain functions that conflict with Visual Studio SDK/gnu library, so move them to folder _manual-link_.
Conflict function list:
check:
- sprintf
- gettimeofday
- localtime_r
...

gettimeofday:
- gettimeofday

Related: #9501.

Note: these 2 ports do not contain any features.