### PR TITLE
[vcpkg_fixup_pkgconfig] skip checks on paths with spaces

### DIFF
--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -135,7 +135,6 @@ function(vcpkg_fixup_pkgconfig_check_files pkg_cfg_cmd _file _config _system_lib
 
     string(REPLACE "\\ " "##" _pkg_lib_paths_output "${_pkg_lib_paths_output}") # Whitespace path protection
     string(REPLACE "${CURRENT_INSTALLED_DIR}" "CURRENT_INSTALLED_DIR" _pkg_lib_paths_output "${_pkg_lib_paths_output}") # Whitespace path protection
-    string(REPLACE "${CURRENT_INSTALLED_DIR_LOWER}" "CURRENT_INSTALLED_DIR" _pkg_lib_paths_output "${_pkg_lib_paths_output}") # Whitespace path protection
     string(REGEX REPLACE "(^[\t ]*|[\t ]+)-L" ";" _pkg_lib_paths_output "${_pkg_lib_paths_output}")
     debug_message("-L LIST TRANSFORMATION:'${_pkg_lib_paths_output}'")
     string(REGEX REPLACE "^[\t ]*;" "" _pkg_lib_paths_output "${_pkg_lib_paths_output}")
@@ -151,12 +150,9 @@ function(vcpkg_fixup_pkgconfig_check_files pkg_cfg_cmd _file _config _system_lib
     endforeach()
     debug_message("LIBS AFTER -L<path> REMOVAL:'${_pkg_libs_output}'")
 
-    string(TOLOWER "${CURRENT_INSTALLED_DIR}" CURRENT_INSTALLED_DIR_LOWER)
-    
     #Make the remaining libs a proper CMake List
     string(REPLACE "\\ " "##" _pkg_libs_output "${_pkg_libs_output}") # Whitespace path protection
     string(REPLACE "${CURRENT_INSTALLED_DIR}" "CURRENT_INSTALLED_DIR" _pkg_libs_output "${_pkg_libs_output}") # Whitespace path protection
-    string(REPLACE "${CURRENT_INSTALLED_DIR_LOWER}" "CURRENT_INSTALLED_DIR" _pkg_libs_output "${_pkg_libs_output}") # Whitespace path protection
     string(REGEX REPLACE "(^[\t ]*|[\t ]+)-l" ";-l" _pkg_libs_output "${_pkg_libs_output}")
     string(REGEX REPLACE "[\t ]*(-pthreads?)" ";\\1" _pkg_libs_output "${_pkg_libs_output}") # handle pthread without -l here (makes a lot of problems otherwise)
     string(REGEX REPLACE "^[\t ]*;[\t ]*" "" _pkg_libs_output "${_pkg_libs_output}")

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -113,6 +113,8 @@ function(vcpkg_fixup_pkgconfig_check_files pkg_cfg_cmd _file _config _system_lib
         debug_message("pkg-config error output:${_pkg_error_out}")
     endif()
 
+    # This does not correctly return -L paths with spaces. It only returns up to the first space on windows.
+    # Maybe running with native pkg-config on windows solves it ??? Otherwise try to quote all -L""
     execute_process(COMMAND "${pkg_cfg_cmd}" --print-errors --static --libs-only-L ${_package_name}
                     WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
                     RESULT_VARIABLE _pkg_error_var


### PR DESCRIPTION
- skip checks on paths with spaces
- introduce VCPKG_SKIP_PKGCONFIG_CHECK to skip the pkg-config if set to true|on
- some additional string replacements which might make spaces in paths work if a native pkg-config is used. 

closes  #12689
