### PR TITLE
[osg] Fix conflict when asio and boost-asio are installed.

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,8 +1,8 @@
 Source: osg
-Version: 3.6.4-2
+Version: 3.6.4-3
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
-Build-Depends: zlib, fontconfig, boost-asio (!windows), freeglut (windows), expat (windows), openimageio (osx)
+Build-Depends: zlib, fontconfig, boost-asio (!windows), boost-core (!windows), boost-logic (!windows), boost-lexical-cast (!windows), boost-smart-ptr (!windows), boost-tuple (!windows), boost-bind (!windows), freeglut (windows), expat (windows), openimageio (osx)
 
 Feature: collada
 Description: Support for Collada (.dae) files

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         remove-prefix.patch # Remove this patch when cmake fix Findosg_functions.cmake
         fix-liblas.patch
         fix-nvtt.patch
+        use-boost-asio.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/osg/use-boost-asio.patch
+++ b/ports/osg/use-boost-asio.patch
@@ -1,0 +1,92 @@
+diff --git a/CMakeModules/FindAsio.cmake b/CMakeModules/FindAsio.cmake
+index 433d5c7..04a0edf 100644
+--- a/CMakeModules/FindAsio.cmake
++++ b/CMakeModules/FindAsio.cmake
+@@ -1,22 +1,7 @@
+ # Locate ASIO-headers (http://think-async.com/Asio)
+-# This module defines
+-# ASIO_FOUND, if false, do not try to link to gdal
+-# ASIO_INCLUDE_DIR, where to find the headers
+-#
+ # Created by Stephan Maximilian Huber
+ 
+-FIND_PATH(ASIO_INCLUDE_DIR
+-  NAMES
+-    asio.hpp
+-  PATHS
+-    /usr/include
+-    /usr/local/include
+-)
+-
+-SET(ASIO_FOUND "NO")
+-IF(ASIO_INCLUDE_DIR)
+-    FIND_PACKAGE( Boost 1.37 )
+-    IF(Boost_FOUND)
+-        SET(ASIO_FOUND "YES")
+-    ENDIF()
++FIND_PACKAGE( Boost 1.37 COMPONENTS asio )
++IF(Boost_FOUND)
++    SET(ASIO_FOUND "YES")
+ ENDIF()
+diff --git a/src/osgPlugins/RestHttpDevice/CMakeLists.txt b/src/osgPlugins/RestHttpDevice/CMakeLists.txt
+index 8464b9d..073e8ed 100644
+--- a/src/osgPlugins/RestHttpDevice/CMakeLists.txt
++++ b/src/osgPlugins/RestHttpDevice/CMakeLists.txt
+@@ -1,5 +1,4 @@
+ INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS})
+-INCLUDE_DIRECTORIES(${ASIO_INCLUDE_DIR})
+     
+ SET(TARGET_SRC
+     connection.cpp
+diff --git a/src/osgPlugins/RestHttpDevice/connection.hpp b/src/osgPlugins/RestHttpDevice/connection.hpp
+index 99f3a93..b205759 100644
+--- a/src/osgPlugins/RestHttpDevice/connection.hpp
++++ b/src/osgPlugins/RestHttpDevice/connection.hpp
+@@ -11,7 +11,7 @@
+ #ifndef HTTP_SERVER_CONNECTION_HPP
+ #define HTTP_SERVER_CONNECTION_HPP
+ 
+-#include <asio.hpp>
++#include <boost/asio.hpp>
+ #include <boost/array.hpp>
+ #include <boost/noncopyable.hpp>
+ #include <boost/shared_ptr.hpp>
+diff --git a/src/osgPlugins/RestHttpDevice/io_service_pool.hpp b/src/osgPlugins/RestHttpDevice/io_service_pool.hpp
+index 1d363a8..b6e7195 100644
+--- a/src/osgPlugins/RestHttpDevice/io_service_pool.hpp
++++ b/src/osgPlugins/RestHttpDevice/io_service_pool.hpp
+@@ -11,7 +11,7 @@
+ #ifndef HTTP_SERVER_IO_SERVICE_POOL_HPP
+ #define HTTP_SERVER_IO_SERVICE_POOL_HPP
+ 
+-#include <asio.hpp>
++#include <boost/asio.hpp>
+ #include <vector>
+ #include <boost/noncopyable.hpp>
+ #include <boost/shared_ptr.hpp>
+diff --git a/src/osgPlugins/RestHttpDevice/reply.hpp b/src/osgPlugins/RestHttpDevice/reply.hpp
+index 89f264a..b63d0b9 100644
+--- a/src/osgPlugins/RestHttpDevice/reply.hpp
++++ b/src/osgPlugins/RestHttpDevice/reply.hpp
+@@ -13,7 +13,7 @@
+ 
+ #include <string>
+ #include <vector>
+-#include <asio.hpp>
++#include <boost/asio.hpp>
+ #include "header.hpp"
+ 
+ namespace http {
+diff --git a/src/osgPlugins/RestHttpDevice/server.hpp b/src/osgPlugins/RestHttpDevice/server.hpp
+index a14f263..91c4b62 100644
+--- a/src/osgPlugins/RestHttpDevice/server.hpp
++++ b/src/osgPlugins/RestHttpDevice/server.hpp
+@@ -11,7 +11,7 @@
+ #ifndef HTTP_SERVER_SERVER_HPP
+ #define HTTP_SERVER_SERVER_HPP
+ 
+-#include <asio.hpp>
++#include <boost/asio.hpp>
+ #include <string>
+ #include <vector>
+ #include <boost/noncopyable.hpp>


### PR DESCRIPTION
When asio and boost-asio are installed, osg's build scripts would choose the standalone version of asio, but uses features specific to boost-asio. This patch forces the port to always use boost-asio, as the original CONTROL file indicated was the intent.

Also fixed transitive dependencies not being declared that just happened to get installed because boost-asio is a dependency.

Replaces https://github.com/microsoft/vcpkg/pull/11645 without introducing potential undefined behavior by switching from boost::bind to std::bind (because std::bind does not transfer asio associated_executor and associated_allocator in asio's completion token protocol).

Co-authored by @JackBoosY

Related: #11502 [#921](https://github.com/openscenegraph/OpenSceneGraph/issues/921).

Fix #11686
