### PR TITLE
[cpp-netlib] Fix usage with boost 1.73

### DIFF
--- a/ports/cpp-netlib/CONTROL
+++ b/ports/cpp-netlib/CONTROL
@@ -1,6 +1,7 @@
 Source: cpp-netlib
-Version: 0.13.0-3
+Version: 0.13.0
+Port-Version: 4
 Homepage: https://cpp-netlib.org/
-Build-Depends: boost
+Build-Depends: boost-spirit, boost-smart-ptr, boost-asio, boost-program-options, boost-assign
 Description: A collection of network-related routines/implementations geared towards providing a robust cross-platform networking library
 Supports: !uwp

--- a/ports/cpp-netlib/CONTROL
+++ b/ports/cpp-netlib/CONTROL
@@ -2,6 +2,6 @@ Source: cpp-netlib
 Version: 0.13.0
 Port-Version: 4
 Homepage: https://cpp-netlib.org/
-Build-Depends: boost-spirit, boost-smart-ptr, boost-asio, boost-program-options, boost-assign
+Build-Depends: boost-spirit, boost-smart-ptr, boost-asio, boost-program-options, boost-assign, boost-logic, boost-scope-exit
 Description: A collection of network-related routines/implementations geared towards providing a robust cross-platform networking library
 Supports: !uwp

--- a/ports/cpp-netlib/portfile.cmake
+++ b/ports/cpp-netlib/portfile.cmake
@@ -5,18 +5,21 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cpp-netlib/cpp-netlib
-    REF cpp-netlib-0.13.0-final
-    SHA512 1839bf1acb7917acd2957f1008a44ed26a38849afb5843bfa0d5c557dde530afab4183d8d273a87d6416aad2b3a59fdecdef5fbb62bc91ed484486c80a1de5eb
+    REF 31d304cdf52b485f465ada433d8905171b61cbff
+    SHA512 6d157e6d950dd76a6d16b9c13d4d29f188d9f540eb0b44ab169016e1d7a360995e51d9923b532503a17dd2c8e0e2a38b2f9b531db03b33239e7fb9ca4d047b0c
     HEAD_REF master
+    # Updator's note: cpp-netlib has many templates that are not fully instantiated when not building examples.
+    # This patch specifically fixes one of those issues
+    # To test updates, enable building examples below (may also require patching out uses of cxxopts)
+    PATCHES stream-handler-executor.patch
 )
 
- vcpkg_configure_cmake(
-      SOURCE_PATH ${SOURCE_PATH}
-      PREFER_NINJA
-	  OPTIONS
-      -DCPP-NETLIB_BUILD_TESTS=off
-      -DCPP-NETLIB_BUILD_EXAMPLES=off
-
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DCPP-NETLIB_BUILD_TESTS=OFF
+        -DCPP-NETLIB_BUILD_EXAMPLES=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/cpp-netlib/stream-handler-executor.patch
+++ b/ports/cpp-netlib/stream-handler-executor.patch
@@ -1,0 +1,27 @@
+diff --git a/boost/network/protocol/stream_handler.hpp b/boost/network/protocol/stream_handler.hpp
+index ffb09b8..f3b3e99 100644
+--- a/boost/network/protocol/stream_handler.hpp
++++ b/boost/network/protocol/stream_handler.hpp
+@@ -41,6 +40,7 @@ typedef boost::asio::ssl::context ssl_context;
+ 
+ struct stream_handler {
+  public:
++  typedef tcp_socket::executor_type executor_type;
+   stream_handler(std::shared_ptr<tcp_socket> socket)
+       : tcp_sock_(std::move(socket)), ssl_enabled(false) {}
+ 
+@@ -52,12 +52,12 @@ struct stream_handler {
+   stream_handler(boost::asio::io_service& io,
+                  std::shared_ptr<ssl_context> ctx =
+                      std::shared_ptr<ssl_context>()) {
+-    tcp_sock_ = std::make_shared<tcp_socket>(boost::ref(io));
++    tcp_sock_ = std::make_shared<tcp_socket>(io.get_executor());
+     ssl_enabled = false;
+     if (ctx) {
+       /// SSL is enabled
+       ssl_sock_ =
+-          std::make_shared<ssl_socket>(boost::ref(io), boost::ref(*ctx));
++          std::make_shared<ssl_socket>(io.get_executor(), boost::ref(*ctx));
+       ssl_enabled = true;
+     }
+   }


### PR DESCRIPTION
**Describe the pull request**
`cpp-netlib` has several templates that are not instantiated when building the core library. These templates fail when used against boost 1.73.

This PR updates the source to use the latest version of the 0.13-release branch along with adding an additional patch to fix compilation of the samples.

- What does your PR fix?
Fixes #13591, https://github.com/cpp-netlib/cpp-netlib/issues/890, https://github.com/cpp-netlib/cpp-netlib/issues/888

- Which triplets are supported/not supported? Have you updated the CI baseline?
Yes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes