### PR TITLE
[crashpad] Add build support for linux

### DIFF
--- a/ports/crashpad/CONTROL
+++ b/ports/crashpad/CONTROL
@@ -1,7 +1,7 @@
 Source: crashpad
-Version: 2020-03-18
+Version: 2020-03-18-1
 Homepage: https://chromium.googlesource.com/crashpad/crashpad/+/master/README.md
 Description: Crashpad is a crash-reporting system.
   Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss.
 Build-Depends: zlib
-Supports: x64 & (osx|windows)
+Supports: x64 & (osx|windows|linux)

--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_fail_port_install(
     ON_ARCH "x86" "arm" "arm64"
-    ON_TARGET "UWP" "LINUX")
+    ON_TARGET "UWP")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -30,6 +30,15 @@ checkout_in_path(
     "https://chromium.googlesource.com/chromium/mini_chromium"
     "c426ff98e1d9e9d59777fe8b883a5c0ceeca9ca3"
 )
+
+if(VCPKG_TARGET_IS_LINUX)
+	# linux support files
+	checkout_in_path(
+	   "${SOURCE_PATH}/third_party/lss/lss"
+	   "https://chromium.googlesource.com/linux-syscall-support"
+	   "851f3a53a06ce834f9c2f7b2745e02f93b90fdd2"
+	)
+endif()
 
 function(replace_gn_dependency INPUT_FILE OUTPUT_FILE LIBRARY_NAMES)
     unset(_LIBRARY_DEB CACHE)
@@ -114,6 +123,9 @@ install_headers("${SOURCE_PATH}/client")
 install_headers("${SOURCE_PATH}/util")
 install_headers("${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/base")
 install_headers("${SOURCE_PATH}/third_party/mini_chromium/mini_chromium/build")
+if(VCPKG_TARGET_IS_LINUX)
+	install_headers("${SOURCE_PATH}/third_party/lss/lss")
+endif()
 
 # remove empty directories
 file(REMOVE_RECURSE 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -293,7 +293,6 @@ cpr:x64-linux=ignore
 cpuinfo:arm64-windows=ignore
 crashpad:arm64-windows=fail
 crashpad:arm-uwp=fail
-crashpad:x64-linux=fail
 crashpad:x64-uwp=fail
 crashpad:x86-windows=fail
 crfsuite:arm-uwp=fail


### PR DESCRIPTION
**Describe the pull request**
Add linux build support for ``crashpad`` package

- Which triplets are supported/not supported? Have you updated the CI baseline?
``crashpad:x64-linux`` is now supported and CI baseline is updated

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes