### PR TITLE
[portaudio] Fix build on windows

### DIFF
--- a/ports/portaudio/CONTROL
+++ b/ports/portaudio/CONTROL
@@ -1,4 +1,5 @@
 Source: portaudio
 Version: 2020-02-02
+Port-Version: 1
 Homepage: https://app.assembla.com/spaces/portaudio/wiki
 Description: PortAudio Portable Cross-platform Audio I/O API PortAudio is a free, cross-platform, open-source, audio I/O library.  It lets you write simple audio programs in 'C' or C++ that will compile and run on many platforms including Windows, Macintosh OS X, and Unix (OSS/ALSA). It is intended to promote the exchange of audio software between developers on different platforms. Many applications use PortAudio for Audio I/O.

--- a/ports/portaudio/portfile.cmake
+++ b/ports/portaudio/portfile.cmake
@@ -7,6 +7,9 @@ vcpkg_from_git(
         fix-include.patch
 )
 
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} dynamic PA_BUILD_SHARED)
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static PA_BUILD_STATIC)
+
 # NOTE: the ASIO backend will be built automatically if the ASIO-SDK is provided
 # in a sibling folder of the portaudio source in vcpkg/buildtrees/portaudio/src
 vcpkg_configure_cmake(
@@ -18,6 +21,8 @@ vcpkg_configure_cmake(
         -DPA_USE_WDMKS=ON
         -DPA_USE_WMME=ON
         -DPA_LIBNAME_ADD_SUFFIX=OFF
+        -DPA_BUILD_SHARED=${PA_BUILD_SHARED}
+        -DPA_BUILD_STATIC=${PA_BUILD_STATIC}
     OPTIONS_DEBUG
         -DPA_ENABLE_DEBUG_OUTPUT:BOOL=ON
 )
@@ -34,4 +39,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/portaudio RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? I couldn't build portaudio on windows. This fixes this, and now we also only build static when static linking or shared when shared linking.

