### PR TITLE
[slikenet] Add cmake config and targets file

### DIFF
--- a/ports/slikenet/CONTROL
+++ b/ports/slikenet/CONTROL
@@ -1,5 +1,6 @@
 Source: slikenet
-Version: 2019-10-22_1
+Version: 2019-10-22-2
 Homepage: https://github.com/SLikeSoft/SLikeNet
 Description: SLikeNetT is an Open Source/Free Software cross-platform network engine written in C++ and specifially designed for games (and applications which have comparable requirements on a network engine like games) building upon the discontinued RakNet network engine which had more than 13 years of active development.
 Build-Depends: openssl
+Supports: !uwp

--- a/ports/slikenet/fix-install.patch
+++ b/ports/slikenet/fix-install.patch
@@ -1,49 +1,51 @@
 diff --git a/Lib/DLL/CMakeLists.txt b/Lib/DLL/CMakeLists.txt
-index 2d1e078..7e705cf 100644
+index 7f6453d..48f9562 100644
 --- a/Lib/DLL/CMakeLists.txt
 +++ b/Lib/DLL/CMakeLists.txt
-@@ -50,13 +50,13 @@ ELSE(WIN32 AND NOT UNIX)
+@@ -50,6 +50,7 @@ ELSE(WIN32 AND NOT UNIX)
  ENDIF(WIN32 AND NOT UNIX)
  
  target_link_libraries(SLikeNetDLL ${SLIKENET_LIBRARY_LIBS})
--IF(NOT WIN32 OR UNIX)
--	configure_file(../../slikenet-config-version.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake @ONLY)
--
--	install(TARGETS SLikeNetDLL EXPORT SLikeNetDLL DESTINATION lib/slikenet-${SLikeNet_VERSION})
-+IF(1)
-+	install(TARGETS SLikeNetDLL 
-+            EXPORT SLikeNetDLL 
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib
-+            ARCHIVE DESTINATION lib)
- 	INSTALL(FILES ${ALL_COMPATIBILITY_HEADER_SRC} DESTINATION include/slikenet-${SLikeNet_VERSION})
- 	INSTALL(FILES ${ALL_COMPATIBILITY_HEADER_SRC_2} DESTINATION include/slikenet-${SLikeNet_VERSION}/slikenet/slikenet)
- 	INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION include/slikenet-${SLikeNet_VERSION}/slikenet/include/slikenet)
--	INSTALL(FILES ../../slikenet-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
--	INSTALL(EXPORT SLikeNetDLL DESTINATION lib/slikenet-${SLikeNet_VERSION})
--ENDIF(NOT WIN32 OR UNIX)
-+ENDIF(1)
++if(0)
+ IF(NOT WIN32 OR UNIX)
+ 	configure_file(../../slikenet-config-version.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake @ONLY)
+ 
+@@ -60,3 +61,12 @@ IF(NOT WIN32 OR UNIX)
+ 	INSTALL(FILES ../../slikenet-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
+ 	INSTALL(EXPORT SLikeNetDLL DESTINATION lib/slikenet-${SLikeNet_VERSION})
+ ENDIF(NOT WIN32 OR UNIX)
++endif()
++
++install(TARGETS SLikeNetDLL
++		EXPORT SLikeNetDLL
++		RUNTIME DESTINATION bin
++		LIBRARY DESTINATION lib
++		ARCHIVE DESTINATION lib)
++INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION include/slikenet)
++install(EXPORT SLikeNetDLL FILE slikenetTargets.cmake DESTINATION share/slikenet)
 diff --git a/Lib/LibStatic/CMakeLists.txt b/Lib/LibStatic/CMakeLists.txt
-index 955a99d..9211c45 100644
+index f936fa5..a5dcc4f 100644
 --- a/Lib/LibStatic/CMakeLists.txt
 +++ b/Lib/LibStatic/CMakeLists.txt
-@@ -54,13 +54,14 @@ IF(WIN32 AND NOT UNIX)
+@@ -50,6 +50,8 @@ ELSE(WIN32 AND NOT UNIX)
+ ENDIF(WIN32 AND NOT UNIX)
+ 
+ target_link_libraries(SLikeNetLibStatic ${SLIKENET_LIBRARY_LIBS})
++
++if(0)
+ IF(WIN32 AND NOT UNIX)
  	IF(NOT ${CMAKE_GENERATOR} STREQUAL "MSYS Makefiles")
  		set_target_properties(SLikeNetLibStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:\"LIBCD.lib LIBCMTD.lib MSVCRT.lib\"" )
- 	ENDIF(NOT ${CMAKE_GENERATOR} STREQUAL "MSYS Makefiles")
--ELSE(WIN32 AND NOT UNIX)
--	configure_file(../../slikenet-config-version.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake @ONLY)
-+ENDIF(WIN32 AND NOT UNIX)
- 
- 	INSTALL(TARGETS SLikeNetLibStatic EXPORT SLikeNetLibStatic DESTINATION lib/slikenet-${SLikeNet_VERSION})
-+	INSTALL(TARGETS SLikeNetLibStatic 
-+            EXPORT SLikeNetLibStatic 
-+            RUNTIME DESTINATION bin
-+            LIBRARY DESTINATION lib
-+            ARCHIVE DESTINATION share/slikenet)
- 	INSTALL(FILES ${ALL_COMPATIBILITY_HEADER_SRC} DESTINATION include/slikenet-${SLikeNet_VERSION})
- 	INSTALL(FILES ${ALL_COMPATIBILITY_HEADER_SRC_2} DESTINATION include/slikenet-${SLikeNet_VERSION}/slikenet)
- 	INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION include/slikenet-${SLikeNet_VERSION}/include/slikenet)
--	INSTALL(FILES ../../slikenet-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
--	INSTALL(EXPORT SLikeNetLibStatic FILE slikenet.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
--ENDIF(WIN32 AND NOT UNIX)
+@@ -64,3 +66,12 @@ ELSE(WIN32 AND NOT UNIX)
+ 	INSTALL(FILES ../../slikenet-config.cmake ${CMAKE_CURRENT_BINARY_DIR}/slikenet-config-version.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
+ 	INSTALL(EXPORT SLikeNetLibStatic FILE slikenet.cmake DESTINATION lib/slikenet-${SLikeNet_VERSION})
+ ENDIF(WIN32 AND NOT UNIX)
++endif()
++
++INSTALL(TARGETS SLikeNetLibStatic
++		EXPORT SLikeNetLibStatic
++		RUNTIME DESTINATION bin
++		LIBRARY DESTINATION lib
++		ARCHIVE DESTINATION lib)
++INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION include/slikenet)
++INSTALL(EXPORT SLikeNetLibStatic FILE slikenetTargets.cmake DESTINATION share/slikenet)

--- a/ports/slikenet/portfile.cmake
+++ b/ports/slikenet/portfile.cmake
@@ -36,5 +36,8 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/slikenet)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/slikenet-config.cmake" "${CURRENT_PACKAGES_DIR}/share/slikenet/slikenet-config.cmake" COPYONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/slikenet/vcpkg-cmake-wrapper.cmake" COPYONLY)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/slikenet/portfile.cmake
+++ b/ports/slikenet/portfile.cmake
@@ -33,6 +33,8 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/slikenet)
 
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/slikenet-config.cmake" "${CURRENT_PACKAGES_DIR}/share/slikenet/slikenet-config.cmake" COPYONLY)
 file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/slikenet/slikenet-config.cmake
+++ b/ports/slikenet/slikenet-config.cmake
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(OpenSSL)
+set(slikenet_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include")
+include(${CMAKE_CURRENT_LIST_DIR}/slikenetTargets.cmake)

--- a/ports/slikenet/usage
+++ b/ports/slikenet/usage
@@ -1,0 +1,4 @@
+The package slikenet provides CMake targets:
+
+    find_package(slikenet CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE SLikeNet)

--- a/ports/slikenet/vcpkg-cmake-wrapper.cmake
+++ b/ports/slikenet/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,11 @@
+_find_package(${ARGS})
+
+if(NOT TARGET SLikeNet AND TARGET SLikeNetDLL)
+add_library(SLikeNet INTERFACE IMPORTED)
+set_target_properties(SLikeNet PROPERTIES INTERFACE_LINK_LIBRARIES SLikeNetDLL)
+endif()
+
+if(NOT TARGET SLikeNet AND TARGET SLikeNetLibStatic)
+add_library(SLikeNet INTERFACE IMPORTED)
+set_target_properties(SLikeNet PROPERTIES INTERFACE_LINK_LIBRARIES SLikeNetLibStatic)
+endif()


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/11960

1. Add cmake config files
2. Export cmake targtes
3. The static and dynamic targets name are different, and vcpkg-cmake-wrapper to handle it.