### PR TITLE
[vcpkg] Add mirror to download Strawberry Perl

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -63,7 +63,10 @@ function(vcpkg_find_acquire_program VAR)
     set(PATHS ${DOWNLOADS}/tools/perl/perl/bin)
     set(BREW_PACKAGE_NAME "perl")
     set(APT_PACKAGE_NAME "perl")
-    set(URL "http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip")
+    set(URL 
+      "https://strawberry.perl.bot/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip"
+      "http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip"
+    )
     set(ARCHIVE "strawberry-perl-5.30.0.1-32bit.zip")
     set(HASH d353d3dc743ebdc6d1e9f6f2b7a6db3c387c1ce6c890bae8adc8ae5deae8404f4c5e3cf249d1e151e7256d4c5ee9cd317e6c41f3b6f244340de18a24b938e0c4)
   elseif(VAR MATCHES "NASM")


### PR DESCRIPTION
Last several days Strawberry Perl official download server has issues that lead to extremely slow download rates
(sometimes it takes more than 1 hour to download ~150MB).
This commit adds non-official mirror of Strawberry Perl to the list of available URLs.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
