### PR TITLE
[folly] Fix build error C3861

### DIFF
--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,6 +1,6 @@
 Source: folly
 Version: 2019.10.21.00
-Port-version: 3
+Port-Version: 3
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr

--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,6 @@
 Source: folly
-Version: 2019.10.21.00-2
+Version: 2019.10.21.00
+Port-version: 3
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr

--- a/ports/folly/folly_c3861.patch
+++ b/ports/folly/folly_c3861.patch
@@ -1,0 +1,50 @@
+diff --git a/folly/portability/Builtins.h b/folly/portability/Builtins.h
+index 971cb88..7894333 100644
+--- a/folly/portability/Builtins.h
++++ b/folly/portability/Builtins.h
+@@ -41,7 +41,7 @@ FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
+   }
+ }
+ 
+-#if !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #if !defined(_MSC_VER) || (_MSC_VER < 1923)
+ FOLLY_ALWAYS_INLINE int __builtin_clz(unsigned int x) {
+   unsigned long index;
+   return int(_BitScanReverse(&index, (unsigned long)x) ? 31 - index : 32);
+@@ -93,7 +93,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
+   return int(_BitScanForward64(&index, x) ? index : 64);
+ }
+ #endif
+-#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+ 
+ FOLLY_ALWAYS_INLINE int __builtin_ffs(int x) {
+   unsigned long index;
+@@ -119,15 +119,15 @@ FOLLY_ALWAYS_INLINE int __builtin_popcount(unsigned int x) {
+   return int(__popcnt(x));
+ }
+ 
+-#if !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #if !defined(_MSC_VER) || (_MSC_VER < 1923)
+ FOLLY_ALWAYS_INLINE int __builtin_popcountl(unsigned long x) {
+   static_assert(sizeof(x) == 4, "");
+   return int(__popcnt(x));
+ }
+-#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+ #endif
+ 
+-#if !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #if !defined(_MSC_VER) || (_MSC_VER < 1923)
+ #if defined(_M_IX86)
+ FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+   return int(__popcnt((unsigned int)(x >> 32))) +
+@@ -138,7 +138,7 @@ FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
+   return int(__popcnt64(x));
+ }
+ #endif
+-#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
++// #endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
+ 
+ FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
+   // I really hope frame is zero...

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         disable-non-underscore-posix-names.patch
         boost-1.70.patch
         fix-addbit.patch
+        folly_c3861.patch
 )
 
 file(COPY


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Folly build failed on CI unstable testing with the following error, add a patch to fix this error. I have submit an issue on upstream https://github.com/facebook/folly/issues/1412
```
F:\0712\buildtrees\folly\src\46d6707604-9be5d31935.clean\folly/GroupVarint.h(265): error C3861: '__builtin_clz': identifier not found
F:\0712\buildtrees\folly\src\46d6707604-9be5d31935.clean\folly/GroupVarint.h(301): warning C5054: operator '+': deprecated between enumerations of different types
F:\0712\buildtrees\folly\src\46d6707604-9be5d31935.clean\folly/GroupVarint.h(364): warning C5054: operator '+': deprecated between enumerations of different types
F:\0712\buildtrees\folly\src\46d6707604-9be5d31935.clean\folly/GroupVarint.h(453): error C3861: '__builtin_clzll': identifier not found
```
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes