### PR TITLE
[gettext] fix library placement on macOS

### DIFF
--- a/ports/gettext/CMakeLists.txt
+++ b/ports/gettext/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 install(TARGETS libintl
   EXPORT unofficial-gettext-targets
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION bin
+  LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,5 +1,5 @@
 Source: gettext
-Version: 0.19-12
+Version: 0.19-13
 Homepage: https://www.gnu.org/software/gettext/
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.
 Build-Depends: libiconv


### PR DESCRIPTION
When building the dynamic library in macOS the dylib is placed in the bin directory, and should be placed in the lib directory.