### PR TITLE
[nanodbc] Set unixodbc as a dependency under non-Windows

### DIFF
--- a/ports/nanodbc/CONTROL
+++ b/ports/nanodbc/CONTROL
@@ -1,5 +1,6 @@
 Source: nanodbc
-Version: 2.12.4-8
+Version: 2.12.4
+Port-Version: 9
 Homepage: https://github.com/lexicalunit/nanodbc
 Description: A small C++ wrapper for the native C ODBC API.
-Build-Depends: unixodbc
+Build-Depends: unixodbc(!windows)


### PR DESCRIPTION
Fixes #12248.