### PR TITLE
[pe-parse] Add new port

### DIFF
--- a/ports/pe-parse/CONTROL
+++ b/ports/pe-parse/CONTROL
@@ -1,0 +1,4 @@
+Source: pe-parse
+Version: 1.1.0
+Description: pe-parse is a principled, lightweight C/C++ PE parser
+Build-Depends: icu

--- a/ports/pe-parse/CONTROL
+++ b/ports/pe-parse/CONTROL
@@ -1,3 +1,4 @@
 Source: pe-parse
 Version: 1.2.0
 Description: pe-parse is a principled, lightweight C/C++ PE parser
+Homepage: https://github.com/trailofbits/pe-parse

--- a/ports/pe-parse/CONTROL
+++ b/ports/pe-parse/CONTROL
@@ -1,4 +1,3 @@
 Source: pe-parse
-Version: 1.1.0
+Version: 1.2.0
 Description: pe-parse is a principled, lightweight C/C++ PE parser
-Build-Depends: icu

--- a/ports/pe-parse/CONTROL
+++ b/ports/pe-parse/CONTROL
@@ -2,3 +2,4 @@ Source: pe-parse
 Version: 1.2.0
 Description: pe-parse is a principled, lightweight C/C++ PE parser
 Homepage: https://github.com/trailofbits/pe-parse
+Supports: !uwp

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -9,8 +9,7 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-        -DBUILD_COMMAND_LINE_TOOLS=OFF
+    OPTIONS -DBUILD_COMMAND_LINE_TOOLS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO trailofbits/pe-parse
+    REF v1.2.0
+    SHA512 916ec515585ba1e83e2c6ae29667fd25bd4cac90c39e587ae6847dc9d503186e8853bd80f4e2a99177a3214f5c51eceff85fa610cadbc2bc1d3a79251e8ce942
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_COMMAND_LINE_TOOLS=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/pe-parse TARGET_PATH share/pe-parse)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(
+    INSTALL
+    "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/pe-parse"
+    RENAME copyright
+)


### PR DESCRIPTION
Adds a port for [pe-parse](https://github.com/trailofbits/pe-parse), a principled, lightweight parser for the PE executable format.

- What does your PR fix?

None.

- Which triplets are supported/not supported? Have you updated the CI baseline?

All default triplets should work.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so!
