### PR TITLE
[hunspell] Avoid automatically added lib prefix

### DIFF
--- a/ports/hunspell/CMakeLists.txt
+++ b/ports/hunspell/CMakeLists.txt
@@ -60,6 +60,8 @@ set(LIBHUNSPELL_HDRS
 
 #hunspell/libhunspell
 add_library(libhunspell ${LIBHUNSPELL_HDRS} ${LIBHUNSPELL_SRCS})
+set_target_properties(libhunspell PROPERTIES PREFIX "")
+
 target_compile_definitions(libhunspell PRIVATE -DBUILDING_LIBHUNSPELL)
 install(TARGETS libhunspell
     ARCHIVE DESTINATION lib

--- a/ports/hunspell/CMakeLists.txt
+++ b/ports/hunspell/CMakeLists.txt
@@ -60,6 +60,8 @@ set(LIBHUNSPELL_HDRS
 
 #hunspell/libhunspell
 add_library(libhunspell ${LIBHUNSPELL_HDRS} ${LIBHUNSPELL_SRCS})
+
+#Avoid automatically added lib prefix 'lib' for hunspell
 set_target_properties(libhunspell PROPERTIES PREFIX "")
 
 target_compile_definitions(libhunspell PRIVATE -DBUILDING_LIBHUNSPELL)

--- a/ports/hunspell/CONTROL
+++ b/ports/hunspell/CONTROL
@@ -1,6 +1,6 @@
 Source: hunspell
 Version: 1.7.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/hunspell/hunspell
 Description: The most popular spellchecking library.
 

--- a/ports/hunspell/CONTROL
+++ b/ports/hunspell/CONTROL
@@ -1,5 +1,6 @@
 Source: hunspell
-Version: 1.7.0-1
+Version: 1.7.0
+Port-Version: 1
 Homepage: https://github.com/hunspell/hunspell
 Description: The most popular spellchecking library.
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14606

Avoid automatically added lib prefix 'lib' for hunspell.

All features test passed with x86-windows.