### PR TITLE
[cppzmq] update to 4.7.1

### DIFF
--- a/ports/cppzmq/CONTROL
+++ b/ports/cppzmq/CONTROL
@@ -1,5 +1,5 @@
 Source: cppzmq
-Version: 4.6.0
+Version: 4.7.1
 Build-Depends: zeromq
 Homepage: https://github.com/zeromq/cppzmq
 Description: lightweight messaging kernel, C++ bindings

--- a/ports/cppzmq/portfile.cmake
+++ b/ports/cppzmq/portfile.cmake
@@ -19,5 +19,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/cppzmq)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/${PORT}/libzmq-pkg-config)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/cppzmq/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/cppzmq/portfile.cmake
+++ b/ports/cppzmq/portfile.cmake
@@ -1,10 +1,8 @@
-include(vcpkg_common_functions)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/cppzmq
-    REF 8d5c9a88988dcbebb72939ca0939d432230ffde1 # v4.6.0
-    SHA512 45f94a8473cafa6a764a7b4d037284ce2fabbc542a763865f7af6885ebe44498f06215092e4bf4f5d7d26b2fb5585316ed022e300e9c2a8b9647284a444345b2
+    REF 76bf169fd67b8e99c1b0e6490029d9cd5ef97666 # v4.7.1
+    SHA512 03d7444b36937521e2826c7dd2f6cf55d820d0e4d66c30e3947527e13ba2d7cd68f426b5bfedb5a0d0deb4245893a872d5132b68ef966063d72fcd95e42e3eed
     HEAD_REF master
 )
 
@@ -18,8 +16,8 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/cppzmq)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/cppzmq/libzmq-pkg-config)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/${PORT}/libzmq-pkg-config)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/cppzmq)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/cppzmq/LICENSE ${CURRENT_PACKAGES_DIR}/share/cppzmq/copyright)
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/cppzmq/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)


### PR DESCRIPTION
Fix #14270 

Update cppzmq to the latest version 4.7.1

Note: No feature need to test
