### PR TITLE
[vcpkg] Fix Catch2 include path in documentation

### DIFF
--- a/docs/tool-maintainers/testing.md
+++ b/docs/tool-maintainers/testing.md
@@ -77,7 +77,7 @@ First, we should create a file, `example.cpp`, in `toolsrc/src/vcpkg-test`:
 
 ```cpp
 // vcpkg-test/example.cpp
-#include <vcpkg-test/catch.h>
+#include <catch2/catch.hpp>
 ```
 
 This is the minimum file needed for tests; let's rebuild!


### PR DESCRIPTION
**Describe the pull request**
This fixes the vcpkg-maintainer documentation so that it no longer uses wrong (old) include path for Catch2.
