### PR TITLE
[assimp] Fix missing find dependency utfcpp

### DIFF
--- a/ports/assimp/CONTROL
+++ b/ports/assimp/CONTROL
@@ -1,6 +1,6 @@
 Source: assimp
 Version: 5.0.1
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/assimp/assimp
 Description: The Open Asset import library
 Build-Depends: zlib, rapidjson, minizip, stb, kubazip, irrlicht, polyclipping, utfcpp, poly2tri

--- a/ports/assimp/portfile.cmake
+++ b/ports/assimp/portfile.cmake
@@ -55,6 +55,7 @@ find_dependency(polyclipping CONFIG)
 find_dependency(minizip CONFIG)
 find_dependency(kubazip CONFIG)
 find_dependency(poly2tri CONFIG)
+find_dependency(utf8cpp CONFIG)
 ${ASSIMP_CONFIG}")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
In #13521, I added dependency utfcpp but missed add `find_dependency(utf8cpp CONFIG)`.

Fixes #14045.