### PR TITLE
[libusb] build fails on windows due to symlink in extracted archive

### DIFF
--- a/ports/libusb/CONTROL
+++ b/ports/libusb/CONTROL
@@ -1,5 +1,6 @@
 Source: libusb
-Version: 1.0.23-1
+Version: 1.0.23
+Port-Version: 2
 Homepage: https://github.com/libusb/libusb
 Description: a cross-platform library to access USB devices
 Supports: !uwp

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -39,6 +39,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
       endif()
   endif()
 
+  # The README file in the archive is a symlink to README.md and cause issues with the windows MSBUILD process
+  file(REMOVE ${SOURCE_PATH}/README)
+
   vcpkg_install_msbuild(
       SOURCE_PATH ${SOURCE_PATH}
       PROJECT_SUBPATH msvc/libusb_${LIBUSB_PROJECT_TYPE}_${MSVS_VERSION}.vcxproj

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -39,7 +39,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
       endif()
   endif()
 
-  # The README file in the archive is a symlink to README.md and cause issues with the windows MSBUILD process
+  # The README file in the archive is a symlink to README.md 
+  # which causes issues with the windows MSBUILD process
   file(REMOVE ${SOURCE_PATH}/README)
 
   vcpkg_install_msbuild(


### PR DESCRIPTION
**Describe the pull request**

- Downloaded file `libusb-libusb-e782eeb2514266f6738e242cdcb18e3ae1ed06fa.tar.gz` contains an embedded symlink file: README [README.md] 
- Added cmake command to remove the symlink file after the download/extract function and before the vcpkg_install_msbuild() function within the VCPKG_TARGET_IS_WINDOWS section, approxiamately line 42/43 with comment.
- the `file(REMOVE ${SOURCE_PATH}/README` only deletes the symlink which msbuild has issues with, not the actual README.md file.

- What does your PR fix? Fixes #12642 

- Which triplets are supported/not supported? Effects only Windows msbuilds, does not affect triplet support

- Have you updated the CI baseline? No changes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
