### PR TITLE
 addition LLVM Compiler Toolchain extension for MSVC v160/2019 only

### DIFF
--- a/scripts/azure-pipelines/windows/provision-image.ps1
+++ b/scripts/azure-pipelines/windows/provision-image.ps1
@@ -297,7 +297,7 @@ Function InstallLLVMExtensions {
   )
   try {
     Write-Host 'Downloading LLVM Extensions...'
-    [string]$installerPath = Get-TempFilePath -Extension 'exe'
+    [string]$installerPath = Get-TempFilePath -Extension 'vsix'
     curl.exe -L -o $installerPath -s -S $Url
     Write-Host 'Installing LLVM Extensions...'
     $vsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise"

--- a/scripts/azure-pipelines/windows/provision-image.ps1
+++ b/scripts/azure-pipelines/windows/provision-image.ps1
@@ -301,7 +301,8 @@ Function InstallLLVMExtensions {
     curl.exe -L -o $installerPath -s -S $Url
     Write-Host 'Installing LLVM Extensions...'
     $vsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise"
-    $proc = Start-Process "$vsPath\Common7\IDE\VSIXInstaller.exe" "/q /a `"$installerPath`"" -Wait -PassThru
+    $vsixPath = "$env:installerPath\llvm2019.vsix"
+    $proc = Start-Process "$vsPath\Common7\IDE\VSIXInstaller.exe" "/q /a $vsixPath" -Wait -PassThru
     $exitCode = $proc.ExitCode
     if ($exitCode -eq 0) {
       Write-Host 'Installation successful!'

--- a/scripts/azure-pipelines/windows/provision-image.ps1
+++ b/scripts/azure-pipelines/windows/provision-image.ps1
@@ -285,8 +285,7 @@ Function InstallZip {
 Installs LLVM Extensions
 
 .DESCRIPTION
-Downloads the LLVM Extensions installer located at $Url, and installs it with the
-correct flags.
+Downloads the LLVM Extensions installer located at $Url, and installs it with the correct flags.
 
 .PARAMETER Url
 The URL of the installer.

--- a/scripts/azure-pipelines/windows/provision-image.ps1
+++ b/scripts/azure-pipelines/windows/provision-image.ps1
@@ -297,12 +297,10 @@ Function InstallLLVMExtensions {
   )
   try {
     Write-Host 'Downloading LLVM Extensions...'
-    [string]$installerPath = Get-TempFilePath -Extension 'vsix'
     curl.exe -L -o $installerPath -s -S $Url
     Write-Host 'Installing LLVM Extensions...'
     $vsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise"
-    $vsixPath = "$env:installerPath\llvm2019.vsix"
-    $proc = Start-Process "$vsPath\Common7\IDE\VSIXInstaller.exe" "/q /a $vsixPath" -Wait -PassThru
+    $proc = Start-Process "$vsPath\Common7\IDE\VSIXInstaller.exe" "/q /a $installerPath/llvm2019.vsix" -Wait -PassThru
     $exitCode = $proc.ExitCode
     if ($exitCode -eq 0) {
       Write-Host 'Installation successful!'


### PR DESCRIPTION
https://marketplace.visualstudio.com/items?itemName=MarekAniola.mangh-llvm2019

> Inspired by:
> 
>     LLVM Compiler Toolchain extension for Visual Studio 2017
>     Bug 42290 - LLVM Compiler Toolchain extension does not support Visual Studio 2019
>     Microsoft/PTVS Build error: The specified InstallRoot value of 'VCTargets' is invalid for item #5243
