### PR TITLE
[xerces-c] Change url for xerces-c and the signature

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/xerces-c
-    REF Xerces-C_3_2_2
-    SHA512 66f60fe9194376ac0ca99d13ea5bce23ada86e0261dde30686c21ceb5499e754dab8eb0a98adadd83522bda62709377715501f6dac49763e3a686f9171cc63ea
+    REF v3.2.2
+    SHA512 e4b2d3499fb4d1d1bcaf991ee858f352112683084b9cc7855c0e52e7fc8cc982a8e3cd548fa30718af6a6dee40e460d82ffcd3480a50f7e7516b462b2c2080c6
     HEAD_REF trunk
     PATCHES
         disable-tests.patch


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #

- Which triplets are supported/not supported? Have you updated the CI baseline?
No impact on the triplet only the git download is fixed
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes, the change is small enough to have any impact than the download url and the sha hash