### PR TITLE
[sdl2-gfx] Fix build error on non windows

### DIFF
--- a/ports/sdl2-gfx/CMakeLists.txt
+++ b/ports/sdl2-gfx/CMakeLists.txt
@@ -24,7 +24,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include/SDL2>
 )
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE ${SDL_GFX_DEFINES})
+if(WIN32)
+    add_compile_definitions(${SDL_GFX_DEFINES})
+endif()
 target_include_directories(${PROJECT_NAME} PRIVATE ${SDL_INCLUDE_DIR}/SDL2)
 target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2)
 

--- a/ports/sdl2-gfx/CONTROL
+++ b/ports/sdl2-gfx/CONTROL
@@ -1,4 +1,5 @@
 Source: sdl2-gfx
-Version: 1.0.4-5
+Version: 1.0.4-6
 Build-Depends: sdl2
 Description: Graphics primitives (line, circle, rectangle etc.) with AA support, rotozoomer and other drawing related support functions wrapped up in a C based add-on library for the Simple Direct Media (SDL) cross-platform API layer.
+Supports: windows

--- a/ports/sdl2-gfx/CONTROL
+++ b/ports/sdl2-gfx/CONTROL
@@ -2,4 +2,4 @@ Source: sdl2-gfx
 Version: 1.0.4-6
 Build-Depends: sdl2
 Description: Graphics primitives (line, circle, rectangle etc.) with AA support, rotozoomer and other drawing related support functions wrapped up in a C based add-on library for the Simple Direct Media (SDL) cross-platform API layer.
-Supports: windows
+Supports: !osx

--- a/ports/sdl2-gfx/CONTROL
+++ b/ports/sdl2-gfx/CONTROL
@@ -2,4 +2,3 @@ Source: sdl2-gfx
 Version: 1.0.4-6
 Build-Depends: sdl2
 Description: Graphics primitives (line, circle, rectangle etc.) with AA support, rotozoomer and other drawing related support functions wrapped up in a C based add-on library for the Simple Direct Media (SDL) cross-platform API layer.
-Supports: !osx

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "osx")
-
 set(VERSION 1.0.4)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "linux" "osx")
 
 set(VERSION 1.0.4)
 
@@ -28,7 +28,6 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2-gfx)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/sdl2-gfx/COPYING ${CURRENT_PACKAGES_DIR}/share/sdl2-gfx/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(ON_TARGET "linux" "osx")
+vcpkg_fail_port_install(ON_TARGET "osx")
 
 set(VERSION 1.0.4)
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1584,7 +1584,6 @@ sdformat6:x64-linux=ignore
 sdl1:arm-uwp=fail
 sdl1:x64-uwp=fail
 sdl1:x64-osx=fail
-sdl2-gfx:x64-linux=fail
 sdl2-gfx:x64-osx=fail
 sdl2-image:arm-uwp=fail
 sdl2-image:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1584,7 +1584,6 @@ sdformat6:x64-linux=ignore
 sdl1:arm-uwp=fail
 sdl1:x64-uwp=fail
 sdl1:x64-osx=fail
-sdl2-gfx:x64-osx=fail
 sdl2-image:arm-uwp=fail
 sdl2-image:x64-uwp=fail
 sdl2-mixer:arm-uwp=fail


### PR DESCRIPTION
`windows.h` is only needed on Windows platform.
So I updated it only when `WIN32`, the related definitions could be added.
Other changes:
- Remove` include(vcpkg_common_functions)`
- Add unsupported messages
- Update copyright
- Add `Supports: widows` field to `CONTROL` file

Related issue #10570 

Note: No features need to test.