### PR TITLE
[sqlitecpp] Fix dependency port

### DIFF
--- a/ports/sqlitecpp/CONTROL
+++ b/ports/sqlitecpp/CONTROL
@@ -1,6 +1,6 @@
 Source: sqlitecpp
 Version: 3.0.0
-Port-Version: 1
+Port-Version: 2
 Build-Depends: sqlite3
 Homepage: https://github.com/SRombauts/SQLiteCpp
 Description: SQLiteC++ (SQLiteCpp) is a smart and easy to use C++ SQLite3 wrapper.

--- a/ports/sqlitecpp/fix_dependency.patch
+++ b/ports/sqlitecpp/fix_dependency.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake/SQLiteCppConfig.cmake.in b/cmake/SQLiteCppConfig.cmake.in
+index 82c32db..a485ad8 100644
+--- a/cmake/SQLiteCppConfig.cmake.in
++++ b/cmake/SQLiteCppConfig.cmake.in
+@@ -1,5 +1,5 @@
+ include(CMakeFindDependencyMacro)
+-find_dependency(SQLite3)
++find_dependency(unofficial-sqlite3)
+ 
+ @PACKAGE_INIT@
+ 

--- a/ports/sqlitecpp/portfile.cmake
+++ b/ports/sqlitecpp/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     SHA512 d48b5915a2674f7f6da2737fa365e2202373e95cd20e819281b765a597e2fa8b8ae33f6553d65b6a8a93741e31633de3c75caf84fffa4313154c43ce634b1323
     PATCHES
         0001-Find-external-sqlite3.patch
+        fix_dependency.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/13102

The dependency port sqlite change from sqlite3 to unofficial-sqlite3, udpate it in sqlitecpp config file.