### PR TITLE
Fix bootstrapping MSYS2 pacman (#11499)

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,5 +1,5 @@
 Source: ffmpeg
-Version: 4.2-11
+Version: 4.2-12
 Build-Depends: zlib
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.

--- a/ports/ffnvcodec/CONTROL
+++ b/ports/ffnvcodec/CONTROL
@@ -1,4 +1,4 @@
 Source: ffnvcodec
-Version: 9.1.23.1
+Version: 9.1.23.1-1
 Homepage: https://github.com/FFmpeg/nv-codec-headers
 Description: FFmpeg version of Nvidia Codec SDK headers.

--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,5 +1,5 @@
 Source: icu
-Version: 67.1-1
+Version: 67.1-2
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,5 +1,5 @@
 Source: libpq
-Version: 12.2-2
+Version: 12.2-3
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,5 +1,5 @@
 Source: libvpx
-Version: 1.8.1-6
+Version: 1.8.1-7
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
 Supports: !(uwp&arm)

--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -1,4 +1,4 @@
 Source: openssl-unix
-Version: 1.1.1d-5
+Version: 1.1.1d-4
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: !(windows|uwp)

--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -1,4 +1,4 @@
 Source: openssl-unix
-Version: 1.1.1d-4
+Version: 1.1.1d-5
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: !(windows|uwp)

--- a/ports/tensorflow-cc/CONTROL
+++ b/ports/tensorflow-cc/CONTROL
@@ -1,5 +1,5 @@
 Source: tensorflow-cc
-Version: 1.14-2
+Version: 1.14-3
 Description: Library for computation using data flow graphs for scalable machine learning
 Build-Depends: c-ares
 Supports: !x86

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -98,6 +98,18 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;gpgconf --homedir /etc/pacman.d/gnupg --kill all"
       WORKING_DIRECTORY ${TOOLPATH}
     )
+    # we need to update pacman before anything else due to pacman transitioning
+    # to using zstd packages, and our pacman is too old to support those
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Sy pacman --noconfirm"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    # dash relies on specific versions of the base packages, which prevents us
+    # from doing a proper update. However, we don't need it so we remove it
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Rc dash --noconfirm"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
     _execute_process(
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Syu --noconfirm"
       WORKING_DIRECTORY ${TOOLPATH}


### PR DESCRIPTION
MSYS2 pacman recently transitioned to using .zstd packages from .xz packages, but we bootstrap from a pacman that doesn't support those. We need to add some additional bootstrap steps before pacman works. Note that this conflicts with #12044, so one of us will have to edit their PR to match the other.

**Describe the pull request**

- What does your PR fix? Fixes #11499

- Which triplets are supported/not supported? Have you updated the CI baseline? These changes shouldn't affect different triplets since it uses an internal msys2 tree.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? To the best of my knowledge yes.
