### PR TITLE
[vcpkg ci] Update formatting CI

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -5,7 +5,20 @@ variables:
   windows-pool: 'PrWin-2020-06-30'
   linux-pool: 'PrLin-2020-06-30'
 
-jobs:
+stages:
+- stage: check-formatting
+  pool: $(windows-pool)
+  jobs:
+  - job:
+    steps:
+    - task: Powershell@2
+      displayName: 'Check C++ Formatting'
+      inputs:
+        filePath: 'scripts/azure-pipelines/windows/check-formatting.ps1'
+        arguments: '-Toolsrc ./toolsrc'
+- stage: run-port-ci
+  dependsOn: check-formatting
+  jobs:
   - template: windows/azure-pipelines.yml
     parameters:
       triplet: x86-windows

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -32,7 +32,7 @@ stages:
 - stage: run_port_ci
   displayName: 'Run the Port CI'
   dependsOn:
-  - check_formatting
+  - check_cxx_formatting
   - check_manifest_formatting
   jobs:
   - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -6,7 +6,8 @@ variables:
   linux-pool: 'PrLin-2020-06-30'
 
 stages:
-- stage: check_formatting
+- stage: check_cxx_formatting
+  displayName: 'Check the formatting of the C++'
   pool: $(windows-pool)
   jobs:
   - job:
@@ -14,10 +15,25 @@ stages:
     - task: Powershell@2
       displayName: 'Check C++ Formatting'
       inputs:
-        filePath: 'scripts/azure-pipelines/windows/check-formatting.ps1'
+        filePath: 'scripts/azure-pipelines/windows/Check-CxxFormatting.ps1'
         arguments: '-Toolsrc ./toolsrc'
+- stage: check_manifest_formatting
+  displayName: Check the formatting of port manifests
+  pool: $(windows-pool)
+  dependsOn: []
+  jobs:
+  - job:
+    steps:
+    - task: Powershell@2
+      displayName: 'Check port manifest Formatting'
+      inputs:
+        filePath: 'scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1'
+        arguments: '-PortsTree ./ports'
 - stage: run_port_ci
-  dependsOn: check_formatting
+  displayName: 'Run the Port CI'
+  dependsOn:
+  - check_formatting
+  - check_manifest_formatting
   jobs:
   - template: windows/azure-pipelines.yml
     parameters:

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -16,7 +16,7 @@ stages:
       displayName: 'Check C++ Formatting'
       inputs:
         filePath: 'scripts/azure-pipelines/windows/Check-CxxFormatting.ps1'
-        arguments: '-Toolsrc ./toolsrc'
+        arguments: '-Root .'
 - stage: check_manifest_formatting
   displayName: Check the formatting of port manifests
   pool: $(windows-pool)
@@ -28,7 +28,7 @@ stages:
       displayName: 'Check port manifest Formatting'
       inputs:
         filePath: 'scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1'
-        arguments: '-PortsTree ./ports'
+        arguments: '-Root . -Downloads D:\Downloads'
 - stage: run_port_ci
   displayName: 'Run the Port CI'
   dependsOn:

--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   linux-pool: 'PrLin-2020-06-30'
 
 stages:
-- stage: check-formatting
+- stage: check_formatting
   pool: $(windows-pool)
   jobs:
   - job:
@@ -16,8 +16,8 @@ stages:
       inputs:
         filePath: 'scripts/azure-pipelines/windows/check-formatting.ps1'
         arguments: '-Toolsrc ./toolsrc'
-- stage: run-port-ci
-  dependsOn: check-formatting
+- stage: run_port_ci
+  dependsOn: check_formatting
   jobs:
   - template: windows/azure-pipelines.yml
     parameters:

--- a/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
@@ -1,9 +1,7 @@
-#Requires -Version 3.0
-
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True)]
-    [string]$Toolsrc,
+    [string]$Root,
     [Parameter()]
     [switch]$IgnoreErrors # allows one to just format
 )
@@ -15,20 +13,20 @@ if (-not (Test-Path $clangFormat))
     throw
 }
 
-$Toolsrc = Get-Item $Toolsrc
-Push-Location $Toolsrc
+$toolsrc = Get-Item "$Root/toolsrc"
+Push-Location $toolsrc
 
 try
 {
-    $files = Get-ChildItem -Recurse -LiteralPath "$Toolsrc/src" -Filter '*.cpp'
-    $files += Get-ChildItem -Recurse -LiteralPath "$Toolsrc/include/vcpkg" -Filter '*.h'
-    $files += Get-ChildItem -Recurse -LiteralPath "$Toolsrc/include/vcpkg-test" -Filter '*.h'
-    $files += Get-Item "$Toolsrc/include/pch.h"
+    $files = Get-ChildItem -Recurse -LiteralPath "$toolsrc/src" -Filter '*.cpp'
+    $files += Get-ChildItem -Recurse -LiteralPath "$toolsrc/include/vcpkg" -Filter '*.h'
+    $files += Get-ChildItem -Recurse -LiteralPath "$toolsrc/include/vcpkg-test" -Filter '*.h'
+    $files += Get-Item "$toolsrc/include/pch.h"
     $fileNames = $files.FullName
 
     & $clangFormat -style=file -i @fileNames
 
-    $changedFiles = & "$PSScriptRoot/Get-ChangedFiles.ps1" -Directory $Toolsrc
+    $changedFiles = & "$PSScriptRoot/Get-ChangedFiles.ps1" -Directory $toolsrc
     if (-not $IgnoreErrors -and $null -ne $changedFiles)
     {
         $msg = @(
@@ -41,7 +39,7 @@ try
         $msg += ""
 
         $msg += "clang-format should produce the following diff:"
-        $msg += git diff $Toolsrc
+        $msg += git diff $toolsrc
 
         Write-Error ($msg -join "`n")
         throw

--- a/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 3.0
+
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True)]
@@ -26,10 +28,7 @@ try
 
     & $clangFormat -style=file -i @fileNames
 
-    $changedFiles = git status --porcelain $Toolsrc | ForEach-Object {
-        (-split $_)[1]
-    }
-
+    $changedFiles = & "$PSScriptRoot/Get-ChangedFiles.ps1" -Directory $Toolsrc
     if (-not $IgnoreErrors -and $null -ne $changedFiles)
     {
         $msg = @(

--- a/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
@@ -31,7 +31,7 @@ if (-not (Test-Path "$Root/vcpkg.exe"))
     }
 }
 
-& "$vcpkgRoot/vcpkg.exe" 'x-format-manifest' '--all'
+& "$Root/vcpkg.exe" 'x-format-manifest' '--all'
 $changedFiles = & "$PSScriptRoot/Get-ChangedFiles.ps1" -Directory $portsTree
 if (-not $IgnoreErrors -and $null -ne $changedFiles)
 {

--- a/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 3.0
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True)]
+    [string]$PortsTree,
+    [Parameter()]
+    [switch]$IgnoreErrors # allows one to just format
+)
+
+$vcpkgRoot = $PSScriptRoot ` # .../vcpkg/scripts/azure-pipelines/windows
+    | Split-Path ` # .../vcpkg/scripts/azure-pipelines
+    | Split-Path ` # .../vcpkg/scripts
+    | Split-Path # .../vcpkg
+
+$PortsTree = Get-Item $PortsTree
+
+if (-not (Test-Path "$vcpkgRoot/.vcpkg-root"))
+{
+    Write-Error "The vcpkg root was not at $vcpkgRoot; did the script get moved?"
+    throw
+}
+
+if (-not (Test-Path "$vcpkgRoot/vcpkg.exe"))
+{
+    & "$vcpkgRoot/bootstrap-vcpkg.bat"
+    if (-not $?)
+    {
+        Write-Error "Bootstrapping vcpkg failed"
+        throw
+    }
+}
+
+& "$vcpkgRoot/vcpkg.exe" 'x-format-manifest' '--all'
+$changedFiles = & "$PSScriptRoot/Get-ChangedFiles.ps1" -Directory $PortsTree
+if (-not $IgnoreErrors -and $null -ne $changedFiles)
+{
+    $msg = @(
+        "",
+        "The formatting of the manifest files didn't match our expectation.",
+        "If your build fails here, you need to run:"
+    )
+    $msg += "    vcpkg x-format-manifest --all"
+    $msg += ""
+
+    $msg += "vcpkg should produce the following diff:"
+    $msg += git diff $Toolsrc
+
+    Write-Error ($msg -join "`n")
+    throw
+}

--- a/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-ManifestFormatting.ps1
@@ -8,10 +8,14 @@ Param(
     [switch]$IgnoreErrors # allows one to just format
 )
 
-$vcpkgRoot = $PSScriptRoot ` # .../vcpkg/scripts/azure-pipelines/windows
-    | Split-Path ` # .../vcpkg/scripts/azure-pipelines
-    | Split-Path ` # .../vcpkg/scripts
-    | Split-Path # .../vcpkg
+# .../vcpkg/scripts/azure-pipelines/windows
+# .../vcpkg/scripts/azure-pipelines
+# .../vcpkg/scripts
+# .../vcpkg
+$vcpkgRoot = $PSScriptRoot `
+    | Split-Path `
+    | Split-Path `
+    | Split-Path
 
 $PortsTree = Get-Item $PortsTree
 

--- a/scripts/azure-pipelines/windows/Get-ChangedFiles.ps1
+++ b/scripts/azure-pipelines/windows/Get-ChangedFiles.ps1
@@ -1,0 +1,9 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True)]
+    [string]$Directory
+)
+
+git status --porcelain $Directory | ForEach-Object {
+    (-split $_)[1]
+}

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -20,13 +20,7 @@ jobs:
     condition: always()
     inputs:
       filePath: 'scripts/azure-pipelines/windows/disk-space.ps1'
-  - task: Powershell@2
-    displayName: 'Check C++ Formatting'
-    condition: eq('${{ parameters.triplet }}', 'x86-windows')
-    inputs:
-      filePath: 'scripts/azure-pipelines/windows/check-formatting.ps1'
-      arguments: '-Toolsrc ./toolsrc'
-    # Note: D: is the Azure machines' temporary disk.
+  # Note: D: is the Azure machines' temporary disk.
   - task: CmdLine@2
     displayName: 'Build vcpkg'
     inputs:


### PR DESCRIPTION
First, stage the formatting, so that we don't run CI if the formatting is wonky; second, format port manifests in CI with `x-format-manifest`.