### PR TITLE
[gettext] Fix Unicode path support on Windows

### DIFF
--- a/ports/gettext/0003-Fix-win-unicode-paths.patch
+++ b/ports/gettext/0003-Fix-win-unicode-paths.patch
@@ -1,0 +1,60 @@
+diff --git "a/gettext-runtime/intl/loadmsgcat.c" "b/gettext-runtime/intl/loadmsgcat.c"
+index 63351523..c078de3f 100644
+--- a/gettext-runtime/intl/loadmsgcat.c
++++ b/gettext-runtime/intl/loadmsgcat.c
+@@ -477,6 +477,55 @@ char *alloca ();
+ # define munmap(addr, len)	__munmap (addr, len)
+ #endif
+ 
++#ifdef _WIN32
++/* Provide wrapper of "open" for Windows that supports UTF-8 filenames. */
++# ifndef WIN32_LEAN_AND_MEAN
++#  define WIN32_LEAN_AND_MEAN
++# endif
++# ifndef WIN32_EXTRA_LEAN
++#  define WIN32_EXTRA_LEAN
++# endif
++# undef NOMINMAX
++# define NOMINMAX
++# include <Windows.h>	// For: MultiByteToWideChar
++# include <io.h>
++# include <wchar.h>
++
++int _open_utf8_windows_wrapper(
++   const char *filename,
++   int flags
++)
++{
++	int wstr_len = -1;
++	wchar_t* pUtf16FileName = NULL;
++	int fh = -1;
++
++	// on Windows, convert the filename from UTF-8 to UTF-16
++	wstr_len = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
++	if (wstr_len <= 0)
++	{
++		// MultiByteToWideChar failed
++		errno = ENOENT;
++		return -1;
++	}
++	pUtf16FileName = malloc(wstr_len * sizeof(wchar_t));
++	if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, pUtf16FileName, wstr_len) == 0)
++	{
++		// MultiByteToWideChar failed
++		free(pUtf16FileName);
++		errno = ENOENT;
++		return -1;
++	}
++
++	// and call _wopen
++	fh = _wopen(pUtf16FileName, flags);
++
++	free(pUtf16FileName);
++	return fh;
++}
++# define open(name, flags)	_open_utf8_windows_wrapper(name, flags)
++#endif // #ifdef _WIN32
++
+ /* For those losing systems which don't have `alloca' we have to add
+    some additional code emulating it.  */
+ #ifdef HAVE_ALLOCA

--- a/ports/gettext/CMakeLists.txt
+++ b/ports/gettext/CMakeLists.txt
@@ -120,7 +120,7 @@ if(NOT WIN32)
     target_link_libraries(libintl PRIVATE Threads::Threads)
 endif()
 if (WIN32)
-    target_link_libraries(libintl PRIVATE Advapi32.lib)
+    target_link_libraries(libintl PRIVATE kernel32.lib Advapi32.lib)
 endif()
 
 install(TARGETS libintl

--- a/ports/gettext/CONTROL
+++ b/ports/gettext/CONTROL
@@ -1,5 +1,5 @@
 Source: gettext
-Version: 0.19-13
+Version: 0.19-14
 Homepage: https://www.gnu.org/software/gettext/
 Description: The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.
 Build-Depends: libiconv

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -25,6 +25,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         0001-Fix-macro-definitions.patch
         0002-Fix-uwp-build.patch
+        0003-Fix-win-unicode-paths.patch
 )
 
 file(COPY


### PR DESCRIPTION
Fixes Unicode path support on Windows.

Gettext uses [`open`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open?view=vs-2019) internally, which does *not* support / expect UTF-8 filenames on the MSVCRT.

> How to reproduce:
> - Use gettext on Windows, call `bindtextdomain` with a UTF-8 dirname containing characters outside of the ASCII range (as works on other platforms)

This PR adds a new patch, which provides a wrapper for `open` that converts the input UTF-8 `char*` to UTF-16 and then calls [`_wopen`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen?view=vs-2019).

- What does your PR fix?

Fixes issue #9854

> gettext fails to load message catalogs from dirnames containing non-ASCII Unicode characters

- Which triplets are supported/not supported? Have you updated the CI baseline?

No change to CI baseline. (This only impacts Windows triplets.)

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

CONTROL file updated.
