### PR TITLE
[libyuv] Fix static build issue

### DIFF
--- a/ports/libyuv/CONTROL
+++ b/ports/libyuv/CONTROL
@@ -1,4 +1,6 @@
 Source: libyuv
-Version: fec9121-2
+Version: fec9121
+Port-Version: 3
+Homepage: https://chromium.googlesource.com/libyuv/libyuv
 Build-Depends: libjpeg-turbo
 Description: libyuv is an open source project that includes YUV scaling and conversion functionality.

--- a/ports/libyuv/fix-build-type.patch
+++ b/ports/libyuv/fix-build-type.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 50442cd..6358fd0 100644
+index 50442cd..fdc82f2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,25 +28,35 @@ LIST ( SORT			ly_unittest_sources )
+@@ -28,24 +28,32 @@ LIST ( SORT			ly_unittest_sources )
  INCLUDE_DIRECTORIES( BEFORE ${ly_inc_dir} )
  
  # this creates the static library (.a)
@@ -32,29 +32,17 @@ index 50442cd..6358fd0 100644
 -  include_directories( ${JPEG_INCLUDE_DIR} )
 -  target_link_libraries( ${ly_lib_shared} PUBLIC ${JPEG_LIBRARY} )
 -  target_link_libraries( yuvconvert ${JPEG_LIBRARY} )
--  add_definitions( -DHAVE_JPEG )
 +  include_directories( ${JPEG_INCLUDE_DIR})
 +  if( BUILD_SHARED_LIBS)
 +    target_link_libraries(${ly_lib_shared} PUBLIC ${JPEG_LIBRARY})
-+    target_compile_definitions(${ly_lib_shared} PUBLIC HAVE_JPEG)
 +  else()
 +    target_link_libraries(${ly_lib_static} PUBLIC ${JPEG_LIBRARY})
-+    target_compile_definitions(${ly_lib_static} PUBLIC HAVE_JPEG)
 +  endif()
 +  target_link_libraries(yuvconvert ${JPEG_LIBRARY})
-+  target_compile_definitions(yuvconvert PUBLIC HAVE_JPEG)
+   add_definitions( -DHAVE_JPEG )
  endif()
  
- if(TEST)
-@@ -73,6 +83,7 @@ if(TEST)
-   endif()
-   if (JPEG_FOUND)
-     target_link_libraries(libyuv_unittest ${JPEG_LIBRARY})
-+    target_compile_definitions(libyuv_unittest PUBLIC HAVE_JPEG)
-   endif()
- 
-   if(NACL AND NACL_LIBC STREQUAL "newlib")
-@@ -88,11 +99,13 @@ endif()
+@@ -88,11 +96,13 @@ endif()
  
  
  # install the conversion tool, .so, .a, and all the header files

--- a/ports/libyuv/fix-build-type.patch
+++ b/ports/libyuv/fix-build-type.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 097434b..8f8864f 100644
+index 50442cd..6358fd0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,21 +28,25 @@ LIST ( SORT			ly_unittest_sources )
+@@ -28,25 +28,35 @@ LIST ( SORT			ly_unittest_sources )
  INCLUDE_DIRECTORIES( BEFORE ${ly_inc_dir} )
  
  # this creates the static library (.a)
@@ -22,18 +22,39 @@ index 097434b..8f8864f 100644
 -TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_static} )
 -
 +if (BUILD_SHARED_LIBS)
-+    TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_shared} )
++    TARGET_LINK_LIBRARIES   ( yuvconvert ${ly_lib_shared} )
 +else()
-+    TARGET_LINK_LIBRARIES	( yuvconvert ${ly_lib_static} )
++    TARGET_LINK_LIBRARIES   ( yuvconvert ${ly_lib_static} )
 +endif()
  
  INCLUDE ( FindJPEG )
--if (JPEG_FOUND)
-+if (JPEG_FOUND AND BUILD_SHARED_LIBS)
-   include_directories( ${JPEG_INCLUDE_DIR} )
-   target_link_libraries( ${ly_lib_shared} PUBLIC ${JPEG_LIBRARY} )
-   target_link_libraries( yuvconvert ${JPEG_LIBRARY} )
-@@ -88,11 +92,13 @@ endif()
+ if (JPEG_FOUND)
+-  include_directories( ${JPEG_INCLUDE_DIR} )
+-  target_link_libraries( ${ly_lib_shared} PUBLIC ${JPEG_LIBRARY} )
+-  target_link_libraries( yuvconvert ${JPEG_LIBRARY} )
+-  add_definitions( -DHAVE_JPEG )
++  include_directories( ${JPEG_INCLUDE_DIR})
++  if( BUILD_SHARED_LIBS)
++    target_link_libraries(${ly_lib_shared} PUBLIC ${JPEG_LIBRARY})
++    target_compile_definitions(${ly_lib_shared} PUBLIC HAVE_JPEG)
++  else()
++    target_link_libraries(${ly_lib_static} PUBLIC ${JPEG_LIBRARY})
++    target_compile_definitions(${ly_lib_static} PUBLIC HAVE_JPEG)
++  endif()
++  target_link_libraries(yuvconvert ${JPEG_LIBRARY})
++  target_compile_definitions(yuvconvert PUBLIC HAVE_JPEG)
+ endif()
+ 
+ if(TEST)
+@@ -73,6 +83,7 @@ if(TEST)
+   endif()
+   if (JPEG_FOUND)
+     target_link_libraries(libyuv_unittest ${JPEG_LIBRARY})
++    target_compile_definitions(libyuv_unittest PUBLIC HAVE_JPEG)
+   endif()
+ 
+   if(NACL AND NACL_LIBC STREQUAL "newlib")
+@@ -88,11 +99,13 @@ endif()
  
  
  # install the conversion tool, .so, .a, and all the header files

--- a/ports/libyuv/libyuv-config.cmake
+++ b/ports/libyuv/libyuv-config.cmake
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
-find_dependency(JPEG REQUIRED)
+find_dependency(JPEG)
 
 set(libyuv_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include")
 include("${CMAKE_CURRENT_LIST_DIR}/libyuv-targets.cmake")

--- a/ports/libyuv/portfile.cmake
+++ b/ports/libyuv/portfile.cmake
@@ -25,5 +25,8 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/libyuv)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/libyuv/convert.h "#ifdef HAVE_JPEG" "#if 1")
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/libyuv/convert_argb.h "#ifdef HAVE_JPEG" "#if 1")
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/libyuv-config.cmake  ${CURRENT_PACKAGES_DIR}/share/libyuv COPYONLY)
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/12335

Changes:
1. The logic 'if (JPEG_FOUND AND BUILD_SHARED_LIBS)' change skips an entire block which defines loading dependent jpeg libraries In PR https://github.com/microsoft/vcpkg/pull/8769.  update it in the patch.
2. Replace the '#ifdef HAVE_JPEG' with '#if 1' in header files.
3. Remove 'REQUIRED' in find_dependency in config files.

Test pass with x64-windows-static:

CMakeLists.txt file:
```
cmake_minimum_required(VERSION 3.0)
project(example)
find_package(libyuv CONFIG REQUIRED)
add_executable(example example.cpp)
target_link_libraries(example PRIVATE yuv)
```
example.cpp file:
```
#include <iostream>
#include <libyuv/convert.h>

int main(int argc, char *argv[])
{
    int foo = libyuv::MJPGSize(nullptr, 42, nullptr, nullptr);
      return 0;
}
```