### PR TITLE
[uchardet] Update to 0.0.7

### DIFF
--- a/ports/uchardet/CONTROL
+++ b/ports/uchardet/CONTROL
@@ -1,5 +1,5 @@
 Source: uchardet
-Version: 2020-04-26
+Version: 0.0.7
 Description: An encoding detector library ported from Mozilla
 Homepage: https://cgit.freedesktop.org/uchardet/uchardet/
 

--- a/ports/uchardet/portfile.cmake
+++ b/ports/uchardet/portfile.cmake
@@ -1,7 +1,9 @@
-vcpkg_from_git(
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://gitlab.freedesktop.org/uchardet/uchardet
-    REF 8681fc060ea07f646434cd2d324e4a5aa7c495c4
+    REPO uchardet/uchardet
+    REF v0.0.7
+    SHA512 d5a12fdc42b0431aa6112e3d906568b15a181d49718d5f9c983e1bdf4827bc0b43aed0ebd08952ddc275e10ad52a3badf96ef40537268b1c355b2c248b1d2aaa
 )
 
 vcpkg_check_features(


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Update uchardet to release 0.0.7. The previous port uses a git commit between 0.0.6 and 0.0.7.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Nothing changed.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.