### PR TITLE
[libfreenect2] add opengl and opencl features

### DIFF
--- a/ports/libfreenect2/CONTROL
+++ b/ports/libfreenect2/CONTROL
@@ -12,7 +12,3 @@ Build-Depends: opengl, glfw3
 Feature: opencl
 Description: OpenCL support for libfreenect2
 Build-Depends: opencl
-
-Feature: cuda
-Description: CUDA support for libfreenect2
-Build-Depends: cuda

--- a/ports/libfreenect2/CONTROL
+++ b/ports/libfreenect2/CONTROL
@@ -1,5 +1,18 @@
 Source: libfreenect2
-Version: 0.2.0-3
+Version: 0.2.0-4
 Build-Depends: libusb, libjpeg-turbo
 Homepage: https://github.com/OpenKinect/libfreenect2
 Description: Open source drivers for the Kinect for Windows v2 device
+Default-Features: opengl
+
+Feature: opengl
+Description: OpenGL support for libfreenect2
+Build-Depends: opengl, glfw3
+
+Feature: opencl
+Description: OpenCL support for libfreenect2
+Build-Depends: opencl
+
+Feature: cuda
+Description: CUDA support for libfreenect2
+Build-Depends: cuda

--- a/ports/libfreenect2/portfile.cmake
+++ b/ports/libfreenect2/portfile.cmake
@@ -21,13 +21,13 @@ file(WRITE ${SOURCE_PATH}/examples/CMakeLists.txt "${EXAMPLECMAKE}")
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     opengl     ENABLE_OPENGL
     opencl     ENABLE_OPENCL
-    cuda       ENABLE_CUDA
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+        -DENABLE_CUDA=OFF
         # FEATURES
         ${FEATURE_OPTIONS}
 )

--- a/ports/libfreenect2/portfile.cmake
+++ b/ports/libfreenect2/portfile.cmake
@@ -18,11 +18,18 @@ string(REPLACE "(WIN32)"
                "(WIN32_DISABLE)" EXAMPLECMAKE "${EXAMPLECMAKE}")
 file(WRITE ${SOURCE_PATH}/examples/CMakeLists.txt "${EXAMPLECMAKE}")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    opengl     ENABLE_OPENGL
+    opencl     ENABLE_OPENCL
+    cuda       ENABLE_CUDA
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DENABLE_CUDA=OFF
+        # FEATURES
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #9540

- Which triplets are supported/not supported? Have you updated the CI baseline?
Only x64-windows was tested.
Due to nvcc's limitation: "nvcc fatal   : 32 bit compilation is only supported for Microsoft Visual Studio 2013 and earlier", so I cannot compile x86-windows.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes