### PR TITLE
Omit telemetry message when bootstrapping with `-disableMetrics`

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -412,13 +412,16 @@ if ($ec -ne 0)
 }
 Write-Host "`nBuilding vcpkg.exe... done.`n"
 
-Write-Host @"
+if (-not $disableMetrics)
+{
+    Write-Host @"
 Telemetry
 ---------
 vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running bootstrap-vcpkg.bat with -disableMetrics.
 Read more about vcpkg telemetry at docs/about/privacy.md
 
 "@
+}
 
 Write-Verbose "Placing vcpkg.exe in the correct location"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -263,8 +263,10 @@ mkdir -p "$buildDir"
 rm -rf "$vcpkgRootDir/vcpkg"
 cp "$buildDir/vcpkg" "$vcpkgRootDir/"
 
-echo "Telemetry"
-echo "---------"
-echo "vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running bootstrap-vcpkg.sh with -disableMetrics"
-echo "Read more about vcpkg telemetry at docs/about/privacy.md"
-echo ""
+if ! [ "$vcpkgDisableMetrics" = "ON" ]; then
+    echo "Telemetry"
+    echo "---------"
+    echo "vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running bootstrap-vcpkg.sh with -disableMetrics"
+    echo "Read more about vcpkg telemetry at docs/about/privacy.md"
+    echo ""
+fi


### PR DESCRIPTION
Fix #9688 