### PR TITLE
[efsw] Fix share location

### DIFF
--- a/ports/efsw/fix-cmake-config-path.patch
+++ b/ports/efsw/fix-cmake-config-path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2e591d..51f3e8a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,7 +119,7 @@ endif()
+ 
+ include(CMakePackageConfigHelpers)
+ 
+-set(packageDestDir "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}")
++set(packageDestDir "${CMAKE_INSTALL_LIBDIR}/cmake")
+ 
+ configure_package_config_file(
+ 	${CMAKE_CURRENT_SOURCE_DIR}/efswConfig.cmake.in

--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF b62d04829bb0a6f3cacc7859e0b046a3c053bc50
     SHA512 fc16ef6ad330941dc0a1112ce645b57bd126d353556d50f45fadf150f25edd42c1d4946bc54d629d94c208d67d4ce17dbf5d1079cbeed51f0f6b1ccbe2199132
     HEAD_REF master
+    PATCHES fix-cmake-config-path.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
Efsw did not work with FindPackage, because the location of the cmake
config files was in an extra directory (share/efsw/efsw).  This patches
the cmake file to fix it.

Fixes #14128

