### PR TITLE
[vcpkg] Fixed 'update' command output

### DIFF
--- a/toolsrc/src/vcpkg/update.cpp
+++ b/toolsrc/src/vcpkg/update.cpp
@@ -80,7 +80,7 @@ namespace vcpkg::Update
 #else
             auto vcpkg_cmd = "./vcpkg";
 #endif
-            System::print2("\n"
+            System::printf("\n"
                            "To update these packages and all dependencies, run\n"
                            "    %s upgrade\n"
                            "\n"


### PR DESCRIPTION
Currently output of the 'update' command is a little bit broken. Instead of replacing %s placeholder with program name it just prints it after base text. Somebody used print2 instead of printf.

```
To update these packages and all dependencies, run
    %s upgrade

To only remove outdated packages, run
    %s remove --outdated

.\vcpkg.\vcpkg
```

This patch fixes the output.