### PR TITLE
[oniguruma] Update to 6.9.4

### DIFF
--- a/ports/oniguruma/CONTROL
+++ b/ports/oniguruma/CONTROL
@@ -1,5 +1,5 @@
 Source: oniguruma
-Version: 6.9.3
+Version: 6.9.4
 Description: Modern and flexible regular expressions library
 Homepage: https://github.com/kkos/oniguruma
 

--- a/ports/oniguruma/fix-uwp.patch
+++ b/ports/oniguruma/fix-uwp.patch
@@ -1,0 +1,26 @@
+diff --git a/src/regcomp.c b/src/regcomp.c
+index 69d4b95..380f441 100644
+--- a/src/regcomp.c
++++ b/src/regcomp.c
+@@ -3880,7 +3880,7 @@ reduce_string_list(Node* node)
+     {
+       Node* prev;
+       Node* curr;
+-      Node* prev_node;
++      Node* prev_node = NULL;
+       Node* next_node;
+ 
+       prev = NULL_NODE;
+diff --git a/src/regexec.c b/src/regexec.c
+index ce498c6..6848c0f 100644
+--- a/src/regexec.c
++++ b/src/regexec.c
+@@ -4216,7 +4216,7 @@ regset_search_body_position_lead(OnigRegSet* set,
+ {
+   int r, n, i;
+   UChar *s, *prev;
+-  UChar *low, *high, *low_prev;
++  UChar *low, *high, *low_prev = NULL;
+   UChar* sch_range;
+   regex_t* reg;
+   OnigEncoding enc;

--- a/ports/oniguruma/portfile.cmake
+++ b/ports/oniguruma/portfile.cmake
@@ -1,11 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kkos/oniguruma
-    REF v6.9.3
-    SHA512 a0f4da26ba08de516c05b5e4b803a9cf8013489c3743ecf27fbc3f66f835eef8fca81b9ed2bd68729a470fe897994046843a4fd31d44a9584ff8dabd1748df21
+    REF e03900b038a274ee2f1341039e9003875c11e47d # v6.9.4
+    SHA512 77772e3994acbdde86a7405d24423fff101061e24cc8cd85975d3ab092935fc91c0c3b991fe2fa9e9a857b5254db7d923256cdb29a2e2d8a3cdd41837ed690f6
     HEAD_REF master
+    PATCHES fix-uwp.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -45,7 +44,4 @@ else()
 endif()
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-
-# CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME ${PORT})
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Update to 6.9.4, remove `vcpkg_test_cmake`.

Related: #9986.

Note: All features passed in the following triplets test:
- x86-windows
- x64-windows
- x64-windows-static