### PR TITLE
[xerces-c] rename feature from xmlch_wchar to xmlch-wchar

### DIFF
--- a/ports/xerces-c/CONTROL
+++ b/ports/xerces-c/CONTROL
@@ -1,5 +1,5 @@
 Source: xerces-c
-Version: 3.2.3
+Version: 3.2.3-1
 Homepage: https://github.com/apache/xerces-c
 Description: Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.
 
@@ -7,6 +7,6 @@ Feature: icu
 Description: ICU support
 Build-Depends: icu
 
-Feature: xmlch_wchar
+Feature: xmlch-wchar
 Description: XMLCh type uses wchar_t
 

--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -13,7 +13,7 @@ set(DISABLE_ICU ON)
 if("icu" IN_LIST FEATURES)
     set(DISABLE_ICU OFF)
 endif()
-if ("xmlch_wchar" IN_LIST FEATURES)
+if ("xmlch-wchar" IN_LIST FEATURES)
     set(XMLCHTYPE -Dxmlch-type=wchar_t)
 endif()
 


### PR DESCRIPTION
- What does your PR fix?

Error: :1:21: invalid character in feature name (must be lowercase, digits, '-')
on expression: xerces-c[xmlch_wchar]

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes