### PR TITLE
[vcpkg formatting] Fix format regex

### DIFF
--- a/toolsrc/.clang-format
+++ b/toolsrc/.clang-format
@@ -39,9 +39,9 @@ IncludeCategories:
     Priority: -1
   - Regex: '^<catch2/catch\.hpp>$'
     Priority: 1
-  - Regex: '^<vcpkg/base/*\.h>$'
+  - Regex: '^<vcpkg/base/.*\.h>$'
     Priority: 2
-  - Regex: '^<vcpkg/*\.h>$'
+  - Regex: '^<vcpkg/.*\.h>$'
     Priority: 3
   - Regex: '^<[a-z0-9_]*\.h>$'
     Priority: 4

--- a/toolsrc/include/vcpkg-test/util.h
+++ b/toolsrc/include/vcpkg-test/util.h
@@ -2,11 +2,12 @@
 
 #include <catch2/catch.hpp>
 
-#include <memory>
-
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/pragmas.h>
+
 #include <vcpkg/statusparagraph.h>
+
+#include <memory>
 
 #define CHECK_EC(ec)                                                                                                   \
     do                                                                                                                 \

--- a/toolsrc/include/vcpkg/archives.h
+++ b/toolsrc/include/vcpkg/archives.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Archives

--- a/toolsrc/include/vcpkg/base/chrono.h
+++ b/toolsrc/include/vcpkg/base/chrono.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <chrono>
-#include <string>
-
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/optional.h>
+
+#include <chrono>
+#include <string>
 
 namespace vcpkg::Chrono
 {

--- a/toolsrc/include/vcpkg/base/cofffilereader.h
+++ b/toolsrc/include/vcpkg/base/cofffilereader.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
-
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/machinetype.h>
+
+#include <vector>
 
 namespace vcpkg::CoffFileReader
 {

--- a/toolsrc/include/vcpkg/base/enums.h
+++ b/toolsrc/include/vcpkg/base/enums.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/lineinfo.h>
+
+#include <string>
 
 namespace vcpkg::Enums
 {

--- a/toolsrc/include/vcpkg/base/expected.h
+++ b/toolsrc/include/vcpkg/base/expected.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <system_error>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/stringliteral.h>
+
+#include <system_error>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/base/graphs.h
+++ b/toolsrc/include/vcpkg/base/graphs.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <vcpkg/base/checks.h>
+#include <vcpkg/base/system.print.h>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <vcpkg/base/checks.h>
-#include <vcpkg/base/system.print.h>
 
 namespace vcpkg::Graphs
 {

--- a/toolsrc/include/vcpkg/base/hash.h
+++ b/toolsrc/include/vcpkg/base/hash.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/files.h>
+
+#include <string>
 
 namespace vcpkg::Hash
 {

--- a/toolsrc/include/vcpkg/base/json.h
+++ b/toolsrc/include/vcpkg/base/json.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <vcpkg/base/expected.h>
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/parse.h>
+#include <vcpkg/base/stringview.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -7,11 +12,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <vcpkg/base/expected.h>
-#include <vcpkg/base/files.h>
-#include <vcpkg/base/parse.h>
-#include <vcpkg/base/stringview.h>
 
 namespace vcpkg::Json
 {

--- a/toolsrc/include/vcpkg/base/optional.h
+++ b/toolsrc/include/vcpkg/base/optional.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <type_traits>
-#include <utility>
-
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/pragmas.h>
+
+#include <type_traits>
+#include <utility>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/base/parse.h
+++ b/toolsrc/include/vcpkg/base/parse.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <memory>
-#include <string>
-
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/unicode.h>
+
 #include <vcpkg/textrowcol.h>
+
+#include <memory>
+#include <string>
 
 namespace vcpkg::Parse
 {

--- a/toolsrc/include/vcpkg/base/stringliteral.h
+++ b/toolsrc/include/vcpkg/base/stringliteral.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/zstringview.h>
+
+#include <string>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/base/strings.h
+++ b/toolsrc/include/vcpkg/base/strings.h
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <errno.h>
-#include <inttypes.h>
-#include <limits.h>
-
-#include <vector>
-
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/pragmas.h>
 #include <vcpkg/base/stringliteral.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/view.h>
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include <vector>
 
 namespace vcpkg::Strings::details
 {

--- a/toolsrc/include/vcpkg/base/stringview.h
+++ b/toolsrc/include/vcpkg/base/stringview.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <vcpkg/base/optional.h>
+
 #include <limits>
 #include <string>
 #include <vector>
-
-#include <vcpkg/base/optional.h>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/base/system.debug.h
+++ b/toolsrc/include/vcpkg/base/system.debug.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <atomic>
-
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/system.print.h>
+
+#include <atomic>
 
 namespace vcpkg::Debug
 {

--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/zstringview.h>
+
 #include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <vcpkg/base/files.h>
-#include <vcpkg/base/zstringview.h>
 
 namespace vcpkg::System
 {

--- a/toolsrc/include/vcpkg/base/zstringview.h
+++ b/toolsrc/include/vcpkg/base/zstringview.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <vcpkg/base/stringview.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <string>
-
-#include <vcpkg/base/stringview.h>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/binarycaching.h
+++ b/toolsrc/include/vcpkg/binarycaching.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/packagespec.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/toolsrc/include/vcpkg/binarycaching.private.h
+++ b/toolsrc/include/vcpkg/binarycaching.private.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/dependencies.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <string>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -1,20 +1,21 @@
 #pragma once
 
-#include <array>
-#include <map>
-#include <set>
-#include <vector>
-
 #include <vcpkg/base/cstringview.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/triplet.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <array>
+#include <map>
+#include <set>
+#include <vector>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/buildenvironment.h
+++ b/toolsrc/include/vcpkg/buildenvironment.h
@@ -1,8 +1,9 @@
+#include <vcpkg/base/system.process.h>
+
+#include <vcpkg/vcpkgpaths.h>
+
 #include <string>
 #include <vector>
-
-#include <vcpkg/base/system.process.h>
-#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/cmakevars.h
+++ b/toolsrc/include/vcpkg/cmakevars.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/optional.h>
+
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/toolsrc/include/vcpkg/commands.h
+++ b/toolsrc/include/vcpkg/commands.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <array>
-#include <map>
-#include <vector>
-
 #include <vcpkg/build.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <array>
+#include <map>
+#include <vector>
 
 namespace vcpkg::Commands
 {

--- a/toolsrc/include/vcpkg/dependencies.h
+++ b/toolsrc/include/vcpkg/dependencies.h
@@ -1,17 +1,18 @@
 #pragma once
 
-#include <functional>
-#include <map>
-#include <vector>
-
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <functional>
+#include <map>
+#include <vector>
 
 namespace vcpkg::Graphs
 {

--- a/toolsrc/include/vcpkg/export.chocolatey.h
+++ b/toolsrc/include/vcpkg/export.chocolatey.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
-
 #include <vcpkg/dependencies.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <vector>
 
 namespace vcpkg::Export::Chocolatey
 {

--- a/toolsrc/include/vcpkg/export.ifw.h
+++ b/toolsrc/include/vcpkg/export.ifw.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <vcpkg/dependencies.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <string>
+#include <vector>
 
 namespace vcpkg::Export::IFW
 {

--- a/toolsrc/include/vcpkg/export.prefab.h
+++ b/toolsrc/include/vcpkg/export.prefab.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
-
 #include <vcpkg/base/system.h>
+
 #include <vcpkg/dependencies.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <vector>
 
 namespace vcpkg::Export::Prefab
 {

--- a/toolsrc/include/vcpkg/globalstate.h
+++ b/toolsrc/include/vcpkg/globalstate.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <atomic>
-#include <string>
-
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/util.h>
+
+#include <atomic>
+#include <string>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/help.h
+++ b/toolsrc/include/vcpkg/help.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <string>
 
 namespace vcpkg::Help
 {

--- a/toolsrc/include/vcpkg/install.h
+++ b/toolsrc/include/vcpkg/install.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include <vector>
-
 #include <vcpkg/base/chrono.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <vector>
 
 namespace vcpkg::Install
 {

--- a/toolsrc/include/vcpkg/metrics.h
+++ b/toolsrc/include/vcpkg/metrics.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/util.h>
+
+#include <string>
 
 namespace vcpkg::Metrics
 {

--- a/toolsrc/include/vcpkg/packagespec.h
+++ b/toolsrc/include/vcpkg/packagespec.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/optional.h>
+
 #include <vcpkg/platform-expression.h>
 #include <vcpkg/triplet.h>
 

--- a/toolsrc/include/vcpkg/paragraphparser.h
+++ b/toolsrc/include/vcpkg/paragraphparser.h
@@ -1,14 +1,15 @@
 #pragma once
 
+#include <vcpkg/base/expected.h>
+
+#include <vcpkg/packagespec.h>
+#include <vcpkg/textrowcol.h>
+
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <vcpkg/base/expected.h>
-#include <vcpkg/packagespec.h>
-#include <vcpkg/textrowcol.h>
 
 namespace vcpkg::Parse
 {

--- a/toolsrc/include/vcpkg/paragraphs.h
+++ b/toolsrc/include/vcpkg/paragraphs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/expected.h>
+
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/paragraphparser.h>
 #include <vcpkg/vcpkgpaths.h>

--- a/toolsrc/include/vcpkg/platform-expression.h
+++ b/toolsrc/include/vcpkg/platform-expression.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
-#include <unordered_map>
-
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/stringview.h>
+
+#include <string>
+#include <unordered_map>
 
 namespace vcpkg::PlatformExpression
 {

--- a/toolsrc/include/vcpkg/portfileprovider.h
+++ b/toolsrc/include/vcpkg/portfileprovider.h
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/expected.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/sourceparagraph.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/toolsrc/include/vcpkg/postbuildlint.buildtype.h
+++ b/toolsrc/include/vcpkg/postbuildlint.buildtype.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <vcpkg/base/cstringview.h>
+
+#include <vcpkg/build.h>
+
 #include <array>
 #include <regex>
-
-#include <vcpkg/base/cstringview.h>
-#include <vcpkg/build.h>
 
 namespace vcpkg::PostBuildLint
 {

--- a/toolsrc/include/vcpkg/sourceparagraph.h
+++ b/toolsrc/include/vcpkg/sourceparagraph.h
@@ -5,6 +5,7 @@
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphparser.h>
 #include <vcpkg/platform-expression.h>

--- a/toolsrc/include/vcpkg/statusparagraph.h
+++ b/toolsrc/include/vcpkg/statusparagraph.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <map>
-
 #include <vcpkg/binaryparagraph.h>
+
+#include <map>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/statusparagraphs.h
+++ b/toolsrc/include/vcpkg/statusparagraphs.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <vcpkg/statusparagraph.h>
+
 #include <iterator>
 #include <memory>
-
-#include <vcpkg/statusparagraph.h>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/tools.h
+++ b/toolsrc/include/vcpkg/tools.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <vcpkg/base/files.h>
+
 #include <string>
 #include <utility>
-
-#include <vcpkg/base/files.h>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/triplet.h
+++ b/toolsrc/include/vcpkg/triplet.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/system.h>
+
 #include <vcpkg/vcpkgcmdarguments.h>
+
+#include <string>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/userconfig.h
+++ b/toolsrc/include/vcpkg/userconfig.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include <vcpkg/base/files.h>
+
+#include <string>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/stringliteral.h>
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace vcpkg
 {

--- a/toolsrc/include/vcpkg/vcpkglib.h
+++ b/toolsrc/include/vcpkg/vcpkglib.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/base/sortedvector.h>
+
 #include <vcpkg/statusparagraphs.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -5,6 +5,7 @@
 #include <vcpkg/base/lazy.h>
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/tools.h>

--- a/toolsrc/src/vcpkg-fuzz/main.cpp
+++ b/toolsrc/src/vcpkg-fuzz/main.cpp
@@ -1,15 +1,16 @@
-#include <string.h>
-
-#include <iostream>
-#include <sstream>
-#include <utility>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/unicode.h>
+
 #include <vcpkg/platform-expression.h>
+
+#include <string.h>
+
+#include <iostream>
+#include <sstream>
+#include <utility>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg-test/arguments.cpp
+++ b/toolsrc/src/vcpkg-test/arguments.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch.hpp>
 
-#include <vector>
-
 #include <vcpkg/vcpkgcmdarguments.h>
+
+#include <vector>
 
 using vcpkg::CommandSetting;
 using vcpkg::CommandStructure;

--- a/toolsrc/src/vcpkg-test/binarycaching.cpp
+++ b/toolsrc/src/vcpkg-test/binarycaching.cpp
@@ -1,14 +1,15 @@
 #include <catch2/catch.hpp>
 
-#include <string>
-
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/binarycaching.private.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/sourceparagraph.h>
 #include <vcpkg/vcpkgcmdarguments.h>
+
+#include <string>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg-test/commands.build.cpp
+++ b/toolsrc/src/vcpkg-test/commands.build.cpp
@@ -1,13 +1,15 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/files.h>
+
+#include <vcpkg/commands.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
+
 #include <iterator>
 #include <string>
 
 #include <vcpkg-test/util.h>
-#include <vcpkg/base/files.h>
-#include <vcpkg/commands.h>
-#include <vcpkg/vcpkgcmdarguments.h>
-#include <vcpkg/vcpkgpaths.h>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg-test/commands.create.cpp
+++ b/toolsrc/src/vcpkg-test/commands.create.cpp
@@ -1,12 +1,13 @@
 #include <catch2/catch.hpp>
 
-#include <iterator>
-#include <string>
-
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 #include <vcpkg/vcpkgpaths.h>
+
+#include <iterator>
+#include <string>
 
 TEST_CASE ("create smoke test", "[commands-create]")
 {

--- a/toolsrc/src/vcpkg-test/dependencies.cpp
+++ b/toolsrc/src/vcpkg-test/dependencies.cpp
@@ -1,10 +1,11 @@
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/mockcmakevarprovider.h>
-#include <vcpkg-test/util.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/paragraphparser.h>
 #include <vcpkg/sourceparagraph.h>
+
+#include <vcpkg-test/mockcmakevarprovider.h>
+#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Parse;

--- a/toolsrc/src/vcpkg-test/files.cpp
+++ b/toolsrc/src/vcpkg-test/files.cpp
@@ -1,12 +1,13 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/strings.h>
+
 #include <iostream>
 #include <random>
 #include <vector>
 
 #include <vcpkg-test/util.h>
-#include <vcpkg/base/files.h>
-#include <vcpkg/base/strings.h>
 
 using vcpkg::Test::AllowSymlinks;
 using vcpkg::Test::base_temporary_directory;

--- a/toolsrc/src/vcpkg-test/hash.cpp
+++ b/toolsrc/src/vcpkg-test/hash.cpp
@@ -1,11 +1,11 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/hash.h>
+
 #include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <map>
-
-#include <vcpkg/base/hash.h>
 
 namespace Hash = vcpkg::Hash;
 using vcpkg::StringView;

--- a/toolsrc/src/vcpkg-test/json.cpp
+++ b/toolsrc/src/vcpkg-test/json.cpp
@@ -1,10 +1,11 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/json.h>
+#include <vcpkg/base/unicode.h>
+
 #include <iostream>
 
 #include "math.h"
-#include <vcpkg/base/json.h>
-#include <vcpkg/base/unicode.h>
 
 // TODO: remove this once we switch to C++20 completely
 // This is the worst, but we also can't really deal with it any other way.

--- a/toolsrc/src/vcpkg-test/manifests.cpp
+++ b/toolsrc/src/vcpkg-test/manifests.cpp
@@ -1,10 +1,12 @@
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/util.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/sourceparagraph.h>
+
+#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Paragraphs;

--- a/toolsrc/src/vcpkg-test/optional.cpp
+++ b/toolsrc/src/vcpkg-test/optional.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch.hpp>
 
-#include <vector>
-
 #include <vcpkg/base/optional.h>
+
+#include <vector>
 
 namespace
 {

--- a/toolsrc/src/vcpkg-test/paragraph.cpp
+++ b/toolsrc/src/vcpkg-test/paragraph.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/util.h>
 #include <vcpkg/base/strings.h>
+
 #include <vcpkg/paragraphs.h>
+
+#include <vcpkg-test/util.h>
 
 namespace Strings = vcpkg::Strings;
 using vcpkg::Parse::Paragraph;

--- a/toolsrc/src/vcpkg-test/plan.cpp
+++ b/toolsrc/src/vcpkg-test/plan.cpp
@@ -1,16 +1,18 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/graphs.h>
+
+#include <vcpkg/dependencies.h>
+#include <vcpkg/portfileprovider.h>
+#include <vcpkg/sourceparagraph.h>
+#include <vcpkg/triplet.h>
+
 #include <memory>
 #include <unordered_map>
 #include <vector>
 
 #include <vcpkg-test/mockcmakevarprovider.h>
 #include <vcpkg-test/util.h>
-#include <vcpkg/base/graphs.h>
-#include <vcpkg/dependencies.h>
-#include <vcpkg/portfileprovider.h>
-#include <vcpkg/sourceparagraph.h>
-#include <vcpkg/triplet.h>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg-test/specifier.cpp
+++ b/toolsrc/src/vcpkg-test/specifier.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/packagespec.h>
 
 using namespace vcpkg;

--- a/toolsrc/src/vcpkg-test/statusparagraphs.cpp
+++ b/toolsrc/src/vcpkg-test/statusparagraphs.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/util.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/statusparagraphs.h>
+
+#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Paragraphs;

--- a/toolsrc/src/vcpkg-test/strings.cpp
+++ b/toolsrc/src/vcpkg-test/strings.cpp
@@ -1,12 +1,12 @@
 #include <catch2/catch.hpp>
 
+#include <vcpkg/base/strings.h>
+
 #include <stdint.h>
 
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <vcpkg/base/strings.h>
 
 TEST_CASE ("b32 encoding", "[strings]")
 {

--- a/toolsrc/src/vcpkg-test/system.cpp
+++ b/toolsrc/src/vcpkg-test/system.cpp
@@ -2,14 +2,14 @@
 
 #include <catch2/catch.hpp>
 
-#include <string>
-
 #include <vcpkg/base/optional.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/stringview.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/zstringview.h>
+
+#include <string>
 
 using vcpkg::nullopt;
 using vcpkg::Optional;

--- a/toolsrc/src/vcpkg-test/update.cpp
+++ b/toolsrc/src/vcpkg-test/update.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/util.h>
 #include <vcpkg/base/sortedvector.h>
+
 #include <vcpkg/update.h>
+
+#include <vcpkg-test/util.h>
 
 using namespace vcpkg;
 using namespace vcpkg::Update;

--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -2,11 +2,13 @@
 
 #include <catch2/catch.hpp>
 
-#include <vcpkg-test/util.h>
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/statusparagraph.h>
+
+#include <vcpkg-test/util.h>
 
 // used to get the implementation specific compiler flags (i.e., __cpp_lib_filesystem)
 #include <ciso646>

--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -1,10 +1,5 @@
 #include <vcpkg/base/system_headers.h>
 
-#include <cassert>
-#include <fstream>
-#include <memory>
-#include <random>
-
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/pragmas.h>
@@ -12,6 +7,7 @@
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/globalstate.h>
 #include <vcpkg/help.h>
@@ -20,6 +16,11 @@
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/userconfig.h>
 #include <vcpkg/vcpkglib.h>
+
+#include <cassert>
+#include <fstream>
+#include <memory>
+#include <random>
 
 #if defined(_WIN32)
 #pragma comment(lib, "ole32")

--- a/toolsrc/src/vcpkg/archives.cpp
+++ b/toolsrc/src/vcpkg/archives.cpp
@@ -1,7 +1,8 @@
 #include "pch.h"
 
-#include <vcpkg/archives.h>
 #include <vcpkg/base/system.process.h>
+
+#include <vcpkg/archives.h>
 #include <vcpkg/commands.h>
 
 namespace vcpkg::Archives

--- a/toolsrc/src/vcpkg/base/json.cpp
+++ b/toolsrc/src/vcpkg/base/json.cpp
@@ -1,11 +1,11 @@
 #include "pch.h"
 
-#include <inttypes.h>
-
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/unicode.h>
+
+#include <inttypes.h>
 
 namespace vcpkg::Json
 {

--- a/toolsrc/src/vcpkg/base/parse.cpp
+++ b/toolsrc/src/vcpkg/base/parse.cpp
@@ -1,12 +1,13 @@
 #include "pch.h"
 
-#include <utility>
-
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphparser.h>
+
+#include <utility>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg/base/stringview.cpp
+++ b/toolsrc/src/vcpkg/base/stringview.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
 
-#include <cstring>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/lineinfo.h>
 #include <vcpkg/base/stringview.h>
+
+#include <cstring>
 
 namespace vcpkg
 {

--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -1,12 +1,12 @@
 #include "pch.h"
 
-#include <ctime>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/util.h>
+
+#include <ctime>
 
 using namespace vcpkg::System;
 

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -1,13 +1,13 @@
 #include "pch.h"
 
-#include <ctime>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
+#include <ctime>
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>

--- a/toolsrc/src/vcpkg/base/uint128.cpp
+++ b/toolsrc/src/vcpkg/base/uint128.cpp
@@ -1,6 +1,6 @@
-#include <limits>
-
 #include <vcpkg/base/uint128.h>
+
+#include <limits>
 
 namespace vcpkg
 {

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/binarycaching.private.h>
 #include <vcpkg/build.h>

--- a/toolsrc/src/vcpkg/binaryparagraph.cpp
+++ b/toolsrc/src/vcpkg/binaryparagraph.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/paragraphparser.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -11,6 +11,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/build.h>
 #include <vcpkg/buildenvironment.h>

--- a/toolsrc/src/vcpkg/cmakevars.cpp
+++ b/toolsrc/src/vcpkg/cmakevars.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/base/span.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/buildenvironment.h>
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/dependencies.h>

--- a/toolsrc/src/vcpkg/commands.autocomplete.cpp
+++ b/toolsrc/src/vcpkg/commands.autocomplete.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/install.h>
 #include <vcpkg/metrics.h>

--- a/toolsrc/src/vcpkg/commands.cache.cpp
+++ b/toolsrc/src/vcpkg/commands.cache.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/stringliteral.h>
 #include <vcpkg/base/system.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/build.h>
 #include <vcpkg/commands.h>

--- a/toolsrc/src/vcpkg/commands.ciclean.cpp
+++ b/toolsrc/src/vcpkg/commands.ciclean.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/vcpkgcmdarguments.h>
 

--- a/toolsrc/src/vcpkg/commands.contact.cpp
+++ b/toolsrc/src/vcpkg/commands.contact.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/userconfig.h>

--- a/toolsrc/src/vcpkg/commands.cpp
+++ b/toolsrc/src/vcpkg/commands.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/export.h>

--- a/toolsrc/src/vcpkg/commands.create.cpp
+++ b/toolsrc/src/vcpkg/commands.create.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/buildenvironment.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>

--- a/toolsrc/src/vcpkg/commands.dependinfo.cpp
+++ b/toolsrc/src/vcpkg/commands.dependinfo.cpp
@@ -1,16 +1,17 @@
 #include "pch.h"
 
-#include <vector>
-
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/help.h>
 #include <vcpkg/input.h>
 #include <vcpkg/install.h>
 #include <vcpkg/packagespec.h>
+
+#include <vector>
 
 using vcpkg::Dependencies::ActionPlan;
 using vcpkg::Dependencies::InstallPlanAction;

--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -1,13 +1,14 @@
 #include "pch.h"
 
-#include <limits.h>
-
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/paragraphs.h>
+
+#include <limits.h>
 
 #if defined(_WIN32)
 namespace

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/commands.h>

--- a/toolsrc/src/vcpkg/commands.exportifw.cpp
+++ b/toolsrc/src/vcpkg/commands.exportifw.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/export.h>
 #include <vcpkg/export.ifw.h>

--- a/toolsrc/src/vcpkg/commands.format-manifest.cpp
+++ b/toolsrc/src/vcpkg/commands.format-manifest.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/system.debug.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/portfileprovider.h>
 

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/metrics.h>
 #include <vcpkg/userconfig.h>

--- a/toolsrc/src/vcpkg/commands.list.cpp
+++ b/toolsrc/src/vcpkg/commands.list.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/vcpkglib.h>

--- a/toolsrc/src/vcpkg/commands.owns.cpp
+++ b/toolsrc/src/vcpkg/commands.owns.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/vcpkglib.h>

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 

--- a/toolsrc/src/vcpkg/commands.portsdiff.cpp
+++ b/toolsrc/src/vcpkg/commands.portsdiff.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/commands.search.cpp
+++ b/toolsrc/src/vcpkg/commands.search.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/globalstate.h>

--- a/toolsrc/src/vcpkg/commands.setinstalled.cpp
+++ b/toolsrc/src/vcpkg/commands.setinstalled.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/globalstate.h>

--- a/toolsrc/src/vcpkg/commands.upgrade.cpp
+++ b/toolsrc/src/vcpkg/commands.upgrade.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/dependencies.h>

--- a/toolsrc/src/vcpkg/commands.version.cpp
+++ b/toolsrc/src/vcpkg/commands.version.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/metrics.h>

--- a/toolsrc/src/vcpkg/commands.xvsinstances.cpp
+++ b/toolsrc/src/vcpkg/commands.xvsinstances.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/visualstudio.h>

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/graphs.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/dependencies.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/export.chocolatey.cpp
+++ b/toolsrc/src/vcpkg/export.chocolatey.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/export.chocolatey.h>
 #include <vcpkg/export.h>

--- a/toolsrc/src/vcpkg/export.cpp
+++ b/toolsrc/src/vcpkg/export.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/export.chocolatey.h>

--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/commands.h>

--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/export.h>

--- a/toolsrc/src/vcpkg/input.cpp
+++ b/toolsrc/src/vcpkg/input.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/input.h>

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -4,6 +4,7 @@
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binarycaching.h>
 #include <vcpkg/build.h>
 #include <vcpkg/cmakevars.h>

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/json.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.process.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/metrics.h>
 

--- a/toolsrc/src/vcpkg/packagespec.cpp
+++ b/toolsrc/src/vcpkg/packagespec.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphparser.h>
 

--- a/toolsrc/src/vcpkg/paragraphparseresult.cpp
+++ b/toolsrc/src/vcpkg/paragraphparseresult.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/checks.h>
+
 #include <vcpkg/paragraphparseresult.h>
 
 namespace vcpkg

--- a/toolsrc/src/vcpkg/paragraphs.cpp
+++ b/toolsrc/src/vcpkg/paragraphs.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/binaryparagraph.h>
 #include <vcpkg/paragraphparseresult.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/platform-expression.cpp
+++ b/toolsrc/src/vcpkg/platform-expression.cpp
@@ -1,13 +1,14 @@
 #include "pch.h"
 
-#include <string>
-#include <vector>
-
 #include <vcpkg/base/parse.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/platform-expression.h>
+
+#include <string>
+#include <vector>
 
 namespace vcpkg::PlatformExpression
 {

--- a/toolsrc/src/vcpkg/portfileprovider.cpp
+++ b/toolsrc/src/vcpkg/portfileprovider.cpp
@@ -1,6 +1,7 @@
-#include <pch.h>
+#include "pch.h"
 
 #include <vcpkg/base/system.debug.h>
+
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/sourceparagraph.h>

--- a/toolsrc/src/vcpkg/postbuildlint.buildtype.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.buildtype.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/checks.h>
+
 #include <vcpkg/postbuildlint.buildtype.h>
 
 using vcpkg::Build::ConfigurationType;

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/packagespec.h>
 #include <vcpkg/postbuildlint.buildtype.h>

--- a/toolsrc/src/vcpkg/remove.cpp
+++ b/toolsrc/src/vcpkg/remove.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/dependencies.h>
 #include <vcpkg/help.h>

--- a/toolsrc/src/vcpkg/sourceparagraph.cpp
+++ b/toolsrc/src/vcpkg/sourceparagraph.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/packagespec.h>
 #include <vcpkg/platform-expression.h>
 #include <vcpkg/sourceparagraph.h>

--- a/toolsrc/src/vcpkg/statusparagraph.cpp
+++ b/toolsrc/src/vcpkg/statusparagraph.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/statusparagraph.h>
 
 using namespace vcpkg::Parse;

--- a/toolsrc/src/vcpkg/statusparagraphs.cpp
+++ b/toolsrc/src/vcpkg/statusparagraphs.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/checks.h>
+
 #include <vcpkg/statusparagraphs.h>
 
 namespace vcpkg

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-#include <vcpkg/archives.h>
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/files.h>
@@ -10,6 +9,8 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
+#include <vcpkg/archives.h>
 #include <vcpkg/tools.h>
 #include <vcpkg/vcpkgpaths.h>
 

--- a/toolsrc/src/vcpkg/triplet.cpp
+++ b/toolsrc/src/vcpkg/triplet.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/strings.h>
+
 #include <vcpkg/triplet.h>
 
 namespace vcpkg

--- a/toolsrc/src/vcpkg/update.cpp
+++ b/toolsrc/src/vcpkg/update.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/help.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/userconfig.cpp
+++ b/toolsrc/src/vcpkg/userconfig.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/lazy.h>
 #include <vcpkg/base/system.h>
+
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/userconfig.h>
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -2,6 +2,7 @@
 
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
+
 #include <vcpkg/commands.h>
 #include <vcpkg/globalstate.h>
 #include <vcpkg/metrics.h>

--- a/toolsrc/src/vcpkg/vcpkglib.cpp
+++ b/toolsrc/src/vcpkg/vcpkglib.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
 #include <vcpkg/vcpkglib.h>

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/build.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/globalstate.h>

--- a/toolsrc/src/vcpkg/versiont.cpp
+++ b/toolsrc/src/vcpkg/versiont.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include <vcpkg/base/strings.h>
+
 #include <vcpkg/versiont.h>
 
 namespace vcpkg

--- a/toolsrc/src/vcpkg/visualstudio.cpp
+++ b/toolsrc/src/vcpkg/visualstudio.cpp
@@ -7,6 +7,7 @@
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
 #include <vcpkg/base/util.h>
+
 #include <vcpkg/visualstudio.h>
 
 namespace vcpkg::VisualStudio

--- a/toolsrc/src/vcpkgmetricsuploader.cpp
+++ b/toolsrc/src/vcpkgmetricsuploader.cpp
@@ -1,10 +1,11 @@
 #include <vcpkg/base/system_headers.h>
 
-#include <shellapi.h>
-
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
+
 #include <vcpkg/metrics.h>
+
+#include <shellapi.h>
 
 using namespace vcpkg;
 


### PR DESCRIPTION
The existing regexes use `/*` to mean `/.*`, which doesn't work! Fix this bug.