### PR TITLE
[sdl2pp] Fix SDL_pixels.h cannot be found

### DIFF
--- a/ports/sdl2pp/CONTROL
+++ b/ports/sdl2pp/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2pp
-Version: 0.16.0-2
+Version: 0.16.0-3
 Description: C++11 bindings/wrapper for SDL2
 Homepage: https://sdl2pp.amdmi3.ru
 Build-Depends: sdl2, sdl2-mixer, sdl2-image, sdl2-ttf

--- a/ports/sdl2pp/fix-c1083-error.patch
+++ b/ports/sdl2pp/fix-c1083-error.patch
@@ -1,0 +1,13 @@
+diff --git a/SDL2pp/Color.hh b/SDL2pp/Color.hh
+index 5bd6e80..b3300f4 100644
+--- a/SDL2pp/Color.hh
++++ b/SDL2pp/Color.hh
+@@ -24,7 +24,7 @@
+ 
+ #include <ostream>
+ 
+-#include <SDL_pixels.h>
++#include <SDL2/SDL_pixels.h>
+ 
+ #include <SDL2pp/Export.hh>
+ 

--- a/ports/sdl2pp/portfile.cmake
+++ b/ports/sdl2pp/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 0.16.0
     SHA512 36603a0b1c3ba9294fffa5368357866e5689ceed9743352ff52c096d8b0070cc3f8708a5e837c10c871b410b6bda3ed7e8e3b95cb9afc136d91afb035cde6361
     HEAD_REF master
-    PATCHES fix-dependencies.patch
+    PATCHES 
+        fix-dependencies.patch
+        fix-c1083-error.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/FindSDL2.cmake


### PR DESCRIPTION
When using, `SDL_pixels.h` cannot be found in project.
Since in `SDL2pp/Color.hh` file, it included `<SDL_pixels.h>` instead of `<SDL2/SDL_pixels.h>`.

Fix #12041

Note: No feature needs to test.
