### PR TITLE
[vcpkg|toolchain] a bit of cleanup and improvements

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -197,10 +197,10 @@ if (NOT DEFINED VCPKG_TRIPLET_DIR)
     set(VCPKG_TRIPLET_DIR "${_VCPKG_INSTALLED_DIR_DEFAULT}/${VCPKG_TARGET_TRIPLET}"
             CACHE PATH
             "The directory which contains the installed libraries for the selected triplet")
-    set(_VCPKG_INSTALLED_DIR "${VCPKG_TRIPLET_DIR}/.."
-            CACHE INTERNAL
-            "The directory which contains the installed libraries for each triplet")
 endif()
+set(_VCPKG_INSTALLED_DIR "${VCPKG_TRIPLET_DIR}/.."
+        CACHE INTERNAL
+        "The directory which contains the installed libraries for each triplet")
 
 # CMAKE_EXECUTABLE_SUFFIX is not yet defined
 if (CMAKE_HOST_WIN32)

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -231,7 +231,7 @@ if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT _CMAKE_IN_TRY_COMPILE)
     set(VCPKG_INSTALL_CMD   "${_VCPKG_EXECUTABLE}" install
                             --triplet ${VCPKG_TARGET_TRIPLET}
                             --vcpkg-root "${_VCPKG_ROOT_DIR}"
-                            "--x-manifest-root=\"${_VCPKG_MANIFEST_DIR}\""
+                            "--x-manifest-root=${_VCPKG_MANIFEST_DIR}"
                             "--x-install-root=\"${_VCPKG_INSTALLED_DIR}\""
                             --binarycaching)
 

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -182,8 +182,8 @@ Install the dependencies listed in your manifest:
 ]] 
     ON "VCPKG_MANIFEST_MODE" OFF)
 
+_vcpkg_get_directory_name_of_file_above(_VCPKG_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}" ".vcpkg-root")
 if(NOT _VCPKG_ROOT_DIR)
-    _vcpkg_get_directory_name_of_file_above(_VCPKG_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}" ".vcpkg-root")
     message(FATAL_ERROR "Could not find .vcpkg-root")
 endif()
 

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -2,50 +2,8 @@
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 
 # VCPKG toolchain options.
-option(VCPKG_VERBOSE "Enables messages from the VCPKG toolchain for debugging purposes." OFF)
+option(VCPKG_VERBOSE "Enables messages from the vcpkg toolchain for debugging purposes." OFF)
 mark_as_advanced(VCPKG_VERBOSE)
-
-function(_vcpkg_get_directory_name_of_file_above OUT DIRECTORY FILENAME)
-    set(_vcpkg_get_dir_candidate ${DIRECTORY})
-    while(IS_DIRECTORY ${_vcpkg_get_dir_candidate} AND NOT DEFINED _vcpkg_get_dir_out)
-        if(EXISTS ${_vcpkg_get_dir_candidate}/${FILENAME})
-            set(_vcpkg_get_dir_out ${_vcpkg_get_dir_candidate})
-        else()
-            get_filename_component(_vcpkg_get_dir_candidate_tmp ${_vcpkg_get_dir_candidate} DIRECTORY)
-            if(_vcpkg_get_dir_candidate STREQUAL _vcpkg_get_dir_candidate_tmp) # we've reached the root
-                set(_vcpkg_get_dir_out "${OUT}-NOTFOUND")
-            else()
-                set(_vcpkg_get_dir_candidate ${_vcpkg_get_dir_candidate_tmp})
-            endif()
-        endif()
-    endwhile()
-
-    set(${OUT} ${_vcpkg_get_dir_out} CACHE INTERNAL "_vcpkg_get_directory_name_of_file_above: ${OUT}")
-endfunction()
-
-_vcpkg_get_directory_name_of_file_above(_VCPKG_MANIFEST_DIR ${CMAKE_CURRENT_SOURCE_DIR} "vcpkg.json")
-if(NOT DEFINED VCPKG_MANIFEST_MODE)
-    if(_VCPKG_MANIFEST_DIR)
-        set(VCPKG_MANIFEST_MODE ON)
-    else()
-        set(VCPKG_MANIFEST_MODE OFF)
-    endif()
-elseif(VCPKG_MANIFEST_MODE AND NOT _VCPKG_MANIFEST_DIR)
-    message(FATAL_ERROR
-        "vcpkg manifest mode was enabled, but we couldn't find a manifest file (vcpkg.json) "
-        "in any directories above ${CMAKE_CURRENT_SOURCE_DIR}. Please add a manifest, or "
-        "disable manifests by turning off VCPKG_MANIFEST_MODE.")
-endif()
-
-if(VCPKG_MANIFEST_MODE)
-    option(VCPKG_MANIFEST_INSTALL
-[[
-Install the dependencies listed in your manifest:
-    If this is off, you will have to manually install your dependencies.
-    See https://github.com/microsoft/vcpkg/tree/master/docs/specifications/manifests.md for more info.
-]]
-        ON)
-endif()
 
 # Determine whether the toolchain is loaded during a try-compile configuration
 get_property(_CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE)
@@ -74,16 +32,18 @@ endif()
 if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL)
     set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL "MinSizeRel;Release;")
     if(VCPKG_VERBOSE)
-        message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL set to MinSizeRel;Release;")
+        message(VERBOSE "[vcpkg]: CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL set to MinSizeRel;Release;")
     endif()
 endif()
 if(NOT DEFINED CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO)
     set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release;")
     if(VCPKG_VERBOSE)
-        message(STATUS "VCPKG-Info: CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO set to RelWithDebInfo;Release;")
+        message(VERBOSE "[vcpkg]: CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO set to RelWithDebInfo;Release;")
     endif()
 endif()
 
+
+## vvvvv Automatic triplet selection
 if(VCPKG_TARGET_TRIPLET)
 elseif(CMAKE_GENERATOR_PLATFORM MATCHES "^[Ww][Ii][Nn]32$")
     set(_VCPKG_TARGET_TRIPLET_ARCH x86)
@@ -121,14 +81,14 @@ else()
         elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED CMAKE_SYSTEM_NAME AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
             list(LENGTH CMAKE_OSX_ARCHITECTURES arch_count)
             if(arch_count EQUAL 0)
-                message(WARNING "Unable to determine target architecture. "
+                message(WARNING "[vcpkg]: Unable to determine target architecture. "
                                 "Consider providing a value for the CMAKE_OSX_ARCHITECTURES cache variable. "
                                 "Continuing without vcpkg.")
                 set(VCPKG_TOOLCHAIN ON)
                 return()
             else()
                 if(arch_count GREATER 1)
-                    message(WARNING "Detected more than one target architecture. Using the first one.")
+                    message(WARNING "[vcpkg]: Detected more than one target architecture. Using the first one.")
                 endif()
                 list(GET CMAKE_OSX_ARCHITECTURES 0 target_arch)
                 if(target_arch STREQUAL arm64)
@@ -144,7 +104,7 @@ else()
                 elseif(target_arch STREQUAL i386)
                     set(_VCPKG_TARGET_TRIPLET_ARCH x86)
                 else()
-                    message(WARNING "Unable to determine target architecture, continuing without vcpkg.")
+                    message(WARNING "[vcpkg]: Unable to determine target architecture, continuing without vcpkg.")
                     set(VCPKG_TOOLCHAIN ON)
                     return()
                 endif()
@@ -153,9 +113,9 @@ else()
             set(_VCPKG_TARGET_TRIPLET_ARCH x64)
         else()
             if( _CMAKE_IN_TRY_COMPILE )
-                message(STATUS "Unable to determine target architecture, continuing without vcpkg.")
+                message(STATUS "[vcpkg]: Unable to determine target architecture, continuing without vcpkg.")
             else()
-                message(WARNING "Unable to determine target architecture, continuing without vcpkg.")
+                message(WARNING "[vcpkg]: Unable to determine target architecture, continuing without vcpkg.")
             endif()
             set(VCPKG_TOOLCHAIN ON)
             return()
@@ -178,62 +138,151 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR (NOT CMAKE_SYSTEM_NAME AND CMAKE_
 endif()
 
 set(VCPKG_TARGET_TRIPLET ${_VCPKG_TARGET_TRIPLET_ARCH}-${_VCPKG_TARGET_TRIPLET_PLAT} CACHE STRING "Vcpkg target triplet (ex. x86-windows)")
-set(_VCPKG_TOOLCHAIN_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(_VCPKG_TOOLCHAIN_DIR "${CMAKE_CURRENT_LIST_DIR}")
+## ^^^^^ Automatic triplet selection
 
-if(NOT DEFINED _VCPKG_ROOT_DIR)
-    # Detect .vcpkg-root to figure VCPKG_ROOT_DIR
-    set(_VCPKG_ROOT_DIR_CANDIDATE ${CMAKE_CURRENT_LIST_DIR})
-    while(IS_DIRECTORY ${_VCPKG_ROOT_DIR_CANDIDATE} AND NOT EXISTS "${_VCPKG_ROOT_DIR_CANDIDATE}/.vcpkg-root")
-        get_filename_component(_VCPKG_ROOT_DIR_TEMP ${_VCPKG_ROOT_DIR_CANDIDATE} DIRECTORY)
-        if (_VCPKG_ROOT_DIR_TEMP STREQUAL _VCPKG_ROOT_DIR_CANDIDATE) # If unchanged, we have reached the root of the drive
+# can we replace this with a find_file instead?
+# vcpkg.json should probably always be placed in CMAKE_CURRENT_SOURCE_DIR OR CMAKE_SOURCE_DIR if not otherwise specified
+# .vcpkg-root should probably always be loaceted in VCPKG_ROOT which is ../../ of CMAKE_CURRENT_LIST_DIR
+function(_vcpkg_get_directory_name_of_file_above OUT DIRECTORY FILENAME) 
+    set(_vcpkg_get_dir_candidate "${DIRECTORY}")
+    while(IS_DIRECTORY "${_vcpkg_get_dir_candidate}" AND NOT DEFINED _vcpkg_get_dir_out)
+        if(EXISTS "${_vcpkg_get_dir_candidate}/${FILENAME}")
+            set(_vcpkg_get_dir_out "${_vcpkg_get_dir_candidate}")
         else()
-            SET(_VCPKG_ROOT_DIR_CANDIDATE ${_VCPKG_ROOT_DIR_TEMP})
+            get_filename_component(_vcpkg_get_dir_candidate_tmp "${_vcpkg_get_dir_candidate}" DIRECTORY)
+            if(_vcpkg_get_dir_candidate STREQUAL _vcpkg_get_dir_candidate_tmp) # we've reached the root dir
+                set(_vcpkg_get_dir_out "${OUT}-NOTFOUND")
+            elseif(_vcpkg_get_dir_candidate STREQUAL CMAKE_SOURCE_DIR OR _vcpkg_get_dir_candidate STREQUAL CMAKE_BINARY_DIR) # don't leak out source/buildtree!
+                set(_vcpkg_get_dir_out "${OUT}-NOTFOUND")
+            else()
+                set(_vcpkg_get_dir_candidate "${_vcpkg_get_dir_candidate_tmp}")
+            endif()
         endif()
     endwhile()
-    set(_VCPKG_ROOT_DIR ${_VCPKG_ROOT_DIR_CANDIDATE} CACHE INTERNAL "Vcpkg root directory")
+    set(${OUT} "${_vcpkg_get_dir_out}" PARENT_SCOPE)
+endfunction()
+
+_vcpkg_get_directory_name_of_file_above(_VCPKG_MANIFEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}" "vcpkg.json") # Should this be CMAKE_SOURCE_DIR instead?
+include(CMakeDependentOption)
+CMAKE_DEPENDENT_OPTION (VCPKG_MANIFEST_MODE "Use vcpkg manifest mode by providing a vcpkg.json in the source directory." ON "EXISTS ${_VCPKG_MANIFEST_DIR}" OFF)
+
+if(VCPKG_MANIFEST_MODE AND NOT _VCPKG_MANIFEST_DIR)
+    message(FATAL_ERROR
+        "vcpkg manifest mode was enabled, but we couldn't find a manifest file (vcpkg.json) "
+        "in any directories above ${CMAKE_CURRENT_SOURCE_DIR}. Please add a manifest, or "
+        "disable manifests by turning off VCPKG_MANIFEST_MODE.")
 endif()
 
-_vcpkg_get_directory_name_of_file_above(_VCPKG_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR} ".vcpkg-root")
+CMAKE_DEPENDENT_OPTION(VCPKG_MANIFEST_INSTALL
+[[
+Install the dependencies listed in your manifest:
+    If this is off, you will have to manually install your dependencies.
+    See https://github.com/microsoft/vcpkg/tree/master/docs/specifications/manifests.md for more info.
+]] 
+    ON "VCPKG_MANIFEST_MODE" OFF)
+
 if(NOT _VCPKG_ROOT_DIR)
+    _vcpkg_get_directory_name_of_file_above(_VCPKG_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}" ".vcpkg-root")
     message(FATAL_ERROR "Could not find .vcpkg-root")
 endif()
 
-if (NOT DEFINED _VCPKG_INSTALLED_DIR)
+if (NOT DEFINED VCPKG_TRIPLET_DIR)
     if(_VCPKG_MANIFEST_DIR)
-        set(_VCPKG_INSTALLED_DIR ${CMAKE_BINARY_DIR}/vcpkg_installed)
+        set(_VCPKG_INSTALLED_DIR_DEFAULT "${CMAKE_BINARY_DIR}/vcpkg_installed")
     else()
-        set(_VCPKG_INSTALLED_DIR ${_VCPKG_ROOT_DIR}/installed)
+        set(_VCPKG_INSTALLED_DIR_DEFAULT "${_VCPKG_ROOT_DIR}/installed")
     endif()
 
-    set(_VCPKG_INSTALLED_DIR ${_VCPKG_INSTALLED_DIR}
-        CACHE PATH
-        "The directory which contains the installed libraries for each triplet")
+    set(VCPKG_TRIPLET_DIR "${_VCPKG_INSTALLED_DIR_DEFAULT}/${VCPKG_TARGET_TRIPLET}"
+            CACHE PATH
+            "The directory which contains the installed libraries for the selected triplet")
+    set(_VCPKG_INSTALLED_DIR "${VCPKG_TRIPLET_DIR}/.."
+            CACHE INTERNAL
+            "The directory which contains the installed libraries for each triplet")
 endif()
 
+# CMAKE_EXECUTABLE_SUFFIX is not yet defined
+if (CMAKE_HOST_WIN32)
+    set(_VCPKG_EXECUTABLE "${_VCPKG_ROOT_DIR}/vcpkg.exe")
+    set(_VCPKG_BOOTSTRAP_SCRIPT "${_VCPKG_ROOT_DIR}/bootstrap-vcpkg.bat")
+else()
+    set(_VCPKG_EXECUTABLE "${_VCPKG_ROOT_DIR}/vcpkg")
+    set(_VCPKG_BOOTSTRAP_SCRIPT "${_VCPKG_ROOT_DIR}/bootstrap-vcpkg.sh")
+endif()
+
+if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT _CMAKE_IN_TRY_COMPILE)
+    if(NOT EXISTS "${_VCPKG_EXECUTABLE}")
+        message(STATUS "[vcpkg]: Bootstrapping vcpkg before install")
+
+        execute_process(
+            COMMAND "${_VCPKG_BOOTSTRAP_SCRIPT}"
+            RESULT_VARIABLE _VCPKG_BOOTSTRAP_RESULT)
+
+        if (NOT _VCPKG_BOOTSTRAP_RESULT EQUAL 0)
+            message(FATAL_ERROR "[vcpkg]: Bootstrapping vcpkg before install - failed")
+        endif()
+
+        message(STATUS "[vcpkg]: Bootstrapping vcpkg before install - done")
+    endif()
+
+    message(STATUS "[vcpkg]: Running vcpkg install")
+
+    set(VCPKG_INSTALL_CMD   "${_VCPKG_EXECUTABLE}" install
+                            --triplet ${VCPKG_TARGET_TRIPLET}
+                            --vcpkg-root "${_VCPKG_ROOT_DIR}"
+                            "--x-manifest-root=\"${_VCPKG_MANIFEST_DIR}\""
+                            "--x-install-root=\"${_VCPKG_INSTALLED_DIR}\""
+                            --binarycaching)
+
+    if(VCPKG_PORT_OVERLAYS)
+        foreach(_overlay IN LISTS VCPKG_PORT_OVERLAYS)
+            list(APPEND VCPKG_INSTALL_CMD "--overlay-ports=\"${_overlay}\"")
+        endforeach()
+    endif()
+
+    if(VCPKG_VERBOSE)
+        message(VERBOSE "[vcpkg]: Executing vcpkg as: ${VCPKG_INSTALL_CMD}")
+    endif()
+    execute_process(COMMAND ${VCPKG_INSTALL_CMD} RESULT_VARIABLE _VCPKG_INSTALL_RESULT) 
+    #Shouldn't the output be stored somewhere? especially if there is an error?
+
+    if (NOT _VCPKG_INSTALL_RESULT EQUAL 0)
+        message(FATAL_ERROR "[vcpkg]: Running vcpkg install - failed")
+    endif()
+
+    message(STATUS "[vcpkg]: Running vcpkg install - done")
+
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${_VCPKG_MANIFEST_DIR}/vcpkg.json"
+        "${_VCPKG_INSTALLED_DIR}/vcpkg/status")
+endif()
+
+## Setup CMake
 if(CMAKE_BUILD_TYPE MATCHES "^[Dd][Ee][Bb][Uu][Gg]$" OR NOT DEFINED CMAKE_BUILD_TYPE) #Debug build: Put Debug paths before Release paths.
     list(APPEND CMAKE_PREFIX_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}
+        ${VCPKG_TRIPLET_DIR}/debug ${VCPKG_TRIPLET_DIR}
     )
     list(APPEND CMAKE_LIBRARY_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/manual-link ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/manual-link
+        ${VCPKG_TRIPLET_DIR}/debug/lib/manual-link ${VCPKG_TRIPLET_DIR}/lib/manual-link
     )
     list(APPEND CMAKE_FIND_ROOT_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}
+        ${VCPKG_TRIPLET_DIR}/debug ${VCPKG_TRIPLET_DIR}
     )
 else() #Release build: Put Release paths before Debug paths. Debug Paths are required so that CMake generates correct info in autogenerated target files.
     list(APPEND CMAKE_PREFIX_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug
+        ${VCPKG_TRIPLET_DIR} ${VCPKG_TRIPLET_DIR}/debug
     )
     list(APPEND CMAKE_LIBRARY_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/manual-link ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib/manual-link
+        ${VCPKG_TRIPLET_DIR}/lib/manual-link ${VCPKG_TRIPLET_DIR}/debug/lib/manual-link
     )
     list(APPEND CMAKE_FIND_ROOT_PATH
-        ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET} ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug
+        ${VCPKG_TRIPLET_DIR} ${VCPKG_TRIPLET_DIR}/debug
     )
 endif()
 
-# If one CMAKE_FIND_ROOT_PATH_MODE_* variables is set to ONLY, to  make sure that ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}
-# and ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug are searched, it is not sufficient to just add them to CMAKE_FIND_ROOT_PATH,
+# If one CMAKE_FIND_ROOT_PATH_MODE_* variables is set to ONLY, to  make sure that ${VCPKG_TRIPLET_DIR}
+# and ${VCPKG_TRIPLET_DIR}/debug are searched, it is not sufficient to just add them to CMAKE_FIND_ROOT_PATH,
 # as CMAKE_FIND_ROOT_PATH specify "one or more directories to be prepended to all other search directories", so to make sure that
 # the libraries are searched as they are, it is necessary to add "/" to the CMAKE_PREFIX_PATH
 if(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE STREQUAL "ONLY" OR
@@ -271,61 +320,15 @@ set(CMAKE_SYSTEM_IGNORE_PATH
     "C:/OpenSSL-Win64/lib/VC/static"
 )
 
-list(APPEND CMAKE_PROGRAM_PATH ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools)
-file(GLOB _VCPKG_TOOLS_DIRS ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/*)
+list(APPEND CMAKE_PROGRAM_PATH ${VCPKG_TRIPLET_DIR}/tools)
+file(GLOB _VCPKG_TOOLS_DIRS ${VCPKG_TRIPLET_DIR}/tools/*)
 foreach(_VCPKG_TOOLS_DIR ${_VCPKG_TOOLS_DIRS})
     if(IS_DIRECTORY ${_VCPKG_TOOLS_DIR})
         list(APPEND CMAKE_PROGRAM_PATH ${_VCPKG_TOOLS_DIR})
     endif()
 endforeach()
 
-
-# CMAKE_EXECUTABLE_SUFFIX is not yet defined
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-    set(_VCPKG_EXECUTABLE "${_VCPKG_ROOT_DIR}/vcpkg.exe")
-    set(_VCPKG_BOOTSTRAP_SCRIPT "${_VCPKG_ROOT_DIR}/bootstrap-vcpkg.bat")
-else()
-    set(_VCPKG_EXECUTABLE "${_VCPKG_ROOT_DIR}/vcpkg")
-    set(_VCPKG_BOOTSTRAP_SCRIPT "${_VCPKG_ROOT_DIR}/bootstrap-vcpkg.sh")
-endif()
-
-if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT _CMAKE_IN_TRY_COMPILE)
-    if(NOT EXISTS "${_VCPKG_EXECUTABLE}")
-        message(STATUS "Bootstrapping vcpkg before install")
-
-        execute_process(
-            COMMAND "${_VCPKG_BOOTSTRAP_SCRIPT}"
-            RESULT_VARIABLE _VCPKG_BOOTSTRAP_RESULT)
-
-        if (NOT _VCPKG_BOOTSTRAP_RESULT EQUAL 0)
-            message(FATAL_ERROR "Bootstrapping vcpkg before install - failed")
-        endif()
-
-        message(STATUS "Bootstrapping vcpkg before install - done")
-    endif()
-
-    message(STATUS "Running vcpkg install")
-
-    execute_process(
-        COMMAND "${_VCPKG_EXECUTABLE}" install
-            --triplet ${VCPKG_TARGET_TRIPLET}
-            --vcpkg-root ${_VCPKG_ROOT_DIR}
-            --x-manifest-root=${_VCPKG_MANIFEST_DIR}
-            --x-install-root=${_VCPKG_INSTALLED_DIR}
-            --binarycaching
-        RESULT_VARIABLE _VCPKG_INSTALL_RESULT)
-
-    if (NOT _VCPKG_INSTALL_RESULT EQUAL 0)
-        message(FATAL_ERROR "Running vcpkg install - failed")
-    endif()
-
-    message(STATUS "Running vcpkg install - done")
-
-    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
-        "${_VCPKG_MANIFEST_DIR}/vcpkg.json"
-        "${_VCPKG_INSTALLED_DIR}/vcpkg/status")
-endif()
-
+## Overrides of CMake functions
 option(VCPKG_APPLOCAL_DEPS "Automatically copy dependencies into the output directory for executables." ON)
 function(add_executable name)
     _add_executable(${ARGV})
@@ -392,7 +395,7 @@ macro(${VCPKG_OVERRIDE_FIND_PACKAGE_NAME} name)
     if(EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/${_vcpkg_lowercase_name}/vcpkg-cmake-wrapper.cmake")
         set(ARGS "${ARGV}")
         include(${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/${_vcpkg_lowercase_name}/vcpkg-cmake-wrapper.cmake)
-    elseif("${name}" STREQUAL "Boost" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/boost")
+    elseif("${name}" STREQUAL "Boost" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/boost") 
         # Checking for the boost headers disables this wrapper unless the user has installed at least one boost library
         set(Boost_USE_STATIC_LIBS OFF)
         set(Boost_USE_MULTITHREADED ON)
@@ -401,7 +404,7 @@ macro(${VCPKG_OVERRIDE_FIND_PACKAGE_NAME} name)
         unset(Boost_USE_STATIC_RUNTIME CACHE)
         set(Boost_COMPILER "-vc140")
         _find_package(${ARGV})
-    elseif("${name}" STREQUAL "ICU" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/unicode/utf.h")
+    elseif("${name}" STREQUAL "ICU" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/unicode/utf.h") # needs to be move to a wrapper if still necessary!
         function(_vcpkg_find_in_list)
             list(FIND ARGV "COMPONENTS" COMPONENTS_IDX)
             set(COMPONENTS_IDX ${COMPONENTS_IDX} PARENT_SCOPE)
@@ -412,7 +415,7 @@ macro(${VCPKG_OVERRIDE_FIND_PACKAGE_NAME} name)
         else()
             _find_package(${ARGV})
         endif()
-    elseif("${name}" STREQUAL "GSL" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/gsl")
+    elseif("${name}" STREQUAL "GSL" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/gsl") # needs to be move to a wrapper if still necessary!
         _find_package(${ARGV})
         if(GSL_FOUND AND TARGET GSL::gsl)
             set_property( TARGET GSL::gslcblas APPEND PROPERTY IMPORTED_CONFIGURATIONS Release )
@@ -424,7 +427,7 @@ macro(${VCPKG_OVERRIDE_FIND_PACKAGE_NAME} name)
                 set_target_properties( GSL::gslcblas PROPERTIES IMPORTED_LOCATION_DEBUG "${GSL_CBLAS_LIBRARY_DEBUG}" )
             endif()
         endif()
-    elseif("${name}" STREQUAL "CURL" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/curl")
+    elseif("${name}" STREQUAL "CURL" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/curl") # needs to be move to a wrapper!
         _find_package(${ARGV})
         if(CURL_FOUND)
             if(EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nghttp2.lib")
@@ -433,7 +436,7 @@ macro(${VCPKG_OVERRIDE_FIND_PACKAGE_NAME} name)
                     "optimized" "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/nghttp2.lib")
             endif()
         endif()
-    elseif("${_vcpkg_lowercase_name}" STREQUAL "grpc" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/grpc")
+    elseif("${_vcpkg_lowercase_name}" STREQUAL "grpc" AND EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/grpc") # needs to be move to a wrapper if still necessary!
         _find_package(gRPC ${ARGN})
     else()
         _find_package(${ARGV})

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -163,7 +163,7 @@ function(_vcpkg_get_directory_name_of_file_above OUT DIRECTORY FILENAME)
     set(${OUT} "${_vcpkg_get_dir_out}" PARENT_SCOPE)
 endfunction()
 
-_vcpkg_get_directory_name_of_file_above(_VCPKG_MANIFEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}" "vcpkg.json") # Should this be CMAKE_SOURCE_DIR instead?
+_vcpkg_get_directory_name_of_file_above(_VCPKG_MANIFEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg_manifest" "vcpkg.json") # Should this be CMAKE_SOURCE_DIR instead?
 include(CMakeDependentOption)
 CMAKE_DEPENDENT_OPTION (VCPKG_MANIFEST_MODE "Use vcpkg manifest mode by providing a vcpkg.json in the source directory." ON "EXISTS ${_VCPKG_MANIFEST_DIR}" OFF)
 
@@ -235,6 +235,10 @@ if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT _CMAKE_IN_TRY_COMPILE)
                             "--x-install-root=\"${_VCPKG_INSTALLED_DIR}\""
                             --binarycaching)
 
+    _vcpkg_get_directory_name_of_file_above(VCPKG_OVERLAY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg_manifest" "vcpkg.overlay")
+    if(VCPKG_OVERLAY_DIR AND NOT VCPKG_PORT_OVERLAYS)
+        list(APPEND VCPKG_PORT_OVERLAYS "${VCPKG_OVERLAY_DIR}/vcpkg.overlay")
+    endif()
     if(VCPKG_PORT_OVERLAYS)
         foreach(_overlay IN LISTS VCPKG_PORT_OVERLAYS)
             list(APPEND VCPKG_INSTALL_CMD "--overlay-ports=\"${_overlay}\"")

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -233,7 +233,8 @@ if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_INSTALL AND NOT _CMAKE_IN_TRY_COMPILE)
                             --triplet ${VCPKG_TARGET_TRIPLET}
                             --vcpkg-root "${_VCPKG_ROOT_DIR}"
                             "--x-manifest-root=${_VCPKG_MANIFEST_DIR}"
-                            "--x-install-root=\"${_VCPKG_INSTALLED_DIR}\""
+                            "--x-install-root=${_VCPKG_INSTALLED_DIR}"
+                            ${VCPKG_ADDITIONAL_INSTALL_ARGS}
                             )
 
     _vcpkg_get_directory_name_of_file_above(_VCPKG_OVERLAY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg_manifest" "vcpkg.overlay")

--- a/toolsrc/src/vcpkg/vcpkglib.cpp
+++ b/toolsrc/src/vcpkg/vcpkglib.cpp
@@ -2,8 +2,8 @@
 
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
-#include <vcpkg/base/util.h>
 #include <vcpkg/base/system.debug.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>

--- a/toolsrc/src/vcpkg/vcpkglib.cpp
+++ b/toolsrc/src/vcpkg/vcpkglib.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/strings.h>
 #include <vcpkg/base/util.h>
+#include <vcpkg/base/system.debug.h>
 
 #include <vcpkg/metrics.h>
 #include <vcpkg/paragraphs.h>
@@ -24,7 +25,7 @@ namespace vcpkg
 
             fs.rename(vcpkg_dir_status_file_old, vcpkg_dir_status_file, VCPKG_LINE_INFO);
         }
-
+        Debug::print("Trying to load database from ", vcpkg_dir_status_file.u8string(), '\n');
         auto pghs = Paragraphs::get_paragraphs(fs, vcpkg_dir_status_file).value_or_exit(VCPKG_LINE_INFO);
 
         std::vector<std::unique_ptr<StatusParagraph>> status_pghs;


### PR DESCRIPTION
- moves manifest stuff logical together
- dont let `_vcpkg_get_directory_name_of_file_above` leak out of `CMAKE_SOURCE_DIR` or `CMAKE_BINARY_DIR` if searching for the manifest
- remove unnecessary double `.vcpkg.root` detection
- prefix all messages with `[vcpkg]:` so that user know that this message is comming from the vcpkg toolchain and not from cmake
- use `CMAKE_DEPENDENT_OPTION` instead of unnecessary `if() endif()` constructs
- use `VCPKG_TRIPLET_DIR` as user defined directory instead of `_VCPKG_INSTALLED_DIR`. Assume `_VCPKG_INSTALLED_DIR=VCPKG_TRIPLET_DIR/..` instead of `VCPKG_TRIPLET_DIR=_VCPKG_INSTALLED_DIR/VCPKG_TARGET_TRIPLET` (we could drop `VCPKG_TARGET_TRIPLET` since changing this value ALWAYS requires a clean reconfigure or we need to use https://cmake.org/cmake/help/v3.18/command/variable_watch.html and force a clean reconfigure. We could also deduce `VCPKG_TARGET_TRIPLET` from `VCPKG_TRIPLET_DIR`)
- properly use quotes `"<somepath>"` in the vcpkg invocation
- add the possiblity to define `VCPKG_OVERLAY_PORTS` to invoke vcpkg with overlay ports in manifest mode 
- introduced `vcpkg.overlays` as a default file for port overlay information
- added `vcpkg_manifest` as a default first search path for manifest information instead of `CMAKE_CURRENT_SOURCE_DIR` (It should still pick it up if the manifest is in `CMAKE_CURRENT_SOURCE_DIR`)

@strega-nil: please comment and test ;)