### PR TITLE
[Morton-nd] Update version to v3.0.0

### DIFF
--- a/ports/morton-nd/CONTROL
+++ b/ports/morton-nd/CONTROL
@@ -1,3 +1,4 @@
 Source: morton-nd
 Version: 3.0.0
+Homepage: https://github.com/kevinhartman/morton-nd
 Description: header-only constexpr library for fast Morton encoding/decoding in N dimensions.

--- a/ports/morton-nd/CONTROL
+++ b/ports/morton-nd/CONTROL
@@ -1,3 +1,3 @@
 Source: morton-nd
-Version: 2.0.0
-Description: (C++14) header-only library for fast Morton encoding/decoding in N dimensions.
+Version: 3.0.0
+Description: header-only constexpr library for fast Morton encoding/decoding in N dimensions.

--- a/ports/morton-nd/portfile.cmake
+++ b/ports/morton-nd/portfile.cmake
@@ -1,5 +1,4 @@
 #header-only library
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -29,6 +28,3 @@ file(REMOVE_RECURSE
 # Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
 file(COPY ${SOURCE_PATH}/NOTICE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
-# CMake integration test
-vcpkg_test_cmake(PACKAGE_NAME ${PORT})

--- a/ports/morton-nd/portfile.cmake
+++ b/ports/morton-nd/portfile.cmake
@@ -1,16 +1,34 @@
 #header-only library
 include(vcpkg_common_functions)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kevinhartman/morton-nd
-    REF v2.0.0
-    SHA512 f349187a9c6094ebdc8dc10a0b028e119a82721946e2f629b3f64edade9665a97824d6a52496e470da61e5b65ae46c953346b271c2db11f5f2e3c7748de03daf
+    REF v3.0.0
+    SHA512 659c903c0c4a4ee4179d01950a952fe0c40d2c426063c10515ae5d2ad13ec8ca6b83d8de50c9eb86dd3c2c3747e1594d832f0c28cd6d414703baf9a7ab2f1f36
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/morton-nd)
-file(COPY ${SOURCE_PATH}/NOTICE DESTINATION ${CURRENT_PACKAGES_DIR}/share/morton-nd)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/morton-nd/LICENSE ${CURRENT_PACKAGES_DIR}/share/morton-nd/copyright)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
 
-file(GLOB HEADER_FILES ${SOURCE_PATH}/morton-nd/include/*.h)
-file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/morton-nd)
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/morton-nd/cmake TARGET_PATH)
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug
+    ${CURRENT_PACKAGES_DIR}/share/doc
+)
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(COPY ${SOURCE_PATH}/NOTICE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# CMake integration test
+vcpkg_test_cmake(PACKAGE_NAME ${PORT})


### PR DESCRIPTION
**Describe the pull request**
Morton ND now also provides its own CMake integration, which this portfile uses directly.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I've tested this on macOS. Presumably the CI system will test it on other platforms as well?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I believe so.
