### PR TITLE
[libigl] Fix dynamic build and enable header-only mode

### DIFF
--- a/ports/libigl/CONTROL
+++ b/ports/libigl/CONTROL
@@ -1,6 +1,6 @@
 Source: libigl
 Version: 2.2.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/libigl/libigl
 Description: libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.
 Build-Depends: eigen3

--- a/ports/libigl/fix-config.patch
+++ b/ports/libigl/fix-config.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/libigl-config.cmake.in b/cmake/libigl-config.cmake.in
+index 21aa2468..0aa6d8a0 100644
+--- a/cmake/libigl-config.cmake.in
++++ b/cmake/libigl-config.cmake.in
+@@ -27,5 +27,23 @@ if (TARGET igl::common)
+   endif()
+ endif()
+ 
++ include(CMakeFindDependencyMacro)
++if (TARGET igl::embree)
++  find_dependency(embree 3 CONFIG REQUIRED)
++endif()
++if (TARGET igl::xml)
++  find_dependency(tinyxml2 CONFIG REQUIRED)
++endif()
++if (TARGET igl::opengl)
++  find_dependency(OpenGL REQUIRED)
++  find_dependency(glad CONFIG REQUIRED)
++  if (TARGET igl::opengl_glfw)
++    find_dependency(glfw3 CONFIG REQUIRED)
++    if (TARGET igl::opengl_glfw_imgui)
++      find_dependency(imgui CONFIG REQUIRED)
++    endif()
++  endif()
++endif()
++
+ check_required_components(libigl)
+ 

--- a/ports/libigl/fix-dependency.patch
+++ b/ports/libigl/fix-dependency.patch
@@ -34,15 +34,17 @@ index d07bbb3..a33cefa 100644
      igl_download_embree()
  
      set(EMBREE_TESTING_INTENSITY 0 CACHE STRING "")
-@@ -315,8 +316,8 @@ if(LIBIGL_WITH_EMBREE)
+@@ -315,8 +315,11 @@ if(LIBIGL_WITH_EMBREE)
    endif()
  
    compile_igl_module("embree")
--  target_link_libraries(igl_embree ${IGL_SCOPE} embree)
+   target_link_libraries(igl_embree ${IGL_SCOPE} embree)
 -  target_include_directories(igl_embree ${IGL_SCOPE} ${EMBREE_DIR}/include)
-+  target_link_libraries(igl_embree ${IGL_SCOPE} ${EMBREE_LIBRARIES})
-+  target_include_directories(igl_embree ${IGL_SCOPE} ${EMBREE_INCLUDE_DIRS})
++  if(LIBIGL_USE_STATIC_LIBRARY)
++  find_package(TBB CONFIG REQUIRED)
++  target_link_libraries(igl_embree ${IGL_SCOPE} TBB::tbb)
    target_compile_definitions(igl_embree ${IGL_SCOPE} -DEMBREE_STATIC_LIB)
++  endif()
  endif()
  
 @@ -358,11 +359,12 @@ if(LIBIGL_WITH_OPENGL)
@@ -126,7 +128,8 @@ index d07bbb3..a33cefa 100644
    compile_igl_module("xml")
 -  target_link_libraries(igl_xml ${IGL_SCOPE} tinyxml2)
 +  target_link_libraries(igl_xml ${IGL_SCOPE} tinyxml2::tinyxml2)
-   target_include_directories(igl_xml ${IGL_SCOPE} ${TINYXML2_DIR})
+-   target_include_directories(igl_xml ${IGL_SCOPE} ${TINYXML2_DIR})
++
  endif()
  
 diff --git a/include/igl/opengl/glfw/imgui/ImGuiHelpers.h b/include/igl/opengl/glfw/imgui/ImGuiHelpers.h

--- a/ports/libigl/install-extra-headers.patch
+++ b/ports/libigl/install-extra-headers.patch
@@ -2,13 +2,19 @@ diff --git a/cmake/libigl.cmake b/cmake/libigl.cmake
 index a33cefa..0014375 100644
 --- a/cmake/libigl.cmake
 +++ b/cmake/libigl.cmake
-@@ -560,6 +560,55 @@ export(
+@@ -560,6 +560,85 @@ export(
  # Install headers for core library
  install_dir_files(core)
  install_dir_files(copyleft)
 + 
 +if (LIBIGL_WITH_EMBREE)
 +    install_dir_files(embree)
++#    if(NOT LIBIGL_USE_STATIC_LIBRARY)
++    install(TARGETS igl_embree EXPORT igl-export)
++    export(TARGETS igl_embree
++        APPEND FILE libigl-export.cmake EXPORT_LINK_INTERFACE_LIBRARIES
++    )
++#    endif()
 +endif()
 + 
 +if (LIBIGL_WITH_CGAL)
@@ -30,14 +36,32 @@ index a33cefa..0014375 100644
 +if (LIBIGL_WITH_OPENGL OR LIBIGL_WITH_OPENGL_GLFW OR LIBIGL_WITH_OPENGL_GLFW_IMGUI)
 +    install_dir_files(copyleft/opengl2)
 +    install_dir_files(opengl)
++#    if(NOT LIBIGL_USE_STATIC_LIBRARY)
++    install(TARGETS igl_opengl EXPORT igl-export)
++    export(TARGETS igl_opengl
++        APPEND FILE libigl-export.cmake EXPORT_LINK_INTERFACE_LIBRARIES
++    )
++#    endif()
 +endif()
 +
 +if (LIBIGL_WITH_OPENGL_GLFW OR LIBIGL_WITH_OPENGL_GLFW_IMGUI)
 +    install_dir_files(opengl/glfw)
++#    if(NOT LIBIGL_USE_STATIC_LIBRARY)
++    install(TARGETS igl_opengl_glfw EXPORT igl-export)
++    export(TARGETS igl_opengl_glfw
++        APPEND FILE libigl-export.cmake EXPORT_LINK_INTERFACE_LIBRARIES
++    )
++#    endif()
 +endif()
 +
 +if (LIBIGL_WITH_OPENGL_GLFW_IMGUI)
 +    install_dir_files(opengl/glfw/imgui)
++#    if(NOT LIBIGL_USE_STATIC_LIBRARY)
++    install(TARGETS igl_opengl_glfw_imgui EXPORT igl-export)
++    export(TARGETS igl_opengl_glfw_imgui
++        APPEND FILE libigl-export.cmake EXPORT_LINK_INTERFACE_LIBRARIES
++    )
++#    endif()
 +endif()
 +
 +if (LIBIGL_WITH_PNG)
@@ -54,6 +78,12 @@ index a33cefa..0014375 100644
 +
 +if (LIBIGL_WITH_XML)
 +    install_dir_files(xml)
++#    if(NOT LIBIGL_USE_STATIC_LIBRARY)
++    install(TARGETS igl_xml EXPORT igl-export)
++    export(TARGETS igl_xml
++        APPEND FILE libigl-export.cmake EXPORT_LINK_INTERFACE_LIBRARIES
++    )
++#    endif()
 +endif()
  
  # Write package configuration file

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -1,7 +1,5 @@
 vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 
-#vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libigl/libigl

--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+#vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -12,16 +12,12 @@ vcpkg_from_github(
         fix-dependency.patch
         fix-imgui-set-cond.patch
         install-extra-headers.patch
+        fix-config.patch
 )
 
 set(LIBIGL_BUILD_STATIC OFF)
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(LIBIGL_BUILD_STATIC ON)
-endif()
-
-if ("imgui" IN_LIST FEATURES AND NOT VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    # Remove this after add port libigl-imgui
-    message(FATAL_ERROR "Feature imgui does not support non-static build currently")
 endif()
 
 if ("test" IN_LIST FEATURES AND NOT EXISTS ${SOURCE_PATH}/tests/data)


### PR DESCRIPTION
This is an attempt at getting rid of libigl huge static .lib file and getting the header-library mode. I could make it work on my machine (Windows VS2019 Clang 10) with the current set of modifications. Not necessarily optimal nor "clean", but hopefully a good start to resolve the issue. 

Let me know if anything is missing or feel free to take over from here.

- What does your PR fix? Fixes #14371 

- Which triplets are supported/not supported? Have you updated the CI baseline?
Dynamic library version works on windows but not the static, and other platform untested. I don't know what is the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I think so.