### PR TITLE
[nowide] Add new port

### DIFF
--- a/ports/nowide/CONTROL
+++ b/ports/nowide/CONTROL
@@ -1,0 +1,4 @@
+Source: nowide
+Version: 10.0.1
+Homepage: https://github.com/boostorg/nowide
+Description: Boost nowide module (standalone)

--- a/ports/nowide/portfile.cmake
+++ b/ports/nowide/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/boostorg/nowide/releases/download/v10.0.1/nowide_standalone_v10.0.1.tar.gz"
+    FILENAME "nowide_standalone_v10.0.1.tar.gz"
+    SHA512 b349983127532fcfcb2bd29ce327634ea8d980e1da6a67fe44d0a5761a81c6cc78e518439970099b155732c3edb0fa8f1f1a1df5018d59b8cb699626c121f95e
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/nowide TARGET_PATH share/${PORT})
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? --- N/A but helps #11035

- Which triplets are supported/not supported? Have you updated the CI baseline? --- I don't know, but I'd like to make x{64,86}-windows supported at least

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  --- ~~No as for now but I will make it do later (removing boiler plates)~~ I did it and I can say yes now

Boost::nowide can be independent from other Boost modules.  I wouldn't like to use this module with other huge modules and implemented the recipe for this standalone version first.

I have to write a simple program using this module to test before giving feedbacks.