### PR TITLE
[opencl] fix crt linkage for x64-windows-static-md

### DIFF
--- a/ports/opencl/CONTROL
+++ b/ports/opencl/CONTROL
@@ -1,6 +1,6 @@
 Source: opencl
 Version: 2.2
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/KhronosGroup/OpenCL-Headers
 Description: C/C++ headers and ICD loader (Installable Client Driver) for OpenCL
 

--- a/ports/opencl/portfile.cmake
+++ b/ports/opencl/portfile.cmake
@@ -60,11 +60,7 @@ vcpkg_from_github(
         0001-include-unistd-for-gete-ug-id.patch
 )
 
-if(VCPKG_CRT_LINKAGE STREQUAL static)
-  set(USE_DYNAMIC_VCXX_RUNTIME OFF)
-else()
-  set(USE_DYNAMIC_VCXX_RUNTIME ON)
-endif()
+string(COMPARE EQUAL ${VCPKG_CRT_LINKAGE} dynamic USE_DYNAMIC_VCXX_RUNTIME)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/opencl/portfile.cmake
+++ b/ports/opencl/portfile.cmake
@@ -60,12 +60,19 @@ vcpkg_from_github(
         0001-include-unistd-for-gete-ug-id.patch
 )
 
+if(VCPKG_CRT_LINKAGE STREQUAL static)
+  set(USE_DYNAMIC_VCXX_RUNTIME OFF)
+else()
+  set(USE_DYNAMIC_VCXX_RUNTIME ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DOPENCL_ICD_LOADER_HEADERS_DIR=${CURRENT_PACKAGES_DIR}/include
         -DOPENCL_ICD_LOADER_REQUIRE_WDK=${WITH_WDK}
+        -DUSE_DYNAMIC_VCXX_RUNTIME=${USE_DYNAMIC_VCXX_RUNTIME}
 )
 
 vcpkg_build_cmake(TARGET OpenCL)


### PR DESCRIPTION
- What does your PR fix? Currently, opencl:x64-windows-static-md fails to build due to wrong CRT linkage (for instance, see https://ci.appveyor.com/project/mcmtroffaes/ffmpeg-msvc-build/builds/35686191/job/3fum797k27hod6d4#L242). This patch fixes that.

- Which triplets are supported/not supported? Have you updated the CI baseline? No change to baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.