### PR TITLE
[libffi] fix crash in debug

### DIFF
--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,4 +1,4 @@
 Source: libffi
-Version: 3.3-3
+Version: 3.3-4
 Homepage: https://github.com/libffi/libffi
 Description: Portable, high level programming interface to various calling conventions

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,4 +1,5 @@
 Source: libffi
-Version: 3.3-4
+Version: 3.3
+Port-Version: 4
 Homepage: https://github.com/libffi/libffi
 Description: Portable, high level programming interface to various calling conventions

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         win64-disable-stackframe-check.patch
+        win32-disable-stackframe-check.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF v3.3
     SHA512 62798fb31ba65fa2a0e1f71dd3daca30edcf745dc562c6f8e7126e54db92572cc63f5aa36d927dd08375bb6f38a2380ebe6c5735f35990681878fc78fc9dbc83
     HEAD_REF master
+    PATCHES
+        win64-disable-stackframe-check.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/libffi/win32-disable-stackframe-check.patch
+++ b/ports/libffi/win32-disable-stackframe-check.patch
@@ -1,0 +1,50 @@
+Rolf Gebhardt <rolf.gebhardt@lbs-sw.de>
+22 Jul 2020
+[PATCH] x86/win32: disable runtime stack frame checks with msvc
+ around built assembly
+
+based on the patch for x86/win64:
+
+From 53291b332b1bc061a3409d3b60c38f313609b98e Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Fri, 16 Mar 2018 15:10:04 +1100
+Subject: [PATCH] x86/win64: disable runtime stack frame checks with msvc
+ around built assembly
+
+MSVC can add truntime code that checks if a stack frame is mismanaged
+however our custom assembly delibrately accesses and modifies the parent
+stack frame.  Fortunately we can disable that specific check for the
+function call so do that.
+---
+ src/x86/ffi.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/x86/ffi.c b/src/x86/ffi.c
+index 9a59218..9f5d703 100644
+--- a/src/x86/ffi.c
++++ b/src/x86/ffi.c
+@@ -255,6 +255,14 @@ static const struct abi_params abi_params[FFI_LAST_ABI] = {
+
+ extern void FFI_DECLARE_FASTCALL ffi_call_i386(struct call_frame *, char *) FFI_HIDDEN;
+
++/* we perform some black magic here to use some of the parent's
++ * stack frame in ff_call_win() that breaks with the msvc compiler
++ * with the /RTCs or /GZ flags.  Disable the 'Stack frame run time
++ * error checking' for this function so we don't hit weird exceptions
++ * in debug builds */
++#if defined(_MSC_VER)
++#pragma runtime_checks("s", off)
++#endif
+ static void
+ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
+              void **avalue, void *closure)
+@@ -390,6 +398,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
+
+   ffi_call_i386 (frame, stack);
+ }
++#if defined(_MSC_VER)
++#pragma runtime_checks("s", restore)
++#endif
+
+ void
+ ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)

--- a/ports/libffi/win64-disable-stackframe-check.patch
+++ b/ports/libffi/win64-disable-stackframe-check.patch
@@ -1,0 +1,43 @@
+From 53291b332b1bc061a3409d3b60c38f313609b98e Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Fri, 16 Mar 2018 15:10:04 +1100
+Subject: [PATCH] x86/win64: disable runtime stack frame checks with msvc
+ around built assembly
+
+MSVC can add truntime code that checks if a stack frame is mismanaged
+however our custom assembly delibrately accesses and modifies the parent
+stack frame.  Fortunately we can disable that specific check for the
+function call so do that.
+---
+ src/x86/ffiw64.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/x86/ffiw64.c b/src/x86/ffiw64.c
+index f7875252..88bb3a34 100644
+--- a/src/x86/ffiw64.c
++++ b/src/x86/ffiw64.c
+@@ -106,6 +106,14 @@ EFI64(ffi_prep_cif_machdep)(ffi_cif *cif)
+   return FFI_OK;
+ }
+ 
++/* we perform some black magic here to use some of the parent's
++ * stack frame in ff_call_win64() that breaks with the msvc compiler
++ * with the /RTCs or /GZ flags.  Disable the 'Stack frame run time
++ * error checking' for this function so we don't hit weird exceptions
++ * in debug builds */
++#if defined(_MSC_VER)
++#pragma runtime_checks("s", off)
++#endif
+ static void
+ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
+ 	      void **avalue, void *closure)
+@@ -170,6 +178,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
+ 
+   ffi_call_win64 (stack, frame, closure);
+ }
++#if defined(_MSC_VER)
++#pragma runtime_checks("s", restore)
++#endif
+ 
+ void
+ EFI64(ffi_call)(ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)


### PR DESCRIPTION
Disable runtime stack check for `libffi`.

Fixes #10230 
