### PR TITLE
[libaaplus] Use versioned download link

### DIFF
--- a/ports/libaaplus/CONTROL
+++ b/ports/libaaplus/CONTROL
@@ -1,5 +1,5 @@
 Source: libaaplus
-Version: 2.12
+Version: 2.12-1
 Description: libaaplus is an astronomical computations library by naughter software
 Homepage: http://www.naughter.com/aa.html
 

--- a/ports/libaaplus/portfile.cmake
+++ b/ports/libaaplus/portfile.cmake
@@ -2,16 +2,16 @@ set(VERSION 2.12)
 
 vcpkg_download_distfile(
     ARCHIVE_FILE
-    URLS "http://www.naughter.com/download/aaplus.zip"
-    FILENAME "aaplus.zip"
+    URLS "http://www.naughter.com/download/aaplus_v${VERSION}.zip"
+    FILENAME "aaplus_v${VERSION}.zip"
     SHA512 ec3a3d1346637fbed3ec5093ded821c6d80950a6432378d9826ed842571d8670cd5d2a1c9ff58a18f308e18669d786f72d24961e26bd8e070ee35674688a39e7
 )
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE_FILE}
-	REF ${VERSION}
-	NO_REMOVE_ONE_LEVEL
+    REF ${VERSION}
+    NO_REMOVE_ONE_LEVEL
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
A download link with the version in the filename is provided now for
releases of aaplus.
E.g. http://www.naughter.com/download/aaplus_v2.12.zip instead of
previously http://www.naughter.com/download/aaplus.zip, which was
overwritten, when a new version was released.

**Describe the pull request**

- What does your PR fix? Fixes issue #
The PR implements a stable download link for a released version of aaplus.
This avoids changing SHA512 checksums of http://www.naughter.com/download/aaplus.zip upon each release.
From now on, PJ Naughter kindly provides zip files of releases with the version in the file name.
E.g. http://www.naughter.com/download/aaplus_v2.12.zip
- Which triplets are supported/not supported? Have you updated the CI baseline?
All current triplets are supported
CI baseline: OK, no need to update
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
