### PR TITLE
[protobuf-c] Fix wrong dependency for feature test

### DIFF
--- a/ports/protobuf-c/CONTROL
+++ b/ports/protobuf-c/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf-c
-Version: 1.3.2-1
+Version: 1.3.2-2
 Homepage: https://github.com/protobuf-c/protobuf-c
 Description: This is protobuf-c, a C implementation of the Google Protocol Buffers data serialization format.
 Build-Depends: protobuf
@@ -9,4 +9,4 @@ Description: build tools.
 
 Feature: test
 Description: build test project.
-Build-Depends: protobuf[tools]
+Build-Depends: protobuf-c[tools]


### PR DESCRIPTION
`protobuf` does not have a feature called `test`, it is a `protobuf-c` feature.

Fixes #11519.