### PR TITLE
[vcpkg baseline] Ignore osg-qt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1340,6 +1340,7 @@ osgearth:x64-osx=fail
 osgearth:x64-linux=fail
 osgearth:x64-windows-static=fail
 osg-qt:x64-windows-static=fail
+osg-qt:x64-linux=ignore
 otl:x64-windows=ignore
 otl:x64-windows-static=ignore
 otl:x64-uwp=ignore


### PR DESCRIPTION
Ignore osg-qt in baseline temproarily for unblocking other PRs, it should be enabled after issue https://github.com/microsoft/vcpkg/pull/10603#issuecomment-606321102  fixed