### PR TITLE
[vcpkg] Fix spec instance name

### DIFF
--- a/ports/cub/CONTROL
+++ b/ports/cub/CONTROL
@@ -1,4 +1,4 @@
 Source: cub
-Version: 1.8.0
+Version: 1.8.0-1
 Description: CUB is a flexible library of cooperative threadblock primitives and other utilities for CUDA kernel programming
 Build-Depends: cuda

--- a/ports/vulkan-hpp/CONTROL
+++ b/ports/vulkan-hpp/CONTROL
@@ -1,4 +1,4 @@
 Source: vulkan-hpp
-Version: 2019-05-11
+Version: 2019-05-11-1
 Description: Header only C++ bindings for the Vulkan C API
 Build-Depends: vulkan

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -831,7 +831,7 @@ namespace vcpkg::Build
         {
             for (const FeatureSpec& fspec : kv.second)
             {
-                if (!(status_db.is_installed(fspec) || spec.name() == name))
+                if (!(status_db.is_installed(fspec) || fspec.name() == name))
                 {
                     missing_fspecs.emplace_back(fspec);
                 }


### PR DESCRIPTION
Fix the failure 'PowerShell exited with code '1' in CI testing and vcpkg unstable testing. 

Background:
cub depends on cuda, cuda build failed, then CI will fail with 'PowerShell exited with code '1' 
This issue invoved by PR https://github.com/microsoft/vcpkg/pull/10032

Repro steps:
1.	Get a test machine without installing CUDA
2.	Git clone https://github.com/microsoft/vcpkg
3.	.\bootstrap-vcpkg.bat
4.	.\vcpkg.exe install cub:x64-windows arrow:x64-windows --keep-going
5.	Noticed that the PS exit after install cub, and didn’t install arrow. 