### PR TITLE
[opencv4] Fix INTERFACE_LINK_LIBRARIES error

### DIFF
--- a/ports/opencv4/0010-fix-interface_link_libraries.patch
+++ b/ports/opencv4/0010-fix-interface_link_libraries.patch
@@ -1,0 +1,14 @@
+diff --git a/modules/videoio/cmake/init.cmake b/modules/videoio/cmake/init.cmake
+index 1efef12..0b6dc99 100644
+--- a/modules/videoio/cmake/init.cmake
++++ b/modules/videoio/cmake/init.cmake
+@@ -12,8 +12,8 @@ function(ocv_add_external_target name inc link def)
+   set_target_properties(ocv.3rdparty.${name} PROPERTIES
+     INTERFACE_INCLUDE_DIRECTORIES "${inc}"
+     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${inc}"
+-    INTERFACE_LINK_LIBRARIES "${link}"
+     INTERFACE_COMPILE_DEFINITIONS "${def}")
++  target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
+   if(NOT BUILD_SHARED_LIBS)
+     install(TARGETS ocv.3rdparty.${name} EXPORT OpenCVModules)
+   endif()

--- a/ports/opencv4/0010-fix-interface_link_libraries.patch
+++ b/ports/opencv4/0010-fix-interface_link_libraries.patch
@@ -1,14 +1,22 @@
 diff --git a/modules/videoio/cmake/init.cmake b/modules/videoio/cmake/init.cmake
-index 1efef12..0b6dc99 100644
+index 1efef12..81d5d9f 100644
 --- a/modules/videoio/cmake/init.cmake
 +++ b/modules/videoio/cmake/init.cmake
-@@ -12,8 +12,8 @@ function(ocv_add_external_target name inc link def)
+@@ -12,8 +12,16 @@ function(ocv_add_external_target name inc link def)
    set_target_properties(ocv.3rdparty.${name} PROPERTIES
      INTERFACE_INCLUDE_DIRECTORIES "${inc}"
      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${inc}"
 -    INTERFACE_LINK_LIBRARIES "${link}"
      INTERFACE_COMPILE_DEFINITIONS "${def}")
-+  target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
++  # When cmake version is greater than or equal to 3.11, INTERFACE_LINK_LIBRARIES no longer applies to interface library
++  # See https://github.com/opencv/opencv/pull/18658
++  if (CMAKE_VERSION VERSION_LESS 3.11)
++    set_target_properties(ocv.3rdparty.${name} PROPERTIES
++      INTERFACE_LINK_LIBRARIES "${link}")
++  else()
++    target_link_libraries(ocv.3rdparty.${name} INTERFACE ${link})
++  endif()
++  #
    if(NOT BUILD_SHARED_LIBS)
      install(TARGETS ocv.3rdparty.${name} EXPORT OpenCVModules)
    endif()

--- a/ports/opencv4/CONTROL
+++ b/ports/opencv4/CONTROL
@@ -1,6 +1,6 @@
 Source: opencv4
 Version: 4.3.0
-Port-Version: 3
+Port-Version: 4
 Build-Depends: zlib
 Homepage: https://github.com/opencv/opencv
 Description: computer vision library

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
       0004-fix-policy-CMP0057.patch
       0006-jpeg2000_getref.patch
       0009-fix-uwp.patch
+      0010-fix-interface_link_libraries.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/cmake/FindCUDNN.cmake")

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_from_github(
       0004-fix-policy-CMP0057.patch
       0006-jpeg2000_getref.patch
       0009-fix-uwp.patch
-      0010-fix-interface_link_libraries.patch
+      0010-fix-interface_link_libraries.patch # Remove this patch when the next update
 )
 
 file(REMOVE "${SOURCE_PATH}/cmake/FindCUDNN.cmake")


### PR DESCRIPTION
Fix configure error:
```
INTERFACE_LINK_LIBRARIES: optimized;F:/vcpkg/installed/x64-windows/lib/avcodec.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avcodec.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avdevice.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avdevice.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avfilter.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avfilter.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avformat.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avformat.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avresample.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avresample.lib;optimized;F:/vcpkg/installed/x64-windows/lib/avutil.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/avutil.lib;optimized;F:/vcpkg/installed/x64-windows/lib/postproc.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/postproc.lib;optimized;F:/vcpkg/installed/x64-windows/lib/swresample.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/swresample.lib;optimized;F:/vcpkg/installed/x64-windows/lib/swscale.lib;debug;F:/vcpkg/installed/x64-windows/debug/lib/swscale.lib;optimized;wsock32;debug;wsock32;optimized;ws2_32;debug;ws2_32;optimized;secur32;debug;secur32;optimized;bcrypt;debug;bcrypt;optimized;strmiids;debug;strmiids;optimized;Vfw32;debug;Vfw32;optimized;Shlwapi;debug;Shlwapi;optimized;mfplat;debug;mfplat;optimized;mfuuid;debug;mfuuid
CMake Error at modules/videoio/cmake/init.cmake:13 (set_target_properties):
  Property INTERFACE_LINK_LIBRARIES may not contain link-type keyword
  "optimized".  The INTERFACE_LINK_LIBRARIES property may contain
  configuration-sensitive generator-expressions which may be used to specify
  per-configuration rules.
Call Stack (most recent call first):
  modules/videoio/cmake/detect_ffmpeg.cmake:60 (ocv_add_external_target)
  modules/videoio/cmake/init.cmake:3 (include)
  modules/videoio/cmake/init.cmake:23 (add_backend)
  cmake/OpenCVModule.cmake:312 (include)
  cmake/OpenCVModule.cmake:375 (_add_modules_1)
  modules/CMakeLists.txt:7 (ocv_glob_modules)
```

Fixes #14171.