### PR TITLE
[osgearth] Adapt to the geos latest version

### DIFF
--- a/ports/osgearth/CONTROL
+++ b/ports/osgearth/CONTROL
@@ -1,5 +1,6 @@
 Source: osgearth
 Version: 3.0
+Port-Version: 1
 Homepage: https://github.com/gwaldron/osgearth
 Description:  osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.
 Build-Depends: osg[plugins]

--- a/ports/osgearth/fix-build-with-geos-3-8.patch
+++ b/ports/osgearth/fix-build-with-geos-3-8.patch
@@ -1,0 +1,41 @@
+diff --git a/src/osgEarth/GEOS.cpp b/src/osgEarth/GEOS.cpp
+index 07da3fd..31f97ab 100644
+--- a/src/osgEarth/GEOS.cpp
++++ b/src/osgEarth/GEOS.cpp
+@@ -63,9 +63,13 @@ namespace
+         {
+             coords->push_back( coords->front() );
+         }
++#if GEOS_VERSION_AT_LEAST(3,8)
++        geom::CoordinateSequence::Ptr seq = factory->create(coords);
++        return seq.get();
++#else
+         geom::CoordinateSequence* seq = factory->create( coords );
+-
+         return seq;
++#endif
+     }
+ 
+     geom::Geometry*
+@@ -141,12 +145,20 @@ namespace
+                     if ( shell )
+                     {
+                         const Polygon* poly = static_cast<const Polygon*>(input);
++#if GEOS_VERSION_AT_LEAST(3,8)
++                        std::vector<geom::LinearRing*>* holes = poly->getHoles().size() > 0 ? new std::vector<geom::LinearRing*>() : 0L;
++#else
+                         std::vector<geom::Geometry*>* holes = poly->getHoles().size() > 0 ? new std::vector<geom::Geometry*>() : 0L;
++#endif
+                         if (holes)
+                         {
+                             for( RingCollection::const_iterator r = poly->getHoles().begin(); r != poly->getHoles().end(); ++r )
+                             {
+-                                geom::Geometry* hole = import( r->get(), f );
++#if GEOS_VERSION_AT_LEAST(3,8)
++                                geom::LinearRing* hole = dynamic_cast<geom::LinearRing*>(import( r->get(), f ));
++#else
++                                geom::Geometry* hole = import(r->get(), f);
++#endif
+                                 if (hole)
+                                 {
+                                     if (hole->getGeometryTypeId() == geos::geom::GEOS_LINEARRING)

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
   	  RocksDB.patch
+      fix-build-with-geos-3-8.patch # Remove this patch after https://github.com/gwaldron/osgearth/pull/1497 merge
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Due to the update of geos to 3.8.1, osgearth cannot adapt to the changes of the new version(https://github.com/gwaldron/osgearth/issues/1455). 
Use the unofficial changes https://github.com/gwaldron/osgearth/pull/1497 to fix the issue.

Will merge this issue after https://github.com/gwaldron/osgearth/pull/1497 merged.

Fixes #13292.