### PR TITLE
[opus] Fix for arm64-ios

### DIFF
--- a/ports/opus/CONTROL
+++ b/ports/opus/CONTROL
@@ -1,6 +1,6 @@
 Source: opus
 Version: 1.3.1
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/xiph/opus
 Description: Totally open, royalty-free, highly versatile audio codec
 

--- a/ports/opus/portfile.cmake
+++ b/ports/opus/portfile.cmake
@@ -30,7 +30,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Opus)
 vcpkg_copy_pdbs()
-vcpkg_fixup_pkgconfig()
+vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
 
 file(INSTALL
      ${SOURCE_PATH}/COPYING


### PR DESCRIPTION
Currently, the opus port does not work with arm64-ios since it fails to find libm.

This commit fixes this issue.