### PR TITLE
[dlib] add more granularity in features

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,9 +1,18 @@
 Source: dlib
 Version: 19.19
-Build-Depends: libjpeg-turbo, libpng, sqlite3, fftw3, openblas (!osx), clapack (!osx)
+Build-Depends: libjpeg-turbo, libpng, openblas (!osx), clapack (!osx)
 Homepage: https://github.com/davisking/dlib
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++
+Default-Features: fftw3, sqlite3
 
 Feature: cuda
 Build-Depends: cuda
 Description: CUDA support for dlib
+
+Feature: fftw3
+Build-Depends: fftw3
+Description: fftw3 support for dlib
+
+Feature: sqlite3
+Build-Depends: sqlite3
+Description: sqlite3 support for dlib

--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,5 +1,5 @@
 Source: dlib
-Version: 19.19
+Version: 19.19-1
 Build-Depends: libjpeg-turbo, libpng, openblas (!osx), clapack (!osx)
 Homepage: https://github.com/davisking/dlib
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -21,6 +21,17 @@ file(READ "${SOURCE_PATH}/dlib/CMakeLists.txt" DLIB_CMAKE)
 string(REPLACE "PNG_LIBRARY" "PNG_LIBRARIES" DLIB_CMAKE "${DLIB_CMAKE}")
 file(WRITE "${SOURCE_PATH}/dlib/CMakeLists.txt" "${DLIB_CMAKE}")
 
+
+set(WITH_SQLITE3 OFF)
+if("sqlite3" IN_LIST FEATURES)
+set(WITH_SQLITE3 ON)
+endif()
+
+set(WITH_FFTW3 OFF)
+if("fftw3" IN_LIST FEATURES)
+set(WITH_FFTW3 ON)
+endif()
+
 set(WITH_CUDA OFF)
 if("cuda" IN_LIST FEATURES)
   set(WITH_CUDA ON)
@@ -30,8 +41,8 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DDLIB_LINK_WITH_SQLITE3=ON
-        -DDLIB_USE_FFTW=ON
+        -DDLIB_LINK_WITH_SQLITE3=${WITH_SQLITE3}
+        -DDLIB_USE_FFTW=${WITH_FFTW3}
         -DDLIB_PNG_SUPPORT=ON
         -DDLIB_JPEG_SUPPORT=ON
         -DDLIB_USE_BLAS=ON

--- a/ports/dlib/portfile.cmake
+++ b/ports/dlib/portfile.cmake
@@ -21,33 +21,21 @@ file(READ "${SOURCE_PATH}/dlib/CMakeLists.txt" DLIB_CMAKE)
 string(REPLACE "PNG_LIBRARY" "PNG_LIBRARIES" DLIB_CMAKE "${DLIB_CMAKE}")
 file(WRITE "${SOURCE_PATH}/dlib/CMakeLists.txt" "${DLIB_CMAKE}")
 
-
-set(WITH_SQLITE3 OFF)
-if("sqlite3" IN_LIST FEATURES)
-set(WITH_SQLITE3 ON)
-endif()
-
-set(WITH_FFTW3 OFF)
-if("fftw3" IN_LIST FEATURES)
-set(WITH_FFTW3 ON)
-endif()
-
-set(WITH_CUDA OFF)
-if("cuda" IN_LIST FEATURES)
-  set(WITH_CUDA ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  "sqlite3"   DLIB_LINK_WITH_SQLITE3
+  "fftw3"     DLIB_USE_FFTW
+  "cuda"      DLIB_USE_CUDA
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DDLIB_LINK_WITH_SQLITE3=${WITH_SQLITE3}
-        -DDLIB_USE_FFTW=${WITH_FFTW3}
+        ${FEATURE_OPTIONS}
         -DDLIB_PNG_SUPPORT=ON
         -DDLIB_JPEG_SUPPORT=ON
         -DDLIB_USE_BLAS=ON
         -DDLIB_USE_LAPACK=ON
-        -DDLIB_USE_CUDA=${WITH_CUDA}
         -DDLIB_GIF_SUPPORT=OFF
         -DDLIB_USE_MKL_FFT=OFF
         -DCMAKE_DEBUG_POSTFIX=d


### PR DESCRIPTION
Add more granularity for dlib feature.
the PR don't change default dlib build

we can now use dlib without fftw3 using dlib[core]

I'm not sure if I need to bump the version.