### PR TITLE
[azmq] Update to latest commit

### DIFF
--- a/ports/azmq/CONTROL
+++ b/ports/azmq/CONTROL
@@ -1,6 +1,7 @@
 Source: azmq
-Version: 1.0.2
+Version: 2020-03-03
 Build-Depends: boost-asio, boost-assert, boost-config, boost-container, boost-format, boost-intrusive, boost-iterator, boost-lexical-cast, boost-logic, boost-optional, boost-random, boost-range, boost-regex, boost-system, boost-thread, boost-utility, zeromq
+Homepage: https://github.com/zeromq/azmq
 Description: Boost Asio style bindings for ZeroMQ
   This library is built on top of ZeroMQ's standard C interface and is intended to work well with C++ applications which use the Boost libraries in general, and Asio in particular.
   The main abstraction exposed by the library is azmq::socket which provides an Asio style socket interface to the underlying zeromq socket and interfaces with Asio's io_service(). The socket implementation participates in the io_service's reactor for asynchronous IO and may be freely mixed with other Asio socket types (raw TCP/UDP/Serial/etc.).

--- a/ports/azmq/portfile.cmake
+++ b/ports/azmq/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/azmq
-    REF v1.0.2
-    SHA512 6e60a670d070ddf84dbd406e88225ff12f84ce39e0e64e9aff4314e174506c286d72cfebb5e2e51eab221f6e163a17cce539d052cea3c18954ec495b096f087b
+    REF 6bb101eecb357ad9735ebc36e276b7526652d42d # commit on 2019-05-01 
+    SHA512 18812fd73c3c57aca8b17c2df0af01afb7864253d6ac6ce042e01ef04e81dd454438c9d01f5bb0fd7a4a445082a2eb3dd334ca1e05dafbe4ba602cad95ce7134
     HEAD_REF master
 )
 
@@ -12,4 +10,4 @@ file(COPY ${SOURCE_PATH}/azmq DESTINATION ${CURRENT_PACKAGES_DIR}/include/)
 
 file(INSTALL
     ${SOURCE_PATH}/LICENSE-BOOST_1_0
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/azmq RENAME copyright)
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Update `azmq `to latest commit and support `boost `1.70.

Related issue #10277 

Note: No feature needs to test.
