### PR TITLE
[vcpkg_fixup_pkgconfig] Remove required in first find_program call for pkg-config

### DIFF
--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -276,7 +276,7 @@ function(vcpkg_fixup_pkgconfig)
     endif()
 
     if(NOT PKGCONFIG)
-        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/Cellar/pkg-config/0.29.2_3" REQUIRED)
+        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/Cellar/pkg-config/0.29.2_3")
         if(NOT PKGCONFIG AND CMAKE_HOST_WIN32)
             vcpkg_acquire_msys(MSYS_ROOT PACKAGES pkg-config)
             find_program(PKGCONFIG pkg-config PATHS "${MSYS_ROOT}/usr/bin" REQUIRED)

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -276,7 +276,7 @@ function(vcpkg_fixup_pkgconfig)
     endif()
 
     if(NOT PKGCONFIG)
-        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/bin" "/usr/local/Cellar/pkg-config/0.29.2_3")
+        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/bin")
         if(NOT PKGCONFIG AND CMAKE_HOST_WIN32)
             vcpkg_acquire_msys(MSYS_ROOT PACKAGES pkg-config)
             find_program(PKGCONFIG pkg-config PATHS "${MSYS_ROOT}/usr/bin" REQUIRED)

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -276,7 +276,7 @@ function(vcpkg_fixup_pkgconfig)
     endif()
 
     if(NOT PKGCONFIG)
-        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/Cellar/pkg-config/0.29.2_3")
+        find_program(PKGCONFIG pkg-config PATHS "bin" "/usr/bin" "/usr/local/bin" "/usr/local/Cellar/pkg-config/0.29.2_3")
         if(NOT PKGCONFIG AND CMAKE_HOST_WIN32)
             vcpkg_acquire_msys(MSYS_ROOT PACKAGES pkg-config)
             find_program(PKGCONFIG pkg-config PATHS "${MSYS_ROOT}/usr/bin" REQUIRED)


### PR DESCRIPTION
Due to cmake 3.18 actually respecting it. (Editted from mobile, currently on vacation without wlan access)
closes #12565 