### PR TITLE
[doctest] Update to version 2.3.7

### DIFF
--- a/ports/doctest/CONTROL
+++ b/ports/doctest/CONTROL
@@ -1,4 +1,4 @@
 Source: doctest
-Version: 2.3.6
+Version: 2.3.7
 Homepage: https://github.com/onqtam/doctest
 Description: The fastest feature-rich C++ single-header testing framework for unit tests and TDD

--- a/ports/doctest/portfile.cmake
+++ b/ports/doctest/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO onqtam/doctest
-    REF 2.3.6
-    SHA512 e09d61331e9d7dc11e0c93f377c26f9fcac66c8bb5f02731028d396fb595770580c66b5e20b2dba4a203d9956637a0a8a1e43c63cc90452b103c3144e83dbc1e
+    REF 7d42bd0fab6c44010c8aed9338bd02bea5feba41 #version 2.3.7
+    SHA512 4e71c8dd49a97ee2324207e063d47ce56cfb0371c0e855dd26ce4f169299f1710e4f30a9c5f16a078690c983e6ce7b6d5bb4fe9e0ec6be017905b2381a85b5a6
     HEAD_REF master
 )
 
@@ -20,7 +18,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/doctest)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-configure_file(${SOURCE_PATH}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/doctest/copyright COPYONLY)
-
-# CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME ${PORT})
+configure_file(${SOURCE_PATH}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
Upgrade doctest to verison 2.3.7. No features need to test.
The related issue: #10263 
