### PR TITLE
[jasper] freeglut is not a dependency in macOS

### DIFF
--- a/ports/jasper/CONTROL
+++ b/ports/jasper/CONTROL
@@ -2,4 +2,4 @@ Source: jasper
 Version: 2.0.16-2
 Homepage: https://github.com/mdadams/jasper
 Description: Open source implementation of the JPEG-2000 Part-1 standard
-Build-Depends: libjpeg-turbo, opengl, freeglut
+Build-Depends: libjpeg-turbo, opengl, freeglut (!osx)


### PR DESCRIPTION
**Describe the pull request**

Removing freeglut from macOS list of dependencies.

- What does your PR fix? Fixes issue

Broken Qt 5 in macOS after commit https://github.com/microsoft/vcpkg/commit/f8165f72709cce797058164b389a105ca4c412a9#diff-5df6afe35378f98a8c68a59e1faed145
