### PR TITLE
[abseil] Fix CMake warning

### DIFF
--- a/ports/abseil/fix-cmake-threads-dependency.patch
+++ b/ports/abseil/fix-cmake-threads-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/CMake/abslConfig.cmake.in b/CMake/abslConfig.cmake.in.copy
+index 60847fa77..6d23f63d3 100644
+--- a/CMake/abslConfig.cmake.in
++++ b/CMake/abslConfig.cmake.in
+@@ -1,6 +1,7 @@
+ # absl CMake configuration file.
+
+-include(FindThreads)
++include(CMakeFindDependencyMacro)
++find_dependency(Threads)
+
+ @PACKAGE_INIT@
+

--- a/ports/abseil/fix-cmake-threads-dependency.patch
+++ b/ports/abseil/fix-cmake-threads-dependency.patch
@@ -1,4 +1,4 @@
-diff --git a/CMake/abslConfig.cmake.in b/CMake/abslConfig.cmake.in.copy
+diff --git a/CMake/abslConfig.cmake.in b/CMake/abslConfig.cmake.in
 index 60847fa77..6d23f63d3 100644
 --- a/CMake/abslConfig.cmake.in
 +++ b/CMake/abslConfig.cmake.in

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -11,8 +11,7 @@ set(ABSEIL_PATCHES
     # Remove this patch in next update, see https://github.com/google/cctz/pull/145
     fix-arm-build.patch
 
-    # Fix CMake Threads dependency issue (project developer warning).
-    # Change like https://github.com/abseil/abseil-cpp/commit/68494aae959dfbbf781cdf03a988d2f5fc7e4802
+    # This patch is an upstream commit: https://github.com/abseil/abseil-cpp/commit/68494aae959dfbbf781cdf03a988d2f5fc7e4802
     fix-cmake-threads-dependency.patch
 )
 

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -7,9 +7,13 @@ set(ABSEIL_PATCHES
 
     # This patch is an upstream commit, the related PR: https://github.com/abseil/abseil-cpp/pull/637
     fix-MSVCbuildfail.patch
-    
+
     # Remove this patch in next update, see https://github.com/google/cctz/pull/145
     fix-arm-build.patch
+
+    # Fix CMake Threads dependency issue (project developer warning).
+    # Change like https://github.com/abseil/abseil-cpp/commit/68494aae959dfbbf781cdf03a988d2f5fc7e4802
+    fix-cmake-threads-dependency.patch
 )
 
 if("cxx17" IN_LIST FEATURES)

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version-string": "2020-03-03",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
It applies the same fix as [this abseil commit](https://github.com/abseil/abseil-cpp/commit/68494aae959dfbbf781cdf03a988d2f5fc7e4802)
This warning:
```
CMake Warning (dev) at C:/Users/Dico/AppData/Local/JetBrains/Toolbox/apps/CLion/ch-0/202.6397.106/bin/cmake/win/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:272 (message):
  The package name passed to `find_package_handle_standard_args` (Threads)
  does not match the name of the calling package (absl).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  C:/Users/Dico/AppData/Local/JetBrains/Toolbox/apps/CLion/ch-0/202.6397.106/bin/cmake/win/share/cmake-3.17/Modules/FindThreads.cmake:234 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  C:/repos/vcpkg/installed/x64-windows-static-md/share/absl/abslConfig.cmake:3 (include)
  C:/repos/vcpkg/scripts/buildsystems/vcpkg.cmake:439 (_find_package)
  C:/repos/vcpkg/installed/x64-windows-static-md/share/gRPC/gRPCConfig.cmake:18 (find_package)
  C:/repos/vcpkg/scripts/buildsystems/vcpkg.cmake:437 (_find_package)
  CMakeLists.txt:27 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

- Which triplets are supported/not supported? Have you updated the CI baseline? 
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I read through the guide, I think so, except that there is no CONTROL file in this port (I bumped the version in vcpkg.json)