### PR TITLE
[ffnvcodec] only supports windows and linux

### DIFF
--- a/ports/ffnvcodec/CONTROL
+++ b/ports/ffnvcodec/CONTROL
@@ -1,5 +1,6 @@
 Source: ffnvcodec
 Version: 9.1.23.1
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/FFmpeg/nv-codec-headers
 Description: FFmpeg version of Nvidia Codec SDK headers.
+Supports: windows|linux


### PR DESCRIPTION
This updates the ffnvcodec CONTROL file to indicate that only windows and linux are supported by this package (see https://github.com/FFmpeg/nv-codec-headers/blob/master/README).

- Which triplets are supported/not supported? Have you updated the CI baseline? Only linux and windows are supported. CI baseline was left unchanged.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
