### PR TITLE
[google-cloud-cpp*] Upgrade to latest release

### DIFF
--- a/ports/google-cloud-cpp-common/CONTROL
+++ b/ports/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.16.0-1
+Version: 0.18.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ports/google-cloud-cpp-common/portfile.cmake
+++ b/ports/google-cloud-cpp-common/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-common
-    REF v0.16.0
-    SHA512 2325e4aa28cd883091a562f3de0390bb0139446920183487ed2fbc1e404c90ec6f5e42d5b6f59e1de65be66b61954bc4f66b3f441ad6ec89cd4591ce8ea3321d
+    REF v0.18.0
+    SHA512 030e9574b97667cf3495d206fe21fe6bdf0a2c84f31240c5cfcb82a9db6df77ccb15e000d1f1e56d8dd2a8231c97ed0d0a10c89baf147bc6408a8be2cb452f25
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/google-cloud-cpp-common/portfile.cmake
+++ b/ports/google-cloud-cpp-common/portfile.cmake
@@ -25,9 +25,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(
-    INSTALL ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-common
-    RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp-spanner/CONTROL
+++ b/ports/google-cloud-cpp-spanner/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-spanner
-Version: 0.5.0
+Version: 0.7.0
 Build-Depends: grpc, googleapis, google-cloud-cpp-common
 Description: C++ Client Library for Google Cloud Spanner.
 Homepage: https://github.com/googleapis/google-cloud-cpp-spanner

--- a/ports/google-cloud-cpp-spanner/portfile.cmake
+++ b/ports/google-cloud-cpp-spanner/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-spanner
-    REF v0.5.0
-    SHA512 66878f1de13f1825100c826042baceb7aba89ca3f451b24e9a49adf5f1f954d9d068ce033123bb2f692ccc60acce386a82e64599b8038d6e5096c7c7bd391d12
+    REF v0.7.0
+    SHA512 f3fea6ebe3431102c23737822d17e90d4d301f5854ec17834ee379013c92b1997ff10421ee5f82e35b651cd930dbb8d73e9aad50b754b3fe1395257fa4199dfb
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp-spanner/portfile.cmake
+++ b/ports/google-cloud-cpp-spanner/portfile.cmake
@@ -24,6 +24,6 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/share)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-spanner RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp
-Version: 0.17.0
+Version: 0.18.0
 Build-Depends: grpc, curl[ssl], crc32c, googleapis, google-cloud-cpp-common
 Description: C++ Client Libraries for Google Cloud Platform APIs.
 Homepage: https://github.com/googleapis/google-cloud-cpp

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -26,6 +26,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v0.17.0
-    SHA512 7bfa73db04fe8ff9344201eca8f56107fd895f18b3be44fca45a9f2d64224338980d04841de4418c5c1b7a8ac0768a60e93e5abbed9256567ca7b8bc2bf73cd9
+    REF v0.18.0
+    SHA512 e0678d928ccf5fe2f9ce8828091fb8e2b7d4c1ff41e347eb4bc8768d33997621693a2acf2a68fa11bfecf8f7f44fc95d15e59188b86769592cebcb3cf14cbd14
     HEAD_REF master
     PATCHES
         0001-fix-x86-build.patch

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -556,7 +556,6 @@ gmmlib:x86-windows=fail
 googleapis:arm64-windows=fail
 googleapis:arm-uwp=fail
 googleapis:x64-uwp=fail
-google-cloud-cpp:x64-linux=ignore
 google-cloud-cpp-spanner:x86-windows=fail
 gppanel:x64-osx=fail
 gperf:x64-uwp=fail


### PR DESCRIPTION
Upgrade `google-cloud-cpp-common`, `google-cloud-cpp` and `google-cloud-cpp-spanner` to the latest release of each. These all need to be upgraded simultaneously.  I also removed the (I understand obsolete) `include(vcpkg_common_functions)` commands on each portfile.

- What does your PR fix? Fixes issue #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

I removed `google-cloud-cpp:x64-linux=ignore` from the baseline because it compiles fine for me.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so.
