### PR TITLE
[imgui-sfml] Force imgui-sfml to be a static library

### DIFF
--- a/ports/imgui-sfml/004-fix-find-sfml.patch
+++ b/ports/imgui-sfml/004-fix-find-sfml.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d7a3fa..614564f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,9 +32,6 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+ 
+ if (IMGUI_SFML_FIND_SFML)
+-	if (NOT BUILD_SHARED_LIBS)
+-		set(SFML_STATIC_LIBRARIES ON)
+-	endif()
+ 	find_package(SFML COMPONENTS graphics system window)
+ 
+ 	if(NOT SFML_FOUND)

--- a/ports/imgui-sfml/CONTROL
+++ b/ports/imgui-sfml/CONTROL
@@ -1,5 +1,5 @@
 Source: imgui-sfml
-Version: 2.1
+Version: 2.1-1
 Homepage: https://github.com/eliasdaler/imgui-sfml
 Description: ImGui binding for use with SFML
 Build-Depends: sfml, imgui

--- a/ports/imgui-sfml/portfile.cmake
+++ b/ports/imgui-sfml/portfile.cmake
@@ -1,5 +1,3 @@
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SFML_STATIC)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -14,6 +12,18 @@ vcpkg_from_github(
         0003-fix_osx.patch
         004-fix-find-sfml.patch
 )
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    file(GLOB SFML_DYNAMIC_LIBS "${CURRENT_INSTALLED_DIR}/bin/sfml-*")
+else()
+    file(GLOB SFML_DYNAMIC_LIBS "${CURRENT_INSTALLED_DIR}/bin/libsfml-*")
+endif()
+
+if (SFML_DYNAMIC_LIBS)
+    set(SFML_STATIC OFF)
+else()
+    set(SFML_STATIC ON)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/imgui-sfml/portfile.cmake
+++ b/ports/imgui-sfml/portfile.cmake
@@ -1,4 +1,6 @@
-include(vcpkg_common_functions)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SFML_STATIC)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -10,15 +12,20 @@ vcpkg_from_github(
         0001-fix_find_package.patch
         0002-fix_imgui_config.patch
         0003-fix_osx.patch
+        004-fix-find-sfml.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DSFML_STATIC_LIBRARIES=${SFML_STATIC}
 )
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ImGui-SFML)
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/imgui-sfml/copyright COPYONLY)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Force imgui-sfml to be a static library to avoid the issue of loading global variables in imgui twice.

Related: #9660.