### PR TITLE
[ignition-transport8] Fix ignition-transport8 version

### DIFF
--- a/ports/ignition-transport8/CONTROL
+++ b/ports/ignition-transport8/CONTROL
@@ -1,4 +1,4 @@
 Source: ignition-transport8
-Version: 8.0.0
+Version: 8.1.0
 Build-Depends: cppzmq, ignition-cmake2, ignition-msgs5, libuuid (!windows&!uwp), protobuf, sqlite3, zeromq
 Description: Transport middleware for robotics


### PR DESCRIPTION
Fixes the version in CONTROL (8.0.0) different than the one in the portfile (8.1.0)

![image](https://user-images.githubusercontent.com/703240/99094986-d57d8680-25d4-11eb-8413-9c55d6d4b87b.png)

ref: https://github.com/microsoft/vcpkg/blob/master/ports/ignition-transport8/portfile.cmake#L4