### PR TITLE
[icu] Add MSVC ARM64 support

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,6 +1,6 @@
 Source: icu
 Version: 67.1
-Port-Version: 5
+Port-Version: 6
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -532,7 +532,6 @@ hiredis:x64-uwp=fail
 hpx:x64-windows-static=fail
 hpx:x64-linux=fail
 libhsplasma:x64-windows-static=fail
-icu:arm64-windows=fail
 icu:arm-uwp=fail
 icu:x64-uwp=fail
 idevicerestore:x64-linux=fail


### PR DESCRIPTION
- What does your PR fix?

This PR adds support for building icu using MSVC for ARM64.

- Which triplets are supported/not supported? Have you updated the CI baseline?

ARM64, yes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes