### PR TITLE
[azure-iot-sdk-c] Fixed the CMake config export.

### DIFF
--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-iot-sdk-c
-Version: 2020-02-04.2
+Version: 2020-02-04.1-1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
 

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-iot-sdk-c
-Version: 2020-02-04.1
+Version: 2020-02-04.2
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
 

--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,7 +1,8 @@
 Source: azure-iot-sdk-c
 Version: 2020-02-04.1-1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
-Description: A C99 SDK for connecting devices to Microsoft Azure IoT services 
+Description: A C99 SDK for connecting devices to Microsoft Azure IoT services
+Homepage: https://github.com/Azure/azure-iot-sdk-c
 
 Feature: public-preview
 Description: A version of the azure-iot-sdk-c containing public-preview features.

--- a/ports/azure-iot-sdk-c/fix-cmake.patch
+++ b/ports/azure-iot-sdk-c/fix-cmake.patch
@@ -1,0 +1,40 @@
+diff --git a/provisioning_client/CMakeLists.txt b/provisioning_client/CMakeLists.txt
+index c39188dca..d4ef43cb3 100644
+--- a/provisioning_client/CMakeLists.txt
++++ b/provisioning_client/CMakeLists.txt
+@@ -359,7 +359,7 @@ if(${use_installed_dependencies})
+         set(CMAKE_INSTALL_LIBDIR "lib")
+     endif()
+ 
+-    install(TARGETS ${provisioning_libs} EXPORT azure_prov_sdksTargets
++    install(TARGETS ${provisioning_libs} EXPORT azure_iot_sdksTargets
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+@@ -374,26 +374,6 @@ if(${use_installed_dependencies})
+         VERSION ${PROV_SDK_VERSION}
+         COMPATIBILITY SameMajorVersion
+     )
+-
+-    configure_file("../configs/${PROJECT_NAME}Config.cmake"
+-        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+-        COPYONLY
+-    )
+-
+-    install(EXPORT azure_prov_sdksTargets
+-        FILE
+-            "${PROJECT_NAME}Targets.cmake"
+-        DESTINATION
+-            ${package_location}
+-    )
+-
+-    install(
+-        FILES
+-            "../configs/${PROJECT_NAME}Config.cmake"
+-            "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+-        DESTINATION
+-            ${package_location}
+-    )
+ else()
+     # Install Provisioning libs
+     if(NOT DEFINED CMAKE_INSTALL_LIBDIR)

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -18,7 +18,7 @@ else()
         REF c8b6a108fd7e01c1d89d9150b5d209f17e54fc4e
         SHA512 43d7bb9696c9f5d64ec38b017b3b9fcbf86a8a3e8f21b129546b822fe00640f775ca362ec124a8cc37c4c9634de50d88d38952f04a7f4cfc08ad7c25463770ef
         HEAD_REF master
-        PATCHES improve-external-deps.patch
+        PATCHES improve-external-deps.patch fix-cmake.patch
     )
 endif()
 

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -9,7 +9,9 @@ if("public-preview" IN_LIST FEATURES)
         REF cb2e8d390df56ffa31d08ca0a79ab58ff96160cc
         SHA512 6798b17d6768b3ccbd0eb66719b50f364cd951736eb71110e2dc9deca054a1566ff88b9e8c5e9b52536e4308cad6cd3cbebff3282c123083e3afaee5535e724b
         HEAD_REF public-preview
-        PATCHES improve-external-deps.patch
+        PATCHES
+            improve-external-deps.patch
+            fix-cmake.patch
     )
 else()
     vcpkg_from_github(
@@ -18,7 +20,9 @@ else()
         REF c8b6a108fd7e01c1d89d9150b5d209f17e54fc4e
         SHA512 43d7bb9696c9f5d64ec38b017b3b9fcbf86a8a3e8f21b129546b822fe00640f775ca362ec124a8cc37c4c9634de50d88d38952f04a7f4cfc08ad7c25463770ef
         HEAD_REF master
-        PATCHES improve-external-deps.patch fix-cmake.patch
+        PATCHES
+            improve-external-deps.patch
+            fix-cmake.patch
     )
 endif()
 

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 if("public-preview" IN_LIST FEATURES)

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -56,7 +56,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/azure_iot_sdks)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/azure-iot-sdk-c/copyright COPYONLY)
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
 
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
The `azure-iot-sdk-c` port seems not to be really usable by using CMake config files.

When one tries to consume the library by the following block:

```cmake
find_package(azure_iot_sdks CONFIG REQUIRED)
# Note: 7 target(s) were omitted.
target_link_libraries(main PRIVATE serializer iothub_client prov_auth_client digitaltwin_client)
```

Soon one will see this error when running CMake:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
IOTHUB_CLIENT_INCLUDES
```

From my end, the problem is that `iothub_client` target is not exported from its CMake configs, but only `${provisioning_libs}` get exported.

This patch is attempting to correct this behavior.