### PR TITLE
[fftw3] Fix SIMD compiler flag and mingw build failure

### DIFF
--- a/ports/fftw3/aligned_malloc.patch
+++ b/ports/fftw3/aligned_malloc.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake.config.h.in b/cmake.config.h.in
+index 1f4c505..fd763cc 100644
+--- a/cmake.config.h.in
++++ b/cmake.config.h.in
+@@ -112,6 +112,10 @@
+    you don't. */
+ #cmakedefine01 HAVE_DECL_POSIX_MEMALIGN
+
++/* Define to 1 if you have the declaration of `_aligned_malloc', and to 0 if you
++   don't. */
++#cmakedefine01 HAVE_DECL_ALIGNED_MALLOC
++
+ /* Define to 1 if you have the declaration of `sinl', and to 0 if you don't.
+    */
+ #cmakedefine01 HAVE_DECL_SINL
+@@ -184,6 +188,9 @@
+ /* Define to 1 if you have the `memalign' function. */
+ #cmakedefine HAVE_MEMALIGN 1
+
++/* Define to 1 if you have the `_aligned_malloc' function. */
++#cmakedefine HAVE_ALIGNED_MALLOC 1
++
+ /* Define to 1 if you have the `memmove' function. */
+ #cmakedefine HAVE_MEMMOVE 1
+
+diff --git a/kernel/kalloc.c b/kernel/kalloc.c
+index e42f6f3..ffc2257 100644
+--- a/kernel/kalloc.c
++++ b/kernel/kalloc.c
+@@ -103,7 +103,7 @@ void *X(kernel_malloc)(size_t n)
+ #    undef real_free
+ #    define real_free _mm_free
+
+-#  elif defined(_MSC_VER)
++#  elif defined(_MSC_VER) || defined (HAVE_ALIGNED_MALLOC)
+      /* MS Visual C++ 6.0 with a "Processor Pack" supports SIMD
+        and _aligned_malloc/free (uses malloc.h) */
+      p = (void *) _aligned_malloc(n, MIN_ALIGNMENT);

--- a/ports/fftw3/fftw3_arch_fix.patch
+++ b/ports/fftw3/fftw3_arch_fix.patch
@@ -2,6 +2,23 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 95bd537a..245acc8f 100644
 --- a/CMakeLists.txt	
 +++ b/CMakeLists.txt
+@@ -66,6 +66,8 @@
+ check_prototype_definition (sinl "long double sinl( long double arg )" "0" math.h HAVE_DECL_SINL)
+ check_prototype_definition (memalign "void *memalign(size_t alignment, size_t size)" "0" malloc.h HAVE_DECL_MEMALIGN)
+ check_prototype_definition (posix_memalign "int posix_memalign(void **memptr, size_t alignment, size_t size)" "0" stdlib.h HAVE_DECL_POSIX_MEMALIGN)
++check_prototype_definition (_aligned_malloc "void* __cdecl _aligned_malloc(size_t _Size, size_t _Alignment)" "0" malloc.h HAVE_DECL_ALIGNED_MALLOC)
++ 
+ 
+ include (CheckSymbolExists)
+ check_symbol_exists (clock_gettime time.h HAVE_CLOCK_GETTIME)
+@@ -75,6 +77,7 @@
+ check_symbol_exists (srand48 stdlib.h HAVE_SRAND48)
+ check_symbol_exists (memalign malloc.h HAVE_MEMALIGN)
+ check_symbol_exists (posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
++check_symbol_exists (_aligned_malloc malloc.h HAVE_ALIGNED_MALLOC)
+ check_symbol_exists (mach_absolute_time mach/mach_time.h HAVE_MACH_ABSOLUTE_TIME)
+ check_symbol_exists (alloca alloca.h HAVE_ALLOCA)
+ if (NOT HAVE_ALLOCA)
 @@ -131,6 +131,7 @@ endif ()
  
  include (CheckCCompilerFlag)

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_extract_source_archive_ex(
         omp_test.patch
         patch_targets.patch
         fftw3_arch_fix.patch
+        aligned_malloc.patch
 )
 
 if ("openmp" IN_LIST FEATURES)
@@ -22,40 +23,40 @@ else()
 endif()
 
 if ("avx" IN_LIST FEATURES)
-    set(HAVE_AVX ON)
-    set(HAVE_SSE ON)
-    set(HAVE_SSE2 ON)
+    set(ENABLE_AVX ON)
+    set(ENABLE_SSE ON)
+    set(ENABLE_SSE2 ON)
 else()
-    set(HAVE_AVX OFF)
+    set(ENABLE_AVX OFF)
 endif()
 
 if ("avx2" IN_LIST FEATURES)
-    set(HAVE_AVX2 ON)
-    set(HAVE_FMA ON)
-    set(HAVE_SSE ON)
-    set(HAVE_SSE2 ON)
+    set(ENABLE_AVX2 ON)
+    set(ENABLE_FMA ON)
+    set(ENABLE_SSE ON)
+    set(ENABLE_SSE2 ON)
 else()
-    set(HAVE_AVX2 OFF)
-    set(HAVE_FMA OFF)
+    set(ENABLE_AVX2 OFF)
+    set(ENABLE_FMA OFF)
 endif()
 
 if ("sse" IN_LIST FEATURES)
-    set(HAVE_SSE ON)
+    set(ENABLE_SSE ON)
 else()
-    set(HAVE_SSE OFF)
+    set(ENABLE_SSE OFF)
 endif()
 
 if ("sse2" IN_LIST FEATURES)
-    set(HAVE_SSE2 ON)
-    set(HAVE_SSE ON)
+    set(ENABLE_SSE2 ON)
+    set(ENABLE_SSE ON)
 else()
-    set(HAVE_SSE2 OFF)
+    set(ENABLE_SSE2 OFF)
 endif()
 
 if ("threads" IN_LIST FEATURES)
-    set(HAVE_THREADS ON)
+    set(ENABLE_THREADS ON)
 else()
-    set(HAVE_THREADS OFF)
+    set(ENABLE_THREADS OFF)
 endif()
 
 set(ENABLE_FLOAT_CMAKE fftw3f)
@@ -81,13 +82,13 @@ foreach(PRECISION ENABLE_FLOAT ENABLE_LONG_DOUBLE ENABLE_DEFAULT_PRECISION)
         OPTIONS 
             -D${PRECISION}=ON
             -DENABLE_OPENMP=${ENABLE_OPENMP}
-            -DHAVE_SSE=${HAVE_SSE}
-            -DHAVE_SSE2=${HAVE_SSE2}
-            -DHAVE_AVX=${HAVE_AVX}
-            -DHAVE_AVX2=${HAVE_AVX2}
-            -DHAVE_FMA=${HAVE_FMA}
-            -DENABLE_THREADS=${HAVE_THREADS}
-            -DWITH_COMBINED_THREADS=${HAVE_THREADS}
+            -DENABLE_SSE=${ENABLE_SSE}
+            -DENABLE_SSE2=${ENABLE_SSE2}
+            -DENABLE_AVX=${ENABLE_AVX}
+            -DENABLE_AVX2=${ENABLE_AVX2}
+            -DENABLE_FMA=${ENABLE_FMA}
+            -DENABLE_THREADS=${ENABLE_THREADS}
+            -DWITH_COMBINED_THREADS=${ENABLE_THREADS}
             -DBUILD_TESTS=OFF
         )
     endif()

--- a/ports/fftw3/portfile.cmake
+++ b/ports/fftw3/portfile.cmake
@@ -16,48 +16,16 @@ vcpkg_extract_source_archive_ex(
         aligned_malloc.patch
 )
 
-if ("openmp" IN_LIST FEATURES)
-    set(ENABLE_OPENMP ON)
-else()
-    set(ENABLE_OPENMP OFF)
-endif()
-
-if ("avx" IN_LIST FEATURES)
-    set(ENABLE_AVX ON)
-    set(ENABLE_SSE ON)
-    set(ENABLE_SSE2 ON)
-else()
-    set(ENABLE_AVX OFF)
-endif()
-
-if ("avx2" IN_LIST FEATURES)
-    set(ENABLE_AVX2 ON)
-    set(ENABLE_FMA ON)
-    set(ENABLE_SSE ON)
-    set(ENABLE_SSE2 ON)
-else()
-    set(ENABLE_AVX2 OFF)
-    set(ENABLE_FMA OFF)
-endif()
-
-if ("sse" IN_LIST FEATURES)
-    set(ENABLE_SSE ON)
-else()
-    set(ENABLE_SSE OFF)
-endif()
-
-if ("sse2" IN_LIST FEATURES)
-    set(ENABLE_SSE2 ON)
-    set(ENABLE_SSE ON)
-else()
-    set(ENABLE_SSE2 OFF)
-endif()
-
-if ("threads" IN_LIST FEATURES)
-    set(ENABLE_THREADS ON)
-else()
-    set(ENABLE_THREADS OFF)
-endif()
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    openmp ENABLE_OPENMP
+    threads ENABLE_THREADS
+    threads WITH_COMBINED_THREADS
+    avx2 ENABLE_AVX2
+    avx ENABLE_AVX
+    sse2 ENABLE_SSE2
+    sse ENABLE_SSE
+)
 
 set(ENABLE_FLOAT_CMAKE fftw3f)
 set(ENABLE_LONG_DOUBLE_CMAKE fftw3l)
@@ -81,14 +49,7 @@ foreach(PRECISION ENABLE_FLOAT ENABLE_LONG_DOUBLE ENABLE_DEFAULT_PRECISION)
         PREFER_NINJA
         OPTIONS 
             -D${PRECISION}=ON
-            -DENABLE_OPENMP=${ENABLE_OPENMP}
-            -DENABLE_SSE=${ENABLE_SSE}
-            -DENABLE_SSE2=${ENABLE_SSE2}
-            -DENABLE_AVX=${ENABLE_AVX}
-            -DENABLE_AVX2=${ENABLE_AVX2}
-            -DENABLE_FMA=${ENABLE_FMA}
-            -DENABLE_THREADS=${ENABLE_THREADS}
-            -DWITH_COMBINED_THREADS=${ENABLE_THREADS}
+            ${FEATURE_OPTIONS}
             -DBUILD_TESTS=OFF
         )
     endif()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #
Fix two things: 
1. `vcpkg install fftw3[avx2]:x64-windows` doesn't actually apply /arch:AVX2 compiler flag. (issue #9793)
2. `vcpkg install fftw3:x64-mingw` fails

- Which triplets are supported/not supported? Have you updated the CI baseline?
Tested with `x64-windows` and `x64-mingw`

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes