### PR TITLE
[harfbuzz] fix icu linkage

### DIFF
--- a/ports/harfbuzz/CONTROL
+++ b/ports/harfbuzz/CONTROL
@@ -1,5 +1,6 @@
 Source: harfbuzz
 Version: 2.7.2
+Port-Version: 1
 Description: HarfBuzz OpenType text shaping engine
 Homepage: https://github.com/behdad/harfbuzz
 Build-Depends: freetype[core], ragel, gettext (osx)

--- a/ports/harfbuzz/icu.patch
+++ b/ports/harfbuzz/icu.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eb6cc9007..209128695 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,19 +226,13 @@ if (HB_HAVE_ICU)
+   add_definitions(-DHAVE_ICU)
+ 
+   # https://github.com/WebKit/webkit/blob/master/Source/cmake/FindICU.cmake
+-  find_package(PkgConfig)
+-  pkg_check_modules(PC_ICU QUIET icu-uc)
+-
+-  find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
+-  find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
++  find_package(ICU COMPONENTS uc REQUIRED)
+ 
+-  include_directories(${ICU_INCLUDE_DIR})
++  include_directories(${ICU_INCLUDE_DIRS})
+ 
+   list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-icu.h)
+ 
+-  list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
+-
+-  mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
++  list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARIES})
+ endif ()
+ 
+ if (APPLE AND HB_HAVE_CORETEXT)

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         # This patch is required for propagating the full list of dependencies from glib
         glib-cmake.patch
         fix_include.patch
+        icu.patch
 )
 
 file(READ ${SOURCE_PATH}/CMakeLists.txt _contents)


### PR DESCRIPTION
just fixing the icu linkage in harfbuzz
discovered in https://github.com/microsoft/vcpkg/pull/14333 due to CI failing (qt6-)qtbase builds. 
