### PR TITLE
[test] Rerun libxml2

### DIFF
--- a/ports/libxml2/CONTROL
+++ b/ports/libxml2/CONTROL
@@ -1,5 +1,5 @@
 Source: libxml2
-Version: 2.9.9-5
+Version: 2.9.9-6
 Homepage: https://xmlsoft.org/
 Description: Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform)
 Build-Depends: zlib, libiconv, liblzma

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
@@ -31,5 +29,5 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage
 vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/libxml2)
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 endif()


### PR DESCRIPTION
llibxml2 failed on osx pipeline in the PR #10770 

```
Undefined symbols for architecture x86_64:
  "_iconv", referenced from:
      _xmlIconvWrapper in libxml2.a(encoding.c.o)
  "_iconv_close", referenced from:
      _xmlFindCharEncodingHandler in libxml2.a(encoding.c.o)
      _xmlCharEncCloseFunc in libxml2.a(encoding.c.o)
  "_iconv_open", referenced from:
      _xmlFindCharEncodingHandler in libxml2.a(encoding.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
I checked the CMakeLists.txt and found that iconv has been linked. And I also cannot reproduce this on my local. 

Related issue #11001.
