### PR TITLE
[openssl] Update the version

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,5 +1,5 @@
 Source: openssl
-Version: 1
+Version: 1.1.1d
 Homepage: https://www.openssl.org
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Build-Depends: openssl-windows (windows), openssl-uwp (uwp), openssl-unix (!uwp&!windows)

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -1,4 +1,2 @@
-include(vcpkg_common_functions)
-
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/openssl/)


### PR DESCRIPTION
`openssl-windows`, `opnessl-unix`,` openssl-uwp` have been updated to 1.1.1d.

So we should update `openssl `to the same version.

Related #8566.
