### PR TITLE
[vcpkg-acquire-msys] Update pacman before any other package.

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.2-8
+Version: 4.2-9
 Build-Depends: zlib
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -91,6 +91,64 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman-key --init;pacman-key --populate"
       WORKING_DIRECTORY ${TOOLPATH}
     )
+
+    # workaround for https://github.com/msys2/MSYS2-packages/issues/1962
+    # update the package manager manually
+    if(_vam_HOST_ARCHITECTURE STREQUAL "AMD64")
+      set(ARCHIVE_LIBZSTD "libzstd-1.4.4-2-x86_64.pkg.tar.xz")
+      set(HASH_LIBZSTD 7f8d93f8340be8fc2ed9aa60b78bd5b05b954ca6f081d475ccd14dda088c5b1c992a4e7c0c0575877d021edf7f2f55545f21a77212cad244c78866b73f7d2a0c)
+      set(ARCHIVE_ZSTD "zstd-1.4.4-2-x86_64.pkg.tar.xz")
+      set(HASH_ZSTD 2be7e243d4e600d092aa6a630d24cfc536a6c06a4fa8e0909b0364569d2f938e24f220de1f52edbc36adc7c69ca23a2a730675f2da82c1530d3d91136089d3e2)
+      set(ARCHIVE_PACMAN "pacman-5.2.1-6-x86_64.pkg.tar.xz")
+      set(HASH_PACMAN d52a1352af7e4cd020fe4083390f48d1c1976a8c8dcb12611de9bbdd7dd07d71f2e32b107d4daef29ff09d8344f545aed239544824225e282f309438178e123e)
+      set(URL_ARCH x86_64)
+    else()
+      set(ARCHIVE_LIBZSTD "libzstd-1.4.4-2-i686.pkg.tar.xz")
+      set(HASH_LIBZSTD 5c8c3a259a3ede68a389a782ec6db76e942e90c8ee00b81417e09bb3d604564ce7a28c6d575be786a8cd2e931d2549fe9db7f238a9fbfff159542ec35d42774b)
+      set(ARCHIVE_ZSTD "zstd-1.4.4-2-i686.pkg.tar.xz")
+      set(HASH_ZSTD c806d78cfd5c9c4c37b82748b98397bb79413f8525fb6c7af35879b947afe3ea4d06e67902b6abe2386052352abe2db2f889f41b42a5c6913d723d0f316dcc41)
+      set(ARCHIVE_PACMAN "pacman-5.2.1-6-i686.pkg.tar.xz")
+      set(HASH_PACMAN 9f22bc4d2c62f6d823fd2b24ba872d37a6a69a87608f63f9217e8e5f1ce37331e0a795ed6ce7793615f0e240b3ab6359e45259f3a548bd357a27f7f5d0b0a5b4)
+      set(URL_ARCH i686)
+    endif()
+    vcpkg_download_distfile(ARCHIVE_LIBZSTD_PATH
+        URLS "https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/${URL_ARCH}/${ARCHIVE_LIBZSTD}/download"
+             "http://repo.msys2.org/msys/${URL_ARCH}/${ARCHIVE_LIBZSTD}"
+        FILENAME ${ARCHIVE_LIBZSTD}
+        SHA512 ${HASH_LIBZSTD}
+    )
+    vcpkg_download_distfile(ARCHIVE_ZSTD_PATH
+        URLS "https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/${URL_ARCH}/${ARCHIVE_ZSTD}/download"
+             "http://repo.msys2.org/msys/${URL_ARCH}/${ARCHIVE_ZSTD}"
+        FILENAME ${ARCHIVE_ZSTD}
+        SHA512 ${HASH_ZSTD}
+    )
+    vcpkg_download_distfile(ARCHIVE_PACMAN_PATH
+        URLS "https://sourceforge.net/projects/msys2/files/REPOS/MSYS2/${URL_ARCH}/${ARCHIVE_PACMAN}/download"
+             "http://repo.msys2.org/msys/${URL_ARCH}/${ARCHIVE_PACMAN}"
+        FILENAME ${ARCHIVE_PACMAN}
+        SHA512 ${HASH_PACMAN}
+    )
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman --noconfirm -U ${ARCHIVE_LIBZSTD_PATH}"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman --noconfirm -U ${ARCHIVE_ZSTD_PATH}"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman --noconfirm -U ${ARCHIVE_PACMAN_PATH}"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    # we have to kill all GnuPG daemons otherwise they will interfere with the
+    # subsequent package installs and updates
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;gpgconf --homedir /etc/pacman.d/gnupg --kill all"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    # end workaround
+
     _execute_process(
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Syu --noconfirm"
       WORKING_DIRECTORY ${TOOLPATH}


### PR DESCRIPTION
**Describe the pull request**

Adjusts `vcpkg_acquire_msys` function to update `MSYS2` package manager (`pacman`) before updating any other package to work around package manager's issues (e.g. https://github.com/msys2/MSYS2-packages/issues/1962).

- What does your PR fix?
Fixes #11438

- Which triplets are supported/not supported? Have you updated the CI baseline?
Not applicable.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.