### PR TITLE
[pcl] Change feature pcap dependency to libpcap in UNIX

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.9.1-10
+Version: 1.9.1-11
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
@@ -14,7 +14,7 @@ Build-Depends: vtk[qt]
 
 Feature: pcap
 Description: PCAP support for PCL
-Build-Depends: winpcap
+Build-Depends: winpcap (windows), libpcap (!windows)
 
 Feature: tools
 Description: Build PCL utilities


### PR DESCRIPTION
`winpcap` only support windows, so change feature `pcap` dependency to `libpcap` in UNIX.

Related: #10143.

Already tested successfully in x64-linux.