### PR TITLE
[vcpkg baseline][rest-rpc] Skip check in baseline

### DIFF
--- a/ports/msgpack/CONTROL
+++ b/ports/msgpack/CONTROL
@@ -1,4 +1,5 @@
 Source: msgpack
-Version: 3.2.0-1
+Version: 3.2.0
+Port-Version: 2
 Homepage: https://github.com/msgpack/msgpack-c
 Description: MessagePack is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller.

--- a/ports/msgpack/portfile.cmake
+++ b/ports/msgpack/portfile.cmake
@@ -1,4 +1,7 @@
-include(vcpkg_common_functions)
+if (EXISTS ${CURRENT_INSTALLED_DIR}/include/msgpack/pack.h)
+    message(FATAL_ERROR "Cannot install ${PORT} when rest-rpc is already installed, please remove rest-rpc using \"./vcpkg remove rest-rpc:${TARGET_TRIPLET}\"")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO msgpack/msgpack-c

--- a/ports/rest-rpc/CONTROL
+++ b/ports/rest-rpc/CONTROL
@@ -1,5 +1,6 @@
 Source: rest-rpc
 Version: 0.07
+Port-Version: 1
 Homepage: https://github.com/qicosmos/rest_rpc
 Description: c++11, high performance, cross platform, easy to use rpc framework
 Build-Depends: asio

--- a/ports/rest-rpc/portfile.cmake
+++ b/ports/rest-rpc/portfile.cmake
@@ -1,5 +1,8 @@
-# header-only library
+if (EXISTS ${CURRENT_INSTALLED_DIR}/include/msgpack/pack.h)
+    message(FATAL_ERROR "Cannot install ${PORT} when msgpack is already installed, please remove msgpack using \"./vcpkg remove msgpack:${TARGET_TRIPLET}\"")
+endif()
 
+# header-only library
 set(RESTRPC_VERSION V0.07)
 set(RESTRPC_HASH 148152776c8c4f16e404c62ab3f46618e1817c0b4b186dbcc399c859efd110ed5a207bf56e961c312f80844f696f597068e0abc00e426409d50a2889d30c6d8e)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/rest-rpc-${RESTRPC_VERSION})

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1499,6 +1499,15 @@ reproc:arm-uwp=fail
 reproc:x64-uwp=fail
 restbed:arm-uwp=fail
 restbed:x64-uwp=fail
+# file conflicts with msgpack
+rest-rpc:x86-windows=skip
+rest-rpc:x64-windows=skip
+rest-rpc:x64-windows-static=skip
+rest-rpc:x64-uwp=skip
+rest-rpc:arm-uwp=skip
+rest-rpc:arm64-windows=skip
+rest-rpc:x64-linux=skip
+rest-rpc:x64-osx=skip
 rhash:arm64-windows=fail
 rhash:arm-uwp=fail
 rhash:x64-uwp=fail


### PR DESCRIPTION
Because the `msgpack` in `rest-rpc` is very different from the header file of port `msgpack`, disable the check of `rest-rpc` in the baseline and add error message to notify users.
Error log:
```
Installing package rest-rpc[core]:x86-windows...
The following files are already installed in F:/vcpkg/installed/x86-windows and are in conflict with rest-rpc:x86-windows

Installed by msgpack:x86-windows
    include/msgpack.h
    include/msgpack.hpp
    include/msgpack/adaptor/adaptor_base.hpp
    include/msgpack/adaptor/adaptor_base_decl.hpp
    include/msgpack/adaptor/array_ref.hpp
    include/msgpack/adaptor/array_ref_decl.hpp
    include/msgpack/adaptor/bool.hpp
    include/msgpack/adaptor/boost/fusion.hpp
    include/msgpack/adaptor/boost/msgpack_variant.hpp
    include/msgpack/adaptor/boost/msgpack_variant_decl.hpp
    include/msgpack/adaptor/boost/optional.hpp
...
```