### PR TITLE
[boost-modular-build-helper] Remove has_icu.lib

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,2 +1,3 @@
 Source: boost-modular-build-helper
-Version: 1.73.0-1
+Version: 1.73.0
+Port-Version: 2

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -386,5 +386,13 @@ function(boost_modular_build)
         endif()
     endforeach()
 
+    # boost-regex[icu] and boost-locale[icu] generate has_icu.lib
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib)
+    endif()
+    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/has_icu.lib)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/has_icu.lib)
+    endif()
+
     vcpkg_copy_pdbs()
 endfunction()

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -387,11 +387,11 @@ function(boost_modular_build)
     endforeach()
 
     # boost-regex[icu] and boost-locale[icu] generate has_icu.lib
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib)
-        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib")
     endif()
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/has_icu.lib)
-        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/has_icu.lib)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/has_icu.lib")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/has_icu.lib")
     endif()
 
     vcpkg_copy_pdbs()


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/12221

Remove has_icu.lib which generated by boost-regex[icu] and boost-locale[icu]