### PR TITLE
[freetype] Fix INTERFACE_LINK_LIBRARIES in exported cmake file

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,6 +1,6 @@
 Source: freetype
 Version: 2.10.2
-Port-Version: 4
+Port-Version: 5
 Build-Depends: zlib, brotli
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.

--- a/ports/freetype/fix-exports.patch
+++ b/ports/freetype/fix-exports.patch
@@ -1,0 +1,70 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 04ce73a..cda36a5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -454,31 +454,31 @@ endif ()
+ set(PKG_CONFIG_REQUIRED_PRIVATE "")
+ 
+ if (ZLIB_FOUND)
+-  target_link_libraries(freetype PRIVATE ${ZLIB_LIBRARIES})
+-  target_include_directories(freetype PRIVATE ${ZLIB_INCLUDE_DIRS})
+-  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "zlib")
++  target_link_libraries(freetype PUBLIC ZLIB::ZLIB)
++  target_include_directories(freetype PUBLIC ${ZLIB_INCLUDE_DIRS})
++  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "zlib")
+ endif ()
+ if (BZIP2_FOUND)
+-  target_link_libraries(freetype PRIVATE ${BZIP2_LIBRARIES})
+-  target_include_directories(freetype PRIVATE ${BZIP2_INCLUDE_DIR}) # not BZIP2_INCLUDE_DIRS
+-  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "bzip2")
++  target_link_libraries(freetype PUBLIC ${BZIP2_LIBRARIES})
++  target_include_directories(freetype PUBLIC ${BZIP2_INCLUDE_DIR}) # not BZIP2_INCLUDE_DIRS
++  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "bzip2")
+ endif ()
+ if (PNG_FOUND)
+-  target_link_libraries(freetype PRIVATE ${PNG_LIBRARIES})
+-  target_compile_definitions(freetype PRIVATE ${PNG_DEFINITIONS})
+-  target_include_directories(freetype PRIVATE ${PNG_INCLUDE_DIRS})
+-  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "libpng")
++  target_link_libraries(freetype PUBLIC ${PNG_LIBRARIES})
++  target_compile_definitions(freetype PUBLIC ${PNG_DEFINITIONS})
++  target_include_directories(freetype PUBLIC ${PNG_INCLUDE_DIRS})
++  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "libpng")
+ endif ()
+ if (HARFBUZZ_FOUND)
+-  target_link_libraries(freetype PRIVATE ${HARFBUZZ_LIBRARIES})
+-  target_include_directories(freetype PRIVATE ${HARFBUZZ_INCLUDE_DIRS})
+-  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "harfbuzz >= ${HARFBUZZ_MIN_VERSION}")
++  target_link_libraries(freetype PUBLIC ${HARFBUZZ_LIBRARIES})
++  target_include_directories(freetype PUBLIC ${HARFBUZZ_INCLUDE_DIRS})
++  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "harfbuzz >= ${HARFBUZZ_MIN_VERSION}")
+ endif ()
+ if (BROTLIDEC_FOUND)
+-  target_link_libraries(freetype PRIVATE ${BROTLIDEC_LIBRARIES})
+-  target_compile_definitions(freetype PRIVATE ${BROTLIDEC_DEFINITIONS})
+-  target_include_directories(freetype PRIVATE ${BROTLIDEC_INCLUDE_DIRS})
+-  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "libbrotlidec")
++  target_link_libraries(freetype PUBLIC ${BROTLIDEC_LIBRARIES})
++  target_compile_definitions(freetype PUBLIC ${BROTLIDEC_DEFINITIONS})
++  target_include_directories(freetype PUBLIC ${BROTLIDEC_INCLUDE_DIRS})
++  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "libbrotlidec")
+ endif ()
+ 
+ 
+@@ -562,8 +562,15 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+   install(
+     EXPORT freetype-targets
+       DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freetype
+-      FILE freetype-config.cmake
+       COMPONENT headers)
++
++  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/freetype-config.cmake"
++ [[include(CMakeFindDependencyMacro)
++find_dependency(ZLIB)
++include("${CMAKE_CURRENT_LIST_DIR}/freetype-targets.cmake")
++ ]])
++
++  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/freetype-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freetype)
+ endif ()
+ 
+ 

--- a/ports/freetype/fix-exports.patch
+++ b/ports/freetype/fix-exports.patch
@@ -1,56 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 04ce73a..cda36a5 100644
+index 04ce73a..ee3cc05 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -454,31 +454,31 @@ endif ()
+@@ -454,7 +454,7 @@ endif ()
  set(PKG_CONFIG_REQUIRED_PRIVATE "")
  
  if (ZLIB_FOUND)
 -  target_link_libraries(freetype PRIVATE ${ZLIB_LIBRARIES})
--  target_include_directories(freetype PRIVATE ${ZLIB_INCLUDE_DIRS})
--  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "zlib")
-+  target_link_libraries(freetype PUBLIC ZLIB::ZLIB)
-+  target_include_directories(freetype PUBLIC ${ZLIB_INCLUDE_DIRS})
-+  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "zlib")
++  target_link_libraries(freetype PRIVATE ZLIB::ZLIB)
+   target_include_directories(freetype PRIVATE ${ZLIB_INCLUDE_DIRS})
+   list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "zlib")
  endif ()
- if (BZIP2_FOUND)
--  target_link_libraries(freetype PRIVATE ${BZIP2_LIBRARIES})
--  target_include_directories(freetype PRIVATE ${BZIP2_INCLUDE_DIR}) # not BZIP2_INCLUDE_DIRS
--  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "bzip2")
-+  target_link_libraries(freetype PUBLIC ${BZIP2_LIBRARIES})
-+  target_include_directories(freetype PUBLIC ${BZIP2_INCLUDE_DIR}) # not BZIP2_INCLUDE_DIRS
-+  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "bzip2")
- endif ()
- if (PNG_FOUND)
--  target_link_libraries(freetype PRIVATE ${PNG_LIBRARIES})
--  target_compile_definitions(freetype PRIVATE ${PNG_DEFINITIONS})
--  target_include_directories(freetype PRIVATE ${PNG_INCLUDE_DIRS})
--  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "libpng")
-+  target_link_libraries(freetype PUBLIC ${PNG_LIBRARIES})
-+  target_compile_definitions(freetype PUBLIC ${PNG_DEFINITIONS})
-+  target_include_directories(freetype PUBLIC ${PNG_INCLUDE_DIRS})
-+  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "libpng")
- endif ()
- if (HARFBUZZ_FOUND)
--  target_link_libraries(freetype PRIVATE ${HARFBUZZ_LIBRARIES})
--  target_include_directories(freetype PRIVATE ${HARFBUZZ_INCLUDE_DIRS})
--  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "harfbuzz >= ${HARFBUZZ_MIN_VERSION}")
-+  target_link_libraries(freetype PUBLIC ${HARFBUZZ_LIBRARIES})
-+  target_include_directories(freetype PUBLIC ${HARFBUZZ_INCLUDE_DIRS})
-+  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "harfbuzz >= ${HARFBUZZ_MIN_VERSION}")
- endif ()
- if (BROTLIDEC_FOUND)
--  target_link_libraries(freetype PRIVATE ${BROTLIDEC_LIBRARIES})
--  target_compile_definitions(freetype PRIVATE ${BROTLIDEC_DEFINITIONS})
--  target_include_directories(freetype PRIVATE ${BROTLIDEC_INCLUDE_DIRS})
--  list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "libbrotlidec")
-+  target_link_libraries(freetype PUBLIC ${BROTLIDEC_LIBRARIES})
-+  target_compile_definitions(freetype PUBLIC ${BROTLIDEC_DEFINITIONS})
-+  target_include_directories(freetype PUBLIC ${BROTLIDEC_INCLUDE_DIRS})
-+  list(APPEND PKG_CONFIG_REQUIRED_PUBLIC "libbrotlidec")
- endif ()
- 
- 
 @@ -562,8 +562,15 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    install(
      EXPORT freetype-targets
@@ -59,10 +19,10 @@ index 04ce73a..cda36a5 100644
        COMPONENT headers)
 +
 +  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/freetype-config.cmake"
-+ [[include(CMakeFindDependencyMacro)
++[[include(CMakeFindDependencyMacro)
 +find_dependency(ZLIB)
 +include("${CMAKE_CURRENT_LIST_DIR}/freetype-targets.cmake")
-+ ]])
++]])
 +
 +  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/freetype-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freetype)
  endif ()

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -1,19 +1,17 @@
 set(FT_VERSION 2.10.2)
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://download-mirror.savannah.gnu.org/releases/freetype/freetype-${FT_VERSION}.tar.xz" "https://downloads.sourceforge.net/project/freetype/freetype2/${FT_VERSION}/freetype-${FT_VERSION}.tar.xz"
-    FILENAME "freetype-${FT_VERSION}.tar.xz"
-    SHA512 cf45089bd8893d7de2cdcb59d91bbb300e13dd0f0a9ef80ed697464ba7aeaf46a5a81b82b59638e6b21691754d8f300f23e1f0d11683604541d77f0f581affaa
-)
 
-vcpkg_extract_source_archive_ex(
+vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    REPO freetype/freetype2
     REF ${FT_VERSION}
+    FILENAME freetype-${FT_VERSION}.tar.xz
+    SHA512 cf45089bd8893d7de2cdcb59d91bbb300e13dd0f0a9ef80ed697464ba7aeaf46a5a81b82b59638e6b21691754d8f300f23e1f0d11683604541d77f0f581affaa
     PATCHES
         0001-Fix-install-command.patch
         0003-Fix-UWP.patch
         pkgconfig.patch
         brotli-static.patch
+        fix-exports.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -36,6 +34,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/freetype)
 
 # Rename for easy usage (VS integration; CMake and autotools will not care)
@@ -45,13 +44,13 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/freetype2)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Fix the include dir [freetype2 -> freetype]
-file(READ ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-config.cmake CONFIG_MODULE)
+file(READ ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-targets.cmake CONFIG_MODULE)
 string(REPLACE "\${_IMPORT_PREFIX}/include/freetype2" "\${_IMPORT_PREFIX}/include" CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlicommon-static.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlicommon-static.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlicommon-static.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec-static.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec-static.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec-static.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
 string(REPLACE "\${_IMPORT_PREFIX}/lib/brotlidec.lib" [[\$<\$<NOT:\$<CONFIG:DEBUG>>:${_IMPORT_PREFIX}/lib/brotlidec.lib>;\$<\$<CONFIG:DEBUG>:${_IMPORT_PREFIX}/debug/lib/brotlidec.lib>]] CONFIG_MODULE "${CONFIG_MODULE}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-config.cmake "${CONFIG_MODULE}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/freetype/freetype-targets.cmake "${CONFIG_MODULE}")
 
 find_library(FREETYPE_DEBUG NAMES freetyped PATHS "${CURRENT_PACKAGES_DIR}/debug/lib/" NO_DEFAULT_PATH)
 if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/freetype2.pc")
@@ -67,19 +66,11 @@ if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/freetype2.pc")
     string(REPLACE "-I\${includedir}/freetype2" "-I\${includedir}" _contents "${_contents}")
     file(WRITE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/freetype2.pc" "${_contents}")
 endif()
+
 vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-
-file(COPY
-    ${SOURCE_PATH}/docs/FTL.TXT
-    ${SOURCE_PATH}/docs/GPLv2.TXT
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-)
-file(INSTALL ${SOURCE_PATH}/docs/LICENSE.TXT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     if("bzip2" IN_LIST FEATURES)
@@ -93,3 +84,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake 
         ${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake @ONLY)
 endif()
+
+file(COPY
+    ${SOURCE_PATH}/docs/FTL.TXT
+    ${SOURCE_PATH}/docs/GPLv2.TXT
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+)
+file(INSTALL ${SOURCE_PATH}/docs/LICENSE.TXT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,6 +1,6 @@
 Source: libpng
 Version: 1.6.37
-Port-Version: 12
+Port-Version: 13
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/fix-export-targets.patch
+++ b/ports/libpng/fix-export-targets.patch
@@ -1,0 +1,65 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b45e878..19f8692 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -536,7 +536,7 @@ if(PNG_SHARED)
+     set_target_properties(png PROPERTIES PREFIX "lib")
+     set_target_properties(png PROPERTIES IMPORT_PREFIX "lib")
+   endif()
+-  target_link_libraries(png ${ZLIB_LIBRARY} ${M_LIBRARY})
++  target_link_libraries(png ZLIB::ZLIB ${M_LIBRARY})
+ 
+   if(UNIX AND AWK)
+     if(HAVE_LD_VERSION_SCRIPT)
+@@ -564,7 +564,7 @@ if(PNG_STATIC)
+     # msvc does not append 'lib' - do it here to have consistent name
+     set_target_properties(png_static PROPERTIES PREFIX "lib")
+   endif()
+-  target_link_libraries(png_static ${ZLIB_LIBRARY} ${M_LIBRARY})
++  target_link_libraries(png_static ZLIB::ZLIB ${M_LIBRARY})
+ endif()
+ 
+ if(PNG_FRAMEWORK)
+@@ -581,7 +581,7 @@ if(PNG_FRAMEWORK)
+     XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
+     PUBLIC_HEADER "${libpng_public_hdrs}"
+     OUTPUT_NAME png)
+-  target_link_libraries(png_framework ${ZLIB_LIBRARY} ${M_LIBRARY})
++  target_link_libraries(png_framework ZLIB::ZLIB ${M_LIBRARY})
+ endif()
+ 
+ if(NOT PNG_LIB_TARGETS)
+@@ -746,7 +746,7 @@ if(PNG_SHARED)
+   set(PNG_BIN_TARGETS pngfix)
+ 
+   add_executable(png-fix-itxt ${png_fix_itxt_sources})
+-  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARY} ${M_LIBRARY})
++  target_link_libraries(png-fix-itxt ZLIB::ZLIB ${M_LIBRARY})
+   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
+ endif()
+ 
+@@ -851,7 +851,7 @@ endif()
+ # INSTALL
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+   install(TARGETS ${PNG_LIB_TARGETS}
+-          EXPORT libpng
++          EXPORT libpng-targets
+           RUNTIME DESTINATION bin
+           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -919,7 +919,14 @@ endif()
+ 
+ # Create an export file that CMake users can include() to import our targets.
+ if(NOT SKIP_INSTALL_EXPORT AND NOT SKIP_INSTALL_ALL)
+-  install(EXPORT libpng DESTINATION lib/libpng FILE libpngConfig.cmake)
++  install(EXPORT libpng-targets DESTINATION lib/libpng)
++  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libpng-config.cmake"
++ [[include(CMakeFindDependencyMacro)
++find_dependency(ZLIB)
++include("${CMAKE_CURRENT_LIST_DIR}/libpng-targets.cmake")
++ ]])
++
++  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libpng-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/libpng)
+ endif()
+ 
+ # what's with libpng-manual.txt and all the extra files?

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -42,6 +42,7 @@ vcpkg_from_github(
         pkgconfig.patch
         pkgconfig.2.patch
         ${APNG_EXTRA_PATCH}
+        fix-export-targets.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
Fix wrong INTERFACE_LINK_LIBRARIES in _freetype-config.cmake_:
```
set_target_properties(freetype PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include/freetype"
  INTERFACE_LINK_LIBRARIES "/mnt/d/xlinux/installed/x64-linux/debug/lib/libz.a;\$<\$<NOT:\$<CONFIG:DEBUG>>:/mnt/d/xlinux/installed/x64-linux/lib/libbz2.a>;\$<\$<CONFIG:DEBUG>:/mnt/d/xlinux/installed/x64-linux/debug/lib/libbz2d.a>;\$<\$<NOT:\$<CONFIG:DEBUG>>:/mnt/d/xlinux/installed/x64-linux/debug/lib/libpng.a>;\$<\$<CONFIG:DEBUG>:/mnt/d/xlinux/installed/x64-linux/debug/lib/libpng16d.a>;/mnt/d/xlinux/installed/x64-linux/debug/lib/libz.a"
)
```

Fixes #9952.