### PR TITLE
[Catch2] Update to v3.0.0

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,4 +1,0 @@
-Source: catch2
-Version: 2.13.1
-Description: A modern, header-only test framework for unit testing.
-Homepage: https://github.com/catchorg/Catch2

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
 
 if(USE_V2)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage_v2 DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME usage)
 else()
     file(REMOVE_RECURSE
         ${CURRENT_PACKAGES_DIR}/debug/include

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -33,6 +33,10 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
 
 if(USE_V2)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+    if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
+        message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
+    endif()
+    file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
     file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage_v2 DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME usage)
 else()
     file(REMOVE_RECURSE

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,8 +1,20 @@
+if("v2" IN_LIST FEATURES)
+    set(USE_V2 ON)
+endif()
+
+if(USE_V2)
+    set(GIT_REF ff349a50bfc6214b4081f4ca63c7de35e2162f60) # v2.13.3
+    set(GIT_SHA512 488c95ba5c5f80019abc4f61b3b50536e3dc71f7bf87d51c56cc5928cf32cac0e535e1b08eb4e8e435665e81bf0156f83013ba31a1b3d2b61c692fbf7f019d25)
+else()
+    set(GIT_REF b9853b4b356b83bb580c746c3a1f11101f9af54f) # v3.0.0-preview3
+    set(GIT_SHA512 0223374e44e0198aece32338006534dfc839b253184a4a9468708672f2efc164b083d57b9c83ed694698959c282238bc99b4db77246f9472f89c1d2f330d5c0a)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
-    REF fd9f5ac661f87335ecd70d39849c1d3a90f1c64d # v2.13.1
-    SHA512 4fafd06006034cc02dddd22c381b5817549834dae0aff29ed598edd21a3c67f8ac61a77f51b06f3c59baa96a114ecb19c6df09126215bfc00bef94f8f77b810d
+    REF ${GIT_REF}
+    SHA512 ${GIT_SHA512}
     HEAD_REF master
 )
 
@@ -12,17 +24,27 @@ vcpkg_configure_cmake(
     OPTIONS
         -DBUILD_TESTING=OFF
         -DCATCH_BUILD_EXAMPLES=OFF
+        -DCATCH_INSTALL_DOCS=OFF
 )
 
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
-
-if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
-    message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
+if(USE_V2)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+    if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
+        message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
+    endif()
+    file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
+else()
+    file(REMOVE_RECURSE
+        ${CURRENT_PACKAGES_DIR}/debug/include
+        ${CURRENT_PACKAGES_DIR}/debug/share
+        ${CURRENT_PACKAGES_DIR}/include/catch2/benchmark/internal 
+        ${CURRENT_PACKAGES_DIR}/include/catch2/generators/internal
+    )
+    file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 endif()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -33,10 +33,6 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
 
 if(USE_V2)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
-    if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
-        message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
-    endif()
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
 else()
     file(REMOVE_RECURSE
         ${CURRENT_PACKAGES_DIR}/debug/include

--- a/ports/catch2/usage
+++ b/ports/catch2/usage
@@ -1,0 +1,11 @@
+The package catch2 provides CMake targets:
+
+    find_package(Catch2 CONFIG REQUIRED)
+    target_link_libraries(tests PRIVATE Catch2::Catch2)
+
+    # Or to use the default Catch2 main function
+    target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
+
+If you are using catch2 and your tests no longer compile, you have 2 options.
+1) Follow https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md
+2) Install catch2 with the feature 'v2'

--- a/ports/catch2/usage_v2
+++ b/ports/catch2/usage_v2
@@ -1,0 +1,8 @@
+The package catch2 provides CMake targets:
+
+    find_package(Catch2 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Catch2::Catch2)
+
+Note: it is recommended that you follow the migration guide and 
+update to Catch2 v3.
+https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "catch2",
+  "version-string": "3.0.0",
+  "description": "A modern, header-only test framework for unit testing.",
+  "homepage": "https://github.com/catchorg/Catch2",
+  "features": {
+    "v2": {
+      "description": "An older version of Catch2 (v2.13.3)"
+    }
+  }
+}

--- a/ports/coolprop/CONTROL
+++ b/ports/coolprop/CONTROL
@@ -2,4 +2,4 @@ Source: coolprop
 Version: 6.4.1
 Homepage: https://github.com/CoolProp/CoolProp
 Description: Thermophysical properties for the masses
-Build-Depends: catch, eigen3, pybind11, if97, fmt, rapidjson, msgpack, refprop-headers
+Build-Depends: catch2[v2], eigen3, pybind11, if97, fmt, rapidjson, msgpack, refprop-headers

--- a/ports/coolprop/CONTROL
+++ b/ports/coolprop/CONTROL
@@ -1,5 +1,6 @@
 Source: coolprop
 Version: 6.4.1
+Port-Version: 1
 Homepage: https://github.com/CoolProp/CoolProp
 Description: Thermophysical properties for the masses
 Build-Depends: catch2[v2], eigen3, pybind11, if97, fmt, rapidjson, msgpack, refprop-headers

--- a/ports/msix/CONTROL
+++ b/ports/msix/CONTROL
@@ -1,5 +1,6 @@
 Source: msix
-Version: 1.7-2
+Version: 1.7
+Port-Version: 3
 Build-Depends: xerces-c, zlib, openssl (!uwp&!windows), catch2[v2]
 Homepage: https://github.com/microsoft/msix-packaging
 Description: The MSIX Packaging SDK project is an effort to enable developers on a variety of platforms to pack and unpack packages for the purposes of distribution from either the Microsoft Store, or their own content distribution networks.

--- a/ports/msix/CONTROL
+++ b/ports/msix/CONTROL
@@ -1,6 +1,6 @@
 Source: msix
 Version: 1.7-2
-Build-Depends: xerces-c, zlib, openssl (!uwp&!windows), catch2
+Build-Depends: xerces-c, zlib, openssl (!uwp&!windows), catch2[v2]
 Homepage: https://github.com/microsoft/msix-packaging
 Description: The MSIX Packaging SDK project is an effort to enable developers on a variety of platforms to pack and unpack packages for the purposes of distribution from either the Microsoft Store, or their own content distribution networks.
   The MSIX Packaging APIs that a client app would use to interact with .msix/.appx packages are a subset of those documented here. See sample/ExtractContentsSample/ExtractContentsSample.cpp for additional details.


### PR DESCRIPTION
**Describe the pull request**
Update Catch2 to v3.0.0. As v3.0.0 is a breaking change, this update attempts to help informing users about the change.
1) Informs the user about the update, and where or how to find fixes. 
2) Add a feature to use v2 (updated to 2.13.3) over v3
3) Removes v2's forwarder. I don't think it is needed anymore.

*This pull request is here, waiting for v3.0.0 to come out. It currently is available for testing and review.*

- What does your PR fix? Fixes #14391 

- Which triplets are supported/not supported? Have you updated the CI baseline?
No changes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes, I think so.
