### PR TITLE
[Freetype] Actually prevent linking HarfBuzz on POSIX

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,5 +1,5 @@
 Source: freetype
-Version: 2.10.1-5
+Version: 2.10.1-6
 Build-Depends: zlib
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -33,7 +33,7 @@ endif()
 
 set(OPTIONS)
 if (NOT VCPKG_TARGET_IS_WINDOWS)
-  list(APPEND OPTIONS -DFT_DISABLE_FIND_PACKAGE_Harfbuzz=TRUE)
+  list(APPEND OPTIONS -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=ON)
 endif()
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Correctly fixes #10041
Fixes three typos in #10073

The important environments to test are `x64-osx` and `x64-linux`. On macOS, I have freetype and harfbuzz already installed from Homebrew and noticed that harfbuzz was still being linked and this now correctly prevents Freetype's CMake from finding harfbuzz.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
