### PR TITLE
[vcpkg msys] Fix msys2

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -43,25 +43,14 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     message(FATAL_ERROR "vcpkg_acquire_msys() can only be used on Windows hosts")
   endif()
 
-  # detect host architecture
-  if(DEFINED ENV{PROCESSOR_ARCHITEW6432})
-      set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITEW6432})
-  else()
-      set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITECTURE})
-  endif()
-
-  if(_vam_HOST_ARCHITECTURE STREQUAL "AMD64")
-    set(TOOLSUBPATH msys64)
-    set(URLS
-        "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz"
-        "https://github.com/msys2/msys2-installer/releases/download/2020-07-20/msys2-base-x86_64-20200720.tar.xz"
-    )
-    set(ARCHIVE "msys2-base-x86_64-20200720.tar.xz")
-    set(HASH 1d0841107ded2c7917ebe1810175b940dd9ee9478200d535af0c99b235eb1102659c08cbe0f760e6c1c2a06ecf2f49537c7e0470662a99b72f0f8f0011b5242d)
-    set(STAMP "initialized-msys2_64.stamp")
-  else()
-    message(FATAL_ERROR "msys2 is unfortunately no longer supported on 32-bit Windows.")
-  endif()
+  set(TOOLSUBPATH msys64)
+  set(URLS
+      "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz"
+      "https://github.com/msys2/msys2-installer/releases/download/2020-07-20/msys2-base-x86_64-20200720.tar.xz"
+  )
+  set(ARCHIVE "msys2-base-x86_64-20200720.tar.xz")
+  set(HASH 1d0841107ded2c7917ebe1810175b940dd9ee9478200d535af0c99b235eb1102659c08cbe0f760e6c1c2a06ecf2f49537c7e0470662a99b72f0f8f0011b5242d)
+  set(STAMP "initialized-msys2_64.stamp")
 
   set(PATH_TO_ROOT ${TOOLPATH}/${TOOLSUBPATH})
 

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -43,6 +43,16 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     message(FATAL_ERROR "vcpkg_acquire_msys() can only be used on Windows hosts")
   endif()
 
+  if (DEFINED ENV{PROCESSOR_ARCHITEW6432})
+    set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITEW6432})
+  else()
+    set(_vam_HOST_ARCHITECTURE $ENV{PROCESSOR_ARCHITECTURE})
+  endif()
+
+  if(_vam_HOST_ARCHITECTURE STREQUAL "x86")
+    message(FATAL_ERROR "msys2 is no longer supported on x86 hosts since version 2020-05-17.")
+  endif()
+
   set(TOOLSUBPATH msys64)
   set(URLS
       "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz"

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -52,7 +52,10 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
 
   if(_vam_HOST_ARCHITECTURE STREQUAL "AMD64")
     set(TOOLSUBPATH msys64)
-    set(URLS "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz")
+    set(URLS
+        "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz"
+        "https://github.com/msys2/msys2-installer/releases/download/2020-07-20/msys2-base-x86_64-20200720.tar.xz"
+    )
     set(ARCHIVE "msys2-base-x86_64-20200720.tar.xz")
     set(HASH 1d0841107ded2c7917ebe1810175b940dd9ee9478200d535af0c99b235eb1102659c08cbe0f760e6c1c2a06ecf2f49537c7e0470662a99b72f0f8f0011b5242d)
     set(STAMP "initialized-msys2_64.stamp")

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -52,22 +52,12 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
 
   if(_vam_HOST_ARCHITECTURE STREQUAL "AMD64")
     set(TOOLSUBPATH msys64)
-    set(URLS
-      "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz/download"
-      "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz"
-    )
-    set(ARCHIVE "msys2-base-x86_64-20190524.tar.xz")
-    set(HASH 50796072d01d30cc4a02df0f9dafb70e2584462e1341ef0eff94e2542d3f5173f20f81e8f743e9641b7528ea1492edff20ce83cb40c6e292904905abe2a91ccc)
+    set(URLS "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200720.tar.xz")
+    set(ARCHIVE "msys2-base-x86_64-20200720.tar.xz")
+    set(HASH 1d0841107ded2c7917ebe1810175b940dd9ee9478200d535af0c99b235eb1102659c08cbe0f760e6c1c2a06ecf2f49537c7e0470662a99b72f0f8f0011b5242d)
     set(STAMP "initialized-msys2_64.stamp")
   else()
-    set(TOOLSUBPATH msys32)
-    set(URLS
-      "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz/download"
-      "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz"
-    )
-    set(ARCHIVE "msys2-base-i686-20190524.tar.xz")
-    set(HASH b26d7d432e1eabe2138c4caac5f0a62670f9dab833b9e91ca94b9e13d29a763323b0d30160f09a381ac442b473482dac799be0fea5dd7b28ea2ddd3ba3cd3c25)
-    set(STAMP "initialized-msys2_32.stamp")
+    message(FATAL_ERROR "msys2 is unfortunately no longer supported on 32-bit Windows.")
   endif()
 
   set(PATH_TO_ROOT ${TOOLPATH}/${TOOLSUBPATH})


### PR DESCRIPTION
Update to 2020-07-20. Unfortunately, this drops support for building on x86

cc @ras0219-msft @BillyONeal 