### PR TITLE
[cgltf] Update to 1.5

### DIFF
--- a/ports/cgltf/CONTROL
+++ b/ports/cgltf/CONTROL
@@ -1,3 +1,3 @@
 Source: cgltf
-Version: 1.3
+Version: 1.5
 Description: Single-file glTF 2.0 parser written in C99

--- a/ports/cgltf/CONTROL
+++ b/ports/cgltf/CONTROL
@@ -1,3 +1,4 @@
 Source: cgltf
 Version: 1.5
-Description: Single-file glTF 2.0 parser written in C99
+Homepage: https://github.com/jkuhlmann/cgltf
+Description: Single-file glTF 2.0 loader and writer written in C99

--- a/ports/cgltf/portfile.cmake
+++ b/ports/cgltf/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
 )
 
 file(COPY ${SOURCE_PATH}/cgltf.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY ${SOURCE_PATH}/cgltf_write.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/ports/cgltf/portfile.cmake
+++ b/ports/cgltf/portfile.cmake
@@ -5,8 +5,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jkuhlmann/cgltf
-    REF v1.3
-    SHA512 4fc68654b7903a21156d900184626d1325421092f0dd060b9f20cff1dec29d0a057fc1f3b4e79e36a0cfc6bc7447f7c2ac8a0ecb78c85a337356908a9c69478e
+    REF v1.5
+    SHA512 b27b4f221a09aba1b4fa316ae5c4117f28592c717d606668d9c7e5986f8a9787014467b7c8e545194c69a4df6c7be7a797a16b26081df202da9ffd3a7ccc202f
     HEAD_REF master
 )
 


### PR DESCRIPTION
Update cgltf to v1.5 and copy the `cgltf_write.h` header, which was missing before.