### PR TITLE
[vcpkg] Minor edit to help message for cli depend-info option. Fix for #9534.

### DIFF
--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -105,7 +105,7 @@ namespace vcpkg::Help
                        "  vcpkg create <pkg> <url>\n"
                        "             [archivename]        Create a new package\n"
                        "  vcpkg owns <pat>                Search for files in installed packages\n"
-                       "  vcpkg depend-info [pkg]...      Display a list of dependencies for packages\n"
+                       "  vcpkg depend-info <pkg>...      Display a list of dependencies for packages\n"
                        "  vcpkg env                       Creates a clean shell environment for development or "
                        "compiling.\n"
                        "  vcpkg version                   Display version information\n"


### PR DESCRIPTION
**Describe the pull request**
Minor edit to help message for cli depend-info option to show that the package name is not optional.

- What does your PR fix? Fixes issue #
Fix for #9534.

- Which triplets are supported/not supported? Have you updated the CI baseline?
All triplets supported. 
No.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes (I think).
