### PR TITLE
[libpq] link libdl on linux

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 12.0-1
+Version: 12.0-2
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libpq/vcpkg-cmake-wrapper.cmake
+++ b/ports/libpq/vcpkg-cmake-wrapper.cmake
@@ -6,3 +6,10 @@ PATHS
 NO_DEFAULT_PATH
 )
 _find_package(${ARGS})
+if(PostgreSQL_FOUND)
+    find_library(PostgreSQL_DL_LIBRARY NAMES dl)
+    if(PostgreSQL_DL_LIBRARY)
+        list(APPEND PostgreSQL_LIBRARIES "dl")
+        set_property(TARGET PostgreSQL::PostgreSQL APPEND PROPERTY INTERFACE_LINK_LIBRARIES "dl")
+    endif()
+endif()


### PR DESCRIPTION
**Describe the pull request**
This adds `-dl` to the link line on systems that have `libdl`. Linking to `libpq` on Ubuntu Focal fails to find `dlopen` and friends without it. (I copied the method to do this from the `openssl-unix` port.) 

- What does your PR fix? Fixes issue #
I did not create an issue. I did not find any open issues.

- Which triplets are supported/not supported? Have you updated the CI baseline?
This should not change triplet support if working correctly. The libpq port was already building on Linux and still is. CI baseline already expects it to build.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.