### PR TITLE
[vcpkg] Clean up CMake build system

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -199,11 +199,10 @@ fetchTool()
 
 selectCXX()
 {
-    __output=$1
-
     if [ "x$CXX" = "x" ]; then
-        CXX=g++
-        if which g++-9 >/dev/null 2>&1; then
+        if which g++ >/dev/null 2>&1; then
+            CXX=g++
+        elif which g++-9 >/dev/null 2>&1; then
             CXX=g++-9
         elif which g++-8 >/dev/null 2>&1; then
             CXX=g++-8
@@ -212,24 +211,8 @@ selectCXX()
         elif which g++-6 >/dev/null 2>&1; then
             CXX=g++-6
         fi
+        # If we can't find g++, allow CMake to do the look-up
     fi
-
-    gccversion="$("$CXX" -v 2>&1)"
-    gccversion="$(extractStringBetweenDelimiters "$gccversion" "gcc version " ".")"
-    if [ "$gccversion" -lt "6" ]; then
-        echo "CXX ($CXX) is too old; please install a newer compiler such as g++-7."
-        echo "On Ubuntu try the following:"
-        echo "  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y"
-        echo "  sudo apt-get update -y"
-        echo "  sudo apt-get install g++-7 -y"
-        echo "On CentOS try the following:"
-        echo "  sudo yum install centos-release-scl"
-        echo "  sudo yum install devtoolset-7"
-        echo "  scl enable devtoolset-7 bash"
-        return 1
-    fi
-
-    eval $__output="'$CXX'"
 }
 
 # Preparation
@@ -246,10 +229,10 @@ if [ "$os" = "osx" ]; then
     if [ "$vcpkgAllowAppleClang" = "true" ] ; then
         CXX=clang++
     else
-        selectCXX CXX || exit 1
+        selectCXX
     fi
 else
-    selectCXX CXX || exit 1
+    selectCXX
 fi
 
 # Do the build
@@ -257,8 +240,8 @@ buildDir="$vcpkgRootDir/toolsrc/build.rel"
 rm -rf "$buildDir"
 mkdir -p "$buildDir"
 
-(cd "$buildDir" && CXX=$CXX "$cmakeExe" .. -DCMAKE_BUILD_TYPE=Release -G "Ninja" "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DBUILD_TESTING=OFF" "-DVCPKG_DEVELOPMENT_WARNINGS=Off" "-DDEFINE_DISABLE_METRICS=$vcpkgDisableMetrics" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
-(cd "$buildDir" && "$cmakeExe" --build .) || exit 1
+("$cmakeExe" -B "$buildDir" -S toolsrc -DCMAKE_BUILD_TYPE=Release -G "Ninja" "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DBUILD_TESTING=OFF" "-DVCPKG_DEVELOPMENT_WARNINGS=OFF" "-DVCPKG_WARNINGS_AS_ERRORS=OFF" "-DVCPKG_DISABLE_METRICS=$vcpkgDisableMetrics" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
+("$cmakeExe" --build "$buildDir") || exit 1
 
 rm -rf "$vcpkgRootDir/vcpkg"
 cp "$buildDir/vcpkg" "$vcpkgRootDir/"

--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -1,81 +1,42 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(vcpkg C CXX)
+project(vcpkg CXX)
+include(cmake/utilities.cmake)
 
-OPTION(DEFINE_DISABLE_METRICS "Option for disabling metrics" OFF)
-OPTION(VCPKG_ALLOW_APPLE_CLANG "Option for allowing apple clang" OFF)
-OPTION(VCPKG_DEVELOPMENT_WARNINGS "Option for turning on all warnings, and making them errors" ON)
-OPTION(BUILD_TESTING "Option for enabling testing" ON)
-OPTION(VCPKG_BUILD_BENCHMARKING "Option for enabling benchmarking" OFF)
+# ===============
+# === Options ===
+# ===============
 
-# for backwards compatibility with existing code
-if (WERROR)
-    set(VCPKG_DEVELOPMENT_WARNINGS On)
+include(CMakeDependentOption)
+
+option(BUILD_TESTING "Option for enabling testing" ON)
+option(VCPKG_DISABLE_METRICS "Option for disabling metrics" OFF)
+option(VCPKG_ALLOW_APPLE_CLANG "Option for allowing apple clang, even versions that we don't know will work" OFF)
+option(VCPKG_DEVELOPMENT_WARNINGS "Option for turning on all warnings" ON)
+option(VCPKG_WARNINGS_AS_ERRORS "Set warnings to be errors" ${VCPKG_DEVELOPMENT_WARNINGS})
+
+CMAKE_DEPENDENT_OPTION(VCPKG_BUILD_BENCHMARKING "Option for enabling benchmarking" OFF
+    "BUILD_TESTING" OFF)
+
+if(WERROR)
+    message(DEPRECATION "-DWERROR is no longer a supported flag. It doesn't do anything.")
+endif()
+if(DEFINE_DISABLE_METRICS)
+    message(DEPRECATION "DEFINE_DISABLE_METRICS is now called VCPKG_DISABLE_METRICS.")
+    set(VCPKG_DISABLE_METRICS ${DEFINE_DISABLE_METRICS} CACHE BOOL "Option for disabling metrics" FORCE)
 endif()
 
+vcpkg_detect_compiler()
+vcpkg_detect_standard_library()
+vcpkg_detect_std_filesystem()
 
-if (DEFINE_DISABLE_METRICS)
-    set(DISABLE_METRICS_VALUE "1")
-else()
-    set(DISABLE_METRICS_VALUE "0")
-endif()
+# ======================
+# === Compiler Flags ===
+# ======================
 
-if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set(GCC 1)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
-        set(CLANG 1)
-        # Disable linking with libc++fs because this features are added in libc++ library
-        set(NO_LIBCXXFS 1)
-    elseif(NOT VCPKG_ALLOW_APPLE_CLANG)
-        message(FATAL_ERROR
-"Building the vcpkg tool requires support for the C++ Filesystem TS.
-Apple clang versions 10.01 and below do not have support for it.
-Please install gcc6 or newer from homebrew (brew install gcc@6).
-If you would like to try anyway, pass --allowAppleClang to bootstrap.sh.")
-    else()
-        set(CLANG 1)
-    endif()
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang")
-    set(CLANG 1)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "9.0.0")
-        set(NO_LIBCXXFS 1)
-        add_compile_definitions(_LIBCPP_NO_EXPERIMENTAL_DEPRECATION_WARNING_FILESYSTEM=1)
-    endif()
-elseif(NOT MSVC)
-    message(FATAL_ERROR "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
-endif()
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-
-add_definitions(-DDISABLE_METRICS=${DISABLE_METRICS_VALUE})
-include_directories(include)
-link_libraries(Threads::Threads)
-
-if(CLANG AND NOT MSVC)
-    include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("#include <iostream>
-                               int main() { return __GLIBCXX__; }" USES_LIBSTDCXX)
-    check_cxx_source_compiles("#include <iostream>
-                               int main() { return _LIBCPP_VERSION; }" USES_LIBCXX)
-    if ( NOT USES_LIBSTDCXX AND NOT USES_LIBCXX )
-        message(FATAL_ERROR "Can't find which C++ runtime is in use")
-    endif()
-endif()
-
-if(GCC OR (CLANG AND USES_LIBSTDCXX))
-    include(CheckCXXSourceCompiles)
-    set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
-    check_cxx_source_compiles("#include <experimental/filesystem>
-                               int main() { return 0; }" LINKS_TO_STDCXX_FS)
-    unset(CMAKE_REQUIRED_LIBRARIES)
-    if (LINKS_TO_STDCXX_FS)
-        link_libraries(stdc++fs)
-    endif()
-elseif(CLANG AND NOT MSVC AND NOT NO_LIBCXXFS)
-    link_libraries(c++fs)
-endif()
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
 
 if(MSVC)
     # either MSVC, or clang-cl
@@ -83,89 +44,108 @@ if(MSVC)
 
     if (MSVC_VERSION GREATER 1900)
         # Visual Studio 2017 or later
-        add_compile_options(-std:c++17 -permissive-)
-    else()
-        # Visual Studio 2015
-        add_compile_options(-std:c++latest)
+        add_compile_options(-permissive-)
     endif()
 
     if(VCPKG_DEVELOPMENT_WARNINGS)
-        string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-        add_compile_options(-W4 -WX)
+        string(REGEX REPLACE "[-/]W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-        if (CLANG)
+        add_compile_options(-W4)
+        if(VCPKG_COMPILER STREQUAL "clang")
             add_compile_options(-Wmissing-prototypes -Wno-missing-field-initializers)
         endif()
     endif()
-elseif(GCC OR CLANG)
-    add_compile_options(-std=c++1z)
 
+    if(VCPKG_WARNINGS_AS_ERRORS)
+        add_compile_options(-WX)
+    endif()
+else()
     if(VCPKG_DEVELOPMENT_WARNINGS)
-        add_compile_options(-Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move -Werror)
+        add_compile_options(-Wall -Wextra -Wpedantic -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-redundant-move)
 
         # GCC and clang have different names for the same warning
-        if (GCC)
+        if(VCPKG_COMPILER STREQUAL "gcc")
             add_compile_options(-Wmissing-declarations)
-        elseif(CLANG)
+        elseif(VCPKG_COMPILER STREQUAL "clang")
             add_compile_options(-Wmissing-prototypes)
         endif()
     endif()
+
+    if(VCPKG_WARNINGS_AS_ERRORS)
+        add_compile_options(-Werror)
+    endif()
 endif()
 
-file(GLOB_RECURSE VCPKGLIB_SOURCES CONFIGURE_DEPENDS src/vcpkg/*.cpp)
+# ========================
+# === System Libraries ===
+# ========================
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+link_libraries(Threads::Threads)
+
+add_compile_definitions(VCPKG_USE_STD_FILESYSTEM=$<BOOL:${VCPKG_USE_STD_FILESYSTEM}>)
+if(VCPKG_REQUIRE_LINK_CXXFS)
+    if(VCPKG_STANDARD_LIBRARY STREQUAL "libstdc++")
+        link_libraries(stdc++fs)
+    elseif(VCPKG_STANDARD_LIBRARY STREQUAL "libc++")
+        link_libraries(c++fs)
+    endif()
+endif()
+
+if (MINGW)
+    add_compile_definitions(
+        UNICODE
+        _WIN32_WINNT=0x0601
+        WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
+        __fastfail=exit)
+    link_libraries(winhttp bcrypt version ole32 uuid)
+endif()
+
+
+# ===============
+# === Targets ===
+# ===============
+
+add_compile_definitions(VCPKG_DISABLE_METRICS=$<BOOL:${VCPKG_DISABLE_METRICS}>)
+include_directories(include)
+file(GLOB_RECURSE VCPKGLIB_SOURCES CONFIGURE_DEPENDS src/vcpkg/*.cpp)
 add_library(vcpkglib OBJECT ${VCPKGLIB_SOURCES})
+
 add_executable(vcpkg src/vcpkg.cpp $<TARGET_OBJECTS:vcpkglib>)
 
 if (BUILD_TESTING)
     file(GLOB_RECURSE VCPKGTEST_SOURCES CONFIGURE_DEPENDS src/vcpkg-test/*.cpp)
 
     enable_testing()
-    add_executable(vcpkg-test
-        ${VCPKGTEST_SOURCES}
-        $<TARGET_OBJECTS:vcpkglib>)
-
+    add_executable(vcpkg-test ${VCPKGTEST_SOURCES} $<TARGET_OBJECTS:vcpkglib>)
     add_test(NAME default COMMAND vcpkg-test)
 
     if (VCPKG_BUILD_BENCHMARKING)
         target_compile_options(vcpkg-test PRIVATE -DCATCH_CONFIG_ENABLE_BENCHMARKING)
     endif()
-
-    find_program(CLANG_FORMAT clang-format)
-    if (CLANG_FORMAT)
-        file(GLOB_RECURSE VCPKG_FORMAT_SOURCES CONFIGURE_DEPENDS src/*.cpp include/pch.h include/vcpkg/*.h include/vcpkg-test/*.h)
-        add_custom_target(format COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_FORMAT_SOURCES})
-    endif()
 endif()
+
+find_program(CLANG_FORMAT clang-format)
+if(CLANG_FORMAT)
+    file(GLOB_RECURSE VCPKG_FORMAT_SOURCES CONFIGURE_DEPENDS src/*.cpp include/pch.h include/vcpkg/*.h include/vcpkg-test/*.h)
+    add_custom_target(format COMMAND ${CLANG_FORMAT} -i -verbose ${VCPKG_FORMAT_SOURCES})
+endif()
+
+# ===========
+# === PCH ===
+# ===========
 
 if(MSVC)
-  get_target_property(_srcs vcpkglib SOURCES)
+    get_target_property(_srcs vcpkglib SOURCES)
 
-  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
-    set_property(SOURCE src/pch.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/pch.pch")
-    set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pch.pch")
-  endif()
+    if(NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+        set_property(SOURCE src/pch.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/pch.pch")
+        set_property(SOURCE ${_srcs} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pch.pch")
+    endif()
 
-  set_source_files_properties(src/pch.cpp PROPERTIES COMPILE_FLAGS "/Ycpch.h")
-  target_sources(vcpkglib PRIVATE src/pch.cpp)
-  target_compile_options(vcpkglib PRIVATE /Yupch.h /FIpch.h /Zm200)
+    set_source_files_properties(src/pch.cpp PROPERTIES COMPILE_FLAGS "/Ycpch.h")
+    target_sources(vcpkglib PRIVATE src/pch.cpp)
+    target_compile_options(vcpkglib PRIVATE /Yupch.h /FIpch.h /Zm200)
 endif()
 
-if (MINGW)
-  include(CheckCXXSourceCompiles)
-    check_cxx_source_compiles("#include <experimental/filesystem>
-                               int main() { return 0; }" USES_EXPERIMENTAL_FS)
-
-  if (NOT USES_EXPERIMENTAL_FS)
-    add_compile_definitions(USE_STD_FILESYSTEM)
-  endif()
-
-  add_compile_definitions(
-    UNICODE
-    _WIN32_WINNT=0x0601
-    WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY=4
-    __fastfail=exit)
-  foreach(tgt vcpkg vcpkg-test)
-    target_link_libraries(${tgt} PRIVATE winhttp bcrypt version ole32 uuid)
-  endforeach()
-endif()

--- a/toolsrc/cmake/utilities.cmake
+++ b/toolsrc/cmake/utilities.cmake
@@ -1,0 +1,164 @@
+# Outputs to Cache: VCPKG_COMPILER
+function(vcpkg_detect_compiler)
+    if(NOT DEFINED CACHE{VCPKG_COMPILER})
+        if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+                message(FATAL_ERROR
+                    "The g++ version picked up is too old; please install a newer compiler such as g++-7.
+                    On Ubuntu try the following:
+                        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+                        sudo apt-get update -y
+                        sudo apt-get install g++-7 -y
+                    On CentOS try the following:
+                        sudo yum install centos-release-scl
+                        sudo yum install devtoolset-7
+                        scl enable devtoolset-7 bash")
+            endif()
+
+            set(COMPILER "gcc")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0.0" AND NOT VCPKG_ALLOW_APPLE_CLANG)
+                message(FATAL_ERROR
+        "Building the vcpkg tool requires support for the C++ Filesystem TS.
+        Apple clang versions 10.01 and below do not have support for it.
+        Please install gcc6 or newer from homebrew (brew install gcc).
+        If you would like to try anyway, pass --allowAppleClang to bootstrap.sh.")
+            endif()
+            set(COMPILER "clang")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang")
+            set(COMPILER "clang")
+        elseif(MSVC)
+            set(COMPILER "msvc")
+        else()
+            message(FATAL_ERROR "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
+        endif()
+
+        set(VCPKG_COMPILER ${COMPILER}
+            CACHE STRING
+            "The compiler in use; one of gcc, clang, msvc")
+    endif()
+endfunction()
+
+# Outputs to Cache: VCPKG_STANDARD_LIBRARY
+function(vcpkg_detect_standard_library)
+    if(NOT DEFINED CACHE{VCPKG_STANDARD_LIBRARY})
+        include(CheckCXXSourceCompiles)
+
+        message(STATUS "Detecting the C++ standard library")
+
+        # note: since <ciso646> is the smallest header, generally it's used to get the standard library version
+        set(CMAKE_REQUIRED_QUIET ON)
+        check_cxx_source_compiles(
+            "#include <ciso646>
+            #if !defined(__GLIBCXX__)
+            #error not libstdc++
+            #endif
+            int main() {}"
+            _VCPKG_STANDARD_LIBRARY_LIBSTDCXX)
+        check_cxx_source_compiles(
+            "#include <ciso646>
+            #if !defined(_LIBCPP_VERSION)
+            #error not libc++
+            #endif
+            int main() {}"
+            _VCPKG_STANDARD_LIBRARY_LIBCXX)
+        check_cxx_source_compiles(
+            "#include <ciso646>
+            #if !defined(_MSVC_STL_VERSION)
+            #error not MSVC stl
+            #endif
+            int main() {}"
+            _VCPKG_STANDARD_LIBRARY_MSVC_STL)
+        if(_VCPKG_STANDARD_LIBRARY_LIBSTDCXX)
+            set(STANDARD_LIBRARY "libstdc++")
+        elseif(_VCPKG_STANDARD_LIBRARY_LIBCXX)
+            set(STANDARD_LIBRARY "libc++")
+        elseif(_VCPKG_STANDARD_LIBRARY_MSVC_STL)
+            set(STANDARD_LIBRARY "msvc-stl")
+        else()
+            message(FATAL_ERROR "Can't find which C++ runtime is in use")
+        endif()
+
+        set(VCPKG_STANDARD_LIBRARY ${STANDARD_LIBRARY}
+            CACHE STRING
+            "The C++ standard library in use; one of libstdc++, libc++, msvc-stl")
+
+        message(STATUS "Detecting the C++ standard library - ${VCPKG_STANDARD_LIBRARY}")
+    endif()
+endfunction()
+
+# Outputs to Cache: VCPKG_USE_STD_FILESYSTEM, VCPKG_REQUIRE_LINK_CXXFS
+function(vcpkg_detect_std_filesystem)
+    vcpkg_detect_standard_library()
+
+    if(NOT DEFINED CACHE{VCPKG_USE_STD_FILESYSTEM})
+        include(CheckCXXSourceCompiles)
+
+        message(STATUS "Detecting how to use the C++ filesystem library")
+
+        set(CMAKE_REQUIRED_QUIET ON)
+        if(VCPKG_STANDARD_LIBRARY STREQUAL "libstdc++")
+            check_cxx_source_compiles(
+                "#include <ciso646>
+                #if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 9
+                #error libstdc++ after version 9 does not require -lstdc++fs
+                #endif
+                int main() {}"
+                _VCPKG_REQUIRE_LINK_CXXFS)
+
+            check_cxx_source_compiles(
+                "#include <ciso646>
+                #if !defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE < 8
+                #error libstdc++ before version 8 doesn't support <filesystem>
+                #endif
+                int main() {}"
+                _VCPKG_USE_STD_FILESYSTEM)
+        elseif(VCPKG_STANDARD_LIBRARY STREQUAL "libc++")
+            if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+                # AppleClang never requires (or allows) -lc++fs, even with libc++ version 8.0.0
+                set(_VCPKG_REQUIRE_LINK_CXXFS OFF)
+            else()
+                check_cxx_source_compiles(
+                    "#include <ciso646>
+                    #if _LIBCPP_VERSION >= 9000
+                    #error libc++ after version 9 does not require -lc++fs
+                    #endif
+                    int main() {}"
+                    _VCPKG_REQUIRE_LINK_CXXFS)
+            endif()
+
+            # We don't support versions of libc++ < 7.0.0, and libc++ 7.0.0 has <filesystem>
+            set(_VCPKG_USE_STD_FILESYSTEM ON)
+        elseif(VCPKG_STANDARD_LIBRARY STREQUAL "msvc-stl")
+            check_cxx_source_compiles(
+                "#include <ciso646>
+                #if !defined(_MSVC_STL_UPDATE) || _MSVC_STL_UPDATE < 201803
+                #error MSVC STL before 15.7 doesn't support <filesystem>
+                #endif
+                int main() {}"
+                _VCPKG_USE_STD_FILESYSTEM)
+
+            set(_VCPKG_REQUIRE_LINK_CXXFS OFF)
+        endif()
+
+        set(VCPKG_USE_STD_FILESYSTEM ${_VCPKG_USE_STD_FILESYSTEM}
+            CACHE BOOL
+            "Whether to use <filesystem>, as opposed to <experimental/filesystem>"
+            FORCE)
+        set(VCPKG_REQUIRE_LINK_CXXFS ${_VCPKG_REQUIRE_LINK_CXXFS}
+            CACHE BOOL
+            "Whether it's required to pass -l[std]c++fs in order to use <filesystem>"
+            FORCE)
+
+        if(VCPKG_USE_STD_FILESYSTEM)
+            set(msg "<filesystem>")
+        else()
+            set(msg "<experimental/filesystem>")
+        endif()
+        if(VCPKG_REQUIRE_LINK_CXXFS)
+            set(msg "${msg} with -l[std]c++fs")
+        endif()
+
+        message(STATUS "Detecting how to use the C++ filesystem library - ${msg}")
+    endif()
+endfunction()

--- a/toolsrc/include/pch.h
+++ b/toolsrc/include/pch.h
@@ -31,7 +31,7 @@
 #include <cstdint>
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #include <cstring>
-#if USE_STD_FILESYSTEM
+#if VCPKG_USE_STD_FILESYSTEM
 #include <filesystem>
 #else
 #include <experimental/filesystem>
@@ -54,7 +54,12 @@
 #else
 #include <sys/time.h>
 #endif
+
 #include <sys/types.h>
+// glibc defines major and minor in sys/types.h, and should not
+#undef major
+#undef minor
+
 #include <system_error>
 #include <thread>
 #include <time.h>

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -3,7 +3,7 @@
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/ignore_errors.h>
 
-#if USE_STD_FILESYSTEM
+#if VCPKG_USE_STD_FILESYSTEM
 #include <filesystem>
 #else
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
@@ -12,7 +12,7 @@
 
 namespace fs
 {
-#if USE_STD_FILESYSTEM
+#if VCPKG_USE_STD_FILESYSTEM
     namespace stdfs = std::filesystem;
 #else
     namespace stdfs = std::experimental::filesystem;

--- a/toolsrc/src/vcpkg-test/paragraph.cpp
+++ b/toolsrc/src/vcpkg-test/paragraph.cpp
@@ -8,6 +8,8 @@
 namespace Strings = vcpkg::Strings;
 using vcpkg::Parse::Paragraph;
 
+namespace {
+
 auto test_parse_control_file(const std::vector<std::unordered_map<std::string, std::string>>& v)
 {
     std::vector<Paragraph> pghs;
@@ -27,6 +29,8 @@ auto test_make_binary_paragraph(const std::unordered_map<std::string, std::strin
         pgh.emplace(kv.first, std::make_pair(kv.second, vcpkg::Parse::TextRowCol{}));
 
     return vcpkg::BinaryParagraph(std::move(pgh));
+}
+
 }
 
 TEST_CASE ("SourceParagraph construct minimum", "[paragraph]")

--- a/toolsrc/src/vcpkg/base/hash.cpp
+++ b/toolsrc/src/vcpkg/base/hash.cpp
@@ -51,13 +51,14 @@ namespace vcpkg::Hash
         }
     }
 
-    template<class T>
-    void top_bits(T) = delete;
-
-    [[maybe_unused]] static uchar top_bits(uchar x) noexcept { return x; }
-    [[maybe_unused]] static uchar top_bits(std::uint32_t x) noexcept { return (x >> 24) & 0xFF; }
-    [[maybe_unused]] static uchar top_bits(std::uint64_t x) noexcept { return (x >> 56) & 0xFF; }
-    [[maybe_unused]] static uchar top_bits(UInt128 x) noexcept { return top_bits(x.top_64_bits()); }
+    template <class UIntTy>
+    auto top_bits(UIntTy x) -> std::enable_if_t<std::is_unsigned<UIntTy>::value, uchar> {
+        return static_cast<uchar>(x >> ((sizeof(x) - 1) * 8));
+    }
+    template <class UIntTy>
+    auto top_bits(UIntTy x) -> decltype(top_bits(x.top_64_bits())) {
+        return top_bits(x.top_64_bits());
+    }
 
     // treats UIntTy as big endian for the purpose of this mapping
     template<class UIntTy>

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -532,6 +532,7 @@ namespace vcpkg
         Debug::print(
             "cmd_execute() returned ", exit_code, " after ", static_cast<unsigned int>(timer.microseconds()), " us\n");
 #else
+        (void)env;
         Debug::print("system(", cmd_line, ")\n");
         fflush(nullptr);
         int exit_code = system(cmd_line.c_str());
@@ -587,6 +588,7 @@ namespace vcpkg
         }();
         g_ctrl_c_state.transition_from_spawn_process();
 #else
+        (void)env;
         const auto actual_cmd_line = Strings::format(R"###(%s 2>&1)###", cmd_line);
 
         Debug::print("popen(", actual_cmd_line, ")\n");

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -255,6 +255,7 @@ namespace vcpkg::Build
                                   }));
     }
 
+#if defined(_WIN32)
     static const std::unordered_map<std::string, std::string>& make_env_passthrough(const PreBuildInfo& pre_build_info)
     {
         static Cache<std::vector<std::string>, std::unordered_map<std::string, std::string>> envs;
@@ -274,6 +275,7 @@ namespace vcpkg::Build
             return env;
         });
     }
+#endif
 
     std::string make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
     {
@@ -824,7 +826,6 @@ namespace vcpkg::Build
         auto binary_caching_enabled = binaries_provider && action.build_options.binary_caching == BinaryCaching::YES;
 
         auto& fs = paths.get_filesystem();
-        Triplet triplet = action.spec.triplet();
         auto& spec = action.spec;
         const std::string& name = action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
                                       .source_control_file->core_paragraph->name;
@@ -1056,7 +1057,7 @@ namespace vcpkg::Build
                     public_abi_override = variable_value.empty() ? nullopt : Optional<std::string>{variable_value};
                     break;
                 case VcpkgTripletVar::LOAD_VCVARS_ENV:
-                        if (variable_value.empty()) 
+                        if (variable_value.empty())
                         {
                             load_vcvars_env = true;
                             if(external_toolchain_file)

--- a/toolsrc/src/vcpkg/export.cpp
+++ b/toolsrc/src/vcpkg/export.cpp
@@ -197,7 +197,6 @@ namespace vcpkg::Export
     {
         constexpr const ArchiveFormat ZIP(ArchiveFormat::BackingEnum::ZIP, "zip", "zip");
         constexpr const ArchiveFormat SEVEN_ZIP(ArchiveFormat::BackingEnum::SEVEN_ZIP, "7z", "7zip");
-        constexpr const ArchiveFormat AAR(ArchiveFormat::BackingEnum::ZIP, "aar", "zip");
     }
 
     static fs::path do_archive_export(const VcpkgPaths& paths,
@@ -297,7 +296,7 @@ namespace vcpkg::Export
     static constexpr StringLiteral OPTION_CHOCOLATEY_MAINTAINER = "--x-maintainer";
     static constexpr StringLiteral OPTION_CHOCOLATEY_VERSION_SUFFIX = "--x-version-suffix";
     static constexpr StringLiteral OPTION_ALL_INSTALLED = "--x-all-installed";
-    
+
     static constexpr StringLiteral OPTION_PREFAB = "--prefab";
     static constexpr StringLiteral OPTION_PREFAB_GROUP_ID = "--prefab-group-id";
     static constexpr StringLiteral OPTION_PREFAB_ARTIFACT_ID = "--prefab-artifact-id";
@@ -306,7 +305,7 @@ namespace vcpkg::Export
     static constexpr StringLiteral OPTION_PREFAB_SDK_TARGET_VERSION = "--prefab-target-sdk";
     static constexpr StringLiteral OPTION_PREFAB_ENABLE_MAVEN = "--prefab-maven";
     static constexpr StringLiteral OPTION_PREFAB_ENABLE_DEBUG = "--prefab-debug";
-    
+
 
 
 
@@ -444,7 +443,7 @@ namespace vcpkg::Export
                             {OPTION_IFW_CONFIG_FILE_PATH, ret.ifw_options.maybe_config_file_path},
                             {OPTION_IFW_INSTALLER_FILE_PATH, ret.ifw_options.maybe_installer_file_path},
                         });
-        
+
         options_implies(OPTION_PREFAB,
                         ret.prefab,
                         {

--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -18,9 +18,9 @@ namespace vcpkg::Export::Prefab
     using Install::InstallDir;
     using System::CPUArchitecture;
 
-   
 
-    std::vector<fs::path> find_modules(const VcpkgPaths& system, const fs::path& root, const std::string& ext)
+
+    static std::vector<fs::path> find_modules(const VcpkgPaths& system, const fs::path& root, const std::string& ext)
     {
         std::vector<fs::path> paths;
         Files::Filesystem& utils = system.get_filesystem();
@@ -58,7 +58,7 @@ namespace vcpkg::Export::Prefab
             .append("}");
     }
 
-    std::string jsonify(const std::vector<std::string>& dependencies)
+    static std::string jsonify(const std::vector<std::string>& dependencies)
     {
         std::vector<std::string> deps;
         for (const auto& dep : dependencies)
@@ -68,7 +68,7 @@ namespace vcpkg::Export::Prefab
         return Strings::join(",", deps);
     }
 
-    std::string null_if_empty(const std::string& str)
+    static std::string null_if_empty(const std::string& str)
     {
         std::string copy = str;
         if (copy.size() == 0)
@@ -82,7 +82,7 @@ namespace vcpkg::Export::Prefab
         return copy;
     }
 
-    std::string null_if_empty_array(const std::string& str)
+    static std::string null_if_empty_array(const std::string& str)
     {
         std::string copy = str;
         if (copy.size() == 0)
@@ -218,7 +218,7 @@ namespace vcpkg::Export::Prefab
 #endif
     }
 
-    void maven_install(const fs::path& aar, const fs::path& pom, const Options& prefab_options)
+    static void maven_install(const fs::path& aar, const fs::path& pom, const Options& prefab_options)
     {
         if(prefab_options.enable_debug){
             System::print2("\n[DEBUG] Installing POM and AAR file to ~/.m2\n\n");
@@ -234,7 +234,7 @@ namespace vcpkg::Export::Prefab
         Checks::check_exit(VCPKG_LINE_INFO, exit_code == 0, "Error: %s installing maven file", aar.generic_u8string());
     }
 
-    Build::PreBuildInfo build_info_from_triplet(const VcpkgPaths& paths,
+    static Build::PreBuildInfo build_info_from_triplet(const VcpkgPaths& paths,
                                                 const std::unique_ptr<CMakeVars::CMakeVarProvider>& provider,
                                                 const Triplet& triplet)
     {
@@ -244,7 +244,7 @@ namespace vcpkg::Export::Prefab
         return pre_build_info;
     }
 
-    bool is_supported(const Build::PreBuildInfo& info)
+    static bool is_supported(const Build::PreBuildInfo& info)
     {
         return Strings::case_insensitive_ascii_equals(info.cmake_system_name, "android");
     }
@@ -271,7 +271,7 @@ namespace vcpkg::Export::Prefab
                                                              {CPUArchitecture::ARM, 16},
                                                              {CPUArchitecture::X64, 21},
                                                              {CPUArchitecture::X86, 16}};
-        
+
 
         std::vector<Triplet> triplets;
         std::unordered_map<Triplet, std::string> triplet_abi_map;
@@ -280,9 +280,9 @@ namespace vcpkg::Export::Prefab
         for (auto& triplet_file : available_triplets){
             if (triplet_file.name.size() > 0){
                 Triplet triplet = Triplet::from_canonical_name(std::move(triplet_file.name));
-                auto build_info = build_info_from_triplet(paths, provider, triplet);
-                if (is_supported(build_info)){
-                    auto cpu_architecture =System::to_cpu_architecture(build_info.target_architecture).value_or_exit(VCPKG_LINE_INFO);
+                auto triplet_build_info = build_info_from_triplet(paths, provider, triplet);
+                if (is_supported(triplet_build_info)){
+                    auto cpu_architecture = System::to_cpu_architecture(triplet_build_info.target_architecture).value_or_exit(VCPKG_LINE_INFO);
                     auto required_arch = required_archs.find(cpu_architecture);
                     if (required_arch != required_archs.end()){
                         triplets.push_back(triplet);
@@ -378,8 +378,8 @@ namespace vcpkg::Export::Prefab
             const std::string name = action.spec.name();
             auto dependencies = action.dependencies(default_triplet);
 
-            const auto build_info = Build::read_build_info(utils, paths.build_info_file_path(action.spec));
-            const bool is_empty_package  = build_info.policies.is_enabled(Build::BuildPolicy::EMPTY_PACKAGE);
+            const auto action_build_info = Build::read_build_info(utils, paths.build_info_file_path(action.spec));
+            const bool is_empty_package  = action_build_info.policies.is_enabled(Build::BuildPolicy::EMPTY_PACKAGE);
 
 
             if(is_empty_package){
@@ -503,7 +503,7 @@ namespace vcpkg::Export::Prefab
                 for(auto triplet: triplets){
                     triplet_names.push_back(triplet.canonical_name());
                 }
-                System::print2(Strings::format("[DEBUG] Found %d triplets\n\t%s\n\n", triplets.size(), 
+                System::print2(Strings::format("[DEBUG] Found %d triplets\n\t%s\n\n", triplets.size(),
                     Strings::join("\n\t", triplet_names)));
             }
 
@@ -562,14 +562,14 @@ namespace vcpkg::Export::Prefab
                         ABIMetadata ab;
                         ab.abi = triplet_abi_map[triplet];
                         ab.api =  triplet_api_map[triplet];
-                        
+
                         ab.stl = Strings::contains(extension, "a") ?"c++_static": "c++_shared";
                         ab.ndk = version.major();
 
                         if(prefab_options.enable_debug){
                             System::print2(Strings::format("[DEBUG] Found module %s:%s\n", module_name, ab.abi));
                         }
-                       
+
                         module_name = Strings::trim(std::move(module_name));
 
                         if (Strings::starts_with(module_name, "lib"))
@@ -580,7 +580,7 @@ namespace vcpkg::Export::Prefab
                         fs::path module_libs_dir =
                             module_dir / "libs" / Strings::format("android.%s", ab.abi);
                         utils.create_directories(module_libs_dir, error_code);
-                      
+
                         fs::path abi_path = module_libs_dir / "abi.json";
 
                         if(prefab_options.enable_debug){
@@ -597,7 +597,7 @@ namespace vcpkg::Export::Prefab
                                         fs::copy_options::overwrite_existing,
                                         error_code);
                         if(prefab_options.enable_debug){
-                            System::print2(Strings::format("\tCopying libs\n\tFrom %s\n\tTo %s\n", 
+                            System::print2(Strings::format("\tCopying libs\n\tFrom %s\n\tTo %s\n",
                                 installed_module_path.generic_u8string(), exported_module_path.generic_u8string()));
                         }
                         fs::path installed_headers_dir = installed_dir / "include";
@@ -629,7 +629,7 @@ namespace vcpkg::Export::Prefab
             fs::path pom_path = per_package_dir_path / "pom.xml";
 
             if(prefab_options.enable_debug){
-                System::print2(Strings::format("[DEBUG] Exporting AAR And POM\n\tAAR Path %s\n\tPOM Path %s\n", 
+                System::print2(Strings::format("[DEBUG] Exporting AAR And POM\n\tAAR Path %s\n\tPOM Path %s\n",
                     exported_archive_path.generic_u8string(), pom_path.generic_u8string()));
             }
 

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -297,7 +297,7 @@ namespace vcpkg::Install
     using Build::BuildResult;
     using Build::ExtendedBuildResult;
 
-    ExtendedBuildResult perform_install_plan_action(const VcpkgPaths& paths,
+    static ExtendedBuildResult perform_install_plan_action(const VcpkgPaths& paths,
                                                     InstallPlanAction& action,
                                                     StatusParagraphs& status_db,
                                                     IBinaryProvider* binaries_provider)

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -240,7 +240,7 @@ namespace vcpkg::Metrics
 
     static MetricMessage g_metricmessage;
     static bool g_should_send_metrics =
-#if defined(NDEBUG) && (DISABLE_METRICS == 0)
+#if defined(NDEBUG) && (VCPKG_DISABLE_METRICS == 0)
         true
 #else
         false
@@ -248,7 +248,7 @@ namespace vcpkg::Metrics
         ;
     static bool g_should_print_metrics = false;
 
-    bool get_compiled_metrics_enabled() { return DISABLE_METRICS == 0; }
+    bool get_compiled_metrics_enabled() { return VCPKG_DISABLE_METRICS == 0; }
 
     std::string get_MAC_user()
     {

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -738,7 +738,7 @@ namespace vcpkg::PostBuildLint
             System::printf(System::Color::warning,
                            "Expected %s crt linkage, but the following libs had invalid crt linkage:\n\n",
                            expected_build_type.to_string());
-            for (const BuildTypeAndFile btf : libs_with_invalid_crt)
+            for (const BuildTypeAndFile& btf : libs_with_invalid_crt)
             {
                 System::printf("    %s: %s\n", btf.file.generic_string(), btf.build_type.to_string());
             }
@@ -786,7 +786,7 @@ namespace vcpkg::PostBuildLint
         if (!dlls_with_outdated_crt.empty())
         {
             System::print2(System::Color::warning, "Detected outdated dynamic CRT in the following files:\n\n");
-            for (const OutdatedDynamicCrtAndFile btf : dlls_with_outdated_crt)
+            for (const OutdatedDynamicCrtAndFile& btf : dlls_with_outdated_crt)
             {
                 System::print2("    ", btf.file.u8string(), ": ", btf.outdated_crt.name, "\n");
             }

--- a/toolsrc/vcpkglib/vcpkglib.vcxproj
+++ b/toolsrc/vcpkglib/vcpkglib.vcxproj
@@ -74,11 +74,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VCPKG_DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -92,7 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VCPKG_DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -108,7 +108,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VCPKG_DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -127,7 +127,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VCPKG_DISABLE_METRICS=$(DISABLE_METRICS);VCPKG_VERSION=$(VCPKG_VERSION);_MBCS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/toolsrc/vcpkgmetricsuploader/vcpkgmetricsuploader.vcxproj
+++ b/toolsrc/vcpkgmetricsuploader/vcpkgmetricsuploader.vcxproj
@@ -71,7 +71,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include</AdditionalIncludeDirectories>

--- a/toolsrc/vcpkgtest/vcpkgtest.vcxproj
+++ b/toolsrc/vcpkgtest/vcpkgtest.vcxproj
@@ -109,7 +109,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\include;$(VCInstallDir)UnitTest\include;$(VsInstallRoot)\VC\Auxiliary\VS\UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
There are quite a few changes to the CMake build system packaged up into
one set here:
* Added `toolsrc/cmake/utilities.cmake`, which contains the following:
  * `vcpkg_detect_compiler` -- get the name of the C++ compiler, as one
    of {gcc, clang, msvc}
  * `vcpkg_detect_standard_library` -- get the name of the standard
    library we're linking to, as one of {libstdc++, libc++, msvc-stl}
  * `vcpkg_detect_std_filesystem` -- figure out how to link and call
    into C++17's filesystem; whether one needs to link to `stdc++fs` or
    `c++fs`, and whether to use `<filesystem>` or
    `<experimental/filesystem>`.
* Added a `VCPKG_WARNINGS_AS_ERRORS`, split off from
  `VCPKG_DEVELOPMENT_WARNINGS`, which allows one to use the development
  warnings without passing -Werror
* Rename `DEFINE_DISABLE_METRICS` to `VCPKG_DISABLE_METRICS` -- the
  former will now print a deprecation message and set the latter.
* Now, print a deprecation message on `WERROR`; it doesn't do anything
  since the behavior it requested is now the default.
* Pass `-std=c++17` if the compiler allows it, instead of `-std=c++1z`
* Do some code movement
* Pass `USE_STD_FILESYSTEM` if possible, instead of only on minGW
  * Renamed to `VCPKG_USE_STD_FILESYSTEM`

Additionally, we now pass `/W4` in Debug mode on x86 in the Visual
Studio build system; this brings it in line with the CMake build system,
and the x64 Visual Studio build system.

And finally, we make some minor code changes to support compiling in
VCPKG_DEVELOPMENT_WARNINGS mode.
