### PR TITLE
[vcpkg] Hotfix regression in #12523

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -25,7 +25,7 @@ endfunction()
 
 if(NOT DEFINED VCPKG_MANIFEST_DIR)
     if(EXISTS "${CMAKE_SOURCE_DIR}/vcpkg.json")
-        set(_VCPKG_MANIFEST_DIR "${CMAKE_SOURCE_DIR}/vcpkg.json")
+        set(_VCPKG_MANIFEST_DIR "${CMAKE_SOURCE_DIR}")
     endif()
 else()
     set(_VCPKG_MANIFEST_DIR ${VCPKG_MANIFEST_DIR})


### PR DESCRIPTION
PR #12523 causes cmake to pass `--x-manifest-dir=/path/to/source/vcpkg.json` to vcpkg, which then fails to load `/path/to/source/vcpkg.json/vcpkg.json`. This reverts that regression.

Without this patch:
```
1> Working directory: C:\src\mlcard\out\build\x64-Release
1> [CMake] -- Running vcpkg install
1> [CMake] Failed to read manifest C:\src\mlcard\vcpkg.json\vcpkg.json: no such file or directory
1> [CMake] CMake Error at C:/src/vcpkg/scripts/buildsystems/vcpkg.cmake:337 (message):
1> [CMake]   Running vcpkg install - failed
1> [CMake] Call Stack (most recent call first):
1> [CMake]   out/build/x64-Release/CMakeFiles/3.17.20032601-MSVC_2/CMakeSystem.cmake:6 (include)
1> [CMake]   CMakeLists.txt:10 (project)
```

With this patch:
```
1> Working directory: C:\src\mlcard\out\build\x64-Release
1> [CMake] -- Running vcpkg install
1> [CMake] Your feedback is important to improve Vcpkg! Please take 3 minutes to complete our survey by running: vcpkg contact --survey
1> [CMake] Detecting compiler hash for triplet x64-windows-static...
1> [CMake] All requested packages are currently installed.
```

This should have an end-to-end test associated with it, ideally implemented in https://github.com/microsoft/vcpkg/blob/master/scripts/azure-pipelines/end-to-end-tests.ps1, however this PR is limited to just the hotfix.

@strega-nil