### PR TITLE
[embree3] added cleanup command to embree3 port for static build

### DIFF
--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,5 +1,5 @@
 Source: embree3
-Version: 3.6.1
+Version: 3.6.1-1
 Homepage: https://github.com/embree/embree
 Description: High Performance Ray Tracing Kernels.
 Build-Depends: tbb

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -51,7 +51,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/uninstall.command ${CURRENT_PACKAGES_DIR}/debug/uninstall.command)
+if (EXISTS ${CURRENT_PACKAGES_DIR}/uninstall.command)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/uninstall.command)
+endif()
+if (EXISTS ${CURRENT_PACKAGES_DIR}/debug/uninstall.command)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/uninstall.command)
+endif()
 
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/embree/doc)
 

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -48,6 +48,10 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/embree3 TARGET_PATH share/embree)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/uninstall.command ${CURRENT_PACKAGES_DIR}/debug/uninstall.command)
 
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/embree/doc)
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -395,7 +395,6 @@ ecsutil:x64-uwp=fail
 embree2:x64-linux=fail
 embree2:x64-osx=fail
 embree2:x64-windows-static=fail
-embree3:x64-osx=fail
 enet:arm-uwp=fail
 enet:x64-uwp=fail
 epsilon:arm-uwp=fail


### PR DESCRIPTION
This PR adds a cleanup command to the port file for embree3 to cleanup empty bin directories left empty when using a static build. Fixes issue #9072

