### PR TITLE
[qhull] Fix target cannot be found by cmake

### DIFF
--- a/ports/qhull/CONTROL
+++ b/ports/qhull/CONTROL
@@ -1,4 +1,4 @@
 Source: qhull
-Version: 7.3.2-2
+Version: 7.3.2-3
 Homepage: https://github.com/qhull/qhull
 Description: computes the convex hull, Delaunay triangulation, Voronoi diagram

--- a/ports/qhull/fix-target-cannot-found.patch
+++ b/ports/qhull/fix-target-cannot-found.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 14df8e9..97ec1d3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -335,7 +335,7 @@ set(
+ 
+ include_directories(${CMAKE_SOURCE_DIR}/src)
+ 
+-if(CMAKE_BUILD_TYPE MATCHES "[dD]ebug")
++if(0)
+     set(qhull_CPP qhullcpp_d)
+     set(qhull_SHARED qhull_d) 
+     set(qhull_SHAREDP qhull_pd)
+@@ -354,9 +354,12 @@ endif()
+ set(
+     qhull_TARGETS_INSTALL
+         ${qhull_CPP} ${qhull_STATIC} ${qhull_STATICR} ${qhull_SHAREDR}
+-        qhull rbox qconvex qdelaunay qvoronoi qhalf
+         ${qhull_SHARED} ${qhull_SHAREDP}  # Deprecated, use qhull_r instead
+ )
++set(
++    qhull_TARGETS_TOOL
++        qhull rbox qconvex qdelaunay qvoronoi qhalf
++)
+ set(
+     qhull_TARGETS_TEST   # Unused
+         user_eg user_eg2 user_eg3 user_egp testqset testqset_r
+@@ -622,6 +625,9 @@ install(TARGETS ${qhull_TARGETS_INSTALL} EXPORT QhullTargets
+         LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+         INCLUDES DESTINATION include)
++        
++install(TARGETS ${qhull_TARGETS_TOOL} EXPORT QhullTargets
++        RUNTIME DESTINATION tool)
+ 
+ include(CMakePackageConfigHelpers)
+ 

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO qhull/qhull
@@ -9,21 +7,9 @@ vcpkg_from_github(
     PATCHES
         uwp.patch
         mac-fix.patch
+        fix-target-cannot-found.patch
 )
-if(${TARGET_TRIPLET} STREQUAL "x64-windows-static") 
-# workaround for visual studio toolset regression LNK1201 (remove if solved)
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS 
-        -DINCLUDE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/include
-        -DMAN_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
-        -DDOC_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/doc/qhull
-    OPTIONS_RELEASE
-        -DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib
-    OPTIONS_DEBUG
-        -DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib
-)
-else()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -36,7 +22,6 @@ vcpkg_configure_cmake(
     OPTIONS_DEBUG
         -DLIB_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib
 )
-endif()
 
 vcpkg_install_cmake()
 
@@ -47,23 +32,11 @@ file(GLOB_RECURSE HTMFILES ${CURRENT_PACKAGES_DIR}/include/*.htm)
 file(REMOVE ${HTMFILES})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc)
 
-file(GLOB EXEFILES_RELEASE ${CURRENT_PACKAGES_DIR}/bin/*.exe)
-file(GLOB EXEFILES_DEBUG ${CURRENT_PACKAGES_DIR}/debug/bin/*.exe)
-file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/qhull)
-if(EXEFILES_RELEASE OR EXEFILES_DEBUG)
-    file(REMOVE ${EXEFILES_RELEASE} ${EXEFILES_DEBUG})
-endif()
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_d.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_p.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_pd.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_r.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_rd.lib)
-else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhullcpp.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhullcpp_d.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhullstatic.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhullstatic_d.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhullstatic_r.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhullstatic_rd.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_p.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_p.lib)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/qhull_r.lib ${CURRENT_PACKAGES_DIR}/debug/lib/qhull_r.lib)
 endif()
 
-file(COPY ${SOURCE_PATH}/README.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/qhull)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/qhull/README.txt ${CURRENT_PACKAGES_DIR}/share/qhull/copyright)
+file(INSTALL ${SOURCE_PATH}/README.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
When we using `find_package(Qhull CONFIG REQUIRED)` to find `Qhull`, it will always use `QhullTargets-debug.cmake` and all the targets are not found.
Since before exporting targets, all libs are added suffix `-d` if build debug type.

I remove the suffix `-d ` and also do the related changes.

Related issue #9836 

Note: No feature needs to test.
