### PR TITLE
[ms-gsl] Update to v2.1.0, the "end of 2019 snapshot"

### DIFF
--- a/ports/coroutine/CONTROL
+++ b/ports/coroutine/CONTROL
@@ -1,4 +1,4 @@
 Source: coroutine
-Version: 1.4.3
+Version: 2020-01-13
 Build-Depends: ms-gsl
 Description: C++ coroutine helper/example library

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -4,12 +4,11 @@ if(${VCPKG_TARGET_ARCHITECTURE} MATCHES x86)
     message(FATAL_ERROR "This library doesn't support x86 arch. Please use x64 instead. If it is critical, create an issue at the repo: github.com/luncliff/coroutine")
 endif()
 
-# changed to 1.4.2
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            luncliff/coroutine
-    REF 74467cb470a6bf8b9559a56ebdcb68ff915d871e
-    SHA512 5d61a23c5fe33c544943659dedecff487bb20f288f9c99f137f37bb777317672f299599b740e53cae42c355595fdfdffe183ade39e828b1f3b4aa821a47cb50e
+    REF fcd970807e9a47c250c1a4e06c7dc6d93079b684
+    SHA512 517f1c1726e4adc36cd34379c545324c99861d7cb5ebd3cebe0b7132fe5b61969a00e405bc106bb8f089f37d3a7ca9b1bcdc665a5cd6dfcaaf6856be37bec5b0
     HEAD_REF        master
 )
 

--- a/ports/ms-gsl/CONTROL
+++ b/ports/ms-gsl/CONTROL
@@ -1,4 +1,4 @@
 Source: ms-gsl
-Version: 2019-07-11
+Version: 2.1.0
 Homepage: https://github.com/Microsoft/GSL
 Description: Microsoft implementation of the Guidelines Support Library

--- a/ports/ms-gsl/portfile.cmake
+++ b/ports/ms-gsl/portfile.cmake
@@ -1,11 +1,9 @@
 #header-only library
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/GSL
-    REF 1212beae777dba02c230ece8c0c0ec12790047ea
-    SHA512 754d0adf32cea1da759be9adb8a64c301ae1cb8556853411bcea4c400079e8e310f1fb8d03f1f26f81553eab24b75fea24a67b9b51d8d92bb4f266e155938230
+    REF 7e99e76c9761d0d0b0848b91f8648830670ee872
+    SHA512 9a5ea7d22497a56918a83c248d9f707e98544dce90835cf9bf877213df8751cdb350b6343d0205e7b17fc27e234a17906876aff99c177d5f2b96df96d15a215c
     HEAD_REF master
 )
 


### PR DESCRIPTION
- What does your PR fix?
  - [ms-gsl]
    - This updates the GSL to the versioned snapshot created at the end of 2019.
    [Changes for v2.1.0](https://github.com/microsoft/GSL/releases/tag/v2.1.0).
    Didn't update to the current HEAD, because not all CI builds are succeeding on Linux.
    (The testsuite of the GSL is being migrating from Catch to GTest.)
    - Removing the deprecated `include(vcpkg_common_functions)`.
  - [coroutine]
    Updated with a fix (luncliff/coroutine#45) required to build with recent versions of the GSL.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No changes.