### PR TITLE
[gtkmm] fix missing symbol exports with gtkmm release build

### DIFF
--- a/ports/gtkmm/CONTROL
+++ b/ports/gtkmm/CONTROL
@@ -1,5 +1,6 @@
 Source: gtkmm
-Version: 3.22.2-2
+Version: 3.22.2
+Port-Version: 4
 Homepage: https://www.gtkmm.org/
 Description: gtkmm is the official C++ interface for the popular GUI library GTK+.
 Build-Depends: glib, atk, gtk, gdk-pixbuf, pango, cairo, libepoxy, gettext, glibmm, atkmm, cairomm, pangomm

--- a/ports/gtkmm/fix_treeviewcolumn.patch
+++ b/ports/gtkmm/fix_treeviewcolumn.patch
@@ -1,0 +1,15 @@
+diff --git a/gtk/gtkmm/treeviewcolumn.h b/gtk/gtkmm/treeviewcolumn.h
+index f2a77c1..c66302a 100644
+--- a/gtk/gtkmm/treeviewcolumn.h
++++ b/gtk/gtkmm/treeviewcolumn.h
+@@ -1026,9 +1026,7 @@ void TreeViewColumn::pack_end(const TreeModelColumn<T_ModelColumnType>& column,
+ template <class T_ModelColumnType> inline
+ TreeViewColumn::TreeViewColumn(const Glib::ustring& title,
+                                const TreeModelColumn<T_ModelColumnType>& column)
+-:
+-  Glib::ObjectBase(nullptr), // not (yet) a custom class
+-  Gtk::Object(Glib::ConstructParams(class_init_(), "title", title.c_str(), nullptr))
++: TreeViewColumn (title)
+ {
+   pack_start(column, true /* expand */);
+ }

--- a/ports/gtkmm/portfile.cmake
+++ b/ports/gtkmm/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
     PATCHES
         fix_properties.patch
+        fix_treeviewcolumn.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/msvc_recommended_pragmas.h DESTINATION ${SOURCE_PATH}/MSVC_Net2013)


### PR DESCRIPTION
**fix unresolved external Gtk::TreeViewColumn::`vbase destructor'(void) in release build by avoiding calling base class constructor from inline code**

Fixes #3339
