### PR TITLE
[vcpkg] Show Empty Object on vcpkg --list when used with --x-json

### DIFF
--- a/toolsrc/src/vcpkg/commands.list.cpp
+++ b/toolsrc/src/vcpkg/commands.list.cpp
@@ -95,7 +95,10 @@ namespace vcpkg::Commands::List
 
         if (installed_ipv.empty())
         {
-            System::print2("No packages are installed. Did you mean `search`?\n");
+            if (args.output_json())
+                System::print2(Json::stringify(Json::Object(), {}));
+            else
+                System::print2("No packages are installed. Did you mean `search`?\n");
             Checks::exit_success(VCPKG_LINE_INFO);
         }
 


### PR DESCRIPTION
Thanks to @strega-nil for recommending using `Json::stringify` over my initial idea of simply printing an empty object directly `System::print2('{}');`

Closes #13637

**Describe the pull request**

- What does your PR fix? Fixes #13637

- Which triplets are supported/not supported? Have you updated the CI baseline?
N.A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
