### PR TITLE
[librabbitmq] Update to use rabbitmq-config.cmake

### DIFF
--- a/ports/librabbitmq/CONTROL
+++ b/ports/librabbitmq/CONTROL
@@ -1,5 +1,5 @@
 Source: librabbitmq
-Version: 0.10.0
+Version: 0.10.0-1
 Build-Depends: openssl
 Homepage: https://github.com/alanxz/rabbitmq-c
 Description: A C-language AMQP client library for use with v2.0+ of the RabbitMQ broker.

--- a/ports/librabbitmq/CONTROL
+++ b/ports/librabbitmq/CONTROL
@@ -1,5 +1,5 @@
 Source: librabbitmq
-Version: 0.10.0-1
+Version: 2020-06-03
 Build-Depends: openssl
 Homepage: https://github.com/alanxz/rabbitmq-c
 Description: A C-language AMQP client library for use with v2.0+ of the RabbitMQ broker.

--- a/ports/librabbitmq/portfile.cmake
+++ b/ports/librabbitmq/portfile.cmake
@@ -1,9 +1,7 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO alanxz/rabbitmq-c
-  REF d416b8b16d196085106cfe137a0ff6919a9f6752 # v0.10.0
+  REF d416b8b16d196085106cfe137a0ff6919a9f6752 
   SHA512 3fc137893fc18509a3e583cc8d40a8e91f219063237b9fd018a65cf14da188914ddba3a031c4bc033a886fed19fc6291d1b28b55458b9163eb6d20425b0474dc
   HEAD_REF master
   PATCHES
@@ -29,4 +27,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/rabbitmq-c TARGET_PATH share/rab
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
-file(INSTALL ${SOURCE_PATH}/LICENSE-MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/librabbitmq RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE-MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${port} RENAME copyright)

--- a/ports/librabbitmq/portfile.cmake
+++ b/ports/librabbitmq/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO alanxz/rabbitmq-c
-  REF ffe918a5fcef72038a88054dca3c56762b1953d4 # v0.10.0
-  SHA512 05756176feffc3ccff9bf4f8416191c382c9e5b51d7dd72664cea0407c847d50cb4048b8669415d879396c0c7e8c1c38c65a66a98701e55de09afed893abc5a0
+  REF d416b8b16d196085106cfe137a0ff6919a9f6752 # v0.10.0
+  SHA512 3fc137893fc18509a3e583cc8d40a8e91f219063237b9fd018a65cf14da188914ddba3a031c4bc033a886fed19fc6291d1b28b55458b9163eb6d20425b0474dc
   HEAD_REF master
   PATCHES
 	fix-uwpwarning.patch
@@ -23,6 +23,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/rabbitmq-c TARGET_PATH share/rabbitmq-c)
 
 vcpkg_copy_pdbs()
 

--- a/ports/librabbitmq/portfile.cmake
+++ b/ports/librabbitmq/portfile.cmake
@@ -27,4 +27,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/rabbitmq-c TARGET_PATH share/rab
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
-file(INSTALL ${SOURCE_PATH}/LICENSE-MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${port} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE-MIT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
The rabbitmq-c library recently merged a pull request that implemented config-file generation. Vcpkg can now better integrate librabbitmq into it's ecosystem. I tested this works on the following triplets: x64-linux, x64-windows, and a custom x64-windows-static which just changes library linkage from "dynamic" to "static".