### PR TITLE
[vcpkg] Fix toolsrc CMake build error

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -717,9 +717,9 @@ namespace vcpkg::Files
 
         virtual fs::path absolute(const fs::path& path, std::error_code& ec) const override
         {
-#if USE_STD_FILESYSTEM
+#if VCPKG_USE_STD_FILESYSTEM 
             return fs::stdfs::absolute(path, ec);
-#else // ^^^ USE_STD_FILESYSTEM / !USE_STD_FILESYSTEM vvv
+#else // ^^^ VCPKG_USE_STD_FILESYSTEM  / !VCPKG_USE_STD_FILESYSTEM  vvv
 #if _WIN32
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);


### PR DESCRIPTION
Currently, using CMake to build `vcpkg/toolsrc ` project with MSVC cmake ninja, It will fail:
```
F:\test\vcpkg\toolsrc\build>cmake --build .
[0/2] Re-checking globbed directories...
[24/96] Building CXX object CMakeFiles\vcpkglib.dir\src\vcpkg\base\files.cpp.obj
FAILED: CMakeFiles/vcpkglib.dir/src/vcpkg/base/files.cpp.obj
"E:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610\bin\Hostx64\x86\cl.exe"  /nologo /TP -DVCPKG_DISABLE_METRICS=0 -DVCPKG_USE_STD_FILESYSTEM=1 -I..\include /DWIN32 /D_WINDOWS  /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1   -FC -permissive- -utf-8 -W4 -WX /Yupch.h /FIpch.h /Zm200 -std:c++17 /showIncludes /FoCMakeFiles\vcpkglib.dir\src\vcpkg\base\files.cpp.obj /FdCMakeFiles\vcpkglib.dir\ /FS -c ..\src\vcpkg\base\files.cpp
F:\test\vcpkg\toolsrc\src\vcpkg\base\files.cpp(725): error C2039: 'system_complete': is not a member of 'std::filesystem'
E:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610\include\fstream(28): note: see declaration of 'std::filesystem'
F:\test\vcpkg\toolsrc\src\vcpkg\base\files.cpp(725): error C3861: 'system_complete': identifier not found
[26/96] Building CXX object CMakeFiles\vcpkglib.dir\src\vcpkg\base\system.cpp.obj
ninja: build stopped: subcommand failed.
```
It seems to be related with this PR #10817.

I update USE_STD_FILESYSTEM as VCPKG_USE_STD_FILESYSTEM, which can build without any error.

Related issue #10957.
