### PR TITLE
[magnum] fixes adding any feature that depends on any other feature it will enable all the defaults

### DIFF
--- a/ports/magnum/CONTROL
+++ b/ports/magnum/CONTROL
@@ -1,6 +1,6 @@
 Source: magnum
 Version: 2020.06
-Port-Version: 1
+Port-Version: 2
 Build-Depends: corrade[utility]
 Description: C++11/C++14 graphics middleware for games and data visualization
 Homepage: https://magnum.graphics/
@@ -8,27 +8,27 @@ Default-Features: anyaudioimporter, anyimageimporter, anyimageconverter, anyscen
 
 Feature: al-info
 Description: magnum-al-info utility
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 
 Feature: anyimageimporter
 Description: AnyImageImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: anyaudioimporter
 Description: AnyAudioImporter plugin
-Build-Depends: magnum[audio], corrade[pluginmanager]
+Build-Depends: magnum[core,audio], corrade[pluginmanager]
 
 Feature: anyimageconverter
 Description: AnyImageConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: anysceneconverter
 Description: AnySceneConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: anysceneimporter
 Description: AnySceneImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: audio
 Description: Audio library
@@ -39,18 +39,18 @@ Description: DebugTools library
 
 Feature: distancefieldconverter
 Description: magnum-distancefieldconverter utility
-Build-Depends: magnum[texturetools], magnum[gl]
+Build-Depends: magnum[core,texturetools], magnum[core,gl]
 
 Feature: fontconverter
 Description: magnum-fontconverter utility
-Build-Depends: magnum[text], magnum[gl]
+Build-Depends: magnum[core,text], magnum[core,gl]
 
 Feature: gl
 Description: GL library
 
 Feature: gl-info
 Description: gl-info utility
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: glfwapplication
 Description: GlfwApplication library
@@ -58,35 +58,35 @@ Build-Depends: glfw3
 
 Feature: imageconverter
 Description: magnum-imageconverter utility
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: magnumfont
 Description: MagnumFont plugin
-Build-Depends: magnum[text]
+Build-Depends: magnum[core,text]
 
 Feature: magnumfontconverter
 Description: MagnumFontConverter plugin
-Build-Depends: magnum[text], magnum[tgaimageconverter]
+Build-Depends: magnum[core,text], magnum[core,tgaimageconverter]
 
 Feature: meshtools
 Description: MeshTools library
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: objimporter
 Description: ObjImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: tgaimageconverter
 Description: TgaImageConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: opengltester
 Description: OpenGLTester library
-Build-Depends: corrade[testsuite], magnum[gl]
+Build-Depends: corrade[testsuite], magnum[core,gl]
 
 Feature: primitives
 Description: Primitives library
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: sdl2application
 Description: Sdl2Application library
@@ -97,22 +97,22 @@ Description: SceneGraph library
 
 Feature: sceneconverter
 Description: magnum-sceneconverter utility
-Build-Depends: magnum[anysceneconverter]
+Build-Depends: magnum[core,anysceneconverter]
 
 Feature: shaders
 Description: Shaders library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: text
 Description: Text library
-Build-Depends: magnum[texturetools], magnum[gl], corrade[pluginmanager]
+Build-Depends: magnum[core,texturetools], magnum[core,gl], corrade[pluginmanager]
 
 Feature: texturetools
 Description: TextureTools library
 
 Feature: tgaimporter
 Description: TgaImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: trade
 Description: Trade library
@@ -120,36 +120,36 @@ Build-Depends: corrade[pluginmanager]
 
 Feature: wavaudioimporter
 Description: WavAudioImporter plugin
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 
 Feature: windowlesscglapplication
 Description: WindowlessCglApplication library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: cglcontext
 Description: CglContext library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: windowlesswglapplication
 Description: WindowlessWglApplication library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: wglcontext
 Description: WglContext library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: windowlesseglapplication
 Description: WindowlessEglApplication library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: eglcontext
 Description: EglContext library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: windowlessglxapplication
 Description: WindowlessGlxApplication library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]
 
 Feature: glxcontext
 Description: GlxContext library
-Build-Depends: magnum[gl]
+Build-Depends: magnum[core,gl]


### PR DESCRIPTION
`vcpkg install magnum[core,shaders]` will install all the default features instead of just `gl`

Related to issue #11097 
