### PR TITLE
[libmariadb] Include bundled zlib and openssl

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -2,3 +2,12 @@ Source: libmariadb
 Version: 3.1.7-1
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
+Default-Features: zlib, openssl
+
+Feature: zlib
+Build-Depends: zlib
+Description: Use internal zlib
+
+Feature: openssl
+Build-Depends: openssl
+Description: Enable SSL support

--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,5 +1,6 @@
 Source: libmariadb
-Version: 3.1.7-1
+Version: 3.1.7
+Port-Version: 2
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
 Default-Features: zlib, openssl

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -17,13 +17,23 @@ vcpkg_from_github(
 			fix-InstallPath.patch
 )
 
+set(WITH_ZLIB OFF)
+if("zlib" IN_LIST FEATURES)
+    set(WITH_ZLIB ON)
+endif()
+set(WITH_SSL OFF)
+if("openssl" IN_LIST FEATURES)
+    set(WITH_SSL ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DWITH_UNITTEST=OFF
-        -DWITH_SSL=OFF
+        -DWITH_SSL=${WITH_SSL}
         -DWITH_CURL=OFF
+		-DWITH_EXTERNAL_ZLIB=${WITH_ZLIB}
 )
 
 vcpkg_install_cmake()

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -28,9 +28,7 @@ vcpkg_configure_cmake(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DWITH_UNITTEST=OFF
-        -DWITH_SSL=${WITH_SSL}
         -DWITH_CURL=OFF
-        -DWITH_EXTERNAL_ZLIB=${WITH_ZLIB}
 )
 
 vcpkg_install_cmake()

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -33,7 +33,7 @@ vcpkg_configure_cmake(
         -DWITH_UNITTEST=OFF
         -DWITH_SSL=${WITH_SSL}
         -DWITH_CURL=OFF
-		-DWITH_EXTERNAL_ZLIB=${WITH_ZLIB}
+        -DWITH_EXTERNAL_ZLIB=${WITH_ZLIB}
 )
 
 vcpkg_install_cmake()

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DWITH_UNITTEST=OFF
         -DWITH_SSL=${WITH_SSL}
         -DWITH_CURL=OFF

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -17,14 +17,10 @@ vcpkg_from_github(
 			fix-InstallPath.patch
 )
 
-set(WITH_ZLIB OFF)
-if("zlib" IN_LIST FEATURES)
-    set(WITH_ZLIB ON)
-endif()
-set(WITH_SSL OFF)
-if("openssl" IN_LIST FEATURES)
-    set(WITH_SSL ON)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    zlib WITH_EXTERNAL_ZLIB
+    openssl WITH_SSL
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
This pull request adds using vcpkg's openssl and zlib with libmariadb.

The first one fixes autolink issues when linking agains python27 or libpng (due to the fact that both inflate functions are autolinked with zlib and libmariadb)
The second change enables libmariadb to use SSL functions.