### PR TITLE
[cpprestsdk] Avoid using pkg-config to find OpenSSL libraries on Linux

### DIFF
--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,5 +1,5 @@
 Source: cpprestsdk
-Version: 2.10.16
+Version: 2.10.16-1
 Build-Depends: openssl (!uwp&!windows), boost-system (!uwp&!windows),
   boost-date-time (!uwp&!windows), boost-regex (!uwp&!windows), boost-thread (!uwp&!windows),
   boost-filesystem (!uwp&!windows), boost-random (!uwp&!windows), boost-chrono (!uwp&!windows),

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -32,6 +32,7 @@ vcpkg_configure_cmake(
         -DBUILD_SAMPLES=OFF
         -DCPPREST_EXPORT_DIR=share/cpprestsdk
         -DWERROR=OFF
+        -DPKG_CONFIG_EXECUTABLE=FALSE
     OPTIONS_DEBUG
         -DCPPREST_INSTALL_HEADERS=OFF
 )


### PR DESCRIPTION
When linking to a vcpkg-built C++ REST SDK on Linux, I noticed my executables being generated had redundant references to libssl.so.1.1 and libcrypto.so.1.1, rather than the static libraries built by vcpkg being used.

I tracked the issue down to an issue in the C++ REST SDK cpprest_find_openssl.cmake file. I have submitted a pull request to the project directly (https://github.com/microsoft/cpprestsdk/pull/1438) but this should fix the issue in the mean time.