### PR TITLE
[sdl1] Fix incorrect compilation type after dynamic build

### DIFF
--- a/ports/sdl1/CONTROL
+++ b/ports/sdl1/CONTROL
@@ -1,3 +1,3 @@
 Source: sdl1
-Version: 1.2.15-9
+Version: 1.2.15-10
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl1/CONTROL
+++ b/ports/sdl1/CONTROL
@@ -1,3 +1,4 @@
 Source: sdl1
 Version: 1.2.15-10
+Homepage: https://www.libsdl.org
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.

--- a/ports/sdl1/portfile.cmake
+++ b/ports/sdl1/portfile.cmake
@@ -16,11 +16,11 @@ if (VCPKG_TARGET_IS_WINDOWS)
     file(COPY ${CMAKE_CURRENT_LIST_DIR}/SDL1_2017.sln DESTINATION ${SOURCE_PATH}/VisualC/ )
     
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/SDL_static.vcxproj DESTINATION ${SOURCE_PATH}/VisualC/SDL RENAME SDL.vcxproj)
-        file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/SDLmain_static.vcxproj DESTINATION ${SOURCE_PATH}/VisualC/SDLmain RENAME SDLmain.vcxproj)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/SDL_static.vcxproj  ${SOURCE_PATH}/VisualC/SDL/SDL.vcxproj COPYONLY)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/SDLmain_static.vcxproj ${SOURCE_PATH}/VisualC/SDLmain/SDLmain.vcxproj COPYONLY)
     else()
-        file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/SDL_dynamic.vcxproj DESTINATION ${SOURCE_PATH}/VisualC/SDL RENAME SDL.vcxproj)
-        file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/SDLmain_dynamic.vcxproj DESTINATION ${SOURCE_PATH}/VisualC/SDLmain RENAME SDLmain.vcxproj)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/SDL_dynamic.vcxproj ${SOURCE_PATH}/VisualC/SDL/SDL.vcxproj COPYONLY)
+        configure_file(${CMAKE_CURRENT_LIST_DIR}/SDLmain_dynamic.vcxproj ${SOURCE_PATH}/VisualC/SDLmain/SDLmain.vcxproj COPYONLY)
     endif()
     
     # This text file gets copied as a library, and included as one in the package 


### PR DESCRIPTION
When building dynamically, `vcxproj` has been copied into the source path, which caused skipping copying `vcxproj` during static builds and thus building the wrong link type.

Related: #8281 #10082.

Note: this port doesn't contain any features.