### PR TITLE
[vcpkg] Use named mutex to serialize dll copies

### DIFF
--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -12,24 +12,53 @@ if ($copiedFilesLog)
     Set-Content -Path $copiedFilesLog -Value "" -Encoding UTF8
 }
 
+function computeHash([System.Security.Cryptography.HashAlgorithm]$alg, [string]$str) {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($str)
+    $hash = $alg.ComputeHash($bytes)
+    return [Convert]::ToBase64String($hash)
+}
+
+function getMutex([string]$targetDir) {
+    $sha512Hash = [System.Security.Cryptography.SHA512]::Create()
+    if ($sha512Hash) {
+        $hash = computeHash $sha512Hash $targetDir
+        $mtxName = "VcpkgAppLocalDeployBinary-" + $hash
+        return New-Object System.Threading.Mutex($false, $mtxName)
+    }
+
+    return New-Object System.Threading.Mutex($false, "VcpkgAppLocalDeployBinary")
+}
+
 # Note: this function signature is depended upon by the qtdeploy.ps1 script introduced in 5.7.1-7
 function deployBinary([string]$targetBinaryDir, [string]$SourceDir, [string]$targetBinaryName) {
-    if (Test-Path "$targetBinaryDir\$targetBinaryName") {
-        $sourceModTime = (Get-Item $SourceDir\$targetBinaryName).LastWriteTime
-        $destModTime = (Get-Item $targetBinaryDir\$targetBinaryName).LastWriteTime
-        if ($destModTime -lt $sourceModTime) {
-            Write-Verbose "  ${targetBinaryName}: Updating $SourceDir\$targetBinaryName"
+    try {
+        $mtx = getMutex($targetBinaryDir)
+        if ($mtx) {
+            $mtx.WaitOne() | Out-Null
+        }
+
+        if (Test-Path "$targetBinaryDir\$targetBinaryName") {
+            $sourceModTime = (Get-Item $SourceDir\$targetBinaryName).LastWriteTime
+            $destModTime = (Get-Item $targetBinaryDir\$targetBinaryName).LastWriteTime
+            if ($destModTime -lt $sourceModTime) {
+                Write-Verbose "  ${targetBinaryName}: Updating $SourceDir\$targetBinaryName"
+                Copy-Item "$SourceDir\$targetBinaryName" $targetBinaryDir
+            } else {
+                Write-Verbose "  ${targetBinaryName}: already present"
+            }
+        }
+        else {
+            Write-Verbose "  ${targetBinaryName}: Copying $SourceDir\$targetBinaryName"
             Copy-Item "$SourceDir\$targetBinaryName" $targetBinaryDir
-        } else {
-            Write-Verbose "  ${targetBinaryName}: already present"
+        }
+        if ($copiedFilesLog) { Add-Content $copiedFilesLog "$targetBinaryDir\$targetBinaryName" -Encoding UTF8 }
+        if ($tlogFile) { Add-Content $tlogFile "$targetBinaryDir\$targetBinaryName" -Encoding Unicode }
+    } finally {
+        if ($mtx) {
+            $mtx.ReleaseMutex() | Out-Null
+            $mtx.Dispose() | Out-Null
         }
     }
-    else {
-        Write-Verbose "  ${targetBinaryName}: Copying $SourceDir\$targetBinaryName"
-        Copy-Item "$SourceDir\$targetBinaryName" $targetBinaryDir
-    }
-    if ($copiedFilesLog) { Add-Content $copiedFilesLog "$targetBinaryDir\$targetBinaryName" -Encoding UTF8 }
-    if ($tlogFile) { Add-Content $tlogFile "$targetBinaryDir\$targetBinaryName" -Encoding Unicode }
 }
 
 


### PR DESCRIPTION
Fixes #11089

I'm not sure if this is the best idea, but it does seem to prevent multiple parallel build workers from clobbering a common `CMAKE_RUNTIME_OUTPUT_DIRECTORY` when copying runtime deps via `applocal.ps1`.