### PR TITLE
[benchmark] Add MSVC ARM64 support

### DIFF
--- a/ports/benchmark/0001-Add-MSVC-ARM64-support.patch
+++ b/ports/benchmark/0001-Add-MSVC-ARM64-support.patch
@@ -1,0 +1,61 @@
+From a31f7c3f8f215e66de00a0c3fb0c39607f182b81 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Janiszewski?= <janisozaur@gmail.com>
+Date: Mon, 5 Oct 2020 20:53:33 +0200
+Subject: [PATCH] Add MSVC ARM64 support
+
+---
+ CMakeLists.txt   | 11 +++++++++++
+ src/cycleclock.h |  8 +++++++-
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 67c0b70..d87f381 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -35,6 +35,17 @@ option(BENCHMARK_DOWNLOAD_DEPENDENCIES "Allow the downloading and in-tree buildi
+ option(BENCHMARK_ENABLE_GTEST_TESTS "Enable building the unit tests which depend on gtest" ON)
+ 
+ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
++if(MSVC)
++    # As of CMake 3.18, CMAKE_SYSTEM_PROCESSOR is not set properly for MSVC and
++    # cross-compilation (e.g. Host=x86_64, target=aarch64) requires using the
++    # undocumented, but working variable.
++    # See https://gitlab.kitware.com/cmake/cmake/-/issues/15170
++    set(CMAKE_SYSTEM_PROCESSOR ${MSVC_CXX_ARCHITECTURE_ID})
++    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ARM")
++      set(CMAKE_CROSSCOMPILING TRUE)
++    endif()
++endif()
++
+ set(ENABLE_ASSEMBLY_TESTS_DEFAULT OFF)
+ function(should_enable_assembly_tests)
+   if(CMAKE_BUILD_TYPE)
+diff --git a/src/cycleclock.h b/src/cycleclock.h
+index d5d62c4..338d68b 100644
+--- a/src/cycleclock.h
++++ b/src/cycleclock.h
+@@ -36,7 +36,7 @@
+ // declarations of some other intrinsics, breaking compilation.
+ // Therefore, we simply declare __rdtsc ourselves. See also
+ // http://connect.microsoft.com/VisualStudio/feedback/details/262047
+-#if defined(COMPILER_MSVC) && !defined(_M_IX86)
++#if defined(COMPILER_MSVC) && !defined(_M_IX86) && !defined(_M_ARM64)
+ extern "C" uint64_t __rdtsc();
+ #pragma intrinsic(__rdtsc)
+ #endif
+@@ -106,6 +106,12 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
+   // when I know it will work.  Otherwise, I'll use __rdtsc and hope
+   // the code is being compiled with a non-ancient compiler.
+   _asm rdtsc
++#elif defined(COMPILER_MSVC) && defined(_M_ARM64)
++  // See https://docs.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=vs-2019
++  // and https://reviews.llvm.org/D53115
++  int64_t virtual_timer_value;
++  virtual_timer_value = _ReadStatusReg(ARM64_CNTVCT);
++  return virtual_timer_value;
+ #elif defined(COMPILER_MSVC)
+   return __rdtsc();
+ #elif defined(BENCHMARK_OS_NACL)
+-- 
+2.28.0
+

--- a/ports/benchmark/CONTROL
+++ b/ports/benchmark/CONTROL
@@ -1,5 +1,6 @@
 Source: benchmark
 Version: 1.5.2
+Port-Version: 1
 Homepage: https://github.com/google/benchmark
 Description: A library to support the benchmarking of functions, similar to unit-tests.
 Supports: !uwp

--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_from_github(
     REF 73d4d5e8d6d449fc8663765a42aa8aeeee844489 # v1.5.2
     SHA512 b87a7c207eb85187165df8ff99ab1bbf5d38fc2a6d839e267a71987951c94e33b55fd7fbee6f2b59202b0379a7e9705b73b193edaea0b9c742eddf3fcbe5f48e
     HEAD_REF master
+    PATCHES
+        0001-Add-MSVC-ARM64-support.patch # https://github.com/google/benchmark/pull/1052
 )
 
 vcpkg_configure_cmake(

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -97,7 +97,6 @@ bde:x64-uwp=fail
 bde:x64-windows=fail
 bde:x64-windows-static=fail
 bde:x86-windows=fail
-benchmark:arm64-windows=fail
 benchmark:arm-uwp=fail
 benchmark:x64-uwp=fail
 berkeleydb:arm-uwp=fail


### PR DESCRIPTION
Adds MSVC ARM64 support to Google Benchmark.

PR sent upstream over week ago with no changes requested, but not merged yet and no information about planned releases.