### PR TITLE
[libmariadb] Export target mariadbclient

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,6 +1,6 @@
 Source: libmariadb
 Version: 3.1.10
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
 Default-Features: zlib, openssl

--- a/ports/libmariadb/export-cmake-targets.patch
+++ b/ports/libmariadb/export-cmake-targets.patch
@@ -1,8 +1,12 @@
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index 083a863..7bc32b4 100644
+index 083a863..d911fa7 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -460,10 +460,21 @@ INSTALL(TARGETS mariadbclient
+@@ -457,13 +457,25 @@ ENDIF()
+ 
+ INSTALL(TARGETS mariadbclient
+           COMPONENT Development
++          EXPORT unofficial-libmariadb-targets
            LIBRARY DESTINATION lib)
  INSTALL(TARGETS libmariadb
            COMPONENT SharedLibraries


### PR DESCRIPTION
Fix configure error:
```
CMake Error: install(EXPORT "unofficial-libmariadb-targets" ...) includes target "libmariadb" which requires target "mariadbclient" that is not in any export set.
```
Since `libmariadb` was skipped on the baseline, the pipeline test could not catch this regression.

Fixes #14532.

All features are tested successful on `x86-windows`, `x64-windows-static` and `x64-linux` manually.