### PR TITLE
[duktape] x64-osx fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -378,6 +378,11 @@ duilib:arm-uwp=fail
 duilib:x64-linux=fail
 duilib:x64-osx=fail
 duilib:x64-uwp=fail
+
+# requires python@2 from brew, but that no longer exists
+# python2 EOL yay!
+duktape:x64-osx=skip
+
 dxut:arm64-windows=fail
 dxut:arm-uwp=fail
 dxut:x64-linux=fail


### PR DESCRIPTION
brew no longer contains python2, since it's EOL, and duktape requires that for now

see https://github.com/svaarala/duktape/issues/1794