### PR TITLE
[libpng[apng]] Add msys installation to use awk

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,6 +1,6 @@
 Source: libpng
 Version: 1.6.37
-Port-Version: 11
+Port-Version: 12
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -4,7 +4,7 @@ set(LIBPNG_VER 1.6.37)
 set(LIBPNG_APNG_OPTION )
 if ("apng" IN_LIST FEATURES)
     # Get (g)awk installed
-    vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk NO_DEFAULT_PACKAGES)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk)
     set(AWK_EXE_PATH "${MSYS_ROOT}/usr/bin")
     vcpkg_add_to_path("${AWK_EXE_PATH}")
     

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -3,6 +3,11 @@ set(LIBPNG_VER 1.6.37)
 # Download the apng patch
 set(LIBPNG_APNG_OPTION )
 if ("apng" IN_LIST FEATURES)
+    # Get (g)awk installed
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk NO_DEFAULT_PACKAGES)
+    set(AWK_EXE_PATH "${MSYS_ROOT}/usr/bin")
+    vcpkg_add_to_path("${AWK_EXE_PATH}")
+    
     set(LIBPNG_APG_PATCH_NAME libpng-${LIBPNG_VER}-apng.patch)
     set(LIBPNG_APG_PATCH_PATH ${CURRENT_BUILDTREES_DIR}/src/${LIBPNG_APG_PATCH_NAME})
     if (NOT EXISTS ${LIBPNG_APG_PATCH_PATH})


### PR DESCRIPTION
libpng[apng], the libpng library with the animated PNG patch, defines -DPNG_PREFIX=a as part of its portfile. However, this flag does not have any effect on the library and the symbols generated will not have the "a" prefix attached. This is because awk is required to run the header/source file updates. This [draft] PR intends to fix this by adding MSYS to the mix for apng-flavored builds, install [g]awk, and then adding MSYS to the PATH to pick up the awk dependency.

**Describe the pull request**

- What does your PR fix? Attempts to fix #13837

- Which triplets are supported/not supported? Have you updated the CI baseline?
No updates to the CI baseline. Pending checks to ensure that Linux/Mac will still work with this change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes - leaving this in draft as the issue is being discussed in the issue above + in this PR.
