### PR TITLE
[aria2c] vcpkg_download_distfile (connect-timeout)

### DIFF
--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -125,6 +125,10 @@ function(vcpkg_download_distfile VAR)
             endif()
             _execute_process(
                 COMMAND ${ARIA2} ${vcpkg_download_distfile_URLS}
+                --connect-timeout=60
+                --max-connection-per-server=3
+                --retry-wait=2
+                --max-tries=5
                 -o temp/${vcpkg_download_distfile_FILENAME}
                 -l download-${vcpkg_download_distfile_FILENAME}-detailed.log
                 ${request_headers}

--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -125,7 +125,7 @@ function(vcpkg_download_distfile VAR)
             endif()
             _execute_process(
                 COMMAND ${ARIA2} ${vcpkg_download_distfile_URLS}
-                --connect-timeout=60
+                --connect-timeout=15
                 --max-connection-per-server=3
                 --retry-wait=2
                 --max-tries=5

--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -125,7 +125,7 @@ function(vcpkg_download_distfile VAR)
             endif()
             _execute_process(
                 COMMAND ${ARIA2} ${vcpkg_download_distfile_URLS}
-                --connect-timeout=15
+#                --connect-timeout=120
                 --max-connection-per-server=3
                 --retry-wait=2
                 --max-tries=5


### PR DESCRIPTION
add env aria2c

test
```
aria2c https://downloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz --connect-timeout=15 --max-connection-per-server=3 --retry-wait=2 --max-tr
ies=5 -o example_13.tar.gz -l download-detailed.log
```