### PR TITLE
[curl] Fix cmake configure error 

### DIFF
--- a/ports/curl/0010_fix_othertests_cmake.patch
+++ b/ports/curl/0010_fix_othertests_cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMake/OtherTests.cmake b/CMake/OtherTests.cmake
+index c1c9aa3..378a5bd 100644
+--- a/CMake/OtherTests.cmake
++++ b/CMake/OtherTests.cmake
+@@ -185,6 +185,7 @@ if(HAVE_SIGNAL_H)
+   set(CMAKE_REQUIRED_FLAGS "-DHAVE_SIGNAL_H")
+   set(CMAKE_EXTRA_INCLUDE_FILES "signal.h")
+ endif()
++unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
+ check_type_size("sig_atomic_t" SIZEOF_SIG_ATOMIC_T)
+ if(HAVE_SIZEOF_SIG_ATOMIC_T)
+   check_c_source_compiles("

--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.68.0-2
+Version: 7.68.0-3
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl
 Description: A library for transferring data with URLs

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         0007_disable_tool_export_curl_target.patch
         0008_fix_tools_path.patch
         0009_fix_openssl_config.patch
+        0010_fix_othertests_cmake.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)


### PR DESCRIPTION
in othertests.cmake check_type_size call, CMAKE_TRY_COMPILE_TARGET_TYPE was set to STATIC_LIBRARY, therefore cmake try_compile failed with messeage cannot copy executable ''

- Which triplets are supported/not supported?
 - Tested on x64-windows.

 -Have you updated the CI baseline?
 -No

- Does your PR follow the [maintainer guide]?
- Yes I think.
