### PR TITLE
[fmt] Add usage file

### DIFF
--- a/ports/fmt/CONTROL
+++ b/ports/fmt/CONTROL
@@ -1,5 +1,5 @@
 Source: fmt
 Version: 7.0.3
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/fmtlib/fmt
 Description: Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -59,4 +59,6 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
+# Handle post-build CMake instructions
 vcpkg_copy_pdbs()
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/fmt/usage
+++ b/ports/fmt/usage
@@ -1,0 +1,7 @@
+The package fmt provides CMake targets:
+
+    find_package(fmt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE fmt::fmt)
+
+    # Or use the header-only version
+    target_link_libraries(main PRIVATE fmt::fmt-header-only)


### PR DESCRIPTION
**Describe the pull request**

### What does your PR fix?

When `fmt` is installed from `vcpkg`, you get the output:

```
The package fmt:x64-windows provides CMake targets:

    find_package(fmt CONFIG REQUIRED)
    target_link_libraries(main PRIVATE fmt::fmt fmt::fmt-header-only)
```

Unfortunately that's not correct, we shouldn't link both `fmt::fmt` and the header only version, `fmt::fmt-header-only`.

This PR adds a usage file to instead show to the user the CMake statements from `fmt` own documentation: https://fmt.dev/latest/usage.html#usage-with-cmake.

### Which triplets are supported/not supported? Have you updated the CI baseline?

I don't think anything has to be updated. Just tell me if I have to change something.

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I believe so, yes.
