### PR TITLE
[sentry-native] Disable warning C5105

### DIFF
--- a/ports/sentry-native/CONTROL
+++ b/ports/sentry-native/CONTROL
@@ -1,5 +1,6 @@
 Source: sentry-native
 Version: 0.4.3
+Port-Version: 1
 Homepage: https://sentry.io/
 Description: Sentry SDK for C, C++ and native applications.
 Build-Depends: curl (!windows)

--- a/ports/sentry-native/fix-warningC5105.patch
+++ b/ports/sentry-native/fix-warningC5105.patch
@@ -1,0 +1,12 @@
+diff --git a/external/crashpad/third_party/zlib/zlib/x86.c b/external/crashpad/third_party/zlib/zlib/x86.c
+index e56fe8b..902e373 100644
+--- a/external/crashpad/third_party/zlib/zlib/x86.c
++++ b/external/crashpad/third_party/zlib/zlib/x86.c
+@@ -8,6 +8,7 @@
+  * For conditions of distribution and use, see copyright notice in zlib.h
+  */
+ 
++#pragma warning(disable : 5105)
+ #include "x86.h"
+ #include "zutil.h"
+ 

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES fix-warningC5105.patch
     NO_REMOVE_ONE_LEVEL
 )
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
`sentry-native` build failed on Visual Studio 2019 version 16.8 with the following error, disable warning C5105 to fix this error.
```
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winbase.h(9461): error C2220: the following warning is treated as an error
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winbase.h(9461): warning C5105: macro expansion producing 'defined' has undefined behavior
```
Upstream issue: https://github.com/getsentry/sentry-native/issues/415