### PR TITLE
[grpc] Fix generate plugin grpc_csharp_ext

### DIFF
--- a/ports/grpc/00011-fix-csharp_plugin.patch
+++ b/ports/grpc/00011-fix-csharp_plugin.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 77cf3de..8bceae6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1812,10 +1812,14 @@ endif()
+ 
+ if(gRPC_BUILD_CSHARP_EXT)
+ 
+-add_library(grpc_csharp_ext SHARED
++add_library(grpc_csharp_ext
+   src/csharp/ext/grpc_csharp_ext.c
+ )
+ 
++if (WIN32 AND BUILD_SHARED_LIBS)
++    target_compile_definitions(grpc_csharp_ext PUBLIC GPR_WINDOWS)
++endif()
++
+ set_target_properties(grpc_csharp_ext PROPERTIES
+   VERSION ${gRPC_CORE_VERSION}
+   SOVERSION ${gRPC_CORE_SOVERSION}
+@@ -1829,6 +1833,12 @@ if(WIN32 AND MSVC)
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_csharp_ext.pdb
+       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+     )
++    
++    install(TARGETS grpc_csharp_ext
++      RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
++      LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
++      ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
++    )
+   endif()
+ endif()
+ 

--- a/ports/grpc/CONTROL
+++ b/ports/grpc/CONTROL
@@ -1,5 +1,6 @@
 Source: grpc
 Version: 1.29.1
+Port-Version: 1
 Build-Depends: zlib, openssl, protobuf, c-ares (!uwp), upb, abseil
 Homepage: https://github.com/grpc/grpc
 Description: An RPC library and framework

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         00005-fix-uwp-error.patch
         00009-use-system-upb.patch
         00010-add-feature-absl-sync.patch
+        00011-fix-csharp_plugin.patch
         snprintf.patch
 )
 


### PR DESCRIPTION
In _grpc_csharp_ext.c_ line 31:
```cpp
#ifdef GPR_WINDOWS
#define GPR_EXPORT __declspec(dllexport)
#define GPR_CALLTYPE __stdcall
#endif

#ifndef GPR_EXPORT
#define GPR_EXPORT
#endif
```
Since we set grpc to use the build as a static library, the plugin cannot be installed correctly.

Fixes #12579.