### PR TITLE
[vcpkg baseline] Fix libhdfs3

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -775,7 +775,6 @@ libhdfs3:x64-uwp=fail
 libhdfs3:x64-windows=fail
 libhdfs3:x64-windows-static=fail
 libhdfs3:x86-windows=fail
-libhdfs3:x64-linux=fail
 libhydrogen:arm64-windows=fail
 libics:arm-uwp=fail
 libics:x64-uwp=fail


### PR DESCRIPTION
We now install kerberos in the Linux CI pipeline.

CC #10290 