### PR TITLE
Update Alembic version to 1.7.12

### DIFF
--- a/ports/alembic/CONTROL
+++ b/ports/alembic/CONTROL
@@ -1,5 +1,5 @@
 Source: alembic
-Version: 1.7.11-6
+Version: 1.7.12
 Build-Depends: ilmbase, hdf5
 Description: Alembic is an open framework for storing and sharing scene data that includes a C++ library, a file format, and client plugins and applications.
 Homepage: https://alembic.io/

--- a/ports/alembic/portfile.cmake
+++ b/ports/alembic/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO alembic/alembic
-    REF 1.7.11
-    SHA512 94b9c218a2fe6e2e24205aff4a2f6bab784851c2aa15592fb60ea91f0e8038b0c0656a118f3a5cba0d3de8917dd90b74d0e2d1c4ac034b9ee3f5d0741d9f6b70
+    REF 1.7.12
+    SHA512 e05e0b24056c17f01784ced1f9606a269974de195f1aca8a6fce2123314e7ee609f70df77ac7fe18dc7f0c04fb883d38cc7de9b963caacf9586aaa24d4ac6210
     HEAD_REF master
     PATCHES
         fix-C1083.patch

--- a/ports/alembic/portfile.cmake
+++ b/ports/alembic/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_buildpath_length_warning(37)
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)


### PR DESCRIPTION
Updates Alembic portfile.cmake to use the v1.7.12 release to support C++17 builds using Alembic.