### PR TITLE
[libsamplerate, sdl2-gfx] Fix build error with Visual Studio 2019 version 16.8

### DIFF
--- a/ports/libsamplerate/Use-the-lrintf-intrinsic.patch
+++ b/ports/libsamplerate/Use-the-lrintf-intrinsic.patch
@@ -1,0 +1,39 @@
+diff --git a/src/float_cast.h b/src/float_cast.h
+index 0318427..8499e69 100644
+--- a/src/float_cast.h
++++ b/src/float_cast.h
+@@ -117,6 +117,9 @@
+ 	**	most likely both WIN32 and WIN64 will be defined in 64-bit case.
+ 	*/
+ 
++/* MSVC pre 16.8 do not have lrintf */
++#if defined(_MSC_VER) && _MSC_VER < 1928
++
+ 	#include	<math.h>
+ 
+ 	/*	Win64 doesn't seem to have these functions, nor inline assembly.
+@@ -136,12 +139,16 @@
+ 	{
+ 		return _mm_cvtss_si32(_mm_load_ss(&flt));
+ 	}
++#endif
+ 
+ #elif (defined (WIN32) || defined (_WIN32))
+ 
+ 	#undef		HAVE_LRINT_REPLACEMENT
+ 	#define		HAVE_LRINT_REPLACEMENT	1
+ 
++/* MSVC pre 16.8 do not have lrintf */
++#if defined(_MSC_VER) && _MSC_VER < 1928
++
+ 	#include	<math.h>
+ 
+ 	/*
+@@ -172,6 +179,7 @@
+ 
+ 		return intgr ;
+ 	}
++#endif
+ 
+ #elif (defined (__MWERKS__) && defined (macintosh))
+ 

--- a/ports/libsamplerate/portfile.cmake
+++ b/ports/libsamplerate/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF f6730d03c3e7660bb6ecad8816f1b09c5825142a # v0.1.9
     SHA512 6a349c9144d024212fc78dc0d9e39bdc1a43abaf590fcfbf84396af22834545962d5ef10176b48b21fcae2ce62d12277b682059383805d059f4dd2b9f6708478
     HEAD_REF master
+    PATCHES Use-the-lrintf-intrinsic.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH}/src)

--- a/ports/libsamplerate/vcpkg.json
+++ b/ports/libsamplerate/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libsamplerate",
   "version-string": "0.1.9.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Sample Rate Converter for audio",
   "homepage": "https://www.mega-nerd.com/SRC"
 }

--- a/ports/sdl2-gfx/002-use-the-lrintf-intrinsic.patch
+++ b/ports/sdl2-gfx/002-use-the-lrintf-intrinsic.patch
@@ -1,0 +1,14 @@
+diff --git a/SDL2_gfxPrimitives.c b/SDL2_gfxPrimitives.c
+index d8afb10..6c88288 100644
+--- a/SDL2_gfxPrimitives.c
++++ b/SDL2_gfxPrimitives.c
+@@ -1757,7 +1757,8 @@ int filledCircleRGBA(SDL_Renderer * renderer, Sint16 x, Sint16 y, Sint16 rad, Ui
+ /* ----- AA Ellipse */
+ 
+ /* Windows targets do not have lrint, so provide a local inline version */
+-#if defined(_MSC_VER)
++/* MSVC pre 16.8 do not have lrint */
++#if defined(_MSC_VER) && _MSC_VER < 1928
+ /* Detect 64bit and use intrinsic version */
+ #ifdef _M_X64
+ #include <emmintrin.h>

--- a/ports/sdl2-gfx/CONTROL
+++ b/ports/sdl2-gfx/CONTROL
@@ -1,4 +1,5 @@
 Source: sdl2-gfx
-Version: 1.0.4-6
+Version: 1.0.4
+Port-Version: 7
 Build-Depends: sdl2
 Description: Graphics primitives (line, circle, rectangle etc.) with AA support, rotozoomer and other drawing related support functions wrapped up in a C based add-on library for the Simple Direct Media (SDL) cross-platform API layer.

--- a/ports/sdl2-gfx/portfile.cmake
+++ b/ports/sdl2-gfx/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive_ex(
     REF ${VERSION}
     PATCHES
         001-lrint-arm64.patch
+        002-use-the-lrintf-intrinsic.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Visual Studio 2019 version 16.8 do not have `lrint` and `lrintf`. So `libsamplerate` and `sdl2-gfx` build failed on Visual Studio 2019 version 16.8 with the following error:
libsamplerate:
```
D:\buildtrees\libsamplerate\src\9c5825142a-a07e6bb3f6.clean\src\float_cast.h(130): error C2169: 'lrint': intrinsic function, cannot be defined
D:\buildtrees\libsamplerate\src\9c5825142a-a07e6bb3f6.clean\src\float_cast.h(136): error C2169: 'lrintf': intrinsic function, cannot be defined
```
sdl2-gfx:
```
D:\buildtrees\sdl2-gfx\src\1.0.4-86ce4cf464.clean\SDL2_gfxPrimitives.c(1766): error C2169: 'lrint': intrinsic function, cannot be defined
```
Adding patch to fix this error. The upstream of `libsamplerate` remove `float_cast.h` in latest version. 
