### PR TITLE
[abseil] Fix usage issue

### DIFF
--- a/ports/abseil/CONTROL
+++ b/ports/abseil/CONTROL
@@ -1,5 +1,5 @@
 Source: abseil
-Version: 2020-03-03-6
+Version: 2020-03-03-7
 Homepage: https://github.com/abseil/abseil-cpp
 Description: an open-source collection designed to augment the C++ standard library.
   Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -52,6 +52,19 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
                     ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/include/absl/copts
                     ${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata
-                    ${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata)
+                    ${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/config.h
+        "#elif defined(ABSL_CONSUME_DLL)" "#elif 1"
+    )
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h
+        "&& !defined(ABSL_CONSUME_DLL)" "&& 0"
+    )
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/container/internal/hashtablez_sampler.h
+        "!defined(ABSL_CONSUME_DLL)" "0"
+    )
+endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
In _include/absl/base/config.h_ line 659:
```
#if defined(_MSC_VER)
#if defined(ABSL_BUILD_DLL)
#define ABSL_DLL __declspec(dllexport)
#elif defined(ABSL_CONSUME_DLL)
#define ABSL_DLL __declspec(dllimport)
#else
#define ABSL_DLL
#endif
#else
#define ABSL_DLL
#endif  // defined(_MSC_VER)
```

Macro `ABSL_CONSUME_DLL` should be defined when using dynamic library.

Fixes #12021.