### PR TITLE
[skyr-url] Changed version number to 1.9.0

### DIFF
--- a/ports/skyr-url/CONTROL
+++ b/ports/skyr-url/CONTROL
@@ -1,5 +1,5 @@
 Source: skyr-url
-Version: 1.7.5
+Version: 1.9.0
 Build-Depends: tl-expected, nlohmann-json
 Homepage: https://github.com/cpp-netlib/url
 Description: A C++ library that implements the WhatWG URL specification

--- a/ports/skyr-url/portfile.cmake
+++ b/ports/skyr-url/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO cpp-netlib/url
-        REF v1.7.5-1
-        SHA512 0d54b8528a0497fb9692a3f7ffdce909e7a79712f3a84c03a12463095246fe18ddb3b42471e130c033944a9d15ef2870b302d73b956975bc1c0cba14f4833196
+        REF v1.9.0
+        SHA512 14c0ebb8fa143a733ee07a412c23be4afc0b2c414d722483181a8453fe37e3b1616071cee0f7f8c052ff03c7127fdb1da31be9be108601001aa2c6c80fc2448b
         HEAD_REF master
 )
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

Changes version number of skyr-url to 1.9.0

- Which triplets are supported/not supported? Have you updated the CI baseline?

x64-osx, x64-linux, x64-windows

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
