### PR TITLE
[sdl2-mixer] Enable native MIDI support on macOS

### DIFF
--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -91,10 +91,16 @@ add_library(SDL2_mixer
     music_wav.c
     version.rc)
 
-if(WIN32)
+if(WIN32 OR APPLE)
     list(APPEND SDL_MIXER_DEFINES MUSIC_MID_NATIVE)
-    target_sources(SDL2_mixer PRIVATE music_nativemidi.c native_midi/native_midi_common.c native_midi/native_midi_win32.c)
-    target_link_libraries(SDL2_mixer ${SDL_MIXER_LIBRARIES} Winmm)
+    target_sources(SDL2_mixer PRIVATE music_nativemidi.c native_midi/native_midi_common.c)
+    target_link_libraries(SDL2_mixer ${SDL_MIXER_LIBRARIES})
+    if(WIN32)
+        target_sources(SDL2_mixer PRIVATE native_midi/native_midi_win32.c)
+        target_link_libraries(SDL2_mixer Winmm)
+    elseif(APPLE)
+        target_sources(SDL2_mixer PRIVATE native_midi/native_midi_macosx.c)
+    endif()
 endif()
 
 set_target_properties(SDL2_mixer PROPERTIES DEFINE_SYMBOL SDL2_EXPORTS)

--- a/ports/sdl2-mixer/CONTROL
+++ b/ports/sdl2-mixer/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2-mixer
-Version: 2.0.4-8
+Version: 2.0.4-9
 Homepage: https://www.libsdl.org/projects/SDL_mixer
 Description: Multi-channel audio mixer library for SDL.
 Build-Depends: sdl2


### PR DESCRIPTION
Enable native MIDI support for sdl2-mixer on macOS, like it is done on Windows.