### PR TITLE
[shogun] Fix target.cmake path 

### DIFF
--- a/ports/shogun/CONTROL
+++ b/ports/shogun/CONTROL
@@ -1,4 +1,5 @@
 Source: shogun
-Version: 6.1.4
+Version: 6.1.4-1
 Build-Depends: bzip2, eigen3, liblzma, libxml2, openblas (x64&!osx), nlopt, rxcpp, snappy, zlib, protobuf, curl, lzo, dirent
+Homepage: https://github.com/shogun-toolbox/shogun
 Description: Unified and efficient Machine Learning

--- a/ports/shogun/MSDirent.cmake
+++ b/ports/shogun/MSDirent.cmake
@@ -1,1 +1,0 @@
-find_path(MSDIRENT_INCLUDE_DIR NAMES dirent.h)

--- a/ports/shogun/cmake-config.in.patch
+++ b/ports/shogun/cmake-config.in.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake/ShogunConfig.cmake.in b/cmake/ShogunConfig.cmake.in
+index e8e8035..a5097cb 100644
+--- a/cmake/ShogunConfig.cmake.in
++++ b/cmake/ShogunConfig.cmake.in
+@@ -2,5 +2,5 @@
+ 
+ set_and_check(shogun_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+ 
+-include("@PACKAGE_CONFIG_PACKAGE_DIR@/ShogunTargets.cmake")
++include("@PACKAGE_CONFIG_PACKAGE_DIR@/../../../share/shogun/ShogunTargets.cmake")
+ check_required_components(shogun)

--- a/ports/shogun/fix-dirent.patch
+++ b/ports/shogun/fix-dirent.patch
@@ -1,0 +1,17 @@
+diff --git a/src/shogun/CMakeLists.txt b/src/shogun/CMakeLists.txt
+index fd76961..396251c 100644
+--- a/src/shogun/CMakeLists.txt
++++ b/src/shogun/CMakeLists.txt
+@@ -170,10 +170,10 @@ IF(MSVC)
+   ENDIF()
+ 
+   # bundle dirent
+-  include(external/MSDirent)
++  find_path(MSDIRENT_INCLUDE_DIR NAMES dirent.h)
+   SHOGUN_INCLUDE_DIRS(SCOPE PUBLIC
+     $<BUILD_INTERFACE:${MSDIRENT_INCLUDE_DIR}>
+-    $<INSTALL_INTERFACE:include/shogun/lib/external/MSDirent>
++    $<INSTALL_INTERFACE:include>
+   )
+ 
+   target_link_libraries(shogun PUBLIC winmm)

--- a/ports/shogun/portfile.cmake
+++ b/ports/shogun/portfile.cmake
@@ -15,11 +15,8 @@ vcpkg_from_github(
     PATCHES
         cmake.patch
         cmake-config.in.patch
+        fix-dirent.patch
 )
-
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/external)
-file(MAKE_DIRECTORY ${SOURCE_PATH}/cmake/external)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/MSDirent.cmake DESTINATION ${SOURCE_PATH}/cmake/external)
 
 vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)

--- a/ports/shogun/portfile.cmake
+++ b/ports/shogun/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
@@ -16,6 +14,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         cmake.patch
+        cmake-config.in.patch
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/external)
@@ -52,7 +51,6 @@ vcpkg_configure_cmake(
         -DCMAKE_DISABLE_FIND_PACKAGE_Doxygen=TRUE
         -DCMAKE_DISABLE_FIND_PACKAGE_CURL=TRUE
         -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=${CMAKE_DISABLE_FIND_PACKAGE_BLAS}
-
         -DINSTALL_TARGETS=shogun-static
 )
 
@@ -67,5 +65,4 @@ file(REMOVE_RECURSE
 )
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/shogun)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/shogun/COPYING ${CURRENT_PACKAGES_DIR}/share/shogun/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
In `ShogunConfig.cmake` file, using this to include` ShogunTarget.cmake` file.
`include("${PACKAGE_PREFIX_DIR}/lib/cmake/shogun/ShogunTargets.cmake")`
So I modified this path as `include("@PACKAGE_CONFIG_PACKAGE_DIR@/../../../share/shogun/ShogunTargets.cmake")` in 
`ShogunConfig.cmake.in` to fix this issue.

Also remove _ports/shogun/MSDirent.cmake_ and update the way to `dirent.h`.

Related issue #9969 

Note: No feature needs to test.


