### PR TITLE
[apr,apr-util] Upgrade from 1.6.* to 1.7.0

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,5 +1,5 @@
 Source: apr-util
-Version: 1.6.1-1
+Version: 1.6.0-5
 Homepage: https://apr.apache.org/
 Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
 Build-Depends: expat, apr, openssl

--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -1,83 +1,46 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://archive.apache.org/dist/apr/apr-util-1.6.1.tar.bz2"
-    FILENAME "apr-util-1.6.1.tar.bz2"
-    SHA512 40eff8a37c0634f7fdddd6ca5e596b38de15fd10767a34c30bbe49c632816e8f3e1e230678034f578dd5816a94f246fb5dfdf48d644829af13bf28de3225205d
+include(vcpkg_common_functions)
 
+vcpkg_download_distfile(ARCHIVE
+  URLS "https://archive.apache.org/dist/apr/apr-util-1.6.0-win32-src.zip"
+  FILENAME "apr-util-1.6.0-win32-src.zip"
+  SHA512 98679ea181d3132020713481703bbefa0c174e0b2a0df65dfdd176e9771935e1f9455c4242bac19dded9414abe2b9d293fcc674ab16f96d8987bcf26346fce3a
 )
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_extract_source_archive_ex(
-        OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE ${ARCHIVE}
-        PATCHES
-            use-vcpkg-expat.patch
-            apr.patch
-    )
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    PATCHES
+        use-vcpkg-expat.patch
+        apr.patch
+)
 
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-      set(APU_DECLARE_EXPORT ON)
-      set(APU_DECLARE_STATIC OFF)
-    else()
-      set(APU_DECLARE_EXPORT OFF)
-      set(APU_DECLARE_STATIC ON)
-    endif()
-
-    vcpkg_configure_cmake(
-      SOURCE_PATH ${SOURCE_PATH}
-      PREFER_NINJA
-      OPTIONS
-        -DAPU_DECLARE_EXPORT=${APU_DECLARE_EXPORT}
-        -DAPU_DECLARE_STATIC=${APU_DECLARE_STATIC}
-      OPTIONS_DEBUG
-        -DDISABLE_INSTALL_HEADERS=ON
-    )
-
-    vcpkg_install_cmake()
-    vcpkg_copy_pdbs()
-
-    file(READ ${CURRENT_PACKAGES_DIR}/include/apu.h  APU_H)
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-      string(REPLACE "defined(APU_DECLARE_EXPORT)" "1" APU_H "${APU_H}")
-    else()
-      string(REPLACE "defined(APU_DECLARE_STATIC)" "1" APU_H "${APU_H}")
-    endif()
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/apu.h "${APU_H}")
-
-else(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_extract_source_archive_ex(
-        OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE ${ARCHIVE} 
-    )
-
-    # To cross-compile you will need a triplet file that locates the tool chain and sets --host and --cache parameters of "./configure".
-    # The ${VCPKG_PLATFORM_TOOLSET}.cache file must have been generated on the targeted host using "./configure -C".
-    # For example, to target aarch64-linux-gnu, triplets/aarch64-linux-gnu.cmake should contain (beyond the standard content):
-    # set(VCPKG_PLATFORM_TOOLSET aarch64-linux-gnu)
-    # set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${MY_CROSS_DIR}/cmake/Toolchain-${VCPKG_PLATFORM_TOOLSET}.cmake)
-    # set(CONFIGURE_PARAMETER_1 --host=${VCPKG_PLATFORM_TOOLSET})
-    # set(CONFIGURE_PARAMETER_2 --cache-file=${MY_CROSS_DIR}/autoconf/${VCPKG_PLATFORM_TOOLSET}.cache)
-    if(CONFIGURE_PARAMETER_1)
-        message(STATUS "Configuring apr-util with ${CONFIGURE_PARAMETER_1} ${CONFIGURE_PARAMETER_2} ${CONFIGURE_PARAMETER_3}")
-    else()
-        message(STATUS "Configuring apr-util")
-    endif()
-
-    vcpkg_configure_make(
-        SOURCE_PATH "${SOURCE_PATH}"
-        NO_DEBUG
-        OPTIONS 
-            "--prefix=${CURRENT_INSTALLED_DIR}"
-            "--with-apr=${CURRENT_INSTALLED_DIR}/tools/apr"
-            "--with-openssl=${CURRENT_INSTALLED_DIR}"
-            "-with-expat=${CURRENT_INSTALLED_DIR}"
-            "${CONFIGURE_PARAMETER_1}"
-            "${CONFIGURE_PARAMETER_2}"
-            "${CONFIGURE_PARAMETER_3}"
-    )
-
-    vcpkg_install_make()
-
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  set(APU_DECLARE_EXPORT ON)
+  set(APU_DECLARE_STATIC OFF)
+else()
+  set(APU_DECLARE_EXPORT OFF)
+  set(APU_DECLARE_STATIC ON)
 endif()
 
-# Handle copyright
+vcpkg_configure_cmake(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+    -DAPU_DECLARE_EXPORT=${APU_DECLARE_EXPORT}
+    -DAPU_DECLARE_STATIC=${APU_DECLARE_STATIC}
+  OPTIONS_DEBUG
+    -DDISABLE_INSTALL_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(READ ${CURRENT_PACKAGES_DIR}/include/apu.h  APU_H)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+  string(REPLACE "defined(APU_DECLARE_EXPORT)" "1" APU_H "${APU_H}")
+else()
+  string(REPLACE "defined(APU_DECLARE_STATIC)" "1" APU_H "${APU_H}")
+endif()
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/apu.h "${APU_H}")
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/apr-util/use-vcpkg-expat.patch
+++ b/ports/apr-util/use-vcpkg-expat.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9ae90b19..b0e86e2c 100644
+index 43fdf49..56424c3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -29,8 +29,9 @@ OPTION(APR_HAS_LDAP         "LDAP support"                              ON)
+@@ -27,8 +27,9 @@ OPTION(APR_HAS_LDAP         "LDAP support"                              ON)
  OPTION(INSTALL_PDB          "Install .pdb files (if generated)"         ON)
  OPTION(APR_BUILD_TESTAPR    "Build the test suite"                      OFF)
  OPTION(TEST_STATIC_LIBS     "Test programs use APR static libraries instead of shared libraries?" OFF)
@@ -14,19 +14,42 @@ index 9ae90b19..b0e86e2c 100644
  
  IF(NOT EXISTS "${APR_INCLUDE_DIR}/apr.h")
    MESSAGE(FATAL_ERROR "APR include directory ${APR_INCLUDE_DIR} is not correct.")
-@@ -65,8 +66,8 @@ IF(NOT EXPAT_FOUND)
-   MESSAGE(FATAL_ERROR "Expat is required, and it wasn't found!")
- ENDIF()
+@@ -75,8 +76,8 @@ CONFIGURE_FILE(include/apu_want.hw
+                COPYONLY)
  
--SET(XMLLIB_INCLUDE_DIR   ${EXPAT_INCLUDE_DIRS})
--SET(XMLLIB_LIBRARIES     ${EXPAT_LIBRARIES})
+ # TBD:
+-# SET(XMLLIB_INCLUDE_DIR   ${CMAKE_CURRENT_SOURCE_DIR}/xml/expat/lib)
+-SET(XMLLIB_LIBRARIES     libexpat)
 +find_path(XMLLIB_INCLUDE_DIR expat.h)
 +find_library(XMLLIB_LIBRARIES NAMES expat)
  
  SET(LDAP_LIBRARIES)
  IF(APR_HAS_LDAP)
-@@ -229,17 +230,21 @@ SET(dbd_drivers)
+@@ -217,11 +218,11 @@ SET(APR_TEST_SOURCES
+   test/testxml.c
+ )
+ 
+-SET(EXPAT_SOURCES
+-  xml/expat/lib/xmlrole.c
+-  xml/expat/lib/xmltok.c
+-  xml/expat/lib/xmlparse.c
+-)
++# SET(EXPAT_SOURCES
++#   xml/expat/lib/xmlrole.c
++#   xml/expat/lib/xmltok.c
++#   xml/expat/lib/xmlparse.c
++# )
+ 
+ SET(install_targets)
+ SET(install_bin_pdb)
+@@ -230,21 +231,25 @@ SET(dbd_drivers)
  # Note: The WINNT definition on some targets is used only by libaprutil.rc.
+ 
+ # static expat (not installed)
+-ADD_LIBRARY(libexpat STATIC ${EXPAT_SOURCES})
+-SET_TARGET_PROPERTIES(libexpat PROPERTIES COMPILE_DEFINITIONS "XML_STATIC;COMPILED_FROM_DSP")
++# ADD_LIBRARY(libexpat STATIC ${EXPAT_SOURCES})
++# SET_TARGET_PROPERTIES(libexpat PROPERTIES COMPILE_DEFINITIONS "XML_STATIC;COMPILED_FROM_DSP")
  
  # libaprutil-1 is shared, aprutil-1 is static
 +if(BUILD_SHARED_LIBS)
@@ -34,56 +57,45 @@ index 9ae90b19..b0e86e2c 100644
  SET(install_targets ${install_targets} libaprutil-1)
  SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/libaprutil-1.pdb)
  TARGET_LINK_LIBRARIES(libaprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
--SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_EXPORT;XML_STATIC;WINNT")
-+SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_IMPORT;XML_STATIC;WINNT")
+ SET_TARGET_PROPERTIES(libaprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_EXPORT;APR_DECLARE_EXPORT;XML_STATIC;WINNT")
  
-+else(BUILD_SHARED_LIBS)
++else()
  ADD_LIBRARY(aprutil-1 STATIC ${APR_SOURCES} ${APR_PUBLIC_HEADERS_GENERATED})
  SET(install_targets ${install_targets} aprutil-1)
  TARGET_LINK_LIBRARIES(aprutil-1 ${APR_LIBRARIES} ${XMLLIB_LIBRARIES})
  SET_TARGET_PROPERTIES(aprutil-1 PROPERTIES COMPILE_DEFINITIONS "APU_DECLARE_STATIC;APR_DECLARE_STATIC;APU_DSO_MODULE_BUILD;XML_STATIC")
--
-+endif(BUILD_SHARED_LIBS)
-+ 
++endif()
+ 
 +if(BUILD_SHARED_LIBS)
  IF(APU_HAVE_CRYPTO)
    IF(NOT OPENSSL_FOUND)
      MESSAGE(FATAL_ERROR "Only OpenSSL-based crypto is currently implemented in the cmake build")
-@@ -249,7 +254,7 @@ IF(APU_HAVE_CRYPTO)
-   SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_crypto_openssl-1.pdb)
-   SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES INCLUDE_DIRECTORIES "${APR_INCLUDE_DIRECTORIES};${OPENSSL_INCLUDE_DIR}")
-   SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
--  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_crypto_openssl")
-+  SET_TARGET_PROPERTIES(apr_crypto_openssl-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_crypto_openssl")
-   TARGET_LINK_LIBRARIES(apr_crypto_openssl-1 libaprutil-1 ${APR_LIBRARIES} ${OPENSSL_LIBRARIES})
- ENDIF()
- 
-@@ -260,8 +265,8 @@ IF(APU_HAVE_ODBC)
-   SET(dbd_drivers ${dbd_drivers} odbc)
-   TARGET_LINK_LIBRARIES(apr_dbd_odbc-1 libaprutil-1 ${APR_LIBRARIES} odbc32 odbccp32)
-   SET_PROPERTY(TARGET apr_dbd_odbc-1 APPEND PROPERTY LINK_FLAGS /export:apr_dbd_odbc_driver)
--  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_EXPORT;APR_DECLARE_EXPORT;APU_DSO_MODULE_BUILD;WINNT")
--  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_dbd_odbc")
-+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_DEFINITIONS "APU_HAVE_ODBC;HAVE_SQL_H;APU_DECLARE_IMPORT;APR_DECLARE_IMPORT;APU_DSO_MODULE_BUILD;WINNT")
-+  SET_TARGET_PROPERTIES(apr_dbd_odbc-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_dbd_odbc")
+@@ -270,7 +275,7 @@ IF(APU_HAVE_ODBC)
  ENDIF()
  
  IF(APR_HAS_LDAP)
-@@ -271,11 +276,12 @@ IF(APR_HAS_LDAP)
+-  ADD_LIBRARY(apr_ldap-1 SHARED ldap/apr_ldap_init.c ldap/apr_ldap_option.c 
++  ADD_LIBRARY(apr_ldap-1 SHARED ldap/apr_ldap_init.c ldap/apr_ldap_option.c
+               ldap/apr_ldap_rebind.c libaprutil.rc)
+   SET(install_targets ${install_targets} apr_ldap-1)
    SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/apr_ldap-1.pdb)
-   TARGET_LINK_LIBRARIES(apr_ldap-1 libaprutil-1 ${APR_LIBRARIES} ${LDAP_LIBRARIES})
-   SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_DEFINITIONS "WINNT")
--  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_EXPORT=1 -DAPU_DECLARE_EXPORT=1 -DDLL_NAME=apr_ldap")
-+  SET_TARGET_PROPERTIES(apr_ldap-1 PROPERTIES COMPILE_FLAGS "-DAPR_DECLARE_IMPORT -DAPU_DECLARE_IMPORT -DDLL_NAME=apr_ldap")
-   SET(apr_ldap_libraries apr_ldap-1)
+@@ -281,6 +286,7 @@ IF(APR_HAS_LDAP)
  ELSE()
    SET(apr_ldap_libraries)
  ENDIF()
-+endif(BUILD_SHARED_LIBS)
++endif()
  
  IF(APR_BUILD_TESTAPR)
    ENABLE_TESTING()
-@@ -289,7 +295,7 @@ IF(APR_BUILD_TESTAPR)
+@@ -288,13 +294,13 @@ IF(APR_BUILD_TESTAPR)
+   ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
+ 
+   # copy data files to build directory so that we can run programs from there
+-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory 
++  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E make_directory
+                   ${PROJECT_BINARY_DIR}/data)
+-  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
++  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy_if_different
                    ${PROJECT_SOURCE_DIR}/test/data/billion-laughs.xml
                    ${PROJECT_BINARY_DIR}/data/billion-laughs.xml)
  
@@ -92,7 +104,7 @@ index 9ae90b19..b0e86e2c 100644
      SET(whichapr    aprutil-1)
      SET(apiflag     "-DAPR_DECLARE_STATIC -DAPU_DECLARE_STATIC")
    ELSE()
-@@ -325,13 +331,15 @@ INSTALL(TARGETS ${install_targets}
+@@ -330,13 +336,15 @@ INSTALL(TARGETS ${install_targets}
          ARCHIVE DESTINATION lib
         )
  
@@ -101,11 +113,11 @@ index 9ae90b19..b0e86e2c 100644
 -          DESTINATION bin
 -          CONFIGURATIONS RelWithDebInfo Debug)
 -ENDIF()
-+#IF(INSTALL_PDB)
-+#  INSTALL(FILES ${install_bin_pdb}
-+#          DESTINATION bin
-+#          CONFIGURATIONS RelWithDebInfo Debug)
-+#ENDIF()
++# IF(INSTALL_PDB)
++#   INSTALL(FILES ${install_bin_pdb}
++#           DESTINATION bin
++#           CONFIGURATIONS RelWithDebInfo Debug)
++# ENDIF()
  
 -INSTALL(FILES ${APR_PUBLIC_HEADERS_STATIC} ${APR_PUBLIC_HEADERS_GENERATED} DESTINATION include)
 +if(NOT DISABLE_INSTALL_HEADERS)

--- a/ports/apr/CONTROL
+++ b/ports/apr/CONTROL
@@ -1,5 +1,5 @@
 Source: apr
-Version: 1.7.0-1
+Version: 1.6.5-3
 Homepage: https://apr.apache.org/
 Description: The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.
 Supports: !uwp

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -2,12 +2,14 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()
 
-set(VERSION 1.7.0)
+include(vcpkg_common_functions)
+
+set(VERSION 1.6.5)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.apache.org/dist/apr/apr-${VERSION}.tar.bz2"
     FILENAME "apr-${VERSION}.tar.bz2"
-    SHA512 3dc42d5caf17aab16f5c154080f020d5aed761e22db4c5f6506917f6bfd2bf8becfb40af919042bd4ce1077d5de74aa666f5edfba7f275efba78e8893c115148
+    SHA512 d3511e320457b5531f565813e626e7941f6b82864852db6aa03dd298a65dbccdcdc4bd580f5314f8be45d268388edab25efe88cf8340b7d2897a4dbe9d0a41fc
 )
 
 vcpkg_extract_source_archive_ex(
@@ -15,76 +17,46 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-        private-headers   INSTALL_PRIVATE_H
-    )
-
-    vcpkg_configure_cmake(
-        SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
-        OPTIONS
-            -DINSTALL_PDB=OFF
-            -DMIN_WINDOWS_VER=Windows7
-            -DAPR_HAVE_IPV6=ON
-            -DAPR_INSTALL_PRIVATE_H=${INSTALL_PRIVATE_H}
-            ${FEATURE_OPTIONS}
-    )
-
-    vcpkg_install_cmake()
-
-    # There is no way to suppress installation of the headers in debug builds.
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-    # Both dynamic and static are built, so keep only the one needed
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/apr-1.lib
-                    ${CURRENT_PACKAGES_DIR}/lib/aprapp-1.lib
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/apr-1.lib
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/aprapp-1.lib)
-    else()
-        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libapr-1.lib
-                    ${CURRENT_PACKAGES_DIR}/lib/libaprapp-1.lib
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/libapr-1.lib
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/libaprapp-1.lib)
-        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    endif()
-
-    vcpkg_copy_pdbs()
+if("private-headers" IN_LIST FEATURES)
+    set(INSTALL_PRIVATE_H ON)
 else()
-    # To cross-compile you will need a triplet file that locates the tool chain and sets --host and --cache parameters of "./configure".
-    # The ${VCPKG_PLATFORM_TOOLSET}.cache file must have been generated on the targeted host using "./configure -C".
-    # For example, to target aarch64-linux-gnu, triplets/aarch64-linux-gnu.cmake should contain (beyond the standard content):
-    # set(VCPKG_PLATFORM_TOOLSET aarch64-linux-gnu)
-    # set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${MY_CROSS_DIR}/cmake/Toolchain-${VCPKG_PLATFORM_TOOLSET}.cmake)
-    # set(CONFIGURE_PARAMETER_1 --host=${VCPKG_PLATFORM_TOOLSET})
-    # set(CONFIGURE_PARAMETER_2 --cache-file=${MY_CROSS_DIR}/autoconf/${VCPKG_PLATFORM_TOOLSET}.cache)
-    if(CONFIGURE_PARAMETER_1)
-        message(STATUS "Configuring apr with ${CONFIGURE_PARAMETER_1} ${CONFIGURE_PARAMETER_2} ${CONFIGURE_PARAMETER_3}")
-    else()
-        message(STATUS "Configuring apr")
-    endif()
-    vcpkg_configure_make(
-        SOURCE_PATH "${SOURCE_PATH}"
-        NO_DEBUG
-        OPTIONS
-            "--prefix=${CURRENT_INSTALLED_DIR}"
-            "${CONFIGURE_PARAMETER_1}"
-            "${CONFIGURE_PARAMETER_2}"
-            "${CONFIGURE_PARAMETER_3}"
-    )
+    set(INSTALL_PRIVATE_H OFF)
+endif()
 
-    vcpkg_install_make()
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DINSTALL_PDB=OFF
+        -DMIN_WINDOWS_VER=Windows7
+        -DAPR_HAVE_IPV6=ON
+        -DAPR_INSTALL_PRIVATE_H=${INSTALL_PRIVATE_H}
+    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
+    # OPTIONS_RELEASE -DOPTIMIZE=1
+    # OPTIONS_DEBUG -DDEBUGGABLE=1
+)
 
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/apr-1.pc
-        "-lapr-\${APR_MAJOR_VERSION}" "-lapr-1"
-    )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/lib/pkgconfig/apr-1.pc
-        "-lapr-\${APR_MAJOR_VERSION}" "-lapr-1"
-    )
-    vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES pthread rt dl)
+vcpkg_install_cmake()
+
+# There is no way to suppress installation of the headers in debug builds.
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Both dynamic and static are built, so keep only the one needed
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/apr-1.lib
+                ${CURRENT_PACKAGES_DIR}/lib/aprapp-1.lib
+                ${CURRENT_PACKAGES_DIR}/debug/lib/apr-1.lib
+                ${CURRENT_PACKAGES_DIR}/debug/lib/aprapp-1.lib)
+else()
+    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libapr-1.lib
+                ${CURRENT_PACKAGES_DIR}/lib/libaprapp-1.lib
+                ${CURRENT_PACKAGES_DIR}/debug/lib/libapr-1.lib
+                ${CURRENT_PACKAGES_DIR}/debug/lib/libaprapp-1.lib)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/apr)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/apr/LICENSE ${CURRENT_PACKAGES_DIR}/share/apr/copyright)
 
+vcpkg_copy_pdbs()


### PR DESCRIPTION
**Describe the pull request**
Released April 5 2019.

- What does your PR fix? Fixes issue #
Upgrades. Also was getting an error, let's see if this fixes:
```
vcpkg$ ./vcpkg install apr
Computing installation plan...
The following packages will be built and installed:
    apr[core]:x64-linux
Starting package 1/1: apr:x64-linux
Building package apr[core]:x64-linux...
-- Downloading https://www.apache.org/dist/apr/apr-1.6.5.tar.bz2...
-- Extracting source vcpkg/downloads/apr-1.6.5.tar.bz2
-- Using source at vcpkg/buildtrees/apr/src/apr-1-fbc95c0cfd
-- Configuring x64-linux-dbg
-- Configuring x64-linux-rel
-- Building x64-linux-dbg
CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:136 (message):
    Command failed: cpkg/downloads/tools/cmake-3.14.0-linux/cmake-3.14.0-Linux-x86_64/bin/cmake --build . --config Debug --target install -- -v
    Working Directory: vcpkg/buildtrees/apr/x64-linux-dbg
    See logs for more information:
      vcpkg/buildtrees/apr/install-x64-linux-dbg-out.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_build_cmake.cmake:91 (vcpkg_execute_build_process)
  scripts/cmake/vcpkg_install_cmake.cmake:24 (vcpkg_build_cmake)
  ports/apr/portfile.cmake:39 (vcpkg_install_cmake)
  scripts/ports.cmake:90 (include)


Error: Building package apr:x64-linux failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: apr:x64-linux
  Vcpkg version: 2020.02.04-unknownhash-external

Additionally, attach any relevant sections from the log files above.
```

- Which triplets are supported/not supported? Have you updated the CI baseline?
Let's see if they pass!

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
