### PR TITLE
[otl libaaplus forge] Fix build issues

### DIFF
--- a/ports/forge/CONTROL
+++ b/ports/forge/CONTROL
@@ -1,4 +1,4 @@
 Source: forge
-Version: 1.0.4-1
+Version: 1.0.4-2
 Description: Helps with high performance visualizations involving OpenGL-CUDA/OpenCL interop.
 Build-Depends: glfw3, glm, glbinding, freetype, boost-functional, freeimage, fontconfig (!windows)

--- a/ports/forge/portfile.cmake
+++ b/ports/forge/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     message(FATAL_ERROR "This port currently only supports x64 architecture")
 endif()
@@ -25,15 +23,20 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH share/Forge/cmake)
+endif()
 
 file(GLOB DLLS ${CURRENT_PACKAGES_DIR}/bin/* ${CURRENT_PACKAGES_DIR}/debug/bin/*)
 list(FILTER DLLS EXCLUDE REGEX "forge\\.dll\$")
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
     ${CURRENT_PACKAGES_DIR}/debug/examples
     ${CURRENT_PACKAGES_DIR}/examples
     ${DLLS}
 )
 
-file(INSTALL ${SOURCE_PATH}/.github/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/forge RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/.github/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libaaplus/CONTROL
+++ b/ports/libaaplus/CONTROL
@@ -1,5 +1,5 @@
 Source: libaaplus
-Version: 2.1.0
+Version: 2.1.0-1
 Description: libaaplus is an astronomical computations library by naughter software
 Homepage: http://www.naughter.com/aa.html
 

--- a/ports/libaaplus/portfile.cmake
+++ b/ports/libaaplus/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(
     ARCHIVE_FILE
     URLS "http://www.naughter.com/download/aaplus.zip"
     FILENAME "aaplus.zip"
-    SHA512 ef814a36fa567e806be5e5345abd89e1a8d32da1c392c251e5b74aea86b866ebc74bc17885a0eff303b170cfe226670cd6f69095702396cc9d6fcbc1a769de4f
+    SHA512 ec3a3d1346637fbed3ec5093ded821c6d80950a6432378d9826ed842571d8670cd5d2a1c9ff58a18f308e18669d786f72d24961e26bd8e070ee35674688a39e7
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/otl/CONTROL
+++ b/ports/otl/CONTROL
@@ -1,4 +1,4 @@
 Source: otl
-Version: 4.0.448-1
+Version: 4.0.448-2
 Description: Oracle, Odbc and DB2-CLI Template Library
 Homepage: http://otl.sourceforge.net/

--- a/ports/otl/portfile.cmake
+++ b/ports/otl/portfile.cmake
@@ -3,7 +3,7 @@ set(OTL_VERSION 40448)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://otl.sourceforge.net/otlv4_${OTL_VERSION}.zip"
     FILENAME "otl-v${OTL_VERSION}.zip"
-    SHA512 285bf8bb0fa38ab3030af09a2939fd8e2eaadd14e65d05c6e18f4bc12070ba4e112c41e2d38c546338d51bdf09748b158b1799599f5ed9a7959a7799869b1305
+    SHA512 3ddc7efb79e0f8349783b18fd8c95a778721a7589f4a69168365c072e8fa09f7ec9679c89dcceb844b16e816c6e561f995f1fdd50e8df983e7ff0186083c246c
 )
 
 vcpkg_extract_source_archive_ex(


### PR DESCRIPTION
Fix build issue:
1. otl/libaaplus: Update hash
2. forge: fix cmake targets path on Linux.

otl and forge have no features, libaaplus feature 'tools' test pass on x86-windows x64-windows and linux.

Note: ogre failed due to missing ‘libxaw7-dev installation on test machine, it passed after install it locally.