### PR TITLE
[vcpkg] Use https sources for common tools

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -54,7 +54,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     set(TOOLSUBPATH msys64)
     set(URLS
       "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz/download"
-      "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz"
+      "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz"
     )
     set(ARCHIVE "msys2-base-x86_64-20190524.tar.xz")
     set(HASH 50796072d01d30cc4a02df0f9dafb70e2584462e1341ef0eff94e2542d3f5173f20f81e8f743e9641b7528ea1492edff20ce83cb40c6e292904905abe2a91ccc)
@@ -63,7 +63,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     set(TOOLSUBPATH msys32)
     set(URLS
       "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz/download"
-      "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz"
+      "https://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz"
     )
     set(ARCHIVE "msys2-base-i686-20190524.tar.xz")
     set(HASH b26d7d432e1eabe2138c4caac5f0a62670f9dab833b9e91ca94b9e13d29a763323b0d30160f09a381ac442b473482dac799be0fea5dd7b28ea2ddd3ba3cd3c25)
@@ -84,12 +84,12 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     # download the new keyring, without it new packages and package updates
     # might not install
     vcpkg_download_distfile(KEYRING_PATH
-        URLS http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+        URLS https://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
         FILENAME msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
         SHA512 a5023fd17ccf6364bc6e27c5e63aea25f1fc264a5247cbae4008864c828c38c3e0b4de09ded650e28d2e24e319b5fcf7a9c0da0fa3a8ac81679470fc6bd120c9
     )
     vcpkg_download_distfile(KEYRING_SIG_PATH
-        URLS http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
+        URLS https://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
         FILENAME msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig
         SHA512 c326fefd13f58339afe0d0dc78306aa6ab27cafa8c4d792c2d34aa81fdd1f759d490990ab79daa9664a03a6dfa14ffd2b2ad828bf19a883410112d01f5ed6c4c
     )

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -79,8 +79,8 @@ function(vcpkg_find_acquire_program VAR)
     set(BREW_PACKAGE_NAME "nasm")
     set(APT_PACKAGE_NAME "nasm")
     set(URL
-      "http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win32/nasm-2.14.02-win32.zip"
-      "http://fossies.org/windows/misc/nasm-2.14.02-win32.zip"
+      "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win32/nasm-2.14.02-win32.zip"
+      "https://fossies.org/windows/misc/nasm-2.14.02-win32.zip"
     )
     set(ARCHIVE "nasm-2.14.02-win32.zip")
     set(HASH a0f16a9f3b668b086e3c4e23a33ff725998e120f2e3ccac8c28293fd4faeae6fc59398919e1b89eed7461685d2730de02f2eb83e321f73609f35bf6b17a23d1e)
@@ -192,8 +192,8 @@ function(vcpkg_find_acquire_program VAR)
     set(SUBDIR "jom-1.1.3")
     set(PATHS ${DOWNLOADS}/tools/jom/${SUBDIR})
     set(URL
-      "http://download.qt.io/official_releases/jom/jom_1_1_3.zip"
-      "http://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_1_1_3.zip"
+      "https://download.qt.io/official_releases/jom/jom_1_1_3.zip"
+      "https://mirrors.ocf.berkeley.edu/qt/official_releases/jom/jom_1_1_3.zip"
     )
     set(ARCHIVE "jom_1_1_3.zip")
     set(HASH 5b158ead86be4eb3a6780928d9163f8562372f30bde051d8c281d81027b766119a6e9241166b91de0aa6146836cea77e5121290e62e31b7a959407840fc57b33)
@@ -341,7 +341,7 @@ function(vcpkg_find_acquire_program VAR)
     set(DOXYGEN_VERSION 1.8.17)
     set(PATHS ${DOWNLOADS}/tools/doxygen)
     set(URL
-      "http://doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.windows.bin.zip"
+      "https://doxygen.nl/files/doxygen-${DOXYGEN_VERSION}.windows.bin.zip"
       "https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.windows.bin.zip")
     set(ARCHIVE "doxygen-${DOXYGEN_VERSION}.windows.bin.zip")
     set(HASH 6bac47ec552486783a70cc73b44cf86b4ceda12aba6b52835c2221712bd0a6c845cecec178c9ddaa88237f5a781f797add528f47e4ed017c7888eb1dd2bc0b4b)


### PR DESCRIPTION
Upgrade links to common tools to HTTPS. Manually tested all the links affected