### PR TITLE
[azure-kinect-sensor-sdk] Disable parallel configure due to source directory writes

### DIFF
--- a/ports/azure-kinect-sensor-sdk/CONTROL
+++ b/ports/azure-kinect-sensor-sdk/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-kinect-sensor-sdk
-Version: 1.4.0-alpha.0-3
+Version: 1.4.0-alpha.0-4
 Homepage: https://github.com/microsoft/Azure-Kinect-Sensor-SDK
 Description: Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.
 Build-Depends: azure-c-shared-utility, glfw3, gtest, imgui, libusb, spdlog, cjson, ebml, libjpeg-turbo, matroska, libsoundio, libyuv

--- a/ports/azure-kinect-sensor-sdk/portfile.cmake
+++ b/ports/azure-kinect-sensor-sdk/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # .rc file needs windows.h, so do not use PREFER_NINJA here
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS ${FEATURE_OPTIONS}
     -DK4A_SOURCE_LINK=OFF
     -DK4A_MTE_VERSION=ON


### PR DESCRIPTION
Azure kinect sensor sdk performs a `configure_file()` call into the source directory, which results in flaky builds. Disable parallel configure to resolve this issue.
