### PR TITLE
[dlib] Fix dependency port sqlite3

### DIFF
--- a/ports/dlib/CONTROL
+++ b/ports/dlib/CONTROL
@@ -1,6 +1,6 @@
 Source: dlib
 Version: 19.21
-Port-Version: 3
+Port-Version: 4
 Build-Depends: libjpeg-turbo, libpng, openblas, lapack
 Homepage: https://github.com/davisking/dlib
 Description: Modern C++ toolkit containing machine learning algorithms and tools for creating complex software in C++

--- a/ports/dlib/fix-sqlite3-fftw-linkage.patch
+++ b/ports/dlib/fix-sqlite3-fftw-linkage.patch
@@ -15,8 +15,8 @@ diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
 -            set(DLIB_LINK_WITH_SQLITE3 OFF CACHE STRING ${DLIB_LINK_WITH_SQLITE3_STR} FORCE )
 -         endif()
 -         mark_as_advanced(sqlite sqlite_path)
-+         find_package(sqlite3 CONFIG)
-+         set(dlib_needed_libraries ${dlib_needed_libraries} sqlite3 )
++         find_package(unofficial-sqlite3 CONFIG)
++         set(dlib_needed_libraries ${dlib_needed_libraries} unofficial::sqlite3::sqlite3)
        endif()
  
  
@@ -49,7 +49,7 @@ diff --git a/dlib/CMakeLists.txt b/dlib/CMakeLists.txt
 +   find_dependency(FFTW3 CONFIG)
 +endif()
 +if("@DLIB_LINK_WITH_SQLITE3@")
-+   find_dependency(sqlite3 CONFIG)
++   find_dependency(unofficial-sqlite3 CONFIG)
 +endif()
 +
  set(dlib_LIBRARIES dlib::dlib)


### PR DESCRIPTION
Fix dependency port sqlite3 from sqlite3 to unofficial-sqlite3, also checked other ports which rely on sqlite3, they have been already updated.
