### PR TITLE
[vcpkg] Correctly record default feature list in BinaryParagraphs. Fixes #10678.

### DIFF
--- a/toolsrc/src/vcpkg/binaryparagraph.cpp
+++ b/toolsrc/src/vcpkg/binaryparagraph.cpp
@@ -149,5 +149,7 @@ namespace vcpkg
         if (!pgh.description.empty()) out_str.append("Description: ").append(pgh.description).push_back('\n');
 
         out_str.append("Type: ").append(Type::to_string(pgh.type)).push_back('\n');
+        if (!pgh.default_features.empty())
+            out_str.append("Default-Features: ").append(Strings::join(", ", pgh.default_features)).push_back('\n');
     }
 }

--- a/toolsrc/src/vcpkg/binaryparagraph.cpp
+++ b/toolsrc/src/vcpkg/binaryparagraph.cpp
@@ -85,13 +85,14 @@ namespace vcpkg
                                      Triplet triplet,
                                      const std::string& abi_tag,
                                      const std::vector<FeatureSpec>& deps)
-        : version(spgh.version)
+        : spec(spgh.name, triplet)
+        , version(spgh.version)
         , description(spgh.description)
         , maintainer(spgh.maintainer)
         , abi(abi_tag)
         , type(spgh.type)
+        , default_features(spgh.default_features)
     {
-        this->spec = PackageSpec(spgh.name, triplet);
         this->depends = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec().name(); });
         Util::sort_unique_erase(this->depends);
     }
@@ -100,9 +101,14 @@ namespace vcpkg
                                      const FeatureParagraph& fpgh,
                                      Triplet triplet,
                                      const std ::vector<FeatureSpec>& deps)
-        : version(), description(fpgh.description), maintainer(), feature(fpgh.name), type(spgh.type)
+        : spec(spgh.name, triplet)
+        , version()
+        , description(fpgh.description)
+        , maintainer()
+        , feature(fpgh.name)
+        , type(spgh.type)
+        , default_features()
     {
-        this->spec = PackageSpec(spgh.name, triplet);
         this->depends = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec().name(); });
         Util::sort_unique_erase(this->depends);
     }

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -106,15 +106,13 @@ namespace vcpkg::Dependencies
                     &m_scfl.source_control_file->find_dependencies_for_feature(feature).value_or_exit(VCPKG_LINE_INFO);
 
                 std::vector<FeatureSpec> dep_list;
-                if (maybe_vars)
+                if (auto vars = maybe_vars.get())
                 {
                     // Qualified dependency resolution is available
-                    auto fullspec_list = filter_dependencies(
-                        *qualified_deps, m_spec.triplet(), maybe_vars.value_or_exit(VCPKG_LINE_INFO));
+                    auto fullspec_list = filter_dependencies(*qualified_deps, m_spec.triplet(), *vars);
 
                     for (auto&& fspec : fullspec_list)
                     {
-                        // TODO: this is incorrect and does not handle default features nor "*"
                         Util::Vectors::append(&dep_list, fspec.to_feature_specs({"default"}, {"default"}));
                     }
 


### PR DESCRIPTION
When determining the precise list of features requested by a particular package reference (`FullPackageSpec` in the code), the resolution algorithm must sometimes consult the list of default dependencies for the already installed package. This is because a reference such as `cpprestsdk[compression]` refers to the union of `cpprestsdk`'s declared default features and the `compression` feature. In the case of depending upon an already installed package, we resolve defaults to the _installed package's_ list until that package has been determined to need rebuilding.

Unfortunately, we were silently not recording the list of defaults for packages, which caused all references to default features in already installed packages to misbehave and not actually require any features.

- What does your PR fix?

Fixes an underlying bug discovered in issue #10678. Users will need to rebuild all packages with default features to fully fix the problem. Requires also merging #11082 for a full resolution of @Ghabry's issue.

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes