### PR TITLE
[vcpkg] [llvm] Bump Linux VM memory size and do all operations on the temporary disk.

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,5 @@
 Source: llvm
-Version: 10.0.0
+Version: 10.0.0-1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -142,6 +142,9 @@ vcpkg_configure_cmake(
         -DLLVM_BUILD_EXAMPLES=OFF
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_BUILD_TESTS=OFF
+        # Disable optional dependencies to libxml2 and zlib
+        -DLLVM_ENABLE_LIBXML2=OFF
+        -DLLVM_ENABLE_ZLIB=OFF
         # Force TableGen to be built with optimization. This will significantly improve build time.
         -DLLVM_OPTIMIZED_TABLEGEN=ON
         # LLVM generates CMake error due to Visual Studio version 16.4 is known to miscompile part of LLVM.

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -3,7 +3,7 @@
 #
 variables:
   windows-pool: 'PrWin-2020-04-28'
-  linux-pool: 'PrLin-2020-04-30'
+  linux-pool: 'PrLin-2020-05-07'
 
 jobs:
   - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/clean-tombstones.yml
+++ b/scripts/azure-pipelines/clean-tombstones.yml
@@ -3,7 +3,7 @@
 #
 variables:
   windows-pool: 'PrWin-2020-04-28'
-  linux-pool: 'PrLin-2020-04-30'
+  linux-pool: 'PrLin-2020-05-07'
 
 jobs:
   - job: windows

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -27,8 +27,7 @@ jobs:
   - powershell: |
       $skipList = ./scripts/azure-pipelines/generate-skip-list.ps1 -Triplet "x64-linux" -BaselineFile "$(System.DefaultWorkingDirectory)/scripts/ci.baseline.txt"
       mkdir $(System.ArtifactsDirectory)/xml-results
-      mkdir /ci/home
-      $env:HOME = '/ci/home'
+      $env:HOME = '/home/root'
       ./vcpkg ci x64-linux --x-xunit="$(System.ArtifactsDirectory)/xml-results/x64-linux.xml" --exclude=$skipList --binarycaching
     displayName: '** Test Modified Ports **'
   - task: PowerShell@2

--- a/scripts/azure-pipelines/linux/create-vmss.ps1
+++ b/scripts/azure-pipelines/linux/create-vmss.ps1
@@ -258,7 +258,7 @@ $StorageContext = New-AzStorageContext `
   -StorageAccountKey $StorageAccountKey
 
 New-AzStorageShare -Name 'archives' -Context $StorageContext
-Set-AzStorageShareQuota -ShareName 'archives' -Context $StorageContext -Quota 5120
+Set-AzStorageShareQuota -ShareName 'archives' -Context $StorageContext -Quota 1024
 
 ####################################################################################################
 Write-Progress `

--- a/scripts/azure-pipelines/linux/create-vmss.ps1
+++ b/scripts/azure-pipelines/linux/create-vmss.ps1
@@ -18,10 +18,9 @@ or are running from Azure Cloud Shell.
 
 $Location = 'westus2'
 $Prefix = 'PrLin-' + (Get-Date -Format 'yyyy-MM-dd')
-$VMSize = 'Standard_F16s_v2'
+$VMSize = 'Standard_D16a_v4'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
-$InstalledDiskSizeInGB = 1024
 $ErrorActionPreference = 'Stop'
 
 $ProgressActivity = 'Creating Scale Set'
@@ -273,7 +272,7 @@ $Nic = New-AzNetworkInterface `
   -Location $Location `
   -Subnet $VirtualNetwork.Subnets[0]
 
-$VM = New-AzVMConfig -Name $ProtoVMName -VMSize $VMSize
+$VM = New-AzVMConfig -Name $ProtoVMName -VMSize $VMSize -Priority 'Spot' -MaxPrice -1
 $VM = Set-AzVMOperatingSystem `
   -VM $VM `
   -Linux `
@@ -377,22 +376,13 @@ $Vmss = Set-AzVmssOsProfile `
   -VirtualMachineScaleSet $Vmss `
   -ComputerNamePrefix $LiveVMPrefix `
   -AdminUsername AdminUser `
-  -AdminPassword $AdminPW `
-  -CustomData ([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("#!/bin/bash`n/etc/provision-disks.sh`n")))
+  -AdminPassword $AdminPW
 
 $Vmss = Set-AzVmssStorageProfile `
   -VirtualMachineScaleSet $Vmss `
   -OsDiskCreateOption 'FromImage' `
   -OsDiskCaching ReadWrite `
   -ImageReferenceId $Image.Id
-
-$Vmss = Add-AzVmssDataDisk `
-  -VirtualMachineScaleSet $Vmss `
-  -Lun 0 `
-  -Caching 'ReadWrite' `
-  -CreateOption Empty `
-  -DiskSizeGB 1024 `
-  -StorageAccountType 'StandardSSD_LRS'
 
 New-AzVmss `
   -ResourceGroupName $ResourceGroupName `

--- a/scripts/azure-pipelines/linux/initialize-environment.sh
+++ b/scripts/azure-pipelines/linux/initialize-environment.sh
@@ -4,12 +4,9 @@
 
 # Cleans up the environment to prevent contamination across builds.
 if [ ! -d "archives" ]; then
-    ln -s /ci/archives archives
-fi
-if [ ! -d "installed" ]; then
-    ln -s /ci/installed installed
+    ln -s /archives archives
 fi
 
-rm -rf installed/*
+rm -rf installed
 rm -rf buildtrees
-rm -rf packages
+rm -rf packages/*

--- a/scripts/azure-pipelines/windows/create-vmss.ps1
+++ b/scripts/azure-pipelines/windows/create-vmss.ps1
@@ -308,7 +308,7 @@ $Nic = New-AzNetworkInterface `
   -Location $Location `
   -Subnet $VirtualNetwork.Subnets[0]
 
-$VM = New-AzVMConfig -Name $ProtoVMName -VMSize $VMSize
+$VM = New-AzVMConfig -Name $ProtoVMName -VMSize $VMSize -Priority 'Spot' -MaxPrice -1
 $VM = Set-AzVMOperatingSystem `
   -VM $VM `
   -Windows `

--- a/scripts/azure-pipelines/windows/create-vmss.ps1
+++ b/scripts/azure-pipelines/windows/create-vmss.ps1
@@ -294,7 +294,7 @@ $StorageContext = New-AzStorageContext `
   -StorageAccountKey $StorageAccountKey
 
 New-AzStorageShare -Name 'archives' -Context $StorageContext
-Set-AzStorageShareQuota -ShareName 'archives' -Context $StorageContext -Quota 5120
+Set-AzStorageShareQuota -ShareName 'archives' -Context $StorageContext -Quota 2048
 
 ####################################################################################################
 Write-Progress `

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1006,7 +1006,6 @@ llgl:arm-uwp=fail
 llgl:x64-uwp=fail
 llvm:arm-uwp=fail
 llvm:arm64-windows=fail
-llvm:x64-linux=fail
 llvm:x64-uwp=fail
 lmdb:arm64-windows=fail
 lmdb:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1133,7 +1133,17 @@ mpg123:x64-uwp=fail
 mpir:arm64-windows=fail
 mpir:arm-uwp=fail
 mpir:x64-uwp=fail
-
+# Building package gmp[core]:x64-linux... done
+# Installing package gmp[core]:x64-linux...
+# The following files are already installed in /mnt/1/s/installed/x64-linux and are in conflict with gmp:x64-linux
+#
+# Installed by mpir:x64-linux
+#     debug/lib/libgmp.a
+#     debug/lib/libgmp.la
+#     include/gmp.h
+#     lib/libgmp.a
+#     lib/libgmp.la
+mpir:x64-linux=skip
 #Conflicts with angle and qt-5base
 ms-angle:arm64-windows      = skip
 ms-angle:arm-uwp            = skip


### PR DESCRIPTION
* Fixes LLVM build dying due to the OOM killer.
* Integrates #11180 