### PR TITLE
[vcpkg baseline][osg] Fix build error when building plugin RestHttpDevice

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,5 +1,5 @@
 Source: osg
-Version: 3.6.4-2
+Version: 3.6.4-3
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: zlib, fontconfig, boost-asio (!windows), freeglut (windows), expat (windows), openimageio (osx)

--- a/ports/osg/fix-asio-error.patch
+++ b/ports/osg/fix-asio-error.patch
@@ -1,0 +1,31 @@
+diff --git a/src/osgPlugins/RestHttpDevice/server.cpp b/src/osgPlugins/RestHttpDevice/server.cpp
+index d0231ef..8d71e5c 100644
+--- a/src/osgPlugins/RestHttpDevice/server.cpp
++++ b/src/osgPlugins/RestHttpDevice/server.cpp
+@@ -9,7 +9,7 @@
+ //
+ 
+ #include "server.hpp"
+-#include <boost/bind.hpp>
++#include <functional>
+ 
+ namespace http {
+ namespace server {
+@@ -31,7 +31,7 @@ server::server(const std::string& address, const std::string& port,
+   acceptor_.bind(endpoint);
+   acceptor_.listen();
+   acceptor_.async_accept(new_connection_->socket(),
+-      boost::bind(&server::handle_accept, this,
++      std::bind(&server::handle_accept, this,
+         asio::placeholders::error));
+ }
+ 
+@@ -56,7 +56,7 @@ void server::handle_accept(const asio::error_code& e)
+     new_connection_.reset(new connection(
+           io_service_pool_.get_io_service(), request_handler_));
+     acceptor_.async_accept(new_connection_->socket(),
+-        boost::bind(&server::handle_accept, this,
++        std::bind(&server::handle_accept, this,
+           asio::placeholders::error));
+   }
+   else

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         remove-prefix.patch # Remove this patch when cmake fix Findosg_functions.cmake
         fix-liblas.patch
         fix-nvtt.patch
+        fix-asio-error.patch # Upstream issue https://github.com/openscenegraph/OpenSceneGraph/issues/921
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")


### PR DESCRIPTION
Use [unofficial workaroud](https://github.com/chriskohlhoff/asio/issues/316) to fix build error:
```
/mnt/_work/1/s/buildtrees/osg/src/raph-3.6.4-c5448290ed/src/osgPlugins/RestHttpDevice/server.cpp:35:29: error: ‘error’ is not a member of ‘asio::placeholders’
         asio::placeholders::error));
                             ^~~~~
```

Related: #11502 [#921](https://github.com/openscenegraph/OpenSceneGraph/issues/921).

Fix #11686