### PR TITLE
[LibZippp] add encryption feature

### DIFF
--- a/ports/libzippp/CONTROL
+++ b/ports/libzippp/CONTROL
@@ -1,6 +1,6 @@
 Source: libzippp
 Version: 4.0-1.7.3
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/ctabin/libzippp
 Description: Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling
 Build-Depends: zlib, libzip[core,bzip2]

--- a/ports/libzippp/CONTROL
+++ b/ports/libzippp/CONTROL
@@ -4,3 +4,6 @@ Port-Version: 1
 Homepage: https://github.com/ctabin/libzippp
 Description: Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling
 Build-Depends: zlib, libzip[core,bzip2]
+
+Feature: encryption
+Description: Support encryption

--- a/ports/libzippp/portfile.cmake
+++ b/ports/libzippp/portfile.cmake
@@ -6,10 +6,16 @@ vcpkg_from_github(
     HEAD_REF libzippp-v4.0-1.7.3
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    encryption LIBZIPPP_ENABLE_ENCRYPTION
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DLIBZIPPP_BUILD_TESTS=OFF
     OPTIONS_DEBUG
         -DLIBZIPPP_INSTALL_HEADERS=OFF


### PR DESCRIPTION
Currently the libzippp build without the encryption module enabled. This PR give the possibility to install the `encryption` feature.