### PR TITLE
[cpp-netlib] Fix cmake path, add homepage

### DIFF
--- a/ports/cpp-netlib/CONTROL
+++ b/ports/cpp-netlib/CONTROL
@@ -1,4 +1,5 @@
 Source: cpp-netlib
-Version: 0.13.0-2
+Version: 0.13.0-3
+Homepage: https://cpp-netlib.org/
 Build-Depends: boost
 Description: A collection of network-related routines/implementations geared towards providing a robust cross-platform networking library

--- a/ports/cpp-netlib/portfile.cmake
+++ b/ports/cpp-netlib/portfile.cmake
@@ -1,8 +1,4 @@
-include(vcpkg_common_functions)
-
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "${PORT} does not currently support UWP")
-endif()
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -27,10 +23,10 @@ vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-  vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/cppnetlib)
 else()
-  vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/cppnetlib)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/cppnetlib TARGET_PATH share/cppnetlib)
 endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
cpp-netlib generated cmake files prefix is `cppnetlib`, so rename it's cmake path to `cppnetlib`.

Related: #9518.

Note: this port doesn't contain any features.