### PR TITLE
[vcpkg] Remove all uses of Foo::Foo() noexcept = default; to fix #9955

### DIFF
--- a/toolsrc/include/vcpkg/packagespec.h
+++ b/toolsrc/include/vcpkg/packagespec.h
@@ -20,8 +20,8 @@ namespace vcpkg
     ///
     struct PackageSpec
     {
-        PackageSpec() noexcept = default;
-        PackageSpec(std::string name, Triplet triplet) : m_name(std::move(name)), m_triplet(triplet) { }
+        PackageSpec() = default;
+        PackageSpec(std::string name, Triplet triplet) : m_name(std::move(name)), m_triplet(triplet) {}
 
         static std::vector<PackageSpec> to_package_specs(const std::vector<std::string>& ports, Triplet triplet);
 
@@ -54,7 +54,7 @@ namespace vcpkg
     ///
     struct FeatureSpec
     {
-        FeatureSpec(const PackageSpec& spec, const std::string& feature) : m_spec(spec), m_feature(feature) { }
+        FeatureSpec(const PackageSpec& spec, const std::string& feature) : m_spec(spec), m_feature(feature) {}
 
         const std::string& name() const { return m_spec.name(); }
         const std::string& feature() const { return m_feature; }
@@ -97,7 +97,7 @@ namespace vcpkg
         PackageSpec package_spec;
         std::vector<std::string> features;
 
-        FullPackageSpec() noexcept = default;
+        FullPackageSpec() = default;
         explicit FullPackageSpec(PackageSpec spec, std::vector<std::string> features = {})
             : package_spec(std::move(spec)), features(std::move(features))
         {


### PR DESCRIPTION
This PR fixes #9955, however it does not introduce a way to ensure this is maintainable long term.

Tested using docker with `centos:7`:
```bash
yum install centos-release-scl
yum install devtoolset-8
scl enable devtoolset-8 bash
./bootstrap-vcpkg.sh
```

- What does your PR fix? Fixes #9955

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes