### PR TITLE
[embree3] Fix usage in static build

### DIFF
--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,5 +1,6 @@
 Source: embree3
 Version: 3.11.0
+Port-Version: 1
 Homepage: https://github.com/embree/embree
 Description: High Performance Ray Tracing Kernels.
 Build-Depends: tbb

--- a/ports/embree3/fix-static-usage.patch
+++ b/ports/embree3/fix-static-usage.patch
@@ -1,0 +1,21 @@
+diff --git a/common/cmake/embree-config.cmake b/common/cmake/embree-config.cmake
+index 14ce929..7e2e8f5 100644
+--- a/common/cmake/embree-config.cmake
++++ b/common/cmake/embree-config.cmake
+@@ -50,6 +50,16 @@ IF (EMBREE_STATIC_LIB)
+   INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/simd-targets.cmake")
+   INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/lexers-targets.cmake")
+   INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/tasking-targets.cmake")
++  
++  IF(EMBREE_ISA_SSE42)
++    INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_sse42-targets.cmake")
++  ENDIF()
++  IF(EMBREE_ISA_AVX)
++      INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_avx-targets.cmake")
++  ENDIF()
++  IF(EMBREE_ISA_AVX2)
++      INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_avx2-targets.cmake")
++  ENDIF()
+ ENDIF()
+ 
+ INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree-targets.cmake")

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-path.patch
+        fix-static-usage.patch
 )
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static EMBREE_STATIC_LIB)


### PR DESCRIPTION
In static usage, `embree3 `failed with the following error:
```
CMake Error at F:/12691/vcpkg/scripts/buildsystems/vcpkg.cmake:455 (_find_package):
  Found package configuration file:

    F:/12691/vcpkg/installed/x64-windows-static/share/embree/embree-config.cmake

  but it set embree_FOUND to FALSE so package "embree" is considered to be
  NOT FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  embree_sse42 embree_avx embree_avx2
```
Related https://github.com/microsoft/vcpkg/pull/12691#issuecomment-675374629

Note: No feature needs to test.
