### PR TITLE
[vcpkg] fix bug in Filesystem::absolute

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -724,12 +724,12 @@ namespace vcpkg::Files
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);
 #else // ^^^ _WIN32 / !_WIN32 vvv
-            if (!path.is_absolute()) {
+            if (path.is_absolute()) {
+                return path;
+            } else {
                 auto current_path = this->current_path(ec);
                 if (ec) return fs::path();
                 return std::move(current_path) / path;
-            } else {
-                return path;
             }
 #endif
 #endif

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -717,14 +717,14 @@ namespace vcpkg::Files
 
         virtual fs::path absolute(const fs::path& path, std::error_code& ec) const override
         {
-#if VCPKG_USE_STD_FILESYSTEM 
+#if VCPKG_USE_STD_FILESYSTEM
             return fs::stdfs::absolute(path, ec);
 #else // ^^^ VCPKG_USE_STD_FILESYSTEM  / !VCPKG_USE_STD_FILESYSTEM  vvv
 #if _WIN32
             // absolute was called system_complete in experimental filesystem
             return fs::stdfs::system_complete(path, ec);
 #else // ^^^ _WIN32 / !_WIN32 vvv
-            if (path.is_absolute()) {
+            if (!path.is_absolute()) {
                 auto current_path = this->current_path(ec);
                 if (ec) return fs::path();
                 return std::move(current_path) / path;


### PR DESCRIPTION
Currently, `absolute('/x/y') = <cwd>/x/y`, and `absolute('x/y') = x/y`; the line is reversed.