### PR TITLE
[VCPKG baseline][libmicrohttpd] Change the installed header file path

### DIFF
--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,5 +1,6 @@
 Source: libmicrohttpd
-Version: 0.9.63-3
+Version: 0.9.63
+Port-Version: 4
 Homepage: https://www.gnu.org/software/libmicrohttpd/
 Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application
 Supports: !(arm|uwp)

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -39,7 +39,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
     
     file(GLOB MICROHTTPD_HEADERS ${SOURCE_PATH}/src/include/*h)
     foreach(MICROHTTPD_HEADER ${MICROHTTPD_HEADERS})
-        file(COPY ${MICROHTTPD_HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+        file(COPY ${MICROHTTPD_HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include/libmicrohttpd)
     endforeach()
 else()
     vcpkg_configure_make(

--- a/ports/nrf-ble-driver/CONTROL
+++ b/ports/nrf-ble-driver/CONTROL
@@ -1,4 +1,5 @@
 Source: nrf-ble-driver
 Version: 4.1.2
+Port-Version: 1
 Description: BLE driver is a library for Bluetooth Low Energy communication using Nordic Semiconductor development kits.
 Build-Depends: spdlog, catch2, cli11, asio


### PR DESCRIPTION
Some header files in `nrf-ble-driver` include `platform.h`, and this file exists in both `nrf-ble-driver` and `libmicrohttpd`. This leads to abnormal usage.

Change the installed header file path to _include/libmicrohttpd_ to avoid file conflicts with `nrf-ble-driver`.

Related: #12434 #12084 #11208 #11208 #12342  etc.
