### PR TITLE
[flac] Disable stack smash protection and FORTIFY_SOURCE for mingw

### DIFF
--- a/ports/libflac/CONTROL
+++ b/ports/libflac/CONTROL
@@ -1,6 +1,6 @@
 Source: libflac
 Version: 1.3.3
-Port-Version: 2
+Port-Version: 3
 Homepage: https://xiph.org/flac/
 Description: Library for manipulating FLAC files
 Build-Depends: libogg

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -15,6 +15,13 @@ else()
     set(BUILD_SHARED_LIBS OFF)
 endif()
 
+if(VCPKG_TARGET_IS_MINGW)
+    set(WITH_STACK_PROTECTOR OFF)
+    set(DISABLE_FORTIFYING "-D_FORTIFY_SOURCE=0")
+else()
+    set(WITH_STACK_PROTECTOR ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -23,7 +30,10 @@ vcpkg_configure_cmake(
         -DBUILD_EXAMPLES=OFF
         -DBUILD_DOCS=OFF
         -DBUILD_TESTING=OFF
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        -DWITH_STACK_PROTECTOR=${WITH_STACK_PROTECTOR}
+        -DCMAKE_C_FLAGS=${DISABLE_FORTIFYING}
+        -DCMAKE_CXX_FLAGS=${DISABLE_FORTIFYING})
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -17,7 +17,8 @@ endif()
 
 if(VCPKG_TARGET_IS_MINGW)
     set(WITH_STACK_PROTECTOR OFF)
-    set(DISABLE_FORTIFYING "-D_FORTIFY_SOURCE=0")
+    string(APPEND VCPKG_C_FLAGS "-D_FORTIFY_SOURCE=0")
+    string(APPEND VCPKG_CXX_FLAGS "-D_FORTIFY_SOURCE=0")
 else()
     set(WITH_STACK_PROTECTOR ON)
 endif()
@@ -31,9 +32,7 @@ vcpkg_configure_cmake(
         -DBUILD_DOCS=OFF
         -DBUILD_TESTING=OFF
         -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-        -DWITH_STACK_PROTECTOR=${WITH_STACK_PROTECTOR}
-        -DCMAKE_C_FLAGS=${DISABLE_FORTIFYING}
-        -DCMAKE_CXX_FLAGS=${DISABLE_FORTIFYING})
+        -DWITH_STACK_PROTECTOR=${WITH_STACK_PROTECTOR})
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(
@@ -67,5 +66,4 @@ endif()
 
 # This license (BSD) is relevant only for library - if someone would want to install
 # FLAC cmd line tools as well additional license (GPL) should be included
-file(COPY ${SOURCE_PATH}/COPYING.Xiph DESTINATION ${CURRENT_PACKAGES_DIR}/share/libflac)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libflac/COPYING.Xiph ${CURRENT_PACKAGES_DIR}/share/libflac/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING.Xiph DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
This disables stack protection and FORTIFY_SOURCE on mingw, since it depends on libssp from GCC, which can cause licensing problems since libssp is GPL
- Which triplets are supported/not supported? Have you updated the CI baseline?
All `mingw` triplets
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes