### PR TITLE
[libigl] Install extra headers when feature selected

### DIFF
--- a/ports/libigl/CONTROL
+++ b/ports/libigl/CONTROL
@@ -1,5 +1,6 @@
 Source: libigl
 Version: 2.2.0
+Port-Version: 1
 Homepage: https://github.com/libigl/libigl
 Description: libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.
 Build-Depends: eigen3

--- a/ports/libigl/install-extra-headers.patch
+++ b/ports/libigl/install-extra-headers.patch
@@ -1,0 +1,35 @@
+diff --git a/cmake/libigl.cmake b/cmake/libigl.cmake
+index a33cefa..991cf0d 100644
+--- a/cmake/libigl.cmake
++++ b/cmake/libigl.cmake
+@@ -561,6 +561,30 @@ export(
+ install_dir_files(core)
+ install_dir_files(copyleft)
+ 
++if (LIBIGL_WITH_EMBREE)
++    install_dir_files(embree)
++endif()
++
++if (LIBIGL_WITH_OPENGL OR LIBIGL_WITH_OPENGL_GLFW OR LIBIGL_WITH_OPENGL_GLFW_IMGUI)
++    install_dir_files(opengl)
++endif()
++
++if (LIBIGL_WITH_PNG)
++    install_dir_files(png)
++endif()
++
++if (LIBIGL_WITH_PREDICATES)
++    install_dir_files(predicates)
++endif()
++
++if (LIBIGL_WITH_TRIANGLE)
++    install_dir_files(triangle)
++endif()
++
++if (LIBIGL_WITH_XML)
++    install_dir_files(xml)
++endif()
++
+ # Write package configuration file
+ configure_package_config_file(
+   ${CMAKE_CURRENT_LIST_DIR}/libigl-config.cmake.in

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         fix-dependency.patch
         fix-imgui-set-cond.patch
+        install-extra-headers.patch
 )
 
 set(LIBIGL_BUILD_STATIC OFF)


### PR DESCRIPTION
Now, some feature headers are not installed to _include_, fix this.
Fixes #11986.