### PR TITLE
[dartsim] Fix version in vcpkg.json

### DIFF
--- a/ports/dartsim/vcpkg.json
+++ b/ports/dartsim/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dartsim",
-  "version-string": "9.4.0",
+  "version-string": "6.9.4",
   "description": "Dynamic Animation and Robotics Toolkit",
   "homepage": "https://dartsim.github.io/",
   "dependencies": [


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? This PR fixes the wrong version in the vcpkg.json of the dartsim port.

- Which triplets are supported/not supported? Have you updated the CI baseline? The PR should not affect the triplets supported or not. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
