### PR TITLE
Fix/clang10 linux

### DIFF
--- a/toolsrc/src/vcpkg/base/system.cpp
+++ b/toolsrc/src/vcpkg/base/system.cpp
@@ -162,25 +162,6 @@ namespace vcpkg
         return s_home;
     }
 #else
-    static const ExpectedS<fs::path>& get_xdg_config_home() noexcept
-    {
-        static ExpectedS<fs::path> s_home = [] {
-            auto maybe_home = System::get_environment_variable("XDG_CONFIG_HOME");
-            if (auto p = maybe_home.get())
-            {
-                return ExpectedS<fs::path>(fs::u8path(*p));
-            }
-            else
-            {
-                return System::get_home_dir().map([](fs::path home) {
-                    home /= fs::u8path(".config");
-                    return home;
-                });
-            }
-        }();
-        return s_home;
-    }
-
     static const ExpectedS<fs::path>& get_xdg_cache_home() noexcept
     {
         static ExpectedS<fs::path> s_home = [] {

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -89,7 +89,7 @@ namespace vcpkg::Build
     {
         auto var_provider_storage = CMakeVars::make_triplet_cmake_var_provider(paths);
         auto& var_provider = *var_provider_storage;
-        var_provider.load_dep_info_vars(std::array<PackageSpec, 1>{full_spec.package_spec});
+        var_provider.load_dep_info_vars({{full_spec.package_spec}});
 
         StatusParagraphs status_db = database_load_check(paths);
 
@@ -302,9 +302,9 @@ namespace vcpkg::Build
                                   }));
     }
 
+#if defined(_WIN32)
     const System::Environment& EnvCache::get_action_env(const VcpkgPaths& paths, const AbiInfo& abi_info)
     {
-#if defined(_WIN32)
         std::string build_env_cmd =
             make_build_env_cmd(*abi_info.pre_build_info, abi_info.toolset.value_or_exit(VCPKG_LINE_INFO));
 
@@ -340,10 +340,13 @@ namespace vcpkg::Build
             else
                 return System::cmd_execute_modify_env(build_env_cmd, clean_env);
         });
-#else
-        return System::get_clean_environment();
-#endif
     }
+#else
+    const System::Environment& EnvCache::get_action_env(const VcpkgPaths&, const AbiInfo&)
+    {
+        return System::get_clean_environment();
+    }
+#endif
 
     static std::string load_compiler_hash(const VcpkgPaths& paths, const AbiInfo& abi_info);
 
@@ -524,7 +527,7 @@ namespace vcpkg::Build
         }
         Checks::check_exit(VCPKG_LINE_INFO,
                            !compiler_hash.empty(),
-                           "Error occured while detecting compiler information. Pass `--debug` for more information.");
+                           "Error occurred while detecting compiler information. Pass `--debug` for more information.");
 
         Debug::print("Detecting compiler hash for triplet ", triplet, ": ", compiler_hash, "\n");
         return compiler_hash;


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Fixes warnings treated as errors on Clang 10.0.0 Linux. Also one unused fn.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Does not apply (this is a fix for the tool).

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

**Additional notice** (so to understand some of these changes)

- I like the idea of Span<> being a view into contiguous memory (it basically avoids going through abstracted iterators).

- When initializing them with vectors, we are making a claim that will not necessarily last: std::vector may need to re-allocate at some point, so it will all move elsewhere. But while within a fn called with a temporary object, it's fairly safe. 

- Clang is wiser than other compilers and won't let us just go ahead and use vectors for that reason. So I changed it to the address of the first element, and the count (totally equivalent, and the potential risks made explicit).

Of course, I may have completely misunderstood something here, so comments and clarifications are very welcome.

**Compiler Messages**

```
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin


/home/ignacio/src/tests/vcpkg/toolsrc/src/vcpkg/base/system.cpp:163:39: error: unused function 'get_xdg_config_home' [-Werror,-Wunused-function]
    static const ExpectedS<fs::path>& get_xdg_config_home() noexcept
                                      ^
1 error generated.
make[2]: *** [CMakeFiles/vcpkglib.dir/build.make:219: CMakeFiles/vcpkglib.dir/src/vcpkg/base/system.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:162: CMakeFiles/vcpkglib.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
/home/ignacio/src/tests/vcpkg/toolsrc/src/vcpkg/build.cpp:303:75: error: unused parameter 'paths' [-Werror,-Wunused-parameter]
    const System::Environment& EnvCache::get_action_env(const VcpkgPaths& paths, const AbiInfo& abi_info)
                                                                          ^
/home/ignacio/src/tests/vcpkg/toolsrc/src/vcpkg/build.cpp:303:97: error: unused parameter 'abi_info' [-Werror,-Wunused-parameter]
    const System::Environment& EnvCache::get_action_env(const VcpkgPaths& paths, const AbiInfo& abi_info)
                                                                                                ^
2 errors generated.
make[2]: *** [CMakeFiles/vcpkglib.dir/build.make:323: CMakeFiles/vcpkglib.dir/src/vcpkg/build.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:162: CMakeFiles/vcpkglib.dir/all] Error 2
make: *** [Makefile:95: all] Error 2
```