### PR TITLE
[PCL] Remove -fext-numeric-literals when building x64-osx

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,6 +1,6 @@
 Source: pcl
 Version: 1.11.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-sort, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio

--- a/ports/pcl/boost-1.70.patch
+++ b/ports/pcl/boost-1.70.patch
@@ -6,7 +6,7 @@ index b301cf1..789b660 100644
  
  # Boost (required)
  include("${PCL_SOURCE_DIR}/cmake/pcl_find_boost.cmake")
-+if (NOT APPLE AND NOT WIN32)
++if (NOT APPLE AND NOT WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 +    add_definitions(-fext-numeric-literals)
 +endif()
  


### PR DESCRIPTION
`-fext-numeric-literals` does not exist in clang and it builds just fine without it