### PR TITLE
[opencv4] Add GTK support for opencv4 portfile

### DIFF
--- a/ports/opencv4/CONTROL
+++ b/ports/opencv4/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv4
-Version: 4.1.1-3
+Version: 4.1.1-4
 Build-Depends: protobuf, zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library
@@ -95,3 +95,7 @@ Description: Halide support for opencv
 
 Feature: world
 Description: Compile to a single package support for opencv
+
+Feature: gtk
+Build-Depends: gtk
+Description: gtk support for opencv

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -46,6 +46,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "tiff"     WITH_TIFF
  "webp"     WITH_WEBP
  "world"    BUILD_opencv_world
+ "gtk"      WITH_GTK
 )
 
 # Cannot use vcpkg_check_features() for "ipp", "ovis", "tbb", and "vtk".


### PR DESCRIPTION
**Describe the pull request**
Add GTK support for opencv4 portfile

- What does your PR fix? Fixes issue #
with out this diff, the opencv4 built by vcpkg causes below error when calling GUI based functions like cv::imshow():
Rebuild the library with Windows, GTK+ 2.x or Carbon support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function cvimshow

- Which triplets are supported/not supported? Have you updated the CI baseline?
triplets tested: x64-linux (should also affect x86-linux)
no update to the CI baseline

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
It seems to comply with the guide
