### PR TITLE
[vcpkg] Overlay triplets environment support similar to overlay ports #12640

### DIFF
--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -38,6 +38,13 @@ Example: `D:\2017`
 
 This environment variable can be set to a triplet name which will be used for unqualified triplet references in command lines.
 
+#### VCPKG_OVERLAY_TRIPLETS
+
+This environment variable allows users to override triplets with alternate versions. List paths to overlays using 
+the platform dependent PATH seperator (Windows `;` | others `:`) 
+
+Example (Windows): `C:\custom-triplets\boost;C:\custom-triplets\sqlite3`
+
 #### VCPKG_OVERLAY_PORTS
 
 This environment variable allows users to override ports with alternate versions according to the

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -133,6 +133,7 @@ namespace vcpkg
         constexpr static StringLiteral OVERLAY_PORTS_ENV = "VCPKG_OVERLAY_PORTS";
         constexpr static StringLiteral OVERLAY_PORTS_ARG = "overlay-ports";
         std::vector<std::string> overlay_ports;
+        constexpr static StringLiteral OVERLAY_TRIPLETS_ENV = "VCPKG_OVERLAY_TRIPLETS";
         constexpr static StringLiteral OVERLAY_TRIPLETS_ARG = "overlay-triplets";
         std::vector<std::string> overlay_triplets;
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -613,6 +613,7 @@ namespace vcpkg
         table.format(opt(OVERLAY_PORTS_ARG, "=", "<path>"), "Specify directories to be used when searching for ports");
         table.format("", "(also: " + format_environment_variable("VCPKG_OVERLAY_PORTS") + ')');
         table.format(opt(OVERLAY_TRIPLETS_ARG, "=", "<path>"), "Specify directories containing triplets files");
+        table.format("", "(also: " + format_environment_variable("VCPKG_OVERLAY_TRIPLETS") + ')');
         table.format(opt(BINARY_SOURCES_ARG, "=", "<path>"),
                      "Add sources for binary caching. See 'vcpkg help binarycaching'");
         table.format(opt(DOWNLOADS_ROOT_DIR_ARG, "=", "<path>"), "Specify the downloads root directory");
@@ -657,6 +658,19 @@ namespace vcpkg
                 auto overlays = Strings::split(*unpacked, ':');
 #endif
                 overlay_ports.insert(std::end(overlay_ports), std::begin(overlays), std::end(overlays));
+            }
+        }
+
+        {
+            const auto vcpkg_overlay_triplets_env = System::get_environment_variable(OVERLAY_TRIPLETS_ENV);
+            if (const auto unpacked = vcpkg_overlay_triplets_env.get())
+            {
+#ifdef WIN32
+                auto triplets = Strings::split(*unpacked, ';');
+#else
+                auto triplets = Strings::split(*unpacked, ':');
+#endif
+                overlay_triplets.insert(std::end(overlay_triplets), std::begin(triplets), std::end(triplets));
             }
         }
 


### PR DESCRIPTION
This add support for specifying `VCPKG_OVERLAY_TRIPLETS` as an environment variable. Similar to what was done for the `VCPKG_OVERLAY_PORTS` in #12640