### PR TITLE
[vcpkg] Fix Windows pipeline's outdated Ninja reference

### DIFF
--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
         :: TRANSITION, get these tools on the VMs next time we roll them
         .\vcpkg.exe fetch cmake
         .\vcpkg.exe fetch ninja
-        set PATH=${{ variables.VCPKG_DOWNLOADS }}\tools\cmake-3.17.2-windows\cmake-3.17.2-win32-x86\bin;${{ variables.VCPKG_DOWNLOADS }}\tools\ninja-1.10.0-windows;%PATH%
+        set PATH=${{ variables.VCPKG_DOWNLOADS }}\tools\cmake-3.17.2-windows\cmake-3.17.2-win32-x86\bin;${{ variables.VCPKG_DOWNLOADS }}\tools\ninja-1.10.1-windows;%PATH%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x86 -host_arch=x86
         rmdir /s /q build.x86.debug > nul 2> nul
         cmake.exe -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DVCPKG_DEVELOPMENT_WARNINGS=ON -DVCPKG_WARNINGS_AS_ERRORS=ON -DVCPKG_BUILD_FUZZING=ON -B build.x86.debug -S toolsrc


### PR DESCRIPTION
See build failure https://dev.azure.com/vcpkg/public/_build/results?buildId=43297&view=logs&jobId=5dffab7c-3299-5a76-7b02-e037cd868fad&j=5dffab7c-3299-5a76-7b02-e037cd868fad&t=b938c090-f58c-5e82-2e1f-dc98810cfed1