### PR TITLE
[mlpack] Explicitly depend on stb

### DIFF
--- a/ports/mlpack/CONTROL
+++ b/ports/mlpack/CONTROL
@@ -1,8 +1,8 @@
 Source: mlpack
-Version: 3.2.2-2
+Version: 3.2.2-3
 Homepage: https://github.com/mlpack/mlpack
 Description: mlpack is a fast, flexible machine learning library, written in C++, that aims to provide fast, extensible implementations of cutting-edge machine learning algorithms.
-Build-Depends: openblas (!osx), clapack (!osx), boost, armadillo, ensmallen
+Build-Depends: openblas (!osx), clapack (!osx), boost, armadillo, ensmallen, stb
 
 Feature: tools
 Description: Build command-line executables.

--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -28,6 +28,10 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTS=OFF
+        -DDOWNLOAD_STB_IMAGE=OFF
+        -DDOWNLOAD_ENSMALLEN=OFF
+        -DBUILD_PYTHON_BINDINGS=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
         ${FEATURE_OPTIONS}
 )
 vcpkg_install_cmake()

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1092,10 +1092,6 @@ microsoft-signalr:x64-uwp=skip
 microsoft-signalr:x64-windows=skip
 microsoft-signalr:x64-windows-static=skip
 microsoft-signalr:x86-windows=skip
-# conflicts with stb
-mlpack:x86-windows=skip
-mlpack:x64-windows=skip
-mlpack:x64-windows-static=skip
 mman:x64-linux=fail
 mman:x64-osx=fail
 mmloader:arm64-windows=fail


### PR DESCRIPTION
`mlpack` installs `/include/stb_image.h` when built outside the presence of stb. This PR adds stb as an explicit dependency, ensuring the package does not conflict.

As a drive-by fix, this also disables git-based version detection which generates files into the source directory.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Yes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes