### PR TITLE
[bzip2] Add SHA512 hash check

### DIFF
--- a/ports/bzip2/CONTROL
+++ b/ports/bzip2/CONTROL
@@ -1,4 +1,0 @@
-Source: bzip2
-Version: 1.0.8
-Homepage: http://www.bzip.org/
-Description: High-quality data compressor.

--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://sourceware.org/git/bzip2.git
-    REF 75a94bea3918e612b879d6a11ca64b8689526147
+    REF 75a94bea3918e612b879d6a11ca64b8689526147 # REFERENCE BZIP2 VERSION 1.0.8
     SHA512 4611105f9090477b5f6f6dbd303a282099df71644e04d8a998ef81de487f6c8cac4c0ec1283ad737f6767c51f1e3b4e24e2ee021c6dd085925617d9ed145b2ba
     PATCHES
         fix-import-export-macros.patch

--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -2,6 +2,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://sourceware.org/git/bzip2.git
     REF 75a94bea3918e612b879d6a11ca64b8689526147
+    SHA512 4611105f9090477b5f6f6dbd303a282099df71644e04d8a998ef81de487f6c8cac4c0ec1283ad737f6767c51f1e3b4e24e2ee021c6dd085925617d9ed145b2ba
     PATCHES
         fix-import-export-macros.patch
 )

--- a/ports/bzip2/vcpkg.json
+++ b/ports/bzip2/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "bzip2",
+  "version-string": "1.0.8",
+  "port-version": 1,
+  "description": "bzip2 is a freely available, patent free, high-quality data compressor. It typically compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical compressors), whilst being around twice as fast at compression and six times faster at decompression.",
+  "homepage": "https://sourceware.org/bzip2/",
+  "documentation": "https://sourceware.org/bzip2/docs.html"
+}


### PR DESCRIPTION
**Describe the pull request**

1. Add SHA512 hash check to portfile.cmake
2. Delete old style CONTROL file
3. Add new style vcpkg.json file

- What does your PR fix? Fixes #13224 ([bzip2] Update to 1.0.8. #13178 - missing SHA512 hash check)

- Which triplets are supported/not supported? Changes made should not change triplets supported/not supported

- Have you updated the CI baseline? Changes made should not effect CI baseline

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes it should
