### PR TITLE
[nettle] Fix nettle version

### DIFF
--- a/ports/nettle/CONTROL
+++ b/ports/nettle/CONTROL
@@ -1,5 +1,5 @@
 Source: nettle
-Version: 3.5.1 
+Version: 3.5.1
 Homepage: https://git.lysator.liu.se/nettle/nettle
 Description: Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.
 Build-Depends: gmp, vs-yasm (windows)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

Without it the info incorrectly installed into `vcpkg\installed\vcpkg\info\nettle_3.5.1 _x64-windows.list` which leads to error with build openssl-sys for Rust:

```
note: vcpkg did not find openssl: Could not look up details of packages in vcpkg tree Could not open port manifest file
vcpkg\installed\vcpkg\info\nettle_3.5.1_x64-windows.list
```

- Which triplets are supported/not supported? Have you updated the CI baseline?

All triples. No.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.