### PR TITLE
[ogre] Temporary disable dependency qt

### DIFF
--- a/ports/ogre/disable-dependency-qt.patch
+++ b/ports/ogre/disable-dependency-qt.patch
@@ -1,0 +1,14 @@
+diff --git a/CMake/Dependencies.cmake b/CMake/Dependencies.cmake
+index 068dd27..721121b 100644
+--- a/CMake/Dependencies.cmake
++++ b/CMake/Dependencies.cmake
+@@ -346,7 +346,9 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
+     )
+   endif()
+ 
++  if (0)
+   find_package(Qt5 COMPONENTS Core Gui QUIET)
++  endif()
+   macro_log_feature(Qt5_FOUND "Qt" "optional integration with the Qt Library for window creation and input" "http://www.qt.io/" FALSE "" "")
+ endif()
+ 

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_github(
         toolchain_fixes.patch
         fix-dependency.patch
         fix-findimgui.patch
+        disable-dependency-qt.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/CMake/Packages/FindOpenEXR.cmake")

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre",
   "version-string": "1.12.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [


### PR DESCRIPTION
Currently ogre does not set the dependency qt, but in the cmake configuration, if it is detected that qt has been installed, the related features will be automatically enabled, which will cause error:
```
Components\Bites\include\moc_OgreApplicationContextQt.cpp(59): warning C4273: 'OgreBites::ApplicationContextQt::qt_static_metacall': inconsistent dll linkage
D:\buildtrees\ogre\x64-windows-static-dbg\Components\Bites\include\../../../../src/eddf310f0b-3998636895.clean/Components/Bites/include/OgreApplicationContextQt.h(32): note: see previous definition of 'qt_static_metacall'
Components\Bites\include\moc_OgreApplicationContextQt.cpp(66): warning C4273: 'staticMetaObject': inconsistent dll linkage
D:\buildtrees\ogre\x64-windows-static-dbg\Components\Bites\include\../../../../src/eddf310f0b-3998636895.clean/Components/Bites/include/OgreApplicationContextQt.h(32): note: see previous definition of 'public: static QMetaObject const OgreBites::ApplicationContextQt::staticMetaObject'
Components\Bites\include\moc_OgreApplicationContextQt.cpp(66): error C2491: 'OgreBites::ApplicationContextQt::staticMetaObject': definition of dllimport static data member not allowed
Components\Bites\include\moc_OgreApplicationContextQt.cpp(77): warning C4273: 'OgreBites::ApplicationContextQt::metaObject': inconsistent dll linkage
D:\buildtrees\ogre\x64-windows-static-dbg\Components\Bites\include\../../../../src/eddf310f0b-3998636895.clean/Components/Bites/include/OgreApplicationContextQt.h(32): note: see previous definition of 'metaObject'
Components\Bites\include\moc_OgreApplicationContextQt.cpp(82): warning C4273: 'OgreBites::ApplicationContextQt::qt_metacast': inconsistent dll linkage
D:\buildtrees\ogre\x64-windows-static-dbg\Components\Bites\include\../../../../src/eddf310f0b-3998636895.clean/Components/Bites/include/OgreApplicationContextQt.h(32): note: see previous definition of 'qt_metacast'
Components\Bites\include\moc_OgreApplicationContextQt.cpp(92): warning C4273: 'OgreBites::ApplicationContextQt::qt_metacall': inconsistent dll linkage
D:\buildtrees\ogre\x64-windows-static-dbg\Components\Bites\include\../../../../src/eddf310f0b-3998636895.clean/Components/Bites/include/OgreApplicationContextQt.h(32): note: see previous definition of 'qt_metacall'
```

Temporary disable it to fix this issue.

Related: #14220.