### PR TITLE
[seal] Disable SEAL_USE_MSGSL and add default feature zlib

### DIFF
--- a/ports/seal/CONTROL
+++ b/ports/seal/CONTROL
@@ -1,4 +1,9 @@
 Source: seal
-Version: 3.4.5
+Version: 3.4.5-1
 Homepage: https://github.com/microsoft/SEAL
 Description: Microsoft SEAL is an easy-to-use and powerful homomorphic encryption library.
+Default-Features: zlib
+
+Feature: zlib
+Build-Depends: zlib
+Description: Use zlib for compressed serialization

--- a/ports/seal/portfile.cmake
+++ b/ports/seal/portfile.cmake
@@ -25,12 +25,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    zlib SEAL_USE_ZLIB
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/native/src
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DALLOW_COMMAND_LINE_BUILD=ON
         -DSEAL_LIB_BUILD_TYPE=${SEAL_LIB_BUILD_TYPE}
+        -DSEAL_USE_MSGSL=OFF # issue https://github.com/microsoft/SEAL/issues/159
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
1. Since `seal` will fail to compile (source bug) when using `ms-gsl`, disable this option `SEAL_USE_MSGSL` and re-enable it after future fixes.
2. Add feature and set it as default feature (According to CMakeLists.txt in source).

Related: [#159](https://github.com/microsoft/SEAL/issues/159) #10918 #11502.