### PR TITLE
[botan] ask for amalgamation build on windows

### DIFF
--- a/ports/botan/CONTROL
+++ b/ports/botan/CONTROL
@@ -3,3 +3,6 @@ Version: 2.15.0
 Port-Version: 1
 Homepage: https://botan.randombit.net
 Description: A cryptography library written in C++11
+
+Feature: amalgamation
+Description: Do an amalgamation build of the library

--- a/ports/botan/CONTROL
+++ b/ports/botan/CONTROL
@@ -1,4 +1,5 @@
 Source: botan
 Version: 2.15.0
+Port-Version: 1
 Homepage: https://botan.randombit.net
 Description: A cryptography library written in C++11

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -75,6 +75,7 @@ function(BOTAN_BUILD BOTAN_BUILD_TYPE)
                             --link-method=copy)
     if(CMAKE_HOST_WIN32)
         list(APPEND configure_arguments ${BOTAN_MSVC_RUNTIME}${BOTAN_MSVC_RUNTIME_SUFFIX})
+        list(APPEND configure_arguments --amalgamation)
     endif()
 
     vcpkg_execute_required_process(

--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -46,6 +46,10 @@ else()
     message(FATAL_ERROR "Unsupported architecture")
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    amalgamation BOTAN_AMALGAMATION
+)
+
 function(BOTAN_BUILD BOTAN_BUILD_TYPE)
 
     if(BOTAN_BUILD_TYPE STREQUAL "dbg")
@@ -75,6 +79,9 @@ function(BOTAN_BUILD BOTAN_BUILD_TYPE)
                             --link-method=copy)
     if(CMAKE_HOST_WIN32)
         list(APPEND configure_arguments ${BOTAN_MSVC_RUNTIME}${BOTAN_MSVC_RUNTIME_SUFFIX})
+    endif()
+
+    if("-DBOTAN_AMALGAMATION=ON" IN_LIST FEATURE_OPTIONS)
         list(APPEND configure_arguments --amalgamation)
     endif()
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

On Windows, I get the following error building botan:
`Can't start command: C:\WINDOWS\system32\cmd.exe /C link /DLL    build\obj\lib\buildtrees_botan_src_89b3286ac4-fdb28db12d.clean_src_lib_asn1_alg_id.obj (...) build\obj\lib\buildtrees_botan_src_89b3286ac4-fdb28db12d.clean_src_lib_x509_x509self.obj crypt32.lib user32.lib ws2_32.lib /OUT:.\botan.dll`
The entire LIBOBJS variable in the generated Makefile is over 36000 characters long.

I looked into patching botan at first, but I didn't immediately get their custom configure script, and I found this to be the easiest solution. I scoped it under Windows to avoid longer build times on other systems.

I'm of course open for other suggestions for fixing the build error.


- Which triplets are supported/not supported? Have you updated the CI baseline?

NA

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes