### PR TITLE
[pixel] Add warning message on Linux

### DIFF
--- a/ports/pixel/CONTROL
+++ b/ports/pixel/CONTROL
@@ -1,4 +1,6 @@
 Source: pixel
-Version: 0.3
+Version: 0.3-1
 Description: Simple 2D Graphics based on standard and portable OpenGL.
 Build-Depends: glew, opengl, sdl2
+Homepage: https://github.com/dascandy/pixel
+Supports: !windows

--- a/ports/pixel/portfile.cmake
+++ b/ports/pixel/portfile.cmake
@@ -1,4 +1,9 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "Windows")
+
+if(VCPKG_TARGET_IS_LINUX)
+    message(WARNING"${PORT} currently requires libglu1-mesa from the system package manager:
+    This can be installed on Ubuntu systems via sudo apt install libglu1-mesa-dev")
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
Add warning message for installing` libglu1-mesa-dev` on Ubuntu.
Other changes:
- Add `Homepage `and `Supports `in CONTROL
- Remove unused functions
- Add unsupported messages

Related issue #10593 

Note: No features need test.
