### PR TITLE
[ogre/ogre-next] Add conflict error message

### DIFF
--- a/ports/ogre-next/CONTROL
+++ b/ports/ogre-next/CONTROL
@@ -1,5 +1,5 @@
 Source: ogre-next
-Version: 2019-10-20
+Version: 2019-10-20-1
 Build-Depends: zlib, freeimage, freetype, rapidjson, openvr, boost-thread, boost-date-time, poco, tbb, sdl2, tinyxml, zziplib
 Homepage: https://github.com/OGRECave/ogre-next
 Description: Ogre 2.1 & 2.2 - scene-oriented, flexible 3D engine written in C++

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -1,6 +1,8 @@
 # This portfile is based (shamelessly copied and adapted a bit) on 'ogre' portfile.
 
-include(vcpkg_common_functions)
+if (EXISTS "${CURRENT_INSTALLED_DIR}/Media/HLMS/Blendfunctions_piece_fs.glslt")
+    message(FATAL_ERROR "FATAL ERROR: ogre-next and ogre are incompatible.")
+endif()
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     message("${PORT} currently requires the following library from the system package manager:\n    Xaw\n\nIt can be installed on Ubuntu systems via apt-get install libxaw7-dev")
@@ -114,6 +116,6 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/ogre-next RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/ogre-next/portfile.cmake
+++ b/ports/ogre-next/portfile.cmake
@@ -89,7 +89,7 @@ endif()
 
 #Remove OgreMain*.lib from lib/ folder, because autolink would complain, since it defines a main symbol
 #manual-link subfolder is here to the rescue!
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Release")
         file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/ogre/CONTROL
+++ b/ports/ogre/CONTROL
@@ -1,5 +1,5 @@
 Source: ogre
-Version: 1.12.1
+Version: 1.12.1-1
 Build-Depends: freeimage, freetype, zlib, zziplib
 Homepage: https://github.com/OGRECave/ogre
 Description: 3D Object-Oriented Graphics Rendering Engine

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -1,4 +1,6 @@
-include(vcpkg_common_functions)
+if (EXISTS "${CURRENT_INSTALLED_DIR}/Media/HLMS/Blendfunctions_piece_fs.glslt")
+    message(FATAL_ERROR "FATAL ERROR: ogre-next and ogre are incompatible.")
+endif()
 
 if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message("${PORT} currently requires the following library from the system package manager:\n    Xaw\n\nIt can be installed on Ubuntu systems via apt-get install libxaw7-dev")
@@ -24,29 +26,12 @@ endif()
 
 # Configure features
 
-if("d3d9" IN_LIST FEATURES)
-    set(WITH_D3D9 ON)
-else()
-    set(WITH_D3D9 OFF)
-endif()
-
-if("java" IN_LIST FEATURES)
-    set(WITH_JAVA ON)
-else()
-    set(WITH_JAVA OFF)
-endif()
-
-if("python" IN_LIST FEATURES)
-    set(WITH_PYTHON ON)
-else()
-    set(WITH_PYTHON OFF)
-endif()
-
-if("csharp" IN_LIST FEATURES)
-    set(WITH_CSHARP ON)
-else()
-    set(WITH_CSHARP OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    d3d9   WITH_D3D9
+    java   WITH_JAVA
+    python WITH_PYTHON
+    csharp WITH_CSHARP
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -73,10 +58,7 @@ vcpkg_configure_cmake(
         -DOGRE_BUILD_RENDERSYSTEM_GLES=OFF
         -DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF
 # Optional stuff
-        -DOGRE_BUILD_COMPONENT_JAVA=${WITH_JAVA}
-        -DOGRE_BUILD_COMPONENT_PYTHON=${WITH_PYTHON}
-        -DOGRE_BUILD_COMPONENT_CSHARP=${WITH_CSHARP}
-        -DOGRE_BUILD_RENDERSYSTEM_D3D9=${WITH_D3D9}
+        ${FEATURE_OPTIONS}
 # vcpkg specific stuff
         -DOGRE_CMAKE_DIR=share/ogre
 )
@@ -105,7 +87,7 @@ endif()
 
 #Remove OgreMain*.lib from lib/ folder, because autolink would complain, since it defines a main symbol
 #manual-link subfolder is here to the rescue!
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Release")
         file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -132,6 +114,6 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/ogre RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -27,10 +27,10 @@ endif()
 # Configure features
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    d3d9   WITH_D3D9
-    java   WITH_JAVA
-    python WITH_PYTHON
-    csharp WITH_CSHARP
+    d3d9   OGRE_BUILD_RENDERSYSTEM_D3D9
+    java   OGRE_BUILD_COMPONENT_JAVA
+    python OGRE_BUILD_COMPONENT_PYTHON
+    csharp OGRE_BUILD_COMPONENT_CSHARP
 )
 
 vcpkg_configure_cmake(

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -2,7 +2,7 @@ if (EXISTS "${CURRENT_INSTALLED_DIR}/Media/HLMS/Blendfunctions_piece_fs.glslt")
     message(FATAL_ERROR "FATAL ERROR: ogre-next and ogre are incompatible.")
 endif()
 
-if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_TARGET_IS_WINDOWS)
     message("${PORT} currently requires the following library from the system package manager:\n    Xaw\n\nIt can be installed on Ubuntu systems via apt-get install libxaw7-dev")
 endif()
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #11278
`ogre` and `ogre-next` can't  be installed  together. Add conflict error message for them.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes