### PR TITLE
[proj] Added support for optionally building the tools

### DIFF
--- a/ports/proj4/CONTROL
+++ b/ports/proj4/CONTROL
@@ -1,6 +1,6 @@
 Source: proj4
 Version: 6.3.1
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/OSGeo/PROJ
 Description: PROJ.4 library for cartographic projections
 Build-Depends: sqlite3[core]

--- a/ports/proj4/CONTROL
+++ b/ports/proj4/CONTROL
@@ -9,3 +9,7 @@ Default-Features: database
 Feature: database
 Build-Depends: sqlite3[tool] (!uwp&!arm)
 Description: generate database
+
+Feature: tools
+Build-Depends:
+Description: generate tools

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -22,6 +22,12 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     database BUILD_PROJ_DATABASE
+    tools BUILD_CCT
+    tools BUILD_CS2CS
+    tools BUILD_GEOD
+    tools BUILD_GIE
+    tools BUILD_PROJ
+    tools BUILD_PROJINFO
 )
 if ("database" IN_LIST FEATURES)
     if (VCPKG_TARGET_IS_WINDOWS)
@@ -53,18 +59,17 @@ vcpkg_configure_cmake(
     -DPROJ_LIB_SUBDIR=lib
     -DPROJ_INCLUDE_SUBDIR=include
     -DPROJ_DATA_SUBDIR=share/proj4
-    -DBUILD_CCT=OFF
-    -DBUILD_CS2CS=OFF
-    -DBUILD_GEOD=OFF
-    -DBUILD_GIE=OFF
-    -DBUILD_PROJ=OFF
-    -DBUILD_PROJINFO=OFF
     -DPROJ_TESTS=OFF
     -DEXE_SQLITE3=${SQLITE3_BIN_PATH}/sqlite3${BIN_SUFFIX}
 )
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/proj4)
+if ("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES cct cs2cs geod gie proj projinfo AUTO_CLEAN)
+    file(GLOB debug_tools ${CURRENT_PACKAGES_DIR}/debug/bin/*_d${BIN_SUFFIX})
+    file(REMOVE ${debug_tools})
+endif ()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-sqlite-dependency-export.patch
         fix-linux-build.patch
         use-sqlite3-config.patch
+        tools-cmake.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -67,8 +68,6 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/proj4)
 if ("tools" IN_LIST FEATURES)
     vcpkg_copy_tools(TOOL_NAMES cct cs2cs geod gie proj projinfo AUTO_CLEAN)
-    file(GLOB debug_tools ${CURRENT_PACKAGES_DIR}/debug/bin/*_d${BIN_SUFFIX})
-    file(REMOVE ${debug_tools})
 endif ()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/proj4/tools-cmake.patch
+++ b/ports/proj4/tools-cmake.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 48c785a..e2b5485 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -69,11 +69,3 @@ if(BUILD_GIE)
+   include(bin_gie.cmake)
+   set(BIN_TARGETS ${BIN_TARGETS} gie)
+ endif()
+-
+-if(MSVC OR CMAKE_CONFIGURATION_TYPES)
+-  if(BIN_TARGETS)
+-    # Add _d suffix for your debug versions of the tools
+-    set_target_properties(${BIN_TARGETS} PROPERTIES
+-      DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+-  endif()
+-endif()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
  - Added support for building PROJ tools which are generally needed when developing with the library (but not actual mandatory dependency).

- Which triplets are supported/not supported? Have you updated the CI baseline?
  - No changes to how the main library is built.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - Yes. Tools are installed in tools directory and debug versions of tools are removed. `Port-Version` is not increased since library itself is not modified.
