### PR TITLE
change export.prefab.cpp encoding to utf-8 bom

### DIFF
--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -1,4 +1,4 @@
-#include <vcpkg/base/checks.h>
+﻿#include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

Fixes compile warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss.

- What brings the problem?

It happend in a comment paragraph in line 336-364, which uses box-drawing characters which not belonged to ASCII:

```cpp
        /*
        prefab
        └── <name>
            ├── aar
            │   ├── AndroidManifest.xml
            │   ├── META-INF
            │   │   └── LICENCE
            │   └── prefab
            │       ├── modules
            │       │   └── <module>
            │       │       ├── include
            │       │       ├── libs
            │       │       │   ├── android.arm64-v8a
            │       │       │   │   ├── abi.json
            │       │       │   │   └── lib<module>.so
            │       │       │   ├── android.armeabi-v7a
            │       │       │   │   ├── abi.json
            │       │       │   │   └── lib<module>.so
            │       │       │   ├── android.x86
            │       │       │   │   ├── abi.json
            │       │       │   │   └── lib<module>.so
            │       │       │   └── android.x86_64
            │       │       │       ├── abi.json
            │       │       │       └── lib<module>.so
            │       │       └── module.json
            │       └── prefab.json
            ├── <name>-<version>.aar
            └── pom.xml
        */
```

- How does your PR fix it?

Just simply change the file encoding from UTF-8 to UTF-8 BOM, so it can be compiled with MSVC/gcc/clang without extra configuration.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Support all existing triplets without modification to CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes