### PR TITLE
[soci] fixed SOCI_CXX11 flag

### DIFF
--- a/ports/soci/CONTROL
+++ b/ports/soci/CONTROL
@@ -1,5 +1,5 @@
 Source: soci
-Version: 4.0.0
+Version: 4.0.0-1
 Homepage: https://github.com/SOCI/soci
 Description: SOCI database access library
 

--- a/ports/soci/portfile.cmake
+++ b/ports/soci/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SOCI/soci

--- a/ports/soci/portfile.cmake
+++ b/ports/soci/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DSOCI_TESTS=OFF
-        -DSOCI_CXX_C11=ON
+        -DSOCI_CXX11=ON
         -DSOCI_LIBDIR:STRING=lib # This is to always have output in the lib folder and not lib64 for 64-bit builds
         -DLIBDIR:STRING=lib
         -DSOCI_STATIC=${SOCI_STATIC}


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #

the flag was renamed in 02a5cae2c5640f2147ef7399497f8b444c40d9bf, which is ancestor of 3742c894ab8ba5fd51b6a156980e8b34db0f3063 that is used in vcpkg.

- Which triplets are supported/not supported? Have you updated the CI baseline?

All. No.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I hope so.
