### PR TITLE
[vcpkg_execute_build_process] Re-fix qt5 components build

### DIFF
--- a/ports/qt5/CONTROL
+++ b/ports/qt5/CONTROL
@@ -1,6 +1,6 @@
 Source: qt5
 Version: 5.15.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework
 Build-Depends: qt5-base[core]

--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -63,7 +63,7 @@ function(vcpkg_execute_build_process)
            OR out_contents MATCHES "LINK : fatal error LNK1104:"
            OR out_contents MATCHES "LINK : fatal error LNK1201:"
             # The linker ran out of memory during execution. We will try continuing once more, with parallelism disabled.
-           OR out_contents MATCHES "Cannot create parent directory"
+           OR err_contents MATCHES "Cannot create parent directory" OR err_contents MATCHES "Cannot write file"
             # Multiple threads using the same directory at the same time cause conflicts, will try again.
            )
             message(STATUS "Restarting Build without parallelism because memory exceeded")


### PR DESCRIPTION
Fix my PR #12529.
The specified content is in the error log instead of the info log.

Related: #11836 #12857.