### PR TITLE
[winreg] Update to 2.2.3

### DIFF
--- a/ports/winreg/CONTROL
+++ b/ports/winreg/CONTROL
@@ -1,5 +1,5 @@
 Source: winreg
-Version: 2.2.2
+Version: 2.2.3
 Homepage: https://github.com/GiovanniDicanio/WinReg
 Description: High-level C++ wrapper around the Windows Registry C API.
 Supports: windows|uwp

--- a/ports/winreg/portfile.cmake
+++ b/ports/winreg/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_fail_port_install(ON_TARGET "linux" "osx")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GiovanniDicanio/WinReg
-    REF 5102b656389aa2909ca69d74e8b694e8451d85b1 #v2.2.2
-    SHA512 3f46eccf5bcc76c71848463ac898953bb8d7737200ea55900f064ad95da6953e643233f7faa5c3288fa42cbb599da62b324abaec3509dfa969430c464ac586fe 
+    REF 1dfd91d80ec89d36236e41dd75f2c5ddb31093a1 #v2.2.3
+    SHA512 5d43cd15f958411407ae636234c8e1c3d43d5dbd074b93d578245d75405fb2ec7a9d4924d7eb9141fc9ce42391846d22a2e3945e53bdf43fbd78ccbce397c03e 
     HEAD_REF master
 )
 


### PR DESCRIPTION
Update winreg to the latest version 2.2.3.

Related issue #11013 

Note: No features need to test.
