### PR TITLE
[vcpkg] Skip all files named .DS_Store, no need to check if the file is regular

### DIFF
--- a/toolsrc/src/vcpkg/paragraphs.cpp
+++ b/toolsrc/src/vcpkg/paragraphs.cpp
@@ -354,9 +354,8 @@ namespace vcpkg::Paragraphs
         Util::sort(port_dirs);
 
         // TODO: search in `b-` for ports starting with `b`
-        Util::erase_remove_if(port_dirs, [&](auto&& port_dir_entry) {
-            return fs.is_regular_file(port_dir_entry) && port_dir_entry.filename() == ".DS_Store";
-        });
+        Util::erase_remove_if(port_dirs,
+                              [&](auto&& port_dir_entry) { return port_dir_entry.filename() == ".DS_Store"; });
 
         for (auto&& path : port_dirs)
         {


### PR DESCRIPTION
`fs::is_regular_file()` requires an extra `stat` call and can fail.