### PR TITLE
[boost-modular-build-helper] fix _WIN32_WINNT definition

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,2 +1,2 @@
 Source: boost-modular-build-helper
-Version: 1.72.0
+Version: 1.72.0-1

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -264,8 +264,6 @@ function(boost_modular_build)
         string(REPLACE "\\" "/" PLATFORM_WINMD_DIR ${PLATFORM_WINMD_DIR}) # escape backslashes
 
         set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <cflags>-Zl <compileflags> /AI\"${PLATFORM_WINMD_DIR}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
-    else()
-        set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <compileflags>-D_WIN32_WINNT=0x0602")
     endif()
 
     configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/user-config.jam @ONLY)


### PR DESCRIPTION
**Describe the pull request**

14358e8b257a27f86a58bf95aaca1625c1ec2a26 modified _WIN32_WINNT of [boost's msvc.jam](https://github.com/boostorg/build/blob/8c3900ae5efe3e84460ac61fdcf1975e791991c9/src/tools/msvc.jam#L508-L514).
- before
  - windows-api: not defined.
  - store: _WIN32_WINNT=0x0602
  - phone: _WIN32_WINNT=0x0602
- after
  - windows-api: _WIN32_WINNT=0x0602 (this is bug).
  - store: _WIN32_WINNT=0x0A00
  - phone: not supported.

So, windows-api should not be set.

---
- What does your PR fix?
  Fixes issue #9119

- Which triplets are supported/not supported? Have you updated the CI baseline?
  fix for x86-windows and x64-windows.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.
