### PR TITLE
[speexdsp] Change repo to github

### DIFF
--- a/ports/speexdsp/CONTROL
+++ b/ports/speexdsp/CONTROL
@@ -1,5 +1,5 @@
 Source: speexdsp
-Version: 1.2.0-1
-Homepage: https://ftp.osuosl.org/pub/xiph/releases/speex/
+Version: 1.2.0-2
+Homepage: https://speex.org/
 Description: A patent-free, Open Source/Free Software DSP library.
 Build-Depends:

--- a/ports/speexdsp/portfile.cmake
+++ b/ports/speexdsp/portfile.cmake
@@ -1,14 +1,9 @@
-include(vcpkg_common_functions)
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://downloads.xiph.org/releases/speex/speexdsp-1.2.0.tar.gz"
-    FILENAME "speexdsp-1.2.0.tar.gz"
-    SHA512 e357cd5377415ea66c862302c7cf8bf6a10063cacd903f0846478975b87974cf5bdf00e2c6759d8f4f453c4c869cf284e9dc948a84a83d7b2ab96bd5405c05ec
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    REPO xiph/speexdsp
+    REF  64cbfa9bca7479a758351aa02bb4abdd76baa9e7 #1.2.0
+    SHA512 b92488e1efd4d763cd2d438b88a1b708d2a9d8f804dc2b016bfb29c4f7366624d3cf86a23645067393274e100c1bd6467def0eb98575f04ffcaf49b20f1f1105
+    HEAD_REF master
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
Since speexdsp cannot access the current repo, switch to github.

Related: #10767.