### PR TITLE
[vcpkg.targets] Fix #12292 regression with MSBuild targets

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg-general.xml
+++ b/scripts/buildsystems/msbuild/vcpkg-general.xml
@@ -37,7 +37,7 @@
   </BoolProperty>
   <BoolProperty Name="VcpkgAutoLink"
                 DisplayName="Use AutoLink"
-                Description="Enables automatic linking with libraries build using Vcpkg"
+                Description="Enables automatic linking with libraries build using Vcpkg. Does not work with lld-link.exe."
                 Category="General"
                 Default="true">
   </BoolProperty>

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -64,7 +64,7 @@
     <VcpkgApplocalDeps Condition="'$(VcpkgApplocalDeps)' == ''">true</VcpkgApplocalDeps>
     <!-- Deactivate Autolinking if lld is used as a linker. (Until a better way to solve the problem is found!).
     Tried to add /lib as a parameter to the linker call but was unable to find a way to pass it as the first parameter. -->
-    <VcpkgAutoLink Condition="'$(UseLldLink)' == 'true' and '$(VcpkgAutoLink)' == ''">false</VcpkgAutoLink>
+    <VcpkgAutoLink Condition="'$(UseLldLink)' == 'true'">false</VcpkgAutoLink>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(VcpkgEnabled)' == 'true'">


### PR DESCRIPTION
This PR fixes a regression that was introduced with the Property Pages.

Previously, `vcpkg.targets` disabled auto-linking when the user was using lld-link but retained the ability for the user to manually set `VcpkgAutoLink` to `true` and re-enable it. This relied on `VcpkgAutoLink` being empty if the user did not explicitly set it.

However, the Property Pages changes added a default value of `true` which could then be overridden by the user to `false`. This regressed the default suppression when users use lld-link.

- What does your PR fix? Fixes #12292
