### PR TITLE
[Portaudio] Disable debug logging by default

### DIFF
--- a/ports/portaudio/CONTROL
+++ b/ports/portaudio/CONTROL
@@ -1,4 +1,4 @@
 Source: portaudio
-Version: 2019-11-5
+Version: 2020-02-02
 Homepage: https://app.assembla.com/spaces/portaudio/wiki
 Description: PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -12,12 +12,19 @@ vcpkg_from_git(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
+    OPTIONS_RELEASE
         -DPA_USE_DS=ON
         -DPA_USE_WASAPI=ON
         -DPA_USE_WDMKS=ON
         -DPA_USE_WMME=ON
         -DPA_LIBNAME_ADD_SUFFIX=OFF
+    OPTIONS_DEBUG
+    	-DPA_USE_DS=ON
+        -DPA_USE_WASAPI=ON
+        -DPA_USE_WDMKS=ON
+        -DPA_USE_WMME=ON
+        -DPA_LIBNAME_ADD_SUFFIX=OFF
+        -DPA_ENABLE_DEBUG_OUTPUT:BOOL=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_configure_cmake(
         -DPA_USE_WASAPI=ON
         -DPA_USE_WDMKS=ON
         -DPA_USE_WMME=ON
-        -DPA_ENABLE_DEBUG_OUTPUT:BOOL=ON
         -DPA_LIBNAME_ADD_SUFFIX=OFF
 )
 

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -12,18 +12,13 @@ vcpkg_from_git(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS_RELEASE
-        -DPA_USE_DS=ON
-        -DPA_USE_WASAPI=ON
-        -DPA_USE_WDMKS=ON
-        -DPA_USE_WMME=ON
-        -DPA_LIBNAME_ADD_SUFFIX=OFF
-    OPTIONS_DEBUG
+    OPTIONS
     	-DPA_USE_DS=ON
         -DPA_USE_WASAPI=ON
         -DPA_USE_WDMKS=ON
         -DPA_USE_WMME=ON
         -DPA_LIBNAME_ADD_SUFFIX=OFF
+    OPTIONS_DEBUG
         -DPA_ENABLE_DEBUG_OUTPUT:BOOL=ON
 )
 


### PR DESCRIPTION
This PR removes the debug output that is on by default for every client of VCPKG that uses portaudio. This debug logging appears on stderr and is in debug and release builds. This should be an opt in feature and I'm not sure the performance cost (probably not much).

The workaround to redirect the output from stderr to somewhere else can't be used AFAIK with the current set of headers installed by VCPKG. 