### PR TITLE
[osg] Update dependency sdl2 as sdl1

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,5 +1,5 @@
 Source: osg
-Version: 3.6.4-1
+Version: 3.6.4-2
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig, sdl1, boost-asio (!windows), libxml2 (windows), giflib (windows), freeglut (windows), expat (windows), libiconv (windows)

--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -2,7 +2,7 @@ Source: osg
 Version: 3.6.4-1
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
-Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig, sdl2, boost-asio (!windows), libxml2 (windows), giflib (windows), freeglut (windows), expat (windows), libiconv (windows)
+Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig, sdl1, boost-asio (!windows), libxml2 (windows), giflib (windows), freeglut (windows), expat (windows), libiconv (windows)
 
 Feature: collada
 Description: Support for Collada (.dae) files


### PR DESCRIPTION
Since  this file `#include <SDL/SDL.h>` is from `sdl1 `instead of `sdl2`. 
I also tried to use `SDL2 `to build, but there were many errors in `SDL2/SDL.h`.
So I update the dependency `sdl2 `as `sdl1 `in CONTROL file.

Related issue #10320

Note: The feature tested pass in `x86-windows` triplet.
