### PR TITLE
[nghttp2] Fix to build nghttp2 statically

### DIFF
--- a/ports/nghttp2/CONTROL
+++ b/ports/nghttp2/CONTROL
@@ -1,4 +1,4 @@
 Source: nghttp2
-Version: 1.39.2-1
+Version: 1.39.2-2
 Homepage: https://github.com/nghttp2/nghttp2
 Description: Implementation of the Hypertext Transfer Protocol version 2 in C

--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -13,13 +13,27 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DENABLE_LIB_ONLY=ON
-        -DENABLE_ASIO_LIB=OFF
-)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DENABLE_LIB_ONLY=ON
+            -DENABLE_ASIO_LIB=OFF
+            -DENABLE_STATIC_LIB=ON
+            -DENABLE_SHARED_LIB=OFF
+    )
+else()
+    vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+            -DENABLE_LIB_ONLY=ON
+            -DENABLE_ASIO_LIB=OFF
+            -DENABLE_STATIC_LIB=OFF
+            -DENABLE_SHARED_LIB=ON
+    )
+endif()
 
 vcpkg_install_cmake()
 

--- a/ports/nghttp2/portfile.cmake
+++ b/ports/nghttp2/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 set(LIB_NAME nghttp2)
 set(LIB_VERSION 1.39.2)
 
@@ -13,27 +11,23 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_configure_cmake(
-        SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
-        OPTIONS
-            -DENABLE_LIB_ONLY=ON
-            -DENABLE_ASIO_LIB=OFF
-            -DENABLE_STATIC_LIB=ON
-            -DENABLE_SHARED_LIB=OFF
-    )
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(ENABLE_STATIC_LIB ON)
+    set(ENABLE_SHARED_LIB OFF)
 else()
-    vcpkg_configure_cmake(
-        SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
-        OPTIONS
-            -DENABLE_LIB_ONLY=ON
-            -DENABLE_ASIO_LIB=OFF
-            -DENABLE_STATIC_LIB=OFF
-            -DENABLE_SHARED_LIB=ON
-    )
+    set(ENABLE_STATIC_LIB OFF)
+    set(ENABLE_SHARED_LIB ON)
 endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DENABLE_LIB_ONLY=ON
+        -DENABLE_ASIO_LIB=OFF
+        -DENABLE_STATIC_LIB=${ENABLE_STATIC_LIB}
+        -DENABLE_SHARED_LIB=${ENABLE_SHARED_LIB}
+)
 
 vcpkg_install_cmake()
 
@@ -46,6 +40,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${LIB_NAME} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #11492.

nghttp2 is always build dynamic.  nghttp2 uses non standard option to build the static library. see #11492. 
This PR honors whether the triplet is static or dynamic.

- Which triplets are supported/not supported? Have you updated the CI baseline?

I've only tested x64-linux

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I think so.