### PR TITLE
[assimp] Fix assimp-vc142-mt cannot be found in VS2019

### DIFF
--- a/ports/assimp/CONTROL
+++ b/ports/assimp/CONTROL
@@ -1,5 +1,5 @@
 Source: assimp
-Version: 5.0.1
+Version: 5.0.1-1
 Homepage: https://github.com/assimp/assimp
 Description: The Open Asset import library
 Build-Depends: zlib, rapidjson, minizip

--- a/ports/assimp/match-vs2019.patch
+++ b/ports/assimp/match-vs2019.patch
@@ -1,0 +1,22 @@
+diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
+index 30568ff..3943d99 100644
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1143,9 +1143,6 @@ ENDIF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
+ if( MSVC )
+   # in order to prevent DLL hell, each of the DLLs have to be suffixed with the major version and msvc prefix
+   # CMake 3.12 added a variable for this
+-  if(MSVC_TOOLSET_VERSION)
+-    set(MSVC_PREFIX "vc${MSVC_TOOLSET_VERSION}")
+-  else()
+     if( MSVC70 OR MSVC71 )
+       set(MSVC_PREFIX "vc70")
+     elseif( MSVC80 )
+@@ -1168,7 +1165,6 @@ if( MSVC )
+       MESSAGE(WARNING "unknown msvc version ${MSVC_VERSION}")
+       set(MSVC_PREFIX "vc150")
+     endif()
+-  endif()
+   set(LIBRARY_SUFFIX "${ASSIMP_LIBRARY_SUFFIX}-${MSVC_PREFIX}-mt" CACHE STRING "the suffix for the assimp windows library")
+ endif()
+ 

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-static-build-error.patch
         cmake-policy.patch
         fix_minizip.patch
+        match-vs2019.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake-modules/FindZLIB.cmake)


### PR DESCRIPTION
When using assimp in a cmake project in Visual Studio 2019, it will post the failure:
```
-CMake Error at D:/App/vcpkg/installed/x64-windows/share/assimp/assimpTargets.cmake:86 (message):
  The imported target "assimp::assimp" references the file

     D:/App/vcpkg/installed/x64-windows/debug/lib/assimp-vc142-mtd.lib
```
Since it generated `assimp-vc141-mtd.lib`, but required for `assimp-vc142-mtd.lib`.

Update the way to judge Visual Studio version to fix this.

Fix #11352

Note: No feature needs to test.
