### PR TITLE
[vcpkg_execute_build_process] Retry on CMakeFiles/install.util failure (antivirus workaround)

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 # LLVM documentation recommends always using static library linkage when
 # building with Microsoft toolchain; it's also the default on other platforms
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -112,10 +112,14 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/bin
     ${CURRENT_PACKAGES_DIR}/msbuild-bin
     ${CURRENT_PACKAGES_DIR}/tools/msbuild-bin
-    ${CURRENT_PACKAGES_DIR}/include/llvm/BinaryFormat/WasmRelocs
 )
 
-# Remove two empty include subdirectorys if they are indeed empty
+# Remove three empty include subdirectorys if they are indeed empty
+file(GLOB X ${CURRENT_PACKAGES_DIR}/include/llvm/BinaryFormat/WasmRelocs/*)
+if(NOT X)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/llvm/BinaryFormat/WasmRelocs)
+endif()
+
 file(GLOB MCANALYSISFILES ${CURRENT_PACKAGES_DIR}/include/llvm/MC/MCAnalysis/*)
 if(NOT MCANALYSISFILES)
   file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/llvm/MC/MCAnalysis)


### PR DESCRIPTION
Due to the number of binaries produced all at once, the LLVM build can overwhelm antivirus software and cause the cmake install.util copy step to fail. This PR adds a detect+retry for that case.