### PR TITLE
Update baseline to resolve file conflicts with nanovg and stb

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1586,6 +1586,8 @@ speexdsp:x64-linux=fail
 speexdsp:x64-osx=fail
 spirv-tools:arm-uwp=fail
 spirv-tools:x64-uwp=fail
+# conflicts with nanovg
+stb:x86-windows=skip
 stormlib:arm-uwp=fail
 stormlib:x64-uwp=fail
 string-theory:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1587,7 +1587,7 @@ speexdsp:x64-osx=fail
 spirv-tools:arm-uwp=fail
 spirv-tools:x64-uwp=fail
 # conflicts with nanovg
-stb:x86-windows=skip
+stb:x86-windows=ignore
 stormlib:arm-uwp=fail
 stormlib:x64-uwp=fail
 string-theory:arm-uwp=fail


### PR DESCRIPTION
port stb and nanovg have file conflicts:
```
2020-01-04T12:18:04.9047756Z The following files are already installed in C:/vsts/_work/3/s/installed/x86-windows and are in conflict with stb:x86-windows
2020-01-04T12:18:04.9049652Z 
2020-01-04T12:18:04.9051732Z Installed by nanovg:x86-windows
2020-01-04T12:18:04.9053626Z     include/stb_image.h
```

So far the pipeline has only reported `x86-windows` conflicts and less than 10 ports depend on stb, so only `stb:x86-windows=ignore` is added.

Related: #9552 #9550.