### PR TITLE
[freetype] Remove feature 'harfbuzz'

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,5 @@
 Source: freetype
-Version: 2.10.1-3
+Version: 2.10.1-4
 Build-Depends: zlib
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.
@@ -8,10 +8,6 @@ Default-Features: bzip2, png
 Feature: bzip2
 Build-Depends: bzip2
 Description: Support bzip2 compressed fonts.
-
-Feature: harfbuzz
-Build-Depends: harfbuzz
-Description: Improve auto-hinting of OpenType fonts.
 
 Feature: png
 Build-Depends: libpng

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -19,11 +19,9 @@ vcpkg_extract_source_archive_ex(
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         bzip2       FT_WITH_BZIP2
-        harfbuzz    FT_WITH_HARFBUZZ
         png         FT_WITH_PNG
     INVERTED_FEATURES
         bzip2       CMAKE_DISABLE_FIND_PACKAGE_BZip2
-        harfbuzz    CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz
         png         CMAKE_DISABLE_FIND_PACKAGE_PNG
 )
 


### PR DESCRIPTION
Fix related issue https://github.com/microsoft/vcpkg/issues/9850

PR https://github.com/microsoft/vcpkg/pull/9706/ added harfbuzz as a feature to freetype, however, we have harfbuzz which depend on freetype, so it failed with 'cycle detected', considered other ports also depend on harfbuzz, so remove feature 'harfbuzz' from freetype.

All features test pass on x86-windows and x64-windows.