### PR TITLE
[tinyfiledialogs] Fix tinyfiledialogs not being fetchable from sourceforge

### DIFF
--- a/ports/tinyfiledialogs/CONTROL
+++ b/ports/tinyfiledialogs/CONTROL
@@ -1,3 +1,3 @@
 Source: tinyfiledialogs
-Version: 3.3.8-1
+Version: 3.4.3
 Description: Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more

--- a/ports/tinyfiledialogs/CONTROL
+++ b/ports/tinyfiledialogs/CONTROL
@@ -1,3 +1,4 @@
 Source: tinyfiledialogs
 Version: 3.4.3
 Description: Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more
+Homepage: https://sourceforge.net/projects/tinyfiledialogs/

--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_git(

--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://github.com/native-toolkit/tinyfiledialogs
-    REF f2379486f0e516cab528fc49991ad1b36c2e2831
+    URL https://git.code.sf.net/p/tinyfiledialogs/code
+    REF f7789c57db4269495a6702625351a15e5ee17542
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.code.sf.net/p/tinyfiledialogs/code
-    REF 331f93e903e0555399bf81479114dda978a77d7c
+    URL https://github.com/native-toolkit/tinyfiledialogs
+    REF f2379486f0e516cab528fc49991ad1b36c2e2831
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
**Describe the pull request**
Fix tinyfiledialogs not being fetchable from sourceforge. Use github instead.

- What does your PR fix? Fixes issue #
No issue was created, but i encountered issues on my local machine.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No update outside of git url

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
