### PR TITLE
[libwebsockets] add libuv support

### DIFF
--- a/ports/libwebsockets/CMakeLists.patch
+++ b/ports/libwebsockets/CMakeLists.patch
@@ -1,8 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4daeec85e..34e5e197d 100644
---- a/CMakeLists.txt	
+index 7772ed0..656e5a0 100644
+--- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1822,7 +1822,7 @@ endif()
+@@ -1767,7 +1767,7 @@ endif(LWS_WITH_LIBEV)
+ if (LWS_WITH_LIBUV)
+ 	if (NOT LIBUV_FOUND)
+ 		find_path(LIBUV_INCLUDE_DIRS NAMES uv.h)
+-		find_library(LIBUV_LIBRARIES NAMES uv)
++		find_library(LIBUV_LIBRARIES NAMES uv libuv)
+ 		if(LIBUV_INCLUDE_DIRS AND LIBUV_LIBRARIES)
+ 			set(LIBUV_FOUND 1)
+ 		endif()
+@@ -1826,7 +1826,7 @@ endif()
  if (WINCE)
  	list(APPEND LIB_LIST ws2.lib)
  elseif (WIN32)

--- a/ports/libwebsockets/CONTROL
+++ b/ports/libwebsockets/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebsockets
 Version: 3.2.2
-Build-Depends: zlib, openssl
+Build-Depends: zlib, openssl, libuv
 Homepage: https://github.com/warmcat/libwebsockets
 Description: Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.

--- a/ports/libwebsockets/CONTROL
+++ b/ports/libwebsockets/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebsockets
-Version: 3.2.2
+Version: 3.2.2-1
 Build-Depends: zlib, openssl, libuv
 Homepage: https://github.com/warmcat/libwebsockets
 Description: Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
@@ -141,6 +139,7 @@ vcpkg_configure_cmake(
         -DLWS_IPV6=ON
         -DLWS_HTTP2=ON
         -DLWS_WITH_HTTP_STREAM_COMPRESSION=ON # Since zlib is already a dependency
+        -DLWS_WITH_LIBUV=ON
     # OPTIONS_RELEASE -DOPTIMIZE=1
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )


### PR DESCRIPTION
Add libuv support to libwebsockets.

I'm trying to build [ttyd](https://github.com/tsl0922/ttyd) with vcpkg, requires libuv support for libwebsockets.
