### PR TITLE
[pcl] check SSE flags

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,6 @@
 Source: pcl
 Version: 1.11.0
+Port-Version: 1
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, vtk, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-sort, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio

--- a/ports/pcl/fix-check-sse.patch
+++ b/ports/pcl/fix-check-sse.patch
@@ -7,7 +7,7 @@ index e580b1a..572ea06 100644
  # check for SSE flags
  include("${PCL_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
 -if(PCL_ENABLE_SSE AND "${CMAKE_CXX_FLAGS}" STREQUAL "${CMAKE_CXX_FLAGS_DEFAULT}")
-+if(1)
++if(PCL_ENABLE_SSE)
    PCL_CHECK_FOR_SSE()
  endif()
  

--- a/ports/pcl/fix-check-sse.patch
+++ b/ports/pcl/fix-check-sse.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e580b1a..572ea06 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ endif()
+ 
+ # check for SSE flags
+ include("${PCL_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
+-if(PCL_ENABLE_SSE AND "${CMAKE_CXX_FLAGS}" STREQUAL "${CMAKE_CXX_FLAGS_DEFAULT}")
++if(1)
+   PCL_CHECK_FOR_SSE()
+ endif()
+ 

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         boost-1.70.patch
         fix-link-libpng.patch
         remove-broken-targets.patch
+        fix-check-sse.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindFLANN.cmake)


### PR DESCRIPTION
vcpkg add extra cxx flag `-fpic`, so pcl didn't check sse flags.

Fixes #11137.