### PR TITLE
[mp3lame] fix crt linkage

### DIFF
--- a/ports/mp3lame/CONTROL
+++ b/ports/mp3lame/CONTROL
@@ -1,4 +1,5 @@
 Source: mp3lame
-Version: 3.100-3
+Version: 3.100
+Port-Version: 4
 Homepage: http://lame.sourceforge.net/
 Description: LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.

--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -141,6 +141,6 @@ else()
 endif()
 
 file(COPY ${SOURCE_PATH}/include/lame.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/lame)
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/mp3lame/copyright COPYONLY)
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in ${CURRENT_PACKAGES_DIR}/share/mp3lame/mp3lame-config.cmake @ONLY)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/mp3lame)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/mp3lame/portfile.cmake
+++ b/ports/mp3lame/portfile.cmake
@@ -35,7 +35,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     foreach(vcxproj ${vcxprojs})
         file(READ "${SOURCE_PATH}/vc_solution/${vcxproj}" vcxproj_con)
         
-        if(NOT VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        if(NOT VCPKG_CRT_LINKAGE STREQUAL dynamic)
             string(REPLACE "DLL</RuntimeLibrary>" "</RuntimeLibrary>" vcxproj_con "${vcxproj_con}")
         endif()
 


### PR DESCRIPTION
Currently, mp3lame fails to build with the x64-windows-static-md triplet, as the library gets compiled with the wrong crt linkage. This patch corrects the port file so actual crt linkage matches requested crt linkage. Prior to this patch, crt linkage matched the library linkage (which works for the supported triplets but not for custom triplets).

Patch was tested with x64-windows, x64-windows-static, and x64-windows-static-md triplets.

- What does your PR fix? See above.

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? To the best of my knowledge, yes.