### PR TITLE
[vcpkg] Further parser improvements (part 2)

### DIFF
--- a/toolsrc/include/vcpkg-test/util.h
+++ b/toolsrc/include/vcpkg-test/util.h
@@ -23,6 +23,18 @@ namespace vcpkg::Test
         const std::vector<std::pair<const char*, const char*>>& features = {},
         const std::vector<const char*>& default_features = {});
 
+    inline auto test_parse_control_file(const std::vector<std::unordered_map<std::string, std::string>>& v)
+    {
+        std::vector<vcpkg::Parse::Paragraph> pghs;
+        for (auto&& p : v)
+        {
+            pghs.emplace_back();
+            for (auto&& kv : p)
+                pghs.back().emplace(kv.first, std::make_pair(kv.second, vcpkg::Parse::TextRowCol{}));
+        }
+        return vcpkg::SourceControlFile::parse_control_file("", std::move(pghs));
+    }
+
     std::unique_ptr<vcpkg::StatusParagraph> make_status_pgh(const char* name,
                                                             const char* depends = "",
                                                             const char* default_features = "",

--- a/toolsrc/include/vcpkg/binaryparagraph.h
+++ b/toolsrc/include/vcpkg/binaryparagraph.h
@@ -12,7 +12,7 @@ namespace vcpkg
     struct BinaryParagraph
     {
         BinaryParagraph();
-        explicit BinaryParagraph(Parse::RawParagraph fields);
+        explicit BinaryParagraph(Parse::Paragraph fields);
         BinaryParagraph(const SourceParagraph& spgh,
                         Triplet triplet,
                         const std::string& abi_tag,

--- a/toolsrc/include/vcpkg/paragraphparser.h
+++ b/toolsrc/include/vcpkg/paragraphparser.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/packagespec.h>
+#include <vcpkg/textrowcol.h>
 
 #include <memory>
 #include <string>
@@ -21,25 +22,30 @@ namespace vcpkg::Parse
     template<class P>
     using ParseExpected = vcpkg::ExpectedT<std::unique_ptr<P>, std::unique_ptr<ParseControlErrorInfo>>;
 
-    using RawParagraph = std::unordered_map<std::string, std::string>;
+    using Paragraph = std::unordered_map<std::string, std::pair<std::string, TextRowCol>>;
 
     struct ParagraphParser
     {
-        ParagraphParser(RawParagraph&& fields) : fields(std::move(fields)) {}
+        ParagraphParser(Paragraph&& fields) : fields(std::move(fields)) {}
 
         void required_field(const std::string& fieldname, std::string& out);
-        std::string optional_field(const std::string& fieldname) const;
+        std::string optional_field(const std::string& fieldname);
+        void required_field(const std::string& fieldname, std::pair<std::string&, TextRowCol&> out);
+        void optional_field(const std::string& fieldname, std::pair<std::string&, TextRowCol&> out);
         std::unique_ptr<ParseControlErrorInfo> error_info(const std::string& name) const;
 
     private:
-        RawParagraph&& fields;
+        Paragraph&& fields;
         std::vector<std::string> missing_fields;
     };
 
     ExpectedS<std::vector<std::string>> parse_default_features_list(const std::string& str,
-                                                                    CStringView origin = "<unknown>");
+                                                                    CStringView origin = "<unknown>",
+                                                                    TextRowCol textrowcol = {});
     ExpectedS<std::vector<ParsedQualifiedSpecifier>> parse_qualified_specifier_list(const std::string& str,
-                                                                                    CStringView origin = "<unknown>");
+                                                                                    CStringView origin = "<unknown>",
+                                                                                    TextRowCol textrowcol = {});
     ExpectedS<std::vector<Dependency>> parse_dependencies_list(const std::string& str,
-                                                               CStringView origin = "<unknown>");
+                                                               CStringView origin = "<unknown>",
+                                                               TextRowCol textrowcol = {});
 }

--- a/toolsrc/include/vcpkg/paragraphs.h
+++ b/toolsrc/include/vcpkg/paragraphs.h
@@ -8,11 +8,11 @@
 
 namespace vcpkg::Paragraphs
 {
-    using RawParagraph = Parse::RawParagraph;
+    using Paragraph = Parse::Paragraph;
 
-    ExpectedS<RawParagraph> get_single_paragraph(const Files::Filesystem& fs, const fs::path& control_path);
-    ExpectedS<std::vector<RawParagraph>> get_paragraphs(const Files::Filesystem& fs, const fs::path& control_path);
-    ExpectedS<std::vector<RawParagraph>> parse_paragraphs(const std::string& str, const std::string& origin);
+    ExpectedS<Paragraph> get_single_paragraph(const Files::Filesystem& fs, const fs::path& control_path);
+    ExpectedS<std::vector<Paragraph>> get_paragraphs(const Files::Filesystem& fs, const fs::path& control_path);
+    ExpectedS<std::vector<Paragraph>> parse_paragraphs(const std::string& str, const std::string& origin);
 
     Parse::ParseExpected<SourceControlFile> try_load_port(const Files::Filesystem& fs, const fs::path& control_path);
 

--- a/toolsrc/include/vcpkg/parse.h
+++ b/toolsrc/include/vcpkg/parse.h
@@ -18,14 +18,20 @@ namespace vcpkg::Parse
 
     struct ParseError : IParseError
     {
-        ParseError(std::string origin, int row, int column, std::string line, std::string message)
-            : origin(std::move(origin)), row(row), column(column), line(std::move(line)), message(std::move(message))
+        ParseError(std::string origin, int row, int column, int caret_col, std::string line, std::string message)
+            : origin(std::move(origin))
+            , row(row)
+            , column(column)
+            , caret_col(caret_col)
+            , line(std::move(line))
+            , message(std::move(message))
         {
         }
 
         const std::string origin;
         const int row;
         const int column;
+        const int caret_col;
         const std::string line;
         const std::string message;
 
@@ -105,27 +111,8 @@ namespace vcpkg::Parse
         const char* it() const { return m_it; }
         char cur() const { return *m_it; }
         SourceLoc cur_loc() const { return {m_it, row, column}; }
-        char next()
-        {
-            char ch = *m_it;
-            // See https://www.gnu.org/prep/standards/standards.html#Errors
-            if (ch == '\t')
-                column = (column + 7) / 8 * 8 + 1; // round to next 8-width tab stop
-            else if (ch == '\n')
-            {
-                row++;
-                column = 1;
-            }
-            else if (ch == '\0')
-            {
-                return '\0';
-            }
-            else
-            {
-                ++column;
-            }
-            return *++m_it;
-        }
+        TextRowCol cur_rowcol() const { return {row, column}; }
+        char next();
         bool at_eof() const { return *m_it == 0; }
 
         void add_error(std::string message) { add_error(std::move(message), cur_loc()); }

--- a/toolsrc/include/vcpkg/sourceparagraph.h
+++ b/toolsrc/include/vcpkg/sourceparagraph.h
@@ -70,7 +70,7 @@ namespace vcpkg
         }
 
         static Parse::ParseExpected<SourceControlFile> parse_control_file(
-            const fs::path& path_to_control, std::vector<Parse::RawParagraph>&& control_paragraphs);
+            const fs::path& path_to_control, std::vector<Parse::Paragraph>&& control_paragraphs);
 
         std::unique_ptr<SourceParagraph> core_paragraph;
         std::vector<std::unique_ptr<FeatureParagraph>> feature_paragraphs;

--- a/toolsrc/include/vcpkg/statusparagraph.h
+++ b/toolsrc/include/vcpkg/statusparagraph.h
@@ -30,7 +30,7 @@ namespace vcpkg
     struct StatusParagraph
     {
         StatusParagraph() noexcept;
-        explicit StatusParagraph(Parse::RawParagraph&& fields);
+        explicit StatusParagraph(Parse::Paragraph&& fields);
 
         bool is_installed() const { return want == Want::INSTALL && state == InstallState::INSTALLED; }
 

--- a/toolsrc/src/vcpkg-test/paragraph.cpp
+++ b/toolsrc/src/vcpkg-test/paragraph.cpp
@@ -6,15 +6,35 @@
 #include <vcpkg/paragraphs.h>
 
 namespace Strings = vcpkg::Strings;
+using vcpkg::Parse::Paragraph;
+
+auto test_parse_control_file(const std::vector<std::unordered_map<std::string, std::string>>& v)
+{
+    std::vector<Paragraph> pghs;
+    for (auto&& p : v)
+    {
+        pghs.emplace_back();
+        for (auto&& kv : p)
+            pghs.back().emplace(kv.first, std::make_pair(kv.second, vcpkg::Parse::TextRowCol{}));
+    }
+    return vcpkg::SourceControlFile::parse_control_file("", std::move(pghs));
+}
+
+auto test_make_binary_paragraph(const std::unordered_map<std::string, std::string>& v)
+{
+    Paragraph pgh;
+    for (auto&& kv : v)
+        pgh.emplace(kv.first, std::make_pair(kv.second, vcpkg::Parse::TextRowCol{}));
+
+    return vcpkg::BinaryParagraph(std::move(pgh));
+}
 
 TEST_CASE ("SourceParagraph construct minimum", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "zlib"},
-                                                         {"Version", "1.2.8"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "zlib"},
+        {"Version", "1.2.8"},
+    }});
 
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
@@ -28,16 +48,14 @@ TEST_CASE ("SourceParagraph construct minimum", "[paragraph]")
 
 TEST_CASE ("SourceParagraph construct maximum", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "s"},
-                                                         {"Version", "v"},
-                                                         {"Maintainer", "m"},
-                                                         {"Description", "d"},
-                                                         {"Build-Depends", "bd"},
-                                                         {"Default-Features", "df"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "s"},
+        {"Version", "v"},
+        {"Maintainer", "m"},
+        {"Description", "d"},
+        {"Build-Depends", "bd"},
+        {"Default-Features", "df"},
+    }});
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
 
@@ -53,13 +71,11 @@ TEST_CASE ("SourceParagraph construct maximum", "[paragraph]")
 
 TEST_CASE ("SourceParagraph two depends", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "zlib"},
-                                                         {"Version", "1.2.8"},
-                                                         {"Build-Depends", "z, openssl"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "zlib"},
+        {"Version", "1.2.8"},
+        {"Build-Depends", "z, openssl"},
+    }});
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
 
@@ -70,13 +86,11 @@ TEST_CASE ("SourceParagraph two depends", "[paragraph]")
 
 TEST_CASE ("SourceParagraph three depends", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "zlib"},
-                                                         {"Version", "1.2.8"},
-                                                         {"Build-Depends", "z, openssl, xyz"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "zlib"},
+        {"Version", "1.2.8"},
+        {"Build-Depends", "z, openssl, xyz"},
+    }});
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
 
@@ -88,13 +102,11 @@ TEST_CASE ("SourceParagraph three depends", "[paragraph]")
 
 TEST_CASE ("SourceParagraph construct qualified depends", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "zlib"},
-                                                         {"Version", "1.2.8"},
-                                                         {"Build-Depends", "liba (windows), libb (uwp)"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "zlib"},
+        {"Version", "1.2.8"},
+        {"Build-Depends", "liba (windows), libb (uwp)"},
+    }});
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
 
@@ -111,13 +123,11 @@ TEST_CASE ("SourceParagraph construct qualified depends", "[paragraph]")
 
 TEST_CASE ("SourceParagraph default features", "[paragraph]")
 {
-    auto m_pgh =
-        vcpkg::SourceControlFile::parse_control_file("",
-                                                     std::vector<std::unordered_map<std::string, std::string>>{{
-                                                         {"Source", "a"},
-                                                         {"Version", "1.0"},
-                                                         {"Default-Features", "a1"},
-                                                     }});
+    auto m_pgh = test_parse_control_file({{
+        {"Source", "a"},
+        {"Version", "1.0"},
+        {"Default-Features", "a1"},
+    }});
     REQUIRE(m_pgh.has_value());
     auto& pgh = **m_pgh.get();
 
@@ -127,7 +137,7 @@ TEST_CASE ("SourceParagraph default features", "[paragraph]")
 
 TEST_CASE ("BinaryParagraph construct minimum", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -144,7 +154,7 @@ TEST_CASE ("BinaryParagraph construct minimum", "[paragraph]")
 
 TEST_CASE ("BinaryParagraph construct maximum", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "s"},
         {"Version", "v"},
         {"Architecture", "x86-windows"},
@@ -164,7 +174,7 @@ TEST_CASE ("BinaryParagraph construct maximum", "[paragraph]")
 
 TEST_CASE ("BinaryParagraph three depends", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -180,7 +190,7 @@ TEST_CASE ("BinaryParagraph three depends", "[paragraph]")
 
 TEST_CASE ("BinaryParagraph abi", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -194,7 +204,7 @@ TEST_CASE ("BinaryParagraph abi", "[paragraph]")
 
 TEST_CASE ("BinaryParagraph default features", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "a"},
         {"Version", "1.0"},
         {"Architecture", "x86-windows"},
@@ -220,7 +230,7 @@ TEST_CASE ("parse paragraphs one field", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(str, "").value_or_exit(VCPKG_LINE_INFO);
     REQUIRE(pghs.size() == 1);
     REQUIRE(pghs[0].size() == 1);
-    REQUIRE(pghs[0]["f1"] == "v1");
+    REQUIRE(pghs[0]["f1"].first == "v1");
 }
 
 TEST_CASE ("parse paragraphs one pgh", "[paragraph]")
@@ -230,8 +240,8 @@ TEST_CASE ("parse paragraphs one pgh", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(str, "").value_or_exit(VCPKG_LINE_INFO);
     REQUIRE(pghs.size() == 1);
     REQUIRE(pghs[0].size() == 2);
-    REQUIRE(pghs[0]["f1"] == "v1");
-    REQUIRE(pghs[0]["f2"] == "v2");
+    REQUIRE(pghs[0]["f1"].first == "v1");
+    REQUIRE(pghs[0]["f2"].first == "v2");
 }
 
 TEST_CASE ("parse paragraphs two pgh", "[paragraph]")
@@ -245,11 +255,11 @@ TEST_CASE ("parse paragraphs two pgh", "[paragraph]")
 
     REQUIRE(pghs.size() == 2);
     REQUIRE(pghs[0].size() == 2);
-    REQUIRE(pghs[0]["f1"] == "v1");
-    REQUIRE(pghs[0]["f2"] == "v2");
+    REQUIRE(pghs[0]["f1"].first == "v1");
+    REQUIRE(pghs[0]["f2"].first == "v2");
     REQUIRE(pghs[1].size() == 2);
-    REQUIRE(pghs[1]["f3"] == "v3");
-    REQUIRE(pghs[1]["f4"] == "v4");
+    REQUIRE(pghs[1]["f3"].first == "v3");
+    REQUIRE(pghs[1]["f4"].first == "v4");
 }
 
 TEST_CASE ("parse paragraphs field names", "[paragraph]")
@@ -286,8 +296,8 @@ TEST_CASE ("parse paragraphs empty fields", "[paragraph]")
 
     REQUIRE(pghs.size() == 1);
     REQUIRE(pghs[0].size() == 2);
-    REQUIRE(pghs[0]["f1"] == "");
-    REQUIRE(pghs[0]["f2"] == "");
+    REQUIRE(pghs[0]["f1"].first == "");
+    REQUIRE(pghs[0]["f2"].first == "");
     REQUIRE(pghs[0].size() == 2);
 }
 
@@ -301,8 +311,8 @@ TEST_CASE ("parse paragraphs multiline fields", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(str, "").value_or_exit(VCPKG_LINE_INFO);
 
     REQUIRE(pghs.size() == 1);
-    REQUIRE(pghs[0]["f1"] == "simple\n f1");
-    REQUIRE(pghs[0]["f2"] == "\n f2\n continue");
+    REQUIRE(pghs[0]["f1"].first == "simple\n f1");
+    REQUIRE(pghs[0]["f2"].first == "\n f2\n continue");
 }
 
 TEST_CASE ("parse paragraphs crlfs", "[paragraph]")
@@ -316,11 +326,11 @@ TEST_CASE ("parse paragraphs crlfs", "[paragraph]")
 
     REQUIRE(pghs.size() == 2);
     REQUIRE(pghs[0].size() == 2);
-    REQUIRE(pghs[0]["f1"] == "v1");
-    REQUIRE(pghs[0]["f2"] == "v2");
+    REQUIRE(pghs[0]["f1"].first == "v1");
+    REQUIRE(pghs[0]["f2"].first == "v2");
     REQUIRE(pghs[1].size() == 2);
-    REQUIRE(pghs[1]["f3"] == "v3");
-    REQUIRE(pghs[1]["f4"] == "v4");
+    REQUIRE(pghs[1]["f3"].first == "v3");
+    REQUIRE(pghs[1]["f4"].first == "v4");
 }
 
 TEST_CASE ("parse paragraphs comment", "[paragraph]")
@@ -338,11 +348,11 @@ TEST_CASE ("parse paragraphs comment", "[paragraph]")
 
     REQUIRE(pghs.size() == 2);
     REQUIRE(pghs[0].size() == 2);
-    REQUIRE(pghs[0]["f1"] == "v1");
-    REQUIRE(pghs[0]["f2"] == "v2");
+    REQUIRE(pghs[0]["f1"].first == "v1");
+    REQUIRE(pghs[0]["f2"].first == "v2");
     REQUIRE(pghs[1].size());
-    REQUIRE(pghs[1]["f3"] == "v3");
-    REQUIRE(pghs[1]["f4"] == "v4");
+    REQUIRE(pghs[1]["f3"].first == "v3");
+    REQUIRE(pghs[1]["f4"].first == "v4");
 }
 
 TEST_CASE ("parse comment before single line feed", "[paragraph]")
@@ -351,12 +361,12 @@ TEST_CASE ("parse comment before single line feed", "[paragraph]")
                       "#comment\n";
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(str, "").value_or_exit(VCPKG_LINE_INFO);
     REQUIRE(pghs[0].size() == 1);
-    REQUIRE(pghs[0]["f1"] == "v1");
+    REQUIRE(pghs[0]["f1"].first == "v1");
 }
 
 TEST_CASE ("BinaryParagraph serialize min", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -367,16 +377,16 @@ TEST_CASE ("BinaryParagraph serialize min", "[paragraph]")
 
     REQUIRE(pghs.size() == 1);
     REQUIRE(pghs[0].size() == 5);
-    REQUIRE(pghs[0]["Package"] == "zlib");
-    REQUIRE(pghs[0]["Version"] == "1.2.8");
-    REQUIRE(pghs[0]["Architecture"] == "x86-windows");
-    REQUIRE(pghs[0]["Multi-Arch"] == "same");
-    REQUIRE(pghs[0]["Type"] == "Port");
+    REQUIRE(pghs[0]["Package"].first == "zlib");
+    REQUIRE(pghs[0]["Version"].first == "1.2.8");
+    REQUIRE(pghs[0]["Architecture"].first == "x86-windows");
+    REQUIRE(pghs[0]["Multi-Arch"].first == "same");
+    REQUIRE(pghs[0]["Type"].first == "Port");
 }
 
 TEST_CASE ("BinaryParagraph serialize max", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -390,18 +400,18 @@ TEST_CASE ("BinaryParagraph serialize max", "[paragraph]")
 
     REQUIRE(pghs.size() == 1);
     REQUIRE(pghs[0].size() == 8);
-    REQUIRE(pghs[0]["Package"] == "zlib");
-    REQUIRE(pghs[0]["Version"] == "1.2.8");
-    REQUIRE(pghs[0]["Architecture"] == "x86-windows");
-    REQUIRE(pghs[0]["Multi-Arch"] == "same");
-    REQUIRE(pghs[0]["Description"] == "first line\n second line");
-    REQUIRE(pghs[0]["Depends"] == "dep");
-    REQUIRE(pghs[0]["Type"] == "Port");
+    REQUIRE(pghs[0]["Package"].first == "zlib");
+    REQUIRE(pghs[0]["Version"].first == "1.2.8");
+    REQUIRE(pghs[0]["Architecture"].first == "x86-windows");
+    REQUIRE(pghs[0]["Multi-Arch"].first == "same");
+    REQUIRE(pghs[0]["Description"].first == "first line\n second line");
+    REQUIRE(pghs[0]["Depends"].first == "dep");
+    REQUIRE(pghs[0]["Type"].first == "Port");
 }
 
 TEST_CASE ("BinaryParagraph serialize multiple deps", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -412,12 +422,12 @@ TEST_CASE ("BinaryParagraph serialize multiple deps", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(ss, "").value_or_exit(VCPKG_LINE_INFO);
 
     REQUIRE(pghs.size() == 1);
-    REQUIRE(pghs[0]["Depends"] == "a, b, c");
+    REQUIRE(pghs[0]["Depends"].first == "a, b, c");
 }
 
 TEST_CASE ("BinaryParagraph serialize abi", "[paragraph]")
 {
-    vcpkg::BinaryParagraph pgh({
+    auto pgh = test_make_binary_paragraph({
         {"Package", "zlib"},
         {"Version", "1.2.8"},
         {"Architecture", "x86-windows"},
@@ -429,5 +439,5 @@ TEST_CASE ("BinaryParagraph serialize abi", "[paragraph]")
     auto pghs = vcpkg::Paragraphs::parse_paragraphs(ss, "").value_or_exit(VCPKG_LINE_INFO);
 
     REQUIRE(pghs.size() == 1);
-    REQUIRE(pghs[0]["Abi"] == "123abc");
+    REQUIRE(pghs[0]["Abi"].first == "123abc");
 }

--- a/toolsrc/src/vcpkg-test/statusparagraphs.cpp
+++ b/toolsrc/src/vcpkg-test/statusparagraphs.cpp
@@ -24,7 +24,7 @@ Status: install ok installed
     REQUIRE(pghs);
 
     StatusParagraphs status_db(
-        Util::fmap(*pghs.get(), [](RawParagraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
+        Util::fmap(*pghs.get(), [](Paragraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
 
     auto it = status_db.find_installed({"ffmpeg", Triplet::X64_WINDOWS});
     REQUIRE(it != status_db.end());
@@ -45,7 +45,7 @@ Status: purge ok not-installed
     REQUIRE(pghs);
 
     StatusParagraphs status_db(
-        Util::fmap(*pghs.get(), [](RawParagraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
+        Util::fmap(*pghs.get(), [](Paragraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
 
     auto it = status_db.find_installed({"ffmpeg", Triplet::X64_WINDOWS});
     REQUIRE(it == status_db.end());
@@ -74,7 +74,7 @@ Status: purge ok not-installed
     REQUIRE(pghs);
 
     StatusParagraphs status_db(
-        Util::fmap(*pghs.get(), [](RawParagraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
+        Util::fmap(*pghs.get(), [](Paragraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
 
     auto it = status_db.find_installed({"ffmpeg", Triplet::X64_WINDOWS});
     REQUIRE(it != status_db.end());
@@ -106,7 +106,7 @@ Status: install ok installed
     REQUIRE(pghs);
 
     StatusParagraphs status_db(
-        Util::fmap(*pghs.get(), [](RawParagraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
+        Util::fmap(*pghs.get(), [](Paragraph& rpgh) { return std::make_unique<StatusParagraph>(std::move(rpgh)); }));
 
     // Feature "openssl" is installed and should therefore be found
     auto it = status_db.find_installed({{"ffmpeg", Triplet::X64_WINDOWS}, "openssl"});

--- a/toolsrc/src/vcpkg-test/update.cpp
+++ b/toolsrc/src/vcpkg-test/update.cpp
@@ -20,7 +20,7 @@ TEST_CASE ("find outdated packages basic", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileLocation> map;
-    auto scf = unwrap(SourceControlFile::parse_control_file("", Pgh{{{"Source", "a"}, {"Version", "0"}}}));
+    auto scf = unwrap(test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}));
     map.emplace("a", SourceControlFileLocation{std::move(scf), ""});
     PortFileProvider::MapPortFileProvider provider(map);
 
@@ -44,7 +44,7 @@ TEST_CASE ("find outdated packages features", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileLocation> map;
-    auto scf = unwrap(SourceControlFile::parse_control_file("", Pgh{{{"Source", "a"}, {"Version", "0"}}}));
+    auto scf = unwrap(test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}));
     map.emplace("a", SourceControlFileLocation{std::move(scf), ""});
     PortFileProvider::MapPortFileProvider provider(map);
 
@@ -70,7 +70,7 @@ TEST_CASE ("find outdated packages features 2", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileLocation> map;
-    auto scf = unwrap(SourceControlFile::parse_control_file("", Pgh{{{"Source", "a"}, {"Version", "0"}}}));
+    auto scf = unwrap(test_parse_control_file({{{"Source", "a"}, {"Version", "0"}}}));
     map.emplace("a", SourceControlFileLocation{std::move(scf), ""});
     PortFileProvider::MapPortFileProvider provider(map);
 
@@ -91,7 +91,7 @@ TEST_CASE ("find outdated packages none", "[update]")
     StatusParagraphs status_db(std::move(status_paragraphs));
 
     std::unordered_map<std::string, SourceControlFileLocation> map;
-    auto scf = unwrap(SourceControlFile::parse_control_file("", Pgh{{{"Source", "a"}, {"Version", "2"}}}));
+    auto scf = unwrap(test_parse_control_file({{{"Source", "a"}, {"Version", "2"}}}));
     map.emplace("a", SourceControlFileLocation{std::move(scf), ""});
     PortFileProvider::MapPortFileProvider provider(map);
 

--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -58,7 +58,7 @@ namespace vcpkg::Test
                 {"Build-Depends", feature.second},
             });
         }
-        auto m_pgh = vcpkg::SourceControlFile::parse_control_file("", std::move(scf_pghs));
+        auto m_pgh = test_parse_control_file(std::move(scf_pghs));
         REQUIRE(m_pgh.has_value());
         return std::move(*m_pgh.get());
     }
@@ -68,14 +68,13 @@ namespace vcpkg::Test
                                                             const char* default_features,
                                                             const char* triplet)
     {
-        using Pgh = std::unordered_map<std::string, std::string>;
-        return std::make_unique<StatusParagraph>(Pgh{{"Package", name},
-                                                     {"Version", "1"},
-                                                     {"Architecture", triplet},
-                                                     {"Multi-Arch", "same"},
-                                                     {"Depends", depends},
-                                                     {"Default-Features", default_features},
-                                                     {"Status", "install ok installed"}});
+        return std::make_unique<StatusParagraph>(Parse::Paragraph{{"Package", {name, {}}},
+                                                                  {"Version", {"1", {}}},
+                                                                  {"Architecture", {triplet, {}}},
+                                                                  {"Multi-Arch", {"same", {}}},
+                                                                  {"Depends", {depends, {}}},
+                                                                  {"Default-Features", {default_features, {}}},
+                                                                  {"Status", {"install ok installed", {}}}});
     }
 
     std::unique_ptr<StatusParagraph> make_status_feature_pgh(const char* name,
@@ -83,14 +82,12 @@ namespace vcpkg::Test
                                                              const char* depends,
                                                              const char* triplet)
     {
-        using Pgh = std::unordered_map<std::string, std::string>;
-        return std::make_unique<StatusParagraph>(Pgh{{"Package", name},
-                                                     {"Version", "1"},
-                                                     {"Feature", feature},
-                                                     {"Architecture", triplet},
-                                                     {"Multi-Arch", "same"},
-                                                     {"Depends", depends},
-                                                     {"Status", "install ok installed"}});
+        return std::make_unique<StatusParagraph>(Parse::Paragraph{{"Package", {name, {}}},
+                                                                  {"Feature", {feature, {}}},
+                                                                  {"Architecture", {triplet, {}}},
+                                                                  {"Multi-Arch", {"same", {}}},
+                                                                  {"Depends", {depends, {}}},
+                                                                  {"Status", {"install ok installed", {}}}});
     }
 
     PackageSpec PackageSpecMap::emplace(const char* name,

--- a/toolsrc/src/vcpkg/binaryparagraph.cpp
+++ b/toolsrc/src/vcpkg/binaryparagraph.cpp
@@ -30,7 +30,7 @@ namespace vcpkg
 
     BinaryParagraph::BinaryParagraph() = default;
 
-    BinaryParagraph::BinaryParagraph(Parse::RawParagraph fields)
+    BinaryParagraph::BinaryParagraph(Parse::Paragraph fields)
     {
         using namespace vcpkg::Parse;
 

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -1011,7 +1011,7 @@ namespace vcpkg::Build
                                Commands::Version::version());
     }
 
-    static BuildInfo inner_create_buildinfo(Parse::RawParagraph pgh)
+    static BuildInfo inner_create_buildinfo(Parse::Paragraph pgh)
     {
         Parse::ParagraphParser parser(std::move(pgh));
 
@@ -1068,7 +1068,7 @@ namespace vcpkg::Build
 
     BuildInfo read_build_info(const Files::Filesystem& fs, const fs::path& filepath)
     {
-        const ExpectedS<Parse::RawParagraph> pghs = Paragraphs::get_single_paragraph(fs, filepath);
+        const ExpectedS<Parse::Paragraph> pghs = Paragraphs::get_single_paragraph(fs, filepath);
         Checks::check_exit(
             VCPKG_LINE_INFO, pghs.get() != nullptr, "Invalid BUILD_INFO file for package: %s", pghs.error());
         return inner_create_buildinfo(*pghs.get());

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -224,12 +224,10 @@ namespace vcpkg::Commands::CI
     };
 
     static bool supported_for_triplet(const CMakeVars::TripletCMakeVarProvider& var_provider,
-
                                       const InstallPlanAction* install_plan)
     {
-        const std::string& supports_expression =
-            install_plan->source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
-                .source_control_file->core_paragraph->supports_expression;
+        auto&& scfl = install_plan->source_control_file_location.value_or_exit(VCPKG_LINE_INFO);
+        const std::string& supports_expression = scfl.source_control_file->core_paragraph->supports_expression;
         if (supports_expression.empty())
         {
             return true; // default to 'supported'

--- a/toolsrc/src/vcpkg/statusparagraph.cpp
+++ b/toolsrc/src/vcpkg/statusparagraph.cpp
@@ -24,12 +24,12 @@ namespace vcpkg
             .push_back('\n');
     }
 
-    StatusParagraph::StatusParagraph(Parse::RawParagraph&& fields)
+    StatusParagraph::StatusParagraph(Parse::Paragraph&& fields)
         : want(Want::ERROR_STATE), state(InstallState::ERROR_STATE)
     {
         auto status_it = fields.find(BinaryParagraphRequiredField::STATUS);
         Checks::check_exit(VCPKG_LINE_INFO, status_it != fields.end(), "Expected 'Status' field in status paragraph");
-        std::string status_field = std::move(status_it->second);
+        std::string status_field = std::move(status_it->second.first);
         fields.erase(status_it);
 
         this->package = BinaryParagraph(std::move(fields));

--- a/toolsrc/src/vcpkg/userconfig.cpp
+++ b/toolsrc/src/vcpkg/userconfig.cpp
@@ -51,7 +51,7 @@ namespace vcpkg
             {
                 const auto& pghs = *p_pghs;
 
-                Parse::RawParagraph keys;
+                Parse::Paragraph keys;
                 if (pghs.size() > 0) keys = pghs[0];
 
                 for (size_t x = 1; x < pghs.size(); ++x)
@@ -60,10 +60,10 @@ namespace vcpkg
                         keys.insert(p);
                 }
 
-                ret.user_id = keys["User-Id"];
-                ret.user_time = keys["User-Since"];
-                ret.user_mac = keys["Mac-Hash"];
-                ret.last_completed_survey = keys["Survey-Completed"];
+                ret.user_id = keys["User-Id"].first;
+                ret.user_time = keys["User-Since"].first;
+                ret.user_mac = keys["Mac-Hash"].first;
+                ret.last_completed_survey = keys["Survey-Completed"].first;
             }
         }
         catch (...)


### PR DESCRIPTION
The text source and location information are now tracked into the parser for `Build-Depends` and `Default-Features`.

**Example:**
```
# ports/zlib/CONTROL
Source: zlib
Version: 1.2.11-5
Homepage: https://www.zlib.net/
Description: A compression library
Build-Depends: zoo, Bat
```
```
# current behavior
PS C:\src\vcpkg2> .\toolsrc\out\build\x64-Debug\vcpkg.exe install zlib --dry-run
Computing installation plan...
Failed at [C:\src\vcpkg2\toolsrc\src\vcpkg\sourceparagraph.cpp(131)] with message:
Error: <unknown>:1:6: invalid character in package name (must be lowercase, digits, '-')
   on expression: "zoo, Bat"
                        ^
```
```
# new behavior
PS C:\src\vcpkg2> .\toolsrc\out\build\x64-Debug\vcpkg.exe install zlib --dry-run
Computing installation plan...
Failed at [C:\src\vcpkg2\toolsrc\src\vcpkg\sourceparagraph.cpp(135)] with message:
Error: C:\src\vcpkg2\ports\zlib\CONTROL:5:21: invalid character in package name (must be lowercase, digits, '-')
   on expression: "zoo, Bat"
                        ^
```