### PR TITLE
[vcpkg baseline] Fix openimageio and pangolin build failures on Linux

### DIFF
--- a/ports/libheif/CONTROL
+++ b/ports/libheif/CONTROL
@@ -1,5 +1,6 @@
 Source: libheif
 Version: 1.7.0
+Port-Version: 1
 Homepage: http://www.libheif.org/
 Description: Open h.265 video codec implementation. 
 Build-Depends: x265, libde265

--- a/ports/libheif/install-extra-headers.patch
+++ b/ports/libheif/install-extra-headers.patch
@@ -1,0 +1,12 @@
+diff --git a/libheif/CMakeLists.txt b/libheif/CMakeLists.txt
+index 6d683ec..dc2c4eb 100644
+--- a/libheif/CMakeLists.txt
++++ b/libheif/CMakeLists.txt
+@@ -17,6 +17,7 @@ set(libheif_headers
+     heif_plugin_registry.h
+     heif_limits.h
+     heif_plugin.h
++    heif_cxx.h
+     logging.h
+     ${CMAKE_CURRENT_BINARY_DIR}/heif_version.h
+ )

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         dont_build_examples_and_gdk_pixbuf.patch
         remove_finding_pkgconfig.patch
+        install-extra-headers.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,9 +1,9 @@
 Source: openimageio
 Version: 2.1.16.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/OpenImageIO/oiio
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
-Build-Depends: libjpeg-turbo, tiff, libpng, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace, fmt
+Build-Depends: libjpeg-turbo, tiff, libpng, libheif, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace, fmt
 
 Feature: libraw
 Build-Depends: libraw

--- a/ports/pangolin/CONTROL
+++ b/ports/pangolin/CONTROL
@@ -1,6 +1,6 @@
 Source: pangolin
 Version: 0.5
-Port-Version: 8
+Port-Version: 9
 Build-Depends: eigen3, glew, libpng, libjpeg-turbo, ffmpeg
 Homepage: https://github.com/stevenlovegrove/Pangolin
 Description: Lightweight GUI Library

--- a/ports/pangolin/fix-dependency-python.patch
+++ b/ports/pangolin/fix-dependency-python.patch
@@ -1,5 +1,5 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 7f364a7..b6567a2 100644
+index 7f364a7..9e0baac 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -213,6 +213,9 @@ endif()
@@ -7,7 +7,7 @@ index 7f364a7..b6567a2 100644
  if(BUILD_PANGOLIN_GUI AND BUILD_PANGOLIN_VARS AND PYTHONLIBS_FOUND AND NOT _WIN_)
    set(HAVE_PYTHON 1)
 +  if (UNIX)
-+    set(PYTHON_LIBRARY ${PYTHON_LIBRARY} dl)
++    set(PYTHON_LIBRARY ${PYTHON_LIBRARY} dl util)
 +  endif()
    list(APPEND HEADERS
      ${INCDIR}/console/ConsoleInterpreter.h


### PR DESCRIPTION
For openimageio:
```
/mnt/vcpkg-ci/buildtrees/openimageio/src/9c73ea82cc-f088f982ce.clean/src/heif.imageio/heifinput.cpp:8:10: fatal error: libheif/heif_cxx.h: No such file or directory
 #include <libheif/heif_cxx.h>
          ^~~~~~~~~~~~~~~~~~~~
```
This need to add libheif to the dependency list and install this extra headers.

For pangolin:
```
: && /usr/bin/c++  -std=c++0x -Wall -Wextra -fPIC -g  -rdynamic examples/SharedMemoryVideoWriter/CMakeFiles/SharedMemoryVideoWriter.dir/main.cpp.o  -o examples/SharedMemoryVideoWriter/SharedMemoryVideoWriter  src/libpangolin.a  -lrt  -lpthread  -lGL  -lGLU  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libGLEWd.a  -lSM  -lICE  -lX11  -lXext  /mnt/vcpkg-ci/installed/x64-linux/lib/libpython3.8.a  -ldl  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libavformat.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libavdevice.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libavcodec.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libavutil.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libswscale.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libswresample.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libpng16d.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libz.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libjpeg.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libtiffd.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/liblzmad.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libz.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libjpeg.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libtiffd.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/liblzmad.a  -lm && :
/mnt/vcpkg-ci/installed/x64-linux/lib/libpython3.8.a(posixmodule.o): In function `os_openpty_impl':
/mnt/vcpkg-ci/buildtrees/python3/src/v3.8.3-43b03f2bf0.clean-x64-linux-release/./Modules/posixmodule.c:6683: undefined reference to `openpty'
```
This is caused by not adding the `libutil` library in the Linux system when pangolin uses python.

Related: #12672 #11836 #10132 etc.