### PR TITLE
[pybind11] Update to v2.5.0

### DIFF
--- a/ports/pybind11/CONTROL
+++ b/ports/pybind11/CONTROL
@@ -1,5 +1,5 @@
 Source: pybind11
-Version: 2.4.3
+Version: 2.5.0
 Homepage: https://github.com/pybind/pybind11
 Description: pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.
 Build-Depends: python3 (windows)

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
-    REF 80d452484c5409444b0ec19383faa84bb7a4d351 # v2.4.3
-    SHA512 987f8c075ff3e4f90ab27a6121f3767a82939e35cd2143649819c8d39b09d1c234d39fa204ed5f6bd1d9ec97c275f590df358769d7726a16ccb720a91c550883
+    REF 3b1dbebabc801c9cf6f0953a4c20b904d444f879 # v2.5.0
+    SHA512 1a75d29447dbba96eebf8ecdebad1be0dd5327c32f5122b0ece9d9ec22eae4feacd0efb3a5070b3a135a892b1682c7215b0c529b179493694df932945a379f4c
     HEAD_REF master
 )
 

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pybind/pybind11
@@ -9,9 +7,8 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-
 get_filename_component(PYPATH ${PYTHON3} PATH)
-set(ENV{PATH} "$ENV{PATH};${PYPATH}")
+vcpkg_add_to_path("${PYPATH}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -34,4 +31,4 @@ vcpkg_install_cmake()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/)
 
 # copy license
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pybind11/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

Updates pybind11 to the latest stable version v2.5.0 from v2.4.3.

- What does your PR fix? Fixes #12371 

- Which triplets are supported/not supported? Have you updated the CI baseline?

Supports all the previously supported triplets (all), but have checked on personal x64-linux and x64-windows. No changed to the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
