### PR TITLE
[celero] Fix usage error

### DIFF
--- a/ports/celero/CONTROL
+++ b/ports/celero/CONTROL
@@ -1,4 +1,4 @@
 Source: celero
-Version: 2.6.0
+Version: 2.6.0-1
 Homepage: https://github.com/DigitalInBlue/Celero
 Description: Celero is a modern cross-platform (Windows, Linux, MacOS) Microbenchmarking library for C++.

--- a/ports/celero/fix-win32-define.patch
+++ b/ports/celero/fix-win32-define.patch
@@ -1,0 +1,490 @@
+diff --git a/README.md b/README.md
+index 5b83f2d..151f5d1 100644
+--- a/README.md
++++ b/README.md
+@@ -166,7 +166,7 @@ Here is an example of a simple Celero Benchmark. (Note: This is a complete, runn
+ 
+ #include <random>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/experiments/DemoSimple/DemoSimple.cpp b/experiments/DemoSimple/DemoSimple.cpp
+index 2a0a0c3..f0c300f 100644
+--- a/experiments/DemoSimple/DemoSimple.cpp
++++ b/experiments/DemoSimple/DemoSimple.cpp
+@@ -2,7 +2,7 @@
+ 
+ #include <random>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/experiments/DemoSimpleJUnit/DemoSimpleJUnit.cpp b/experiments/DemoSimpleJUnit/DemoSimpleJUnit.cpp
+index 86c47c1..0be4ac2 100644
+--- a/experiments/DemoSimpleJUnit/DemoSimpleJUnit.cpp
++++ b/experiments/DemoSimpleJUnit/DemoSimpleJUnit.cpp
+@@ -1,6 +1,6 @@
+ #include <celero/Celero.h>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/experiments/DemoTransform/DemoTransform.cpp b/experiments/DemoTransform/DemoTransform.cpp
+index 25b37a2..55e7e60 100644
+--- a/experiments/DemoTransform/DemoTransform.cpp
++++ b/experiments/DemoTransform/DemoTransform.cpp
+@@ -4,7 +4,7 @@
+ #include <algorithm>
+ #include <functional>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/experiments/ExperimentSortingRandomInts/ExperimentSortingRandomInts.cpp b/experiments/ExperimentSortingRandomInts/ExperimentSortingRandomInts.cpp
+index 0f3b8ed..e8f85c5 100644
+--- a/experiments/ExperimentSortingRandomInts/ExperimentSortingRandomInts.cpp
++++ b/experiments/ExperimentSortingRandomInts/ExperimentSortingRandomInts.cpp
+@@ -1,7 +1,7 @@
+ #include <celero/Celero.h>
+ #include <algorithm>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/experiments/ExperimentSortingRandomIntsUDM/ExperimentSortingRandomIntsUDM.cpp b/experiments/ExperimentSortingRandomIntsUDM/ExperimentSortingRandomIntsUDM.cpp
+index e724fa2..8df7296 100644
+--- a/experiments/ExperimentSortingRandomIntsUDM/ExperimentSortingRandomIntsUDM.cpp
++++ b/experiments/ExperimentSortingRandomIntsUDM/ExperimentSortingRandomIntsUDM.cpp
+@@ -3,7 +3,7 @@
+ #include <iostream>
+ #include <string>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cmath>
+ #include <cstdlib>
+ #endif
+diff --git a/include/celero/Celero.h b/include/celero/Celero.h
+index aaf38ef..a7c91d4 100644
+--- a/include/celero/Celero.h
++++ b/include/celero/Celero.h
+@@ -31,7 +31,7 @@
+ /// It is highly encouraged to only run this code compiled in a "Release" mode to use all available optimizations.
+ ///
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <process.h>
+ #endif
+ 
+diff --git a/include/celero/CommandLine.h b/include/celero/CommandLine.h
+index 230417a..82204f9 100644
+--- a/include/celero/CommandLine.h
++++ b/include/celero/CommandLine.h
+@@ -38,7 +38,7 @@
+ #include <typeinfo>
+ #include <vector>
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <cxxabi.h>
+ #endif
+ 
+@@ -115,7 +115,7 @@ namespace cmdline
+ 			return lexical_cast_t<Target, Source, detail::is_same<Target, Source>::value>::cast(arg);
+ 		}
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ 		static inline std::string demangle(const std::string &)
+ 		{
+ 			return std::string();
+diff --git a/include/celero/Export.h b/include/celero/Export.h
+index b672b15..a074e37 100644
+--- a/include/celero/Export.h
++++ b/include/celero/Export.h
+@@ -23,7 +23,7 @@
+ #define CELERO_EXPORT
+ #define CELERO_EXPORT_C
+ #else
+-#ifdef WIN32
++#ifdef _WIN32
+ #if defined CELERO_EXPORTS
+ #define CELERO_EXPORT _declspec(dllexport)
+ #define CELERO_EXPORT_C extern "C" _declspec(dllexport)
+diff --git a/include/celero/Utilities.h b/include/celero/Utilities.h
+index 4f409e5..93e3c53 100644
+--- a/include/celero/Utilities.h
++++ b/include/celero/Utilities.h
+@@ -19,7 +19,7 @@
+ /// limitations under the License.
+ ///
+ 
+-#ifndef WIN32
++#ifndef _WIN32
+ #include <unistd.h>
+ #endif
+ 
+diff --git a/src/Console.cpp b/src/Console.cpp
+index 91e2059..b4c62ec 100644
+--- a/src/Console.cpp
++++ b/src/Console.cpp
+@@ -20,14 +20,14 @@
+ 
+ using namespace celero;
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <Windows.h>
+ #include <stdio.h>
+ #else
+ #include <iostream>
+ #endif
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ auto WinColor() -> decltype(GetStdHandle(STD_OUTPUT_HANDLE))
+ {
+ 	auto h = GetStdHandle(STD_OUTPUT_HANDLE);
+@@ -39,7 +39,7 @@ auto WinColor() -> decltype(GetStdHandle(STD_OUTPUT_HANDLE))
+ 
+ void Red()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED);
+ #else
+@@ -49,7 +49,7 @@ void Red()
+ 
+ void RedBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_INTENSITY);
+ #else
+@@ -59,7 +59,7 @@ void RedBold()
+ 
+ void Green()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_GREEN);
+ #else
+@@ -69,7 +69,7 @@ void Green()
+ 
+ void GreenBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+ #else
+@@ -79,7 +79,7 @@ void GreenBold()
+ 
+ void Blue()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_BLUE);
+ #else
+@@ -89,7 +89,7 @@ void Blue()
+ 
+ void BlueBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+ #else
+@@ -99,7 +99,7 @@ void BlueBold()
+ 
+ void Cyan()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_BLUE | FOREGROUND_GREEN);
+ #else
+@@ -109,7 +109,7 @@ void Cyan()
+ 
+ void CyanBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+ #else
+@@ -119,7 +119,7 @@ void CyanBold()
+ 
+ void Yellow()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_GREEN);
+ #else
+@@ -129,7 +129,7 @@ void Yellow()
+ 
+ void YellowBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY);
+ #else
+@@ -139,7 +139,7 @@ void YellowBold()
+ 
+ void White()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+ #else
+@@ -149,7 +149,7 @@ void White()
+ 
+ void WhiteBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+ #else
+@@ -159,7 +159,7 @@ void WhiteBold()
+ 
+ void WhiteOnRed()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, BACKGROUND_RED | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE);
+ #else
+@@ -169,7 +169,7 @@ void WhiteOnRed()
+ 
+ void WhiteOnRedBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, BACKGROUND_RED | FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+ #else
+@@ -179,7 +179,7 @@ void WhiteOnRedBold()
+ 
+ void PurpleBold()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	auto h = WinColor();
+ 	SetConsoleTextAttribute(h, FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+ #else
+@@ -189,7 +189,7 @@ void PurpleBold()
+ 
+ void Default()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	White();
+ #else
+ 	std::cout << "\033[0m";
+diff --git a/src/Exceptions.cpp b/src/Exceptions.cpp
+index 9cb1918..7780774 100644
+--- a/src/Exceptions.cpp
++++ b/src/Exceptions.cpp
+@@ -21,7 +21,7 @@
+ #include <celero/Console.h>
+ #include <celero/TestFixture.h>
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <Windows.h>
+ #endif // WIN32
+ 
+diff --git a/src/Memory.cpp b/src/Memory.cpp
+index f1662d4..fde7f19 100644
+--- a/src/Memory.cpp
++++ b/src/Memory.cpp
+@@ -19,7 +19,7 @@
+ #include <celero/Memory.h>
+ #include <sstream>
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <Windows.h>
+ 
+ #include <Psapi.h>
+@@ -53,7 +53,7 @@
+ 
+ using namespace celero;
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #else
+ constexpr int64_t Kilobytes2Bytes{1024};
+ 
+@@ -120,7 +120,7 @@ celero::RAMReport celero::RAMReport::operator-(const RAMReport& x)
+ 
+ int64_t celero::GetRAMSystemTotal()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -155,7 +155,7 @@ int64_t celero::GetRAMSystemTotal()
+ 
+ int64_t celero::GetRAMSystemAvailable()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -167,7 +167,7 @@ int64_t celero::GetRAMSystemAvailable()
+ 
+ int64_t celero::GetRAMSystemUsed()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	return celero::GetRAMSystemTotal() - celero::GetRAMSystemAvailable();
+ #elif defined(__APPLE__)
+ 	int mib[2];
+@@ -198,7 +198,7 @@ int64_t celero::GetRAMSystemUsed()
+ 
+ int64_t celero::GetRAMSystemUsedByCurrentProcess()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	PROCESS_MEMORY_COUNTERS_EX pmc;
+ 	GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PPROCESS_MEMORY_COUNTERS>(&pmc), sizeof(pmc));
+ 	return static_cast<int64_t>(pmc.WorkingSetSize);
+@@ -209,7 +209,7 @@ int64_t celero::GetRAMSystemUsedByCurrentProcess()
+ 
+ int64_t celero::GetRAMPhysicalTotal()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -225,7 +225,7 @@ int64_t celero::GetRAMPhysicalTotal()
+ 
+ int64_t celero::GetRAMPhysicalAvailable()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -237,7 +237,7 @@ int64_t celero::GetRAMPhysicalAvailable()
+ 
+ int64_t celero::GetRAMPhysicalUsed()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	return celero::GetRAMPhysicalTotal() - celero::GetRAMPhysicalAvailable();
+ #elif defined(__APPLE__)
+ 	struct rusage rusage;
+@@ -252,7 +252,7 @@ int64_t celero::GetRAMPhysicalUsed()
+ 
+ int64_t celero::GetRAMPhysicalUsedByCurrentProcess()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	PROCESS_MEMORY_COUNTERS_EX pmc;
+ 	GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PPROCESS_MEMORY_COUNTERS>(&pmc), sizeof(pmc));
+ 	return static_cast<int64_t>(pmc.WorkingSetSize);
+@@ -306,7 +306,7 @@ int64_t celero::GetRAMPhysicalUsedByCurrentProcessPeak()
+ 
+ int64_t celero::GetRAMVirtualTotal()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -322,7 +322,7 @@ int64_t celero::GetRAMVirtualTotal()
+ 
+ int64_t celero::GetRAMVirtualAvailable()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	MEMORYSTATUSEX memInfo;
+ 	memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+ 	GlobalMemoryStatusEx(&memInfo);
+@@ -334,7 +334,7 @@ int64_t celero::GetRAMVirtualAvailable()
+ 
+ int64_t celero::GetRAMVirtualUsed()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	return celero::GetRAMVirtualTotal() - celero::GetRAMVirtualAvailable();
+ #elif defined(__APPLE__)
+ 	return -1;
+@@ -348,7 +348,7 @@ int64_t celero::GetRAMVirtualUsed()
+ 
+ int64_t celero::GetRAMVirtualUsedByCurrentProcess()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	PROCESS_MEMORY_COUNTERS_EX pmc;
+ 	GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PPROCESS_MEMORY_COUNTERS>(&pmc), sizeof(pmc));
+ 	return pmc.PrivateUsage;
+diff --git a/src/Timer.cpp b/src/Timer.cpp
+index 7792722..fa24e74 100644
+--- a/src/Timer.cpp
++++ b/src/Timer.cpp
+@@ -20,7 +20,7 @@
+ #include <celero/Timer.h>
+ #include <iostream>
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <Windows.h>
+ LARGE_INTEGER QPCFrequency;
+ #else
+@@ -29,7 +29,7 @@ LARGE_INTEGER QPCFrequency;
+ 
+ uint64_t celero::timer::GetSystemTime()
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	LARGE_INTEGER timeStorage;
+ 	QueryPerformanceCounter(&timeStorage);
+ 	if(QPCFrequency.QuadPart != 0)
+@@ -46,7 +46,7 @@ uint64_t celero::timer::GetSystemTime()
+ 
+ double celero::timer::CachePerformanceFrequency(bool quiet)
+ {
+-#ifdef WIN32
++#ifdef _WIN32
+ 	QueryPerformanceFrequency(&QPCFrequency);
+ 	if(QPCFrequency.QuadPart == 0)
+ 	{
+diff --git a/src/Utilities.cpp b/src/Utilities.cpp
+index 6d9a266..0e4f1c4 100644
+--- a/src/Utilities.cpp
++++ b/src/Utilities.cpp
+@@ -19,7 +19,7 @@
+ #include <celero/Print.h>
+ #include <celero/Utilities.h>
+ 
+-#ifdef WIN32
++#ifdef _WIN32
+ #include <Windows.h>
+ 
+ #include <PowrProf.h>

--- a/ports/celero/portfile.cmake
+++ b/ports/celero/portfile.cmake
@@ -1,11 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DigitalInBlue/Celero
-    REF 83b592b134cb41e2e5611714bce0bf61413eb12b
+    REF 83b592b134cb41e2e5611714bce0bf61413eb12b #2.6.0
     SHA512 3315b56467c17330f603c6710996c1a76f67068960b1356ca92db1ab23fca9f27a2dda9be521a19b88efc2e961095ee5523924b135d380681a4328c09d963e8c
     HEAD_REF master
+    PATCHES fix-win32-define.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" CELERO_COMPILE_DYNAMIC_LIBRARIES)
@@ -26,6 +25,10 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/celero/Export.h "ifdef CELERO_STATIC" "if 1")
+endif()
+
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/celero/celero-target.cmake ${CURRENT_PACKAGES_DIR}/share/celero/celero-config.cmake)
 
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/celero RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fix build failure when using offical sample code:
- Modify `WIN32` to `_WIN32`
- Modify `#ifdef CELERO_STATIC` to `#if 1` when building static.

Related: #5790.

This port doesn't contain any features.