### PR TITLE
[netcdf-c] Fix linkage error

### DIFF
--- a/ports/netcdf-c/CONTROL
+++ b/ports/netcdf-c/CONTROL
@@ -1,5 +1,6 @@
 Source: netcdf-c
 Version: 4.7.4
+Port-Version: 1
 Build-Depends: hdf5, curl
 Homepage: https://github.com/Unidata/netcdf-c
 Description: a set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.

--- a/ports/netcdf-c/fix-linkage-error.patch
+++ b/ports/netcdf-c/fix-linkage-error.patch
@@ -1,0 +1,19 @@
+diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
+index 8aeeab7..5b578f7 100644
+--- a/liblib/CMakeLists.txt
++++ b/liblib/CMakeLists.txt
+@@ -70,8 +70,14 @@ ENDIF()
+ IF(USE_HDF5 OR USE_NETCDF4)
+   if(TARGET hdf5::hdf5-shared)
+     SET(TLL_LIBS ${TLL_LIBS} hdf5::hdf5-shared hdf5::hdf5_hl-shared)
++    if(USE_PARALLEL)
++      list(APPEND TLL_LIBS ${MPI_C_LIBRARIES})
++    endif()
+   else()
+     SET(TLL_LIBS ${TLL_LIBS} hdf5::hdf5-static hdf5::hdf5_hl-static)
++    if(USE_PARALLEL)
++      list(APPEND TLL_LIBS ${MPI_C_LIBRARIES})
++    endif()
+   endif()
+ ENDIF()
+ 

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         config-pkg-location.patch
         use_targets.patch
         fix-dependency-libmath.patch
+        fix-linkage-error.patch
 )
 
 #Remove outdated find modules


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14263

```
[139/140] cmd.exe /C "cd . && D:\Dokumenty\Projects\lib\vcpkg\downloads\tools\cmake-3.18.4-windows\cmake-3.18.4-win32-x86\bin\cmake.exe -E vs_link_dll --intdir=liblib\CMakeFiles\netcdf.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\1427~1.291\bin\Hostx64\x86\link.exe  @CMakeFiles\netcdf.rsp  /out:liblib\netcdf.dll /implib:liblib\netcdf.lib /pdb:liblib\netcdf.pdb /dll /version:18.0 /machine:X86 /LARGEADDRESSAWARE /STACK:40000000 /nologo    /debug /INCREMENTAL  /NODEFAULTLIB:MSVCRT  && cd ."
FAILED: liblib/netcdf.dll liblib/netcdf.lib 
cmd.exe /C "cd . && D:\Dokumenty\Projects\lib\vcpkg\downloads\tools\cmake-3.18.4-windows\cmake-3.18.4-win32-x86\bin\cmake.exe -E vs_link_dll --intdir=liblib\CMakeFiles\netcdf.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\1427~1.291\bin\Hostx64\x86\link.exe  @CMakeFiles\netcdf.rsp  /out:liblib\netcdf.dll /implib:liblib\netcdf.lib /pdb:liblib\netcdf.pdb /dll /version:18.0 /machine:X86 /LARGEADDRESSAWARE /STACK:40000000 /nologo    /debug /INCREMENTAL  /NODEFAULTLIB:MSVCRT  && cd ."
LINK Pass 1: command "C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\1427~1.291\bin\Hostx64\x86\link.exe @CMakeFiles\netcdf.rsp /out:liblib\netcdf.dll /implib:liblib\netcdf.lib /pdb:liblib\netcdf.pdb /dll /version:18.0 /machine:X86 /LARGEADDRESSAWARE /STACK:40000000 /nologo /debug /INCREMENTAL /NODEFAULTLIB:MSVCRT /MANIFEST /MANIFESTFILE:liblib\CMakeFiles\netcdf.dir/intermediate.manifest liblib\CMakeFiles\netcdf.dir/manifest.res" failed (exit code 1120) with the following output:
   Creating library liblib\netcdf.lib and object liblib\netcdf.exp
dinfermodel.c.obj : error LNK2019: unresolved external symbol _MPI_Error_class@8 referenced in function _openmagic
dinfermodel.c.obj : error LNK2019: unresolved external symbol _MPI_File_open@20 referenced in function _openmagic
dinfermodel.c.obj : error LNK2019: unresolved external symbol _MPI_File_close@4 referenced in function _closemagic
dinfermodel.c.obj : error LNK2019: unresolved external symbol _MPI_File_get_size@8 referenced in function _openmagic
dinfermodel.c.obj : error LNK2019: unresolved external symbol _MPI_File_read_at_all@28 referenced in function _readmagic
hdf5file.c.obj : error LNK2019: unresolved external symbol _MPI_Comm_free@4 referenced in function _nc4_close_netcdf4_file
hdf5create.c.obj : error LNK2001: unresolved external symbol _MPI_Comm_free@4
hdf5open.c.obj : error LNK2001: unresolved external symbol _MPI_Comm_free@4
hdf5file.c.obj : error LNK2019: unresolved external symbol _MPI_Info_free@4 referenced in function _nc4_close_netcdf4_file
hdf5create.c.obj : error LNK2001: unresolved external symbol _MPI_Info_free@4
hdf5open.c.obj : error LNK2001: unresolved external symbol _MPI_Info_free@4
hdf5create.c.obj : error LNK2019: unresolved external symbol _MPI_Comm_dup@8 referenced in function _nc4_create_file
hdf5open.c.obj : error LNK2001: unresolved external symbol _MPI_Comm_dup@8
hdf5create.c.obj : error LNK2019: unresolved external symbol _MPI_Info_dup@8 referenced in function _nc4_create_file
hdf5open.c.obj : error LNK2001: unresolved external symbol _MPI_Info_dup@8
hdf5var.c.obj : error LNK2019: unresolved external symbol _MPI_Allreduce@24 referenced in function _NC4_put_vars
liblib\netcdf.dll : fatal error LNK1120: 10 unresolved externals
ninja: build stopped: subcommand failed.

```
check if `hdf5` was built with parallel support, it also requires `mpi `to build.

Since `hdf5 `has a dependency of `mpi`, there is no need to add `mpi `as one of dependencies for `netcdf-c`.

I just add `mpi` to the link libraries.

Note: No feature needs to test.





