### PR TITLE
[vcpkg] Remove use of std::variant and std::visit to fix VS2015.

### DIFF
--- a/toolsrc/include/vcpkg/base/stringview.h
+++ b/toolsrc/include/vcpkg/base/stringview.h
@@ -43,20 +43,7 @@ namespace vcpkg
         std::string to_string() const;
         void to_string(std::string& out) const;
 
-        constexpr StringView substr(size_t pos, size_t count = std::numeric_limits<size_t>::max()) const
-        {
-            if (pos > m_size)
-            {
-                return StringView();
-            }
-
-            if (count > m_size - pos)
-            {
-                return StringView(m_ptr + pos, m_size - pos);
-            }
-
-            return StringView(m_ptr + pos, count);
-        }
+        StringView substr(size_t pos, size_t count = std::numeric_limits<size_t>::max()) const;
 
         constexpr char byte_at_index(size_t pos) const { return m_ptr[pos]; }
 

--- a/toolsrc/src/vcpkg/base/stringview.cpp
+++ b/toolsrc/src/vcpkg/base/stringview.cpp
@@ -71,10 +71,25 @@ namespace vcpkg
         return result.front();
     }
 
-    StringView::StringView(const std::string& s) : m_ptr(s.data()), m_size(s.size()) { }
+    StringView::StringView(const std::string& s) : m_ptr(s.data()), m_size(s.size()) {}
 
     std::string StringView::to_string() const { return std::string(m_ptr, m_size); }
     void StringView::to_string(std::string& s) const { s.append(m_ptr, m_size); }
+
+    StringView StringView::substr(size_t pos, size_t count) const
+    {
+        if (pos > m_size)
+        {
+            return StringView();
+        }
+
+        if (count > m_size - pos)
+        {
+            return StringView(m_ptr + pos, m_size - pos);
+        }
+
+        return StringView(m_ptr + pos, count);
+    }
 
     bool operator==(StringView lhs, StringView rhs) noexcept
     {

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -578,7 +578,7 @@ namespace vcpkg
 
     void VcpkgCmdArguments::append_common_options(HelpTableFormatter& table)
     {
-        constexpr static auto opt = [](StringView arg, StringView joiner, StringView value) {
+        static auto opt = [](StringView arg, StringView joiner, StringView value) {
             return Strings::format("--%s%s%s", arg, joiner, value);
         };
 
@@ -683,9 +683,7 @@ namespace vcpkg
         {
             StringView flag;
             bool enabled;
-        } flags[] = {
-            {BINARY_CACHING_FEATURE, binary_caching_enabled()}
-        };
+        } flags[] = {{BINARY_CACHING_FEATURE, binary_caching_enabled()}};
 
         for (const auto& flag : flags)
         {


### PR DESCRIPTION
Fixes #12220. Additionally, the v140 toolset should be added to the CI infrastructure so we can avoid breakages in the future, however we should not hold back this hotfix waiting for a new CI rollout.
