### PR TITLE
[vcpkg baseline][rtabmap] Fix dependency issue when build tools

### DIFF
--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -10,10 +10,17 @@ vcpkg_from_github(
         001_opencv.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    tools BUILD_TOOLS
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
+        ${FEATURE_OPTIONS}
+        -DBUILD_APP=OFF
+        -DBUILD_EXAMPLES=OFF
         -DWITH_QT=OFF
         -DWITH_SUPERPOINT_TORCH=OFF
         -DWITH_PYMATCHER=OFF
@@ -53,7 +60,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-vcpkg_copy_tools(
+if("tools" IN_LIST FEATURES)
+  vcpkg_copy_tools(
     TOOL_NAMES
         rtabmap-camera
         rtabmap-console
@@ -67,8 +75,10 @@ vcpkg_copy_tools(
         rtabmap-reprocess
         rtabmap-res_tool
         rtabmap-rgbd_dataset
+        rtabmap-euroc_dataset
     AUTO_CLEAN
-)
+  )
+endif()
 
 file(REMOVE_RECURSE 
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -60,6 +60,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
+vcpkg_copy_tools(TOOL_NAMES rtabmap-res_tool AUTO_CLEAN)
+
 if("tools" IN_LIST FEATURES)
   vcpkg_copy_tools(
     TOOL_NAMES
@@ -73,7 +75,6 @@ if("tools" IN_LIST FEATURES)
         rtabmap-recovery
         rtabmap-report
         rtabmap-reprocess
-        rtabmap-res_tool
         rtabmap-rgbd_dataset
         rtabmap-euroc_dataset
     AUTO_CLEAN

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -9,5 +9,13 @@
     "opencv",
     "pcl",
     "zlib"
-  ]
+  ],
+  "features": {
+    "tools":{
+      "description": "Build tools",
+      "dependencies": [
+        "yaml-cpp"
+       ]
+    }
+  }
 }

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -11,11 +11,11 @@
     "zlib"
   ],
   "features": {
-    "tools":{
+    "tools": {
       "description": "Build tools",
       "dependencies": [
         "yaml-cpp"
-       ]
+      ]
     }
   }
 }


### PR DESCRIPTION
Related https://github.com/microsoft/vcpkg/pull/14290

1.Update to build tools as a feature
2. When build tools, it requires yaml-cpp to build rtabmap-euroc_dataset, add the dependency.

Check all tools in https://github.com/introlab/rtabmap/blob/master/tools/CMakeLists.txt
- [X] ImagesJoiner and StereoEval tools not installed by the Upstream
- [X] The rtabmap_gui not built since we disabled QT, 
- [X] OPENCV_NONFREE not found when I installed opencv[nonfree] feature, I didn't find related macro exported. So I think we have coverred all tools here.

Failrues:
```
- Performing post-build validation
The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    D:/packages/rtabmap_x64-windows/bin/rtabmap-euroc_dataset.exe

The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    D:/packages/rtabmap_x64-windows/debug/bin/rtabmap-euroc_dataset.exe

Found 2 error(s). Please correct the portfile:
```