### PR TITLE
[vcpkg] Do not build the metrics uploader with MSBuild when metrics are disabled

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -426,5 +426,10 @@ Read more about vcpkg telemetry at docs/about/privacy.md
 Write-Verbose "Placing vcpkg.exe in the correct location"
 
 Copy-Item "$vcpkgReleaseDir\vcpkg.exe" "$vcpkgRootDir\vcpkg.exe"
-Copy-Item "$vcpkgReleaseDir\vcpkgmetricsuploader.exe" "$vcpkgRootDir\scripts\vcpkgmetricsuploader.exe"
+
+if (-not $disableMetrics)
+{
+    Copy-Item "$vcpkgReleaseDir\vcpkgmetricsuploader.exe" "$vcpkgRootDir\scripts\vcpkgmetricsuploader.exe"
+}
+
 Remove-Item "$vcpkgReleaseDir" -Force -Recurse -ErrorAction SilentlyContinue

--- a/toolsrc/dirs.proj
+++ b/toolsrc/dirs.proj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <ProjectFile Include="vcpkglib\vcpkglib.vcxproj"/>
     <ProjectFile Include="vcpkg\vcpkg.vcxproj"/>
-    <ProjectFile Include="vcpkgmetricsuploader\vcpkgmetricsuploader.vcxproj"/>
+    <ProjectFile Include="vcpkgmetricsuploader\vcpkgmetricsuploader.vcxproj" Condition="'$(DISABLE_METRICS)'!='1'"/>
   </ItemGroup>
 
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #11286

This PR skips building the vcpkgmetricsuploader project when `-disableMetrics` is used during bootstrapping with MSBuild as requested in the issue mentioned above. It adds a condition to the project file and skips copying the executable.

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.