### PR TITLE
[openal-soft] Update OpenAL Soft to 1.20.0

### DIFF
--- a/ports/openal-soft/CONTROL
+++ b/ports/openal-soft/CONTROL
@@ -1,4 +1,4 @@
 Source: openal-soft
-Version: 1.19.1-2
+Version: 1.20.0
 Homepage: https://github.com/kcat/openal-soft
 Description: OpenAL Soft is an LGPL-licensed, cross-platform, software implementation of the OpenAL 3D audio API.

--- a/ports/openal-soft/dont-export-symbols-in-static-build.patch
+++ b/ports/openal-soft/dont-export-symbols-in-static-build.patch
@@ -1,5 +1,5 @@
 diff --git a/config.h.in b/config.h.in
-index a71b54f..8d84645 100644
+index 4a1e2b00..d5496972 100644
 --- a/config.h.in
 +++ b/config.h.in
 @@ -1,6 +1,8 @@
@@ -8,6 +8,7 @@ index a71b54f..8d84645 100644
  #define AL_API  ${EXPORT_DECL}
  #define ALC_API ${EXPORT_DECL}
 +#endif
+
+ /* Define a restrict macro for non-aliased pointers */
+ #define RESTRICT ${RESTRICT_DECL}
  
- /* Define any available alignment declaration */
- #define ALIGN(x) ${ALIGN_DECL}

--- a/ports/openal-soft/fix-arm-builds.patch
+++ b/ports/openal-soft/fix-arm-builds.patch
@@ -1,17 +1,51 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 39b80250..e2a1ed76 100644
+index 98f9ad49..50b4297f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1409,6 +1409,7 @@ ELSE()
+@@ -1193,6 +1193,7 @@ SET_TARGET_PROPERTIES(common PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+ UNSET(HAS_ROUTER)
+ SET(IMPL_TARGET OpenAL) # Either OpenAL or soft_oal.
+ SET(SUBSYS_FLAG )
++SET(COMMON_LIB )
+
+ # Build main library
+ IF(LIBTYPE STREQUAL "STATIC")
+@@ -1203,12 +1204,15 @@ IF(LIBTYPE STREQUAL "STATIC")
+     ADD_LIBRARY(${IMPL_TARGET} STATIC ${COMMON_OBJS} ${OPENAL_OBJS} ${ALC_OBJS})
+     TARGET_LINK_LIBRARIES(${IMPL_TARGET} PRIVATE ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB})
+ ELSE()
++    SET(COMMON_LIB common)
++
+     IF(WIN32)
+         IF(MSVC)
+             SET(SUBSYS_FLAG ${SUBSYS_FLAG} "/SUBSYSTEM:WINDOWS")
          ELSEIF(CMAKE_COMPILER_IS_GNUCC)
              SET(SUBSYS_FLAG ${SUBSYS_FLAG} "-mwindows")
          ENDIF()
-+        SET(COMMON_LIB ${COMMON_LIB} shell32 ole32)
++        set(COMMON_LIB ${COMMON_LIB} shell32 ole32)
      ENDIF()
- 
-     IF(WIN32 AND ALSOFT_BUILD_ROUTER)
+
+     SET(RC_CONFIG resources/openal32.rc)
+@@ -1223,7 +1227,7 @@ ELSE()
+         TARGET_COMPILE_DEFINITIONS(OpenAL
+             PRIVATE AL_BUILD_LIBRARY AL_ALEXT_PROTOTYPES ${CPP_DEFS})
+         TARGET_COMPILE_OPTIONS(OpenAL PRIVATE ${C_FLAGS})
+-        TARGET_LINK_LIBRARIES(OpenAL PRIVATE common ${LINKER_FLAGS})
++        TARGET_LINK_LIBRARIES(OpenAL PRIVATE ${COMMON_LIB} ${LINKER_FLAGS})
+         TARGET_INCLUDE_DIRECTORIES(OpenAL
+           PUBLIC
+             $<BUILD_INTERFACE:${OpenAL_SOURCE_DIR}/include>
+@@ -1248,7 +1252,7 @@ ELSE()
+     IF(WIN32)
+         SET_TARGET_PROPERTIES(${IMPL_TARGET} PROPERTIES PREFIX "")
+     ENDIF()
+-    TARGET_LINK_LIBRARIES(${IMPL_TARGET} PRIVATE common ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB})
++    TARGET_LINK_LIBRARIES(${IMPL_TARGET} PRIVATE ${COMMON_LIB} ${LINKER_FLAGS} ${EXTRA_LIBS} ${MATH_LIB})
+ ENDIF()
+
+ TARGET_INCLUDE_DIRECTORIES(${IMPL_TARGET}
 diff --git a/native-tools/CMakeLists.txt b/native-tools/CMakeLists.txt
-index 5e816bba..16f3be12 100644
+index 5e816bba..5d7919f6 100644
 --- a/native-tools/CMakeLists.txt
 +++ b/native-tools/CMakeLists.txt
 @@ -24,6 +24,11 @@ set_target_properties(bsincgen PROPERTIES OUTPUT_NAME bsincgen)
@@ -27,4 +61,3 @@ index 5e816bba..16f3be12 100644
 +    set(BSINCGEN_LIB ${BSINCGEN_LIB} shell32)
 +endif()
 +target_link_libraries(bsincgen ${BSINCGEN_LIB})
-\ No newline at end of file

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -6,8 +6,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
-    REF openal-soft-1.19.1
-    SHA512 4a64cc90ddeaa3773610b0bc8023d231100f3396f3fc5bd079db81600f80a789c75e6af03391bfc78a903c96bb71f8052a9ae802ea81422028e5b12b7eb6c47b
+    REF openal-soft-1.20.0
+    SHA512 d106bf8f96b32a61fadc0ee54882ce5041e4cbc35bf573296a210c83815b6c7be056ee3ed7617196dda5f89f2acd7163375f14b0cf24934faa0eda1fdb4f82a9
     HEAD_REF master
     PATCHES
         dont-export-symbols-in-static-build.patch

--- a/ports/openal-soft/portfile.cmake
+++ b/ports/openal-soft/portfile.cmake
@@ -1,8 +1,5 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-    message(FATAL_ERROR "WindowsStore not supported")
-endif()
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
-include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcat/openal-soft
@@ -20,10 +17,12 @@ else()
     set(OPENAL_LIBTYPE "STATIC")
 endif()
 
-if(VCPKG_CMAKE_SYSTEM_NAME)
+if(VCPKG_TARGET_IS_LINUX)
     set(ALSOFT_REQUIRE_WINDOWS OFF)
     set(ALSOFT_REQUIRE_LINUX ON)
-else()
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
     set(ALSOFT_REQUIRE_WINDOWS ON)
     set(ALSOFT_REQUIRE_LINUX OFF)
 endif()
@@ -69,9 +68,7 @@ foreach(HEADER al.h alc.h)
     file(WRITE ${CURRENT_PACKAGES_DIR}/include/AL/${HEADER} "${AL_H}")
 endforeach()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/openal-soft)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/openal-soft/COPYING ${CURRENT_PACKAGES_DIR}/share/openal-soft/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
 vcpkg_copy_pdbs()


### PR DESCRIPTION
Update OpenAL Soft to its latest version.

I tried to replicate the same fixes the patches were trying to do before, as 1.20.0 made some changes to its CMake files. Just need to see what the CI says.
