### PR TITLE
[nlohmann-json] Switch to use vcpkg_from_github

### DIFF
--- a/ports/nlohmann-json/CONTROL
+++ b/ports/nlohmann-json/CONTROL
@@ -1,4 +1,4 @@
 Source: nlohmann-json
-Version: 3.7.3
+Version: 3.7.3-1
 Homepage: https://github.com/nlohmann/json
 Description: JSON for Modern C++

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -1,24 +1,10 @@
-set(SOURCE_VERSION 3.7.3)
-set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/nlohmann-json-v${SOURCE_VERSION})
-
-file(MAKE_DIRECTORY ${SOURCE_PATH})
-
-function(download_src SUBPATH SHA512)
-    vcpkg_download_distfile(FILE
-        URLS "https://github.com/nlohmann/json/raw/v${SOURCE_VERSION}/${SUBPATH}"
-        FILENAME "nlohmann-json-v${SOURCE_VERSION}/${SUBPATH}"
-        SHA512 ${SHA512}
-    )
-    get_filename_component(SUBPATH_DIR "${SOURCE_PATH}/${SUBPATH}" DIRECTORY)
-    file(COPY ${FILE} DESTINATION ${SUBPATH_DIR})
-endfunction()
-
-download_src(CMakeLists.txt 11ba0b69282e636e496ab854334addd9a13537bddf644d551d67e71a9f5ca2f1fda640c175bed77c279348d72a42dbe00358f16d90defaf33e4a740c850f7d7d)
-download_src(LICENSE.MIT 44e6d9510dd66195211aa8ce3e6eef55be524e82c5864f3bfb85f2ac1215529c8ca370c8746de61ad5739e5af1633a5985085dacd1ffe220cd21d06433936801)
-download_src(nlohmann_json.natvis 9bce6758db0e54777394a4e718e60a281952b15f0c6dc6a6ad4a6d023c958b5515b2d39b7d4c66c03f0d3fdfdc1d6c23afb8b8419f1345c9d44d7b9a9ee2582b)
-download_src(cmake/config.cmake.in 7caab6166baa891f77f5b632ac4a920e548610ec41777b885ec51fe68d3665ffe91984dd2881caf22298b5392dfbd84b526fda252467bb66de9eb90e6e6ade5a)
-download_src(single_include/nlohmann/json.hpp 4ecbbdd2c5e88c897096670cfdaa7ec00483ac9ed6e8ac33be23b05f4da70f213e10c4b381f5e8799619a24a58f417f04dd442d1d59a2e0bfca3385007e620d5)
-
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nlohmann/json
+    REF e7b3b40b5a95bc74b9a7f662830a27c49ffc01b4 # v3.7.3
+    SHA512 b57dfb6ceda9de13e9da1bb5a6399c259bcdfd6c14f656c145126247459b4963109704e359bb565a2dc806356969f2af8e28a15b5fa9ed4cdcc993d586c91936
+    HEAD_REF master
+)
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -47,5 +33,4 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/nlohmann_json.natvis)
     )
 endif()
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/nlohmann-json RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/issues/10199

Update nlohmann-json to use vcpkg_from_github.
It doesn't contains any features.