### PR TITLE
[vcpkg] Disable vcpkg_copy_tool_dependencies on non-Windows

### DIFF
--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -17,23 +17,25 @@
 ## * [glib](https://github.com/Microsoft/vcpkg/blob/master/ports/glib/portfile.cmake)
 ## * [fltk](https://github.com/Microsoft/vcpkg/blob/master/ports/fltk/portfile.cmake)
 function(vcpkg_copy_tool_dependencies TOOL_DIR)
-    find_program(PWSH_EXE pwsh)
-    if (NOT PWSH_EXE)
-        message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
+    if (VCPKG_TARGET_IS_WINDOWS)
+        find_program(PWSH_EXE pwsh)
+        if (NOT PWSH_EXE)
+            message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
+        endif()
+        macro(search_for_dependencies PATH_TO_SEARCH)
+            file(GLOB TOOLS "${TOOL_DIR}/*.exe" "${TOOL_DIR}/*.dll")
+            foreach(TOOL IN LISTS TOOLS)
+                vcpkg_execute_required_process(
+                    COMMAND "${PWSH_EXE}" -noprofile -executionpolicy Bypass -nologo
+                        -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
+                        -targetBinary "${TOOL}"
+                        -installedDir "${PATH_TO_SEARCH}"
+                    WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
+                    LOGNAME copy-tool-dependencies
+                )
+            endforeach()
+        endmacro()
+        search_for_dependencies("${CURRENT_PACKAGES_DIR}/bin")
+        search_for_dependencies("${CURRENT_INSTALLED_DIR}/bin")
     endif()
-    macro(search_for_dependencies PATH_TO_SEARCH)
-        file(GLOB TOOLS "${TOOL_DIR}/*.exe" "${TOOL_DIR}/*.dll")
-        foreach(TOOL IN LISTS TOOLS)
-            vcpkg_execute_required_process(
-                COMMAND "${PWSH_EXE}" -noprofile -executionpolicy Bypass -nologo
-                    -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
-                    -targetBinary "${TOOL}"
-                    -installedDir "${PATH_TO_SEARCH}"
-                WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
-                LOGNAME copy-tool-dependencies
-            )
-        endforeach()
-    endmacro()
-    search_for_dependencies("${CURRENT_PACKAGES_DIR}/bin")
-    search_for_dependencies("${CURRENT_INSTALLED_DIR}/bin")
 endfunction()


### PR DESCRIPTION
This is clearly looking for *.exe and *.dll, so it has Windows assumptions. Moreover, it fails on non-Windows platforms where vcpkg doesn't always make powershell-core available.

Resolves #14358
