### PR TITLE
[vcpkg] Add missing check for x86

### DIFF
--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -47,7 +47,7 @@ namespace vcpkg
 #else // ^^^ defined(_WIN32) / !defined(_WIN32) vvv
 #if defined(__x86_64__) || defined(_M_X64)
         return CPUArchitecture::X64;
-#elif defined(__x86__) || defined(_M_X86)
+#elif defined(__x86__) || defined(_M_X86) || defined(__i386__)
         return CPUArchitecture::X86;
 #elif defined(__arm__) || defined(_M_ARM)
         return CPUArchitecture::ARM;


### PR DESCRIPTION
Under FreeBSD 11.3 with GCC 9 x86, noone of the x86 macro are defined making vcpkg impossible to build.
This commit adds __i386__ as list of possible macros in order to allow vcpkg to be built.