### PR TITLE
[ignition-common3] Add new port 🤖

### DIFF
--- a/ports/ignition-common3/CONTROL
+++ b/ports/ignition-common3/CONTROL
@@ -1,0 +1,5 @@
+Source: ignition-common3
+Version: 3.9.0
+Build-Depends: dlfcn-win32 (windows|uwp), ffmpeg, freeimage, gts, ignition-cmake2, ignition-math6, ignition-modularscripts, libuuid (!windows&!uwp), tinyxml2
+Homepage: https://ignitionrobotics.org/libs/common
+Description: Common libraries for robotics applications

--- a/ports/ignition-common3/portfile.cmake
+++ b/ports/ignition-common3/portfile.cmake
@@ -5,7 +5,7 @@ ignition_modular_library(NAME common
                          SHA512 8d052850cbb125e334494c9ad9b234c371fe310327dba997515651f29479d747dffa55b0aa822f2a78e6317a4df2d41389c7a07165cdc08894fdfb116e4d9756)
 
 # Remove non-relocatable helper scripts (see https://github.com/ignitionrobotics/ign-common/issues/82)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/ign_remotery_vis" "${CURRENT_PACKAGES_DIR}/debug/bin'/ign_remotery_vis")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/ign_remotery_vis" "${CURRENT_PACKAGES_DIR}/debug/bin/ign_remotery_vis")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/ignition-common3/portfile.cmake
+++ b/ports/ignition-common3/portfile.cmake
@@ -1,0 +1,12 @@
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME common
+                         VERSION "3.9.0"
+                         SHA512 8d052850cbb125e334494c9ad9b234c371fe310327dba997515651f29479d747dffa55b0aa822f2a78e6317a4df2d41389c7a07165cdc08894fdfb116e4d9756)
+
+# Remove non-relocatable helper scripts (see https://github.com/ignitionrobotics/ign-common/issues/82)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/ign_remotery_vis" "${CURRENT_PACKAGES_DIR}/debug/bin'/ign_remotery_vis")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()


### PR DESCRIPTION
- What does your PR fix? 
  - This PR adds a new port for the new major  version of the [ignition-common](https://ignitionrobotics.org/libs/common) library. 

- Which triplets are supported/not supported?
  - All tested triplet (for which the dependency are actually available) should be supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - I hope.

As discussed in https://github.com/microsoft/vcpkg/pull/7781, different major version of ignition robotics libraries (https://ignitionrobotics.org/) can be installed side by side, so each new major version is added as a new port. 

In particular, ignition-common3 is a dependency for Gazebo 11 (http://gazebosim.org/blog/gazebo11) and for Ignition Robotics Citadel (that contains Ignition Gazebo 3, see https://www.openrobotics.org/blog/2019/12/11/ignition-citadel-released).
