### PR TITLE
[ijg-libjpeg] add new port

### DIFF
--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.13)
+project (libjpeg LANGUAGES C)
+
+option(BUILD_EXECUTABLES OFF)
+
+# todo: jconfig.h must be genrated
+list(APPEND PUBLIC_HEADERS jpeglib.h jerror.h jmorecfg.h jconfig.h)
+
+add_library(jpeg
+    ${PUBLIC_HEADERS} jinclude.h jpegint.h jversion.h
+    transupp.h jidctflt.c jidctfst.c jidctint.c jquant1.c jquant2.c jutils.c jmemnobs.c jaricom.c jerror.c jdatadst.c jdatasrc.c 
+    jmemsys.h
+      jmemmgr.c
+    cdjpeg.h cderror.h
+      jcmaster.c jcmarker.c jcmainct.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolor.c jcdctmgr.c jchuff.c jcsample.c jctrans.c jcinit.c jcomapi.c jcparam.c jcprepct.c 
+      jdmaster.c jdmarker.c jdmainct.c jdapimin.c jdapistd.c jdarith.c jdcoefct.c jdcolor.c jddctmgr.c jdhuff.c jdsample.c jdtrans.c jdinput.c jdmerge.c jdpostct.c
+    jdct.h 
+      jfdctflt.c jfdctfst.c jfdctint.c
+)
+
+install(FILES       ${PUBLIC_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
+install(FILES       README install.txt usage.txt libjpeg.txt change.log
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share
+)
+install(TARGETS jpeg
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+if(BUILD_EXECUTABLES)
+    add_executable(cjpeg      cdjpeg.c cjpeg.c rdbmp.c rdgif.c rdppm.c rdrle.c rdtarga.c rdswitch.c)
+    target_link_libraries(cjpeg PRIVATE jpeg)
+    
+    add_executable(djpeg      cdjpeg.c djpeg.c wrbmp.c wrgif.c wrppm.c wrrle.c wrtarga.c rdcolmap.c)
+    target_link_libraries(djpeg PRIVATE jpeg)
+    
+    add_executable(jpegtran   jpegtran.c cdjpeg.c rdswitch.c transupp.c)
+    target_link_libraries(jpegtran PRIVATE jpeg)
+    
+    add_executable(rdjpgcom   rdjpgcom.c)
+    add_executable(wrjpgcom   wrjpgcom.c)
+
+    install(TARGETS cjpeg djpeg jpegtran rdjpgcom wrjpgcom
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+    )
+endif ()

--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project (libjpeg LANGUAGES C)
+project(libjpeg LANGUAGES C)
 
 option(BUILD_EXECUTABLES OFF)
 
@@ -17,12 +17,22 @@ add_library(jpeg
     jdct.h 
       jfdctflt.c jfdctfst.c jfdctint.c
 )
+set_target_properties(jpeg
+PROPERTIES
+    WINDOWS_EXPORT_ALL_SYMBOLS true
+)
+if(WIN32)
+    target_compile_definitions(jpeg
+    PRIVATE
+        _CRT_SECURE_NO_WARNINGS
+    )
+endif()
 
 install(FILES       ${PUBLIC_HEADERS}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include
 )
 install(FILES       README install.txt usage.txt libjpeg.txt change.log
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}
 )
 install(TARGETS jpeg
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
@@ -43,7 +53,7 @@ if(BUILD_EXECUTABLES)
     add_executable(rdjpgcom   rdjpgcom.c)
     add_executable(wrjpgcom   wrjpgcom.c)
 
-    install(TARGETS cjpeg djpeg jpegtran rdjpgcom wrjpgcom
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+    install(TARGETS     cjpeg djpeg jpegtran rdjpgcom wrjpgcom
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/tools
     )
-endif ()
+endif()

--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -17,10 +17,7 @@ add_library(jpeg
     jdct.h 
       jfdctflt.c jfdctfst.c jfdctint.c
 )
-set_target_properties(jpeg
-PROPERTIES
-    WINDOWS_EXPORT_ALL_SYMBOLS true
-)
+
 if(WIN32)
     target_compile_definitions(jpeg
     PRIVATE

--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libjpeg LANGUAGES C)
 
 option(BUILD_EXECUTABLES OFF)
 
-# todo: jconfig.h must be genrated
+# note: jconfig.h must be genrated. Please reference the install.txt in jpegsr9d.zip
 list(APPEND PUBLIC_HEADERS jpeglib.h jerror.h jmorecfg.h jconfig.h)
 
 add_library(jpeg

--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -28,9 +28,6 @@ endif()
 install(FILES       ${PUBLIC_HEADERS}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include
 )
-install(FILES       README install.txt usage.txt libjpeg.txt change.log
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}
-)
 install(TARGETS jpeg
         RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib

--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -3,7 +3,17 @@ project(libjpeg LANGUAGES C)
 
 option(BUILD_EXECUTABLES OFF)
 
-# note: jconfig.h must be genrated. Please reference the install.txt in jpegsr9d.zip
+#
+# jconfig.h is a public header, so it must be genrated. Please reference the install.txt in jpegsr9d.zip
+#
+# jconfig.txt should contain #cmakedefine which is modified by porfile.cmake of ijg-libjpeg port in VcPkg
+# By doing this we can skip 'configure' step. Visit https://github.com/LuaDist/libjpeg
+#
+include(CheckIncludeFile)
+check_include_file(stddef.h HAVE_STDDEF_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
+configure_file(jconfig.txt ${CMAKE_CURRENT_SOURCE_DIR}/jconfig.h)
+
 list(APPEND PUBLIC_HEADERS jpeglib.h jerror.h jmorecfg.h jconfig.h)
 
 add_library(jpeg

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -1,4 +1,6 @@
 
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_download_distfile(ARCHIVE
     URLS        "http://www.ijg.org/files/jpegsr9d.zip"
     FILENAME    "jpegsr9d.zip"

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -10,16 +10,17 @@ vcpkg_extract_source_archive_ex(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-# todo: jconfig.h must be genrated
+# todo: jconfig.h should be genrated when `configure` is available
 file(RENAME ${SOURCE_PATH}/jconfig.txt ${SOURCE_PATH}/jconfig.h)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DBUILD_EXECUTABLES=ON
+        -DBUILD_EXECUTABLES=OFF
 )
 vcpkg_install_cmake()
+vcpkg_copy_pdbs()
 
 # There is no LICENSE file, but README containes some legal text.
 file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -1,0 +1,31 @@
+
+vcpkg_download_distfile(ARCHIVE
+    URLS        "http://www.ijg.org/files/jpegsr9d.zip"
+    FILENAME    "jpegsr9d.zip"
+    SHA512      441a783c945fd549693dbe3932d8d35e1ea00d8464870646760ed84a636facb4d7afe0ca3ab988e7281a71e41c2e96be618b8c6a898f116517e639720bba82a3
+)
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+# todo: jconfig.h must be genrated
+file(RENAME ${SOURCE_PATH}/jconfig.txt ${SOURCE_PATH}/jconfig.h)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_EXECUTABLES=ON
+)
+vcpkg_install_cmake()
+
+# There is no LICENSE file, but README containes some legal text.
+file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -1,4 +1,7 @@
 
+#
+# The port conflicts with 'libjpeg-turbo', 'mozjpeg'
+#
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -1,7 +1,10 @@
 
-#
-# The port conflicts with 'libjpeg-turbo', 'mozjpeg'
-#
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/libturbo-jpeg/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'libturbo-jpeg'. Please remove libturbo-jpeg:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
+if(EXISTS ${CURRENT_INSTALLED_DIR}/share/mozjpeg/copyright)
+    message(FATAL_ERROR "'${PORT}' conflicts with 'mozjpeg'. Please remove mozjpeg:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
+endif()
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
@@ -15,8 +18,15 @@ vcpkg_extract_source_archive_ex(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-# todo: jconfig.h should be genrated when `configure` is available
-file(RENAME ${SOURCE_PATH}/jconfig.txt ${SOURCE_PATH}/jconfig.h)
+# jconfig.h should be genrated when `configure` is available
+if(true)# 
+    vcpkg_execute_required_process(
+        COMMAND configure
+        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
+    )
+else()
+    file(RENAME ${SOURCE_PATH}/jconfig.txt ${SOURCE_PATH}/jconfig.h)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -1,4 +1,3 @@
-
 if(EXISTS ${CURRENT_INSTALLED_DIR}/share/libturbo-jpeg/copyright)
     message(FATAL_ERROR "'${PORT}' conflicts with 'libturbo-jpeg'. Please remove libturbo-jpeg:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
@@ -7,7 +6,6 @@ if(EXISTS ${CURRENT_INSTALLED_DIR}/share/mozjpeg/copyright)
 endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    # The release doesn't have `__declspec(dllexport)`.
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -17,7 +17,6 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 if(VCPKG_TARGET_IS_LINUX)
     # The deflated files are using CRLF. change them to LF before generating jconfig.h
     find_program(DOS2UNIX dos2unix REQUIRED)
@@ -49,6 +48,7 @@ if(VCPKG_TARGET_IS_LINUX)
 else()
     file(RENAME ${SOURCE_PATH}/jconfig.txt ${SOURCE_PATH}/jconfig.h)
 endif()
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -5,7 +5,11 @@ endif()
 if(EXISTS ${CURRENT_INSTALLED_DIR}/share/mozjpeg/copyright)
     message(FATAL_ERROR "'${PORT}' conflicts with 'mozjpeg'. Please remove mozjpeg:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    # the release doesn't have `__declspec(dllexport)`.
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_download_distfile(ARCHIVE
     URLS        "http://www.ijg.org/files/jpegsr9d.zip"

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "ijg-libjpeg",
+  "version-string": "2020-01-12",
+  "homepage": "http://www.ijg.org/",
+  "description": "Independent JPEG Group's JPEG software",
+  "dependencies": []
+}

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -3,5 +3,6 @@
   "version-string": "2020-01-12",
   "homepage": "http://www.ijg.org/",
   "description": "Independent JPEG Group's JPEG software",
+  "supports": "!emscripten & !wasm32",
   "dependencies": []
 }

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ijg-libjpeg",
   "version-string": "9d",
-  "homepage": "http://www.ijg.org/",
   "description": "Independent JPEG Group's JPEG software",
+  "homepage": "http://www.ijg.org/",
   "supports": "!emscripten & !wasm32"
 }

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ijg-libjpeg",
-  "version-string": "2020-01-12",
+  "version-string": "9d",
   "homepage": "http://www.ijg.org/",
   "description": "Independent JPEG Group's JPEG software",
   "supports": "!emscripten & !wasm32",

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -3,6 +3,5 @@
   "version-string": "9d",
   "homepage": "http://www.ijg.org/",
   "description": "Independent JPEG Group's JPEG software",
-  "supports": "!emscripten & !wasm32",
-  "dependencies": []
+  "supports": "!emscripten & !wasm32"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1027,7 +1027,6 @@ mozjpeg:x64-uwp            = skip
 mozjpeg:x64-windows        = skip
 mozjpeg:x64-windows-static = skip
 mozjpeg:x86-windows        = skip
-
 # mpir conflicts with gmp
 # see https://github.com/microsoft/vcpkg/issues/11756
 mpir:x86-windows=skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1018,6 +1018,13 @@ mozjpeg:x64-uwp            = skip
 mozjpeg:x64-windows        = skip
 mozjpeg:x64-windows-static = skip
 mozjpeg:x86-windows        = skip
+ijg-libjpeg:x64-linux          = skip
+ijg-libjpeg:x64-osx            = skip
+ijg-libjpeg:x64-uwp            = skip
+ijg-libjpeg:x64-windows        = skip
+ijg-libjpeg:x64-windows-static = skip
+ijg-libjpeg:x86-windows        = skip
+
 # mpir conflicts with gmp
 # see https://github.com/microsoft/vcpkg/issues/11756
 mpir:x86-windows=skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -545,6 +545,15 @@ ignition-msgs5:arm64-windows=fail
 ignition-msgs5:arm-uwp=fail
 ignition-msgs5:x64-uwp=fail
 ignition-msgs5:x64-osx=skip
+# Conflicts with libjpeg-turbo, mozjpeg
+ijg-libjpeg:arm64-windows      = skip
+ijg-libjpeg:arm-uwp            = skip
+ijg-libjpeg:x64-linux          = skip
+ijg-libjpeg:x64-osx            = skip
+ijg-libjpeg:x64-uwp            = skip
+ijg-libjpeg:x64-windows        = skip
+ijg-libjpeg:x64-windows-static = skip
+ijg-libjpeg:x86-windows        = skip
 intel-ipsec:arm64-windows=fail
 intel-ipsec:arm-uwp=fail
 intel-ipsec:x64-osx=fail
@@ -1018,12 +1027,6 @@ mozjpeg:x64-uwp            = skip
 mozjpeg:x64-windows        = skip
 mozjpeg:x64-windows-static = skip
 mozjpeg:x86-windows        = skip
-ijg-libjpeg:x64-linux          = skip
-ijg-libjpeg:x64-osx            = skip
-ijg-libjpeg:x64-uwp            = skip
-ijg-libjpeg:x64-windows        = skip
-ijg-libjpeg:x64-windows-static = skip
-ijg-libjpeg:x86-windows        = skip
 
 # mpir conflicts with gmp
 # see https://github.com/microsoft/vcpkg/issues/11756


### PR DESCRIPTION
### Changes

#### Which triplets are supported/not supported? Have you updated the CI baseline?

Build status of the fork - https://dev.azure.com/luncliff/personal/_build?definitionId=47&_a=summary

* Pass
    * x64-uwp
    * x64-windows
    * x64-windows-static
    * x86-windows
    * x64-osx
    * x64-linux ~~(requires tool `dos2unix`)~~
* Fail
    * s390x-linux
    * wasm32-emscripten

#### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? 
Yes 👍 

### ~Works In Progress~

* [x] Test available triplets and update `"supports"`
* [x] ~~`jconfig.h` generation with `configure` in the release (Linux)~~
    * use `configure_file` to generate `jconfig.h` (this is how https://github.com/LuaDist/libjpeg works)
* [x] **Feedback for the following Issues**

### Issues

#### 1. The port uses date for its [`version-string`](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/manifest-files.md#version-string) (solved)

Its archive is named `jpegsr9d.zip`. README specifies `release 9d of 12-Jan-2020`.
I'm confused about this case, so applied `2020-01-12` temporarily.  

Can `version-string` be `9d` in this case? (like `tbb`'s `2020_U3`...?)

#### 2. The port defines its own CMakeLists.txt (solved)

The official release(http://www.ijg.org/files/jpegsr9d.zip) already contains `configure` for the UNIX machine, but nothing for the Windows environment. The file is for the case. 

Does it right to add CMakeLists.txt in this case?  
or should this port behave differently like `openssl-unix`, `openssl-windows`?

#### 3. The port's output conflicts with 'libjpeg-turbo' (solved)

The port creates `jpeg.lib`, `jpeglib.h`, etc. Which can be installed via `libjpeg-turbo`.

Do I have to skip the build in this `ci.baseline.txt`?




