### PR TITLE
[icu] Disable layoutex feature

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,6 +1,6 @@
 Source: icu
 Version: 67.1
-Port-Version: 4
+Port-Version: 5
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -25,7 +25,7 @@ vcpkg_extract_source_archive_ex(
 vcpkg_find_acquire_program(PYTHON3)
 set(ENV{PYTHON} "${PYTHON3}")
 
-set(CONFIGURE_OPTIONS "--disable-samples --disable-tests")
+set(CONFIGURE_OPTIONS "--disable-samples --disable-tests --disable-layoutex")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     set(CONFIGURE_OPTIONS "${CONFIGURE_OPTIONS} --disable-static --enable-shared")


### PR DESCRIPTION
**Describe the pull request**

icu tries to detect the presence of `icu-le-hb` to select the default value for the `layoutex` feature.

This package is not provided by vcpkg but when this package is otherwise available on the system the build will fail during `vcpkg_fixup_pkgconfig` as the pkg-config file pulls the dependency from the system.

- What does your PR fix? This is the same issue as reported by @phoyd in #13527 but not the same issue as what was reported originally so I am not sure it should be closed.

- Which triplets are supported/not supported? Have you updated the CI baseline?

This PR does not change the triplets supported by this port.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes. (I've followed what seems to be the historical convention on this port to increment the version rather than introducing a port-version)
Fixes #13527