### PR TITLE
Download pkgconfig for protobuf in download mode

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,6 @@
 Source: protobuf
-Version: 3.13.0-1
+Version: 3.13.0
+Port-Version: 1
 Homepage: https://github.com/protocolbuffers/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,5 @@
 Source: protobuf
-Version: 3.13.0
+Version: 3.13.0-1
 Homepage: https://github.com/protocolbuffers/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -38,6 +38,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	zlib	protobuf_WITH_ZLIB
 )
 
+if (VCPKG_DOWNLOAD_MODE)
+    # download PKGCONFIG in download mode which is used in `vcpkg_fixup_pkgconfig()` at the end of this script.
+    # download it here because `vcpkg_configure_cmake()` halts execution in download mode when running configure process.
+    vcpkg_find_acquire_program(PKGCONFIG)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/cmake


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
`vcpkg install protobuf --only-downloads` doesn't download mingw tool pkgconfig because the running is halted in configure process, and download of pkgconfig is expected to happen at the end of install process which is after the halt. The breaks the following run of `vcpkg install protobuf --no-downloads` which complains that pkgconfig is unavailable in local cache. 
This PR fixes the issue by explicitly downloading pkgconfig before configure in download mode.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
