### PR TITLE
[vcpkg] implement copy_symlink working for non-elevated processes

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -151,9 +151,9 @@ namespace vcpkg::Files
             }
             ec.clear();
             return;
-#else  // ^^^ defined(_WIN32) // !defined(_WIN32) vvv
+#else  // ^^^ defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM // !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM vvv
             return fs::stdfs::copy_symlink(oldpath, newpath, ec);
-#endif // ^^^ !defined(_WIN32)
+#endif // ^^^ !defined(_WIN32) || VCPKG_USE_STD_FILESYSTEM
         }
 
         // does _not_ follow symlinks

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -106,7 +106,7 @@ namespace vcpkg::Files
 #if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
             auto handle = CreateFileW(oldpath.c_str(),
                                       GENERIC_READ,
-                                      FILE_SHARE_READ,
+                                      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                                       nullptr /* no security attributes */,
                                       OPEN_EXISTING,
                                       FILE_ATTRIBUTE_NORMAL,

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -103,6 +103,7 @@ namespace vcpkg::Files
 
         fs::path normalize_path(const std::wstring& buffer)
         {
+#if defined(_WIN32)
             // cut off \\?\UNC\ prefix of network shares
             const std::wstring networkprefix = L"\\\\?\\UNC\\";
             if (buffer.substr(0, networkprefix.length()) == networkprefix)
@@ -116,6 +117,7 @@ namespace vcpkg::Files
             {
                 return buffer.substr(driveprefix.length());
             }
+#endif // ^^^ defined(_WIN32)
 
             return buffer;
         }

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -101,27 +101,6 @@ namespace vcpkg::Files
             return status_implementation(false, p, ec);
         }
 
-#if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
-        fs::path normalize_path(const std::wstring& buffer)
-        {
-            // cut off \\?\UNC\ prefix of network shares
-            const std::wstring networkprefix = L"\\\\?\\UNC\\";
-            if (buffer.substr(0, networkprefix.length()) == networkprefix)
-            {
-                return L"\\\\" + buffer.substr(networkprefix.length());
-            }
-
-            // cut off \\?\ prefix before drive:\path
-            const std::wstring driveprefix = L"\\\\?\\";
-            if (buffer.substr(0, driveprefix.length()) == driveprefix)
-            {
-                return buffer.substr(driveprefix.length());
-            }
-#endif // ^^^ defined(_WIN32)
-
-            return buffer;
-        }
-
         fs::path read_symlink_implementation(const fs::path& oldpath, std::error_code& ec)
         {
 #if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
@@ -145,7 +124,7 @@ namespace vcpkg::Files
             const auto rc = GetFinalPathNameByHandleW(handle, buffer, maxsize, 0);
             if (rc > 0 && rc < maxsize)
             {
-                target = normalize_path(buffer);
+                target = buffer;
             }
             else
             {

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -104,6 +104,7 @@ namespace vcpkg::Files
         fs::path read_symlink_implementation(const fs::path& oldpath, std::error_code& ec)
         {
 #if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
+                ec.clear();
             auto handle = CreateFileW(oldpath.c_str(),
                                       0, // open just the metadata
                                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -127,8 +127,7 @@ namespace vcpkg::Files
             }
             else
             {
-                const auto err = GetLastError();
-                ec.assign(err, std::system_category());
+                ec.assign(GetLastError(), std::system_category());
             }
             CloseHandle(handle);
             return target;

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -124,7 +124,7 @@ namespace vcpkg::Files
 
         fs::path read_symlink_implementation(const fs::path& oldpath, std::error_code& ec)
         {
-#if defined(_WIN32)
+#if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
             auto handle = CreateFileW(oldpath.c_str(),
                                       GENERIC_READ,
                                       FILE_SHARE_READ,

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -105,7 +105,7 @@ namespace vcpkg::Files
         {
 #if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
             auto handle = CreateFileW(oldpath.c_str(),
-                                      GENERIC_READ,
+                                      0, // open just the metadata
                                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                                       nullptr /* no security attributes */,
                                       OPEN_EXISTING,

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -161,7 +161,7 @@ namespace vcpkg::Files
 
         void copy_symlink_implementation(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec)
         {
-#if defined(_WIN32)
+#if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
             const auto target = read_symlink_implementation(oldpath, ec);
             if (ec) return;
 

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -101,9 +101,9 @@ namespace vcpkg::Files
             return status_implementation(false, p, ec);
         }
 
+#if defined(_WIN32) && !VCPKG_USE_STD_FILESYSTEM
         fs::path normalize_path(const std::wstring& buffer)
         {
-#if defined(_WIN32)
             // cut off \\?\UNC\ prefix of network shares
             const std::wstring networkprefix = L"\\\\?\\UNC\\";
             if (buffer.substr(0, networkprefix.length()) == networkprefix)

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -113,8 +113,7 @@ namespace vcpkg::Files
                                       nullptr /* no template file */);
             if (handle == INVALID_HANDLE_VALUE)
             {
-                const auto err = GetLastError();
-                ec.assign(err, std::system_category());
+                ec.assign(GetLastError(), std::system_category());
                 return oldpath;
             }
             fs::path target;


### PR DESCRIPTION
Function `fs::stdfs::copy_symlink` used by `install_files_and_write_listfile` requires the vcpkg process to be running elevated (Windows). Otherwise it always failed with `operation not permitted` error.

This PR fixes inability to copy symlink in non-elevated processes.
I tried to instal libressl via command

```
install --recurse libressl[core]:x64-windows
```

Description of the problem is here: https://github.com/microsoft/vcpkg/pull/11949#issuecomment-657478099
