### PR TITLE
[vcpkg] Fix tool lookup without `which`

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -666,6 +666,10 @@ namespace vcpkg::Files
 #if defined(_WIN32)
             static constexpr StringLiteral EXTS[] = {".cmd", ".exe", ".bat"};
             auto paths = Strings::split(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO), ";");
+#else
+            static constexpr StringLiteral EXTS[] = {""};
+            auto paths = Strings::split(System::get_environment_variable("PATH").value_or_exit(VCPKG_LINE_INFO), ":");
+#endif
 
             std::vector<fs::path> ret;
             std::error_code ec;
@@ -684,16 +688,6 @@ namespace vcpkg::Files
             }
 
             return ret;
-#else
-            const std::string cmd = Strings::concat("which ", name);
-            auto out = System::cmd_execute_and_capture_output(cmd);
-            if (out.exit_code != 0)
-            {
-                return {};
-            }
-
-            return Util::fmap(Strings::split(out.output, "\n"), [](auto&& s) { return fs::path(s); });
-#endif
         }
     };
 


### PR DESCRIPTION
On Linux and macOS, if `which` is not installed (notably in Amazon's
amazonlinux docker base image), vcpkg fails to find system-installed
versions of tools. This is an issue when we don't attempt to install our
own versions of the tools, like with git (we fail to find any version of
git, and thus can't install any ports which come from a git repository).

Fixes #9927