### PR TITLE
[freerdp] Fix dynamic library path in cmake files

### DIFF
--- a/ports/freerdp/CONTROL
+++ b/ports/freerdp/CONTROL
@@ -1,5 +1,5 @@
 Source: freerdp
-Version: 2.0.0-rc4-5
+Version: 2.0.0-rc4-6
 Homepage: https://github.com/FreeRDP/FreeRDP
 Description: A free implementation of the Remote Desktop Protocol (RDP)
 Build-Depends: openssl, glib (!windows)

--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -11,6 +11,10 @@ vcpkg_from_github(
         fix-include-install-path.patch
 )
 
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libxfixes-dev\n")
+endif()
+
 if(VCPKG_CRT_LINKAGE STREQUAL "static")
     set(FREERDP_CRT_LINKAGE -DMSVC_RUNTIME=static)
 endif()

--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -69,9 +69,26 @@ foreach(PACKAGE FreeRDP-Client2 FreeRDP2 WinPR2)
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/${PACKAGE} ${CURRENT_PACKAGES_DIR}/debug/lib/cmake/${PACKAGE}_temp/${PACKAGE})
 endforeach()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/FreeRDP-Client2_temp/FreeRDP-Client2 TARGET_PATH share/freerdp-client)
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/FreeRDP2_temp/FreeRDP2)
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/WinPR2_temp/WinPR2 TARGET_PATH share/winpr)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/FreeRDP-Client2_temp/FreeRDP-Client2 TARGET_PATH share/FreeRDP-Client)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/FreeRDP2_temp/FreeRDP2 TARGET_PATH share/FreeRDP)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/WinPR2_temp/WinPR2 TARGET_PATH share/WinPR)
+
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-debug.cmake
+    "debug/lib/winpr2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "debug/bin/winpr2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-debug.cmake
+    "debug/lib/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "debug/bin/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-release.cmake
+    "lib/winpr2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "bin/winpr2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-release.cmake
+    "lib/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "bin/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/debug/share


### PR DESCRIPTION
Some dynamic libraries path in _share/WinPR/WinPRTargets-debug.cmake_ / _share/WinPR/WinPRTargets-release.cmake_ is incorrect, so fix it.

Related: #10513. 