### PR TITLE
Fix vcpkg_fixup_cmake_targets to work correctly on MinGW

### DIFF
--- a/ports/akali/CONTROL
+++ b/ports/akali/CONTROL
@@ -1,4 +1,4 @@
 Source: akali
-Version: 1.41
+Version: 1.41-1
 Description: C++ Common Library.
 Homepage: https://github.com/winsoft666/akali

--- a/ports/akali/CONTROL
+++ b/ports/akali/CONTROL
@@ -1,4 +1,5 @@
 Source: akali
-Version: 1.41-1
+Version: 1.41
+Port-Version: 1
 Description: C++ Common Library.
 Homepage: https://github.com/winsoft666/akali

--- a/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
+++ b/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
@@ -53,11 +53,7 @@ function(vcpkg_fixup_cmake_targets)
         set(_vfct_TARGET_PATH share/${PORT})
     endif()
 
-    if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        set(EXECUTABLE_SUFFIX "\\.exe")
-    else()
-        set(EXECUTABLE_SUFFIX)
-    endif()
+    string(REPLACE "." "\\." EXECUTABLE_SUFFIX "${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
 
     set(DEBUG_SHARE ${CURRENT_PACKAGES_DIR}/debug/${_vfct_TARGET_PATH})
     set(RELEASE_SHARE ${CURRENT_PACKAGES_DIR}/${_vfct_TARGET_PATH})


### PR DESCRIPTION
Handle executable suffix correctly on all targets.
