### PR TITLE
[vcpkg/scripts] Make cmake-vars file OPTIONAL

### DIFF
--- a/scripts/cmake/vcpkg_internal_get_cmake_vars.cmake
+++ b/scripts/cmake/vcpkg_internal_get_cmake_vars.cmake
@@ -53,6 +53,6 @@ function(vcpkg_internal_get_cmake_vars)
         LOGNAME get-cmake-vars-${TARGET_TRIPLET}
     )
 
-    file(WRITE "${${_gcv_OUTPUT_FILE}}" "include(\"${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-dbg.cmake.log\")\ninclude(\"${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-rel.cmake.log\")")
+    file(WRITE "${${_gcv_OUTPUT_FILE}}" "include(\"${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-dbg.cmake.log\" OPTIONAL)\ninclude(\"${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-rel.cmake.log\" OPTIONAL)")
 
 endfunction()


### PR DESCRIPTION
This fixes the case where a custom triplet specifies only one build type.

ping @Neumann-A , author of https://github.com/microsoft/vcpkg/pull/12936 where this line was introduced.

There's almost definitely a more robust solution than this, like one that might warn if the file was missing, but I feel like this PR is a good enough fix, since my custom triplet (Release-builds only) is broken without it.