### PR TITLE
[libffi] Check return value of execute_process()

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -120,7 +120,12 @@ macro(add_assembly ASMFILE)
             COMMAND ${CMAKE_C_COMPILER} /nologo /EP /I. /Iinclude /I${CMAKE_CURRENT_SOURCE_DIR}/include "${ASMFILE_FULL}"
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             OUTPUT_FILE ${ARCH_ASM_NAME}.asm
+            RESULT_VARIABLE retcode
         )
+
+        if(NOT ${retcode} STREQUAL "0")
+            message(FATAL_ERROR "Unable to assemble, exit code: '${retcode}'.")
+        endif()
 
         # Produced *.asm file could be just added to sources.
         # It works in x64 mode, but for some strange reason MASM returns error code when in x86,
@@ -129,7 +134,12 @@ macro(add_assembly ASMFILE)
         execute_process(
             COMMAND ${ARCH_ASSEMBLER} ${ARCH_ASM_NAME}.asm
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            RESULT_VARIABLE retcode
         )
+
+        if(NOT ${retcode} STREQUAL "0")
+            message(FATAL_ERROR "Unable to compile assembly, exit code: '${retcode}'.")
+        endif()
 
         list(APPEND FFI_SOURCES ${CMAKE_BINARY_DIR}/${ARCH_ASM_NAME}.obj)
     else()

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,4 +1,4 @@
 Source: libffi
-Version: 3.3-1
+Version: 3.3-2
 Homepage: https://github.com/libffi/libffi
 Description: Portable, high level programming interface to various calling conventions


### PR DESCRIPTION
I'm currently unable to cross-compile libffi for arm64. The "compile assembly" `execute_process()` step silently fails and CMake later complains that the .obj file is not available. To avoid hiding errors, the return values of the `execute_process()` commands should be checked and a fatal error should be issued.

(Here's the build log, in case smb. is interested: https://ci.appveyor.com/project/derselbst/fluidsynth-g2ouw/builds/31479626/job/hm9u92nejl7083dx#L596)