### PR TITLE
[libzippp] Use VCPKG_TARGET_IS_WINDOWS rather than WIN32 and avoid libzip default features

### DIFF
--- a/ports/libzippp/CONTROL
+++ b/ports/libzippp/CONTROL
@@ -1,5 +1,6 @@
 Source: libzippp
 Version: 4.0-1.7.3
+Port-Version: 1
 Homepage: https://github.com/ctabin/libzippp
 Description: Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling
 Build-Depends: zlib, libzip[bzip2]

--- a/ports/libzippp/CONTROL
+++ b/ports/libzippp/CONTROL
@@ -3,4 +3,4 @@ Version: 4.0-1.7.3
 Port-Version: 1
 Homepage: https://github.com/ctabin/libzippp
 Description: Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling
-Build-Depends: zlib, libzip[bzip2]
+Build-Depends: zlib, libzip[core,bzip2]

--- a/ports/libzippp/portfile.cmake
+++ b/ports/libzippp/portfile.cmake
@@ -1,4 +1,3 @@
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ctabin/libzippp
@@ -18,7 +17,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(WIN32)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake/libzippp")
 else()
     vcpkg_fixup_cmake_targets(CONFIG_PATH "share/libzippp")
@@ -27,4 +26,4 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libzippp RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14057

Update `if(WIN32)` as `if(VCPKG_TAREGT_IS_WINDOWS) ` to check if the platform is windows in portfile.cmake.

Note: No feature needs to test.
