### PR TITLE
[glibmm] Fix build error on Linux

### DIFF
--- a/ports/glibmm/CONTROL
+++ b/ports/glibmm/CONTROL
@@ -1,5 +1,5 @@
 Source: glibmm
-Version: 2.52.1-10
+Version: 2.52.1-11
 Description: This is glibmm, a C++ API for parts of glib that are useful for C++.
 Homepage: https://www.gtkmm.org.
 Build-Depends: zlib, pcre, libffi, gettext, libiconv, glib, libsigcpp

--- a/ports/glibmm/fix-thread.h.patch
+++ b/ports/glibmm/fix-thread.h.patch
@@ -1,0 +1,13 @@
+diff --git a/glib/glibmm/threads.h b/glib/glibmm/threads.h
+index 5350a99..cc48c01 100644
+--- a/glib/glibmm/threads.h
++++ b/glib/glibmm/threads.h
+@@ -657,7 +657,7 @@ public:
+    */
+   inline void replace(T* data);
+ 
+-  GPrivate* gobj() { return gobject_; }
++  GPrivate* gobj() { return &gobject_; }
+ 
+ private:
+   GPrivate gobject_;

--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -1,9 +1,5 @@
-include(vcpkg_common_functions)
-
 # Glib uses winapi functions not available in WindowsStore
-if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "Error: UWP builds are currently not supported.")
-endif()
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.52/glibmm-2.52.1.tar.xz"
@@ -17,6 +13,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         glibmm-api-variant.patch
         fix-define-glibmmconfig.patch
+        fix-thread.h.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
@@ -35,5 +32,5 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 # Handle copyright and readme
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/glibmm RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/glibmm RENAME readme.txt)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME readme.txt)


### PR DESCRIPTION
On some `gcc `versions, `glibmm ` build failed on Linux, due to this error:
```
/usr/share/vcpkg/buildtrees/glibmm/src/glibmm-2-4a92f34a92/glib/glibmm/threads.h:660:29: error: cannot convert ‘GPrivate’ {aka ‘_GPrivate’} to ‘GPrivate*’ {aka ‘_GPrivate*’} in return
  660 |   GPrivate* gobj() { return gobject_; }
      |                             ^~~~~~~~
      |                             |
      |                             GPrivate {aka _GPrivate}
```
Solution:
modify `GPrivate* gobj() { return gobject_; }` as `GPrivate* gobj() { return &gobject_; }` in _.../glib/glibmm/threads.h_ file.

Related issue #9395 

Note: No feature needs to test.


