### PR TITLE
[vcpkg] Fix build scripts on openSUSE and g++9

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -200,9 +200,7 @@ fetchTool()
 selectCXX()
 {
     if [ "x$CXX" = "x" ]; then
-        if which g++ >/dev/null 2>&1; then
-            CXX=g++
-        elif which g++-9 >/dev/null 2>&1; then
+        if which g++-9 >/dev/null 2>&1; then
             CXX=g++-9
         elif which g++-8 >/dev/null 2>&1; then
             CXX=g++-8
@@ -210,6 +208,8 @@ selectCXX()
             CXX=g++-7
         elif which g++-6 >/dev/null 2>&1; then
             CXX=g++-6
+        elif which g++ >/dev/null 2>&1; then
+            CXX=g++
         fi
         # If we can't find g++, allow CMake to do the look-up
     fi
@@ -236,13 +236,12 @@ else
 fi
 
 # Do the build
-srcDir="$vcpkgRootDir/toolsrc"
-buildDir="$srcDir/build.rel"
+buildDir="$vcpkgRootDir/toolsrc/build.rel"
 rm -rf "$buildDir"
 mkdir -p "$buildDir"
 
-("$cmakeExe" -B "$buildDir" -S "$srcDir" -DCMAKE_BUILD_TYPE=Release -G "Ninja" "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DBUILD_TESTING=OFF" "-DVCPKG_DEVELOPMENT_WARNINGS=OFF" "-DVCPKG_WARNINGS_AS_ERRORS=OFF" "-DVCPKG_DISABLE_METRICS=$vcpkgDisableMetrics" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
-("$cmakeExe" --build "$buildDir") || exit 1
+(cd "$buildDir" && CXX="$CXX" "$cmakeExe" .. -DCMAKE_BUILD_TYPE=Release -G "Ninja" "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DBUILD_TESTING=OFF" "-DVCPKG_DEVELOPMENT_WARNINGS=OFF" "-DVCPKG_DISABLE_METRICS=$vcpkgDisableMetrics" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
+(cd "$buildDir" && "$cmakeExe" --build .) || exit 1
 
 rm -rf "$vcpkgRootDir/vcpkg"
 cp "$buildDir/vcpkg" "$vcpkgRootDir/"

--- a/toolsrc/cmake/utilities.cmake
+++ b/toolsrc/cmake/utilities.cmake
@@ -51,21 +51,21 @@ function(vcpkg_detect_standard_library)
         check_cxx_source_compiles(
             "#include <ciso646>
             #if !defined(__GLIBCXX__)
-            #error not libstdc++
+            #error \"not libstdc++\"
             #endif
             int main() {}"
             _VCPKG_STANDARD_LIBRARY_LIBSTDCXX)
         check_cxx_source_compiles(
             "#include <ciso646>
             #if !defined(_LIBCPP_VERSION)
-            #error not libc++
+            #error \"not libc++\"
             #endif
             int main() {}"
             _VCPKG_STANDARD_LIBRARY_LIBCXX)
         check_cxx_source_compiles(
             "#include <ciso646>
             #if !defined(_MSVC_STL_VERSION)
-            #error not MSVC stl
+            #error \"not MSVC stl\"
             #endif
             int main() {}"
             _VCPKG_STANDARD_LIBRARY_MSVC_STL)
@@ -101,7 +101,7 @@ function(vcpkg_detect_std_filesystem)
             check_cxx_source_compiles(
                 "#include <ciso646>
                 #if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 9
-                #error libstdc++ after version 9 does not require -lstdc++fs
+                #error \"libstdc++ after version 9 does not require -lstdc++fs\"
                 #endif
                 int main() {}"
                 _VCPKG_REQUIRE_LINK_CXXFS)
@@ -109,7 +109,7 @@ function(vcpkg_detect_std_filesystem)
             check_cxx_source_compiles(
                 "#include <ciso646>
                 #if !defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE < 8
-                #error libstdc++ before version 8 doesn't support <filesystem>
+                #error \"libstdc++ before version 8 does not support <filesystem>\"
                 #endif
                 int main() {}"
                 _VCPKG_USE_STD_FILESYSTEM)
@@ -121,7 +121,7 @@ function(vcpkg_detect_std_filesystem)
                 check_cxx_source_compiles(
                     "#include <ciso646>
                     #if _LIBCPP_VERSION >= 9000
-                    #error libc++ after version 9 does not require -lc++fs
+                    #error \"libc++ after version 9 does not require -lc++fs\"
                     #endif
                     int main() {}"
                     _VCPKG_REQUIRE_LINK_CXXFS)
@@ -133,7 +133,7 @@ function(vcpkg_detect_std_filesystem)
             check_cxx_source_compiles(
                 "#include <ciso646>
                 #if !defined(_MSVC_STL_UPDATE) || _MSVC_STL_UPDATE < 201803
-                #error MSVC STL before 15.7 doesn't support <filesystem>
+                #error \"MSVC STL before 15.7 does not support <filesystem>\"
                 #endif
                 int main() {}"
                 _VCPKG_USE_STD_FILESYSTEM)


### PR DESCRIPTION
The changes made in #10834 result in linking errors on openSUSE, and some weirdness in the bootstrap (see issue #10847). This fixes those issues.