### PR TITLE
[mingw] add VCPKG cmake_system_name

### DIFF
--- a/docs/maintainers/control-files.md
+++ b/docs/maintainers/control-files.md
@@ -140,6 +140,9 @@ The predefined expressions are computed from standard triplet settings:
 - `static` - `VCPKG_LIBRARY_LINKAGE` == `"static"`
 - `wasm32` - `VCPKG_TARGET_ARCHITECTURE` == `"wasm32"`
 - `emscripten` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Emscripten"`
+- `mingw32` - `VCPKG_TARGET_ARCHITECTURE` == `"MinGW32"`
+- `mingw64` - `VCPKG_TARGET_ARCHITECTURE` == `"MinGW64"`
+- `msys2` - `VCPKG_CMAKE_SYSTEM_NAME` == `"MSYS2"`
 
 These predefined expressions can be overridden in the triplet file via the [`VCPKG_DEP_INFO_OVERRIDE_VARS`](../users/triplets.md) option.
 

--- a/docs/maintainers/control-files.md
+++ b/docs/maintainers/control-files.md
@@ -140,9 +140,7 @@ The predefined expressions are computed from standard triplet settings:
 - `static` - `VCPKG_LIBRARY_LINKAGE` == `"static"`
 - `wasm32` - `VCPKG_TARGET_ARCHITECTURE` == `"wasm32"`
 - `emscripten` - `VCPKG_CMAKE_SYSTEM_NAME` == `"Emscripten"`
-- `mingw32` - `VCPKG_TARGET_ARCHITECTURE` == `"MinGW32"`
-- `mingw64` - `VCPKG_TARGET_ARCHITECTURE` == `"MinGW64"`
-- `msys2` - `VCPKG_CMAKE_SYSTEM_NAME` == `"MSYS2"`
+- `mingw` - `VCPKG_CMAKE_SYSTEM_NAME` == `"MinGW"`
 
 These predefined expressions can be overridden in the triplet file via the [`VCPKG_DEP_INFO_OVERRIDE_VARS`](../users/triplets.md) option.
 

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -29,7 +29,7 @@ Community Triplets are enabled by default, when using a community triplet a mess
 ### VCPKG_TARGET_ARCHITECTURE
 Specifies the target machine architecture.
 
-Valid options are `x86`, `x64`, `arm`, `arm64` and `wasm32`.
+Valid options are `x86`, `x64`, `arm`, `arm64`, `wasm32`, `mingw32` and `mingw64`.
 
 ### VCPKG_CRT_LINKAGE
 Specifies the desired CRT linkage (for MSVC).
@@ -50,6 +50,7 @@ Valid options include any CMake system name, such as:
 - `Darwin` (Mac OSX)
 - `Linux` (Linux)
 - `Emscripten` (WebAssembly)
+- `MSYS2` (MSYS_NT)
 
 ### VCPKG_CMAKE_SYSTEM_VERSION
 Specifies the target platform system version.

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -29,7 +29,7 @@ Community Triplets are enabled by default, when using a community triplet a mess
 ### VCPKG_TARGET_ARCHITECTURE
 Specifies the target machine architecture.
 
-Valid options are `x86`, `x64`, `arm`, `arm64`, `wasm32`, `mingw32` and `mingw64`.
+Valid options are `x86`, `x64`, `arm`, `arm64` and `wasm32`.
 
 ### VCPKG_CRT_LINKAGE
 Specifies the desired CRT linkage (for MSVC).
@@ -50,7 +50,7 @@ Valid options include any CMake system name, such as:
 - `Darwin` (Mac OSX)
 - `Linux` (Linux)
 - `Emscripten` (WebAssembly)
-- `MSYS2` (MSYS_NT)
+- `mingw` (MinGW)
 
 ### VCPKG_CMAKE_SYSTEM_VERSION
 Specifies the target platform system version.

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -50,7 +50,7 @@ Valid options include any CMake system name, such as:
 - `Darwin` (Mac OSX)
 - `Linux` (Linux)
 - `Emscripten` (WebAssembly)
-- `mingw` (MinGW)
+- `MinGW` (Minimalist GNU for Windows)
 
 ### VCPKG_CMAKE_SYSTEM_VERSION
 Specifies the target platform system version.

--- a/toolsrc/src/vcpkg/logicexpression.cpp
+++ b/toolsrc/src/vcpkg/logicexpression.cpp
@@ -174,7 +174,7 @@ namespace vcpkg
                 case Identifier::android: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Android");
                 case Identifier::emscripten: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Emscripten");
                 case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
-                case Identifier::mingw: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw");
+                case Identifier::mingw: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "mingw");
                 case Identifier::static_link: return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
             }
 

--- a/toolsrc/src/vcpkg/logicexpression.cpp
+++ b/toolsrc/src/vcpkg/logicexpression.cpp
@@ -174,7 +174,7 @@ namespace vcpkg
                 case Identifier::android: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Android");
                 case Identifier::emscripten: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Emscripten");
                 case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
-                case Identifier::mingw: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "mingw");
+                case Identifier::mingw: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "MinGW");
                 case Identifier::static_link: return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
             }
 

--- a/toolsrc/src/vcpkg/logicexpression.cpp
+++ b/toolsrc/src/vcpkg/logicexpression.cpp
@@ -20,8 +20,6 @@ namespace vcpkg
         arm,
         arm64,
         wasm32,
-        mingw32,
-        mingw64,
 
         windows,
         linux,
@@ -29,7 +27,7 @@ namespace vcpkg
         uwp,
         android,
         emscripten,
-        msys2,
+        mingw,
 
         static_link,
     };
@@ -120,9 +118,7 @@ namespace vcpkg
                 {"android", Identifier::android},
                 {"emscripten", Identifier::emscripten},
                 {"wasm32", Identifier::wasm32},
-                {"msys2", Identifier::msys2},
-                {"mingw32", Identifier::mingw32},
-                {"mingw64", Identifier::mingw64},
+                {"mingw", Identifier::mingw},
                 {"static", Identifier::static_link},
                 
             };
@@ -178,9 +174,7 @@ namespace vcpkg
                 case Identifier::android: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Android");
                 case Identifier::emscripten: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Emscripten");
                 case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
-                case Identifier::msys2: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "msys2");
-                case Identifier::mingw32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw32");
-                case Identifier::mingw64: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw64");
+                case Identifier::mingw: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw");
                 case Identifier::static_link: return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
             }
 

--- a/toolsrc/src/vcpkg/logicexpression.cpp
+++ b/toolsrc/src/vcpkg/logicexpression.cpp
@@ -19,6 +19,9 @@ namespace vcpkg
         x86,
         arm,
         arm64,
+        wasm32,
+        mingw32,
+        mingw64,
 
         windows,
         linux,
@@ -26,7 +29,7 @@ namespace vcpkg
         uwp,
         android,
         emscripten,
-        wasm32,
+        msys2,
 
         static_link,
     };
@@ -117,7 +120,11 @@ namespace vcpkg
                 {"android", Identifier::android},
                 {"emscripten", Identifier::emscripten},
                 {"wasm32", Identifier::wasm32},
+                {"msys2", Identifier::msys2},
+                {"mingw32", Identifier::mingw32},
+                {"mingw64", Identifier::mingw64},
                 {"static", Identifier::static_link},
+                
             };
 
             auto id_pair = id_map.find(name);
@@ -171,6 +178,9 @@ namespace vcpkg
                 case Identifier::android: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Android");
                 case Identifier::emscripten: return true_if_exists_and_equal("VCPKG_CMAKE_SYSTEM_NAME", "Emscripten");
                 case Identifier::wasm32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "wasm32");
+                case Identifier::msys2: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "msys2");
+                case Identifier::mingw32: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw32");
+                case Identifier::mingw64: return true_if_exists_and_equal("VCPKG_TARGET_ARCHITECTURE", "mingw64");
                 case Identifier::static_link: return true_if_exists_and_equal("VCPKG_LIBRARY_LINKAGE", "static");
             }
 


### PR DESCRIPTION
> `Supports: !mingw or Supports: (mingw|windows)  ... `
> 
> `vcpkg_fail_port_install(MESSAGE "Only ... is supported by ${PORT}" ON_TARGET MinGW)`

logic

VCPKG_CMAKE_SYSTEM_NAME MinGW
https://github.com/microsoft/vcpkg/blob/ffa7fd27cfa29f206d1fd2ccfc722cad4aaeef3d/triplets/community/x64-mingw.cmake#L6

____

> **example**

> VCPKG_CMAKE_SYSTEM_NAME WindowsStore
> https://github.com/microsoft/vcpkg/blob/ffa7fd27cfa29f206d1fd2ccfc722cad4aaeef3d/triplets/community/arm64-uwp.cmake#L5
> 
> VCPKG_CMAKE_SYSTEM_NAME Emscripten
> https://github.com/microsoft/vcpkg/blob/ffa7fd27cfa29f206d1fd2ccfc722cad4aaeef3d/triplets/community/wasm32-emscripten.cmake#L14


_____


why is there no compiler definition? as in the example

https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/cross_compiling/Mingw

https://gitlab.kitware.com/cmake/community/uploads/265a703419aeaa26bef8044b92911e37/Toolchain-cross-mingw32-linux.cmake


```
# for 32 or 64 bits mingw-w64
# see http://mingw-w64.sourceforge.net/
set(COMPILER_PREFIX "i686-w64-mingw32")
#set(COMPILER_PREFIX "x86_64-w64-mingw32"

# which compilers to use for C and C++
find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
#SET(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
#SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
#SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)


# here is the target environment located
SET(USER_ROOT_PATH /home/erk/erk-win32-dev)
SET(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX} ${USER_ROOT_PATH})

# adjust the default behaviour of the FIND_XXX() commands:
# search headers and libraries in the target environment, search 
# programs in the host environment
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
```
