### PR TITLE
[sdl2] skip ibus on linux

### DIFF
--- a/ports/sdl2/0007-sdl2-skip-ibus-on-linux.patch
+++ b/ports/sdl2/0007-sdl2-skip-ibus-on-linux.patch
@@ -1,0 +1,16 @@
+--- CMakeLists.orig.txt 2020-10-28 09:08:51.925900284 +0100
++++ CMakeLists.txt      2020-10-28 09:09:10.034165780 +0100
+@@ -1197,13 +1197,6 @@
+         list(APPEND EXTRA_LIBS ${DBUS_LIBRARIES})
+       endif()
+ 
+-      pkg_search_module(IBUS ibus-1.0 ibus)
+-      if(IBUS_FOUND)
+-        set(HAVE_IBUS_IBUS_H TRUE)
+-        include_directories(${IBUS_INCLUDE_DIRS})
+-        list(APPEND EXTRA_LIBS ${IBUS_LIBRARIES})
+-        add_definitions(-DSDL_USE_IME)
+-      endif()
+       if(HAVE_LIBUNWIND_H)
+         # We've already found the header, so REQUIRE the lib to be present
+         pkg_search_module(UNWIND REQUIRED libunwind)

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive_ex(
         disable-wcslcpy-and-wcslcat-for-windows.patch
         fix-EventToken-header-reference.patch
         0006-sdl2-Enable-creation-of-pkg-cfg-file-on-windows.patch
+        0007-sdl2-skip-ibus-on-linux.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version-string": "2.0.12",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {


### PR DESCRIPTION
**Describe the pull request**

This patch removes all ibus detection on linux. When detected, ibus will add glib-2.0, gobject-2.0, gio-2.0 and ibus-1.0 as link libraries to the resulting sdl2 library. By skipping ibus entirely, we avoid having to declare these libraries as system libraries and adding a dependency on glib2.

- What does your PR fix? Fixes #13551

- Which triplets are supported/not supported? Have you updated the CI baseline?

The patch applies to a Linux-only part of sdl2's CMakeLists. Baseline updated before opening PR.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes