### PR TITLE
[vcpkg] Better vcpkg_apply_patches error message

### DIFF
--- a/scripts/cmake/vcpkg_apply_patches.cmake
+++ b/scripts/cmake/vcpkg_apply_patches.cmake
@@ -41,13 +41,14 @@ function(vcpkg_apply_patches)
         _execute_process(
             COMMAND ${GIT} --work-tree=. --git-dir=.git apply "${ABSOLUTE_PATCH}" --ignore-whitespace --whitespace=nowarn --verbose
             OUTPUT_FILE ${CURRENT_BUILDTREES_DIR}/${LOGNAME}-out.log
-            ERROR_FILE ${CURRENT_BUILDTREES_DIR}/${LOGNAME}-err.log
+            ERROR_VARIABLE error
             WORKING_DIRECTORY ${_ap_SOURCE_PATH}
             RESULT_VARIABLE error_code
         )
+        file(WRITE "${CURRENT_BUILDTREES_DIR}/${LOGNAME}-err.log" "${error}")
 
         if(error_code AND NOT _ap_QUIET)
-            message(FATAL_ERROR "Applying patch failed. Patch needs to be updated to work with source being used by vcpkg!")
+            message(FATAL_ERROR "Applying patch failed. ${error}")
         endif()
 
         math(EXPR PATCHNUM "${PATCHNUM}+1")


### PR DESCRIPTION
This PR makes vcpkg_apply_patches to show git error instead of writing it into logs.
I think it would be more reasonable because it's actually one line. It makes easier to understand what's wrong with patches.

Before:
```
CMake Error at scripts/cmake/vcpkg_apply_patches.cmake:50 (message):
  Applying patch failed.  Patch needs to be updated to work with source being
  used by vcpkg!
  ```

After:
```
CMake Error at scripts/cmake/vcpkg_apply_patches.cmake:50 (message):
  Applying patch failed. error: corrupt patch at line 8
  ```