### PR TITLE
[monkeys-audio] Update to 5.38

### DIFF
--- a/ports/monkeys-audio/CONTROL
+++ b/ports/monkeys-audio/CONTROL
@@ -3,7 +3,7 @@ Version: 5.38
 Homepage: https://monkeysaudio.com
 Description: Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.
   Audio files compressed with it ends with .ape extension.
-Supports: !uwp
+Supports: !(uwp|osx|linux)
 
 Feature: tools
 Description: Build monkeys-audio tools

--- a/ports/monkeys-audio/CONTROL
+++ b/ports/monkeys-audio/CONTROL
@@ -1,5 +1,5 @@
 Source: monkeys-audio
-Version: 5.24
+Version: 5.38
 Homepage: https://monkeysaudio.com
 Description: Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.
   Audio files compressed with it ends with .ape extension.

--- a/ports/monkeys-audio/fix-project-config.patch
+++ b/ports/monkeys-audio/fix-project-config.patch
@@ -1,0 +1,16 @@
+diff --git a/Source/Projects/VS2019/MACDll/MACDll.vcxproj b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+index 4e84b52..79882b0 100644
+--- a/Source/Projects/VS2019/MACDll/MACDll.vcxproj
++++ b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
+@@ -75,10 +75,9 @@
+     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>C:\Applications\Winamp\plugins\</OutDir>
++    <OutDir>$(Configuration)\</OutDir>
+     <IntDir>$(Configuration)\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+-    <TargetName>in_ape.dll</TargetName>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <OutDir>$(Configuration)\</OutDir>

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -2,12 +2,13 @@ vcpkg_fail_port_install(ON_TARGET "UWP" "OSX" "Linux")
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 
-set(MA_VERSION 524)
+set(MA_VERSION 538d)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://monkeysaudio.com/files/MAC_SDK_${MA_VERSION}.zip"
     FILENAME "MAC_SDK_${MA_VERSION}.zip"
-    SHA512 799035463f16dc94439e14c6b4a3755fbcf67e924d1c4925e26bb8172ff77122cf3e347f84d7e470dbddde79430f590dbeb1f69d6419cd36633cc8c616ea04f8
+    SHA512 2274d69161fad7740332585792da57e8f82634545da0aa13a5be975434a3df8526d1fd727b3f074ba928e4e252de2e5510e4f6616bb3cf469ef93b65dd55696b
+    PATCHES fix-project-config.patch
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -8,13 +8,13 @@ vcpkg_download_distfile(ARCHIVE
     URLS "https://monkeysaudio.com/files/MAC_SDK_${MA_VERSION}.zip"
     FILENAME "MAC_SDK_${MA_VERSION}.zip"
     SHA512 2274d69161fad7740332585792da57e8f82634545da0aa13a5be975434a3df8526d1fd727b3f074ba928e4e252de2e5510e4f6616bb3cf469ef93b65dd55696b
-    PATCHES fix-project-config.patch
 )
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL
+    PATCHES fix-project-config.patch
 )
 
 file(REMOVE_RECURSE


### PR DESCRIPTION
Since the repo no longer provides the download path of the old version, update to 5.38.

Related: #7733

All features are tested successful in the following triplets:
- x86-windows
- x64-windows
- x64-windows-static