### PR TITLE
[io2d] Add warning: Installing io2d need macOS 10.14 or higher

### DIFF
--- a/ports/io2d/CONTROL
+++ b/ports/io2d/CONTROL
@@ -1,4 +1,4 @@
 Source: io2d
-Version: 2019-07-11-2
+Version: 2019-07-11-3
 Description: a lightweight, cross platform drawing library
 Build-Depends: cairo (!osx), cairo[x11] (linux), graphicsmagick (!osx)

--- a/ports/io2d/portfile.cmake
+++ b/ports/io2d/portfile.cmake
@@ -1,5 +1,9 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if (VCPKG_TARGET_IS_OSX)
+    message(WARNING "Building with a macOS version less than 10.14 is not supported.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cpp-io2d/P0267_RefImpl
@@ -43,5 +47,3 @@ if (NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-vcpkg_test_cmake(PACKAGE_NAME io2d)


### PR DESCRIPTION
Due to `std::get` introduced in masOS 10.14, so installing io2d need masOS 10.14 or higher version.
Related issue: #10245. No features need to test.
