### PR TITLE
[ffmpeg] Add avisynthplus support

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.2-10
+Version: 4.2-11
 Build-Depends: zlib
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
@@ -57,3 +57,7 @@ Description: Libav audio resampling library support in ffmpeg
 Feature: nvcodec
 Build-Depends: ffnvcodec, cuda
 Description: Hardware accelerated codecs
+
+Feature: avisynthplus
+Build-Depends: avisynthplus
+Description: avisynthplus support in ffmpeg

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -141,6 +141,12 @@ else()
     set(OPTIONS "${OPTIONS} --disable-cuda --disable-nvenc --disable-cuvid --disable-libnpp")
 endif()
 
+if("avisynthplus" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-avisynth --enable-gpl")
+else()
+    set(OPTIONS "${OPTIONS} --disable-avisynth --disable-gpl")
+endif()
+
 set(OPTIONS_CROSS "")
 
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")


### PR DESCRIPTION
Add `avisynthplus` feature for ffmpeg.

Fix #10906 

Note: Feature `avisynthplus` has passed with the following triplets:
- x86-windows
- x64-windows

`avisynthplus` only supports dynamic build.
