### PR TITLE
[nrf-ble-driver] Update to v4.1.2

### DIFF
--- a/ports/nrf-ble-driver/CONTROL
+++ b/ports/nrf-ble-driver/CONTROL
@@ -1,4 +1,4 @@
 Source: nrf-ble-driver
-Version: 4.1.1-2
+Version: 4.1.2
 Description: BLE driver is a library for Bluetooth Low Energy communication using Nordic Semiconductor development kits.
-Build-Depends: asio, catch2
+Build-Depends: spdlog, catch2, cli11, asio

--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -11,8 +11,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NordicSemiconductor/pc-ble-driver
-    REF v4.1.1
-    SHA512 bb1853993b3f37836a8f7402e5c0452e8423c3a1c6e651cf353025022a32e16c72f06e2266e283c72fa7ddb0da7cf8cecb875a7a7762565599f2908c4858ce8e
+    REF v4.1.2
+    SHA512 93ab29d8f84ef8b39c931e22af87ec84457b4927c2dd61da2f2052a7ea6862adff0e21d6ad4296c2f277660a81147043dd3fbe9282d47a5186e617f7adec8a2b
     HEAD_REF master
     PATCHES
         001-arm64-support.patch

--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NordicSemiconductor/pc-ble-driver
     REF v4.1.2
-    SHA512 173f66a81589dedc661770449e7196e4efbcb57c31f55070dee001c67ad739c51aef845970d8fe297aae00a91609aa314fbadfd6024f392722975183d9ac0a1f
+    SHA512 625a52151f2c78421e48e90ff60292c6106e8504b55a26c7df716df75e051a40d2ee4a26c57b5daaa370e53a79002fe965aee8a0d8749f7dce380e8e4a617c95
     HEAD_REF master
     PATCHES
         001-arm64-support.patch
@@ -28,12 +28,19 @@ set(ENV{PATH} "$ENV{PATH};${GIT_EXE_DIRPATH}")
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DDISABLE_EXAMPLES= -DDISABLE_TESTS= -DNRF_BLE_DRIVER_VERSION=4.1.1 -DCONNECTIVITY_VERSION=4.1.1
+    OPTIONS -DDISABLE_EXAMPLES= -DDISABLE_TESTS= -DNRF_BLE_DRIVER_VERSION=4.1.2 -DCONNECTIVITY_VERSION=4.1.2
 )
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets()
+
+# Copy hex files into shared folder for package
+foreach(HEX_DIR IN ITEMS "sd_api_v2" "sd_api_v3" "sd_api_v5" "sd_api_v6")
+    set(TARGET_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}/hex/${HEX_DIR}")
+    file(MAKE_DIRECTORY ${TARGET_DIRECTORY})
+    file(INSTALL "${SOURCE_PATH}/hex/${HEX_DIR}" DESTINATION ${TARGET_DIRECTORY}/..)
+endforeach()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/nrf-ble-driver/portfile.cmake
+++ b/ports/nrf-ble-driver/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NordicSemiconductor/pc-ble-driver
     REF v4.1.2
-    SHA512 93ab29d8f84ef8b39c931e22af87ec84457b4927c2dd61da2f2052a7ea6862adff0e21d6ad4296c2f277660a81147043dd3fbe9282d47a5186e617f7adec8a2b
+    SHA512 173f66a81589dedc661770449e7196e4efbcb57c31f55070dee001c67ad739c51aef845970d8fe297aae00a91609aa314fbadfd6024f392722975183d9ac0a1f
     HEAD_REF master
     PATCHES
         001-arm64-support.patch


### PR DESCRIPTION
**Describe the pull request**
This pull request updated nrf-ble-driver to v4.1.2

- What does your PR fix? Fixes #
Fixes issues in the v4.1.1 release of nrf-ble-driver

- Which triplets are supported/not supported? Have you updated the CI baseline?
Supported: x86-windows, x64-windows, x64-linux, x64-osx

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
