### PR TITLE
[vcpkg] Fix build on older compilers.

### DIFF
--- a/toolsrc/include/vcpkg/base/expected.h
+++ b/toolsrc/include/vcpkg/base/expected.h
@@ -4,6 +4,7 @@
 #include <vcpkg/base/stringliteral.h>
 
 #include <system_error>
+#include <type_traits>
 
 namespace vcpkg
 {
@@ -111,7 +112,7 @@ namespace vcpkg
         ExpectedT(S&& s, ExpectedRightTag = {}) : m_s(std::move(s)) { }
 
         ExpectedT(const T& t, ExpectedLeftTag = {}) : m_t(t) { }
-        template<class = std::enable_if<!std::is_reference_v<T>>>
+        template<class = std::enable_if<!std::is_reference<T>::value>>
         ExpectedT(T&& t, ExpectedLeftTag = {}) : m_t(std::move(t))
         {
         }

--- a/toolsrc/include/vcpkg/base/span.h
+++ b/toolsrc/include/vcpkg/base/span.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <initializer_list>
+#include <type_traits>
 #include <vector>
 
 namespace vcpkg
@@ -29,7 +30,7 @@ namespace vcpkg
         {
         }
 
-        template<size_t N, class = std::enable_if_t<std::is_const_v<T>>>
+        template<size_t N, class = std::enable_if_t<std::is_const<T>::value>>
         constexpr Span(std::remove_const_t<T> (&arr)[N]) noexcept : m_ptr(arr), m_count(N)
         {
         }


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

  - `std::is_const_v` and `std::is_reference_v` are introduced in c++17, not available when using older compilers. This change replaces them with `std::is_const<T>::value` and `std::is_reference<T>::value`.
  - https://en.cppreference.com/w/cpp/types/is_const
  - https://en.cppreference.com/w/cpp/types/is_reference

- Which triplets are supported/not supported? Have you updated the CI baseline?

  - No CI baseline updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

  - Yes.

Signed-off-by: Hans <hans@dkmt.io>