### PR TITLE
Now able to build curl with openssl for UWP

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.68.0-1
+Version: 7.68.0-2
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl
 Description: A library for transferring data with URLs

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -16,7 +16,7 @@ Build-Depends: nghttp2, curl[ssl]
 Description: HTTP2 support
 
 Feature: ssl
-Build-Depends: curl[openssl] (!windows&!osx), curl[winssl] (windows), curl[sectransp] (osx)
+Build-Depends: curl[openssl] (!windows&!osx), curl[winssl] (windows&!uwp), curl[sectransp] (osx)
 Description: Default SSL backend
 
 Feature: ssh
@@ -25,7 +25,7 @@ Description: SSH support via libssh2
 
 # SSL backends
 Feature: openssl
-Build-Depends: openssl
+Build-Depends: openssl (!uwp), openssl-uwp (uwp)
 Description: SSL support (OpenSSL)
 
 Feature: winssl

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -25,7 +25,7 @@ Description: SSH support via libssh2
 
 # SSL backends
 Feature: openssl
-Build-Depends: openssl (!uwp), openssl-uwp (uwp)
+Build-Depends: openssl-windows (windows&!uwp), openssl-uwp (uwp), openssl-unix (!uwp&!windows)
 Description: SSL support (OpenSSL)
 
 Feature: winssl

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -25,7 +25,7 @@ Description: SSH support via libssh2
 
 # SSL backends
 Feature: openssl
-Build-Depends: openssl-windows (windows&!uwp), openssl-uwp (uwp), openssl-unix (!uwp&!windows)
+Build-Depends: openssl (!uwp), openssl-uwp (uwp)
 Description: SSL support (OpenSSL)
 
 Feature: winssl


### PR DESCRIPTION
With this change we are once again able to build curl with OpenSSL support for UWP.