### PR TITLE
[libmariadb] Update the patch

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,5 +1,6 @@
 Source: libmariadb
 Version: 3.1.9
+Port-Version: 1
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
 Default-Features: zlib, openssl

--- a/ports/libmariadb/fix-InstallPath.patch
+++ b/ports/libmariadb/fix-InstallPath.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/install_plugins.cmake b/cmake/install_plugins.cmake
-index cd5616c..d058a5c 100644
+index b8d15ba..7f59db7 100644
 --- a/cmake/install_plugins.cmake
 +++ b/cmake/install_plugins.cmake
 @@ -8,7 +8,7 @@
@@ -8,14 +8,14 @@ index cd5616c..d058a5c 100644
  MACRO(INSTALL_PLUGIN name binary_dir)
 -  INSTALL(TARGETS ${name} COMPONENT ClientPlugins DESTINATION ${INSTALL_PLUGINDIR})
 +  INSTALL(TARGETS ${name} COMPONENT ClientPlugins DESTINATION ${INSTALL_PLUGINDIR}/../../../bin/plugin)
-   IF(WIN32)
-     FILE(APPEND ${CC_BINARY_DIR}/win/packaging/plugin.conf "<File Id=\"${name}.dll\" Name=\"${name}.dll\" DiskId=\"1\" Source=\"${binary_dir}/${CMAKE_BUILD_TYPE}/${name}.dll\"/>\n")
-     FILE(APPEND ${CC_BINARY_DIR}/win/packaging/plugin.conf "<File Id=\"${name}.pdb\" Name=\"${name}.pdb\" DiskId=\"1\" Source=\"${binary_dir}/${CMAKE_BUILD_TYPE}/${name}.pdb\"/>\n")
+   IF(MSVC)
+     INSTALL(FILES $<TARGET_PDB_FILE:${name}> COMPONENT Debuginfo
+       DESTINATION symbols CONFIGURATIONS Debug RelWithDebInfo)
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index a1f039e..03a3a6f 100644
+index f406b37..a9ae9d7 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -386,10 +386,10 @@ ADD_LIBRARY(mariadbclient STATIC  ${MARIADB_OBJECTS} ${EMPTY_FILE})
+@@ -395,10 +395,10 @@ ADD_LIBRARY(mariadbclient STATIC  ${MARIADB_OBJECTS} ${EMPTY_FILE})
  TARGET_LINK_LIBRARIES(mariadbclient ${SYSTEM_LIBS})
  
  IF(UNIX)
@@ -25,24 +25,25 @@ index a1f039e..03a3a6f 100644
  ELSE()
 -  ADD_LIBRARY(libmariadb SHARED ${libmariadb_RC} mariadbclient.def)
 +  ADD_LIBRARY(libmariadb ${libmariadb_RC} mariadbclient.def)
-   TARGET_LINK_LIBRARIES(libmariadb  mariadbclient)
+   TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE mariadbclient)
    SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
  ENDIF()
-@@ -441,13 +441,14 @@ ENDIF()
+@@ -452,13 +452,14 @@ ENDIF()
  
  INSTALL(TARGETS mariadbclient
            COMPONENT Development
 -          DESTINATION ${INSTALL_LIBDIR})
 +          LIBRARY DESTINATION lib)
  INSTALL(TARGETS libmariadb
-           COMPONENT SharedLibraries
+-          COMPONENT SharedLibraries
 -        DESTINATION ${INSTALL_LIBDIR})
-+		  RUNTIME DESTINATION bin
-+		  LIBRARY DESTINATION lib
-+		  ARCHIVE DESTINATION lib)
++        COMPONENT SharedLibraries
++        RUNTIME DESTINATION bin
++        LIBRARY DESTINATION lib
++        ARCHIVE DESTINATION lib)
  
 -
--IF(WIN32)
+-IF(MSVC)
 +IF(0)
     # On Windows, install PDB
     INSTALL(FILES $<TARGET_PDB_FILE:libmariadb> DESTINATION "${INSTALL_LIBDIR}"

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -1,9 +1,6 @@
-
 if (EXISTS "${CURRENT_INSTALLED_DIR}/share/libmysql")
     message(FATAL_ERROR "FATAL ERROR: libmysql and libmariadb are incompatible.")
 endif()
-
-include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -12,9 +9,9 @@ vcpkg_from_github(
     SHA512 6f200b984b0642bd75dd8b1ca8f6b996c4b9236c4180255d15dee369a10b3b802c0e8e1942135aeb3c279f3087ff4b19096e5fef15935f4b76cf4fcb344d9133
     HEAD_REF master
     PATCHES
-            md.patch
-            disable-test-build.patch
-			fix-InstallPath.patch
+        md.patch
+        disable-test-build.patch
+        fix-InstallPath.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -64,6 +61,4 @@ file(RENAME
     ${CURRENT_PACKAGES_DIR}/include/mariadb
     ${CURRENT_PACKAGES_DIR}/include/mysql)
 
-# copy license file
-file(COPY ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/libmariadb)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libmariadb/COPYING.LIB ${CURRENT_PACKAGES_DIR}/share/libmariadb/copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14041

Update the patch to match the latest source, no new changes involved.

Recently we update libmariadb to latest release revision, the patches outdate, however the CI system haven't catch the regressions. since mariadb clashes with mysql, we don't test it.



