### PR TITLE
[osg] Fix sdl2 include path

### DIFF
--- a/ports/osg/fix-sdl.patch
+++ b/ports/osg/fix-sdl.patch
@@ -32,7 +32,7 @@ index 9de15b1..ae96e11 100644
  #if USE_SDL || USE_SDL2
  
 -#include "SDL.h"
-+#include <SDL/SDL.h>
++#include <SDL2/SDL.h>
  
  static void soundReadCallback(void * user_data, uint8_t * data, int datalen)
  {


### PR DESCRIPTION
OSG depends on sdl2 only, which has headers at <SDL2/*.h>. OSG is failing to build unless you happened to also have SDL1 installed. 

https://github.com/microsoft/vcpkg/blob/master/ports/osg/CONTROL -> depends on sdl2 only