### PR TITLE
[cpprestsdk] Disable websockets by default.

### DIFF
--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,5 +1,5 @@
 Source: cpprestsdk
-Version: 2.10.15
+Version: 2.10.15-1
 Build-Depends: openssl (!uwp&!windows), boost-system (!uwp&!windows),
   boost-date-time (!uwp&!windows), boost-regex (!uwp&!windows), boost-thread (!uwp&!windows),
   boost-filesystem (!uwp&!windows), boost-random (!uwp&!windows), boost-chrono (!uwp&!windows),
@@ -10,7 +10,7 @@ Description: C++11 JSON, REST, and OAuth library
 Default-Features: default-features
 
 Feature: default-features
-Build-Depends: cpprestsdk[brotli] (windows), cpprestsdk[core,compression,websockets]
+Build-Depends: cpprestsdk[brotli] (windows), cpprestsdk[core,compression]
 Description: Features installed by default
 
 Feature: compression

--- a/ports/signalrclient/CONTROL
+++ b/ports/signalrclient/CONTROL
@@ -1,5 +1,5 @@
 Source: signalrclient
-Version: 1.0.0-beta1-7
-Build-Depends: cpprestsdk, openssl
+Version: 1.0.0-beta1-8
+Build-Depends: cpprestsdk[default-features,websockets], openssl
 Homepage: https://github.com/aspnet/SignalR-Client-Cpp
 Description: C++ client for SignalR.


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #
The websockets backend cpprestsdk uses is websocketpp, which was last
committed to in late 2018 and appears defunct. Additionally, the
websockets feature brings an otherwise unnecessary Boost dependency on
Windows which takes a relatively long time to build.

Customers who still want the websockets bits can turn on the optional feature.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Everything cpprestsdk already supported. I don't believe CI baseline edits are necessary.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
As far as I know.