### PR TITLE
[raylib] Fix the feature issue

### DIFF
--- a/ports/raylib/CONTROL
+++ b/ports/raylib/CONTROL
@@ -1,9 +1,10 @@
 Source: raylib
 Version: 3.0.0
-Port-Version: 1
+Port-Version: 2
 Description: A simple and easy-to-use library to enjoy videogames programming
 Homepage: https://github.com/raysan5/raylib
 Supports: !(arm|uwp)
+Default-Features: use-audio
 
-Feature: non-audio
-Description: Build raylib without audio module
+Feature: use-audio
+Description: Build raylib with audio module

--- a/ports/raylib/portfile.cmake
+++ b/ports/raylib/portfile.cmake
@@ -25,8 +25,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    INVERTED_FEATURES
-    non-audio USE_AUDIO
+    use-audio USE_AUDIO
 )
 
 vcpkg_configure_cmake(
@@ -37,8 +36,8 @@ vcpkg_configure_cmake(
         -DBUILD_GAMES=OFF
         -DSHARED=${SHARED}
         -DSTATIC=${STATIC}
-        -DUSE_AUDIO=${USE_AUDIO}
         -DUSE_EXTERNAL_GLFW=OFF # externl glfw3 causes build errors on Windows
+        ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DENABLE_ASAN=ON
         -DENABLE_UBSAN=ON
@@ -74,8 +73,5 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     )
 endif()
 
-# Install usage
 configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
-
-# Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/12707

The original feature 'non-audio' added, however, the ${FEATURE_OPTIONS} wasn't added to cmake, then related symble doesn't export, that cause the link errors when use the raylib.

Change it build as default feature now.

Test:
```
#include "raylib.h"

int main(void)
{
	const int screenWidth = 800;
	const int screenHeight = 450;

	InitWindow(screenHeight, screenHeight, "raylib example");
	InitAudioDevice();
	Music music = LoadMusicStream("woop.mp3");
	PlayMusicStream(music);
}
```