### PR TITLE
[vcpkg] Fix build on Windows 8.1 SDK

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -141,7 +141,12 @@ namespace vcpkg::Files
             const auto target = read_symlink_implementation(oldpath, ec);
             if (ec) return;
 
-            const DWORD flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+            const DWORD flags =
+#if defined(SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE)
+                SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+#else
+                0;
+#endif
             if (!CreateSymbolicLinkW(newpath.c_str(), target.c_str(), flags))
             {
                 const auto err = GetLastError();


### PR DESCRIPTION
PR #12400 added `SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE`, which was added in an SDK that is newer than the oldest we support. Therefore, check for the existence of that flag before we use it.

cc @BillyONeal