### PR TITLE
[icu] Update automake dependency 1.15 -> 1.16

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,5 +1,6 @@
 Source: icu
-Version: 67.1-3
+Version: 67.1
+Port-Version: 4
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -77,7 +77,7 @@ else()
     set(CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS} --host=i686-pc-mingw32")
 
     # Acquire tools
-    vcpkg_acquire_msys(MSYS_ROOT PACKAGES make automake1.15)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES make automake1.16)
 
     # Insert msys into the path between the compiler toolset and windows system32. This prevents masking of "link.exe" but DOES mask "find.exe".
     string(REPLACE ";$ENV{SystemRoot}\\system32;" ";${MSYS_ROOT}/usr/bin;$ENV{SystemRoot}\\system32;" NEWPATH "$ENV{PATH}")
@@ -85,7 +85,7 @@ else()
     set(ENV{PATH} "${NEWPATH}")
     set(BASH ${MSYS_ROOT}/usr/bin/bash.exe)
 
-    set(AUTOMAKE_DIR ${MSYS_ROOT}/usr/share/automake-1.15)
+    set(AUTOMAKE_DIR ${MSYS_ROOT}/usr/share/automake-1.16)
     file(COPY ${AUTOMAKE_DIR}/config.guess ${AUTOMAKE_DIR}/config.sub DESTINATION ${SOURCE_PATH}/source)
 
     if(VCPKG_CRT_LINKAGE STREQUAL static)


### PR DESCRIPTION
automake 1.15 is not available through msys anymore; automake 1.16 is the oldest available version.

**Describe the pull request**

- What does your PR fix? Fixes #13979

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
