### PR TITLE
[gzip-hpp] Add new port

### DIFF
--- a/ports/gzip-hpp/CONTROL
+++ b/ports/gzip-hpp/CONTROL
@@ -1,0 +1,5 @@
+Source: gzip-hpp
+Version: 0.1.0
+Homepage: https://github.com/mapbox/gzip-hpp/
+Description: Gzip header-only C++ library
+Build-Depends: zlib

--- a/ports/gzip-hpp/portfile.cmake
+++ b/ports/gzip-hpp/portfile.cmake
@@ -1,0 +1,12 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mapbox/gzip-hpp
+    REF v0.1.0 
+    SHA512 4f332f08e842583b421932f14ee736a64d090ac22fd4e4654e5d84667c2fd6dcd73206b27b7c0c4f364104af7f4a5ad765c38125574bc239fa93b0b0ec4dad56
+    HEAD_REF master
+)
+
+file(COPY ${SOURCE_PATH}/include/gzip DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/gzip-hpp/portfile.cmake
+++ b/ports/gzip-hpp/portfile.cmake
@@ -1,3 +1,5 @@
+# header-only library
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mapbox/gzip-hpp


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
Adds gzip-hpp header only library https://github.com/mapbox/gzip-hpp

- Which triplets are supported/not supported? Have you updated the CI baseline?
Pretty sure everything should be supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes