### PR TITLE
[ffmpeg] simplify openssl library search, and fix linux openssl feature linking

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
 Version: 4.3.1
-Port-Version: 6
+Port-Version: 7
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/FindFFMPEG.cmake.in
+++ b/ports/ffmpeg/FindFFMPEG.cmake.in
@@ -112,11 +112,7 @@ endif()
 
 if(@ENABLE_OPENSSL@)
   find_dependency(OpenSSL)
-  select_library_configurations_from_targets(BASENAME SSL TARGETS OpenSSL::SSL OpenSSL::Crypto)
-  list(APPEND FFMPEG_PLATFORM_DEPENDENT_LIBS ${SSL_LIBRARIES})
-  if(WIN32 AND NOT CYGWIN)
-    list(APPEND FFMPEG_PLATFORM_DEPENDENT_LIBS Crypt32)
-  endif()
+  list(APPEND FFMPEG_PLATFORM_DEPENDENT_LIBS ${OPENSSL_LIBRARIES})
 endif()
 
 if(@ENABLE_OPUS@)


### PR DESCRIPTION
- What does your PR fix? Fixes linking of openssl on x64-linux, whilst also simplifying openssl library search code (thanks to the work done in #14308).

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? To the best of my knowledge, yes.