### PR TITLE
[gtest] Rollback to a release version.

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,4 +1,4 @@
 Source: gtest
-Version: 2019-10-09-1
+Version: 1.10.0
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF cd17fa2abda2a2e4111cdabd62a87aea16835014 #version 1.10.0 commit on 2019.10.09
-    SHA512 0899ebc21821e1978e8831ac89698fc88bf98ec7e22b9dd4f9eea0459396f6834ef35f6ee2afd1b8ca9432722e561c30905f8d87614d012bb711d295ebc1d833
+    REF release-1.10.0
+    SHA512 bd52abe938c3722adc2347afad52ea3a17ecc76730d8d16b065e165bc7477d762bce0997a427131866a89f1001e3f3315198204ffa5d643a9355f1f4d0d7b1a9
     HEAD_REF master
     PATCHES
         0002-Fix-z7-override.patch


### PR DESCRIPTION
[gtest] Rollback to a release version 1.10.0. Related issue #9768.
