### PR TITLE
[vcpkg] pass -disableMetrics to bootstrap on git bash

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,14 +6,6 @@ while [ "$vcpkgRootDir" != "/" ] && ! [ -e "$vcpkgRootDir/.vcpkg-root" ]; do
     vcpkgRootDir="$(dirname "$vcpkgRootDir")"
 done
 
-# Enable using this entry point on windows from git bash by redirecting to the .bat file.
-unixName=$(uname -s | sed 's/MINGW.*_NT.*/MINGW_NT/')
-if [ "$unixName" = "MINGW_NT" ]; then
-  vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
-  cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat" || exit 1
-  exit 0
-fi
-
 # Argument parsing
 vcpkgDisableMetrics="OFF"
 vcpkgUseSystem=false
@@ -40,6 +32,20 @@ do
         exit 1
     fi
 done
+
+# Enable using this entry point on windows from git bash by redirecting to the .bat file.
+unixName=$(uname -s | sed 's/MINGW.*_NT.*/MINGW_NT/')
+if [ "$unixName" = "MINGW_NT" ]; then
+    if [ "$vcpkgDisableMetrics" = "ON" ]; then
+        args="-disableMetrics"
+    else
+        args=""
+    fi
+
+    vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
+    cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat $args" || exit 1
+    exit 0
+fi
 
 if [ -z ${VCPKG_DOWNLOADS+x} ]; then
     downloadsDir="$vcpkgRootDir/downloads"


### PR DESCRIPTION
in git bash, we call back into bootstrap-vcpkg.bat,
but we don't pass -disableMetrics through.
This commit corrects this.

Fixes #11274