### PR TITLE
[libssh] Update to 0.9.5

### DIFF
--- a/ports/libssh/CONTROL
+++ b/ports/libssh/CONTROL
@@ -1,5 +1,5 @@
 Source: libssh
-Version: 0.9.3-2
+Version: 0.9.5
 Homepage: https://www.libssh.org/
 Description: libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side
 Default-Features: crypto

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -1,10 +1,10 @@
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
-set(VERSION 0.9.3)
+set(VERSION 0.9.5)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.libssh.org/files/0.9/libssh-${VERSION}.tar.xz"
     FILENAME "libssh-${VERSION}.tar.xz"
-    SHA512 6e59718565daeca6d224426cc1095a112deff9af8e0b021917e04f08bb7409263c35724de95f591f38e26f0fb3bbbbc69b679b6775edc21dec158d241b076c6f
+    SHA512 64e692a0bfa7f73585ea7b7b8b1d4c9a7f9be59565bfd4de32ca8cd9db121f87e7ad51f5c80269fbd99545af34dcf1894374ed8a6d6c1ac5f8601c026572ac18
 )
 
 vcpkg_extract_source_archive_ex(
@@ -43,11 +43,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    file(READ ${CURRENT_PACKAGES_DIR}/share/libssh/libssh-config.cmake _contents)
+    file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/libssh-config.cmake _contents)
     string(REPLACE ".dll" ".lib" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/libssh/libssh-config.cmake "${_contents}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/libssh-config.cmake "${_contents}")
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libssh RENAME copyright)
-file(INSTALL ${CURRENT_PORT_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/libssh)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${CURRENT_PORT_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -39,7 +39,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     vcpkg_replace_string(
 	    ${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h 
 	    "#ifdef LIBSSH_STATIC"
-		"#if 1"
+	    "#if 1"
 	)	
 endif()
 

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -14,9 +14,9 @@ vcpkg_extract_source_archive_ex(
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-                     FEATURES
-                         mbedtls WITH_MBEDTLS
-                         zlib WITH_ZLIB
+    FEATURES
+    mbedtls WITH_MBEDTLS
+    zlib    WITH_ZLIB
 )
 
 vcpkg_configure_cmake(
@@ -36,16 +36,19 @@ vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-
-    file(READ ${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h _contents)
-    string(REPLACE "#ifdef LIBSSH_STATIC" "#if 1" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h "${_contents}")
+    vcpkg_replace_string(
+	    ${CURRENT_PACKAGES_DIR}/include/libssh/libssh.h 
+	    "#ifdef LIBSSH_STATIC"
+		"#if 1"
+	)	
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/libssh-config.cmake _contents)
-    string(REPLACE ".dll" ".lib" _contents "${_contents}")
-    file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/libssh-config.cmake "${_contents}")
+    vcpkg_replace_string(
+	    ${CURRENT_PACKAGES_DIR}/share/libssh/libssh-config.cmake
+	    ".dll"
+	    ".lib"
+	)
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
Fix #13476 

Update libssh to the latest version 0.9.5

All features tested successfully in the following triplets

- x86-windows
- x64-windows
- x64-windows-static
