### PR TITLE
[libyuv] Find dependency port libjpeg-turbo

### DIFF
--- a/ports/libyuv/CONTROL
+++ b/ports/libyuv/CONTROL
@@ -1,4 +1,4 @@
 Source: libyuv
-Version: fec9121-1
+Version: fec9121-2
 Build-Depends: libjpeg-turbo
 Description: libyuv is an open source project that includes YUV scaling and conversion functionality.

--- a/ports/libyuv/fix-build-type.patch
+++ b/ports/libyuv/fix-build-type.patch
@@ -40,14 +40,14 @@ index 097434b..8f8864f 100644
 -INSTALL ( TARGETS yuvconvert DESTINATION bin )
 +INSTALL ( TARGETS yuvconvert DESTINATION tools )
  INSTALL ( FILES ${ly_include_files} DESTINATION include/libyuv )
--INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-export DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
--INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-export LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
+-INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-targets DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
+-INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-targets LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
 -
 +if (NOT BUILD_SHARED_LIBS)
-+    INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-export DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
++    INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-targets DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
 +else()
-+    INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-export LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
++    INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-targets LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
 +endif()
- INSTALL( EXPORT libyuv-export FILE libyuv-config.cmake DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )
+ INSTALL( EXPORT libyuv-targets DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )
  
  # create the .deb and .rpm packages using cpack

--- a/ports/libyuv/fix_cmakelists.patch
+++ b/ports/libyuv/fix_cmakelists.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ed4948f0..9f48ebde 100644
+index ed4948f..5b4e112 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -2,10 +2,14 @@
@@ -52,10 +52,10 @@ index ed4948f0..9f48ebde 100644
 -INSTALL ( DIRECTORY ${PROJECT_SOURCE_DIR}/include/		DESTINATION include )
 +INSTALL ( TARGETS yuvconvert DESTINATION bin )
 +INSTALL ( FILES ${ly_include_files} DESTINATION include/libyuv )
-+INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-export DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
-+INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-export LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
++INSTALL ( TARGETS ${ly_lib_static} EXPORT libyuv-targets DESTINATION lib INCLUDES DESTINATION include PUBLIC_HEADER DESTINATION include )
++INSTALL ( TARGETS ${ly_lib_shared} EXPORT libyuv-targets LIBRARY DESTINATION lib RUNTIME DESTINATION bin )
 +
-+INSTALL( EXPORT libyuv-export FILE libyuv-config.cmake DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )
++INSTALL( EXPORT libyuv-targets DESTINATION share/cmake/libyuv/ EXPORT_LINK_INTERFACE_LIBRARIES )
  
  # create the .deb and .rpm packages using cpack
  INCLUDE ( CM_linux_packages.cmake )

--- a/ports/libyuv/libyuv-config.cmake
+++ b/ports/libyuv/libyuv-config.cmake
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+find_dependency(JPEG REQUIRED)
+
+set(libyuv_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include")
+include("${CMAKE_CURRENT_LIST_DIR}/libyuv-targets.cmake")

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -23,5 +23,7 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/libyuv)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libyuv RENAME copyright)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/libyuv-config.cmake  ${CURRENT_PACKAGES_DIR}/share/libyuv COPYONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Add libyuv-config.cmake to handle 'can't not find libjpeg-turbo pkg" when use libyuv.
Update the patch to match the changes. it rename the targets file to config file before.

