### PR TITLE
[mongo-cxx-driver] Patch std::atomic P0883 changes

### DIFF
--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,5 +1,5 @@
 Source: mongo-cxx-driver
-Version: 3.4.0-4
+Version: 3.4.0-5
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Homepage: https://github.com/mongodb/mongo-cxx-driver
 Description: MongoDB C++ Driver.

--- a/ports/mongo-cxx-driver/github-654.patch
+++ b/ports/mongo-cxx-driver/github-654.patch
@@ -1,0 +1,30 @@
+From e1a92d8bf8f07abc89350a956819b78df05bc4fe Mon Sep 17 00:00:00 2001
+From: Billy Robert O'Neal III <bion@microsoft.com>
+Date: Mon, 25 May 2020 20:47:58 -0700
+Subject: [PATCH] Disable trivially_constructible test for atomic on MSVC++.
+
+MSVC++ implements P0883 unconditionally, which changes the rules for std::atomic. It removes atomic's trivial constructor, and makes the default constructor value initialize the T.
+
+Note that Mongo was not following the C++11 rules, because it used the atomic before calling atomic_init first. MSVC++ never implemented the C++11 rules and previously default initialized the T.
+
+All versions of MSVC++ will provide constant initialization of the guarded value "current_instance". In old versions, atomic didn't implement P0883 due to bugs in the constexpr evaluator; in current versions the constexpr evaluator was fixed and atomic value initializes unconditionally. Therefore, this PR disables the check whenever MSVC++'s standard library is detected.
+
+See https://github.com/microsoft/STL/issues/661 for further discussion.
+---
+ src/mongocxx/instance.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/mongocxx/instance.cpp b/src/mongocxx/instance.cpp
+index e67d41ec7..6eb456c65 100644
+--- a/src/mongocxx/instance.cpp
++++ b/src/mongocxx/instance.cpp
+@@ -75,7 +75,8 @@ typename std::aligned_storage<sizeof(instance), alignof(instance)>::type sentine
+ std::atomic<instance*> current_instance{nullptr};
+ static_assert(std::is_standard_layout<decltype(current_instance)>::value,
+               "Must be standard layout");
+-#if (!defined(__GNUC__) || (defined(__clang__) && !defined(__GLIBCXX__))) || (__GNUC__ >= 5)
++#if (!defined(_MSVC_STL_VERSION)) \
++    && ((!defined(__GNUC__) || (defined(__clang__) && !defined(__GLIBCXX__))) || (__GNUC__ >= 5))
+ static_assert(std::is_trivially_constructible<decltype(current_instance)>::value,
+               "Must be trivially constructible");
+ #endif

--- a/ports/mongo-cxx-driver/portfile.cmake
+++ b/ports/mongo-cxx-driver/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         disable_test_and_example.patch
         fix-dependency-libbson.patch
         fix-dependency-mongocdriver.patch
+        github-654.patch
 )
 
 if ("mnmlstc" IN_LIST FEATURES)


### PR DESCRIPTION
Previously submitted as https://github.com/mongodb/mongo-cxx-driver/pull/654

Fixes the ability to compile this port on Visual Studio 2019 version 16.6.
