### PR TITLE
[Arrow] Update to 0.17.1

### DIFF
--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -1,5 +1,5 @@
 Source: arrow
-Version: 0.17.0-2
+Version: 0.17.1
 Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algorithm, flatbuffers, rapidjson, zlib, lz4, brotli, bzip2, zstd, snappy, gflags, thrift, double-conversion, glog, uriparser, openssl
 Homepage: https://github.com/apache/arrow
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.

--- a/ports/arrow/all.patch
+++ b/ports/arrow/all.patch
@@ -1,8 +1,8 @@
 diff --git a/cpp/cmake_modules/BuildUtils.cmake b/cpp/cmake_modules/BuildUtils.cmake
-index f5f0ad7..3dca82e 100644
+index e4e13cb70..58ca626da 100644
 --- a/cpp/cmake_modules/BuildUtils.cmake
 +++ b/cpp/cmake_modules/BuildUtils.cmake
-@@ -305,7 +305,7 @@ function(ADD_ARROW_LIB LIB_NAME)
+@@ -335,7 +335,7 @@ function(ADD_ARROW_LIB LIB_NAME)
        target_include_directories(${LIB_NAME}_static PRIVATE ${ARG_PRIVATE_INCLUDES})
      endif()
  
@@ -11,8 +11,22 @@ index f5f0ad7..3dca82e 100644
        set(LIB_NAME_STATIC ${LIB_NAME}_static)
      else()
        set(LIB_NAME_STATIC ${LIB_NAME})
+diff --git a/cpp/cmake_modules/FindBrotli.cmake b/cpp/cmake_modules/FindBrotli.cmake
+index bf47915c4..053e605a0 100644
+--- a/cpp/cmake_modules/FindBrotli.cmake
++++ b/cpp/cmake_modules/FindBrotli.cmake
+@@ -64,8 +64,7 @@ if(BROTLI_ROOT)
+             PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES}
+             NO_DEFAULT_PATH)
+ else()
+-  pkg_check_modules(BROTLI_PC libbrotlicommon libbrotlienc libbrotlidec)
+-  if(BROTLI_PC_FOUND)
++  if(0) # Find via pkg_check_modules disabled as incompatible with vcpkg
+     set(BROTLI_INCLUDE_DIR "${BROTLI_PC_libbrotlicommon_INCLUDEDIR}")
+ 
+     # Some systems (e.g. Fedora) don't fill Brotli_LIBRARY_DIRS, so add the other dirs here.
 diff --git a/cpp/cmake_modules/FindLz4.cmake b/cpp/cmake_modules/FindLz4.cmake
-index 8410916..a196b25 100644
+index 841091643..a196b251d 100644
 --- a/cpp/cmake_modules/FindLz4.cmake
 +++ b/cpp/cmake_modules/FindLz4.cmake
 @@ -19,14 +19,16 @@ if(MSVC AND NOT DEFINED LZ4_MSVC_STATIC_LIB_SUFFIX)
@@ -53,10 +67,10 @@ index 8410916..a196b25 100644
        PATH_SUFFIXES ${LIB_PATH_SUFFIXES})
      find_path(LZ4_INCLUDE_DIR NAMES lz4.h PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES})
 diff --git a/cpp/cmake_modules/FindThrift.cmake b/cpp/cmake_modules/FindThrift.cmake
-index f9d6296..82b8d22 100644
+index bb3eb5608..0b03d37d3 100644
 --- a/cpp/cmake_modules/FindThrift.cmake
 +++ b/cpp/cmake_modules/FindThrift.cmake
-@@ -54,6 +54,10 @@ if(MSVC AND NOT THRIFT_MSVC_STATIC_LIB_SUFFIX)
+@@ -43,6 +43,10 @@ if(MSVC AND NOT THRIFT_MSVC_STATIC_LIB_SUFFIX)
    set(THRIFT_MSVC_STATIC_LIB_SUFFIX md)
  endif()
  
@@ -67,7 +81,7 @@ index f9d6296..82b8d22 100644
  if(Thrift_ROOT)
    find_library(THRIFT_STATIC_LIB thrift${THRIFT_MSVC_STATIC_LIB_SUFFIX}
                 PATHS ${Thrift_ROOT}
-@@ -74,16 +78,14 @@ else()
+@@ -61,16 +65,14 @@ else()
  
      list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
  
@@ -88,7 +102,7 @@ index f9d6296..82b8d22 100644
      find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h PATH_SUFFIXES "include")
      find_program(THRIFT_COMPILER thrift PATH_SUFFIXES "bin")
 diff --git a/cpp/cmake_modules/FindZSTD.cmake b/cpp/cmake_modules/FindZSTD.cmake
-index 8e47086..d7ce559 100644
+index 8e47086e8..d87906a25 100644
 --- a/cpp/cmake_modules/FindZSTD.cmake
 +++ b/cpp/cmake_modules/FindZSTD.cmake
 @@ -19,14 +19,18 @@ if(MSVC AND NOT DEFINED ZSTD_MSVC_STATIC_LIB_SUFFIX)
@@ -112,7 +126,13 @@ index 8e47086..d7ce559 100644
                       "${CMAKE_SHARED_LIBRARY_PREFIX}zstd${CMAKE_SHARED_LIBRARY_SUFFIX}"
                 PATHS ${ZSTD_ROOT}
                 PATH_SUFFIXES ${LIB_PATH_SUFFIXES}
-@@ -44,14 +48,14 @@ else()
+@@ -39,19 +43,18 @@ if(ZSTD_ROOT)
+ 
+ else()
+   # Second, find via pkg_check_modules
+-  pkg_check_modules(ZSTD_PC libzstd)
+-  if(ZSTD_PC_FOUND)
++  if(0) # Disabled as incompatible with vcpkg
      set(ZSTD_INCLUDE_DIR "${ZSTD_PC_INCLUDEDIR}")
  
      list(APPEND ZSTD_PC_LIBRARY_DIRS "${ZSTD_PC_LIBDIR}")
@@ -130,10 +150,10 @@ index 8e47086..d7ce559 100644
                   PATH_SUFFIXES ${LIB_PATH_SUFFIXES})
      find_path(ZSTD_INCLUDE_DIR NAMES zstd.h PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES})
 diff --git a/cpp/cmake_modules/SetupCxxFlags.cmake b/cpp/cmake_modules/SetupCxxFlags.cmake
-index 75b33c2..80cac9a 100644
+index 6110a5aa5..3270d74a9 100644
 --- a/cpp/cmake_modules/SetupCxxFlags.cmake
 +++ b/cpp/cmake_modules/SetupCxxFlags.cmake
-@@ -128,7 +128,9 @@ macro(arrow_add_werror_if_debug)
+@@ -163,7 +163,9 @@ macro(arrow_add_werror_if_debug)
    if("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
      # Treat all compiler warnings as errors
      if(MSVC)

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(ON_ARCH x86 arm arm64)
+vcpkg_fail_port_install(ON_ARCH "x86" "arm" "arm64")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -12,6 +12,15 @@ vcpkg_from_github(
         all.patch
 )
 
+if(VCPKG_TARGET_IS_LINUX)
+    vcpkg_find_acquire_program(BISON)
+    vcpkg_find_acquire_program(FLEX)
+endif()
+
+if (VCPKG_TARGET_IS_OSX)
+    vcpkg_find_acquire_program(BISON)
+endif()
+
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ARROW_BUILD_STATIC)
 

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow
-    REF apache-arrow-0.17.0
-    SHA512 293737db80defa0f8766f726dc228ace50936f7124647de15c2e024c2901ded1cda893d771d38aa4e9ab19ff7eb06b11dfc230587ca5b17cdd87e681fc3009ca
+    REF apache-arrow-0.17.1
+    SHA512 2a1a637d6df08e19d0c8313c51e1baf8902db677b072f8787c4f9faf8bdec94357ac8af839718d449377b508fe4f6e31b011cbdc6ccf029b6a66f567172569aa
     HEAD_REF master
     PATCHES
         all.patch

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -12,15 +12,6 @@ vcpkg_from_github(
         all.patch
 )
 
-if(VCPKG_TARGET_IS_LINUX)
-    vcpkg_find_acquire_program(BISON)
-    vcpkg_find_acquire_program(FLEX)
-endif()
-
-if (VCPKG_TARGET_IS_OSX)
-    vcpkg_find_acquire_program(BISON)
-endif()
-
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" ARROW_BUILD_SHARED)
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "static" ARROW_BUILD_STATIC)
 

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -1,6 +1,4 @@
-if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-  message(FATAL_ERROR "Apache Arrow only supports x64")
-endif()
+vcpkg_fail_port_install(ON_ARCH x86 arm arm64)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -84,7 +84,6 @@ apr:arm64-windows=fail
 argtable2:arm-uwp=fail
 argtable2:x64-uwp=fail
 arrow:arm64-windows=fail
-arrow:x64-linux=fail
 arrow:x86-windows=fail
 asiosdk:x64-linux=fail
 asiosdk:x64-osx=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1815,6 +1815,7 @@ theia:x64-windows-static = skip
 theia:x86-windows        = skip
 thor:x64-linux=fail
 thor:x64-osx=fail
+thrift:x64-osx=fail
 tidy-html5:arm-uwp=fail
 tidy-html5:x64-uwp=fail
 tinkerforge:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1815,7 +1815,6 @@ theia:x64-windows-static = skip
 theia:x86-windows        = skip
 thor:x64-linux=fail
 thor:x64-osx=fail
-thrift:x64-osx=fail
 tidy-html5:arm-uwp=fail
 tidy-html5:x64-uwp=fail
 tinkerforge:arm-uwp=fail


### PR DESCRIPTION
Updates Arrow from 0.17.0 to the recently released 0.17.1.

Built and successfully tested on Windows (x64-static), Linux (x64) and macOS (x64) via ParquetSharp CI:
https://github.com/G-Research/ParquetSharp/pull/136