### PR TITLE
[coroutine] Fix error C7651

### DIFF
--- a/ports/coroutine/CONTROL
+++ b/ports/coroutine/CONTROL
@@ -1,6 +1,0 @@
-Source: coroutine
-Homepage: https://github.com/luncliff/coroutine
-Version: 1.5.0
-Build-Depends: ms-gsl
-Description: C++ 20 Coroutines helper/example library
-Supports: !uwp

--- a/ports/coroutine/fix-errorC7651.patch
+++ b/ports/coroutine/fix-errorC7651.patch
@@ -1,0 +1,68 @@
+diff --git a/modules/portable/frame.cpp b/modules/portable/frame.cpp
+index 2cedf81..f413f28 100644
+--- a/modules/portable/frame.cpp
++++ b/modules/portable/frame.cpp
+@@ -77,13 +77,31 @@ size_t _coro_done(void*);
+ //
+ // intrinsic: Clang/GCC
+ //
+-extern "C" {
+-bool __builtin_coro_done(void*);
+-void __builtin_coro_resume(void*);
+-void __builtin_coro_destroy(void*);
+-// void* __builtin_coro_promise(void* ptr, int align, bool p);
++//extern "C" {
++template <bool B>
++void resume_wrapper(void *p)
++{
++    if constexpr (B)
++        __builtin_coro_resume(p);
++}
++
++template <bool B>
++void destroy_wrapper(void *p)
++{
++    if constexpr(B)
++        __builtin_coro_destroy(p);
+ }
+ 
++template <bool B>
++bool done_wrapper(void *p)
++{
++    if constexpr(B)
++        return __builtin_coro_done(p);
++    return false;
++}
++// void* __builtin_coro_promise(void* ptr, int align, bool p);
++//}
++
+ bool _coro_finished(portable_coro_prefix* _Handle);
+ 
+ #if defined(__clang__)
+@@ -124,7 +142,7 @@ bool portable_coro_done(portable_coro_prefix* _Handle) {
+     if constexpr (is_msvc) {
+         return _coro_finished(_Handle);
+     } else if constexpr (is_clang) {
+-        return __builtin_coro_done(_Handle);
++        return done_wrapper<true>(_Handle);
+     }
+     return false; // follow `noop_coroutine`
+ }
+@@ -133,7 +151,7 @@ void portable_coro_resume(portable_coro_prefix* _Handle) {
+     if constexpr (is_msvc) {
+         _coro_resume(_Handle);
+     } else if constexpr (is_clang) {
+-        __builtin_coro_resume(_Handle);
++       resume_wrapper<true>(_Handle); 
+     }
+ }
+ 
+@@ -141,7 +159,7 @@ void portable_coro_destroy(portable_coro_prefix* _Handle) {
+     if constexpr (is_msvc) {
+         _coro_destroy(_Handle);
+     } else if constexpr (is_clang) {
+-        __builtin_coro_destroy(_Handle);
++        destroy_wrapper<true>(_Handle);
+     }
+ }
+ 

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     REF             1.5.0
     SHA512          61b91fdc641b6905b884e99c5bf193ec2cf6962144ab3baafdb9432115757d96f3797f116b30356f0d21417b23082bc908f75042721caeab3329c4910b654594
     HEAD_REF        master
-	PATCHES fix-errorC7651.patch
+    PATCHES fix-errorC7651.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/coroutine/portfile.cmake
+++ b/ports/coroutine/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     REF             1.5.0
     SHA512          61b91fdc641b6905b884e99c5bf193ec2cf6962144ab3baafdb9432115757d96f3797f116b30356f0d21417b23082bc908f75042721caeab3329c4910b654594
     HEAD_REF        master
+	PATCHES fix-errorC7651.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/coroutine/vcpkg.json
+++ b/ports/coroutine/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "coroutine",
+  "version-string": "1.5.0",
+  "port-version": "1",
+  "description": "C++ 20 Coroutines helper/example library",
+  "homepage": "https://github.com/luncliff/coroutine",
+  "dependencies": [
+    "ms-gsl"
+  ],
+  "supports": "!uwp"
+}


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Coroutine build failed on CI unstable testing with the following error C7651, add a patch to fix this error. I have submit an issue on upstream https://github.com/luncliff/coroutine/issues/51
```
F:\0712\buildtrees\coroutine\src\1.5.0-36192178c9.clean\modules\portable\frame.cpp(136): error C7651: __builtin_coro_resume cannot be used with /await. Use '/std:c++latest' or later for standard coroutine support
F:\0712\buildtrees\coroutine\src\1.5.0-36192178c9.clean\modules\portable\frame.cpp(144): error C7651: __builtin_coro_destroy cannot be used with /await. Use '/std:c++latest' or later for standard coroutine support
```
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes