### PR TITLE
[telnetpp] Add missing <ostream> for Visual Studio 2019 16.6

### DIFF
--- a/ports/telnetpp/CONTROL
+++ b/ports/telnetpp/CONTROL
@@ -1,5 +1,5 @@
 Source: telnetpp
-Version: 2.0-3
+Version: 2.0-4
 Homepage: https://github.com/KazDragon/telnetpp
 Description: Telnet++ is an implementation of the Telnet Session Layer protocol using C++14
 Build-Depends: boost-container, boost-signals2, boost-variant, gsl-lite, boost-exception

--- a/ports/telnetpp/github-215.patch
+++ b/ports/telnetpp/github-215.patch
@@ -1,7 +1,3 @@
-From df53cf93d35f74db22eaadcac87bd0c88ea87f5d Mon Sep 17 00:00:00 2001
-From: Cheney-Wang <v-xincwa@microsoft.com>
-Date: Wed, 12 Feb 2020 04:12:46 -0800
-Subject: [PATCH 1/2] Include <ostream> in variable.hpp
 
 ---
  include/telnetpp/options/msdp/variable.hpp | 1 +

--- a/ports/telnetpp/github-215.patch
+++ b/ports/telnetpp/github-215.patch
@@ -16,10 +16,6 @@ index 16dae0c..d74a6da 100644
  namespace telnetpp { namespace options { namespace msdp {
  
 
-From ea7477eba057fec5ca8178eaacd5b11c5745a9e7 Mon Sep 17 00:00:00 2001
-From: Cheney-Wang <v-xincwa@microsoft.com>
-Date: Thu, 20 Feb 2020 04:17:39 -0800
-Subject: [PATCH 2/2] Include <ostream> in variable.cpp
 
 ---
  include/telnetpp/options/msdp/variable.hpp | 1 -

--- a/ports/telnetpp/github-215.patch
+++ b/ports/telnetpp/github-215.patch
@@ -1,0 +1,55 @@
+From df53cf93d35f74db22eaadcac87bd0c88ea87f5d Mon Sep 17 00:00:00 2001
+From: Cheney-Wang <v-xincwa@microsoft.com>
+Date: Wed, 12 Feb 2020 04:12:46 -0800
+Subject: [PATCH 1/2] Include <ostream> in variable.hpp
+
+---
+ include/telnetpp/options/msdp/variable.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/telnetpp/options/msdp/variable.hpp b/include/telnetpp/options/msdp/variable.hpp
+index 16dae0c..d74a6da 100644
+--- a/include/telnetpp/options/msdp/variable.hpp
++++ b/include/telnetpp/options/msdp/variable.hpp
+@@ -5,6 +5,7 @@
+ #include <boost/variant.hpp>
+ #include <iosfwd>
+ #include <string>
++#include <ostream>
+ 
+ namespace telnetpp { namespace options { namespace msdp {
+ 
+
+From ea7477eba057fec5ca8178eaacd5b11c5745a9e7 Mon Sep 17 00:00:00 2001
+From: Cheney-Wang <v-xincwa@microsoft.com>
+Date: Thu, 20 Feb 2020 04:17:39 -0800
+Subject: [PATCH 2/2] Include <ostream> in variable.cpp
+
+---
+ include/telnetpp/options/msdp/variable.hpp | 1 -
+ src/options/msdp/variable.cpp              | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/telnetpp/options/msdp/variable.hpp b/include/telnetpp/options/msdp/variable.hpp
+index d74a6da..16dae0c 100644
+--- a/include/telnetpp/options/msdp/variable.hpp
++++ b/include/telnetpp/options/msdp/variable.hpp
+@@ -5,7 +5,6 @@
+ #include <boost/variant.hpp>
+ #include <iosfwd>
+ #include <string>
+-#include <ostream>
+ 
+ namespace telnetpp { namespace options { namespace msdp {
+ 
+diff --git a/src/options/msdp/variable.cpp b/src/options/msdp/variable.cpp
+index dc779ea..82549e9 100644
+--- a/src/options/msdp/variable.cpp
++++ b/src/options/msdp/variable.cpp
+@@ -1,5 +1,6 @@
+ #include "telnetpp/options/msdp/variable.hpp"
+ #include "telnetpp/detail/lambda_visitor.hpp"
++#include <ostream>
+ 
+ namespace telnetpp { namespace options { namespace msdp {
+ 

--- a/ports/telnetpp/portfile.cmake
+++ b/ports/telnetpp/portfile.cmake
@@ -8,7 +8,9 @@ vcpkg_from_github(
   REF 8dc780579293153ad2ae9ad6943815c050d4c659
   SHA512 280a8e6c0392f5822b05968520d176d1510f00c12a2502f6039f4f1f78a558e61f825a231fb70b7de6fd21a18b24734eea3ba36a24b29f2a7e9856b1f4de5217
   HEAD_REF master
-  PATCHES fix-build-error.patch
+  PATCHES
+    fix-build-error.patch
+    github-215.patch
 )
 
 set(USE_ZLIB OFF)


### PR DESCRIPTION
Previously submitted as https://github.com/KazDragon/telnetpp/pull/215
