### PR TITLE
[irrlicht] Patch moved sysctl.h header file

### DIFF
--- a/ports/irrlicht/fix-sysctl.patch
+++ b/ports/irrlicht/fix-sysctl.patch
@@ -1,0 +1,12 @@
+--- a/source/Irrlicht/COSOperator.cpp
++++ b/source/Irrlicht/COSOperator.cpp
+@@ -11,8 +11,8 @@
+ #else
+ #include <string.h>
+ #include <unistd.h>
+-#ifndef _IRR_SOLARIS_PLATFORM_
+ #include <sys/types.h>
++#ifdef _IRR_OSX_PLATFORM_
+ #include <sys/sysctl.h>
+ #endif
+ #endif

--- a/ports/irrlicht/portfile.cmake
+++ b/ports/irrlicht/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_sourceforge(
     REF 1.8/1.8.4
     FILENAME "irrlicht-1.8.4.zip"
     SHA512 de69ddd2c6bc80a1b27b9a620e3697b1baa552f24c7d624076d471f3aecd9b15f71dce3b640811e6ece20f49b57688d428e3503936a7926b3e3b0cc696af98d1
-    PATCHES fix-encoding.patch
+    PATCHES fix-encoding.patch fix-sysctl.patch
 )
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt ${SOURCE_PATH}/CMakeLists.txt COPYONLY)


### PR DESCRIPTION
Sysctl has been deprecated for a while and in newer versions of glibc it
is removed which leads to a compilation error on modern Linux. This is
fixed in SVN trunk of irrlich so I copied the include guards from there.
In this case sysctl headers are only loaded for OS X where they are also
actually used.
