### PR TITLE
[abseil] Configure abseil to use std:: types when feature cxx17 is enabled

### DIFF
--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -1,5 +1,5 @@
 Source: abseil
-Version: 2020-03-03-3
+Version: 2020-03-03-4
 Homepage: https://github.com/abseil/abseil-cpp
 Description: an open-source collection designed to augment the C++ standard library.
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.

--- a/ports/abseil/fix-use-cxx17-stdlib-types.patch
+++ b/ports/abseil/fix-use-cxx17-stdlib-types.patch
@@ -1,0 +1,40 @@
+diff --git a/absl/base/options.h b/absl/base/options.h
+index 234137c..1fb77e4 100644
+--- a/absl/base/options.h
++++ b/absl/base/options.h
+@@ -100,7 +100,7 @@
+ // User code should not inspect this macro.  To check in the preprocessor if
+ // absl::any is a typedef of std::any, use the feature macro ABSL_USES_STD_ANY.
+ 
+-#define ABSL_OPTION_USE_STD_ANY 2
++#define ABSL_OPTION_USE_STD_ANY 1
+ 
+ 
+ // ABSL_OPTION_USE_STD_OPTIONAL
+@@ -127,7 +127,7 @@
+ // absl::optional is a typedef of std::optional, use the feature macro
+ // ABSL_USES_STD_OPTIONAL.
+ 
+-#define ABSL_OPTION_USE_STD_OPTIONAL 2
++#define ABSL_OPTION_USE_STD_OPTIONAL 1
+ 
+ 
+ // ABSL_OPTION_USE_STD_STRING_VIEW
+@@ -154,7 +154,7 @@
+ // absl::string_view is a typedef of std::string_view, use the feature macro
+ // ABSL_USES_STD_STRING_VIEW.
+ 
+-#define ABSL_OPTION_USE_STD_STRING_VIEW 2
++#define ABSL_OPTION_USE_STD_STRING_VIEW 1
+ 
+ // ABSL_OPTION_USE_STD_VARIANT
+ //
+@@ -180,7 +180,7 @@
+ // absl::variant is a typedef of std::variant, use the feature macro
+ // ABSL_USES_STD_VARIANT.
+ 
+-#define ABSL_OPTION_USE_STD_VARIANT 2
++#define ABSL_OPTION_USE_STD_VARIANT 1
+ 
+ 
+ // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -1,15 +1,30 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+set(ABSEIL_PATCHES
+    fix-uwp-build.patch
+
+    # This patch is an upstream commit, the related PR: https://github.com/abseil/abseil-cpp/pull/637
+    fix-MSVCbuildfail.patch
+)
+
+if("cxx17" IN_LIST FEATURES)
+    # in C++17 mode, use std::any, std::optional, std::string_view, std::variant
+    # instead of the library replacement types
+    list(APPEND ABSEIL_PATCHES fix-use-cxx17-stdlib-types.patch)
+else()
+    # fore use of library replacement types, otherwise the automatic
+    # detection can cause ABI issues depending on which compiler options
+    # are enabled for consuming user code
+    list(APPEND ABSEIL_PATCHES fix-lnk2019-error.patch)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO abseil/abseil-cpp
     REF 06f0e767d13d4d68071c4fc51e25724e0fc8bc74 #commit 2020-03-03
     SHA512 f6e2302676ddae39d84d8ec92dbd13520ae214013b43455f14ced3ae6938b94cedb06cfc40eb1781dac48f02cd35ed80673ed2d871541ef4438c282a9a4133b9
     HEAD_REF master
-    PATCHES 
-        fix-lnk2019-error.patch
-        fix-uwp-build.patch
-        fix-MSVCbuildfail.patch #This patch is an upstream commit, the related PR: https://github.com/abseil/abseil-cpp/pull/637
+    PATCHES ${ABSEIL_PATCHES}
 )
 
 set(CMAKE_CXX_STANDARD  )


### PR DESCRIPTION
Patches `absl/base/options.h` type selection macros to use either value
0 (when feature `cxx17` is not enabled) to ensure that always absl:: types are used. This was already
done by the pre-existing `fix-lnk2019-error.patch` in the port.
When feature `cxx17` is enabled instead value 1 is used to force abseil to use
the std:: types.

Abseil can use `std::any`, `std::optional`, `std::string_view`, and `std::variant`
or its own internal replacement types. Which ones are used
is configured by setting macros in `absl/base/options.h` to values 0/1/2
where 0 means always use `absl::` types, 1 is always use `std::` types (and
require a C++17 library), 2 detect if the standard library supports the
types and use them if available (see also comments in `absl/base/options.h`).