### PR TITLE
[python3] Fix installation on OpenSUSE

### DIFF
--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -1,6 +1,6 @@
 Source: python3
 Version: 3.8.3
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/python/cpython
 Description: The Python programming language as an embeddable library
 Build-Depends: libffi, openssl, zlib (!uwp&!windows)

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -161,17 +161,16 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		)
 
 		message(STATUS "Installing ${TARGET_TRIPLET}-rel lib files...")
-		file(GLOB LIBS
+		file(GLOB PY_LIBS
 			${OUT_PATH_RELEASE}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/*)
-		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/Lib
+		file(INSTALL ${PY_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/Lib
 			PATTERN "*.pyc" EXCLUDE
 			PATTERN "*__pycache__*" EXCLUDE
 		)
 
 		message(STATUS "Installing ${TARGET_TRIPLET}-rel share files...")
-		file(GLOB LIBS
-			${OUT_PATH_RELEASE}/lib/pkgconfig/*)
-		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}
+		file(GLOB PKGCFG ${OUT_PATH_RELEASE}/lib/pkgconfig/*)
+		file(INSTALL ${PKGCFG} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}
 			PATTERN "*.pyc" EXCLUDE
 			PATTERN "*__pycache__*" EXCLUDE
 		)
@@ -179,6 +178,9 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		message(STATUS "Installing ${TARGET_TRIPLET}-rel Python library files...")
 		file(GLOB LIBS
 			${OUT_PATH_RELEASE}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.*)
+        if (NOT LIBS)
+            file(GLOB LIBS ${OUT_PATH_RELEASE}/lib64/*)
+        endif()
 		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib
 			PATTERN "*.pyc" EXCLUDE
 			PATTERN "*__pycache__*" EXCLUDE
@@ -233,6 +235,10 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 		message(STATUS "Installing ${TARGET_TRIPLET}-dbg Python library files...")
 		file(GLOB LIBS
 			${OUT_PATH_DEBUG}/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}d.*)
+        if (NOT LIBS)
+            file(GLOB LIBS
+                ${OUT_PATH_DEBUG}/lib64/*)
+        endif()
 		file(INSTALL ${LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
 			PATTERN "*.pyc" EXCLUDE
 			PATTERN "*__pycache__*" EXCLUDE


### PR DESCRIPTION
On OpenSUSE, the python3 libraries are generated in _BUILD_ROOT/lib64_ instead of _BUILD_ROOT/lib/libpython${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}._.
Fix this issue.

Fixes #13261.