### PR TITLE
[loguru] Fix link issue

### DIFF
--- a/ports/loguru/CONTROL
+++ b/ports/loguru/CONTROL
@@ -1,4 +1,4 @@
 Source: loguru
-Version: v2.1.0
+Version: 2.1.0-1
 Homepage: https://github.com/emilk/loguru
 Description: A lightweight and flexible C++ logging library

--- a/ports/loguru/portfile.cmake
+++ b/ports/loguru/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 if(VCPKG_TARGET_IS_WINDOWS)
     file(INSTALL ${SOURCE_PATH}/loguru.hpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
+    file(INSTALL ${SOURCE_PATH}/loguru.cpp DESTINATION ${CURRENT_PACKAGES_DIR}/include/loguru)
 endif()
 
 if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)


### PR DESCRIPTION
Fix link issue that in https://github.com/microsoft/vcpkg/pull/8682#issuecomment-583780674

loguru is header only librariy on windows, it's need loguru.cpp file when use it base on https://github.com/emilk/loguru#compiling, so also install loguru.cpp file.