### PR TITLE
Revert some of "[vcpkg] Remove powershell from the 'run vcpkg ci'"...

### DIFF
--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -22,13 +22,8 @@ jobs:
   - powershell: |
       $skipList = ./scripts/azure-pipelines/generate-skip-list.ps1 -Triplet "${{ parameters.triplet }}" -BaselineFile "$(System.DefaultWorkingDirectory)\scripts\ci.baseline.txt"
       mkdir $(System.ArtifactsDirectory)\xml-results
-      $command = ".\vcpkg.exe ci ${{ parameters.triplet }} --x-xunit=`"$(System.ArtifactsDirectory)\xml-results\${{ parameters.triplet }}.xml`" --exclude=$skipList --binarycaching"
-      Set-Content -Path 'run_ci.cmd' -Value $command -Encoding ASCII
-    displayName: 'Write Test Modified Ports Batch File'
-  - task: BatchScript@1
+      .\vcpkg.exe ci ${{ parameters.triplet }} --x-xunit=`"$(System.ArtifactsDirectory)\xml-results\${{ parameters.triplet }}.xml`" --exclude=$skipList --binarycaching
     displayName: '** Test Modified Ports **'
-    inputs:
-      filename: 'run_ci.cmd'
   - task: PowerShell@2
     displayName: 'Analyze results and prepare test logs'
     inputs:


### PR DESCRIPTION
This reverts some of commit f2c46e717d61945fbd51dfd382f46416aa199566.

While using the cmd script bit avoids the hangs we were experiencing when msys broke, using the cmd script path causes azure pipelines to replace all hashes with ***, making much of the CI output useless. This goes back to just running the command directly.