### PR TITLE
[urdfdom] Fixing up _IMPORT_PREFIX

### DIFF
--- a/ports/urdfdom/0003_import_prefix.patch
+++ b/ports/urdfdom/0003_import_prefix.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/urdfdom-config.cmake.in b/cmake/urdfdom-config.cmake.in
+index fb81b47..3ccad51 100644
+--- a/cmake/urdfdom-config.cmake.in
++++ b/cmake/urdfdom-config.cmake.in
+@@ -3,6 +3,10 @@ if (@PKG_NAME@_CONFIG_INCLUDED)
+ endif()
+ set(@PKG_NAME@_CONFIG_INCLUDED TRUE)
+ 
++# Vcpkg fix-ups
++get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++
+ set(@PKG_NAME@_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include" "@TinyXML_INCLUDE_DIRS@")
+ 
+ foreach(lib @PKG_LIBRARIES@)

--- a/ports/urdfdom/CONTROL
+++ b/ports/urdfdom/CONTROL
@@ -1,5 +1,5 @@
 Source: urdfdom
-Version: 1.0.4
+Version: 1.0.4-1
 Homepage: https://github.com/ros/urdfdom
 Description: Provides core data structures and a simple XML parsers for populating the class data structures from an URDF file.
 Build-Depends: console-bridge, tinyxml, urdfdom-headers

--- a/ports/urdfdom/portfile.cmake
+++ b/ports/urdfdom/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
   PATCHES
     0001_use_math_defines.patch
     0002_fix_exports.patch
+    0003_import_prefix.patch
 )
 
 vcpkg_configure_cmake(
@@ -28,10 +29,6 @@ else()
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/urdfdom)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/urdfdom)
 endif()
-
-file(READ ${CURRENT_PACKAGES_DIR}/share/urdfdom/urdfdom-config.cmake _contents)
-string(REPLACE "\${_IMPORT_PREFIX}" "\${CMAKE_CURRENT_LIST_DIR}/../.." _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/urdfdom/urdfdom-config.cmake "${_contents}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)

--- a/ports/urdfdom/portfile.cmake
+++ b/ports/urdfdom/portfile.cmake
@@ -29,6 +29,10 @@ else()
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/urdfdom)
 endif()
 
+file(READ ${CURRENT_PACKAGES_DIR}/share/urdfdom/urdfdom-config.cmake _contents)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${CMAKE_CURRENT_LIST_DIR}/../.." _contents "${_contents}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/urdfdom/urdfdom-config.cmake "${_contents}")
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
 


### PR DESCRIPTION
In the resulting `urdfdom-config.cmake`, it contains an uninitialized variables `${_IMPORT_PREFIX}`. The patch is fixing it up by replacing with `${CMAKE_CURRENT_LIST_DIR}/../..`.