### PR TITLE
[wxwidgets] Apply fix to wxWidgets for copy and paste macOS

### DIFF
--- a/ports/wxwidgets/CONTROL
+++ b/ports/wxwidgets/CONTROL
@@ -1,5 +1,5 @@
 Source: wxwidgets
-Version: 3.1.3
+Version: 3.1.3-1
 Homepage: https://github.com/wxWidgets/wxWidgets
 Description: wxWidgets is a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.
 Build-Depends: zlib, libpng, tiff, expat

--- a/ports/wxwidgets/fix-macos-clipboard.patch
+++ b/ports/wxwidgets/fix-macos-clipboard.patch
@@ -1,0 +1,26 @@
+diff --git a/src/osx/carbon/clipbrd.cpp b/src/osx/carbon/clipbrd.cpp
+index 274e200..6012d37 100644
+--- a/src/osx/carbon/clipbrd.cpp
++++ b/src/osx/carbon/clipbrd.cpp
+@@ -60,7 +60,11 @@ void wxClipboard::Clear()
+ 
+ bool wxClipboard::Flush()
+ {
+-    return false;
++    wxCHECK_MSG( m_open, false, wxT("clipboard not open") );
++
++    wxOSXPasteboard::GetGeneralClipboard()->Flush();
++
++    return true;
+ }
+ 
+ bool wxClipboard::Open()
+@@ -105,6 +109,8 @@ bool wxClipboard::AddData( wxDataObject *data )
+ 
+     data->WriteToSink(wxOSXPasteboard::GetGeneralClipboard());
+ 
++    Flush();
++
+     m_data = data;
+ 
+     return true;

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REF v3.1.3
     SHA512 4ecb5c2d13f9bda7aa3c12e887c351a0004509ec24bdd440542bec67e1b6dca20e7838a01236a71dd3cf2e1ba0653c40878047f406464cb2c9ee07c26d6f2599
     HEAD_REF master
-    PATCHES disable-platform-lib-dir.patch
+    PATCHES disable-platform-lib-dir.patch fix-macos-clipboard.patch
 )
 
 set(OPTIONS)


### PR DESCRIPTION
Fixes copy and paste on macOS. See [wxWidget's Trac #18553](https://trac.wxwidgets.org/ticket/18553). Patch has long been applied wxWidgets master, this just backports it to the released development version. I've tested the fix locally and it works correctly.

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes though the fix only affects for macOS builds.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I hope so.