### PR TITLE
[vcpkg] Fix issue #9916; `vcpkg upgrade` did not `load_tag_vars()`

### DIFF
--- a/toolsrc/include/vcpkg/cmakevars.h
+++ b/toolsrc/include/vcpkg/cmakevars.h
@@ -1,15 +1,21 @@
 #pragma once
 
-#include <vcpkg/base/hash.h>
-#include <vcpkg/base/system.process.h>
+#include <vcpkg/base/optional.h>
 
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg::Dependencies
+{
+    struct ActionPlan;
+}
 
 namespace vcpkg::CMakeVars
 {
     struct CMakeVarProvider
     {
+        virtual ~CMakeVarProvider() = default;
+
         virtual Optional<const std::unordered_map<std::string, std::string>&> get_generic_triplet_vars(
             Triplet triplet) const = 0;
 
@@ -25,45 +31,10 @@ namespace vcpkg::CMakeVars
 
         virtual void load_tag_vars(Span<const FullPackageSpec> specs,
                                    const PortFileProvider::PortFileProvider& port_provider) const = 0;
+
+        void load_tag_vars(const vcpkg::Dependencies::ActionPlan& action_plan,
+                           const PortFileProvider::PortFileProvider& port_provider) const;
     };
 
-    struct TripletCMakeVarProvider : Util::ResourceBase, CMakeVarProvider
-    {
-    private:
-        fs::path create_tag_extraction_file(
-            const Span<const std::pair<const FullPackageSpec*, std::string>>& spec_abi_settings) const;
-
-        fs::path create_dep_info_extraction_file(const Span<const PackageSpec> specs) const;
-
-        void launch_and_split(const fs::path& script_path,
-                              std::vector<std::vector<std::pair<std::string, std::string>>>& vars) const;
-
-    public:
-        explicit TripletCMakeVarProvider(const vcpkg::VcpkgPaths& paths) : paths(paths) {}
-
-        void load_generic_triplet_vars(Triplet triplet) const override;
-
-        void load_dep_info_vars(Span<const PackageSpec> specs) const override;
-
-        void load_tag_vars(Span<const FullPackageSpec> specs,
-                           const PortFileProvider::PortFileProvider& port_provider) const override;
-
-        Optional<const std::unordered_map<std::string, std::string>&> get_generic_triplet_vars(
-            Triplet triplet) const override;
-
-        Optional<const std::unordered_map<std::string, std::string>&> get_dep_info_vars(
-            const PackageSpec& spec) const override;
-
-        Optional<const std::unordered_map<std::string, std::string>&> get_tag_vars(
-            const PackageSpec& spec) const override;
-
-    private:
-        const VcpkgPaths& paths;
-        const fs::path& cmake_exe_path = paths.get_tool_exe(Tools::CMAKE);
-        const fs::path get_tags_path = paths.scripts / "vcpkg_get_tags.cmake";
-        const fs::path get_dep_info_path = paths.scripts / "vcpkg_get_dep_info.cmake";
-        mutable std::unordered_map<PackageSpec, std::unordered_map<std::string, std::string>> dep_resolution_vars;
-        mutable std::unordered_map<PackageSpec, std::unordered_map<std::string, std::string>> tag_vars;
-        mutable std::unordered_map<Triplet, std::unordered_map<std::string, std::string>> generic_triplet_vars;
-    };
+    std::unique_ptr<CMakeVarProvider> make_triplet_cmake_var_provider(const vcpkg::VcpkgPaths& paths);
 }

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -43,7 +43,8 @@ namespace vcpkg::Build::Command
     {
         vcpkg::Util::unused(options);
 
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
         var_provider.load_dep_info_vars(std::array<PackageSpec, 1>{full_spec.package_spec});
         var_provider.load_tag_vars(std::array<FullPackageSpec, 1>{full_spec}, provider);
 

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -223,7 +223,7 @@ namespace vcpkg::Commands::CI
         std::map<PackageSpec, std::string> abi_tag_map;
     };
 
-    static bool supported_for_triplet(const CMakeVars::TripletCMakeVarProvider& var_provider,
+    static bool supported_for_triplet(const CMakeVars::CMakeVarProvider& var_provider,
                                       const InstallPlanAction* install_plan)
     {
         auto&& scfl = install_plan->source_control_file_location.value_or_exit(VCPKG_LINE_INFO);
@@ -253,7 +253,7 @@ namespace vcpkg::Commands::CI
         const VcpkgPaths& paths,
         const std::set<std::string>& exclusions,
         const PortFileProvider::PortFileProvider& provider,
-        const CMakeVars::TripletCMakeVarProvider& var_provider,
+        const CMakeVars::CMakeVarProvider& var_provider,
         const std::vector<FullPackageSpec>& specs,
         const bool purge_tombstones)
     {
@@ -449,7 +449,8 @@ namespace vcpkg::Commands::CI
         StatusParagraphs status_db = database_load_check(paths);
 
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports.get());
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
 
         const Build::BuildPackageOptions install_plan_options = {
             Build::UseHeadVersion::NO,

--- a/toolsrc/src/vcpkg/commands.dependinfo.cpp
+++ b/toolsrc/src/vcpkg/commands.dependinfo.cpp
@@ -252,7 +252,8 @@ namespace vcpkg::Commands::DependInfo
         }
 
         PathsPortFileProvider provider(paths, args.overlay_ports.get());
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
 
         // By passing an empty status_db, we should get a plan containing all dependencies.
         // All actions in the plan should be install actions, as there's no installed packages to remove.

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -40,7 +40,8 @@ namespace vcpkg::Commands::Env
         const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
 
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports.get());
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
 
         var_provider.load_generic_triplet_vars(triplet);
 

--- a/toolsrc/src/vcpkg/commands.upgrade.cpp
+++ b/toolsrc/src/vcpkg/commands.upgrade.cpp
@@ -45,7 +45,8 @@ namespace vcpkg::Commands::Upgrade
 
         // Load ports from ports dirs
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports.get());
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
 
         // input sanitization
         const std::vector<PackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
@@ -179,6 +180,8 @@ namespace vcpkg::Commands::Upgrade
                            "--no-dry-run option.\n");
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
+
+        var_provider.load_tag_vars(action_plan, provider);
 
         const Install::InstallSummary summary =
             Install::perform(action_plan, keep_going, paths, status_db, var_provider);

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -677,22 +677,20 @@ namespace vcpkg::Install
 
         //// Load ports from ports dirs
         PortFileProvider::PathsPortFileProvider provider(paths, args.overlay_ports.get());
-        CMakeVars::TripletCMakeVarProvider var_provider(paths);
+        auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
+        auto& var_provider = *var_provider_storage;
 
         // Note: action_plan will hold raw pointers to SourceControlFileLocations from this map
         auto action_plan = Dependencies::create_feature_install_plan(provider, var_provider, specs, status_db);
 
-        std::vector<FullPackageSpec> install_package_specs;
         for (auto&& action : action_plan.install_actions)
         {
             action.build_options = install_plan_options;
             if (action.request_type != RequestType::USER_REQUESTED)
                 action.build_options.use_head_version = Build::UseHeadVersion::NO;
-
-            install_package_specs.emplace_back(FullPackageSpec{action.spec, action.feature_list});
         }
 
-        var_provider.load_tag_vars(install_package_specs, provider);
+        var_provider.load_tag_vars(action_plan, provider);
 
         // install plan will be empty if it is already installed - need to change this at status paragraph part
         Checks::check_exit(VCPKG_LINE_INFO, !action_plan.empty(), "Install plan cannot be empty");


### PR DESCRIPTION
`vcpkg upgrade` did not load the tag vars for all ports to be installed, which resulted in #9916.

- What does your PR fix?
Fixes issue #9916 
