### PR TITLE
[hpx] Fix cmake config issue

### DIFF
--- a/ports/hpx/CONTROL
+++ b/ports/hpx/CONTROL
@@ -1,5 +1,6 @@
 Source: hpx
 Version: 1.5.1
+Port-Version: 1
 Build-Depends: hwloc, boost-accumulators, boost-algorithm, boost-asio, boost-bimap, boost-config, boost-context, boost-dynamic-bitset, boost-exception, boost-filesystem, boost-iostreams, boost-lockfree, boost-program-options, boost-range, boost-spirit, boost-system, boost-throw-exception, boost-variant, boost-winapi
 Homepage: https://github.com/STEllAR-GROUP/hpx
 Description: The C++ Standards Library for Concurrency and Parallelism

--- a/ports/hpx/portfile.cmake
+++ b/ports/hpx/portfile.cmake
@@ -42,6 +42,11 @@ foreach(CMAKE_FILE IN LISTS CMAKE_FILES)
 endforeach()
 
 vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/HPXConfig.cmake"
+    "set(HPX_BUILD_TYPE \"Release\")"
+    "set(HPX_BUILD_TYPE \"\${CMAKE_BUILD_TYPE}\")")
+
+vcpkg_replace_string(
     "${CURRENT_PACKAGES_DIR}/share/${PORT}/HPXMacros.cmake"
     "set(CMAKE_MODULE_PATH \${CMAKE_MODULE_PATH} \"\${CMAKE_CURRENT_LIST_DIR}\")"
     "list(APPEND CMAKE_MODULE_PATH \"\${CMAKE_CURRENT_LIST_DIR}\")")


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14104

The  HPX_BUILD_TYPE set to release in HPXConfig.cmake file, this cause build failure when using the port in debug configuration.
Update it to ${CMAKE_BUILD_TYPE}.