### PR TITLE
[openssl] Update to 1.1.1h

### DIFF
--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -1,5 +1,5 @@
 Source: openssl-unix
-Version: 1.1.1g
+Version: 1.1.1h
 Port-Version: 4
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: !(windows|uwp)

--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -1,5 +1,4 @@
 Source: openssl-unix
 Version: 1.1.1h
-Port-Version: 4
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: !(windows|uwp)

--- a/ports/openssl-unix/portfile.cmake
+++ b/ports/openssl-unix/portfile.cmake
@@ -9,12 +9,12 @@ endif()
 
 vcpkg_find_acquire_program(PERL)
 
-set(OPENSSL_VERSION 1.1.1g)
+set(OPENSSL_VERSION 1.1.1h)
 
 vcpkg_download_distfile(OPENSSL_SOURCE_ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL_VERSION}.tar.gz"
     FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
-    SHA512 01e3d0b1bceeed8fb066f542ef5480862001556e0f612e017442330bbd7e5faee228b2de3513d7fc347446b7f217e27de1003dc9d7214d5833b97593f3ec25ab
+    SHA512 da50fd99325841ed7a4367d9251c771ce505a443a73b327d8a46b2c6a7d2ea99e43551a164efc86f8743b22c2bdb0020bf24a9cbd445e9d68868b2dc1d34033a
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/openssl-uwp/CONTROL
+++ b/ports/openssl-uwp/CONTROL
@@ -1,5 +1,5 @@
 Source: openssl-uwp
-Version: 1.1.1g
+Version: 1.1.1h
 Port-Version: 1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: uwp

--- a/ports/openssl-uwp/CONTROL
+++ b/ports/openssl-uwp/CONTROL
@@ -1,5 +1,4 @@
 Source: openssl-uwp
 Version: 1.1.1h
-Port-Version: 1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: uwp

--- a/ports/openssl-uwp/portfile.cmake
+++ b/ports/openssl-uwp/portfile.cmake
@@ -13,12 +13,12 @@ get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path("${PERL_EXE_PATH}")
 vcpkg_add_to_path("${JOM_EXE_PATH}")
 
-set(OPENSSL_VERSION 1.1.1g)
+set(OPENSSL_VERSION 1.1.1h)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL_VERSION}.tar.gz"
     FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
-    SHA512 01e3d0b1bceeed8fb066f542ef5480862001556e0f612e017442330bbd7e5faee228b2de3513d7fc347446b7f217e27de1003dc9d7214d5833b97593f3ec25ab
+    SHA512 da50fd99325841ed7a4367d9251c771ce505a443a73b327d8a46b2c6a7d2ea99e43551a164efc86f8743b22c2bdb0020bf24a9cbd445e9d68868b2dc1d34033a
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,5 +1,4 @@
 Source: openssl-windows
 Version: 1.1.1h
-Port-Version: 1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: windows

--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,5 +1,5 @@
 Source: openssl-windows
-Version: 1.1.1g
+Version: 1.1.1h
 Port-Version: 1
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 Supports: windows

--- a/ports/openssl-windows/portfile.cmake
+++ b/ports/openssl-windows/portfile.cmake
@@ -6,7 +6,7 @@ endif()
 
 vcpkg_find_acquire_program(PERL)
 
-set(OPENSSL_VERSION 1.1.1g)
+set(OPENSSL_VERSION 1.1.1h)
 
 get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path("${PERL_EXE_PATH}")
@@ -14,7 +14,7 @@ vcpkg_add_to_path("${PERL_EXE_PATH}")
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL_VERSION}.tar.gz"
     FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
-    SHA512 01e3d0b1bceeed8fb066f542ef5480862001556e0f612e017442330bbd7e5faee228b2de3513d7fc347446b7f217e27de1003dc9d7214d5833b97593f3ec25ab
+    SHA512 da50fd99325841ed7a4367d9251c771ce505a443a73b327d8a46b2c6a7d2ea99e43551a164efc86f8743b22c2bdb0020bf24a9cbd445e9d68868b2dc1d34033a
 )
 
 vcpkg_extract_source_archive_ex(


### PR DESCRIPTION
- What does your PR fix? Regular port update https://github.com/openssl/openssl/releases/tag/OpenSSL_1_1_1h

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
