### PR TITLE
Fix support for toolchains that set CMAKE_FIND_ROOT_PATH_MODE_* variables to ONLY

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -230,6 +230,16 @@ else() #Release build: Put Release paths before Debug paths. Debug Paths are req
     )
 endif()
 
+# If one CMAKE_FIND_ROOT_PATH_MODE_* variables is set to ONLY, to  make sure that ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} 
+# and ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug are searched, it is not sufficient to just add them to CMAKE_FIND_ROOT_PATH,
+# as CMAKE_FIND_ROOT_PATH specify "one or more directories to be prepended to all other search directories", so to make sure that 
+# the libraries are searched as they are, it is necessary to add "/" to the CMAKE_PREFIX_PATH
+if(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY" OR 
+   CMAKE_FIND_ROOT_PATH_MODE_LIBRARY STREQUAL "ONLY" OR
+   CMAKE_FIND_ROOT_PATH_MODE_PACKAGE STREQUAL "ONLY")
+   list(APPEND CMAKE_PREFIX_PATH "/")
+endif()
+
 set(VCPKG_CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})
 
 file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" _programfiles)


### PR DESCRIPTION
The vcpkg toolchain in `scripts/buildsystems/vcpkg.cmake` adds the installation prefixes to `CMAKE_FIND_ROOT_PATH`, but that directory is not searched directly by [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html), but  it is **prepended**  to all the usual search paths (for example the one specified by `CMAKE_PREFIX_PATH`).  To make sure that `find_package`  search in the directory specified in `CMAKE_FIND_ROOT_PATH` even if `CMAKE_FIND_ROOT_PATH` is set to `ONLY`, it is necessary to also add `/` to `CMAKE_PREFIX_PATH`.

- What does your PR fix? 

This PR ensure that:
~~~
C:\src\vcpkg-wasm>vcpkg.exe install spdlog:wasm32-emscripten
~~~
works fine, and in general is necessary for any `wasm32-emscripten` port that find its dependencies via `find_package`, as discussed in https://github.com/microsoft/vcpkg/pull/11323#issuecomment-629813053 . It probably also fixes https://github.com/microsoft/vcpkg/issues/8216, but I did not tested it.

- Which triplets are supported/not supported? Have you updated the CI baseline?
This fix was developed for ports of the `wasm32-emscripten` triplets, but it probably also applies to other triplets, but it should not affect any officially supported triplet.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
