### PR TITLE
[shiva-sfml]Fix config error and build error

### DIFF
--- a/ports/shiva-sfml/CONTROL
+++ b/ports/shiva-sfml/CONTROL
@@ -1,4 +1,5 @@
 Source: shiva-sfml
-Version: 1.0
+Version: 1.0-1
+Homepage: https://github.com/Milerius/shiva
 Description: shiva-sfml plugins of shiva C++ engine
 Build-Depends: sfml (windows), shiva

--- a/ports/shiva-sfml/portfile.cmake
+++ b/ports/shiva-sfml/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+vcpkg_find_acquire_program(PYTHON2)
 
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
@@ -12,11 +12,14 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-          -DSHIVA_BUILD_TESTS=OFF -DSHIVA_USE_SFML_AS_RENDERER=ON -DSHIVA_INSTALL_PLUGINS=ON -DSHIVA_BUILD_EXAMPLES=OFF     
+          -DSHIVA_BUILD_TESTS=OFF
+          -DSHIVA_USE_SFML_AS_RENDERER=ON
+          -DSHIVA_INSTALL_PLUGINS=ON
+          -DSHIVA_BUILD_EXAMPLES=OFF
+          -DPYTHON_EXECUTABLE=${PYTHON2}
 )
 
 vcpkg_install_cmake()
-
 
 if (VCPKG_CMAKE_SYSTEM_NAME)
   file(GLOB PLUGINS_RELEASE ${SOURCE_PATH}/bin/Release/systems/*)
@@ -29,7 +32,6 @@ endif()
 message(STATUS "PLUGINS_RELEASE -> ${PLUGINS_RELEASE}")
 message(STATUS "PLUGINS_DEBUG -> ${PLUGINS_DEBUG}")
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/shiva-sfml)
-
 
 if (VCPKG_CMAKE_SYSTEM_NAME)
   set(SUFFIX_BINARY lib)

--- a/ports/sol2/CONTROL
+++ b/ports/sol2/CONTROL
@@ -1,5 +1,5 @@
 Source: sol2
-Version: 3.2.0
+Version: 3.2.0-1
 Homepage: https://github.com/ThePhD/sol2
 Description: Sol v2.0 - a C++ <-> Lua API wrapper with advanced features and top notch performance - is here, and it's great
 Build-Depends: lua (windows)

--- a/ports/sol2/portfile.cmake
+++ b/ports/sol2/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+#header-only library
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -25,5 +25,6 @@ file(
 )
 
 file(INSTALL ${SOURCE_PATH}/single/include/sol DESTINATION ${CURRENT_PACKAGES_DIR}/include/)
+file(INSTALL ${SOURCE_PATH}/include/sol DESTINATION ${CURRENT_PACKAGES_DIR}/include/)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fixes issue https://github.com/microsoft/vcpkg/issues/9116
1. shiva-sfml installation failed with cmake error: Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE), add PYTHON_EXECUTABLE to fix this issue.
2. After above issue fixed, shiva-sfml build failed with error:  missing sol/xxxxx include files. These files should be generated when sol2 installed, so fix this error in `sol2\portfile.cmake`.
3. Add homepage to shiva-sfml.
4. Remove the deprecated function and blank line.


