### PR TITLE
[vcpkg_configure_make] Correct parameter SKIP_CONFIGURE

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -192,7 +192,7 @@ function(vcpkg_configure_make)
         set(_csc_AUTOCONFIG ON)
     elseif(EXISTS "${SRC_DIR}/autogen.sh") # Run autogen
         set(REQUIRES_AUTOGEN TRUE)
-    elseif (csc_SKIP_CONFIGURE)
+    elseif (csc_SKIP_CONFIGURE AND NOT EXISTS "${SRC_DIR}/configure")
         message(STATUS "Skip the configuration step")
     else()
         message(FATAL_ERROR "Could not determine method to configure make")

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -192,6 +192,8 @@ function(vcpkg_configure_make)
         set(_csc_AUTOCONFIG ON)
     elseif(EXISTS "${SRC_DIR}/autogen.sh") # Run autogen
         set(REQUIRES_AUTOGEN TRUE)
+    elseif (csc_SKIP_CONFIGURE)
+        message(STATUS "Skip the configuration step")
     else()
         message(FATAL_ERROR "Could not determine method to configure make")
     endif()

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -192,7 +192,7 @@ function(vcpkg_configure_make)
         set(_csc_AUTOCONFIG ON)
     elseif(EXISTS "${SRC_DIR}/autogen.sh") # Run autogen
         set(REQUIRES_AUTOGEN TRUE)
-    elseif (csc_SKIP_CONFIGURE AND NOT EXISTS "${SRC_DIR}/configure")
+    elseif (csc_SKIP_CONFIGURE AND NOT EXISTS "${SRC_DIR}/configure") # Must use configure when it exists; When SKIP_CONFIGURE is not used and configure does not exist, report error
         message(STATUS "Skip the configuration step")
     else()
         message(FATAL_ERROR "Could not determine method to configure make")

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -192,7 +192,7 @@ function(vcpkg_configure_make)
         set(_csc_AUTOCONFIG ON)
     elseif(EXISTS "${SRC_DIR}/autogen.sh") # Run autogen
         set(REQUIRES_AUTOGEN TRUE)
-    elseif (csc_SKIP_CONFIGURE AND NOT EXISTS "${SRC_DIR}/configure") # Must use configure when it exists; When SKIP_CONFIGURE is not used and configure does not exist, report error
+    elseif (_csc_SKIP_CONFIGURE AND NOT EXISTS "${SRC_DIR}/configure") # Must use configure when it exists; When SKIP_CONFIGURE is not used and configure does not exist, report error
         message(STATUS "Skip the configuration step")
     else()
         message(FATAL_ERROR "Could not determine method to configure make")


### PR DESCRIPTION
Ignore autogen and autoconfig judgment when using `SKIP_CONFIGURE`.

Fixes #14389.