### PR TITLE
[boost-uninstall] Add port to easily uninstall all boost components

### DIFF
--- a/ports/boost-build/CONTROL
+++ b/ports/boost-build/CONTROL
@@ -1,5 +1,6 @@
 Source: boost-build
 Version: 1.73.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/boostorg/build
 Description: Boost.Build
+Build-Depends: boost-uninstall

--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,3 +1,4 @@
 Source: boost-modular-build-helper
 Version: 1.73.0
-Port-Version: 3
+Port-Version: 4
+Build-Depends: boost-uninstall

--- a/ports/boost-uninstall/CONTROL
+++ b/ports/boost-uninstall/CONTROL
@@ -1,0 +1,4 @@
+Source: boost-uninstall
+Version: 1.73.0
+Homepage: https://boost.org
+Description: boost uninstall port

--- a/ports/boost-uninstall/portfile.cmake
+++ b/ports/boost-uninstall/portfile.cmake
@@ -1,0 +1,1 @@
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/boost-uninstall/portfile.cmake
+++ b/ports/boost-uninstall/portfile.cmake
@@ -1,5 +1,4 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
 message(STATUS "\nPlease use the following command when you need to remove all boost ports/components:\n\
-
     \"./vcpkg remove boost-uninstall:${TARGET_TRIPLET} --recurse\"\n")

--- a/ports/boost-uninstall/portfile.cmake
+++ b/ports/boost-uninstall/portfile.cmake
@@ -1,4 +1,5 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
-message(STATUS "\nPlease using the following command when you need to remove all boost ports/components:\n\
+message(STATUS "\nPlease use the following command when you need to remove all boost ports/components:\n\
+
     \"./vcpkg remove boost-uninstall:${TARGET_TRIPLET} --recurse\"\n")

--- a/ports/boost-uninstall/portfile.cmake
+++ b/ports/boost-uninstall/portfile.cmake
@@ -1,1 +1,4 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+message(STATUS "\nPlease using the following command when you need to remove all boost ports/components:\n\
+    \"./vcpkg remove boost-uninstall --recurse\"\n")

--- a/ports/boost-uninstall/portfile.cmake
+++ b/ports/boost-uninstall/portfile.cmake
@@ -1,4 +1,4 @@
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
 
 message(STATUS "\nPlease using the following command when you need to remove all boost ports/components:\n\
-    \"./vcpkg remove boost-uninstall --recurse\"\n")
+    \"./vcpkg remove boost-uninstall:${TARGET_TRIPLET} --recurse\"\n")

--- a/ports/boost-vcpkg-helpers/CONTROL
+++ b/ports/boost-vcpkg-helpers/CONTROL
@@ -1,3 +1,5 @@
 Source: boost-vcpkg-helpers
 Version: 7
+Port-Version: 1
 Description: a set of vcpkg-internal scripts used to modularize boost
+Build-Depends: boost-uninstall


### PR DESCRIPTION
Since boost contains three additional installation function ports(`boost-build`, `boost-vcpkg-helpers`, `boost-modual-build-helper`), removing all boost components requires the following three steps:
1. `./vcpkg remove boost-vcpkg-helpers --recurse`
2. `./vcpkg remove boost-modular-build-helper`
3. `./vcpkg remove boost-build`

Add a port to easily uninstall all boost components using the following command:
```sh
./vcpkg remove boost-uninstall --recurse
```