### PR TITLE
Update MSYS2 download source. Resolve #10322

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -54,6 +54,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     set(TOOLSUBPATH msys64)
     set(URLS
       "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz/download"
+      "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz"
     )
     set(ARCHIVE "msys2-base-x86_64-20190524.tar.xz")
     set(HASH 50796072d01d30cc4a02df0f9dafb70e2584462e1341ef0eff94e2542d3f5173f20f81e8f743e9641b7528ea1492edff20ce83cb40c6e292904905abe2a91ccc)
@@ -62,6 +63,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     set(TOOLSUBPATH msys32)
     set(URLS
       "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz/download"
+      "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz"
     )
     set(ARCHIVE "msys2-base-i686-20190524.tar.xz")
     set(HASH b26d7d432e1eabe2138c4caac5f0a62670f9dab833b9e91ca94b9e13d29a763323b0d30160f09a381ac442b473482dac799be0fea5dd7b28ea2ddd3ba3cd3c25)

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -53,18 +53,18 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
   if(_vam_HOST_ARCHITECTURE STREQUAL "AMD64")
     set(TOOLSUBPATH msys64)
     set(URLS
-      "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20181211.tar.xz"
+      "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz/download"
     )
-    set(ARCHIVE "msys2-base-x86_64-20181211.tar.xz")
-    set(HASH 1efb9a7ff1daa2d3147ac0fda8e9a645696dbd19a33c986b844bc037d946dddb3353db5a52794ac668718812854400d918e4db13b4a2d0e6f5a9dfe716b48056)
+    set(ARCHIVE "msys2-base-x86_64-20190524.tar.xz")
+    set(HASH 50796072d01d30cc4a02df0f9dafb70e2584462e1341ef0eff94e2542d3f5173f20f81e8f743e9641b7528ea1492edff20ce83cb40c6e292904905abe2a91ccc)
     set(STAMP "initialized-msys2_64.stamp")
   else()
     set(TOOLSUBPATH msys32)
     set(URLS
-      "http://repo.msys2.org/distrib/i686/msys2-base-i686-20181211.tar.xz"
+      "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz/download"
     )
-    set(ARCHIVE "msys2-base-i686-20181211.tar.xz")
-    set(HASH a9b9680a511bb205b87811b303eb29d62e2fd851000304f8b087c5893a3891c2aa2d46217ae989e31b5d52a6ba34ac5e6a5e624d9c917df00a752ade4debc20f)
+    set(ARCHIVE "msys2-base-i686-20190524.tar.xz")
+    set(HASH b26d7d432e1eabe2138c4caac5f0a62670f9dab833b9e91ca94b9e13d29a763323b0d30160f09a381ac442b473482dac799be0fea5dd7b28ea2ddd3ba3cd3c25)
     set(STAMP "initialized-msys2_32.stamp")
   endif()
 


### PR DESCRIPTION
**Describe the pull request**

1. What does your PR fix? Fixes issue #


Proposal to resolve https://github.com/microsoft/vcpkg/issues/10322
* Use Sourceforge as MSYS2 download source (up to SF to choose mirror, fair to everyone and more reliable)
* Updated msys2 version to 2019-05-24 (Otherwise need to spend extra time on ```pacman -Syu```)
* Updated SHA512 accordingly
* Tested with building icu:x64-windows

2. Which triplets are supported/not supported? Have you updated the CI baseline?
* support x86-windows and x64-windows

3. Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
