### PR TITLE
[random123] new port

### DIFF
--- a/ports/random123/CONTROL
+++ b/ports/random123/CONTROL
@@ -1,0 +1,4 @@
+Source: random123
+Version: 1.09
+Homepage: http://www.deshawresearch.com/resources_random123.html
+Description: Random123 is a library of 'counter-based' random number generators (CBRNGs), in which the Nth random number can be obtained by applying a stateless mixing function to N instead of the conventional approach of using N iterations of a stateful transformation.

--- a/ports/random123/portfile.cmake
+++ b/ports/random123/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-# Copy the single reusable library header
+# Copy the headers that define this package to the install location.
 file(GLOB header_files 
      ${SOURCE_PATH}/include/Random123/*.h 
      ${SOURCE_PATH}/include/Random123/*.hpp ) 
@@ -26,7 +26,6 @@ file(COPY ${SOURCE_PATH}/include/Random123/conventional
      DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} )
 file(COPY ${SOURCE_PATH}/include/Random123/features
      DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} )
-#file(COPY ${SOURCE_PATH}/include/Random123 DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/random123/portfile.cmake
+++ b/ports/random123/portfile.cmake
@@ -1,0 +1,32 @@
+# Random123 - Header-only library
+
+include(vcpkg_common_functions)
+
+set(VERSION 1.09)
+
+vcpkg_download_distfile( 
+    ARCHIVE
+    URLS "http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-${VERSION}.tar.gz"
+    FILENAME "Random123-${VERSION}.tar.gz "
+    SHA512 7bd72dffa53ca8d835b4a4cf49171618cd46f4b329d7a09486efaf2e1565c98b80ff05e3bccc244fabd7013f139058511fb2e39399bfe51fd6b68cd9e63da1ac
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+# Copy the single reusable library header
+file(GLOB header_files 
+     ${SOURCE_PATH}/include/Random123/*.h 
+     ${SOURCE_PATH}/include/Random123/*.hpp ) 
+file(COPY ${header_files}
+     DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} )
+file(COPY ${SOURCE_PATH}/include/Random123/conventional
+     DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} )
+file(COPY ${SOURCE_PATH}/include/Random123/features
+     DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} )
+#file(COPY ${SOURCE_PATH}/include/Random123 DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Add a new port for header-only C++ package Random123**

- Since this is a header-only install, it should support all triplets.  I haven't done anything with the CI baseline.
- This install [might require a patch](https://github.com/spack/spack/tree/develop/var/spack/repos/builtin/packages/random123) for _ARM+gcc_ or builds that use the _IBM XL_ compiler.  These patches were not included in this PR because I don't currently have access to these tools and I couldn't certify that these patches work.

