### PR TITLE
[abseil] Fix CompressedTuple move constructor on MSVC

### DIFF
--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -1,5 +1,5 @@
 Source: abseil
-Version: 2020-03-03-2
+Version: 2020-03-03-3
 Homepage: https://github.com/abseil/abseil-cpp
 Description: an open-source collection designed to augment the C++ standard library.
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.

--- a/ports/abseil/fix-MSVCbuildfail.patch
+++ b/ports/abseil/fix-MSVCbuildfail.patch
@@ -1,0 +1,65 @@
+diff --git a/absl/container/internal/compressed_tuple.h b/absl/container/internal/compressed_tuple.h
+index 4bfe92f..02bfd03 100644
+--- a/absl/container/internal/compressed_tuple.h
++++ b/absl/container/internal/compressed_tuple.h
+@@ -169,9 +169,33 @@ constexpr bool ShouldAnyUseBase() {
+ }
+ 
+ template <typename T, typename V>
+-using TupleMoveConstructible = typename std::conditional<
+-      std::is_reference<T>::value, std::is_convertible<V, T>,
+-      std::is_constructible<T, V&&>>::type;
++using TupleElementMoveConstructible =
++    typename std::conditional<std::is_reference<T>::value,
++                              std::is_convertible<V, T>,
++                              std::is_constructible<T, V&&>>::type;
++
++template <bool SizeMatches, class T, class... Vs>
++struct TupleMoveConstructible : std::false_type {};
++
++template <class... Ts, class... Vs>
++struct TupleMoveConstructible<true, CompressedTuple<Ts...>, Vs...>
++    : std::integral_constant<
++          bool, absl::conjunction<
++                    TupleElementMoveConstructible<Ts, Vs&&>...>::value> {};
++
++template <typename T>
++struct compressed_tuple_size;
++
++template <typename... Es>
++struct compressed_tuple_size<CompressedTuple<Es...>>
++    : public std::integral_constant<std::size_t, sizeof...(Es)> {};
++
++template <class T, class... Vs>
++struct TupleItemsMoveConstructible
++    : std::integral_constant<
++          bool, TupleMoveConstructible<compressed_tuple_size<T>::value ==
++                                           sizeof...(Vs),
++                                       T, Vs...>::value> {};
+ 
+ }  // namespace internal_compressed_tuple
+ 
+@@ -217,17 +241,18 @@ class ABSL_INTERNAL_COMPRESSED_TUPLE_DECLSPEC CompressedTuple
+   explicit constexpr CompressedTuple(const Ts&... base)
+       : CompressedTuple::CompressedTupleImpl(absl::in_place, base...) {}
+ 
+-  template <typename... Vs,
++  template <typename First, typename... Vs,
+             absl::enable_if_t<
+                 absl::conjunction<
+                     // Ensure we are not hiding default copy/move constructors.
+                     absl::negation<std::is_same<void(CompressedTuple),
+-                                                void(absl::decay_t<Vs>...)>>,
+-                    internal_compressed_tuple::TupleMoveConstructible<
+-                        Ts, Vs&&>...>::value,
++                                                void(absl::decay_t<First>)>>,
++                    internal_compressed_tuple::TupleItemsMoveConstructible<
++                        CompressedTuple<Ts...>, First, Vs...>>::value,
+                 bool> = true>
+-  explicit constexpr CompressedTuple(Vs&&... base)
++  explicit constexpr CompressedTuple(First&& first, Vs&&... base)
+       : CompressedTuple::CompressedTupleImpl(absl::in_place,
++                                             absl::forward<First>(first),
+                                              absl::forward<Vs>(base)...) {}
+ 
+   template <int I>

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     PATCHES 
         fix-lnk2019-error.patch
         fix-uwp-build.patch
-        fix-MSVCbuildfail.patch
+        fix-MSVCbuildfail.patch #This patch is an upstream commit, the related PR: https://github.com/abseil/abseil-cpp/pull/637
 )
 
 set(CMAKE_CXX_STANDARD  )

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES 
         fix-lnk2019-error.patch
         fix-uwp-build.patch
+        fix-MSVCbuildfail.patch
 )
 
 set(CMAKE_CXX_STANDARD  )


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #10690 
   Fix compile error with /permissive- on MSVC2019:
   `error C3546: '...': there are no parameter packs available to expand`
- The related source PR: https://github.com/abseil/abseil-cpp/pull/637
- The feature test pass.
