### PR TITLE
[vcpkg] Vcpkg appinstall deps fixes

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -459,7 +459,7 @@ function(x_vcpkg_install_local_dependencies)
         cmake_parse_arguments(__VCPKG_APPINSTALL "" "DESTINATION" "TARGETS" ${ARGN})
 
         foreach(TARGET ${__VCPKG_APPINSTALL_TARGETS})
-            _install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
+            install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                 execute_process(COMMAND 
                     powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
                     -targetBinary \"${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -462,7 +462,7 @@ function(x_vcpkg_install_local_dependencies)
             install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                 execute_process(COMMAND 
                     powershell -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
-                    -targetBinary \"${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
+                    -targetBinary \"\${CMAKE_INSTALL_PREFIX}/${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
                     -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
                     -OutVariable out)")
         endforeach()


### PR DESCRIPTION
@Shatur95 mentioned in issue #1653 that he was missing `_install` if `install` is not overriden with a custom function than `_install` will not be found so we should refer to install in this function

Also I was prefixing the `${CMAKE_INSTALL_PREFIX}` in my custom `install` override but as @Shatur95 points out it makes more sense to do that in the vcpkg.cmake file.

This is a continuation/bugfix on #13011