### PR TITLE
[vcpkg] Add CMake heuristics for header-only libraries

### DIFF
--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -622,7 +622,7 @@ namespace vcpkg::Install
                 if (Strings::case_insensitive_ascii_contains(suffix, "/lib/") ||
                     Strings::case_insensitive_ascii_contains(suffix, "/bin/"))
                 {
-                    if (!Strings::ends_with(suffix, ".pc")) is_header_only = false;
+                    if (!Strings::ends_with(suffix, ".pc") && !Strings::ends_with(suffix, "/")) is_header_only = false;
                 }
 
                 if (is_header_only && header_path.empty())

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -578,6 +578,8 @@ namespace vcpkg::Install
         {
             std::map<std::string, std::string> config_files;
             std::map<std::string, std::vector<std::string>> library_targets;
+            bool is_header_only = true;
+            std::string header_path;
 
             for (auto&& suffix : *p_lines)
             {
@@ -617,10 +619,42 @@ namespace vcpkg::Install
                             config_files[find_package_name] = root;
                     }
                 }
+                if (Strings::case_insensitive_ascii_contains(suffix, "/lib/") ||
+                    Strings::case_insensitive_ascii_contains(suffix, "/bin/"))
+                {
+                    if (!Strings::ends_with(suffix, ".pc")) is_header_only = false;
+                }
+
+                if (is_header_only && header_path.empty())
+                {
+                    auto it = suffix.find("/include/");
+                    if (it != std::string::npos && !Strings::ends_with(suffix, "/"))
+                    {
+                        header_path = suffix.substr(it + 9);
+                    }
+                }
             }
 
             if (library_targets.empty())
             {
+                if (is_header_only && !header_path.empty())
+                {
+                    static auto cmakeify = [](std::string name) {
+                        auto n = Strings::ascii_to_uppercase(Strings::replace_all(std::move(name), "-", "_"));
+                        if (n.empty() || Parse::ParserBase::is_ascii_digit(n[0]))
+                        {
+                            n.insert(n.begin(), '_');
+                        }
+                        return n;
+                    };
+
+                    const auto name = cmakeify(bpgh.spec.name());
+                    auto msg = Strings::concat(
+                        "The package ", bpgh.spec, " is header only and can be used from CMake via:\n\n");
+                    Strings::append(msg, "    find_path(", name, "_INCLUDE_DIRS \"", header_path, "\")\n");
+                    Strings::append(msg, "    target_include_directories(main PRIVATE ${", name, "_INCLUDE_DIRS})\n\n");
+                    System::print2(msg);
+                }
             }
             else
             {


### PR DESCRIPTION
Adds heuristics to vcpkg to detect header-only libraries and suggest CMake help of the form:

```
The package chaiscript:x86-windows is header only and can be used from CMake via:

    find_path(CHAISCRIPT_INCLUDE_DIRS "chaiscript/chaiscript.hpp")
    target_include_directories(main PRIVATE ${CHAISCRIPT_INCLUDE_DIRS})

The package jwt-cpp:x86-windows is header only and can be used from CMake via:

    find_path(JWT_CPP_INCLUDE_DIRS "jwt-cpp/base.h")
    target_include_directories(main PRIVATE ${JWT_CPP_INCLUDE_DIRS})

```

Generalizes #12365.
