### PR TITLE
[vtk] Add find dependency pugixml in cmake config file

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-11
+Version: 8.2.0-12
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/fix-pugixml-link.patch
+++ b/ports/vtk/fix-pugixml-link.patch
@@ -1,5 +1,19 @@
+diff --git a/CMake/VTKConfig.cmake.in b/CMake/VTKConfig.cmake.in
+index d28e0cc..7ed48bc 100644
+--- a/CMake/VTKConfig.cmake.in
++++ b/CMake/VTKConfig.cmake.in
+@@ -88,6 +88,9 @@ if(VTK_HAS_VTKM AND NOT TARGET vtkm_cont)
+                )
+ endif()
+ 
++# Find dependencies
++include(CMakeFindDependencyMacro)
++find_dependency(pugixml REQUIRED)
+ 
+ #-----------------------------------------------------------------------------
+ # Load requested modules.
 diff --git a/IO/CityGML/CMakeLists.txt b/IO/CityGML/CMakeLists.txt
-index ce979ba..322e2de 100644
+index ce979ba..744c6f1 100644
 --- a/IO/CityGML/CMakeLists.txt
 +++ b/IO/CityGML/CMakeLists.txt
 @@ -4,8 +4,5 @@ vtk_module_library(vtkIOCityGML ${Module_SRCS})
@@ -12,18 +26,3 @@ index ce979ba..322e2de 100644
 -  vtk_module_link_libraries(vtkIOCityGML LINK_PRIVATE ${pugixml_LIBRARIES})
 +  vtk_module_link_libraries(vtkIOCityGML LINK_PUBLIC pugixml)
  endif()
-diff --git a/CMake/VTKConfig.cmake.in b/CMake/VTKConfig.cmake.in
-index d28e0cc..1158db5 100644
---- a/CMake/VTKConfig.cmake.in
-+++ b/CMake/VTKConfig.cmake.in
-@@ -88,7 +88,9 @@ if(VTK_HAS_VTKM AND NOT TARGET vtkm_cont)
-                )
- endif()
- 
--
-+# Find dependencies
-+include(CMakeFindDependencyMacro)
-+find_dependency(pugixml REQUIRED)
- #-----------------------------------------------------------------------------
- # Load requested modules.
- 

--- a/ports/vtk/fix-pugixml-link.patch
+++ b/ports/vtk/fix-pugixml-link.patch
@@ -12,3 +12,18 @@ index ce979ba..322e2de 100644
 -  vtk_module_link_libraries(vtkIOCityGML LINK_PRIVATE ${pugixml_LIBRARIES})
 +  vtk_module_link_libraries(vtkIOCityGML LINK_PUBLIC pugixml)
  endif()
+diff --git a/CMake/VTKConfig.cmake.in b/CMake/VTKConfig.cmake.in
+index d28e0cc..1158db5 100644
+--- a/CMake/VTKConfig.cmake.in
++++ b/CMake/VTKConfig.cmake.in
+@@ -88,7 +88,9 @@ if(VTK_HAS_VTKM AND NOT TARGET vtkm_cont)
+                )
+ endif()
+ 
+-
++# Find dependencies
++include(CMakeFindDependencyMacro)
++find_dependency(pugixml REQUIRED)
+ #-----------------------------------------------------------------------------
+ # Load requested modules.
+ 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -250,8 +250,8 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/vtk)
+
 # =============================================================================
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/Copyright.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/vtk)


### PR DESCRIPTION
When using vtk, `VTKTargets.cmake` calls `pugixml` by name. However, `VTKConfig.cmake` did not add the code to find pugixml, so I added it.

Related: #9947.

