### PR TITLE
[simdjson] Fix error LNK2001 when compile with /fsanitize=address in MSVC

### DIFF
--- a/ports/simdjson/CONTROL
+++ b/ports/simdjson/CONTROL
@@ -1,5 +1,5 @@
 Source: simdjson
-Version: 2019-12-27
+Version: 2019-12-27-1
 Description: A extremely fast JSON library that can parse gigabytes of JSON per second
 Homepage: https://github.com/lemire/simdjson
 Supports: !(x86|arm|arm64)

--- a/ports/simdjson/Fix-error-LNK2001.patch
+++ b/ports/simdjson/Fix-error-LNK2001.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/cmake/FindOptions.cmake b/tools/cmake/FindOptions.cmake
+index f9854c1..0c4d331 100644
+--- a/tools/cmake/FindOptions.cmake
++++ b/tools/cmake/FindOptions.cmake
+@@ -4,9 +4,9 @@ endmacro(append)
+ 
+ set(SANITIZE_FLAGS "")
+ if(SIMDJSON_SANITIZE)
+-  set(SIMDJSON_SANITIZE_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all")
+   if (CMAKE_COMPILER_IS_GNUCC)
+     # Ubuntu bug for GCC 5.0+ (safe for all versions)
++    set(SIMDJSON_SANITIZE_FLAGS "-fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all")
+     append(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=gold")
+     append(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold")
+   endif()

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -7,7 +7,8 @@ vcpkg_from_github(
     REF 4da06830f1389c8cd33171f5ab3558e79f0ece04
     SHA512 ffb11ee91f97d975fba2946653c9c847565933380f94e334d15e627f77a7a750702c539ca55d17e077b2ed0a79006f56a3b9a202d888bb7e2e3f0484237cb537
     HEAD_REF master
-    PATCHES ${CMAKE_CURRENT_LIST_DIR}/no_benchmark.patch
+    PATCHES no_benchmark.patch
+            Fix-error-LNK2001.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SIMDJSON_BUILD_STATIC)

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -9,7 +9,6 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         no_benchmark.patch
-
        Fix-error-LNK2001.patch
 
 )

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -10,7 +10,6 @@ vcpkg_from_github(
     PATCHES 
         no_benchmark.patch
         Fix-error-LNK2001.patch
-
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SIMDJSON_BUILD_STATIC)

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         no_benchmark.patch
-       Fix-error-LNK2001.patch
+        Fix-error-LNK2001.patch
 
 )
 

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -7,7 +7,9 @@ vcpkg_from_github(
     REF 4da06830f1389c8cd33171f5ab3558e79f0ece04
     SHA512 ffb11ee91f97d975fba2946653c9c847565933380f94e334d15e627f77a7a750702c539ca55d17e077b2ed0a79006f56a3b9a202d888bb7e2e3f0484237cb537
     HEAD_REF master
-    PATCHES no_benchmark.patch
+    PATCHES 
+        no_benchmark.patch
+
             Fix-error-LNK2001.patch
 )
 

--- a/ports/simdjson/portfile.cmake
+++ b/ports/simdjson/portfile.cmake
@@ -10,7 +10,8 @@ vcpkg_from_github(
     PATCHES 
         no_benchmark.patch
 
-            Fix-error-LNK2001.patch
+       Fix-error-LNK2001.patch
+
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SIMDJSON_BUILD_STATIC)


### PR DESCRIPTION
**Describe the pull request**
In VS2019 16.7 preview 2, simdjson build failed with error LNK2001: unresolved external symbol __asan_memset when compile with the option -fsanitize=address.
This option was added into the compile command as a gcc compile option.
For fixing this issue, I changed the variable that sets the compile option to take effect only in a GCC environment.





