### PR TITLE
[harfbuzz] Change build depends from freetype to freetype[core]

### DIFF
--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,8 +1,8 @@
 Source: harfbuzz
-Version: 2.5.3
+Version: 2.5.3-1
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
-Build-Depends: freetype, ragel, gettext (osx)
+Build-Depends: freetype[core], ragel, gettext (osx)
 Default-Features: ucdn
 
 Feature: graphite2


### PR DESCRIPTION
The freetype dependencies libpng and bzip2 are not required for the functionality of harfbuzz.

See the discussion under https://github.com/microsoft/vcpkg/issues/10678#issuecomment-621243075

There I believed that this is a bug in the vcpkg dependency resolution but it is actually an issue with the CONTROL file.

> Ah so the bug is actually the inverse of what I thought.
> Well what only matters is that the result is consistent :).
> 
> And thanks for the hint about the Build-Depends.
> 
> Changing harfbuzz to
> 
> ```
> Build-Depends: freetype[core], ragel, gettext (osx)
> ```
> 
> will give:
> 
> ```
> > vcpkg install harfbuzz[core,ucdn]
> Computing installation plan...
> The following packages will be built and installed:
>   * bzip2[core]:x86-windows
>   * freetype[bzip2,core,png]:x86-windows
>     harfbuzz[core,ucdn]:x86-windows
>   * libpng[core]:x86-windows
>   * ragel[core]:x86-windows
>   * zlib[core]:x86-windows
> 
> > vcpkg install freetype[core] harfbuzz[core,ucdn]
> Computing installation plan...
> The following packages will be built and installed:
>     freetype[core]:x86-windows
>     harfbuzz[core,ucdn]:x86-windows
>   * ragel[core]:x86-windows
>   * zlib[core]:x86-windows
> ```
> 
> Which is exactly what I would have expected. Thanks! :)




