### PR TITLE
[protobuf] Correct protobuf under android (Fix issue #8218)

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.11.4
+Version: 3.11.4-1
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/fix-android-log.patch
+++ b/ports/protobuf/fix-android-log.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
+index 6bf86a277..424854798 100644
+--- a/cmake/libprotobuf-lite.cmake
++++ b/cmake/libprotobuf-lite.cmake
+@@ -67,6 +67,9 @@ target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
+ if(protobuf_LINK_LIBATOMIC)
+   target_link_libraries(libprotobuf-lite atomic)
+ endif()
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++       target_link_libraries(libprotobuf-lite log)
++endif()
+ target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
+ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+   target_compile_definitions(libprotobuf-lite
+diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
+index 0c12596c2..a5be494fb 100644
+--- a/cmake/libprotobuf.cmake
++++ b/cmake/libprotobuf.cmake
+@@ -121,6 +121,9 @@ endif()
+ if(protobuf_LINK_LIBATOMIC)
+   target_link_libraries(libprotobuf atomic)
+ endif()
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++       target_link_libraries(libprotobuf log)
++endif()
+ target_include_directories(libprotobuf PUBLIC ${protobuf_source_dir}/src)
+ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+   target_compile_definitions(libprotobuf

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-uwp.patch
+        fix-android-log.patch
 )
 
 if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")


### PR DESCRIPTION
**Describe the pull request**
This PR fixes and issue for protobuf when building for Android. 
When linking, an error "undefined reference to '__android_log_write' was happening.

The original error is likely inside protobuf CMakeLists, which should link the log library under Android: see [this issue in protobuf repo](https://github.com/protocolbuffers/protobuf/issues/2719)

**This fixes https://github.com/microsoft/vcpkg/issues/8218**

- Which triplets are supported/not supported? 
There is no official Android triplet at the moment. I will add an example triplet below. 

- Have you updated the CI baseline?
No

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

---- 

There is no official android triplet file. So, I provide an example one below. May be it could be an inspiration for a triplet in the community folder (however I am *not* an android expert).

**Steps to reproduce the build**

1. Use this triplet file:

`triplets/android-armeabi-v7a.cmake`
````cmake
set(VCPKG_TARGET_ARCHITECTURE arm)
set(VCPKG_CRT_LINKAGE static)
set(VCPKG_LIBRARY_LINKAGE dynamic)
set(VCPKG_CMAKE_SYSTEM_NAME Android)

set(ANDROID_NDK_HOME $ENV{ANDROID_NDK_HOME})
if ("${ANDROID_NDK_HOME}" MATCHES "^$")
  message(FATAL_ERROR 
    "Please set an env variable ANDROID_NDK_HOME pointing to your ndk-bundle folder. 
    For example: export ANDROID_NDK_HOME=/home/your-account/Android/Sdk/ndk-bundle")
endif()
set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake)

set(ANDROID_ABI armeabi-v7a)
# ANDROID_ABI can be : "armeabi-v7a" , "armeabi-v7a with NEON", "arm64-v8a", "x86" or "x86_64"
````

2. Download and install the [android ndk-bundle](https://developer.android.com/ndk/downloads/)

3. Set an env var to the ndk-bundle folder
````
    export ANDROID_NDK_HOME=/home/your-account/Android/Sdk/ndk-bundle
````

4. Build the protobuf package
````
    ./vcpkg install "protobuf:android-armeabi-v7a"
````
