### PR TITLE
[libexif] Update to 0.6.22

### DIFF
--- a/ports/libexif/CONTROL
+++ b/ports/libexif/CONTROL
@@ -1,5 +1,5 @@
 Source: libexif
-Version: 0.6.21-2
+Version: 0.6.22
 Homepage: https://libexif.github.io/
 Description: a library for parsing, editing, and saving EXIF data
 Supports: !uwp

--- a/ports/libexif/portfile.cmake
+++ b/ports/libexif/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "libexif currently only supports being built for desktop")
 endif()
@@ -27,4 +25,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libexif RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libexif/portfile.cmake
+++ b/ports/libexif/portfile.cmake
@@ -1,6 +1,4 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "libexif currently only supports being built for desktop")
-endif()
+vcpkg_fail_port_install(ON_TARGET uwp)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/libexif/portfile.cmake
+++ b/ports/libexif/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libexif/libexif
-    REF libexif-0_6_21-release
-    SHA512 aecba54eb9c8b4ce29d11985a547074b381d72027b563c7aef865852b661a6f18a258c748fca6b16198344f4a86568b658071ac95cc1d332f576c6160e1f257d
+    REF libexif-0_6_22-release
+    SHA512 6c63abe2734c9e83fb04adb00bdd77f687165007c0efd0279df26c101363b990604050c430c7dd73dfa8735dd2fd196334d321bdb114d4869998f21e7bed5b43
     HEAD_REF master
     PATCHES add-missing-_stdint-h.patch
 )


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

Update libexif version from 0.6.21 to 0.6.22

From the [release page on github](https://github.com/libexif/libexif/releases/tag/libexif-0_6_22-release):

> It largely contains stability, security and bugfixes.
>
> Some EXIF 2.3 tags have been added.
>
> It is ABI compatible to 0.6.21 release.

- Which triplets are supported/not supported? Have you updated the CI baseline?

No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.