### PR TITLE
[google-cloud-cpp*] update to latest release

### DIFF
--- a/ports/google-cloud-cpp-common/CONTROL
+++ b/ports/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.20.0
+Version: 0.21.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ports/google-cloud-cpp-common/portfile.cmake
+++ b/ports/google-cloud-cpp-common/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-common
-    REF v0.20.0
-    SHA512 9b6c26a91cd5fc5d95bcbe7fb8dff106e5bf169ab535a9b6315319800fa0cbd875142a033a3c5ff21df028d221601ffbe8d1feb2349cb156025122abdd715851
+    REF v0.21.0
+    SHA512 a339c6f57ac539f1c45f2fb92311e5d48e29a4406a1e0cfda2f1dc18e8c6db345588ad0bebd2c23531e572982d4429ee73b4f0c3df1ba8028d4100d9b12ecaa1
     HEAD_REF master)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/google-cloud-cpp-spanner/CONTROL
+++ b/ports/google-cloud-cpp-spanner/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-spanner
-Version: 0.7.0
+Version: 0.9.0
 Build-Depends: grpc, googleapis, google-cloud-cpp-common
 Description: C++ Client Library for Google Cloud Spanner.
 Homepage: https://github.com/googleapis/google-cloud-cpp-spanner

--- a/ports/google-cloud-cpp-spanner/portfile.cmake
+++ b/ports/google-cloud-cpp-spanner/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp-spanner
-    REF v0.7.0
-    SHA512 f3fea6ebe3431102c23737822d17e90d4d301f5854ec17834ee379013c92b1997ff10421ee5f82e35b651cd930dbb8d73e9aad50b754b3fe1395257fa4199dfb
+    REF v0.9.0
+    SHA512 2a53489c266d85ef9f03d747c088edd4401db1d01ba6c79862c9ccedaee39993941772e59ed5d697b61d05438e0c89c512e50def59fd0ef4fb0359c6bdff7324
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/CONTROL
+++ b/ports/google-cloud-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp
-Version: 0.19.0
+Version: 0.20.0
 Build-Depends: grpc, curl[ssl], crc32c, googleapis, google-cloud-cpp-common
 Description: C++ Client Libraries for Google Cloud Platform APIs.
 Homepage: https://github.com/googleapis/google-cloud-cpp

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v0.19.0
-    SHA512 8473e1aa2d83e46c1120e3a276e3ed2c9e33dd33d042d398ea48b90befa0bc41fa483d922489fe83faa61e5c4eafc0b22d5e8442c01c84aece6cfed673d34ead
+    REF v0.20.0
+    SHA512 6e760f56186ee4bf2fca0e8e4e031e8a508a1e820a470513912e8e0bbcd7855cc1d7834f855a7d5b040492241d6cae1e27117d1de46fb3167c962d700c905be2
     HEAD_REF master
     PATCHES
         0001-fix-x86-build.patch


### PR DESCRIPTION
Update google-cloud-cpp-common to v0.21.0, google-cloud-cpp to v0.20.0,
and google-cloud-cpp-spanner to v0.9.0. These changes need to be atomic,
thus the single PR.

- What does your PR fix? Fixes issue #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A. Same triplets as before.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes, I think so.
