### PR TITLE
[gamma] Fix find dependency libsndfile

### DIFF
--- a/ports/gamma/CMakeLists.txt
+++ b/ports/gamma/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required (VERSION 3.0)
 project (gamma)
 
 # dependent on libsndfile and portaudio
-find_path(LIBSNDFILE_H sndfile.h)
-find_library(LIBSNDFILE_LIB NAMES libsndfile-1 libsndfile)
+find_package(SndFile CONFIG REQUIRED)
 find_path(PORTAUDIO_H portaudio.h)
 find_library(PORTAUDIO_LIB NAMES portaudio)
 
@@ -25,10 +24,10 @@ set(SOURCEFILES
         src/Timer.cpp
         src/SoundFile.cpp)
 
-include_directories(. Gamma ${CMAKE_INSTALL_FULL_INCLUDEDIR} ${PORTAUDIO_H} ${LIBSNDFILE_H})
+include_directories(. Gamma ${CMAKE_INSTALL_FULL_INCLUDEDIR} ${PORTAUDIO_H})
 
 add_library (gamma ${SOURCEFILES})
-target_link_libraries(gamma PUBLIC ${LIBSNDFILE_LIB} ${PORTAUDIO_LIB})
+target_link_libraries(gamma PUBLIC SndFile::sndfile ${PORTAUDIO_LIB})
 
 install(
   TARGETS gamma

--- a/ports/gamma/CONTROL
+++ b/ports/gamma/CONTROL
@@ -1,4 +1,5 @@
 Source: gamma
-Version: gamma-2018-01-27-1
+Version: gamma-2018-01-27
+Port-Version: 2
 Build-Depends: libsndfile, portaudio
 Description: Gamma is a cross-platform, C++ library for doing generic synthesis and filtering of signals. It is oriented towards real-time sound and graphics applications, but is equally useful for non-real-time tasks. Gamma is designed to be "light-footed" in terms of memory and processing making it highly suitable for plug-in development or embedding in other C++ projects.

--- a/ports/gamma/CONTROL
+++ b/ports/gamma/CONTROL
@@ -1,5 +1,6 @@
 Source: gamma
 Version: gamma-2018-01-27
 Port-Version: 2
+Homepage: https://github.com/LancePutnam/Gamma
 Build-Depends: libsndfile, portaudio
 Description: Gamma is a cross-platform, C++ library for doing generic synthesis and filtering of signals. It is oriented towards real-time sound and graphics applications, but is equally useful for non-real-time tasks. Gamma is designed to be "light-footed" in terms of memory and processing making it highly suitable for plug-in development or embedding in other C++ projects.

--- a/ports/gamma/portfile.cmake
+++ b/ports/gamma/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 set(GAMMA_RELEASE_TAG "cc442ad0c5da369966cd937a96925c7b9a04e9e5")
@@ -24,4 +22,4 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/gamma RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
libsndfile updates the cmake-related code that sets the name of the generated library, causing the name to change from `libsndfile-1.lib` to `sndfile.lib`.
Adapt to this change.

Fixes #13697.