### PR TITLE
[Arrow] Add filesystem feature

### DIFF
--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -1,5 +1,5 @@
 Source: arrow
-Version: 0.17.0-1
+Version: 0.17.0-2
 Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algorithm, flatbuffers, rapidjson, zlib, lz4, brotli, bzip2, zstd, snappy, gflags, thrift, double-conversion, glog, uriparser, openssl
 Homepage: https://github.com/apache/arrow
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.

--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -4,7 +4,7 @@ Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algor
 Homepage: https://github.com/apache/arrow
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.
 Supports: x64
-Default-Features: csv, json, parquet
+Default-Features: csv, json, parquet, filesystem
 
 Feature: csv
 Description: CSV file support
@@ -14,3 +14,6 @@ Description: JSON file support
 
 Feature: parquet
 Description: Parquet file support
+
+Feature: filesystem
+Description: Local filesystem support

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -16,9 +16,10 @@ string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ARROW_BUILD_STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    "csv"      ARROW_CSV
-    "json"     ARROW_JSON
-    "parquet"  ARROW_PARQUET
+    "csv"         ARROW_CSV
+    "json"        ARROW_JSON
+    "parquet"     ARROW_PARQUET
+    "filesystem"  ARROW_FILESYSTEM
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
**Describe the pull request**
Arrow has optional features for working with filesystems. This PR adds an optional `filesystem` feature for generic (local) filesystem support. S3 and HDFS aren't added as options but could be with the appropriate dependencies.

- What does your PR fix? Fixes issue #

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change expected.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes