### PR TITLE
[vcpkg] Warn on unmatched removal with reasonable alternative

### DIFF
--- a/toolsrc/src/vcpkg/remove.cpp
+++ b/toolsrc/src/vcpkg/remove.cpp
@@ -178,10 +178,8 @@ namespace vcpkg::Remove
 
         if (purge == Purge::YES)
         {
-            System::printf("Purging package %s...\n", display_name);
             Files::Filesystem& fs = paths.get_filesystem();
             fs.remove_all(paths.packages / action.spec.dir(), VCPKG_LINE_INFO);
-            System::printf(System::Color::success, "Purging package %s... done\n", display_name);
         }
     }
 
@@ -193,7 +191,7 @@ namespace vcpkg::Remove
 
     static constexpr std::array<CommandSwitch, 5> SWITCHES = {{
         {OPTION_PURGE, "Remove the cached copy of the package (default)"},
-        {OPTION_NO_PURGE, "Do not remove the cached copy of the package"},
+        {OPTION_NO_PURGE, "Do not remove the cached copy of the package (deprecated)"},
         {OPTION_RECURSE, "Allow removal of packages not explicitly specified on the command line"},
         {OPTION_DRY_RUN, "Print the packages to be removed, but do not remove them"},
         {OPTION_OUTDATED, "Select all packages with versions that do not match the portfiles"},
@@ -291,6 +289,27 @@ namespace vcpkg::Remove
                 System::print2(System::Color::warning,
                                "If you are sure you want to remove them, run the command with the --recurse option\n");
                 Checks::exit_fail(VCPKG_LINE_INFO);
+            }
+        }
+
+        for (const auto& action : remove_plan)
+        {
+            if (action.plan_type == RemovePlanType::NOT_INSTALLED && action.request_type == RequestType::USER_REQUESTED)
+            {
+                // The user requested removing a package that was not installed. If the port is installed for another
+                // triplet, warn the user that they may have meant that other package.
+                for (const auto& package : status_db)
+                {
+                    if (package->is_installed() && !package->package.is_feature() &&
+                        package->package.spec.name() == action.spec.name())
+                    {
+                        System::print2(
+                            System::Color::warning,
+                            "Another installed package matches the name of an unmatched request. Did you mean ",
+                            package->package.spec,
+                            "?\n");
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This PR causes vcpkg to warn if the user attempts to remove a package that is not installed, but has the same port installed in a different triplet.

Before:
```
> ./vcpkg remove zlib:x64-windows --dry-run
The following packages are not installed, so not removed:
    zlib:x64-windows

> ./vcpkg remove zlib:x86-windows --dry-run
The following packages will be removed:
  * cpprestsdk:x86-windows
    zlib:x86-windows
Additional packages (*) need to be removed to complete this operation.
If you are sure you want to remove them, run the command with the --recurse option
```
After:
```
> .\toolsrc\out\build\x64-Release\vcpkg remove zlib:x64-windows --dry-run
The following packages are not installed, so not removed:
    zlib:x64-windows
Another installed package matches the name of an unmatched request. Did you mean zlib:x86-windows?
Another installed package matches the name of an unmatched request. Did you mean zlib:arm64-windows?
Another installed package matches the name of an unmatched request. Did you mean zlib:x64-uwp?

> .\toolsrc\out\build\x64-Release\vcpkg remove zlib:x86-windows --dry-run
The following packages will be removed:
  * cpprestsdk:x86-windows
    zlib:x86-windows
Additional packages (*) need to be removed to complete this operation.
If you are sure you want to remove them, run the command with the --recurse option
```

Additionally, I have deprecated the (relatively) undocumented "purge" feature and removed extraneous messages to reduce noise.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes