### PR TITLE
[polyhook2] Update to new version

### DIFF
--- a/ports/polyhook2/CONTROL
+++ b/ports/polyhook2/CONTROL
@@ -1,5 +1,5 @@
 Source: polyhook2
-Version: 2020-08-29
+Version: 2020-09-22
 Homepage: https://github.com/stevemk14ebr/PolyHook_2_0
 Description: C++17, x86/x64 Hooking Libary v2.0
 Supports: !(arm|uwp|linux|osx)

--- a/ports/polyhook2/portfile.cmake
+++ b/ports/polyhook2/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "Linux" "OSX" "UWP")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO stevemk14ebr/PolyHook_2_0
-    REF  b3c0baf639614c4b4ca56e5df2e9da688986917b
-    SHA512 a1fb531fcbd7d6ac084efc7a67b7a1d9e661f0e770df02db7458a311c54ca1a1f11b8be0ae438a40259603414bfb2e64bab69d45754bc910363daa912e995550
+    REF  99a4b7da142f35380564f462e537f4fe04e5b5f0
+    SHA512 2a8e77344deffe5ca345dd6102b92b9154c3c7d36f2b99cfa3bae96cf37078dc9cdeae671f82bfef5d98bbb72507dc39ae569e7b8bcb9698d8bc787dca438d83
     HEAD_REF master
 )
 

--- a/ports/polyhook2/portfile.cmake
+++ b/ports/polyhook2/portfile.cmake
@@ -18,12 +18,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     virtuals  POLYHOOK_FEATURE_VIRTUALS
 )
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    set(BUILD_SHARED_LIB OFF)
-else()
-    set(BUILD_SHARED_LIB ON)
-endif()
-
 if (VCPKG_CRT_LINKAGE STREQUAL "static")
     set(BUILD_STATIC_RUNTIME ON)
 else()

--- a/ports/polyhook2/portfile.cmake
+++ b/ports/polyhook2/portfile.cmake
@@ -18,6 +18,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     virtuals  POLYHOOK_FEATURE_VIRTUALS
 )
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(BUILD_SHARED_LIB OFF)
+else()
+    set(BUILD_SHARED_LIB ON)
+endif()
+
 if (VCPKG_CRT_LINKAGE STREQUAL "static")
     set(BUILD_STATIC_RUNTIME ON)
 else()


### PR DESCRIPTION
Updates polyhook2 to latest. Supports the triples x86-windows, x86-windows-static, x64-windows, x64-windows-static. PR tested locally on my system and all tests pass.