### PR TITLE
[nana] Fix the version and language standard

### DIFF
--- a/ports/nana/CMakeLists.txt
+++ b/ports/nana/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
-project(nana VERSION 1.5.5 LANGUAGES CXX)
+project(nana VERSION 1.7.2 LANGUAGES CXX)
 
 option(NANA_ENABLE_PNG "Enable PNG support" OFF)
 option(NANA_ENABLE_JPEG "Enable JPEG support" OFF)
@@ -26,7 +26,7 @@ target_include_directories(nana PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-target_compile_features(nana PUBLIC cxx_std_14)
+target_compile_features(nana PUBLIC cxx_std_17)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_link_libraries(nana PUBLIC c++experimental)

--- a/ports/nana/CONTROL
+++ b/ports/nana/CONTROL
@@ -1,5 +1,6 @@
 Source: nana
-Version: 1.7.2-3
+Version: 1.7.2
+Port-Version: 4
 Homepage: https://github.com/cnjinhao/nana
 Description: Cross-platform library for GUI programming in modern C++ style.
 Build-Depends: libpng, libjpeg-turbo, freetype (!uwp&&!windows), fontconfig (!uwp&&!windows)


### PR DESCRIPTION
Closes https://github.com/microsoft/vcpkg/issues/5671

1. Update the verison in CMakeLists.txt
2. The original source https://github.com/cnjinhao/nana/blob/master/CMakeLists.txt#L34 set language standard is cxx_std_17, so update it as well.