### PR TITLE
[p-ranav-csv2] Add new port

### DIFF
--- a/ports/p-ranav-csv/CONTROL
+++ b/ports/p-ranav-csv/CONTROL
@@ -1,4 +1,4 @@
 Source: p-ranav-csv
 Version: 2019-07-11
-Description: CSV for modern C++
+Description: [deprecated] CSV for modern C++
 Homepage: https://github.com/p-ranav/csv

--- a/ports/p-ranav-csv2/CONTROL
+++ b/ports/p-ranav-csv2/CONTROL
@@ -1,0 +1,4 @@
+Source: p-ranav-csv2
+Version: 2020-06-02
+Homepage: https://github.com/p-ranav/csv2
+Description: CSV for modern C++

--- a/ports/p-ranav-csv2/portfile.cmake
+++ b/ports/p-ranav-csv2/portfile.cmake
@@ -1,0 +1,25 @@
+# header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO p-ranav/csv2
+    REF d659f90b637bb0de6c32246583fc4bb7caade215
+    SHA512 d00b1356907a7e22529e3ac4a7b979c6868311e8a98e4fd8b0a8b1f0d94b2425854242649a80a933084202834f5cee1fe17b51476fcc17e87b00e1e3cb8ed0e9
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCSV2_BUILD_TESTS=OFF
+        -DCSV2_SAMPLES=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share ${CURRENT_PACKAGES_DIR}/share/licenses)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.mio DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Adds csv2 header only library https://github.com/p-ranav/csv2
Also marks their previous [p-ranav-csv](https://github.com/p-ranav/csv) port as deprecated 
- Which triplets are supported/not supported? Have you updated the CI baseline?
*Pretty* sure everything should be supported. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

The port could *probably* be called just "csv2" but still seems too generic.