### PR TITLE
[llvm] fix llvm-tblgen build with MSVC v19.26

### DIFF
--- a/ports/llvm/0003-fix-vs2019-v16.6.patch
+++ b/ports/llvm/0003-fix-vs2019-v16.6.patch
@@ -1,0 +1,15 @@
+diff --git a/llvm/include/llvm/Support/ManagedStatic.h b/llvm/include/llvm/Support/ManagedStatic.h
+index bbd0d04ed..f2b41422f 100644
+--- a/llvm/include/llvm/Support/ManagedStatic.h
++++ b/llvm/include/llvm/Support/ManagedStatic.h
+@@ -40,8 +40,8 @@ template <typename T, size_t N> struct object_deleter<T[N]> {
+ // constexpr, a dynamic initializer may be emitted depending on optimization
+ // settings. For the affected versions of MSVC, use the old linker
+ // initialization pattern of not providing a constructor and leaving the fields
+-// uninitialized.
+-#if !defined(_MSC_VER) || defined(__clang__)
++// uninitialized. See http://llvm.org/PR41367 for details.
++#if !defined(_MSC_VER) || (_MSC_VER >= 1925) || defined(__clang__)
+ #define LLVM_USE_CONSTEXPR_CTOR
+ #endif
+ 

--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,5 @@
 Source: llvm
-Version: 10.0.0-2
+Version: 10.0.0-3
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
     PATCHES
         0001-allow-to-use-commas.patch
         0002-fix-install-paths.patch
+        0003-fix-vs2019-v16.6.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
Fixes #11558

See http://llvm.org/PR41367 for details.