### PR TITLE
[libvpx] Add cmake config file

### DIFF
--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,5 +1,5 @@
 Source: libvpx
-Version: 1.8.1-4
+Version: 1.8.1-5
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
 Supports: !(uwp|arm|arm64)

--- a/ports/libvpx/libvpx-config.cmake.in
+++ b/ports/libvpx/libvpx-config.cmake.in
@@ -1,0 +1,47 @@
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+# Add library target (note: vpx always has a static build in vcpkg).
+add_library(libvpx::libvpx STATIC IMPORTED)
+
+# Add interface include directories and link interface languages (applies to all configurations).
+set_target_properties(libvpx::libvpx PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+  IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+)
+list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
+
+# Add release configuration properties.
+find_library(_LIBFILE_RELEASE NAMES vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
+set_property(TARGET libvpx::libvpx
+  APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(libvpx::libvpx PROPERTIES
+  IMPORTED_LOCATION_RELEASE ${_LIBFILE_RELEASE})
+list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_RELEASE})
+unset(_LIBFILE_RELEASE CACHE)
+
+# Add debug configuration properties.
+if(@LIBVPX_CONFIG_DEBUG@)
+  find_library(_LIBFILE_DEBUG NAMES vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
+  set_property(TARGET libvpx::libvpx
+    APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+  set_target_properties(libvpx::libvpx PROPERTIES
+    IMPORTED_LOCATION_DEBUG ${_LIBFILE_DEBUG})
+  list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_DEBUG})
+endif()
+unset(_LIBFILE_DEBUG CACHE)
+
+# Check header and library files are present.
+foreach(file ${_IMPORT_CHECK_FILES} )
+  if(NOT EXISTS "${file}" )
+    message(FATAL_ERROR "libvpx::libvpx references the file
+   \"${file}\"
+but this file does not exist.  Possible reasons include:
+* The file was deleted, renamed, or moved to another location.
+* An install or uninstall procedure did not complete successfully.
+")
+  endif()
+endforeach()
+unset(_IMPORT_CHECK_FILES)

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -217,7 +217,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
 else()
     set(LIBVPX_CONFIG_DEBUG OFF)
 endif()
-configure_file(${CMAKE_CURRENT_LIST_DIR}/libvpx-config.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/libvpx-config.cmake @ONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/unofficial-libvpx-config.cmake.in ${CURRENT_PACKAGES_DIR}/share/unofficial-libvpx/unofficial-libvpx-config.cmake @ONLY)
 
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libvpx)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libvpx/LICENSE ${CURRENT_PACKAGES_DIR}/share/libvpx/copyright)

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -212,5 +212,12 @@ else()
     endif()
 endif()
 
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    set(LIBVPX_CONFIG_DEBUG ON)
+else()
+    set(LIBVPX_CONFIG_DEBUG OFF)
+endif()
+configure_file(${CMAKE_CURRENT_LIST_DIR}/libvpx-config.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/libvpx-config.cmake @ONLY)
+
 file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libvpx)
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/libvpx/LICENSE ${CURRENT_PACKAGES_DIR}/share/libvpx/copyright)

--- a/ports/libvpx/unofficial-libvpx-config.cmake.in
+++ b/ports/libvpx/unofficial-libvpx-config.cmake.in
@@ -4,10 +4,10 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 
 # Add library target (note: vpx always has a static build in vcpkg).
-add_library(libvpx::libvpx STATIC IMPORTED)
+add_library(unofficial::libvpx::libvpx STATIC IMPORTED)
 
 # Add interface include directories and link interface languages (applies to all configurations).
-set_target_properties(libvpx::libvpx PROPERTIES
+set_target_properties(unofficial::libvpx::libvpx PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
   IMPORTED_LINK_INTERFACE_LANGUAGES "C"
 )
@@ -15,9 +15,9 @@ list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
 
 # Add release configuration properties.
 find_library(_LIBFILE_RELEASE NAMES vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
-set_property(TARGET libvpx::libvpx
+set_property(TARGET unofficial::libvpx::libvpx
   APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-set_target_properties(libvpx::libvpx PROPERTIES
+set_target_properties(unofficial::libvpx::libvpx PROPERTIES
   IMPORTED_LOCATION_RELEASE ${_LIBFILE_RELEASE})
 list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_RELEASE})
 unset(_LIBFILE_RELEASE CACHE)
@@ -25,9 +25,9 @@ unset(_LIBFILE_RELEASE CACHE)
 # Add debug configuration properties.
 if(@LIBVPX_CONFIG_DEBUG@)
   find_library(_LIBFILE_DEBUG NAMES vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
-  set_property(TARGET libvpx::libvpx
+  set_property(TARGET unofficial::libvpx::libvpx
     APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-  set_target_properties(libvpx::libvpx PROPERTIES
+  set_target_properties(unofficial::libvpx::libvpx PROPERTIES
     IMPORTED_LOCATION_DEBUG ${_LIBFILE_DEBUG})
   list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_DEBUG})
 endif()
@@ -36,7 +36,7 @@ unset(_LIBFILE_DEBUG CACHE)
 # Check header and library files are present.
 foreach(file ${_IMPORT_CHECK_FILES} )
   if(NOT EXISTS "${file}" )
-    message(FATAL_ERROR "libvpx::libvpx references the file
+    message(FATAL_ERROR "unofficial::libvpx::libvpx references the file
    \"${file}\"
 but this file does not exist.  Possible reasons include:
 * The file was deleted, renamed, or moved to another location.

--- a/ports/libvpx/unofficial-libvpx-config.cmake.in
+++ b/ports/libvpx/unofficial-libvpx-config.cmake.in
@@ -1,47 +1,49 @@
-# Compute the installation prefix relative to this file.
-get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(NOT TARGET unofficial::libvpx::libvpx)
+  # Compute the installation prefix relative to this file.
+  get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 
-# Add library target (note: vpx always has a static build in vcpkg).
-add_library(unofficial::libvpx::libvpx STATIC IMPORTED)
+  # Add library target (note: vpx always has a static build in vcpkg).
+  add_library(unofficial::libvpx::libvpx STATIC IMPORTED)
 
-# Add interface include directories and link interface languages (applies to all configurations).
-set_target_properties(unofficial::libvpx::libvpx PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
-  IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-)
-list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
-
-# Add release configuration properties.
-find_library(_LIBFILE_RELEASE NAMES vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
-set_property(TARGET unofficial::libvpx::libvpx
-  APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-set_target_properties(unofficial::libvpx::libvpx PROPERTIES
-  IMPORTED_LOCATION_RELEASE ${_LIBFILE_RELEASE})
-list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_RELEASE})
-unset(_LIBFILE_RELEASE CACHE)
-
-# Add debug configuration properties.
-if(@LIBVPX_CONFIG_DEBUG@)
-  find_library(_LIBFILE_DEBUG NAMES vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
-  set_property(TARGET unofficial::libvpx::libvpx
-    APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+  # Add interface include directories and link interface languages (applies to all configurations).
   set_target_properties(unofficial::libvpx::libvpx PROPERTIES
-    IMPORTED_LOCATION_DEBUG ${_LIBFILE_DEBUG})
-  list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_DEBUG})
-endif()
-unset(_LIBFILE_DEBUG CACHE)
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+  )
+  list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
 
-# Check header and library files are present.
-foreach(file ${_IMPORT_CHECK_FILES} )
-  if(NOT EXISTS "${file}" )
-    message(FATAL_ERROR "unofficial::libvpx::libvpx references the file
+  # Add release configuration properties.
+  find_library(_LIBFILE_RELEASE NAMES vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
+  set_property(TARGET unofficial::libvpx::libvpx
+    APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+  set_target_properties(unofficial::libvpx::libvpx PROPERTIES
+    IMPORTED_LOCATION_RELEASE ${_LIBFILE_RELEASE})
+  list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_RELEASE})
+  unset(_LIBFILE_RELEASE CACHE)
+
+  # Add debug configuration properties.
+  if(@LIBVPX_CONFIG_DEBUG@)
+    find_library(_LIBFILE_DEBUG NAMES vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
+    set_property(TARGET unofficial::libvpx::libvpx
+      APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+    set_target_properties(unofficial::libvpx::libvpx PROPERTIES
+      IMPORTED_LOCATION_DEBUG ${_LIBFILE_DEBUG})
+    list(APPEND _IMPORT_CHECK_FILES ${_LIBFILE_DEBUG})
+    unset(_LIBFILE_DEBUG CACHE)
+  endif()
+
+  # Check header and library files are present.
+  foreach(file ${_IMPORT_CHECK_FILES} )
+    if(NOT EXISTS "${file}" )
+      message(FATAL_ERROR "unofficial::libvpx::libvpx references the file
    \"${file}\"
 but this file does not exist.  Possible reasons include:
 * The file was deleted, renamed, or moved to another location.
 * An install or uninstall procedure did not complete successfully.
 ")
-  endif()
-endforeach()
-unset(_IMPORT_CHECK_FILES)
+    endif()
+  endforeach()
+  unset(_IMPORT_CHECK_FILES)
+endif()


### PR DESCRIPTION
This allows libvpx to be used with

find_package(libvpx CONFIG REQUIRED)
target_link_libraries(main PRIVATE libvpx::libvpx)

**Describe the pull request**

- What does your PR fix? See above.

- Which triplets are supported/not supported? Have you updated the CI baseline? Tested on all supported windows triplets. Should work also on linux/darwin provided the same library naming convention is used (vpx base name for release, vpxd base name for debug). If not, it is easy to add alternate names.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
