### PR TITLE
[vcpkg] Revert change which causes sources to be purged by default in `vcpkg build`

### DIFF
--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -126,6 +126,8 @@ namespace vcpkg::Build
         Checks::check_exit(VCPKG_LINE_INFO, action != nullptr);
         ASSUME(action != nullptr);
         action->build_options = default_build_package_options;
+        action->build_options.clean_buildtrees = CleanBuildtrees::NO;
+        action->build_options.clean_packages = CleanPackages::NO;
 
         const auto build_timer = Chrono::ElapsedTimer::create_started();
         const auto result = Build::build_package(paths, *action, binaryprovider, build_logs_recorder, status_db);


### PR DESCRIPTION
`vcpkg build` is a semi-documented command used for inner-loop package development. During this development, it's important that the sources and package files are kept around after failures for inspection and improvement.