### PR TITLE
[ideviceinstaller] Declare dependency getopt for <getopt.h>

### DIFF
--- a/ports/ideviceinstaller/CONTROL
+++ b/ports/ideviceinstaller/CONTROL
@@ -1,4 +1,4 @@
 Source: ideviceinstaller
-Version: 1.1.2.23-1
+Version: 1.1.2.23-2
 Description: Manage apps of iOS devices
-Build-Depends: libimobiledevice, libzip
+Build-Depends: libimobiledevice, libzip, getopt-win32


### PR DESCRIPTION
**Describe the pull request**

ideviceinstaller looks for <getopt.h> which passed in CI before because that port happened to get installed first.
