### PR TITLE
[gamedev-framework] fix install path of *.cmake files

### DIFF
--- a/ports/gamedev-framework/CONTROL
+++ b/ports/gamedev-framework/CONTROL
@@ -1,5 +1,6 @@
 Source: gamedev-framework
 Version: 0.17
+Port-Version: 1
 Homepage: https://github.com/GamedevFramework/gf
 Description: gf is a framework to build 2D games in C++14.
 Build-Depends: sdl2, freetype, zlib, boost-algorithm, boost-filesystem, boost-heap, boost-container, stb, pugixml

--- a/ports/gamedev-framework/portfile.cmake
+++ b/ports/gamedev-framework/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/gf)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/gf TARGET_PATH share/gf)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE


### PR DESCRIPTION
The port name (gamedev-framework) differs from the package name (gf). The cmake files were installed in the default directory (`share/${PORT}`) which prevented the use of the port as cmake searches the files in `share/gf`. The `TARGET_PATH` of `vcpkg_fixup_cmake_targets` handles this case.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.