### PR TITLE
[vcpkg] X_VCPKG_APPINSTALL_DEPS_INSTALL optionally install dependencies on install

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -469,6 +469,46 @@ function(x_vcpkg_install_local_dependencies)
     endif()
 endfunction()
 
+set(X_VCPKG_APPLOCAL_DEPS_INSTALL ${X_VCPKG_APPLOCAL_DEPS_INSTALL} CACHE BOOL "(experimental) Automatically copy dependencies into the install target directory for executables.")
+if(${X_VCPKG_APPLOCAL_DEPS_INSTALL})
+    function(install)
+        _install(${ARGV})
+
+        if(${ARGV0} STREQUAL "TARGETS")
+            # Will contain the list of targets
+            set(PARSED_TARGETS "")
+
+            # Destination - [RUNTIME] DESTINATION argument overrides this
+            set(DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+
+            # Parse arguments given to the install function to find targets and (runtime) destination
+            set(MODIFIER "") # Modifier for the command in the argument
+            set(LAST_COMMAND "") # Last command we found to process
+            foreach(ARG ${ARGN})
+                if(${ARG} MATCHES "ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE")
+                    set(MODIFIER ${ARG})
+                    continue()
+                endif()
+
+                if("${ARG}" MATCHES "TARGETS|DESTINATION|PERMISSIONS|CONFIGURATIONS|COMPONENT|NAMELINK_COMPONENT|OPTIONAL|EXCLUDE_FROM_ALL|NAMELINK_ONLY|NAMELINK_SKIP")
+                    set(LAST_COMMAND ${ARG})
+                    continue()
+                endif()
+
+                if("${LAST_COMMAND}" STREQUAL "TARGETS")
+                    list(APPEND PARSED_TARGETS "${ARG}")
+                endif()
+
+                if("${LAST_COMMAND}" STREQUAL "DESTINATION" AND ("${MODIFIER}" STREQUAL "" OR "${MODIFIER}" STREQUAL "RUNTIME"))
+                    set(DESTINATION "${ARG}")
+                endif()
+            endforeach()
+
+            x_vcpkg_install_local_dependencies(TARGETS ${PARSED_TARGETS} DESTINATION ${DESTINATION})
+        endif()
+    endfunction()
+endif()
+
 if(NOT DEFINED VCPKG_OVERRIDE_FIND_PACKAGE_NAME)
     set(VCPKG_OVERRIDE_FIND_PACKAGE_NAME find_package)
 endif()

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -474,7 +474,7 @@ if(${X_VCPKG_APPLOCAL_DEPS_INSTALL})
     function(install)
         _install(${ARGV})
 
-        if(${ARGV0} STREQUAL "TARGETS")
+        if(ARGV0 STREQUAL "TARGETS")
             # Will contain the list of targets
             set(PARSED_TARGETS "")
 
@@ -485,21 +485,21 @@ if(${X_VCPKG_APPLOCAL_DEPS_INSTALL})
             set(MODIFIER "") # Modifier for the command in the argument
             set(LAST_COMMAND "") # Last command we found to process
             foreach(ARG ${ARGN})
-                if(${ARG} MATCHES "ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE")
+                if(ARG MATCHES "ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE")
                     set(MODIFIER ${ARG})
                     continue()
                 endif()
 
-                if("${ARG}" MATCHES "TARGETS|DESTINATION|PERMISSIONS|CONFIGURATIONS|COMPONENT|NAMELINK_COMPONENT|OPTIONAL|EXCLUDE_FROM_ALL|NAMELINK_ONLY|NAMELINK_SKIP")
+                if(ARG MATCHES "TARGETS|DESTINATION|PERMISSIONS|CONFIGURATIONS|COMPONENT|NAMELINK_COMPONENT|OPTIONAL|EXCLUDE_FROM_ALL|NAMELINK_ONLY|NAMELINK_SKIP")
                     set(LAST_COMMAND ${ARG})
                     continue()
                 endif()
 
-                if("${LAST_COMMAND}" STREQUAL "TARGETS")
+                if(LAST_COMMAND STREQUAL "TARGETS")
                     list(APPEND PARSED_TARGETS "${ARG}")
                 endif()
 
-                if("${LAST_COMMAND}" STREQUAL "DESTINATION" AND ("${MODIFIER}" STREQUAL "" OR "${MODIFIER}" STREQUAL "RUNTIME"))
+                if(LAST_COMMAND STREQUAL "DESTINATION" AND (MODIFIER STREQUAL "" OR MODIFIER STREQUAL "RUNTIME"))
                     set(DESTINATION "${ARG}")
                 endif()
             endforeach()

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -470,7 +470,7 @@ function(x_vcpkg_install_local_dependencies)
 endfunction()
 
 set(X_VCPKG_APPLOCAL_DEPS_INSTALL ${X_VCPKG_APPLOCAL_DEPS_INSTALL} CACHE BOOL "(experimental) Automatically copy dependencies into the install target directory for executables.")
-if(${X_VCPKG_APPLOCAL_DEPS_INSTALL})
+if(X_VCPKG_APPLOCAL_DEPS_INSTALL)
     function(install)
         _install(${ARGV})
 


### PR DESCRIPTION
Continuing on the work from #14129 #13011 this adds an install command override again as proposed initially but behind an `if` check for the variable `X_VCPKG_APPLOCAL_DEPS_INSTALL` marking it as experimental and allowing the feature to _just work_ as I initially intended.

I was already using the install function as used here in my own projects but I think this allows everybody to really use the functionality introduced by the `x_vcpkg_install_local_dependencies` function.

As originally requested in #1653