### PR TITLE
[ignition-modular-scripts] Migrate from Bitbucket to GitHub 🤖

### DIFF
--- a/ports/ignition-cmake0/CONTROL
+++ b/ports/ignition-cmake0/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-cmake0
-Version: 0.6.2-1
+Version: 0.6.2-2
 Homepage: https://ignitionrobotics.org/libs/cmake
 Description: CMake helper functions for building robotic applications
 Build-Depends: ignition-modularscripts

--- a/ports/ignition-cmake0/portfile.cmake
+++ b/ports/ignition-cmake0/portfile.cmake
@@ -7,7 +7,7 @@ set(PACKAGE_VERSION "0.6.1")
 ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION} 
                          REF "ignition-cmake_${PACKAGE_VERSION}"
-                         SHA512 fcd3ad6b5289697c4928c71b820e2adaa758c730f52cba3f8cc714e44ca0c9f04f432ae5b98b5f258c4851c4666740b58066a25c55ff3a6de975cd8a57991b6b
+                         SHA512 bd57cd43dd944fef264353b67fbbbab989d4bb638b684f80868a8b61fe0b854e156e00852b967c7caa8598315bea60bd8b27ff000410e93c4f04185a13c90489
                          # Ensure that gtest is not compiled (backport of https://bitbucket.org/ignitionrobotics/ign-cmake/pull-requests/163)
                          PATCHES do-not-compile-gtest.patch
 						 # Support for ARM64 (backport of https://bitbucket.org/ignitionrobotics/ign-cmake/pull-requests/168)

--- a/ports/ignition-cmake2/CONTROL
+++ b/ports/ignition-cmake2/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-cmake2
-Version: 2.1.1
+Version: 2.1.1-1
 Homepage: https://ignitionrobotics.org/libs/cmake
 Description: CMake helper functions for building robotic applications
 Build-Depends: ignition-modularscripts

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -4,7 +4,7 @@ set(PACKAGE_VERSION "2.1.1")
 
 ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION}
-                         SHA512 4d22a45ccc9582c7e4b370b884511782d1629fa3e257dd92300388b5050d22fa63dd4a6ef8942abb9ebbc300df4cd526d1d8a7088a92b0073e152c16c7b97e2b)
+                         SHA512 4dce0ef477b737a217179478262ef9c9eafffbd6933023b43a3506ea76502955ab5ae8a94d779c13ad4ca15849cdfbe9f9d696af2ccc102522239040b9540fd9)
 
 # Permit empty include folder
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/ignition-common1/CONTROL
+++ b/ports/ignition-common1/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-common1
-Version: 1.1.1
+Version: 1.1.1-1
 Build-Depends: dlfcn-win32 (windows|uwp), ffmpeg (!windows&!uwp), freeimage (!windows&!uwp), gts (!windows&!uwp), ignition-cmake0, ignition-math4, tinyxml2 (!windows&!uwp)
 Description: Common libraries for robotics applications

--- a/ports/ignition-common1/portfile.cmake
+++ b/ports/ignition-common1/portfile.cmake
@@ -5,4 +5,4 @@ include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_l
 ignition_modular_library(NAME common
                          VERSION "1.1.1"
                          REF ignition-common_1.1.1
-                         SHA512 8453e1cf2337898b81b313aeffd1a7b683fd03184edfae74c81aa861b28036f6b9094fcab36f7a0f68b4204956d7116bd03073c7bdf2e769e47dffcdaad454d6)
+                         SHA512 e96e82dc401281cd31843f4b0ae2c1d23589170869621ea62eb6d6b31b11bd622c14da7046b1993c8fc67a1d39bae9a96b9f8efc8923e305823f963d864975f7)

--- a/ports/ignition-fuel-tools1/CONTROL
+++ b/ports/ignition-fuel-tools1/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-fuel-tools1
-Version: 1.2.0
+Version: 1.2.0-1
 Build-Depends: curl, ignition-cmake0, ignition-common1, libyaml, libzip, jsoncpp
 Description: Tools for using fuel API to download robot models

--- a/ports/ignition-fuel-tools1/portfile.cmake
+++ b/ports/ignition-fuel-tools1/portfile.cmake
@@ -5,6 +5,6 @@ include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_l
 ignition_modular_library(NAME fuel-tools
                          VERSION "1.2.0"
                          CMAKE_PACKAGE_NAME ignition-fuel_tools1
-                         SHA512 5ed8d1429e1f5c0716e06840a4163f7e79a614cf7b6ff326adb69d35639e3ec5f1862edc41c6dc0bd21b16db6d13bee509831a66b10ca2ae3999649f1554a68e
+                         SHA512 a656fed74fb2138b3bcf7d35b25ad06da95cfb9a3ad7ded2c9c54db385f55ea310fd1a72dcf6400b0a6199e376c1ba2d11ee2a08c66e3c2cc8b2ee1b25406986
                          # Ensure yaml is correctly linked (backport of https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/103/use-yaml_target-instead-of-yaml-yaml/diff)
                          PATCHES link-correct-yaml-target.patch)

--- a/ports/ignition-math4/CONTROL
+++ b/ports/ignition-math4/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-math4
-Version: 4.0.0
+Version: 4.0.0-1
 Homepage: https://ignitionrobotics.org/libs/math
 Build-Depends: ignition-cmake0
 Description: Math API for robotic applications

--- a/ports/ignition-math4/portfile.cmake
+++ b/ports/ignition-math4/portfile.cmake
@@ -4,4 +4,4 @@ include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_l
 
 ignition_modular_library(NAME math
                          VERSION "4.0.0"
-                         SHA512 09023b559e7e544e628131189f3a7f57a9b73868f66f81e5ce1a353092940949973e1753f18ead8f655ad88c0e1d1bf51bbf63163760694aab7a97a4c0f6d519)
+                         SHA512 5996af60666a1166fc19b2db9715f7214341becb8eb6071c09315e1f71e759c6de4da99b44312829fc7b2bdef7e0f3671e4d2a92e0d2dd5d5fd782a6c46b012a)

--- a/ports/ignition-modularscripts/CONTROL
+++ b/ports/ignition-modularscripts/CONTROL
@@ -1,3 +1,3 @@
 Source: ignition-modularscripts
-Version: 2020-02-10
+Version: 2020-04-16
 Description: Vcpkg helpers to package ignition libraries

--- a/ports/ignition-modularscripts/ignition_modular_library.cmake
+++ b/ports/ignition-modularscripts/ignition_modular_library.cmake
@@ -55,19 +55,19 @@ endfunction()
 ## The complete version number.
 ##
 ## ### SHA512
-## The SHA512 hash that should match the downloaded  archive. This is forwarded to the `vcpkg_from_bitbucket` command.
+## The SHA512 hash that should match the downloaded  archive. This is forwarded to the `vcpkg_from_github` command.
 ##
 ## ### REF
-## Reference to the tag of the desired release. This is forwarded to the `vcpkg_from_bitbucket` command.
+## Reference to the tag of the desired release. This is forwarded to the `vcpkg_from_github` command.
 ## If not specified, defaults to `ignition-${NAME}${MAJOR_VERSION}_${VERSION}`.
 ##
 ## ### HEAD_REF
-## Reference (tag) to the desired release. This is forwarded to the `vcpkg_from_bitbucket` command.
+## Reference (tag) to the desired release. This is forwarded to the `vcpkg_from_github` command.
 ## If not specified, defaults to `ign-${NAME}${MAJOR_VERSION}`.
 ##
 ## ### PATCHES
 ## A list of patches to be applied to the extracted sources.
-## This is forwarded to the `vcpkg_from_bitbucket` command.
+## This is forwarded to the `vcpkg_from_github` command.
 ##
 ## ### CMAKE_PACKAGE_NAME
 ## The name of the CMake package for the port.
@@ -102,8 +102,8 @@ function(ignition_modular_library)
         set(IML_CMAKE_PACKAGE_NAME ${DEFAULT_CMAKE_PACKAGE_NAME})
     endif()
     
-    # Download library from bitbucket, to support also the --head option
-    vcpkg_from_bitbucket(
+    # Download library from github, to support also the --head option
+    vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO ignitionrobotics/ign-${IML_NAME}
         REF ${IML_REF}

--- a/ports/ignition-msgs1/CONTROL
+++ b/ports/ignition-msgs1/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-msgs1
-Version: 1.0.0
+Version: 1.0.0-1
 Build-Depends: ignition-cmake0, ignition-math4, protobuf
 Description: Middleware protobuf messages for robotics

--- a/ports/ignition-msgs1/portfile.cmake
+++ b/ports/ignition-msgs1/portfile.cmake
@@ -26,7 +26,7 @@ ignition_modular_library(NAME msgs
                          VERSION "1.0.0"
                          # See https://bitbucket.org/ignitionrobotics/ign-msgs/issues/33/the-ignition-msgs1_100-tag-does-not-match
                          REF ignition-msgs_1.0.0
-                         SHA512 15261d9c82c05952b1b7dfc50346e73ab041bf6e2e5a63698e17bfa36b2d261aad2777f770f6dccd0d58eb9c90979fe89a7371dc2ec6050149bf63cafc4f6779
+                         SHA512 3a270f0ac988b947091d4626be48fe8cfed5ddfde5a37b9d0f08fddcbf278099ab231fca11e2dd2296ca54e0350ea14e3f685dc238f0827f18f10ab7b75039de
                          # Fix linking order of protobuf libraries (backport of https://bitbucket.org/ignitionrobotics/ign-msgs/pull-requests/151)
                          PATCHES fix-protobuf-static-link-order.patch)
 

--- a/ports/ignition-transport4/CONTROL
+++ b/ports/ignition-transport4/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-transport4
-Version: 4.0.0
+Version: 4.0.0-1
 Build-Depends: cppzmq, ignition-cmake0, ignition-msgs1, libuuid (!windows&!uwp), protobuf, zeromq
 Description: Transport middleware for robotics

--- a/ports/ignition-transport4/portfile.cmake
+++ b/ports/ignition-transport4/portfile.cmake
@@ -4,4 +4,4 @@ include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_l
 
 ignition_modular_library(NAME transport
                          VERSION "4.0.0"
-                         SHA512 4f8d947e046653fafb27063de3cd97a66c169d53ef48ee5f06b0c0c3a40d7ad0f58028b615a0321aa46ed56aef2acbeeb46a48b2ff3a3d1050df89a3688877c6)
+                         SHA512 d4125044c21fdd6754f3b8b06f372df3f858080d5d33e97ed7a8ef8f6fb9857d562082aad41c89ea9146a33b1c3814305d33c5c8f8bcde66a16477b4a01655b4)


### PR DESCRIPTION
As announced in https://community.gazebosim.org/t/important-gazebo-and-ignition-are-going-to-github/533, the ignition project repositories have been migrated from Bitbucket to GitHub.

This commit updates the ignition_modular_library helpers to use GitHub instead of Bitbucket,
and also update the hashes of all the ignition ports as apparently the archive generated by GitHub
for releases are slightly different from the one generated by Bitbucket.

**Describe the pull request**

- What does your PR fix? 
The PR does not fix any issue, but given that bitbucket will remove the original repos in June 2020, it will prevent future port failures. 

- Which triplets are supported/not supported? Have you updated the CI baseline?
No triplet support should he changed. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes. Furthermore the PR title follows the additional guidelines documented in https://github.com/microsoft/vcpkg/pull/7781#issuecomment-528017994 .
