### PR TITLE
[tinyxml2] Update to 8.0.0; avoid exporting symbols when building static libraries

### DIFF
--- a/ports/tinyxml2/CONTROL
+++ b/ports/tinyxml2/CONTROL
@@ -2,4 +2,3 @@ Source: tinyxml2
 Version: 8.0.0
 Homepage: https://github.com/leethomason/tinyxml2
 Description: A simple, small, efficient, C++ XML parser
-

--- a/ports/tinyxml2/CONTROL
+++ b/ports/tinyxml2/CONTROL
@@ -1,5 +1,5 @@
 Source: tinyxml2
-Version: 7.1.0
+Version: 8.0.0
 Homepage: https://github.com/leethomason/tinyxml2
 Description: A simple, small, efficient, C++ XML parser
 

--- a/ports/tinyxml2/fix-symbol-exports.patch
+++ b/ports/tinyxml2/fix-symbol-exports.patch
@@ -1,0 +1,36 @@
+From f8b048656b9937252ce5fb4ebea9e5df5b203bdb Mon Sep 17 00:00:00 2001
+From: Owen Rudge <owen@owenrudge.net>
+Date: Wed, 27 May 2020 09:40:59 +0100
+Subject: [PATCH] cmake: Don't export symbols if building static library
+
+---
+ CMakeLists.txt | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f9ab07..67b4f33 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,10 +50,16 @@ set(CMAKE_DEBUG_POSTFIX "d")
+ 
+ add_library(tinyxml2 tinyxml2.cpp tinyxml2.h)
+ 
+-set_target_properties(tinyxml2 PROPERTIES
++if(BUILD_SHARED_LIBS)
++    set_target_properties(tinyxml2 PROPERTIES
+         COMPILE_DEFINITIONS "TINYXML2_EXPORT"
+-	VERSION "${GENERIC_LIB_VERSION}"
+-	SOVERSION "${GENERIC_LIB_SOVERSION}")
++        VERSION "${GENERIC_LIB_VERSION}"
++        SOVERSION "${GENERIC_LIB_SOVERSION}")
++else()
++    set_target_properties(tinyxml2 PROPERTIES
++        VERSION "${GENERIC_LIB_VERSION}"
++        SOVERSION "${GENERIC_LIB_SOVERSION}")
++endif()
+ 
+ target_compile_definitions(tinyxml2 PUBLIC $<$<CONFIG:Debug>:TINYXML2_DEBUG>)
+ 
+-- 
+2.25.1.windows.1
+

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -3,9 +3,11 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO leethomason/tinyxml2
-    REF 9c740e8d2341bd46dbe8e87053cdb4d931971967 # 7.1.0
-    SHA512 a0e9634875f4c5f426f41510040b9f078af24adf176d2daf3cb3343d629b8068f3a1841df80a06d977bd19e3acaaa3736719a900754c1fe675631f3337820130
+    REF 8.0.0
+    SHA512 bcbb065c2af34ea681ec556377fd22e720b6f5d4caa73f432b1e34e08603a96f2233763f0ec5ae86b9ee71ddbe3062f58d3794cd3a162ce6903435530de0bba6
     HEAD_REF master
+    PATCHES
+        fix-symbol-exports.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/tinyxml2/portfile.cmake
+++ b/ports/tinyxml2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO leethomason/tinyxml2
@@ -24,8 +22,4 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(COPY
-  ${SOURCE_PATH}/readme.md
-  DESTINATION ${CURRENT_PACKAGES_DIR}/share/tinyxml2
-)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/tinyxml2/readme.md ${CURRENT_PACKAGES_DIR}/share/tinyxml2/copyright)
+file(INSTALL ${SOURCE_PATH}/readme.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
This PR updates tinyxml2 to version 8.0.0. It also adds a patch to prevent symbols being exported from DLLs/EXEs linked with the static version of the library. (This patch has been submitted to https://github.com/leethomason/tinyxml2/pull/820 and hopefully will make it into the next release, so should only be temporary in vcpkg.)

I've tested builds of x86-windows, x86-windows-static, x64-windows, x64-windows-static, arm64-windows, arm64-windows-static. Symbols are still exported from the -windows DLLs correctly, and linked output of -windows-static no longer includes tinyxml2 symbols. Also tested x64-linux which looks to be fine.