### PR TITLE
[sfgui] fix sfgui on macOS

### DIFF
--- a/ports/sfgui/001-fix-corefoundation-link.patch
+++ b/ports/sfgui/001-fix-corefoundation-link.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c0af720..774e2d8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -107,16 +107,8 @@ if( WIN32 )
+ 	set( LIB_PATH "lib" )
+ elseif( APPLE )
+ 	find_library( COREFOUNDATION_LIBRARY CoreFoundation )
+-	mark_as_advanced( COREFOUNDATION_LIBRARY )
+-
+-	add_library( CoreFoundation SHARED IMPORTED )
+-	set_target_properties(
+-		CoreFoundation PROPERTIES
+-			IMPORTED_LOCATION "${COREFOUNDATION_LIBRARY}"
+-			INTERFACE_INCLUDE_DIRECTORIES "/System/Library/Frameworks/CoreFoundation.framework/Headers"
+-	)
+-	
+-	target_link_libraries( ${TARGET} PUBLIC CoreFoundation )
++
++	target_link_libraries( ${TARGET} PUBLIC ${COREFOUNDATION_LIBRARY} )
+ 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
+ 	set( LIB_PATH "lib" )
+ elseif( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )

--- a/ports/sfgui/CONTROL
+++ b/ports/sfgui/CONTROL
@@ -1,5 +1,5 @@
 Source: sfgui
-Version: 0.4.0-2
+Version: 0.4.0-3
 Homepage: https://github.com/TankOs/SFGUI
 Description: simple and fast graphical user interface library
 Build-Depends: sfml

--- a/ports/sfgui/portfile.cmake
+++ b/ports/sfgui/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 0.4.0
     SHA512 15456c6080b7095bcdcec08489b2b91b5cfc36cdf3c0b645b305072e7e835837eb4f95b59371ff176630b2b7ae51da475d8ea0bde5ff7fc0ba74c463bf5f54cf
     HEAD_REF master
+    PATCHES
+        "001-fix-corefoundation-link.patch"
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindSFML.cmake)


### PR DESCRIPTION
There's a minor issue in the original CMakeLists.txt, which breaks SFGUI on macOS 10.15. The framework CoreFoundation is not linked correctly. It's a very simple fix, and just requires a small patch.

PR has been opened on upstream as well, at TankOS/sfgui#82