### PR TITLE
[vcpkg-docs] Add note about GitHub hosted agents

### DIFF
--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -14,6 +14,10 @@ If your CI system of choice is not listed, we welcome PRs to add them!
 
 To use vcpkg with GitHub Packages, we recommend using the `NuGet` backend.
 
+>**NOTE 2020-09-21**: GitHub's hosted agents come with an older, pre-installed copy of vcpkg on the path that does not support the latest binary caching. This means that direct calls to `bootstrap-vcpkg` or `vcpkg` without a path prefix may call an unintended vcpkg instance. We recommend taking the following two steps to avoid issues if you want to use your own copy of vcpkg:
+> 1. Run the equivalent of `rm -rf "$VCPKG_INSTALLATION_ROOT"` using `shell: 'bash'`
+> 2. Always call `vcpkg` and `bootstrap-vcpkg` with a path prefix, such as `./vcpkg`, `vcpkg/vcpkg`, `.\bootstrap-vcpkg.bat`, etc
+
 ```yaml
 # actions.yaml
 #

--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -42,7 +42,7 @@ steps:
     shell: 'bash'
     # Replace <OWNER> with your organization name
     run: >
-      ${{ matrix.mono }} `vcpkg/vcpkg fetch nuget | tail -n 1`
+      ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
       sources add
       -source "https://nuget.pkg.github.com/<OWNER>/index.json"
       -storepasswordincleartext
@@ -54,7 +54,7 @@ steps:
   - name: 'vcpkg package restore'
     shell: 'bash'
     run: >
-      vcpkg/vcpkg install sqlite3 cpprestsdk --triplet ${{ matrix.triplet }}
+      ./vcpkg/vcpkg install sqlite3 cpprestsdk --triplet ${{ matrix.triplet }}
 ```
 
 If you're using [manifests](../specifications/manifests.md), you can omit the `vcpkg package restore` step: it will be run automatically as part of your build.


### PR DESCRIPTION
Add note about preinstalled vcpkg instance on GitHub hosted agents that can result in failures to cache binaries