### PR TITLE
[freetype] static build fix

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,6 +1,6 @@
 Source: freetype
 Version: 2.10.2
-Port-Version: 3
+Port-Version: 4
 Build-Depends: zlib, brotli
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/brotli-static.patch
+++ b/ports/freetype/brotli-static.patch
@@ -2,7 +2,7 @@ diff --git a/builds/cmake/FindBrotliDec.cmake b/builds/cmake/FindBrotliDec.cmake
 index 7c484c7df..0bd49b825 100644
 --- a/builds/cmake/FindBrotliDec.cmake
 +++ b/builds/cmake/FindBrotliDec.cmake
-@@ -34,14 +34,14 @@ find_path(BROTLIDEC_INCLUDE_DIRS
+@@ -34,14 +34,22 @@ find_path(BROTLIDEC_INCLUDE_DIRS
    PATH_SUFFIXES brotli)
  
  find_library(BROTLIDEC_LIBRARIES
@@ -11,6 +11,14 @@ index 7c484c7df..0bd49b825 100644
    HINTS ${PC_BROTLIDEC_LIBDIR}
          ${PC_BROTLIDEC_LIBRARY_DIRS})
  
++find_library(BROTLICOMMON_LIBRARIES
++  NAMES brotlicommon-static
++  HINTS ${PC_BROTLIDEC_LIBDIR}
++        ${PC_BROTLIDEC_LIBRARY_DIRS})
++
++if(BROTLICOMMON_LIBRARIES)
++  set(BROTLIDEC_LIBRARIES ${BROTLIDEC_LIBRARIES} ${BROTLICOMMON_LIBRARIES})
++endif()
  
  include(FindPackageHandleStandardArgs)
  find_package_handle_standard_args(

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -47,6 +47,7 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 # Fix the include dir [freetype2 -> freetype]
 file(READ ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-config.cmake CONFIG_MODULE)
 string(REPLACE "\${_IMPORT_PREFIX}/include/freetype2" "\${_IMPORT_PREFIX}/include" CONFIG_MODULE "${CONFIG_MODULE}")
+string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlicommon-static.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlicommon-static.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlicommon-static.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec-static.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec-static.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec-static.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
@@ -72,12 +73,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(COPY
-    ${SOURCE_PATH}/docs/LICENSE.TXT
     ${SOURCE_PATH}/docs/FTL.TXT
     ${SOURCE_PATH}/docs/GPLv2.TXT
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/freetype
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
 )
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/freetype/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/freetype/copyright)
+file(INSTALL ${SOURCE_PATH}/docs/LICENSE.TXT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
 vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -89,5 +90,6 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         set(USE_PNG ON)
     endif()
 
-    configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake ${CURRENT_PACKAGES_DIR}/share/freetype/vcpkg-cmake-wrapper.cmake @ONLY)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake 
+        ${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake @ONLY)
 endif()


### PR DESCRIPTION
Missing brotlicommon-static.lib dependency closes #13249


freetype depends on [brotli] but when building statically (x64-windows-static) it only links link with brotlidec-static.lib and not the brotlicommon-static.lib leading to link errors.

```
9>brotlidec-static.lib(decode.c.obj) : error LNK2019: unresolved external symbol BrotliTransformDictionaryWord referenced in function ProcessCommandsInternal
9>brotlidec-static.lib(state.c.obj) : error LNK2019: unresolved external symbol BrotliGetDictionary referenced in function BrotliDecoderStateInit
9>brotlidec-static.lib(state.c.obj) : error LNK2019: unresolved external symbol BrotliGetTransforms referenced in function BrotliDecoderStateInit
```

The freetype FindBrotliDec file needs to be patched to handle this