### PR TITLE
[libvpx] fix cmake target for linux

### DIFF
--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,6 +1,6 @@
 Source: libvpx
 Version: 1.9.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
 Supports: !(uwp&arm)

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -213,6 +213,7 @@ else()
         )
 
         file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libvpx_g.a)
     endif()
 endif()
 

--- a/ports/libvpx/unofficial-libvpx-config.cmake.in
+++ b/ports/libvpx/unofficial-libvpx-config.cmake.in
@@ -15,7 +15,7 @@ if(NOT TARGET unofficial::libvpx::libvpx)
   list(APPEND _IMPORT_CHECK_FILES "${_IMPORT_PREFIX}/include/vpx/vpx_codec.h")
 
   # Add release configuration properties.
-  find_library(_LIBFILE_RELEASE NAMES vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
+  find_library(_LIBFILE_RELEASE NAMES vpx vpx@LIBVPX_CRT_SUFFIX@ PATHS "${_IMPORT_PREFIX}/lib/" NO_DEFAULT_PATH)
   set_property(TARGET unofficial::libvpx::libvpx
     APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
   set_target_properties(unofficial::libvpx::libvpx PROPERTIES
@@ -25,7 +25,7 @@ if(NOT TARGET unofficial::libvpx::libvpx)
 
   # Add debug configuration properties.
   if(@LIBVPX_CONFIG_DEBUG@)
-    find_library(_LIBFILE_DEBUG NAMES vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
+    find_library(_LIBFILE_DEBUG NAMES vpx vpx@LIBVPX_CRT_SUFFIX@d PATHS "${_IMPORT_PREFIX}/debug/lib/" NO_DEFAULT_PATH)
     set_property(TARGET unofficial::libvpx::libvpx
       APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
     set_target_properties(unofficial::libvpx::libvpx PROPERTIES


### PR DESCRIPTION
On x64-linux, the debug libraries are called libvpx.a instead of libvpxd.a - this patch fixes the unofficial cmake target to reflect that. In addition, the upstream vpx build script also installs libvpx_g.a as a duplicate of libvpx.a and this patch removes that duplicate file.

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.