### PR TITLE
[opus] Make AVX an optional feature

### DIFF
--- a/ports/opus/CONTROL
+++ b/ports/opus/CONTROL
@@ -1,4 +1,7 @@
 Source: opus
-Version: 1.3.1
+Version: 1.3.1-2
 Homepage: https://github.com/xiph/opus
 Description: Totally open, royalty-free, highly versatile audio codec
+
+Feature: avx
+Description: Builds the library with avx instruction set

--- a/ports/opus/portfile.cmake
+++ b/ports/opus/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH
   SOURCE_PATH
@@ -12,7 +10,14 @@ vcpkg_from_github(
   HEAD_REF
   master)
 
-vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} PREFER_NINJA)
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  avx AVX_SUPPORTED
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${FEATURE_OPTIONS}
+    PREFER_NINJA)
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Opus)
 vcpkg_copy_pdbs()


### PR DESCRIPTION
This makes AVX for opus an optional feature as in some other ports (fftw3)

Emtting AVX by default is still problematic, see: https://github.com/EasyRPG/Player/issues/2059

The CPU mentioned in that issue is from 2013. Unfortunately, Intel disabled AVX on there cheaper CPUs :(
I even found a Pentium CPU from 2017 without AVX support: https://ark.intel.com/content/www/de/de/ark/products/97453/intel-pentium-processor-g4600-3m-cache-3-60-ghz.html

(but my workstation with an i5 from 2012 supports it...)

For opus[core]
```
objdump -d installed/x86-windows-static/lib/opus.lib | grep "vpxor" | wc -l
0
```

For opus[avx]
```
objdump -d installed/x86-windows-static/lib/opus.lib | grep "vpxor" | wc -l
41
```
