### PR TITLE
[xmlwrapp] Add new port

### DIFF
--- a/ports/xmlwrapp/CMakeLists_top.txt
+++ b/ports/xmlwrapp/CMakeLists_top.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.8)
+project(xmlwrapp_project)
+
+option(INSTALL_HEADERS "Install public header files" ON)
+
+subdirs(src/libxml)
+subdirs(src/libxslt)

--- a/ports/xmlwrapp/CMakeLists_xmlwrapp.txt
+++ b/ports/xmlwrapp/CMakeLists_xmlwrapp.txt
@@ -1,0 +1,119 @@
+#require 3.10 to ignore libxml dependent libraries (i.e libiconv, etc.) when dynamically linking
+cmake_minimum_required(VERSION 3.10)
+project (xmlwrapp C)
+
+set(PUB_HDRS  
+    ../../include/xmlwrapp/attributes.h
+    ../../include/xmlwrapp/_cbfo.h
+    ../../include/xmlwrapp/document.h
+    ../../include/xmlwrapp/event_parser.h
+    ../../include/xmlwrapp/errors.h
+    ../../include/xmlwrapp/init.h
+    ../../include/xmlwrapp/node.h
+    ../../include/xmlwrapp/nodes_view.h
+    ../../include/xmlwrapp/schema.h
+    ../../include/xmlwrapp/tree_parser.h
+    ../../include/xmlwrapp/xpath.h
+    ../../include/xmlwrapp/xmlwrapp.h
+    ../../include/xmlwrapp/version.h
+)
+
+set(PRIV_HDRS
+    ait_impl.h
+    dtd_impl.h
+    errors_impl.h
+    node_iterator.h
+    node_manip.h
+    pimpl_base.h
+    utility.h
+)
+
+set (SRC
+    ait_impl.cxx
+    attributes.cxx
+    document.cxx
+    dtd_impl.cxx
+    event_parser.cxx
+    errors.cxx
+    init.cxx
+    node.cxx
+    node_iterator.cxx
+    node_manip.cxx
+    nodes_view.cxx
+    schema.cxx
+    tree_parser.cxx
+    utility.cxx
+    xpath.cxx
+)
+
+#file(READ ../../include/xmlwrapp/export_static.h EXPORT_H)
+
+if(BUILD_SHARED_LIBS)
+    
+    # Generate exports with fixed definition of XMLWRAPP_API for static and dynamic builds
+    set(ORIG_XMLWRAPP_API_DEFINES "[ \t]*#define XMLWRAPP_API[ \t]*[\n][ \t]*#define XSLTWRAPP_API[ \t]*[\n]")
+
+    set(NEW_XMLWRAPP_API_DEFINES [=[
+    #ifdef BUILDING_XMLWRAPP_DLL
+        #define XMLWRAPP_API __declspec(dllexport)
+    #else
+        #define XMLWRAPP_API __declspec(dllimport)
+    #endif
+    #ifdef BUILDING_XSLTWRAPP_DLL
+        #define XSLTWRAPP_API __declspec(dllexport)  
+    #else
+        #define XSLTWRAPP_API __declspec(dllimport)
+    #endif    
+    ]=]
+    )
+    
+    string(REGEX REPLACE ${ORIG_XMLWRAPP_API_DEFINES} ${NEW_XMLWRAPP_API_DEFINES} EXPORT_H "${EXPORT_H}")
+endif()
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/xmlwrapp/export.h "${EXPORT_H}")
+
+list(APPEND PUB_HDRS ${CMAKE_CURRENT_BINARY_DIR}/xmlwrapp/export.h)
+
+add_library(xmlwrapp ${PUB_HDRS} ${PRIV_HDRS} ${SRC})
+
+find_package(LibXml2 REQUIRED)
+
+if(LIBXML2_FOUND)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(xmlwrapp ${LIBXML2_LIBRARY})
+        target_compile_definitions(xmlwrapp PRIVATE BUILDING_XMLWRAPP_DLL)
+    else()
+        target_link_libraries(xmlwrapp ${LIBXML2_LIBRARIES})
+        target_compile_definitions(xmlwrapp PUBLIC LIBXML_STATIC)
+    endif()
+    
+    target_include_directories(xmlwrapp PUBLIC         
+       "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+       ${CMAKE_CURRENT_BINARY_DIR}
+       ${LIBXML2_INCLUDE_DIRS}
+    )
+    target_compile_definitions(xmlwrapp PUBLIC ${LIBXML2_DEFINITIONS})
+
+    if(MSVC)
+        target_compile_definitions(xmlwrapp PUBLIC 
+            _CRT_SECURE_NO_DEPRECATE 
+            _CRT_SECURE_NO_WARNINGS
+            _CRT_NONSTDC_NO_WARNINGS 
+            _SCL_SECURE_NO_WARNINGS)
+    endif()
+endif()    
+
+set(TARGET_INSTALL_OPTIONS)
+if(INSTALL_HEADERS)  
+    
+    set_target_properties(xmlwrapp PROPERTIES PUBLIC_HEADER "${PUB_HDRS}")
+    set(TARGET_INSTALL_OPTIONS PUBLIC_HEADER DESTINATION "include/xmlwrapp")
+endif()
+
+install(TARGETS xmlwrapp
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    ${TARGET_INSTALL_OPTIONS}
+)
+

--- a/ports/xmlwrapp/CMakeLists_xsltwrapp.txt
+++ b/ports/xmlwrapp/CMakeLists_xsltwrapp.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.0)
+project (xsltwrapp C)
+
+set(PUB_HDRS  
+    ../../include/xsltwrapp/init.h
+    ../../include/xsltwrapp/stylesheet.h
+    ../../include/xsltwrapp/xsltwrapp.h
+)
+
+set(PRIV_HDRS 
+    result.h
+)
+
+set (SRC
+    init.cxx
+    stylesheet.cxx
+)
+
+add_library(xsltwrapp ${PUB_HDRS} ${PRIV_HDRS} ${SRC})
+
+find_package(LibXslt REQUIRED)
+
+if(LIBXSLT_FOUND)
+    target_link_libraries(xsltwrapp PUBLIC xmlwrapp ${LIBXSLT_LIBRARIES} ${LIBXSLT_EXSLT_LIBRARIES})
+    target_include_directories(xsltwrapp PUBLIC ${LIBXSLT_INCLUDE_DIR})
+    target_compile_definitions(xsltwrapp PUBLIC ${LIBXSLT_DEFINITIONS})
+endif()    
+   
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xsltwrapp PRIVATE BUILDING_XSLTWRAPP_DLL)
+else()
+    target_compile_definitions(xsltwrapp PUBLIC LIBXSLT_STATIC LIBEXSLT_STATIC)
+endif()
+
+set(TARGET_INSTALL_OPTIONS)
+if(INSTALL_HEADERS)  
+    set_target_properties(xsltwrapp PROPERTIES PUBLIC_HEADER "${PUB_HDRS}")
+    set(TARGET_INSTALL_OPTIONS PUBLIC_HEADER DESTINATION "include/xsltwrapp")
+endif()
+
+install(TARGETS xsltwrapp
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    ${TARGET_INSTALL_OPTIONS}
+)

--- a/ports/xmlwrapp/CONTROL
+++ b/ports/xmlwrapp/CONTROL
@@ -1,0 +1,4 @@
+Source: xmlwrapp
+Version:0.9.0
+Description: xmlwrapp is a modern style C++ library for working with XML data, built atop the venerable libxml2 C library.
+Build-Depends: libxml2, libxslt

--- a/ports/xmlwrapp/fix-export-header.patch
+++ b/ports/xmlwrapp/fix-export-header.patch
@@ -1,0 +1,20 @@
+diff --git a/include/xmlwrapp/export.h b/include/xmlwrapp/export.h
+index b23ead8..6d371c2 100644
+--- a/include/xmlwrapp/export.h
++++ b/include/xmlwrapp/export.h
+@@ -37,8 +37,13 @@
+     #define XMLWRAPP_API   __attribute__ ((visibility("default")))
+     #define XSLTWRAPP_API  __attribute__ ((visibility("default")))
+ #else
+-    #define XMLWRAPP_API
+-    #define XSLTWRAPP_API
++  #ifdef BUILDING_DLL
++    #define XMLWRAPP_API __declspec(dllexport)
++    #define XSLTWRAPP_API __declspec(dllexport)    
++  #else
++    #define XMLWRAPP_API __declspec(dllimport)
++    #define XSLTWRAPP_API __declspec(dllimport)
++  #endif
+ #endif
+ 
+ #if defined(__clang__)

--- a/ports/xmlwrapp/portfile.cmake
+++ b/ports/xmlwrapp/portfile.cmake
@@ -1,0 +1,46 @@
+# Common Ambient Variables:
+#   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
+#   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
+#   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
+#   PORT                      = current port name (zlib, etc)
+#   TARGET_TRIPLET            = current triplet (x86-windows, x64-windows-static, etc)
+#   VCPKG_CRT_LINKAGE         = C runtime linkage type (static, dynamic)
+#   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
+#   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
+#   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
+#
+
+include(vcpkg_common_functions)
+set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xmlwrapp-0.9.0)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/vslavik/xmlwrapp/archive/v0.9.0.zip"
+    FILENAME "v0.9.0.zip"
+    SHA512 04660e1eb92423ba7419ae36969cb5d77a0b01ab8e627a73d2c5aeb70d9a21e6578c9befa26fbbb857599f0d73e97768afbc9e652e7febd5eeaae97cc2fd74ac
+)
+vcpkg_extract_source_archive(${ARCHIVE})
+
+#Move the export.h file out of the way for now as it is only appropriate for creating static libraries. The 
+#CMakeLists_xmlwrapp.txt file will copy an appropriate one (i.e static or dll version) to the cmake bin directory.
+if (${SOURCE_PATH}/include/xmlwrapp/export.h)
+    file(RENAME ${SOURCE_PATH}/include/xmlwrapp/export.h ${SOURCE_PATH}/include/xmlwrapp/export_static.h)
+endif()
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_top.txt DESTINATION ${SOURCE_PATH})
+file(RENAME ${SOURCE_PATH}/CMakeLists_top.txt ${SOURCE_PATH}/CMakeLists.txt)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_xmlwrapp.txt DESTINATION ${SOURCE_PATH}/src/libxml)
+file(RENAME ${SOURCE_PATH}/src/libxml/CMakeLists_xmlwrapp.txt ${SOURCE_PATH}/src/libxml/CMakeLists.txt)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists_xsltwrapp.txt DESTINATION ${SOURCE_PATH}/src/libxslt)
+file(RENAME ${SOURCE_PATH}/src/libxslt/CMakeLists_xsltwrapp.txt ${SOURCE_PATH}/src/libxslt/CMakeLists.txt)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+ #   PREFER_NINJA
+    OPTIONS_DEBUG -DINSTALL_HEADERS=OFF
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/xmlwrapp RENAME copyright)


### PR DESCRIPTION
Added port for xmlwrapp (https://github.com/vslavik/xmlwrapp), which is a C++ wrap library for libxml and libxslt.  I have tested on Windows/VS2019 and linux ubuntu/centos.