### PR TITLE
[log4cxx] Fix osx build break by not building tests that require a Java compiler.

### DIFF
--- a/ports/log4cxx/CONTROL
+++ b/ports/log4cxx/CONTROL
@@ -1,5 +1,6 @@
 Source: log4cxx
 Version: 0.11.0
+Port-Version: 1
 Homepage: https://logging.apache.org/log4cxx
 Description: Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR
 Supports: !uwp

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DLOG4CXX_INSTALL_PDB=OFF # Installing pdbs failed on debug static. So, disable it and let vcpkg_copy_pdbs() do it
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This was broken by https://github.com/microsoft/vcpkg/pull/13767 which was accidentally merged without running the OSX validation.