### PR TITLE
[gli] Add CMake config support

### DIFF
--- a/ports/gli/CONTROL
+++ b/ports/gli/CONTROL
@@ -1,5 +1,5 @@
 Source: gli
-Version: dd17acf
+Version: dd17acf-1
 Build-Depends: glm
 Description: OpenGL Image (GLI)
 Homepage: https://gli.g-truc.net

--- a/ports/gli/disable-test.patch
+++ b/ports/gli/disable-test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6eb1a68..610c0bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,7 +71,7 @@ endmacro(addExternalPackageGTC)
+ # Add subdirectory
+ 
+ add_subdirectory(gli)
+-add_subdirectory(test)
++#add_subdirectory(test)
+ #add_subdirectory(doc)
+ 
+ ################################

--- a/ports/gli/portfile.cmake
+++ b/ports/gli/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF dd17acf9cc7fc6e6abe9f9ec69949eeeee1ccd82
     SHA512 9e3a4ab9ee73d5c271b8346cf81339cd3cd0c20d20991524b816313b6a99e8d3a01863316a38cf1a52ef9c5b31d689ecccf6248b12d1d270460c048bf904650b
     HEAD_REF master
+    PATCHES
+        disable-test.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/gli/portfile.cmake
+++ b/ports/gli/portfile.cmake
@@ -1,5 +1,4 @@
 #header-only library
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -9,11 +8,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/gli TARGET_PATH share/gli)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/include/gli/CMakeLists.txt)
+
 # Put the license file where vcpkg expects it
 # manual.md contains the "licenses" section for the project
-file(COPY ${SOURCE_PATH}/manual.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/gli/)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/gli/manual.md ${CURRENT_PACKAGES_DIR}/share/gli/copyright)
-
-# Copy the glm header files
-file(GLOB HEADER_FILES "${SOURCE_PATH}/gli/*.hpp" "${SOURCE_PATH}/gli/core")
-file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/gli)
+file(INSTALL ${SOURCE_PATH}/manual.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
`gli `is a header-only library. Currently, we install its headers directly in vcpkg.

since `gli `has provided gliConfig.cmake file. I update to build `gli `via CMake.

Fix #11598

Note: No feature needs to test.
