### PR TITLE
[blaze] Update to Blaze 3.7

### DIFF
--- a/ports/blaze/CONTROL
+++ b/ports/blaze/CONTROL
@@ -1,5 +1,5 @@
 Source: blaze
-Version: 3.6-1
+Version: 3.7
 Build-Depends: clapack (!osx), boost-exception
 Homepage: https://bitbucket.org/blaze-lib/blaze
 Description: Blaze is an open-source, high-performance C++ math library for dense and sparse arithmetic.

--- a/ports/blaze/portfile.cmake
+++ b/ports/blaze/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO blaze-lib/blaze
-    REF 51fff70fcc70c8bcb167b5daa497babf51b7603e
-    SHA512 7048720d1842a0a8e621f6878c43942664523f889f2659f4334c7428d1177a5a226c95bcb5f84b93cae87c61e188bf91dc2429b1ddfc7b6a7b8eb74ab8c0a1ec
+    REF e9724478a5fd29b9c2f8c45f0be95ad774ab4d4f
+    SHA512 d1699fffe3013d571e34cf5444714647428be257cad90c4bc6cca8051702ff6d086eb731dca408faaf83b9311df4138f55187673235128fcd3c03029af337a75
     HEAD_REF master
 )
 
@@ -12,7 +10,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DBLAZE_SMP_THREADS=C++11
+        -DBLAZE_SMP_THREADS=OpenMP
 )
 
 vcpkg_install_cmake()
@@ -22,5 +20,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/blaze/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/blaze)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/blaze/LICENSE ${CURRENT_PACKAGES_DIR}/share/blaze/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Dear vcpkg maintainers!

This pull request updates the [Blaze](https://bitbucket.org/blaze-lib/blaze/) port to the current release 3.7. To our best knowledge this pull request follows the maintainer guide: The REF has been set to the [v3.7](https://bitbucket.org/blaze-lib/blaze/commits/tag/v3.7) tag and the SHA512 has been determined via running `vcpkg install blaze` using the updated port files. Additionally, we have changed the default configuration from using C++11 threads to OpenMP. Thanks,

Best regards,
Klaus!