### PR TITLE
[baseline] Skip check of clapack:x64-osx in the baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -208,6 +208,7 @@ civetweb:arm-uwp            = skip
 civetweb:x64-uwp            = skip
 # clapack is replaced by lapack-reference. 
 clapack:x64-linux = skip
+clapack:x64-osx = skip
 clapack:x64-windows = skip
 clapack:x64-windows-static = skip
 clapack:x86-windows = skip


### PR DESCRIPTION
lapack-reference replaced clapack in PR #12805, but @Neumann-A forgot to skip osx result.

Related: #12532.