### PR TITLE
[magnum-plugins] Fix file conflict with stb

### DIFF
--- a/ports/magnum-plugins/002-fix-stb-conflict.patch
+++ b/ports/magnum-plugins/002-fix-stb-conflict.patch
@@ -1,0 +1,13 @@
+diff --git a/src/MagnumPlugins/StbImageImporter/StbImageImporter.cpp b/src/MagnumPlugins/StbImageImporter/StbImageImporter.cpp
+index c24a968..1a38162 100644
+--- a/src/MagnumPlugins/StbImageImporter/StbImageImporter.cpp
++++ b/src/MagnumPlugins/StbImageImporter/StbImageImporter.cpp
+@@ -45,7 +45,7 @@
+ #endif
+ 
+ /* Not defining malloc/free, because there's no equivalent for realloc in C++ */
+-#include "stb_image.h"
++#include "external/stb/stb_image.h"
+ 
+ namespace Magnum { namespace Trade {
+ 

--- a/ports/magnum-plugins/CONTROL
+++ b/ports/magnum-plugins/CONTROL
@@ -1,5 +1,6 @@
 Source: magnum-plugins
 Version: 2020.06
+Port-Version: 1
 Build-Depends: magnum[core]
 Description: Plugins for magnum, C++11/C++14 graphics middleware for games and data visualization
 Homepage: https://magnum.graphics/

--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         001-tools-path.patch
+        002-fix-stb-conflict.patch
 )
 
 if("basisimporter" IN_LIST FEATURES OR "basisimageconverter" IN_LIST FEATURES)


### PR DESCRIPTION
```
D:\buildtrees\magnum-plugins\src\v2020.06-f0c46dc4fa.clean\src\MagnumPlugins\StbImageImporter\StbImageImporter.cpp(91): error C3861: 'stbi_set_flip_vertically_on_load_thread': identifier not found
D:\buildtrees\magnum-plugins\src\v2020.06-f0c46dc4fa.clean\src\MagnumPlugins\StbImageImporter\StbImageImporter.cpp(95): error C3861: 'stbi_convert_iphone_png_to_rgb_thread': identifier not found
```

`magnum-plugins` uses internal `stb_image.h`, this file conflict and different with port `stb`, so change the include content.

Related #12103.