### PR TITLE
[vcpkg] proper errorcheck during files installation

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -34,6 +34,7 @@ namespace vcpkg::Files
             WIN32_FILE_ATTRIBUTE_DATA file_attributes;
             auto ft = file_type::unknown;
             auto permissions = perms::unknown;
+            ec.clear();
             if (!GetFileAttributesExW(p.c_str(), GetFileExInfoStandard, &file_attributes))
             {
                 const auto err = GetLastError();

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -75,6 +75,7 @@ namespace vcpkg::Install
         output.push_back(Strings::format(R"(%s/)", destination_subdirectory));
         for (auto&& file : files)
         {
+            ec.clear();
             const auto status = fs.symlink_status(file, ec);
             if (ec)
             {

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -75,7 +75,6 @@ namespace vcpkg::Install
         output.push_back(Strings::format(R"(%s/)", destination_subdirectory));
         for (auto&& file : files)
         {
-            ec.clear();
             const auto status = fs.symlink_status(file, ec);
             if (ec)
             {


### PR DESCRIPTION
If during `install_files_and_write_listfile` an error happens in `for (auto&& file : files)` loop, every file in `files` is skipped due to "saved" error, even if `fs.symlink_status(file, ec)` succeeds.

This PR fixes the behavior, correct files aren't skipped.

Sample output of `vcpkg install libressl[tools]:x64-windows`

without fix - vcpkg complains every file after an error occurs

```
Building package libressl[core,tools]:x64-windows... done
Installing package libressl[core,tools]:x64-windows...
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\debug\lib\crypto.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\debug\lib\ssl-47.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\debug\lib\ssl.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\debug\lib\tls-19.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\debug\lib\tls.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\etc: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\etc\ssl: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\etc\ssl\cert.pem: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\packages\libressl_x64-windows\etc\ssl\openssl.cnf: A required privilege is not held by the client.
...
   and about 100 wrong files
...
Installing package libressl[core,tools]:x64-windows... done
```

with fix - only proper errors

```
Building package libressl[core,tools]:x64-windows... done
Installing package libressl[core,tools]:x64-windows...
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\debug\lib\crypto.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\debug\lib\ssl.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\debug\lib\tls.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\lib\crypto.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\lib\ssl.lib: A required privilege is not held by the client.
failed: C:\SRC\vcpkg\toolsrc\msbuild.x64.debug\installed\x64-windows\lib\tls.lib: A required privilege is not held by the client.
Installing package libressl[core,tools]:x64-windows... done
```

