### PR TITLE
[vcpkg] Fix editable bug

### DIFF
--- a/toolsrc/include/vcpkg/dependencies.h
+++ b/toolsrc/include/vcpkg/dependencies.h
@@ -56,6 +56,7 @@ namespace vcpkg::Dependencies
 
         std::string displayname() const;
         const std::string& public_abi() const;
+        bool has_package_abi() const;
         const Build::PreBuildInfo& pre_build_info(LineInfo linfo) const;
 
         PackageSpec spec;

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -205,7 +205,7 @@ namespace
 
             for (auto&& action : plan.install_actions)
             {
-                if (action.build_options.editable == Build::Editable::YES) continue;
+                if (!action.has_package_abi()) continue;
 
                 auto& spec = action.spec;
                 fs.remove_all(paths.package_dir(spec), VCPKG_LINE_INFO);

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -868,6 +868,7 @@ namespace vcpkg::Build
         abi_tag_entries.emplace_back("features", Strings::join(";", sorted_feature_list));
 
         if (action.build_options.use_head_version == UseHeadVersion::YES) abi_tag_entries.emplace_back("head", "");
+        if (action.build_options.editable == Editable::YES) abi_tag_entries.emplace_back("editable", "");
 
         Util::sort(abi_tag_entries);
 
@@ -1016,7 +1017,7 @@ namespace vcpkg::Build
         std::error_code ec;
         const fs::path abi_package_dir = paths.package_dir(spec) / "share" / spec.name();
         const fs::path abi_file_in_package = paths.package_dir(spec) / "share" / spec.name() / "vcpkg_abi_info.txt";
-        if (action.build_options.editable == Build::Editable::NO)
+        if (action.has_package_abi())
         {
             auto restore = binaries_provider.try_restore(paths, action);
             if (restore == RestoreResult::build_failed)
@@ -1041,7 +1042,7 @@ namespace vcpkg::Build
         fs.copy_file(abi_file, abi_file_in_package, fs::copy_options::none, ec);
         Checks::check_exit(VCPKG_LINE_INFO, !ec, "Could not copy into file: %s", abi_file_in_package.u8string());
 
-        if (action.build_options.editable == Build::Editable::NO && result.code == BuildResult::SUCCEEDED)
+        if (action.has_package_abi() && result.code == BuildResult::SUCCEEDED)
         {
             binaries_provider.push_success(paths, action);
         }

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -416,6 +416,11 @@ namespace vcpkg::Dependencies
             default: Checks::unreachable(VCPKG_LINE_INFO);
         }
     }
+    bool InstallPlanAction::has_package_abi() const
+    {
+        if (!abi_info) return false;
+        return !abi_info.get()->package_abi.empty();
+    }
     const Build::PreBuildInfo& InstallPlanAction::pre_build_info(LineInfo linfo) const
     {
         return *abi_info.value_or_exit(linfo).pre_build_info.get();


### PR DESCRIPTION
'Editable' packages should not have a package_abi: they should transitively prevent downstream packages from having a package_abi.
