### PR TITLE
[azure pipeline] Install gperf on macos testing machine

### DIFF
--- a/scripts/azure-pipelines/osx/configuration/Vagrantfile
+++ b/scripts/azure-pipelines/osx/configuration/Vagrantfile
@@ -21,7 +21,8 @@ brew_formulas = [
   'libtool',
   'mono',
   'pkg-config',
-  'yasm' ]
+  'yasm',
+  'gperf' ]
 
 brew_cask_formulas = [
   'powershell',


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/pull/13701#issuecomment-715245029

Currently the gperf revision is 3.0.1 as default in osx testing machine, which is old, installing gperf on mac default to latest revision 3.1 which contains the fix of the gperf issue.

proxygen also reference the gperf 3.1