### PR TITLE
[apr-util] use find_package(expat)

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,6 +1,6 @@
 Source: apr-util
 Version: 1.6.1
-Port-Version: 2
+Port-Version: 3
 Homepage: https://apr.apache.org/
 Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
 Build-Depends: expat, apr, openssl

--- a/ports/apr-util/use-vcpkg-expat.patch
+++ b/ports/apr-util/use-vcpkg-expat.patch
@@ -26,9 +26,9 @@ index 9ae90b1..71a50b0 100644
  ENDIF()
  
 -IF(NOT EXPAT_FOUND)
-+find_path(XMLLIB_INCLUDE_DIR expat.h)
-+find_library(XMLLIB_LIBRARIES NAMES libexpat libexpatMD)
-+
++find_package(expat)
++set(XMLLIB_INCLUDE_DIR ${EXPAT_INCLUDE_DIRS})
++set(XMLLIB_LIBRARIES ${EXPAT_LIBRARIES})
 +IF(NOT XMLLIB_LIBRARIES)
    MESSAGE(FATAL_ERROR "Expat is required, and it wasn't found!")
  ENDIF()


### PR DESCRIPTION
apr-util finds expat by `find_library(XMLLIB_LIBRARIES NAMES libexpat libexpatMD)`, but expat debug library has name `libexpatd.lib`. So apt-util debug configuration gets release expat. This PR fixes it.
Fixes #13582
