### PR TITLE
[wpilib] update to 2020.1.1

### DIFF
--- a/ports/wpilib/CONTROL
+++ b/ports/wpilib/CONTROL
@@ -1,5 +1,6 @@
 Source: wpilib
-Version: 2019.6.1
+Version: 2020.1.1
+Homepage: https://github.com/wpilibsuite/allwpilib
 Build-Depends: eigen3, libuv
 Description: WPILib is the software library package for the FIRST Robotics Competition. The core install includes wpiutil, a common utilies library, and ntcore, the base NetworkTables library.
 

--- a/ports/wpilib/portfile.cmake
+++ b/ports/wpilib/portfile.cmake
@@ -1,10 +1,10 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "OSX")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wpilibsuite/allwpilib
-    REF d10a1a797720014197c21dee38fdced73454dca4
-    SHA512 a76e8652b6d6a921d466e08bcf162ee1b28c06af031b616b2333f8a9479ffd12d1c301182dac86e5d7d59909a21cbee4e551028393df80671336546c14ecf606
+    REF e874ba9313a8243aa18eefb13e1d88a3999dd80e
+    SHA512 9a2e7abb3739008ed59e716d241a4ec8f0848c655ae8bb7e5bd98090109d6d86115c97ef16ea8881cc28715b691d873ab7be77b515efed8c361cb1f47745697f
 )
 
 set(WITHOUT_JAVA ON)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1755,6 +1755,7 @@ wintoast:x64-uwp=fail
 woff2:x64-linux=fail
 woff2:x64-osx=fail
 woff2:x64-windows-static=fail
+wpilib:x64-osx=fail
 wxwidgets:x64-linux=fail
 wxwidgets:x64-osx=fail
 x264:arm64-windows=fail


### PR DESCRIPTION
We released the initial 2020 release, so updates the port file to use that release

Only supports linux and windows. macOS is not supported, and never will be.