### PR TITLE
[vcpkg] Enable NuGet-based binary caching via mono

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -65,6 +65,18 @@
         <url>https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe</url>
         <sha512>22ea847d8017cd977664d0b13c889cfb13c89143212899a511be217345a4e243d4d8d4099700114a11d26a087e83eb1a3e2b03bdb5e0db48f10403184cd26619</sha512>
     </tool>
+    <tool name="nuget" os="linux">
+        <version>5.5.1</version>
+        <exeRelativePath>nuget.exe</exeRelativePath>
+        <url>https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe</url>
+        <sha512>22ea847d8017cd977664d0b13c889cfb13c89143212899a511be217345a4e243d4d8d4099700114a11d26a087e83eb1a3e2b03bdb5e0db48f10403184cd26619</sha512>
+    </tool>
+    <tool name="nuget" os="osx">
+        <version>5.5.1</version>
+        <exeRelativePath>nuget.exe</exeRelativePath>
+        <url>https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe</url>
+        <sha512>22ea847d8017cd977664d0b13c889cfb13c89143212899a511be217345a4e243d4d8d4099700114a11d26a087e83eb1a3e2b03bdb5e0db48f10403184cd26619</sha512>
+    </tool>
     <tool name="installerbase" os="windows">
         <version>3.1.81</version>
         <exeRelativePath>QtInstallerFramework-win-x86\bin\installerbase.exe</exeRelativePath>

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -20,6 +20,7 @@ namespace vcpkg
         static const std::string MAVEN = "mvn";
         static const std::string CMAKE = "cmake";
         static const std::string GIT = "git";
+        static const std::string MONO = "mono";
         static const std::string NINJA = "ninja";
         static const std::string NUGET = "nuget";
         static const std::string IFW_INSTALLER_BASE = "ifw_installerbase";

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -207,8 +207,7 @@ namespace
                 }
             }
         }
-        RestoreResult precheck(const VcpkgPaths& paths,
-                               const Dependencies::InstallPlanAction& action) override
+        RestoreResult precheck(const VcpkgPaths& paths, const Dependencies::InstallPlanAction& action) override
         {
             const auto& abi_tag = action.abi_info.value_or_exit(VCPKG_LINE_INFO).package_abi;
             auto& fs = paths.get_filesystem();
@@ -317,6 +316,9 @@ namespace
             {
                 // First check using all sources
                 System::CmdLineBuilder cmdline;
+#ifndef _WIN32
+                cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
+#endif
                 cmdline.path_arg(nuget_exe)
                     .string_arg("install")
                     .path_arg(packages_config)
@@ -340,6 +342,9 @@ namespace
             {
                 // Then check using each config
                 System::CmdLineBuilder cmdline;
+#ifndef _WIN32
+                cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
+#endif
                 cmdline.path_arg(nuget_exe)
                     .string_arg("install")
                     .path_arg(packages_config)
@@ -424,6 +429,9 @@ namespace
 
             const auto& nuget_exe = paths.get_tool_exe("nuget");
             System::CmdLineBuilder cmdline;
+#ifndef _WIN32
+            cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
+#endif
             cmdline.path_arg(nuget_exe)
                 .string_arg("pack")
                 .path_arg(nuspec_path)
@@ -450,6 +458,9 @@ namespace
                 for (auto&& write_src : m_write_sources)
                 {
                     System::CmdLineBuilder cmd;
+#ifndef _WIN32
+                    cmd.path_arg(paths.get_tool_exe(Tools::MONO));
+#endif
                     cmd.path_arg(nuget_exe)
                         .string_arg("push")
                         .path_arg(nupkg_path)
@@ -480,6 +491,9 @@ namespace
                 for (auto&& write_cfg : m_write_configs)
                 {
                     System::CmdLineBuilder cmd;
+#ifndef _WIN32
+                    cmd.path_arg(paths.get_tool_exe(Tools::MONO));
+#endif
                     cmd.path_arg(nuget_exe)
                         .string_arg("push")
                         .path_arg(nupkg_path)
@@ -571,8 +585,7 @@ namespace
                 provider->push_failure(paths, abi_tag, spec);
             }
         }
-        RestoreResult precheck(const VcpkgPaths& paths,
-                               const Dependencies::InstallPlanAction& action) override
+        RestoreResult precheck(const VcpkgPaths& paths, const Dependencies::InstallPlanAction& action) override
         {
             for (auto&& provider : m_providers)
             {
@@ -599,8 +612,8 @@ namespace
         {
             return RestoreResult::missing;
         }
-        void push_success(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override { }
-        void push_failure(const VcpkgPaths&, const std::string&, const PackageSpec&) override { }
+        void push_success(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override {}
+        void push_failure(const VcpkgPaths&, const std::string&, const PackageSpec&) override {}
         RestoreResult precheck(const VcpkgPaths&, const Dependencies::InstallPlanAction&) override
         {
             return RestoreResult::missing;

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -135,18 +135,19 @@ namespace vcpkg
         {
             Util::unused(out_candidate_paths);
         }
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const = 0;
+        virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const = 0;
     };
 
-    static Optional<PathAndVersion> find_first_with_sufficient_version(const Files::Filesystem& fs,
+    static Optional<PathAndVersion> find_first_with_sufficient_version(const VcpkgPaths& paths,
                                                                        const ToolProvider& tool_provider,
                                                                        const std::vector<fs::path>& candidates,
                                                                        const std::array<int, 3>& expected_version)
     {
+        const auto& fs = paths.get_filesystem();
         for (auto&& candidate : candidates)
         {
             if (!fs.exists(candidate)) continue;
-            auto maybe_version = tool_provider.get_version(candidate);
+            auto maybe_version = tool_provider.get_version(paths, candidate);
             const auto version = maybe_version.get();
             if (!version) continue;
             const auto parsed_version = parse_version_string(*version);
@@ -218,7 +219,8 @@ namespace vcpkg
                                      const ToolData& tool_data)
     {
         const auto downloaded_path = fetch_tool(paths, tool_provider.tool_data_name(), tool_data);
-        const auto downloaded_version = tool_provider.get_version(downloaded_path).value_or_exit(VCPKG_LINE_INFO);
+        const auto downloaded_version =
+            tool_provider.get_version(paths, downloaded_path).value_or_exit(VCPKG_LINE_INFO);
         return {downloaded_path, downloaded_version};
     }
 
@@ -245,7 +247,7 @@ namespace vcpkg
 
         tool.add_special_paths(candidate_paths);
 
-        const auto maybe_path = find_first_with_sufficient_version(fs, tool, candidate_paths, min_version);
+        const auto maybe_path = find_first_with_sufficient_version(paths, tool, candidate_paths, min_version);
         if (const auto p = maybe_path.get())
         {
             return *p;
@@ -279,7 +281,7 @@ namespace vcpkg
             Util::unused(out_candidate_paths);
 #endif
         }
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const override
+        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", path_to_exe.u8string());
             const auto rc = System::cmd_execute_and_capture_output(cmd);
@@ -305,7 +307,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {3, 5, 1}; }
 
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const override
+        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", path_to_exe.u8string());
             const auto rc = System::cmd_execute_and_capture_output(cmd);
@@ -329,10 +331,16 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {4, 6, 2}; }
 
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const override
+        virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const override
         {
-            const std::string cmd = Strings::format(R"("%s")", path_to_exe.u8string());
-            const auto rc = System::cmd_execute_and_capture_output(cmd);
+            System::CmdLineBuilder cmd;
+#ifndef _WIN32
+            cmd.path_arg(paths.get_tool_exe(Tools::MONO));
+#else
+            Util::unused(paths);
+#endif
+            cmd.path_arg(path_to_exe);
+            const auto rc = System::cmd_execute_and_capture_output(cmd.extract());
             if (rc.exit_code != 0)
             {
                 return nullopt;
@@ -371,7 +379,7 @@ Type 'NuGet help <command>' for help on a specific command.
 #endif
         }
 
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const override
+        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", path_to_exe.u8string());
             const auto rc = System::cmd_execute_and_capture_output(cmd);
@@ -386,6 +394,33 @@ git version 2.17.1.windows.2
             const auto idx = rc.output.find("git version ");
             Checks::check_exit(
                 VCPKG_LINE_INFO, idx != std::string::npos, "Unexpected format of git version string: %s", rc.output);
+            return rc.output.substr(idx);
+        }
+    };
+
+    struct MonoProvider : ToolProvider
+    {
+        std::string m_exe = "mono";
+
+        virtual const std::string& tool_data_name() const override { return m_exe; }
+        virtual const std::string& exe_stem() const override { return m_exe; }
+        virtual std::array<int, 3> default_min_version() const override { return {0, 0, 0}; }
+
+        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        {
+            const auto rc = System::cmd_execute_and_capture_output(
+                System::CmdLineBuilder().path_arg(path_to_exe).string_arg("--version").extract());
+            if (rc.exit_code != 0)
+            {
+                return nullopt;
+            }
+
+            /* Sample output:
+Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50 UTC 2020)
+                */
+            const auto idx = rc.output.find("Mono JIT compiler version ");
+            Checks::check_exit(
+                VCPKG_LINE_INFO, idx != std::string::npos, "Unexpected format of mono version string: %s", rc.output);
             return rc.output.substr(idx);
         }
     };
@@ -411,7 +446,7 @@ git version 2.17.1.windows.2
             // "Qt" / "QtIFW-3.1.0" / "bin" / "installerbase.exe");
         }
 
-        virtual Optional<std::string> get_version(const fs::path& path_to_exe) const override
+        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --framework-version)", path_to_exe.u8string());
             const auto rc = System::cmd_execute_and_capture_output(cmd);
@@ -476,6 +511,7 @@ git version 2.17.1.windows.2
                 }
                 if (tool == Tools::NUGET) return get_path(paths, NuGetProvider());
                 if (tool == Tools::IFW_INSTALLER_BASE) return get_path(paths, IfwInstallerBaseProvider());
+                if (tool == Tools::MONO) return get_path(paths, MonoProvider());
 
                 // For other tools, we simply always auto-download them.
                 auto maybe_tool_data = parse_tool_data_from_xml(paths, tool);


### PR DESCRIPTION
Mono enables the NuGet command line client (`nuget.exe`) to be used unmodified on Unix systems. This PR leverages Mono, when installed separately by the user via `apt install mono-complete` or otherwise, to provide the NuGet-based binary caching flow on non-Windows systems.
