### PR TITLE
[vcpkg baseline][openxr-loader] Fix dependency port jsoncpp

### DIFF
--- a/ports/openxr-loader/CONTROL
+++ b/ports/openxr-loader/CONTROL
@@ -1,6 +1,8 @@
 Source: openxr-loader
 Version: 1.0.11
+Port-Version: 1
 Description: Khronos API for abstracting VR/MR/AR hardware
+Build-Depends: jsoncpp
 Supports: !(arm|uwp)
 
 Feature: vulkan

--- a/ports/openxr-loader/fix-openxr-sdk-jsoncpp.patch
+++ b/ports/openxr-loader/fix-openxr-sdk-jsoncpp.patch
@@ -1,0 +1,30 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c75b145..386494c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -66,7 +66,7 @@ if(NOT VULKAN_INCOMPATIBLE)
+ endif()
+ 
+ find_package(Threads REQUIRED)
+-find_package(JsonCpp)
++find_package(jsoncpp CONFIG REQUIRED)
+ 
+ ### All options defined here
+ option(BUILD_LOADER "Build loader" ON)
+diff --git a/src/loader/CMakeLists.txt b/src/loader/CMakeLists.txt
+index 6a88cf4..0821a3d 100644
+--- a/src/loader/CMakeLists.txt
++++ b/src/loader/CMakeLists.txt
+@@ -67,7 +67,11 @@ add_library(openxr_loader ${LIBRARY_TYPE}
+     ${openxr_loader_RESOURCE_FILE}
+ )
+ if(BUILD_WITH_SYSTEM_JSONCPP)
+-    target_link_libraries(openxr_loader PRIVATE JsonCpp::JsonCpp)
++    if(BUILD_SHARED_LIBS)
++        target_link_libraries(openxr_loader PRIVATE jsoncpp_lib)
++    else()
++        target_link_libraries(openxr_loader PRIVATE jsoncpp_static)
++    endif()
+ else()
+     target_sources(openxr_loader
+         PRIVATE

--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF e3a4e41d61544d8e2eba73f00da99b6818ec472b
     SHA512 26c6b547aa30d89895efcc835dddc3b58ab57f0e450a4ae82655a990a816dd57c70e43267a10da75b1c2bd160189942e443c8e27367d6648417d1c9c134e7694
     HEAD_REF master
+    PATCHES
+        fix-openxr-sdk-jsoncpp.patch
 )
 
 vcpkg_from_github(
@@ -14,6 +16,8 @@ vcpkg_from_github(
     REF 6dee6e228f47857adf5d7673eb90c64f04d33c60
     SHA512 0c522eef95b4d8bdc8e4f1ca852cd9798ff2bca9ef8511446d9cdf80bc314b0da454ab5c203658bbe43d3e7ff3d757b9427c3f75829b2a022a25041d1a2d2b12
     HEAD_REF master
+    PATCHES
+        fix-openxr-sdk-jsoncpp.patch
 )
 
 vcpkg_from_github(
@@ -47,6 +51,7 @@ vcpkg_configure_cmake(
         -DBUILD_CONFORMANCE_TESTS=OFF
         -DDYNAMIC_LOADER=${DYNAMIC_LOADER}
         -DPYTHON_EXECUTABLE=${PYTHON3}
+        -DBUILD_WITH_SYSTEM_JSONCPP=ON
 )
 
 vcpkg_install_cmake()
@@ -74,6 +79,5 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
 vcpkg_copy_pdbs()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/14002

The openxr-loader depends on jsoncpp, if it doesn't find jsoncpp from system, it will built the external source jsoncpp.
Fix it to depend on jsoncpp that installed by vcpkg.

Fix failures:
CMake Error: install(EXPORT "openxr_loader_export" ...) includes target "openxr_loader" which requires target "jsoncpp_interface" that is not in any export set.
CMake Error in src/loader/CMakeLists.txt:
export called with target "openxr_loader" which requires target
"jsoncpp_interface" that is not in any export set.