### PR TITLE
Fix build for VS2015

### DIFF
--- a/toolsrc/include/vcpkg/textrowcol.h
+++ b/toolsrc/include/vcpkg/textrowcol.h
@@ -4,8 +4,8 @@ namespace vcpkg::Parse
 {
     struct TextRowCol
     {
-        TextRowCol() = default;
-        TextRowCol(int row, int column) : row(row), column(column) {}
+        constexpr TextRowCol() noexcept = default;
+        constexpr TextRowCol(int row, int column) noexcept : row(row), column(column) {}
         /// '0' indicates uninitialized; '1' is the first row.
         int row = 0;
         /// '0' indicates uninitialized; '1' is the first column.

--- a/toolsrc/include/vcpkg/textrowcol.h
+++ b/toolsrc/include/vcpkg/textrowcol.h
@@ -4,6 +4,8 @@ namespace vcpkg::Parse
 {
     struct TextRowCol
     {
+        TextRowCol() = default;
+        TextRowCol(int row, int column) : row(row), column(column) {}
         /// '0' indicates uninitialized; '1' is the first row.
         int row = 0;
         /// '0' indicates uninitialized; '1' is the first column.


### PR DESCRIPTION
Fix compilation in VS 2015 by adding the missing constructors for TexRowCol required by VS2015.

Fixes #10085 
Fixes #10011 