### PR TITLE
Enable ICC support in libmupdf

### DIFF
--- a/ports/libmupdf/CMakeLists.txt
+++ b/ports/libmupdf/CMakeLists.txt
@@ -32,9 +32,9 @@ list(FILTER SOURCES EXCLUDE REGEX "source/tests/.*.c$")
 add_library(libmupdf ${SOURCES})
 
 if(WIN32)
-  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0)
+  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0)
 else()
-  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DFZ_ENABLE_ICC=0 -DHAVE_PTHREAD=1)
+  target_compile_definitions(libmupdf PRIVATE -DSHARE_JPEG -DFZ_ENABLE_JS=0 -DHAVE_PTHREAD=1)
 endif()
 target_include_directories(libmupdf
   PUBLIC


### PR DESCRIPTION
**Describe the pull request**

Remove the `FZ_ENABLE_ICC=0` build flag

- What does your PR fix?

Some PDFs do not render correctly when the flag is enabled, this PR fixes this problem:

![image](https://user-images.githubusercontent.com/7120851/97087938-970b3200-15fb-11eb-93a4-918959393147.png)![image](https://user-images.githubusercontent.com/7120851/97087967-c91c9400-15fb-11eb-80bd-523767a55d0d.png)


