### PR TITLE
[libxmlmm ] Add new port libxmlmm 0.6.0

### DIFF
--- a/ports/libxmlmm/CMakeLists.txt
+++ b/ports/libxmlmm/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.8)
+project(libxmlmm CXX)
+
+set(CMAKE_SHARED_LIBRARY_PREFIX)
+set(CMAKE_STATIC_LIBRARY_PREFIX)
+
+find_package(LibXml2 REQUIRED)
+
+set(HEADERS_LIBXMLMM
+	libxmlmm/Attribute.h
+	libxmlmm/CData.h
+	libxmlmm/Comment.h
+	libxmlmm/Content.h
+	libxmlmm/defines.h
+	libxmlmm/Document.h
+	libxmlmm/Element.h
+	libxmlmm/exceptions.h
+	libxmlmm/libxmlmm.h
+	libxmlmm/LibXmlSentry.h
+	libxmlmm/Node.h
+	libxmlmm/ProcessingInstruction.h
+	libxmlmm/Text.h
+	libxmlmm/utils.h
+)
+
+set(SOURCES_LIBXMLMM
+	libxmlmm/Attribute.cpp
+	libxmlmm/CData.cpp
+	libxmlmm/Comment.cpp
+	libxmlmm/Content.cpp
+	libxmlmm/Document.cpp
+	libxmlmm/Element.cpp
+	libxmlmm/LibXmlSentry.cpp
+	libxmlmm/Node.cpp
+	libxmlmm/ProcessingInstruction.cpp
+	libxmlmm/Text.cpp
+	libxmlmm/utils.cpp
+)
+
+add_library(libxmlmm ${SOURCES_LIBXMLMM})
+include_directories(${LIBXML2_INCLUDE_DIRS})
+target_link_libraries (libxmlmm ${LIBXML2_LIBRARIES})
+
+set_target_properties(libxmlmm PROPERTIES
+    CXX_STANDARD 17
+    PUBLIC_HEADER "${HEADERS_LIBXMLMM}"
+)
+
+target_include_directories(libxmlmm PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/libxmlmm>
+    $<INSTALL_INTERFACE:include/libxmlmm>)
+
+install(TARGETS ${PROJECT_NAME}
+    EXPORT litehtmlTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/libxmlmm
+)

--- a/ports/libxmlmm/CMakeLists.txt
+++ b/ports/libxmlmm/CMakeLists.txt
@@ -38,7 +38,7 @@ set(SOURCES_LIBXMLMM
 )
 
 add_library(libxmlmm ${SOURCES_LIBXMLMM})
-include_directories(${LIBXML2_INCLUDE_DIRS})
+include_directories(${LIBXML2_INCLUDE_DIR})
 target_link_libraries (libxmlmm ${LIBXML2_LIBRARIES})
 
 set_target_properties(libxmlmm PROPERTIES

--- a/ports/libxmlmm/CONTROL
+++ b/ports/libxmlmm/CONTROL
@@ -1,0 +1,5 @@
+Source: libxmlmm
+Version: 0.6.0
+Homepage: https://github.com/rioki/libxmlmm
+Description: Libxmlmm is a C++ wrapper for libxml 2.0 that only relies on standard C++ and libxml2.
+Build-Depends: libxml2

--- a/ports/libxmlmm/portfile.cmake
+++ b/ports/libxmlmm/portfile.cmake
@@ -1,4 +1,3 @@
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/libxmlmm/portfile.cmake
+++ b/ports/libxmlmm/portfile.cmake
@@ -1,4 +1,3 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rioki/libxmlmm

--- a/ports/libxmlmm/portfile.cmake
+++ b/ports/libxmlmm/portfile.cmake
@@ -1,0 +1,25 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO rioki/libxmlmm
+    REF r0.6
+    SHA512 4f619e730de2f88b891ef31dd7ced2e6be75fff7f3852ec178843bf8d099d2e1ea84e0fcde35ff7fefc201b026f63e4b5d55f88e48334c49a0333be0327894df
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+# Handle copyright
+configure_file(${SOURCE_PATH}/README.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

Adds libxmlmm in version 0.6.0

- Which triplets are supported/not supported? Have you updated the CI baseline?

Known good triplets:
    x86-windows
    x64-windows
    x64-linux

The code is quite portable and most should be suported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I checked and hope I did all right.
