### PR TITLE
[geos] Upgrade to GEOS 3.6.4

### DIFF
--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,4 +1,4 @@
 Source: geos
-Version: 3.6.3-3
+Version: 3.6.4
 Homepage: https://www.osgeo.org/projects/geos/
 Description: Geometry Engine Open Source

--- a/ports/geos/geos_c-static-support.patch
+++ b/ports/geos/geos_c-static-support.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 927a0fe..8e6c3ea 100644
+index e7d2451..f8cc1ba 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -66,11 +66,7 @@ if(NOT MSVC)
@@ -16,14 +16,17 @@ index 927a0fe..8e6c3ea 100644
  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
    option(GEOS_ENABLE_FLOATSTORE
 diff --git a/capi/CMakeLists.txt b/capi/CMakeLists.txt
-index 859722b..b6e44b6 100644
+index 0607b16..877d611 100644
 --- a/capi/CMakeLists.txt
 +++ b/capi/CMakeLists.txt
-@@ -23,15 +23,23 @@ file(GLOB geos_capi_HEADERS ${CMAKE_BINARY_DIR}/capi/*.h) # fix source_group iss
+@@ -21,17 +21,25 @@ set(geos_c_SOURCES
  
- if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK) 
-   # if building OS X framework, CAPI built into C++ library 
--  add_library(geos_c SHARED ${geos_c_SOURCES}) 
+ file(GLOB geos_capi_HEADERS ${CMAKE_BINARY_DIR}/capi/*.h) # fix source_group issue
+ 
+-if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK AND GEOS_BUILD_SHARED)
++if(NOT GEOS_ENABLE_MACOSX_FRAMEWORK)
+   # if building OS X framework or only building static libs, CAPI built into C++ library)
+-  add_library(geos_c SHARED ${geos_c_SOURCES})
 +  add_library(geos_c ${geos_c_SOURCES})
  
    target_link_libraries(geos_c geos)
@@ -49,19 +52,19 @@ index 859722b..b6e44b6 100644
      set_target_properties(geos_c
        PROPERTIES
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 4a1e688..a33b5f6 100644
+index 3894a56..f86d823 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -23,7 +23,7 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
-     ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_c.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/../capi/geos_ts_c.cpp)
+@@ -24,7 +24,7 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
+   # also 1 binary, so include CAPI here
+   # and, make name all caps
  
 -  add_library(GEOS SHARED ${geos_SOURCES} ${geos_c_SOURCES})
 +  add_library(GEOS ${geos_SOURCES} ${geos_c_SOURCES})
  
-   math(EXPR CVERSION "${VERSION_MAJOR} + 1") 
-  	# VERSION = current version, SOVERSION = compatibility version 
-@@ -61,37 +61,27 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
+   math(EXPR CVERSION "${VERSION_MAJOR} + 1")
+  	# VERSION = current version, SOVERSION = compatibility version
+@@ -62,38 +62,27 @@ if(GEOS_ENABLE_MACOSX_FRAMEWORK)
  
  else()
  
@@ -83,7 +86,8 @@ index 4a1e688..a33b5f6 100644
 -  endif()
 -
 -  if(GEOS_BUILD_STATIC)
--    add_library(geos-static STATIC ${geos_SOURCES} ${geos_ALL_HEADERS})
+-    file(GLOB geos_capi_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/../capi/*.h) # fix source_group issue
+-    add_library(geos-static STATIC ${geos_SOURCES} ${geos_c_SOURCES} ${geos_ALL_HEADERS} ${geos_capi_HEADERS})
 -
 -    set_target_properties(geos-static
 +  else()

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,11 +1,9 @@
-include(vcpkg_common_functions)
-
-set(GEOS_VERSION 3.6.3)
+set(GEOS_VERSION 3.6.4)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"
     FILENAME "geos-${GEOS_VERSION}.tar.bz2"
-    SHA512 f88adcf363433e247a51fb1a2c0b53f39b71aba8a6c01dd08aa416c2e980fe274a195e6edcb5bb5ff8ea81b889da14a1a8fb2849e04669aeba3b6d55754dc96a
+    SHA512 860513d86ee1294814ff3b3240373ee3a9ce88be9508b45f61ccc982bb698d0a1916e9458c37853ce8d69a977db6f12483745859f86617d704a688cfeb83b1e9
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
Update port/geos to version 3.6.4, released 2019-10-04

See details [in this release announcement](http://osgeo-org.1560.x6.nabble.com/GEOS-3-7-3-3-6-4-3-5-2-Released-tt5418254.html)

Note that this is not the current version, as I'd like to re-create each major version, so you can expect me to also create pull requests for GEOS versions 3.7.3 and 3.8.1 (current).

---

- What does your PR fix? None.
- Which triplets are supported/not supported? Have you updated the CI baseline? Not sure, and nope.
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
