### PR TITLE
[boost] Install usage file

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,3 +1,4 @@
 Source: boost-modular-build-helper
 Version: 1.74.0
+Port-Version: 1
 Build-Depends: boost-uninstall

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -148,6 +148,8 @@ function(boost_modular_build)
         if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/lib)
             message(FATAL_ERROR "No libraries were produced. This indicates a failure while building the boost library.")
         endif()
+
+        file(INSTALL ${CURRENT_INSTALLED_DIR}/share/boost-build/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
         return()
     endif()
 
@@ -446,4 +448,5 @@ function(boost_modular_build)
     endif()
 
     vcpkg_copy_pdbs()
+    file(INSTALL ${CURRENT_INSTALLED_DIR}/share/boost-build/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 endfunction()

--- a/ports/boost-modular-build-helper/portfile.cmake
+++ b/ports/boost-modular-build-helper/portfile.cmake
@@ -7,6 +7,7 @@ file(
         ${CMAKE_CURRENT_LIST_DIR}/nothing.bat
         ${CMAKE_CURRENT_LIST_DIR}/user-config.jam
         ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt
+        ${CMAKE_CURRENT_LIST_DIR}/usage
     DESTINATION
         ${CURRENT_PACKAGES_DIR}/share/boost-build
 )

--- a/ports/boost-modular-build-helper/usage
+++ b/ports/boost-modular-build-helper/usage
@@ -1,0 +1,5 @@
+The package boost is compatible with built-in CMake targets:
+
+    find_package(Boost REQUIRED [COMPONENTS <libs>...])
+    target_link_libraries(main PRIVATE ${Boost_LIBRARIES})
+    target_include_directories(main PRIVATE ${Boost_INCLUDE_DIRS})

--- a/ports/boost-modular-build-helper/usage
+++ b/ports/boost-modular-build-helper/usage
@@ -1,5 +1,4 @@
 The package boost is compatible with built-in CMake targets:
 
     find_package(Boost REQUIRED [COMPONENTS <libs>...])
-    target_link_libraries(main PRIVATE ${Boost_LIBRARIES})
-    target_include_directories(main PRIVATE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE Boost::boost Boost::<lib1> Boost::<lib2> ...)

--- a/ports/boost-vcpkg-helpers/CONTROL
+++ b/ports/boost-vcpkg-helpers/CONTROL
@@ -1,5 +1,5 @@
 Source: boost-vcpkg-helpers
 Version: 7
-Port-Version: 1
+Port-Version: 2
 Description: a set of vcpkg-internal scripts used to modularize boost
 Build-Depends: boost-uninstall

--- a/ports/boost-vcpkg-helpers/boost-modular-headers.cmake
+++ b/ports/boost-vcpkg-helpers/boost-modular-headers.cmake
@@ -19,6 +19,6 @@ function(boost_modular_headers)
         FILENAME "boost_LICENSE_1_0.txt"
         SHA512 d6078467835dba8932314c1c1e945569a64b065474d7aced27c9a7acc391d52e9f234138ed9f1aa9cd576f25f12f557e0b733c14891d42c16ecdc4a7bd4d60b8
     )
-
+    file(INSTALL ${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
     file(INSTALL ${ARCHIVE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 endfunction()

--- a/ports/boost-vcpkg-helpers/portfile.cmake
+++ b/ports/boost-vcpkg-helpers/portfile.cmake
@@ -1,7 +1,8 @@
 
-file(
-    COPY ${CMAKE_CURRENT_LIST_DIR}/boost-modular-headers.cmake
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/boost-vcpkg-helpers
+file(COPY
+    ${CMAKE_CURRENT_LIST_DIR}/boost-modular-headers.cmake
+    ${CMAKE_CURRENT_LIST_DIR}/usage
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
 )
 
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/boost-vcpkg-helpers/usage
+++ b/ports/boost-vcpkg-helpers/usage
@@ -1,0 +1,5 @@
+The package boost is compatible with built-in CMake targets:
+
+    find_package(Boost REQUIRED [COMPONENTS <libs>...])
+    target_link_libraries(main PRIVATE ${Boost_LIBRARIES})
+    target_include_directories(main PRIVATE ${Boost_INCLUDE_DIRS})

--- a/ports/boost-vcpkg-helpers/usage
+++ b/ports/boost-vcpkg-helpers/usage
@@ -1,5 +1,4 @@
 The package boost is compatible with built-in CMake targets:
 
     find_package(Boost REQUIRED [COMPONENTS <libs>...])
-    target_link_libraries(main PRIVATE ${Boost_LIBRARIES})
-    target_include_directories(main PRIVATE ${Boost_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE Boost::boost Boost::<lib1> Boost::<lib2> ...)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/13248

The usage information is wrong for boost header only ports, currently the usage file located in https://github.com/microsoft/vcpkg/blob/master/ports/boost/usage, however, it hasn't been installed, this PR will install the usage file for all boost components.

Before:
```
find_path(BOOST_PROCESS_INCLUDE_DIRS "boost/process.hpp")
target_include_directories(main PRIVATE ${BOOST_PROCESS_INCLUDE_DIRS})
```

Now:
The package boost is compatible with built-in CMake targets:

    find_package(Boost REQUIRED [COMPONENTS <libs>...])
    target_link_libraries(main PRIVATE ${Boost_LIBRARIES})
    target_include_directories(main PRIVATE ${Boost_INCLUDE_DIRS})
