### PR TITLE
[vcpkg-ci] Always publish file lists

### DIFF
--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -51,11 +51,11 @@ jobs:
   - bash: |
       python3 scripts/file_script.py /mnt/vcpkg-ci/installed/vcpkg/info/
     displayName: 'Build a file list for all packages'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
 
   - task: PublishBuildArtifacts@1
     displayName: 'Upload file lists for all packages'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
 
     inputs:
       PathtoPublish: scripts/list_files

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -55,11 +55,11 @@ jobs:
   - bash: |
       python3 scripts/file_script.py /Users/vagrant/Data/installed/vcpkg/info/
     displayName: 'Build a file list for all packages'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
 
   - task: PublishBuildArtifacts@1
     displayName: 'Upload file lists for all packages'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
 
     inputs:
       PathtoPublish: scripts/list_files

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
     condition: failed()
   - task: PowerShell@2
     displayName: "Generating all packages files"
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
 
     inputs:
       targetType: inline
@@ -73,7 +73,7 @@ jobs:
         & $(.\vcpkg fetch python3) .\scripts\file_script.py D:\installed\vcpkg\info\
   - task: PublishBuildArtifacts@1
     displayName: 'Upload file lists for all packages'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: always()
     inputs:
       PathtoPublish: scripts/list_files
       ArtifactName: "${{ parameters.triplet }} package file lists"

--- a/scripts/file_script.py
+++ b/scripts/file_script.py
@@ -28,11 +28,14 @@ def main(path):
     except FileExistsError:
         print("Path already exists, continuing...")
 
-    headers = open("scripts/list_files/VCPKGHeadersDatabase.txt", mode='w')
-    output = open("scripts/list_files/VCPKGDatabase.txt", mode='w')
-    gen_all_file_strings(path, getFiles(path), headers, output)
-    headers.close()
-    output.close()
+    try:
+        headers = open("scripts/list_files/VCPKGHeadersDatabase.txt", mode='w')
+        output = open("scripts/list_files/VCPKGDatabase.txt", mode='w')
+        gen_all_file_strings(path, getFiles(path), headers, output)
+        headers.close()
+        output.close()
+    except e:
+        print("Failed to generate file lists")
 
 if __name__ == "__main__":
     main(sys.argv[1])


### PR DESCRIPTION
In PR builds, it is still sometimes useful to observe the list of files that will be produced from the new packages in the PR.

In CI builds, even if some packages fail to build or violate the baseline, it is useful to observe the incomplete list of files.
