### PR TITLE
[vcpkg_find_acquire_program] Add git

### DIFF
--- a/docs/maintainers/vcpkg_find_acquire_program.md
+++ b/docs/maintainers/vcpkg_find_acquire_program.md
@@ -24,6 +24,7 @@ The current list of programs includes:
 - PERL
 - PYTHON2
 - PYTHON3
+- GIT
 - GO
 - JOM
 - MESON

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -24,6 +24,7 @@
 ## - PERL
 ## - PYTHON2
 ## - PYTHON3
+## - GIT
 ## - GO
 ## - JOM
 ## - MESON
@@ -86,6 +87,20 @@ function(vcpkg_find_acquire_program VAR)
     set(_vfa_RENAME "yasm.exe")
     set(NOEXTRACT ON)
     set(HASH c1945669d983b632a10c5ff31e86d6ecbff143c3d8b2c433c0d3d18f84356d2b351f71ac05fd44e5403651b00c31db0d14615d7f9a6ecce5750438d37105c55b)
+  elseif(VAR MATCHES "GIT")
+    set(PROGNAME git)
+    if(CMAKE_HOST_WIN32)
+      set(SUBDIR "git-2.25.1-1-windows")
+      set(URL "https://github.com/git-for-windows/git/releases/download/v2.25.1.windows.1/PortableGit-2.25.1-32-bit.7z.exe")
+      set(ARCHIVE "PortableGit-2.25.1-32-bit.7z.exe")
+      set(HASH 222d6e384ecae5841cb02dc004c4b3f56659d19b662bc93ab531df844c9477c9717c4a1adfb8bc2d3159678238fa4c79ccbdcb5c116eea5eccd652f4b483359e)
+      set(PATHS 
+        "${DOWNLOADS}/tools/${SUBDIR}/mingw32/bin"
+        "${DOWNLOADS}/tools/git/${SUBDIR}/mingw32/bin")
+    else()
+      set(BREW_PACKAGE_NAME "git")
+      set(APT_PACKAGE_NAME "git")
+    endif()
   elseif(VAR MATCHES "GO")
     set(PROGNAME go)
     set(PATHS ${DOWNLOADS}/tools/go/go/bin)
@@ -342,6 +357,12 @@ function(vcpkg_find_acquire_program VAR)
         _execute_process(
           COMMAND msiexec /a ${ARCHIVE_NATIVE_PATH} /qn TARGETDIR=${DESTINATION_NATIVE_PATH}
           WORKING_DIRECTORY ${DOWNLOADS}
+        )
+      elseif("${ARCHIVE_PATH}" MATCHES ".7z.exe$")
+        vcpkg_find_acquire_program(7Z)
+        _execute_process(
+          COMMAND ${7Z} x "${ARCHIVE_PATH}" "-o${PROG_PATH_SUBDIR}" -y -bso0 -bsp0
+          WORKING_DIRECTORY ${PROG_PATH_SUBDIR}
         )
       else()
         _execute_process(

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -29,11 +29,11 @@
         <archiveName>cmake-3.12.4-FreeBSD-x86_64.tar.gz</archiveName>
     </tool>
     <tool name="git" os="windows">
-        <version>2.21.0-1</version>
+        <version>2.25.1-1</version>
         <exeRelativePath>mingw32\bin\git.exe</exeRelativePath>
-        <url>https://github.com/git-for-windows/git/releases/download/v2.21.0.windows.1/PortableGit-2.21.0-32-bit.7z.exe</url>
-        <sha512>d5600fc35e91cfa84e3547e38a9da9798cf0a53810cc35ac9a0dee671c4ef0e9fbcbe3eda9c790f8db4eafce7ce58d7a168d28938a66cdcca000bf5a7f5267c1</sha512>
-        <archiveName>PortableGit-2.21.0-32-bit.7z.exe</archiveName>
+        <url>https://github.com/git-for-windows/git/releases/download/v2.25.1.windows.1/PortableGit-2.25.1-32-bit.7z.exe</url>
+        <sha512>222d6e384ecae5841cb02dc004c4b3f56659d19b662bc93ab531df844c9477c9717c4a1adfb8bc2d3159678238fa4c79ccbdcb5c116eea5eccd652f4b483359e</sha512>
+        <archiveName>PortableGit-2.25.1-32-bit.7z.exe</archiveName>
     </tool>
     <tool name="git" os="linux">
         <version>2.7.4</version>


### PR DESCRIPTION
Adds git to the list of `vcpkg_find_acquire_program` tools.

- What does your PR fix?
Follow-up to https://github.com/microsoft/vcpkg/pull/10083#discussion_r386560567

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

Note: `GIT` as a cmake variable is set by the `vcpkg` build call if the `VCPKG_FORCE_SYSTEM_BINARIES` environment variable is not set ([build.cpp](https://github.com/microsoft/vcpkg/blob/5c415ff8a0aad831ee90ee4327f26992d5fe3fb3/toolsrc/src/vcpkg/build.cpp#L389)), in which case `vcpkg_find_acquire_program` will short-circuit in the beginning.
