### PR TITLE
[libvorbis] Fix Windows build when VCPKG_BUILD_TYPE is set

### DIFF
--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -27,7 +27,11 @@ configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copy
 vcpkg_copy_pdbs()
 
 if(WIN32 AND (NOT MINGW))
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/vorbis.pc" "-lm" "")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/vorbis.pc" "-lm" "")
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/vorbis.pc" "-lm" "")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/vorbis.pc" "-lm" "")
+    endif()
 endif()
 vcpkg_fixup_pkgconfig()

--- a/ports/libvorbis/vcpkg.json
+++ b/ports/libvorbis/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libvorbis",
   "version-string": "1.3.7",
+  "port-version": 1,
   "description": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
   "homepage": "https://github.com/xiph/vorbis",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This should fix `libvorbis` port builds on Windows when `VCPKG_BUILD_TYPE` is set

- What does your PR fix?

Fixes #13795

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes to support.
