### PR TITLE
[rpclib] Disable parallel configure

### DIFF
--- a/ports/rpclib/CONTROL
+++ b/ports/rpclib/CONTROL
@@ -1,4 +1,5 @@
 Source: rpclib
-Version: 2.2.1-1
+Version: 2.2.1
+Port-Version: 2
 Homepage: https://github.com/rpclib/rpclib
 Description: a RPC library for C++, providing both a client and server implementation. It is built using modern C++14.

--- a/ports/rpclib/portfile.cmake
+++ b/ports/rpclib/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
@@ -12,6 +10,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
 )
 
@@ -23,5 +22,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/rpclib)
 
 vcpkg_copy_pdbs()
 
-file(COPY ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/rpclib)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/rpclib/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/rpclib/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fix bug:
```
CMake Error at CMakeLists.txt:74 (configure_file):
  configure_file Problem configuring file
```

Related: #12612.