### PR TITLE
[openssl] Add build depends to deprecated openssl ports

### DIFF
--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -2,3 +2,4 @@ Source: openssl-unix
 Version: 1.1.1h
 Description: Deprecated OpenSSL port
 Supports: !(windows|uwp)
+Build-Depends: openssl

--- a/ports/openssl-unix/CONTROL
+++ b/ports/openssl-unix/CONTROL
@@ -1,5 +1,6 @@
 Source: openssl-unix
 Version: 1.1.1h
+Port-Version: 1
 Description: Deprecated OpenSSL port
 Supports: !(windows|uwp)
 Build-Depends: openssl

--- a/ports/openssl-uwp/CONTROL
+++ b/ports/openssl-uwp/CONTROL
@@ -2,3 +2,4 @@ Source: openssl-uwp
 Version: 1.1.1h
 Description: Deprecated OpenSSL port
 Supports: uwp
+Build-Depends: openssl

--- a/ports/openssl-uwp/CONTROL
+++ b/ports/openssl-uwp/CONTROL
@@ -1,5 +1,6 @@
 Source: openssl-uwp
 Version: 1.1.1h
+Port-Version: 1
 Description: Deprecated OpenSSL port
 Supports: uwp
 Build-Depends: openssl

--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -1,5 +1,6 @@
 Source: openssl-windows
 Version: 1.1.1h
+Port-Version: 1
 Description: Deprecated OpenSSL port
 Supports: windows
 Build-Depends: openssl

--- a/ports/openssl-windows/CONTROL
+++ b/ports/openssl-windows/CONTROL
@@ -2,3 +2,4 @@ Source: openssl-windows
 Version: 1.1.1h
 Description: Deprecated OpenSSL port
 Supports: windows
+Build-Depends: openssl


### PR DESCRIPTION
fixes `vcpkg upgrade` for these ports
#14440
#14451
since the `openssl-<x>` port will be automatically removed on upgrade (and unfortunally reinstalled but it can be safely removed in the future after the upgrade).

People already affected need to manually uninstall the `openssl-<x>`

