### PR TITLE
[typo] Fix incorrect Path in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ and go to the CMake settings (Build, Execution, Deployment > CMake).
 Finally, in `CMake options`, add the following line:
 
 ```
--DCMAKE_TOOLCHAIN_FILE=C:/Users/nimazzuc/src/vcpkg/scripts/buildsystems/vcpkg.cmake
+-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
 ```
 
 Unfortunately, you'll have to add this to each profile.

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -239,7 +239,7 @@ $ brew install gcc
 最后在 `CMake options` 中添加以下行:
 
 ```
--DCMAKE_TOOLCHAIN_FILE=C:/Users/nimazzuc/src/vcpkg/scripts/buildsystems/vcpkg.cmake
+-DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
 ```
 
 遗憾的是， 您必须手动将此选项加入每个项目配置文件中。


### PR DESCRIPTION
This pull request fixes the path in the CLion guide where it does not specify correctly the path of vcpkg.