### PR TITLE
[libzip] Fix find_package error

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,5 +1,6 @@
 Source: libzip
 Version: 1.7.1
+Port-Version: 1
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
 Default-Features: bzip2,default-aes

--- a/ports/libzip/fix-findpackage.patch
+++ b/ports/libzip/fix-findpackage.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6e35082..d90c0c4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -482,7 +482,7 @@ CONFIGURE_PACKAGE_CONFIG_FILE("${PROJECT_NAME}.cmake.in" "${PROJECT_BINARY_DIR}/
+ IF(LIBZIP_DO_INSTALL)
+   INSTALL(EXPORT ${PROJECT_NAME}-targets
+     FILE ${PROJECT_NAME}-targets.cmake
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+     )
+ ENDIF()
+ 
+@@ -494,7 +494,7 @@ EXPORT(TARGETS zip
+ IF(LIBZIP_DO_INSTALL)
+   INSTALL(FILES ${PROJECT_BINARY_DIR}/zipconf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   INSTALL(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-version.cmake
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+     )
+ ENDIF()
+ 
+diff --git a/libzip.cmake.in b/libzip.cmake.in
+index 462439b..6caf754 100644
+--- a/libzip.cmake.in
++++ b/libzip.cmake.in
+@@ -1,7 +1,7 @@
+ @PACKAGE_INIT@
+ 
+ # Provide all our library targets to users.
+-include("@PACKAGE_CMAKE_INSTALL_LIBDIR@/cmake/libzip/libzip-targets.cmake")
++include("@PACKAGE_CMAKE_INSTALL_LIBDIR@/../share/libzip/libzip-targets.cmake")
+ 
+ get_filename_component(LIBZIP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ set(LIBZIP_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF dcd9a0bfe1ac2893d7f62bafb19f0a4d7b08c0f7 #v1.7.1
     SHA512 33ad594398f79544636464d6ae0892553a212dc833b508820f81f10823c3a5c4016288d05953176fb8d52919414edd28f26da6037b93129a58826abdcb501d18
     HEAD_REF master
+    PATCHES fix-findpackage.patch
 )
 
 vcpkg_check_features(


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #12600
Fix `find_package(libzip CONFIG REQUIRED)` error.
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes