### PR TITLE
[vcpkg baseline][libfabric] Only support dynamic build

### DIFF
--- a/ports/libfabric/CONTROL
+++ b/ports/libfabric/CONTROL
@@ -1,5 +1,6 @@
 Source: libfabric
-Version: 1.8.1
+Version: 1.8.1-1
 Description: The OpenFabrics Interfaces Working Group (OFIWG) and the Libfabric open-source community are pleased to announce the release of version v1.6.2 of libfabric. See NEWS.md for the list of features and enhancements that have been added since the last release.
 Homepage: https://github.com/ofiwg/libfabric
 Build-Depends: networkdirect-sdk (windows)
+Supports: windows&x64&(!static)

--- a/ports/libfabric/portfile.cmake
+++ b/ports/libfabric/portfile.cmake
@@ -1,9 +1,6 @@
-include(vcpkg_common_functions)
+vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP" ON_ARCH "x86")
 
-if (VCPKG_CMAKE_SYSTEM_NAME)
-    # The library supports Linux/Darwin/BSD, it is just not yet added here
-    message(FATAL_ERROR "vcpkg libfabric currently suports windows.  Please consider a pull request to add additional support!")
-endif()
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -14,10 +11,6 @@ vcpkg_from_github(
     PATCHES
       add_additional_includes.patch
 )
-
-if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-   message(FATAL_ERROR "VCPKG BUILD ERROR: libfabric only supports x64")
-endif()
 
 set(LIBFABRIC_RELEASE_CONFIGURATION "Release-v141")
 set(LIBFABRIC_DEBUG_CONFIGURATION "Debug-v141")
@@ -43,4 +36,4 @@ file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include)
 file(RENAME ${CURRENT_PACKAGES_DIR}/includetemp ${CURRENT_PACKAGES_DIR}/include/libfabric)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libfabric RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -746,6 +746,7 @@ libfabric:x64-linux=fail
 libfabric:x64-osx=fail
 libfabric:x64-uwp=fail
 libfabric:x64-windows=ignore
+libfabric:x64-windows-static=fail
 libfreenect2:arm64-windows=fail
 libgd:x64-linux=ignore
 libgit2:arm-uwp=fail


### PR DESCRIPTION
There is no configuration information for building a static library in libfabric.vcxproj, so static building is disabled.

Related: #11637.