### PR TITLE
[qt5-base] Don't link to "MinCore.lib", it breaks compatibility with Windows 7

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.5-13
+Version: 5.12.5-14
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl, angle (!windows), egl-registry, icu (!uwp), fontconfig (!windows)

--- a/ports/qt5-base/vcpkg-cmake-wrapper.cmake
+++ b/ports/qt5-base/vcpkg-cmake-wrapper.cmake
@@ -44,7 +44,7 @@ if("${_target_type}" STREQUAL "STATIC_LIBRARY")
 
     if(MSVC)
        set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-           Netapi32.lib Ws2_32.lib Mincore.lib Winmm.lib Iphlpapi.lib Wtsapi32.lib Dwmapi.lib Imm32.lib)
+           Crypt32.lib Dnsapi.lib Netapi32.lib Userenv.lib UxTheme.lib Version.lib Ws2_32.lib Winmm.lib Iphlpapi.lib Wtsapi32.lib Dwmapi.lib Imm32.lib)
 
       add_qt_library(Qt5::Core Qt5WindowsUIAutomationSupport qwindows qdirect2d)
     elseif(UNIX AND NOT APPLE)


### PR DESCRIPTION
From https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-81-api-sets:

> Binaries that link to MinCore.lib or MinCore_Downlevel.lib are not designed to work on Windows 7, Windows Server 2008 R2 or earlier. Binaries that need to run on earlier versions of Windows or Windows Server must not use either MinCore.lib or MinCore_Downlevel.lib.

More specifically, linking an application to a target provided by this port causes it to fail to load because it looks for unavailable UCRT DLLs.

This pull request changes the port so that it links to the "normal" libraries rather than `MinCore.lib`, effectively making the port compatible with Windows 7.

Please note that `UxTheme.lib` was already missing:

```cpp
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_OpenThemeData referenced in function "public: class QColor __cdecl QVistaHelper::basicWindowFrameColor(void)" (?basicWindowFrameColor@QVistaHelper@@QEAA?AVQColor@@XZ)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_DrawThemeBackground referenced in function "public: virtual void __cdecl QVistaBackButton::paintEvent(class QPaintEvent *)" (?paintEvent@QVistaBackButton@@UEAAXPEAVQPaintEvent@@@Z)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_GetThemeColor referenced in function "public: class QColor __cdecl QVistaHelper::basicWindowFrameColor(void)" (?basicWindowFrameColor@QVistaHelper@@QEAA?AVQColor@@XZ)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_GetThemeSysFont referenced in function "struct tagLOGFONTW __cdecl getCaptionLogFont(void *)" (?getCaptionLogFont@@YA?AUtagLOGFONTW@@PEAX@Z)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_IsThemeActive referenced in function "private: static bool __cdecl QVistaHelper::drawBlackRect(class QRect const &,struct HDC__ *)" (?drawBlackRect@QVistaHelper@@CA_NAEBVQRect@@PEAUHDC__@@@Z)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_SetWindowThemeAttribute referenced in function "public: void __cdecl QVistaHelper::setTitleBarIconAndCaptionVisible(bool)" (?setTitleBarIconAndCaptionVisible@QVistaHelper@@QEAAX_N@Z)
Qt5Widgets.lib(qwizard_win.obj) : error LNK2019: unresolved external symbol __imp_DrawThemeTextEx referenced in function "private: bool __cdecl QVistaHelper::drawTitleText(class QPainter *,class QString const &,class QRect const &,struct HDC__ *)" (?drawTitleText@QVistaHelper@@AEAA_NPEAVQPainter@@AEBVQString@@AEBVQRect@@PEAUHDC__@@@Z)
```