### PR TITLE
Delete g_binary_caching global that should be passed as a parameter.

### DIFF
--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -34,6 +34,7 @@ namespace vcpkg::Build
         void perform_and_exit_ex(const FullPackageSpec& full_spec,
                                  const SourceControlFileLocation& scfl,
                                  const PortFileProvider::PathsPortFileProvider& provider,
+                                 const bool binary_caching_enabled,
                                  IBinaryProvider& binaryprovider,
                                  const VcpkgPaths& paths);
 

--- a/toolsrc/include/vcpkg/globalstate.h
+++ b/toolsrc/include/vcpkg/globalstate.h
@@ -13,8 +13,6 @@ namespace vcpkg
         static Util::LockGuarded<Chrono::ElapsedTimer> timer;
         static Util::LockGuarded<std::string> g_surveydate;
 
-        static std::atomic<bool> g_binary_caching;
-
         static std::atomic<int> g_init_console_cp;
         static std::atomic<int> g_init_console_output_cp;
         static std::atomic<bool> g_init_console_initialized;

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -130,6 +130,7 @@ namespace vcpkg
         // feature flags
         Optional<bool> feature_packages = nullopt;
         Optional<bool> binary_caching = nullopt;
+        bool binary_caching_enabled() const { return binary_caching.value_or(false); }
 
         std::string command;
         std::vector<std::string> command_arguments;

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -256,16 +256,9 @@ int main(const int argc, const char* const* const argv)
 
     load_config(fs);
 
-    const auto vcpkg_feature_flags_env = System::get_environment_variable("VCPKG_FEATURE_FLAGS");
-    if (const auto v = vcpkg_feature_flags_env.get())
-    {
-        auto flags = Strings::split(*v, ',');
-        if (std::find(flags.begin(), flags.end(), "binarycaching") != flags.end()) GlobalState::g_binary_caching = true;
-    }
-
     VcpkgCmdArguments args = VcpkgCmdArguments::create_from_command_line(fs, argc, argv);
     args.imbue_from_environment();
-    if (const auto p = args.binary_caching.get()) GlobalState::g_binary_caching = *p;
+
     if (const auto p = args.print_metrics.get()) Metrics::g_metrics.lock()->set_print_metrics(*p);
     if (const auto p = args.send_metrics.get()) Metrics::g_metrics.lock()->set_send_metrics(*p);
     if (const auto p = args.disable_metrics.get()) Metrics::g_metrics.lock()->set_disabled(*p);

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -39,6 +39,7 @@ namespace vcpkg::Build::Command
     void perform_and_exit_ex(const FullPackageSpec& full_spec,
                              const SourceControlFileLocation& scfl,
                              const PathsPortFileProvider& provider,
+                             const bool binary_caching_enabled,
                              IBinaryProvider& binaryprovider,
                              const VcpkgPaths& paths)
     {
@@ -69,7 +70,7 @@ namespace vcpkg::Build::Command
             Build::CleanPackages::NO,
             Build::CleanDownloads::NO,
             Build::DownloadTool::BUILT_IN,
-            GlobalState::g_binary_caching ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            binary_caching_enabled ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::NO,
         };
 
@@ -152,7 +153,7 @@ namespace vcpkg::Build::Command
         Checks::check_exit(VCPKG_LINE_INFO, scfl != nullptr, "Error: Couldn't find port '%s'", port_name);
         _Analysis_assume_(scfl != nullptr);
 
-        perform_and_exit_ex(spec, *scfl, provider, *binaryprovider, paths);
+        perform_and_exit_ex(spec, *scfl, provider, args.binary_caching_enabled(), *binaryprovider, paths);
     }
 }
 

--- a/toolsrc/src/vcpkg/commands.buildexternal.cpp
+++ b/toolsrc/src/vcpkg/commands.buildexternal.cpp
@@ -37,7 +37,11 @@ namespace vcpkg::Commands::BuildExternal
         Checks::check_exit(
             VCPKG_LINE_INFO, maybe_scfl.has_value(), "could not load control file for %s", spec.package_spec.name());
 
-        Build::Command::perform_and_exit_ex(
-            spec, maybe_scfl.value_or_exit(VCPKG_LINE_INFO), provider, *binaryprovider, paths);
+        Build::Command::perform_and_exit_ex(spec,
+                                            maybe_scfl.value_or_exit(VCPKG_LINE_INFO),
+                                            provider,
+                                            args.binary_caching_enabled(),
+                                            *binaryprovider,
+                                            paths);
     }
 }

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -257,6 +257,7 @@ namespace vcpkg::Commands::CI
         const CMakeVars::CMakeVarProvider& var_provider,
         const std::vector<FullPackageSpec>& specs,
         const bool purge_tombstones,
+        const bool binary_caching_enabled,
         IBinaryProvider& binaryprovider)
     {
         auto ret = std::make_unique<UnknownCIPortsResults>();
@@ -271,7 +272,7 @@ namespace vcpkg::Commands::CI
             Build::CleanPackages::YES,
             Build::CleanDownloads::NO,
             Build::DownloadTool::BUILT_IN,
-            GlobalState::g_binary_caching ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            binary_caching_enabled ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::YES,
         };
 
@@ -387,7 +388,7 @@ namespace vcpkg::Commands::CI
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, Triplet default_triplet)
     {
-        if (!GlobalState::g_binary_caching)
+        if (!args.binary_caching_enabled())
         {
             System::print2(System::Color::warning, "Warning: Running ci without binary caching!\n");
         }
@@ -430,7 +431,7 @@ namespace vcpkg::Commands::CI
             Build::CleanPackages::YES,
             Build::CleanDownloads::NO,
             Build::DownloadTool::BUILT_IN,
-            GlobalState::g_binary_caching ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            args.binary_caching_enabled() ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::YES,
             Build::PurgeDecompressFailure::YES,
         };
@@ -466,6 +467,7 @@ namespace vcpkg::Commands::CI
                                                          var_provider,
                                                          all_default_full_specs,
                                                          purge_tombstones,
+                                                         args.binary_caching_enabled(),
                                                          *binaryprovider);
             PortFileProvider::MapPortFileProvider new_default_provider(split_specs->default_feature_provider);
 

--- a/toolsrc/src/vcpkg/commands.setinstalled.cpp
+++ b/toolsrc/src/vcpkg/commands.setinstalled.cpp
@@ -47,7 +47,7 @@ namespace vcpkg::Commands::SetInstalled
             Build::CleanPackages::YES,
             Build::CleanDownloads::YES,
             Build::DownloadTool::BUILT_IN,
-            GlobalState::g_binary_caching ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            args.binary_caching_enabled() ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::NO,
         };
 

--- a/toolsrc/src/vcpkg/commands.upgrade.cpp
+++ b/toolsrc/src/vcpkg/commands.upgrade.cpp
@@ -165,7 +165,7 @@ namespace vcpkg::Commands::Upgrade
             Build::CleanPackages::NO,
             Build::CleanDownloads::NO,
             Build::DownloadTool::BUILT_IN,
-            GlobalState::g_binary_caching ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            args.binary_caching_enabled() ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::NO,
         };
 

--- a/toolsrc/src/vcpkg/globalstate.cpp
+++ b/toolsrc/src/vcpkg/globalstate.cpp
@@ -7,8 +7,6 @@ namespace vcpkg
     Util::LockGuarded<Chrono::ElapsedTimer> GlobalState::timer;
     Util::LockGuarded<std::string> GlobalState::g_surveydate;
 
-    std::atomic<bool> GlobalState::g_binary_caching(false);
-
     std::atomic<int> GlobalState::g_init_console_cp(0);
     std::atomic<int> GlobalState::g_init_console_output_cp(0);
     std::atomic<bool> GlobalState::g_init_console_initialized(false);

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -678,7 +678,7 @@ namespace vcpkg::Install
             clean_after_build ? Build::CleanPackages::YES : Build::CleanPackages::NO,
             clean_after_build ? Build::CleanDownloads::YES : Build::CleanDownloads::NO,
             download_tool,
-            (GlobalState::g_binary_caching && !only_downloads) ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
+            (args.binary_caching_enabled() && !only_downloads) ? Build::BinaryCaching::YES : Build::BinaryCaching::NO,
             Build::FailOnTombstone::NO,
         };
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -548,6 +548,17 @@ namespace vcpkg
             }
         }
 
+        const auto vcpkg_feature_flags_env = System::get_environment_variable("VCPKG_FEATURE_FLAGS");
+        if (const auto unpacked = vcpkg_feature_flags_env.get())
+        {
+            auto flags = Strings::split(*unpacked, ',');
+            if (!binary_caching
+                && std::find(flags.begin(), flags.end(), "binarycaching") != flags.end())
+            {
+                binary_caching = true;
+            }
+        }
+
         if (!triplet)
         {
             const auto vcpkg_default_triplet_env = System::get_environment_variable("VCPKG_DEFAULT_TRIPLET");


### PR DESCRIPTION
This change moves the feature flag tests out of `main()`, and gets other components to inspect the binary caching setting locally instead of through a global.
