### PR TITLE
Canonicalize fs::current_path before use.

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -111,6 +111,8 @@ namespace vcpkg
         : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(filesystem, args.compiler_tracking_enabled()))
     {
         original_cwd = filesystem.current_path(VCPKG_LINE_INFO);
+        // This canonical call fixes up incorrect case which we have observed being allowed by PowerShell 5.x
+        original_cwd = filesystem.canonical(VCPKG_LINE_INFO, original_cwd);
         if (args.vcpkg_root_dir)
         {
             root = filesystem.canonical(VCPKG_LINE_INFO, fs::u8path(*args.vcpkg_root_dir));


### PR DESCRIPTION
This change fixes a bug report over Discord wherein a user using PowerShell 5.x called Set-Location, using a path which is incorrect. They entered "C:\tools\vcpkg" but the actual directory is "C:\Tools\vcpkg". Note Tools should be capitalized. PowerShell 5.x allows the current directory to be set this way even though it is "wrong". This causes subsequent parts that look for exact path names, like pkgconfig, to not correct get the right bits.

Before:

```
PS C:\> set-location c:\dev\vcpkg
PS C:\dev\vcpkg> .\bootstrap-vcpkg.bat

Building vcpkg.exe ...

[...]

Building vcpkg.exe... done.

[...]

PS C:\dev\vcpkg> .\vcpkg.exe install curl
Computing installation plan...
The following packages will be built and installed:
    curl[core,non-http,ssl,sspi,winssl]:x86-windows
  * zlib[core]:x86-windows
Additional packages (*) will be modified to complete this operation.
Detecting compiler hash for triplet x86-windows...
A suitable version of powershell-core was not found (required v6.2.1). Downloading portable powershell-core v6.2.1...
  https://github.com/PowerShell/PowerShell/releases/download/v6.2.1/PowerShell-6.2.1-win-x86.zip -> C:\dev\vcpkg\downloaExtracting powershell-core...
A suitable version of 7zip was not found (required v18.1.0). Downloading portable 7zip v18.1.0...
Downloading 7zip...
  https://www.nuget.org/api/v2/package/7-Zip.CommandLine/18.1.0 -> C:\dev\vcpkg\downloads\7-zip.commandline.18.1.0.nupkg
Extracting 7zip...
A suitable version of nuget was not found (required v5.5.1). Downloading portable nuget v5.5.1...
Downloading nuget...
  https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe -> C:\dev\vcpkg\downloads\22ea847d-nuget.exe
Starting package 1/2: zlib:x86-windows
Building package zlib[core]:x86-windows...
Could not locate cached archive: C:\Users\billy\AppData\Local\vcpkg/archives\94\94f460cfa764bc5cd3f76cf2807a516feb681074.zip
-- Downloading http://www.zlib.net/zlib-1.2.11.tar.gz...
-- Extracting source C:/dev/vcpkg/downloads/zlib1211.tar.gz
-- Applying patch cmake_dont_build_more_than_needed.patch
-- Applying patch 0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
-- Applying patch add_debug_postfix_on_mingw.patch
-- Using source at C:/dev/vcpkg/buildtrees/zlib/src/1.2.11-63309e48e5.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Downloading https://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-1-any.pkg.tar.xz...
-- Downloading https://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-8.0.0.5906.c9a21571-1-any.pkg.tar.zst...
-- Fixing pkgconfig file: C:/dev/vcpkg/packages/zlib_x86-windows/lib/pkgconfig/zlib.pc
-- Fixing pkgconfig file: C:/dev/vcpkg/packages/zlib_x86-windows/debug/lib/pkgconfig/zlib.pc
-- CHECK_LIB_zlibd_DEBUG:CHECK_LIB_zlibd_DEBUG-NOTFOUND
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:232 (message):
  Library "zlibd" was not found! If it is a system library use the
  SYSTEM_LIBRARIES parameter for the vcpkg_fixup_pkgconfig call! Otherwise,
  correct the *.pc file
Call Stack (most recent call first):
  scripts/cmake/vcpkg_fixup_pkgconfig.cmake:329 (vcpkg_fixup_pkgconfig_check_files)
  ports/zlib/portfile.cmake:48 (vcpkg_fixup_pkgconfig)
  scripts/ports.cmake:79 (include)

Error: Building package zlib:x86-windows failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: zlib:x86-windows
  Vcpkg version: 2020.06.15-nohash

Additionally, attach any relevant sections from the log files above.
PS C:\dev\vcpkg>
```

After (note difference in case between the PS> prompt and the tool output):

```
PS C:\dev\vcpkg> .\vcpkg.exe x-set-installed
All requested packages are currently installed.

Total elapsed time: 5.9 us

PS C:\dev\vcpkg> .\vcpkg.exe install curl
Computing installation plan...
The following packages will be built and installed:
    curl[core,non-http,ssl,sspi,winssl]:x86-windows
  * zlib[core]:x86-windows
Additional packages (*) will be modified to complete this operation.
Detecting compiler hash for triplet x86-windows...
Starting package 1/2: zlib:x86-windows
Building package zlib[core]:x86-windows...
Could not locate cached archive: C:\Users\billy\AppData\Local\vcpkg/archives\94\94f460cfa764bc5cd3f76cf2807a516feb681074.zip
-- Using cached C:/Dev/vcpkg/downloads/zlib1211.tar.gz
-- Cleaning sources at C:/Dev/vcpkg/buildtrees/zlib/src/1.2.11-63309e48e5.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source C:/Dev/vcpkg/downloads/zlib1211.tar.gz
-- Applying patch cmake_dont_build_more_than_needed.patch
-- Applying patch 0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
-- Applying patch add_debug_postfix_on_mingw.patch
-- Using source at C:/Dev/vcpkg/buildtrees/zlib/src/1.2.11-63309e48e5.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/zlib_x86-windows/lib/pkgconfig/zlib.pc
-- Fixing pkgconfig file: C:/Dev/vcpkg/packages/zlib_x86-windows/debug/lib/pkgconfig/zlib.pc
-- Installing: C:/Dev/vcpkg/packages/zlib_x86-windows/share/zlib/copyright
-- Performing post-build validation
-- Performing post-build validation done
Stored binary cache: C:\Users\billy\AppData\Local\vcpkg/archives\94\94f460cfa764bc5cd3f76cf2807a516feb681074.zip
Building package zlib[core]:x86-windows... done
Installing package zlib[core]:x86-windows...
Installing package zlib[core]:x86-windows... done
Elapsed time for package zlib:x86-windows: 3.693 s
Starting package 2/2: curl:x86-windows
Building package curl[core,non-http,ssl,sspi,winssl]:x86-windows...
Could not locate cached archive: C:\Users\billy\AppData\Local\vcpkg/archives\a4\a49e1cd6bac769230fcfd89b7b912a1aa081fd3a.zip
-- Downloading https://github.com/curl/curl/archive/5a1fc8d33808d7b22f57bdf9403cda7ff07b0670.tar.gz...
-- Extracting source C:/Dev/vcpkg/downloads/curl-curl-5a1fc8d33808d7b22f57bdf9403cda7ff07b0670.tar.gz
-- Applying patch 0002_fix_uwp.patch
-- Applying patch 0004_nghttp2_staticlib.patch
-- Applying patch 0005_remove_imp_suffix.patch
-- Applying patch 0006_fix_tool_depends.patch
-- Applying patch 0007_disable_tool_export_curl_target.patch
-- Applying patch 0009_fix_openssl_config.patch
-- Applying patch 0010_fix_othertests_cmake.patch
-- Applying patch 0011_fix_static_build.patch
-- Using source at C:/Dev/vcpkg/buildtrees/curl/src/7ff07b0670-aace9b898a.clean
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Installing: C:/Dev/vcpkg/packages/curl_x86-windows/share/curl/curl-config
-- Installing: C:/Dev/vcpkg/packages/curl_x86-windows/share/curl/vcpkg-cmake-wrapper.cmake
-- Installing: C:/Dev/vcpkg/packages/curl_x86-windows/share/curl/copyright
-- Performing post-build validation
-- Performing post-build validation done
Stored binary cache: C:\Users\billy\AppData\Local\vcpkg/archives\a4\a49e1cd6bac769230fcfd89b7b912a1aa081fd3a.zip
Building package curl[core,non-http,ssl,sspi,winssl]:x86-windows... done
Installing package curl[core,non-http,ssl,sspi,winssl]:x86-windows...
Installing package curl[core,non-http,ssl,sspi,winssl]:x86-windows... done
Elapsed time for package curl:x86-windows: 47.49 s

Total elapsed time: 52.72 s

The package curl:x86-windows provides CMake targets:

    find_package(CURL CONFIG REQUIRED)
     target_link_libraries(main PRIVATE CURL::libcurl)

PS C:\dev\vcpkg>
```

Fixes #13105
