### PR TITLE
[vcpkg] Map configuration also for single configuration generators

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -26,21 +26,19 @@ if(VCPKG_TOOLCHAIN)
     return()
 endif()
 
-if(DEFINED CMAKE_CONFIGURATION_TYPES) #Generating with a multi config generator
-    #If CMake does not have a mapping for MinSizeRel and RelWithDebInfo in imported targets
-    #it will map those configuration to the first valid configuration in CMAKE_CONFIGURATION_TYPES.
-    #By default this is the debug configuration which is wrong. 
-    if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
-        set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL "MinSizeRel;Release;")
-        if(VCPKG_VERBOSE)
-            message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL set to MinSizeRel;Release;")
-        endif()
+#If CMake does not have a mapping for MinSizeRel and RelWithDebInfo in imported targets
+#it will map those configuration to the first valid configuration in CMAKE_CONFIGURATION_TYPES or the targets IMPORTED_CONFIGURATIONS.
+#In most cases this is the debug configuration which is wrong. 
+if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
+    set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL "MinSizeRel;Release;")
+    if(VCPKG_VERBOSE)
+        message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL set to MinSizeRel;Release;")
     endif()
-    if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
-        set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release;")
-        if(VCPKG_VERBOSE)
-            message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO set to RelWithDebInfo;Release;")
-        endif()
+endif()
+if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
+    set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release;")
+    if(VCPKG_VERBOSE)
+        message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO set to RelWithDebInfo;Release;")
     endif()
 endif()
 


### PR DESCRIPTION
**Describe the pull request**

remove `if(DEFINED CMAKE_CONFIGURATION_TYPES) ` since the mapping is also necessary for single configuration generators. 
