### PR TITLE
[toolsrc] Added missing @ to FATAL_ERROR message

### DIFF
--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -31,7 +31,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
         message(FATAL_ERROR
 "Building the vcpkg tool requires support for the C++ Filesystem TS.
 Apple clang versions 10.01 and below do not have support for it.
-Please install gcc6 or newer from homebrew (brew install gcc6).
+Please install gcc6 or newer from homebrew (brew install gcc@6).
 If you would like to try anyway, pass --allowAppleClang to bootstrap.sh.")
     else()
         set(CLANG 1)


### PR DESCRIPTION
To install a specific version of a package via homebrew, an `@` symbol must be placed in-between the package name and its version.
Added missing symbol to `toolsrc/CMakeLists.txt`

See homebrew console output for reference:
```
Kristofs-Mac-Pro:vcpkg kristofdaja$ brew search gcc
==> Formulae
gcc                     gcc@5                   gcc@7                   x86_64-elf-gcc
gcc@4.9                 gcc@6                   gcc@8
```

**Describe the pull request**

- What does your PR fix? Fixes issue #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
