### PR TITLE
[basisu, gppanel, msgpack11, nana, rapidcheck, folly] Add missing header file of STL

### DIFF
--- a/ports/basisu/CONTROL
+++ b/ports/basisu/CONTROL
@@ -1,5 +1,5 @@
 Source: basisu
-Version: 1.11-3
+Version: 1.11-4
 Homepage: https://github.com/BinomialLLC/basis_universal
 Description: Basis Universal is a supercompressed GPU texture and video compression format that outputs a highly compressed intermediate file format (.basis) that can be quickly transcoded to a wide variety of GPU texture compression formats. 
 Build-Depends: lodepng

--- a/ports/basisu/fix-addostream.patch
+++ b/ports/basisu/fix-addostream.patch
@@ -1,0 +1,12 @@
+diff --git a/src/encoder/basisu_enc.h b/src/encoder/basisu_enc.h
+index 05656da..468f43b 100644
+--- a/src/encoder/basisu_enc.h
++++ b/src/encoder/basisu_enc.h
+@@ -22,6 +22,7 @@
+ #include <functional>
+ #include <thread>
+ #include <unordered_map>
++#include <ostream>
+ 
+ #ifndef _WIN32
+ #include <libgen.h>

--- a/ports/basisu/portfile.cmake
+++ b/ports/basisu/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 497875f756ed0e3eb62e0ff08d55c62242f4be74
     SHA512 2293b78620a7ed510dbecf48bcae5f4b8524fe9020f864c8e79cf94ea9d95d51dddf83a5b4ea29cc95db19f87137bfef1cb68b7fbc6387e08bb42898d81c9303
     HEAD_REF master
+    PATCHES fix-addostream.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,5 @@
 Source: folly
-Version: 2019.10.21.00-1
+Version: 2019.10.21.00-2
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr

--- a/ports/folly/fix-addbit.patch
+++ b/ports/folly/fix-addbit.patch
@@ -1,0 +1,15 @@
+diff --git a/folly/lang/Bits.h b/folly/lang/Bits.h
+index f0beb5b..f86a1a3 100644
+--- a/folly/lang/Bits.h
++++ b/folly/lang/Bits.h
+@@ -64,6 +64,10 @@
+ #include <folly/lang/Assume.h>
+ #include <folly/portability/Builtins.h>
+ 
++#if __has_include(<bit>)
++#include <bit>
++#endif
++
+ namespace folly {
+ 
+ #if __cpp_lib_bit_cast

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         reorder-glog-gflags.patch
         disable-non-underscore-posix-names.patch
         boost-1.70.patch
+        fix-addbit.patch
 )
 
 file(COPY

--- a/ports/gppanel/CONTROL
+++ b/ports/gppanel/CONTROL
@@ -1,5 +1,5 @@
 Source: gppanel
-Version: 2018-04-06
+Version: 2020-05-20
 Build-Depends: wxwidgets
 Homepage: https://github.com/woollybah/gppanel
 Description: gpPanel is chart libary for wxWidget. It inheritance from wxPanel and use modified wxMathPlot library at chart engine. 

--- a/ports/gppanel/portfile.cmake
+++ b/ports/gppanel/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO woollybah/gppanel
-    REF 5ef9674d893bbf5e17da66841cbc6aeeef051b25
-    SHA512 a52eb5c4d9065e29d84374e9c484bae14cf7ff9a80fe6b025be108942a6c4683dd7f64830f78f0f7d45971f930df68f58dadf7c3915178e8908dd220d06a1e2c
+    REF f58a9028f7c9a8e9b4324ff2165951f558365f90
+    SHA512 4ec5fbef4c487d351c60f48b0c0e41c5d077989ab96f827b9fd5ef01c167d50f39a313bd82db1b5df19d14025983e83db4d19cc4048c1c50fc8ef9128de15575
     HEAD_REF master
     PATCHES 00001-fix-build.patch
 )

--- a/ports/msgpack11/CONTROL
+++ b/ports/msgpack11/CONTROL
@@ -1,5 +1,5 @@
 Source: msgpack11
-Version: 0.0.10
+Version: 0.0.10-1
 Homepage: https://msgpack.org
 Build-Depends: gtest
 Description: msgpack11 is a tiny MsgPack library for C++11, providing MsgPack parsing and serialization.This library is inspired by json11.The API of msgpack11 is designed to be similar with json11.

--- a/ports/msgpack11/fix-additerator.patch
+++ b/ports/msgpack11/fix-additerator.patch
@@ -1,0 +1,12 @@
+diff --git a/msgpack11.cpp b/msgpack11.cpp
+index fa572fa..640ba9a 100644
+--- a/msgpack11.cpp
++++ b/msgpack11.cpp
+@@ -10,6 +10,7 @@
+ #include <algorithm>
+ #include <functional>
+ #include <stdexcept>
++#include <iterator>
+ 
+ namespace msgpack11 {
+ 

--- a/ports/msgpack11/portfile.cmake
+++ b/ports/msgpack11/portfile.cmake
@@ -6,7 +6,8 @@ vcpkg_from_github(
     SHA512 7b90893f9cdec529789f6e75703f5945c6fc5c946b8708a7a2cb295faf4af111c8cc61265b636f385641031b85181929205be9c5d155f405909445dce85b4ce8
     HEAD_REF master
     PATCHES
-    	msvc.patch
+        msvc.patch
+        fix-additerator.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/nana/CONTROL
+++ b/ports/nana/CONTROL
@@ -1,5 +1,5 @@
 Source: nana
-Version: 1.7.2-2
+Version: 1.7.2-3
 Homepage: https://github.com/cnjinhao/nana
 Description: Cross-platform library for GUI programming in modern C++ style.
 Build-Depends: libpng, libjpeg-turbo, freetype (!uwp&&!windows), fontconfig (!uwp&&!windows)

--- a/ports/nana/fix-addstdexcept.patch
+++ b/ports/nana/fix-addstdexcept.patch
@@ -1,0 +1,12 @@
+diff --git a/source/datetime.cpp b/source/datetime.cpp
+index e6e8fa5..c3ae852 100644
+--- a/source/datetime.cpp
++++ b/source/datetime.cpp
+@@ -15,6 +15,7 @@
+ 	#include <windows.h>
+ #endif
+ #include <array>
++#include <stdexcept>
+ 
+ namespace {
+ 	std::tm localtime()

--- a/ports/nana/portfile.cmake
+++ b/ports/nana/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     HEAD_REF develop
     PATCHES
         fix-build-error.patch
+        fix-addstdexcept.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/rapidcheck/CONTROL
+++ b/ports/rapidcheck/CONTROL
@@ -1,3 +1,4 @@
 Source: rapidcheck
-Version: 2018-11-05-1
+Version: 2018-11-05-2
+Homepage: https://github.com/emil-e/rapidcheck
 Description: A property-based testing library for C++ (a la QuickCheck) with the goal of being simple to use with as little boilerplate as possible.

--- a/ports/rapidcheck/fix-addiosfwd.patch
+++ b/ports/rapidcheck/fix-addiosfwd.patch
@@ -1,0 +1,12 @@
+diff --git a/include/rapidcheck/Random.h b/include/rapidcheck/Random.h
+index e510673..4b01f58 100644
+--- a/include/rapidcheck/Random.h
++++ b/include/rapidcheck/Random.h
+@@ -3,6 +3,7 @@
+ #include <cstdint>
+ #include <array>
+ #include <limits>
++#include <iosfwd>
+ 
+ namespace rc {
+ 

--- a/ports/rapidcheck/portfile.cmake
+++ b/ports/rapidcheck/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -8,6 +6,7 @@ vcpkg_from_github(
     REF cf9e0d8bd8c94e9dc00dc0ab302352bfaf1a3ac5
     SHA512 6cef62edbda391c3527d63db350842f669841ad2c751a64773250cd40bb65f26c2c394b107ef5530c2d3bd15b7079148fa9778d68a7346225bbb15227b1553c5
     HEAD_REF master
+    PATCHES fix-addiosfwd.patch
 )
 
 vcpkg_configure_cmake(
@@ -18,13 +17,10 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/rapidcheck/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/${PORT}/cmake)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/rapidcheck/copyright COPYONLY)
-
-# Post-build test for cmake libraries
-vcpkg_test_cmake(PACKAGE_NAME rapidcheck)
+configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Since an internal change, <string> doesn't transitively include<ostream>, then these ports build failed like the following error.
`folly\src\46d6707604-d64234cbb5\folly/lang/Bits.h(71): error C2039: 'bit_cast': is not a member of 'std'`
`gppanel\src\eeef051b25-b2b3e8579b\gpPanel\mpScaleY.cpp(146): error C2039: 'fabs': is not a member of 'std'`
For fixing these issues, just need to add the missing header file into the source. 