### PR TITLE
[libvpx] Change default target on Unix

### DIFF
--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,5 +1,5 @@
 Source: libvpx
-Version: 1.8.1-3
+Version: 1.8.1-4
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
 Supports: !(uwp|arm|arm64)

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -129,7 +129,13 @@ else()
         set(OPTIONS "${OPTIONS} --enable-static --disable-shared")
     endif()
 
-    message(STATUS "Building Options: ${OPTIONS}")
+    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(LIBVPX_TARGET "x86_64-linux-gcc")
+    else()
+        set(LIBVPX_TARGET "x86_64-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+    endif()
+
+    message(STATUS "Building info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         message(STATUS "Configuring libvpx for Release")
@@ -138,6 +144,7 @@ else()
         COMMAND
             ${BASH} --noprofile --norc
             "${SOURCE_PATH}/configure"
+            --target=${LIBVPX_TARGET}
             ${OPTIONS}
             ${OPTIONS_RELEASE}
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
@@ -169,6 +176,7 @@ else()
         COMMAND
             ${BASH} --noprofile --norc
             "${SOURCE_PATH}/configure"
+            --target=${LIBVPX_TARGET}
             ${OPTIONS}
             ${OPTIONS_DEBUG}
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -133,12 +133,16 @@ else()
         set(LIBVPX_TARGET_ARCH "x86")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
         set(LIBVPX_TARGET_ARCH "x86_64")
+    else()
+        message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE}")
     endif()
 
     if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
-    else()
+    elseif(VCPKG_TARGET_IS_OSX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+    else()
+        message(FATAL_ERROR "libvpx does not support system ${VCPKG_CMAKE_SYSTEM_NAME}")
     endif()
 
     message(STATUS "Build info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -137,7 +137,7 @@ else()
         message(FATAL_ERROR "libvpx does not support architecture ${VCPKG_TARGET_ARCHITECTURE}")
     endif()
 
-    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(VCPKG_TARGET_IS_LINUX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
     elseif(VCPKG_TARGET_IS_OSX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -128,14 +128,20 @@ else()
     else()
         set(OPTIONS "${OPTIONS} --enable-static --disable-shared")
     endif()
-
-    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set(LIBVPX_TARGET "x86_64-linux-gcc")
-    else()
-        set(LIBVPX_TARGET "x86_64-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+    
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+        set(LIBVPX_TARGET_ARCH "x86")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+        set(LIBVPX_TARGET_ARCH "x86_64")
     endif()
 
-    message(STATUS "Building info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")
+    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-linux-gcc")
+    else()
+        set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
+    endif()
+
+    message(STATUS "Build info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")
 
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         message(STATUS "Configuring libvpx for Release")

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -142,7 +142,7 @@ else()
     elseif(VCPKG_TARGET_IS_OSX)
         set(LIBVPX_TARGET "${LIBVPX_TARGET_ARCH}-darwin17-gcc") # enable latest CPU instructions for best performance and less CPU usage on MacOS
     else()
-        message(FATAL_ERROR "libvpx does not support system ${VCPKG_CMAKE_SYSTEM_NAME}")
+        set(LIBVPX_TARGET "generic-gnu") # use default target
     endif()
 
     message(STATUS "Build info. Target: ${LIBVPX_TARGET}; Options: ${OPTIONS}")


### PR DESCRIPTION
Set default libvpx target to the 'x86_64-darwin17-gcc'. It's macOS 10.13 (High Sierra)

It's required to support the latest CPU features like hardware acceleration.
