### PR TITLE
[ponder] patch missing headers for Visual Studio 2019 16.6

### DIFF
--- a/ports/ponder/CONTROL
+++ b/ports/ponder/CONTROL
@@ -1,3 +1,3 @@
 Source: ponder
-Version: 3.0.0
+Version: 3.0.0-1
 Description: A C++ multi-purpose reflection library.

--- a/ports/ponder/CONTROL
+++ b/ports/ponder/CONTROL
@@ -1,3 +1,4 @@
 Source: ponder
 Version: 3.0.0-1
 Description: A C++ multi-purpose reflection library.
+Homepage: https://github.com/billyquith/ponder

--- a/ports/ponder/github-121.patch
+++ b/ports/ponder/github-121.patch
@@ -1,0 +1,21 @@
+From 83b292f263b92082e981a82f5777d927a61772ee Mon Sep 17 00:00:00 2001
+From: Cheney-Wang <v-xincwa@microsoft.com>
+Date: Fri, 13 Mar 2020 02:50:33 -0700
+Subject: [PATCH] Include <ostream> in config.h
+
+---
+ include/ponder/config.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/ponder/config.hpp b/include/ponder/config.hpp
+index cd035c19..814403cd 100644
+--- a/include/ponder/config.hpp
++++ b/include/ponder/config.hpp
+@@ -60,6 +60,7 @@
+ #if defined(_MSC_VER)
+     #pragma warning(disable: 4275) // non dll-interface class 'X' used as base for dll-interface class 'Y'
+     #pragma warning(disable: 4251) // class 'X' needs to have dll-interface to be used by clients of class 'Y'
++    #include <ostream> //In future MSVC, <string> doesn't transitively <ostream>, ponder will  compile failed with error C2027 and C2065, so add <ostream> for fixing these issues.
+ #endif
+ 
+ #if defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ < 9

--- a/ports/ponder/portfile.cmake
+++ b/ports/ponder/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         no-install-unused.patch
+        github-121.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/ponder/portfile.cmake
+++ b/ports/ponder/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO billyquith/ponder


### PR DESCRIPTION
Previously submitted as https://github.com/billyquith/ponder/pull/121
