### PR TITLE
[libigl] Re-fix install extra headers

### DIFF
--- a/ports/libigl/CONTROL
+++ b/ports/libigl/CONTROL
@@ -1,6 +1,6 @@
 Source: libigl
 Version: 2.2.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/libigl/libigl
 Description: libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.
 Build-Depends: eigen3

--- a/ports/libigl/install-extra-headers.patch
+++ b/ports/libigl/install-extra-headers.patch
@@ -1,17 +1,43 @@
 diff --git a/cmake/libigl.cmake b/cmake/libigl.cmake
-index a33cefa..991cf0d 100644
+index a33cefa..0014375 100644
 --- a/cmake/libigl.cmake
 +++ b/cmake/libigl.cmake
-@@ -561,6 +561,30 @@ export(
+@@ -560,6 +560,55 @@ export(
+ # Install headers for core library
  install_dir_files(core)
  install_dir_files(copyleft)
- 
++ 
 +if (LIBIGL_WITH_EMBREE)
 +    install_dir_files(embree)
 +endif()
++ 
++if (LIBIGL_WITH_CGAL)
++    install_dir_files(copyleft/cgal)
++endif()
++ 
++if (LIBIGL_WITH_COMISO)
++    install_dir_files(copyleft/comiso)
++endif()
++ 
++if (LIBIGL_WITH_CORK)
++    install_dir_files(copyleft/cork)
++endif()
++ 
++if (LIBIGL_WITH_TETGEN)
++    install_dir_files(copyleft/tetgen)
++endif()
 +
 +if (LIBIGL_WITH_OPENGL OR LIBIGL_WITH_OPENGL_GLFW OR LIBIGL_WITH_OPENGL_GLFW_IMGUI)
++    install_dir_files(copyleft/opengl2)
 +    install_dir_files(opengl)
++endif()
++
++if (LIBIGL_WITH_OPENGL_GLFW OR LIBIGL_WITH_OPENGL_GLFW_IMGUI)
++    install_dir_files(opengl/glfw)
++endif()
++
++if (LIBIGL_WITH_OPENGL_GLFW_IMGUI)
++    install_dir_files(opengl/glfw/imgui)
 +endif()
 +
 +if (LIBIGL_WITH_PNG)
@@ -29,7 +55,6 @@ index a33cefa..991cf0d 100644
 +if (LIBIGL_WITH_XML)
 +    install_dir_files(xml)
 +endif()
-+
+ 
  # Write package configuration file
  configure_package_config_file(
-   ${CMAKE_CURRENT_LIST_DIR}/libigl-config.cmake.in


### PR DESCRIPTION
continue PR #13424. since `install_dir_files` is not installed recursively, fix that.

Fixes #11986