### PR TITLE
[ffmpeg] Fix build static error

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.2-5
+Version: 4.2-6
 Build-Depends: zlib
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -256,11 +256,10 @@ if(FILES_TO_REMOVE_LEN GREATER 0)
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-if("ffmpeg" IN_LIST FEATURES OR "ffprobe" IN_LIST FEATURES)
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    endif()
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
+
 vcpkg_copy_pdbs()
 
 # Handle copyright

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
@@ -258,6 +256,11 @@ if(FILES_TO_REMOVE_LEN GREATER 0)
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
+if("ffmpeg" IN_LIST FEATURES OR "ffprobe" IN_LIST FEATURES)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    endif()
+endif()
 vcpkg_copy_pdbs()
 
 # Handle copyright


### PR DESCRIPTION
When building `ffmpeg `with `ffmpeg `or `ffprobe` in static, it will post the error:
```
There should be no bin\ directory in a static build, but D:\GitHub\vcpkg\packages\ffmpeg_x86-windows-static\bin is present.
There should be no debug\bin\ directory in a static build, but D:\GitHub\vcpkg\packages\ffmpeg_x86-windows-static\debug\bin is present.
If the creation of bin\ and/or debug\bin\ cannot be disabled, use this in the portfile to remove them

    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
    endif()

There should be no empty directories in D:\GitHub\vcpkg\packages\ffmpeg_x86-windows-static
The following empty directories were found:

    D:/GitHub/vcpkg/packages/ffmpeg_x86-windows-static/bin
    D:/GitHub/vcpkg/packages/ffmpeg_x86-windows-static/debug/bin
```
So I remove these folder to fix this issue.

Related issue #9949.

Note: All features have been passed with the following triplets:
- x86-windows
- x64-windows-static (except for opencl, openssl, lzma fixed in PR #8797 )
- x64-linux (except for opencl, openssl, lzma fixed in PR #8797 , vpx, x264 only supported on Windows)