### PR TITLE
[libphonenumber] Add new port

### DIFF
--- a/ports/libphonenumber/001-cmakelists-use-find-package.patch
+++ b/ports/libphonenumber/001-cmakelists-use-find-package.patch
@@ -1,0 +1,94 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 3bcb458c..0022417f 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -104,34 +104,28 @@ if (${USE_BOOST} STREQUAL "ON")
+   include_directories (${Boost_INCLUDE_DIRS})
+ endif ()
+ 
+-find_or_build_gtest ()
++find_package(GTest REQUIRED)
+ 
+ if (${USE_RE2} STREQUAL "ON")
+   find_required_library (RE2 re2/re2.h re2 "Google RE2")
+ endif ()
+ 
+-find_required_library (PROTOBUF google/protobuf/message_lite.h protobuf
+-                       "Google Protocol Buffers")
+-check_library_version (PC_PROTOBUF protobuf>=2.4)
++find_package(Protobuf 2.4 REQUIRED)
+ 
+-find_required_library (ICU_UC unicode/uchar.h icuuc "ICU")
+-check_library_version (PC_ICU_UC icu-uc>=4.4)
++find_package(ICU 4.4 REQUIRED COMPONENTS uc data)
+ 
+-set (ICU_INCLUDE_DIR ${ICU_UC_INCLUDE_DIR})
+-set (ICU_LIB ${ICU_UC_LIB})
++set (ICU_INCLUDE_DIR ${ICU_INCLUDE_DIRS})
++set (ICU_LIB ${ICU_UC_LIBRARIES} ${ICU_DATA_LIBRARIES})
+ # If ICU regexp engine is used or if the geocoder is built, use icui18n as well.
+ if (${USE_ICU_REGEXP} STREQUAL "ON" OR ${BUILD_GEOCODER} STREQUAL "ON")
+-  find_required_library (ICU_I18N unicode/regex.h icui18n "ICU")
+-  check_library_version (PC_ICU_I18N icu-i18n>=4.4)
+-  list (APPEND ICU_INCLUDE_DIR ${ICU_I18N_INCLUDE_DIR})
+-  list (APPEND ICU_LIB ${ICU_I18N_LIB})
++  find_package(ICU 4.4 REQUIRED COMPONENTS i18n)
++  list (APPEND ICU_LIB ${ICU_I18N_LIBRARIES})
+ endif ()
+ 
+ find_required_program (PROTOC protoc
+                        "Google Protocol Buffers compiler (protoc)")
+ 
+-find_required_program (JAVA java
+-                       "Java Runtime Environment")
++find_package(Java REQUIRED COMPONENTS Runtime)
+ 
+ if (APPLE)
+   FIND_LIBRARY (COREFOUNDATION_LIB CoreFoundation)
+@@ -165,7 +159,7 @@ set (
+ )
+ 
+ add_custom_command (
+-  COMMAND ${PROTOC_BIN} --cpp_out=${CMAKE_SOURCE_DIR}/src/phonenumbers/
++  COMMAND ${Protobuf_PROTOC_EXECUTABLE} --cpp_out=${CMAKE_SOURCE_DIR}/src/phonenumbers/
+     --proto_path=${RESOURCES_DIR} ${PROTOBUF_SOURCES}
+ 
+   OUTPUT ${PROTOBUF_OUTPUT}
+@@ -272,7 +266,7 @@ function (add_metadata_gen_target TARGET_NAME
+   set (JAR_PATH "${JAR_PATH}/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar")
+ 
+   add_custom_command (
+-    COMMAND ${JAVA_BIN} -jar
++    COMMAND ${Java_JAVA_EXECUTABLE} -jar
+       ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
+       ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+ 
+@@ -379,8 +373,8 @@ if (${BUILD_GEOCODER} STREQUAL "ON")
+       VERSION ${libphonenumber_VERSION_MAJOR}.${libphonenumber_VERSION_MINOR})
+ endif ()
+ 
+-# Build a shared library (with -fPIC).
+-set (BUILD_SHARED_LIB true)
++  # Build a shared library (with -fPIC).
++  set (BUILD_SHARED_LIB true)
+ 
+ if (${USE_RE2} STREQUAL "ON")
+   # RE2 is not always available as a shared library (e.g: package provided by
+@@ -413,7 +407,7 @@ endif ()
+ # Libraries used by both libphonenumber and libgeocoding.
+ set (COMMON_DEPS ${ICU_LIB})
+ 
+-set (LIBRARY_DEPS ${PROTOBUF_LIB})
++set (LIBRARY_DEPS ${Protobuf_LIBRARIES})
+ 
+ if (${USE_BOOST} STREQUAL "ON")
+   list (APPEND LIBRARY_DEPS ${Boost_LIBRARIES})
+@@ -507,7 +501,7 @@ endif ()
+ # Build the testing binary.
+ include_directories ("test")
+ add_executable (libphonenumber_test ${TEST_SOURCES})
+-set (TEST_LIBS phonenumber_testing ${GTEST_LIB})
++set (TEST_LIBS phonenumber_testing ${GTEST_LIBRARIES})
+ 
+ if (NOT WIN32)
+   list (APPEND TEST_LIBS pthread)

--- a/ports/libphonenumber/002-cmakelists-fix-build-static-lib.patch
+++ b/ports/libphonenumber/002-cmakelists-fix-build-static-lib.patch
@@ -1,0 +1,15 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 0022417f..140199a7 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -373,8 +373,10 @@ if (${BUILD_GEOCODER} STREQUAL "ON")
+       VERSION ${libphonenumber_VERSION_MAJOR}.${libphonenumber_VERSION_MINOR})
+ endif ()
+ 
++if (${BUILD_STATIC_LIB} STREQUAL "OFF")
+   # Build a shared library (with -fPIC).
+   set (BUILD_SHARED_LIB true)
++endif ()
+ 
+ if (${USE_RE2} STREQUAL "ON")
+   # RE2 is not always available as a shared library (e.g: package provided by

--- a/ports/libphonenumber/003-cmakelists-regenerate-metadata.patch
+++ b/ports/libphonenumber/003-cmakelists-regenerate-metadata.patch
@@ -1,0 +1,57 @@
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 140199a7..972f7fd6 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -86,6 +86,7 @@ option ("USE_LITE_METADATA" "Use lite metadata" "OFF")
+ option ("USE_RE2" "Use RE2" "OFF")
+ option ("USE_STD_MAP" "Force the use of std::map" "OFF")
+ option ("BUILD_STATIC_LIB" "Build static libraries" "ON")
++option ("REGENERATE_METADATA" "Regenerate metadata instead of using it from the source tree" "ON")
+ 
+ if (${USE_ALTERNATE_FORMATS} STREQUAL "ON")
+   add_definitions ("-DI18N_PHONENUMBERS_USE_ALTERNATE_FORMATS")
+@@ -125,7 +126,9 @@ endif ()
+ find_required_program (PROTOC protoc
+                        "Google Protocol Buffers compiler (protoc)")
+ 
+-find_package(Java REQUIRED COMPONENTS Runtime)
++if (${REGENERATE_METADATA} STREQUAL "ON")
++  find_package(Java REQUIRED COMPONENTS Runtime)
++endif ()
+ 
+ if (APPLE)
+   FIND_LIBRARY (COREFOUNDATION_LIB CoreFoundation)
+@@ -265,14 +268,26 @@ function (add_metadata_gen_target TARGET_NAME
+   set (JAR_PATH "${CMAKE_SOURCE_DIR}/../tools/java/cpp-build/target")
+   set (JAR_PATH "${JAR_PATH}/cpp-build-1.0-SNAPSHOT-jar-with-dependencies.jar")
+ 
+-  add_custom_command (
+-    COMMAND ${Java_JAVA_EXECUTABLE} -jar
+-      ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
+-      ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
++  if (${REGENERATE_METADATA} STREQUAL "ON")
++    add_custom_command (
++      COMMAND ${Java_JAVA_EXECUTABLE} -jar
++        ${JAR_PATH} BuildMetadataCppFromXml ${XML_FILE}
++        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
+ 
+-    OUTPUT ${GEN_OUTPUT}
+-    DEPENDS ${XML_FILE}
+-  )
++      OUTPUT ${GEN_OUTPUT}
++      DEPENDS ${XML_FILE}
++    )
++  else ()
++    add_custom_command (
++      COMMAND echo "skip metadata generation from"
++        ${XML_FILE} "to"
++        ${CMAKE_SOURCE_DIR}/src/phonenumbers ${METADATA_TYPE}
++
++      OUTPUT ${GEN_OUTPUT}
++      DEPENDS ${XML_FILE}
++    )
++  endif ()
++  
+   add_custom_target (
+     ${TARGET_NAME}
+     DEPENDS ${GEN_OUTPUT}

--- a/ports/libphonenumber/CONTROL
+++ b/ports/libphonenumber/CONTROL
@@ -1,0 +1,5 @@
+Source: libphonenumber
+Version: 8.11.4
+Description: Google's common Java, C++ and JavaScript library for parsing, formatting, and validating international phone numbers.
+Homepage: https://github.com/google/libphonenumber
+Build-Depends: protobuf, gtest, icu, boost-thread, boost-smart-ptr, boost-utility

--- a/ports/libphonenumber/portfile.cmake
+++ b/ports/libphonenumber/portfile.cmake
@@ -1,0 +1,36 @@
+# Note libphonenumber supports dynamic library but this port needs additional work to install it properly.
+# Currently would fail during post-build validation:
+#   Import libs were not present in ...
+#   The following DLLs have no exports: .../bin/libphonenumber.dll
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/libphonenumber
+    REF v8.11.4
+    SHA512 6ef958db4b9470a3bfc8cc7169213ef0a7e90247f3e1911e179602810b2a8f8c227422c4f624aa5eb32497712fae878f1cfc053b9189cdc2d4102aa73c6dcfd1
+    HEAD_REF master
+    PATCHES
+        001-cmakelists-use-find-package.patch
+        002-cmakelists-fix-build-static-lib.patch
+        003-cmakelists-regenerate-metadata.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/cpp
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_STATIC_LIB=ON 
+        # Geocoder does not build successfully on Windows
+        -DBUILD_GEOCODER=OFF
+        # Metadata is included in source so regeneration is unnecessary. Disabling removes need for java.exe in build system.
+        # See https://github.com/google/libphonenumber/pull/2363
+        -DREGENERATE_METADATA=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/cpp/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- Fixes issue #7615

- Which triplets are supported/not supported? Have you updated the CI baseline?
So far only tested on x86-windows-static

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
The patches here are not minimized, and some of the changes could be included in the upstream repo. For example 003-cmakelists-regenerate-metadata.patch comes from https://github.com/google/libphonenumber/pull/2363

***Patches***

- 001-cmakelists-use-find-package.patch
  - Use CMake's `find_package` to find dependencies (gtest, boost, protobuf, icu)
- 002-cmakelists-fix-build-static-lib.patch
  - This patch makes libphonenumber not build the shared library version when its `BUILD_STATIC_LIB` option is enabled since the phonenumber.lib import library for the .dll would overwrite the phonenumber.lib static libary.
- 003-cmakelists-regenerate-metadata.patch
  - Part of https://github.com/google/libphonenumber/pull/2363. This option is used and turned off to save build time and not require java runtime during build.