### PR TITLE
[fuzzylite] Fix the headers to import the library with dynamic linkage

### DIFF
--- a/ports/fuzzylite/CONTROL
+++ b/ports/fuzzylite/CONTROL
@@ -1,4 +1,5 @@
 Source: fuzzylite
-Version: 6.0-2
+Version: 6.0
+Port-Version: 3
 Homepage: https://github.com/fuzzylite/fuzzylite
 Description: A fuzzy logic control library in C++

--- a/ports/fuzzylite/portfile.cmake
+++ b/ports/fuzzylite/portfile.cmake
@@ -1,9 +1,3 @@
-include(vcpkg_common_functions)
-
-if(EXISTS "${CURRENT_BUILDTREES_DIR}/src/.git")
-    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src)
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fuzzylite/fuzzylite
@@ -42,4 +36,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/fuzzylite-static-debug.lib ${CURRENT_PACKAGES_DIR}/debug/lib/fuzzylite-debug.lib)
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/fuzzylite RENAME copyright)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/fl/fuzzylite.h
+        "#elif defined(FL_IMPORT_LIBRARY)"
+        "#elif 1"
+    )
+endif()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/13779

FL_IMPORT_LIBRARY should define when use the fuzzylite with dynamic linkage.