### PR TITLE
[cartographer] Fix Targets.cmake file location

### DIFF
--- a/ports/cartographer/CONTROL
+++ b/ports/cartographer/CONTROL
@@ -1,5 +1,5 @@
 Source: cartographer
-Version: 1.0.0-2
+Version: 1.0.0-3
 Build-Depends: ceres[suitesparse], gflags, glog, lua, cairo, boost-iostreams, gtest, protobuf
 Homepage: https://github.com/googlecartographer/cartographer
 Description: Google 2D & 3D SLAM package

--- a/ports/cartographer/fix-cmake-location.patch
+++ b/ports/cartographer/fix-cmake-location.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e3a686be..f2a0c5d8e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -300,7 +300,7 @@ foreach(HDR ${INSTALL_GENERATED_HDRS})
+   )
+ endforeach()
+ 
+-set(CARTOGRAPHER_CMAKE_DIR share/cartographer/cmake)
++set(CARTOGRAPHER_CMAKE_DIR share/cartographer)
+ include(CMakePackageConfigHelpers)
+ configure_package_config_file(
+   cartographer-config.cmake.in
+@@ -311,7 +311,7 @@ configure_package_config_file(
+ 
+ install(
+   EXPORT CartographerExport
+-  DESTINATION share/cartographer/cmake/
++  DESTINATION share/cartographer/
+   FILE CartographerTargets.cmake
+ )
+ 

--- a/ports/cartographer/portfile.cmake
+++ b/ports/cartographer/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
 	PATCHES
         fix-find-packages.patch
         fix-build-error.patch
+        fix-cmake-location.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
## Problem:
`_IMPORT_PREFIX` set in `CartographerTargets.cmake` pointed to a wrong location (e.g. `share` folder).


## Root Cause:

In `cartographer`, the upstream places the cmake files by the below layout:

```
VCPKG\INSTALLED\X64-WINDOWS\SHARE\CARTOGRAPHER
│   cartographer-config.cmake
│   copyright
│   package.xml
│   vcpkg_abi_info.txt
│
├───cmake
│   │   functions.cmake
│   │   CartographerTargets-debug.cmake
│   │   CartographerTargets-release.cmake
│   │   CartographerTargets.cmake
│   │
│   └───modules
│           FindGMock.cmake
│           FindLuaGoogle.cmake
│           FindSphinx.cmake
│
└───configuration_files
        map_builder.lua
        map_builder_server.lua
        pose_graph.lua
        trajectory_builder.lua
        trajectory_builder_2d.lua
        trajectory_builder_3d.lua
```

However, it seems that the [`vcpkg_fixup_cmake_targets`](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_fixup_cmake_targets.md) expects all the CMake files immediately under certain folder layout and it fixes all the `_IMPORT_PREFIX` by [this behavior](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_fixup_cmake_targets.cmake#L165-L168).

In order to accommodate Vcpkg behavior, this pull request is to move the targets CMake files into `share\${PORT}` folder.