### PR TITLE
[loguru] bumped to 2.1.0

### DIFF
--- a/ports/loguru/CONTROL
+++ b/ports/loguru/CONTROL
@@ -1,4 +1,4 @@
 Source: loguru
-Version: v2.0.0
+Version: v2.1.0
 Description: A lightweight and flexible C++ logging library
 Build-Depends:

--- a/ports/loguru/portfile.cmake
+++ b/ports/loguru/portfile.cmake
@@ -3,10 +3,11 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO emilk/loguru
-    REF v2.0.0
-    SHA512 d6358f843689d10a44dc7bf590305cbfb89727e26d971ca4fe439e5468cdb7bcee2aa858368250e9654fb5ecebf63bca9742451881dae78068fecb18f279d988
+    REF v2.1.0
+    SHA512 3458e5381449aec53995f7d1e993bd807dd7a94c912262212ed9bfc4df9e219b4acfc97ea4cbffc55e615e34622545c706217492f88aaecb411d67869f06f0bb
     HEAD_REF master
 )
 
 file(INSTALL ${SOURCE_PATH}/loguru.hpp  DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
+file(INSTALL ${SOURCE_PATH}/loguru.cpp  DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
 file(COPY ${CURRENT_PORT_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/loguru)


### PR DESCRIPTION
- What does your PR fix?
I had trouble successfully using the library before the update since the `loguru.cpp` file was missing which needs to be included once somewhere in the code base (counterintuitively). After that, the `loguru.hpp` can be included as often as one wants.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I only bumped up the version.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.