### PR TITLE
[polyclipping] Fix cmake patch for finding include file

### DIFF
--- a/ports/polyclipping/CONTROL
+++ b/ports/polyclipping/CONTROL
@@ -1,5 +1,5 @@
 Source: polyclipping
 Version: 6.4.2
-Port-Version: 5
+Port-Version: 6
 Homepage: https://sourceforge.net/projects/polyclipping/
 Description: The Clipper library performs clipping and offsetting for both lines and polygons. All four boolean clipping operations are supported - intersection, union, difference and exclusive-or. Polygons can be of any shape including self-intersecting polygons.

--- a/ports/polyclipping/fix_targets.patch
+++ b/ports/polyclipping/fix_targets.patch
@@ -2,7 +2,7 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
 index f0ed7e8..a5ed444 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
-@@ -19,3 +19,11 @@ INSTALL (TARGETS polyclipping LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+@@ -19,3 +19,12 @@ INSTALL (TARGETS polyclipping LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
  INSTALL (FILES "${PCFILE}" DESTINATION "${CMAKE_INSTALL_PKGCONFIGDIR}")
  
  SET_TARGET_PROPERTIES(polyclipping PROPERTIES VERSION 22.0.0 SOVERSION 22 )
@@ -14,3 +14,4 @@ index f0ed7e8..a5ed444 100644
 +    NAMESPACE polyclipping::
 +    DESTINATION share/polyclipping
 +)
++target_include_directories(polyclipping PUBLIC $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
Usage for port polyclipping given by vcpkg is incorrect. Currently it says
```cmake
find_package(polyclipping CONFIG REQUIRED)
target_link_libraries(main PRIVATE polyclipping::polyclipping)
```
However the include file needed to use it cannot be found.
This PR fixes the cmake patch so that the include file can be found by the end user as `#include<polyclipping/clipper.hpp>`

Note that besides the config export there is a findCLIPPER.cmake installed with the library. Alternatively to this fix, a usage file could be created with the following:
```cmake
find_package(CLIPPER CONFIG REQUIRED)
target_include_directories(main PRIVATE ${CLIPPER_INCLUDE_DIRS})
target_link_libraries(main PRIVATE ${CLIPPER_LIBRARIES})
```
It depends on how you would prefer to resolve the issue.
