### PR TITLE
[jsoncons] Update to version 0.155.1

### DIFF
--- a/ports/jsoncons/CONTROL
+++ b/ports/jsoncons/CONTROL
@@ -1,4 +1,4 @@
 Source: jsoncons
-Version: 0.154.1
+Version: 0.155.1
 Description: A C++, header-only library for constructing JSON and JSON-like text and binary data formats, with JSON Pointer, JSON Patch, JSONPath, JMESPath, CSV, MessagePack, CBOR, BSON, UBJSON
 Homepage: https://github.com/danielaparker/jsoncons

--- a/ports/jsoncons/portfile.cmake
+++ b/ports/jsoncons/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danielaparker/jsoncons
-    REF b51fdde4b51b048b4a86aa8d7f1b17fac1ca1c85 # v0.154.1
-    SHA512 aa77bf2d9c6e8f21f0b04f4edcfb6bad486f5f1a7b7ed296101ca4d09da4e916b0425ce7d63408a7ebca238aeb695ac5248da7b94600eec3e7c42d7ddceffb1c
+    REF 0fd102277ca361b8a82cdab97df67d18fe335409 # v0.155.1
+    SHA512 77c64bd0f8ce681a5b517c4a94fbe718e15fa4c5047e718c93413dfa173614818f435419d64313555653966d3a2c35deec15702d9d3768eeba6aba129625fea4
     HEAD_REF master
 )
 


### PR DESCRIPTION
**Describe the pull request**

Update to version 0.155.1

- What does your PR fix? 

Fixes #261

- Which triplets are supported/not supported? Have you updated the CI baseline?

All triplets are supported. CI baseline has been updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
