### PR TITLE
[vcpkg] Fix #13094 by avoiding the comma operator.

### DIFF
--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -195,7 +195,9 @@ namespace vcpkg::Test
             ec.assign(errno, std::system_category());
         }
 #else
-        (void)(target, file, ec);
+        (void)target;
+        (void)file;
+        (void)ec;
         vcpkg::Checks::exit_with_message(VCPKG_LINE_INFO, no_filesystem_message);
 #endif
     }
@@ -217,7 +219,9 @@ namespace vcpkg::Test
 #elif FILESYSTEM_SYMLINK == FILESYSTEM_SYMLINK_UNIX
         ::vcpkg::Test::create_symlink(target, file, ec);
 #else
-        (void)(target, file, ec);
+        (void)target;
+        (void)file;
+        (void)ec;
         vcpkg::Checks::exit_with_message(VCPKG_LINE_INFO, no_filesystem_message);
 #endif
     }

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -601,7 +601,7 @@ namespace vcpkg::Files
                                     std::error_code& ec) override
         {
             this->rename(oldpath, newpath, ec);
-            (void)(temp_suffix);
+            (void)temp_suffix;
 #if !defined(_WIN32)
             if (ec)
             {

--- a/toolsrc/src/vcpkg/base/system.print.cpp
+++ b/toolsrc/src/vcpkg/base/system.print.cpp
@@ -22,7 +22,7 @@ namespace vcpkg::System
 #else
             // TODO: add color handling code
             // it should probably use VT-220 codes
-            (void)(c);
+            (void)c;
             System::print2(message);
 #endif
         }

--- a/toolsrc/src/vcpkg/commands.create.cpp
+++ b/toolsrc/src/vcpkg/commands.create.cpp
@@ -20,7 +20,7 @@ namespace vcpkg::Commands::Create
 
     int perform(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         const std::string port_name = args.command_arguments.at(0);
         const std::string url = args.command_arguments.at(1);
 

--- a/toolsrc/src/vcpkg/commands.fetch.cpp
+++ b/toolsrc/src/vcpkg/commands.fetch.cpp
@@ -16,8 +16,7 @@ namespace vcpkg::Commands::Fetch
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
-
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         const std::string tool = args.command_arguments[0];
         const fs::path tool_path = paths.get_tool_exe(tool);
         System::print2(fs::u8string(tool_path), '\n');

--- a/toolsrc/src/vcpkg/commands.hash.cpp
+++ b/toolsrc/src/vcpkg/commands.hash.cpp
@@ -18,7 +18,7 @@ namespace vcpkg::Commands::Hash
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
 
         const fs::path file_to_hash = args.command_arguments[0];
 

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -533,7 +533,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
 
         if (args.command_arguments[0] == Subcommand::INSTALL)
         {

--- a/toolsrc/src/vcpkg/commands.owns.cpp
+++ b/toolsrc/src/vcpkg/commands.owns.cpp
@@ -33,7 +33,7 @@ namespace vcpkg::Commands::Owns
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
 
         const StatusParagraphs status_db = database_load_check(paths);
         search_file(paths, args.command_arguments[0], status_db);

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -84,8 +84,7 @@ namespace vcpkg::Commands::PortHistory
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
-
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         std::string port_name = args.command_arguments.at(0);
         std::vector<PortControlVersion> versions = read_versions_from_log(paths, port_name);
         System::print2("             version          date    vcpkg commit\n");

--- a/toolsrc/src/vcpkg/commands.portsdiff.cpp
+++ b/toolsrc/src/vcpkg/commands.portsdiff.cpp
@@ -133,8 +133,7 @@ namespace vcpkg::Commands::PortsDiff
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
-
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         const fs::path& git_exe = paths.get_tool_exe(Tools::GIT);
 
         const std::string git_commit_id_for_previous_snapshot = args.command_arguments.at(0);

--- a/toolsrc/src/vcpkg/commands.version.cpp
+++ b/toolsrc/src/vcpkg/commands.version.cpp
@@ -90,8 +90,7 @@ namespace vcpkg::Commands::Version
 
     void perform_and_exit(const VcpkgCmdArguments& args, Files::Filesystem&)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
-
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         System::print2("Vcpkg package management program version ",
                        version(),
                        "\n"

--- a/toolsrc/src/vcpkg/commands.xvsinstances.cpp
+++ b/toolsrc/src/vcpkg/commands.xvsinstances.cpp
@@ -28,7 +28,8 @@ namespace vcpkg::Commands::X_VSInstances
 
         Checks::exit_success(VCPKG_LINE_INFO);
 #else
-        (void)(args, paths);
+        (void)args;
+        (void)paths;
         Checks::exit_with_message(VCPKG_LINE_INFO, "This command is not supported on non-windows platforms.");
 #endif
     }

--- a/toolsrc/src/vcpkg/help.cpp
+++ b/toolsrc/src/vcpkg/help.cpp
@@ -109,7 +109,7 @@ namespace vcpkg::Help
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
 
         if (args.command_arguments.empty())
         {

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -468,7 +468,7 @@ namespace vcpkg::Metrics
         if (request) WinHttpCloseHandle(request);
         if (connect) WinHttpCloseHandle(connect);
         if (session) WinHttpCloseHandle(session);
-#else // ^^^ _WIN32 // !_WIN32 vvv
+#else  // ^^^ _WIN32 // !_WIN32 vvv
         (void)payload;
 #endif // ^^^ !_WIN32
     }

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -380,9 +380,7 @@ namespace vcpkg::Metrics
             return;
         }
 
-#if !defined(_WIN32)
-        (void)(payload);
-#else
+#if defined(_WIN32)
         HINTERNET connect = nullptr, request = nullptr;
         BOOL results = FALSE;
 
@@ -464,13 +462,15 @@ namespace vcpkg::Metrics
             __debugbreak();
             auto err = GetLastError();
             std::cerr << "[DEBUG] failed to connect to server: " << err << "\n";
-#endif
+#endif // NDEBUG
         }
 
         if (request) WinHttpCloseHandle(request);
         if (connect) WinHttpCloseHandle(connect);
         if (session) WinHttpCloseHandle(session);
-#endif
+#else // ^^^ _WIN32 // !_WIN32 vvv
+        (void)payload;
+#endif // ^^^ !_WIN32
     }
 
     void Metrics::flush(Files::Filesystem& fs)

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -556,7 +556,8 @@ namespace vcpkg::PostBuildLint
             return LintStatus::ERROR_DETECTED;
         }
 #endif
-        (void)expected_architecture, (void)files;
+        (void)expected_architecture;
+        (void)files;
         return LintStatus::SUCCESS;
     }
 

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -136,10 +136,7 @@ namespace vcpkg
         virtual const std::string& exe_stem() const = 0;
         virtual std::array<int, 3> default_min_version() const = 0;
 
-        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const
-        {
-            (void)out_candidate_paths;
-        }
+        virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const { (void)out_candidate_paths; }
         virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const = 0;
     };
 

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -138,7 +138,7 @@ namespace vcpkg
 
         virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const
         {
-            (void)(out_candidate_paths);
+            (void)out_candidate_paths;
         }
         virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const = 0;
     };
@@ -283,7 +283,7 @@ namespace vcpkg
                 out_candidate_paths.push_back(*pf / "CMake" / "bin" / "cmake.exe");
 #else
             // TODO: figure out if this should do anything on non-Windows
-            (void)(out_candidate_paths);
+            (void)out_candidate_paths;
 #endif
         }
         virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
@@ -342,7 +342,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
 #ifndef _WIN32
             cmd.path_arg(paths.get_tool_exe(Tools::MONO));
 #else
-            (void)(paths);
+            (void)paths;
 #endif
             cmd.path_arg(path_to_exe);
             const auto rc = System::cmd_execute_and_capture_output(cmd.extract());
@@ -380,7 +380,7 @@ Type 'NuGet help <command>' for help on a specific command.
                 out_candidate_paths.push_back(*pf / "git" / "cmd" / "git.exe");
 #else
             // TODO: figure out if this should do anything on non-windows
-            (void)(out_candidate_paths);
+            (void)out_candidate_paths;
 #endif
         }
 
@@ -441,7 +441,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
 
         virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const override
         {
-            (void)(out_candidate_paths);
+            (void)out_candidate_paths;
             // TODO: Uncomment later
             // const std::vector<fs::path> from_path = Files::find_from_PATH("installerbase");
             // candidate_paths.insert(candidate_paths.end(), from_path.cbegin(), from_path.cend());

--- a/toolsrc/src/vcpkg/update.cpp
+++ b/toolsrc/src/vcpkg/update.cpp
@@ -53,7 +53,7 @@ namespace vcpkg::Update
 
     void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths)
     {
-        (void)(args.parse_arguments(COMMAND_STRUCTURE));
+        (void)args.parse_arguments(COMMAND_STRUCTURE);
         System::print2("Using local portfile versions. To update the local portfiles, use `git pull`.\n");
 
         const StatusParagraphs status_db = database_load_check(paths);


### PR DESCRIPTION
Drive-by remove unused parenthesis and remove macro inversion in metrics.cpp.

Fixes #13094.