### PR TITLE
[cpr] Add find_dependency to cprConfig.cmake

### DIFF
--- a/ports/cpr/CONTROL
+++ b/ports/cpr/CONTROL
@@ -1,5 +1,5 @@
 Source: cpr
-Version: 1.3.0-7
+Version: 1.3.0-8
 Homepage: https://github.com/whoshuu/cpr
 Description: C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.
 Build-Depends: curl[core]

--- a/ports/cpr/cprConfig.cmake
+++ b/ports/cpr/cprConfig.cmake
@@ -25,3 +25,7 @@ endmacro()
 
 include("${CMAKE_CURRENT_LIST_DIR}/cprTargets.cmake")
 check_required_components("cpr")
+
+include(CMakeFindDependencyMacro)
+find_dependency(ZLIB REQUIRED)
+find_dependency(CURL REQUIRED)


### PR DESCRIPTION
Fix using cprConfig.cmake to find dependent ports.

Related: #8715.

Note: this port doesn't contain any features.