### PR TITLE
[openimageio] Fix build tools on windows-static

### DIFF
--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,6 +1,6 @@
 Source: openimageio
 Version: 2.1.16.0
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/OpenImageIO/oiio
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
 Build-Depends: libjpeg-turbo, tiff, libpng, libheif, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace, fmt

--- a/ports/openimageio/fix-libheif.patch
+++ b/ports/openimageio/fix-libheif.patch
@@ -1,0 +1,26 @@
+diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
+index 1a17d1e..2ba4264 100644
+--- a/src/cmake/externalpackages.cmake
++++ b/src/cmake/externalpackages.cmake
+@@ -259,7 +259,7 @@ checked_find_package (Field3D
+                    DEPS         HDF5
+                    DEFINITIONS  -DUSE_FIELD3D=1)
+ checked_find_package (GIF 4)
+-checked_find_package (Libheif 1.3)  # For HEIF/HEIC format
++checked_find_package (libheif CONFIG)  # For HEIF/HEIC format
+ checked_find_package (LibRaw)
+ checked_find_package (OpenJPEG CONFIG)
+ checked_find_package (OpenVDB 5.0
+diff --git a/src/heif.imageio/CMakeLists.txt b/src/heif.imageio/CMakeLists.txt
+index cb5e5f9..f773fd5 100644
+--- a/src/heif.imageio/CMakeLists.txt
++++ b/src/heif.imageio/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ if (LIBHEIF_FOUND)
+     add_oiio_plugin (heifinput.cpp heifoutput.cpp
+                      INCLUDE_DIRS ${LIBHEIF_INCLUDES}
+-                     LINK_LIBRARIES ${LIBHEIF_LIBRARIES}
++                     LINK_LIBRARIES heif
+                      DEFINITIONS "-DUSE_HEIF=1")
+ else ()
+     message (WARNING "heif plugin will not be built")

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         fix-tools-path.patch
         fix-config-cmake.patch
         fix-dependfmt.patch
+        fix-libheif.patch # Remove this patch on the next update
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")


### PR DESCRIPTION
oiio uses the internal `Findheif.cmake` to find `libheif`, and adds the macro `LIBHEIF_EXPORTS` when static, which causes the function declaration to contain `__declspec(dllimport)`, which leads to the link failure.

Fix this issue in the current version, and it has been fixed in the new version.

Fixes #13831.