### PR TITLE
[vcpkg] Add -w dupbuild=warn for ninja

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1420,13 +1420,9 @@ polyhook2:x64-linux=fail
 polyhook2:x64-uwp=fail
 polyhook2:x64-osx=fail
 portable-snippets:arm-uwp=fail
-# Portaudio was broken by Ninja 1.9.0 https://github.com/ninja-build/ninja/pull/1406
 portaudio:arm-uwp=fail
 portaudio:arm64-windows=fail
 portaudio:x64-uwp=fail
-portaudio:x64-windows-static=fail
-portaudio:x64-windows=fail
-portaudio:x86-windows=fail
 portmidi:arm64-windows=fail
 portmidi:arm-uwp=fail
 portmidi:x64-linux=fail
@@ -1726,10 +1722,6 @@ stormlib:arm-uwp=fail
 stormlib:x64-uwp=fail
 stxxl:arm-uwp=fail
 stxxl:x64-uwp=fail
-# Sundials was broken by Ninja 1.9.0 https://github.com/ninja-build/ninja/pull/1406
-sundials:arm64-windows=fail
-sundials:x64-windows=fail
-sundials:x86-windows=fail
 # Conflicts between ports:
 #The following files are already installed in C:/agent/_work/1/s/installed/x64-windows-static
 # and are in conflict with superlu:x64-windows-static

--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -40,7 +40,7 @@ function(vcpkg_build_cmake)
     set(NO_PARALLEL_ARG)
 
     if(_VCPKG_CMAKE_GENERATOR MATCHES "Ninja")
-        set(BUILD_ARGS "-v") # verbose output
+        set(BUILD_ARGS "-v" "-wdupbuild=warn") # verbose output
         set(NO_PARALLEL_ARG "-j1")
     elseif(_VCPKG_CMAKE_GENERATOR MATCHES "Visual Studio")
         set(BUILD_ARGS


### PR DESCRIPTION
Update ninja to 1.10.0, if we build the ports with ninja 1.10.0, it will fail due to this error:

`ninja: error: build.ninja:225: multiple rules generate tmx.lib [-w dupbuild=err]`

There was a change made to ninja between v1.8.2 and v.1.9.0:

when multiple rules are found for building the same binary, lib or file:
prior to ninja v1.9.0 it was a warning, the build continues, but since ninja v1.9.0 it is an error, the build stops.
This should be a ninja bug.

Related references:
https://devzone.nordicsemi.com/f/nordic-q-a/46041/build-error-after-upgrading-to-ninja-release-1-9-0
https://gitlab.kitware.com/cmake/cmake/issues/18900
https://bugs.launchpad.net/kicad/+bug/1829082

Related issue #10887
Fixes #11959


