### PR TITLE
[graphicsmagick] fix Magick++.h header location.

### DIFF
--- a/ports/graphicsmagick/CMakeLists.txt
+++ b/ports/graphicsmagick/CMakeLists.txt
@@ -248,7 +248,7 @@ if (INSTALL_HEADERS)
     install(FILES magick/widget.h DESTINATION include/magick)
     install(FILES magick/xwindow.h DESTINATION include/magick)
  
-    install(FILES Magick++/lib/Magick++.h DESTINATION include/Magick++)
+    install(FILES Magick++/lib/Magick++.h DESTINATION include)
 
     install(FILES Magick++/lib/Magick++/Blob.h DESTINATION include/Magick++)
     install(FILES Magick++/lib/Magick++/BlobRef.h DESTINATION include/Magick++)

--- a/ports/graphicsmagick/CONTROL
+++ b/ports/graphicsmagick/CONTROL
@@ -1,5 +1,5 @@
 Source: graphicsmagick
-Version: 1.3.35
+Version: 1.3.35-1
 Build-Depends: zlib, bzip2, freetype, libjpeg-turbo, libpng, tiff
 Homepage: https://sourceforge.net/projects/graphicsmagick/
 Description: Image processing library


### PR DESCRIPTION
This pull request is to correct a header location for `graphicsmagick`. The issue was discovered when I enabled the [Navigation 2](https://ms-iot.github.io/ROSOnWindows/ros2/nav2.html) stack on Windows. The `Magick++.h` is expected to be placed one level up in the folder layout. Here is a example of the header layout in Ubuntu package: https://packages.ubuntu.com/bionic/amd64/libgraphicsmagick++1-dev/filelist.