### PR TITLE
[Document]Mention --ignore-space-at-eol in patching.md

### DIFF
--- a/docs/examples/patching.md
+++ b/docs/examples/patching.md
@@ -140,7 +140,7 @@ Now we can modify `pngpriv.h` to use `abort()` everywhere.
 
 The output of `git diff` is already in patch format, so we just need to save the patch into the `ports/libpng` directory.
 ```no-highlight
-PS buildtrees\libpng\src\libpng-1.6.24> git diff | out-file -enc ascii ..\..\..\..\ports\libpng\use-abort-on-all-platforms.patch
+PS buildtrees\libpng\src\libpng-1.6.24> git diff --ignore-space-at-eol | out-file -enc ascii ..\..\..\..\ports\libpng\use-abort-on-all-platforms.patch
 ```
 
 Finally, we need to apply the patch after extracting the source.


### PR DESCRIPTION
My attempt to patch `winpcap` port resulted in a huge patch file full of whitespace changes.
`--ignore-space-at-eol` option forces `git diff` to ignore such whitespaces.

https://git-scm.com/docs/diff-options
```
--ignore-space-at-eol
Ignore changes in whitespace at EOL.
```