### PR TITLE
[freetype] Add feature support

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,18 @@
 Source: freetype
-Version: 2.10.1-2
-Build-Depends: zlib, bzip2, libpng
+Version: 2.10.1-3
+Build-Depends: zlib
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.
+Default-Features: bzip2, png
+
+Feature: bzip2
+Build-Depends: bzip2
+Description: Support bzip2 compressed fonts.
+
+Feature: harfbuzz
+Build-Depends: harfbuzz
+Description: Improve auto-hinting of OpenType fonts.
+
+Feature: png
+Build-Depends: libpng
+Description: Support PNG compressed OpenType embedded bitmaps.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(FT_VERSION 2.10.1)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download-mirror.savannah.gnu.org/releases/freetype/freetype-${FT_VERSION}.tar.xz" "https://downloads.sourceforge.net/project/freetype/freetype2/${FT_VERSION}/freetype-${FT_VERSION}.tar.xz"
@@ -8,20 +6,31 @@ vcpkg_download_distfile(ARCHIVE
 )
 
 vcpkg_extract_source_archive_ex(
-OUT_SOURCE_PATH SOURCE_PATH
-ARCHIVE ${ARCHIVE}
-REF ${FT_VERSION}
-PATCHES
-    0001-Fix-install-command.patch
-    0002-Add-CONFIG_INSTALL_PATH-option.patch
-    0003-Fix-UWP.patch
-    0005-Fix-DLL-EXPORTS.patch
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${FT_VERSION}
+    PATCHES
+        0001-Fix-install-command.patch
+        0002-Add-CONFIG_INSTALL_PATH-option.patch
+        0003-Fix-UWP.patch
+        0005-Fix-DLL-EXPORTS.patch
 )
-    
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        bzip2       FT_WITH_BZIP2
+        harfbuzz    FT_WITH_HARFBUZZ
+        png         FT_WITH_PNG
+    INVERTED_FEATURES
+        bzip2       CMAKE_DISABLE_FIND_PACKAGE_BZip2
+        harfbuzz    CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz
+        png         CMAKE_DISABLE_FIND_PACKAGE_PNG
+)
+
 if(NOT ${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
-  set(ENABLE_DLL_EXPORT OFF)
+    set(ENABLE_DLL_EXPORT OFF)
 else()
-  set(ENABLE_DLL_EXPORT ON)
+    set(ENABLE_DLL_EXPORT ON)
 endif()
 
 vcpkg_configure_cmake(
@@ -29,11 +38,8 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DCONFIG_INSTALL_PATH=share/freetype
-        -DFT_WITH_ZLIB=ON
-        -DFT_WITH_BZIP2=ON
-        -DFT_WITH_PNG=ON
-        -DFT_WITH_HARFBUZZ=OFF
-        -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE
+        -DFT_WITH_ZLIB=ON # Force system zlib.
+        ${FEATURE_OPTIONS}
         -DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
 )
 
@@ -78,5 +84,13 @@ file(RENAME ${CURRENT_PACKAGES_DIR}/share/freetype/LICENSE.TXT ${CURRENT_PACKAGE
 vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/freetype)
+    if("bzip2" IN_LIST FEATURES)
+        set(USE_BZIP2 ON)
+    endif()
+
+    if("png" IN_LIST FEATURES)
+        set(USE_PNG ON)
+    endif()
+
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake ${CURRENT_PACKAGES_DIR}/share/freetype/vcpkg-cmake-wrapper.cmake @ONLY)
 endif()

--- a/ports/freetype/vcpkg-cmake-wrapper.cmake
+++ b/ports/freetype/vcpkg-cmake-wrapper.cmake
@@ -1,10 +1,35 @@
 _find_package(${ARGS})
+
 find_package(ZLIB)
-find_package(PNG)
-find_package(BZip2)
-if(TARGET Freetype::Freetype)
-    set_property(TARGET Freetype::Freetype APPEND PROPERTY INTERFACE_LINK_LIBRARIES BZip2::BZip2 PNG::PNG ZLIB::ZLIB)
+
+if(@USE_BZIP2@)
+    find_package(BZip2)
 endif()
+
+if(@USE_PNG@)
+    find_package(PNG)
+endif()
+
+if(TARGET Freetype::Freetype)
+    set_property(TARGET Freetype::Freetype APPEND PROPERTY INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
+
+    if(@USE_BZIP2@)
+        set_property(TARGET Freetype::Freetype APPEND PROPERTY INTERFACE_LINK_LIBRARIES BZip2::BZip2)
+    endif()
+
+    if(@USE_PNG@)
+        set_property(TARGET Freetype::Freetype APPEND PROPERTY INTERFACE_LINK_LIBRARIES PNG::PNG)
+    endif()
+endif()
+
 if(FREETYPE_LIBRARIES)
-    list(APPEND FREETYPE_LIBRARIES ${BZIP2_LIBRARIES} ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
+    list(APPEND FREETYPE_LIBRARIES ${ZLIB_LIBRARIES})
+
+    if(@USE_BZIP2@)
+        list(APPEND FREETYPE_LIBRARIES ${BZIP2_LIBRARIES})
+    endif()
+
+    if(@USE_PNG@)
+        list(APPEND FREETYPE_LIBRARIES ${PNG_LIBRARIES})
+    endif()
 endif()


### PR DESCRIPTION
This change makes bzip2, HarfBuzz and PNG support optional.

This is a draft because I am not sure how to handle features in `vcpkg-cmake-wrapper.cmake`, any guidelines?

Another question is whether it makes sense to keep `bzip2` in `Default-Features`? According to the docs it's used for `*.pcf.bz2` fonts.