### PR TITLE
[x265] Update source and version

### DIFF
--- a/ports/x265/CONTROL
+++ b/ports/x265/CONTROL
@@ -1,5 +1,4 @@
 Source: x265
-Version: 3.2
-Port-Version: 5
-Homepage: https://bitbucket.org/multicoreware/x265
+Version: 3.4
+Homepage: https://github.com/videolan/x265
 Description: x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -34,11 +34,11 @@ vcpkg_copy_pdbs()
 # remove duplicated include files
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
+vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR VCPKG_TARGET_IS_LINUX)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
 endif()
-
-vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
 
 if(WIN32 AND (NOT MINGW))
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -34,19 +34,11 @@ vcpkg_copy_pdbs()
 # remove duplicated include files
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/x265)
-
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/x265 ${CURRENT_PACKAGES_DIR}/tools/x265/x265)
-elseif(VCPKG_TARGET_IS_WINDOWS)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/bin/x265.exe ${CURRENT_PACKAGES_DIR}/tools/x265/x265.exe)
-endif()
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR VCPKG_TARGET_IS_LINUX)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
 endif()
 
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/x265)
+vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
 
 if(WIN32 AND (NOT MINGW))
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -54,6 +46,7 @@ if(WIN32 AND (NOT MINGW))
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc" "-lx265" "-lx265-static")
     endif()
 endif()
+
 if(UNIX)
     vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES numa)
 else()

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -1,17 +1,15 @@
-include(vcpkg_common_functions)
-
-vcpkg_from_bitbucket(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO multicoreware/x265
-    REF 3.2
-    SHA512 e98e26a9d3c2eb7f147ba052d9d8009e1c47e54905375b29e813f33ffddf8b7fac55ea455ae6d28ed1ade2d90f887c7cafe374873cd48b6c5e2560ddd21ccb84
+    REPO videolan/x265
+    REF 07295ba7ab551bb9c1580fdaee3200f1b45711b7 #v3.4
+    SHA512 21a4ef8733a9011eec8b336106c835fbe04689e3a1b820acb11205e35d2baba8c786d9d8cf5f395e78277f921857e4eb8622cf2ef3597bce952d374f7fe9ec29
     HEAD_REF master
     PATCHES
         disable-install-pdb.patch
 )
 
 set(ENABLE_ASSEMBLY OFF)
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_find_acquire_program(NASM)
     get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
     set(ENV{PATH} "$ENV{PATH};${NASM_EXE_PATH}")
@@ -40,7 +38,7 @@ file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/x265)
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     file(RENAME ${CURRENT_PACKAGES_DIR}/bin/x265 ${CURRENT_PACKAGES_DIR}/tools/x265/x265)
-elseif(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+elseif(VCPKG_TARGET_IS_WINDOWS)
     file(RENAME ${CURRENT_PACKAGES_DIR}/bin/x265.exe ${CURRENT_PACKAGES_DIR}/tools/x265/x265.exe)
 endif()
 
@@ -63,5 +61,4 @@ else()
 endif()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/x265)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/x265/COPYING ${CURRENT_PACKAGES_DIR}/share/x265/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #13035
The archive of x265 is not available now, update new source and update version to 3.4
- Which triplets are supported/not supported? Have you updated the CI baseline?
No
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes