### PR TITLE
[lua] Add vcpkg-cmake-wrapper

### DIFF
--- a/ports/lua/CONTROL
+++ b/ports/lua/CONTROL
@@ -1,5 +1,5 @@
 Source: lua
-Version: 5.3.5-4
+Version: 5.3.5-5
 Homepage: https://www.lua.org
 Description: a powerful, fast, lightweight, embeddable scripting language
 

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.lua.org/ftp/lua-5.3.5.tar.gz"
     FILENAME "lua-5.3.5.tar.gz"
@@ -25,7 +23,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+set(ENABLE_LUA_CPP 0)
 if("cpp" IN_LIST FEATURES)
+    set(ENABLE_LUA_CPP 1)
     vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         PREFER_NINJA
@@ -39,6 +39,10 @@ if("cpp" IN_LIST FEATURES)
     vcpkg_install_cmake()
 endif()
 
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/lua)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
         file(READ ${CURRENT_PACKAGES_DIR}/include/luaconf.h LUA_CONF_H)
@@ -47,10 +51,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     endif()
 endif()
 
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/lua)
+# Handle post-build CMake instructions
+configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in  ${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake @ONLY)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 
 # Handle copyright
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/lua/copyright)
-# Handle post-build CMake instructions
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/lua)
-vcpkg_copy_pdbs()
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/lua/vcpkg-cmake-wrapper.cmake.in
+++ b/ports/lua/vcpkg-cmake-wrapper.cmake.in
@@ -1,0 +1,6 @@
+_find_package(${ARGS})
+
+if (@ENABLE_LUA_CPP@)
+    find_library(lua_cpp NAMES lua-c++ liblua-c++ REQUIRED)
+    set(LUA_LIBRARIES ${LUA_LIBRARIES} ${lua_cpp})
+endif()


### PR DESCRIPTION
Add vcpkg-cmake-wrapper to solve the issue that the library lua-c++ cannot be used.

Fixes #11405