### PR TITLE
[mpir, gmp] Add message to handle the conflicts between these two ports

### DIFF
--- a/ports/gmp/CONTROL
+++ b/ports/gmp/CONTROL
@@ -1,5 +1,0 @@
-Source: gmp
-Version: 6.2.0-2
-Homepage: https://gmplib.org/
-Description: The GNU Multiple Precision Arithmetic Library
-Build-Depends: vs-yasm (windows)

--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -1,3 +1,7 @@
+if(EXISTS "${CURRENT_INSTALLED_DIR}/include/gmp.h" OR "${CURRENT_INSTALLED_DIR}/include/gmpxx.h")
+    message(FATAL_ERROR "Can't build ${PORT} if mpir is installed. Please remove mpir, and try install ${PORT} again if you need it.")
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
@@ -5,9 +9,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
         REF e140dfc8668e96d7e56cbd46467945adcc6b3cc4 #v6.2.0
         SHA512 3b646c142447946bb4556db01214ff130da917bc149946b8cf086f3b01e1cc3d664b941a30a42608799c14461b2f29e4b894b72915d723bd736513c8914729b7
         HEAD_REF master
-        PATCHES vs.build.patch
-                runtime.patch
-                prefix.patch
+        PATCHES 
+            vs.build.patch
+            runtime.patch
+            prefix.patch
     )
     vcpkg_find_acquire_program(YASM)
     get_filename_component(YASM_DIR "${YASM}" DIRECTORY)
@@ -103,5 +108,3 @@ else()
     # # Handle copyright
     file(INSTALL "${SOURCE_PATH}/COPYINGv3" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 endif()
-
-

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "gmp",
+  "version-string": "6.2.0",
+  "port-version": 3,
+  "description": "The GNU Multiple Precision Arithmetic Library",
+  "homepage": "https://gmplib.org",
+  "dependencies": [
+    {
+      "name": "vs-yasm",
+      "platform": "windows"
+    }
+  ]
+}

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -1,5 +1,9 @@
 vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 
+if(EXISTS "${CURRENT_INSTALLED_DIR}/include/gmp.h" OR "${CURRENT_INSTALLED_DIR}/include/gmpxx.h")
+    message(FATAL_ERROR "Can't build ${PORT} if gmp is installed. Please remove gmp, and try to install ${PORT} again if you need it.")
+endif()
+
 if(VCPKG_CRT_LINKAGE STREQUAL "static" AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     message(FATAL_ERROR "${PORT} currently can only be built using the dynamic CRT when building DLLs")
 endif()

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpir",
   "version-string": "3.0.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "supports": "!(uwp | arm)"


### PR DESCRIPTION
- What does your PR fix? Fixes #11756

Both `mpir `and `gmp `will install `gmp.h `and `gmpxx.h` to _include/_ directory when building these two ports. Since these two files are different in each port.

Also update vcpkg.json for `gmp`.

Note: No feature needs to test.

