### PR TITLE
[constexpr-contracts] Changes HEAD_REF from master to main

### DIFF
--- a/ports/constexpr-contracts/portfile.cmake
+++ b/ports/constexpr-contracts/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO cjdb/constexpr-contracts
     REF 58154e9010cb80aad4e95ef6f1835ebd7db3780a # commit 2020-05-25
     SHA512 b634267a4044cd712c8e52f65cd305f437864cab591f2b22104581f70b305ba52889dd46724e6047386463a010ee78fdd951411ea3691b5725d52d13f7adda76
-    HEAD_REF master
+    HEAD_REF main
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
**Describe the pull request**
[cjdb/constexpr-contracts](https://github.com/cjdb/constexpr-contracts) no longer uses `master` as a branch. This patch updates the port to reflect this.

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I think so.
