### PR TITLE
[nettle] Fix build error on Linux

### DIFF
--- a/ports/nettle/CONTROL
+++ b/ports/nettle/CONTROL
@@ -1,5 +1,6 @@
 Source: nettle
-Version: 3.5.1-2
+Version: 3.5.1
+Port-Version: 3
 Homepage: https://git.lysator.liu.se/nettle/nettle
 Description: Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.
 Build-Depends: gmp, vs-yasm (windows)

--- a/ports/nettle/fix-InstallLibPath.patch
+++ b/ports/nettle/fix-InstallLibPath.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 3547cae..58716c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -384,7 +384,7 @@ if test "x$ABI" != xstandard ; then
+ 	libdir='${exec_prefix}/lib32'
+ 	;;
+       *:irix*:64)
+-	libdir='${exec_prefix}/lib64'
++	libdir='${exec_prefix}/lib'
+ 	;;
+       *)
+         AC_MSG_WARN([Don't know where to install $ABI-bit libraries on this system.]); dnl '

--- a/ports/nettle/fix-InstallLibPath.patch
+++ b/ports/nettle/fix-InstallLibPath.patch
@@ -1,9 +1,56 @@
 diff --git a/configure.ac b/configure.ac
-index 3547cae..58716c6 100644
+index 3547cae..f6e6a8e 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -384,7 +384,7 @@ if test "x$ABI" != xstandard ; then
- 	libdir='${exec_prefix}/lib32'
+@@ -310,9 +310,9 @@ case "$host_cpu" in
+ #error 64-bit x86
+ #endif
+     ], [], [
+-      ABI=32
++      ABI=
+     ], [
+-      ABI=64
++      ABI=
+     ])
+     ;;
+   *sparc*)
+@@ -321,9 +321,9 @@ case "$host_cpu" in
+ #error 64-bit sparc
+ #endif
+     ], [], [
+-      ABI=32
++      ABI=
+     ], [
+-      ABI=64
++      ABI=
+     ])
+     ;;
+   *mips*)
+@@ -332,9 +332,9 @@ case "$host_cpu" in
+ #error 64-bit mips
+ #endif
+     ], [], [
+-      ABI=32
++      ABI=
+     ], [
+-      ABI=64
++      ABI=
+     ])
+     ;;
+ esac
+@@ -375,16 +375,16 @@ if test "x$ABI" != xstandard ; then
+       # and 64-bit in lib. Don't know about "kfreebsd", does
+       # it follow the Linux fhs conventions?
+       *:freebsd*:32)
+-	libdir='${exec_prefix}/lib32'
++	libdir='${exec_prefix}/lib'
+ 	;;
+       *:freebsd*:64)
+ 	libdir='${exec_prefix}/lib'
+ 	;;
+       *:irix*:32)
+-	libdir='${exec_prefix}/lib32'
++	libdir='${exec_prefix}/lib'
  	;;
        *:irix*:64)
 -	libdir='${exec_prefix}/lib64'

--- a/ports/nettle/fix-InstallLibPath.patch
+++ b/ports/nettle/fix-InstallLibPath.patch
@@ -1,44 +1,20 @@
 diff --git a/configure.ac b/configure.ac
-index 3547cae..f6e6a8e 100644
+index 3547cae..e13a5bf 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -310,9 +310,9 @@ case "$host_cpu" in
- #error 64-bit x86
- #endif
-     ], [], [
--      ABI=32
-+      ABI=
-     ], [
--      ABI=64
-+      ABI=
-     ])
-     ;;
-   *sparc*)
-@@ -321,9 +321,9 @@ case "$host_cpu" in
- #error 64-bit sparc
- #endif
-     ], [], [
--      ABI=32
-+      ABI=
-     ], [
--      ABI=64
-+      ABI=
-     ])
-     ;;
-   *mips*)
-@@ -332,9 +332,9 @@ case "$host_cpu" in
- #error 64-bit mips
- #endif
-     ], [], [
--      ABI=32
-+      ABI=
-     ], [
--      ABI=64
-+      ABI=
-     ])
-     ;;
- esac
-@@ -375,16 +375,16 @@ if test "x$ABI" != xstandard ; then
+@@ -366,25 +366,25 @@ if test "x$ABI" != xstandard ; then
+ 	else
+ 	  # The dash builtin pwd tries to be "helpful" and remember
+ 	  # symlink names. Use -P option, and hope it's portable enough.
+-	  test -d /usr/lib${ABI} \
+-	    && (cd /usr/lib${ABI} && pwd -P | grep >/dev/null "/lib${ABI}"'$') \
+-	    && libdir='${exec_prefix}/'"lib${ABI}"
++	  test -d /usr/lib \
++	    && (cd /usr/lib && pwd -P | grep >/dev/null "/lib"'$') \
++	    && libdir='${exec_prefix}/'"lib"
+ 	fi
+ 	;;
+       # On freebsd, it seems 32-bit libraries are in lib32,
        # and 64-bit in lib. Don't know about "kfreebsd", does
        # it follow the Linux fhs conventions?
        *:freebsd*:32)

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -106,7 +106,7 @@ else()
         REF  ee5d62898cf070f08beedc410a8d7c418588bd95 #v3.5.1 
         SHA512 881912548f4abb21460f44334de11439749c8a055830849a8beb4332071d11d9196d9eecaeba5bf822819d242356083fba91eb8719a64f90e41766826e6d75e1
         HEAD_REF master # branch name
-        #PATCHES example.patch #patch name
+        PATCHES fix-InstallLibPath.patch
     )
 
     vcpkg_configure_make(


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #13514
Nettle will install `*.pc` to _[VCPKG_path]/packages/nettle_x64-linux/lib64/pkgconfig/_, it will cause nettle build failed with the following error:
```
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:76 (message):
  pkg-config error output:Package hogweed was not found in the pkg-config
  search path.

  Perhaps you should add the directory containing `hogweed.pc'

  to the PKG_CONFIG_PATH environment variable

  Package 'hogweed', required by 'virtual:world', not found
```
Modify the codes in `configure.ac` to fix this eror.
```
      # On freebsd, it seems 32-bit libraries are in lib32,
      # and 64-bit in lib. Don't know about "kfreebsd", does
      # it follow the Linux fhs conventions?
      *:freebsd*:32)
	libdir='${exec_prefix}/lib32'
	;;
      *:freebsd*:64)
	libdir='${exec_prefix}/lib'
	;;
      *:irix*:32)
	libdir='${exec_prefix}/lib32'
	;;
      *:irix*:64)
	libdir='${exec_prefix}/lib'
	;;
```
