### PR TITLE
Python3 offer tool feature

### DIFF
--- a/ports/python3/CONTROL
+++ b/ports/python3/CONTROL
@@ -7,3 +7,6 @@ Build-Depends: libffi, openssl, zlib (!uwp&!windows)
 
 Feature: enable-shared
 Description: Build shared libraries in addition to static ones built by default
+
+Feature: tools
+Description: Build python executable

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -53,9 +53,15 @@ if (VCPKG_TARGET_IS_WINDOWS)
 		message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 	endif()
 
+	vcpkg_execute_build_process( 
+		COMMAND ${SOURCE_PATH}/PCBuild/get_externals.bat 
+		WORKING_DIRECTORY ${SOURCE_PATH}/PCBuild 
+	   )
+
 	vcpkg_build_msbuild(
 		PROJECT_PATH ${SOURCE_PATH}/PCBuild/pythoncore.vcxproj
-		PLATFORM ${BUILD_ARCH})
+		PLATFORM ${BUILD_ARCH}
+		)
 
 	file(INSTALL
 			"${SOURCE_PATH}/Include/"
@@ -91,6 +97,138 @@ if (VCPKG_TARGET_IS_WINDOWS)
 	endif()
 	# Handle copyright
 	file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR} RENAME copyright)
+	
+	
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/python.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/pythonw.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+
+	# All the "stock" and important IO modules
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_asyncio.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_bz2.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+
+	#TBD: Integrate ffi later
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_ctypes.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_decimal.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_elementtree.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+	
+	# wants openssl
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_hashlib.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_lzma.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_msi.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_multiprocessing.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_overlapped.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+	
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_sqlite3.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+	
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_ssl.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_socket.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_queue.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+	
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/_tkinter.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/pyexpat.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/select.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/unicodedata.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	vcpkg_build_msbuild(
+		PROJECT_PATH ${SOURCE_PATH}/PCBuild/winsound.vcxproj
+		PLATFORM ${BUILD_ARCH}
+		)
+		
+	file(GLOB DLLS 
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/*.pyd"
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/lib*.dll"	#libcrypto,libffi,libssl expected
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/sqlite*.dll"	
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/tcl*.dll"
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/tk*.dll"
+		"${SOURCE_PATH}/PCBuild/${OUT_DIR}/vcruntime*.dll"
+	)
+	file(INSTALL ${DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/python3/DLLs)
+	file(INSTALL ${DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/share/python${PYTHON_VERSION_MAJOR}/DLLs)
+	
+	file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/python.exe" DESTINATION ${CURRENT_PACKAGES_DIR}/tools/python3)
+	file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/pythonw.exe" DESTINATION ${CURRENT_PACKAGES_DIR}/tools/python3)
+	file(INSTALL "${SOURCE_PATH}/PCBuild/${OUT_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.dll" DESTINATION ${CURRENT_PACKAGES_DIR}/tools/python3)
+
+
+	file(INSTALL
+			"${SOURCE_PATH}/Lib"
+		DESTINATION
+			"${CURRENT_PACKAGES_DIR}/tools/python3"
+	)
 
 elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
 


### PR DESCRIPTION
This provides the feature for the python3 port to build the executable and make a working python install inside /tools.

Why?
There is a build process I have that requires the python executable to match the python library version being built against, I also need the python modules that don't exist in the python-embed packages that vcpkg_acquire_program retrieves.


This only adds the tool for Windows.


Now I expect problems and have questions for the vcpkg maintainers....

1. Python3 has important modules that used external libraries.

Currently it wants these exact versions of libraries which are tracked by in source script get_externals.bat
```
bzip2-1.0.6
libffi-3.3.0-rc0-r1
openssl-1.1.1f
 sqlite-3.31.1.0
tcl-core-8.6.9.0
tk-8.6.9.0
tix-8.4.3.6
xz-5.2.2 
zlib-1.2.11
```

of which it builds directly with the module source (not static or shared) and others it links shared. 

While I understand vcpkg policy is to use the split out ports. I do not think it's the best plan for python which calls out ~explicit~ versions which the vcpkg port system cannot respect as far I know.
 These shared libraries only get placed in the /share/python3/DLLs folder next to the /share/python3/Lib folder and not /bin which is the standard placement for these shared modules on windows python.


2. I made it install the core python modules in both /share/python3/DLLs and /tools/python3/DLLs. python.exe could be made to use /share/python3/DLLs in theory manually by users invoke it and setting to /share/python3
