### PR TITLE
[sdl2] Fix CMake include directory

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.10-2
+Version: 2.0.10-3
 Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/ports/sdl2/enable-winrt-cmake.patch
+++ b/ports/sdl2/enable-winrt-cmake.patch
@@ -135,7 +135,7 @@ index 0128c7a..bd534e4 100644
  # Always build SDLmain
 +if(NOT WINDOWS_STORE)
  add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
- target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include/SDL2>)
+ target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
  set(_INSTALL_LIBS "SDL2main")
  if (NOT ANDROID)
    set_target_properties(SDL2main PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})

--- a/ports/sdl2/fix-cmake-include-dir.patch
+++ b/ports/sdl2/fix-cmake-include-dir.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bd59d89b2..85ebe5f7b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1789,7 +1789,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
+ 
+ # Always build SDLmain
+ add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
+-target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include/SDL2>)
++target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
+ set(_INSTALL_LIBS "SDL2main")
+ if (NOT ANDROID)
+   set_target_properties(SDL2main PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+@@ -1820,7 +1820,7 @@ if(SDL_SHARED)
+   endif()
+   set(_INSTALL_LIBS "SDL2" ${_INSTALL_LIBS})
+   target_link_libraries(SDL2 ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+-  target_include_directories(SDL2 PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include/SDL2>)
++  target_include_directories(SDL2 PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
+   if (NOT ANDROID)
+     set_target_properties(SDL2 PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+   endif()
+@@ -1860,7 +1860,7 @@ if(SDL_STATIC)
+   # libraries - do we need to consider this?
+   set(_INSTALL_LIBS "SDL2-static" ${_INSTALL_LIBS})
+   target_link_libraries(SDL2-static ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+-  target_include_directories(SDL2-static PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include/SDL2>)
++  target_include_directories(SDL2-static PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
+   if (NOT ANDROID)
+     set_target_properties(SDL2-static PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+   endif()

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SDL-Mirror/SDL
@@ -8,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         export-symbols-only-in-shared-build.patch
+        fix-cmake-include-dir.patch
         enable-winrt-cmake.patch
         fix-arm64-headers.patch
         disable-hidapi-for-uwp.patch
@@ -18,18 +17,16 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
 
-set(VULKAN_VIDEO OFF)
-if("vulkan" IN_LIST FEATURES)
-    set(VULKAN_VIDEO ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    vulkan  VIDEO_VULKAN
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DSDL_STATIC=${SDL_STATIC}
         -DSDL_SHARED=${SDL_SHARED}
-        -DVIDEO_VULKAN=${VULKAN_VIDEO}
         -DFORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DLIBC=ON
 )


### PR DESCRIPTION
Currently, MSBuild expects SDL2 to be included as `#include <SDL2/SDL.h>`. This change causes CMake to match it. This also works better on non-vcpkg builds and differentiates with SDL1.