### PR TITLE
[secp256k1] Fix build failures and export cmake targets

### DIFF
--- a/ports/secp256k1/CMakeLists.txt
+++ b/ports/secp256k1/CMakeLists.txt
@@ -12,15 +12,24 @@ add_definitions(
 file(GLOB SOURCES src/secp256k1.c)
 add_library(secp256k1 ${SOURCES})
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-install(TARGETS secp256k1
-    RUNTIME DESTINATION bin
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
+target_include_directories(secp256k1 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 
 if(INSTALL_HEADERS)
     file(GLOB HEADERS include/*.h)
     install(FILES ${HEADERS} DESTINATION include)
 endif()
+
+install(TARGETS secp256k1 EXPORT unofficial-secp256k1-targets
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+)
+
+install(
+    EXPORT unofficial-secp256k1-targets
+    FILE unofficial-secp256k1-targets.cmake
+    NAMESPACE unofficial::
+    DESTINATION share/unofficial-secp256k1
+)

--- a/ports/secp256k1/CONTROL
+++ b/ports/secp256k1/CONTROL
@@ -1,4 +1,5 @@
 Source: secp256k1
-Version: 2017-19-10-0b7024185045a49a1a6a4c5615bf31c94f63d9c4-2
+Version: 2017-19-10
+Port-Version: 3
 Homepage: https://github.com/bitcoin-core/secp256k1
 Description: Optimized C library for EC operations on curve

--- a/ports/secp256k1/portfile.cmake
+++ b/ports/secp256k1/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -20,6 +18,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/secp256k1 RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+configure_file(${CMAKE_CURRENT_LIST_DIR}/secp256k1-config.cmake ${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}/unofficial-secp256k1-config.cmake @ONLY)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/secp256k1/secp256k1-config.cmake
+++ b/ports/secp256k1/secp256k1-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/unofficial-secp256k1-targets.cmake")

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1579,8 +1579,6 @@ sdl2-net:x64-uwp=fail
 # https://github.com/microsoft/vcpkg/issues/10918
 seal:arm-uwp=fail
 seal:x64-uwp=fail
-secp256k1:x64-linux=fail
-secp256k1:x64-osx=fail
 sentencepiece:arm64-windows=fail
 sentencepiece:arm-uwp=fail
 sentencepiece:x64-uwp=fail


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/12622

1. Add missing include path
2. Export the cmake targets
3. Remove secp256k1:x64-linux=fail and secp256k1:x64-osx=fail in ci baseline file.
