### PR TITLE
[vcpkg] Remove Windows 7 from supported OSes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For short description of available commands, run `vcpkg help`.
 
 ## Quick Start
 Prerequisites:
-- Windows 10, 8.1, 7, Linux, or MacOS
+- Windows 10, 8.1, Linux, or MacOS
 - Visual Studio 2015 Update 3 or newer (on Windows)
 - Git
 - gcc >= 7 or equivalent clang (on Linux)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #
This PR removes Windows 7 from the list of supported OSes in README.md

  Windows 7 is unsupported as of January 14th 2020, see here for details: https://www.microsoft.com/en-gb/windows/windows-7-end-of-life-support-information

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A, documentation change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
N/A, documentation change
