### PR TITLE
[ICU] Fix ICU so Debug configs can build with it.

### DIFF
--- a/ports/icu/remove-MD-from-configure.patch
+++ b/ports/icu/remove-MD-from-configure.patch
@@ -7,12 +7,10 @@ diff -urN a/source/runConfigureICU b/source/runConfigureICU
          CXX=cl; export CXX
 -        RELEASE_CFLAGS='-Gy -MD'
 -        RELEASE_CXXFLAGS='-Gy -MD'
--        DEBUG_CFLAGS='-FS -Zi -MDd'
--        DEBUG_CXXFLAGS='-FS -Zi -MDd'
 +        RELEASE_CFLAGS='-Gy'
 +        RELEASE_CXXFLAGS='-Gy'
-+        DEBUG_CFLAGS='-FS -Zi'
-+        DEBUG_CXXFLAGS='-FS -Zi'
+         DEBUG_CFLAGS='-FS -Zi -MDd'
+         DEBUG_CXXFLAGS='-FS -Zi -MDd'
          DEBUG_LDFLAGS='-DEBUG'
          ;;
      *BSD)


### PR DESCRIPTION
I was trying to integrate ICU into a personal project. ICU would build correctly through vcpkg in all configurations, and it would integrate just fine in Release in my project, but would cause my project to fail to start to build in Debug configs. Ninja would fail saying it couldn't find icuuc.lib (when icuucd.lib existed where it's supposed to).

This change partially reverts the patch that broke this feature and fixes the issue.
