### PR TITLE
[gtest] Remove autodetectable usage information

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,5 +1,5 @@
 Source: gtest
 Version: 1.10.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -76,4 +76,3 @@ endif()
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/googletest/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})


### PR DESCRIPTION
Extracted from #12199

By policy, we use `usage` information only to supplement when our heuristics fail, not to provide additional information beyond those heuristics.