### PR TITLE
[cpprestsdk] Fix find dependency openssl

### DIFF
--- a/ports/cpprestsdk/CONTROL
+++ b/ports/cpprestsdk/CONTROL
@@ -1,5 +1,5 @@
 Source: cpprestsdk
-Version: 2.10.16-1
+Version: 2.10.16-2
 Build-Depends: openssl (!uwp&!windows), boost-system (!uwp&!windows),
   boost-date-time (!uwp&!windows), boost-regex (!uwp&!windows), boost-thread (!uwp&!windows),
   boost-filesystem (!uwp&!windows), boost-random (!uwp&!windows), boost-chrono (!uwp&!windows),

--- a/ports/cpprestsdk/fix-find-openssl.patch
+++ b/ports/cpprestsdk/fix-find-openssl.patch
@@ -1,0 +1,18 @@
+diff --git a/Release/cmake/cpprest_find_openssl.cmake b/Release/cmake/cpprest_find_openssl.cmake
+index 9333663..c1df089 100644
+--- a/Release/cmake/cpprest_find_openssl.cmake
++++ b/Release/cmake/cpprest_find_openssl.cmake
+@@ -36,8 +36,11 @@ function(cpprest_find_openssl)
+         # Prefer a homebrew version of OpenSSL over the one in /usr/lib
+         file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl*/*)
+         # Prefer the latest (make the latest one first)
+-        list(REVERSE OPENSSL_ROOT_DIR)
+-        list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
++        if(OPENSSL_ROOT_DIR)
++          # Prefer the latest (make the latest one first)
++          list(REVERSE OPENSSL_ROOT_DIR)
++          list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
++        endif()
+       endif()
+       # This should prevent linking against the system provided 0.9.8y
+       message(STATUS "OPENSSL_ROOT_DIR = ${OPENSSL_ROOT_DIR}")

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_github(
 )
 
 set(OPTIONS)
-if(NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_TARGET_IS_UWP)
     SET(WEBSOCKETPP_PATH "${CURRENT_INSTALLED_DIR}/share/websocketpp")
     list(APPEND OPTIONS
         -DWEBSOCKETPP_CONFIG=${WEBSOCKETPP_PATH}
@@ -42,7 +42,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/cpprestsdk)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
 
 file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v2.10.16
     SHA512 d850b26051439dd10edcecd006075c64c61c565193cd76870af175bd343a72ecc59485deb0f907807071a57dd256b67139ad5d016f19cb38f7142357f430be1c
     HEAD_REF master
+    PATCHES fix-find-openssl.patch
 )
 
 set(OPTIONS)
@@ -39,11 +40,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_copy_pdbs()
+
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/share/cpprestsdk)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/share ${CURRENT_PACKAGES_DIR}/lib/share)
 
-file(INSTALL
-    ${SOURCE_PATH}/license.txt
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/cpprestsdk RENAME copyright)
-
-vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
According to [official changes](https://github.com/microsoft/cpprestsdk/commit/ccd74e1b62fcffa3c7ac37fc90152433b20baf2f), fix find dependency openssl.

Fixes #11807