### PR TITLE
[vcpkg] Fix bullet lists for integration.md on readthedocs.io

### DIFF
--- a/docs/users/integration.md
+++ b/docs/users/integration.md
@@ -22,6 +22,7 @@ This will implicitly add Include Directories, Link Directories, and Link Librari
 For the vast majority of libraries, this is all you need to do -- just File -> New Project and write code! However, some libraries perform conflicting behaviors such as redefining `main()`. Since you need to choose per-project which of these conflicting options you want, you will need to add those libraries to your linker inputs manually.
 
 Here are some examples, though this is not an exhaustive list:
+
 - Gtest provides `gtest`, `gmock`, `gtest_main`, and `gmock_main`
 - SDL2 provides `SDL2main`
 - SFML provides `sfml-main`
@@ -81,6 +82,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
 #### Manual compiler settings
 
 Libraries are installed into the `installed\` subfolder, partitioned by architecture (e.g. x86-windows):
+
 * The header files are installed to `installed\x86-windows\include`
 * Release `.lib` files are installed to `installed\x86-windows\lib` or `installed\x86-windows\lib\manual-link`
 * Release `.dll` files are installed to `installed\x86-windows\bin`
@@ -112,6 +114,7 @@ Please also see our [blog post](https://blogs.msdn.microsoft.com/vcblog/2017/05/
 <a name="triplet-selection"></a>
 ### Triplet selection
 Every integration mechanism besides manually adding the folders will deduce a [triplet][] for your project as one of:
+
 - x86-windows
 - x64-windows
 - x86-uwp


### PR DESCRIPTION
Fix for markdownlint rule [MD032 - Lists should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.20.4/doc/Rules.md#md032)

**Describe the pull request**

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
