### PR TITLE
[skyr-url] Bumped version of skyr-url to 1.5.2

### DIFF
--- a/ports/skyr-url/CONTROL
+++ b/ports/skyr-url/CONTROL
@@ -1,5 +1,5 @@
 Source: skyr-url
-Version: 1.4.3
+Version: 1.5.1
 Build-Depends: tl-expected
 Homepage: https://github.com/cpp-netlib/url
 Description: A C++ library that implements the WhatWG URL specification

--- a/ports/skyr-url/portfile.cmake
+++ b/ports/skyr-url/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO cpp-netlib/url
         REF v1.5.1
-        SHA512 0259b6eed43e480779d35990bdebd32bdbd3c30a548fba46a6b03afd742c3fd862d2a2cba6f49a6baf669763e7701c12b457530e424f2b7175533911e911ae3b
+        SHA512 1d1efab8f41467c15b194acfb10610892c61e6bd786f9c5480e39498849d7fe0801e4e41aa194e780eb597dba57048efec75d042c4c6fb72422a3a704bd61824
         HEAD_REF master
 )
 
@@ -12,10 +12,10 @@ vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         PREFER_NINJA
         OPTIONS
-            -DSkyr_BUILD_TESTS=OFF
-            -DSkyr_BUILD_DOCS=OFF
-            -DSkyr_BUILD_EXAMPLES=OFF
-            -DSkyr_WARNINGS_AS_ERRORS=OFF
+            -Dskyr_BUILD_TESTS=OFF
+            -Dskyr_BUILD_DOCS=OFF
+            -Dskyr_BUILD_EXAMPLES=OFF
+            -Dskyr_WARNINGS_AS_ERRORS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/skyr-url/portfile.cmake
+++ b/ports/skyr-url/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO cpp-netlib/url
-        REF v1.4.5
-        SHA512 39501217e331a904daf928a5874f81808a9665a9e8debe39c15a3fb7607ab293a5a1b335062cc7ac8f4fe239d4233a2c5ed0e9b45dbec7edcc267eb3d25509d3
+        REF v1.5.1
+        SHA512 0259b6eed43e480779d35990bdebd32bdbd3c30a548fba46a6b03afd742c3fd862d2a2cba6f49a6baf669763e7701c12b457530e424f2b7175533911e911ae3b
         HEAD_REF master
 )
 
@@ -22,6 +22,7 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/skyr-url RENAME copyright)

--- a/ports/skyr-url/portfile.cmake
+++ b/ports/skyr-url/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO cpp-netlib/url
-        REF v1.5.1
-        SHA512 1d1efab8f41467c15b194acfb10610892c61e6bd786f9c5480e39498849d7fe0801e4e41aa194e780eb597dba57048efec75d042c4c6fb72422a3a704bd61824
+        REF v1.5.2
+        SHA512 7679aae7eefe46e957409271f766d41282d038216f80bdee8239da79456ca091394d17134913224c1fda915c12aae83af9aea4b2bc634cd4853ced43c9c08b9e
         HEAD_REF master
 )
 


### PR DESCRIPTION
- What does your PR fix? Fixes issue #

Following the integration of skyr-url (#10463), this PR fixes some failures in the configuration script which prevented the library being used as a dependency using find_package.
