### PR TITLE
[vcpkg] Fix vcpkg_acquire_msys failing on path with spaces

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -107,7 +107,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     )
     # install the new keyring
     _execute_process(
-      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman-key --verify ${KEYRING_SIG_PATH}"
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman-key --verify \"${KEYRING_SIG_PATH}\""
       WORKING_DIRECTORY ${TOOLPATH}
       RESULT_VARIABLE _vam_error_code
     )
@@ -115,7 +115,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       message(FATAL_ERROR "Cannot verify MSYS2 keyring.")
     endif()
     _execute_process(
-      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -U ${KEYRING_PATH} --noconfirm"
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -U \"${KEYRING_PATH}\" --noconfirm"
       WORKING_DIRECTORY ${TOOLPATH}
     )
     # we have to kill all GnuPG daemons otherwise bash would potentially not be


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

If vcpkg is installed on a path with spaces, packages that need to install MSYS2 fail due to unquoted paths in vcpkg_acquire_msys.

This adds the missing quotes where appropriate.

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes