### PR TITLE
[qt5] reactivate qt5-activeqt for CI coverage

### DIFF
--- a/ports/qt5-activeqt/CONTROL
+++ b/ports/qt5-activeqt/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-activeqt
-Version: 5.12.8
+Version: 5.12.8-1
 Description: Qt5 ActiveQt Module - ActiveX components
-Build-Depends:  qt5-base
+Build-Depends:  qt5-base, qt5-declarative
 Supports: windows

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1460,40 +1460,8 @@ qhull:x64-uwp=ignore
 qpid-proton:arm-uwp=fail
 qpid-proton:x64-uwp=fail
 qpid-proton:x64-windows-static=fail
-#qt5-activeqt is skipped because it conflicts with qt5-declarative:
-# Starting package 142/820: qt5-declarative:x86-windows
-# Building package qt5-declarative[core]:x86-windows...
-# Using cached binary package: C:\agent\_work\1\s\archives\94\9428e63fede20a51ac0631a9d94d8773e593dd06.zip
-# Building package qt5-declarative[core]:x86-windows... done
-# Installing package qt5-declarative[core]:x86-windows...
-#     The following files are already installed in C:/agent/_work/1/s/installed/x86-windows and are in conflict with qt5-declarative:x86-windows
-#
-# Installed by qt5-activeqt:x86-windows
-#     tools/qt5/bin/Qt5Gui.dll
-#     tools/qt5/bin/Qt5Widgets.dll
-#     tools/qt5/bin/bz2.dll
-#     tools/qt5/bin/freetype.dll
-#     tools/qt5/bin/glib-2.dll
-#     tools/qt5/bin/harfbuzz.dll
-#     tools/qt5/bin/jpeg62.dll
-#     tools/qt5/bin/libcharset.dll
-#     tools/qt5/bin/libiconv.dll
-#     tools/qt5/bin/libintl.dll
-#     tools/qt5/bin/libpng16.dll
-#     tools/qt5/bin/pcre.dll
-#     tools/qt5/bin/plugins/imageformats/qgif.dll
-#     tools/qt5/bin/plugins/imageformats/qico.dll
-#     tools/qt5/bin/plugins/imageformats/qjpeg.dll
-#     tools/qt5/bin/plugins/platforms/qwindows.dll
-#     tools/qt5/bin/plugins/styles/qwindowsvistastyle.dll
-qt5-activeqt:arm-uwp=skip
-qt5-activeqt:arm64-windows=skip
 qt5-activeqt:x64-linux=fail
 qt5-activeqt:x64-osx=fail
-qt5-activeqt:x64-uwp=skip
-qt5-activeqt:x64-windows-static=skip
-qt5-activeqt:x64-windows=skip
-qt5-activeqt:x86-windows=skip
 qt5-macextras:x64-linux=fail
 qt5-macextras:x64-windows=fail
 qt5-macextras:x64-windows-static=fail


### PR DESCRIPTION
This is required so that qt5-tools is not skipped in CI which affects CI coverage.
In general Qt5 ports should not be build apart from each other but as complete package!
Or VCPKG should accept installing duplicated *.dll in every folder except for /bin or debug/bin. The alternative would be to accept executables in bin which would make duplicating any dlls unnecessary

The layout of the Qt5 ports in tools/bin is required in this way since external tools lik the QtVsTools expect every tool in one and the same bin folder. 
