### PR TITLE
[vcpkg] Add write-only binary caching for CI.

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -28,13 +28,13 @@ supplied, binary caching will be used.
 
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string]$Triplet,
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     $ArchivesRoot,
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     $WorkingRoot,
     [ValidateNotNullOrEmpty()]
@@ -53,33 +53,34 @@ $buildtreesRoot = Join-Path $WorkingRoot 'buildtrees'
 $installRoot = Join-Path $WorkingRoot 'installed'
 $packagesRoot = Join-Path $WorkingRoot 'packages'
 $commonArgs = @(
+    '--binarycaching',
     "--x-buildtrees-root=$buildtreesRoot",
     "--x-install-root=$installRoot",
     "--x-packages-root=$packagesRoot"
 )
 
-$binaryCaching = $false
+$binaryCachingMode = 'readwrite'
 if ([string]::IsNullOrWhiteSpace($BuildReason)) {
-    Write-Host 'Build reason not specified, defaulting to using binary caching.'
-    $binaryCaching = $true
-} elseif ($BuildReason -eq 'PullRequest') {
-    Write-Host 'Build reason was Pull Request, using binary caching.'
-    $binaryCaching = $true
+    Write-Host 'Build reason not specified, defaulting to using binary caching in read write mode.'
+}
+elseif ($BuildReason -eq 'PullRequest') {
+    Write-Host 'Build reason was Pull Request, using binary caching in read write mode.'
+}
+else {
+    Write-Host "Build reason was $BuildReason, using binary caching in write only mode."
+    $binaryCachingMode = 'write'
 }
 
-if ($binaryCaching) {
-    $commonArgs += @(
-        '--binarycaching',
-        "--x-binarysource=clear;files,$ArchivesRoot,upload"
-    )
-}
+$commonArgs += @("--x-binarysource=clear;files,$ArchivesRoot,$binaryCachingMode")
 
 if ($Triplet -eq 'x64-linux') {
     $env:HOME = '/home/agent'
     $executableExtension = [string]::Empty
-} elseif ($Triplet -eq 'x64-osx') {
+}
+elseif ($Triplet -eq 'x64-osx') {
     $executableExtension = [string]::Empty
-} else {
+}
+else {
     $executableExtension = '.exe'
 }
 

--- a/toolsrc/src/vcpkg-test/binaryconfigparser.cpp
+++ b/toolsrc/src/vcpkg-test/binaryconfigparser.cpp
@@ -44,11 +44,19 @@ TEST_CASE ("BinaryConfigParser files provider", "[binaryconfigparser]")
         REQUIRE(!parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",upload", {});
+        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",read", {});
         REQUIRE(parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",upload,extra", {});
+        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",write", {});
+        REQUIRE(parsed.has_value());
+    }
+    {
+        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",readwrite", {});
+        REQUIRE(parsed.has_value());
+    }
+    {
+        auto parsed = create_binary_provider_from_configs_pure("files," ABSOLUTE_PATH ",readwrite,extra", {});
         REQUIRE(!parsed.has_value());
     }
     {
@@ -68,11 +76,19 @@ TEST_CASE ("BinaryConfigParser default provider", "[binaryconfigparser]")
         REQUIRE(!parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("default,upload", {});
+        auto parsed = create_binary_provider_from_configs_pure("default,read", {});
         REQUIRE(parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("default,upload,extra", {});
+        auto parsed = create_binary_provider_from_configs_pure("default,readwrite", {});
+        REQUIRE(parsed.has_value());
+    }
+    {
+        auto parsed = create_binary_provider_from_configs_pure("default,write", {});
+        REQUIRE(parsed.has_value());
+    }
+    {
+        auto parsed = create_binary_provider_from_configs_pure("default,read,extra", {});
         REQUIRE(!parsed.has_value());
     }
 }
@@ -96,11 +112,11 @@ TEST_CASE ("BinaryConfigParser multiple providers", "[binaryconfigparser]")
         REQUIRE(parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("clear;default,upload", {});
+        auto parsed = create_binary_provider_from_configs_pure("clear;default,readwrite", {});
         REQUIRE(parsed.has_value());
     }
     {
-        auto parsed = create_binary_provider_from_configs_pure("clear;default,upload;clear;clear", {});
+        auto parsed = create_binary_provider_from_configs_pure("clear;default,readwrite;clear;clear", {});
         REQUIRE(parsed.has_value());
     }
     {

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -443,7 +443,6 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                 else
                 {
                     Checks::check_exit(VCPKG_LINE_INFO, segments.size() > 1);
-                    Checks::check_exit(VCPKG_LINE_INFO, segments.size() > 1);
                     return add_error("unexpected arguments: binary config 'default' can only accept"
                                      " 'read', readwrite', or 'write' as a first argument",
                                      segments[1].first);

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -66,7 +66,7 @@ namespace
         {
         }
         ~ArchivesBinaryProvider() = default;
-        void prefetch() override {}
+        void prefetch() override { }
         RestoreResult try_restore(const VcpkgPaths& paths, const Dependencies::InstallPlanAction& action) override
         {
             const auto& abi_tag = action.abi_info.value_or_exit(VCPKG_LINE_INFO).package_abi;
@@ -249,13 +249,13 @@ namespace
 
     struct NullBinaryProvider : IBinaryProvider
     {
-        void prefetch() override {}
+        void prefetch() override { }
         RestoreResult try_restore(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override
         {
             return RestoreResult::missing;
         }
-        void push_success(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override {}
-        void push_failure(const VcpkgPaths&, const std::string&, const PackageSpec&) override {}
+        void push_success(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override { }
+        void push_failure(const VcpkgPaths&, const std::string&, const PackageSpec&) override { }
         RestoreResult precheck(const VcpkgPaths&, const Dependencies::InstallPlanAction&, bool) override
         {
             return RestoreResult::missing;
@@ -358,39 +358,56 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
             else if (segments[0].second == "files")
             {
                 if (segments.size() < 2)
+                {
                     return add_error("expected arguments: binary config 'files' requires at least a path argument",
                                      segments[0].first);
+                }
 
                 auto p = fs::u8path(segments[1].second);
                 if (!p.is_absolute())
+                {
                     return add_error("expected arguments: path arguments for binary config strings must be absolute",
                                      segments[1].first);
+                }
 
-                if (segments.size() > 3)
+                std::string mode;
+                switch (segments.size())
                 {
-                    return add_error("unexpected arguments: binary config 'files' does not take more than 2 arguments",
-                                     segments[3].first);
+                    case 2: mode = "read"; break;
+                    case 3: mode = segments[2].second; break;
+                    default:
+                        return add_error("unexpected arguments: binary config 'files' requires 1 or 2 arguments",
+                                         segments[3].first);
                 }
-                else if (segments.size() == 3)
+
+                if (mode == "read")
                 {
-                    if (segments[2].second != "upload")
-                    {
-                        return add_error("unexpected arguments: binary config 'files' can only accept 'upload' as "
-                                         "a second argument",
-                                         segments[2].first);
-                    }
-                    else
-                    {
-                        archives_to_write.push_back(p);
-                    }
+                    archives_to_read.push_back(std::move(p));
                 }
-                archives_to_read.push_back(std::move(p));
+                else if (mode == "write")
+                {
+                    archives_to_write.push_back(std::move(p));
+                }
+                else if (mode == "readwrite")
+                {
+                    archives_to_read.push_back(p);
+                    archives_to_write.push_back(std::move(p));
+                }
+                else
+                {
+                    Checks::check_exit(VCPKG_LINE_INFO, segments.size() > 2);
+                    return add_error("unexpected arguments: binary config 'files' can only accept"
+                                     " 'read', readwrite', or 'write' as a second argument",
+                                     segments[2].first);
+                }
             }
             else if (segments[0].second == "default")
             {
                 if (segments.size() > 2)
+                {
                     return add_error("unexpected arguments: binary config 'default' does not take more than 1 argument",
                                      segments[0].first);
+                }
 
                 auto&& maybe_home = System::get_platform_cache_home();
                 if (!maybe_home.has_value()) return add_error(maybe_home.error(), segments[0].first);
@@ -398,21 +415,39 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                 auto p = *maybe_home.get();
                 p /= fs::u8path("vcpkg/archives");
                 if (!p.is_absolute())
-                    return add_error("default path was not absolute: " + p.u8string(), segments[0].first);
-                if (segments.size() == 2)
                 {
-                    if (segments[1].second != "upload")
-                    {
-                        return add_error(
-                            "unexpected arguments: binary config 'default' can only accept 'upload' as an argument",
-                            segments[1].first);
-                    }
-                    else
-                    {
-                        archives_to_write.push_back(p);
-                    }
+                    return add_error("default path was not absolute: " + p.u8string(), segments[0].first);
                 }
-                archives_to_read.push_back(std::move(p));
+
+                std::string mode;
+                switch (segments.size())
+                {
+                    case 1: mode = "read"; break;
+                    case 2: mode = segments[1].second; break;
+                    default: Checks::unreachable(VCPKG_LINE_INFO);
+                }
+
+                if (mode == "read")
+                {
+                    archives_to_read.push_back(std::move(p));
+                }
+                else if (mode == "write")
+                {
+                    archives_to_write.push_back(std::move(p));
+                }
+                else if (mode == "readwrite")
+                {
+                    archives_to_read.push_back(p);
+                    archives_to_write.push_back(std::move(p));
+                }
+                else
+                {
+                    Checks::check_exit(VCPKG_LINE_INFO, segments.size() > 1);
+                    Checks::check_exit(VCPKG_LINE_INFO, segments.size() > 1);
+                    return add_error("unexpected arguments: binary config 'default' can only accept"
+                                     " 'read', readwrite', or 'write' as a first argument",
+                                     segments[1].first);
+                }
             }
             else
             {

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -846,7 +846,7 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                 }
                 else if (mode == "readwrite")
                 {
-                    state->archives_to_write.push_back(p);
+                    state->archives_to_read.push_back(p);
                     state->archives_to_write.push_back(std::move(p));
                 }
                 else
@@ -963,7 +963,7 @@ ExpectedS<std::unique_ptr<IBinaryProvider>> vcpkg::create_binary_provider_from_c
                 }
                 else if (mode == "readwrite")
                 {
-                    state->archives_to_write.push_back(p);
+                    state->archives_to_read.push_back(p);
                     state->archives_to_write.push_back(std::move(p));
                 }
                 else


### PR DESCRIPTION
This lets PRs take advantage of builds done in our CI but still leaves the CI building all the things.

Changes to the binary caching spec made as comments over at https://github.com/microsoft/vcpkg/pull/11204#pullrequestreview-438518901
