### PR TITLE
[efsw] Fix share location

### DIFF
--- a/ports/efsw/CONTROL
+++ b/ports/efsw/CONTROL
@@ -1,5 +1,6 @@
 Source: efsw
 Version: 2020-06-08
+Port-Version: 1
 Homepage: https://github.com/SpartanJ/efsw
 Description: efsw is a C++ cross-platform file system watcher and notifier.
 Supports: !uwp

--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/efsw/portfile.cmake
+++ b/ports/efsw/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/efsw)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14128 
Efsw did not work with FindPackage, because the location of the cmake
config files was in an extra directory (share/efsw/efsw).This problem can 
be solved by modifying the CONFIG_PATH of vcpkg_fixup_cmake_targets 
to prevent it from copying the entire folder

