### PR TITLE
[Vcpkg] Fix macOS applocal.py dependency bundling error

### DIFF
--- a/scripts/buildsystems/osx/applocal.py
+++ b/scripts/buildsystems/osx/applocal.py
@@ -84,7 +84,7 @@ def get_dependencies(filename):
     deps = []
     if proc_out.retcode == 0:
         # some string splitting
-        deps = [s.strip().split(' ')[0] for s in proc_out.stdout.splitlines()[1:] if s]
+        deps = [s.strip().split(b' ')[0].decode('utf-8') for s in proc_out.stdout.splitlines()[1:] if s]
         # prevent infinite recursion when a binary depends on itself (seen with QtWidgets)...
         deps = [s for s in deps if os.path.basename(filename) not in s]
     return deps


### PR DESCRIPTION
This is the same issue and fix applied here https://github.com/OpenZWave/ozw-admin/issues/4.

This issue occurs when building a `.app` bundle (when `MACOSX_BUNDLE` is ON). I believe it's related to Python version or macOS Catalina. Vcpkg is using Python 3.8.1 (validated by print statement within applocal.py itself).

Let me know if I can validate anything else. I was hoping to add an automated test for running macOS app package builds, but it looks to me like we don't have automated testing of Vcpkg itself for macOS ☹️.

**Describe the pull request**

- What does your PR fix? Fixes issue #
Currently no open issue, though this is a problem.

- Which triplets are supported/not supported? Have you updated the CI baseline?
This is relevant only for macOS. Problem was observed on Catalina (so, 64-bit only).
