### PR TITLE
[ccd] Add emscripten support

### DIFF
--- a/ports/ccd/CONTROL
+++ b/ports/ccd/CONTROL
@@ -1,4 +1,4 @@
 Source: ccd
-Version: 2.1-3
+Version: 2.1-4
 Homepage: https://github.com/danfis/libccd
 Description: Library for collision detection between two convex shapes

--- a/ports/ccd/portfile.cmake
+++ b/ports/ccd/portfile.cmake
@@ -1,16 +1,18 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danfis/libccd
     REF v2.1
     SHA512 ff037d9c4df50f09600cf9b3514b259b2850ff43f74817853f5665d22812891168f70bd3cc3969b2c9e3c706f6254991a65421476349607fbd04d894b217456d
     HEAD_REF master
+    # Backport https://github.com/danfis/libccd/pull/70 to support Emscripten
+    PATCHES "support-emscripten.patch"
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/ccd/support-emscripten.patch
+++ b/ports/ccd/support-emscripten.patch
@@ -1,0 +1,25 @@
+From c3616f28d33019047e8e71df8abeb0493159539e Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sun, 17 May 2020 11:42:24 +0200
+Subject: [PATCH] Fix configuration with  Emscripten
+
+In Emscripten there is no separate libm library, so there is no need to explicitly link it,
+and in particular the find_library call would fail as there is not libm to find.
+See https://stackoverflow.com/questions/24663915/how-can-i-link-libm-to-my-emscripten-port
+---
+ src/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1407080..357ed76 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -48,7 +48,7 @@ target_include_directories(ccd PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+ 
+-if(NOT WIN32)
++if(NOT WIN32 AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Emscripten"))
+   find_library(LIBM_LIBRARY NAMES m)
+   if(NOT LIBM_LIBRARY)
+     message(FATAL_ERROR "Could NOT find required library LibM")


### PR DESCRIPTION
Backport upstream patch: https://github.com/danfis/libccd/pull/70
Disable BUILD_TESTING, that has also the nice side effect of a faster build on all triplets.

- What does your PR fix? This PR fixes compilation of the ccd port on custom triplets that use Emscripten.

- Which triplets are supported/not supported? Have you updated the CI baseline? The CI baseline should not be affected.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
