### PR TITLE
[harfbuzz,skia] Update and replace Skia dependencies with vcpkg

### DIFF
--- a/ports/harfbuzz/0001-fix-cmake-export.patch
+++ b/ports/harfbuzz/0001-fix-cmake-export.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 019e205..8a464a5 100644
+index 71830b6f5..a25cb09dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -795,7 +795,7 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+@@ -712,7 +712,7 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    )
    install(EXPORT harfbuzzConfig
        NAMESPACE harfbuzz::
 -      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/harfbuzz
 +      DESTINATION share/harfbuzz
    )
-   if (HB_BUILD_UTILS)
-     if (WIN32 AND BUILD_SHARED_LIBS)
+   if (HB_HAVE_ICU)
+     install(TARGETS harfbuzz-icu

--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,9 +1,8 @@
 Source: harfbuzz
-Version: 2.5.3-1
+Version: 2.6.6
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
 Build-Depends: freetype[core], ragel, gettext (osx)
-Default-Features: ucdn
 
 Feature: graphite2
 Build-Depends: graphite2
@@ -12,9 +11,6 @@ Description: Graphite2 shaper support
 Feature: icu
 Build-Depends: icu
 Description: icu support for harfbuzz
-
-Feature: ucdn
-Description: Builtin (UCDN) Unicode callbacks support
 
 Feature: glib
 Build-Depends: glib

--- a/ports/harfbuzz/glib-cmake.patch
+++ b/ports/harfbuzz/glib-cmake.patch
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2d6e77e8..36e4b4e6 100644
+index 9b21bef2c..ae741ef63 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -306,22 +306,14 @@ endif ()
+@@ -213,21 +213,13 @@ endif ()
  if (HB_HAVE_GLIB)
    add_definitions(-DHAVE_GLIB)
- 
+
 -  # https://github.com/WebKit/webkit/blob/master/Source/cmake/FindGLIB.cmake
 -  find_package(PkgConfig)
 -  pkg_check_modules(PC_GLIB QUIET glib-2.0)
@@ -18,14 +18,13 @@ index 2d6e77e8..36e4b4e6 100644
 +  find_package(Threads REQUIRED)
 +  find_package(unofficial-iconv REQUIRED)
 +  find_package(unofficial-glib CONFIG REQUIRED)
- 
-   list(APPEND project_sources ${PROJECT_SOURCE_DIR}/src/hb-glib.cc)
+
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-glib.h)
- 
+
 -  list(APPEND THIRD_PARTY_LIBS ${GLIB_LIBRARIES})
 -
 -  mark_as_advanced(GLIB_LIBRARIES GLIBCONFIG_INCLUDE_DIR GLIB_INCLUDE_DIR)
 +  list(APPEND THIRD_PARTY_LIBS unofficial::glib::glib)
  endif ()
- 
+
  if (HB_HAVE_ICU)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF 2.5.3
-    SHA512 d541463b3647fc2c7ddaa29aedcea1c3bde5e26e0d529384d66d630af3aaf2a4befb3c4d47c93833f099339a0f951fb132011a02c57fc00ba543bd1b17026ffa
+    REF 2.6.6
+    SHA512 3ddf3e6eccf28ca1441544f0b67e243c6a85a32122bfc0f8092b3cc465b20a25aa3cb72404070d2627b9e204f86412c3bfb9aaca272c5492d8448facc1971a7d
     HEAD_REF master
     PATCHES
         0001-fix-cmake-export.patch
@@ -26,44 +24,17 @@ if("${_contents}" MATCHES "find_library\\(GLIB_LIBRARIES")
     message(FATAL_ERROR "Harfbuzz's cmake must not directly find_library() glib.")
 endif()
 
-SET(HB_HAVE_ICU "OFF")
-if("icu" IN_LIST FEATURES)
-    SET(HB_HAVE_ICU "ON")
-endif()
-
-SET(HB_HAVE_GRAPHITE2 "OFF")
-if("graphite2" IN_LIST FEATURES)
-    SET(HB_HAVE_GRAPHITE2 "ON")
-endif()
-
-## Unicode callbacks
-
-# Builtin (UCDN)
-set(BUILTIN_UCDN OFF)
-if("ucdn" IN_LIST FEATURES)
-    set(BUILTIN_UCDN ON)
-endif()
-
-# Glib
-set(HAVE_GLIB OFF)
-if("glib" IN_LIST FEATURES)
-    set(HAVE_GLIB ON)
-endif()
-
-# At least one Unicode callback must be specified, or harfbuzz compilation fails
-if(NOT (BUILTIN_UCDN OR HAVE_GLIB))
-    message(FATAL_ERROR "Error: At least one Unicode callback must be specified (ucdn, glib).")
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    icu         HB_HAVE_ICU
+    graphite2   HB_HAVE_GRAPHITE2
+    glib        HB_HAVE_GLIB
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DHB_HAVE_FREETYPE=ON
-        -DHB_BUILTIN_UCDN=${BUILTIN_UCDN}
-        -DHB_HAVE_ICU=${HB_HAVE_ICU}
-        -DHB_HAVE_GLIB=${HAVE_GLIB}
-        -DHB_HAVE_GRAPHITE2=${HB_HAVE_GRAPHITE2}
         -DHB_BUILD_TESTS=OFF
     OPTIONS_DEBUG
         -DSKIP_INSTALL_HEADERS=ON
@@ -74,7 +45,7 @@ vcpkg_fixup_cmake_targets()
 
 vcpkg_copy_pdbs()
 
-if (HAVE_GLIB)
+if ("glib" IN_LIST FEATURES)
     # Propagate dependency on glib downstream
     file(READ "${CURRENT_PACKAGES_DIR}/share/harfbuzz/harfbuzzConfig.cmake" _contents)
     file(WRITE "${CURRENT_PACKAGES_DIR}/share/harfbuzz/harfbuzzConfig.cmake" "
@@ -86,6 +57,4 @@ ${_contents}
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/harfbuzz RENAME copyright)
-
-vcpkg_test_cmake(PACKAGE_NAME harfbuzz)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -162,12 +162,24 @@ find_library(SSL_DEBUG ssl ssleay32 ssld ssleay32d PATHS "${CURRENT_INSTALLED_DI
 find_library(EAY_RELEASE libeay32 crypto libcrypto PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
 find_library(EAY_DEBUG libeay32 crypto libcrypto libeay32d cryptod libcryptod PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
 
+set(FREETYPE_RELEASE_ALL "${FREETYPE_RELEASE} ${BZ2_RELEASE} ${LIBPNG_RELEASE} ${ZLIB_RELEASE}")
+set(FREETYPE_DEBUG_ALL "${FREETYPE_DEBUG} ${BZ2_DEBUG} ${LIBPNG_DEBUG} ${ZLIB_DEBUG}")
+
+# If HarfBuzz is built with GLib enabled, it must be statically link
+set(GLIB_LIB_VERSION 2.0)
+find_library(GLIB_RELEASE NAMES glib-${GLIB_LIB_VERSION} PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
+find_library(GLIB_DEBUG NAMES glib-${GLIB_LIB_VERSION} PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
+if(GLIB_RELEASE MATCHES "-NOTFOUND" OR GLIB_DEBUG MATCHES "-NOTFOUND")
+    set(GLIB_RELEASE "")
+    set(GLIB_DEBUG "")
+endif()
+
 set(RELEASE_OPTIONS
             "LIBJPEG_LIBS=${JPEG_RELEASE}"
             "ZLIB_LIBS=${ZLIB_RELEASE}"
             "LIBPNG_LIBS=${LIBPNG_RELEASE} ${ZLIB_RELEASE}"
             "PCRE2_LIBS=${PCRE2_RELEASE}"
-            "FREETYPE_LIBS=${FREETYPE_RELEASE} ${BZ2_RELEASE} ${LIBPNG_RELEASE} ${ZLIB_RELEASE}"
+            "FREETYPE_LIBS=${FREETYPE_RELEASE_ALL}"
             "ICU_LIBS=${ICU_RELEASE}"
             "QMAKE_LIBS_PRIVATE+=${BZ2_RELEASE}"
             "QMAKE_LIBS_PRIVATE+=${LIBPNG_RELEASE}"            
@@ -177,7 +189,7 @@ set(DEBUG_OPTIONS
             "ZLIB_LIBS=${ZLIB_DEBUG}"
             "LIBPNG_LIBS=${LIBPNG_DEBUG} ${ZLIB_DEBUG}"
             "PCRE2_LIBS=${PCRE2_DEBUG}"
-            "FREETYPE_LIBS=${FREETYPE_DEBUG} ${BZ2_DEBUG} ${LIBPNG_DEBUG} ${ZLIB_DEBUG}"
+            "FREETYPE_LIBS=${FREETYPE_DEBUG_ALL}"
             "ICU_LIBS=${ICU_DEBUG}"
             "QMAKE_LIBS_PRIVATE+=${BZ2_DEBUG}"
             "QMAKE_LIBS_PRIVATE+=${LIBPNG_DEBUG}"
@@ -196,14 +208,14 @@ if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND RELEASE_OPTIONS
             "PSQL_LIBS=${PSQL_RELEASE} ${SSL_RELEASE} ${EAY_RELEASE} ws2_32.lib secur32.lib advapi32.lib shell32.lib crypt32.lib user32.lib gdi32.lib"
             "SQLITE_LIBS=${SQLITE_RELEASE}"
-            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE}"
+            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE} ${FREETYPE_RELEASE_ALL}"
             "OPENSSL_LIBS=${SSL_RELEASE} ${EAY_RELEASE} ws2_32.lib secur32.lib advapi32.lib shell32.lib crypt32.lib user32.lib gdi32.lib"
         )
         
     list(APPEND DEBUG_OPTIONS
             "PSQL_LIBS=${PSQL_DEBUG} ${SSL_DEBUG} ${EAY_DEBUG} ws2_32.lib secur32.lib advapi32.lib shell32.lib crypt32.lib user32.lib gdi32.lib"
             "SQLITE_LIBS=${SQLITE_DEBUG}"
-            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG}"
+            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG} ${FREETYPE_DEBUG_ALL}"
             "OPENSSL_LIBS=${SSL_DEBUG} ${EAY_DEBUG} ws2_32.lib secur32.lib advapi32.lib shell32.lib crypt32.lib user32.lib gdi32.lib"
         )
 elseif(VCPKG_TARGET_IS_LINUX)
@@ -214,14 +226,14 @@ elseif(VCPKG_TARGET_IS_LINUX)
     list(APPEND RELEASE_OPTIONS
             "PSQL_LIBS=${PSQL_RELEASE} ${SSL_RELEASE} ${EAY_RELEASE} -ldl -lpthread"
             "SQLITE_LIBS=${SQLITE_RELEASE} -ldl -lpthread"
-            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE}"
+            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE} ${FREETYPE_RELEASE_ALL} ${GLIB_RELEASE} -lpthread"
             "OPENSSL_LIBS=${SSL_RELEASE} ${EAY_RELEASE} -ldl -lpthread"
             "FONTCONFIG_LIBS=${FONTCONFIG_RELEASE} ${FREETYPE_RELEASE} ${EXPAT_RELEASE}"
         )
     list(APPEND DEBUG_OPTIONS
             "PSQL_LIBS=${PSQL_DEBUG} ${SSL_DEBUG} ${EAY_DEBUG} -ldl -lpthread"
             "SQLITE_LIBS=${SQLITE_DEBUG} -ldl -lpthread"
-            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG}"
+            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG} ${FREETYPE_DEBUG_ALL} ${GLIB_DEBUG} -lpthread"
             "OPENSSL_LIBS=${SSL_DEBUG} ${EAY_DEBUG} -ldl -lpthread"
             "FONTCONFIG_LIBS=${FONTCONFIG_DEBUG} ${FREETYPE_DEBUG} ${EXPAT_DEBUG}"
         )
@@ -252,14 +264,14 @@ elseif(VCPKG_TARGET_IS_OSX)
     list(APPEND RELEASE_OPTIONS
             "PSQL_LIBS=${PSQL_RELEASE} ${SSL_RELEASE} ${EAY_RELEASE} -ldl -lpthread"
             "SQLITE_LIBS=${SQLITE_RELEASE} -ldl -lpthread"
-            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE} -framework ApplicationServices"
+            "HARFBUZZ_LIBS=${HARFBUZZ_RELEASE} ${FREETYPE_RELEASE_ALL} -framework ApplicationServices"
             "OPENSSL_LIBS=${SSL_RELEASE} ${EAY_RELEASE} -ldl -lpthread"
             "FONTCONFIG_LIBS=${FONTCONFIG_RELEASE} ${FREETYPE_RELEASE} ${EXPAT_RELEASE} -liconv"
         )
     list(APPEND DEBUG_OPTIONS
             "PSQL_LIBS=${PSQL_DEBUG} ${SSL_DEBUG} ${EAY_DEBUG} -ldl -lpthread"
             "SQLITE_LIBS=${SQLITE_DEBUG} -ldl -lpthread"
-            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG} -framework ApplicationServices"
+            "HARFBUZZ_LIBS=${HARFBUZZ_DEBUG} ${FREETYPE_DEBUG_ALL} -framework ApplicationServices"
             "OPENSSL_LIBS=${SSL_DEBUG} ${EAY_DEBUG} -ldl -lpthread"
             "FONTCONFIG_LIBS=${FONTCONFIG_DEBUG} ${FREETYPE_DEBUG} ${EXPAT_DEBUG} -liconv"
         )

--- a/ports/skia/CONTROL
+++ b/ports/skia/CONTROL
@@ -1,10 +1,11 @@
 Source: skia
-Version: 2020-02-15-1
+Version: 2020-05-18-1
 Homepage: https://skia.org
 Description: Skia is an open source 2D graphics library which provides common APIs that work across a variety of hardware and software platforms.
   It serves as the graphics engine for Google Chrome and Chrome OS, Android, Mozilla Firefox and Firefox OS, and many other products.
   Skia is sponsored and managed by Google, but is available for use by anyone under the BSD Free Software License. While engineering of the core components is done by the Skia development team, we consider contributions from any source.
 Supports: x64 & (osx | windows)
+Build-Depends: expat, freetype[core], icu, harfbuzz[icu], libjpeg-turbo, libpng, libwebp, zlib
 
 Feature: metal
 Description: metal support for skia

--- a/ports/skia/expat.gn
+++ b/ports/skia/expat.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("expat") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/freetype2.gn
+++ b/ports/skia/freetype2.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("freetype2") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/harfbuzz.gn
+++ b/ports/skia/harfbuzz.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("harfbuzz") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/icu.gn
+++ b/ports/skia/icu.gn
@@ -1,0 +1,11 @@
+import("../third_party.gni")
+
+system("icu") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+  defines = @_DEFINITIONS@
+}

--- a/ports/skia/libjpeg-turbo.gn
+++ b/ports/skia/libjpeg-turbo.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("libjpeg") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/libpng.gn
+++ b/ports/skia/libpng.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("libpng") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/libwebp.gn
+++ b/ports/skia/libwebp.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("libwebp") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/piex.gn
+++ b/ports/skia/piex.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("piex") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/ports/skia/skiaConfig.cmake.in
+++ b/ports/skia/skiaConfig.cmake.in
@@ -1,4 +1,5 @@
-add_library(skia::skia SHARED IMPORTED)
+add_library(skia INTERFACE)
+add_library(skia::skia ALIAS skia)
 set(SKIA_DEP_DBG @SKIA_DEP_DBG@)
 set(SKIA_DEP_REL @SKIA_DEP_REL@)
 
@@ -17,62 +18,68 @@ if(_IMPORT_PREFIX STREQUAL "/")
   set(_IMPORT_PREFIX "")
 endif()
 
-if(WIN32)
-    if(SKIA_LIBRARY_IMPLIB_DBG)
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_IMPLIB_DEBUG "${_IMPORT_PREFIX}/debug/lib/${SKIA_LIBRARY_IMPLIB_DBG}"
-        )
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/bin/${SKIA_LIBRARY_NAME_DBG}"
-        )
-    else()
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_IMPLIB_DEBUG "${_IMPORT_PREFIX}/debug/lib/${SKIA_LIBRARY_NAME_DBG}"
-        )
-    endif()
+find_library(SKIA_LIB NAMES skia skia.dll)
+target_link_libraries(skia INTERFACE "${SKIA_LIB}")
 
-    if(SKIA_LIBRARY_IMPLIB_REL)
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/${SKIA_LIBRARY_IMPLIB_REL}"
-        )
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/bin/${SKIA_LIBRARY_NAME_REL}"
-        )
-    else()
-        set_property(TARGET skia::skia PROPERTY
-            IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/${SKIA_LIBRARY_NAME_REL}"
-        )
-    endif()
-else()
-    set_property(TARGET skia::skia PROPERTY
-        IMPORTED_LOCATION_DEBUG "${_IMPORT_PREFIX}/debug/lib/${SKIA_LIBRARY_NAME_DBG}"
-    )
-    set_property(TARGET skia::skia PROPERTY
-        IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/${SKIA_LIBRARY_NAME_REL}"
-    )
-endif()
+function(set_dependencies CONFIG LIBRARIES)
+    foreach(LIB ${LIBRARIES})
+        if(LIB MATCHES "^/")
+            if(WIN32)
+                string(SUBSTRING "${LIB}" 1 -1 LIB)
+            endif()
+            target_link_libraries(skia INTERFACE 
+                "$<$<CONFIG:${CONFIG}>:${LIB}>")
+        else()
+            string(REGEX REPLACE "\\.framework" "" LIB ${LIB})
+            string(REGEX REPLACE "[^a-zA-Z]" "_" LIB_NAME ${LIB})
+            string(TOUPPER ${LIB_NAME} LIB_NAME)
+            set(LIB_NAME SKIA_${LIB_NAME}_LIBRARY)
+            find_library(${LIB_NAME} ${LIB})
+            target_link_libraries(skia INTERFACE 
+                "$<$<CONFIG:${CONFIG}>:${${LIB_NAME}}>")
+        endif()
+    endforeach()
+endfunction()
 
-foreach(LIB ${SKIA_DEP_DBG})
-    string(REGEX REPLACE "\\.framework" "" LIB ${LIB})
-    string(REGEX REPLACE "[^a-zA-Z]" "_" LIB_NAME ${LIB})
-    string(TOUPPER ${LIB_NAME} LIB_NAME)
-    set(LIB_NAME SKIA_${LIB_NAME}_LIBRARY)
-    find_library(${LIB_NAME} ${LIB})
-    set_property(TARGET skia::skia
-            APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-            "$<$<CONFIG:Debug>:${${LIB_NAME}}>")
-endforeach()
+set_dependencies(Debug "${SKIA_DEP_DBG}")
+set_dependencies(Release "${SKIA_DEP_REL}")
 
-foreach(LIB ${SKIA_DEP_REL})
-    string(REGEX REPLACE "\\.framework" "" LIB ${LIB})
-    string(REGEX REPLACE "[^a-zA-Z]" "_" LIB_NAME ${LIB})
-    string(TOUPPER ${LIB_NAME} LIB_NAME)
-    set(LIB_NAME SKIA_${LIB_NAME}_LIBRARY)
-    find_library(${LIB_NAME} ${LIB})
-    set_property(TARGET skia::skia
-            APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-            "$<$<CONFIG:Release>:${${LIB_NAME}}>")
-endforeach()
+set(SKIA_DEFINITIONS_DBG
+        _CRT_SECURE_NO_WARNINGS
+        _HAS_EXCEPTIONS=0
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+        SK_GL
+        SK_ENABLE_DUMP_GPU
+        SK_SUPPORT_PDF
+        SK_HAS_JPEG_LIBRARY
+        SK_USE_LIBGIFCODEC
+        SK_HAS_HEIF_LIBRARY
+        SK_HAS_PNG_LIBRARY
+        SK_ENABLE_SKSL_INTERPRETER
+        SK_HAS_WEBP_LIBRARY
+        SK_XML
+        SKIA_DLL
+        SK_SUPPORT_ATLAS_TEXT=1)
 
-target_include_directories(skia::skia INTERFACE ${_IMPORT_PREFIX}/include)
-target_compile_definitions(skia::skia INTERFACE ${SKIA_PUBLIC_DEFINITIONS})
+set(SKIA_DEFINITIONS_REL
+        _CRT_SECURE_NO_WARNINGS
+        _HAS_EXCEPTIONS=0
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+        NDEBUG
+        SK_GL
+        SK_SUPPORT_PDF
+        SK_HAS_JPEG_LIBRARY
+        SK_USE_LIBGIFCODEC
+        SK_HAS_PNG_LIBRARY
+        SK_HAS_WEBP_LIBRARY
+        SK_XML
+        SKIA_DLL)
+
+target_compile_definitions(skia INTERFACE
+        $<$<CONFIG:Debug>:${SKIA_DEFINITIONS_DBG}>
+        $<$<CONFIG:Release>:${SKIA_DEFINITIONS_REL}>)
+
+target_include_directories(skia INTERFACE ${_IMPORT_PREFIX}/include)
+target_compile_definitions(skia INTERFACE ${SKIA_PUBLIC_DEFINITIONS})

--- a/ports/skia/zlib.gn
+++ b/ports/skia/zlib.gn
@@ -1,0 +1,10 @@
+import("../third_party.gni")
+
+system("zlib") {
+  include_dirs = @_INCLUDES@
+  if(is_debug) {
+    libs = @_LIBS_DBG@
+  } else {
+    libs = @_LIBS_REL@
+  }
+}

--- a/scripts/azure-pipelines/windows/initialize-environment.ps1
+++ b/scripts/azure-pipelines/windows/initialize-environment.ps1
@@ -25,7 +25,7 @@ $StorageAccountKey = $env:StorageAccountKey
 function Remove-DirectorySymlink {
     Param([string]$Path)
     if (Test-Path $Path) {
-        [System.IO.Directory]::Delete($Path)
+        [System.IO.Directory]::Delete($Path, $true)
     }
 }
 

--- a/scripts/cmake/vcpkg_install_gn.cmake
+++ b/scripts/cmake/vcpkg_install_gn.cmake
@@ -68,6 +68,12 @@ function(vcpkg_install_gn)
                             string(REGEX REPLACE "^/" "" OUTPUT "${OUTPUT}")
                         endif()
                     endif()
+
+                    if(NOT EXISTS "${OUTPUT}")
+                        message(STATUS "Output for target, ${TARGET} doesn't exist: ${OUTPUT}.")
+                        continue()
+                    endif()
+                    
                     if(TARGET_TYPE STREQUAL "executable")
                         file(INSTALL "${OUTPUT}" DESTINATION "${INSTALL_DIR}/tools")
                     elseif("${OUTPUT}" MATCHES "(\\.dll|\\.pdb)$")


### PR DESCRIPTION
Updates HarfBuzz to the latest release (2.6.6) and replaces most in-source Skia dependencies with ones provided by vcpkg.

Fixes #11285, fixes #10895, fixes #10075

- Which triplets are supported/not supported? 
N/A

- Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
