### PR TITLE
[avisynthplus] Add new port

### DIFF
--- a/ports/avisynthplus/CONTROL
+++ b/ports/avisynthplus/CONTROL
@@ -1,0 +1,4 @@
+Source: avisynthplus
+Version: 3.5.0
+Homepage: http://avs-plus.net/
+Description: An improved version of the AviSynth frameserver, with improved features and developer friendliness

--- a/ports/avisynthplus/CONTROL
+++ b/ports/avisynthplus/CONTROL
@@ -2,3 +2,4 @@ Source: avisynthplus
 Version: 3.5.0
 Homepage: http://avs-plus.net/
 Description: An improved version of the AviSynth frameserver, with improved features and developer friendliness
+Supports: windows&!(uwp|arm|static)

--- a/ports/avisynthplus/generate-version-3.5.patch
+++ b/ports/avisynthplus/generate-version-3.5.patch
@@ -1,0 +1,20 @@
+diff --git a/avs_core/Version.cmake b/avs_core/Version.cmake
+index e2be19d2..1d4dd922 100644
+--- a/avs_core/Version.cmake
++++ b/avs_core/Version.cmake
+@@ -1,12 +1,4 @@
+-EXECUTE_PROCESS(
+-    COMMAND "${GIT}" --git-dir=${REPO}/.git  rev-list --count HEAD
+-    OUTPUT_VARIABLE AVS_SEQREV
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
+-EXECUTE_PROCESS(
+-    COMMAND "${GIT}" --git-dir=${REPO}/.git  rev-parse --abbrev-ref HEAD
+-    OUTPUT_VARIABLE AVS_BRANCH
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-)
++set(AVS_SEQREV 3043)
++set(AVS_BRANCH 3.5)
+ CONFIGURE_FILE(${SRC} ${DST} @ONLY)
+  
+\ No newline at end of file

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AviSynth/AviSynthPlus

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AviSynth/AviSynthPlus
+    REF e17f4f80055009bf45b37e1b6d1790bd1c1a93b2 # 3.5.0
+    SHA512 40d2f63416e0e812dd6c7db9b17c09c51295d192bdc4dc46daa063e20731a3451a2b797dab351d31dbb43842eb2c2cdb148da16e5b92816423e3cbf40fff23b0
+    HEAD_REF master
+    PATCHES
+        generate-version-3.5.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DENABLE_PLUGINS=OFF
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL ${SOURCE_PATH}/distrib/gpl.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/avisynthplus RENAME copyright)

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP" "arm" "arm64")
+
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -104,6 +104,7 @@ atlmfc:x64-linux=fail
 atlmfc:x64-osx=fail
 aubio:x64-linux=fail
 aubio:x64-osx=fail
+avisynthplus:x64-windows-static=fail
 avro-c:arm-uwp=fail
 avro-c:x64-linux=fail
 avro-c:x64-osx=fail


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #
This PR adds the AviSynth+ port. It does not fix any issue. AviSynth+ is a dependency of FFMS2, so it could be related to #684 and #9105.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I'm only able to test x64-windows triplet. I have not updated the CI baseline. AviSynth+ only officially support Windows, and has experimental support for linux.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
