### PR TITLE
[tinyexr] update to commit fdaeecb@2020-03-15

### DIFF
--- a/ports/tinyexr/CONTROL
+++ b/ports/tinyexr/CONTROL
@@ -1,4 +1,4 @@
 Source: tinyexr
-Version: 0.9.5-d16ea6-1
+Version: 2020-03-15
 Homepage: https://github.com/syoyo/tinyexr
 Description: Library to load and save OpenEXR(.exr) images

--- a/ports/tinyexr/portfile.cmake
+++ b/ports/tinyexr/portfile.cmake
@@ -1,15 +1,12 @@
-# header-only
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyexr
-    REF d16ea6347ae78bcee984fb57cab1f023aeda4fb0
-    SHA512 63399688d7894f9ac4b893b2142202b36108b5029b11c40c3f9ad0f0135625fb0c8e0d54cec88d92c016774648dc829a946d9575c5f19afea56542c00759546e
+    REF fdaeecbbc1bac1a417c6af2f4dab43d3840ed036
+    SHA512 0d875e197bc82dd5addb8e08e9ba1a9a02e108cc9dd14e5ea17de032cda5ad599f6d10d6c7959d545e05ab30d6daa34f98061f23faeb1c15caf96b6cb76483a3
     HEAD_REF master
 )
 
 file(COPY ${SOURCE_PATH}/tinyexr.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-# Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/tinyexr)


### PR DESCRIPTION
I'm currently preparing a cmake integrated bgfx port (requested here #1303) which requires a newer tinyexr version.
