### PR TITLE
[folly] Fix findpackage error messages

### DIFF
--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,6 +1,6 @@
 Source: folly
 Version: 2019.10.21.00
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -90,6 +90,7 @@ FILE(WRITE ${CURRENT_PACKAGES_DIR}/share/folly/folly-config.cmake
 find_dependency(Threads)
 find_dependency(glog CONFIG)
 find_dependency(gflags CONFIG REQUIRED)
+find_dependency(ZLIB CONFIG)
 ${_contents}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -90,7 +90,7 @@ FILE(WRITE ${CURRENT_PACKAGES_DIR}/share/folly/folly-config.cmake
 find_dependency(Threads)
 find_dependency(glog CONFIG)
 find_dependency(gflags CONFIG REQUIRED)
-find_dependency(ZLIB CONFIG)
+find_dependency(ZLIB)
 ${_contents}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #13196
Target "folly_example1" links to target "ZLIB::ZLIB" but the target was not found.Add find_dependency(ZLIB) in the folly-config.cmake file, and finally modify it in the cmake.in file to fix error
