### PR TITLE
[vcpkg] Fix "[commands-build] build smoke test"

### DIFF
--- a/toolsrc/src/vcpkg-test/commands.build.cpp
+++ b/toolsrc/src/vcpkg-test/commands.build.cpp
@@ -16,6 +16,7 @@ TEST_CASE ("build smoke test", "[commands-build]")
 
     auto& fs_wrapper = Files::get_real_filesystem();
     VcpkgCmdArguments args = VcpkgCmdArguments::create_from_arg_sequence(std::begin(args_raw), std::end(args_raw));
+    args.binary_caching = false;
     args.buildtrees_root_dir =
         std::make_unique<std::string>((Test::base_temporary_directory() / fs::u8path("buildtrees")).u8string());
     args.install_root_dir =

--- a/toolsrc/src/vcpkg-test/commands.build.cpp
+++ b/toolsrc/src/vcpkg-test/commands.build.cpp
@@ -6,15 +6,26 @@
 #include <vcpkg/commands.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+#include <vcpkg-test/util.h>
+
+using namespace vcpkg;
 
 TEST_CASE ("build smoke test", "[commands-build]")
 {
-    using namespace vcpkg;
     static const std::string args_raw[] = {"build", "zlib"};
 
     auto& fs_wrapper = Files::get_real_filesystem();
     VcpkgCmdArguments args = VcpkgCmdArguments::create_from_arg_sequence(std::begin(args_raw), std::end(args_raw));
+    args.buildtrees_root_dir =
+        std::make_unique<std::string>((Test::base_temporary_directory() / fs::u8path("buildtrees")).u8string());
+    args.install_root_dir =
+        std::make_unique<std::string>((Test::base_temporary_directory() / fs::u8path("installed")).u8string());
+    args.packages_root_dir =
+        std::make_unique<std::string>((Test::base_temporary_directory() / fs::u8path("packages")).u8string());
     VcpkgPaths paths(fs_wrapper, args);
+    if (fs_wrapper.exists(paths.buildtrees)) fs_wrapper.remove_all_inside(paths.buildtrees, VCPKG_LINE_INFO);
+    if (fs_wrapper.exists(paths.packages)) fs_wrapper.remove_all_inside(paths.packages, VCPKG_LINE_INFO);
+    if (fs_wrapper.exists(paths.installed)) fs_wrapper.remove_all_inside(paths.installed, VCPKG_LINE_INFO);
     auto triplet = default_triplet(args);
     const auto exit_code = Build::Command::perform(args, paths, triplet);
     REQUIRE(exit_code == 0);

--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -155,9 +155,12 @@ namespace vcpkg::Test
 #endif
     }
 
-    const static fs::path BASE_TEMPORARY_DIRECTORY = internal_base_temporary_directory();
 
-    const fs::path& base_temporary_directory() noexcept { return BASE_TEMPORARY_DIRECTORY; }
+    const fs::path& base_temporary_directory() noexcept
+    {
+        const static fs::path BASE_TEMPORARY_DIRECTORY = internal_base_temporary_directory();
+        return BASE_TEMPORARY_DIRECTORY;
+    }
 
 #if FILESYSTEM_SYMLINK == FILESYSTEM_SYMLINK_NONE
     constexpr char no_filesystem_message[] =

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -140,7 +140,7 @@ namespace vcpkg::Build
         {
             System::print2(System::Color::error, Build::create_error_message(result.code, spec), '\n');
             System::print2(Build::create_user_troubleshooting_message(spec), '\n');
-            Checks::exit_fail(VCPKG_LINE_INFO);
+            return 1;
         }
 
         return 0;

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -143,7 +143,7 @@ namespace vcpkg::Build
             Checks::exit_fail(VCPKG_LINE_INFO);
         }
 
-        Checks::exit_success(VCPKG_LINE_INFO);
+        return 0;
     }
 
     int Command::perform(const VcpkgCmdArguments& args, const VcpkgPaths& paths, Triplet default_triplet)


### PR DESCRIPTION
1. Do not exit with a success code in Build::perform, because this causes failures in other tests to be ignored.
2. Use temp directory to avoid interference with the current set of {installed, buildtrees, packages}
3. Explicitly disable binary caching

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes