### PR TITLE
[libarchive] Disable C4061 which causes build to fail in Visual Studio 2019 16.6

### DIFF
--- a/ports/libarchive/CONTROL
+++ b/ports/libarchive/CONTROL
@@ -1,5 +1,5 @@
 Source: libarchive
-Version: 3.4.1-2
+Version: 3.4.1-3
 Homepage: https://github.com/libarchive/libarchive
 Description: Library for reading and writing streaming archives
 Build-Depends: zlib

--- a/ports/libarchive/disable-c4061.patch
+++ b/ports/libarchive/disable-c4061.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 911ae5b..0e12b56 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -151,9 +151,6 @@ IF (MSVC)
+   #################################################################
+   # Set compile flags for debug build.
+   # This is added into CMAKE_C_FLAGS when CMAKE_BUILD_TYPE is "Debug"
+-  # Enable level 4 C4061: The enumerate has no associated handler in a switch
+-  #                       statement.
+-  SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /we4061")
+   # Enable level 4 C4254: A larger bit field was assigned to a smaller bit
+   #                       field.
+   SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /we4254")

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-lz4.patch
         fix-zstd.patch
         fix-cpu-set.patch
+        disable-c4061.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
Fixes #11481
