### PR TITLE
Enable mbedtls's threading support for libssh

### DIFF
--- a/ports/libssh/CONTROL
+++ b/ports/libssh/CONTROL
@@ -1,5 +1,5 @@
 Source: libssh
-Version: 0.9.3
+Version: 0.9.3-1
 Homepage: https://www.libssh.org/
 Description: libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side
 Default-Features: crypto
@@ -10,7 +10,7 @@ Build-Depends: libssh[mbedtls]
 Description: Default crypto backend
 
 Feature: mbedtls
-Build-Depends: mbedtls
+Build-Depends: mbedtls[pthreads]
 Description: Crypto support (mbedTLS)
 
 Feature: openssl

--- a/ports/mbedtls/CONTROL
+++ b/ports/mbedtls/CONTROL
@@ -4,5 +4,5 @@ Homepage: https://github.com/ARMmbed/mbedtls
 Description: An open source, portable, easy to use, readable and flexible SSL library
 
 Feature: pthreads
-Build-Depends: pthreads
+Build-Depends: pthreads (windows)
 Description: Multi-threading support

--- a/ports/mbedtls/CONTROL
+++ b/ports/mbedtls/CONTROL
@@ -1,4 +1,8 @@
 Source: mbedtls
-Version: 2.16.3
+Version: 2.16.3-1
 Homepage: https://github.com/ARMmbed/mbedtls
 Description: An open source, portable, easy to use, readable and flexible SSL library
+
+Feature: pthreads
+Build-Depends: pthreads
+Description: Multi-threading support

--- a/ports/mbedtls/enable-pthread.patch
+++ b/ports/mbedtls/enable-pthread.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5f7d0d886..96455dbad 100644
+index 5f7d0d886..d65cfeb2b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,6 +7,7 @@ endif()
  
  option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
  option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
-+option(ENABLE_PTHREADS4W "Build mbed TLS with PThreads4W" OFF)
++option(ENABLE_PTHREAD "Build mbed TLS with pthread" OFF)
  
  option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
  
@@ -18,13 +18,19 @@ index 5f7d0d886..96455dbad 100644
  
  if(ENABLE_ZLIB_SUPPORT)
      find_package(ZLIB)
-@@ -183,6 +185,11 @@ if(ENABLE_ZLIB_SUPPORT)
+@@ -183,6 +185,17 @@ if(ENABLE_ZLIB_SUPPORT)
      endif(ZLIB_FOUND)
  endif(ENABLE_ZLIB_SUPPORT)
  
-+if(ENABLE_PTHREADS4W)
-+    find_package(pthreads_windows REQUIRED)
-+    include_directories(${PThreads4W_INCLUDE_DIR})
++if(ENABLE_PTHREAD)
++    if(WIN32)
++        find_package(pthreads_windows REQUIRED)
++        include_directories(${PThreads4W_INCLUDE_DIR})
++    else()
++        set(CMAKE_THREAD_PREFER_PTHREAD ON)
++        find_package(Threads REQUIRED)
++    endif()
++    set(LINK_WITH_PTHREAD ON)
 +endif()
 +
  add_subdirectory(library)
@@ -63,28 +69,30 @@ index 5df962ef6..f205bf599 100644
  
 diff --git a/include/mbedtls/config_threading.h.in b/include/mbedtls/config_threading.h.in
 new file mode 100644
-index 000000000..c08ebf07a
+index 000000000..f6286ed9c
 --- /dev/null
 +++ b/include/mbedtls/config_threading.h.in
 @@ -0,0 +1,6 @@
-+#cmakedefine ENABLE_PTHREADS4W
++#cmakedefine ENABLE_PTHREAD
 +
-+#ifdef ENABLE_PTHREADS4W
++#ifdef ENABLE_PTHREAD
 +#define MBEDTLS_THREADING_C
 +#define MBEDTLS_THREADING_PTHREAD
 +#endif
 diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
-index 9330cff9b..838b774ac 100644
+index 9330cff9b..54a815ee7 100644
 --- a/library/CMakeLists.txt
 +++ b/library/CMakeLists.txt
-@@ -127,6 +127,10 @@ if(ENABLE_ZLIB_SUPPORT)
-     set(libs ${libs} ${ZLIB_LIBRARIES})
+@@ -128,7 +128,11 @@ if(ENABLE_ZLIB_SUPPORT)
  endif(ENABLE_ZLIB_SUPPORT)
  
-+if(ENABLE_PTHREADS4W)
-+    set(libs ${libs} ${PThreads4W_LIBRARY})
-+endif()
-+
  if(LINK_WITH_PTHREAD)
-     set(libs ${libs} pthread)
+-    set(libs ${libs} pthread)
++    if(WIN32)
++        set(libs ${libs} ${PThreads4W_LIBRARY})
++    else()
++        set(libs ${libs} pthread)
++    endif()
  endif()
+ 
+ if (NOT USE_STATIC_MBEDTLS_LIBRARY AND NOT USE_SHARED_MBEDTLS_LIBRARY)

--- a/ports/mbedtls/enable-pthreads4w.patch
+++ b/ports/mbedtls/enable-pthreads4w.patch
@@ -1,0 +1,90 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5f7d0d886..96455dbad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,6 +7,7 @@ endif()
+ 
+ option(USE_PKCS11_HELPER_LIBRARY "Build mbed TLS with the pkcs11-helper library." OFF)
+ option(ENABLE_ZLIB_SUPPORT "Build mbed TLS with zlib library." OFF)
++option(ENABLE_PTHREADS4W "Build mbed TLS with PThreads4W" OFF)
+ 
+ option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
+ 
+@@ -174,6 +175,7 @@ else()
+ endif()
+ 
+ include_directories(include/)
++include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
+ 
+ if(ENABLE_ZLIB_SUPPORT)
+     find_package(ZLIB)
+@@ -183,6 +185,11 @@ if(ENABLE_ZLIB_SUPPORT)
+     endif(ZLIB_FOUND)
+ endif(ENABLE_ZLIB_SUPPORT)
+ 
++if(ENABLE_PTHREADS4W)
++    find_package(pthreads_windows REQUIRED)
++    include_directories(${PThreads4W_INCLUDE_DIR})
++endif()
++
+ add_subdirectory(library)
+ add_subdirectory(include)
+ 
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index c2f2bd4e6..e110cd50c 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -1,9 +1,13 @@
+ option(INSTALL_MBEDTLS_HEADERS "Install mbed TLS headers." ON)
+ 
++configure_file(mbedtls/config_threading.h.in mbedtls/config_threading.h)
++
+ if(INSTALL_MBEDTLS_HEADERS)
+ 
+     file(GLOB headers "mbedtls/*.h")
+ 
++    set(headers ${headers} ${CMAKE_CURRENT_BINARY_DIR}/mbedtls/config_threading.h)
++
+     install(FILES ${headers}
+         DESTINATION include/mbedtls
+         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+diff --git a/include/mbedtls/config.h b/include/mbedtls/config.h
+index 5df962ef6..f205bf599 100644
+--- a/include/mbedtls/config.h
++++ b/include/mbedtls/config.h
+@@ -26,6 +26,8 @@
+  *  This file is part of mbed TLS (https://tls.mbed.org)
+  */
+ 
++#include "mbedtls/config_threading.h"
++
+ #ifndef MBEDTLS_CONFIG_H
+ #define MBEDTLS_CONFIG_H
+ 
+diff --git a/include/mbedtls/config_threading.h.in b/include/mbedtls/config_threading.h.in
+new file mode 100644
+index 000000000..c08ebf07a
+--- /dev/null
++++ b/include/mbedtls/config_threading.h.in
+@@ -0,0 +1,6 @@
++#cmakedefine ENABLE_PTHREADS4W
++
++#ifdef ENABLE_PTHREADS4W
++#define MBEDTLS_THREADING_C
++#define MBEDTLS_THREADING_PTHREAD
++#endif
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index 9330cff9b..838b774ac 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -127,6 +127,10 @@ if(ENABLE_ZLIB_SUPPORT)
+     set(libs ${libs} ${ZLIB_LIBRARIES})
+ endif(ENABLE_ZLIB_SUPPORT)
+ 
++if(ENABLE_PTHREADS4W)
++    set(libs ${libs} ${PThreads4W_LIBRARY})
++endif()
++
+ if(LINK_WITH_PTHREAD)
+     set(libs ${libs} pthread)
+ endif()

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -31,4 +31,8 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/mbedtls RENAME copyright)
 
+if(WIN32 AND pthreads IN_LIST FEATURES)
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/mbedtls)
+endif()
+
 vcpkg_copy_pdbs()

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -8,12 +8,22 @@ vcpkg_from_github(
     REF mbedtls-2.16.3
     SHA512 3d798f7de9c33325585d5d7c8608cc16acdcf42c246d283b2fb8a29f5e419f2899342965ff297432ef2ab20c91eaee28d6ca53349f5a68b0a4fd29d6905fc64c
     HEAD_REF master
+    PATCHES
+        enable-pthreads4w.patch
 )
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        pthreads ENABLE_PTHREADS4W
+)
+
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DENABLE_TESTING=OFF
         -DENABLE_PROGRAMS=OFF
 )

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(VCPKG_LIBRARY_LINKAGE static)
 
 vcpkg_from_github(
@@ -17,7 +15,6 @@ vcpkg_check_features(
     FEATURES
         pthreads ENABLE_PTHREADS4W
 )
-
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/mbedtls/portfile.cmake
+++ b/ports/mbedtls/portfile.cmake
@@ -7,13 +7,13 @@ vcpkg_from_github(
     SHA512 3d798f7de9c33325585d5d7c8608cc16acdcf42c246d283b2fb8a29f5e419f2899342965ff297432ef2ab20c91eaee28d6ca53349f5a68b0a4fd29d6905fc64c
     HEAD_REF master
     PATCHES
-        enable-pthreads4w.patch
+        enable-pthread.patch
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        pthreads ENABLE_PTHREADS4W
+        pthreads ENABLE_PTHREAD
 )
 
 vcpkg_configure_cmake(

--- a/ports/mbedtls/vcpkg-cmake-wrapper.cmake
+++ b/ports/mbedtls/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,29 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h)
+
+find_library(MBEDTLS_CRYPTO_LIBRARY mbedcrypto)
+find_package(pthreads_windows QUIET)
+set(MBEDTLS_CRYPTO_LIBRARY ${MBEDTLS_CRYPTO_LIBRARY} ${PThreads4W_LIBRARY})
+find_library(MBEDTLS_X509_LIBRARY mbedx509)
+find_library(MBEDTLS_TLS_LIBRARY mbedtls)
+set(MBEDTLS_LIBRARIES ${MBEDTLS_CRYPTO_LIBRARY} ${MBEDTLS_X509_LIBRARY} ${MBEDTLS_TLS_LIBRARY})
+
+if (MBEDTLS_INCLUDE_DIR AND EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
+    file(
+        STRINGS ${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h _MBEDTLS_VERLINE
+        REGEX "^#define[ \t]+MBEDTLS_VERSION_STRING[\t ].*"
+    )
+    string(REGEX REPLACE ".*MBEDTLS_VERSION_STRING[\t ]+\"(.*)\"" "\\1" MBEDTLS_VERSION ${_MBEDTLS_VERLINE})
+endif()
+
+find_package_handle_standard_args(
+    mbedTLS
+    REQUIRED_VARS
+        MBEDTLS_INCLUDE_DIR
+        MBEDTLS_CRYPTO_LIBRARY
+        MBEDTLS_X509_LIBRARY
+        MBEDTLS_TLS_LIBRARY
+        PThreads4W_FOUND
+    VERSION_VAR MBEDTLS_VERSION
+)


### PR DESCRIPTION
libssh requires threading support being enabled for mbedtls to work with it.

This fixes #10012 