### PR TITLE
[vcpkg] Keep sym links in Linux zip cache files

### DIFF
--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -60,7 +60,7 @@ namespace
             System::get_clean_environment());
 #else
         System::cmd_execute_clean(
-            Strings::format(R"(cd '%s' && zip --quiet -r '%s' *)", fs::u8string(source), fs::u8string(destination)));
+            Strings::format(R"(cd '%s' && zip --quiet -y -r '%s' *)", fs::u8string(source), fs::u8string(destination)));
 #endif
     }
 


### PR DESCRIPTION
See #13608 for more information. This adds the `-y` option to the zip command on non-Windows platforms.

- What does your PR fix? 
Fixes #13608 

- Which triplets are supported/not supported? Have you updated the CI baseline? 
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? 
✔