### PR TITLE
[paho-mqtt] Fix Windows platform predefined macros

### DIFF
--- a/ports/paho-mqtt/CONTROL
+++ b/ports/paho-mqtt/CONTROL
@@ -1,5 +1,5 @@
 Source: paho-mqtt
-Version: 1.3.0-1
+Version: 1.3.0-2
 Homepage: https://github.com/eclipse/paho.mqtt.c
 Description: Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols aimed at new, existing, and emerging applications for the Internet of Things
 Build-Depends: openssl

--- a/ports/paho-mqtt/fix-win-macro.patch
+++ b/ports/paho-mqtt/fix-win-macro.patch
@@ -1,0 +1,13 @@
+diff --git a/src/MQTTProperties.h b/src/MQTTProperties.h
+index deec124..872032c 100644
+--- a/src/MQTTProperties.h
++++ b/src/MQTTProperties.h
+@@ -50,7 +50,7 @@ enum MQTTPropertyCodes {
+   MQTTPROPERTY_CODE_SHARED_SUBSCRIPTION_AVAILABLE = 42/**< The value is 241 */
+ };
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+   #define DLLImport __declspec(dllimport)
+   #define DLLExport __declspec(dllexport)
+ #else

--- a/ports/paho-mqtt/fix-win-macro.patch
+++ b/ports/paho-mqtt/fix-win-macro.patch
@@ -11,3 +11,69 @@ index deec124..872032c 100644
    #define DLLImport __declspec(dllimport)
    #define DLLExport __declspec(dllexport)
  #else
+diff --git a/src/MQTTAsync.h b/src/MQTTAsync.h
+index 1b3593d..04718f8 100644
+--- a/src/MQTTAsync.h
++++ b/src/MQTTAsync.h
+@@ -92,7 +92,7 @@
+  extern "C" {
+ #endif
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+   #define DLLImport __declspec(dllimport)
+   #define DLLExport __declspec(dllexport)
+ #else
+@@ -1764,7 +1764,7 @@ int main(int argc, char* argv[])
+          "on topic %s for client with ClientID: %s\n",
+          PAYLOAD, TOPIC, CLIENTID);
+ 	while (!finished)
+-		#if defined(WIN32) || defined(WIN64)
++		#if defined(_WIN32) || defined(_WIN64)
+ 			Sleep(100);
+ 		#else
+ 			usleep(10000L);
+@@ -1914,7 +1914,7 @@ int main(int argc, char* argv[])
+ 	}
+ 
+ 	while	(!subscribed)
+-		#if defined(WIN32) || defined(WIN64)
++		#if defined(_WIN32) || defined(_WIN64)
+ 			Sleep(100);
+ 		#else
+ 			usleep(10000L);
+@@ -1935,7 +1935,7 @@ int main(int argc, char* argv[])
+ 		exit(EXIT_FAILURE);
+ 	}
+  	while	(!disc_finished)
+-		#if defined(WIN32) || defined(WIN64)
++		#if defined(_WIN32) || defined(_WIN64)
+ 			Sleep(100);
+ 		#else
+ 			usleep(10000L);
+diff --git a/src/MQTTClient.h b/src/MQTTClient.h
+index b3fadbe..130b804 100644
+--- a/src/MQTTClient.h
++++ b/src/MQTTClient.h
+@@ -110,7 +110,7 @@
+  extern "C" {
+ #endif
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+   #define DLLImport __declspec(dllimport)
+   #define DLLExport __declspec(dllexport)
+ #else
+diff --git a/src/MQTTReasonCodes.h b/src/MQTTReasonCodes.h
+index 369543b..38c299b 100644
+--- a/src/MQTTReasonCodes.h
++++ b/src/MQTTReasonCodes.h
+@@ -66,7 +66,7 @@ enum MQTTReasonCodes {
+   MQTTREASONCODE_WILDCARD_SUBSCRIPTIONS_NOT_SUPPORTED = 162
+ };
+ 
+-#if defined(WIN32) || defined(WIN64)
++#if defined(_WIN32) || defined(_WIN64)
+   #define DLLImport __declspec(dllimport)
+   #define DLLExport __declspec(dllexport)
+ #else

--- a/ports/paho-mqtt/portfile.cmake
+++ b/ports/paho-mqtt/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO eclipse/paho.mqtt.c
@@ -12,6 +10,7 @@ vcpkg_from_github(
          fix-static-build.patch
          fix-unresolvedsymbol-arm.patch
          export-cmake-targets.patch
+         fix-win-macro.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAHO_BUILD_STATIC)
@@ -19,15 +18,17 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PAHO_BUILD_STATIC)
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
-  OPTIONS -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_STATIC=${PAHO_BUILD_STATIC} -DPAHO_ENABLE_TESTING=FALSE
+  OPTIONS
+    -DPAHO_WITH_SSL=TRUE
+    -DPAHO_BUILD_STATIC=${PAHO_BUILD_STATIC}
+    -DPAHO_ENABLE_TESTING=FALSE
 )
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/eclipse-paho-mqtt-c TARGET_PATH share/eclipse-paho-mqtt-c)
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/paho-mqtt/README.md ${CURRENT_PACKAGES_DIR}/share/paho-mqtt/readme)
-file(INSTALL ${SOURCE_PATH}/about.html DESTINATION ${CURRENT_PACKAGES_DIR}/share/paho-mqtt RENAME copyright)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/paho-mqtt/README.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/readme)
+file(INSTALL ${SOURCE_PATH}/about.html DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
According to [msdn documentation](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019), fix predefined `WIN32` and `WIN64`.

Related: #9742.