### PR TITLE
[vcpkg] Ignore dependencies not found errors when downloading mode

### DIFF
--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -954,7 +954,7 @@ namespace vcpkg::Build
             }
         }
 
-        if (!missing_fspecs.empty())
+        if (!missing_fspecs.empty() && !Util::Enum::to_bool(action.build_options.only_downloads))
         {
             return {BuildResult::CASCADED_DUE_TO_MISSING_DEPENDENCIES, std::move(missing_fspecs)};
         }


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/blob/811cb0cc387d786b30d216d6d5c3a4e6df7491c2/toolsrc/src/vcpkg/build.cpp#L957

Here, when the current port dependency is detected as unsuccessful, it will return failure, but it is not judged whether it is in download mode.

Fixes #10950.