### PR TITLE
[fontconfig] Fix fonts.conf install path

### DIFF
--- a/ports/fontconfig/CMakeLists.txt
+++ b/ports/fontconfig/CMakeLists.txt
@@ -74,8 +74,8 @@ if(NOT FC_SKIP_TOOLS)
     set(FC_CACHEDIR WINDOWSTEMPDIR_FONTCONFIG_CACHE)
     set(CONFIGDIR ./fonts/conf.d)
     configure_file(fonts.conf.in ${CMAKE_SOURCE_DIR}/fonts.conf @ONLY)
-    install(FILES fonts.conf DESTINATION tools/fontconfig/fonts)
-    install(DIRECTORY conf.d DESTINATION tools/fontconfig/fonts FILES_MATCHING PATTERN "*.conf")
+    install(FILES fonts.conf DESTINATION tools/fontconfig)
+    install(DIRECTORY conf.d DESTINATION tools/fontconfig FILES_MATCHING PATTERN "*.conf")
 endif()
 
 install(

--- a/ports/fontconfig/CONTROL
+++ b/ports/fontconfig/CONTROL
@@ -1,5 +1,6 @@
 Source: fontconfig
-Version: 2.12.4-10
+Version: 2.12.4
+Port-Version: 11
 Homepage: https://www.freedesktop.org/software/fontconfig/front.html
 Description: Library for configuring and customizing font access.
 Build-Depends: freetype, expat, libiconv, dirent

--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -1,6 +1,3 @@
-
-include(vcpkg_common_functions)
-
 set(FONTCONFIG_VERSION 2.12.4)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.freedesktop.org/software/fontconfig/release/fontconfig-${FONTCONFIG_VERSION}.tar.gz"
@@ -45,7 +42,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     endforeach()
 endif()
 
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/fontconfig)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/fontconfig/COPYING ${CURRENT_PACKAGES_DIR}/share/fontconfig/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
-vcpkg_test_cmake(PACKAGE_NAME unofficial-fontconfig)
+#vcpkg_test_cmake(PACKAGE_NAME unofficial-fontconfig)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #12307
Fix fonts.conf install path.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes