### PR TITLE
[libgit2] Add features pcre,pcre2 to choose regex backend

### DIFF
--- a/ports/libgit2/CONTROL
+++ b/ports/libgit2/CONTROL
@@ -1,7 +1,7 @@
 Source: libgit2
 Version: 0.99.0-1
 Homepage: https://github.com/libgit2/libgit2
-Build-Depends: openssl (!windows&&!uwp)
+Build-Depends: zlib, openssl (!windows&&!uwp)
 Description: Git linkable library
 Supports: !uwp
 

--- a/ports/libgit2/CONTROL
+++ b/ports/libgit2/CONTROL
@@ -4,3 +4,11 @@ Homepage: https://github.com/libgit2/libgit2
 Build-Depends: openssl (!windows&&!uwp)
 Description: Git linkable library
 Supports: !uwp
+
+Feature: pcre
+Description: Build against external libpcre
+Build-Depends: pcre
+
+Feature: pcre2
+Description: Build against external libpcre2
+Build-Depends: pcre2

--- a/ports/libgit2/CONTROL
+++ b/ports/libgit2/CONTROL
@@ -1,5 +1,5 @@
 Source: libgit2
-Version: 0.99.0
+Version: 0.99.0-1
 Homepage: https://github.com/libgit2/libgit2
 Build-Depends: openssl (!windows&&!uwp)
 Description: Git linkable library

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -11,11 +11,20 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)
 
+if ("pcre" IN_LIST FEATURES)
+    set(REGEX_BACKEND pcre)
+elseif ("pcre2" IN_LIST FEATURES)
+    set(REGEX_BACKEND pcre2)
+else()
+    set(REGEX_BACKEND builtin)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DBUILD_CLAR=OFF
+        -DREGEX_BACKEND=${REGEX_BACKEND}
         -DSTATIC_CRT=${STATIC_CRT}
 )
 


### PR DESCRIPTION
With the update to 0.99.0, this [change](https://github.com/libgit2/libgit2/commit/69ecdad5a494957afcf2447cc6edac6934f2b1b6) was included. When REGEX_BACKEND is not specified, libgit2 preferentially builds against system libpcre, which is not always desirable.

With this patch:
- `core` will use the built-in `pcre` as libgit2 did prior to 0.99.0
- `pcre` will use vcpkg `pcre`
- `pcre2` will use vcpkg `pcre2`

