### PR TITLE
[libflac] require NASM for libflac[asm]

### DIFF
--- a/ports/libflac/CONTROL
+++ b/ports/libflac/CONTROL
@@ -1,6 +1,6 @@
 Source: libflac
 Version: 1.3.3
-Port-Version: 4
+Port-Version: 5
 Homepage: https://xiph.org/flac/
 Description: Library for manipulating FLAC files
 Build-Depends: libogg

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -23,9 +23,9 @@ if("asm" IN_LIST FEATURES)
         message(FATAL_ERROR "Feature asm only supports x86 architecture.")
     endif()
 
-	VCPKG_FIND_ACQUIRE_PROGRAM(NASM)
-	GET_FILENAME_COMPONENT(NASM_PATH ${NASM} DIRECTORY)
-	vcpkg_add_to_path("${NASM_PATH}")
+    VCPKG_FIND_ACQUIRE_PROGRAM(NASM)
+    GET_FILENAME_COMPONENT(NASM_PATH ${NASM} DIRECTORY)
+    vcpkg_add_to_path("${NASM_PATH}")
 endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libflac/portfile.cmake
+++ b/ports/libflac/portfile.cmake
@@ -22,6 +22,10 @@ if("asm" IN_LIST FEATURES)
     if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
         message(FATAL_ERROR "Feature asm only supports x86 architecture.")
     endif()
+
+	VCPKG_FIND_ACQUIRE_PROGRAM(NASM)
+	GET_FILENAME_COMPONENT(NASM_PATH ${NASM} DIRECTORY)
+	vcpkg_add_to_path("${NASM_PATH}")
 endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 

This pull request will make sure NASM is used when libflac is compiled with assembler [asm] support.

Without this patch, if NASM is not installed, the compilation will complete, silently ignoring the request for assembler support.

- Which triplets are supported/not supported? Have you updated the CI baseline?

This does only affect x86, since the asm option is x86-only.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

As far as I can see yes, let me know if there are changes needed.

