### PR TITLE
[vcpkg] Introduce Job Objects to improve ctrl-c performance on Windows

### DIFF
--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -61,4 +61,9 @@ namespace vcpkg::System
                                     std::function<void(StringView)> data_cb,
                                     const Environment& env = {});
     void register_console_ctrl_handler();
+#if defined(_WIN32)
+    void initialize_global_job_object();
+    void enter_interactive_subprocess();
+    void exit_interactive_subprocess();
+#endif
 }

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -269,7 +269,7 @@ int wmain(int, const wchar_t* const* const);
 #include <shellapi.h>
 int main(int argc, const char* const* const /*argv*/)
 {
-    wchar_t **wargv;
+    wchar_t** wargv;
     wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
     return wmain(argc, wargv);
 }
@@ -292,6 +292,7 @@ int main(const int argc, const char* const* const argv)
     SetConsoleCP(CP_UTF8);
     SetConsoleOutputCP(CP_UTF8);
 
+    System::initialize_global_job_object();
 #endif
 
     Checks::register_global_shutdown_handler([]() {

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -89,7 +89,7 @@ namespace vcpkg::Commands::Env
             }
         }();
 
-        std::string cmd = args.command_arguments.empty() ? "cmd" : args.command_arguments.at(0);
+        std::string cmd = args.command_arguments.empty() ? "cmd" : ("cmd /c " + args.command_arguments.at(0));
 #ifdef _WIN32
         System::enter_interactive_subprocess();
 #endif

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -79,7 +79,14 @@ namespace vcpkg::Commands::Env
             if (build_env_cmd.empty())
                 return clean_env;
             else
+            {
+#ifdef _WIN32
                 return System::cmd_execute_modify_env(build_env_cmd, clean_env);
+#else
+                Checks::exit_with_message(VCPKG_LINE_INFO,
+                                          "Build environment commands are not supported on this platform");
+#endif
+            }
         }();
 
         std::string cmd = args.command_arguments.empty() ? "cmd" : args.command_arguments.at(0);

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -48,7 +48,7 @@ namespace vcpkg::Commands::Env
         const Build::PreBuildInfo pre_build_info(
             paths, triplet, var_provider.get_generic_triplet_vars(triplet).value_or_exit(VCPKG_LINE_INFO));
         const Toolset& toolset = paths.get_toolset(pre_build_info);
-        auto env_cmd = Build::make_build_env_cmd(pre_build_info, toolset);
+        auto build_env_cmd = Build::make_build_env_cmd(pre_build_info, toolset);
 
         std::unordered_map<std::string, std::string> extra_env = {};
         const bool add_bin = Util::Sets::contains(options.switches, OPTION_BIN);
@@ -74,12 +74,22 @@ namespace vcpkg::Commands::Env
         if (add_python) extra_env.emplace("PYTHONPATH", (paths.installed / triplet.to_string() / "python").u8string());
         if (path_vars.size() > 0) extra_env.emplace("PATH", Strings::join(";", path_vars));
 
-        std::string env_cmd_prefix = env_cmd.empty() ? "" : Strings::format("%s && ", env_cmd);
-        std::string env_cmd_suffix =
-            args.command_arguments.empty() ? "cmd" : Strings::format("cmd /c %s", args.command_arguments.at(0));
+        auto env = [&] {
+            auto clean_env = System::get_modified_clean_environment(extra_env);
+            if (build_env_cmd.empty())
+                return clean_env;
+            else
+                return System::cmd_execute_modify_env(build_env_cmd, clean_env);
+        }();
 
-        const std::string cmd = Strings::format("%s%s", env_cmd_prefix, env_cmd_suffix);
-        System::cmd_execute(cmd, System::get_modified_clean_environment(extra_env));
-        Checks::exit_success(VCPKG_LINE_INFO);
+        std::string cmd = args.command_arguments.empty() ? "cmd" : args.command_arguments.at(0);
+#ifdef _WIN32
+        System::enter_interactive_subprocess();
+#endif
+        auto rc = System::cmd_execute(cmd, env);
+#ifdef _WIN32
+        System::exit_interactive_subprocess();
+#endif
+        Checks::exit_with_code(VCPKG_LINE_INFO, rc);
     }
 }


### PR DESCRIPTION
On Windows, vsdevcmd.bat and cmd.exe in general sometimes fail to respond to ctrl-c. Because vcpkg needs to invoke these commands early on for many commands, this results in vcpkg appearing to "ignore" or "lag" when hitting ctrl-c.

This PR introduces a Windows Job Object[1] around all child processes spawned by Vcpkg, utilizing `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` to quickly and correctly terminate the entire process subtree when the user presses ctrl-c.

Three areas need special handling:
1. `vcpkg edit` obviously needs the editor to outlast vcpkg itself (in the case of a GUI editor like VS Code)
2. `vcpkg env` is often used to spawn a shell, which has its own (appropriate) special handling for ctrl-c
3. Our telemetry executable needs to continue in the background so we can return control to the user as quickly as possible

[1] https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects
