### PR TITLE
[vcpkg, libpq] separate static and shared library installations

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,6 +1,6 @@
 Source: libpq
 Version: 12.2
-Port-Version: 6
+Port-Version: 7
 Build-Depends: libpq[bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libpq/Makefile
+++ b/ports/libpq/Makefile
@@ -1,0 +1,34 @@
+subdir = .
+top_builddir = .
+include src/Makefile.global
+
+.NOTPARALLEL:
+
+ifeq ($(LIBPQ_LIBRARY_TYPE), shared)
+LIBPQ_LIB_SUFFIX = _shlib
+endif
+
+ifeq ($(LIBPQ_LIBRARY_TYPE), static)
+LIBPQ_INSTALL_LIBS = install-stlib
+endif
+
+.PHONY: all
+all:
+	$(MAKE) -C src/include MAKELEVEL=0
+	$(MAKE) -C src/common MAKELEVEL=0 libpgcommon$(LIBPQ_LIB_SUFFIX).a
+	$(MAKE) -C src/port MAKELEVEL=0 libpgport$(LIBPQ_LIB_SUFFIX).a
+	$(MAKE) -C src/interfaces/libpq MAKELEVEL=0 all-$(LIBPQ_LIBRARY_TYPE)-lib
+	$(MAKE) -C src/bin/pg_config MAKELEVEL=0
+
+.PHONY: install-stlib
+install-stlib:
+	$(MAKE) -C src/common MAKELEVEL=0 install -o all
+	rm -f '$(DESTDIR)$(libdir)/libpgcommon_shlib.a'
+	$(MAKE) -C src/port MAKELEVEL=0 install -o all
+	rm -f '$(DESTDIR)$(libdir)/libpgport_shlib.a'
+
+.PHONY: install
+install: $(LIBPQ_INSTALL_LIBS)
+	$(MAKE) -C src/include MAKELEVEL=0 install
+	$(MAKE) -C src/interfaces/libpq MAKELEVEL=0 install-lib-$(LIBPQ_LIBRARY_TYPE) install-lib-pc install -o all -o install-lib
+	$(MAKE) -C src/bin/pg_config MAKELEVEL=0 install

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -252,6 +252,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
 
     message(STATUS "Cleanup libpq ${TARGET_TRIPLET}... - done")
 else()
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/Makefile DESTINATION ${SOURCE_PATH})
+
     if("${FEATURES}" MATCHES "openssl")
         list(APPEND BUILD_OPTS --with-openssl)
     endif()
@@ -274,11 +276,13 @@ else()
             --enable-debug
     )
 
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+      set(ENV{LIBPQ_LIBRARY_TYPE} shared)
+    else()
+      set(ENV{LIBPQ_LIBRARY_TYPE} static)
+    endif()
     vcpkg_install_make()
 
-    # instead?
-    #    make -C src/include install
-    #    make -C src/interfaces install
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -80,7 +80,7 @@ function(vcpkg_build_make)
         # Set make command and install command
         set(MAKE_OPTS ${_bc_MAKE_OPTIONS} V=1 -j ${VCPKG_CONCURRENCY} -f Makefile ${_bc_BUILD_TARGET})
         set(NO_PARALLEL_MAKE_OPTS ${_bc_MAKE_OPTIONS} V=1 -j 1 -f Makefile ${_bc_BUILD_TARGET})
-        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} install DESTDIR=${CURRENT_PACKAGES_DIR})
+        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} -f Makefile install DESTDIR=${CURRENT_PACKAGES_DIR})
     endif()
 
     # Since includes are buildtype independent those are setup by vcpkg_configure_make


### PR DESCRIPTION
Currently, libpq installation uses a top-level install target on non-Windows platforms. This results in having shared libraries installed even when all other libraries are static. Because CMake prefers shared libraries over static, builds result in shared library being linked, which does not correspond to triplet and other packages installations. Moreover, it causes packaging issues, since shared libraries have to be installed together with the binary.

This PR fixes the behavior by installing only libpq.a for the usual x64-linux triplet.