### PR TITLE
[suitesparse] Enable compiling SuiteSparse DLLs

### DIFF
--- a/ports/suitesparse/CONTROL
+++ b/ports/suitesparse/CONTROL
@@ -1,5 +1,5 @@
 Source: suitesparse
-Version: 5.4.0-4
+Version: 5.4.0-5
 Build-Depends: clapack (!osx)
 Homepage: http://faculty.cse.tamu.edu/davis/SuiteSparse
 Description: algebra library

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(SUITESPARSE_VER 5.4.0)
 set(SUITESPARSEWIN_VER 1.4.0)
 
@@ -63,5 +61,5 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/suitesparse-${SUITESPARSE_VER})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/suitesparse RENAME copyright)
-file(INSTALL ${SUITESPARSEWIN_SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/suitesparse RENAME copyright_suitesparse-metis-for-windows)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SUITESPARSEWIN_SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright_suitesparse-metis-for-windows)

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -1,7 +1,5 @@
 include(vcpkg_common_functions)
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 set(SUITESPARSE_VER 5.4.0)
 set(SUITESPARSEWIN_VER 1.4.0)
 


### PR DESCRIPTION
It seems that some time ago several libraries had their dynamic libraries disabled if they did not export their symbols, but at least with suitesparse this is not the case; I have used it in my projects without further modification.