### PR TITLE
Use libwebsocket's master for libuv-related bugfixes

### DIFF
--- a/ports/libwebsockets/CONTROL
+++ b/ports/libwebsockets/CONTROL
@@ -1,5 +1,5 @@
 Source: libwebsockets
-Version: 4.1.2
+Version: 4.1.3
 Build-Depends: zlib, openssl, libuv, pthreads (windows)
 Homepage: https://github.com/warmcat/libwebsockets
 Description: Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
-    REF 64232ddc4cf67ccc75683a42a322e596b3611069 # v4.1.2
-    SHA512 199f25b969860a436cee5d1dd210ccde0ad7aaf4836c24aa4a5d0252bb13a61b12d96529e6ebf45dc78f4ec9ade11a324a0f2de51991e9e66045b57348ce6eec
+    REF e400b3bf5540ace538b684dd54450ecee3fc53c9 # v4.1.2
+    SHA512 f64fd4331aa71827745c1864131651bf757d5053cc7d3645063dfa64d7b437ac2b79e183f7b93d67ca61f371f31b37e5f4ebeafc5d0058f79d0fe95f8aafee87
     HEAD_REF master
     PATCHES
         CMakeLists.patch

--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO warmcat/libwebsockets
-    REF e400b3bf5540ace538b684dd54450ecee3fc53c9 # v4.1.2
-    SHA512 f64fd4331aa71827745c1864131651bf757d5053cc7d3645063dfa64d7b437ac2b79e183f7b93d67ca61f371f31b37e5f4ebeafc5d0058f79d0fe95f8aafee87
+    REF dbc3acd5ebd199a706ba9968f573015aa2fcd161 # v4.1.3
+    SHA512 96d59556b86a321b9e298f88177b4a21a9e304ea5463dccba037be96abaab7d60162b672dc0228a670ea37c54047d14c58d76c11b578fe339ac7a2eb0e1e8871
     HEAD_REF master
     PATCHES
         CMakeLists.patch


### PR DESCRIPTION
**PR moves libwesocket's version to current master**

In the last two weeks LWS team fixed and pushed to master few important bugs related to using libuv foreign loops. I tested the code pretty extensively and propose to use master for builds.

In my windows setup I tested the triplet x64-windows-static.