### PR TITLE
[vcpkg baseline] Retrigger failed port apr-util

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,5 +1,5 @@
 Source: apr-util
-Version: 1.6.1-1
+Version: 1.6.1-2
 Homepage: https://apr.apache.org/
 Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
 Build-Depends: expat, apr, openssl

--- a/ports/apr/CONTROL
+++ b/ports/apr/CONTROL
@@ -1,5 +1,5 @@
 Source: apr
-Version: 1.7.0
+Version: 1.7.0-1
 Homepage: https://apr.apache.org/
 Description: The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.
 Supports: !uwp


### PR DESCRIPTION
**Describe the pull request**

Attempts to reproduce #11923 from master on the CI since I can't reproduce this locally (lack of an appropriate local OSX configuration).

- What does your PR fix?
- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
