### PR TITLE
[protobuf-c] Fix tool protoc-gen-c crash

### DIFF
--- a/ports/protobuf-c/CONTROL
+++ b/ports/protobuf-c/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf-c
-Version: 1.3.2
+Version: 1.3.2-1
 Homepage: https://github.com/protobuf-c/protobuf-c
 Description: This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.
 Build-Depends: protobuf

--- a/ports/protobuf-c/fix-usage-issue.patch
+++ b/ports/protobuf-c/fix-usage-issue.patch
@@ -1,0 +1,36 @@
+diff --git a/build-cmake/CMakeLists.txt b/build-cmake/CMakeLists.txt
+index 7c6a04d..83534cb 100644
+--- a/build-cmake/CMakeLists.txt
++++ b/build-cmake/CMakeLists.txt
+@@ -14,6 +14,11 @@ option(BUILD_PROTO3 "BUILD_PROTO3" ON)
+ INCLUDE(TestBigEndian)
+ TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
+ 
++
++IF(CMAKE_HOST_UNIX)
++	FIND_PACKAGE(Threads REQUIRED)
++ENDIF()
++
+ SET(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+ ADD_DEFINITIONS(-DPACKAGE_VERSION="${PACKAGE_VERSION}")
+ ADD_DEFINITIONS(-DPACKAGE_STRING="${PACKAGE_STRING}")
+@@ -67,6 +72,9 @@ FILE(GLOB PROTOC_GEN_C_SRC ${MAIN_DIR}/protoc-c/*.h ${MAIN_DIR}/protoc-c/*.cc )
+ ADD_EXECUTABLE(protoc-gen-c ${PROTOC_GEN_C_SRC})
+ 
+ TARGET_LINK_LIBRARIES(protoc-gen-c ${PROTOBUF_PROTOC_LIBRARY} ${PROTOBUF_LIBRARY})
++IF(CMAKE_HOST_UNIX)
++    TARGET_LINK_LIBRARIES(protoc-gen-c ${CMAKE_THREAD_LIBS_INIT})
++ENDIF()
+ ENDIF()
+ 
+ IF(WITH_TEST AND WITH_TOOLS)
+@@ -99,6 +107,9 @@ GENERATE_TEST_SOURCES(${TEST_DIR}/test-full.proto t/test-full.pb-c.c t/test-full
+ 
+ ADD_EXECUTABLE(cxx-generate-packed-data ${TEST_DIR}/generated-code2/cxx-generate-packed-data.cc t/test-full.pb.h t/test-full.pb.cc)
+ TARGET_LINK_LIBRARIES(cxx-generate-packed-data ${PROTOBUF_LIBRARY})
++IF (CMAKE_HOST_UNIX)
++    TARGET_LINK_LIBRARIES(cxx-generate-packed-data ${CMAKE_THREAD_LIBS_INIT})
++ENDIF()
+ 
+ FILE(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/t/generated-code2)
+ ADD_CUSTOM_COMMAND(OUTPUT t/generated-code2/test-full-cxx-output.inc

--- a/ports/protobuf-c/portfile.cmake
+++ b/ports/protobuf-c/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF 1390409f4ee4e26d0635310995b516eb702c3f9e #1.3.2
     SHA512 5c60883c4ef064c641875bfe7f89bf255a29dd20b5e0be5878cbaec03f2efd1f926c3e40dc0090cb172b8eef227fddafe86051f08edb3e1c26d0bd6aca673e41
     HEAD_REF master
-    PATCHES fix-features.patch
+    PATCHES
+        fix-features.patch
+        fix-usage-issue.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
Fix crash issue when using tool `protoc-gen-c`：
```
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
--c_out: protoc-gen-c: Plugin killed by signal 6.
```

Fixes: #10745.

Thanks @lipnitsk !