### PR TITLE
[azure-storage-cpp] Azure storage only requires gettext on OSX

### DIFF
--- a/ports/azure-storage-cpp/CONTROL
+++ b/ports/azure-storage-cpp/CONTROL
@@ -1,6 +1,6 @@
 Source: azure-storage-cpp
-Version: 7.1.0
-Build-Depends: cpprestsdk[core], atlmfc (windows), boost-log (!windows&!uwp), boost-locale (!windows&!uwp), libxml2 (!windows&!uwp), libuuid (!windows&!uwp&!osx), gettext
+Version: 7.1.0-1
+Build-Depends: cpprestsdk[core], atlmfc (windows), boost-log (!windows&!uwp), boost-locale (!windows&!uwp), libxml2 (!windows&!uwp), libuuid (!windows&!uwp&!osx), gettext (osx)
 Description: Microsoft Azure Storage Client SDK for C++
   A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues. This client library enables working with the Microsoft Azure storage services which include the blob service for storing binary and text data, the file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
 Homepage: https://blogs.msdn.com/b/windowsazurestorage/

--- a/ports/azure-storage-cpp/portfile.cmake
+++ b/ports/azure-storage-cpp/portfile.cmake
@@ -1,8 +1,4 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "${PORT} does not currently support UWP")
-endif()
-
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -19,7 +15,10 @@ vcpkg_configure_cmake(
         -DCMAKE_FIND_FRAMEWORK=LAST
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF
-        -DGETTEXT_LIB_DIR=${CURRENT_INSTALLED_DIR}/include
+    OPTIONS_RELEASE
+        -DGETTEXT_LIB_DIR=${CURRENT_INSTALLED_DIR}/lib
+    OPTIONS_DEBUG
+        -DGETTEXT_LIB_DIR=${CURRENT_INSTALLED_DIR}/debug/lib
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
**Qualifies `azure-storage-cpp`'s dependency on `gettext` to only on OSX**

- What does your PR fix?

azure-storage-cpp does not use gettext directly on any platforms; however I believe it is transitively used by the system copy of libuuid on OSX. The best solution would be to transition to using the vcpkg copy of libuuid, however until then there's no reason to pessimize other platforms.
