### PR TITLE
Upgrade CGAL to 5.0.2

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,5 +1,5 @@
 Source: cgal
-Version: 5.0.1
+Version: 5.0.2
 Build-Depends: mpfr, mpir, zlib, boost-format, boost-container, boost-ptr-container, boost-iterator, boost-variant, boost-any, boost-unordered, boost-random, boost-foreach, boost-graph, boost-heap, boost-logic, boost-multiprecision
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -46,7 +46,7 @@ endif()
 file(WRITE ${CURRENT_PACKAGES_DIR}/lib/cgal/CGALConfig.cmake "include (\$\{CMAKE_CURRENT_LIST_DIR\}/../../share/cgal/CGALConfig.cmake)")
 
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/Installation/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 file(
     COPY

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_buildpath_length_warning(37)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CGAL/cgal
-    REF releases/CGAL-5.0.1
-    SHA512 656e207bdc7003dd2e3e4b31b33f9ac3af5074e4892dda645f67fccdc0ac22982d8bf3c62f9c556847ba0447c14f79923712fc6320f8c10ea77e17bf77eb3e2f
+    REF releases/CGAL-5.0.2
+    SHA512 108f1d6f68674e123fd90143049f30a7e7965827468828f75ba7ae0b7ba174690520bafdf0648853c1b28895d6a9a0c7349c03e678c13395a84ffe7397c97e99
     HEAD_REF master
 )
 

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_buildpath_length_warning(37)
 
 vcpkg_from_github(
@@ -11,9 +9,10 @@ vcpkg_from_github(
 )
 
 set(WITH_CGAL_Qt5  OFF)
-if("qt" IN_LIST FEATURES)
-  set(WITH_CGAL_Qt5 ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    qt WITH_CGAL_Qt5
+    )
+
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -21,7 +20,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DCGAL_HEADER_ONLY=ON
         -DCGAL_INSTALL_CMAKE_DIR=share/cgal
-        -DWITH_CGAL_Qt5=${WITH_CGAL_Qt5}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
@@ -46,8 +45,8 @@ endif()
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/lib/cgal/CGALConfig.cmake "include (\$\{CMAKE_CURRENT_LIST_DIR\}/../../share/cgal/CGALConfig.cmake)")
 
-file(COPY ${SOURCE_PATH}/Installation/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/cgal/LICENSE ${CURRENT_PACKAGES_DIR}/share/cgal/copyright)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 file(
     COPY
@@ -59,4 +58,3 @@ file(
 )
 
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/cgal)
-vcpkg_test_cmake(PACKAGE_NAME CGAL)


### PR DESCRIPTION
This PR upgrades CGAL to the version 5.0.2.