### PR TITLE
[10270] patch to fix infinite loop in grpc trace

### DIFF
--- a/ports/grpc/00010-fix-trace-loop.patch
+++ b/ports/grpc/00010-fix-trace-loop.patch
@@ -1,0 +1,17 @@
+diff --git a/src/core/lib/debug/trace.cc b/src/core/lib/debug/trace.cc
+index 84c0a3805d..47cbaa9dff 100644
+--- a/src/core/lib/debug/trace.cc
++++ b/src/core/lib/debug/trace.cc
+@@ -70,8 +70,10 @@ bool TraceFlagList::Set(const char* name, bool enabled) {
+ }
+ 
+ void TraceFlagList::Add(TraceFlag* flag) {
+-  flag->next_tracer_ = root_tracer_;
+-  root_tracer_ = flag;
++  TraceFlag** next = &root_tracer_;
++  while(*next) next = &(*next)->next_tracer_;
++  flag->next_tracer_ = nullptr;
++  *next = flag;
+ }
+ 
+ void TraceFlagList::LogAllTracers() {

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         00004-link-gdi32-on-windows.patch
         00005-fix-uwp-error.patch
         00009-use-system-upb.patch
+        00010-fix-trace-loop.patch
 )
 
 if(VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")


### PR DESCRIPTION
On Ubuntu, grpc might exhibit infinite loop. This issue is documented for 1.24.3 here: grpc/grpc#20757 and it is still relevant for 1.27.1. This patch fixes infinite loop.

- What does your PR fix? Fixes issue #10270

- Which triplets are supported/not supported? Have you updated the CI baseline? 
All 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes