### PR TITLE
[vcpkg metrics] Allow someone to opt out after build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Code licensed under the [MIT License](LICENSE.txt).
 
 ## Telemetry
 
-vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by running `bootstrap-vcpkg.bat` or `bootstrap-vcpkg.sh` with `-disableMetrics`.
+vcpkg collects usage data in order to help us improve your experience.
+The data collected by Microsoft is anonymous.
+You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics,
+passing --disable-metrics to vcpkg on the command line,
+or by setting the VCPKG_DISABLE_METRICS environment variable.
 
 Read more about vcpkg telemetry at docs/about/privacy.md

--- a/docs/about/privacy.md
+++ b/docs/about/privacy.md
@@ -1,7 +1,7 @@
 # Vcpkg telemetry and privacy
 
 vcpkg collects telemetry data to understand usage issues, such as failing packages, and to guide tool improvements. The collected data is anonymous.
-For more information about how Microsoft protects your privacy, see https://privacy.microsoft.com/en-US/privacystatement#mainenterprisedeveloperproductsmodule 
+For more information about how Microsoft protects your privacy, see https://privacy.microsoft.com/en-US/privacystatement#mainenterprisedeveloperproductsmodule
 
 ## Scope
 
@@ -22,7 +22,11 @@ vcpkg displays text similar to the following when you build vcpkg. This is how M
 ```
 Telemetry
 ---------
-vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics.
+vcpkg collects usage data in order to help us improve your experience.
+The data collected by Microsoft is anonymous.
+You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics,
+passing --disable-metrics to vcpkg on the command line,
+or by setting the VCPKG_DISABLE_METRICS environment variable.
 
 Read more about vcpkg telemetry at docs/about/privacy.md
 ```
@@ -39,7 +43,7 @@ You can see the telemetry events any command by appending `--printmetrics` after
 
 In the source code (included in `toolsrc\`), you can search for calls to the functions `track_property()` and `track_metric()` to see every specific data point we collect.
 
-## Avoid inadvertent disclosure information 
+## Avoid inadvertent disclosure information
 
 vcpkg contributors and anyone else running a version of vcpkg that they built themselves should consider the path to their source code. If a crash occurs when using vcpkg, the file path from the build machine is collected as part of the stack trace and isn't hashed.
 Because of this, builds of vcpkg shouldn't be located in directories whose path names expose personal or sensitive information.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -341,7 +341,7 @@ if ($disableMetrics)
 $platform = "x86"
 $vcpkgReleaseDir = "$vcpkgSourcesPath\msbuild.x86.release"
 if($PSVersionTable.PSVersion.Major -le 2)
-{ 
+{
     $architecture=(Get-WmiObject win32_operatingsystem | Select-Object osarchitecture).osarchitecture
 }
 else
@@ -417,9 +417,13 @@ if (-not $disableMetrics)
     Write-Host @"
 Telemetry
 ---------
-vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running bootstrap-vcpkg.bat with -disableMetrics.
-Read more about vcpkg telemetry at docs/about/privacy.md
+vcpkg collects usage data in order to help us improve your experience.
+The data collected by Microsoft is anonymous.
+You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics,
+passing --disable-metrics to vcpkg on the command line,
+or by setting the VCPKG_DISABLE_METRICS environment variable.
 
+Read more about vcpkg telemetry at docs/about/privacy.md
 "@
 }
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -256,9 +256,15 @@ rm -rf "$vcpkgRootDir/vcpkg"
 cp "$buildDir/vcpkg" "$vcpkgRootDir/"
 
 if ! [ "$vcpkgDisableMetrics" = "ON" ]; then
-    echo "Telemetry"
-    echo "---------"
-    echo "vcpkg collects usage data in order to help us improve your experience. The data collected by Microsoft is anonymous. You can opt-out of telemetry by re-running bootstrap-vcpkg.sh with -disableMetrics"
-    echo "Read more about vcpkg telemetry at docs/about/privacy.md"
-    echo ""
+    cat <<EOF
+Telemetry
+---------
+vcpkg collects usage data in order to help us improve your experience.
+The data collected by Microsoft is anonymous.
+You can opt-out of telemetry by re-running the bootstrap-vcpkg script with -disableMetrics,
+passing --disable-metrics to vcpkg on the command line,
+or by setting the VCPKG_DISABLE_METRICS environment variable.
+
+Read more about vcpkg telemetry at docs/about/privacy.md
+EOF
 fi

--- a/toolsrc/.clang-format
+++ b/toolsrc/.clang-format
@@ -32,3 +32,6 @@ ForEachMacros: [TEST_CASE, SECTION]
 PenaltyReturnTypeOnItsOwnLine: 1000
 SpaceAfterTemplateKeyword: false
 SpaceBeforeCpp11BracedList: false
+
+IncludeBlocks: Preserve
+SortIncludes: false

--- a/toolsrc/include/pch.h
+++ b/toolsrc/include/pch.h
@@ -9,6 +9,12 @@
 #include <winhttp.h>
 #endif
 
+#include <math.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -16,10 +22,6 @@
 #include <cctype>
 #include <chrono>
 #include <codecvt>
-#include <cstdarg>
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
 
 #if VCPKG_USE_STD_FILESYSTEM
 #include <filesystem>

--- a/toolsrc/include/vcpkg/base/json.h
+++ b/toolsrc/include/vcpkg/base/json.h
@@ -146,8 +146,12 @@ namespace vcpkg::Json
         using iterator = underlying_t::iterator;
         using const_iterator = underlying_t::const_iterator;
 
-        void push_back(Value&& value) { this->underlying_.push_back(std::move(value)); }
-        void insert_before(iterator it, Value&& value) { this->underlying_.insert(it, std::move(value)); }
+        Value& push_back(Value&& value);
+        Object& push_back(Object&& value);
+        Array& push_back(Array&& value);
+        Value& insert_before(iterator it, Value&& value);
+        Object& insert_before(iterator it, Object&& value);
+        Array& insert_before(iterator it, Array&& value);
 
         std::size_t size() const noexcept { return this->underlying_.size(); }
 
@@ -192,11 +196,15 @@ namespace vcpkg::Json
         Object clone() const noexcept;
 
         // asserts if the key is found
-        void insert(std::string key, Value value) noexcept;
+        Value& insert(std::string key, Value&& value);
+        Object& insert(std::string key, Object&& value);
+        Array& insert(std::string key, Array&& value);
 
         // replaces the value if the key is found, otherwise inserts a new
         // value.
-        void insert_or_replace(std::string key, Value value) noexcept;
+        Value& insert_or_replace(std::string key, Value&& value);
+        Object& insert_or_replace(std::string key, Object&& value);
+        Array& insert_or_replace(std::string key, Array&& value);
 
         // returns whether the key existed
         bool remove(StringView key) noexcept;
@@ -265,6 +273,9 @@ namespace vcpkg::Json
         const Files::Filesystem&, const fs::path&, std::error_code& ec) noexcept;
     ExpectedT<std::pair<Value, JsonStyle>, std::unique_ptr<Parse::IParseError>> parse(
         StringView text, const fs::path& filepath = "") noexcept;
-    std::string stringify(const Value&, JsonStyle style) noexcept;
+
+    std::string stringify(const Value&, JsonStyle style);
+    std::string stringify(const Object&, JsonStyle style);
+    std::string stringify(const Array&, JsonStyle style);
 
 }

--- a/toolsrc/include/vcpkg/metrics.h
+++ b/toolsrc/include/vcpkg/metrics.h
@@ -10,12 +10,15 @@ namespace vcpkg::Metrics
     {
         void set_send_metrics(bool should_send_metrics);
         void set_print_metrics(bool should_print_metrics);
+        void set_disabled(bool disabled);
         void set_user_information(const std::string& user_id, const std::string& first_use_time);
         static void init_user_information(std::string& user_id, std::string& first_use_time);
 
         void track_metric(const std::string& name, double value);
         void track_buildtime(const std::string& name, double value);
         void track_property(const std::string& name, const std::string& value);
+
+        bool metrics_enabled();
 
         void upload(const std::string& payload);
         void flush();
@@ -24,5 +27,4 @@ namespace vcpkg::Metrics
     extern Util::LockGuarded<Metrics> g_metrics;
 
     std::string get_MAC_user();
-    bool get_compiled_metrics_enabled();
 }

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -94,6 +94,8 @@ namespace vcpkg
         std::vector<std::string> binarysources;
         Optional<bool> debug = nullopt;
         Optional<bool> sendmetrics = nullopt;
+        // fully disable metrics -- both printing and sending
+        Optional<bool> disable_metrics = nullopt;
         Optional<bool> printmetrics = nullopt;
 
         // feature flags

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -333,6 +333,11 @@ int main(const int argc, const char* const* const argv)
         auto flags = Strings::split(*v, ',');
         if (std::find(flags.begin(), flags.end(), "binarycaching") != flags.end()) GlobalState::g_binary_caching = true;
     }
+    const auto vcpkg_disable_metrics_env = System::get_environment_variable("VCPKG_DISABLE_METRICS");
+    if (vcpkg_disable_metrics_env.has_value())
+    {
+        Metrics::g_metrics.lock()->set_disabled(true);
+    }
 
     const VcpkgCmdArguments args = VcpkgCmdArguments::create_from_command_line(argc, argv);
 
@@ -340,7 +345,19 @@ int main(const int argc, const char* const* const argv)
 
     if (const auto p = args.printmetrics.get()) Metrics::g_metrics.lock()->set_print_metrics(*p);
     if (const auto p = args.sendmetrics.get()) Metrics::g_metrics.lock()->set_send_metrics(*p);
+    if (const auto p = args.disable_metrics.get()) Metrics::g_metrics.lock()->set_disabled(*p);
     if (const auto p = args.debug.get()) Debug::g_debugging = *p;
+
+    if (args.sendmetrics.has_value() && !Metrics::g_metrics.lock()->metrics_enabled())
+    {
+        System::print2(System::Color::warning,
+                       "Warning: passed either --sendmetrics or --no-sendmetrics, but metrics are disabled.");
+    }
+    if (args.printmetrics.has_value() && !Metrics::g_metrics.lock()->metrics_enabled())
+    {
+        System::print2(System::Color::warning,
+                       "Warning: passed either --printmetrics or --no-printmetrics, but metrics are disabled.");
+    }
 
     if (Debug::g_debugging)
     {

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -351,12 +351,12 @@ int main(const int argc, const char* const* const argv)
     if (args.sendmetrics.has_value() && !Metrics::g_metrics.lock()->metrics_enabled())
     {
         System::print2(System::Color::warning,
-                       "Warning: passed either --sendmetrics or --no-sendmetrics, but metrics are disabled.");
+                       "Warning: passed either --sendmetrics or --no-sendmetrics, but metrics are disabled.\n");
     }
     if (args.printmetrics.has_value() && !Metrics::g_metrics.lock()->metrics_enabled())
     {
         System::print2(System::Color::warning,
-                       "Warning: passed either --printmetrics or --no-printmetrics, but metrics are disabled.");
+                       "Warning: passed either --printmetrics or --no-printmetrics, but metrics are disabled.\n");
     }
 
     if (Debug::g_debugging)

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -237,6 +237,7 @@ namespace vcpkg
             L"USERDOMAIN_ROAMINGPROFILE",
             L"USERNAME",
             L"USERPROFILE",
+            L"VCPKG_DISABLE_METRICS",
             L"windir",
             // Enables proxy information to be passed to Curl, the underlying download library in cmake.exe
             L"http_proxy",
@@ -558,6 +559,7 @@ VCPKG_MSVC_WARNING(suppress : 6335) // Leaking process information handle 'proce
         (void)env;
         Debug::print("system(", cmd_line, ")\n");
         fflush(nullptr);
+
         int exit_code = system(cmd_line.c_str());
         Debug::print(
             "system() returned ", exit_code, " after ", static_cast<unsigned int>(timer.microseconds()), " us\n");
@@ -617,6 +619,7 @@ VCPKG_MSVC_WARNING(suppress : 6335) // Leaking process information handle 'proce
         Debug::print("popen(", actual_cmd_line, ")\n");
         // Flush stdout before launching external process
         fflush(stdout);
+
         const auto pipe = popen(actual_cmd_line.c_str(), "r");
         if (pipe == nullptr)
         {

--- a/toolsrc/src/vcpkg/commands.version.cpp
+++ b/toolsrc/src/vcpkg/commands.version.cpp
@@ -32,7 +32,7 @@ namespace vcpkg::Commands::Version
 #ifndef NDEBUG
             + std::string("-debug")
 #endif
-            + std::string(Metrics::get_compiled_metrics_enabled() ? "" : "-external");
+            ;
         return S_VERSION;
     }
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -212,6 +212,11 @@ namespace vcpkg
                     parse_switch(true, "printmetrics", args.printmetrics);
                     continue;
                 }
+                if (arg == "--disable-metrics")
+                {
+                    parse_switch(true, "printmetrics", args.disable_metrics);
+                    continue;
+                }
                 if (arg == "--no-sendmetrics")
                 {
                     parse_switch(false, "sendmetrics", args.sendmetrics);
@@ -220,6 +225,11 @@ namespace vcpkg
                 if (arg == "--no-printmetrics")
                 {
                     parse_switch(false, "printmetrics", args.printmetrics);
+                    continue;
+                }
+                if (arg == "--no-disable-metrics")
+                {
+                    parse_switch(false, "printmetrics", args.disable_metrics);
                     continue;
                 }
                 if (arg == "--featurepackages")


### PR DESCRIPTION
This PR adds an option `--disable-metrics` and an environment variable `VCPKG_DISABLE_METRICS` which turn off metrics, even if the binary was built with metrics enabled.

Additionally, as a drive-by, we now use the built-in JSON support.

Fixes issue #11542 