### PR TITLE
[abseil] Update to 20200923.2 version

### DIFF
--- a/ports/abseil/fix-lnk2019-error.patch
+++ b/ports/abseil/fix-lnk2019-error.patch
@@ -1,40 +1,45 @@
-diff --git a/absl/base/options.h b/absl/base/options.h
-index 234137c..1fb77e4 100644
---- a/absl/base/options.h
-+++ b/absl/base/options.h
-@@ -100,7 +100,7 @@
- // User code should not inspect this macro.  To check in the preprocessor if
- // absl::any is a typedef of std::any, use the feature macro ABSL_USES_STD_ANY.
- 
--#define ABSL_OPTION_USE_STD_ANY 2
-+#define ABSL_OPTION_USE_STD_ANY 0
- 
- 
- // ABSL_OPTION_USE_STD_OPTIONAL
-@@ -127,7 +127,7 @@
- // absl::optional is a typedef of std::optional, use the feature macro
- // ABSL_USES_STD_OPTIONAL.
- 
--#define ABSL_OPTION_USE_STD_OPTIONAL 2
-+#define ABSL_OPTION_USE_STD_OPTIONAL 0
- 
- 
- // ABSL_OPTION_USE_STD_STRING_VIEW
-@@ -154,7 +154,7 @@
- // absl::string_view is a typedef of std::string_view, use the feature macro
- // ABSL_USES_STD_STRING_VIEW.
- 
--#define ABSL_OPTION_USE_STD_STRING_VIEW 2
-+#define ABSL_OPTION_USE_STD_STRING_VIEW 0
- 
- // ABSL_OPTION_USE_STD_VARIANT
- //
-@@ -180,7 +180,7 @@
- // absl::variant is a typedef of std::variant, use the feature macro
- // ABSL_USES_STD_VARIANT.
- 
--#define ABSL_OPTION_USE_STD_VARIANT 2
-+#define ABSL_OPTION_USE_STD_VARIANT 0
- 
- 
- // ABSL_OPTION_USE_INLINE_NAMESPACE
+diff-- git a / absl / base / options.h b / absl / base /
+        options.h index 234137c..1fb77e4 100644 ---a / absl / base /
+        options.h++ +
+    b / absl / base / options.h @ @-100,
+    7 + 100,
+    7 @ @
+        // User code should not inspect this macro.  To check in the
+        // preprocessor if absl::any is a typedef of std::any, use the feature
+        // macro ABSL_USES_STD_ANY.
+
+        -#define ABSL_OPTION_USE_STD_ANY 2 +
+        #define ABSL_OPTION_USE_STD_ANY 0
+
+        // ABSL_OPTION_USE_STD_OPTIONAL
+        @ @-127,
+    7 + 127,
+    7 @ @
+        // absl::optional is a typedef of std::optional, use the feature macro
+        // ABSL_USES_STD_OPTIONAL.
+
+        -#define ABSL_OPTION_USE_STD_OPTIONAL 2 +
+        #define ABSL_OPTION_USE_STD_OPTIONAL 0
+
+        // ABSL_OPTION_USE_STD_STRING_VIEW
+        @ @-154,
+    7 + 154,
+    7 @ @
+        // absl::string_view is a typedef of std::string_view, use the feature
+        // macro ABSL_USES_STD_STRING_VIEW.
+
+        -#define ABSL_OPTION_USE_STD_STRING_VIEW 2 +
+        #define ABSL_OPTION_USE_STD_STRING_VIEW 0
+
+        // ABSL_OPTION_USE_STD_VARIANT
+        //
+        @ @-180,
+    7 + 180,
+    7 @ @
+        // absl::variant is a typedef of std::variant, use the feature macro
+        // ABSL_USES_STD_VARIANT.
+
+        -#define ABSL_OPTION_USE_STD_VARIANT 2 +
+        #define ABSL_OPTION_USE_STD_VARIANT 0
+
+        // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/ports/abseil/fix-use-cxx17-stdlib-types.patch
+++ b/ports/abseil/fix-use-cxx17-stdlib-types.patch
@@ -1,40 +1,45 @@
-diff --git a/absl/base/options.h b/absl/base/options.h
-index 234137c..1fb77e4 100644
---- a/absl/base/options.h
-+++ b/absl/base/options.h
-@@ -100,7 +100,7 @@
- // User code should not inspect this macro.  To check in the preprocessor if
- // absl::any is a typedef of std::any, use the feature macro ABSL_USES_STD_ANY.
- 
--#define ABSL_OPTION_USE_STD_ANY 2
-+#define ABSL_OPTION_USE_STD_ANY 1
- 
- 
- // ABSL_OPTION_USE_STD_OPTIONAL
-@@ -127,7 +127,7 @@
- // absl::optional is a typedef of std::optional, use the feature macro
- // ABSL_USES_STD_OPTIONAL.
- 
--#define ABSL_OPTION_USE_STD_OPTIONAL 2
-+#define ABSL_OPTION_USE_STD_OPTIONAL 1
- 
- 
- // ABSL_OPTION_USE_STD_STRING_VIEW
-@@ -154,7 +154,7 @@
- // absl::string_view is a typedef of std::string_view, use the feature macro
- // ABSL_USES_STD_STRING_VIEW.
- 
--#define ABSL_OPTION_USE_STD_STRING_VIEW 2
-+#define ABSL_OPTION_USE_STD_STRING_VIEW 1
- 
- // ABSL_OPTION_USE_STD_VARIANT
- //
-@@ -180,7 +180,7 @@
- // absl::variant is a typedef of std::variant, use the feature macro
- // ABSL_USES_STD_VARIANT.
- 
--#define ABSL_OPTION_USE_STD_VARIANT 2
-+#define ABSL_OPTION_USE_STD_VARIANT 1
- 
- 
- // ABSL_OPTION_USE_INLINE_NAMESPACE
+diff-- git a / absl / base / options.h b / absl / base /
+        options.h index 234137c..1fb77e4 100644 ---a / absl / base /
+        options.h++ +
+    b / absl / base / options.h @ @-100,
+    7 + 100,
+    7 @ @
+        // User code should not inspect this macro.  To check in the
+        // preprocessor if absl::any is a typedef of std::any, use the feature
+        // macro ABSL_USES_STD_ANY.
+
+        -#define ABSL_OPTION_USE_STD_ANY 2 +
+        #define ABSL_OPTION_USE_STD_ANY 1
+
+        // ABSL_OPTION_USE_STD_OPTIONAL
+        @ @-127,
+    7 + 127,
+    7 @ @
+        // absl::optional is a typedef of std::optional, use the feature macro
+        // ABSL_USES_STD_OPTIONAL.
+
+        -#define ABSL_OPTION_USE_STD_OPTIONAL 2 +
+        #define ABSL_OPTION_USE_STD_OPTIONAL 1
+
+        // ABSL_OPTION_USE_STD_STRING_VIEW
+        @ @-154,
+    7 + 154,
+    7 @ @
+        // absl::string_view is a typedef of std::string_view, use the feature
+        // macro ABSL_USES_STD_STRING_VIEW.
+
+        -#define ABSL_OPTION_USE_STD_STRING_VIEW 2 +
+        #define ABSL_OPTION_USE_STD_STRING_VIEW 1
+
+        // ABSL_OPTION_USE_STD_VARIANT
+        //
+        @ @-180,
+    7 + 180,
+    7 @ @
+        // absl::variant is a typedef of std::variant, use the feature macro
+        // ABSL_USES_STD_VARIANT.
+
+        -#define ABSL_OPTION_USE_STD_VARIANT 2 +
+        #define ABSL_OPTION_USE_STD_VARIANT 1
+
+        // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -1,61 +1,85 @@
 if (NOT VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY) endif()
 
-if("cxx17" IN_LIST FEATURES)
-    # in C++17 mode, use std::any, std::optional, std::string_view, std::variant
-    # instead of the library replacement types
-    list(APPEND ABSEIL_PATCHES fix-use-cxx17-stdlib-types.patch)
-else()
-    # force use of library replacement types, otherwise the automatic
+<<<<<<< HEAD
+    == == ==
+    = set(ABSEIL_PATCHES)
 
-    # detection can cause ABI issues depending on which compiler options
-    # are enabled for consuming user code
-    list(APPEND ABSEIL_PATCHES fix-lnk2019-error.patch)
-endif()
+>>>>>>> a08f2dc10... [abseil] Update to 20200923.2 version
+        if ("cxx17" IN_LIST FEATURES)
+#in C++ 17 mode, use std::any, std::optional, std::string_view, std::variant
+#instead of the library replacement types
+            list(APPEND ABSEIL_PATCHES fix - use - cxx17 - stdlib -
+                 types.patch) else()
+#force use of library replacement types, otherwise the automatic
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO abseil/abseil-cpp
-    REF 0f3bb466b868b523cf1dc9b2aaaed65c77b28862 #LTS 20200923, Patch 2
-    SHA512 17e766a2f7a655a3877eb3accc5745a910b69a5e2426b7ce7f6d31095523dd32d48a709c5f8380488b4cb93ce9faadedc08f0481dbdbd00cf68831541d724b4d
-    HEAD_REF master
-    PATCHES ${ABSEIL_PATCHES}
-)
+#detection can cause ABI issues depending on which compiler options
+#are enabled for consuming user code
+                list(APPEND ABSEIL_PATCHES fix - lnk2019 - error.patch) endif()
 
-set(CMAKE_CXX_STANDARD 11)
-if("cxx17" IN_LIST FEATURES)
-    set(CMAKE_CXX_STANDARD 17)
-endif()
+                    vcpkg_from_github(
+                        OUT_SOURCE_PATH SOURCE_PATH REPO abseil / abseil -
+                        cpp REF 0f3bb466b868b523cf1dc9b2aaaed65c77b28862 #commit 2020 -
+                        10 -
+                        21 SHA512 17e766a2f7a655a3877eb3accc5745a910b69a5e2426b7ce7f6d31095523dd32d48a709c5f8380488b4cb93ce9faadedc08f0481dbdbd00cf68831541d724b4d HEAD_REF
+                            master PATCHES ${ABSEIL_PATCHES})
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS
-        -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
-)
+                        set(CMAKE_CXX_STANDARD 11) if (
+                            "cxx17" IN_LIST
+                                FEATURES) set(CMAKE_CXX_STANDARD 17) endif()
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/absl TARGET_PATH share/absl)
+                            vcpkg_configure_cmake(
+                                SOURCE_PATH ${
+                                    SOURCE_PATH} PREFER_NINJA OPTIONS -
+                                    DCMAKE_CXX_STANDARD = ${CMAKE_CXX_STANDARD})
 
-vcpkg_copy_pdbs()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/include
-                    ${CURRENT_PACKAGES_DIR}/include/absl/copts
-                    ${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata
-                    ${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata
-)
+                                vcpkg_install_cmake() vcpkg_fixup_cmake_targets(
+                                    CONFIG_PATH lib / cmake /
+                                    absl TARGET_PATH share / absl)
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/config.h
-        "#elif defined(ABSL_CONSUME_DLL)" "#elif 1"
-    )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h
-        "&& !defined(ABSL_CONSUME_DLL)" "&& 0"
-    )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/container/internal/hashtablez_sampler.h
-        "!defined(ABSL_CONSUME_DLL)" "0"
-    )
-endif()
+                                    vcpkg_copy_pdbs() file(
+                                        REMOVE_RECURSE ${CURRENT_PACKAGES_DIR} /
+                                        debug / share ${CURRENT_PACKAGES_DIR} /
+                                        debug /
+                                        include ${CURRENT_PACKAGES_DIR} /
+                                        include / absl /
+                                        copts ${CURRENT_PACKAGES_DIR} /
+                                        include / absl / strings /
+                                        testdata ${CURRENT_PACKAGES_DIR} /
+                                        include / absl / time / internal /
+                                        cctz / testdata)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+                                        if (VCPKG_LIBRARY_LINKAGE STREQUAL
+                                                dynamic)
+                                            vcpkg_replace_string(
+                                                ${CURRENT_PACKAGES_DIR} /
+                                                include / absl / base /
+                                                config.h
+                                                "#elif "
+                                                "defined(ABSL_CONSUME_DLL)"
+                                                "#elif 1")
+                                                vcpkg_replace_string(
+                                                    ${CURRENT_PACKAGES_DIR} /
+                                                    include / absl / base /
+                                                    internal /
+                                                    thread_identity.h
+                                                    "&& "
+                                                    "!defined(ABSL_CONSUME_DLL)"
+                                                    "&& 0")
+                                                    vcpkg_replace_string(
+                                                        ${CURRENT_PACKAGES_DIR} /
+                                                        include / absl /
+                                                        container / internal /
+                                                        hashtablez_sampler.h
+                                                        "!defined(ABSL_CONSUME_"
+                                                        "DLL)"
+                                                        "0") endif()
+
+                                                        file(
+                                                            INSTALL ${
+                                                                SOURCE_PATH} /
+                                                            LICENSE DESTINATION ${
+                                                                CURRENT_PACKAGES_DIR} /
+                                                            share /
+                                                            ${PORT} RENAME
+                                                                copyright)

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
-  "version-string": "2020-09-23",
+  "version-string": "2020-10-21",
+  "port-version": 0,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
@@ -10,8 +11,6 @@
   "homepage": "https://github.com/abseil/abseil-cpp",
   "supports": "(x64 | arm64) & (linux | osx | windows)",
   "features": {
-    "cxx17": {
-      "description": "Enable compiler C++17."
-    }
+    "cxx17" : { "description" : "Enable compiler C++17." }
   }
 }


### PR DESCRIPTION
Update **abseil** version to the 20200923.2 version.

**Important note:** A few patches are not necessary anymore because all of them are fixed with the latest abseil version.
