### PR TITLE
[ignition-cmake2] Add new port 🤖

### DIFF
--- a/ports/ignition-cmake2/CONTROL
+++ b/ports/ignition-cmake2/CONTROL
@@ -1,0 +1,5 @@
+Source: ignition-cmake2
+Version: 2.1.1
+Homepage: https://ignitionrobotics.org/libs/cmake
+Description: CMake helper functions for building robotic applications
+Build-Depends: ignition-modularscripts

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -1,0 +1,16 @@
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+set(PACKAGE_VERSION "2.1.1")
+
+ignition_modular_library(NAME cmake
+                         VERSION ${PACKAGE_VERSION}
+                         SHA512 4d22a45ccc9582c7e4b370b884511782d1629fa3e257dd92300388b5050d22fa63dd4a6ef8942abb9ebbc300df4cd526d1d8a7088a92b0073e152c16c7b97e2b)
+
+# Permit empty include folder
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+# Remove unneccessary directory, as ignition-cmake is a pure CMake package
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
+
+# Install custom usage
+configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)

--- a/ports/ignition-cmake2/usage
+++ b/ports/ignition-cmake2/usage
@@ -1,0 +1,3 @@
+The package ignition-cmake2 provides CMake integration:
+
+    find_package(ignition-cmake2 CONFIG REQUIRED)

--- a/ports/ignition-modularscripts/CONTROL
+++ b/ports/ignition-modularscripts/CONTROL
@@ -1,3 +1,3 @@
 Source: ignition-modularscripts
-Version: 2019-09-11
+Version: 2020-02-10
 Description: Vcpkg helpers to package ignition libraries

--- a/ports/ignition-modularscripts/ignition_modular_library.cmake
+++ b/ports/ignition-modularscripts/ignition_modular_library.cmake
@@ -8,23 +8,21 @@ function(ignition_modular_build_library NAME MAJOR_VERSION SOURCE_PATH CMAKE_PAC
 
     vcpkg_install_cmake()
 
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/${CMAKE_PACKAGE_NAME}" TARGET_PATH "share/${CMAKE_PACKAGE_NAME}")
+    # If necessary, move the CMake config files
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake")
+        vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/${CMAKE_PACKAGE_NAME}" TARGET_PATH "share/${CMAKE_PACKAGE_NAME}")
 
-    file(GLOB_RECURSE CMAKE_RELEASE_FILES 
-                      "${CURRENT_PACKAGES_DIR}/lib/cmake/${CMAKE_PACKAGE_NAME}/*")
+        file(GLOB_RECURSE CMAKE_RELEASE_FILES
+                          "${CURRENT_PACKAGES_DIR}/lib/cmake/${CMAKE_PACKAGE_NAME}/*")
 
-    file(COPY ${CMAKE_RELEASE_FILES} DESTINATION 
-              "${CURRENT_PACKAGES_DIR}/share/${CMAKE_PACKAGE_NAME}/")
+        file(COPY ${CMAKE_RELEASE_FILES} DESTINATION
+                  "${CURRENT_PACKAGES_DIR}/share/${CMAKE_PACKAGE_NAME}/")
 
-    # Remove debug files
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include 
-                        ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
-                        ${CURRENT_PACKAGES_DIR}/debug/share)
-
-
-
-    # Post-build test for cmake libraries 
-    vcpkg_test_cmake(PACKAGE_NAME ${CMAKE_PACKAGE_NAME})
+        # Remove debug files
+        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                            ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+                            ${CURRENT_PACKAGES_DIR}/debug/share)
+    endif()
 
     # Find the relevant license file and install it
     if(EXISTS "${SOURCE_PATH}/LICENSE")


### PR DESCRIPTION
Add a port for ignition-cmake2. As discussed in https://github.com/microsoft/vcpkg/pull/7781, different major version of ignition robotics libraries (https://ignitionrobotics.org/) can be installed side by side, so each new major version is added as a new port. 

In particular, ignition-cmake2 is a dependency for Gazebo 11 (http://gazebosim.org/blog/gazebo11) and for Ignition Robotics Citadel (that contains Ignition Gazebo 3, see https://www.openrobotics.org/blog/2019/12/11/ignition-citadel-released).

As far as I was able to test, this port should support all the triplets.

Related issue:
* https://github.com/microsoft/vcpkg/issues/8014#issuecomment-578431035