### PR TITLE
[Arrow] Update to 1.0.1

### DIFF
--- a/ports/arrow/CONTROL
+++ b/ports/arrow/CONTROL
@@ -1,5 +1,5 @@
 Source: arrow
-Version: 1.0.0
+Version: 1.0.1
 Build-Depends: boost-system, boost-filesystem, boost-multiprecision, boost-algorithm, flatbuffers, rapidjson, zlib, lz4, brotli, bzip2, zstd, snappy, gflags, thrift, double-conversion, glog, uriparser, openssl, utf8proc
 Homepage: https://github.com/apache/arrow
 Description: Apache Arrow is a columnar in-memory analytics layer designed to accelerate big data. It houses a set of canonical in-memory representations of flat and hierarchical data along with multiple language-bindings for structure manipulation. It also provides IPC and common algorithm implementations.

--- a/ports/arrow/all.patch
+++ b/ports/arrow/all.patch
@@ -26,7 +26,7 @@ index bf47915c4..053e605a0 100644
  
      # Some systems (e.g. Fedora) don't fill Brotli_LIBRARY_DIRS, so add the other dirs here.
 diff --git a/cpp/cmake_modules/FindLz4.cmake b/cpp/cmake_modules/FindLz4.cmake
-index 841091643..a196b251d 100644
+index 841091643..bb5a00a50 100644
 --- a/cpp/cmake_modules/FindLz4.cmake
 +++ b/cpp/cmake_modules/FindLz4.cmake
 @@ -19,14 +19,16 @@ if(MSVC AND NOT DEFINED LZ4_MSVC_STATIC_LIB_SUFFIX)
@@ -49,7 +49,14 @@ index 841091643..a196b251d 100644
            "${CMAKE_SHARED_LIBRARY_PREFIX}lz4_static${CMAKE_SHARED_LIBRARY_SUFFIX}"
      PATHS ${LZ4_ROOT}
      PATH_SUFFIXES ${LIB_PATH_SUFFIXES}
-@@ -43,14 +45,14 @@ else()
+@@ -38,19 +40,19 @@ if(LZ4_ROOT)
+             PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES})
+ 
+ else()
+-  pkg_check_modules(LZ4_PC liblz4)
+-  if(LZ4_PC_FOUND)
++  #pkg_check_modules(LZ4_PC liblz4)
++  if(0) #if(LZ4_PC_FOUND)  # Disabled as sometimes incompatible with vcpkg on Linux and OSX
      set(LZ4_INCLUDE_DIR "${LZ4_PC_INCLUDEDIR}")
  
      list(APPEND LZ4_PC_LIBRARY_DIRS "${LZ4_PC_LIBDIR}")

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "x86" "arm" "arm64")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow
-    REF apache-arrow-1.0.0
-    SHA512 cfbe22a7987658cce15f83c3be50435567f2b8156fa50007ae103418b969c6075dbf2858c25787a40feb391e84075905dd045300beb7fcedf4344823f8c4be20
+    REF apache-arrow-1.0.1
+    SHA512 46fedecaf7fa0ff0d8b4ac5f3d7bcbcb75ce4f65d272f775dedd61f091f975cf03fc55e91e46021df9872a82712ca9c9e4eb35414cf46c0f49a26f7a5a3dd50c
     HEAD_REF master
     PATCHES
         all.patch


### PR DESCRIPTION
Update Arrow from 1.0.0 to the recently released 1.0.1.

Passes vcpkg CI and ParquetSharp CI (https://github.com/G-Research/ParquetSharp/pull/146).