### PR TITLE
[protobuf]: upgrade to v3.11.3

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.11.2
+Version: 3.11.3
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.11.2
-    SHA512 8319c1e003e5fc64e91b512de016ec1cf10265b294d3b4beea60856beaeb02b4d7682343c74b2c12b0f6d4d6258451af9b9d72bcb4b495293b7637da21030c8f
+    REF v3.11.3
+    SHA512 beac21d495bfd8e9b40120d1db9fd82251958f954533fc6f76cd0b9c28f92533ac35368a4c298ebb1d8e09047b670ed3bd948bb7da6eb5cca7fdc0c1c44aa39b
     HEAD_REF master
     PATCHES
         fix-uwp.patch

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf


### PR DESCRIPTION
Upgrade protobuf to v3.11.3, this release includes important fixes for protobuf generated code on Windows.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Same triplets as before, no need to update the ci baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so.
