### PR TITLE
[openmpi/vcpkg_build_make] Disable parallel build

### DIFF
--- a/ports/openmpi/CONTROL
+++ b/ports/openmpi/CONTROL
@@ -1,6 +1,6 @@
 Source: openmpi
 Version: 4.0.3
-Port-Version: 2
+Port-Version: 3
 Homepage: https://www.open-mpi.org/
 Description: The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.
 Supports: !(windows|uwp)

--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -30,7 +30,7 @@ vcpkg_configure_make(
             --enable-debug
 )
 
-vcpkg_install_make()
+vcpkg_install_make(DISABLE_PARALLEL)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -63,8 +63,10 @@ function(vcpkg_execute_build_process)
            OR out_contents MATCHES "LINK : fatal error LNK1104:"
            OR out_contents MATCHES "LINK : fatal error LNK1201:"
             # The linker ran out of memory during execution. We will try continuing once more, with parallelism disabled.
-           OR out_contents MATCHES "Cannot create parent directory"
+           OR err_contents MATCHES "Cannot create parent directory" OR err_contents MATCHES "Cannot write file"
             # Multiple threads using the same directory at the same time cause conflicts, will try again.
+           OR err_contents MATCHES "Can't open"
+            # Multiple threads caused the wrong order of creating folders and creating files in folders
            )
             message(STATUS "Restarting Build without parallelism because memory exceeded")
             set(LOG_OUT "${CURRENT_BUILDTREES_DIR}/${_ebp_LOGNAME}-out-1.log")


### PR DESCRIPTION
When building openmpi:x64-osx, the compiler report error:
```
Can't open profile/psizeof_f08.f90 for writing at ../../../.././../src/openmpi-4-d5305a6659.clean/ompi/mpi/fortran/base/gen-mpi-sizeof.pl line 189.
make[2]: *** [profile/psizeof_f08.f90] Error 2
make[2]: *** Waiting for unfinished jobs....
mkdir: profile: File exists
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```
It should be caused by parallel build, so add a parameter to disable parallel build.

Related: #12738.