### PR TITLE
[vcpkg] VCPKG_APPINSTALL_DEPS install dependencies on install #1653

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -388,9 +388,9 @@ function(add_library name)
     endif()
 endfunction()
 
-option(VCPKG_APPINSTALL_DEPS "Automatically copy dependencies into the install directory for executables and libraries." OFF)
+option(x_VCPKG_APPINSTALL_DEPS "Automatically copy dependencies into the install directory for executables and libraries." OFF)
 function(x_vcpkg_install_local_dependencies)
-    if(VCPKG_APPINSTALL_DEPS)
+    if(x_VCPKG_APPINSTALL_DEPS)
         if(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "windows|uwp")
             # Parse command line
             cmake_parse_arguments(__VCPKG_APPINSTALL "" "DESTINATION" "TARGETS" ${ARGN})

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -428,7 +428,7 @@ function(install)
                     _install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                         execute_process(COMMAND 
                             powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
-                            -targetBinary ${__VCPKG_INSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>
+                            -targetBinary \"${__VCPKG_INSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
                             -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
                             -OutVariable out)")
                 endforeach()

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -388,7 +388,7 @@ function(add_library name)
     endif()
 endfunction()
 
-option(VCPKG_APPINSTALL_DEPS "Automatically copy dependencies into the install directory for executables and libraries." ON)
+option(VCPKG_APPINSTALL_DEPS "Automatically copy dependencies into the install directory for executables and libraries." OFF)
 function(install)
     _install(${ARGV})
 

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -388,22 +388,23 @@ function(add_library name)
     endif()
 endfunction()
 
-option(x_VCPKG_APPINSTALL_DEPS "Automatically copy dependencies into the install directory for executables and libraries." OFF)
+# This is an experimental function to enable applocal install of dependencies as part of the `make install` process
+# Arguments:
+#   TARGETS - a list of installed targets to have dependencies copied for
+#   DESTINATION - the runtime directory for those targets (usually `bin`)
 function(x_vcpkg_install_local_dependencies)
-    if(x_VCPKG_APPINSTALL_DEPS)
-        if(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "windows|uwp")
-            # Parse command line
-            cmake_parse_arguments(__VCPKG_APPINSTALL "" "DESTINATION" "TARGETS" ${ARGN})
+    if(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "windows|uwp")
+        # Parse command line
+        cmake_parse_arguments(__VCPKG_APPINSTALL "" "DESTINATION" "TARGETS" ${ARGN})
 
-            foreach(TARGET ${__VCPKG_APPINSTALL_TARGETS})
-                _install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
-                    execute_process(COMMAND 
-                        powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
-                        -targetBinary \"${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
-                        -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
-                        -OutVariable out)")
-            endforeach()
-        endif()
+        foreach(TARGET ${__VCPKG_APPINSTALL_TARGETS})
+            _install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
+                execute_process(COMMAND 
+                    powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
+                    -targetBinary \"${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
+                    -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
+                    -OutVariable out)")
+        endforeach()
     endif()
 endfunction()
 

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -425,7 +425,6 @@ function(install)
                 endforeach()
 
                 foreach(TARGET ${__VCPKG_INSTALL_TARGETS})
-                    message("Found target: ${TARGET}")
                     install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                         execute_process(COMMAND 
                             powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -425,7 +425,7 @@ function(install)
                 endforeach()
 
                 foreach(TARGET ${__VCPKG_INSTALL_TARGETS})
-                    install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
+                    _install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                         execute_process(COMMAND 
                             powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
                             -targetBinary ${__VCPKG_INSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>


### PR DESCRIPTION
This fixes the issue of #1653 - CMake: provide option to deploy DLLs on install() like VCPKG_APPLOCAL_DEPS

The option is VCPKG_APPINSTALL_DEPS only works on Windows platforms and takes the logic used in the add_executable / add_library part of the post build step to determine the libraries during install.