### PR TITLE
[BitSerializer] Update to version 0.9

### DIFF
--- a/ports/bitserializer-cpprestjson/CONTROL
+++ b/ports/bitserializer-cpprestjson/CONTROL
@@ -1,4 +1,5 @@
 Source: bitserializer-cpprestjson
-Version: 0.8
+Version: 0.9
 Build-Depends: bitserializer, cpprestsdk
-Description: This is an implementation of the BitSerializer archive for serialization JSON (based on CppRestSDK library).
+Description: C++ 17 library for serialization, module for support JSON (implementation based on the CppRestSDK library)
+Homepage: https://bitbucket.org/Pavel_Kisliak/bitserializer

--- a/ports/bitserializer-cpprestjson/portfile.cmake
+++ b/ports/bitserializer-cpprestjson/portfile.cmake
@@ -1,13 +1,19 @@
-include(vcpkg_common_functions)
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Pavel_Kisliak/BitSerializer
-	REF 0.8
-	SHA512 6df5b3f7a472a55ba0aace22c44cb2adaf178fbc7f920dcaf7d7015f81badde98d64911ddb620e99a708214140d7c29561775c1b0fe60fef6f24d465a4eac093
+	REF 0.9
+	SHA512 74515a1a8338935c52752200d96abc0c0ee2c2b0b42880b1d10c8f56b5f8eb30680bd96b64eb2b352764128ad6a1fcd59749f481883c48a06230d652bee05902
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/archives/bitserializer_cpprest_json DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/archives/bitserializer_cpprest_json
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/bitserializer-cpprestjson/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/bitserializer-cpprestjson RENAME copyright)

--- a/ports/bitserializer-rapidjson/CONTROL
+++ b/ports/bitserializer-rapidjson/CONTROL
@@ -1,4 +1,5 @@
 Source: bitserializer-rapidjson
-Version: 0.8
+Version: 0.9
 Build-Depends: bitserializer, rapidjson
-Description: This is an implementation of the BitSerializer archive for serialization JSON (based on the RapidJson library).
+Description: C++ 17 library for serialization, module for support JSON (implementation based on the RapidJson library)
+Homepage: https://bitbucket.org/Pavel_Kisliak/bitserializer

--- a/ports/bitserializer-rapidjson/portfile.cmake
+++ b/ports/bitserializer-rapidjson/portfile.cmake
@@ -1,13 +1,19 @@
-include(vcpkg_common_functions)
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Pavel_Kisliak/BitSerializer
-	REF 0.8
-	SHA512 6df5b3f7a472a55ba0aace22c44cb2adaf178fbc7f920dcaf7d7015f81badde98d64911ddb620e99a708214140d7c29561775c1b0fe60fef6f24d465a4eac093
+	REF 0.9
+	SHA512 74515a1a8338935c52752200d96abc0c0ee2c2b0b42880b1d10c8f56b5f8eb30680bd96b64eb2b352764128ad6a1fcd59749f481883c48a06230d652bee05902
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/archives/bitserializer_rapidjson DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/archives/bitserializer_rapidjson
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/bitserializer-rapidjson/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/bitserializer-rapidjson RENAME copyright)

--- a/ports/bitserializer/CONTROL
+++ b/ports/bitserializer/CONTROL
@@ -1,3 +1,4 @@
 Source: bitserializer
-Version: 0.8
-Description: The core part of library for serialization of arbitrary C++ types to various output formats.
+Version: 0.9
+Description: Core part of C++ 17 library for serialization to JSON, XML, YAML
+Homepage: https://bitbucket.org/Pavel_Kisliak/bitserializer

--- a/ports/bitserializer/portfile.cmake
+++ b/ports/bitserializer/portfile.cmake
@@ -1,13 +1,19 @@
-include(vcpkg_common_functions)
 vcpkg_from_bitbucket(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Pavel_Kisliak/BitSerializer
-	REF 0.8
-	SHA512 6df5b3f7a472a55ba0aace22c44cb2adaf178fbc7f920dcaf7d7015f81badde98d64911ddb620e99a708214140d7c29561775c1b0fe60fef6f24d465a4eac093
+	REF 0.9
+	SHA512 74515a1a8338935c52752200d96abc0c0ee2c2b0b42880b1d10c8f56b5f8eb30680bd96b64eb2b352764128ad6a1fcd59749f481883c48a06230d652bee05902
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/core/bitserializer DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/core
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/bitserializer/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/bitserializer RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Update BitSerializer to new version 0.9, this PR updates existing modules:
- bitserializer
- bitserializer-cpprestjson
- bitserializer-rapidjson


- What does your PR fix? Fixes issue #
_N/A_

- Which triplets are supported/not supported? Have you updated the CI baseline?
_All triplets should be supported (but not of all tested). No changes in the CI baseline._

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
√