### PR TITLE
[nng] Update nng to version 1.2.5

### DIFF
--- a/ports/nng/CONTROL
+++ b/ports/nng/CONTROL
@@ -1,5 +1,5 @@
 Source: nng
-Version: 2019-02-27
+Version: v1.2.5
 Description: NNG, like its predecessors nanomsg (and to some extent ZeroMQ), is a lightweight, broker-less library, offering a simple API to solve common recurring messaging problems, such as publish/subscribe, RPC-style request/reply, or service discovery.
 
 Feature: mbedtls

--- a/ports/nng/portfile.cmake
+++ b/ports/nng/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanomsg/nng
-    REF ddeac617c9914284038241870cb99ae174fb3755
-    SHA512 c45f322dfa3fba42db0561d95546159cc5e0768345d27f0bee53bdb71e77d5892e2e9bea50a625094ebf3c67b0c3fe0a8edea2660ebcb4fd0991fb0602055bc1
+    REF v1.2.5
+    SHA512 41abf4d7e49f82d0c627db45730ed4751f302758210a21d646037d6f7e1a04998aa590a7aae8e4726d1dcaec723fc9bb9d5f405c34620212b8da5d1b8c34bce8
     HEAD_REF master
 )
 

--- a/ports/nngpp/CONTROL
+++ b/ports/nngpp/CONTROL
@@ -1,5 +1,5 @@
 Source: nngpp
-Version: 2019-07-25
+Version: nng-v1.2.4
 Homepage:https://github.com/cwzx/nngpp
 Description: C++ wrapper around the nanomsg NNG API.
 Build-Depends: nng

--- a/ports/nngpp/portfile.cmake
+++ b/ports/nngpp/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cwzx/nngpp
-    REF 3351f54e6e774505d8d8b88064d04eb98e0b1cda
-    SHA512 6f72d1085b58ee7a8941294e7479661d8fc2c22cc8af2cee9c2cef11d508032a860c0061851bda07cf995ec8f57e5a25e241a15114a91c487d8aad6def2d4ce5
+    REF nng-v1.2.4
+    SHA512 6f30bacbf46c00c606099407e4d92d607c6010e8460b7abe25855befad1ecc67900bddcdb9aef86d7233dabb1feb8f94946618fc66cc37d2a7f982f470713f5a
     HEAD_REF master
 )
 


### PR DESCRIPTION
this PR updates the version nng to the latest (v1.2.5) in order for it to work correctly with nngpp.