### PR TITLE
[vcpkg baseline][qca] Disable plugin botan temporary

### DIFF
--- a/ports/qca/0003-disable-plugin-botan.patch
+++ b/ports/qca/0003-disable-plugin-botan.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/CMakeLists.txt b/plugins/CMakeLists.txt
+index 6d354dc..dd344a6 100644
+--- a/plugins/CMakeLists.txt
++++ b/plugins/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${QCA_LIB_NAME}/crypto")
+ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/${QCA_LIB_NAME}/crypto")
+ 
+-set(PLUGINS "botan;cyrus-sasl;gcrypt;gnupg;logger;nss;ossl;pkcs11;softstore" CACHE INTERNAL "")
++set(PLUGINS "cyrus-sasl;gcrypt;gnupg;logger;nss;ossl;pkcs11;softstore" CACHE INTERNAL "")
+ 
+ # Initialize WITH_${PLUGIN}_PLUGIN cache variables
+ foreach(PLUGIN IN LISTS PLUGINS)

--- a/ports/qca/CONTROL
+++ b/ports/qca/CONTROL
@@ -1,5 +1,6 @@
 Source: qca
 Version: 2.3.1
+Port-Version: 1
 Description: Qt Cryptographic Architecture (QCA).
 Homepage: https://cgit.kde.org/qca.git/
 Build-Depends: qt5-base[core]

--- a/ports/qca/portfile.cmake
+++ b/ports/qca/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
     PATCHES
         0001-fix-path-for-vcpkg.patch
         0002-fix-build-error.patch
+        0003-disable-plugin-botan.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")


### PR DESCRIPTION
Due to find pkgconfig issue:
```
CMake Error at D:/downloads/tools/cmake-3.18.2-windows/cmake-3.18.2-win32-x86/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)

      Reason given by package: The command
        "D:/downloads/tools/perl/5.30.0.1/perl/bin/pkg-config" --version
      failed with output
        

Call Stack (most recent call first):
  D:/downloads/tools/cmake-3.18.2-windows/cmake-3.18.2-win32-x86/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  D:/downloads/tools/cmake-3.18.2-windows/cmake-3.18.2-win32-x86/share/cmake-3.18/Modules/FindPkgConfig.cmake:59 (find_package_handle_standard_args)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:530 (_find_package)
  plugins/qca-botan/CMakeLists.txt:1 (find_package)
```
disable this plugin to fix the baseline issue.

Related: #12612.