### PR TITLE
[pango] fix macOS dynamic library

### DIFF
--- a/ports/pango/CMakeLists.txt
+++ b/ports/pango/CMakeLists.txt
@@ -59,6 +59,11 @@ find_library(FREETYPE_LIBRARY freetype${FT_SUFFIX})
 find_path(HARFBUZZ_INCLUDE_DIR harfbuzz/hb.h)
 find_library(HARFBUZZ_LIBRARY harfbuzz)
 
+if (APPLE)
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    link_libraries(${COREFOUNDATION_LIBRARY})
+endif()
+
 set(FONT_INCLUDE_DIRS ${FREETYPE_INCLUDE_DIR} ${FONTCONFIG_INCLUDE_DIR} ${HARFBUZZ_INCLUDE_DIR}/harfbuzz)
 set(FONT_LIBRARIES ${FREETYPE_LIBRARY} ${FONTCONFIG_LIBRARY} ${HARFBUZZ_LIBRARY})
 
@@ -151,7 +156,11 @@ if(WIN32)
 endif()
 
 pango_add_module(pangocairo ${PANGO_CAIRO_SOURCES})
-target_link_libraries(pangocairo ${CAIRO_LIBRARIES} pango pangowin32 pangoft2 ${FONT_LIBRARIES})
+list(APPEND PANGO_CAIRO_LIBRARIES  ${CAIRO_LIBRARIES} pango pangoft2 ${FONT_LIBRARIES})
+if (WIN32)
+    list(APPEND PANGO_CAIRO_LIBRARIES pangowin32)
+endif()
+target_link_libraries(pangocairo ${PANGO_CAIRO_LIBRARIES}) 
 target_include_directories(pangocairo PRIVATE ${CAIRO_INCLUDE_DIR} ${FONT_INCLUDE_DIRS})
 
 

--- a/ports/pango/CONTROL
+++ b/ports/pango/CONTROL
@@ -1,5 +1,5 @@
 Source: pango
-Version: 1.40.11-5
+Version: 1.40.11-6
 Homepage: https://ftp.gnome.org/pub/GNOME/sources/pango/
 Description: Text and font handling library.
 Build-Depends: glib, gettext, cairo, fontconfig, freetype, harfbuzz[glib] (!(windows&static))


### PR DESCRIPTION
Fixes the build for a dynamic library in macOS.
It needed to link to CoreFoundation, and added pangowin32 files only if on Windows.