### PR TITLE
[llvm] Disable optional dependencies to libxml2 and zlib

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,5 @@
 Source: llvm
-Version: 10.0.0
+Version: 10.0.0-1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -142,6 +142,9 @@ vcpkg_configure_cmake(
         -DLLVM_BUILD_EXAMPLES=OFF
         -DLLVM_INCLUDE_TESTS=OFF
         -DLLVM_BUILD_TESTS=OFF
+        # Disable optional dependencies to libxml2 and zlib
+        -DLLVM_ENABLE_LIBXML2=OFF
+        -DLLVM_ENABLE_ZLIB=OFF
         # Force TableGen to be built with optimization. This will significantly improve build time.
         -DLLVM_OPTIMIZED_TABLEGEN=ON
         # LLVM generates CMake error due to Visual Studio version 16.4 is known to miscompile part of LLVM.


### PR DESCRIPTION
This PR fixes LLVM CMake error on Linux with installed Libxml2:

```
/usr/bin/ar: creating t.a
CMake Error at lib/WindowsManifest/CMakeLists.txt:11 (get_filename_component):
  get_filename_component unknown component optimized

-- Version: 0.0.0
-- Performing Test HAVE_GNU_POSIX_REGEX
-- Performing Test HAVE_GNU_POSIX_REGEX
-- Performing Test HAVE_GNU_POSIX_REGEX -- failed to compile
-- Performing Test HAVE_POSIX_REGEX
-- Performing Test HAVE_POSIX_REGEX
-- Performing Test HAVE_POSIX_REGEX -- success
-- Performing Test HAVE_STEADY_CLOCK
-- Performing Test HAVE_STEADY_CLOCK
-- Performing Test HAVE_STEADY_CLOCK -- success
```

Steps to reproduce:

`vcpkg install libxml2 llvm`

Related to #11174, #10295
