### PR TITLE
[vcpkg baseline] Remove replxx:x86-windows=fail

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1474,6 +1474,8 @@ qt5-macextras:x64-linux=fail
 qt5-macextras:x64-windows=fail
 qt5-macextras:x64-windows-static=fail
 qt5-macextras:x86-windows=fail
+# in theory this should not be true, but something is wrong.
+qt5-tools:x64-linux=fail
 qt5-winextras:x64-linux=fail
 qt5-winextras:x64-osx=fail
 quickfast:x64-linux=ignore
@@ -1534,7 +1536,6 @@ redis-plus-plus:arm64-windows=fail
 replxx:arm-uwp=fail
 replxx:x64-uwp=fail
 replxx:arm64-windows=fail
-replxx:x86-windows=fail
 reproc:arm-uwp=fail
 reproc:x64-uwp=fail
 restbed:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1474,8 +1474,6 @@ qt5-macextras:x64-linux=fail
 qt5-macextras:x64-windows=fail
 qt5-macextras:x64-windows-static=fail
 qt5-macextras:x86-windows=fail
-# in theory this should not be true, but something is wrong.
-qt5-tools:x64-linux=fail
 qt5-winextras:x64-linux=fail
 qt5-winextras:x64-osx=fail
 quickfast:x64-linux=ignore


### PR DESCRIPTION
replxx seems to compile on x86 windows now?