### PR TITLE
[azure-iot-sdk-c] Fix feature name and enable to build

### DIFF
--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,5 +1,5 @@
 Source: azure-iot-sdk-c
-Version: 2020-06-17-1
+Version: 2020-06-17-2
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services
 Homepage: https://github.com/Azure/azure-iot-sdk-c
@@ -8,5 +8,5 @@ Feature: public-preview
 Description: A version of the azure-iot-sdk-c containing public-preview features.
 Build-Depends: azure-uamqp-c[public-preview], azure-umqtt-c[public-preview], azure-c-shared-utility[public-preview], azure-uhttp-c[public-preview], azure-macro-utils-c[public-preview], umock-c[public-preview]
 
-Feature: use_prov_client
+Feature: use-prov-client
 Description: Enables device provisioning client for DPS

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -24,13 +24,9 @@ else()
     )
 endif()
 
-if("use_prov_client" IN_LIST FEATURES)
-    message(STATUS "use prov_client")
-    set(USE_PROV_CLIENT 1)
-else()
-    message(STATUS "NO prov_client")
-    set(USE_PROV_CLIENT 0)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    use-prov-client use_prov_client
+)
 
 file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/azure-c-shared-utility/configs/)
 file(COPY ${SOURCE_PATH}/configs/azure_iot_sdksFunctions.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/cmake/azure_iot_sdks/)
@@ -38,13 +34,12 @@ file(COPY ${SOURCE_PATH}/configs/azure_iot_sdksFunctions.cmake DESTINATION ${CUR
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -Dskip_samples=ON
         -Duse_installed_dependencies=ON
         -Duse_default_uuid=ON
         -Dbuild_as_dynamic=OFF
         -Duse_edge_modules=ON
-        -Duse_prov_client=${USE_PROV_CLIENT}
         -Dhsm_type_symm_key=${USE_PROV_CLIENT}
 )
 
@@ -57,4 +52,3 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
 
 vcpkg_copy_pdbs()
-

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -40,7 +40,7 @@ vcpkg_configure_cmake(
         -Duse_default_uuid=ON
         -Dbuild_as_dynamic=OFF
         -Duse_edge_modules=ON
-        -Dhsm_type_symm_key=${USE_PROV_CLIENT}
+        -Dhsm_type_symm_key=${use_prov_client}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Update feature name `use_prov_client` as `use-prov-client` and make sure this feature can work.

Also update the way to handle features as `vcpkg_check_features()`.

Fix #12180 

Note: All features have passed with the following triplets:
- x86-windows
- x64-windows
- x64-windows-static
