### PR TITLE
[vcpkg] Fix ParagraphParser::required_field()

### DIFF
--- a/toolsrc/src/vcpkg/base/parse.cpp
+++ b/toolsrc/src/vcpkg/base/parse.cpp
@@ -149,7 +149,7 @@ namespace vcpkg::Parse
     {
         std::string out;
         TextRowCol ignore;
-        optional_field(fieldname, {out, ignore});
+        required_field(fieldname, {out, ignore});
         return out;
     }
 


### PR DESCRIPTION
Fix typo.
ParagraphParser::required_field() method should call appropriate function.