### PR TITLE
[vcpkg] Always publish failure logs, even on success.

### DIFF
--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)/failure-logs'
       ArtifactName: 'failure logs for x64-linux'
-    condition: failed()
+    condition: always()
   - bash: |
       python3 scripts/file_script.py /mnt/vcpkg-ci/installed/vcpkg/info/
     displayName: 'Build a file list for all packages'

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)/failure-logs'
       ArtifactName: 'failure logs for x64-osx'
-    condition: failed()
+    condition: always()
   - bash: |
       python3 scripts/file_script.py /Users/vagrant/Data/installed/vcpkg/info/
     displayName: 'Build a file list for all packages'

--- a/scripts/azure-pipelines/windows-unstable/job.yml
+++ b/scripts/azure-pipelines/windows-unstable/job.yml
@@ -87,4 +87,4 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\failure-logs'
       ArtifactName: 'failure logs for ${{ parameters.triplet }}'
-    condition: failed()
+    condition: always()

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -70,7 +70,7 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\failure-logs'
       ArtifactName: 'failure logs for ${{ parameters.triplet }}'
-    condition: failed()
+    condition: always()
   - task: PowerShell@2
     displayName: 'Build a file list for all packages'
     condition: always()


### PR DESCRIPTION
This way we get failure logs for things excluded by ci.baseline.txt in the nightly builds.