### PR TITLE
[casclib, stormlib] Fix the linkage issue on Linux

### DIFF
--- a/ports/casclib/CONTROL
+++ b/ports/casclib/CONTROL
@@ -1,4 +1,4 @@
 Source: casclib
-Version: 1.50b-1
-Build-Depends: zlib
+Version: 1.50b-2
+Build-Depends: zlib, stormlib
 Description: An open-source implementation of library for reading CASC storage from Blizzard games since 2014

--- a/ports/casclib/portfile.cmake
+++ b/ports/casclib/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         ctype_for_mac.patch
+        remove_Set_GetLastError_implementation.patch
 )
 
 file(COPY 

--- a/ports/casclib/remove_Set_GetLastError_implementation.patch
+++ b/ports/casclib/remove_Set_GetLastError_implementation.patch
@@ -1,0 +1,23 @@
+diff --git a/src/common/Common.cpp b/src/common/Common.cpp
+index 2860671..42ca4bf 100644
+--- a/src/common/Common.cpp
++++ b/src/common/Common.cpp
+@@ -65,17 +65,7 @@ unsigned char IntToHexChar[] = "0123456789abcdef";
+ // GetLastError/SetLastError support for non-Windows platform
+ 
+ #ifndef PLATFORM_WINDOWS
+-static DWORD dwLastError = ERROR_SUCCESS;
+-
+-DWORD GetLastError()
+-{
+-    return dwLastError;
+-}
+-
+-void SetLastError(DWORD dwErrCode)
+-{
+-    dwLastError = dwErrCode;
+-}
++// use  stormlibs implementation
+ #endif
+ 
+ //-----------------------------------------------------------------------------


### PR DESCRIPTION
Both stormlib and casclib implement 
GetLastError()
SetLastError()

on Linux. Therefore projects using both libraries cannot link on Linux.
The change neither effect users on Windows nor users who are using only one of the libs on Linux.

