### PR TITLE
[libimobiledevice] Update to 1.2.185 and fix usbmuxd build

### DIFF
--- a/ports/libimobiledevice/CONTROL
+++ b/ports/libimobiledevice/CONTROL
@@ -1,4 +1,5 @@
 Source: libimobiledevice
 Version: 1.2.185
+Homepage: http://www.libimobiledevice.org
 Description: A cross-platform protocol library to communicate with iOS devices
 Build-Depends: libplist, libusbmuxd, openssl, dirent, getopt

--- a/ports/libimobiledevice/CONTROL
+++ b/ports/libimobiledevice/CONTROL
@@ -1,4 +1,4 @@
 Source: libimobiledevice
-Version: 1.2.137
+Version: 1.2.185
 Description: A cross-platform protocol library to communicate with iOS devices
 Build-Depends: libplist, libusbmuxd, openssl, dirent, getopt

--- a/ports/libimobiledevice/portfile.cmake
+++ b/ports/libimobiledevice/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libimobiledevice-win32/libimobiledevice
-    REF 7cf5cb4b9675ddcaed5ea3d7ee2c8848da18d691 # v1.2.137
-    SHA512 cfc32d3414af333d3410c292660b526f2339d210bc2cc3ddf1de87c951bff526c731c4d61609441b3c1ce8e2d1398e6d4c35fdae3e7434bfd5050e5975047a11
+    REF 37cb65f04249705eb5844821fd925b9edee8866c # v1.2.185
+    SHA512 00a44de9552d3cf3daf3d490ad700188e20c72b24b8a6e9ca32d1d9fa53572479a5cbe85d130cd24fb1a2528c5e2cb238ab4caab35c5d93033c53b5c4c189bc6
     HEAD_REF msvc-master
 )
 

--- a/ports/usbmuxd/CONTROL
+++ b/ports/usbmuxd/CONTROL
@@ -1,4 +1,5 @@
 Source: usbmuxd
 Version: 1.2.76-1
+Homepage: http://www.libimobiledevice.org
 Description: A socket daemon to multiplex connections from and to iOS devices
 Build-Depends: libimobiledevice, libusb, libusb-win32, pthreads

--- a/ports/usbmuxd/CONTROL
+++ b/ports/usbmuxd/CONTROL
@@ -1,4 +1,4 @@
 Source: usbmuxd
-Version: 1.2.76
+Version: 1.2.76-1
 Description: A socket daemon to multiplex connections from and to iOS devices
 Build-Depends: libimobiledevice, libusb, libusb-win32, pthreads

--- a/ports/usbmuxd/fix-dependence-libimobiledevice.patch
+++ b/ports/usbmuxd/fix-dependence-libimobiledevice.patch
@@ -1,0 +1,14 @@
+diff --git a/src/preflight.c b/src/preflight.c
+index aca193e..f012286 100644
+--- a/src/preflight.c
++++ b/src/preflight.c
+@@ -54,9 +54,6 @@
+ #include "log.h"
+ 
+ #ifdef HAVE_LIBIMOBILEDEVICE
+-enum connection_type {
+-	CONNECTION_USBMUXD = 1
+-};
+ 
+ struct idevice_private {
+ 	char *udid;

--- a/ports/usbmuxd/portfile.cmake
+++ b/ports/usbmuxd/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libimobiledevice-win32/usbmuxd
@@ -8,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master-msvc
     PATCHES
         fix-dependence-pthreads.patch
+        fix-dependence-libimobiledevice.patch
 )
 
 vcpkg_install_msbuild(


### PR DESCRIPTION
Related: #9986

Note: these 2 ports do not contain any features.