### PR TITLE
[vcpkg] Add a definition for OVERLAY_TRIPLET_ENV

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -912,6 +912,7 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ARG;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ARG;
+    constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::BINARY_SOURCES_ARG;
 


### PR DESCRIPTION
This definition is needed in C++14/gcc 6 to compile.
