### PR TITLE
[fluidsynth] Update to 2.1.0

### DIFF
--- a/ports/fluidsynth/CONTROL
+++ b/ports/fluidsynth/CONTROL
@@ -1,4 +1,5 @@
 Source: fluidsynth
-Version: 2.0.5-1
+Version: 2.1.0
+Homepage: https://github.com/FluidSynth/fluidsynth
 Description: FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.
 Build-Depends: glib

--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO FluidSynth/fluidsynth
-    REF v2.0.5
-    SHA512 5344ac889d2927dc2465bae40096d756a9bf9b1100e287ba0621c55ffc76f9cb8fa763f6bc832d701cd0ad2997965cf344f58ae4b3dd445eb3491e3659c093d9
+    REF 37c9ae2bf431a764032f023b3b2c0c0b86b7c272 #v2.1.0
+    SHA512 1eea26b7d71fd09e748df0989f7df42ab57a74d8d853a835da734120ee1198c0b8d73a39b8640aef8ef0c1788c9a329671de899882601da55ec20ab6ca3ff778
     HEAD_REF master
     PATCHES
        force-x86-gentables.patch
@@ -31,4 +29,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/fluidsynth RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Update `fluidsynth ` to latest released version 2.1.0.

Related issue #9834 

Note: No feature needs to test.
