### PR TITLE
[google-cloud-cpp-common] Upgrade to v0.20.0 release

### DIFF
--- a/ports/google-cloud-cpp-common/CONTROL
+++ b/ports/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.19.0
+Version: 0.20.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ports/google-cloud-cpp-common/portfile.cmake
+++ b/ports/google-cloud-cpp-common/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-common
-    REF v0.19.0
-    SHA512 c297cdba8f4037b19ebb92af643730a92f7a50d6341d7fbb130446c6d2c1391732fdc4ef550b95261b8decfc10d138847efa97af6f8e48968e071bc13e853684
+    REF v0.20.0
+    SHA512 9b6c26a91cd5fc5d95bcbe7fb8dff106e5bf169ab535a9b6315319800fa0cbd875142a033a3c5ff21df028d221601ffbe8d1feb2349cb156025122abdd715851
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
**Describe the pull request**

Upgrade gooogle-cloud-cpp-common to the latest (v0.20.0) release.

- What does your PR fix? Fixes issue #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I think so.
