### PR TITLE
[gSoap] Update to 2.8.105 and add a required shared directory

### DIFF
--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -1,5 +1,5 @@
 Source: gsoap
-Version: 2.8.102-4
+Version: 2.8.102-1
 Build-Depends: curl
 Homepage: https://sourceforge.net/projects/gsoap2/
 Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.

--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -1,5 +1,5 @@
 Source: gsoap
-Version: 2.8.105-1
+Version: 2.8.105
 Build-Depends: curl
 Homepage: https://sourceforge.net/projects/gsoap2/
 Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.

--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -3,4 +3,4 @@ Version: 2.8.105
 Build-Depends: curl
 Homepage: https://sourceforge.net/projects/gsoap2/
 Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.
-Supports: (x86 | x64) & windows
+Supports: !(linux|osx|arm|uwp)

--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -1,5 +1,5 @@
 Source: gsoap
-Version: 2.8.102-1
+Version: 2.8.105-1
 Build-Depends: curl
 Homepage: https://sourceforge.net/projects/gsoap2/
 Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.

--- a/ports/gsoap/portfile.cmake
+++ b/ports/gsoap/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsoap2
     REF gsoap-2.8
-    FILENAME "gsoap_2.8.102.zip"
-    SHA512 3cff65605b15f820c9d56e32575231fb6fb89927bafc1db85ac1f879acd8496d6f38b558e994d17cce475beae0976d5fafcff7f22b28cdfbec8b7ec4b08bcbe7
+    FILENAME "gsoap_2.8.105.zip"
+    SHA512 3b7b66ef738e9ba78f0c9d5ec141faab102dc2ed7c528e84358d530ec8cb913c559438bb86ae0f22e0736c4cd9be9e74f364a44257189ccaa1e6d001317f99de
     PATCHES fix-build-in-windows.patch
 )
 
@@ -42,6 +42,9 @@ file(COPY ${SOURCE_PATH}/gsoap/stdsoap2.h ${SOURCE_PATH}/gsoap/stdsoap2.c ${SOUR
 
 # Handle import files
 file(COPY ${SOURCE_PATH}/gsoap/import DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Handle custom files
+file(COPY ${SOURCE_PATH}/gsoap/custom DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 
 # Handle plugin files
 file(COPY ${SOURCE_PATH}/gsoap/plugin DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -537,9 +537,6 @@ graphqlparser:x64-uwp=fail
 gsl:arm-uwp=fail
 gsl:x64-uwp=fail
 # https://github.com/microsoft/vcpkg/pull/11048
-gsoap:x64-linux=fail
-gsoap:x64-osx=fail
-gsoap:x64-uwp=fail
 gtk:x64-linux=fail
 guetzli:x64-osx=fail
 h3:arm64-windows=fail


### PR DESCRIPTION
Updated to the newly released upstream version.
This requires a new directory - "custom" - to be copied to the gSoap share folder