### PR TITLE
MSYS2 dependencies

### DIFF
--- a/docs/maintainers/vcpkg_acquire_msys.md
+++ b/docs/maintainers/vcpkg_acquire_msys.md
@@ -29,6 +29,10 @@ vcpkg_execute_required_process(
 )
 ```
 
+### Modifying vcpkg_acquire_msys
+A change to `vcpkg_acquire_msys` should be accompanied by an increment of `tool-msys` port's version.
+This ensures all the MSYS2 dependent ports are built with the same MSYS2 environment.
+
 ## Examples
 
 * [ffmpeg](https://github.com/Microsoft/vcpkg/blob/master/ports/ffmpeg/portfile.cmake)

--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
-Version: 4.2-10
-Build-Depends: zlib
+Version: 4.2-11
+Build-Depends: zlib, tool-msys (windows)
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffnvcodec/CONTROL
+++ b/ports/ffnvcodec/CONTROL
@@ -1,4 +1,5 @@
 Source: ffnvcodec
-Version: 9.1.23.1
+Version: 9.1.23.1-1
 Homepage: https://github.com/FFmpeg/nv-codec-headers
 Description: FFmpeg version of Nvidia Codec SDK headers.
+Build-Depends: tool-msys (windows)

--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,5 +1,6 @@
 Source: icu
-Version: 67.1
+Version: 67.1-1
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
+Build-Depends: tool-msys (windows)
 Supports: !(arm|uwp)

--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 12.2-2
+Version: 12.2-3
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/
@@ -35,7 +35,7 @@ Build-Depends: tcl, libpq[core,client]
 Description: build the PL/Tcl procedural language(dynamic only?) (--with-tcl)
 
 Feature: nls
-Build-Depends: gettext
+Build-Depends: gettext, tool-msys (windows)
 Description: Native Language Support (--enable-nls[=LANGUAGES])
 
 Feature: kerberos

--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,5 +1,6 @@
 Source: libvpx
-Version: 1.8.1-6
+Version: 1.8.1-7
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
+Build-Depends: tool-msys (windows)
 Supports: !(uwp&arm)

--- a/ports/tensorflow-cc/CONTROL
+++ b/ports/tensorflow-cc/CONTROL
@@ -1,5 +1,5 @@
 Source: tensorflow-cc
-Version: 1.14-2
+Version: 1.14-3
 Description: Library for computation using data flow graphs for scalable machine learning
-Build-Depends: c-ares
+Build-Depends: c-ares, tool-msys (windows)
 Supports: !x86

--- a/ports/tool-meson/CONTROL
+++ b/ports/tool-meson/CONTROL
@@ -1,4 +1,5 @@
 Source: tool-meson
-Version: 0.54.2
+Version: 0.54.2-1
 Homepage: https://github.com/mesonbuild/meson
 Description: Meson build system
+Build-Depends: tool-msys (windows)

--- a/ports/tool-msys/CONTROL
+++ b/ports/tool-msys/CONTROL
@@ -1,0 +1,5 @@
+Source: tool-msys
+Version: 2019-05-24
+Homepage: https://www.msys2.org/
+Description: MSYS2 software distro and building platform for Windows
+Supports: windows

--- a/ports/tool-msys/portfile.cmake
+++ b/ports/tool-msys/portfile.cmake
@@ -1,0 +1,7 @@
+# This port represents a dependency on the MSYS2 build system.
+# In the future, it is expected that this port acquires and installs MSYS2.
+# Currently it is used to update MSYS2 installation and to rebuild the ports using vcpkg_acquire_msys.
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_acquire_msys(MSYS_ROOT)

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -114,7 +114,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       WORKING_DIRECTORY ${TOOLPATH}
     )
     _execute_process(
-      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Syu --noconfirm"
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Syu --noconfirm --cachedir \"${DOWNLOADS}\""
       WORKING_DIRECTORY ${TOOLPATH}
     )
     file(WRITE "${TOOLPATH}/${STAMP}" "${PORT_VERSION}")
@@ -129,7 +129,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     set(ENV{PATH} ${PATH_TO_ROOT}/usr/bin)
     vcpkg_execute_required_process(
       ALLOW_IN_DOWNLOAD_MODE
-      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "pacman -S --noconfirm --needed ${_am_PACKAGES}"
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "pacman -S --noconfirm --cachedir \"${DOWNLOADS}\" --needed ${_am_PACKAGES}"
       WORKING_DIRECTORY ${TOOLPATH}
       LOGNAME msys-pacman-${TARGET_TRIPLET}
     )

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -376,6 +376,7 @@ namespace vcpkg::Build
         std::vector<System::CMakeVariable> variables{
             {"CMD", "BUILD"},
             {"PORT", scf.core_paragraph->name},
+            {"PORT_VERSION", scf.core_paragraph->version},
             {"CURRENT_PORT_DIR", scfl.source_location},
             {"TARGET_TRIPLET", triplet.canonical_name()},
             {"TARGET_TRIPLET_FILE", paths.get_triplet_file_path(triplet).u8string()},


### PR DESCRIPTION
**Describe the pull request**

Adds `tool-msys` metaport to update `MSYS2` installation and rebuild the ports using `vcpkg_acquire_msys` when the latter is changed (it's a maintainer's responsibility to increment the metaport's version when making changes to `vcpkg_acquire_msys`).

Sets `<vcpkg>/downloads` directory as an `MSYS2` package cache to reuse them after `MSYS2` updates.

Additionally introduces `PORT_VERSION` variable providing access to the version string from port's `CONTROL` file to CMake scripts.

- What does your PR fix?
Fixes #11873

- Which triplets are supported/not supported? Have you updated the CI baseline?
Not applicable.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

Waiting on #11836 to conclude, as it introduces a dependency metaport for `vcpkg_configure_make` which itself is dependent on `vcpkg_acquire_msys`.