### PR TITLE
[vcpkg] Make C++ the primary github language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * -text
+ports/** -linguist-detectable
 
 # Declare files that will always have LF line endings on checkout.
 scripts/ci.baseline.txt text eol=lf


### PR DESCRIPTION
set the linguist settings up so that github treats vcpkg as a C++
project (basically, ignore /ports)

