### PR TITLE
[nuspell] update port to v3.1.0

### DIFF
--- a/ports/nuspell/CONTROL
+++ b/ports/nuspell/CONTROL
@@ -1,5 +1,5 @@
 Source: nuspell
-Version: 3.0.0
+Version: 3.1.0
 Description: Nuspell is a free and open source spell checker library and
   command-line program designed for languages with rich morphology and complex
   word compounding.

--- a/ports/nuspell/cmake-disable-cli-and-docs.patch
+++ b/ports/nuspell/cmake-disable-cli-and-docs.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6ca0212..8c14d24 100644
+index a498118..161f0f3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -18,8 +18,6 @@ if (subproject)
@@ -8,9 +8,9 @@ index 6ca0212..8c14d24 100644
  
 -add_subdirectory(docs)
 -
- option(BUILD_TESTING "Build the testing tree." ON)
- if (BUILD_TESTING)
-     enable_testing()
+ function(find_catch2_from_source)
+     set(Catch2_FOUND Catch2-NOTFOUND PARENT_SCOPE)
+     set(catch_cmake_lists ${PROJECT_SOURCE_DIR}/external/Catch2/CMakeLists.txt)
 diff --git a/src/nuspell/CMakeLists.txt b/src/nuspell/CMakeLists.txt
 index 22894f6..d58ad43 100644
 --- a/src/nuspell/CMakeLists.txt

--- a/ports/nuspell/portfile.cmake
+++ b/ports/nuspell/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nuspell/nuspell
-    REF v3.0.0
-    SHA512 d9cd7dd276e2bca43dec3abaf11c5206695949b9fda8c9b86f2772cc7e8fa95bf17c685a2ef9ca87fe3c4f0b55f2fcb435bc21c187355f5e3fa35dcafab2c8c2
+    REF v3.1.0
+    SHA512 a9bedfd6e2d77fd34d249cf7aa1fcb6bde5bced26f02f8a2dd860416a61488c9b7016a0df6015052fcccb272b342e6205db601107f46efa44c9d78ce261a826c
     HEAD_REF master
 
     PATCHES cmake-disable-cli-and-docs.patch


### PR DESCRIPTION
This PR updates the port Nuspell to the [latest version 3.1.0](https://github.com/nuspell/nuspell/releases/tag/v3.1.0).