### PR TITLE
[nettle] Fix build failure on osx

### DIFF
--- a/ports/nettle/CONTROL
+++ b/ports/nettle/CONTROL
@@ -1,6 +1,6 @@
 Source: nettle
 Version: 3.5.1
-Port-Version: 3
+Port-Version: 4
 Homepage: https://git.lysator.liu.se/nettle/nettle
 Description: Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.
 Build-Depends: gmp, vs-yasm (windows)

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -113,7 +113,6 @@ else()
         set(OPTIONS --disable-static)
     else()
         set(OPTIONS --disable-shared)
-
     endif()
 
     vcpkg_configure_make(

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -108,12 +108,19 @@ else()
         HEAD_REF master # branch name
         PATCHES fix-InstallLibPath.patch
     )
+    
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        set(OPTIONS --disable-shared)
+    else()
+        set(OPTIONS --disable-static)
+    endif()
 
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
         AUTOCONFIG
         OPTIONS
             --disable-documentation
+            --disable-openssl
             ${OPTIONS}
     )
 

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -110,7 +110,8 @@ else()
     )
     
     if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-        set(OPTIONS --disable-shared)
+        set(OPTIONS --disable-static)
+
     else()
         set(OPTIONS --disable-static)
     endif()
@@ -136,5 +137,4 @@ else()
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     endif()
 endif()
-
 

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -113,7 +113,8 @@ else()
         set(OPTIONS --disable-static)
 
     else()
-        set(OPTIONS --disable-static)
+        set(OPTIONS --disable-shared)
+
     endif()
 
     vcpkg_configure_make(
@@ -137,4 +138,3 @@ else()
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
     endif()
 endif()
-

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -111,7 +111,6 @@ else()
     
     if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         set(OPTIONS --disable-static)
-
     else()
         set(OPTIONS --disable-shared)
 


### PR DESCRIPTION
Disable option `openssl` on OSX to fix the build failure:
```
Undefined symbols for architecture x86_64:
  "_EVP_bf_ecb", referenced from:
      _openssl_bf128_set_encrypt_key in nettle-openssl.o
      _openssl_bf128_set_decrypt_key in nettle-openssl.o
  "_EVP_cast5_ecb", referenced from:
      _openssl_cast128_set_encrypt_key in nettle-openssl.o
      _openssl_cast128_set_decrypt_key in nettle-openssl.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [nettle-benchmark] Error 1
make[1]: *** Waiting for unfinished jobs....
ld: warning: PIE disabled. Absolute addressing (perhaps -mdynamic-no-pic) not allowed in code signed PIE, but used in ___gmpn_divexact_1 from /Volumes/External/CraftRoot/download/git/extragear/kmymoney/vcpkg_installed/x64-osx/debug/lib//libgmp.a(dive_1.o). To fix this warning, don't compile with -mdynamic-no-pic or link with -Wl,-no_pie
make: *** [all] Error 2
```

Fixes #13949.