### PR TITLE
[libtorrent] add iconv feature on windows and clean up portfile

### DIFF
--- a/ports/libtorrent/CONTROL
+++ b/ports/libtorrent/CONTROL
@@ -1,5 +1,5 @@
 Source: libtorrent
-Version: 1.2.6
+Version: 1.2.6-1
 Homepage: https://github.com/arvidn/libtorrent
 Description: An efficient feature complete C++ BitTorrent implementation
 Build-Depends: openssl, boost-system, boost-date-time, boost-chrono, boost-random, boost-asio, boost-crc, boost-config, boost-iterator, boost-scope-exit, boost-multiprecision
@@ -10,6 +10,10 @@ Description: build with deprecated functions enabled
 
 Feature: examples
 Description: build the examples in the examples directory
+
+Feature: iconv
+Build-Depends: libiconv (windows)
+Description: build with libiconv on Windows
 
 Feature: python
 Build-Depends: boost-python, libtorrent[deprfun]

--- a/ports/libtorrent/fix_find_iconv.patch
+++ b/ports/libtorrent/fix_find_iconv.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 303f905e4..6bdbc5ac4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -603,24 +603,19 @@ target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME mutabl
+ target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME streaming DEFAULT ON
+ 	DESCRIPTION "Enables support for piece deadline" DISABLED TORRENT_DISABLE_STREAMING)
+ 
+-find_public_dependency(Iconv)
+-if(MSVC)
+-	set(iconv_package_type OPTIONAL)
+-else()
+-	set(iconv_package_type RECOMMENDED)
+-endif()
++find_public_dependency(unofficial-iconv REQUIRED)
+ 
+-set_package_properties(Iconv
++set_package_properties(unofficial-iconv
+ 	PROPERTIES
+ 		URL "https://www.gnu.org/software/libiconv/"
+-		DESCRIPTION "GNU encoding conversion library"
+-		TYPE ${iconv_package_type}
++		DESCRIPTION "GNU encoding conversion library (unofficial vcpkg CMake port)"
++		TYPE REQUIRED
+ 		PURPOSE "Convert strings between various encodings"
+ )
+ 
+-if(Iconv_FOUND)
++if(unofficial-iconv_FOUND)
+ 	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_USE_ICONV)
+-	target_link_libraries(torrent-rasterbar PRIVATE Iconv::Iconv)
++	target_link_libraries(torrent-rasterbar PRIVATE unofficial::iconv::libiconv unofficial::iconv::libcharset)
+ endif()
+ 
+ find_public_dependency(OpenSSL)

--- a/ports/libtorrent/no_use_iconv.patch
+++ b/ports/libtorrent/no_use_iconv.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 303f905e4..1810c23c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -603,26 +603,6 @@ target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME mutabl
+ target_optional_compile_definitions(torrent-rasterbar PUBLIC FEATURE NAME streaming DEFAULT ON
+ 	DESCRIPTION "Enables support for piece deadline" DISABLED TORRENT_DISABLE_STREAMING)
+ 
+-find_public_dependency(Iconv)
+-if(MSVC)
+-	set(iconv_package_type OPTIONAL)
+-else()
+-	set(iconv_package_type RECOMMENDED)
+-endif()
+-
+-set_package_properties(Iconv
+-	PROPERTIES
+-		URL "https://www.gnu.org/software/libiconv/"
+-		DESCRIPTION "GNU encoding conversion library"
+-		TYPE ${iconv_package_type}
+-		PURPOSE "Convert strings between various encodings"
+-)
+-
+-if(Iconv_FOUND)
+-	target_compile_definitions(torrent-rasterbar PUBLIC TORRENT_USE_ICONV)
+-	target_link_libraries(torrent-rasterbar PRIVATE Iconv::Iconv)
+-endif()
+-
+ find_public_dependency(OpenSSL)
+ set_package_properties(OpenSSL
+ 	PROPERTIES


### PR DESCRIPTION
**What does your PR fix?**

- Introduces the `iconv` feature on Windows. Also prevents Windows builds from accidentally picking up `Iconv` with CMake's built-in `FindIconv`, which causes builds of software that uses libtorrent to fail linking.
- Drops the `export.hpp` customizations. They are not needed anymore. Tested with the method mentioned in https://github.com/microsoft/vcpkg/pull/7345#issuecomment-524478011 with all standard windows triplets, and on linux - no linking failures.
- Fixes call to `vcpkg_fixup_cmake_targets`, now target directory uses actual package name (capitalization was wrong)
- Adjusts some variable names and comments in the portfile

**Which triplets are supported/not supported? Have you updated the CI baseline?**

No change in triplet support.

**Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?**

Yes.