### PR TITLE
[libpng] Fix missing symbols when compiling for ARM

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,5 +1,5 @@
 Source: libpng
-Version: 1.6.37-7
+Version: 1.6.37-8
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -58,6 +58,7 @@ vcpkg_configure_cmake(
     OPTIONS
         ${LIBPNG_APNG_OPTION}
         ${LIBPNG_HARDWARE_OPTIMIZATIONS_OPTION}
+        -DPNG_ARM_NEON=on
         -DPNG_STATIC=${PNG_STATIC_LIBS}
         -DPNG_SHARED=${PNG_SHARED_LIBS}
         -DPNG_TESTS=OFF

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(LIBPNG_VER 1.6.37)
 
 # Download the apng patch
@@ -8,6 +6,9 @@ if ("apng" IN_LIST FEATURES)
     set(LIBPNG_APG_PATCH_NAME libpng-${LIBPNG_VER}-apng.patch)
     set(LIBPNG_APG_PATCH_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIBPNG_APG_PATCH_NAME})
     if (NOT EXISTS ${LIBPNG_APG_PATCH_PATH})
+        if (NOT EXISTS ${CURRENT_BUILDTREES_DIR}/src)
+            file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src)
+        endif()
         vcpkg_download_distfile(LIBPNG_APNG_PATCH_ARCHIVE
             URLS "https://downloads.sourceforge.net/project/libpng-apng/libpng16/${LIBPNG_VER}/${LIBPNG_APG_PATCH_NAME}.gz"
             FILENAME "${LIBPNG_APG_PATCH_NAME}.gz"


### PR DESCRIPTION
**What does your PR fix?**

When cross-compiling for Linux ARM targets when libpng is a transitive dependency, I found some symbols were missing at link-time because it has to be explicitly enabled for the architecture.

**Which triplets are supported/not supported? Have you updated the CI baseline?**
This would affect all triplets targeting ARM and ARM64 

**Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?**
Yes
