### PR TITLE
[replxx] Add missing header <stdexcept> needed to name std::runtime_error for replxx.

### DIFF
--- a/ports/replxx/CONTROL
+++ b/ports/replxx/CONTROL
@@ -1,6 +1,5 @@
 Source: replxx
-Version: 0.0.2-1
+Version: 0.0.2-2
 Homepage: https://github.com/AmokHuginnsson/replxx
 Description: A small, portable GNU readline replacement for Linux, Windows and MacOS which is capable of handling UTF-8 characters.
 Supports: !uwp
-

--- a/ports/replxx/add-stdexcept.patch
+++ b/ports/replxx/add-stdexcept.patch
@@ -1,0 +1,17 @@
+diff --git a/src/io.cxx b/src/io.cxx
+index a098867..6159e4b 100644
+--- a/src/io.cxx
++++ b/src/io.cxx
+@@ -2,6 +2,7 @@
+ #include <cerrno>
+ #include <cstdlib>
+ #include <cstring>
++#include <stdexcept>
+ #include <array>
+ 
+ #ifdef _WIN32
+@@ -671,4 +672,3 @@ int Terminal::read_verbatim( char32_t* buffer_, int size_ ) {
+ #endif
+ 
+ }
+-

--- a/ports/replxx/portfile.cmake
+++ b/ports/replxx/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
         REF 45696c250ce39ab21dedeea962b94d7827007a8c
         SHA512 7beec508fa3049fe5a736a487728506d646d26d7194ef7453fc07bceade1982430808fab0a10ca9b1c43a8b87bf3a973f5cfe4aa22ed06927647c9a7244167fd
         HEAD_REF master
+        PATCHES
+                add-stdexcept.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Already applied upstream as https://github.com/AmokHuginnsson/replxx/commit/723d9c84869511dfb5e63f5c3d3372ac38114713

- What does your PR fix? Fixes build of replxx on Visual Studio 2019 version 16.6