### PR TITLE
[protobuf] Update to 3.11.4

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.11.3
+Version: 3.11.4
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -32,11 +32,10 @@ else()
   set(VCPKG_BUILD_STATIC_CRT ON)
 endif()
 
-if("zlib" IN_LIST FEATURES)
-    set(protobuf_WITH_ZLIB ON)
-else()
-    set(protobuf_WITH_ZLIB OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+	zlib	protobuf_WITH_ZLIB
+)
+
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/cmake
@@ -48,6 +47,7 @@ vcpkg_configure_cmake(
         -Dprotobuf_BUILD_TESTS=OFF
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+		${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -47,7 +47,7 @@ vcpkg_configure_cmake(
         -Dprotobuf_BUILD_TESTS=OFF
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
-	${FEATURE_OPTIONS}
+         ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -47,7 +47,7 @@ vcpkg_configure_cmake(
         -Dprotobuf_BUILD_TESTS=OFF
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
-		${FEATURE_OPTIONS}
+	${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.11.3
-    SHA512 beac21d495bfd8e9b40120d1db9fd82251958f954533fc6f76cd0b9c28f92533ac35368a4c298ebb1d8e09047b670ed3bd948bb7da6eb5cca7fdc0c1c44aa39b
+    REF v3.11.4
+    SHA512 777bbb0e9e2375eaebe6b8c87abd660bac70ee469c9ad00dd25917b82d7fb5bbe33cf87f0d69c90e19d55c07a7285ec20974ba4768623ce9ccfadf147fd5e261
     HEAD_REF master
     PATCHES
         fix-uwp.patch


### PR DESCRIPTION
**Describe the pull request**

Simple update to Protobuf, updating it from 3.11.3 to 3.11.4

- What does your PR fix? Fixes issue #
Updates Google-Protobuf from 3.11.3 to 3.11.4

- Which triplets are supported/not supported? Have you updated the CI baseline?
Unchanged from supported protobuf triplets

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes!