### PR TITLE
[qhull] Fix Mac support

### DIFF
--- a/ports/qhull/CONTROL
+++ b/ports/qhull/CONTROL
@@ -1,4 +1,4 @@
 Source: qhull
-Version: 7.3.2-1
+Version: 7.3.2-2
 Homepage: https://github.com/qhull/qhull
 Description: computes the convex hull, Delaunay triangulation, Voronoi diagram

--- a/ports/qhull/mac-fix.patch
+++ b/ports/qhull/mac-fix.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 07d3da2..14df8e9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -626,18 +626,18 @@ install(TARGETS ${qhull_TARGETS_INSTALL} EXPORT QhullTargets
+ include(CMakePackageConfigHelpers)
+ 
+ write_basic_package_version_file(
+-    "${CMAKE_CURRENT_BINARY_DIR}/Qhull/QhullConfigVersion.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/QhullExport/QhullConfigVersion.cmake"
+     VERSION ${qhull_VERSION}
+     COMPATIBILITY AnyNewerVersion
+ )
+ 
+ export(EXPORT QhullTargets
+-  FILE "${CMAKE_CURRENT_BINARY_DIR}/Qhull/QhullTargets.cmake"
++  FILE "${CMAKE_CURRENT_BINARY_DIR}/QhullExport/QhullTargets.cmake"
+   NAMESPACE Qhull::
+ )
+ 
+ configure_file(${PROJECT_SOURCE_DIR}/build/config.cmake.in
+-  "${CMAKE_CURRENT_BINARY_DIR}/Qhull/QhullConfig.cmake"
++  "${CMAKE_CURRENT_BINARY_DIR}/QhullExport/QhullConfig.cmake"
+   @ONLY
+ )
+ 
+@@ -652,8 +652,8 @@ install(EXPORT QhullTargets
+ )
+ install(
+   FILES
+-    "${CMAKE_CURRENT_BINARY_DIR}/Qhull/QhullConfig.cmake"
+-    "${CMAKE_CURRENT_BINARY_DIR}/Qhull/QhullConfigVersion.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/QhullExport/QhullConfig.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/QhullExport/QhullConfigVersion.cmake"
+   DESTINATION
+     ${ConfigPackageLocation}
+   COMPONENT

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF v7.3.2 # Qhull 2019.1
     SHA512 aea2c70179de10f648aba960129a3b9a3fe309a0eb085bdb86f697e3d4b214570c241e88d4f0b4d2974137759ee7086452d0a3957c4b2a256708402fb3c9eb3d
     HEAD_REF master
-	PATCHES uwp.patch
+    PATCHES
+        uwp.patch
+        mac-fix.patch
 )
 if(${TARGET_TRIPLET} STREQUAL "x64-windows-static") 
 # workaround for visual studio toolset regression LNK1201 (remove if solved)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
  - Might fix part of issue #9600 (`qhull: build failure: can't open output file for writing: qhull, errno=21 for architecture x86_64 `)
- Which triplets are supported/not supported? Have you updated the CI baseline?
  - Same as before; no update required
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - Yes

Related issue: https://github.com/qhull/qhull/pull/49