### PR TITLE
[curl] fix vcpkg-cmake-wrapper missing ZLIB find_package call

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Version: 7.68.0-2
+Version: 7.68.0-3
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl
 Description: A library for transferring data with URLs

--- a/ports/curl/vcpkg-cmake-wrapper.cmake
+++ b/ports/curl/vcpkg-cmake-wrapper.cmake
@@ -2,6 +2,7 @@ list(REMOVE_ITEM ARGS "NO_MODULE")
 list(REMOVE_ITEM ARGS "CONFIG")
 list(REMOVE_ITEM ARGS "MODULE")
 
+_find_package(ZLIB)
 _find_package(${ARGS} CONFIG)
 
 if(TARGET CURL::libcurl)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1534,7 +1534,6 @@ redis-plus-plus:arm64-windows=fail
 replxx:arm-uwp=fail
 replxx:x64-uwp=fail
 replxx:arm64-windows=fail
-replxx:x86-windows=fail
 reproc:arm-uwp=fail
 reproc:x64-uwp=fail
 restbed:arm-uwp=fail


### PR DESCRIPTION
Fixes: #10714 

**Describe the pull request**

- What does your PR fix? Fixes issue #10714 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes