### PR TITLE
[jasper] freeglut is not a dependency in macOS

### DIFF
--- a/ports/jasper/CONTROL
+++ b/ports/jasper/CONTROL
@@ -1,5 +1,5 @@
 Source: jasper
-Version: 2.0.16-2
+Version: 2.0.16-3
 Homepage: https://github.com/mdadams/jasper
 Description: Open source implementation of the JPEG-2000 Part-1 standard
-Build-Depends: libjpeg-turbo, opengl, freeglut
+Build-Depends: libjpeg-turbo, opengl, freeglut (!osx)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1172,6 +1172,7 @@ ogdf:x64-uwp            = skip
 ogdf:x64-windows        = skip
 ogdf:x64-windows-static = skip
 ogdf:x86-windows        = skip
+ogre:x64-osx=fail
 # Conflicts with ogre
 ogre-next:arm64-windows      = skip
 ogre-next:arm-uwp            = skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -468,7 +468,6 @@ freeglut:arm64-windows=fail
 freeglut:arm-uwp=fail
 freeglut:x64-uwp=fail
 freeglut:x64-osx=fail
-freeimage:x64-osx=fail
 freerdp:arm64-windows=fail
 freerdp:arm-uwp=fail
 freerdp:x64-osx=fail


### PR DESCRIPTION
Also remove freeimage:x64-osx from baseline as it now compiles

- What does your PR fix? Fixes issue #

Broken Qt 5 in macOS after commit https://github.com/microsoft/vcpkg/commit/f8165f72709cce797058164b389a105ca4c412a9#diff-5df6afe35378f98a8c68a59e1faed145
