### PR TITLE
[ecsutil] Update ECSUtil v1.0.7.9

### DIFF
--- a/ports/ecsutil/CONTROL
+++ b/ports/ecsutil/CONTROL
@@ -3,3 +3,4 @@ Version: 1.0.7.9
 Homepage: https://github.com/EMCECS/ecs-object-client-windows-cpp
 Description: Native Windows SDK for accessing ECS via the S3 HTTP protocol.
 Build-Depends: atlmfc (windows)
+Supports: windows&(x64|x86)

--- a/ports/ecsutil/CONTROL
+++ b/ports/ecsutil/CONTROL
@@ -1,5 +1,5 @@
 Source: ecsutil
-Version: 1.0.7.8
+Version: 1.0.7.9
 Homepage: https://github.com/EMCECS/ecs-object-client-windows-cpp
 Description: Native Windows SDK for accessing ECS via the S3 HTTP protocol.
 Build-Depends: atlmfc (windows)

--- a/ports/ecsutil/portfile.cmake
+++ b/ports/ecsutil/portfile.cmake
@@ -1,15 +1,7 @@
-include(vcpkg_common_functions)
 
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "UWP" "Linux" "OSX")
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     set(PLATFORM x86)
-elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    set(PLATFORM x64)
-else()
-    message(FATAL_ERROR "Unsupported architecture")
-endif()
-
-if(VCPKG_CMAKE_SYSTEM_NAME)
-    message(FATAL_ERROR "Unsupported platform. ECSUTIL currently only supports windows desktop.")
 endif()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)

--- a/ports/ecsutil/portfile.cmake
+++ b/ports/ecsutil/portfile.cmake
@@ -28,8 +28,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO EMCECS/ecs-object-client-windows-cpp
-    REF v1.0.7.8
-    SHA512 33b15e16e8568db57a670c91e77b7624e3b70e02e18a8b337f4967b3aca4a36d3f6d87ddab60720a93fb5a4798948ec264eb273d8f31fb7e4bf4a86c1e89579a
+    REF v1.0.7.9
+    SHA512 4e5b52911b5a4193afd74c2503980c44679fb7b77bb783f15f87551afc521b342fa6a9bd0ad8293bc1c99baf8cb68c884926fb7fe3c7a15c7aa7e9ad1139d16c
     HEAD_REF master
 )
 


### PR DESCRIPTION
Update to ECSUtil v1.0.7.9

Triplets supported:
x86-windows
x86-windows-static
x86-windows-static-md
x64-windows
x64-windows-static
x64-windows-static-md
