### PR TITLE
[python3] Fix dynamic build error on Linux

### DIFF
--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -1,8 +1,9 @@
 Source: python3
-Version: 3.7.3-2
+Version: 3.7.3-3
 Homepage: https://github.com/python/cpython
 Description: The Python programming language as an embeddable library
 Build-Depends: libffi, openssl
 
 Feature: enable-shared
 Description: Build shared libraries in addition to static ones built by default
+Build-Depends: zlib (!uwp&!windows)

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -18,6 +18,9 @@ vcpkg_from_github(
 
 if("enable-shared" IN_LIST FEATURES)
 	set(_ENABLED_SHARED --enable-shared)
+    if(VCPKG_TARGET_IS_LINUX)
+        message(WARNING"Feature enable-shared requires libffi-devel from the system package manager, please install it on Ubuntu system via sudo apt-get install libffi-dev.")
+    endif()
 else()
 	unset(_ENABLED_SHARED)
 endif()

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1092,6 +1092,10 @@ miniupnpc:arm-uwp=fail
 miniupnpc:x64-uwp=fail
 minizip:arm-uwp=fail
 minizip:x64-uwp=fail
+# conflicts with stb
+mlpack:x86-windows=skip
+mlpack:x64-windows=skip
+mlpack:x64-windows-static=skip
 mman:x64-linux=fail
 mman:x64-osx=fail
 # mmx installs many problematic headers, such as `json.h` and `sched.h`


### PR DESCRIPTION
Feature `enable-shared` build error on Linux lack of `zlib `dependency.

So I add the dependency to this feature on non windows.

Also add the prompt message that `libffi-devel` is required for` enable-shared` on Linux.

Fix  #11101 

Note: Feature has passed with the following triplets:   
- x64-windows
- x64-linux
