### PR TITLE
[fcl] Explicity handle FCL_USE_X64_SSE CMake option

### DIFF
--- a/ports/fcl/CONTROL
+++ b/ports/fcl/CONTROL
@@ -1,5 +1,5 @@
 Source: fcl
-Version: 0.6.0
+Version: 0.6.0-1
 Homepage: https://github.com/flexible-collision-library/fcl
 Description: a library for performing three types of proximity queries on a pair of geometric models composed of triangles
 Build-Depends: ccd, octomap, eigen3

--- a/ports/fcl/portfile.cmake
+++ b/ports/fcl/portfile.cmake
@@ -14,12 +14,19 @@ else()
     set(FCL_STATIC_LIBRARY OFF)
 endif()
 
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(FCL_USE_X64_SSE ON)
+else()
+    set(FCL_USE_X64_SSE OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DFCL_STATIC_LIBRARY=${FCL_STATIC_LIBRARY}
         -DFCL_BUILD_TESTS=OFF
+        -DFCL_USE_X64_SSE=${FCL_USE_X64_SSE}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
The FCL_USE_X64_SSE option is enabled by default in fcl, but it only make sense to enable SSE flags when targeting either x86 or x64.

Related upstream PR: https://github.com/flexible-collision-library/fcl/pull/470 .

- What does your PR fix? There is no relative issue. 

- Which triplets are supported/not supported? Have you updated the CI baseline? The CI baseline should not change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
