### PR TITLE
[vcpkg] Use SSH keys instead of password authentication when minting Linux scale sets

### DIFF
--- a/scripts/azure-pipelines/linux/create-vmss.ps1
+++ b/scripts/azure-pipelines/linux/create-vmss.ps1
@@ -40,7 +40,7 @@ Write-Progress `
 $sshDir = [System.IO.Path]::GetTempPath() + [System.IO.Path]::GetRandomFileName()
 mkdir $sshDir
 try {
-  ssh-keygen.exe -q -b 2048 -t rsa -f "$sshDir/key" -P `"`"
+  ssh-keygen.exe -q -b 2048 -t rsa -f "$sshDir/key" -P '""'
   $sshPublicKey = Get-Content "$sshDir/key.pub"
 } finally {
   Remove-Item $sshDir -Recurse -Force

--- a/scripts/azure-pipelines/linux/create-vmss.ps1
+++ b/scripts/azure-pipelines/linux/create-vmss.ps1
@@ -29,11 +29,6 @@ $ProgressActivity = 'Creating Scale Set'
 $TotalProgress = 11
 $CurrentProgress = 1
 
-if (-Not (Test-Path ~/.ssh/id_rsa.pub)) {
-  Write-Error 'You need to generate an SSH key first. Try running ssh-keygen.'
-}
-
-
 Import-Module "$PSScriptRoot/../create-vmss-helpers.psm1" -DisableNameChecking
 
 ####################################################################################################

--- a/scripts/azure-pipelines/linux/create-vmss.ps1
+++ b/scripts/azure-pipelines/linux/create-vmss.ps1
@@ -40,7 +40,7 @@ Write-Progress `
 $sshDir = [System.IO.Path]::GetTempPath() + [System.IO.Path]::GetRandomFileName()
 mkdir $sshDir
 try {
-  ssh-keygen.exe -q -b 2048 -t rsa -f "$sshDir/key" -P '""'
+  ssh-keygen.exe -q -b 2048 -t rsa -f "$sshDir/key" -P [string]::Empty
   $sshPublicKey = Get-Content "$sshDir/key.pub"
 } finally {
   Remove-Item $sshDir -Recurse -Force

--- a/scripts/azure-pipelines/windows/create-vmss.ps1
+++ b/scripts/azure-pipelines/windows/create-vmss.ps1
@@ -195,7 +195,7 @@ New-AzVm `
 ####################################################################################################
 Write-Progress `
   -Activity $ProgressActivity `
-  -Status 'Running provisioning script provision-image.ps1 in VM' `
+  -Status 'Running provisioning script provision-image.txt (as a .ps1) in VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
 Invoke-AzVMRunCommand `


### PR DESCRIPTION
This is required by a future Azure DevDiv security policy which will fail VM creations that don't disable password auth.
