### PR TITLE
[magic-enum] Update to v0.7.0

### DIFF
--- a/ports/magic-enum/CONTROL
+++ b/ports/magic-enum/CONTROL
@@ -1,4 +1,4 @@
 Source: magic-enum
-Version: 0.6.6
+Version: 0.7.0
 Description: Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.
 Homepage: https://github.com/Neargye/magic_enum

--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.6.6
-    SHA512 aeab69a87d0bcac93a987489a7bce9bd5971b7df1a5f83bfe9c58292dec736aa3b60a238c38d04080608199ea45c946da50b13934fb320e5f63e38b9185b526f
+    REF v0.7.0
+    SHA512 f56c081063846b87e8b811babe9a0e961efd29bef52359e14cb33773f8393640196c0808e201800c3adb82d0bf362d1f941e31df0fc3739d35a367f918409822
     HEAD_REF master
 )
 
@@ -14,6 +14,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DMAGIC_ENUM_OPT_BUILD_EXAMPLES=OFF
         -DMAGIC_ENUM_OPT_BUILD_TESTS=OFF
+        -DMAGIC_ENUM_OPT_INSTALL=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
Update magic-enum to v0.7.0

Changelog:
https://github.com/Neargye/magic_enum/releases/tag/v0.7.0