### PR TITLE
[vcpkg] add out/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ __pycache__/
 archives
 .DS_Store
 prefab/
+out/


### PR DESCRIPTION
**Describe the pull request**

After I use `vcpkg` to install some c++ depencdies, I want to check if `vcpkg` content is clean(sometimes I will modify package content for tweaking build), so I will use `git status` to check it.  But I've seen:
![圖片](https://user-images.githubusercontent.com/31742569/83346345-18f97680-a34e-11ea-817c-af400ae60f60.png)

Is it appropriate to add `out/` auto-generated content to `.gitignore` list?  Thanks!