### PR TITLE
Fix libtommath linking with MSVC

### DIFF
--- a/ports/libtommath/portfile.cmake
+++ b/ports/libtommath/portfile.cmake
@@ -15,6 +15,44 @@ if(VCPKG_TARGET_IS_WINDOWS)
         set(CRTFLAG "/MT")
     endif()
 
+    set(LIBTOMMATH_RAND_PLATFORM ${SOURCE_PATH}/bn_s_mp_rand_platform.c)
+
+    file(READ ${LIBTOMMATH_RAND_PLATFORM} _contents)
+
+    string(
+        REPLACE
+        "if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM))"
+        "// if ((err != MP_OKAY) && MP_HAS(S_READ_ARC4RANDOM))"
+        _contents
+        "${_contents}"
+    )
+
+    string(
+        REPLACE
+        "if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))"
+        "// if ((err != MP_OKAY) && MP_HAS(S_READ_GETRANDOM))"
+        _contents
+        "${_contents}"
+    )
+
+    string(
+        REPLACE
+        "if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))"
+        "// if ((err != MP_OKAY) && MP_HAS(S_READ_URANDOM))"
+        _contents
+        "${_contents}"
+    )
+
+    string(
+        REPLACE
+        "if ((err != MP_OKAY) && MP_HAS(S_READ_LTM_RNG))"
+        "// if ((err != MP_OKAY) && MP_HAS(S_READ_LTM_RNG))"
+        _contents
+        "${_contents}"
+    )
+
+    file(WRITE ${LIBTOMMATH_RAND_PLATFORM} "${_contents}")
+
     # Make sure we start from a clean slate
     vcpkg_execute_build_process(
         COMMAND nmake -f ${SOURCE_PATH}/makefile.msvc clean


### PR DESCRIPTION
- _What does your PR fix?_ Fixes linking with MSVC-built libtommath, [see](https://github.com/libtom/libtommath/blob/c18817cc229f9c60a0a70b76cf49077e91983f41/s_mp_rand_platform.c#L120-L138).

- _Which triplets are supported/not supported?_ *-windows[-static], uwp not tested, but this can only improve, not worsen.

- _Have you updated the CI baseline?_ No need.

- _Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?_ Hopefully.

Should affect only MSVC builds.