### PR TITLE
[libsquish] add missing SQUISH_EXPORT

### DIFF
--- a/ports/libsquish/CONTROL
+++ b/ports/libsquish/CONTROL
@@ -1,4 +1,4 @@
 Source: libsquish
-Version: 1.15-2
+Version: 1.15-3
 Homepage: https://sourceforge.net/projects/libsquish
 Description: Open source DXT compression library.

--- a/ports/libsquish/fix-export-symbols.patch
+++ b/ports/libsquish/fix-export-symbols.patch
@@ -44,6 +44,13 @@ index 14c9bb5..aaffbb2 100644
 +
  //! All squish API functions live in this namespace.
  namespace squish {
+
+@@ -115,5 +117,5 @@
+ */
+-void CompressMasked( u8 const* rgba, int mask, void* block, int flags, float* metric = 0 );
++SQUISH_EXPORT void CompressMasked( u8 const* rgba, int mask, void* block, int flags, float* metric = 0 );
+ 
+ // -----------------------------------------------------------------------------
  
 @@ -176,7 +178,7 @@ inline void Compress( u8 const* rgba, void* block, int flags, float* metric = 0
      however, DXT1 will be used by default if none is specified. All other flags


### PR DESCRIPTION
**Describe the pull request**

Adds missing export #define for CompressMasked function

- What does your PR fix? Fixes issue #
no recorded issue
- Which triplets are supported/not supported? Have you updated the CI baseline?
All triplets should be supported
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes
