### PR TITLE
[raylib] Add remaining headers and fix CMake

### DIFF
--- a/ports/raylib/CONTROL
+++ b/ports/raylib/CONTROL
@@ -1,5 +1,5 @@
 Source: raylib
-Version: 3.0.0
+Version: 3.0.0-1
 Description: A simple and easy-to-use library to enjoy videogames programming
 Homepage: https://github.com/raysan5/raylib
 Supports: !(arm|uwp)

--- a/ports/raylib/fix-cmake-static.patch
+++ b/ports/raylib/fix-cmake-static.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/raylib-config.cmake b/cmake/raylib-config.cmake
+index b5358740..140a2830 100644
+--- a/cmake/raylib-config.cmake
++++ b/cmake/raylib-config.cmake
+@@ -27,11 +27,7 @@ find_path(raylib_INCLUDE_DIR
+     HINTS ${${XPREFIX}_INCLUDE_DIRS}
+ )
+ 
+-set(RAYLIB_NAMES raylib)
+-
+-if (raylib_USE_STATIC_LIBS)
+-    set(RAYLIB_NAMES libraylib.a raylib.lib ${RAYLIB_NAMES})
+-endif()
++set(RAYLIB_NAMES raylib raylib_static)
+ 
+ find_library(raylib_LIBRARY
+     NAMES ${RAYLIB_NAMES}

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -19,6 +19,8 @@ vcpkg_from_github(
     REF 7ef114d1da2c34a70bba5442497103441647d8f3 # 3.0.0
     SHA512 e15df6f0f95d9580d6211459815f174496b1385c9797a682d372a03b1175c9eb38e51b3b27077346d5e1a2d6ee2d5c636e03e8fd3ca9a73a7fa2a67afd255bd2
     HEAD_REF master
+    PATCHES
+        fix-cmake-static.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED)
@@ -76,6 +78,8 @@ endif()
 
 file(INSTALL ${SOURCE_PATH}/src/raymath.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 file(INSTALL ${SOURCE_PATH}/src/rlgl.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/src/physac.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/src/raudio.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
 # Install usage
 configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -74,6 +74,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
+file(INSTALL ${SOURCE_PATH}/src/raymath.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(INSTALL ${SOURCE_PATH}/src/rlgl.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
 # Install usage
 configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Two headers were missing from raylib: raymath.h and rlgl.h. While these headers are NOT required to use the base library, they are expected headers to use in tandem with, or standalone to raylib.

- Which triplets are supported/not supported? Have you updated the CI baseline? Should support all the same triplets.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
