### PR TITLE
[vcpkg] fix cmake paths in tags.

### DIFF
--- a/toolsrc/src/vcpkg/cmakevars.cpp
+++ b/toolsrc/src/vcpkg/cmakevars.cpp
@@ -91,9 +91,9 @@ namespace vcpkg::CMakeVars
                             "if(VCPKG_TRIPLET_ID EQUAL ",
                             p.second,
                             ")\n",
-                            "include(",
+                            "include(\"",
                             paths.get_triplet_file_path(p.first).generic_string(),
-                            ")\n",
+                            "\")\n",
                             "\nendif()\n");
         }
         Strings::append(extraction_file, "endmacro()\n");

--- a/toolsrc/src/vcpkg/cmakevars.cpp
+++ b/toolsrc/src/vcpkg/cmakevars.cpp
@@ -91,7 +91,9 @@ namespace vcpkg::CMakeVars
                             "if(VCPKG_TRIPLET_ID EQUAL ",
                             p.second,
                             ")\n",
-                            fs.read_contents(paths.get_triplet_file_path(p.first), VCPKG_LINE_INFO),
+                            "include(",
+                            paths.get_triplet_file_path(p.first).generic_string(),
+                            ")\n",
                             "\nendif()\n");
         }
         Strings::append(extraction_file, "endmacro()\n");


### PR DESCRIPTION
Currently you cannot do the following:
`set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/x64-windows-llvm.toolchain.cmake")`
since vcpkg copies the contents of the triplet into the tag file resulting in wrong paths e.g.:
`VCPKG_CHAINLOAD_TOOLCHAIN_FILE=E:/src/AllProjects/vcpkg/buildtrees/x64-windows-llvm.toolchain.cmake`

This PR fixes the behavior by simply including the triplet instead of copying it resulting in the correct paths:
`VCPKG_CHAINLOAD_TOOLCHAIN_FILE=E:/src/AllProjects/my-vcpkg-triplets/x64-windows-llvm.toolchain.cmake`
making it possible to relocated toolchain files and triplets. 
