### PR TITLE
[libzip] Enable support for zstd compression

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,5 +1,6 @@
 Source: libzip
 Version: 1.7.3
+Port-Version: 1
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
 Default-Features: bzip2,default-aes
@@ -33,4 +34,4 @@ Description: AES (encryption) support using mbedtls
 
 Feature: zstd
 Build-Depends: zstd
-Description: Zstandard - Fast real-time compression algorithm
+Description: Support enable use of Zstandard

--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -30,3 +30,7 @@ Description: AES( encryption) support using Apple's Common Crypto API
 Feature: mbedtls
 Build-Depends: mbedtls
 Description: AES (encryption) support using mbedtls
+
+Feature: zstd
+Build-Depends: zstd
+Description: Zstandard - Fast real-time compression algorithm

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_check_features(
     wincrypto ENABLE_WINDOWS_CRYPTO
     commoncrypto ENABLE_COMMONCRYPTO
     mbedtls ENABLE_MBEDTLS
+    zstd ENABLE_ZSTD 
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #13985 

Enable support for zstd compression

All features are tested successfully in the following triplets:
- x86-windows
- x64-windows
- x64-windows-static
