### PR TITLE
[pcl] Fix link to libpng

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,5 @@
 Source: pcl
-Version: 1.9.1-11
+Version: 1.9.1-12
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio

--- a/ports/pcl/fix-link-libpng.patch
+++ b/ports/pcl/fix-link-libpng.patch
@@ -1,0 +1,20 @@
+diff --git a/io/CMakeLists.txt b/io/CMakeLists.txt
+index a17cb2d..b2a56b3 100644
+--- a/io/CMakeLists.txt
++++ b/io/CMakeLists.txt
+@@ -330,11 +330,13 @@ if(build)
+     add_definitions(${VTK_DEFINES})
+     PCL_ADD_LIBRARY("${LIB_NAME}" "${SUBSYS_NAME}" ${srcs} ${incs} ${compression_incs} ${impl_incs} ${OPENNI_INCLUDES} ${OPENNI2_INCLUDES})
+     target_include_directories(${LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${VTK_INCLUDE_DIRECTORIES})
+-    link_directories(${VTK_LINK_DIRECTORIES})
+-    target_link_libraries("${LIB_NAME}" pcl_common pcl_io_ply ${VTK_LIBRARIES} )
++    
+     if(PNG_FOUND)
+       target_link_libraries("${LIB_NAME}" ${PNG_LIBRARIES})
+     endif(PNG_FOUND)
++    
++    link_directories(${VTK_LINK_DIRECTORIES})
++    target_link_libraries("${LIB_NAME}" pcl_common pcl_io_ply ${VTK_LIBRARIES} )
+ 
+     if(LIBUSB_1_FOUND)
+       target_link_libraries("${LIB_NAME}" ${LIBUSB_1_LIBRARIES})

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -10,8 +10,8 @@ vcpkg_from_github(
         use_flann_targets.patch
         boost-1.70.patch
         cuda_10_1.patch
-		# Patch for https://github.com/microsoft/vcpkg/issues/7660
-		use_target_link_libraries_in_pclconfig.patch
+        # Patch for https://github.com/microsoft/vcpkg/issues/7660
+        use_target_link_libraries_in_pclconfig.patch
         fix-link-libpng.patch
 )
 

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         cuda_10_1.patch
 		# Patch for https://github.com/microsoft/vcpkg/issues/7660
 		use_target_link_libraries_in_pclconfig.patch
+        fix-link-libpng.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindFLANN.cmake)


### PR DESCRIPTION
Now, pcl will always link to release libpng.dll.
So fix this issue.

Related: #8241.

Thanks @yuanchen-zhu.