### PR TITLE
[vcpkg] Fix GCC-6 build.

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -911,6 +911,7 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::TRIPLET_ARG;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ARG;
+    constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ARG;
 
     constexpr StringLiteral VcpkgCmdArguments::BINARY_SOURCES_ARG;


### PR DESCRIPTION
Fixes #13937.

Fixes MicrosoftDocs/vscodespaces#827.

@strega-nil Please merge if this LGTY & is green.