### PR TITLE
[vcpkg] VcpkgCurrentInstalledDir was left uninitialized

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -54,6 +54,7 @@
     <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Debug'))">Debug</VcpkgNormalizedConfiguration>
     <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Release')) or '$(VcpkgConfiguration)' == 'RelWithDebInfo' or '$(VcpkgConfiguration)' == 'MinSizeRel'">Release</VcpkgNormalizedConfiguration>
     <VcpkgRoot Condition="'$(VcpkgRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .vcpkg-root))\</VcpkgRoot>
+    <VcpkgCurrentInstalledDir Condition="'$(VcpkgCurrentInstalledDir)' == ''">$(VcpkgRoot)installed\$(VcpkgTriplet)\</VcpkgCurrentInstalledDir>
     <!-- We add a trailing slash if it is missing in a different property because msbuild's default behavior does not
     allow us to override a console provided property here. -->
     <VcpkgRootSanitized>$(VcpkgRoot)</VcpkgRootSanitized>


### PR DESCRIPTION
It was broken in the commit: https://github.com/microsoft/vcpkg/commit/4fb225608532e9fb2fd2f5f1dbe9ec092cdc7c93#diff-f7a49059a86ff0bb925110f33551a677R57

This commit just reverts the change.

