### PR TITLE
[opencolorio] fix lcms dependency

### DIFF
--- a/ports/opencolorio/0001-lcms-dependency-search.patch
+++ b/ports/opencolorio/0001-lcms-dependency-search.patch
@@ -17,7 +17,7 @@ index d31b4e3..778b631 100644
 +
 +    find_library(LCMS_LIBRARIES
 +        LIBRARY_NAMES
-+            lcms2
++            lcms
 +        HINTS
 +            ${LCMS_LIBRARY_DIRS}
 +    )

--- a/ports/opencolorio/CONTROL
+++ b/ports/opencolorio/CONTROL
@@ -1,5 +1,5 @@
 Source: opencolorio
-Version: 1.1.1-1
+Version: 1.1.1-2
 Homepage: https://opencolorio.org/
 Description: OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.
 Build-Depends: glew[core], freeglut[core], lcms[core], yaml-cpp[core], tinyxml[core]

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_definitions)
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(_BUILD_SHARED OFF)
     set(_BUILD_STATIC ON)
@@ -95,6 +93,4 @@ file(REMOVE
     ${CURRENT_PACKAGES_DIR}/debug/OpenColorIOConfig.cmake
 )
 
-# Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fix related issue https://github.com/microsoft/vcpkg/issues/9710

lcms updated library name from lcms2 to lcms, update the lcms searched name in patch file.

Feature 'applications' test pass 86-windows and x64-windows.