### PR TITLE
[ignition-math6] Add new port 🤖

### DIFF
--- a/ports/ignition-cmake2/CONTROL
+++ b/ports/ignition-cmake2/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-cmake2
-Version: 2.1.1-1
+Version: 2.2.0
 Homepage: https://ignitionrobotics.org/libs/cmake
 Description: CMake helper functions for building robotic applications
 Build-Depends: ignition-modularscripts

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -1,10 +1,10 @@
 include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
 
-set(PACKAGE_VERSION "2.1.1")
+set(PACKAGE_VERSION "2.2.0")
 
 ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION}
-                         SHA512 4dce0ef477b737a217179478262ef9c9eafffbd6933023b43a3506ea76502955ab5ae8a94d779c13ad4ca15849cdfbe9f9d696af2ccc102522239040b9540fd9)
+                         SHA512 079b6d0cc5e2de83cf01f5731dd4e2e55e18e46c7506b6267a19a230fbbaa7b89053be4b42ca21584cf7fdd64de1d6305c7bc16fa3e0c5751b098fd0e5b98149)
 
 # Permit empty include folder
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/ignition-math6/CONTROL
+++ b/ports/ignition-math6/CONTROL
@@ -1,0 +1,5 @@
+Source: ignition-math6
+Version: 6.4.0
+Homepage: https://ignitionrobotics.org/libs/math
+Build-Depends: eigen3, ignition-cmake2, ignition-modularscripts
+Description: Math API for robotic applications

--- a/ports/ignition-math6/portfile.cmake
+++ b/ports/ignition-math6/portfile.cmake
@@ -1,0 +1,5 @@
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME math
+                         VERSION "6.4.0"
+                         SHA512 8a6e672ef6de591d25200f288deaaa16cc43e3c90804ee5ead0f06345036afbfa40acb531eb5b6a1fa80bd34c0c5964662cc0659d8bed2c811ad7c776d6f77cb)


### PR DESCRIPTION
- What does your PR fix? 
  - This PR adds a new port for the new major  version of the [ignition-math](https://ignitionrobotics.org/libs/math) library. 

- Which triplets are supported/not supported?
  - All tested triplet should be supported

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - I hope.

As discussed in https://github.com/microsoft/vcpkg/pull/7781, different major version of ignition robotics libraries (https://ignitionrobotics.org/) can be installed side by side, so each new major version is added as a new port. 

In particular, ignition-math6 is a dependency for Gazebo 11 (http://gazebosim.org/blog/gazebo11) and for Ignition Robotics Citadel (that contains Ignition Gazebo 3, see https://www.openrobotics.org/blog/2019/12/11/ignition-citadel-released).

To fix the build on arm64-windows, this PR also bumps the ignition-cmake2 version to 2.2.0, that contains a fix for arm64-windows (https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-cmake/pull-requests/168/page/1).
