### PR TITLE
[ffmpeg] use nasm instead of yasm

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
 Version: 4.3.1
-Port-Version: 9
+Port-Version: 10
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -23,9 +23,16 @@ if (SOURCE_PATH MATCHES " ")
     message(FATAL_ERROR "Error: ffmpeg will not build with spaces in the path. Please use a directory with no spaces")
 endif()
 
-vcpkg_find_acquire_program(NASM)
-get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
-vcpkg_add_to_path(${NASM_EXE_PATH})
+
+if(${VCPKG_TARGET_ARCHITECTURE} STREQUAL x86)
+    vcpkg_find_acquire_program(YASM)
+    get_filename_component(YASM_EXE_PATH ${YASM} DIRECTORY)
+    vcpkg_add_to_path(${YASM_EXE_PATH})
+else()
+    vcpkg_find_acquire_program(NASM)
+    get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+    vcpkg_add_to_path(${NASM_EXE_PATH})
+endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     #We're assuming that if we're building for Windows we're using MSVC

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -25,6 +25,7 @@ endif()
 
 
 if(${VCPKG_TARGET_ARCHITECTURE} STREQUAL x86)
+    # ffmpeg nasm build gives link error on x86, so fall back to yasm
     vcpkg_find_acquire_program(YASM)
     get_filename_component(YASM_EXE_PATH ${YASM} DIRECTORY)
     vcpkg_add_to_path(${YASM_EXE_PATH})

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -36,7 +36,6 @@ else()
     set(LIB_PATH_VAR "LIBRARY_PATH")
 endif()
 
-set(ENV{PATH} "$ENV{PATH}${VCPKG_HOST_PATH_SEPARATOR}${YASM_EXE_PATH}")
 set(OPTIONS "--enable-asm --enable-x86asm --disable-doc --enable-debug --enable-runtime-cpudetect")
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -23,8 +23,9 @@ if (SOURCE_PATH MATCHES " ")
     message(FATAL_ERROR "Error: ffmpeg will not build with spaces in the path. Please use a directory with no spaces")
 endif()
 
-vcpkg_find_acquire_program(YASM)
-get_filename_component(YASM_EXE_PATH ${YASM} DIRECTORY)
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+vcpkg_add_to_path(${NASM_EXE_PATH})
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     #We're assuming that if we're building for Windows we're using MSVC
@@ -36,7 +37,7 @@ else()
 endif()
 
 set(ENV{PATH} "$ENV{PATH}${VCPKG_HOST_PATH_SEPARATOR}${YASM_EXE_PATH}")
-set(OPTIONS "--enable-asm --enable-yasm --disable-doc --enable-debug --enable-runtime-cpudetect")
+set(OPTIONS "--enable-asm --enable-x86asm --disable-doc --enable-debug --enable-runtime-cpudetect")
 
 if(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1878,7 +1878,7 @@
     },
     "ffmpeg": {
       "baseline": "4.3.1",
-      "port-version": 9
+      "port-version": 10
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c6f542b5fc09816849fc9703885880119398fa6c",
+      "git-tree": "93395ca1a700faa1c8c6ce04ef4a6dfa26e9fade",
       "version-string": "4.3.1",
       "port-version": 10
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6f542b5fc09816849fc9703885880119398fa6c",
+      "version-string": "4.3.1",
+      "port-version": 10
+    },
+    {
       "git-tree": "f591a51746536b99b4621d39ea7e0dcd8a693016",
       "version-string": "4.3.1",
       "port-version": 9


### PR DESCRIPTION
- What does your PR fix? Yasm is no longer being actively maintained, so it seems like a good idea to switch to nasm since upstream supports it. Patch also replaces the deprecated --enable-yasm option with --enable-x86asm.

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes, to the best of my knowledge.
