### PR TITLE
[libmicrohttpd] Add `platform.h` to restricted header list.

### DIFF
--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,5 +1,6 @@
 Source: libmicrohttpd
-Version: 0.9.63-3
+Version: 0.9.63
+Port-Version: 4
 Homepage: https://www.gnu.org/software/libmicrohttpd/
 Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application
 Supports: !(arm|uwp)

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -3,7 +3,9 @@ vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "arm")
 set(MICROHTTPD_VERSION 0.9.63)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+    URLS
+        "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
     FILENAME "libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
     SHA512 cb99e7af84fb6d7c0fd3894a9dc0fbff14959b35347506bd3211a65bbfad36455007b9e67493e97c9d8394834408df10eeabdc7758573e6aae0ba6f5f87afe17
 )
@@ -15,32 +17,21 @@ vcpkg_extract_source_archive_ex(
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)
-    if (TRIPLET_SYSTEM_ARCH MATCHES "x86")
-        set(MSBUILD_PLATFORM "Win32")
-    else ()
-        set(MSBUILD_PLATFORM "x64")
-    endif()
-    
-    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-        set(MICROHTTPD_CONFIGURATION_RELEASE "Release-dll")
-        set(MICROHTTPD_CONFIGURATION_DEBUG "Debug-dll")
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(CFG_SUFFIX "dll")
     else()
-        set(MICROHTTPD_CONFIGURATION_RELEASE "Release-static")
-        set(MICROHTTPD_CONFIGURATION_DEBUG "Debug-static")
+        set(CFG_SUFFIX "static")
     endif()
 
     vcpkg_install_msbuild(
-        SOURCE_PATH ${SOURCE_PATH}
+        SOURCE_PATH "${SOURCE_PATH}"
         PROJECT_SUBPATH w32/VS2015/libmicrohttpd.vcxproj
-        PLATFORM ${MSBUILD_PLATFORM}
-        RELEASE_CONFIGURATION ${MICROHTTPD_CONFIGURATION_RELEASE}
-        DEBUG_CONFIGURATION ${MICROHTTPD_CONFIGURATION_DEBUG}
+        RELEASE_CONFIGURATION "Release-${CFG_SUFFIX}"
+        DEBUG_CONFIGURATION "Debug-${CFG_SUFFIX}"
     )
     
-    file(GLOB MICROHTTPD_HEADERS ${SOURCE_PATH}/src/include/*h)
-    foreach(MICROHTTPD_HEADER ${MICROHTTPD_HEADERS})
-        file(COPY ${MICROHTTPD_HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-    endforeach()
+    file(GLOB MICROHTTPD_HEADERS ${SOURCE_PATH}/src/include/microhttpd*.h)
+    file(COPY ${MICROHTTPD_HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 else()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -153,6 +153,7 @@ namespace vcpkg::PostBuildLint
             "config.h",
             "local.h",
             "slice.h",
+            "platform.h",
         };
         static constexpr Span<const StringLiteral> restricted_lists[] = {
             restricted_sys_filenames, restricted_crt_filenames, restricted_general_filenames};


### PR DESCRIPTION
Fixes #12450.

No other ports currently publish `platform.h` based on the CI file list, so I did not globally invalidate cached binaries.