### PR TITLE
[itk] Fix find dependency gdcm

### DIFF
--- a/ports/itk/CONTROL
+++ b/ports/itk/CONTROL
@@ -1,8 +1,9 @@
 Source: itk
-Version: 5.0.1-2
+Version: 5.0.1
+Port-Version: 3
 Description: Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.
 Homepage: https://github.com/InsightSoftwareConsortium/ITK
-Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp], openjpeg
+Build-Depends: double-conversion, libjpeg-turbo, zlib, libpng, tiff, expat, eigen3, hdf5[cpp], openjpeg, gdcm
 
 Feature: vtk
 Description: Build ITKVtkGlue module.

--- a/ports/itk/fix-depends-gdcm.patch
+++ b/ports/itk/fix-depends-gdcm.patch
@@ -1,0 +1,21 @@
+diff --git a/Modules/ThirdParty/GDCM/CMakeLists.txt b/Modules/ThirdParty/GDCM/CMakeLists.txt
+index f1b68ef..3ac1f33 100644
+--- a/Modules/ThirdParty/GDCM/CMakeLists.txt
++++ b/Modules/ThirdParty/GDCM/CMakeLists.txt
+@@ -10,14 +10,14 @@ if(ITK_USE_SYSTEM_GDCM)
+   # When this module is loaded by an app, load GDCM too.
+   set(ITKGDCM_EXPORT_CODE_INSTALL "
+ set(GDCM_DIR \"${GDCM_DIR}\")
+-find_package(GDCM REQUIRED)
++find_package(GDCM CONFIG REQUIRED)
+ ")
+   set(ITKGDCM_EXPORT_CODE_BUILD "
+ if(NOT ITK_BINARY_DIR)
+   set(CMAKE_MODULE_PATH \"${CMAKE_CURRENT_SOURCE_DIR}/CMake\" \${CMAKE_MODULE_PATH})
+ 
+   set(GDCM_DIR \"${GDCM_DIR}\")
+-  find_package(GDCM REQUIRED)
++  find_package(GDCM CONFIG REQUIRED)
+ endif()
+ ")
+ 

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_buildpath_length_warning(37)
 
 vcpkg_from_github(
@@ -11,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         fix_openjpeg_search.patch
         fix_libminc_config_path.patch
+        fix-depends-gdcm.patch
 )
 
 if ("vtk" IN_LIST FEATURES)
@@ -37,6 +36,7 @@ vcpkg_configure_cmake(
         -DITK_INSTALL_PACKAGE_DIR=share/itk
         -DITK_USE_64BITS_IDS=${USE_64BITS_IDS}
         -DITK_USE_CONCEPT_CHECKING=ON
+        -DITK_USE_SYSTEM_GDCM=ON
         #-DITK_USE_SYSTEM_LIBRARIES=ON # enables USE_SYSTEM for all third party libraries, some of which do not have vcpkg ports such as CastXML, SWIG, MINC etc
         -DITK_USE_SYSTEM_DOUBLECONVERSION=ON
         -DITK_USE_SYSTEM_EXPAT=ON


### PR DESCRIPTION
Use vcpkg gdcm instead of built-in gdcm.

Fixes #12298.