### PR TITLE
[scnlib] Update scnlib to 0.3 to resolve missing header errors.

### DIFF
--- a/ports/scnlib/CONTROL
+++ b/ports/scnlib/CONTROL
@@ -1,4 +1,4 @@
 Source: scnlib
-Version:  0.1.2
+Version:  0.3
 Description: scnlib is a modern C++ library for replacing scanf and std::istream
 Homepage: https://scnlib.dev/

--- a/ports/scnlib/portfile.cmake
+++ b/ports/scnlib/portfile.cmake
@@ -1,12 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO eliaskosunen/scnlib
-    REF v0.1.2
-    SHA512 bb2aa176517d6547d62800839b7e9d86821a4006f7d09a8b3731b67f6fd7130f5cf8d73e7c8331c7c50f1dd5ca19bd3759bb0e181fcaed2f0bfb7fd8276ef141
+    REF v0.3
+    SHA512 91ab0ff5d7d2e4a4924bfa00cafc49c3b0d88b87f4adbdce786be0f51913e3c61c6948c27da6af1e020646e610540dc63323fbf7b59f9210266f1ba79bf95adc
     HEAD_REF master
 )
 
@@ -14,7 +12,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-      -DSCN_TESTS=OFF 
+      -DSCN_TESTS=OFF
       -DSCN_EXAMPLES=OFF
       -DSCN_BENCHMARKS=OFF
       -DSCN_DOCS=OFF


### PR DESCRIPTION
**Describe the pull request**

scnlib currently fails to build with Visual Studio 2019 version 16.6 because it doesn't include the correct headers; this has been fixed in the new version.
