### PR TITLE
[pixman] fix build failure on ARM32 due to sse2

### DIFF
--- a/ports/pixman/CMakeLists.txt
+++ b/ports/pixman/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(pixman-1 ${SOURCES})
 target_include_directories(pixman-1 PUBLIC $<INSTALL_INTERFACE:include>)
 target_compile_definitions(pixman-1 ${PIXMAN_DEFS})
 
-if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+if(USE_SSE2 AND UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     target_compile_options(pixman-1 PRIVATE -msse2)
 endif()
 

--- a/ports/pixman/CONTROL
+++ b/ports/pixman/CONTROL
@@ -1,4 +1,5 @@
 Source: pixman
-Version: 0.38.4-1
+Version: 0.38.4
+Port-Version: 2
 Homepage: https://www.cairographics.org/releases
 Description: Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.


### PR DESCRIPTION
* CMakeFile.txt fix: Use the USE_SSE2 flag in the if-statement to apply '-msse2'.
* This fixes #14178 since USE_SSE2 is not enabled on ARM.