### PR TITLE
[vcpkg] Add support to more paths for vcpkg usage hint

### DIFF
--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -625,6 +625,11 @@ namespace vcpkg::Install
                     auto path = paths.installed / suffix;
                     auto maybe_contents = fs.read_contents(path);
                     auto find_package_name = fs::u8string(path.parent_path().filename());
+                    if (Strings::case_insensitive_ascii_equals("cmake", find_package_name) &&
+                        path.parent_path().has_parent_path())
+                    {
+                        find_package_name = fs::u8string(path.parent_path().parent_path().filename());
+                    }
                     if (auto p_contents = maybe_contents.get())
                     {
                         std::sregex_iterator next(p_contents->begin(), p_contents->end(), cmake_library_regex);


### PR DESCRIPTION
Currently vcpkg will auto-generate a usage hint for installed packages.
These usage hints support the following paths under `/share/`:

* `<prefix>/(lib/<arch>|lib*|share)/cmake/<name>*/`
* `<prefix>/(lib/<arch>|lib*|share)/<name>*/`
* `<prefix>/<name>*/(lib/<arch>|lib*|share)/cmake/<name>*/`
* `<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/`

This PR adds support for:

* `<prefix>/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/`
* `<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/`

You can read more about these paths here:
https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure

Fixes #10881
