### PR TITLE
[libmysql] Fix for missing "ADD_COMPILE_FLAGS" command

### DIFF
--- a/ports/libmysql/CONTROL
+++ b/ports/libmysql/CONTROL
@@ -1,5 +1,5 @@
 Source: libmysql
-Version: 8.0.4-5
+Version: 8.0.4-6
 Homepage: https://github.com/mysql/mysql-server
 Build-Depends: boost-algorithm, boost-geometry, boost-optional, boost-functional, boost-graph, openssl, icu, libevent, liblzma, lz4, zlib
 Description: A MySQL client library for C development.

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -14,8 +14,6 @@ if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
     message(WARNING "libmysql needs ncurses on LINUX, please install ncurses first.\nOn Debian/Ubuntu, package name is libncurses5-dev, on Redhat and derivates it is ncurses-devel.")
 endif()
 
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mysql/mysql-server

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -1,13 +1,7 @@
+vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "x86")
+
 if (EXISTS "${CURRENT_INSTALLED_DIR}/include/mysql/mysql.h")
     message(FATAL_ERROR "FATAL ERROR: libmysql and libmariadb are incompatible.")
-endif()
-
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "libmysql cannot currently be cross-compiled for UWP")
-endif()
-
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" AND NOT CMAKE_SYSTEM_NAME OR CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "Oracle has dropped support in libmysql for 32-bit Windows.")
 endif()
 
 if (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -75,7 +75,8 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/bin
     ${CURRENT_PACKAGES_DIR}/docs
     ${CURRENT_PACKAGES_DIR}/debug/docs
-    ${CURRENT_PACKAGES_DIR}/lib/debug)
+    ${CURRENT_PACKAGES_DIR}/lib/debug
+    ${CURRENT_PACKAGES_DIR}/lib/plugin/debug)
 
 # remove misc files
 file(REMOVE

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_from_github(
         ignore-boost-version.patch
         system-libs.patch
         linux_libmysql.patch
+        re2_add_compile_flags.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/include/boost_1_65_0)

--- a/ports/libmysql/portfile.cmake
+++ b/ports/libmysql/portfile.cmake
@@ -120,5 +120,4 @@ string(REPLACE "#include <mysql/udf_registration_types.h>" "#include \"mysql/udf
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/mysql/mysql_com.h "${_contents}")
 
 # copy license
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmysql)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libmysql/LICENSE ${CURRENT_PACKAGES_DIR}/share/libmysql/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libmysql/re2_add_compile_flags.patch
+++ b/ports/libmysql/re2_add_compile_flags.patch
@@ -1,0 +1,12 @@
+diff --git a/extra/re2/CMakeLists.txt b/extra/re2/CMakeLists.txt
+index ca39db726..965f2c8dc 100644
+--- a/extra/re2/CMakeLists.txt
++++ b/extra/re2/CMakeLists.txt
+@@ -71,6 +71,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+                              HAVE_TAUTOLOGICAL_UNDEFINED_COMPARE)
+   IF(HAVE_TAUTOLOGICAL_UNDEFINED_COMPARE)
+     # Boost source has unused local typedefs.
++    INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/compile_flags.cmake)
+     ADD_COMPILE_FLAGS(${RE2_SOURCES}
+                       COMPILE_FLAGS "-Wno-tautological-undefined-compare")
+   ENDIF()

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -7,10 +7,10 @@
 ##   fail - the port does not build in the CI system.
 ##          This is not necessarily the same as if a port is expected to build
 ##          on a developers machine because it may fail due to the machine
-##          configuration.  When set to fail the CI system will still attempt 
+##          configuration.  When set to fail the CI system will still attempt
 ##          to build the port and will report a CI failure until this file is updated.
 ##   skip - Do not build this port in the CI system.
-##          This is added to ports that may be flaky or conflict with other 
+##          This is added to ports that may be flaky or conflict with other
 ##          ports.  Please comment for why a port is skipped so it can be
 ##          removed when the issue is resolved.
 ##   ignore - attempt to build the port, but do not fail the CI test if the
@@ -27,7 +27,7 @@
 ##    x64-windows
 ##    x64-windows-static
 ##    x86-windows
-##   
+##
 
 
 # Add new items alphabetically
@@ -837,7 +837,6 @@ libmodplug:arm-uwp=fail
 libmodplug:x64-uwp=fail
 libmupdf:x64-linux=fail
 libmupdf:x64-osx=fail
-libmysql:x64-osx=fail
 libmysql:x86-windows=fail
 libnice:x64-linux=fail
 libnice:x64-osx=fail
@@ -1544,7 +1543,7 @@ rpclib:x86-windows=ignore
 rpclib:x64-windows-static=ignore
 rttr:arm-uwp=fail
 rttr:x64-uwp=fail
-rxspencer:x64-uwp=fail  
+rxspencer:x64-uwp=fail
 rxspencer:arm-uwp=fail
 scintilla:arm-uwp=fail
 scintilla:x64-linux=fail


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #5204

- Which triplets are supported/not supported? Have you updated the CI baseline? Tested `x64-osx` and `x64-windows`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.

When installing `libmysql` on Mac + Clang, CMake will generate a configuration error because a necessary file (`cmake/compile_flags.cmake` from the `libmysql` sources) did not get included:

```
CMake Error at extra/re2/CMakeLists.txt:74 (ADD_COMPILE_FLAGS):
  Unknown CMake command "ADD_COMPILE_FLAGS".
```

This PR...

- Adds a patch for `extra/re2/CMakeLists.txt` that fixes the "unknown command ADD_COMPILE_FLAGS" error.
- Removes an empty directory after the installation of `libmysql` that the post-installation checks would complain about.