### PR TITLE
[tesseract] port update to 4.1.1 release

### DIFF
--- a/ports/tesseract/CONTROL
+++ b/ports/tesseract/CONTROL
@@ -1,5 +1,5 @@
 Source: tesseract
-Version: 4.1.0-4
+Version: 4.1.1
 Homepage: https://github.com/tesseract-ocr/tesseract
 Description: An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.
 Build-Depends: leptonica

--- a/ports/tesseract/fix-text2image.patch
+++ b/ports/tesseract/fix-text2image.patch
@@ -5,9 +5,9 @@ index 8fd96a9..186341e 100644
 @@ -52,7 +52,7 @@ endif()
  # experimental
  
- if (NOT CPPAN_BUILD)
--    find_package(ICU COMPONENTS uc i18n)
-+    find_package(ICU REQUIRED COMPONENTS i18n uc)
+ if (NOT CPPAN_BUILD AND NOT SW_BUILD)
+-    find_package(ICU 52.1 COMPONENTS uc i18n)
++    find_package(ICU 52.1 REQUIRED COMPONENTS i18n uc)
  endif()
  
  ########################################
@@ -18,17 +18,17 @@ index 8fd96a9..186341e 100644
 +if(UNIX)
 +    list(APPEND ICU_LIBRARIES ${CMAKE_DL_LIBS})
 +endif()
- if (NOT CPPAN_BUILD)
- target_link_libraries       (unicharset_training common_training ${ICU_LIBRARIES})
- else()
-@@ -253,16 +256,27 @@ if (NOT CPPAN_BUILD)
+ if (CPPAN_BUILD)
+ target_link_libraries       (unicharset_training common_training pvt.cppan.demo.unicode.icu.i18n)
+ elseif (SW_BUILD)
+@@ -253,16 +256,27 @@ if (NOT CPPAN_BUILD AND NOT SW_BUILD)
  find_package(PkgConfig)
  endif()
  
--if (PKG_CONFIG_FOUND OR CPPAN_BUILD)
+-if (PKG_CONFIG_FOUND OR CPPAN_BUILD OR SW_BUILD)
 -
 -if (PKG_CONFIG_FOUND)
--pkg_check_modules(Pango REQUIRED pango)
+-pkg_check_modules(Pango REQUIRED pango>=1.22.0)
 -pkg_check_modules(Cairo REQUIRED cairo)
 -pkg_check_modules(PangoFt2 REQUIRED pangoft2)
 -pkg_check_modules(PangoCairo REQUIRED pangocairo)

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tesseract-ocr/tesseract
-    REF 4.1.0
-    SHA512 d617f5c5b826640b2871dbe3d7973bcc5e66fafd837921a20e009d683806ed50f0f258aa455019d99fc54f5cb65c2fa0380e3a3c92b39ab0684b8799c730b09d
+    REF 4.1.1
+    SHA512 017723a2268be789fe98978eed02fd294968cc8050dde376dee026f56f2b99df42db935049ae5e72c4519a920e263b40af1a6a40d9942e66608145b3131a71a2
     PATCHES
         fix-tiff-linkage.patch
         fix-text2image.patch


### PR DESCRIPTION
Port update to 4.1.1 release

What does your PR fix?
- fix-text2image.patch changing according to new 4.1.1 sources
- portfile.cmake changing according to 4.1.1 version

Which triplets are supported/not supported? Have you updated the CI baseline?
- x64-windows-static
- x64-linux-static
- x86-windows-static
