### PR TITLE
[infoware] Bump version to 0.5.5

### DIFF
--- a/ports/infoware/CONTROL
+++ b/ports/infoware/CONTROL
@@ -1,6 +1,6 @@
 Source: infoware
 Homepage: https://github.com/ThePhD/infoware
-Version: 0.5.4
+Version: 0.5.5
 Description: C++ Library for pulling system and hardware information, without hitting the command line.
 # Note that independent usage and testing may work, but it seems to fail in CI environments for potential cross-compilation,
 # and is thusly noted here to note break how vcpkg builds things!

--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/infoware
-    REF v0.5.4
-    SHA512 16c7c39ca59128fe6489ec70b0d840d48cc44e57fe0d7d2dc864443cf8be288ceaf32e28246f6ac2dda495662d7a38d1e6ddf49172a73aac55445ecea95a29a8
+    REF v0.5.5
+    SHA512 06aea2c3a51df30cfc220eafb603620c3cf5f00b0d5935486ac46c6c2333972910af2b53fc1e2187b5fce0aa9650323a0dff526d768ff54888bfc549a8173903
     HEAD_REF master
 )
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? The infoware version being out of date.

- Which triplets are supported/not supported? Same ones. Have you updated the CI baseline? Still pretty sure I didn't.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Likewise I hope it still does.