### PR TITLE
[xxhash] Add xxhsum feature and support dynamic build

### DIFF
--- a/ports/xxhash/CONTROL
+++ b/ports/xxhash/CONTROL
@@ -1,4 +1,8 @@
 Source: xxhash
 Version: 0.8.0
+Port-Version: 1
 Homepage: https://github.com/Cyan4973/xxHash
 Description: Extremely fast hash algorithm
+
+Feature: xxhsum
+Description: Build the xxhsum binary

--- a/ports/xxhash/portfile.cmake
+++ b/ports/xxhash/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Cyan4973/xxHash
@@ -8,16 +6,24 @@ vcpkg_from_github(
     HEAD_REF dev
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    xxhsum XXHASH_BUILD_XXHSUM
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/cmake_unofficial
     PREFER_NINJA
+    OPTIONS ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/xxHash TARGET_PATH share/${PORT})
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+if("xxhsum" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES xxhsum AUTO_CLEAN)
+endif()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14224

Currently, `xxhsum.exe` is not copied to _share/xxhash_ directory, which causes that `xxhash `cannot be found successfully via `find_package()`.

Add `xxhsum` as a feature to fix this issue.

Also remove `vcpkg_check_linkage(ONLY_STATIC_LIBRARY)` to support dynamic build.

Note: The feature has been passed with the following triplets:

- x86-windows
- x64-windows
- x64-windows-static
