### PR TITLE
[libwebsockets] Update to v3.2.2

### DIFF
--- a/ports/libwebsockets/CONTROL
+++ b/ports/libwebsockets/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebsockets
-Version: 3.2.0-2
+Version: 3.2.2
 Build-Depends: zlib, openssl
 Homepage: https://github.com/warmcat/libwebsockets
 Description: Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
-    REF v3.2.0
-    SHA512 afc1c9e259d6d48000b09da111af4129680d50474cdfedbad197ee22260d57a837b67cc6a3f8e6b1aa7ce7dc5d3fd900569783631540501709868125c6d1e4da
+    REF v3.2.2
+    SHA512 be6cd57ae1d15de059c277ce56e9ccc87f7918811b40a427c96978397f2b1d446e1b5ed6ae62a6aa82c6d775871d6a15885d283d74d7887e98205ab61d206fc0
     HEAD_REF master
     PATCHES
         CMakeLists.patch


### PR DESCRIPTION
Updates libwebsocket portfile.cmake to use the v3.2.2 release.