### PR TITLE
[tmx] Fix build failure

### DIFF
--- a/ports/tmx/CONTROL
+++ b/ports/tmx/CONTROL
@@ -1,4 +1,5 @@
 Source: tmx
-Version: 1.0.0-1
+Version: 1.0.0
+Port-Version: 2
 Description: A portable C library to load tiled maps in your games.
 Build-Depends: zlib, libxml2

--- a/ports/tmx/fix-build-error.patch
+++ b/ports/tmx/fix-build-error.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b29edce..48d0553 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,8 +66,9 @@ write_basic_package_version_file("tmxConfigVersion.cmake" COMPATIBILITY SameMajo
+ #   Build
+ #-----------#
+ 
+-list(APPEND targets tmx)
++set(targets tmx)
+ 
++if (NOT BUILD_SHARED_LIBS)
+ add_library(tmx STATIC ${SOURCES})
+ set_target_properties(tmx PROPERTIES VERSION ${BUILD_VERSION})
+ 
+@@ -75,8 +76,8 @@ set_property(TARGET tmx
+              APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+              $<INSTALL_INTERFACE:include>)
+ 
+-if(BUILD_SHARED_LIBS)
+-    list(APPEND targets tmx_shared)
++else()
++    set(targets tmx_shared)
+ 
+     add_library(tmx_shared SHARED ${SOURCES})
+     target_link_libraries(tmx_shared PRIVATE ${libs})

--- a/ports/tmx/portfile.cmake
+++ b/ports/tmx/portfile.cmake
@@ -1,11 +1,10 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO baylej/tmx
     REF tmx_1.0.0
     HEAD_REF master
     SHA512 d045c45efd03f91a81dae471cb9ddc80d222b3ac52e13b729deeaf3e07d0a03b8e0956b30336ef410c72ddbbf33bea6811da5454b88d44b1db75683ef2a9383a
+    PATCHES fix-build-error.patch
 )
 
 vcpkg_configure_cmake(

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1699,13 +1699,6 @@ tinyutf8:arm64-windows=fail
 tinyutf8:arm-uwp=fail
 tinyutf8:x64-uwp=fail
 
-#Flaky on windows only due to error PRI210: 0x80070020 - File move failed
-tmx:arm64-windows      = skip
-tmx:arm-uwp            = skip
-tmx:x64-uwp            = skip
-tmx:x64-windows        = skip
-tmx:x64-windows-static = skip
-tmx:x86-windows        = skip
 tmxlite:arm-uwp=fail
 tmxlite:x64-uwp=fail
 tmxparser:arm64-windows=fail


### PR DESCRIPTION
Fix mutiple targets:
```
CMake Error:
  Running

   'C:/Users/jankl/Source/Repos/vcpkg/downloads/tools/ninja/1.10.0-windows/ninja.exe' '-C' 'C:/Users/jankl/Source/Repos/vcpkg/buildtrees/tmx/x64-windows-rel' '-t' 'cleandead'

  failed with:

   ninja: error: build.ninja:225: multiple rules generate tmx.lib [-w dupbuild=err]

CMake Error:
  Running

   'C:/Users/jankl/Source/Repos/vcpkg/downloads/tools/ninja/1.10.0-windows/ninja.exe' '-C' 'C:/Users/jankl/Source/Repos/vcpkg/buildtrees/tmx/x64-windows-rel' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:225: multiple rules generate tmx.lib [-w dupbuild=err]
```

Fixes #13391.