### PR TITLE
[pcre2] Fix -mshstk needed with -fcf-protection

### DIFF
--- a/ports/pcre2/CONTROL
+++ b/ports/pcre2/CONTROL
@@ -1,4 +1,5 @@
 Source: pcre2
 Version: 10.35
+Port-Version: 1
 Homepage: https://pcre.org/
 Description: PCRE2 is a re-working of the original Perl Compatible Regular Expressions library

--- a/ports/pcre2/pcre2-10.35_add_check_for_Intel_CET.patch
+++ b/ports/pcre2/pcre2-10.35_add_check_for_Intel_CET.patch
@@ -1,0 +1,26 @@
+--- a/CMakeLists.txt	2020-05-09 16:43:10.000000000 +0200
++++ b/CMakeLists.txt	2020-07-09 19:33:12.725648600 +0200
+@@ -146,6 +146,23 @@
+ )
+ set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})
+ 
++# Check whether Intel CET is enabled, and if so, adjust compiler flags. This
++# code was written by PH, trying to imitate the logic from the autotools 
++# configuration.
++
++CHECK_C_SOURCE_COMPILES(
++  "#ifndef __CET__
++   #error CET is not enabled
++   #endif
++   int main() { return 0; }"
++  INTEL_CET_ENABLED
++)
++
++IF (INTEL_CET_ENABLED)
++  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mshstk")
++ENDIF(INTEL_CET_ENABLED)
++
++
+ # User-configurable options
+ #
+ # Note: CMakeSetup displays these in alphabetical order, regardless of

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -4,6 +4,7 @@ set(PATCHES
         pcre2-10.35_fix-space.patch # Upstream: https://bugs.exim.org/show_bug.cgi?id=2588
         pcre2-10.35_fix-uwp.patch
         pcre2-10.35_fix_postfix_for_debug_Windows_builds.patch # Upstream: https://bugs.exim.org/show_bug.cgi?id=2600
+        pcre2-10.35_add_check_for_Intel_CET.patch # Upstream: https://bugs.exim.org/show_bug.cgi?id=2578
 )
 
 vcpkg_download_distfile(ARCHIVE


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
  - Fixes the following error:
  `src/sljit/sljitConfigInternal.h:219:2: error:`
  `#error "-mshstk is needed to compile with -fcf-protection"`
  - Upstream bug report:
  https://bugs.exim.org/show_bug.cgi?id=2578
  - Add patch based on upstream commit:
  https://vcs.pcre.org/pcre2?view=revision&revision=1256
  - Fixes #12343
- Which triplets are supported/not supported? Have you updated the CI baseline?
All official triplets are supported
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
