### PR TITLE
[pugixml] Fix pkgconfig file

### DIFF
--- a/ports/pugixml/CONTROL
+++ b/ports/pugixml/CONTROL
@@ -1,4 +1,5 @@
 Source: pugixml
-Version: 1.10-1
+Version: 1.10
+Port-Version: 2
 Homepage: https://github.com/zeux/pugixml
 Description: C++ XML processing library

--- a/ports/pugixml/portfile.cmake
+++ b/ports/pugixml/portfile.cmake
@@ -1,11 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeux/pugixml
     REF v1.10
     SHA512 0634053d4f757b9293997763bb2e51595197c192f3974e954975d6d6ff91e4a6cb7c194efa530e0eef1a2a93db16592c5630010b6482430dff5ffc6879e84b6a
     HEAD_REF master
+    PATCHES pugixml-v1.10_fix_debug_pkgconfig.patch # Upstream: https://github.com/zeux/pugixml/pull/363
 )
 
 vcpkg_configure_cmake(
@@ -17,7 +16,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/pugixml)
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/readme.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/pugixml RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/readme.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pugixml/pugixml-v1.10_fix_debug_pkgconfig.patch
+++ b/ports/pugixml/pugixml-v1.10_fix_debug_pkgconfig.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f043962..b281cba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,6 +94,16 @@ install(TARGETS ${LIBRARY} EXPORT pugixml-config
+ install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
+ install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
+ 
++if (USE_POSTFIX)
++  if(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
++    set(LIB_POSTFIX "_r")
++  elseif(CMAKE_BUILD_TYPE MATCHES MinSizeRel)
++    set(LIB_POSTFIX "_m")
++  elseif(CMAKE_BUILD_TYPE MATCHES Debug)
++    set(LIB_POSTFIX "_d")
++  endif()
++endif()
++
+ configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
+ install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig)
+ 
+diff --git a/scripts/pugixml.pc.in b/scripts/pugixml.pc.in
+index f9c3fd4..7958774 100644
+--- a/scripts/pugixml.pc.in
++++ b/scripts/pugixml.pc.in
+@@ -8,4 +8,4 @@ Description: Light-weight, simple and fast XML parser for C++ with XPath support
+ URL: https://pugixml.org/
+ Version: @pugixml_VERSION@
+ Cflags: -I${includedir}
+-Libs: -L${libdir} -lpugixml
++Libs: -L${libdir} -lpugixml@LIB_POSTFIX@


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
  - Add missing `vcpkg_fixup_pkgconfig()`, which was detected in
  https://github.com/microsoft/vcpkg/pull/12151#issuecomment-651581440
  - Fix debug POSTFIX in **`pugixml.pc`** file using
  `pugixml-v1.10_fix_debug_pkgconfig.patch`
  based on upstream: https://github.com/zeux/pugixml/pull/363
  This results in the following contents of **`pugixml.pc`**:
  Release:
  `  Libs: -L${libdir} -lpugixml`
  Debug:
  `  Libs: -L${libdir} -lpugixml_d`

- Which triplets are supported/not supported? Have you updated the CI baseline?
All official triplets are supported
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
