### PR TITLE
[vcpkg] Resolve --overlay-ports is only working for relative parths since fix…

### DIFF
--- a/toolsrc/src/vcpkg/portfileprovider.cpp
+++ b/toolsrc/src/vcpkg/portfileprovider.cpp
@@ -35,7 +35,15 @@ namespace vcpkg::PortFileProvider
             {
                 if (!overlay_path.empty())
                 {
-                    auto overlay = fs.canonical(VCPKG_LINE_INFO, paths.original_cwd / fs::u8path(overlay_path));
+                    fs::path overlay = fs::u8path(overlay_path);
+                    if (overlay.is_absolute())
+                    {
+                        overlay = fs.canonical(VCPKG_LINE_INFO, overlay);
+                    }
+                    else
+                    {
+                        overlay = fs.canonical(VCPKG_LINE_INFO, paths.original_cwd / overlay);
+                    }
 
                     Debug::print("Using overlay: ", overlay.u8string(), "\n");
 

--- a/toolsrc/src/vcpkg/portfileprovider.cpp
+++ b/toolsrc/src/vcpkg/portfileprovider.cpp
@@ -35,7 +35,7 @@ namespace vcpkg::PortFileProvider
             {
                 if (!overlay_path.empty())
                 {
-                    fs::path overlay = fs::u8path(overlay_path);
+                    auto overlay = fs::u8path(overlay_path);
                     if (overlay.is_absolute())
                     {
                         overlay = fs.canonical(VCPKG_LINE_INFO, overlay);


### PR DESCRIPTION
… for 

Fixes https://github.com/microsoft/vcpkg/issues/11301

**Describe the pull request**
Since the fix https://github.com/microsoft/vcpkg/issues/10771 the --overlay-ports parameter does not work with absolute paths any more. 

- What does your PR fix? Fixes issue #
Fixes: https://github.com/microsoft/vcpkg/issues/11301

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
