### PR TITLE
Disable fluidlite in CI.

### DIFF
--- a/ports/fluidlite/portfile.cmake
+++ b/ports/fluidlite/portfile.cmake
@@ -1,3 +1,7 @@
+if(EXISTS "${CURRENT_INSTALLED_DIR}/include/fluidsynth/settings.h")
+  message(FATAL_ERROR "Can't build fluidlite if fluidsynth is installed. Please remove fluidsynth, and try to install fluidlite again if you need it.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO divideconcept/FluidLite

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -422,6 +422,16 @@ flint:x64-osx=fail
 fltk:arm-uwp=fail
 fltk:x64-uwp=fail
 fluidsynth:x64-osx=fail
+# fluidlite conflicts with fluidsynth; we test fluidsynth rather than fluidlite because
+# fluidlite has no dependencies and thus is less likely to be broken by another package.
+fluidlite:arm-uwp=skip
+fluidlite:arm64-windows=skip
+fluidlite:x64-linux=skip
+fluidlite:x64-osx=skip
+fluidlite:x64-uwp=skip
+fluidlite:x64-windows-static=skip
+fluidlite:x64-windows=skip
+fluidlite:x86-windows=skip
 fmem:arm-uwp=fail
 fmem:x64-uwp=fail
 fmi4cpp:arm-uwp=fail


### PR DESCRIPTION
Fluidlite, added 3 days ago in https://github.com/microsoft/vcpkg/pull/13006 , tries to install the same files as fluidsynth; it's similar to the 'boringssl' situation. Given that fluidlite doens't have any dependencies, this change disables that one rather than fluidsynth,

```
Starting package 543/1349: fluidsynth:x86-windows
Building package fluidsynth[core]:x86-windows...
-- Downloading https://github.com/FluidSynth/fluidsynth/archive/2393aef3bd0b4e78084cfe16735d402bc1497edd.tar.gz...
-- Extracting source D:/downloads/FluidSynth-fluidsynth-2393aef3bd0b4e78084cfe16735d402bc1497edd.tar.gz
-- Applying patch force-x86-gentables.patch
-- Using source at D:/buildtrees/fluidsynth/src/2bc1497edd-d19340b672.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Installing: D:/packages/fluidsynth_x86-windows/share/fluidsynth/copyright
-- Performing post-build validation
-- Performing post-build validation done
Stored binary cache: W:\67\67c77d45b2c7b460f24349792075d19b9a2b218f.zip
Building package fluidsynth[core]:x86-windows... done
Installing package fluidsynth[core]:x86-windows...
The following files are already installed in D:/installed/x86-windows and are in conflict with fluidsynth:x86-windows

Installed by fluidlite:x86-windows
    include/fluidsynth/gen.h
    include/fluidsynth/log.h
    include/fluidsynth/misc.h
    include/fluidsynth/mod.h
    include/fluidsynth/settings.h
    include/fluidsynth/sfont.h
    include/fluidsynth/synth.h
    include/fluidsynth/types.h
    include/fluidsynth/version.h
    include/fluidsynth/voice.h

Elapsed time for package fluidsynth:x86-windows: 46.12 s
```