### PR TITLE
[vcpkg] Remove hard-coded ApiKey from nuget push

### DIFF
--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -393,8 +393,6 @@ namespace
                     cmd.path_arg(nuget_exe)
                         .string_arg("push")
                         .path_arg(nupkg_path)
-                        .string_arg("-ApiKey")
-                        .string_arg("AzureDevOps")
                         .string_arg("-ForceEnglishOutput")
                         .string_arg("-Source")
                         .string_arg(write_src);
@@ -426,8 +424,6 @@ namespace
                     cmd.path_arg(nuget_exe)
                         .string_arg("push")
                         .path_arg(nupkg_path)
-                        .string_arg("-ApiKey")
-                        .string_arg("AzureDevOps")
                         .string_arg("-ForceEnglishOutput")
                         .string_arg("-ConfigFile")
                         .path_arg(write_cfg);


### PR DESCRIPTION
**Describe the pull request**
After experimenting with vcpkg binary caching feature and trying to upload the built binaries to GitHub Packages using NuGet, I ran into a similar authentication issue as #12984.

This PR removes the hard-coded NuGet API key so that a user's specified key can be used in a `VCPKG_BINARY_SOURCES` environment variable.

This was my first time using NuGet and setting everything up with GitHub Packages, so if this hard-coded key name is somehow intentional, I'd like to know how to work around this or what a better binary caching setup would look like.

- What does your PR fix?
Fixes #12984 

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.