### PR TITLE
[usockets] Add features

### DIFF
--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -20,6 +20,27 @@ include_directories(APPEND "${CMAKE_CURRENT_LIST_DIR}/src")
 
 file(GLOB SOURCES src/*.c src/eventing/*.c)
 
+set(USOCKETS_EXT_INCLUDE_DIR )
+set(USOCKETS_EXT_LIBS )
+
+if (CMAKE_USE_OPENSSL)
+    find_package(OpenSSL REQUIRED)
+    file(GLOB SSL_SOURCES src/crypto/*.c)
+    list(APPEND SOURCES ${SSL_SOURCES})
+    list(APPEND USOCKETS_EXT_LIBS OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
+if (CMAKE_USE_EVENT)
+    file(GLOB SSL_SOURCES src/eventing/*.c)
+    list(APPEND SOURCES ${SSL_SOURCES})
+    list(APPEND USOCKETS_EXT_INCLUDE_DIR src/internal/eventing)
+endif()
+
+if (CMAKE_USE_NETWORK)
+    list(APPEND USOCKETS_EXT_INCLUDE_DIR src/internal/networking)
+    list(APPEND USOCKETS_EXT_LIBS Ws2_32)
+endif()
+
 add_library(uSockets ${SOURCES})
 
 if (${LIBUS_USE_LIBUV})
@@ -27,8 +48,8 @@ if (${LIBUS_USE_LIBUV})
 endif()
 
 target_compile_definitions(uSockets PRIVATE ${NOT_USE_OPENSSL} ${USE_OPENSSL})
-target_include_directories(uSockets PUBLIC ${OPENSSL_INCLUDE_DIR} ${LIBUV_INCLUDE_DIR} )
-target_link_libraries(uSockets PUBLIC ${OPENSSL_LIBRARIES} ${LIBUV_LIBRARY})
+target_include_directories(uSockets PUBLIC ${OPENSSL_INCLUDE_DIR} ${LIBUV_INCLUDE_DIR} ${USOCKETS_EXT_INCLUDE_DIR})
+target_link_libraries(uSockets PUBLIC ${OPENSSL_LIBRARIES} ${LIBUV_LIBRARY} ${USOCKETS_EXT_LIBS})
 
 install(TARGETS uSockets
     RUNTIME DESTINATION bin

--- a/ports/usockets/CONTROL
+++ b/ports/usockets/CONTROL
@@ -1,4 +1,15 @@
 Source: usockets
-Version: 0.3.5
+Version: 0.3.5-1
 Build-Depends:libuv
 Description: Miniscule cross-platform eventing, networking & crypto for async applications
+
+Feature: ssl
+Build-Depends: openssl
+Description: Build usockets with openssl support
+
+Feature: event
+Description: Build usockets with epoll support
+
+Feature: network
+Build-Depends: winsock2
+Description: Build usockets with winsock support

--- a/ports/usockets/portfile.cmake
+++ b/ports/usockets/portfile.cmake
@@ -12,13 +12,20 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-set(USE_OPENSSL OFF)
+if ("network" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "Feature network only support Windows")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    ssl CMAKE_USE_OPENSSL
+    event CMAKE_USE_EVENT
+    network CMAKE_USE_NETWORK
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS 
-        -DCMAKE_USE_OPENSSL=${USE_OPENSSL}
+    OPTIONS ${FEATURE_OPTIONS}
         -DLIBUS_USE_LIBUV=${USE_LIBUV}
     OPTIONS_DEBUG
         -DINSTALL_HEADERS=OFF


### PR DESCRIPTION
Since openssl has been update to 1.1.0, re-add feature `ssl` and add other 2 features `event` and `network`.

Related: #10292.

Note: All features passed in the following triplets test:
- x86-windows
- x64-windows
- x64-windows-static