### PR TITLE
[sdl2] Fix build when VCPKG_BUILD_TYPE is set to "release"

### DIFF
--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,9 +1,0 @@
-Source: sdl2
-Version: 2.0.12
-Port-Version: 5
-Homepage: https://www.libsdl.org/download-2.0.php
-Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
-
-Feature: vulkan
-Description: Vulkan functionality for SDL
-Build-Depends: vulkan

--- a/ports/sdl2/CONTROL
+++ b/ports/sdl2/CONTROL
@@ -1,6 +1,6 @@
 Source: sdl2
 Version: 2.0.12
-Port-Version: 4
+Port-Version: 5
 Homepage: https://www.libsdl.org/download-2.0.php
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -92,7 +92,9 @@ file(STRINGS "${SOURCE_PATH}/CMakeLists.txt" DYLIB_CURRENT_VERSION REGEX ${DYLIB
 string(REGEX REPLACE ${DYLIB_COMPATIBILITY_VERSION_REGEX} "\\1" DYLIB_COMPATIBILITY_VERSION "${DYLIB_COMPATIBILITY_VERSION}")
 string(REGEX REPLACE ${DYLIB_CURRENT_VERSION_REGEX} "\\1" DYLIB_CURRENT_VERSION "${DYLIB_CURRENT_VERSION}")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2" "-lSDL2d")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+	vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/sdl2.pc" "-lSDL2" "-lSDL2d")
+endif()
 
 vcpkg_fixup_pkgconfig(
     IGNORE_FLAGS "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/lib/pkgconfig/../../lib" "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/../../lib" "-Wl,--enable-new-dtags" "-Wl,--no-undefined" "-Wl,-undefined,error" "-Wl,-compatibility_version,${DYLIB_COMPATIBILITY_VERSION}" "-Wl,-current_version,${DYLIB_CURRENT_VERSION}" "-Wl,-weak_framework,Metal" "-Wl,-weak_framework,QuartzCore"

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "sdl2",
+  "version-string": "2.0.12",
+  "port-version": 5,
+  "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
+  "homepage": "https://www.libsdl.org/download-2.0.php",
+  "features": {
+    "vulkan": {
+      "description": "Vulkan functionality for SDL",
+      "dependencies": [
+        "vulkan"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**Describe the pull request**

Fix `sdl2` port build when `VCPKG_BUILD_TYPE` is set to `release`

- What does your PR fix?

Fixes #13800

- Which triplets are supported/not supported? Have you updated the CI baseline?

No changes to support.
