### PR TITLE
Add "Unix Makefiles" support to vcpkg

### DIFF
--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -48,6 +48,8 @@ function(vcpkg_build_cmake)
             "/p:UseIntelMKL=No"
         )
         set(PARALLEL_ARG "/m")
+    elseif( _VCPKG_CMAKE_GENERATOR MATCHES "Unix Makefiles" )
+        set(NO_PARALLEL_ARG "-j1")
     elseif(_VCPKG_CMAKE_GENERATOR MATCHES "NMake")
         # No options are currently added for nmake builds
     else()


### PR DESCRIPTION
- What does your PR fix?
This patch adds the ability to use "Unix Makefiles" as an optional generator.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I think any POSIX platform with GNU Make should be supported. Though I have only tested that on x64-linux.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yup
