### PR TITLE
[curl] add disable ldap option

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -47,7 +47,10 @@ Build-Depends: c-ares
 Description: c-ares support
 
 Feature: sspi
-Description: SSPI support 
+Description: SSPI support
 
 Feature: brotli
 Description: brotli support (brotli)
+
+Feature: disable-ldap
+Description: disable win32 ldap support

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -39,7 +39,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     brotli      CURL_BROTLI
     schannel    CMAKE_USE_SCHANNEL
     sectransp   CMAKE_USE_SECTRANSP
-    
+    disable-ldap  DISABLE_LDAP
+
     INVERTED_FEATURES
     non-http HTTP_ONLY
 )
@@ -47,6 +48,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 set(SECTRANSP_OPTIONS)
 if("sectransp" IN_LIST FEATURES)
     set(SECTRANSP_OPTIONS -DCURL_CA_PATH=none)
+endif()
+
+if (DISABLE_LDAP)
+    set(LDAP_OPTION -DUSE_WIN32_LDAP=OFF)
 endif()
 
 # UWP targets
@@ -66,6 +71,7 @@ vcpkg_configure_cmake(
     OPTIONS ${FEATURE_OPTIONS}
         ${UWP_OPTIONS}
         ${SECTRANSP_OPTIONS}
+        ${LDAP_OPTION}
         -DBUILD_TESTING=OFF
         -DENABLE_MANUAL=OFF
         -DCURL_STATICLIB=${CURL_STATICLIB}


### PR DESCRIPTION
This PR tries to add a disable ldap option to curl, so that curl does not link to wldap32.dll anymore.

I am not sure I am doing this right, though. Also didn't fully understand the options... Is there a way to negate a feature?

It would be cool to be able to do `curl[~ldap]` to turn ldap off.