### PR TITLE
[libpq] Fix build failure when vcpkg path contains spaces

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 12.0
+Version: 12.0-1
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -173,7 +173,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
             /p:UseIntelMKL=No
             /p:WindowsTargetPlatformVersion=${VCPKG_TARGET_PLATFORM_VERSION}
             /m
-            /p:ForceImportBeforeCppTargets=${SCRIPTS}/buildsystems/msbuild/vcpkg.targets
+            /p:ForceImportBeforeCppTargets=\"${SCRIPTS}/buildsystems/msbuild/vcpkg.targets\"
             /p:VcpkgTriplet=${TARGET_TRIPLET}"
             )
         if(HAS_TOOLS)


### PR DESCRIPTION
This fixes libpq not building when vcpkg is installed in a path with spaces (due to unquoted paths).

Not sure a port version bump is necessary since this doesn't change the output.