### PR TITLE
[OGRE] Fix Overlay optional component build.

### DIFF
--- a/ports/ogre/fix-dependency.patch
+++ b/ports/ogre/fix-dependency.patch
@@ -2,16 +2,20 @@ diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
 index 959fdf5..dcd28bb 100644
 --- a/CMake/Dependencies.cmake
 +++ b/CMake/Dependencies.cmake
-@@ -217,7 +217,7 @@ find_package(FreeImage)
+@@ -217,7 +217,11 @@
  macro_log_feature(FreeImage_FOUND "freeimage" "Support for commonly used graphics image formats" "http://freeimage.sourceforge.net" FALSE "" "")
  
  # Find FreeType
 -find_package(Freetype)
 +find_package(freetype CONFIG REQUIRED)
++if(freetype_FOUND AND TARGET freetype)
++  set(FREETYPE_FOUND True)
++  set(FREETYPE_LIBRARIES freetype)
++endif()
  macro_log_feature(FREETYPE_FOUND "freetype" "Portable font engine" "http://www.freetype.org" FALSE "" "")
  
  # Find X11
-@@ -291,7 +291,7 @@ macro_log_feature(SWIG_FOUND "SWIG" "Language bindings (Python, Java, C#) for OG
+@@ -291,7 +295,7 @@
  # Find sdl2
  if(NOT ANDROID AND NOT EMSCRIPTEN)
    # find script does not work in cross compilation environment

--- a/ports/ogre/fix-findimgui.patch
+++ b/ports/ogre/fix-findimgui.patch
@@ -33,3 +33,24 @@ index 1cea873..d3e756e 100644
    target_include_directories(OgreOverlay PUBLIC
      PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/imgui>"
      PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/imgui/misc/freetype>")
+--- a/Components/Bites/CMakeLists.txt
++++ n/Components/Bites/CMakeLists.txt
+@@ -125,6 +125,9 @@
+ endif()
+ 
+ if(OGRE_BUILD_COMPONENT_OVERLAY_IMGUI)
++  find_package(imgui CONFIG REQUIRED)
++  find_path(IMGUI_INCLUDE_DIR imgui.h)
++  list(APPEND DEPENDENCIES imgui::imgui)
+   list(APPEND SOURCES
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/OgreImGuiInputListener.cpp")
+ endif()
+@@ -143,7 +146,7 @@
+ 
+ if(OGRE_STATIC AND APPLE AND OGRE_BUILD_PLUGIN_CG)
+   # workaround so the Cg framework is found in the above condition
+-  target_include_directories(OgreBites PUBLIC ${Cg_INCLUDE_DIRS})
++  target_include_directories(OgreBites PUBLIC ${Cg_INCLUDE_DIRS} ${IMGUI_INCLUDE_DIR})
+ endif()
+ 
+ if(SDL2_FOUND)

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ogre",
   "version-string": "1.12.7",
+  "port-version": 1,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [


### PR DESCRIPTION
The `OGRE-Overlay` component is not actually enabled and built in vcpkg port, because it cannot find `Freetype` in the search space. This patch is to update the `Freetype` searching logic respectively and it will trigger the Overlay to be built.