### PR TITLE
[vcpkg] Add metrics for binarycaching feature

### DIFF
--- a/toolsrc/src/vcpkg/commands.setinstalled.cpp
+++ b/toolsrc/src/vcpkg/commands.setinstalled.cpp
@@ -6,6 +6,7 @@
 #include <vcpkg/help.h>
 #include <vcpkg/input.h>
 #include <vcpkg/install.h>
+#include <vcpkg/metrics.h>
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/remove.h>
 #include <vcpkg/vcpkgcmdarguments.h>
@@ -141,6 +142,7 @@ namespace vcpkg::Commands::SetInstalled
         auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
         if (it_pkgsconfig != options.settings.end())
         {
+            Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
             pkgsconfig = it_pkgsconfig->second;
         }
 

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -786,6 +786,7 @@ namespace vcpkg::Install
             auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
             if (it_pkgsconfig != options.settings.end())
             {
+                Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
                 pkgsconfig = fs::u8path(it_pkgsconfig->second);
             }
             auto manifest_path = paths.get_manifest_path().value_or_exit(VCPKG_LINE_INFO);
@@ -924,6 +925,7 @@ namespace vcpkg::Install
         auto it_pkgsconfig = options.settings.find(OPTION_WRITE_PACKAGES_CONFIG);
         if (it_pkgsconfig != options.settings.end())
         {
+            Metrics::g_metrics.lock()->track_property("x-write-nuget-packages-config", "defined");
             Build::compute_all_abis(paths, action_plan, var_provider, status_db);
 
             auto pkgsconfig_path = Files::combine(paths.original_cwd, fs::u8path(it_pkgsconfig->second));


### PR DESCRIPTION
Adds boolean metrics for:
- Defining `VCPKG_DEFAULT_BINARY_CACHE`
- Defining `VCPKG_BINARY_SOURCES`
- Defining `VCPKG_NUGET_REPOSITORY`
- Defining `GITHUB_REPOSITORY`
- Passing `--x-write-nuget-packages-config`
- Passing `--binarysource`
- Using `clear` as a binary source
- Using `nuget`/`nugetconfig` as a binary source