### PR TITLE
[vcpkg] Add a schema file for vcpkg.json

### DIFF
--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "title": "Vcpkg manifest",
   "description": "Vcpkg manifest file. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md.",
   "definitions": {

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -2,14 +2,26 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Vcpkg manifest",
   "description": "Vcpkg manifest file. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md.",
-
   "definitions": {
     "identifier": {
-      "type": "string",
-      "pattern": "[a-z0-9]+(-[a-z0-9]+)*"
+      "description": "Identifiers used for feature names.",
+      "allOf": [
+        {
+          "description": "Identifier are lowercase with digits and dashes.",
+          "type": "string",
+          "pattern": "[a-z0-9]+(-[a-z0-9]+)*"
+        },
+        {
+          "not": {
+            "description": "Identifiers must not be a Windows filesystem reserved name.",
+            "type": "string",
+            "pattern": "^prn|aux|nul|con|lpt[1-9]|com[1-9]|core|default$"
+          }
+        }
+      ]
     },
     "package-name": {
-      "title": "Name of a package.",
+      "description": "Name of a package.",
       "allOf": [
         {
           "description": "Package name must be a dot-separated list of valid identifiers",
@@ -104,11 +116,13 @@
       "patternProperties": {
         "^[$]": {}
       },
-      "required": ["name", "description"],
+      "required": [
+        "name",
+        "description"
+      ],
       "additionalProperties": false
     }
   },
-
   "type": "object",
   "properties": {
     "name": {

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -14,7 +14,7 @@
         },
         {
           "not": {
-            "description": "Identifiers must not be a Windows filesystem reserved name.",
+            "description": "Identifiers must not be a Windows filesystem or vcpkg reserved name.",
             "type": "string",
             "pattern": "^prn|aux|nul|con|lpt[1-9]|com[1-9]|core|default$"
           }
@@ -31,7 +31,7 @@
         },
         {
           "not": {
-            "description": "Identifiers must not be a Windows filesystem reserved name.",
+            "description": "Identifiers must not be a Windows filesystem or vcpkg reserved name.",
             "type": "string",
             "pattern": "(^|\\.)(prn|aux|nul|con|lpt[1-9]|com[1-9]|core|default)(\\.|$)"
           }

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -74,7 +74,7 @@
         }
       },
       "patternProperties": {
-        "^[$]": {}
+        "^\\$": {}
       },
       "required": [
         "name"
@@ -115,7 +115,7 @@
         }
       },
       "patternProperties": {
-        "^[$]": {}
+        "^\\$": {}
       },
       "required": [
         "name",
@@ -196,7 +196,7 @@
     }
   },
   "patternProperties": {
-    "^[$]": {}
+    "^\\$": {}
   },
   "required": [
     "name",

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -88,11 +88,9 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Name of the feature.",
           "$ref": "#/definitions/identifier"
         },
         "description": {
-          "description": "Description of the feature.",
           "$ref": "#/definitions/descriptionField"
         },
         "dependencies": {

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -8,7 +8,7 @@
       "type": "string",
       "pattern": "[a-z0-9]+(-[a-z0-9]+)*"
     },
-    "packageName": {
+    "package-name": {
       "title": "Name of a package.",
       "allOf": [
         {
@@ -25,7 +25,7 @@
         }
       ]
     },
-    "descriptionField": {
+    "description-field": {
       "description": "A string or array of strings containing the description of a package or feature.",
       "oneOf": [
         {
@@ -39,12 +39,12 @@
         }
       ]
     },
-    "dependencyObject": {
+    "dependency-object": {
       "description": "Expanded form of a dependency with explicit features and platform.",
       "type": "object",
       "properties": {
         "name": {
-          "$ref": "#/definitions/packageName"
+          "$ref": "#/definitions/package-name"
         },
         "features": {
           "type": "array",
@@ -57,7 +57,7 @@
           "default": true
         },
         "platform": {
-          "$ref": "#/definitions/platformExpression"
+          "$ref": "#/definitions/platform-expression"
         }
       },
       "patternProperties": {
@@ -72,14 +72,14 @@
       "description": "A dependency fetchable by Vcpkg.",
       "oneOf": [
         {
-          "$ref": "#/definitions/packageName"
+          "$ref": "#/definitions/package-name"
         },
         {
-          "$ref": "#/definitions/dependencyObject"
+          "$ref": "#/definitions/dependency-object"
         }
       ]
     },
-    "platformExpression": {
+    "platform-expression": {
       "description": "A specification of a set of platforms. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md#definitions.",
       "type": "string"
     },
@@ -91,7 +91,7 @@
           "$ref": "#/definitions/identifier"
         },
         "description": {
-          "$ref": "#/definitions/descriptionField"
+          "$ref": "#/definitions/description-field"
         },
         "dependencies": {
           "description": "Dependencies used by this feature.",
@@ -112,7 +112,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "$ref": "#/definitions/packageName"
+      "$ref": "#/definitions/package-name"
     },
     "version-string": {
       "description": "A string without semantic meaning, equivalent to `CONTROL`'s `Version` field.",
@@ -132,7 +132,7 @@
       }
     },
     "description": {
-      "$ref": "#/definitions/descriptionField"
+      "$ref": "#/definitions/description-field"
     },
     "homepage": {
       "description": "A url which points to the homepage of a package.",
@@ -177,7 +177,7 @@
       }
     },
     "supports": {
-      "$ref": "#/definitions/platformExpression"
+      "$ref": "#/definitions/platform-expression"
     }
   },
   "patternProperties": {

--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Vcpkg manifest",
+  "description": "Vcpkg manifest file. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md.",
+
+  "definitions": {
+    "identifier": {
+      "type": "string",
+      "pattern": "[a-z0-9]+(-[a-z0-9]+)*"
+    },
+    "packageName": {
+      "title": "Name of a package.",
+      "allOf": [
+        {
+          "description": "Package name must be a dot-separated list of valid identifiers",
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*(\\.[a-z0-9]+(-[a-z0-9]+)*)*$"
+        },
+        {
+          "not": {
+            "description": "Identifiers must not be a Windows filesystem reserved name.",
+            "type": "string",
+            "pattern": "(^|\\.)(prn|aux|nul|con|lpt[1-9]|com[1-9]|core|default)(\\.|$)"
+          }
+        }
+      ]
+    },
+    "descriptionField": {
+      "description": "A string or array of strings containing the description of a package or feature.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "dependencyObject": {
+      "description": "Expanded form of a dependency with explicit features and platform.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/packageName"
+        },
+        "features": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/identifier"
+          }
+        },
+        "default-features": {
+          "type": "boolean",
+          "default": true
+        },
+        "platform": {
+          "$ref": "#/definitions/platformExpression"
+        }
+      },
+      "patternProperties": {
+        "^[$]": {}
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "dependency": {
+      "description": "A dependency fetchable by Vcpkg.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageName"
+        },
+        {
+          "$ref": "#/definitions/dependencyObject"
+        }
+      ]
+    },
+    "platformExpression": {
+      "description": "A specification of a set of platforms. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md#definitions.",
+      "type": "string"
+    },
+    "feature": {
+      "description": "A package feature that can be activated by consumers.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the feature.",
+          "$ref": "#/definitions/identifier"
+        },
+        "description": {
+          "description": "Description of the feature.",
+          "$ref": "#/definitions/descriptionField"
+        },
+        "dependencies": {
+          "description": "Dependencies used by this feature.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        }
+      },
+      "patternProperties": {
+        "^[$]": {}
+      },
+      "required": ["name", "description"],
+      "additionalProperties": false
+    }
+  },
+
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/packageName"
+    },
+    "version-string": {
+      "description": "A string without semantic meaning, equivalent to `CONTROL`'s `Version` field.",
+      "type": "string"
+    },
+    "port-version": {
+      "description": "A non-negative integer. If this field doesn't exist, it's assumed to be `0`.",
+      "type": "integer",
+      "minimum": 0,
+      "default": 0
+    },
+    "maintainers": {
+      "description": "An array of strings which contain the authors of a package",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "description": {
+      "$ref": "#/definitions/descriptionField"
+    },
+    "homepage": {
+      "description": "A url which points to the homepage of a package.",
+      "type": "string",
+      "format": "uri"
+    },
+    "documentation": {
+      "description": "A url which points to the documentation of a package.",
+      "type": "string",
+      "format": "uri"
+    },
+    "license": {
+      "description": "An SPDX license expression at version 3.9.",
+      "type": "string"
+    },
+    "dependencies": {
+      "description": "Dependencies that are always required.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dependency"
+      }
+    },
+    "dev-dependencies": {
+      "description": "Dependencies only required for developers (testing and the like).",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dependency"
+      }
+    },
+    "features": {
+      "description": "An array of features supported by the package",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/feature"
+      }
+    },
+    "default-features": {
+      "description": "Features enabled by default with the package.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/identifier"
+      }
+    },
+    "supports": {
+      "$ref": "#/definitions/platformExpression"
+    }
+  },
+  "patternProperties": {
+    "^[$]": {}
+  },
+  "required": [
+    "name",
+    "version-string"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This is related to #12175 .

This is absolutely not as tested as it should be, but I'm not sure how to go about it. I gess some set of known valid and known invalid manifest files would be required.

I choose the path an filename fairly arbitrarily, feel free to move it around.