### PR TITLE
[onnxruntime-gpu] Add port for onnxruntime (GPU)

### DIFF
--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -1,6 +1,6 @@
-vcpkg_fail_port_install(MESSAGE "onnxruntime currently only supports Windows platforms" ON_TARGET "UWP" "LINUX" "ANDROID" "FREEBSD" "OSX")
-vcpkg_fail_port_install(MESSAGE "onnxruntime currently only supports x64 architecture" ON_ARCH "x86" "arm" "arm64")
-vcpkg_fail_port_install(MESSAGE "onnxruntime currently does not support static libraries" ON_LIBRARY_LINKAGE "static")
+vcpkg_fail_port_install(ON_ARCH "x86" "arm" ON_TARGET "UWP" "LINUX" "ANDROID" "FREEBSD" "OSX")
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 set(VERSION 1.5.1)
 

--- a/ports/onnxruntime-gpu/portfile.cmake
+++ b/ports/onnxruntime-gpu/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_fail_port_install(MESSAGE "onnxruntime currently only supports Windows platforms" ON_TARGET "UWP" "LINUX" "ANDROID" "FREEBSD" "OSX")
+vcpkg_fail_port_install(MESSAGE "onnxruntime currently only supports x64 architecture" ON_ARCH "x86" "arm" "arm64")
+vcpkg_fail_port_install(MESSAGE "onnxruntime currently does not support static libraries" ON_LIBRARY_LINKAGE "static")
+
+set(VERSION 1.5.1)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/microsoft/onnxruntime/releases/download/v1.5.1/onnxruntime-win-x64-gpu-1.5.1.zip"
+    FILENAME "onnxruntime-win-x64-gpu-1.5.1.zip"
+    SHA512 893dbed1196b5c9730744dc5566cd3ad8ec677cbea04dd0572efc9a8b3563d3f1cbf40d0dea3d624d9451dc33272c0ae44d53d6deee6f249fa2520e60718ee52
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+    REF ${VERSION}
+)
+
+file(MAKE_DIRECTORY
+        ${CURRENT_PACKAGES_DIR}/include
+        ${CURRENT_PACKAGES_DIR}/lib
+        ${CURRENT_PACKAGES_DIR}/bin
+        ${CURRENT_PACKAGES_DIR}/debug/lib
+        ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+
+file(COPY
+        ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/include
+        DESTINATION ${CURRENT_PACKAGES_DIR}
+    )
+
+file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/lib/onnxruntime.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/lib/onnxruntime.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/lib/onnxruntime.dll
+    DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+file(COPY ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/lib/onnxruntime.dll
+    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+
+# # Handle copyright
+file(INSTALL ${SOURCE_PATH}/onnxruntime-win-x64-gpu-1.5.1/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/onnxruntime-gpu/vcpkg.json
+++ b/ports/onnxruntime-gpu/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "onnxruntime-gpu",
+  "version-string": "1.5.1",
+  "description": "onnxruntime (GPU)",
+  "homepage": "https://github.com/microsoft/onnxruntime",
+  "supports": "windows & !x86 & !uwp & !static & !arm"
+}


### PR DESCRIPTION
**Describe the pull request**

This port uses the binaries created by Microsoft for the onnxruntime which will run with a GPU. 

It is currently used for an internal build but I thought it would be good to offer it to more people, which is why I've raised this PR. Whilst I appreciate this doesn't actually build the binaries, it does show how to include binaries and libraries from elsewhere that can then be included in your projects.

- currently only supports the triplets x64-windows
- PR follows the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
