### PR TITLE
[mongo-c-driver] Fix find_package error

### DIFF
--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,5 +1,5 @@
 Source: mongo-c-driver
-Version: 1.16.1
+Version: 1.16.1-1
 Build-Depends: libbson, openssl (!windows), zlib
 Description: Client library written in C for MongoDB.
 Homepage: https://github.com/mongodb/mongo-c-driver

--- a/ports/mongo-c-driver/usage
+++ b/ports/mongo-c-driver/usage
@@ -1,6 +1,6 @@
 The package mongo-c-driver is compatible with built-in CMake targets:
 	
-	find_package(mongo-c-driver CONFIG REQUIRED)
+	find_package(libmongoc-1.0 CONFIG REQUIRED)
 	
 	target_include_directories(main PRIVATE ${MONGOC_INCLUDE_DIRS})
 	target_link_libraries(main PRIVATE ${MONGOC_LIBRARIES})


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes issue #11141 
Fix use find_package can't find mongo-c-driver.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
