### PR TITLE
[cpp-taskflow] Update to v2.5.0 and fix x64-windows build with /bigobj

### DIFF
--- a/ports/cpp-taskflow/0001-Compile-with-bigobj-on-MSVC.patch
+++ b/ports/cpp-taskflow/0001-Compile-with-bigobj-on-MSVC.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 33e9247..29be3a3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,6 +35,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+   endif()
+ ## microsoft visual c++
+ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
++  add_definitions(/bigobj)
+   if(NOT MSVC_VERSION GREATER_EQUAL 1914)
+     message(STATUS "CMAKE_CXX_COMPILER_VERSION: ${CMAKE_CXX_COMPILER_VERSION}")
+     message(FATAL_ERROR "\nTaskflow requires MSVC++ at least v14.14") 
+-- 
+2.17.1.windows.2
+

--- a/ports/cpp-taskflow/CONTROL
+++ b/ports/cpp-taskflow/CONTROL
@@ -1,4 +1,5 @@
 Source: cpp-taskflow
-Version: 2.5.0-1
+Version: 2.5.0
+
 Description: Fast Parallel Tasking Programming Library using Modern C++.
 Homepage: https://github.com/taskflow/taskflow

--- a/ports/cpp-taskflow/CONTROL
+++ b/ports/cpp-taskflow/CONTROL
@@ -1,4 +1,4 @@
 Source: cpp-taskflow
-Version: 2.2.0-1
+Version: 2.5.0-1
 Description: Fast Parallel Tasking Programming Library using Modern C++.
 Homepage: https://github.com/taskflow/taskflow

--- a/ports/cpp-taskflow/CONTROL
+++ b/ports/cpp-taskflow/CONTROL
@@ -1,5 +1,4 @@
 Source: cpp-taskflow
 Version: 2.5.0
-
 Description: Fast Parallel Tasking Programming Library using Modern C++.
 Homepage: https://github.com/taskflow/taskflow

--- a/ports/cpp-taskflow/portfile.cmake
+++ b/ports/cpp-taskflow/portfile.cmake
@@ -2,9 +2,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taskflow/taskflow
-    REF v2.2.0
-    SHA512 1aa4e9d7324f56eb33cd4986d721035f0abf12e022da956bafc0b16cf6cb82d152334ae58edc4581ab2f6d44989ca21cdd590ad560d6f1a4f905710fe08d0091
+    REF v2.5.0
+    SHA512 49f38a14a207db085a2e3581b3698cdb3be4fa65c11194db454bd2fb65da2d744347c6a10a7a903b04cc2dd5cac65ef389d400c66d2a23521c3bbe2283357890
     HEAD_REF master
+	PATCHES 
+		"0001-Compile-with-bigobj-on-MSVC.patch"
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Update taskflow port to v2.5.0 and fix x64-windows build with /bigobj