### PR TITLE
[aws-sdk-cpp] Make aws-sdk-cpp rpath relocatable

### DIFF
--- a/ports/aws-sdk-cpp/CONTROL
+++ b/ports/aws-sdk-cpp/CONTROL
@@ -1,6 +1,6 @@
 Source: aws-sdk-cpp
 Version: 1.8.83
-Port-Version: 0
+Port-Version: 1
 Homepage: https://github.com/aws/aws-sdk-cpp
 Description: AWS SDK for C++
 Build-Depends: openssl (!uwp&!windows), curl (!uwp&!windows), aws-c-event-stream

--- a/ports/aws-sdk-cpp/patch-relocatable-rpath.patch
+++ b/ports/aws-sdk-cpp/patch-relocatable-rpath.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a653e38628..76d6067646 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -142,7 +142,6 @@ else()
+ endif()
+ 
+ # Add Linker search paths to RPATH so as to fix the problem where some linkers can't find cross-compiled dependent libraries in customer paths when linking executables.
+-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+ 
+ # build third-party targets
+ if (BUILD_DEPS)

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -17,7 +17,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/compute_build_only.cmake)
 
 string(REPLACE ";" "\\\\\\\\\\;" BUILD_ONLY "${BUILD_ONLY}")
 
-if(APPLE)
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
     set(rpath "@loader_path")
 else()
     set(rpath "\$ORIGIN")

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF e98e5732ec7319051f162f7314ae361c85d0a8c9 # 1.8.83
     SHA512 da540db60551be833ea0315dd93241f9740ab953ed5657c1c7a8c401ae52a4e75b116758420b0a8a4ebb79358dff8377f5e052b180b36f0af27a36003f28bd56
     HEAD_REF master
+    PATCHES patch-relocatable-rpath.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" FORCE_SHARED_CRT)
@@ -16,6 +17,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/compute_build_only.cmake)
 
 string(REPLACE ";" "\\\\\\\\\\;" BUILD_ONLY "${BUILD_ONLY}")
 
+if(APPLE)
+    set(rpath "@loader_path")
+else()
+    set(rpath "\$ORIGIN")
+endif()
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     DISABLE_PARALLEL_CONFIGURE
@@ -27,6 +33,7 @@ vcpkg_configure_cmake(
         -DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE
         -DBUILD_ONLY=${BUILD_ONLY}
         -DBUILD_DEPS=OFF
+        -DCMAKE_INSTALL_RPATH=${rpath}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This is important since vcpkg offers binary caching which could be
shared between different machines (as long as both machines use the same
"toolchains" [more technically, as long as the vcpkg hash is the same])

**Describe the pull request**

- What does your PR fix? Fixes #14544

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes related to triplets support or to CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
