### PR TITLE
[cpprestsdk] Update version to fix uwp build

### DIFF
--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,5 +1,5 @@
 Source: cpprestsdk
-Version: 2.10.14-1
+Version: 2020-02-18
 Build-Depends: openssl (!uwp&!windows), boost-system (!uwp&!windows), 
   boost-date-time (!uwp&!windows), boost-regex (!uwp&!windows), boost-thread (!uwp&!windows),
   boost-filesystem (!uwp&!windows), boost-random (!uwp&!windows), boost-chrono (!uwp&!windows), 

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/cpprestsdk
-    REF v2.10.14
-    SHA512 7208b8c31e42a9bda2bf1d5c65527e54e3f946ec57743aaf7058c12a311de78de354d5ff859f35b3a8936c8964ac5695a692e234f3365edc426cf9580f76cd4f
+    REF 96e7d20e398b629de2935f9ac32cfa2780cd0b0b
+    SHA512 9f44b8be102489b88e088a654b6a59cd883c294d2b95cfe9e13a90de5300efabe25736bbb371945bd87329b02d5fe2c2cc9ee9d334f79c89768d2a26a8ba9ed5
     HEAD_REF master
 )
 
@@ -16,31 +14,21 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
         -DWEBSOCKETPP_CONFIG_VERSION=${WEBSOCKETPP_PATH})
 endif()
 
-set(CPPREST_EXCLUDE_BROTLI ON)
-if ("brotli" IN_LIST FEATURES)
-    set(CPPREST_EXCLUDE_BROTLI OFF)
-endif()
-
-set(CPPREST_EXCLUDE_COMPRESSION ON)
-if ("compression" IN_LIST FEATURES)
-    set(CPPREST_EXCLUDE_COMPRESSION OFF)
-endif()
-
-set(CPPREST_EXCLUDE_WEBSOCKETS ON)
-if("websockets" IN_LIST FEATURES)
-    set(CPPREST_EXCLUDE_WEBSOCKETS OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    INVERTED_FEATURES
+    brotli CPPREST_EXCLUDE_BROTLI
+    compression CPPREST_EXCLUDE_COMPRESSION
+    websockets CPPREST_EXCLUDE_WEBSOCKETS
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/Release
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         ${OPTIONS}
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF
-        -DCPPREST_EXCLUDE_BROTLI=${CPPREST_EXCLUDE_BROTLI}
-        -DCPPREST_EXCLUDE_COMPRESSION=${CPPREST_EXCLUDE_COMPRESSION}
-        -DCPPREST_EXCLUDE_WEBSOCKETS=${CPPREST_EXCLUDE_WEBSOCKETS}
         -DCPPREST_EXPORT_DIR=share/cpprestsdk
         -DWERROR=OFF
     OPTIONS_DEBUG
@@ -49,11 +37,10 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_copy_pdbs()
+
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/cpprestsdk)
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
 
-file(INSTALL
-    ${SOURCE_PATH}/license.txt
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpprestsdk RENAME copyright)
-
-vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
When building `cpprestsdk:x86-uwp`, some errors ocurred:
```
c1xx: error C2338: two-phase name lookup is not supported for C++/CLI, C++/CX, or OpenMP; use /Zc:twoPhase-
```

So I update version to fix this issue.

Related: #7540 [#1227](https://github.com/microsoft/cpprestsdk/issues/1227)。

Note: All features passed in the following triplets test:
- x86-windows
- x64-windows
- x64-windows-static