### PR TITLE
[eigen3] [ignition-modularscripts] Fix installed pkgconfig files

### DIFF
--- a/ports/eigen3/CONTROL
+++ b/ports/eigen3/CONTROL
@@ -1,4 +1,4 @@
 Source: eigen3
-Version: 3.3.7-4
+Version: 3.3.7-5
 Homepage: http://eigen.tuxfamily.org
 Description: C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -16,19 +16,24 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DEIGEN_BUILD_PKGCONFIG=ON
     OPTIONS_RELEASE
         -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3
+        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig
     OPTIONS_DEBUG
         -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/share/eigen3
+        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
 )
 
 vcpkg_install_cmake()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/eigen3/Eigen3Targets.cmake" EIGEN_TARGETS)
 string(REPLACE "set(_IMPORT_PREFIX " "get_filename_component(_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}/../..\" ABSOLUTE) #" EIGEN_TARGETS "${EIGEN_TARGETS}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/eigen3/Eigen3Targets.cmake" "${EIGEN_TARGETS}")
+
+vcpkg_fixup_pkgconfig()
 
 file(GLOB INCLUDES ${CURRENT_PACKAGES_DIR}/include/eigen3/*)
 # Copy the eigen header files to conventional location for user-wide MSBuild integration

--- a/ports/ignition-cmake2/CONTROL
+++ b/ports/ignition-cmake2/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-cmake2
-Version: 2.2.0
+Version: 2.2.0-1
 Homepage: https://ignitionrobotics.org/libs/cmake
 Description: CMake helper functions for building robotic applications
 Build-Depends: ignition-modularscripts

--- a/ports/ignition-cmake2/portfile.cmake
+++ b/ports/ignition-cmake2/portfile.cmake
@@ -6,11 +6,5 @@ ignition_modular_library(NAME cmake
                          VERSION ${PACKAGE_VERSION}
                          SHA512 079b6d0cc5e2de83cf01f5731dd4e2e55e18e46c7506b6267a19a230fbbaa7b89053be4b42ca21584cf7fdd64de1d6305c7bc16fa3e0c5751b098fd0e5b98149)
 
-# Permit empty include folder
-set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
-
-# Remove unneccessary directory, as ignition-cmake is a pure CMake package
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug)
-
 # Install custom usage
 configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)

--- a/ports/ignition-fuel-tools1/CONTROL
+++ b/ports/ignition-fuel-tools1/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-fuel-tools1
-Version: 1.2.0-1
+Version: 1.2.0-2
 Build-Depends: curl, ignition-cmake0, ignition-common1, libyaml, libzip, jsoncpp
 Description: Tools for using fuel API to download robot models

--- a/ports/ignition-fuel-tools1/portfile.cmake
+++ b/ports/ignition-fuel-tools1/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
 
 ignition_modular_library(NAME fuel-tools
@@ -7,4 +5,7 @@ ignition_modular_library(NAME fuel-tools
                          CMAKE_PACKAGE_NAME ignition-fuel_tools1
                          SHA512 a656fed74fb2138b3bcf7d35b25ad06da95cfb9a3ad7ded2c9c54db385f55ea310fd1a72dcf6400b0a6199e376c1ba2d11ee2a08c66e3c2cc8b2ee1b25406986
                          # Ensure yaml is correctly linked (backport of https://bitbucket.org/ignitionrobotics/ign-fuel-tools/pull-requests/103/use-yaml_target-instead-of-yaml-yaml/diff)
-                         PATCHES link-correct-yaml-target.patch)
+                         PATCHES link-correct-yaml-target.patch
+                         # This can  be removed when the pc file of curl is fixed
+                         DISABLE_PKGCONFIG_INSTALL
+                         )

--- a/ports/ignition-modularscripts/CONTROL
+++ b/ports/ignition-modularscripts/CONTROL
@@ -1,3 +1,3 @@
 Source: ignition-modularscripts
-Version: 2020-04-16
+Version: 2020-05-09
 Description: Vcpkg helpers to package ignition libraries

--- a/ports/ignition-transport4/CONTROL
+++ b/ports/ignition-transport4/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-transport4
-Version: 4.0.0-1
-Build-Depends: cppzmq, ignition-cmake0, ignition-msgs1, libuuid (!windows&!uwp), protobuf, zeromq
+Version: 4.0.0-2
+Build-Depends: cppzmq, ignition-cmake0, ignition-modularscripts, ignition-msgs1, libuuid (!windows&!uwp), protobuf, zeromq
 Description: Transport middleware for robotics

--- a/ports/ignition-transport4/portfile.cmake
+++ b/ports/ignition-transport4/portfile.cmake
@@ -1,7 +1,7 @@
-include(vcpkg_common_functions)
-
 include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
 
 ignition_modular_library(NAME transport
                          VERSION "4.0.0"
-                         SHA512 d4125044c21fdd6754f3b8b06f372df3f858080d5d33e97ed7a8ef8f6fb9857d562082aad41c89ea9146a33b1c3814305d33c5c8f8bcde66a16477b4a01655b4)
+                         SHA512 d4125044c21fdd6754f3b8b06f372df3f858080d5d33e97ed7a8ef8f6fb9857d562082aad41c89ea9146a33b1c3814305d33c5c8f8bcde66a16477b4a01655b4
+                         # This can  be removed when the pc file of libuuid on Windows is fixed
+                         DISABLE_PKGCONFIG_INSTALL)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
  - This PR fixes the installed pkgconfig files for ignition libraries and some dependent ports. It is related to https://github.com/microsoft/vcpkg/issues/11087, but clearly it does not fix it completely.

- Which triplets are supported/not supported? Have you updated the CI baseline?
  - This PR should  not affected the supported or not supported  triplets.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - Yes
