### PR TITLE
[freerdp] Fix include install path

### DIFF
--- a/ports/freerdp/CONTROL
+++ b/ports/freerdp/CONTROL
@@ -1,5 +1,5 @@
 Source: freerdp
-Version: 2.0.0-rc4-4
+Version: 2.0.0-rc4-5
 Homepage: https://github.com/FreeRDP/FreeRDP
 Description: A free implementation of the Remote Desktop Protocol (RDP)
 Build-Depends: openssl, glib (!windows)

--- a/ports/freerdp/fix-include-install-path.patch
+++ b/ports/freerdp/fix-include-install-path.patch
@@ -1,0 +1,26 @@
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index a020dc5..0bc1157 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -19,7 +19,7 @@
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/freerdp/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/freerdp/version.h)
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/freerdp/build-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/freerdp/build-config.h)
+-set(FREERDP_INSTALL_INCLUDE_DIR include/freerdp${FREERDP_VERSION_MAJOR}/freerdp)
++set(FREERDP_INSTALL_INCLUDE_DIR include/freerdp)
+ 
+ file(GLOB FREERDP_HEADERS "freerdp/*.h")
+ install(FILES ${FREERDP_HEADERS} DESTINATION ${FREERDP_INSTALL_INCLUDE_DIR} COMPONENT headers)
+diff --git a/winpr/include/CMakeLists.txt b/winpr/include/CMakeLists.txt
+index 452383d..3faab0c 100644
+--- a/winpr/include/CMakeLists.txt
++++ b/winpr/include/CMakeLists.txt
+@@ -17,7 +17,7 @@
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/winpr/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/winpr/version.h)
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/winpr/wtypes.h.in ${CMAKE_CURRENT_BINARY_DIR}/winpr/wtypes.h)
+-set(WINPR_INSTALL_INCLUDE_DIR include/winpr${WINPR_VERSION_MAJOR}/winpr)
++set(WINPR_INSTALL_INCLUDE_DIR include/winpr)
+ 
+ file(GLOB WINPR_HEADERS "winpr/*.h")
+ install(FILES ${WINPR_HEADERS} DESTINATION ${WINPR_INSTALL_INCLUDE_DIR} COMPONENT headers)

--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         DontInstallSystemRuntimeLibs.patch
         fix-linux-build.patch
         openssl_threads.patch
+        fix-include-install-path.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL "static")


### PR DESCRIPTION
Now `freerdp `install headers to _include/freerdp2/freerdp_ and _include/winpr2/winpr_.
They should be _include/freerdp_ and _include/winpr_.

So I remove the middle directory to fix this issue.

Related issue #9872 

Note: No feature needs to test.
