### PR TITLE
[python3] Modernize port + added --enable-shared

### DIFF
--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -1,5 +1,8 @@
 Source: python3
-Version: 3.7.3
+Version: 3.7.3-1
 Homepage: https://github.com/python/cpython
 Description: The Python programming language as an embeddable library
 Build-Depends: libffi, openssl
+
+Feature: enable-shared
+Description: Build shared libraries in addition to static ones built by default

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -8,8 +8,6 @@ set(PYTHON_VERSION_MINOR  7)
 set(PYTHON_VERSION_PATCH  3)
 set(PYTHON_VERSION        ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.${PYTHON_VERSION_PATCH})
 
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH TEMP_SOURCE_PATH
     REPO python/cpython
@@ -18,14 +16,23 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if("enable-shared" IN_LIST FEATURES)
+	set(_ENABLED_SHARED --enable-shared)
+else()
+	unset(_ENABLED_SHARED)
+endif()
+
 if (VCPKG_TARGET_IS_WINDOWS)
+	if(DEFINED _ENABLED_SHARED)
+		message(WARNING "enable-shared requested, by Windows build already produce a shared library by default")
+	endif()
 	set(SOURCE_PATH "${TEMP_SOURCE_PATH}-Lib-Win")
 	file(REMOVE_RECURSE ${SOURCE_PATH})
 	file(RENAME "${TEMP_SOURCE_PATH}" ${SOURCE_PATH})
-	
+
 	# We need per-triplet directories because we need to patch the project files differently based on the linkage
 	# Because the patches patch the same file, they have to be applied in the correct order
-	
+
 	if (VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
 		set(BUILD_ARCH "Win32")
 		set(OUT_DIR "win32")
@@ -41,29 +48,40 @@ if (VCPKG_TARGET_IS_WINDOWS)
 		PLATFORM ${BUILD_ARCH})
 
 	file(GLOB HEADERS ${SOURCE_PATH}/Include/*.h)
-	file(COPY ${HEADERS} ${SOURCE_PATH}/PC/pyconfig.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-	file(COPY ${SOURCE_PATH}/Lib DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR})
-	file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+	file(INSTALL
+			${HEADERS}
+			"${SOURCE_PATH}/PC/pyconfig.h"
+		DESTINATION
+			"${CURRENT_PACKAGES_DIR}/include/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
+	)
+	file(INSTALL
+			"${SOURCE_PATH}/Lib"
+		DESTINATION
+			"${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}"
+	)
+	file(INSTALL
+			"${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.lib"
+		DESTINATION
+			"${CURRENT_PACKAGES_DIR}/lib"
+	)
 
 	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-		file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+		file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d.lib" DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 	endif()
 
 	if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-		file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+		file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.dll" DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
 
 		if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-			file(COPY ${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+			file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d.dll" DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
 		endif()
-
 	endif()
 
 	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 		vcpkg_copy_pdbs()
 	endif()
 	# Handle copyright
-	file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR})
-	file(RENAME ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/LICENSE ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/copyright)
+	file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR} RENAME copyright)
 
 elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 
@@ -85,7 +103,7 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 	if (NOT MAKE)
 		message(FATAL_ERROR "MAKE not found")
 	endif()
-	
+
 	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 		################
 		# Release build
@@ -93,18 +111,28 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
 		set(OUT_PATH_RELEASE ${SOURCE_PATH_RELEASE}/../../make-build-${TARGET_TRIPLET}-release)
 		file(MAKE_DIRECTORY ${OUT_PATH_RELEASE})
-		
+
 		if(VCPKG_TARGET_IS_OSX)
 			vcpkg_execute_build_process(
-			  COMMAND "${SOURCE_PATH_RELEASE}/configure" --prefix=${OUT_PATH_RELEASE} --with-openssl=${CURRENT_INSTALLED_DIR} "CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include -framework CoreFoundation" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/lib" "LIBS=-liconv"
-			  WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
-			  LOGNAME config-${TARGET_TRIPLET}-rel
+				COMMAND
+					"${SOURCE_PATH_RELEASE}/configure"
+					${_ENABLED_SHARED}
+					--prefix=${OUT_PATH_RELEASE}
+					--with-openssl=${CURRENT_INSTALLED_DIR}
+					"CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include -framework CoreFoundation" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/lib" "LIBS=-liconv"
+				WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
+				LOGNAME config-${TARGET_TRIPLET}-rel
 			)
 		else()
 			vcpkg_execute_build_process(
-			  COMMAND "${SOURCE_PATH_RELEASE}/configure" --prefix=${OUT_PATH_RELEASE} --with-openssl=${CURRENT_INSTALLED_DIR} "CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/lib"
-			  WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
-			  LOGNAME config-${TARGET_TRIPLET}-rel
+				COMMAND
+					"${SOURCE_PATH_RELEASE}/configure"
+					${_ENABLED_SHARED}
+					--prefix=${OUT_PATH_RELEASE}
+					--with-openssl=${CURRENT_INSTALLED_DIR}
+				"CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/lib"
+				WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
+				LOGNAME config-${TARGET_TRIPLET}-rel
 			)
 		endif()
 
@@ -116,7 +144,7 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		  WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
 		  LOGNAME make-build-${TARGET_TRIPLET}-release
 		)
-		
+
 		message(STATUS "Installing ${TARGET_TRIPLET}-rel")
 		vcpkg_execute_build_process(
 		  COMMAND make install
@@ -124,13 +152,37 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		  LOGNAME make-install-${TARGET_TRIPLET}-release
 		)
 
-		file(GLOB HEADERS ${OUT_PATH_RELEASE}/include/*)
-		file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-		file(GLOB LIBS ${OUT_PATH_RELEASE}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/*)
-		file(COPY ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/Lib)
-		file(GLOB LIBS ${OUT_PATH_RELEASE}/lib/pkgconfig/*)
-		file(COPY ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR})
-		file(COPY ${OUT_PATH_RELEASE}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}m.a DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+		message(STATUS "Installing ${TARGET_TRIPLET}-rel headers...")
+		file(GLOB HEADERS
+			${OUT_PATH_RELEASE}/include/*)
+		file(INSTALL ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include
+			PATTERN "*__pycache__*" EXCLUDE
+		)
+
+		message(STATUS "Installing ${TARGET_TRIPLET}-rel lib files...")
+		file(GLOB LIBS
+			${OUT_PATH_RELEASE}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/*)
+		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/Lib
+			PATTERN "*.pyc" EXCLUDE
+			PATTERN "*__pycache__*" EXCLUDE
+		)
+
+		message(STATUS "Installing ${TARGET_TRIPLET}-rel share files...")
+		file(GLOB LIBS
+			${OUT_PATH_RELEASE}/lib/pkgconfig/*)
+		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}
+			PATTERN "*.pyc" EXCLUDE
+			PATTERN "*__pycache__*" EXCLUDE
+		)
+
+		message(STATUS "Installing ${TARGET_TRIPLET}-rel Python library files...")
+		file(GLOB LIBS
+			${OUT_PATH_RELEASE}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}m.*)
+		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+			PATTERN "*.pyc" EXCLUDE
+			PATTERN "*__pycache__*" EXCLUDE
+		)
+
 		message(STATUS "Installing ${TARGET_TRIPLET}-rel done")
 
 	endif()
@@ -145,15 +197,27 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 
 		if(VCPKG_TARGET_IS_OSX)
 			vcpkg_execute_build_process(
-			  COMMAND "${SOURCE_PATH_DEBUG}/configure" --with-pydebug --prefix=${OUT_PATH_DEBUG} --with-openssl=${CURRENT_INSTALLED_DIR}/debug "CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include -framework CoreFoundation" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/debug/lib" "LIBS=-liconv"
-			  WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
-			  LOGNAME config-${TARGET_TRIPLET}-debug
+				COMMAND
+					"${SOURCE_PATH_DEBUG}/configure"
+					--with-pydebug
+					${_ENABLED_SHARED}
+					--prefix=${OUT_PATH_DEBUG}
+					--with-openssl=${CURRENT_INSTALLED_DIR}/debug
+					"CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include -framework CoreFoundation" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/debug/lib" "LIBS=-liconv"
+				WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
+				LOGNAME config-${TARGET_TRIPLET}-debug
 			)
 		else()
 			vcpkg_execute_build_process(
-			  COMMAND "${SOURCE_PATH_DEBUG}/configure" --with-pydebug --prefix=${OUT_PATH_DEBUG} --with-openssl=${CURRENT_INSTALLED_DIR}/debug "CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/debug/lib"
-			  WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
-			  LOGNAME config-${TARGET_TRIPLET}-debug
+				COMMAND
+					"${SOURCE_PATH_DEBUG}/configure"
+					--with-pydebug
+					${_ENABLED_SHARED}
+					--prefix=${OUT_PATH_DEBUG}
+					--with-openssl=${CURRENT_INSTALLED_DIR}/debug
+					"CPPFLAGS=-I${CURRENT_INSTALLED_DIR}/include" "LDFLAGS=-L${CURRENT_INSTALLED_DIR}/debug/lib"
+				WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
+				LOGNAME config-${TARGET_TRIPLET}-debug
 			)
 		endif()
 
@@ -164,7 +228,7 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		  WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
 		  LOGNAME make-build-${TARGET_TRIPLET}-debug
 		)
-		
+
 		message(STATUS "Installing ${TARGET_TRIPLET}-dbg")
 		vcpkg_execute_build_process(
 		  COMMAND make install
@@ -172,12 +236,18 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		  LOGNAME make-install-${TARGET_TRIPLET}-debug
 		)
 
-		file(COPY ${OUT_PATH_DEBUG}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}dm.a DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+		message(STATUS "Installing ${TARGET_TRIPLET}-dbg Python library files...")
+		file(GLOB LIBS
+			${OUT_PATH_DEBUG}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}dm.*)
+		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
+			PATTERN "*.pyc" EXCLUDE
+			PATTERN "*__pycache__*" EXCLUDE
+		)
+
 		message(STATUS "Installing ${TARGET_TRIPLET}-dbg done")
 
 	endif()
 	# Handle copyright
-	file(COPY ${SOURCE_PATH_RELEASE}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR})
-	file(RENAME ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/LICENSE ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/copyright)
+	file(INSTALL ${SOURCE_PATH_RELEASE}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR} RENAME copyright)
 
 endif()


### PR DESCRIPTION
Modernize port + added Feature to request to build shared libraries

- What does your PR fix?
No logged issue, but the problem arose when trying to use this port to build Python extensions on Linux : shared library are needed, even when we are using VCPKG_LIBRARY_LINKAGE as static

- Which triplets are supported/not supported? Have you updated the CI baseline?
No CI update, works at least with windows & linux

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
It should !
