### PR TITLE
[skia] Fix vswhere.exe can't find VS2017 with -sort

### DIFF
--- a/ports/skia/CONTROL
+++ b/ports/skia/CONTROL
@@ -1,5 +1,5 @@
 Source: skia
-Version: 2020-02-15
+Version: 2020-02-15-1
 Homepage: https://skia.org
 Description: Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.
   It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -51,22 +51,6 @@ endif()
 set(OPTIONS_REL "${OPTIONS} is_official_build=true")
 set(OPTIONS_DBG "${OPTIONS} is_debug=true")
 
-function(find_msvc_path PATH)
-    vcpkg_get_program_files_32_bit(PROGRAM_FILES)
-    file(TO_CMAKE_PATH "${PROGRAM_FILES}" PROGRAM_FILES)
-    set(VSWHERE "${PROGRAM_FILES}/Microsoft Visual Studio/Installer/vswhere.exe")
-    execute_process(
-        COMMAND "${VSWHERE}" -prerelease -legacy -products * -utf8 -property installationPath
-        WORKING_DIRECTORY "${SOURCE_PATH}"
-        OUTPUT_VARIABLE OUTPUT_
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    string(REGEX REPLACE "\n|(\r\n)" ";" OUTPUT_ "${OUTPUT_}")
-    list(GET OUTPUT_ 0 OUTPUT_)
-    
-    set(${PATH} "${OUTPUT_}" PARENT_SCOPE)
-endfunction()
-
 if(CMAKE_HOST_WIN32)
     # Load toolchains
     if(NOT VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
@@ -95,8 +79,8 @@ if(CMAKE_HOST_WIN32)
     set(OPTIONS_REL "${OPTIONS_REL} extra_cflags_c=${SKIA_C_FLAGS_REL} \
         extra_cflags_cc=${SKIA_CXX_FLAGS_REL}")
 
-    find_msvc_path(WIN_VC)
-    set(WIN_VC "${WIN_VC}\\VC")
+    set(WIN_VC "$ENV{VCINSTALLDIR}")
+    string(REPLACE "\\VC\\" "\\VC" WIN_VC "${WIN_VC}")
     set(OPTIONS_DBG "${OPTIONS_DBG} win_vc=\"${WIN_VC}\"")
     set(OPTIONS_REL "${OPTIONS_REL} win_vc=\"${WIN_VC}\"")
 

--- a/ports/skia/portfile.cmake
+++ b/ports/skia/portfile.cmake
@@ -56,7 +56,7 @@ function(find_msvc_path PATH)
     file(TO_CMAKE_PATH "${PROGRAM_FILES}" PROGRAM_FILES)
     set(VSWHERE "${PROGRAM_FILES}/Microsoft Visual Studio/Installer/vswhere.exe")
     execute_process(
-        COMMAND "${VSWHERE}" -prerelease -legacy -products * -sort -utf8 -property installationPath
+        COMMAND "${VSWHERE}" -prerelease -legacy -products * -utf8 -property installationPath
         WORKING_DIRECTORY "${SOURCE_PATH}"
         OUTPUT_VARIABLE OUTPUT_
         OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Fix vswhere.exe can't find VS2017 with the error as below:
```
ERROR at //gn/BUILDCONFIG.gn:133:29: Script returned non-zero exit code.
    win_toolchain_version = exec_script("//gn/highest_version_dir.py",
                            ^----------
Current dir: F:/0315/vcpkg/buildtrees/skia/x64-windows-dbg/
Command: F:/0315/vcpkg/downloads/tools/python/python-2.7.16-x64/python.exe F:/0315/vcpkg/buildtrees/skia/src/3c01b69efb-0a98da8354/gn/highest_version_dir.py "Visual Studio Locator version 2.5.2+gebb9f26a3d [query version 1.18.21.37008]\VC/Tools/MSVC" "[0-9]{2}\.[0-9]{2}\.[0-9]{5}"
Returned 1.
```
I used the command to find VS on cmd, and I got the error as below:
```
C:\Program Files (x86)\Microsoft Visual Studio\Installer>vswhere.exe -prerelease -legacy -products * -sort -utf8 -property installationPath
Visual Studio Locator version 2.5.2+gebb9f26a3d [query version 1.18.21.37008]
Copyright (C) Microsoft Corporation. All rights reserved.

Error 0x57: Unknown parameter: sort
```
I have submit an issue on the source page: https://github.com/microsoft/vswhere/issues/216
No features need to test.