### PR TITLE
[bitserializer-pugixml] Add new port

### DIFF
--- a/ports/bitserializer-pugixml/CONTROL
+++ b/ports/bitserializer-pugixml/CONTROL
@@ -1,0 +1,5 @@
+Source: bitserializer-pugixml
+Version: 0.9
+Build-Depends: bitserializer, pugixml
+Description: C++ 17 library for serialization, module for support XML (implementation based on the PugiXml library)
+Homepage: https://bitbucket.org/Pavel_Kisliak/bitserializer

--- a/ports/bitserializer-pugixml/portfile.cmake
+++ b/ports/bitserializer-pugixml/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_bitbucket(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Pavel_Kisliak/BitSerializer
+    REF 0.9
+    SHA512 74515a1a8338935c52752200d96abc0c0ee2c2b0b42880b1d10c8f56b5f8eb30680bd96b64eb2b352764128ad6a1fcd59749f481883c48a06230d652bee05902
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/archives/bitserializer_pugixml
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/bitserializer-pugixml/cmake)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/bitserializer-pugixml RENAME copyright)


### PR DESCRIPTION
Add new port with library **bitserializer-pugixml** which is sub-module of BitSerializer.
This PR depends from PR #11157 (with updates core library), please merge after.

- What does your PR fix? Fixes issue #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
All triplets should be supported (but not of all tested). No changes in the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
√