### PR TITLE
[vcpkg] Fix build type in vcpkg_build_make.cmake [x264] Modernize

### DIFF
--- a/ports/libosip2/CONTROL
+++ b/ports/libosip2/CONTROL
@@ -1,4 +1,4 @@
 Source: libosip2
-Version: 5.1.0-2
+Version: 5.1.0-3
 Homepage: https://www.gnu.org/software/osip/
 Description: oSIP is an LGPL implementation of SIP. It's stable, portable, flexible and compliant! -may be more-! It is used mostly with eXosip2 stack (GPL) which provides simpler API for User-Agent implementation.

--- a/ports/x264/CONTROL
+++ b/ports/x264/CONTROL
@@ -1,4 +1,4 @@
 Source: x264
-Version: 157-303c484ec828ed0-6
+Version: 157-303c484ec828ed0-7
 Homepage: https://github.com/mirror/x264
 Description: x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -1,6 +1,6 @@
 set(X264_VERSION 157)
 
-vcpkg_fail_port_install("Linux" "OSX")
+vcpkg_fail_port_install(ON_TARGET "Linux" "OSX")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -28,7 +28,7 @@ vcpkg_configure_make(
 
 vcpkg_install_make()
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_TARGET_IS_UWP)
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/x264)
     file(RENAME ${CURRENT_PACKAGES_DIR}/bin/x264.exe ${CURRENT_PACKAGES_DIR}/tools/x264/x264.exe)
 endif()

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -1,10 +1,6 @@
-include(vcpkg_common_functions)
-
 set(X264_VERSION 157)
 
-if (NOT VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "x264 only support windows.")
-endif()
+vcpkg_fail_port_install("Linux" "OSX")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -61,5 +57,4 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/x264)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/x264/COPYING ${CURRENT_PACKAGES_DIR}/share/x264/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -142,37 +142,39 @@ function(vcpkg_build_make)
     
     if (_bc_ENABLE_INSTALL)
         foreach(BUILDTYPE "debug" "release")
-            if(BUILDTYPE STREQUAL "debug")
-                # Skip debug generate
-                if (_VCPKG_NO_DEBUG)
-                    continue()
-                endif()
-                set(SHORT_BUILDTYPE "-dbg")
-            else()
-                # In NO_DEBUG mode, we only use ${TARGET_TRIPLET} directory.
-                if (_VCPKG_NO_DEBUG)
-                    set(SHORT_BUILDTYPE "")
+            if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL BUILDTYPE)
+                if(BUILDTYPE STREQUAL "debug")
+                    # Skip debug generate
+                    if (_VCPKG_NO_DEBUG)
+                        continue()
+                    endif()
+                    set(SHORT_BUILDTYPE "-dbg")
                 else()
-                    set(SHORT_BUILDTYPE "-rel")
+                    # In NO_DEBUG mode, we only use ${TARGET_TRIPLET} directory.
+                    if (_VCPKG_NO_DEBUG)
+                        set(SHORT_BUILDTYPE "")
+                    else()
+                        set(SHORT_BUILDTYPE "-rel")
+                    endif()
                 endif()
-            endif()
             
-            message(STATUS "Installing ${TARGET_TRIPLET}${SHORT_BUILDTYPE}")
-            if (CMAKE_HOST_WIN32)
-                # In windows we can remotely call make
-                set(WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${SHORT_BUILDTYPE})
-                vcpkg_execute_build_process(
-                    COMMAND "${MAKE} ${INSTALL_OPTS}"
-                    WORKING_DIRECTORY ${WORKING_DIRECTORY}
-                    LOGNAME "install-${TARGET_TRIPLET}${SHORT_BUILDTYPE}"
-                )
-            else()
-                set(WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${SHORT_BUILDTYPE}${_VCPKG_PROJECT_SUBPATH})
-                vcpkg_execute_build_process(
-                    COMMAND "${MAKE};${INSTALL_OPTS}"
-                    WORKING_DIRECTORY ${WORKING_DIRECTORY}
-                    LOGNAME "install-${TARGET_TRIPLET}${SHORT_BUILDTYPE}"
-                )
+                message(STATUS "Installing ${TARGET_TRIPLET}${SHORT_BUILDTYPE}")
+                if (CMAKE_HOST_WIN32)
+                    # In windows we can remotely call make
+                    set(WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${SHORT_BUILDTYPE})
+                    vcpkg_execute_build_process(
+                        COMMAND "${MAKE} ${INSTALL_OPTS}"
+                        WORKING_DIRECTORY ${WORKING_DIRECTORY}
+                        LOGNAME "install-${TARGET_TRIPLET}${SHORT_BUILDTYPE}"
+                    )
+                else()
+                    set(WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${SHORT_BUILDTYPE}${_VCPKG_PROJECT_SUBPATH})
+                    vcpkg_execute_build_process(
+                        COMMAND "${MAKE};${INSTALL_OPTS}"
+                        WORKING_DIRECTORY ${WORKING_DIRECTORY}
+                        LOGNAME "install-${TARGET_TRIPLET}${SHORT_BUILDTYPE}"
+                    )
+                endif()
             endif()
         endforeach()
     endif()


### PR DESCRIPTION
When only building release type use `vcpkg_build_make()`, it will cause failures like this:
`make: *** No rule to make target 'install'. Stop.`

The solution:
Add the following code when installing targets to fix this issue.
```
if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL BUILDTYPE)

endif()
```

Related issue #9590 

Note: No feature needs to test.