### PR TITLE
[kenlm, pdal] Fix const overload on Visual Studio 2019 version 16.8

### DIFF
--- a/ports/kenlm/fix-const-overloaded.patch
+++ b/ports/kenlm/fix-const-overloaded.patch
@@ -1,0 +1,14 @@
+diff --git a/util/proxy_iterator.hh b/util/proxy_iterator.hh
+index 8aa697b..9de2663 100644
+--- a/util/proxy_iterator.hh
++++ b/util/proxy_iterator.hh
+@@ -77,8 +77,7 @@ template <class Proxy> class ProxyIterator {
+ 
+     std::ptrdiff_t operator-(const S &other) const { return I() - other.I(); }
+ 
+-    Proxy operator*() { return p_; }
+-    const Proxy operator*() const { return p_; }
++    Proxy operator*() const { return p_; }
+     Proxy *operator->() { return &p_; }
+     const Proxy *operator->() const { return &p_; }
+     Proxy operator[](std::ptrdiff_t amount) const { return *(*this + amount); }

--- a/ports/kenlm/portfile.cmake
+++ b/ports/kenlm/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF 1f054617eca14eae921e987b4b4eeb2b1d91de6b
     SHA512 c18f9c22fbbb1f54ebe9c3b771fb2d7c09d502141d1b3645cff9db44cc51b3c976311ff0db79b60f410622579d043f185c56a4c7386e1b0ba8708e433238968b
     HEAD_REF master
-    PATCHES fix-boost.patch
+    PATCHES 
+        fix-boost.patch
+        fix-const-overloaded.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/modules/FindEigen3.cmake)

--- a/ports/kenlm/vcpkg.json
+++ b/ports/kenlm/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kenlm",
   "version-string": "20200924",
+  "port-version": 1,
   "description": "KenLM: Faster and Smaller Language Model Queries",
   "supports": "!(arm64 & windows)",
   "dependencies": [

--- a/ports/pdal/0004-fix-const-overloaded.patch
+++ b/ports/pdal/0004-fix-const-overloaded.patch
@@ -1,0 +1,13 @@
+diff --git a/pdal/PointViewIter.hpp b/pdal/PointViewIter.hpp
+index 0c387be..ccb0721 100644
+--- a/pdal/PointViewIter.hpp
++++ b/pdal/PointViewIter.hpp
+@@ -139,7 +139,7 @@ public:
+ 
+     bool operator==(const PointViewIter& i)
+         { return m_id == i.m_id; }
+-    bool operator!=(const PointViewIter& i)
++    bool operator!=(const PointViewIter& i) const
+         { return m_id != i.m_id; }
+     bool operator<=(const PointViewIter& i)
+         { return m_id <= i.m_id; }

--- a/ports/pdal/CONTROL
+++ b/ports/pdal/CONTROL
@@ -1,5 +1,5 @@
 Source: pdal
 Version: 1.7.1
-Port-Version: 9
+Port-Version: 10
 Description: PDAL - Point Data Abstraction Library is a library for manipulating point cloud data.
 Build-Depends: gdal, geos, jsoncpp, libgeotiff, laszip, boost-system, boost-filesystem

--- a/ports/pdal/portfile.cmake
+++ b/ports/pdal/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive_ex(
         fix-dependency.patch
         libpq.patch
         fix-CPL_DLL.patch
+        0004-fix-const-overloaded.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/pdal/gitsha.cpp")


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Due to const overload, `kenlm` and `pdal` build failed on Visual Studio 2019 version 16.8 with the following error. Adding patch to fix these error.

kenlm:
```
E:\repro\binaries.amd64ret\inc\algorithm(7280): error C2678: binary '=': no operator found which takes a left-hand operand of type 'const Proxy' (or there is no acceptable conversion)
        with
        [
            Proxy=lm::ngram::trie::`anonymous-namespace'::PartialViewProxy
        ]
E:\1102\vcpkg\buildtrees\kenlm\src\2b1d91de6b-8796a520fb.clean\lm\trie_sort.cc(47): note: could be 'lm::ngram::trie::`anonymous-namespace'::PartialViewProxy &lm::ngram::trie::`anonymous-namespace'::PartialViewProxy::operator =(const util::ValueBlock &)'
E:\1102\vcpkg\buildtrees\kenlm\src\2b1d91de6b-8796a520fb.clean\lm\trie_sort.cc(42): note: or       'lm::ngram::trie::`anonymous-namespace'::PartialViewProxy &lm::ngram::trie::`anonymous-namespace'::PartialViewProxy::operator =(const lm::ngram::trie::`anonymous-namespace'::PartialViewProxy &)'
```
pdal:
```
\vcfs\Builds\msvc\fe\20201103.01\binaries.amd64ret\inc\algorithm(7408): error C2678: binary '!=': no operator found which takes a left-hand operand of type 'const _BidIt' (or there is no acceptable conversion)
        with
        [
            _BidIt=pdal::PointViewIter
        ]
E:\1102\vcpkg\buildtrees\pdal\src\PDAL-1-e601d67d7a\pdal/PointViewIter.hpp(142): note: could be 'bool pdal::PointViewIter::operator !=(const pdal::PointViewIter &)'
\vcfs\Builds\msvc\fe\20201103.01\binaries.amd64ret\inc\thread(240): note: or       'bool std::operator !=(std::thread::id,std::thread::id) noexcept'
E:\1102\vcpkg\buildtrees\pdal\src\PDAL-1-e601d67d7a\pdal/Metadata.hpp(687): note: or       'bool pdal::operator !=(const pdal::MetadataNode &,const pdal::MetadataNode &)' [found using argument-dependent lookup]
\vcfs\Builds\msvc\fe\20201103.01\binaries.amd64ret\inc\algorithm(7408): note: while trying to match the argument list '(const _BidIt, const _BidIt)'
        with
        [
            _BidIt=pdal::PointViewIter
        ]
```
I have submit issue on `kenlm` upstream https://github.com/kpu/kenlm/issues/308.
The latest source of `pdal` has removed `PointViewIter.hpp`, and PR #14055 will change `pdal` download source to https://github.com/PDAL/PDAL.