### PR TITLE
[suitesparse] Fixing `SuiteSparse_INCLUDE_DIRS` is not usable from the port.

### DIFF
--- a/ports/suitesparse/CONTROL
+++ b/ports/suitesparse/CONTROL
@@ -1,5 +1,5 @@
 Source: suitesparse
-Version: 5.4.0-5
+Version: 5.4.0-6
 Build-Depends: clapack (!osx)
 Homepage: http://faculty.cse.tamu.edu/davis/SuiteSparse
 Description: algebra library

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -63,3 +63,5 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(INSTALL ${SUITESPARSEWIN_SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright_suitesparse-metis-for-windows)
+
+vcpkg_test_cmake(PACKAGE_NAME suitesparse)

--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -63,5 +63,3 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(INSTALL ${SUITESPARSEWIN_SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright_suitesparse-metis-for-windows)
-
-vcpkg_test_cmake(PACKAGE_NAME suitesparse)

--- a/ports/suitesparse/suitesparse.patch
+++ b/ports/suitesparse/suitesparse.patch
@@ -117,12 +117,14 @@ index c6e2834..5ef08a6 100644
  # Disable COMPLEX numbers: disable it by default, since it causes problems in some platforms.
  SET(HAVE_COMPLEX OFF CACHE BOOL "Enables building SuiteSparse with complex numbers (disabled by default to avoid problems in some platforms)")
 diff --git a/cmake/SuiteSparse-config-install.cmake.in b/cmake/SuiteSparse-config-install.cmake.in
-index cb1f51f..49387b8 100644
+index cb1f51f..12f654c 100644
 --- a/cmake/SuiteSparse-config-install.cmake.in
 +++ b/cmake/SuiteSparse-config-install.cmake.in
-@@ -4,13 +4,10 @@ get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_SELF_DIR}" PATH)
+@@ -2,15 +2,11 @@
+ get_filename_component(_SuiteSparse_SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_SELF_DIR}" PATH)
  get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
- get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
+-get_filename_component(_SuiteSparse_PREFIX "${_SuiteSparse_PREFIX}" PATH)
  
 -find_package(LAPACK CONFIG)
 -if (NOT LAPACK_FOUND) # Load the LAPACK package with which we were built.
@@ -136,7 +138,7 @@ index cb1f51f..49387b8 100644
  
  # Report SuiteSparse header search locations.
  set(SuiteSparse_INCLUDE_DIRS ${_SuiteSparse_PREFIX}/include)
-@@ -31,6 +28,11 @@ set(SuiteSparse_LIBRARIES
+@@ -31,6 +27,10 @@ set(SuiteSparse_LIBRARIES
  	SuiteSparse::spqr
  	@SuiteSparse_EXPORTED_METIS_LIBS@
  )
@@ -147,4 +149,3 @@ index cb1f51f..49387b8 100644
 +
 +set(SUITESPARSE_FOUND TRUE)
 +set(SuiteSparse_FOUND TRUE)
-+


### PR DESCRIPTION
The `suitesparse` exports a CMake variable `SuiteSparse_INCLUDE_DIRS`, which is pointing to a non-existing location from this Vcpkg port. However this doesn't repro if I skip using Vcpkg and go directly build it from the upstream. There are some delta between Vcpkg port and the upstream.

It turned out, in this `suitesparse` Vcpkg port, it moves its `CMake` config files into `share/suitesparse/` from `lib/cmake/suitesparse-xxx` by `vcpkg_fixup_cmake_targets`. However, the config file computes the installed root by assuming it is under `lib/cmake/suitesparse-xxx`, and this produces an unusable CMake config file in Vcpkg port.

This pull request is to fix up the computation logic to accommodate the new location (`share/suitesparse/`) by Vcpkg port.