### PR TITLE
Fix VTK duplicate linking libraries

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,5 +1,5 @@
 Source: vtk
-Version: 8.2.0-13
+Version: 8.2.0-14
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5, libjpeg-turbo, proj4, lz4, libtheora, eigen3, double-conversion, pugixml, libharu, sqlite3, netcdf-c

--- a/ports/vtk/fix-vtklibraries.patch
+++ b/ports/vtk/fix-vtklibraries.patch
@@ -1,0 +1,15 @@
+diff --git a/CMake/vtkModuleAPI.cmake b/CMake/vtkModuleAPI.cmake
+index d8211eca..d67f65c3 100644
+--- a/CMake/vtkModuleAPI.cmake
++++ b/CMake/vtkModuleAPI.cmake
+@@ -159,7 +159,9 @@ macro(vtk_module_config ns)
+   foreach(v ${ns}_LIBRARIES ${ns}_INCLUDE_DIRS ${ns}_LIBRARY_DIRS
+             ${ns}_RUNTIME_LIBRARY_DIRS _${ns}_AUTOINIT)
+     if(${v})
+-      list(REMOVE_DUPLICATES ${v})
++      if(NOT "${v}" STREQUAL "VTK_LIBRARIES")
++        list(REMOVE_DUPLICATES ${v})
++      endif()
+     endif()
+   endforeach()
+ 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_from_github(
         fix-find-lzma.patch
         fix-proj4.patch
         fix-VTKConfig-cmake.patch
+        fix-vtklibraries.patch
 )
 
 # Remove the FindGLEW.cmake and FindPythonLibs.cmake that are distributed with VTK,


### PR DESCRIPTION
**Describe the pull request**
Fixes VTK to not mix debug and release 3. party libraries, however they are still added two times, but it doesn't seem to cause trouble. Guess the linker can identify its already added or?
I propose this for now as it fixes the immediate problem, where the other is more nice to have. And soon 9.0 will probably take over soon -> #9960.

- What does your PR fix? Fixes issue #10373 #8241

Probably fixes this : #10314

- Which triplets are supported/not supported? Have you updated the CI baseline?
Should be for all non-static triplets. Haven't updated the CI baseline, no.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Should do so yes.