### PR TITLE
[osg] Fix feature plugin

### DIFF
--- a/ports/coin/CONTROL
+++ b/ports/coin/CONTROL
@@ -1,7 +1,8 @@
 Source: coin
 Version: 4.0.0
+Port-Version: 1
 Description: A high-level 3D visualization library with Open Inventor 2.1 API
-Build-Depends: boost-assert, boost-config, boost-lexical-cast, boost-math, boost-smart-ptr, boost-static-assert
+Build-Depends: boost-assert, boost-config, boost-lexical-cast, boost-math, boost-smart-ptr, boost-static-assert, opengl-registry
 Homepage: https://github.com/coin3d/coin
 Default-Features: simage, zlib
 Supports: !(arm|arm64|uwp)

--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,6 +1,6 @@
 Source: osg
 Version: 3.6.5
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
 Build-Depends: zlib, fontconfig, boost-asio (!windows), boost-core (!windows), boost-logic (!windows), boost-lexical-cast (!windows), boost-smart-ptr (!windows), boost-tuple (!windows), boost-bind (!windows), freeglut (windows), expat (windows), openimageio (osx)
@@ -19,7 +19,7 @@ Build-Depends: freetype, sdl1, sdl2, libiconv (windows)
 
 Feature: plugins
 Description: Build OSG Plugins - Disable for compile testing examples on a time limit
-Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt
+Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt, opengl-registry
 
 Feature: packages
 Description: Set to ON to generate CPack configuration files and packaging targets

--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -19,7 +19,7 @@ Build-Depends: freetype, sdl1, sdl2, libiconv (windows)
 
 Feature: plugins
 Description: Build OSG Plugins - Disable for compile testing examples on a time limit
-Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt, opengl-registry
+Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt, coin
 
 Feature: packages
 Description: Set to ON to generate CPack configuration files and packaging targets

--- a/ports/osg/fix-dependency-coin.patch
+++ b/ports/osg/fix-dependency-coin.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 798b8b9..c975d78 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -740,7 +740,7 @@ ELSE()
+ # Common to all platforms except android:
+     FIND_PACKAGE(Freetype)
+     FIND_PACKAGE(ilmbase)
+-    FIND_PACKAGE(Inventor)
++    FIND_PACKAGE(coin CONFIG)
+     FIND_PACKAGE(Jasper)
+     FIND_PACKAGE(OpenEXR)
+     FIND_PACKAGE(OpenCascade)
+diff --git a/src/osgPlugins/Inventor/CMakeLists.txt b/src/osgPlugins/Inventor/CMakeLists.txt
+index 963a494..e34b6b8 100644
+--- a/src/osgPlugins/Inventor/CMakeLists.txt
++++ b/src/osgPlugins/Inventor/CMakeLists.txt
+@@ -17,10 +17,6 @@ SET(TARGET_HDRS
+     ShuttleCallback.h
+ )
+ 
+-ADD_DEFINITIONS(-DCOIN_DLL)
+-
+-INCLUDE_DIRECTORIES(${INVENTOR_INCLUDE_DIR})
+-
+-SET(TARGET_ADDED_LIBRARIES ${INVENTOR_LIBRARY})
++SET(TARGET_ADDED_LIBRARIES Coin::Coin)
+ 
+ SETUP_PLUGIN(iv iv)

--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         fix-liblas.patch
         fix-nvtt.patch
         use-boost-asio.patch
+        fix-dependency-coin.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/osgearth/CONTROL
+++ b/ports/osgearth/CONTROL
@@ -1,6 +1,6 @@
 Source: osgearth
 Version: 3.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/gwaldron/osgearth
 Description:  osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.
 Build-Depends: osg[plugins]


### PR DESCRIPTION
When building osg[plugin]:
```
installed\x86-windows\include\Inventor/system/gl-headers.h(50,10): fatal error C1083: Cannot open include file: 'GL/glext.h': No such file or directory (compiling source file D:\buildtrees\osg\src\raph-3.6.5-4fd22a77bc.clean\src\osgPlugins\Inventor\ConvertFromInventor.cpp) [D:\buildtrees\osg\x86-windows-dbg\src\osgPlugins\Inventor\osgdb_iv.vcxproj]
```
Fix this issue.