### PR TITLE
[freetype] Disabled Harfbuzz check for non-Windows platforms

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,5 @@
 Source: freetype
-Version: 2.10.1-4
+Version: 2.10.1-5
 Build-Depends: zlib
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -31,28 +31,21 @@ else()
     set(ENABLE_DLL_EXPORT ON)
 endif()
 
-if(NOT WIN32)
-	vcpkg_configure_cmake(
-		SOURCE_PATH ${SOURCE_PATH}
-		PREFER_NINJA
-		OPTIONS
-			-DCONFIG_INSTALL_PATH=share/freetype
-			-DFT_WITH_ZLIB=ON # Force system zlib.
-			-DFT_DISABLE_FIND_PACKAGE_Harfbuzz=TRUE
-			${FEATURE_OPTIONS}
-			-DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
-	)
-else()
-	vcpkg_configure_cmake(
-		SOURCE_PATH ${SOURCE_PATH}
-		PREFER_NINJA
-		OPTIONS
-			-DCONFIG_INSTALL_PATH=share/freetype
-			-DFT_WITH_ZLIB=ON # Force system zlib.
-			${FEATURE_OPTIONS}
-			-DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
-	)
+set(OPTIONS)
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+  list(APPEND OPTIONS -DFT_DISABLE_FIND_PACKAGE_Harfbuzz=TRUE)
 endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCONFIG_INSTALL_PATH=share/freetype
+        -DFT_WITH_ZLIB=ON # Force system zlib.
+        ${FEATURE_OPTIONS}
+        -DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
+        ${OPTIONS}
+)
 
 vcpkg_install_cmake()
 

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -31,15 +31,28 @@ else()
     set(ENABLE_DLL_EXPORT ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DCONFIG_INSTALL_PATH=share/freetype
-        -DFT_WITH_ZLIB=ON # Force system zlib.
-        ${FEATURE_OPTIONS}
-        -DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
-)
+if(NOT WIN32)
+	vcpkg_configure_cmake(
+		SOURCE_PATH ${SOURCE_PATH}
+		PREFER_NINJA
+		OPTIONS
+			-DCONFIG_INSTALL_PATH=share/freetype
+			-DFT_WITH_ZLIB=ON # Force system zlib.
+			-DFT_DISABLE_FIND_PACKAGE_Harfbuzz=TRUE
+			${FEATURE_OPTIONS}
+			-DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
+	)
+else()
+	vcpkg_configure_cmake(
+		SOURCE_PATH ${SOURCE_PATH}
+		PREFER_NINJA
+		OPTIONS
+			-DCONFIG_INSTALL_PATH=share/freetype
+			-DFT_WITH_ZLIB=ON # Force system zlib.
+			${FEATURE_OPTIONS}
+			-DENABLE_DLL_EXPORT=${ENABLE_DLL_EXPORT}
+	)
+endif()
 
 vcpkg_install_cmake()
 


### PR DESCRIPTION
- What does your PR fix? 
Fixes issue #10041 
Resolves linking errors when building on Linux-based platforms

- Which triplets are supported/not supported? Have you updated the CI baseline?
 No change.
 
- Does your PR follow the maintainer guide?
 I think so.
