### PR TITLE
[scintilla] Add static linking to Scintilla

### DIFF
--- a/ports/scintilla/0001-static-build.patch
+++ b/ports/scintilla/0001-static-build.patch
@@ -1,0 +1,46 @@
+diff --git a/win32/SciLexer.vcxproj b/win32/SciLexer.vcxproj
+index b2e993c..c8774f1 100644
+--- a/win32/SciLexer.vcxproj
++++ b/win32/SciLexer.vcxproj
+@@ -33,7 +33,7 @@
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup>
+-    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <ConfigurationType>StaticLibrary</ConfigurationType>
+     <CharacterSet>Unicode</CharacterSet>
+     <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+@@ -88,6 +88,7 @@
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -97,6 +98,7 @@
+     <ClCompile>
+       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
+@@ -117,6 +119,7 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+@@ -129,6 +132,7 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <LanguageStandard>stdcpp17</LanguageStandard>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+     </ClCompile>
+     <Link>
+       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+-- 

--- a/ports/scintilla/0001-static-lib.patch
+++ b/ports/scintilla/0001-static-lib.patch
@@ -1,0 +1,14 @@
+diff --git a/win32/SciLexer.vcxproj b/win32/SciLexer.vcxproj
+index b2e993c..c8774f1 100644
+--- a/win32/SciLexer.vcxproj
++++ b/win32/SciLexer.vcxproj
+@@ -33,7 +33,7 @@
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup>
+-    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <ConfigurationType>StaticLibrary</ConfigurationType>
+     <CharacterSet>Unicode</CharacterSet>
+     <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+-- 

--- a/ports/scintilla/0002-static-crt.patch
+++ b/ports/scintilla/0002-static-crt.patch
@@ -2,15 +2,6 @@ diff --git a/win32/SciLexer.vcxproj b/win32/SciLexer.vcxproj
 index b2e993c..c8774f1 100644
 --- a/win32/SciLexer.vcxproj
 +++ b/win32/SciLexer.vcxproj
-@@ -33,7 +33,7 @@
-   </PropertyGroup>
-   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-   <PropertyGroup>
--    <ConfigurationType>DynamicLibrary</ConfigurationType>
-+    <ConfigurationType>StaticLibrary</ConfigurationType>
-     <CharacterSet>Unicode</CharacterSet>
-     <PlatformToolset>v141</PlatformToolset>
-   </PropertyGroup>
 @@ -88,6 +88,7 @@
      <ClCompile>
        <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/ports/scintilla/CONTROL
+++ b/ports/scintilla/CONTROL
@@ -1,4 +1,5 @@
 Source: scintilla
 Version: 4.2.3
+Port-Version: 1
 Homepage: https://www.scintilla.org/
 Description: A free source code editing component for Win32, GTK+, and OS X

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -5,19 +5,21 @@ vcpkg_download_distfile(ARCHIVE
   FILENAME "scintilla423.zip"
   SHA512 82a595782119ce5bb48c39f4cb9b29605c4cdc276f605ebd3e3b3ecae003ef2132102e21be8943c8b36ec40957e2e50f4ebc0086a5096901fa0e8e5e178db750
 )
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  list(APPEND PATCHES 0001-static-lib.patch)
+endif()
+
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+  list(APPEND PATCHES 0002-static-crt.patch)
+endif()
+
 vcpkg_extract_source_archive_ex(
   OUT_SOURCE_PATH SOURCE_PATH
   ARCHIVE ${ARCHIVE}
   REF 4.2.3
+  PATCHES ${PATCHES}
 )
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-  vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
-    PATCHES
-      ${CMAKE_CURRENT_LIST_DIR}/0001-static-build.patch
-  )
-endif()
 
 vcpkg_install_msbuild(
   SOURCE_PATH ${SOURCE_PATH}

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -1,7 +1,5 @@
 vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP")
 
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
-
 vcpkg_download_distfile(ARCHIVE
   URLS "http://www.scintilla.org/scintilla423.zip"
   FILENAME "scintilla423.zip"
@@ -13,6 +11,14 @@ vcpkg_extract_source_archive_ex(
   REF 4.2.3
 )
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+  vcpkg_apply_patches(
+    SOURCE_PATH ${SOURCE_PATH}
+    PATCHES
+      ${CMAKE_CURRENT_LIST_DIR}/0001-static-build.patch
+  )
+endif()
+
 vcpkg_install_msbuild(
   SOURCE_PATH ${SOURCE_PATH}
   PROJECT_SUBPATH Win32/SciLexer.vcxproj
@@ -20,3 +26,5 @@ vcpkg_install_msbuild(
   LICENSE_SUBPATH License.txt
   ALLOW_ROOT_INCLUDES
 )
+
+vcpkg_copy_pdbs()

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -28,5 +28,3 @@ vcpkg_install_msbuild(
   LICENSE_SUBPATH License.txt
   ALLOW_ROOT_INCLUDES
 )
-
-vcpkg_copy_pdbs()

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1520,7 +1520,6 @@ scintilla:arm-uwp=fail
 scintilla:x64-linux=fail
 scintilla:x64-osx=fail
 scintilla:x64-uwp=fail
-scintilla:x64-windows-static=fail
 sciter:arm64-windows=fail
 sciter:arm-uwp=fail
 sciter:x64-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

Static linking is officially supported by Scintilla. See https://www.scintilla.org/ScintillaDoc.html, at the bottom of the document, section "Building Scintilla". This PR adds static linking on Windows.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Tested successfully:
x64-windows
x64-windows-static
x64-windows-static-md
x86-windows
x86-windows-static
x86-windows-static-md


- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes, it does.
