### PR TITLE
[pcre] Use vcpkg_from_sourceforge as a fallback

### DIFF
--- a/ports/pcre/CONTROL
+++ b/ports/pcre/CONTROL
@@ -1,4 +1,4 @@
 Source: pcre
-Version: 8.44-4
+Version: 8.44-5
 Homepage: https://www.pcre.org/
 Description: Perl Compatible Regular Expressions

--- a/ports/pcre/CONTROL
+++ b/ports/pcre/CONTROL
@@ -1,4 +1,5 @@
 Source: pcre
-Version: 8.44-5
+Version: 8.44
+Port-Version: 5
 Homepage: https://www.pcre.org/
 Description: Perl Compatible Regular Expressions

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -1,21 +1,34 @@
 set(PCRE_VERSION 8.44)
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.zip"
-         "https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VERSION}/pcre-${PCRE_VERSION}.zip"
-    FILENAME "pcre-${PCRE_VERSION}.zip"
-    SHA512 adddec1236b25ff1c90e73835c2ba25d60a5839cbde2d6be7838a8ec099f7443dede931dc39002943243e21afea572eda71ee8739058e72235a192e4324398f0
-)
-
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    PATCHES
+set(EXPECTED_SHA adddec1236b25ff1c90e73835c2ba25d60a5839cbde2d6be7838a8ec099f7443dede931dc39002943243e21afea572eda71ee8739058e72235a192e4324398f0)
+set(PATCHES
         # Fix CMake Deprecation Warning concerning OLD behavior for policy CMP0026
         # Suppress MSVC compiler warnings C4703, C4146, C4308, which fixes errors
         # under x64-uwp and arm-uwp
-        pcre-8.44_suppress_cmake_and_compiler_warnings-errors.patch
+        pcre-8.44_suppress_cmake_and_compiler_warnings-errors.patch)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.zip"
+    FILENAME "pcre-${PCRE_VERSION}.zip"
+    SHA512 ${EXPECTED_SHA}
+    SILENT_EXIT
 )
+
+if (EXISTS "${ARCHIVE}")
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE ${ARCHIVE}
+        PATCHES ${PATCHES}
+    )
+else()
+    vcpkg_from_sourceforge(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO pcre/pcre
+        REF ${PCRE_VERSION}
+        FILENAME "pcre-${PCRE_VERSION}.zip"
+        SHA512 ${EXPECTED_SHA}
+        PATCHES ${PATCHES}
+    )
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
When I did pcre2 in https://github.com/microsoft/vcpkg/pull/12233 I didn't realize there was a plain pcre to fix up.