### PR TITLE
[google-cloud-cpp-spanner] Upgrade to the v0.5.0 release.

### DIFF
--- a/ports/google-cloud-cpp-spanner/CONTROL
+++ b/ports/google-cloud-cpp-spanner/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-spanner
-Version: 0.3.0
-Build-Depends: grpc, curl[ssl], crc32c, googleapis, google-cloud-cpp-common
+Version: 0.5.0
+Build-Depends: grpc, googleapis, google-cloud-cpp-common
 Description: C++ Client Library for Google Cloud Spanner.
 Homepage: https://github.com/googleapis/google-cloud-cpp-spanner

--- a/ports/google-cloud-cpp-spanner/portfile.cmake
+++ b/ports/google-cloud-cpp-spanner/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-spanner
-    REF v0.3.0
-    SHA512 8148a78b83770d38d4ad9ce3c4e7229920b731c2150214bdd0e89a94d1d0d618322f36cb7e8cd0cb0281ee3dae328b87cac5ccd25cb36bef5762cc5c93921616
+    REF v0.5.0
+    SHA512 66878f1de13f1825100c826042baceb7aba89ca3f451b24e9a49adf5f1f954d9d068ce033123bb2f692ccc60acce386a82e64599b8038d6e5096c7c7bd391d12
     HEAD_REF master
 )
 


### PR DESCRIPTION
Upgrade google-cloud-cpp-spanner to the latest (v0.5.0, created today) release.

- Which triplets are supported/not supported? Have you updated the CI baseline?

The x86-windows* triplets are not supported, they were not supported before this PR.  I think the baseline does not require an update in this case.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so.
