### PR TITLE
[vcpkg] Small touchups for vcpkg unit tests

### DIFF
--- a/toolsrc/CMakeLists.txt
+++ b/toolsrc/CMakeLists.txt
@@ -120,7 +120,7 @@ if (BUILD_TESTING)
 
     enable_testing()
     add_executable(vcpkg-test ${VCPKGTEST_SOURCES} $<TARGET_OBJECTS:vcpkglib>)
-    add_test(NAME default COMMAND vcpkg-test)
+    add_test(NAME default COMMAND vcpkg-test --order rand --rng-seed time)
 
     if (VCPKG_BUILD_BENCHMARKING)
         target_compile_options(vcpkg-test PRIVATE -DCATCH_CONFIG_ENABLE_BENCHMARKING)

--- a/toolsrc/src/vcpkg-test/optional.cpp
+++ b/toolsrc/src/vcpkg-test/optional.cpp
@@ -19,9 +19,9 @@ TEST_CASE ("equal", "[optional]")
     using vcpkg::Optional;
 
     CHECK(Optional<int>{} == Optional<int>{});
-    CHECK(!(Optional<int>{} == Optional<int>{42}));
-    CHECK(!(Optional<int>{42} == Optional<int>{}));
-    CHECK(!(Optional<int>{1729} == Optional<int>{42}));
+    CHECK_FALSE(Optional<int>{} == Optional<int>{42});
+    CHECK_FALSE(Optional<int>{42} == Optional<int>{});
+    CHECK_FALSE(Optional<int>{1729} == Optional<int>{42});
     CHECK(Optional<int>{42} == Optional<int>{42});
 }
 


### PR DESCRIPTION
**Describe the pull request**

This improve vcpkg's unit tests a bit, per conversation with @strega-nil.

1. Fixed bad style in negating tests with binary expression in assertion in vcpkg's `Optional` tests
2. Made CTest run the tests in randomized order