### PR TITLE
[qt5-base] Add Xorg dependency libx11-xcb-dev

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-base
-Version: 5.12.8-2
+Version: 5.12.8-3
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl, angle (!windows), egl-registry, icu (!uwp), fontconfig (!windows)

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -6,6 +6,10 @@ else()
     option(QT_OPENSSL_LINK "Link against OpenSSL at compile-time." OFF)
 endif()
 
+if (VCPKG_TARGET_IS_LINUX)
+    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libx11-xcb-dev\n\nThese can be installed on Ubuntu systems via apt-get install libx11-xcb-dev.")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #11220
Add Xorg dependency `libx11-xcb-dev` for `qt5-base`.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes