### PR TITLE
[imgui] Add messages for unsupported features

### DIFF
--- a/ports/imgui/CONTROL
+++ b/ports/imgui/CONTROL
@@ -1,6 +1,6 @@
 Source: imgui
 Version: 1.77
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/ocornut/imgui
 Description: Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.
 

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -10,6 +10,10 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
+if(("metal-binding" IN_LIST FEATURES OR "osx-binding" IN_LIST FEATURES) AND (NOT VCPKG_TARGET_IS_OSX))
+    message(FATAL_ERROR "Feature metal-binding and osx-binding are only supported on osx.")
+endif()
+
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     allegro5-binding            IMGUI_BUILD_ALLEGRO5_BINDING
     dx9-binding                 IMGUI_BUILD_DX9_BINDING


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #12887 

Add the related unsupported messages for feature `metal-binding` and` osx-binding` since they are only supported on osx.

Note: All features (except for `metal-binding` and` osx-binding`)  have passed with the following triplets:

-  x64-windows
- x64-windows-static



