### PR TITLE
[Thrift] should work on x64-osx

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1816,7 +1816,6 @@ theia:x64-windows-static = skip
 theia:x86-windows        = skip
 thor:x64-linux=fail
 thor:x64-osx=fail
-thrift:x64-osx=fail
 tidy-html5:arm-uwp=fail
 tidy-html5:x64-uwp=fail
 tinkerforge:arm-uwp=fail


### PR DESCRIPTION
`thrift:x64-osx=fail` is set in ci.baseline.txt. However this should work. 

Created a PR to see if it now succeeds in CI.