### PR TITLE
Allow use of VS LLVM clang-format.

### DIFF
--- a/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
+++ b/scripts/azure-pipelines/windows/Check-CxxFormatting.ps1
@@ -9,8 +9,12 @@ Param(
 $clangFormat = 'C:\Program Files\LLVM\bin\clang-format.exe'
 if (-not (Test-Path $clangFormat))
 {
-    Write-Error "clang-format not found; is it installed in the CI machines?"
-    throw
+    $clangFormat = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin\clang-format.exe'
+    if (-not (Test-Path $clangFormat))
+    {
+        Write-Error 'clang-format not found; is it installed in the CI machines?'
+        throw
+    }
 }
 
 $toolsrc = Get-Item "$Root/toolsrc"


### PR DESCRIPTION
This makes it easier to run that .ps1 locally. Note that VS 16.7 comes with Clang 10, the same version we were manually installing on the machines before.