### PR TITLE
[xorstr] Update to fix GCC warnings and compilation error

### DIFF
--- a/ports/xorstr/CONTROL
+++ b/ports/xorstr/CONTROL
@@ -1,4 +1,4 @@
 Source: xorstr
-Version: 2019-08-10
+Version: 2020-02-11
 Description: Heavily vectorized c++17 compile time string encryption
 Homepage: https://github.com/JustasMasiulis/xorstr

--- a/ports/xorstr/portfile.cmake
+++ b/ports/xorstr/portfile.cmake
@@ -5,8 +5,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JustasMasiulis/xorstr
-    REF 5d7371dcb70601ce9c252d475cc3dc6cf8f1e0db
-    SHA512 7625d2ebdb95a5414f0a1ac7ac8951b612d5159be5eccce4e13b88a4d17ffa3c65ff81ce5df5b64064b5712da7238ec1f564d2c213852731cad30c367ebad72e
+    REF a774b984f5b5f15d39ba0a8623cd3c70c05d6007
+    SHA512 339fe945e39d27dfc9a9f42bbf4ef008405934668784ee4b661ee9dd04ab0a0bea442c07e7315d1746edd047a6bb7aca7d382314a48fc593633d811cf67bdb2d
     HEAD_REF master
 )
 


### PR DESCRIPTION
- What does your PR fix?
https://github.com/JustasMasiulis/xorstr/issues/25

- Which triplets are supported/not supported? Have you updated the CI baseline?
No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.