### PR TITLE
[google-cloud-cpp{,-common}] upgrade to latest release

### DIFF
--- a/ports/google-cloud-cpp-common/CONTROL
+++ b/ports/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.18.0
+Version: 0.19.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ports/google-cloud-cpp-common/portfile.cmake
+++ b/ports/google-cloud-cpp-common/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-common
-    REF v0.18.0
-    SHA512 030e9574b97667cf3495d206fe21fe6bdf0a2c84f31240c5cfcb82a9db6df77ccb15e000d1f1e56d8dd2a8231c97ed0d0a10c89baf147bc6408a8be2cb452f25
+    REF v0.19.0
+    SHA512 c297cdba8f4037b19ebb92af643730a92f7a50d6341d7fbb130446c6d2c1391732fdc4ef550b95261b8decfc10d138847efa97af6f8e48968e071bc13e853684
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp
-Version: 0.18.0
+Version: 0.19.0
 Build-Depends: grpc, curl[ssl], crc32c, googleapis, google-cloud-cpp-common
 Description: C++ Client Libraries for Google Cloud Platform APIs.
 Homepage: https://github.com/googleapis/google-cloud-cpp

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v0.18.0
-    SHA512 e0678d928ccf5fe2f9ce8828091fb8e2b7d4c1ff41e347eb4bc8768d33997621693a2acf2a68fa11bfecf8f7f44fc95d15e59188b86769592cebcb3cf14cbd14
+    REF v0.19.0
+    SHA512 8473e1aa2d83e46c1120e3a276e3ed2c9e33dd33d042d398ea48b90befa0bc41fa483d922489fe83faa61e5c4eafc0b22d5e8442c01c84aece6cfed673d34ead
     HEAD_REF master
     PATCHES
         0001-fix-x86-build.patch


### PR DESCRIPTION
Upgrade `gooogle-cloud-cpp` and `google-cloud-cpp-common` to the latest release. Both need to be updated in a single PR.

- What does your PR fix? Fixes issue #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes to the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
