### PR TITLE
[angle] Add egl renderer to list of files compiled for linux

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -139,6 +139,9 @@ if(WINDOWS_DESKTOP OR LINUX OR APPLE)
             "src/libANGLE/renderer/gl/glx/*.cpp"
             "src/libANGLE/renderer/gl/glx/*.inl"
             "src/libANGLE/renderer/gl/glx/*.h"
+            "src/libANGLE/renderer/gl/egl/*.cpp"
+            "src/libANGLE/renderer/gl/egl/*.inl"
+            "src/libANGLE/renderer/gl/egl/*.h"
         )
     endif()
 

--- a/ports/angle/CONTROL
+++ b/ports/angle/CONTROL
@@ -1,5 +1,5 @@
 Source: angle
-Version: 2020-05-15
+Version: 2020-05-15-1
 Homepage: https://github.com/google/angle
 Description: A conformant OpenGL ES implementation for Windows, Mac and Linux.
   The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support.


### PR DESCRIPTION
For linux builds add egl to the list of files compiled.
Not including them causes linking issues on linux with the following undefined reference 
rx::DisplayEGL::DisplayEGL 
as per the following code snippet from
rc/libANGLE/Display.cpp:287
```
#    elif defined(ANGLE_PLATFORM_LINUX)
#        if defined(ANGLE_USE_OZONE)
            impl = new rx::DisplayOzone(state);
#        else
            if (deviceType == EGL_PLATFORM_ANGLE_DEVICE_TYPE_EGL_ANGLE)
            {
                impl = new rx::DisplayEGL(state);
            }
#            if defined(ANGLE_USE_X11)
            else
            {
                impl = new rx::DisplayGLX(state);
            }
#            endif
```
Fixes # 12110 https://github.com/microsoft/vcpkg/issues/12110