### PR TITLE
[vcpkg] [cuda] minor fixes for cuda and vcpkg

### DIFF
--- a/ports/cuda/CONTROL
+++ b/ports/cuda/CONTROL
@@ -1,4 +1,4 @@
 Source: cuda
-Version: 10.1-1
+Version: 10.1-2
 Description: A parallel computing platform and programming model
 Homepage: https://developer.nvidia.com/cuda-toolkit

--- a/ports/cuda/portfile.cmake
+++ b/ports/cuda/portfile.cmake
@@ -66,13 +66,11 @@ endif()
 # Copyright (c) 2005-2016 NVIDIA Corporation
 # Built on Sat_Sep__3_19:05:48_CDT_2016
 # Cuda compilation tools, release 8.0, V8.0.44
-string(REGEX MATCH "V([0-9]+)\\.([0-9]+)\\.([0-9]+)" CUDA_VERSION ${NVCC_OUTPUT})
+string(REGEX MATCH "V(([0-9]+)\\.([0-9]+)\\.([0-9]+))" CUDA_MATCH ${NVCC_OUTPUT})
+set(CUDA_VERSION ${CMAKE_MATCH_1})
 message(STATUS "Found CUDA ${CUDA_VERSION}")
-set(CUDA_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(CUDA_VERSION_MINOR ${CMAKE_MATCH_2})
-set(CUDA_VERSION_PATCH ${CMAKE_MATCH_3})
 
-if (CUDA_VERSION_MAJOR LESS 10 AND CUDA_VERSION_MINOR LESS 1)
+if (CUDA_VERSION VERSION_LESS ${CUDA_REQUIRED_VERSION})
     message(FATAL_ERROR "CUDA ${CUDA_VERSION} found, but v${CUDA_REQUIRED_VERSION} is required. Please download and install a more recent version of CUDA from:"
                         "\n    https://developer.nvidia.com/cuda-downloads\n")
 endif()

--- a/toolsrc/src/vcpkg/binaryparagraph.cpp
+++ b/toolsrc/src/vcpkg/binaryparagraph.cpp
@@ -89,9 +89,9 @@ namespace vcpkg
         , version(spgh.version)
         , description(spgh.description)
         , maintainer(spgh.maintainer)
+        , default_features(spgh.default_features)
         , abi(abi_tag)
         , type(spgh.type)
-        , default_features(spgh.default_features)
     {
         this->depends = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec().name(); });
         Util::sort_unique_erase(this->depends);
@@ -106,8 +106,8 @@ namespace vcpkg
         , description(fpgh.description)
         , maintainer()
         , feature(fpgh.name)
-        , type(spgh.type)
         , default_features()
+        , type(spgh.type)
     {
         this->depends = Util::fmap(deps, [](const FeatureSpec& spec) { return spec.spec().name(); });
         Util::sort_unique_erase(this->depends);


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

* ~~it fixes the initialization order of some class attributes for vcpkg, clang raise an error (and ISO C++ requires field designators to be specified in declaration order)~~ done in #11239

* ~~minor improvement in cuda port, extract the version directly from the nvcc pattern VX.Y.Z and compare to declared variable `CUDA_REQUIRED_VERSION` instead of performing a check with hardcoded values. This improves maintainability, next time the required version is changed, it has to be changed in only one place.~~ see  #11322 

- Which triplets are supported/not supported? Have you updated the CI baseline?
No changes in terms of supported triplets

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
