### PR TITLE
[openblas] Fix generating pkg-config file

### DIFF
--- a/ports/openblas/CONTROL
+++ b/ports/openblas/CONTROL
@@ -1,6 +1,6 @@
 Source: openblas
 Version: 0.3.9
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/xianyi/OpenBLAS
 Build-Depends: pthread (linux&osx)
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.

--- a/ports/openblas/fix-pkg-config.patch
+++ b/ports/openblas/fix-pkg-config.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c324e224..4b82d767 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -389,11 +389,9 @@ if(NOT NO_LAPACKE)
+ 	install (FILES ${CMAKE_BINARY_DIR}/lapacke_mangling.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openblas${SUFFIX64})
+ endif()
+ 
+-include(FindPkgConfig QUIET)
+-if(PKG_CONFIG_FOUND)
+-	configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc @ONLY)
+-	install (FILES ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+-endif()
++# Install pkg-config files
++configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc @ONLY)
++install (FILES ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+ 
+ 
+ # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-space-path.patch
         fix-redefinition-function.patch
         github_2481.patch
+        fix-pkg-config.patch
 )
 
 find_program(GIT NAMES git git.cmd)


### PR DESCRIPTION
This PR makes sure that the pkg-config files are created correctly by the OpenBLAS configure/build steps.

OpenBLAS only creates the pkg-config files when pkg-config can be found during the CMake configure step (see https://github.com/xianyi/OpenBLAS/blob/efdd237a91646f0ce58815ef6507c04e393813a6/CMakeLists.txt#L392-L396).

To make sure the files are always created we find pkg-config beforehand and pass it to OpenBLAS CMake call via `-DPKG_CONFIG_EXECUTABLE`.

Some notes on the current implementation:

- The code to detect pkg-config was taken from the `vcpkg_fixup_pkgconfig` script. I would prefer to add pkg-config to `vcpkg_find_acquire_program` but I was not sure whether this is desired for a tool that will be installed through `msys` on windows.
- On my machine it was important to look for pkg-config before adding Perl to PATH. Otherwise a pkg-config distribution from within Perl at `<vcpkg_root>\downloads\tools\perl\perl\bin` was found, that is actually wrapped in a batch file and thus lead to errors afterwards. This might be important to take into account whenever vcpkg tries to find pkg-config.

edit: an alternative way to fix this would be to patch the OpenBLAS CMake files to always generate the pkg-config, since to my best knowledge pkg-config is actually not required to generate the files. But I kind of preferred to not introduce another patch that would have to be maintained for the next OpenBLAS version.
