### PR TITLE
Add post-build usage info for Lua port.

### DIFF
--- a/ports/lua/CONTROL
+++ b/ports/lua/CONTROL
@@ -1,5 +1,5 @@
 Source: lua
-Version: 5.3.5-2
+Version: 5.3.5-3
 Homepage: https://www.lua.org
 Description: a powerful, fast, lightweight, embeddable scripting language
 

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -51,4 +51,6 @@ vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/lua)
 
 # Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/lua/copyright)
+# Copy post-build CMake instructions
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/lua)
 vcpkg_copy_pdbs()

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -51,6 +51,6 @@ vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/lua)
 
 # Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/lua/copyright)
-# Copy post-build CMake instructions
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/lua)
+# Handle post-build CMake instructions
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/lua)
 vcpkg_copy_pdbs()

--- a/ports/lua/usage
+++ b/ports/lua/usage
@@ -1,0 +1,9 @@
+Use this package via the module FindLua that comes with CMake. To use in your CMakeLists.txt:
+
+    include(FindLua)
+    find_package(lua REQUIRED)
+    target_link_libraries(main PRIVATE ${LUA_LIBRARIES})
+    target_include_directories(main PRIVATE ${LUA_INCLUDE_DIR})
+
+For more information about the variables set by this module, please see:
+    https://cmake.org/cmake/help/latest/module/FindLua.html


### PR DESCRIPTION
Currently there are no instructions for using the Lua package after installation. This adds the necessary info.

- What does your PR fix? n/a

- Which triplets are supported/not supported? Have you updated the CI baseline?
n/a?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I believe so.
