### PR TITLE
[abseil] Fix feature name error

### DIFF
--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -1,10 +1,10 @@
 Source: abseil
-Version: 2020-03-03-1
+Version: 2020-03-03-2
 Homepage: https://github.com/abseil/abseil-cpp
 Description: an open-source collection designed to augment the C++ standard library.
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.
   In some cases, Abseil provides pieces missing from the C++ standard; in others, Abseil provides alternatives to the standard for special needs we've found through usage in the Google code base. We denote those cases clearly within the library code we provide you.
   Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole.
 
-Feature: c++17
+Feature: cxx17
 Description: Enable compiler C++17.

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
 )
 
 set(CMAKE_CXX_STANDARD  )
-if("c++17" IN_LIST FEATURES)
+if("cxx17" IN_LIST FEATURES)
     set(CMAKE_CXX_STANDARD 17)
 endif()
 


### PR DESCRIPTION
Modify feature name c++17 to cxx17, fix the error:
```
Error: <unknown>:1:9: invalid character in feature name (must be lowercase, digits, '-', or '*')
   on expression: "abseil[c++17]"
```
The related PR: #8248