### PR TITLE
[googleapis]: Upgrade to v0.4.1 release.

### DIFF
--- a/ports/googleapis/CONTROL
+++ b/ports/googleapis/CONTROL
@@ -1,5 +1,5 @@
 Source: googleapis
-Version: 0.1.5
+Version: 0.4.1
 Build-Depends: grpc, protobuf
 Description: C++ Proto Libraries for Google APIs.
 Homepage: https://github.com/googleapis/cpp-cmakefiles

--- a/ports/googleapis/portfile.cmake
+++ b/ports/googleapis/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if (VCPKG_TARGET_IS_UWP)
     message(FATAL_ERROR "Package `googleapis` doesn't support UWP")
 endif()
@@ -9,8 +7,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/cpp-cmakefiles
-    REF v0.1.5
-    SHA512 7c940cd60490c64b67b608b10dc85f8be33b370737e0d2a6c73015fc5b9b921b07aceef672f6cdef86878d766e4f2c89af28869e06677ca1ddbbf11fe8b5f963
+    REF v0.4.1
+    SHA512 b854833b74ae10aa249ee3926f0faa766a2d9dc82283a33d21b6e933a6b1feee0b0ba711f258b2a9face0de0f4f5e7bb87230fb8dd45ba7be279903ee00c1d8a
     HEAD_REF master
 )
 
@@ -25,7 +23,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/googleapis RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
Upgrade the googleapis package to the latest release (v0.4.1)

- What does your PR fix? Fixes issue #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so.

