### PR TITLE
[vcpkg] Use XDG/LOCALAPPDATA for default binary caching path

### DIFF
--- a/toolsrc/include/vcpkg/base/system.h
+++ b/toolsrc/include/vcpkg/base/system.h
@@ -13,10 +13,9 @@ namespace vcpkg::System
 
     const ExpectedS<fs::path>& get_platform_cache_home() noexcept;
 
+#ifdef _WIN32
     const ExpectedS<fs::path>& get_appdata_local() noexcept;
-    const ExpectedS<fs::path>& get_xdg_config_home() noexcept;
-    const ExpectedS<fs::path>& get_xdg_cache_home() noexcept;
-    const ExpectedS<fs::path>& get_xdg_data_home() noexcept;
+#endif
 
     Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
 

--- a/toolsrc/include/vcpkg/base/system.h
+++ b/toolsrc/include/vcpkg/base/system.h
@@ -9,13 +9,14 @@ namespace vcpkg::System
 {
     Optional<std::string> get_environment_variable(ZStringView varname) noexcept;
 
-    ExpectedS<std::string> get_home_dir() noexcept;
+    const ExpectedS<fs::path>& get_home_dir() noexcept;
 
-    ExpectedS<fs::path> get_xdg_config_home() noexcept;
+    const ExpectedS<fs::path>& get_platform_cache_home() noexcept;
 
-    ExpectedS<fs::path> get_xdg_cache_home() noexcept;
-
-    ExpectedS<fs::path> get_xdg_data_home() noexcept;
+    const ExpectedS<fs::path>& get_appdata_local() noexcept;
+    const ExpectedS<fs::path>& get_xdg_config_home() noexcept;
+    const ExpectedS<fs::path>& get_xdg_cache_home() noexcept;
+    const ExpectedS<fs::path>& get_xdg_data_home() noexcept;
 
     Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
 

--- a/toolsrc/include/vcpkg/base/system.h
+++ b/toolsrc/include/vcpkg/base/system.h
@@ -11,6 +11,12 @@ namespace vcpkg::System
 
     ExpectedS<std::string> get_home_dir() noexcept;
 
+    ExpectedS<fs::path> get_xdg_config_home() noexcept;
+
+    ExpectedS<fs::path> get_xdg_cache_home() noexcept;
+
+    ExpectedS<fs::path> get_xdg_data_home() noexcept;
+
     Optional<std::string> get_registry_string(void* base_hkey, StringView subkey, StringView valuename);
 
     enum class CPUArchitecture

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -156,7 +156,7 @@ namespace vcpkg
             else
             {
                 return System::get_home_dir().map([](fs::path home) {
-                    home.append(fs::u8path(".config"));
+                    home /= fs::u8path(".config");
                     return home;
                 });
             }
@@ -175,7 +175,7 @@ namespace vcpkg
             else
             {
                 return System::get_home_dir().map([](fs::path home) {
-                    home.append(fs::u8path(".cache"));
+                    home /= fs::u8path(".cache");
                     return home;
                 });
             }

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -118,6 +118,55 @@ namespace vcpkg
         return {std::move(*maybe_home.get()), ExpectedLeftTag{}};
     }
 
+    ExpectedS<fs::path> get_xdg_config_home() noexcept
+    {
+        static ExpectedS<fs::path> s_home = [] {
+            auto maybe_home = System::get_environment_variable("XDG_CONFIG_HOME");
+            if (auto p = maybe_home.get())
+            {
+                return ExpectedS<fs::path>(fs::u8path(*p));
+            }
+            else
+            {
+                return System::get_home_dir().map([](std::string home) { return fs::u8path(home) / ".config"; });
+            }
+        }();
+        return s_home;
+    }
+
+    ExpectedS<fs::path> get_xdg_cache_home() noexcept
+    {
+        static ExpectedS<fs::path> s_home = [] {
+            auto maybe_home = System::get_environment_variable("XDG_CACHE_HOME");
+            if (auto p = maybe_home.get())
+            {
+                return ExpectedS<fs::path>(fs::u8path(*p));
+            }
+            else
+            {
+                return System::get_home_dir().map([](std::string home) { return fs::u8path(home) / ".cache"; });
+            }
+        }();
+        return s_home;
+    }
+
+    ExpectedS<fs::path> get_xdg_data_home() noexcept
+    {
+        static ExpectedS<fs::path> s_home = [] {
+            auto maybe_home = System::get_environment_variable("XDG_DATA_HOME");
+            if (auto p = maybe_home.get())
+            {
+                return ExpectedS<fs::path>(fs::u8path(*p));
+            }
+            else
+            {
+                return System::get_home_dir().map(
+                    [](std::string home) { return fs::u8path(home) / ".local" / "share"; });
+            }
+        }();
+        return s_home;
+    }
+
 #if defined(_WIN32)
     static bool is_string_keytype(const DWORD hkey_type)
     {

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -392,10 +392,18 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                     return add_error("unexpected arguments: binary config 'default' does not take more than 1 argument",
                                      segments[0].first);
 
-                auto maybe_home = System::get_home_dir();
+#ifdef _WIN32
+                auto maybe_home = System::get_home_dir().map(
+                    [](std::string s) { return fs::u8path(s).append(".vcpkg").append("archives"); });
+#else
+                auto maybe_home = System::get_xdg_cache_home().map([](fs::path p) {
+                    p.append("vcpkg").append("archives");
+                    return p;
+                });
+#endif
                 if (!maybe_home.has_value()) return add_error(maybe_home.error(), segments[0].first);
 
-                auto p = fs::u8path(maybe_home.value_or_exit(VCPKG_LINE_INFO)) / fs::u8path(".vcpkg/archives");
+                auto& p = maybe_home.value_or_exit(VCPKG_LINE_INFO);
                 if (!p.is_absolute())
                     return add_error("default path was not absolute: " + p.u8string(), segments[0].first);
                 if (segments.size() == 2)

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -396,7 +396,7 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                 if (!maybe_home.has_value()) return add_error(maybe_home.error(), segments[0].first);
 
                 auto p = *maybe_home.get();
-                p.append("vcpkg").append("archives");
+                p /= fs::u8path("vcpkg/archives");
                 if (!p.is_absolute())
                     return add_error("default path was not absolute: " + p.u8string(), segments[0].first);
                 if (segments.size() == 2)

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -392,18 +392,11 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                     return add_error("unexpected arguments: binary config 'default' does not take more than 1 argument",
                                      segments[0].first);
 
-#ifdef _WIN32
-                auto maybe_home = System::get_home_dir().map(
-                    [](std::string s) { return fs::u8path(s).append(".vcpkg").append("archives"); });
-#else
-                auto maybe_home = System::get_xdg_cache_home().map([](fs::path p) {
-                    p.append("vcpkg").append("archives");
-                    return p;
-                });
-#endif
+                auto&& maybe_home = System::get_platform_cache_home();
                 if (!maybe_home.has_value()) return add_error(maybe_home.error(), segments[0].first);
 
-                auto& p = maybe_home.value_or_exit(VCPKG_LINE_INFO);
+                auto p = *maybe_home.get();
+                p.append("vcpkg").append("archives");
                 if (!p.is_absolute())
                     return add_error("default path was not absolute: " + p.u8string(), segments[0].first);
                 if (segments.size() == 2)

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -155,17 +155,13 @@ namespace vcpkg::Commands::Integrate
 #if defined(_WIN32)
     static fs::path get_appdata_targets_path()
     {
-        static const fs::path LOCAL_APP_DATA =
-            fs::u8path(System::get_environment_variable("LOCALAPPDATA").value_or_exit(VCPKG_LINE_INFO));
-        return LOCAL_APP_DATA / fs::u8path("vcpkg/vcpkg.user.targets");
+        return System::get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / fs::u8path("vcpkg/vcpkg.user.targets");
     }
 #endif
 #if defined(_WIN32)
     static fs::path get_appdata_props_path()
     {
-        static const fs::path LOCAL_APP_DATA =
-            fs::u8path(System::get_environment_variable("LOCALAPPDATA").value_or_exit(VCPKG_LINE_INFO));
-        return LOCAL_APP_DATA / "vcpkg" / "vcpkg.user.props";
+        return System::get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / fs::u8path("vcpkg/vcpkg.user.props");
     }
 #endif
 
@@ -277,19 +273,20 @@ namespace vcpkg::Commands::Integrate
             const fs::path appdata_src_path2 = tmp_dir / "vcpkg.user.props";
             fs.write_contents(appdata_src_path2,
                               create_appdata_shortcut(paths.buildsystems_msbuild_props.u8string()),
-			      VCPKG_LINE_INFO);
+                              VCPKG_LINE_INFO);
             auto appdata_dst_path2 = get_appdata_props_path();
 
-            const auto rc2 = fs.copy_file(appdata_src_path2, appdata_dst_path2, fs::copy_options::overwrite_existing, ec);
+            const auto rc2 =
+                fs.copy_file(appdata_src_path2, appdata_dst_path2, fs::copy_options::overwrite_existing, ec);
 
             if (!rc2 || ec)
             {
                 System::print2(System::Color::error,
-                                "Error: Failed to copy file: ",
-                                appdata_src_path2.u8string(),
-                                " -> ",
-                                appdata_dst_path2.u8string(),
-								"\n");
+                               "Error: Failed to copy file: ",
+                               appdata_src_path2.u8string(),
+                               " -> ",
+                               appdata_dst_path2.u8string(),
+                               "\n");
                 Checks::exit_fail(VCPKG_LINE_INFO);
             }
         }

--- a/toolsrc/src/vcpkg/userconfig.cpp
+++ b/toolsrc/src/vcpkg/userconfig.cpp
@@ -4,35 +4,14 @@
 #include <vcpkg/base/lazy.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/userconfig.h>
-
-#if defined(_WIN32)
-namespace
-{
-    static vcpkg::Lazy<fs::path> s_localappdata;
-
-    static const fs::path& get_localappdata()
-    {
-        return s_localappdata.get_lazy([]() {
-            fs::path localappdata;
-            {
-                // Config path in AppDataLocal
-                wchar_t* localappdatapath = nullptr;
-                if (S_OK != SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localappdatapath)) __fastfail(1);
-                localappdata = localappdatapath;
-                CoTaskMemFree(localappdatapath);
-            }
-            return localappdata;
-        });
-    }
-}
-#endif
+#include <vcpkg/base/system.h>
 
 namespace vcpkg
 {
     fs::path get_user_dir()
     {
 #if defined(_WIN32)
-        return get_localappdata() / "vcpkg";
+        return System::get_appdata_local().value_or_exit(VCPKG_LINE_INFO) / "vcpkg";
 #else
         auto maybe_home = System::get_environment_variable("HOME");
         return fs::path(maybe_home.value_or("/var")) / ".vcpkg";


### PR DESCRIPTION
For binary caching, we should follow the XDG base directory specification[1] on non-Windows platforms. This means we should use `~/.cache/vcpkg/archives` as the default package storage location instead of `~/.vcpkg/archives`.

On Windows, the appropriate per-user base directory is `%LOCALAPPDATA%`, so we will use `%LOCALAPPATA%/vcpkg/archives`.

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html