### PR TITLE
[google-cloud-cpp] Upgrade to v0.17.0

### DIFF
--- a/ports/google-cloud-cpp/0001-fix-x86-build.patch
+++ b/ports/google-cloud-cpp/0001-fix-x86-build.patch
@@ -1,0 +1,13 @@
+diff --git a/google/cloud/storage/parallel_upload.h b/google/cloud/storage/parallel_upload.h
+index 44f542d..4fd97bd 100644
+--- a/google/cloud/storage/parallel_upload.h
++++ b/google/cloud/storage/parallel_upload.h
+@@ -515,7 +515,7 @@ StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
+ 
+   std::size_t const wanted_num_streams =
+       (std::max<std::size_t>)(1,
+-                              (std::min)(max_streams,
++                              (std::min<std::size_t>)(max_streams,
+                                          div_ceil(file_size, min_stream_size)));
+ 
+   std::uintmax_t const stream_size =

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp
-Version: 0.15.0
+Version: 0.17.0
 Build-Depends: grpc, curl[ssl], crc32c, googleapis, google-cloud-cpp-common
 Description: C++ Client Libraries for Google Cloud Platform APIs.
 Homepage: https://github.com/googleapis/google-cloud-cpp

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF v0.17.0
     SHA512 7bfa73db04fe8ff9344201eca8f56107fd895f18b3be44fca45a9f2d64224338980d04841de4418c5c1b7a8ac0768a60e93e5abbed9256567ca7b8bc2bf73cd9
     HEAD_REF master
+    PATCHES
+        0001-fix-x86-build.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v0.15.0
-    SHA512 f8cc8f9d47a4df1d76ac7b0836fe107f2f199070a89ab5136f66aa1be5f08737495dbb3f4cf7f709ac0a1346648d869af639836b85b552c6791fa8bb85362a91
+    REF v0.17.0
+    SHA512 7bfa73db04fe8ff9344201eca8f56107fd895f18b3be44fca45a9f2d64224338980d04841de4418c5c1b7a8ac0768a60e93e5abbed9256567ca7b8bc2bf73cd9
     HEAD_REF master
 )
 


### PR DESCRIPTION
Upgrade google-cloud-cpp to the (just released) v0.17.0
