### PR TITLE
[prefab-export] do not try to copy headers if the directory does not exist.

### DIFF
--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -547,7 +547,13 @@ namespace vcpkg::Export::Prefab
                     fs::path module_meta_path = module_dir / "module.json";
                     utils.write_contents(module_meta_path, meta.to_json(), VCPKG_LINE_INFO);
 
-                    utils.copy(installed_headers_dir, exported_headers_dir, fs::copy_options::recursive);
+
+                    if (utils.exists(installed_headers_dir)) {
+                        ignore_errors_t dummy;
+                        if (!utils.exists(exported_headers_dir))
+                            utils.create_directory(exported_headers_dir, dummy);
+                        utils.copy(installed_headers_dir, exported_headers_dir, fs::copy_options::recursive);
+                    }
                     break;
                 }
                 else
@@ -607,7 +613,12 @@ namespace vcpkg::Export::Prefab
                                 installed_headers_dir.generic_u8string(), exported_headers_dir.generic_u8string()));
                         }
 
-                        utils.copy(installed_headers_dir, exported_headers_dir, fs::copy_options::recursive);
+                        if (utils.exists(installed_headers_dir)) {
+                            ignore_errors_t dummy;
+                            if (!utils.exists(exported_headers_dir))
+                                utils.create_directory(exported_headers_dir, dummy);
+                            utils.copy(installed_headers_dir, exported_headers_dir, fs::copy_options::recursive);
+                        }
 
                         ModuleMetadata meta;
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #

Partly fixes https://github.com/microsoft/vcpkg/issues/11052

This fixes the actual Android build issue; the packaging step does not abort in the middle.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Not applicable; it is about the latest Android support and there is no android triplets defined yet in this repository.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

It should (but it is first time contribution so any surprise could happen).