### PR TITLE
[LAStools] Update to 200509

### DIFF
--- a/ports/lastools/CONTROL
+++ b/ports/lastools/CONTROL
@@ -1,5 +1,5 @@
 Source: lastools
-Version: 2019-07-10
+Version: 2020-05-09
 Homepage: https://github.com/LAStools/LAStools
 Description: LAStools: award-winning software for efficient LiDAR processing (with LASzip)
 Supports: !uwp

--- a/ports/lastools/fix_install_paths_lastools.patch
+++ b/ports/lastools/fix_install_paths_lastools.patch
@@ -1,0 +1,27 @@
+diff --git a/LASlib/src/CMakeLists.txt b/LASlib/src/CMakeLists.txt
+index 1b170bf..b5c40cb 100644
+--- a/LASlib/src/CMakeLists.txt
++++ b/LASlib/src/CMakeLists.txt
+@@ -99,17 +99,8 @@ if(MSVC)
+     )
+ endif()
+ 
++install(TARGETS LASlib EXPORT LASlib-targets
++	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES ${LAS_INCLUDES} DESTINATION include/LASlib)
+-
+-if (MSVC)
+-	foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+-		install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../lib/${OUTPUTCONFIG} DESTINATION lib/LASlib)
+-	endforeach( OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
+-else()
+-	install(TARGETS LASlib EXPORT laslib-targets
+-		ARCHIVE DESTINATION lib/LASlib
+-		LIBRARY DESTINATION lib/LASlib
+-		RUNTIME DESTINATION lib/LASlib)
+-	install(EXPORT laslib-targets DESTINATION lib/cmake/LASlib)
+-	install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/laslib-config.cmake DESTINATION lib/cmake/LASlib)
+-endif(MSVC)
++install(EXPORT LASlib-targets DESTINATION share/lastools/LASlib)
++install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION share/lastools/LASlib)
+\ No newline at end of file

--- a/ports/lastools/fix_install_paths_lastools.patch
+++ b/ports/lastools/fix_install_paths_lastools.patch
@@ -23,5 +23,5 @@ index 1b170bf..b5c40cb 100644
 -	install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/laslib-config.cmake DESTINATION lib/cmake/LASlib)
 -endif(MSVC)
 +install(EXPORT LASlib-targets DESTINATION share/lastools/LASlib)
-+install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/LASlib-config.cmake DESTINATION share/lastools/LASlib)
++install(FILES ${CMAKE_SOURCE_DIR}/LASlib/src/laslib-config.cmake DESTINATION share/lastools/LASlib)
 \ No newline at end of file

--- a/ports/lastools/portfile.cmake
+++ b/ports/lastools/portfile.cmake
@@ -9,9 +9,11 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO LAStools/LAStools
-    REF f15a702530e098b46c2eb3923f89a68ffa81e668
-    SHA512 df5763b7c69721ba2a24fde2b4092e53136020b88ff4cc0d533279d709c55d7d16d8a4300f0b68829294d9311ed674af5b15306c4ded7a6310e55404737702e0
+    REF 7c444a4bbae16fe43c676824a26419bb740a6ab8
+    SHA512 4503b033a5319caee5570f25a05009c0d05a8c61a43ed78317899faaeba82fbc1f9a8c8433772bb36547c74e850a2e68d20a16f6f22b12b3004da7e1aa2f334b
     HEAD_REF master
+    PATCHES 
+        "fix_install_paths_lastools.patch"
 )
 
 vcpkg_configure_cmake(
@@ -22,12 +24,10 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
      file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
**Describe the pull request**
Update LAStools to version 200509 (2020-05-09)
Link: [https://github.com/LAStools/LAStools](https://github.com/LAStools/LAStools)

Added `fix_install_paths_lastools.patch` to restore vcpkg compatible installation paths within the CMakeLists.txt.

- Which triplets are supported/not supported? 
`x64/:x86-windows`, `x64-linux` are tested and supported.

Have you updated the CI baseline?
- No need, yet.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
