### PR TITLE
[mlpack] Update to 3.4.1

### DIFF
--- a/ports/mlpack/CONTROL
+++ b/ports/mlpack/CONTROL
@@ -2,7 +2,7 @@ Source: mlpack
 Version: 3.4.1
 Homepage: https://github.com/mlpack/mlpack
 Description: mlpack is a fast, flexible machine learning library, written in C++, that aims to provide fast, extensible implementations of cutting-edge machine learning algorithms.
-Build-Depends: openblas, lapack, boost, armadillo, ensmallen, stb
+Build-Depends: boost, armadillo, ensmallen, stb
 Supports: !uwp
 
 Feature: tools

--- a/ports/mlpack/CONTROL
+++ b/ports/mlpack/CONTROL
@@ -1,6 +1,5 @@
 Source: mlpack
-Version: 3.2.2
-Port-Version: 6
+Version: 3.4.1
 Homepage: https://github.com/mlpack/mlpack
 Description: mlpack is a fast, flexible machine learning library, written in C++, that aims to provide fast, extensible implementations of cutting-edge machine learning algorithms.
 Build-Depends: openblas, lapack, boost, armadillo, ensmallen, stb

--- a/ports/mlpack/cmakelists.patch
+++ b/ports/mlpack/cmakelists.patch
@@ -1,34 +1,28 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6fe6d81..c2b567d 100644
+index 6fe6d81..b59555c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -291,11 +291,13 @@ endif()
+@@ -291,7 +291,7 @@ endif()
  #   ENSMALLEN_INCLUDE_DIR - include directory for ensmallen
  #   STB_IMAGE_INCLUDE_DIR - include directory for STB image library
  #   MATHJAX_ROOT - root of MathJax installation
-+find_package(LAPACK REQUIRED)
-+find_package(BLAS REQUIRED)
- find_package(Armadillo "${ARMADILLO_VERSION}" REQUIRED)
+-find_package(Armadillo "${ARMADILLO_VERSION}" REQUIRED)
++find_package(Armadillo CONFIG "${ARMADILLO_VERSION}" REQUIRED)
  
  # Include directories for the previous dependencies.
  set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} ${ARMADILLO_INCLUDE_DIRS})
--set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES})
-+set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
- 
- # Find stb_image.h and stb_image_write.h.
- find_package(StbImage)
-@@ -388,8 +390,8 @@ if (NOT ENSMALLEN_FOUND)
+@@ -388,8 +388,8 @@ if (NOT ENSMALLEN_FOUND)
              "Successfully downloaded ensmallen into ${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/")
  
          # Now we have to also ensure these header files get installed.
 -        install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
 -        install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-+       # install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
-+      #  install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++        #install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
++        #install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
        else ()
          message(FATAL_ERROR "Problem unpacking ensmallen!  Expected only one directory ensmallen-x.y.z/; found ${ENS_DIRECTORIES}. Try removing the directory ${CMAKE_BINARY_DIR}/deps and reconfiguring.")
        endif ()
-@@ -446,6 +448,7 @@ find_package(Boost "${BOOST_VERSION}"
+@@ -446,6 +446,7 @@ find_package(Boost "${BOOST_VERSION}"
      REQUIRED
  )
  
@@ -36,7 +30,7 @@ index 6fe6d81..c2b567d 100644
  link_directories(${Boost_LIBRARY_DIRS})
  
  # In Visual Studio, automatic linking is performed, so we don't need to worry
-@@ -457,10 +460,12 @@ if (MSVC)
+@@ -457,10 +458,12 @@ if (MSVC)
    message("boost lib dirs ${Boost_LIBRARY_DIRS}")
    set(Boost_LIBRARIES "")
  endif ()

--- a/ports/mlpack/cmakelists.patch
+++ b/ports/mlpack/cmakelists.patch
@@ -1,60 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 26757a5..c200b40 100644
+index 6fe6d81..c2b567d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -288,6 +282,7 @@ endif()
- # and find LAPACK and BLAS ourselves, using a slightly modified variant of the
- # script Armadillo uses to find these.
- if (WIN32)
-+ if(0)
-   find_library(LAPACK_LIBRARY
-       NAMES lapack liblapack lapack_win32_MT lapack_win32
-       PATHS "C:/Program Files/Armadillo"
-@@ -305,24 +306,25 @@ if (WIN32)
-   if (NOT BLAS_LIBRARY)
-     message(FATAL_ERROR "Cannot find BLAS library (.lib)!")
-   endif ()
-+ endif()
+@@ -291,11 +291,13 @@ endif()
+ #   ENSMALLEN_INCLUDE_DIR - include directory for ensmallen
+ #   STB_IMAGE_INCLUDE_DIR - include directory for STB image library
+ #   MATHJAX_ROOT - root of MathJax installation
++find_package(LAPACK REQUIRED)
++find_package(BLAS REQUIRED)
+ find_package(Armadillo "${ARMADILLO_VERSION}" REQUIRED)
  
-+  find_package(LAPACK REQUIRED)
-+  find_package(BLAS REQUIRED)
-   # Piggyback LAPACK and BLAS linking into Armadillo link.
-   set(ARMADILLO_LIBRARIES
--      ${ARMADILLO_LIBRARIES} ${BLAS_LIBRARY} ${LAPACK_LIBRARY})
-+      ${ARMADILLO_LIBRARIES} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
+ # Include directories for the previous dependencies.
+ set(MLPACK_INCLUDE_DIRS ${MLPACK_INCLUDE_DIRS} ${ARMADILLO_INCLUDE_DIRS})
+-set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES})
++set(MLPACK_LIBRARIES ${MLPACK_LIBRARIES} ${ARMADILLO_LIBRARIES} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES})
  
-   # Ensure that the libraries are added to the MSVC IDE runtime path.
--  get_filename_component(BLAS_DIR ${BLAS_LIBRARY} DIRECTORY)
--  get_filename_component(LAPACK_DIR ${LAPACK_LIBRARY} DIRECTORY)
- 
-   # Sometimes, especially with an OpenBLAS install via nuget, the DLLs are
-   # actually in ../../bin/x64/.  Automatically add these.
--  if (EXISTS "${BLAS_DIR}/../../bin/x64/")
--    get_filename_component(BLAS_DLL_DIR "${BLAS_DIR}/../../bin/x64" ABSOLUTE)
-+  if (0)
-+    get_filename_component(BLAS_DLL_DIR "${BLAS_DIR}" ABSOLUTE)
-     set(DLL_COPY_DIRS ${DLL_COPY_DIRS} "${BLAS_DLL_DIR}")
-   endif ()
- 
--  if (EXISTS "${LAPACK_DIR}/../../bin/x64/")
--    get_filename_component(LAPACK_DLL_DIR "${LAPACK_DIR}/../../bin/x64" ABSOLUTE)
-+  if (0)
-+    get_filename_component(LAPACK_DLL_DIR "${LAPACK_DIR}" ABSOLUTE)
-     set(DLL_COPY_DIRS ${DLL_COPY_DIRS} "${BLAS_DLL_DIR}")
-   endif ()
- endif ()
-@@ -415,8 +423,8 @@ if (NOT ENSMALLEN_FOUND)
+ # Find stb_image.h and stb_image_write.h.
+ find_package(StbImage)
+@@ -388,8 +390,8 @@ if (NOT ENSMALLEN_FOUND)
              "Successfully downloaded ensmallen into ${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/")
  
          # Now we have to also ensure these header files get installed.
 -        install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
 -        install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-+        #install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
-+        #install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++       # install(DIRECTORY "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen_bits/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ensmallen_bits")
++      #  install(FILES "${CMAKE_BINARY_DIR}/deps/${ENSMALLEN_INCLUDE_DIR}/include/ensmallen.hpp" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
        else ()
          message(FATAL_ERROR "Problem unpacking ensmallen!  Expected only one directory ensmallen-x.y.z/; found ${ENS_DIRECTORIES}. Try removing the directory ${CMAKE_BINARY_DIR}/deps and reconfiguring.")
        endif ()
-@@ -472,6 +480,7 @@ find_package(Boost 1.49
+@@ -446,6 +448,7 @@ find_package(Boost "${BOOST_VERSION}"
      REQUIRED
  )
  
@@ -62,7 +36,7 @@ index 26757a5..c200b40 100644
  link_directories(${Boost_LIBRARY_DIRS})
  
  # In Visual Studio, automatic linking is performed, so we don't need to worry
-@@ -483,10 +492,12 @@ if (MSVC)
+@@ -457,10 +460,12 @@ if (MSVC)
    message("boost lib dirs ${Boost_LIBRARY_DIRS}")
    set(Boost_LIBRARIES "")
  endif ()

--- a/ports/mlpack/portfile.cmake
+++ b/ports/mlpack/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mlpack/mlpack
-    REF a8af4882af5e163ae8c8023653c66c8914ac1c22 # 3.2.2
-    SHA512 879dd24f6cface3e6e1a0990e912ca4463060725c7c105e1e7d228c90123b1f44728cbe1ae327fa20e0e4981626a5d1eb2c411257899ef849c9600891616eed4
+    REF 7ae9ddda86c1751b6509ceb48b27d182feaae439 # 3.4.1
+    SHA512 db68c16b80af7037ac562f93775b6262f1552fbc89daa0c621075e2ff70a8306523da8eb74e33ac15ba34c9ccef8f2746bd1e4efa7c280a5be77b53c69d3f9a1
     HEAD_REF master
     PATCHES
         cmakelists.patch
@@ -35,6 +35,9 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/mlpack)
+
 vcpkg_copy_pdbs()
 
 if("tools" IN_LIST FEATURES)
@@ -85,6 +88,9 @@ if("tools" IN_LIST FEATURES)
         mlpack_range_search
         mlpack_softmax_regression
         mlpack_sparse_coding
+        mlpack_image_converter
+        mlpack_bayesian_linear_regression
+        mlpack_preprocess_one_hot_encoding
     )
 endif()
 


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/13536

1. Update mlpack to latest release revision, and update the patch to match the source change.
2. Remove 'openblas, lapack' in mlpack dependency since mlpack depends on armadillo, armadillo depends on openblas and lapack, they should handled by armadillo.


All features test pass with x64-windows.