### PR TITLE
[vcpkg] Fix the warnings in bootstrap on Ubuntu

### DIFF
--- a/toolsrc/include/vcpkg/export.prefab.h
+++ b/toolsrc/include/vcpkg/export.prefab.h
@@ -7,6 +7,14 @@
 
 #include <vector>
 
+#ifdef minor
+#undef minor
+#endif
+
+#ifdef major
+#undef major
+#endif
+
 namespace vcpkg::Export::Prefab
 {
     constexpr int kFragmentSize = 3;


### PR DESCRIPTION
When running `bootstrap-vcpkg.sh` on Ubuntu, will get several warnings like this:

```
In file included from ../src/vcpkg/export.prefab.cpp:11:0:
../include/vcpkg/export.prefab.h:31:13: warning: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>.
         int minor()  { return this->m_minor; }
```
Since minor and major have been defined in the GNU C library.

Related issue #10750 

Thanks very much for your fix suggestion @atkawa7.