### PR TITLE
[sdformat10] Add new port

### DIFF
--- a/ports/sdformat10/portfile.cmake
+++ b/ports/sdformat10/portfile.cmake
@@ -1,0 +1,41 @@
+vcpkg_fail_port_install(ON_TARGET "linux" "uwp")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO osrf/sdformat
+    REF sdformat10_10.0.0
+    SHA512 1caf98427d25e7c17bfacaab20382c573fac0c965b40ad0c5e0efd32ddfdaa20250d8c79ecf574989ba10b1feb884a9df3927b18ec2cd88f7c66b4d8194bc731
+    HEAD_REF sdf10
+)
+
+# Ruby is required by the sdformat build process
+vcpkg_find_acquire_program(RUBY)
+get_filename_component(RUBY_PATH ${RUBY} DIRECTORY)
+set(_path $ENV{PATH})
+vcpkg_add_to_path(${RUBY_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS 
+        -DBUILD_TESTING=OFF
+        -DUSE_EXTERNAL_URDF=ON
+        -DUSE_EXTERNAL_TINYXML=ON
+)
+
+vcpkg_install_cmake()
+
+# Restore original path
+set(ENV{PATH} ${_path})
+
+# Fix cmake targets and pkg-config file location
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+
+# Remove debug files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+                    ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/sdformat10/vcpkg.json
+++ b/ports/sdformat10/vcpkg.json
@@ -6,7 +6,7 @@
   "supports": "!linux & !uwp",
   "dependencies": [
     "ignition-math6",
-    "urdfdom",
-    "tinyxml2"
+    "tinyxml2",
+    "urdfdom"
   ]
 }

--- a/ports/sdformat10/vcpkg.json
+++ b/ports/sdformat10/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "sdformat10",
+  "version-string": "10.0.0",
+  "description": "Simulation Description Format (SDF) parser and description files.",
+  "homepage": "http://sdformat.org/",
+  "supports": "!linux & !uwp",
+  "dependencies": [
+    "ignition-math6",
+    "urdfdom",
+    "tinyxml2"
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? This PR adds a new major version of the SDFormat library (http://sdformat.org/). As different major versions of this library can be installed side-by-side, the new version is added as a new port.

- Which triplets are supported/not supported? Have you updated the CI baseline? The port supports the same triplets of its previous port sdformat9 .

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
