### PR TITLE
[usd] Fix build error on Linux

### DIFF
--- a/ports/usd/CONTROL
+++ b/ports/usd/CONTROL
@@ -1,4 +1,4 @@
 Source: usd
-Version: 20.02
+Version: 20.02-1
 Build-Depends: boost-assign, boost-crc, boost-date-time, boost-filesystem, boost-format, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-vmd, tbb, zlib
 Description: Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.

--- a/ports/usd/CONTROL
+++ b/ports/usd/CONTROL
@@ -2,3 +2,4 @@ Source: usd
 Version: 20.02-1
 Build-Depends: boost-assign, boost-crc, boost-date-time, boost-filesystem, boost-format, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-vmd, tbb, zlib
 Description: Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.
+Supports: !x86

--- a/ports/usd/fix-build-error.patch
+++ b/ports/usd/fix-build-error.patch
@@ -1,0 +1,13 @@
+diff --git a/pxr/usd/ar/packageUtils.cpp b/pxr/usd/ar/packageUtils.cpp
+index d497587..ed3df29 100644
+--- a/pxr/usd/ar/packageUtils.cpp
++++ b/pxr/usd/ar/packageUtils.cpp
+@@ -29,6 +29,8 @@
+ #include "pxr/base/tf/pathUtils.h"
+ #include "pxr/base/tf/stringUtils.h"
+ 
++#include <algorithm>
++
+ PXR_NAMESPACE_OPEN_SCOPE
+ 
+ namespace

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -1,14 +1,14 @@
 # Don't file if the bin folder exists. We need exe and custom files.
 SET(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PixarAnimationStudios/USD
     REF be1a80f8cb91133ac75e1fc2a2e1832cd10d91c8 # v20.02
     SHA512 12c7cf7e5320b168ddde870b1a68b482515b33bd29206c4f6cbb248b9071b866c47353bf496890e01950abb5f725157eca576f9dc403e15020474f9a653b43fe
     HEAD_REF master
+    PATCHES
+        fix-build-error.patch
 )
 
 vcpkg_find_acquire_program(PYTHON2)

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_ARCH "x86")
+
 # Don't file if the bin folder exists. We need exe and custom files.
 SET(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1886,7 +1886,6 @@ unrar:x64-osx=fail
 unrar:x64-uwp=fail
 unrar:x64-windows-static=fail
 urdfdom:x64-windows-static=fail
-usd:x64-linux=ignore
 usd:x86-windows=fail
 usrsctp:arm-uwp=fail
 usrsctp:x64-uwp=fail


### PR DESCRIPTION
`Usd `build failed on Linux due to this:

```
/home/sh/dev/vcpkg/buildtrees/usd/src/2cd10d91c8-6bd873f966/pxr/usd/ar/packageUtils.cpp:202:41: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
202 | auto innermostCloseRevIt = std::find_if(
```
Add `#include  <algorithm>` to fix  #11419 

Note: No feature needs to test.
