### PR TITLE
[ngspice] Initial port

### DIFF
--- a/ports/ngspice/CONTROL
+++ b/ports/ngspice/CONTROL
@@ -1,0 +1,5 @@
+Source: ngspice
+Version: 32
+Homepage: http://ngspice.sourceforge.net/
+Description: Ngspice is a mixed-level/mixed-signal electronic circuit simulator. It is a successor of the latest stable release of Berkeley SPICE
+Supports: (x86|x64) & windows & !uwp

--- a/ports/ngspice/CONTROL
+++ b/ports/ngspice/CONTROL
@@ -2,4 +2,4 @@ Source: ngspice
 Version: 32
 Homepage: http://ngspice.sourceforge.net/
 Description: Ngspice is a mixed-level/mixed-signal electronic circuit simulator. It is a successor of the latest stable release of Berkeley SPICE
-Supports: (x86|x64) & windows & !uwp
+Supports: !(linux|osx|arm|uwp)

--- a/ports/ngspice/portfile.cmake
+++ b/ports/ngspice/portfile.cmake
@@ -41,7 +41,6 @@ else()
     message(FATAL_ERROR "Sorry but ngspice only can be built in Windows")
 endif()
 
-
 # Unforunately install_msbuild isn't able to dual include directories that effectively layer
 file(GLOB NGSPICE_INCLUDES
     ${SOURCE_PATH}/visualc/src/include/ngspice/*

--- a/ports/ngspice/portfile.cmake
+++ b/ports/ngspice/portfile.cmake
@@ -1,0 +1,51 @@
+vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP" ON_ARCH "arm" "arm64")
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ngspice/ng-spice-rework
+    REF 32
+    FILENAME "ngspice-32.tar.gz"
+    SHA512 222eaa0cd6577a6eb8454bb49a7050a162d430c4b07a4fdc6baf350c5b3f5b018bac640fd44f465ec09c8cba6a9729b1cbe8d3d8c097f672acc2c22fabe8f4bc
+    PATCHES
+        use-winbison-global.patch
+)
+
+vcpkg_find_acquire_program(BISON)
+
+get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
+vcpkg_add_to_path(PREPEND "${BISON_DIR}")
+
+# Ensure its windows
+if (VCPKG_TARGET_IS_WINDOWS)
+    # Sadly, vcpkg globs .libs inside install_msbuild and whines that the 47 year old SPICE format isn't a MSVC lib ;)
+    # We need to kill them off first before the source tree is copied to a tmp location by install_msbuild
+
+    file(REMOVE_RECURSE ${SOURCE_PATH}/contrib)
+    file(REMOVE_RECURSE ${SOURCE_PATH}/examples)
+    file(REMOVE_RECURSE ${SOURCE_PATH}/man)
+    file(REMOVE_RECURSE ${SOURCE_PATH}/tests)
+
+    # We use build_msbuild because install_msbuild is incompatible due to SPICE using .lib for the last 47 years....
+    vcpkg_install_msbuild(
+        USE_VCPKG_INTEGRATION
+        SOURCE_PATH ${SOURCE_PATH}
+        INCLUDES_SUBPATH /src/include
+        LICENSE_SUBPATH COPYING
+        PLATFORM ${TRIPLET_SYSTEM_ARCH}    # install_msbuild swaps x86 for win32(bad) if we dont force our own setting
+        PROJECT_SUBPATH visualc/sharedspice.sln
+        TARGET Build
+    )
+else()
+    message(FATAL_ERROR "Sorry but ngspice only can be built in Windows")
+endif()
+
+
+# Unforunately install_msbuild isn't able to dual include directories that effectively layer
+file(GLOB NGSPICE_INCLUDES
+    ${SOURCE_PATH}/visualc/src/include/ngspice/*
+)
+file(COPY ${NGSPICE_INCLUDES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/ngspice)
+
+vcpkg_copy_pdbs()

--- a/ports/ngspice/use-winbison-global.patch
+++ b/ports/ngspice/use-winbison-global.patch
@@ -1,0 +1,13 @@
+diff --git a/visualc/sharedspice.vcxproj b/visualc/sharedspice.vcxproj
+index 96786b1..f5d9322 100644
+--- a/visualc/sharedspice.vcxproj
++++ b/visualc/sharedspice.vcxproj
+@@ -879,7 +879,7 @@
+   <ItemGroup>
+     <CustomBuild Include="..\src\frontend\parse-bison.y;..\src\spicelib\parser\inpptree-parser.y">
+       <Message>invoke win_bison.exe for %(Identity)</Message>
+-      <Command>..\..\flex-bison\win_bison.exe --output=.\tmp-bison\%(Filename).c --defines=.\tmp-bison\%(Filename).h %(Identity) || exit 1</Command>
++      <Command>win_bison.exe --output=.\tmp-bison\%(Filename).c --defines=.\tmp-bison\%(Filename).h %(Identity) || exit 1</Command>
+       <Outputs>.\tmp-bison\%(Filename).c;.\tmp-bison\%(Filename).h</Outputs>
+     </CustomBuild>
+     <None Include="..\src\sharedspice.map" />

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1149,6 +1149,7 @@ networkdirect-sdk:x64-linux=fail
 networkdirect-sdk:x64-osx=fail
 networkdirect-sdk:x64-uwp=fail
 networkdirect-sdk:x86-windows=fail
+ngspice:x64-windows-static=fail
 nmslib:arm64-windows=fail
 nmslib:arm-uwp=fail
 nmslib:x64-uwp=fail


### PR DESCRIPTION
This adds ngspice, an actively maintained open source SPICE (circuit simulator) as a shared library build for Windows.

This is currently only compatible with x86 and x64 for Windows as those are the only upstream supported arches for Windows (for now)