### PR TITLE
[pangolin] Missing Pangolin header fix: Copy missing pangolin_export.h file regardless of library linkage

### DIFF
--- a/ports/pangolin/CONTROL
+++ b/ports/pangolin/CONTROL
@@ -1,6 +1,6 @@
 Source: pangolin
-Version: 0.5-1
-Port-Version: 9
+Version: 0.5
+Port-Version: 10
 Build-Depends: eigen3, glew, libpng, libjpeg-turbo, ffmpeg
 Homepage: https://github.com/stevenlovegrove/Pangolin
 Description: Lightweight GUI Library

--- a/ports/pangolin/CONTROL
+++ b/ports/pangolin/CONTROL
@@ -1,5 +1,5 @@
 Source: pangolin
-Version: 0.5
+Version: 0.5-1
 Port-Version: 9
 Build-Depends: eigen3, glew, libpng, libjpeg-turbo, ffmpeg
 Homepage: https://github.com/stevenlovegrove/Pangolin

--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -50,7 +50,9 @@ if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinTargets-release.cmake
         "lib/pangolin.dll" "bin/pangolin.dll"
     )
-    
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
     # Copy missing header file
     file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/include/pangolin/pangolin_export.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/pangolin)
 endif()

--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -35,23 +35,6 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(GLOB EXE ${CURRENT_PACKAGES_DIR}/lib/*.dll)
-    file(COPY ${EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-    file(REMOVE ${EXE})
-
-    file(GLOB DEBUG_EXE ${CURRENT_PACKAGES_DIR}/debug/lib/*.dll)
-    file(COPY ${DEBUG_EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(REMOVE ${DEBUG_EXE})
-
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinTargets-debug.cmake
-        "lib/pangolin.dll" "bin/pangolin.dll"
-    )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinTargets-release.cmake
-        "lib/pangolin.dll" "bin/pangolin.dll"
-    )
-endif()
-
 if(VCPKG_TARGET_IS_WINDOWS)
     # Copy missing header file
     file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/include/pangolin/pangolin_export.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/pangolin)

--- a/ports/pangolin/portfile.cmake
+++ b/ports/pangolin/portfile.cmake
@@ -35,6 +35,23 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(GLOB EXE ${CURRENT_PACKAGES_DIR}/lib/*.dll)
+    file(COPY ${EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(REMOVE ${EXE})
+
+    file(GLOB DEBUG_EXE ${CURRENT_PACKAGES_DIR}/debug/lib/*.dll)
+    file(COPY ${DEBUG_EXE} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE ${DEBUG_EXE})
+
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinTargets-debug.cmake
+        "lib/pangolin.dll" "bin/pangolin.dll"
+    )
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/pangolin/PangolinTargets-release.cmake
+        "lib/pangolin.dll" "bin/pangolin.dll"
+    )
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     # Copy missing header file
     file(COPY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/include/pangolin/pangolin_export.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/pangolin)


### PR DESCRIPTION
Previously pangolin_export.h was only copied when  VCPKG_LIBRARY_LINKAGE = "dynamic".  This was a problem since platform.h includes pangolin_export.h regardless of linkage. 

- What does your PR fix? Fixes #13153

- Which triplets are supported/not supported? Have you updated the CI baseline?
This change should not impact triplet support

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes, I believe it does
