### PR TITLE
[vcpkg-help] Reflow and small cleanups

### DIFF
--- a/toolsrc/include/vcpkg/help.h
+++ b/toolsrc/include/vcpkg/help.h
@@ -16,4 +16,16 @@ namespace vcpkg::Help
     void print_usage();
 
     std::string create_example_string(const std::string& command_and_arguments);
+
+    struct HelpTableFormatter
+    {
+        void format(StringView col1, StringView col2);
+
+        std::string m_str;
+
+    private:
+        void newline_indent();
+        void indent();
+    };
+
 }

--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -7,15 +7,53 @@
 #include <vcpkg/install.h>
 #include <vcpkg/remove.h>
 
-// Write environment variable names as %VARIABLE% on Windows and $VARIABLE in *nix
-#ifdef _WIN32
-#define ENVVAR(VARNAME) "%%" #VARNAME "%%"
-#else
-#define ENVVAR(VARNAME) "$" #VARNAME
-#endif
-
 namespace vcpkg::Help
 {
+    void HelpTableFormatter::format(StringView col1, StringView col2)
+    {
+        // 1 space, 32 col1, 1 space, 85 col2 = 119
+        m_str.append(1, ' ');
+        Strings::append(m_str, col1);
+        if (col1.size() > 32)
+        {
+            newline_indent();
+        }
+        else
+        {
+            m_str.append(33 - col1.size(), ' ');
+        }
+        const char* line_start = col2.begin();
+        const char* const e = col2.end();
+        const char* best_break = std::find_if(line_start, e, [](char ch) { return ch == ' ' || ch == '\n'; });
+
+        while (best_break != e)
+        {
+            const char* next_break = std::find_if(best_break + 1, e, [](char ch) { return ch == ' ' || ch == '\n'; });
+            if (next_break - line_start > 85 || *best_break == '\n')
+            {
+                m_str.append(line_start, best_break);
+                line_start = best_break + 1;
+                best_break = next_break;
+                if (line_start != e)
+                {
+                    newline_indent();
+                }
+            }
+            else
+            {
+                best_break = next_break;
+            }
+        }
+        m_str.append(line_start, best_break);
+        m_str.push_back('\n');
+    }
+    void HelpTableFormatter::newline_indent()
+    {
+        m_str.push_back('\n');
+        indent();
+    }
+    void HelpTableFormatter::indent() { m_str.append(34, ' '); }
+
     struct Topic
     {
         using topic_function = void (*)(const VcpkgPaths& paths);
@@ -109,55 +147,55 @@ namespace vcpkg::Help
 
     void print_usage()
     {
-        System::print2("Commands:\n"
-                       "  vcpkg search [pat]              Search for packages available to be built\n"
-                       "  vcpkg install <pkg>...          Install a package\n"
-                       "  vcpkg remove <pkg>...           Uninstall a package\n"
-                       "  vcpkg remove --outdated         Uninstall all out-of-date packages\n"
-                       "  vcpkg list                      List installed packages\n"
-                       "  vcpkg update                    Display list of packages for updating\n"
-                       "  vcpkg upgrade                   Rebuild all outdated packages\n"
-                       "  vcpkg x-history <pkg>           Shows the history of CONTROL versions of a package\n"
-                       "  vcpkg hash <file> [alg]         Hash a file by specific algorithm, default SHA512\n"
-                       "  vcpkg help topics               Display the list of help topics\n"
-                       "  vcpkg help <topic>              Display help for a specific topic\n"
-                       "\n",
-                       Commands::Integrate::INTEGRATE_COMMAND_HELPSTRING, // Integration help
-                       "\n"
-                       "  vcpkg export <pkg>... [opt]...  Exports a package\n"
-                       "  vcpkg edit <pkg>                Open up a port for editing (uses " ENVVAR(EDITOR) //
-                       ", default 'code')\n"
-                       "  vcpkg import <pkg>              Import a pre-built library\n"
-                       "  vcpkg create <pkg> <url>\n"
-                       "             [archivename]        Create a new package\n"
-                       "  vcpkg owns <pat>                Search for files in installed packages\n"
-                       "  vcpkg depend-info <pkg>...      Display a list of dependencies for packages\n"
-                       "  vcpkg env                       Creates a clean shell environment for development or "
-                       "compiling.\n"
-                       "  vcpkg version                   Display version information\n"
-                       "  vcpkg contact                   Display contact information to send feedback\n"
-                       "\n"
-                       "Options:\n"
-                       "  --triplet <t>                   Specify the target architecture triplet\n"
-                       "                                  (default: " ENVVAR(VCPKG_DEFAULT_TRIPLET) //
-                       ", see 'vcpkg help triplet')\n"
-                       "\n"
-                       "  --overlay-ports=<path>          Specify directories to be used when searching for ports\n"
-                       "\n"
-                       "  --overlay-triplets=<path>       Specify directories containing triplets files\n"
-                       "\n"
-                       "  --vcpkg-root <path>             Specify the vcpkg root "
-                       "directory\n"
-                       "                                  (default: " ENVVAR(VCPKG_ROOT) //
-                       ")\n"
-                       "\n"
-                       "  --x-scripts-root=<path>             (Experimental) Specify the scripts root directory\n"
-                       "\n"
-                       "  @response_file                  Specify a "
-                       "response file to provide additional parameters\n"
-                       "\n"
-                       "For more help (including examples) see the "
-                       "accompanying README.md.\n");
+// Write environment variable names as %VARIABLE% on Windows and $VARIABLE in *nix
+#ifdef _WIN32
+#define ENVVAR(VARNAME) "%" #VARNAME "%"
+#else
+#define ENVVAR(VARNAME) "$" #VARNAME
+#endif
+
+        System::print2(
+            "Commands:\n"
+            "  vcpkg search [pat]              Search for packages available to be built\n"
+            "  vcpkg install <pkg>...          Install a package\n"
+            "  vcpkg remove <pkg>...           Uninstall a package\n"
+            "  vcpkg remove --outdated         Uninstall all out-of-date packages\n"
+            "  vcpkg list                      List installed packages\n"
+            "  vcpkg update                    Display list of packages for updating\n"
+            "  vcpkg upgrade                   Rebuild all outdated packages\n"
+            "  vcpkg x-history <pkg>           (Experimental) Shows the history of CONTROL versions of a package\n"
+            "  vcpkg hash <file> [alg]         Hash a file by specific algorithm, default SHA512\n"
+            "  vcpkg help topics               Display the list of help topics\n"
+            "  vcpkg help <topic>              Display help for a specific topic\n"
+            "\n",
+            Commands::Integrate::INTEGRATE_COMMAND_HELPSTRING, // Integration help
+            "\n"
+            "  vcpkg export <pkg>... [opt]...  Exports a package\n"
+            // clang-format off
+            "  vcpkg edit <pkg>                Open up a port for editing (uses " ENVVAR(EDITOR) ", default 'code')\n"
+            "  vcpkg import <pkg>              Import a pre-built library\n"
+            "  vcpkg create <pkg> <url> [archivename]\n"
+            "                                  Create a new package\n"
+            "  vcpkg owns <pat>                Search for files in installed packages\n"
+            "  vcpkg depend-info <pkg>...      Display a list of dependencies for packages\n"
+            "  vcpkg env                       Creates a clean shell environment for development or compiling.\n"
+            "  vcpkg version                   Display version information\n"
+            "  vcpkg contact                   Display contact information to send feedback\n"
+            "\n"
+            "Options:\n"
+            "  --triplet <t>                   Specify the target architecture triplet. See 'vcpkg help triplet'\n"
+            "                                  (default: " ENVVAR(VCPKG_DEFAULT_TRIPLET) ")\n"
+            "  --overlay-ports=<path>          Specify directories to be used when searching for ports\n"
+            "  --overlay-triplets=<path>       Specify directories containing triplets files\n"
+            "  --vcpkg-root <path>             Specify the vcpkg root directory\n"
+            "                                  (default: " ENVVAR(VCPKG_ROOT) ")\n"
+            "  --x-scripts-root=<path>         (Experimental) Specify the scripts root directory\n"
+            "\n"
+            "  @response_file                  Specify a response file to provide additional parameters\n"
+            "\n"
+            "For more help (including examples) see the accompanying README.md and docs folder.\n");
+        // clang-format on
+#undef ENVVAR
     }
 
     std::string create_example_string(const std::string& command_and_arguments)

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -410,27 +410,26 @@ namespace vcpkg
         }
 
         System::print2("Options:\n");
+        Help::HelpTableFormatter table;
         for (auto&& option : command_structure.options.switches)
         {
-            System::printf("    %-40s %s\n", option.name, option.short_help_text);
+            table.format(option.name, option.short_help_text);
         }
         for (auto&& option : command_structure.options.settings)
         {
-            System::printf("    %-40s %s\n", (option.name + "=..."), option.short_help_text);
+            table.format((option.name + "=..."), option.short_help_text);
         }
         for (auto&& option : command_structure.options.multisettings)
         {
-            System::printf("    %-40s %s\n", (option.name + "=..."), option.short_help_text);
+            table.format((option.name + "=..."), option.short_help_text);
         }
-        System::printf("    %-40s %s\n", "--triplet <t>", "Set the default triplet for unqualified packages");
-        System::printf(
-            "    %-40s %s\n", "--overlay-ports=<path>", "Specify directories to be used when searching for ports");
-        System::printf("    %-40s %s\n", "--overlay-triplets=<path>", "Specify directories containing triplets files");
-        System::printf("    %-40s %s\n",
-                       "--vcpkg-root <path>",
-                       "Specify the vcpkg directory to use instead of current directory or tool directory");
-        System::printf("    %-40s %s\n",
-                       "--x-scripts-root=<path>",
-                       "(Experimental) Specify the scripts directory to use instead of default vcpkg scripts directory");
+        table.format("--triplet <t>", "Set the default triplet for unqualified packages");
+        table.format("--overlay-ports=<path>", "Specify directories to be used when searching for ports");
+        table.format("--overlay-triplets=<path>", "Specify directories containing triplets files");
+        table.format("--vcpkg-root <path>",
+                     "Specify the vcpkg directory to use instead of current directory or tool directory");
+        table.format("--x-scripts-root=<path>",
+                     "(Experimental) Specify the scripts directory to use instead of default vcpkg scripts directory");
+        System::print2(table.m_str);
     }
 }


### PR DESCRIPTION
Two primary changes:
1. Introduce `Help::HelpTableFormatter` which can be used to properly reflow text in tables
2. Fix displaying `%%VARNAME%%` for windows environment variables in `vcpkg help`