### PR TITLE
[gsl-lite] Update to version 0.36.0

### DIFF
--- a/ports/gsl-lite/CONTROL
+++ b/ports/gsl-lite/CONTROL
@@ -1,4 +1,4 @@
 Source: gsl-lite
-Version: 0.34.0
-Homepage: https://github.com/martinmoene/gsl-lite
-Description: A single-file header-only version of ISO C++ Guideline Support Library (GSL) for C++98, C++11 and later
+Version: 0.36.0
+Description: A single-file header-only implementation of ISO C++ Guidelines Support Library (GSL) for C++98, C++11 and later.
+Homepage: https://github.com/gsl-lite/gsl-lite/

--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -1,18 +1,32 @@
-include(vcpkg_common_functions)
-
-set(GSL_LITE_VERSION v0.34.0)
-
-vcpkg_download_distfile(HEADER
-    URLS "https://github.com/martinmoene/gsl-lite/raw/${GSL_LITE_VERSION}/include/gsl/gsl-lite.hpp"
-    FILENAME "gsl-lite-${GSL_LITE_VERSION}.hpp"
-    SHA512 e8463ced48fb4c5aae9bab4e9bdf3deb8a6f17d6f712fd9e3855788f6f43c70ad689738f099735071e2e411b285d9b60312bbfc4f99fc0250bdc2ca0f38493d8
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gsl-lite/gsl-lite
+    REF 0190c0e40ca65e7d30dab51bee512ccd29f48bc1
+    SHA512 7ae9bb37bcbc83be3667b504271c209fea97e235fe50b754c3d420a7e97bbe2dd1df17a164dca536fb1455a19c26162d0bc27055d7c1ac495fb77956ec0f4e6d
+    HEAD_REF master
 )
 
-vcpkg_download_distfile(LICENSE
-    URLS "https://github.com/martinmoene/gsl-lite/raw/${GSL_LITE_VERSION}/LICENSE"
-    FILENAME "gsl-lite-LICENSE-${GSL_LITE_VERSION}.txt"
-    SHA512 1feff12bda27a5ec52440a7624de54d841faf3e254fff04ab169b7f312e685f4bfe71236de8b8ef759111ae95bdb69e05f2e8318773b0aff4ba24ea9568749bb
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
 )
 
-file(INSTALL ${HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME gsl-lite.hpp)
-file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/gsl-lite RENAME copyright)
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/gsl-lite" TARGET_PATH "share/gsl-lite")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
+#define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
+#pragma message(\"The header <gsl-lite.hpp> is deprecated and provided only for compatibility; please include <gsl/gsl-lite.hpp> instead.\")
+#include <gsl/gsl-lite.hpp>
+#endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED")
+
+file(
+    INSTALL "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/gsl-lite"
+    RENAME copyright)

--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -12,13 +12,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/gsl-lite" TARGET_PATH "share/gsl-lite")
-
-file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/lib"
-    "${CURRENT_PACKAGES_DIR}/debug"
-)
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/gsl-lite")
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
 #define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
@@ -26,7 +20,9 @@ file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VC
 #include <gsl/gsl-lite.hpp>
 #endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED")
 
-file(
-    INSTALL "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/gsl-lite"
-    RENAME copyright)
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/debug"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/telnetpp/CONTROL
+++ b/ports/telnetpp/CONTROL
@@ -1,8 +1,8 @@
 Source: telnetpp
-Version: 2.0-2
+Version: 2.0-3
 Homepage: https://github.com/KazDragon/telnetpp
 Description: Telnet++ is an implementation of the Telnet Session Layer protocol using C++14
-Build-Depends: boost-container, boost-signals2, boost-variant, gtest, gsl-lite, boost-exception
+Build-Depends: boost-container, boost-signals2, boost-variant, gsl-lite, boost-exception
 Default-Features: zlib
 
 Feature: zlib

--- a/ports/telnetpp/fix-build-error.patch
+++ b/ports/telnetpp/fix-build-error.patch
@@ -1,18 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 09b4f9b..feb3746 100644
+index 09b4f9b..6f72c41 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -22,9 +22,6 @@ message("Building Telnet++ with zlib: ${TELNETPP_WITH_ZLIB}")
+@@ -22,8 +22,8 @@ message("Building Telnet++ with zlib: ${TELNETPP_WITH_ZLIB}")
  message("Building Telnet++ with code coverage: ${TELNETPP_COVERAGE}")
  message("Building Telnet++ with sanitizers: ${TELNETPP_SANITIZE}")
  
 -include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 -conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
--
++find_package(gsl-lite REQUIRED)
++find_package(Boost REQUIRED COMPONENTS container)
+ 
  # The required C++ Standard for Telnet++ is C++14.
  set(CMAKE_CXX_STANDARD 14)
- 
-@@ -154,18 +151,24 @@ add_library(telnetpp
+@@ -154,18 +154,24 @@ add_library(telnetpp
      ${TELNETPP_PRIVATE_INCLUDE_FILES}
  )
  
@@ -28,9 +29,9 @@ index 09b4f9b..feb3746 100644
 -        CONAN_PKG::boost_container
 -        CONAN_PKG::boost_signals2
 -        CONAN_PKG::boost_variant
-+        ${BOOST_CONTAINER_LIBRARY}
-+        ${BOOST_SIGNALS2_LIBRARY}
-+        ${BOOST_VARIANT_LIBRARY}
++        gsl::gsl-lite
++        Boost::boost
++        Boost::container
  )
  
  if (TELNETPP_WITH_ZLIB)
@@ -38,21 +39,21 @@ index 09b4f9b..feb3746 100644
      target_link_libraries(telnetpp
          PRIVATE
 -            CONAN_PKG::zlib
-+            ${ZLIB_LIBRARIES}
++            ZLIB::ZLIB
      )
  endif()
  
-@@ -180,7 +183,8 @@ target_include_directories(telnetpp
+@@ -179,8 +185,7 @@ set_target_properties(telnetpp
+ target_include_directories(telnetpp
      PUBLIC
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include/telnetpp-${TELNETPP_VERSION}>
+-        $<INSTALL_INTERFACE:include/telnetpp-${TELNETPP_VERSION}>
 -        "${Boost_INCLUDE_DIRS}"
-+        $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
-+        $<BUILD_INTERFACE:${GSL_INCLUDE_PATH}>
++        $<INSTALL_INTERFACE:include>
  )
  
  generate_export_header(telnetpp
-@@ -197,17 +201,19 @@ install(
+@@ -197,17 +202,19 @@ install(
          telnetpp
      EXPORT
          telnetpp-config
@@ -75,7 +76,7 @@ index 09b4f9b..feb3746 100644
  )
  
  export(
-@@ -221,7 +227,7 @@ install(
+@@ -221,7 +228,7 @@ install(
      EXPORT
          telnetpp-config
      DESTINATION
@@ -84,7 +85,7 @@ index 09b4f9b..feb3746 100644
  )
  
  include(CMakePackageConfigHelpers)
-@@ -236,7 +242,7 @@ install(
+@@ -236,7 +243,7 @@ install(
      FILES
          "${CMAKE_CURRENT_BINARY_DIR}/telnetpp-config-version.cmake"
      DESTINATION
@@ -93,24 +94,8 @@ index 09b4f9b..feb3746 100644
  )
  
  if (TELNETPP_WITH_TESTS)
-@@ -299,13 +305,13 @@ if (TELNETPP_WITH_TESTS)
-     target_link_libraries(telnetpp_tester
-         PRIVATE
-             telnetpp
--            CONAN_PKG::gtest
-+            GTest::GTest GTest::Main
-     )
- 
-     if (TELNETPP_WITH_ZLIB)
-         target_link_libraries(telnetpp_tester
-             PRIVATE
--                CONAN_PKG::zlib
-+                ${ZLIB_LIBRARIES}
-         )
-     endif()
- 
 diff --git a/include/telnetpp/core.hpp b/include/telnetpp/core.hpp
-index 2362fac..48d340e 100644
+index 2362fac..8710d36 100644
 --- a/include/telnetpp/core.hpp
 +++ b/include/telnetpp/core.hpp
 @@ -1,7 +1,7 @@
@@ -118,35 +103,18 @@ index 2362fac..48d340e 100644
  
  #include "telnetpp/detail/export.hpp"
 -#include <gsl-lite.h>
-+#include <gsl-lite.hpp>
++#include <gsl/gsl-lite.hpp>
  #include <string>
  #include <cstdint>
  
-diff --git a/include/telnetpp/subnegotiation.hpp b/include/telnetpp/subnegotiation.hpp
-index a209b72..1f24fc9 100644
---- a/include/telnetpp/subnegotiation.hpp
-+++ b/include/telnetpp/subnegotiation.hpp
-@@ -15,7 +15,11 @@ public:
-     //* =====================================================================
-     /// \brief Constructor
-     //* =====================================================================
-+#if _WIN32
-+    const subnegotiation(option_type option, bytes content) noexcept
-+#else
-     constexpr subnegotiation(option_type option, bytes content) noexcept
-+#endif
-       : option_(std::move(option)),
-         content_(std::move(content))
-     {
-@@ -32,7 +36,11 @@ public:
-     //* =====================================================================
-     /// \brief Returns the content for this subnegotiation.
-     //* =====================================================================
-+#if _WIN32
-+    const bytes content() const noexcept
-+#else
-     constexpr bytes content() const noexcept
-+#endif
-     {
-         return content_;
-     }
+diff --git a/src/options/msdp/detail/decoder.cpp b/src/options/msdp/detail/decoder.cpp
+index c0b7906..e725693 100644
+--- a/src/options/msdp/detail/decoder.cpp
++++ b/src/options/msdp/detail/decoder.cpp
+@@ -1,5 +1,6 @@
+ #include "telnetpp/options/msdp/detail/decoder.hpp"
+ #include "telnetpp/options/msdp/detail/protocol.hpp"
++#include <vector>
+ #include <cassert>
+ #include <functional>
+ 

--- a/ports/telnetpp/portfile.cmake
+++ b/ports/telnetpp/portfile.cmake
@@ -2,8 +2,6 @@ if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
 
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO KazDragon/telnetpp


### PR DESCRIPTION
- ***What does your PR fix?***

  This PR updates the version of *gsl-lite* to 0.36.0, cf. https://github.com/gsl-lite/gsl-lite/releases/tag/v0.36.0.

  *gsl-lite* recently moved to a new location, https://github.com/gsl-lite/gsl-lite/. This PR also updates the URL to point to the new location of the library.

  The previous portfile simply obtained the "gsl-lite.hpp" header file and deployed it to "${CURRENT_PACKAGES_DIR}/include". The new portfile now uses proper CMake installation instead of just deploying the header file, which has the following benefits:

  - the header is now installed to the correct location (\<gsl/gsl-lite.hpp\> rather than \<gsl-lite.hpp\>)
  - the additional header \<gsl-lite/gsl-lite.hpp\> is also installed
  - the imported CMake targets `gsl::gsl-lite`, `gsl::gsl-lite-v0`, and `gsl::gsl-lite-v1` are now accessible to other projects via `find_package()`

  The new portfile still generates the legacy header \<gsl-lite.hpp\>, but it produces a diagnostic and simply forwards to the proper header \<gsl/gsl-lite.hpp\>:

  ```c++
  #ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
  #define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
  #pragma message("The header <gsl-lite.hpp> is deprecated; please include <gsl/gsl-lite.hpp> instead.")
  #include <gsl/gsl-lite.hpp>
  #endif // GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
  ```

- ***Which triplets are supported/not supported?*** All triplets should be supported. ***Have you updated the CI baseline?*** No.

- ***Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?*** Yes (I think)