### PR TITLE
[libmupdf] fix build error on Linux

### DIFF
--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -5,14 +5,17 @@ set(CMAKE_DEBUG_POSTFIX d)
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/mupdf/pdf/name-table.h")
   find_program(MAKE_EXE NAMES gmake nmake make)
-  execute_process(
-    COMMAND ${MAKE_EXE} "generate"
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  )
-    #execute_process(
-  #  COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
-  #  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  #)
+  if(WIN32)
+    execute_process(
+      COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  else()
+    execute_process(
+      COMMAND ${MAKE_EXE} "generate"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+  endif() 
 endif()
 
 find_package(freetype NO_MODULE REQUIRED)
@@ -29,10 +32,10 @@ list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
 
 add_library(libmupdf ${SOURCES})
 
-if(UNIX)
-    target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
+if(WIN32)
+  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0)
 else()
-    target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0)
+  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
 endif()
 target_include_directories(libmupdf
   PUBLIC

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -9,7 +9,7 @@ if(WIN32)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
 else()
-  find_program(MAKE_EXE NAMES gmake nmake make REQUIRED)
+  find_program(MAKE_EXE NAMES make REQUIRED)
   execute_process(
     COMMAND ${MAKE_EXE} "generate"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -3,20 +3,19 @@ project(libmupdf C)
 
 set(CMAKE_DEBUG_POSTFIX d)
 
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/mupdf/pdf/name-table.h")
-  if(WIN32)
-    execute_process(
-      COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    )
-  else()
-    find_program(MAKE_EXE NAMES gmake nmake make REQUIRED)
-    execute_process(
-      COMMAND ${MAKE_EXE} "generate"
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    )
-  endif() 
-endif()
+if(WIN32)
+  execute_process(
+    COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+else()
+  find_program(MAKE_EXE NAMES gmake nmake make REQUIRED)
+  execute_process(
+    COMMAND ${MAKE_EXE} "generate"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+endif() 
+
 
 find_package(freetype NO_MODULE REQUIRED)
 find_package(JPEG REQUIRED)

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(JPEG REQUIRED)
 find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
 find_library(HARFBUZZ_LIBRARIES harfbuzz)
 find_package(ZLIB REQUIRED)
-find_package(OpenJPEG REQUIRED)
+find_package(OpenJPEG CONFIG REQUIRED)
 find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
 file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
@@ -29,7 +29,11 @@ list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
 
 add_library(libmupdf ${SOURCES})
 
-target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
+if(UNIX)
+    target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
+else()
+    target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0)
+endif()
 target_include_directories(libmupdf
   PUBLIC
     include

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -4,13 +4,13 @@ project(libmupdf C)
 set(CMAKE_DEBUG_POSTFIX d)
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/mupdf/pdf/name-table.h")
-  find_program(MAKE_EXE NAMES gmake nmake make)
   if(WIN32)
     execute_process(
       COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
   else()
+    find_program(MAKE_EXE NAMES gmake nmake make REQUIRED)
     execute_process(
       COMMAND ${MAKE_EXE} "generate"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -4,10 +4,15 @@ project(libmupdf C)
 set(CMAKE_DEBUG_POSTFIX d)
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/mupdf/pdf/name-table.h")
+  find_program(MAKE_EXE NAMES gmake nmake make)
   execute_process(
-    COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
+    COMMAND ${MAKE_EXE} "generate"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
+    #execute_process(
+  #  COMMAND "cmd.exe" "/c" "platform\\win32\\generate.bat"
+  #  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  #)
 endif()
 
 find_package(freetype NO_MODULE REQUIRED)
@@ -15,14 +20,16 @@ find_package(JPEG REQUIRED)
 find_path(HARFBUZZ_INCLUDE hb.h PATH_SUFFIXES harfbuzz)
 find_library(HARFBUZZ_LIBRARIES harfbuzz)
 find_package(ZLIB REQUIRED)
-find_package(openjpeg REQUIRED)
+find_package(OpenJPEG REQUIRED)
 find_library(JBIG2DEC_LIB NAMES jbig2decd jbig2dec)
 
 file(GLOB_RECURSE SOURCES "source/*.c" "generated/*.c")
 list(FILTER SOURCES EXCLUDE REGEX "source/tools/[a-z]*\\.c$")
+list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
+
 add_library(libmupdf ${SOURCES})
 
-target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0)
+target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
 target_include_directories(libmupdf
   PUBLIC
     include

--- a/ports/libmupdf/CONTROL
+++ b/ports/libmupdf/CONTROL
@@ -1,5 +1,6 @@
 Source: libmupdf
-Version: 1.16.1
+Version: 1.16.1-1
 Build-Depends: freetype, libjpeg-turbo, harfbuzz, zlib, curl, glfw3, openjpeg, jbig2dec
 Homepage: https://github.com/ArtifexSoftware/mupdf
 Description: a lightweight PDF, XPS, and E-book library
+Supports: !osx

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "osx")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -18,6 +18,8 @@ vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
 )
 
 vcpkg_install_cmake()

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -832,7 +832,6 @@ libmodman:x64-uwp=fail
 libmodman:x64-windows-static=fail
 libmodplug:arm-uwp=fail
 libmodplug:x64-uwp=fail
-libmupdf:x64-linux=fail
 libmupdf:x64-osx=fail
 libmysql:x86-windows=fail
 libnice:x64-linux=fail


### PR DESCRIPTION
Related to #10556. These changes makes `libmupdf` compile on linux

To do:

- [x] Execute `generate.bat` or `make generate` depending on the platform 
- [x] Don't add the `-DHAVE_PTHREAD` parameter on Windows
- [x] update the Version to 1.16.1-1 in CONTROL file
- [x] If the libmupf supports on linux, you also need to remove 'libmupdf:x64-linux' in scripts/ci.baseline.txt
- [x] This is not as important and might introduce a breaking change trying to fix, but currently the library is built as `liblibmupdf.a` instead of `libmupdf.a`