### PR TITLE
[spdlog] Fix feature spdlog[benchmark] build error

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,5 +1,6 @@
 Source: spdlog
 Version: 1.8.0
+Port-Version: 1
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/fix-featurebuild.patch
+++ b/ports/spdlog/fix-featurebuild.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3a7663b..3e554d6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,7 +171,7 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
+ # ---------------------------------------------------------------------------------------
+ if (SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
+     if (NOT TARGET fmt::fmt)
+-        find_package(fmt 5.3.0 REQUIRED)
++        find_package(fmt CONFIG REQUIRED)
+     endif ()
+     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
+     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)
+diff --git a/bench/async_bench.cpp b/bench/async_bench.cpp
+index d4167a4..ccb5406 100644
+--- a/bench/async_bench.cpp
++++ b/bench/async_bench.cpp
+@@ -9,7 +9,7 @@
+ #include "spdlog/spdlog.h"
+ #include "spdlog/async.h"
+ #include "spdlog/sinks/basic_file_sink.h"
+-#include "spdlog/fmt/bundled/locale.h"
++#include <fmt/locale.h>
+ 
+ #include "utils.h"
+ #include <atomic>
+diff --git a/bench/bench.cpp b/bench/bench.cpp
+index b7d2fc7..e2f8109 100644
+--- a/bench/bench.cpp
++++ b/bench/bench.cpp
+@@ -11,7 +11,7 @@
+ #include "spdlog/sinks/daily_file_sink.h"
+ #include "spdlog/sinks/null_sink.h"
+ #include "spdlog/sinks/rotating_file_sink.h"
+-#include "spdlog/fmt/bundled/locale.h"
++#include <fmt/locale.h>
+ 
+ #include "utils.h"
+ #include <atomic>

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 4a9ccf7e38e257feecce0c579a782741254eaeef # v1.8.0
     SHA512 333f14704e0d0aa88abbe4ddd29aeb009de2f845440559d463f1b7f9c7da32b2fbdba0f2abf97ec2a5c479d2d62bb2220b21a1bc423d62fbbb93952cf829d532
     HEAD_REF v1.x
+    PATCHES fix-featurebuild.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14265
Fix feature `spdlog[benchmark]` build error.

Feature `spdlog[benchmark]` test pass on `x64-windows` `x86-windows` `x64-linux`.
