### PR TITLE
[freerdp] Fix include paths and output

### DIFF
--- a/ports/freerdp/CONTROL
+++ b/ports/freerdp/CONTROL
@@ -1,5 +1,5 @@
 Source: freerdp
-Version: 2.0.0-rc4-6
+Version: 2.0.0-rc4-7
 Homepage: https://github.com/FreeRDP/FreeRDP
 Description: A free implementation of the Remote Desktop Protocol (RDP)
 Build-Depends: openssl, glib (!windows)

--- a/ports/freerdp/fix-include-path.patch
+++ b/ports/freerdp/fix-include-path.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 019926901..91973c888 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -103,7 +103,7 @@ else()
+ endif()
+ message("FREERDP_VERSION=${FREERDP_VERSION_FULL}")
+ 
+-set(FREERDP_INCLUDE_DIR "include/freerdp${FREERDP_VERSION_MAJOR}/")
++set(FREERDP_INCLUDE_DIR "include/freerdp/")
+ 
+ # Compatibility options
+ if(DEFINED STATIC_CHANNELS)
+diff --git a/winpr/CMakeLists.txt b/winpr/CMakeLists.txt
+index 2da25a426..b06f718e9 100644
+--- a/winpr/CMakeLists.txt
++++ b/winpr/CMakeLists.txt
+@@ -193,7 +193,7 @@ if(${CMAKE_VERSION} VERSION_GREATER "2.8.10")
+ 
+ 	SetFreeRDPCMakeInstallDir(WINPR_CMAKE_INSTALL_DIR "WinPR${WINPR_VERSION_MAJOR}")
+ 
+-	set(WINPR_INCLUDE_DIR "include/winpr${WINPR_VERSION_MAJOR}")
++	set(WINPR_INCLUDE_DIR "include/winpr")
+ 
+ 	configure_package_config_file(WinPRConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/WinPRConfig.cmake
+ 		INSTALL_DESTINATION ${WINPR_CMAKE_INSTALL_DIR}

--- a/ports/freerdp/portfile.cmake
+++ b/ports/freerdp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-linux-build.patch
         openssl_threads.patch
         fix-include-install-path.patch
+        fix-include-path.patch
 )
 
 if (NOT VCPKG_TARGET_IS_WINDOWS)
@@ -60,7 +61,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
 else()    
     file(GLOB_RECURSE FREERDP_TOOLS "${CURRENT_PACKAGES_DIR}/bin/*")
     foreach(FREERDP_TOOL ${FREERDP_TOOLS})
-        file(COPY ${FREERDP_TOOL} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+        file(COPY ${FREERDP_TOOL} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
         file(REMOVE ${FREERDP_TOOL})
     endforeach()
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
@@ -92,6 +93,22 @@ vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-release.cm
 vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/WinPR/WinPRTargets-release.cmake
     "lib/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
     "bin/winpr-tools2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/FreeRDP/FreeRDPTargets-debug.cmake
+    "debug/lib/freerdp2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "debug/bin/freerdp2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/FreeRDP/FreeRDPTargets-release.cmake
+    "lib/freerdp2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "bin/freerdp2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/FreeRDP-Client/FreeRDP-ClientTargets-debug.cmake
+    "debug/lib/freerdp-client2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "debug/bin/freerdp-client2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+)
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/FreeRDP-Client/FreeRDP-ClientTargets-release.cmake
+    "lib/freerdp-client2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
+    "bin/freerdp-client2${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}"
 )
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #10627 
Freerdp was unusable before
Includes ended up in `include/freerdp2/freerdp` & `include/winpr2/winpr`, while being looked for in `include/freerdp` & `include/winpr`
Tools were being looked for in `tools/freerdp` but weren't correctly put in subdirectory
Windows dlls were being looked for in `lib/` instead of `bin/`

- Which triplets are supported/not supported?
Tested on both x64-windows and x64-linux 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? think so, the current changes just expanded the previous patches/portfile changes
