### PR TITLE
[sdl2] declare glib-2.0, gobject-2.0, gio-2.0 and ibus-1.0 as SYSTEM_LIBRARIES

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -98,5 +98,5 @@ endif()
 
 vcpkg_fixup_pkgconfig(
     IGNORE_FLAGS "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/lib/pkgconfig/../../lib" "-Wl,-rpath,${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/../../lib" "-Wl,--enable-new-dtags" "-Wl,--no-undefined" "-Wl,-undefined,error" "-Wl,-compatibility_version,${DYLIB_COMPATIBILITY_VERSION}" "-Wl,-current_version,${DYLIB_CURRENT_VERSION}" "-Wl,-weak_framework,Metal" "-Wl,-weak_framework,QuartzCore"
-    SYSTEM_LIBRARIES dbus-1
+    SYSTEM_LIBRARIES dbus-1 glib-2.0 gobject-2.0 gio-2.0 ibus-1.0
 )

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version-string": "2.0.12",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

On Linux, if you've got the ibus development headers installed, the sdl2 build will detect it use it for linking via pkg-config. This in turn adds glib-2.0, gobject-2.0, gio-2.0 and ibus-1.0 to the linked libraries. This PR declares them as SYSTEM_LIBRARIES.

- Which triplets are supported/not supported? Have you updated the CI baseline?

NA

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes