### PR TITLE
[vtk] Fix building with MPI and Python enabled

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 1
+Port-Version: 2
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -68,6 +68,7 @@ endif()
 if("mpi" IN_LIST FEATURES)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_GROUP_ENABLE_MPI=YES
+        -DVTK_USE_MPI=YES
     )
 endif()
 

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -72,6 +72,12 @@ if("mpi" IN_LIST FEATURES)
     )
 endif()
 
+if("mpi" IN_LIST FEATURES AND "python" IN_LIST FEATURES)
+    list(APPEND ADDITIONAL_OPTIONS
+        -DVTK_MODULE_USE_EXTERNAL_VTK_mpi4py=OFF
+    )
+endif()
+
 if("opengl" IN_LIST FEATURES)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_MODULE_ENABLE_VTK_DomainsChemestryOpenGL2=YES


### PR DESCRIPTION
This fixes the configure step of VTK when both MPI and Python are enabled.

To build with MPI, we need to pass `-DVTK_USE_MPI=ON`.

When both MPI and Python are enabled, VTK needs `mpi4py`. This PR enabled VTK to build its own version of mpi4py instead of looking for an external version of it.
I am not 100% sure whether this is the best approach. Maybe having mpi4py as separate port is the better solution. Please note: even though mpi4py is a Python package, usually it is required that mpi4py and VTK are linking to the same MPI implementation to function correctly. Additionally installing mpi4py comes with a header `mpi4py.h` that is required by VTK, so in some sense it is both, a Python package and a C library, just like VTK itself. Let me know what you think.