### PR TITLE
[qt5-base] Fix EGL absolute path on Linux

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.5-11
+Version: 5.12.5-12
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl, angle (!windows), egl-registry, icu (!uwp), fontconfig (!windows)

--- a/ports/qt5-base/patches/Qt5GuiConfigExtras.patch
+++ b/ports/qt5-base/patches/Qt5GuiConfigExtras.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gui/Qt5GuiConfigExtras.cmake.in b/src/gui/Qt5GuiConfigExtras.cmake.in
+index 84dbbfebd..accb86e3f 100644
+--- a/src/gui/Qt5GuiConfigExtras.cmake.in	
++++ b/src/gui/Qt5GuiConfigExtras.cmake.in
+@@ -148,6 +153,8 @@ macro(_qt5gui_find_extra_libs Name Libs LibDir IncDirs)
+ !!ENDIF
+                 unset(Qt5Gui_${_cmake_lib_name}_LIBRARY CACHE)
+ 
++                find_library(Qt5Gui_${_cmake_lib_name}_LIBRARY_DEBUG ${_lib}d ${_lib} NAMES_PER_DIR
++                    PATHS \"${_qt5Gui_install_prefix}/debug/lib\" NO_DEFAULT_PATH)
+                 find_library(Qt5Gui_${_cmake_lib_name}_LIBRARY_DEBUG ${_lib}d
+                     PATHS \"${LibDir}\"
+ !!IF !mac

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -42,6 +42,7 @@ qt_download_submodule(  OUT_SOURCE_PATH SOURCE_PATH
                             #patches/static_opengl.patch #Use this patch if you really want to statically link angle on windows (e.g. using -opengl es2 and -static). 
                                                          #Be carefull since it requires definining _GDI32_ for all dependent projects due to redefinition errors in the 
                                                          #the windows supplied gl.h header and the angle gl.h otherwise. 
+                            patches/Qt5GuiConfigExtras.patch # Patches the library search behavior for EGL since angle is not build with Qt
                     )
 
 # Remove vendored dependencies to ensure they are not picked up by the build
@@ -333,6 +334,14 @@ file(COPY
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/share/qt5
 )
+
+# Fix Qt5GuiConfigExtras EGL path
+if(VCPKG_TARGET_IS_LINUX)
+    set(_file "${CURRENT_PACKAGES_DIR}/share/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake")
+    file(READ "${_file}" _contents)
+    string(REGEX REPLACE "_qt5gui_find_extra_libs\\\(EGL[^\\\n]+" "_qt5gui_find_extra_libs(EGL \"EGL\" \"\" \"\${_qt5Gui_install_prefix}/include\")\n" _contents "${_contents}")
+    file(WRITE "${_file}" "${_contents}")
+endif()
 
 if(QT_BUILD_LATEST)
     file(COPY


### PR DESCRIPTION
- add patch to find the debug library
- manually fix EGL path in Qt5GuiConfigExtras.cmake
