### PR TITLE
[mlpack] Fix build tool error

### DIFF
--- a/ports/mlpack/CONTROL
+++ b/ports/mlpack/CONTROL
@@ -1,5 +1,5 @@
 Source: mlpack
-Version: 3.2.2
+Version: 3.2.2-1
 Homepage: https://github.com/mlpack/mlpack
 Description: mlpack is a fast, flexible machine learning library, written in C++, that aims to provide fast, extensible implementations of cutting-edge machine learning algorithms.
 Build-Depends: openblas (!osx), clapack (!osx), boost, armadillo, ensmallen

--- a/ports/mlpack/CONTROL
+++ b/ports/mlpack/CONTROL
@@ -5,4 +5,4 @@ Description: mlpack is a fast, flexible machine learning library, written in C++
 Build-Depends: openblas (!osx), clapack (!osx), boost, armadillo, ensmallen
 
 Feature: tools
-Description: Build command-line executables and tests.
+Description: Build command-line executables.

--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -20,15 +20,14 @@ file(REMOVE ${SOURCE_PATH}/CMake/ARMA_FindOpenBLAS.cmake)
 file(REMOVE ${SOURCE_PATH}/CMake/FindArmadillo.cmake)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    tools     BUILD_TOOLS
+    tools     BUILD_CLI_EXECUTABLES
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DBUILD_TESTS=${BUILD_TOOLS}
-        -DBUILD_CLI_EXECUTABLES=${BUILD_TOOLS}
+        -DBUILD_TESTS=OFF
         ${FEATURE_OPTIONS}
 )
 vcpkg_install_cmake()


### PR DESCRIPTION
Since `BUILD_TOOLS` does not exist in `mlpack `source code. Even though we pass its value to `BUILD_TESTS` and `BUILD_CLI_EXECUTABLES`. In fact, the values of these two options are not updated via `vcpkg_check_features()` and `${FEATURE_OPTIONS}`

So I removed `BUILD_TOOLS` to fix this issue.
I also removed `test `part from `tools `and set `BUILD_TESTS` as OFF. If needed, we can add `test `as a new feature in the furture.

Related issue #10384 

Note: The feature has been passed with `x64-windows `triplet.
