### PR TITLE
[Arrow] Update to 0.17

### DIFF
--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -1,5 +1,5 @@
 Source: arrow
-Version: 0.16.0
+Version: 0.17.0
 Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algorithm, flatbuffers, rapidjson, zlib, lz4, brotli, bzip2, zstd, snappy, gflags, thrift, double-conversion, glog, uriparser, openssl
 Homepage: https://github.com/apache/arrow
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.

--- a/ports/arrow/all.patch
+++ b/ports/arrow/all.patch
@@ -144,34 +144,3 @@ index 75b33c2..80cac9a 100644
      else()
        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")
      endif()
-diff --git a/cpp/src/arrow/stl.h b/cpp/src/arrow/stl.h
-index 7ae9eaf..b9efdcb 100644
---- a/cpp/src/arrow/stl.h
-+++ b/cpp/src/arrow/stl.h
-@@ -518,6 +518,9 @@ class allocator {
- 
-  private:
-   MemoryPool* pool_;
-+
-+  template <class U>
-+  friend class allocator;
- };
- 
- /// \brief A MemoryPool implementation delegating allocations to a STL allocator
-diff --git a/cpp/src/parquet/schema.h b/cpp/src/parquet/schema.h
-index 87db4de..095ef9a 100644
---- a/cpp/src/parquet/schema.h
-+++ b/cpp/src/parquet/schema.h
-@@ -460,7 +460,11 @@ class PARQUET_EXPORT SchemaDescriptor {
-   // -- -- b     |
-   // -- -- -- c  |
-   // -- -- -- -- d
--  std::unordered_map<int, const schema::NodePtr> leaf_to_base_;
-+#if _MSC_VER >= 1900
-+  std::unordered_map<int, schema::NodePtr> leaf_to_base_;
-+#else
-+   std::unordered_map<int, const schema::NodePtr> leaf_to_base_;
-+#endif
- 
-   // Mapping between ColumnPath DotString to the leaf index
-   std::unordered_multimap<std::string, int> leaf_to_idx_;

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow
-    REF apache-arrow-0.16.0
-    SHA512 c8d693e927218c65526b48f18c4f00f9530d1a8731575b051b017a5350e68114c16dcd41ff578b4c0cc29cc79096621809658b8eac250934ecf0fcaabadf2cf6
+    REF apache-arrow-0.17.0
+    SHA512 293737db80defa0f8766f726dc228ace50936f7124647de15c2e024c2901ded1cda893d771d38aa4e9ab19ff7eb06b11dfc230587ca5b17cdd87e681fc3009ca
     HEAD_REF master
     PATCHES
         all.patch


### PR DESCRIPTION
- Updates Arrow from 0.16 to the newly released 0.17.
- Removes the MSVC 2019 patches, as Arrow now compiles without them (VS2019 is now part of their CI pipeline).
