### PR TITLE
[otl] Update to version 4.0.451

### DIFF
--- a/ports/otl/CONTROL
+++ b/ports/otl/CONTROL
@@ -1,4 +1,4 @@
 Source: otl
-Version: 4.0.448-1
+Version: 4.0.451
 Description: Oracle, Odbc and DB2-CLI Template Library
 Homepage: http://otl.sourceforge.net/

--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -1,9 +1,9 @@
-set(OTL_VERSION 40448)
+set(OTL_VERSION 40451)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
-    FILENAME "otl-v${OTL_VERSION}.zip"
-    SHA512 285bf8bb0fa38ab3030af09a2939fd8e2eaadd14e65d05c6e18f4bc12070ba4e112c41e2d38c546338d51bdf09748b158b1799599f5ed9a7959a7799869b1305
+    FILENAME "otlv4_${OTL_VERSION}.zip"
+    SHA512 add1e54fae20175461d5f09cbe324e98b6f6a3839356136811109cf3251ca96541c101816870c6cc15d7611ad6bf9d576ac8dfce4274419b30866955c5892d15
 )
 
 vcpkg_extract_source_archive_ex(
@@ -13,9 +13,9 @@ vcpkg_extract_source_archive_ex(
 )
 
 file(INSTALL "${SOURCE_PATH}/otlv${OTL_VERSION}.h" 
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include/otl" 
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" 
     RENAME otlv4.h)
 
 file(INSTALL "${SOURCE_PATH}/otlv${OTL_VERSION}.h" 
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/otl" 
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" 
     RENAME copyright)


### PR DESCRIPTION
The current version of otl is now also available with a filename including the version, e.g. otlv4_40451.zip [1, 2]

- Use variable `OTL_VERSION` in portfile
- Rename header file to `otlv4.h`
  This is the current default name of the header file and typically included using:
  `#include "otlv4.h"` or `#include <otlv4.h>`

[1] https://sourceforge.net/p/otl/discussion/208859/thread/fdb9d3bacc/#45bf
[2] http://otl.sourceforge.net/otl3_down.htm

**Describe the pull request**

- What does your PR fix? Fixes issue #
Update otl to the current version 4.0.451
Simplify portfile by using a variable for the version
- Which triplets are supported/not supported? Have you updated the CI baseline?
All triplets are supported. CI-baseline: NA
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
