### PR TITLE
[physx] Add support for checked and profile builds.

### DIFF
--- a/ports/physx/CONTROL
+++ b/ports/physx/CONTROL
@@ -1,5 +1,5 @@
 Source: physx
 Version: 4.1.1
-Port-Version: 4
+Port-Version: 5
 Description: The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs
 Supports: !uwp

--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -109,7 +109,9 @@ vcpkg_execute_required_process(
 	LOGNAME build-${TARGET_TRIPLET}
 )
 
-set(RELEASE_CONFIGURATION "release")
+if(NOT DEFINED RELEASE_CONFIGURATION)
+	set(RELEASE_CONFIGURATION "release")
+endif()
 set(DEBUG_CONFIGURATION "debug")
 
 vcpkg_build_msbuild(


### PR DESCRIPTION
This adds the ability to build the physx port in ["checked" and "profile" mode](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxguide/Manual/BuildingWithPhysX.html#build-configurations) using a custom triplet, enabling reports on API misuse and allowing scene visualization with the NVIDIA PhysX Visual Debugger in Release builds.

- What does your PR fix?
See above
- Which triplets are supported/not supported? Have you updated the CI baseline?
No change
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes