### PR TITLE
[vcpkg baseline] Disable paraview build on OSX

### DIFF
--- a/ports/paraview/CONTROL
+++ b/ports/paraview/CONTROL
@@ -1,9 +1,10 @@
 Source: paraview
 Version: 5.8.0
-Port-Version: 3
+Port-Version: 4
 Homepage: https://www.paraview.org/
 Description: VTK-based Data Analysis and Visualization Application
 Build-Depends: vtk[core,paraview], protobuf, cgns, boost-core, boost-format, boost-algorithm
+Supports: !osx
 
 Feature: vtkm
 Description: enables vtkm for the build of paraview


### PR DESCRIPTION
`paraview:x64-osx` regression will be fixed in #12434. 
Error log:
```
ninja: error: '/Users/vagrant/Data/installed/x64-osx/lib/libmath.a', needed by 'bin/pvrenderserver', missing and no known rule to make it
```

Disable paraview build on OSX for unblcoking PR #12405 #12559.