### PR TITLE
[vcpkg] Improve error messages when failing to find a backing port

### DIFF
--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -265,12 +265,11 @@ namespace vcpkg::Dependencies
                     m_port_provider.get_control_file(ipv.spec().name());
 
                 if (!maybe_scfl)
-                    Checks::exit_with_message(VCPKG_LINE_INFO,
-                                              "We could not find a CONTROL file for ",
-                                              ipv.spec().to_string(),
-                                              ". Please run \"vcpkg remove ",
-                                              ipv.spec().to_string(),
-                                              "\" and re-attempt.");
+                    Checks::exit_with_message(
+                        VCPKG_LINE_INFO,
+                        "We could not find a CONTROL file for '%s'. Please run \"vcpkg remove %s\" and re-attempt.",
+                        ipv.spec().to_string(),
+                        ipv.spec().to_string());
 
                 return m_graph
                     .emplace(std::piecewise_construct,
@@ -684,8 +683,8 @@ namespace vcpkg::Dependencies
                     }
 
                     // And it has at least one qualified dependency
-                    if (paragraph_depends && Util::any_of(*paragraph_depends,
-                                                         [](auto&& dep) { return !dep.qualifier.empty(); }))
+                    if (paragraph_depends &&
+                        Util::any_of(*paragraph_depends, [](auto&& dep) { return !dep.qualifier.empty(); }))
                     {
                         // Add it to the next batch run
                         qualified_dependencies.emplace_back(spec);
@@ -864,9 +863,9 @@ namespace vcpkg::Dependencies
                             continue;
                         }
                         auto&& dep_clust = m_graph->get(fspec.spec());
-                        const auto& default_features =
-                            [&]{
-                            if (dep_clust.m_install_info.has_value()) return dep_clust.m_scfl.source_control_file->core_paragraph->default_features;
+                        const auto& default_features = [&] {
+                            if (dep_clust.m_install_info.has_value())
+                                return dep_clust.m_scfl.source_control_file->core_paragraph->default_features;
                             if (auto p = dep_clust.m_installed.get()) return p->ipv.core->package.default_features;
                             Checks::unreachable(VCPKG_LINE_INFO);
                         }();

--- a/toolsrc/src/vcpkg/portfileprovider.cpp
+++ b/toolsrc/src/vcpkg/portfileprovider.cpp
@@ -85,15 +85,29 @@ namespace vcpkg::PortFileProvider
                 }
             }
 
-            auto found_scf = Paragraphs::try_load_port(filesystem, ports_dir / spec);
-            if (auto scf = found_scf.get())
+            if (filesystem.exists(ports_dir / spec / "CONTROL"))
             {
-                if (scf->get()->core_paragraph->name == spec)
+                auto found_scf = Paragraphs::try_load_port(filesystem, ports_dir / spec);
+                if (auto scf = found_scf.get())
                 {
-                    auto it = cache.emplace(std::piecewise_construct,
-                                            std::forward_as_tuple(spec),
-                                            std::forward_as_tuple(std::move(*scf), ports_dir / spec));
-                    return it.first->second;
+                    if (scf->get()->core_paragraph->name == spec)
+                    {
+                        auto it = cache.emplace(std::piecewise_construct,
+                                                std::forward_as_tuple(spec),
+                                                std::forward_as_tuple(std::move(*scf), ports_dir / spec));
+                        return it.first->second;
+                    }
+                    Checks::exit_with_message(VCPKG_LINE_INFO,
+                                              "Error: Failed to load port from %s: names did not match: '%s' != '%s'",
+                                              (ports_dir / spec).u8string(),
+                                              spec,
+                                              scf->get()->core_paragraph->name);
+                }
+                else
+                {
+                    vcpkg::print_error_message(found_scf.error());
+                    Checks::exit_with_message(
+                        VCPKG_LINE_INFO, "Error: Failed to load port from %s", spec, ports_dir.u8string());
                 }
             }
         }


### PR DESCRIPTION
This PR improves two areas:
1. Improved error messages when attempting to install a partially-created port
2. Display better error messages when working with an unbacked port. This is the issue reported in #9924 and this PR provides a partial workaround by instructing the user to remove the unbacked port.

- What does your PR fix?
Partially fixes issue #9924.
