### PR TITLE
[azure-iot-sdk-c] Fix passing hsm_type_symm_key

### DIFF
--- a/ports/azure-iot-sdk-c/CONTROL
+++ b/ports/azure-iot-sdk-c/CONTROL
@@ -1,5 +1,6 @@
 Source: azure-iot-sdk-c
 Version: 2020-07-19
+Port-Version: 1
 Build-Depends: azure-uamqp-c, azure-umqtt-c, azure-c-shared-utility, parson, azure-uhttp-c, azure-macro-utils-c, umock-c
 Description: A C99 SDK for connecting devices to Microsoft Azure IoT services
 Homepage: https://github.com/Azure/azure-iot-sdk-c

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -25,6 +25,7 @@ else()
 endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    use-prov-client hsm_type_symm_key
     use-prov-client use_prov_client
 )
 
@@ -40,7 +41,6 @@ vcpkg_configure_cmake(
         -Duse_default_uuid=ON
         -Dbuild_as_dynamic=OFF
         -Duse_edge_modules=ON
-        -Dhsm_type_symm_key=${use_prov_client}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
A bug in the port file resulted in `hsm_type_symm_key` not being defined to `ON` when using the feature `use-prov-client`

+@ewertons for review