### PR TITLE
[cairo] fix export symbols on dynamic libraries for macOS

### DIFF
--- a/ports/cairo/CMakeLists.txt
+++ b/ports/cairo/CMakeLists.txt
@@ -208,16 +208,16 @@ set(CAIRO_GOBJECT_SOURCES
 
 # GObject support sources do not include header with export macro
 if(BUILD_SHARED_LIBS)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(MSVC)
         set_source_files_properties(
-            "../util/cairo-gobject/cairo-gobject-enums.c"
-	    "../util/cairo-gobject/cairo-gobject-structs.c"
-	    PROPERTIES COMPILE_DEFINITIONS "cairo_public=__declspec(dllexport)")
+              "../util/cairo-gobject/cairo-gobject-enums.c"
+        "../util/cairo-gobject/cairo-gobject-structs.c"
+        PROPERTIES COMPILE_DEFINITIONS "cairo_public=__declspec(dllexport)")
     else()
-	set_source_files_properties(
-            "../util/cairo-gobject/cairo-gobject-enums.c"
-	    "../util/cairo-gobject/cairo-gobject-structs.c"
-	    PROPERTIES COMPILE_DEFINITIONS "cairo_public=__attribute__((visibility(\"default\")))")
+        set_source_files_properties(
+              "../util/cairo-gobject/cairo-gobject-enums.c"
+        "../util/cairo-gobject/cairo-gobject-structs.c"
+        PROPERTIES COMPILE_DEFINITIONS "cairo_public=__attribute__((visibility(\"default\")))")
     endif()
 endif()
 

--- a/ports/cairo/CMakeLists.txt
+++ b/ports/cairo/CMakeLists.txt
@@ -208,10 +208,17 @@ set(CAIRO_GOBJECT_SOURCES
 
 # GObject support sources do not include header with export macro
 if(BUILD_SHARED_LIBS)
-    set_source_files_properties(
-        "../util/cairo-gobject/cairo-gobject-enums.c"
-        "../util/cairo-gobject/cairo-gobject-structs.c"
-        PROPERTIES COMPILE_DEFINITIONS "cairo_public=__declspec(dllexport)")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set_source_files_properties(
+            "../util/cairo-gobject/cairo-gobject-enums.c"
+	    "../util/cairo-gobject/cairo-gobject-structs.c"
+	    PROPERTIES COMPILE_DEFINITIONS "cairo_public=__declspec(dllexport)")
+    else()
+	set_source_files_properties(
+            "../util/cairo-gobject/cairo-gobject-enums.c"
+	    "../util/cairo-gobject/cairo-gobject-structs.c"
+	    PROPERTIES COMPILE_DEFINITIONS "cairo_public=__attribute__((visibility(\"default\")))")
+    endif()
 endif()
 
 add_library(cairo-gobject ${CAIRO_GOBJECT_SOURCES}) 

--- a/ports/cairo/CONTROL
+++ b/ports/cairo/CONTROL
@@ -1,5 +1,5 @@
 Source: cairo
-Version: 1.16.0-2
+Version: 1.16.0-3
 Homepage: https://cairographics.org
 Description: Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.
 Build-Depends: zlib, libpng, pixman, glib, freetype, fontconfig


### PR DESCRIPTION
Fixed exporting symbols by changing the definition for macOS dynamic libraries (and probably Linux too).