### PR TITLE
[sdformat6] Migrate from Bitbucket to GitHub 🤖

### DIFF
--- a/ports/sdformat6/CONTROL
+++ b/ports/sdformat6/CONTROL
@@ -1,5 +1,5 @@
 Source: sdformat6
-Version: 6.2.0
+Version: 6.2.0-1
 Homepage: http://sdformat.org/
 Build-Depends: boost-any, boost-variant, ignition-math4, urdfdom, tinyxml
 Description: Simulation Description Format (SDF) parser and description files.

--- a/ports/sdformat6/CONTROL
+++ b/ports/sdformat6/CONTROL
@@ -3,3 +3,4 @@ Version: 6.2.0-1
 Homepage: http://sdformat.org/
 Build-Depends: boost-any, boost-variant, ignition-math4, urdfdom, tinyxml
 Description: Simulation Description Format (SDF) parser and description files.
+Supports: !(arm|uwp)

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -1,10 +1,10 @@
 include(vcpkg_common_functions)
 
-vcpkg_from_bitbucket(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osrf/sdformat
     REF sdformat6_6.2.0
-    SHA512 3e3934010438bffbf10c1df29bd486c098e3c1bdf2b0349b69a53fb6f4d2bd3b3c8c4b4a8dfb413da13a638c0794f41c1bff4adb11a889b1552d90ba8b94c495
+    SHA512 3d139ec4b4c9fbfd547ed8bfca0adb5cdca92c1b7cc4d4b554a7c51ccf755b9079c26a006ebfedc5bc5b1ba5e16ad950bb38c47ea97bf97e59a2fd7d12d60620
     HEAD_REF sdf6
 )
 

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -1,4 +1,4 @@
-add vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -1,4 +1,4 @@
-include(vcpkg_common_functions)
+add vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -49,7 +49,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdformat6 RENAME copyright)
-
-# Post-build test for cmake libraries
-vcpkg_test_cmake(PACKAGE_NAME SDFormat)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
As announced in https://community.gazebosim.org/t/important-gazebo-and-ignition-are-going-to-github/533, the sdformat repository has been migrated from Bitbucket to GitHub.

This commit also updates the hash as apparently the archive generated by GitHub is slightly different from the one generated by Bitbucket.

This PR is similar to https://github.com/microsoft/vcpkg/pull/10858 .


**Describe the pull request**

- What does your PR fix? 
The PR does not fix any issue, but given that bitbucket will remove the original repos in June 2020, it will prevent future port failures. 

- Which triplets are supported/not supported? Have you updated the CI baseline?
No triplet support should he changed. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes. Furthermore the PR title follows the additional guidelines documented in https://github.com/microsoft/vcpkg/pull/7781#issuecomment-528017994 .
