### PR TITLE
[pcre] Add pkgconfig files

### DIFF
--- a/ports/pcre/CONTROL
+++ b/ports/pcre/CONTROL
@@ -1,4 +1,4 @@
 Source: pcre
-Version: 8.44
+Version: 8.44-1
 Homepage: https://www.pcre.org/
 Description: Perl Compatible Regular Expressions

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -50,6 +50,53 @@ foreach(FILE ${CURRENT_PACKAGES_DIR}/include/pcre.h ${CURRENT_PACKAGES_DIR}/incl
     file(WRITE ${FILE} "${PCRE_H}")
 endforeach()
 
+# Create pkgconfig files
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(PACKAGE_VERSION ${PCRE_VERSION})
+    set(prefix "${CURRENT_INSTALLED_DIR}")
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${prefix}/lib")
+    set(includedir "\${prefix}/include")
+    configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre.pc" @ONLY)
+    configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre16.pc" @ONLY)
+    configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre32.pc" @ONLY)
+    configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcrecpp.pc" @ONLY)
+    configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcreposix.pc" @ONLY)
+
+    # debug
+    set(prefix "${CURRENT_INSTALLED_DIR}/debug")
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${prefix}/lib")
+    set(includedir "\${prefix}/../include")
+
+    configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc" @ONLY)
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc LIBPCRE.PC)
+    string(REPLACE "-lpcre" "-lpcred" LIBPCRE.PC ${LIBPCRE.PC})
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc ${LIBPCRE.PC})
+
+    configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc" @ONLY)
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc LIBPCRE16.PC)
+    string(REPLACE "-lpcre16" "-lpcre16d" LIBPCRE16.PC ${LIBPCRE16.PC})
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc ${LIBPCRE16.PC})
+
+    configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc" @ONLY)
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc LIBPCRE32.PC)
+    string(REPLACE "-lpcre32" "-lpcre32d" LIBPCRE32.PC ${LIBPCRE32.PC})
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc ${LIBPCRE32.PC})
+
+    configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc" @ONLY)
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc LIBPCRECPP.PC)
+    string(REPLACE "-lpcre -lpcrecpp" "-lpcred -lpcrecppd" LIBPCRECPP.PC ${LIBPCRECPP.PC})
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc ${LIBPCRECPP.PC})
+
+    configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc" @ONLY)
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc LIBPCREPOSIX.PC)
+    string(REPLACE "-lpcreposix" "-lpcreposixd" LIBPCREPOSIX.PC ${LIBPCREPOSIX.PC})
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc ${LIBPCREPOSIX.PC})
+
+    vcpkg_fixup_pkgconfig()
+endif()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -51,51 +51,53 @@ foreach(FILE ${CURRENT_PACKAGES_DIR}/include/pcre.h ${CURRENT_PACKAGES_DIR}/incl
 endforeach()
 
 # Create pkgconfig files
+set(PACKAGE_VERSION ${PCRE_VERSION})
+set(prefix "${CURRENT_INSTALLED_DIR}")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/include")
+if(VCPKG_TARGET_IS_LINUX)
+    # Used here in .pc.in files: Libs.private: @PTHREAD_CFLAGS@
+    set(PTHREAD_CFLAGS "-pthread")
+endif()
+
+configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre16.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre32.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcrecpp.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcreposix.pc" @ONLY)
+
+# debug
+set(prefix "${CURRENT_INSTALLED_DIR}/debug")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/lib")
+set(includedir "\${prefix}/../include")
+
+configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc" @ONLY)
+configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc" @ONLY)
+
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(PACKAGE_VERSION ${PCRE_VERSION})
-    set(prefix "${CURRENT_INSTALLED_DIR}")
-    set(exec_prefix "\${prefix}")
-    set(libdir "\${prefix}/lib")
-    set(includedir "\${prefix}/include")
-    configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre.pc" @ONLY)
-    configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre16.pc" @ONLY)
-    configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcre32.pc" @ONLY)
-    configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcrecpp.pc" @ONLY)
-    configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libpcreposix.pc" @ONLY)
-
-    # debug
-    set(prefix "${CURRENT_INSTALLED_DIR}/debug")
-    set(exec_prefix "\${prefix}")
-    set(libdir "\${prefix}/lib")
-    set(includedir "\${prefix}/../include")
-
-    configure_file("${SOURCE_PATH}/libpcre.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc" @ONLY)
     file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc LIBPCRE.PC)
     string(REPLACE "-lpcre" "-lpcred" LIBPCRE.PC ${LIBPCRE.PC})
     file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre.pc ${LIBPCRE.PC})
-
-    configure_file("${SOURCE_PATH}/libpcre16.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc" @ONLY)
     file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc LIBPCRE16.PC)
     string(REPLACE "-lpcre16" "-lpcre16d" LIBPCRE16.PC ${LIBPCRE16.PC})
     file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre16.pc ${LIBPCRE16.PC})
-
-    configure_file("${SOURCE_PATH}/libpcre32.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc" @ONLY)
     file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc LIBPCRE32.PC)
     string(REPLACE "-lpcre32" "-lpcre32d" LIBPCRE32.PC ${LIBPCRE32.PC})
     file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcre32.pc ${LIBPCRE32.PC})
-
-    configure_file("${SOURCE_PATH}/libpcrecpp.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc" @ONLY)
     file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc LIBPCRECPP.PC)
     string(REPLACE "-lpcre -lpcrecpp" "-lpcred -lpcrecppd" LIBPCRECPP.PC ${LIBPCRECPP.PC})
     file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcrecpp.pc ${LIBPCRECPP.PC})
-
-    configure_file("${SOURCE_PATH}/libpcreposix.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc" @ONLY)
     file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc LIBPCREPOSIX.PC)
     string(REPLACE "-lpcreposix" "-lpcreposixd" LIBPCREPOSIX.PC ${LIBPCREPOSIX.PC})
     file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libpcreposix.pc ${LIBPCREPOSIX.PC})
-
-    vcpkg_fixup_pkgconfig()
 endif()
+
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)


### PR DESCRIPTION
**Describe the pull request**
Add **`pkgconfig`** files to **`pcre`**

- What does your PR fix? Fixes #
So far, `libpcre*.pc` files are missing. This enables `pcre` to be found using `pkgconfig`

- Which triplets are supported/not supported? Have you updated the CI baseline?
All current triplets are supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
