### PR TITLE
[vtk] Fix dependency pugixml link type

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-10
+Version: 8.2.0-11
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/fix-pugixml-link.patch
+++ b/ports/vtk/fix-pugixml-link.patch
@@ -10,5 +10,5 @@ index ce979ba..322e2de 100644
 -  get_target_property(pugixml_LIBRARIES pugixml LOCATION)
 -  include_directories(${pugixml_INCLUDE_DIRS})
 -  vtk_module_link_libraries(vtkIOCityGML LINK_PRIVATE ${pugixml_LIBRARIES})
-+  vtk_module_link_libraries(vtkIOCityGML LINK_PRIVATE pugixml)
++  vtk_module_link_libraries(vtkIOCityGML LINK_PUBLIC pugixml)
  endif()


### PR DESCRIPTION
The way vtk links to pugixml should be `PUBLIC`, otherwise link errors will occur.
Fix this issue.

Related: #9947.