### PR TITLE
Rebuild the failed ports on baseline

### DIFF
--- a/ports/anyrpc/CONTROL
+++ b/ports/anyrpc/CONTROL
@@ -1,4 +1,4 @@
 Source: anyrpc
-Version: 2020-01-13-1
+Version: 2020-01-13-2
 Homepage: https://github.com/sgieseking/anyrpc
 Description: A multiprotocol remote procedure call system for C++.

--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 12.0
+Version: 12.0-1
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/


### PR DESCRIPTION
Baseline issues:
1. libpq:arm64-windows and anyrpc:x64-windows failed, I can't repro the issue locally. Rerun them again.
2. spdk-ipsec:x64-linux, it need to upgrade nasm on our CI test machines. The failures like:
      CMake Error at ports/spdk-ipsec/portfile.cmake:38 (MESSAGE):
       NASM version 2.13.03 (or newer) is required to build this package

Related to https://github.com/microsoft/vcpkg/pull/10436 and other PRs.