### PR TITLE
[opencv4] Changed dependency on qt5 to qt5-base, closes microsoft/vcpkg#11138

### DIFF
--- a/ports/opencv2/CONTROL
+++ b/ports/opencv2/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv2
-Version: 2.4.13.7
+Version: 2.4.13.7-1
 Build-Depends: zlib
 Description: computer vision library, version 2
 Default-Features: eigen, jpeg, opengl, png, tiff
@@ -37,7 +37,7 @@ Build-Depends: libpng
 Description: PNG support for opencv
 
 Feature: qt
-Build-Depends: qt5
+Build-Depends: qt5-base
 Description: Qt GUI support for opencv
 
 Feature: tiff

--- a/ports/opencv3/CONTROL
+++ b/ports/opencv3/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv3
-Version: 3.4.7-2
+Version: 3.4.7-3
 Build-Depends: protobuf, zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library
@@ -63,7 +63,7 @@ Build-Depends: libpng
 Description: PNG support for opencv
 
 Feature: qt
-Build-Depends: qt5
+Build-Depends: qt5-base
 Description: Qt GUI support for opencv
 
 Feature: sfm

--- a/ports/opencv4/CONTROL
+++ b/ports/opencv4/CONTROL
@@ -1,5 +1,5 @@
 Source: opencv4
-Version: 4.1.1-4
+Version: 4.1.1-5
 Build-Depends: protobuf, zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library

--- a/ports/opencv4/CONTROL
+++ b/ports/opencv4/CONTROL
@@ -66,7 +66,7 @@ Build-Depends: libpng
 Description: PNG support for opencv
 
 Feature: qt
-Build-Depends: qt5
+Build-Depends: qt5-base
 Description: Qt GUI support for opencv
 
 Feature: sfm


### PR DESCRIPTION
Resolves the circular dependency causing `CASCADED_DUE_TO_MISSING_DEPENDENCIES` identified by @cenit in #11138 by changing the dependency of the `qt` feature from `qt5` to `qt5-base`

- What does your PR fix? 
   - Fixes issue microsoft/vcpkg#11138

- Which triplets are supported/not supported? Have you updated the CI baseline?
   - Tested on linux/osx-64

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
   - I believe so, yes.
