### PR TITLE
Fix sourceparagraph:BooleanField

### DIFF
--- a/toolsrc/src/vcpkg/sourceparagraph.cpp
+++ b/toolsrc/src/vcpkg/sourceparagraph.cpp
@@ -361,7 +361,7 @@ namespace vcpkg
         using type = bool;
         StringView type_name() { return "a boolean"; }
 
-        Optional<bool> visit_bool(Json::Reader&, StringView, bool b) { return b; }
+        Optional<bool> visit_boolean(Json::Reader&, StringView, bool b) { return b; }
     };
 
     enum class AllowEmpty : bool


### PR DESCRIPTION
the function is called `visit_boolean`, not `visit_bool`.
I wish there was a better way to do this.

Fixes issue #12186 