### PR TITLE
[protobuf] protobuf v3.12.0

### DIFF
--- a/ports/ignition-msgs5/01-protobuf.patch
+++ b/ports/ignition-msgs5/01-protobuf.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f68bf3d..d4d1372 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -135,6 +135,8 @@ if(MSVC)
+   # warning is not important since those members do not need to be interfaced
+   # with.
+   set_source_files_properties(${gen_sources} COMPILE_FLAGS "/wd4251 /wd4146")
++  # Fix for protobuf 3.12 - allow big object files
++  add_definitions(/bigobj)
+ endif()
+ 
+ set_source_files_properties(${gen_headers} ${gen_sources} ${gen_ruby_scripts}

--- a/ports/ignition-msgs5/portfile.cmake
+++ b/ports/ignition-msgs5/portfile.cmake
@@ -12,7 +12,9 @@ vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
 
 ignition_modular_library(NAME msgs
                          VERSION "5.1.0"
-                         SHA512 db485f737c465b310602342a1a751c561473e330eb18d1b322b32d13de246536fe6a7efdf245faaaa9be1c9bfce662b2d39d1bb7cffc37e52690893cb47cc2ee)
+                         SHA512 db485f737c465b310602342a1a751c561473e330eb18d1b322b32d13de246536fe6a7efdf245faaaa9be1c9bfce662b2d39d1bb7cffc37e52690893cb47cc2ee
+                         PATCHES
+                           "01-protobuf.patch")
 
 # Restore old path
 set(ENV{PATH} ${path_backup})

--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.11.4-1
+Version: 3.12.0
 Homepage: https://github.com/google/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/fix-uwp.patch
+++ b/ports/protobuf/fix-uwp.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index f87b0928e..5102a10e3 100644
+index 849679995..dba537a68 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -190,6 +190,7 @@ if (MSVC)
+@@ -198,6 +198,7 @@ if (MSVC)
      /wd4506 # no definition for inline function 'function'
      /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
      /wd4996 # The compiler encountered a deprecated declaration.

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.11.4
-    SHA512 777bbb0e9e2375eaebe6b8c87abd660bac70ee469c9ad00dd25917b82d7fb5bbe33cf87f0d69c90e19d55c07a7285ec20974ba4768623ce9ccfadf147fd5e261
+    REF v3.12.0
+    SHA512 2a5448651db557505ad0ad88e681b88c956de7a7b8b029f8685416629d55b09dd35a0d1219311c524b9981067c3685178d89918d4fc2540d30669e9ad0c7c2d0
     HEAD_REF master
     PATCHES
         fix-uwp.patch


### PR DESCRIPTION
Update **protobuf** package to release [v3.12.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0)