### PR TITLE
[vcpkg] Add `versions` feature flag and version field manifest parsing

### DIFF
--- a/toolsrc/include/vcpkg/fwd/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/fwd/vcpkgcmdarguments.h
@@ -10,4 +10,5 @@ namespace vcpkg
     struct CommandStructure;
     struct HelpTableFormatter;
     struct VcpkgCmdArguments;
+    struct FeatureFlagSettings;
 }

--- a/toolsrc/include/vcpkg/sourceparagraph.h
+++ b/toolsrc/include/vcpkg/sourceparagraph.h
@@ -80,14 +80,15 @@ namespace vcpkg
     /// </summary>
     struct SourceControlFile
     {
-        SourceControlFile() = default;
-        SourceControlFile(const SourceControlFile& scf)
-            : core_paragraph(std::make_unique<SourceParagraph>(*scf.core_paragraph))
+        SourceControlFile clone() const
         {
-            for (const auto& feat_ptr : scf.feature_paragraphs)
+            SourceControlFile ret;
+            ret.core_paragraph = std::make_unique<SourceParagraph>(*core_paragraph);
+            for (const auto& feat_ptr : feature_paragraphs)
             {
-                feature_paragraphs.push_back(std::make_unique<FeatureParagraph>(*feat_ptr));
+                ret.feature_paragraphs.push_back(std::make_unique<FeatureParagraph>(*feat_ptr));
             }
+            return ret;
         }
 
         static Parse::ParseExpected<SourceControlFile> parse_manifest_file(const fs::path& path_to_manifest,
@@ -128,7 +129,7 @@ namespace vcpkg
 
         SourceControlFileLocation clone() const
         {
-            return {std::make_unique<SourceControlFile>(*source_control_file), source_location};
+            return {std::make_unique<SourceControlFile>(source_control_file->clone()), source_location};
         }
 
         std::unique_ptr<SourceControlFile> source_control_file;

--- a/toolsrc/include/vcpkg/sourceparagraph.h
+++ b/toolsrc/include/vcpkg/sourceparagraph.h
@@ -10,6 +10,7 @@
 #include <vcpkg/packagespec.h>
 #include <vcpkg/paragraphparser.h>
 #include <vcpkg/platform-expression.h>
+#include <vcpkg/versions.h>
 
 namespace vcpkg
 {
@@ -54,6 +55,7 @@ namespace vcpkg
     struct SourceParagraph
     {
         std::string name;
+        Versions::Scheme version_scheme = Versions::Scheme::String;
         std::string version;
         int port_version = 0;
         std::vector<std::string> description;
@@ -114,12 +116,6 @@ namespace vcpkg
     /// </summary>
     struct SourceControlFileLocation
     {
-        SourceControlFileLocation(const SourceControlFileLocation& scfl)
-            : source_control_file(std::make_unique<SourceControlFile>(*scfl.source_control_file))
-            , source_location(scfl.source_location)
-        {
-        }
-
         SourceControlFileLocation(std::unique_ptr<SourceControlFile>&& scf, fs::path&& source)
             : source_control_file(std::move(scf)), source_location(std::move(source))
         {
@@ -128,6 +124,11 @@ namespace vcpkg
         SourceControlFileLocation(std::unique_ptr<SourceControlFile>&& scf, const fs::path& source)
             : source_control_file(std::move(scf)), source_location(source)
         {
+        }
+
+        SourceControlFileLocation clone() const
+        {
+            return {std::make_unique<SourceControlFile>(*source_control_file), source_location};
         }
 
         std::unique_ptr<SourceControlFile> source_control_file;

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -98,6 +98,14 @@ namespace vcpkg
         std::string m_str;
     };
 
+    struct FeatureFlagSettings
+    {
+        bool registries;
+        bool compiler_tracking;
+        bool binary_caching;
+        bool versions;
+    };
+
     struct VcpkgCmdArguments
     {
         static VcpkgCmdArguments create_from_command_line(const Files::Filesystem& fs,
@@ -173,12 +181,25 @@ namespace vcpkg
         Optional<bool> manifest_mode = nullopt;
         constexpr static StringLiteral REGISTRIES_FEATURE = "registries";
         Optional<bool> registries_feature = nullopt;
+        constexpr static StringLiteral VERSIONS_FEATURE = "versions";
+        Optional<bool> versions_feature = nullopt;
 
         constexpr static StringLiteral RECURSIVE_DATA_ENV = "VCPKG_X_RECURSIVE_DATA";
 
         bool binary_caching_enabled() const { return binary_caching.value_or(true); }
         bool compiler_tracking_enabled() const { return compiler_tracking.value_or(true); }
         bool registries_enabled() const { return registries_feature.value_or(false); }
+        bool versions_enabled() const { return versions_feature.value_or(false); }
+        FeatureFlagSettings feature_flag_settings() const
+        {
+            FeatureFlagSettings f;
+            f.binary_caching = binary_caching_enabled();
+            f.compiler_tracking = compiler_tracking_enabled();
+            f.registries = registries_enabled();
+            f.versions = versions_enabled();
+            return f;
+        }
+
         bool output_json() const { return json.value_or(false); }
         bool is_recursive_invocation() const { return m_is_recursive_invocation; }
 

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -125,6 +125,7 @@ namespace vcpkg
         const Build::CompilerInfo& get_compiler_info(const Build::AbiInfo& abi_info) const;
         bool manifest_mode_enabled() const { return get_manifest().has_value(); }
 
+        const FeatureFlagSettings& get_feature_flags() const;
         void track_feature_flag_metrics() const;
 
     private:

--- a/toolsrc/include/vcpkg/versions.h
+++ b/toolsrc/include/vcpkg/versions.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vcpkg/fwd/vcpkgpaths.h>
+
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace vcpkg::Versions
+{
+    enum class Scheme
+    {
+        String,
+        Relaxed,
+        Semver,
+        Date
+    };
+}

--- a/toolsrc/include/vcpkg/versions.h
+++ b/toolsrc/include/vcpkg/versions.h
@@ -2,11 +2,6 @@
 
 #include <vcpkg/fwd/vcpkgpaths.h>
 
-#include <set>
-#include <string>
-#include <tuple>
-#include <vector>
-
 namespace vcpkg::Versions
 {
     enum class Scheme

--- a/toolsrc/src/vcpkg-test/manifests.cpp
+++ b/toolsrc/src/vcpkg-test/manifests.cpp
@@ -39,6 +39,7 @@ static Parse::ParseExpected<SourceControlFile> test_parse_manifest(StringView sv
     {
         print_error_message(res.error());
     }
+    REQUIRE(res.has_value() == !expect_fail);
     return res;
 }
 
@@ -57,6 +58,57 @@ TEST_CASE ("manifest construct minimum", "[manifests]")
     REQUIRE(pgh.core_paragraph->maintainers.empty());
     REQUIRE(pgh.core_paragraph->description.empty());
     REQUIRE(pgh.core_paragraph->dependencies.empty());
+}
+
+TEST_CASE ("manifest versioning", "[manifests]")
+{
+    std::tuple<StringLiteral, Versions::Scheme, StringLiteral> data[] = {
+        {R"json({
+    "name": "zlib",
+    "version-string": "abcd"
+}
+)json",
+         Versions::Scheme::String,
+         "abcd"},
+        {R"json({
+    "name": "zlib",
+    "version-date": "2020-01-01"
+}
+)json",
+         Versions::Scheme::Date,
+         "2020-01-01"},
+        {R"json({
+    "name": "zlib",
+    "version": "1.2.3.4.5"
+}
+)json",
+         Versions::Scheme::Relaxed,
+         "1.2.3.4.5"},
+        {R"json({
+    "name": "zlib",
+    "version-semver": "1.2.3-rc3"
+}
+)json",
+         Versions::Scheme::Semver,
+         "1.2.3-rc3"},
+    };
+    for (auto v : data)
+    {
+        auto m_pgh = test_parse_manifest(std::get<0>(v));
+
+        REQUIRE(m_pgh.has_value());
+        auto& pgh = **m_pgh.get();
+        REQUIRE(Json::stringify(serialize_manifest(pgh), Json::JsonStyle::with_spaces(4)) == std::get<0>(v));
+        REQUIRE(pgh.core_paragraph->version_scheme == std::get<1>(v));
+        REQUIRE(pgh.core_paragraph->version == std::get<2>(v));
+    }
+
+    test_parse_manifest(R"json({
+        "name": "zlib",
+        "version-string": "abcd",
+        "version-semver": "1.2.3-rc3"
+    })json",
+                        true);
 }
 
 TEST_CASE ("manifest construct maximum", "[manifests]")

--- a/toolsrc/src/vcpkg-test/plan.cpp
+++ b/toolsrc/src/vcpkg-test/plan.cpp
@@ -389,9 +389,9 @@ TEST_CASE ("basic feature test 8", "[plan]")
     auto spec_c_64 = FullPackageSpec{spec_map.emplace("c", "a[a1]"), {"core"}};
 
     spec_map.triplet = Test::X86_WINDOWS;
-    auto spec_a_86 = FullPackageSpec{spec_map.emplace("a", "b", {{"a1", ""}}), {"core"}};
-    auto spec_b_86 = FullPackageSpec{spec_map.emplace("b")};
-    auto spec_c_86 = FullPackageSpec{spec_map.emplace("c", "a[a1]"), {"core"}};
+    auto spec_a_86 = FullPackageSpec{PackageSpec{"a", Test::X86_WINDOWS}};
+    auto spec_b_86 = FullPackageSpec{PackageSpec{"b", Test::X86_WINDOWS}};
+    auto spec_c_86 = FullPackageSpec{PackageSpec{"c", Test::X86_WINDOWS}};
 
     PortFileProvider::MapPortFileProvider map_port{spec_map.map};
     MockCMakeVarProvider var_provider;

--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -109,6 +109,7 @@ namespace vcpkg::Test
     PackageSpec PackageSpecMap::emplace(vcpkg::SourceControlFileLocation&& scfl)
     {
         const auto& name = scfl.source_control_file->core_paragraph->name;
+        REQUIRE(map.find(name) == map.end());
         map.emplace(name, std::move(scfl));
         return {name, triplet};
     }

--- a/toolsrc/src/vcpkg-test/util.cpp
+++ b/toolsrc/src/vcpkg-test/util.cpp
@@ -108,8 +108,9 @@ namespace vcpkg::Test
 
     PackageSpec PackageSpecMap::emplace(vcpkg::SourceControlFileLocation&& scfl)
     {
-        map.emplace(scfl.source_control_file->core_paragraph->name, std::move(scfl));
-        return {scfl.source_control_file->core_paragraph->name, triplet};
+        const auto& name = scfl.source_control_file->core_paragraph->name;
+        map.emplace(name, std::move(scfl));
+        return {name, triplet};
     }
 
     static AllowSymlinks internal_can_create_symlinks() noexcept

--- a/toolsrc/src/vcpkg/commands.ci.cpp
+++ b/toolsrc/src/vcpkg/commands.ci.cpp
@@ -338,7 +338,7 @@ namespace vcpkg::Commands::CI
                 ret->features.emplace(action.spec, action.feature_list);
                 if (auto scfl = p->source_control_file_location.get())
                 {
-                    auto emp = ret->default_feature_provider.emplace(p->spec.name(), *scfl);
+                    auto emp = ret->default_feature_provider.emplace(p->spec.name(), scfl->clone());
                     emp.first->second.source_control_file->core_paragraph->default_features = p->feature_list;
 
                     p->build_options = vcpkg::Build::default_build_package_options;

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -684,10 +684,15 @@ namespace vcpkg::Dependencies
         std::vector<FeatureSpec> feature_specs;
         for (const FullPackageSpec& spec : specs)
         {
-            const SourceControlFileLocation* scfl = port_provider.get_control_file(spec.package_spec.name()).get();
+            auto maybe_scfl = port_provider.get_control_file(spec.package_spec.name());
 
-            Checks::check_exit(
-                VCPKG_LINE_INFO, scfl, "Error: Cannot find definition for package `%s`.", spec.package_spec.name());
+            Checks::check_exit(VCPKG_LINE_INFO,
+                               maybe_scfl.has_value(),
+                               "Error: while loading port `%s`: %s",
+                               spec.package_spec.name(),
+                               maybe_scfl.error());
+
+            const SourceControlFileLocation* scfl = maybe_scfl.get();
 
             const std::vector<std::string> all_features =
                 Util::fmap(scfl->source_control_file->feature_paragraphs,

--- a/toolsrc/src/vcpkg/portfileprovider.cpp
+++ b/toolsrc/src/vcpkg/portfileprovider.cpp
@@ -5,6 +5,7 @@
 #include <vcpkg/portfileprovider.h>
 #include <vcpkg/registries.h>
 #include <vcpkg/sourceparagraph.h>
+#include <vcpkg/vcpkgcmdarguments.h>
 
 namespace vcpkg::PortFileProvider
 {
@@ -59,16 +60,10 @@ namespace vcpkg::PortFileProvider
         }
     }
 
-    ExpectedS<const SourceControlFileLocation&> PathsPortFileProvider::get_control_file(const std::string& spec) const
+    static Optional<SourceControlFileLocation> try_load_overlay_port(const Files::Filesystem& fs,
+                                                                     View<fs::path> overlay_ports,
+                                                                     const std::string& spec)
     {
-        auto cache_it = cache.find(spec);
-        if (cache_it != cache.end())
-        {
-            return cache_it->second;
-        }
-
-        const auto& fs = paths.get_filesystem();
-
         for (auto&& ports_dir : overlay_ports)
         {
             // Try loading individual port
@@ -79,10 +74,7 @@ namespace vcpkg::PortFileProvider
                 {
                     if (scf->get()->core_paragraph->name == spec)
                     {
-                        auto it = cache.emplace(std::piecewise_construct,
-                                                std::forward_as_tuple(spec),
-                                                std::forward_as_tuple(std::move(*scf), ports_dir));
-                        return it.first->second;
+                        return SourceControlFileLocation{std::move(*scf), ports_dir};
                     }
                 }
                 else
@@ -103,10 +95,7 @@ namespace vcpkg::PortFileProvider
                 {
                     if (scf->get()->core_paragraph->name == spec)
                     {
-                        auto it = cache.emplace(std::piecewise_construct,
-                                                std::forward_as_tuple(std::move(spec)),
-                                                std::forward_as_tuple(std::move(*scf), std::move(ports_spec)));
-                        return it.first->second;
+                        return SourceControlFileLocation{std::move(*scf), std::move(ports_spec)};
                     }
                     Checks::exit_with_message(VCPKG_LINE_INFO,
                                               "Error: Failed to load port from %s: names did not match: '%s' != '%s'",
@@ -122,7 +111,12 @@ namespace vcpkg::PortFileProvider
                 }
             }
         }
+        return nullopt;
+    }
 
+    static Optional<SourceControlFileLocation> try_load_registry_port(const VcpkgPaths& paths, const std::string& spec)
+    {
+        const auto& fs = paths.get_filesystem();
         if (auto registry = paths.get_configuration().registry_set.registry_for_port(spec))
         {
             auto registry_root = registry->get_registry_root(paths);
@@ -135,10 +129,7 @@ namespace vcpkg::PortFileProvider
                 {
                     if (scf->get()->core_paragraph->name == spec)
                     {
-                        auto it = cache.emplace(std::piecewise_construct,
-                                                std::forward_as_tuple(spec),
-                                                std::forward_as_tuple(std::move(*scf), std::move(port_directory)));
-                        return it.first->second;
+                        return SourceControlFileLocation{std::move(*scf), std::move(port_directory)};
                     }
                     Checks::exit_with_message(VCPKG_LINE_INFO,
                                               "Error: Failed to load port from %s: names did not match: '%s' != '%s'",
@@ -154,8 +145,44 @@ namespace vcpkg::PortFileProvider
                 }
             }
         }
+        return nullopt;
+    }
 
-        return std::string("Port definition not found");
+    ExpectedS<const SourceControlFileLocation&> PathsPortFileProvider::get_control_file(const std::string& spec) const
+    {
+        auto cache_it = cache.find(spec);
+        if (cache_it == cache.end())
+        {
+            const auto& fs = paths.get_filesystem();
+            auto maybe_port = try_load_overlay_port(fs, overlay_ports, spec);
+            if (!maybe_port)
+            {
+                maybe_port = try_load_registry_port(paths, spec);
+            }
+            if (auto p = maybe_port.get())
+            {
+                cache_it = cache.emplace(spec, std::move(*p)).first;
+            }
+        }
+
+        if (cache_it == cache.end())
+        {
+            return std::string("Port definition not found");
+        }
+        else
+        {
+            if (!paths.get_feature_flags().versions)
+            {
+                if (cache_it->second.source_control_file->core_paragraph->version_scheme != Versions::Scheme::String)
+                {
+                    return Strings::concat(
+                        "Port definition rejected because the `",
+                        VcpkgCmdArguments::VERSIONS_FEATURE,
+                        "` feature flag is disabled.\nThis can be fixed by using the \"version-string\" field.");
+                }
+            }
+            return cache_it->second;
+        }
     }
 
     std::vector<const SourceControlFileLocation*> PathsPortFileProvider::load_all_control_files() const

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -51,6 +51,7 @@ namespace vcpkg
             {VcpkgCmdArguments::MANIFEST_MODE_FEATURE, args.manifest_mode},
             {VcpkgCmdArguments::COMPILER_TRACKING_FEATURE, args.compiler_tracking},
             {VcpkgCmdArguments::REGISTRIES_FEATURE, args.registries_feature},
+            {VcpkgCmdArguments::VERSIONS_FEATURE, args.versions_feature},
         };
 
         for (const auto& desc : flag_descriptions)
@@ -765,6 +766,7 @@ namespace vcpkg
             {MANIFEST_MODE_FEATURE, manifest_mode},
             {COMPILER_TRACKING_FEATURE, compiler_tracking},
             {REGISTRIES_FEATURE, registries_feature},
+            {VERSIONS_FEATURE, versions_feature},
         };
 
         for (const auto& flag : flags)
@@ -790,6 +792,7 @@ namespace vcpkg
             {BINARY_CACHING_FEATURE, binary_caching_enabled()},
             {COMPILER_TRACKING_FEATURE, compiler_tracking_enabled()},
             {REGISTRIES_FEATURE, registries_enabled()},
+            {VERSIONS_FEATURE, versions_enabled()},
         };
 
         for (const auto& flag : flags)
@@ -931,6 +934,6 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::COMPILER_TRACKING_FEATURE;
     constexpr StringLiteral VcpkgCmdArguments::MANIFEST_MODE_FEATURE;
     constexpr StringLiteral VcpkgCmdArguments::REGISTRIES_FEATURE;
-
     constexpr StringLiteral VcpkgCmdArguments::RECURSIVE_DATA_ENV;
+    constexpr StringLiteral VcpkgCmdArguments::VERSIONS_FEATURE;
 }

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -186,8 +186,11 @@ namespace vcpkg
     {
         struct VcpkgPathsImpl
         {
-            VcpkgPathsImpl(Files::Filesystem& fs, bool compiler_tracking)
-                : fs_ptr(&fs), m_tool_cache(get_tool_cache()), m_env_cache(compiler_tracking)
+            VcpkgPathsImpl(Files::Filesystem& fs, FeatureFlagSettings ff_settings)
+                : fs_ptr(&fs)
+                , m_tool_cache(get_tool_cache())
+                , m_env_cache(ff_settings.compiler_tracking)
+                , m_ff_settings(ff_settings)
             {
             }
 
@@ -209,11 +212,13 @@ namespace vcpkg
             Optional<std::pair<Json::Object, Json::JsonStyle>> m_manifest_doc;
             fs::path m_manifest_path;
             Configuration m_config;
+
+            FeatureFlagSettings m_ff_settings;
         };
     }
 
     VcpkgPaths::VcpkgPaths(Files::Filesystem& filesystem, const VcpkgCmdArguments& args)
-        : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(filesystem, args.compiler_tracking_enabled()))
+        : m_pimpl(std::make_unique<details::VcpkgPathsImpl>(filesystem, args.feature_flag_settings()))
     {
         original_cwd = filesystem.current_path(VCPKG_LINE_INFO);
 #if defined(_WIN32)
@@ -563,6 +568,8 @@ If you wish to silence this error and use classic mode, you can:
     }
 
     Files::Filesystem& VcpkgPaths::get_filesystem() const { return *m_pimpl->fs_ptr; }
+
+    const FeatureFlagSettings& VcpkgPaths::get_feature_flags() const { return m_pimpl->m_ff_settings; }
 
     void VcpkgPaths::track_feature_flag_metrics() const
     {


### PR DESCRIPTION
* Introduce FeatureFlagSettings struct to more easily access feature flags throughout the program
* To avoid users accidentally starting to write "version" instead of "version-string" in their manifests, vcpkg explicitly detects and prevents usage of ports with schemes other than "String"

Example output when changing `abseil`'s field to just `"version"`:
```
PS C:\src\vcpkg> ./vcpkg install abseil
Computing installation plan...
Error: while loading port `abseil`: Port definition rejected because the `versions` feature flag is disabled.
This can be fixed by using the "version-string" field.
```

* Drive-by fix of copiable SourceControlFileLocation and an exposed use-after-move bug

This code is largely extracted from PR #13777