### PR TITLE
[imgui] Add feature bindings and remove feature example

### DIFF
--- a/ports/azure-kinect-sensor-sdk/CONTROL
+++ b/ports/azure-kinect-sensor-sdk/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-kinect-sensor-sdk
-Version: 1.4.0-alpha.0-2
+Version: 1.4.0-alpha.0-3
 Homepage: https://github.com/microsoft/Azure-Kinect-Sensor-SDK
 Description: Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.
 Build-Depends: azure-c-shared-utility, glfw3, gtest, imgui, libusb, spdlog, cjson, ebml, libjpeg-turbo, matroska, libsoundio, libyuv
@@ -9,4 +9,4 @@ Description: Build K4A doxygen documentation.
 
 Feature: tool
 Description: Build tools.
-Build-Depends: gl3w, imgui[example]
+Build-Depends: gl3w, glew, imgui[bindings]

--- a/ports/azure-kinect-sensor-sdk/fix-dependency-imgui.patch
+++ b/ports/azure-kinect-sensor-sdk/fix-dependency-imgui.patch
@@ -1,0 +1,45 @@
+diff --git a/tools/k4aviewer/CMakeLists.txt b/tools/k4aviewer/CMakeLists.txt
+index 6ab38d9..e0c5bad 100644
+--- a/tools/k4aviewer/CMakeLists.txt
++++ b/tools/k4aviewer/CMakeLists.txt
+@@ -35,6 +35,8 @@ set(SOURCE_FILES
+     k4awindowset.cpp
+     perfcounter.cpp
+     ${CMAKE_CURRENT_BINARY_DIR}/version.rc
++    ${IMGUI_EXTERNAL_PATH}/imgui_impl_glfw.cpp
++    ${IMGUI_EXTERNAL_PATH}/imgui_impl_opengl3.cpp
+ )
+ 
+ # Include ${CMAKE_CURRENT_BINARY_DIR}/version.rc in the target's sources
+@@ -54,6 +56,8 @@ include_directories(
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++find_package(GLEW REQUIRED)
++
+ set(EXTERNAL_LIBRARIES
+     k4a::k4a
+     k4a::k4arecord
+@@ -65,6 +69,7 @@ set(EXTERNAL_LIBRARIES
+     glfw
+     ${OPENGL_LIBRARIES}
+     unofficial::gl3w::gl3w
++    GLEW::GLEW
+ )
+ 
+ # On Windows, we need to call into setupapi to get USB container ID information
+diff --git a/tools/k4aviewer/k4aimgui_all.h b/tools/k4aviewer/k4aimgui_all.h
+index e40ccfb..756fb09 100644
+--- a/tools/k4aviewer/k4aimgui_all.h
++++ b/tools/k4aviewer/k4aimgui_all.h
+@@ -34,8 +34,8 @@
+ #include <GL/gl3w.h>
+ #include <GLFW/glfw3.h>
+ #include <imgui.h>
+-#include <imgui_impl_glfw.h>
+-#include <imgui_impl_opengl3.h>
++#include <bindings/imgui_impl_glfw.h>
++#include <bindings/imgui_impl_opengl3.h>
+ 
+ // For disabling buttons, which has not yet been promoted to the public API
+ //

--- a/ports/azure-kinect-sensor-sdk/portfile.cmake
+++ b/ports/azure-kinect-sensor-sdk/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-builds.patch
         disable-c4275.patch
+        fix-dependency-imgui.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -26,6 +27,7 @@ vcpkg_configure_cmake(
     -DK4A_MTE_VERSION=ON
     -DBUILD_EXAMPLES=OFF
     -DWITH_TEST=OFF
+    -DIMGUI_EXTERNAL_PATH=${CURRENT_INSTALLED_DIR}/include/bindings
 )
 
 vcpkg_install_cmake()
@@ -39,6 +41,18 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/k4arecord TARGET_PATH share/k4arecor
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+if ("tool" IN_LIST FEATURES)
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL release)
+        file(GLOB AZURE_TOOLS ${CURRENT_PACKAGES_DIR}/bin/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
+        file(COPY ${AZURE_TOOLS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+        file(REMOVE ${AZURE_TOOLS})
+    endif()
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
+        file(GLOB AZURE_TOOLS ${CURRENT_PACKAGES_DIR}/debug/bin/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
+        file(REMOVE ${AZURE_TOOLS})
+    endif()
+endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)

--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -10,6 +10,7 @@ set(IMGUI_INCLUDES_PUBLIC
 
 set(IMGUI_INCLUDES_PRIVATE
     imgui_internal.h
+    imstb_textedit.h
 )
 
 set(IMGUI_SOURCES
@@ -24,6 +25,8 @@ add_library(${PROJECT_NAME}
     ${IMGUI_INCLUDES_PRIVATE}
     ${IMGUI_SOURCES}
 )
+
+file(GLOB IMGUI_BINDINGS ${CMAKE_CURRENT_SOURCE_DIR}/examples/imgui_impl_* )
 
 target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
 
@@ -40,5 +43,16 @@ if(NOT IMGUI_SKIP_HEADERS)
     install(
         FILES ${IMGUI_INCLUDES_PUBLIC}
         DESTINATION include
+    )
+endif()
+
+if(IMGUI_COPY_BINDINGS)
+    install(
+        FILES ${IMGUI_INCLUDES_PRIVATE}
+        DESTINATION include
+    )
+    install(
+        FILES ${IMGUI_BINDINGS}
+        DESTINATION include/bindings
     )
 endif()

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -3,11 +3,6 @@ Version: 1.74-1
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
-Feature: example
-Description: install example headers
-Build-Depends: glfw3, freeglut, opengl, sdl1
-
-Feature: tools
-Description: build with examples
-Build-Depends: imgui[example]
-
+Feature: bindings
+Description: make available bindings header and source files for supported implementations
+Build-Depends: glfw3, freeglut, opengl, sdl1, allegro5

--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,8 +1,13 @@
 Source: imgui
-Version: 1.74
+Version: 1.74-1
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 
 Feature: example
-Description: build with examples
+Description: install example headers
 Build-Depends: glfw3, freeglut, opengl, sdl1
+
+Feature: tools
+Description: build with examples
+Build-Depends: imgui[example]
+

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -25,18 +25,26 @@ if ("example" IN_LIST FEATURES)
     if (NOT VCPKG_TARGET_IS_WINDOWS)
         message(FATAL_ERROR "Feature example only support windows.")
     endif()
-    vcpkg_build_msbuild(
-        USE_VCPKG_INTEGRATION
-        PROJECT_PATH ${SOURCE_PATH}/examples/imgui_examples.sln
-    )
     
     # Install headers
     file(GLOB IMGUI_EXAMPLE_INCLUDES ${SOURCE_PATH}/examples/*.h)
     file(INSTALL ${IMGUI_EXAMPLE_INCLUDES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-    
-    # Install tools
-    file(GLOB_RECURSE IMGUI_EXAMPLE_BINARIES ${SOURCE_PATH}/examples/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
-    file(INSTALL ${IMGUI_EXAMPLE_BINARIES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+
+    if ("tools" IN_LIST FEATURES)
+        if (TRIPLET_SYSTEM_ARCH MATCHES "x86")
+            set(MSBUILD_PLATFORM "Win32")
+        else ()
+            set(MSBUILD_PLATFORM ${TRIPLET_SYSTEM_ARCH})
+        endif()
+        vcpkg_build_msbuild(
+            USE_VCPKG_INTEGRATION
+            PROJECT_PATH ${SOURCE_PATH}/examples/imgui_examples.sln
+            PLATFORM ${MSBUILD_PLATFORM}
+        )
+        # Install tools
+        file(GLOB_RECURSE IMGUI_EXAMPLE_BINARIES ${SOURCE_PATH}/examples/*${VCPKG_TARGET_EXECUTABLE_SUFFIX})
+        file(INSTALL ${IMGUI_EXAMPLE_BINARIES} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+    endif()
 endif()
 
 vcpkg_copy_pdbs()

--- a/ports/libigl/CONTROL
+++ b/ports/libigl/CONTROL
@@ -1,5 +1,5 @@
 Source: libigl
-Version: 2.1.0-1
+Version: 2.1.0-2
 Homepage: https://github.com/libigl/libigl
 Description: libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.
 Build-Depends: eigen3
@@ -18,7 +18,7 @@ Build-Depends: glfw3
 
 Feature: imgui
 Description: Build with imgui
-Build-Depends: imgui[example]
+Build-Depends: imgui[bindings]
 
 Feature: png
 Description: Build with libpng


### PR DESCRIPTION
Since the binary generated by examples is rarely used, remove feature `examples` and add feature `bindings`.

Related: #10252 #8788.

Note: because the current feature tools still have generation problems, this PR only performs a simple separation feature.

All features passed in the following triplets test:
- x86-windows
- x64-windows
- x64-windows-static