### PR TITLE
docs: fix CMakeLists example for SQLite3

### DIFF
--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -122,7 +122,7 @@ find_package(sqlite3 CONFIG REQUIRED)
 
 add_executable(main main.cpp)
 
-target_link_libraries(main PRIVATE sqlite3))
+target_link_libraries(main PRIVATE sqlite3)
 ```
 ```cpp
 // main.cpp

--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -118,12 +118,11 @@ Now let's make a simple CMake project with a main file.
 cmake_minimum_required(VERSION 3.0)
 project(test)
 
-find_package(SQLite3 REQUIRED)
+find_package(sqlite3 CONFIG REQUIRED)
 
 add_executable(main main.cpp)
 
-target_include_directories(main PRIVATE ${SQLite3_INCLUDE_DIRS})
-target_link_libraries(main ${SQLite3_LIBRARIES})
+target_link_libraries(main PRIVATE sqlite3))
 ```
 ```cpp
 // main.cpp

--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -118,10 +118,12 @@ Now let's make a simple CMake project with a main file.
 cmake_minimum_required(VERSION 3.0)
 project(test)
 
-find_package(Sqlite3 REQUIRED)
+find_package(SQLite3 REQUIRED)
 
 add_executable(main main.cpp)
-target_link_libraries(main sqlite3)
+
+target_include_directories(main PRIVATE ${SQLite3_INCLUDE_DIRS})
+target_link_libraries(main ${SQLite3_LIBRARIES})
 ```
 ```cpp
 // main.cpp


### PR DESCRIPTION
This PR modifies the `CMakeLIsts.txt` listing in the **Installing and Using Packages Example: SQLite** example doc to fix some build issues I was experiencing.

Without `target_include_directories` and linking to the `${SQLite3_LIBRARIES}` variable instead of `sqlite3` directly, `cmake --build .` errors with:

    fatal error C1083: Cannot open include file: 'sqlite3.h': No such file or directory