### PR TITLE
Fix issue "print out missing path in read_lines" #12745.

### DIFF
--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -457,6 +457,7 @@ namespace vcpkg::Files
             std::fstream file_stream(file_path, std::ios_base::in | std::ios_base::binary);
             if (file_stream.fail())
             {
+                Debug::print("Missing path: ", file_path.u8string(), '\n');
                 return std::make_error_code(std::errc::no_such_file_or_directory);
             }
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? **Fixes #12745**

- Which triplets are supported/not supported? Have you updated the CI baseline?
**not relevant**

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
**yes**
