### PR TITLE
[absent] Add new port

### DIFF
--- a/ports/absent/CONTROL
+++ b/ports/absent/CONTROL
@@ -1,3 +1,4 @@
 Source: absent
 Version: 0.3.0
+Homepage: https://github.com/rvarago/absent
 Description: A small library meant to simplify the composition of nullable types in a generic, type-safe, and declarative style for some C++ type constructors 

--- a/ports/absent/CONTROL
+++ b/ports/absent/CONTROL
@@ -1,0 +1,3 @@
+Source: absent
+Version: 0.3.0
+Description: A small library meant to simplify the composition of nullable types in a generic, type-safe, and declarative style for some C++ type constructors 

--- a/ports/absent/portfile.cmake
+++ b/ports/absent/portfile.cmake
@@ -1,0 +1,35 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rvarago/absent
+    REF 0.3.0
+    SHA512 e576a77e7305597ec931c4302a60355241fc8f2bb823d92add1079ea63e8ade39da6f5853135c1e68e3cc4c460dad7a67a76c3c451e645f05a39c2435b048f87
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTS=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH lib/cmake/${PORT}
+)
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug
+    ${CURRENT_PACKAGES_DIR}/lib
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+)
+
+file(INSTALL
+    ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
+)
+

--- a/ports/absent/portfile.cmake
+++ b/ports/absent/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rvarago/absent


### PR DESCRIPTION
**Describe the pull request**
This PR adds a new port for the library: absent. absent is a small library meant to simplify the composition of nullable types in a generic, type-safe, and declarative style
for some C++ type-constructors

- What does your PR fix? Fixes #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
I believe it should work fine for all triplets as long as the compiler supports C++17 or greater.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I hope it does. Please let me know if otherwise.
