### PR TITLE
[ogre] Add assimp as dependency

### DIFF
--- a/ports/ogre/fix-dependency.patch
+++ b/ports/ogre/fix-dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
-index 2ae0b6694..068dd27dd 100644
+index 2ae0b66..e6c55cd 100644
 --- a/CMake/Dependencies.cmake
 +++ b/CMake/Dependencies.cmake
 @@ -242,7 +242,7 @@ find_package(FreeImage)
@@ -11,7 +11,7 @@ index 2ae0b6694..068dd27dd 100644
  macro_log_feature(FREETYPE_FOUND "freetype" "Portable font engine" "http://www.freetype.org" FALSE "" "")
  
  # Find X11
-@@ -310,7 +310,7 @@ find_package(SWIG 3.0.8 QUIET)
+@@ -310,11 +310,11 @@ find_package(SWIG 3.0.8 QUIET)
  macro_log_feature(SWIG_FOUND "SWIG" "Language bindings (Python, Java, C#) for OGRE" "http://www.swig.org/" FALSE "" "")
  
  # pugixml
@@ -20,6 +20,11 @@ index 2ae0b6694..068dd27dd 100644
  macro_log_feature(pugixml_FOUND "pugixml" "Needed for XMLConverter and DotScene Plugin" "https://pugixml.org/" FALSE "" "")
  
  # Assimp
+-find_package(ASSIMP QUIET)
++find_package(Assimp CONFIG REQUIRED)
+ macro_log_feature(ASSIMP_FOUND "Assimp" "Needed for the AssimpLoader Plugin" "https://www.assimp.org/" FALSE "" "")
+ 
+ if(ASSIMP_FOUND)
 @@ -336,7 +336,7 @@ endif()
  # Find sdl2
  if(NOT ANDROID AND NOT EMSCRIPTEN)

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "ogre",
   "version-string": "1.12.9",
-  "port-version": "1",
+  "port-version": 1,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [
+    "assimp",
     "freeimage",
     "freetype",
     {
@@ -16,8 +17,7 @@
     "pugixml",
     "sdl2",
     "zlib",
-    "zziplib",
-    "assimp"
+    "zziplib"
   ],
   "features": {
     "csharp": {

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -16,7 +16,8 @@
     "pugixml",
     "sdl2",
     "zlib",
-    "zziplib"
+    "zziplib",
+    "assimp"
   ],
   "features": {
     "csharp": {

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ogre",
   "version-string": "1.12.9",
+  "port-version": "1",
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre",
   "version-string": "1.12.9",
-  "port-version": "1",
+  "port-version": 1,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [


### PR DESCRIPTION
`
D:\buildtrees\ogre\src\eddf310f0b-53844692ef.clean\PlugIns\Assimp\src\AssimpLoader.cpp(36): fatal error C1083: Cannot open include file: 'assimp/version.h': No such file or directory`

`ogre `requires `assimp `to buid, so add `assimp `as its one of dependecies.

Related #12612
