### PR TITLE
[hyperscan] Add missing dependency "boost-crc" to prevent missing header file compiler error

### DIFF
--- a/ports/hyperscan/CONTROL
+++ b/ports/hyperscan/CONTROL
@@ -1,5 +1,5 @@
 Source: hyperscan
-Version: 5.1.0-3
+Version: 5.1.0-4
 Homepage: https://www.hyperscan.io
 Description: A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.
 Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-crc, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, python3, ragel

--- a/ports/hyperscan/CONTROL
+++ b/ports/hyperscan/CONTROL
@@ -1,4 +1,5 @@
 Source: hyperscan
 Version: 5.1.0-3
+Homepage: https://www.hyperscan.io
 Description: A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.
 Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-crc, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, python3, ragel

--- a/ports/hyperscan/CONTROL
+++ b/ports/hyperscan/CONTROL
@@ -1,4 +1,4 @@
 Source: hyperscan
 Version: 5.1.0-3
 Description: A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.
-Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, python3, ragel
+Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-crc, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, python3, ragel


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #10147

Dependency `boost-crc` was missing from Hyperscan `CONTROL` file.

- Which triplets are supported/not supported? Have you updated the CI baseline? Tested on `x64-osx`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.