### PR TITLE
[vcpkg] Put user-defined configuration triplets path on top of the search queue

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -126,8 +126,6 @@ namespace vcpkg
 
         ports_cmake = filesystem.canonical(VCPKG_LINE_INFO, scripts / fs::u8path("ports.cmake"));
 
-        triplets_dirs.emplace_back(triplets);
-        triplets_dirs.emplace_back(community_triplets);
         if (args.overlay_triplets)
         {
             for (auto&& overlay_triplets_dir : *args.overlay_triplets)
@@ -135,6 +133,8 @@ namespace vcpkg
                 triplets_dirs.emplace_back(filesystem.canonical(VCPKG_LINE_INFO, fs::u8path(overlay_triplets_dir)));
             }
         }
+        triplets_dirs.emplace_back(triplets);
+        triplets_dirs.emplace_back(community_triplets);
     }
 
     fs::path VcpkgPaths::package_dir(const PackageSpec& spec) const { return this->packages / spec.dir(); }


### PR DESCRIPTION
I believe that user-defined configuration triplets paths should be the first when searching for triplet configuration.
This commit puts user-defined configuration triplets (if defined) on top of the search queue before standard paths.
This could help to overwrite default tiplet configuration without setting custom triplet.

P.S. If current implementation is better than my suggestion, feel free to ignore this commit.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
