### PR TITLE
[vcpkg] Mark ARM and x86 on ARM64 and x86 on ARM as supported architectures when searching for toolchains on Windows

### DIFF
--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -157,11 +157,24 @@ namespace vcpkg
         std::vector<CPUArchitecture> supported_architectures;
         supported_architectures.push_back(get_host_processor());
 
-        // AMD64 machines support to run x86 applications
+        // AMD64 machines support running x86 applications and ARM64 machines support running ARM applications
         if (supported_architectures.back() == CPUArchitecture::X64)
         {
             supported_architectures.push_back(CPUArchitecture::X86);
         }
+        else if (supported_architectures.back() == CPUArchitecture::ARM64)
+        {
+            supported_architectures.push_back(CPUArchitecture::ARM);
+        }
+
+#if defined(_WIN32)
+        // On ARM32/64 Windows we can rely on x86 emulation
+        if (supported_architectures.front() == CPUArchitecture::ARM ||
+            supported_architectures.front() == CPUArchitecture::ARM64)
+        {
+            supported_architectures.push_back(CPUArchitecture::X86);
+        }
+#endif
 
         return supported_architectures;
     }


### PR DESCRIPTION
When searching for visual studio toolchain files which can satisfy the host, target pair of `{ARM, ARM64} X {x86, x64, arm, arm64}` we should allow the `x86_{x86, x64, arm, arm64}` toolchain files to be selected because of the Windows x86 emulation on ARM.