### PR TITLE
[vtk] Fix dependency proj4 library name in cmake

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-10
+Version: 8.2.0-11
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -1,8 +1,6 @@
-if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     message(WARNING "You will need to install Xorg dependencies to build vtk:\napt-get install libxt-dev\n")
 endif()
-
-include(vcpkg_common_functions)
 
 set(VTK_SHORT_VERSION "8.2")
 set(VTK_LONG_VERSION "${VTK_SHORT_VERSION}.0")
@@ -83,9 +81,13 @@ if(VTK_WITH_ALL_MODULES)
     )
 endif()
 
-set(PROJ_LIBRARY_REL "${CURRENT_INSTALLED_DIR}/lib/proj.lib")
-set(PROJ_LIBRARY_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/proj_d.lib")
-
+if (VCPKG_TARGET_IS_WINDOWS)
+    set(PROJ_LIBRARY_REL "${CURRENT_INSTALLED_DIR}/lib/proj.lib")
+    set(PROJ_LIBRARY_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/proj_d.lib")
+else()
+    set(PROJ_LIBRARY_REL "${CURRENT_INSTALLED_DIR}/lib/libproj.a")
+    set(PROJ_LIBRARY_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/libproj.a")
+endif()
 # =============================================================================
 # Configure & Install
 
@@ -250,7 +252,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # =============================================================================
 # Handle copyright
-file(COPY ${SOURCE_PATH}/Copyright.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/vtk)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/vtk/Copyright.txt ${CURRENT_PACKAGES_DIR}/share/vtk/copyright)
+file(INSTALL ${SOURCE_PATH}/Copyright.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/vtk)


### PR DESCRIPTION
The proj4 debug / release library name specified in vtk is now stable (named `proj4.lib`), causing linking issues when using vtk.
So I fixed the isuee based on the platform.

Related: #8718.

All features have been tested successfully in the following triplets:
- x86-windows