### PR TITLE
[vcpkg.cmake] error out if the mode has changed

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -5,6 +5,8 @@ mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 option(VCPKG_VERBOSE "Enables messages from the VCPKG toolchain for debugging purposes." OFF)
 mark_as_advanced(VCPKG_VERBOSE)
 
+include(CMakeDependentOption)
+
 function(_vcpkg_get_directory_name_of_file_above OUT DIRECTORY FILENAME)
     set(_vcpkg_get_dir_candidate ${DIRECTORY})
     while(IS_DIRECTORY ${_vcpkg_get_dir_candidate} AND NOT DEFINED _vcpkg_get_dir_out)
@@ -43,15 +45,26 @@ elseif(VCPKG_MANIFEST_MODE AND NOT _VCPKG_MANIFEST_DIR)
         "disable manifests by turning off VCPKG_MANIFEST_MODE.")
 endif()
 
-if(VCPKG_MANIFEST_MODE)
-    option(VCPKG_MANIFEST_INSTALL
-[[
+if(NOT DEFINED _INTERNAL_CHECK_VCPKG_MANIFEST_MODE)
+    set(_INTERNAL_CHECK_VCPKG_MANIFEST_MODE "${VCPKG_MANIFEST_MODE}"
+        CACHE INTERNAL "Making sure VCPKG_MANIFEST_MODE doesn't change")
+endif()
+
+if(NOT VCPKG_MANIFEST_MODE STREQUAL _INTERNAL_CHECK_VCPKG_MANIFEST_MODE)
+    message(FATAL_ERROR [[
+vcpkg manifest mode was enabled for a build directory where it was initially disabled.
+This is not supported. Please delete the build directory and reconfigure.
+]])
+endif()
+
+CMAKE_DEPENDENT_OPTION(VCPKG_MANIFEST_INSTALL [[
 Install the dependencies listed in your manifest:
     If this is off, you will have to manually install your dependencies.
     See https://github.com/microsoft/vcpkg/tree/master/docs/specifications/manifests.md for more info.
 ]]
-        ON)
-endif()
+    ON
+    "VCPKG_MANIFEST_MODE"
+    OFF)
 
 # Determine whether the toolchain is loaded during a try-compile configuration
 get_property(_CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE)


### PR DESCRIPTION
I got a bug report earlier on discord where if a user:

1. Doesn't have manifest mode turned on, and configures a cmake project with the vcpkg toolchain
2. Turns on manifest mode and reconfigures

then the installed directory is set to the initial value (`${VCPKG_ROOT}/installed`), and we run `vcpkg install` with the manifest and that installed directory, which ends up deleting all the packages installed in that installed directory.

This makes certain that the manifest mode switch is constant across configurations, and requires a reconfigure if the configuration is faulty.

As a drive-by fix, switches `VCPKG_MANIFEST_INSTALL` to a `CMAKE_DEPENDENT_OPTION`.