### PR TITLE
[sdl2] apply upstream patch to fix macos vulkan fixes #13773

### DIFF
--- a/ports/sdl2/0008-fix-macos-metal-test.patch
+++ b/ports/sdl2/0008-fix-macos-metal-test.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2020-11-05 16:48:40.000000000 -0800
++++ CMakeLists.txt	2020-11-05 16:49:02.000000000 -0800
+@@ -1701,7 +1701,7 @@
+ 
+     if(VIDEO_VULKAN OR VIDEO_METAL OR RENDER_METAL)
+       set(ORIG_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+-      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -x objective-c")
++      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -ObjC")
+       check_c_source_compiles("
+         #include <AvailabilityMacros.h>
+         #import <Metal/Metal.h>

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_extract_source_archive_ex(
         fix-EventToken-header-reference.patch
         0006-sdl2-Enable-creation-of-pkg-cfg-file-on-windows.patch
         0007-sdl2-skip-ibus-on-linux.patch
+        0008-fix-macos-metal-test.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version-string": "2.0.12",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {


### PR DESCRIPTION
Apply an upstream patch to fix metal support detection on macos

- What does your PR fix? Fixes #13773 

- Which triplets are supported/not supported? Have you updated the CI baseline?
Affects x64-osx
I have not update the CI baseline

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes, I believe so.