### PR TITLE
[websocketpp] Update to 0.8.2

### DIFF
--- a/ports/websocketpp/CONTROL
+++ b/ports/websocketpp/CONTROL
@@ -1,5 +1,5 @@
 Source: websocketpp
-Version: 0.8.1-1
+Version: 0.8.2
 Build-Depends: zlib, openssl, boost-asio
 Homepage: https://github.com/zaphoyd/websocketpp
 Description: Library that implements RFC6455 The WebSocket Protocol

--- a/ports/websocketpp/portfile.cmake
+++ b/ports/websocketpp/portfile.cmake
@@ -1,25 +1,24 @@
 #header-only library
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zaphoyd/websocketpp
-    REF 1c699ce46843a787482a703fdeff9271fbb7bb5d
-    SHA512 9de30e02e09b066dca8d840963e78673ef118e5183f9638b8a5c941116422916fe9fe02bb5271843aeb292a460f159b5957887594c0824a88600e6c4a5620dbd
+    REF 56123c87598f8b1dd471be83ca841ceae07f95ba # 0.8.2
+    SHA512 f185a66e5a7c783254352a6ef87e2e559f681032b7368765d08393ed12bcae76825abed7dcaea73de09df644320409dad46279701f5f469520542a2c9b6a6163
     HEAD_REF master
 )
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/websocketpp)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
 
 # Copy the header files
 file(COPY "${SOURCE_PATH}/websocketpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.hpp")
 
 set(PACKAGE_INSTALL_INCLUDE_DIR "\${CMAKE_CURRENT_LIST_DIR}/../../include")
-set(WEBSOCKETPP_VERSION 0.8.1)
+set(WEBSOCKETPP_VERSION 0.8.2)
 set(PACKAGE_INIT "
 macro(set_and_check)
   set(\${ARGV})
 endmacro()
 ")
-configure_file(${SOURCE_PATH}/websocketpp-config.cmake.in "${CURRENT_PACKAGES_DIR}/share/websocketpp/websocketpp-config.cmake" @ONLY)
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/websocketpp/copyright COPYONLY)
+configure_file(${SOURCE_PATH}/websocketpp-config.cmake.in "${CURRENT_PACKAGES_DIR}/share/${PORT}/websocketpp-config.cmake" @ONLY)
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
The vcpkg port of websocketpp has been pointing to the upstream commit
zaphoyd/websocketpp@1c699ce46843a787482a703fdeff9271fbb7bb5d of a PR, in order to fix build issues of websocketpp 0.8.1 with
boost 1.70 (#6141). This fix has been merged upstream in the meantime
and is part of the release 0.8.2 now.

- Update to WebSocket++/0.8.2 release
- Remove deprecated `include(vcpkg_common_functions)`
- Use `${PORT}` instead of `websocketpp`

**Describe the pull request**

- What does your PR fix? Fixes issue #
Use new upstream release 0.8.2 of websocketpp
Changelog: https://github.com/zaphoyd/websocketpp/blob/master/changelog.md
Info from testing the updated package: All installed files of the vcpkg package of websocketpp stay identical, except version.hpp (0.8.1->0.8.2)
- Which triplets are supported/not supported? Have you updated the CI baseline?
All triplets are supported.
CI baseline: OK, no update required
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
