### PR TITLE
Fix CMake Error at scripts/ports.cmake

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -93,7 +93,7 @@ elseif(CMD MATCHES "^CREATE$")
     if(NOT FILENAME)
         get_filename_component(FILENAME "${URL}" NAME)
     endif()
-    string(REGEX REPLACE "(\\.(zip|gz|tar|tgz|bz2))+\$" "" ROOT_NAME ${FILENAME})
+    string(REGEX REPLACE "(\\.(zip|gz|tar|tgz|bz2))+\$" "" ROOT_NAME ${FILENAME} "" "")
 
     set(DOWNLOAD_PATH "${DOWNLOADS}/${FILENAME}")
     file(TO_NATIVE_PATH ${DOWNLOAD_PATH} NATIVE_DOWNLOAD_PATH)


### PR DESCRIPTION
**Describe the pull request**

An error occurred while exec the command: `vcpkg create demo ./`
Error Message: `string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command.`

my env : 
CMake version: 3.17.3

- What does your PR fix? Fixes #
Fix CMake Error at scripts/ports.cmake

- Which triplets are supported/not supported? Have you updated the CI baseline?
No need to update the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?