### PR TITLE
[sqlpp11-connector-mysql] Remove feature mysql

### DIFF
--- a/ports/sqlpp11-connector-mysql/CONTROL
+++ b/ports/sqlpp11-connector-mysql/CONTROL
@@ -1,14 +1,5 @@
 Source: sqlpp11-connector-mysql
-Version: 0.29-1
+Version: 0.29-2
 Homepage: https://github.com/rbock/sqlpp11-connector-mysql
 Description: A C++ wrapper for MySQL meant to be used in combination with sqlpp11.
-Build-Depends: date, sqlpp11
-Default-Features: mariadb
-
-Feature: mariadb
-Description: Use MariaDB connector
-Build-Depends: libmariadb
-
-Feature: mysql
-Description: Use MySQL connector
-Build-Depends: libmysql
+Build-Depends: date, sqlpp11, libmariadb


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/12040

libmariadb and libmysql are incompatible, so the mariadb and mysql can't be built together. However sqlpp11-connector-mysql depends on libmariadb, remove the default feature would block sqlpp11-connector-mysql, so I revert the change in related PR #11771 