### PR TITLE
[uthenticode] Update to 1.0.4

### DIFF
--- a/ports/uthenticode/CONTROL
+++ b/ports/uthenticode/CONTROL
@@ -1,5 +1,5 @@
 Source: uthenticode
-Version: 1.0.3
+Version: 1.0.4
 Description: A cross-platform library for verifying Authenticode signatures
 Homepage: https://github.com/trailofbits/uthenticode
 Supports: !uwp

--- a/ports/uthenticode/portfile.cmake
+++ b/ports/uthenticode/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/uthenticode
-    REF v1.0.3
-    SHA512 c4a4712aeadae34a74e8535b17af192013254edd322a4453fe567647c21ed8b10b81a5d9d9028fbe2eed7d124cb9e420b6ef516f77bcb8594250c7372a3eff0b
+    REF v1.0.4
+    SHA512 82d5ff61071adefec886a140d253b733cb2318ccf34e831087973b05f7e274b207031e606303f65269a5ed1b45c3c599d79e217cf6229d60c8cc2396e842f32e
     HEAD_REF master
 )
 


### PR DESCRIPTION
Bumps uthenticode to 1.0.4.

- What does your PR fix? Fixes #

None.

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so!