### PR TITLE
[geos] Fix linking of geos for mingw

### DIFF
--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,4 +1,5 @@
 Source: geos
 Version: 3.8.1
+Port-Version: 1
 Homepage: https://www.osgeo.org/projects/geos/
 Description: Geometry Engine Open Source

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -17,12 +17,19 @@ vcpkg_extract_source_archive_ex(
 # NOTE: GEOS provides CMake as optional build configuration, it might not be actively
 # maintained, so CMake build issues may happen between releases.
 
+if(VCPKG_TARGET_IS_MINGW)
+    set(_CMAKE_EXTRA_OPTIONS "-DDISABLE_GEOS_INLINE=ON")
+else()
+    set(_CMAKE_EXTRA_OPTIONS "")
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DCMAKE_DEBUG_POSTFIX=d
         -DBUILD_TESTING=OFF
+        ${_CMAKE_EXTRA_OPTIONS}
 )
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/GEOS)

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,4 +1,4 @@
-set(GEOS_VERSION 3.8.1)
+set(GEOS_VERSION 3.8.1-1)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,4 +1,4 @@
-set(GEOS_VERSION 3.8.1-1)
+set(GEOS_VERSION 3.8.1)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"


### PR DESCRIPTION
- Fixes linking stage failure due to the multiple definitions of the same symbol. One way of fixing this is to disable inlining for small functions by passing DISABLE_GEOS_INLINE=ON for mingw builds.

- This will not affect any other triplets except mingw, I haven't change anything except build flag for this one package

