### PR TITLE
[liblemon] Fix post-build failed

### DIFF
--- a/ports/liblemon/CONTROL
+++ b/ports/liblemon/CONTROL
@@ -1,3 +1,4 @@
 Source: liblemon
-Version: 2019-06-13
+Version: 2019-06-13-1
+Homepag: https://lemon.cs.elte.hu/trac/lemon
 Description: Library for Efficient Modeling and Optimization in Networks

--- a/ports/liblemon/CONTROL
+++ b/ports/liblemon/CONTROL
@@ -1,4 +1,4 @@
 Source: liblemon
 Version: 2019-06-13-1
-Homepag: https://lemon.cs.elte.hu/trac/lemon
+Homepage: https://lemon.cs.elte.hu/trac/lemon
 Description: Library for Efficient Modeling and Optimization in Networks

--- a/ports/liblemon/portfile.cmake
+++ b/ports/liblemon/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 set(VERSION ed2c21cbd6ef)
@@ -15,8 +13,8 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
     REF ${VERSION}
     PATCHES
-        "cmake.patch"
-        "fixup-targets.patch"
+        cmake.patch
+        fixup-targets.patch
 )
 
 vcpkg_configure_cmake(
@@ -40,6 +38,7 @@ vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/liblemon)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/liblemon RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Since `/REDACTED/vcpkg/packages/liblemon_x64-osx/share/doc/lemon/html` is empty.
So on Linux and OSX, we should remove the doc.

Other changes:
Remove deprecated functions.
Add homepage.

Related issue #10096.

Note: No feature needs to test.


`