### PR TITLE
[libpq] only require bison and flex on Windows

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,6 +1,6 @@
 Source: libpq
 Version: 12.2
-Port-Version: 5
+Port-Version: 6
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -67,7 +67,11 @@ vcpkg_extract_source_archive_ex(
 )
 unset(buildenv_contents)
 # Get paths to required programs
-foreach(program_name BISON FLEX PERL)
+set(REQUIRED_PROGRAMS PERL)
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND REQUIRED_PROGRAMS BISON FLEX)
+endif()
+foreach(program_name ${REQUIRED_PROGRAMS})
     # Need to rename win_bison and win_flex to just bison and flex
     vcpkg_find_acquire_program(${program_name})
     get_filename_component(${program_name}_EXE_PATH ${${program_name}} DIRECTORY)


### PR DESCRIPTION
**Describe the pull request**
Only require bison and flex on Windows as generally they are not required when building from tarball. https://www.postgresql.org/message-id/52E7BC1B.6060007%40vmware.com
