### PR TITLE
[marl] Repoint HEAD_REF to `main`

### DIFF
--- a/ports/marl/CONTROL
+++ b/ports/marl/CONTROL
@@ -1,5 +1,5 @@
 Source: marl
-Version: 2020-05-21
+Version: 2020-05-21-1
 Description: A hybrid thread/fiber task scheduler written in C++ 11
 Homepage: https://github.com/google/marl
 Supports: !uwp

--- a/ports/marl/portfile.cmake
+++ b/ports/marl/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO google/marl
     REF 00433d41804f52af29ef6f386f4c479f48c63e66
     SHA512 8e86121cf212e4d7d2cfb1387a8f4c7749c82b8e916f4ea517d0a67696fefa91d900ffcf6f6358586cc341e8620ccb03ce2505b7828fd56a9d7561b9a2523bfd
-    HEAD_REF master
+    HEAD_REF main
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
marl's default branch has been renamed from `master` to `main`.

See https://github.com/google/marl/issues/153 for more details.