### PR TITLE
[infoware] Bump version to 0.5.4

### DIFF
--- a/ports/infoware/CONTROL
+++ b/ports/infoware/CONTROL
@@ -1,6 +1,6 @@
 Source: infoware
 Homepage: https://github.com/ThePhD/infoware
-Version: 0.5.3
+Version: 0.5.4
 Description: C++ Library for pulling system and hardware information, without hitting the command line.
 # Note that independent usage and testing may work, but it seems to fail in CI environments for potential cross-compilation,
 # and is thusly noted here to note break how vcpkg builds things!

--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/infoware
-    REF v0.5.3
-    SHA512 217bb9332214d823445e19f2c465199536e89a36faccea8cb72f8dd41a177e1739969d131ad25d1878e688a3a6cc1290c2125ef9d2205ad4fd334b24b27d491a
+    REF v0.5.4
+    SHA512 16c7c39ca59128fe6489ec70b0d840d48cc44e57fe0d7d2dc864443cf8be288ceaf32e28246f6ac2dda495662d7a38d1e6ddf49172a73aac55445ecea95a29a8
     HEAD_REF master
 )
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? The infoware version being out of date.

- Which triplets are supported/not supported? Same ones. Have you updated the CI baseline? I don't think so?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? I hope so.