### PR TITLE
[vcpkg] Fix forward declarations and missing pragma once

### DIFF
--- a/toolsrc/include/vcpkg/archives.h
+++ b/toolsrc/include/vcpkg/archives.h
@@ -2,7 +2,10 @@
 
 #include <vcpkg/base/files.h>
 
-#include <vcpkg/vcpkgpaths.h>
+namespace vcpkg
+{
+    struct VcpkgPaths;
+}
 
 namespace vcpkg::Archives
 {

--- a/toolsrc/include/vcpkg/buildenvironment.h
+++ b/toolsrc/include/vcpkg/buildenvironment.h
@@ -1,12 +1,14 @@
-#include <vcpkg/base/system.process.h>
+#pragma once
 
-#include <vcpkg/vcpkgpaths.h>
+#include <vcpkg/base/system.process.h>
 
 #include <string>
 #include <vector>
 
 namespace vcpkg
 {
+    struct VcpkgPaths;
+
     std::string make_cmake_cmd(const VcpkgPaths& paths,
                                const fs::path& cmake_script,
                                std::vector<System::CMakeVariable>&& pass_variables);

--- a/toolsrc/include/vcpkg/cmakevars.h
+++ b/toolsrc/include/vcpkg/cmakevars.h
@@ -3,11 +3,15 @@
 #include <vcpkg/base/optional.h>
 
 #include <vcpkg/portfileprovider.h>
-#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Dependencies
 {
     struct ActionPlan;
+}
+
+namespace vcpkg
+{
+    struct VcpkgPaths;
 }
 
 namespace vcpkg::CMakeVars

--- a/toolsrc/include/vcpkg/commands.contact.h
+++ b/toolsrc/include/vcpkg/commands.contact.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Contact
 {

--- a/toolsrc/include/vcpkg/commands.create.h
+++ b/toolsrc/include/vcpkg/commands.create.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Create
 {

--- a/toolsrc/include/vcpkg/commands.dependinfo.h
+++ b/toolsrc/include/vcpkg/commands.dependinfo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::DependInfo
 {

--- a/toolsrc/include/vcpkg/commands.edit.h
+++ b/toolsrc/include/vcpkg/commands.edit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Edit
 {

--- a/toolsrc/include/vcpkg/commands.format-manifest.h
+++ b/toolsrc/include/vcpkg/commands.format-manifest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::FormatManifest
 {

--- a/toolsrc/include/vcpkg/commands.h
+++ b/toolsrc/include/vcpkg/commands.h
@@ -1,16 +1,13 @@
 #pragma once
 
 #include <vcpkg/build.h>
-#include <vcpkg/commands.interface.h>
-#include <vcpkg/dependencies.h>
-#include <vcpkg/statusparagraphs.h>
-
-#include <array>
-#include <map>
-#include <vector>
 
 namespace vcpkg::Commands
 {
+    struct BasicCommand;
+    struct PathsCommand;
+    struct TripletCommand;
+
     template<class T>
     struct PackageNameAndFunction
     {

--- a/toolsrc/include/vcpkg/commands.info.h
+++ b/toolsrc/include/vcpkg/commands.info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Info
 {

--- a/toolsrc/include/vcpkg/commands.integrate.h
+++ b/toolsrc/include/vcpkg/commands.integrate.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Integrate
 {

--- a/toolsrc/include/vcpkg/commands.interface.h
+++ b/toolsrc/include/vcpkg/commands.interface.h
@@ -1,7 +1,16 @@
 #pragma once
 
-#include <vcpkg/vcpkgcmdarguments.h>
-#include <vcpkg/vcpkgpaths.h>
+#include <vcpkg/triplet.h>
+
+namespace vcpkg
+{
+    struct VcpkgCmdArguments;
+    struct VcpkgPaths;
+    namespace Files
+    {
+        struct Filesystem;
+    }
+}
 
 namespace vcpkg::Commands
 {

--- a/toolsrc/include/vcpkg/commands.list.h
+++ b/toolsrc/include/vcpkg/commands.list.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::List
 {

--- a/toolsrc/include/vcpkg/commands.owns.h
+++ b/toolsrc/include/vcpkg/commands.owns.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Owns
 {

--- a/toolsrc/include/vcpkg/commands.search.h
+++ b/toolsrc/include/vcpkg/commands.search.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Search
 {

--- a/toolsrc/include/vcpkg/commands.setinstalled.h
+++ b/toolsrc/include/vcpkg/commands.setinstalled.h
@@ -3,6 +3,7 @@
 #include <vcpkg/cmakevars.h>
 #include <vcpkg/commands.interface.h>
 #include <vcpkg/portfileprovider.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::SetInstalled
 {

--- a/toolsrc/include/vcpkg/commands.upgrade.h
+++ b/toolsrc/include/vcpkg/commands.upgrade.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::Upgrade
 {

--- a/toolsrc/include/vcpkg/commands.xvsinstances.h
+++ b/toolsrc/include/vcpkg/commands.xvsinstances.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::Commands::X_VSInstances
 {

--- a/toolsrc/include/vcpkg/dependencies.h
+++ b/toolsrc/include/vcpkg/dependencies.h
@@ -4,11 +4,7 @@
 #include <vcpkg/base/util.h>
 
 #include <vcpkg/build.h>
-#include <vcpkg/cmakevars.h>
 #include <vcpkg/packagespec.h>
-#include <vcpkg/portfileprovider.h>
-#include <vcpkg/statusparagraphs.h>
-#include <vcpkg/vcpkgpaths.h>
 
 #include <functional>
 #include <map>
@@ -17,6 +13,21 @@
 namespace vcpkg::Graphs
 {
     struct Randomizer;
+}
+
+namespace vcpkg::CMakeVars
+{
+    struct CMakeVarProvider;
+}
+
+namespace vcpkg::PortFileProvider
+{
+    struct PortFileProvider;
+}
+
+namespace vcpkg
+{
+    struct StatusParagraphs;
 }
 
 namespace vcpkg::Dependencies

--- a/toolsrc/include/vcpkg/export.ifw.h
+++ b/toolsrc/include/vcpkg/export.ifw.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <vcpkg/dependencies.h>
-#include <vcpkg/vcpkgpaths.h>
 
 #include <string>
 #include <vector>
+
+namespace vcpkg
+{
+    struct VcpkgPaths;
+}
 
 namespace vcpkg::Export::IFW
 {

--- a/toolsrc/include/vcpkg/help.h
+++ b/toolsrc/include/vcpkg/help.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 #include <string>
 

--- a/toolsrc/src/vcpkg/archives.cpp
+++ b/toolsrc/src/vcpkg/archives.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/archives.h>
 #include <vcpkg/commands.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Archives
 {

--- a/toolsrc/src/vcpkg/buildenvironment.cpp
+++ b/toolsrc/src/vcpkg/buildenvironment.cpp
@@ -1,5 +1,6 @@
 #include <vcpkg/buildenvironment.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg
 {

--- a/toolsrc/src/vcpkg/commands.ciclean.cpp
+++ b/toolsrc/src/vcpkg/commands.ciclean.cpp
@@ -4,6 +4,7 @@
 
 #include <vcpkg/commands.ciclean.h>
 #include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
 
 using namespace vcpkg;
 

--- a/toolsrc/src/vcpkg/commands.contact.cpp
+++ b/toolsrc/src/vcpkg/commands.contact.cpp
@@ -1,6 +1,7 @@
 #include <vcpkg/base/chrono.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.contact.h>
 #include <vcpkg/help.h>

--- a/toolsrc/src/vcpkg/commands.create.cpp
+++ b/toolsrc/src/vcpkg/commands.create.cpp
@@ -1,9 +1,11 @@
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/buildenvironment.h>
 #include <vcpkg/commands.create.h>
 #include <vcpkg/help.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::Create
 {

--- a/toolsrc/src/vcpkg/commands.fetch.cpp
+++ b/toolsrc/src/vcpkg/commands.fetch.cpp
@@ -1,6 +1,8 @@
 #include <vcpkg/base/system.print.h>
 
 #include <vcpkg/commands.fetch.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::Fetch
 {

--- a/toolsrc/src/vcpkg/commands.hash.cpp
+++ b/toolsrc/src/vcpkg/commands.hash.cpp
@@ -1,7 +1,10 @@
 #include <vcpkg/base/hash.h>
 #include <vcpkg/base/system.print.h>
+#include <vcpkg/base/util.h>
 
 #include <vcpkg/commands.hash.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::Hash
 {

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -9,6 +9,7 @@
 #include <vcpkg/metrics.h>
 #include <vcpkg/tools.h>
 #include <vcpkg/userconfig.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::Integrate
 {

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/commands.porthistory.h>
 #include <vcpkg/help.h>
 #include <vcpkg/tools.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Commands::PortHistory
 {

--- a/toolsrc/src/vcpkg/commands.version.cpp
+++ b/toolsrc/src/vcpkg/commands.version.cpp
@@ -3,6 +3,7 @@
 #include <vcpkg/commands.version.h>
 #include <vcpkg/help.h>
 #include <vcpkg/metrics.h>
+#include <vcpkg/vcpkgpaths.h>
 
 #define STRINGIFY(...) #__VA_ARGS__
 #define MACRO_TO_STRING(X) STRINGIFY(X)

--- a/toolsrc/src/vcpkg/commands.xvsinstances.cpp
+++ b/toolsrc/src/vcpkg/commands.xvsinstances.cpp
@@ -27,7 +27,7 @@ namespace vcpkg::Commands::X_VSInstances
 
         Checks::exit_success(VCPKG_LINE_INFO);
 #else
-        Util::unused(args, paths);
+        (void)(args, paths);
         Checks::exit_with_message(VCPKG_LINE_INFO, "This command is not supported on non-windows platforms.");
 #endif
     }


### PR DESCRIPTION
Most of the header files does contain a forward declaration for some incomplete types. In this pull request, I tried to add them to break the dependency between header files as well.

On the other hand, _buildenvironment.h_ file does not contain "_pragma once_" and fixed.