### PR TITLE
[ode] Bump version to 0.16.1

### DIFF
--- a/ports/ode/CONTROL
+++ b/ports/ode/CONTROL
@@ -1,4 +1,4 @@
 Source: ode
-Version: 0.16
+Version: 0.16.1
 Homepage: https://bitbucket.org/odedevs/ode/src/default/
 Description: Open Dynamics Engine

--- a/ports/ode/portfile.cmake
+++ b/ports/ode/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odedevs/ode
-    REF 0.16 
-    SHA512 6a98882aa3e6267423f745ec48f2472d330f94fa395c459e116174093ef1d479368efc0514ef04eff4e62eb7c3520a7a544fc3ed66ff2f1bd06bc13df4110581
+    REF 0.16.1
+    SHA512 04429cae1b8fc703e53880c5de78293cee46fe4855c96ca7006bd5848255a0df004b75716a6b30ff5176df004e2bec29b2a31d4af8e7ac59da18f0af2eed8396
     HEAD_REF master
 )
 
@@ -15,7 +13,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ode-0.16.0)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ode-0.16.1)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)


### PR DESCRIPTION

- What does your PR fix? Fixes issue #
This PR increases the version of ode to 0.16.1 . Actually I looked into the `ode` port because I think there was a change in the hash in the tarball (possible due to hg --> git migration?) that caused the existing port to fail (see https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/runs/618225302). However, as I saw that a new patch release went out, instead of just updating the hash of the old version I also bumper the port to the new version 0.16.1 .  

- Which triplets are supported/not supported? Have you updated the CI baseline?
I just updated the version, I do not think it will change the CI baseline. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
