### PR TITLE
[assimp] Correct assimp export cmake files

### DIFF
--- a/ports/assimp/CONTROL
+++ b/ports/assimp/CONTROL
@@ -1,5 +1,6 @@
 Source: assimp
 Version: 5.0.1
+Port-Version: 1
 Homepage: https://github.com/assimp/assimp
 Description: The Open Asset import library
 Build-Depends: zlib, rapidjson, minizip

--- a/ports/assimp/assimp-config.cmake.in
+++ b/ports/assimp/assimp-config.cmake.in
@@ -1,0 +1,7 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB)
+find_dependency(minizip CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/IrrXMLTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/assimpTargets.cmake")

--- a/ports/assimp/fix-export-cmake.patch
+++ b/ports/assimp/fix-export-cmake.patch
@@ -1,0 +1,78 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4cb6927..4520d92 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -389,7 +389,7 @@ IF(HUNTER_ENABLED)
+       NAMESPACE "${NAMESPACE}"
+       DESTINATION "${CONFIG_INSTALL_DIR}"
+   )
+-ELSE(HUNTER_ENABLED)
++ELSEIF(0)
+   # cmake configuration files
+   CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/assimp-config.cmake.in"         "${CMAKE_CURRENT_BINARY_DIR}/assimp-config.cmake" @ONLY IMMEDIATE)
+   CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/assimpTargets.cmake.in"         "${CMAKE_CURRENT_BINARY_DIR}/assimpTargets.cmake" @ONLY IMMEDIATE)
+diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
+index 30568ff..3aa7e0b 100644
+--- a/code/CMakeLists.txt
++++ b/code/CMakeLists.txt
+@@ -1222,6 +1222,14 @@ IF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
+   TARGET_LINK_LIBRARIES(assimp ${RT_LIBRARY})
+ ENDIF (RT_FOUND AND ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC)
+ 
++include(CMakePackageConfigHelpers)
++set(ASSIMP_VERSION 5.0.0)
++write_basic_package_version_file(assimp-version.cmake VERSION ${ASSIMP_VERSION} COMPATIBILITY ExactVersion)
++configure_package_config_file(assimp-config.cmake.in assimp-config.cmake
++	INSTALL_DESTINATION share
++	PATH_VARS PROJECT_NAME ASSIMP_VERSION
++)
++
+ IF(HUNTER_ENABLED)
+   INSTALL( TARGETS assimp
+     EXPORT "${TARGETS_EXPORT_NAME}"
+@@ -1233,11 +1241,24 @@ IF(HUNTER_ENABLED)
+     INCLUDES DESTINATION "include")
+ ELSE(HUNTER_ENABLED)
+ INSTALL( TARGETS assimp
++    EXPORT assimpTargets
+     LIBRARY DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+     ARCHIVE DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+     RUNTIME DESTINATION ${ASSIMP_BIN_INSTALL_DIR}
+     FRAMEWORK DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+     COMPONENT ${LIBASSIMP_COMPONENT})
++    
++install(FILES
++	${CMAKE_BINARY_DIR}/code/assimp-config.cmake
++	${CMAKE_BINARY_DIR}/code/assimp-version.cmake
++	DESTINATION share/assimp
++)
++
++install(
++	EXPORT assimpTargets
++	NAMESPACE assimp::
++	DESTINATION share/assimp
++)
+ ENDIF(HUNTER_ENABLED)
+ INSTALL( FILES ${PUBLIC_HEADERS} DESTINATION ${ASSIMP_INCLUDE_INSTALL_DIR}/assimp COMPONENT assimp-dev)
+ INSTALL( FILES ${COMPILER_HEADERS} DESTINATION ${ASSIMP_INCLUDE_INSTALL_DIR}/assimp/Compiler COMPONENT assimp-dev)
+diff --git a/contrib/irrXML/CMakeLists.txt b/contrib/irrXML/CMakeLists.txt
+index 7f58af3..85b4d7e 100644
+--- a/contrib/irrXML/CMakeLists.txt
++++ b/contrib/irrXML/CMakeLists.txt
+@@ -22,8 +22,15 @@ set(IRRXML_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "IrrXML_Incl
+ set(IRRXML_LIBRARY "IrrXML" CACHE INTERNAL "IrrXML" )
+ 
+ install(TARGETS IrrXML
++  EXPORT IrrXMLTargets
+   LIBRARY DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+   ARCHIVE DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+   RUNTIME DESTINATION ${ASSIMP_BIN_INSTALL_DIR}
+   FRAMEWORK DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
+   COMPONENT ${LIBASSIMP_COMPONENT})
++
++install(
++	EXPORT IrrXMLTargets
++	NAMESPACE assimp::
++	DESTINATION share/assimp
++)
+\ No newline at end of file

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -9,10 +9,13 @@ vcpkg_from_github(
         fix-static-build-error.patch
         cmake-policy.patch
         fix_minizip.patch
+        fix-export-cmake.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake-modules/FindZLIB.cmake)
 file(REMOVE_RECURSE ${SOURCE_PATH}/contrib/zlib ${SOURCE_PATH}/contrib/gtest ${SOURCE_PATH}/contrib/rapidjson)
+
+file(COPY ${CURRENT_PORT_DIR}/assimp-config.cmake.in DESTINATION ${SOURCE_PATH}/code)
 
 set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
 set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
@@ -37,33 +40,12 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-FILE(GLOB lib_cmake_directories RELATIVE "${CURRENT_PACKAGES_DIR}" "${CURRENT_PACKAGES_DIR}/lib/cmake/assimp-*")
-list(GET lib_cmake_directories 0 lib_cmake_directory)
-vcpkg_fixup_cmake_targets(CONFIG_PATH "${lib_cmake_directory}")
+vcpkg_fixup_cmake_targets()
 
 vcpkg_copy_pdbs()
 
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-
-file(READ ${CURRENT_PACKAGES_DIR}/share/assimp/assimp-config.cmake ASSIMP_CONFIG)
-string(REPLACE "get_filename_component(ASSIMP_ROOT_DIR \"\${_PREFIX}\" PATH)"
-               "set(ASSIMP_ROOT_DIR \${_PREFIX})" ASSIMP_CONFIG ${ASSIMP_CONFIG})
-
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-  if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    string(REPLACE "set( ASSIMP_LIBRARIES \${ASSIMP_LIBRARIES})"
-                   "set( ASSIMP_LIBRARIES optimized \${ASSIMP_LIBRARY_DIRS}/\${ASSIMP_LIBRARIES}.lib debug \${ASSIMP_LIBRARY_DIRS}/../debug/lib/\${ASSIMP_LIBRARIES}d.lib)" ASSIMP_CONFIG ${ASSIMP_CONFIG})
-  else()
-    string(REPLACE "set( ASSIMP_LIBRARIES \${ASSIMP_LIBRARIES})"
-                   "set( ASSIMP_LIBRARIES optimized \${ASSIMP_LIBRARY_DIRS}/\${ASSIMP_LIBRARIES}.lib \${ASSIMP_LIBRARY_DIRS}/IrrXML.lib debug \${ASSIMP_LIBRARY_DIRS}/../debug/lib/\${ASSIMP_LIBRARIES}d.lib \${ASSIMP_LIBRARY_DIRS}/../debug/lib/IrrXMLd.lib)" ASSIMP_CONFIG ${ASSIMP_CONFIG})
-  endif()
-else()
-  string(REPLACE "set( ASSIMP_LIBRARIES \${ASSIMP_LIBRARIES})"
-                 "set( ASSIMP_LIBRARIES optimized \${ASSIMP_LIBRARY_DIRS}/lib\${ASSIMP_LIBRARIES}.a \${ASSIMP_LIBRARY_DIRS}/libIrrXML.a \${ASSIMP_LIBRARY_DIRS}/libz.a debug \${ASSIMP_LIBRARY_DIRS}/../debug/lib/lib\${ASSIMP_LIBRARIES}d.a \${ASSIMP_LIBRARY_DIRS}/../debug/lib/libIrrXMLd.a \${ASSIMP_LIBRARY_DIRS}/../debug/lib/libz.a)" ASSIMP_CONFIG ${ASSIMP_CONFIG})
-endif()
-
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/assimp/assimp-config.cmake "${ASSIMP_CONFIG}")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Since `assimp-config.cmake` and `assimpTargets*.cmake` are handwritten and have dependency issues, use cmake to automatically generate these files.

I already report this issue to the upstream: [#2988](https://github.com/assimp/assimp/issues/2988)

Fixes #12154 #9918 #9022