### PR TITLE
[asmjit] Update to 2020-02-08

### DIFF
--- a/ports/asmjit/CONTROL
+++ b/ports/asmjit/CONTROL
@@ -1,4 +1,4 @@
 Source: asmjit
-Version: 2020-01-20
+Version: 2020-02-08
 Homepage: https://github.com/asmjit/asmjit
 Description: Complete x86/x64 JIT and Remote Assembler for C++

--- a/ports/asmjit/portfile.cmake
+++ b/ports/asmjit/portfile.cmake
@@ -1,8 +1,10 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO asmjit/asmjit
-  REF 7e164e3edeefb76d8a2da4fbe84957ece0d07a13
-  SHA512 19d0a7f7a7cb4e6bd6c03f2e29ab012edf67ba4ba92789fd81e71a4937f1271a5124fa9c02d40d202bad7785b9e5ae21a3a72048cdeb8781c1b927c9717669c8
+  REF 761130b1d8f32b5d3d612d285664fcfef5258149
+  SHA512 a86fd58ba0c8bc81ec575e86a9acdf4a11f2acc9c2facd2a0a8512cffa9ee6fc0bd877a1f33fb52f8f510eff1de654b45cd4f5f5a18c5252ecae22a92db6e93e
   HEAD_REF master
 )
 
@@ -24,9 +26,5 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-endif()
-
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/asmjit RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -95,6 +95,7 @@ asiosdk:arm64-windows=fail
 asiosdk:arm-uwp=fail
 asmjit:arm64-windows=fail
 asmjit:arm-uwp=fail
+asmjit:x64-uwp=fail
 asyncplusplus:arm-uwp=fail
 asyncplusplus:x64-uwp=fail
 atk:x64-osx=fail


### PR DESCRIPTION
As the new version of asmjit adds the `VirtualAllocEx` function that does not support uwp and cannot find the replacement function, it gives up support for uwp.

Related: #9986.

Note: this port does not contain any features.