### PR TITLE
[zeromq]Fix missing system version for mingw builds

### DIFF
--- a/ports/zeromq/CONTROL
+++ b/ports/zeromq/CONTROL
@@ -1,5 +1,5 @@
 Source: zeromq
-Version: 2019-09-20
+Version: 2019-09-20-1
 Homepage: https://github.com/zeromq/libzmq
 Description: The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products
 

--- a/ports/zeromq/CONTROL
+++ b/ports/zeromq/CONTROL
@@ -1,5 +1,6 @@
 Source: zeromq
-Version: 2019-09-20-1
+Version: 2019-09-20
+Port-Version: 1
 Homepage: https://github.com/zeromq/libzmq
 Description: The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products
 

--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -19,6 +19,11 @@ vcpkg_check_features(
         websockets-sha1 DISABLE_WS
 )
 
+set(PLATFORM_OPTIONS)
+if(VCPKG_TARGET_IS_MINGW)
+    set(PLATFORM_OPTIONS "-DCMAKE_SYSTEM_VERSION=6.0")
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -31,6 +36,7 @@ vcpkg_configure_cmake(
         -DWITH_DOCS=OFF
         -DWITH_NSS=OFF
         ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
     OPTIONS_DEBUG
         "-DCMAKE_PDB_OUTPUT_DIRECTORY=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg"
 )


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Fixes missing system version that is required to compile the code. It is detected in the main CMakeLists.txt file and used later as a _WIN32_WINNT - macro get_WIN32_WINNT in CMakeLists.txt. System version is required to be 6.0 or higher for ZeroMQ to work correctly.

- Which triplets are supported/not supported? Have you updated the CI baseline?
This will not affect any other triplets except mingw, CI baseline is not updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I bump the version of the port using YYYY-MM-DD-N format