### PR TITLE
[osg] Fix build failure due to unmet dependency (SDL)

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,8 +1,8 @@
 Source: osg
-Version: 3.6.4-1
+Version: 3.6.4-2
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
-Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig, sdl2, boost-asio (!windows), libxml2 (windows), giflib (windows), freeglut (windows), expat (windows), libiconv (windows)
+Build-Depends: freetype, jasper, openexr, zlib, gdal, giflib, libjpeg-turbo, libpng, tiff, fontconfig, sdl1, boost-asio (!windows), libxml2 (windows), giflib (windows), freeglut (windows), expat (windows), libiconv (windows)
 
 Feature: collada
 Description: Support for Collada (.dae) files


### PR DESCRIPTION
OSG uses either `sdl1` or `sdl2` for building the example `osgmovie.cpp`.

Currently libraries SDL v1 and SDL v2 provide `SDL/SDL.h` and `SDL2/SDL.h`, and the code expects just `SDL/SDL.h`, so `sdl2` fails.

I think this bug got unnoticed because everything works if by chance one has `sdl1` installed beforehand.  Since any version will do, the simplest fix is just to rely on the version working out of the box.

