### PR TITLE
[h5py-lzf] Add new port

### DIFF
--- a/ports/h5py-lzf/0001-disable-H5PLget_plugin-api.patch
+++ b/ports/h5py-lzf/0001-disable-H5PLget_plugin-api.patch
@@ -1,5 +1,5 @@
 diff --git a/lzf/lzf_filter.c b/lzf/lzf_filter.c
-index 951b1e4c..07c888a1 100644
+index 951b1e4c..b2fbffc1 100644
 --- a/lzf/lzf_filter.c
 +++ b/lzf/lzf_filter.c
 @@ -93,9 +93,9 @@ static const H5Z_class_t filter_class = {
@@ -7,10 +7,10 @@ index 951b1e4c..07c888a1 100644
  #include "H5PLextern.h"
  
 -H5PL_type_t H5PLget_plugin_type(void){ return H5PL_TYPE_FILTER; }
-+static H5PL_type_t H5PLget_plugin_type(void){ return H5PL_TYPE_FILTER; }
++//H5PL_type_t H5PLget_plugin_type(void){ return H5PL_TYPE_FILTER; }
  
 -const void *H5PLget_plugin_info(void){ return &filter_class; }
-+static const void *H5PLget_plugin_info(void){ return &filter_class; }
++//const void *H5PLget_plugin_info(void){ return &filter_class; }
  
  #endif
  #endif

--- a/ports/h5py-lzf/0001-hide-H5PLget_plugin_-api.patch
+++ b/ports/h5py-lzf/0001-hide-H5PLget_plugin_-api.patch
@@ -1,0 +1,16 @@
+diff --git a/lzf/lzf_filter.c b/lzf/lzf_filter.c
+index 951b1e4c..07c888a1 100644
+--- a/lzf/lzf_filter.c
++++ b/lzf/lzf_filter.c
+@@ -93,9 +93,9 @@ static const H5Z_class_t filter_class = {
+ 
+ #include "H5PLextern.h"
+ 
+-H5PL_type_t H5PLget_plugin_type(void){ return H5PL_TYPE_FILTER; }
++static H5PL_type_t H5PLget_plugin_type(void){ return H5PL_TYPE_FILTER; }
+ 
+-const void *H5PLget_plugin_info(void){ return &filter_class; }
++static const void *H5PLget_plugin_info(void){ return &filter_class; }
+ 
+ #endif
+ #endif

--- a/ports/h5py-lzf/CMakeLists.txt
+++ b/ports/h5py-lzf/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.13)
+project(h5py-lzf)
+
+find_package(hdf5 CONFIG REQUIRED)
+
+add_library(h5py-lzf STATIC 
+	lzf_filter.c 
+	lzf/lzf_c.c 
+	lzf/lzf_d.c
+)
+
+target_include_directories(h5py-lzf 
+	PUBLIC $<INSTALL_INTERFACE:include>
+)
+
+if(link_hdf5_SHARED)
+	target_link_libraries(h5py-lzf PUBLIC hdf5::hdf5_cpp-shared)
+else()
+	target_link_libraries(h5py-lzf PUBLIC hdf5::hdf5_cpp-static)
+endif()
+
+install(TARGETS h5py-lzf EXPORT h5py-lzf-config 
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
+
+install(EXPORT h5py-lzf-config DESTINATION share/cmake/h5py-lzf)
+install(FILES lzf_filter.h lzf/lzf.h DESTINATION include)

--- a/ports/h5py-lzf/CMakeLists.txt
+++ b/ports/h5py-lzf/CMakeLists.txt
@@ -3,26 +3,9 @@ project(h5py-lzf)
 
 find_package(hdf5 CONFIG REQUIRED)
 
-add_library(h5py-lzf STATIC 
-	lzf_filter.c 
-	lzf/lzf_c.c 
-	lzf/lzf_d.c
-)
-
-target_include_directories(h5py-lzf 
-	PUBLIC $<INSTALL_INTERFACE:include>
-)
-
-if(link_hdf5_SHARED)
-	target_link_libraries(h5py-lzf PUBLIC hdf5::hdf5_cpp-shared)
-else()
-	target_link_libraries(h5py-lzf PUBLIC hdf5::hdf5_cpp-static)
-endif()
-
-install(TARGETS h5py-lzf EXPORT h5py-lzf-config 
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
-
+add_library(h5py-lzf STATIC lzf_filter.c lzf/lzf_c.c lzf/lzf_d.c)
+target_include_directories(h5py-lzf PUBLIC $<INSTALL_INTERFACE:include>)
+target_link_libraries(h5py-lzf PRIVATE libzstd $<IF:${link_hdf5_SHARED},hdf5::hdf5-shared,hdf5::hdf5-static>)
+install(TARGETS h5py-lzf EXPORT h5py-lzf-config ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 install(EXPORT h5py-lzf-config DESTINATION share/cmake/h5py-lzf)
 install(FILES lzf_filter.h lzf/lzf.h DESTINATION include)

--- a/ports/h5py-lzf/CONTROL
+++ b/ports/h5py-lzf/CONTROL
@@ -1,0 +1,5 @@
+Source: h5py-lzf
+Version: 2019-12-04
+Build-Depends: hdf5
+Homepage: https://github.com/h5py/h5py/tree/master/lzf
+Description: The LZF filter is an alternative DEFLATE-style compressor for HDF5 datasets, using the free LZF library by Marc Alexander Lehmann.

--- a/ports/h5py-lzf/portfile.cmake
+++ b/ports/h5py-lzf/portfile.cmake
@@ -1,0 +1,35 @@
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(link_hdf5_SHARED 0)
+else()
+    set(link_hdf5_SHARED 1)
+endif()
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO h5py/h5py
+    REF 81ba118ee66b97a94678e8f5675c4114649dfda4
+    SHA512 c789abdc563f8d2535f0a2ef5e233eb862281559a9cdc3ec560dd69b4d403b6f923f5390390da54851e1bfef1be8de7f80999c25a7f3ac4962ee0620179c6420
+    HEAD_REF master
+    PATCHES
+		0001-hide-H5PLget_plugin_-api.patch
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/lzf)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/lzf
+    PREFER_NINJA
+    OPTIONS
+        -Dlink_hdf5_SHARED=${link_hdf5_SHARED}
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/h5py-lzf)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+configure_file(${SOURCE_PATH}/lzf/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/h5py-lzf/copyright COPYONLY)

--- a/ports/h5py-lzf/portfile.cmake
+++ b/ports/h5py-lzf/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_github(
     SHA512 c789abdc563f8d2535f0a2ef5e233eb862281559a9cdc3ec560dd69b4d403b6f923f5390390da54851e1bfef1be8de7f80999c25a7f3ac4962ee0620179c6420
     HEAD_REF master
     PATCHES
-		0001-hide-H5PLget_plugin_-api.patch
+		0001-disable-H5PLget_plugin-api.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/lzf)
@@ -27,9 +27,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/h5py-lzf)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/${PORT})
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-configure_file(${SOURCE_PATH}/lzf/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/h5py-lzf/copyright COPYONLY)
+configure_file(${SOURCE_PATH}/lzf/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
Home: http://www.h5py.org/lzf/
Repo: https://github.com/h5py/h5py/tree/master/lzf

From https://support.hdfgroup.org/services/filters.html:
> LZF can be used to compress any data type, and requires no compile-time or run-time configuration. HDF5 versions 1.6.5 through 1.8.3 are supported. The filter is written in C and **_can be included directly in C or C++ applications_**; it has no external dependencies. The license is 3-clause BSD (virtually unrestricted, including commercial applications).
