### PR TITLE
[nanodbc] Fix vcpkg_fixup_cmake_targets CONFIG_PATH on unix

### DIFF
--- a/ports/nanodbc/CONTROL
+++ b/ports/nanodbc/CONTROL
@@ -1,5 +1,6 @@
 Source: nanodbc
 Version: 2.13.0
+Port-Version: 1
 Homepage: https://github.com/lexicalunit/nanodbc
 Description: A small C++ wrapper for the native C ODBC API.
 Build-Depends: unixodbc(!windows)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -22,8 +22,10 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-if(EXISTS ${CURRENT_PACKAGES_DIR}/cmake)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+else()
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
 endif()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
In _NANODBC_SRC/CMakeLists.txt_:
```
  if (WIN32 AND NOT MINGW)
    install(EXPORT ${NANODBC_CONFIG} DESTINATION "cmake")
  else()
    install(EXPORT ${NANODBC_CONFIG} DESTINATION "lib/cmake/nanodbc")
  endif()
```
Fix this path on UNIX.

Fixes #13694.