### PR TITLE
[vcpkg] Implement 'repository' tag for NuGet binary caching

### DIFF
--- a/toolsrc/include/vcpkg/binarycaching.private.h
+++ b/toolsrc/include/vcpkg/binarycaching.private.h
@@ -31,9 +31,22 @@ namespace vcpkg
         std::string nupkg_filename() const { return Strings::concat(id, '.', version, ".nupkg"); }
     };
 
+    namespace details
+    {
+        struct NuGetRepoInfo
+        {
+            std::string repo;
+            std::string branch;
+            std::string commit;
+        };
+
+        NuGetRepoInfo get_nuget_repo_info_from_env();
+    }
+
     std::string generate_nuspec(const VcpkgPaths& paths,
                                 const Dependencies::InstallPlanAction& action,
-                                const NugetReference& ref);
+                                const NugetReference& ref,
+                                details::NuGetRepoInfo rinfo = details::get_nuget_repo_info_from_env());
 
     struct XmlSerializer
     {

--- a/toolsrc/src/vcpkg-test/binarycaching.cpp
+++ b/toolsrc/src/vcpkg-test/binarycaching.cpp
@@ -15,6 +15,18 @@
 
 using namespace vcpkg;
 
+#define REQUIRE_EQUAL_TEXT(lhs, rhs)                                                                                   \
+    {                                                                                                                  \
+        auto lhs_lines = Strings::split((lhs), '\n');                                                                  \
+        auto rhs_lines = Strings::split((rhs), '\n');                                                                  \
+        for (size_t i = 0; i < lhs_lines.size() && i < rhs_lines.size(); ++i)                                          \
+        {                                                                                                              \
+            INFO("on line: " << i);                                                                                    \
+            REQUIRE(lhs_lines[i] == rhs_lines[i]);                                                                     \
+        }                                                                                                              \
+        REQUIRE(lhs_lines.size() == rhs_lines.size());                                                                 \
+    }
+
 TEST_CASE ("reformat_version semver-ish", "[reformat_version]")
 {
     REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0-abitag");
@@ -81,13 +93,14 @@ Build-Depends: bzip
 
     REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-packageabi.nupkg");
 
-    auto nuspec = generate_nuspec(paths, ipa, ref);
+    {
+        auto nuspec = generate_nuspec(paths, ipa, ref, {});
 #ifdef _WIN32
 #define PKGPATH "C:\\zlib2_x64-windows\\**"
 #else
 #define PKGPATH "/zlib2_x64-windows/**"
 #endif
-    std::string expected = R"(<package>
+        std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
     <version>1.5.0-packageabi</version>
@@ -106,14 +119,67 @@ Dependencies:
   <files><file src=")" PKGPATH R"(" target=""/></files>
 </package>
 )";
-    auto expected_lines = Strings::split(expected, '\n');
-    auto nuspec_lines = Strings::split(nuspec, '\n');
-    for (size_t i = 0; i < expected_lines.size() && i < nuspec_lines.size(); ++i)
-    {
-        INFO("on line: " << i);
-        REQUIRE(nuspec_lines[i] == expected_lines[i]);
+        REQUIRE_EQUAL_TEXT(nuspec, expected);
     }
-    REQUIRE(nuspec_lines.size() == expected_lines.size());
+
+    {
+        auto nuspec = generate_nuspec(paths, ipa, ref, {"urlvalue"});
+#ifdef _WIN32
+#define PKGPATH "C:\\zlib2_x64-windows\\**"
+#else
+#define PKGPATH "/zlib2_x64-windows/**"
+#endif
+        std::string expected = R"(<package>
+  <metadata>
+    <id>zlib2_x64-windows</id>
+    <version>1.5.0-packageabi</version>
+    <authors>vcpkg</authors>
+    <description>NOT FOR DIRECT USE. Automatically generated cache package.
+
+a spiffy compression library wrapper
+
+Version: 1.5
+Triplet/Compiler hash: tripletabi
+Features: a, b
+Dependencies:
+</description>
+    <packageTypes><packageType name="vcpkg"/></packageTypes>
+    <repository type="git" url="urlvalue"/>
+  </metadata>
+  <files><file src=")" PKGPATH R"(" target=""/></files>
+</package>
+)";
+        REQUIRE_EQUAL_TEXT(nuspec, expected);
+    }
+    {
+        auto nuspec = generate_nuspec(paths, ipa, ref, {"urlvalue", "branchvalue", "commitvalue"});
+#ifdef _WIN32
+#define PKGPATH "C:\\zlib2_x64-windows\\**"
+#else
+#define PKGPATH "/zlib2_x64-windows/**"
+#endif
+        std::string expected = R"(<package>
+  <metadata>
+    <id>zlib2_x64-windows</id>
+    <version>1.5.0-packageabi</version>
+    <authors>vcpkg</authors>
+    <description>NOT FOR DIRECT USE. Automatically generated cache package.
+
+a spiffy compression library wrapper
+
+Version: 1.5
+Triplet/Compiler hash: tripletabi
+Features: a, b
+Dependencies:
+</description>
+    <packageTypes><packageType name="vcpkg"/></packageTypes>
+    <repository type="git" url="urlvalue" branch="branchvalue" commit="commitvalue"/>
+  </metadata>
+  <files><file src=")" PKGPATH R"(" target=""/></files>
+</package>
+)";
+        REQUIRE_EQUAL_TEXT(nuspec, expected);
+    }
 }
 
 TEST_CASE ("XmlSerializer", "[XmlSerializer]")


### PR DESCRIPTION
This tag is required to correctly interface with GitHub Packages, because GHP shares a single remote for the entire organization and uses the repository field to associate a package with a particular repository.

This tag will be automatically generated if the default GitHub Actions environment variables are present (GITHUB_XYZ) or if the user defines VCPKG_NUGET_REPOSITORY.
