### PR TITLE
[vcpkg] Improve performance of compiler tracking

### DIFF
--- a/scripts/detect_compiler/CMakeLists.txt
+++ b/scripts/detect_compiler/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
-project(detect_compiler)
+project(detect_compiler NONE)
+
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_C_COMPILER_ID_RUN 1)
+set(CMAKE_C_COMPILER_FORCED 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_ID_RUN 1)
+set(CMAKE_CXX_COMPILER_FORCED 1)
+
+enable_language(C)
+enable_language(CXX)
 
 file(SHA1 "${CMAKE_CXX_COMPILER}" CXX_HASH)
 file(SHA1 "${CMAKE_C_COMPILER}" C_HASH)

--- a/scripts/detect_compiler/CONTROL
+++ b/scripts/detect_compiler/CONTROL
@@ -1,0 +1,3 @@
+Source: detect-compiler
+Version: 0
+Description: None


### PR DESCRIPTION
This PR improves compiler tracking performance by suppressing unused aspects of the compiler detection process. We simply hash the `CMAKE_CXX_COMPILER` and `CMAKE_C_COMPILER` executables, so we don't care about the compiler's vendor ID or ABI (that information is captured elsewhere).

This PR also fixes a regression introduced with manifest files that now better enforce the requirement of having a `CONTROL`/`vcpkg.json`.

Related: #11204 