### PR TITLE
[sdl2] Fix pkgconfig: missing system libs

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,6 +1,6 @@
 Source: sdl2
 Version: 2.0.12
-Port-Version: 4
+Port-Version: 5
 Homepage: https://www.libsdl.org/download-2.0.php
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -96,5 +96,5 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSD
 
 vcpkg_fixup_pkgconfig(
     IGNORE_FLAGS "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/lib/pkgconfig/../../lib" "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/../../lib" "-Wl,--enable-new-dtags" "-Wl,--no-undefined" "-Wl,-undefined,error" "-Wl,-compatibility_version,${DYLIB_COMPATIBILITY_VERSION}" "-Wl,-current_version,${DYLIB_CURRENT_VERSION}" "-Wl,-weak_framework,Metal" "-Wl,-weak_framework,QuartzCore"
-    SYSTEM_LIBRARIES dbus-1
+    SYSTEM_LIBRARIES dbus-1 glib-2.0 gobject-2.0 gio-2.0 ibus-1.0
 )


### PR DESCRIPTION
```
CMake Error at scripts/cmake/vcpkg_fixup_pkgconfig.cmake:232 (message):
  Library "glib-2.0" was not found! If it is a system library use the
  SYSTEM_LIBRARIES parameter for the vcpkg_fixup_pkgconfig call! Otherwise,
  correct the *.pc file
Call Stack (most recent call first):
  scripts/cmake/vcpkg_fixup_pkgconfig.cmake:298 (vcpkg_fixup_pkgconfig_check_files)
  ports/sdl2/portfile.cmake:97 (vcpkg_fixup_pkgconfig)
  scripts/ports.cmake:79 (include)
```
- Above traceback encountered for all of the following libraries `glib-2.0 gobject-2.0 gio-2.0 ibus-1.0`

- Fixes #13236

