### PR TITLE
[libmariadb] Fix OpenSSL feature option

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,5 +1,6 @@
 Source: libmariadb
 Version: 3.1.10
+Port-Version: 1
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
 Default-Features: zlib, openssl

--- a/ports/libmariadb/portfile.cmake
+++ b/ports/libmariadb/portfile.cmake
@@ -17,9 +17,14 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     zlib WITH_EXTERNAL_ZLIB
-    openssl WITH_SSL
     iconv WITH_ICONV
 )
+
+if("openssl" IN_LIST FEATURES)
+	set(WITH_SSL OPENSSL)
+else()
+	set(WITH_SSL OFF)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -28,6 +33,7 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
         -DWITH_UNITTEST=OFF
         -DWITH_CURL=OFF
+        -DWITH_SSL=${WITH_SSL}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
libmariadb newer versions defines SSL support in a different way than before (as they added GNUTls support).
This commit replaces WITH_SSL=ON to WITH_SSL=OPENSSL to force libmariadb to link agains OpenSSL.

Without this changes, under any other platform than Windows, SSL support will be disabled, while on Windows it will rely on Windows libraries (it also seems to be, as reported in #13848 that automatic linking for such libraries is missing a library)

Linking issues reported in #13848 with drogon:x86-windows are fixed.
