### PR TITLE
[openssl-unix] Fix build error on linux and dynamic linking

### DIFF
--- a/ports/openssl-unix/CMakeLists.txt
+++ b/ports/openssl-unix/CMakeLists.txt
@@ -76,7 +76,7 @@ file(WRITE "${BUILDDIR}/Configure" "${_contents}")
 
 if(BUILD_SHARED_LIBS)
     set(SHARED shared)
-    file(STRINGS "${BUILDDIR}/crypto/opensslv.h" SHLIB_VERSION
+    file(STRINGS "${BUILDDIR}/include/openssl/opensslv.h" SHLIB_VERSION
         REGEX "^#[\t ]*define[\t ]+SHLIB_VERSION_NUMBER[\t ]+\".*\".*")
     string(REGEX REPLACE "^.*SHLIB_VERSION_NUMBER[\t ]+\"([^\"]*)\".*$" "\\1"
         SHLIB_VERSION "${SHLIB_VERSION}")


### PR DESCRIPTION
When we build openssl shared lib on linux, follow [this example](https://vcpkg.readthedocs.io/en/stable/examples/overlay-triplets-linux-dynamic/),  set ```VCPKG_LIBRARY_LINKAGE``` to ```dynamic```,  the openssl-unix failed to build because cannot find ```crypto/opensslv.h```, this PR fixed this.

- What does your PR fix? Fixes issue #
no

- Which triplets are supported/not supported? Have you updated the CI baseline?
custom triplet arm64-linux-dynamic

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes
