### PR TITLE
[eigen3] Update to 3.3.8

### DIFF
--- a/ports/eigen3/CONTROL
+++ b/ports/eigen3/CONTROL
@@ -1,5 +1,4 @@
 Source: eigen3
 Version: 3.3.8
-Port-Version: 1
 Homepage: http://eigen.tuxfamily.org
 Description: C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

--- a/ports/eigen3/CONTROL
+++ b/ports/eigen3/CONTROL
@@ -1,5 +1,5 @@
 Source: eigen3
-Version: 3.3.7
-Port-Version: 7
+Version: 3.3.8
+Port-Version: 1
 Homepage: http://eigen.tuxfamily.org
 Description: C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_gitlab(
     SHA512  5b4b5985b0294e07b3ed1155720cbbfea322fe9ccad0fc8b0a10060b136a9169a15d5b9cb7a434470cadd45dff0a43049edc20d2e1070005481a120212edc355
     HEAD_REF master
     PATCHES fix-cuda-error.patch # issue https://gitlab.com/libeigen/eigen/-/issues/1526
+    PATCHES remove-error-counting-exception.patch # issue https://gitlab.com/libeigen/eigen/-/issues/2011 Hopefully to be addressed in 3.3.9
 )
 
 vcpkg_configure_cmake(

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libeigen/eigen
-    REF 3.3.7
-    SHA512 4cc3717b9cbe78335e05f724919497214edd482d4812aeb1a9fd6da5b3f6d1b194bb93ed0dab9e734b4334a5b88e8f8c339c43c1b2044332286ef5e758f9ecf4
+    REF 3.3.8
+    SHA512  5b4b5985b0294e07b3ed1155720cbbfea322fe9ccad0fc8b0a10060b136a9169a15d5b9cb7a434470cadd45dff0a43049edc20d2e1070005481a120212edc355
     HEAD_REF master
     PATCHES fix-cuda-error.patch # issue https://gitlab.com/libeigen/eigen/-/issues/1526
 )
@@ -17,11 +17,11 @@ vcpkg_configure_cmake(
         -DBUILD_TESTING=OFF
         -DEIGEN_BUILD_PKGCONFIG=ON
     OPTIONS_RELEASE
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/share/eigen3
-        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/lib/pkgconfig
+        -DCMAKEPACKAGE_INSTALL_DIR=share/eigen3
+        -DPKGCONFIG_INSTALL_DIR=lib/pkgconfig
     OPTIONS_DEBUG
-        -DCMAKEPACKAGE_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/share/eigen3
-        -DPKGCONFIG_INSTALL_DIR=${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
+        -DCMAKEPACKAGE_INSTALL_DIR=share/eigen3
+        -DPKGCONFIG_INSTALL_DIR=lib/pkgconfig
 )
 
 vcpkg_install_cmake()

--- a/ports/eigen3/remove-error-counting-exception.patch
+++ b/ports/eigen3/remove-error-counting-exception.patch
@@ -1,0 +1,64 @@
+From ef3cc72cb65e2d500459c178c63e349bacfa834f Mon Sep 17 00:00:00 2001
+From: Luke Peterson <hazelnusse@gmail.com>
+Date: Thu, 8 Oct 2020 12:16:53 -0700
+Subject: [PATCH] Remove error counting in OpenMP parallelize_gemm
+
+This resolves a compilation error associated with
+Eigen::eigen_assert_exception. It also eliminates the counting of
+exceptions that may occur in the OpenMP parallel section. If an
+unhandled exception occurs in this section, the behavior is non-conforming
+according to the OpenMP specification.
+---
+ Eigen/src/Core/products/Parallelizer.h | 14 +++++---------
+ test/CMakeLists.txt                    |  2 +-
+ 2 files changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/Eigen/src/Core/products/Parallelizer.h b/Eigen/src/Core/products/Parallelizer.h
+index 67b2442b5..a3cc05b77 100644
+--- a/Eigen/src/Core/products/Parallelizer.h
++++ b/Eigen/src/Core/products/Parallelizer.h
+@@ -132,8 +132,7 @@ void parallelize_gemm(const Functor& func, Index rows, Index cols, Index depth,
+ 
+   ei_declare_aligned_stack_constructed_variable(GemmParallelInfo<Index>,info,threads,0);
+ 
+-  int errorCount = 0;
+-  #pragma omp parallel num_threads(threads) reduction(+: errorCount)
++  #pragma omp parallel num_threads(threads)
+   {
+     Index i = omp_get_thread_num();
+     // Note that the actual number of threads might be lower than the number of request ones.
+@@ -152,14 +151,11 @@ void parallelize_gemm(const Functor& func, Index rows, Index cols, Index depth,
+     info[i].lhs_start = r0;
+     info[i].lhs_length = actualBlockRows;
+ 
+-    EIGEN_TRY {
+-      if(transpose) func(c0, actualBlockCols, 0, rows, info);
+-      else          func(0, rows, c0, actualBlockCols, info);
+-    } EIGEN_CATCH(...) {
+-      ++errorCount;
+-    }
++    if(transpose)
++      func(c0, actualBlockCols, 0, rows, info);
++    else
++      func(0, rows, c0, actualBlockCols, info);
+   }
+-  if (errorCount) EIGEN_THROW_X(Eigen::eigen_assert_exception());
+ #endif
+ }
+ 
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 0747aa6cb..b02577780 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -163,7 +163,7 @@ ei_add_test(constructor)
+ ei_add_test(linearstructure)
+ ei_add_test(integer_types)
+ ei_add_test(unalignedcount)
+-if(NOT EIGEN_TEST_NO_EXCEPTIONS)
++if(NOT EIGEN_TEST_NO_EXCEPTIONS AND NOT EIGEN_TEST_OPENMP)
+   ei_add_test(exceptions)
+ endif()
+ ei_add_test(redux)
+-- 
+GitLab
+


### PR DESCRIPTION
Update to 3.3.8

Now CMAKEPACKAGE_INSTALL_DIR and PKGCONFIG_INSTALL_DIR are required by Eigen to be relative paths.

- What does your PR fix? Fixes

None.

- Which triplets are supported/not supported? Have you updated the CI baseline?

None added/removed.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.