### PR TITLE
[mpir] only install debug files if VCPKG_BUILD_TYPE is empty or 'debug'

### DIFF
--- a/ports/mpir/CONTROL
+++ b/ports/mpir/CONTROL
@@ -1,5 +1,5 @@
 Source: mpir
-Version: 3.0.0-8
+Version: 3.0.0-9
 Homepage: https://github.com/wbhart/mpir
 Description: Multiple Precision Integers and Rationals.
 Supports: !(uwp|arm)


### PR DESCRIPTION
closes #11962

Fix regression where mpir fails to build with VCPKG_BUILD_TYPE set to release.
