### PR TITLE
[vtk] Fix feature qt and python

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-10
+Version: 8.2.0-11
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -49,7 +49,7 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/FindGDAL.cmake DESTINATION ${SOURCE_PATH}/CM
 
 # =============================================================================
 # Collect CMake options for optional components
-if(VTK_WITH_QT)
+if("qt" IN_LIST FEATURES)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_Group_Qt=ON
         -DVTK_QT_VERSION=5
@@ -57,7 +57,7 @@ if(VTK_WITH_QT)
     )
 endif()
 
-if(VTK_WITH_PYTHON)
+if("python" IN_LIST FEATURES)
     vcpkg_find_acquire_program(PYTHON3)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_WRAP_PYTHON=ON


### PR DESCRIPTION
Fix build feature qt and python.
The variables `VTK_WITH_QT` and` VTK_WITH_PYTHON` should not be used in _portfile.cmake_.

Related: #9023