### PR TITLE
[gtest] Fix installed cmake file path

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,4 +1,5 @@
 Source: gtest
 Version: 1.10.0
+Port-Version: 1
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/GTest)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/GTest TARGET_PATH share/GTest)
 
 file(
     INSTALL


### PR DESCRIPTION
gtest generated `GTestConfig.cmake`, `GTestConfigVersion.cmake` etc.
Fix their installed path.

Related: #12604