### PR TITLE
[vcpkg-acquire-msys] Install new keyring

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -81,6 +81,19 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
         SHA512 ${HASH}
     )
 
+    # download the new keyring, without it new packages and package updates
+    # might not install
+    vcpkg_download_distfile(KEYRING_PATH
+        URLS http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+        FILENAME msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+        SHA512 a5023fd17ccf6364bc6e27c5e63aea25f1fc264a5247cbae4008864c828c38c3e0b4de09ded650e28d2e24e319b5fcf7a9c0da0fa3a8ac81679470fc6bd120c9
+    )
+    vcpkg_download_distfile(KEYRING_SIG_PATH
+        URLS http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
+        FILENAME msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
+        SHA512 c326fefd13f58339afe0d0dc78306aa6ab27cafa8c4d792c2d34aa81fdd1f759d490990ab79daa9664a03a6dfa14ffd2b2ad828bf19a883410112d01f5ed6c4c
+    )
+
     file(REMOVE_RECURSE ${TOOLPATH}/${TOOLSUBPATH})
     file(MAKE_DIRECTORY ${TOOLPATH})
     _execute_process(
@@ -89,6 +102,19 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     )
     _execute_process(
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman-key --init;pacman-key --populate"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    # install the new keyring
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman-key --verify ${KEYRING_SIG_PATH}"
+      WORKING_DIRECTORY ${TOOLPATH}
+      RESULT_VARIABLE _vam_error_code
+    )
+    if(_vam_error_code)
+      message(FATAL_ERROR "Cannot verify MSYS2 keyring.")
+    endif()
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -U ${KEYRING_PATH} --noconfirm"
       WORKING_DIRECTORY ${TOOLPATH}
     )
     # we have to kill all GnuPG daemons otherwise bash would potentially not be


### PR DESCRIPTION
**Describe the pull request**
Adjusts `vcpkg_acquire_msys` script to install the new keyring (see [MSYS2 News](https://www.msys2.org/news/#2020-06-29-new-packagers)).

- What does your PR fix?
   Fixes #12288

- Which triplets are supported/not supported? Have you updated the CI baseline?
   N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
   Yes
