### PR TITLE
[libheif] Fixes static linking when building on MSVC

### DIFF
--- a/ports/libheif/CONTROL
+++ b/ports/libheif/CONTROL
@@ -1,6 +1,6 @@
 Source: libheif
 Version: 1.7.0
-Port-Version: 1
+Port-Version: 2
 Homepage: http://www.libheif.org/
 Description: Open h.265 video codec implementation. 
 Build-Depends: x265, libde265

--- a/ports/libheif/fix-static-build-msvc.patch
+++ b/ports/libheif/fix-static-build-msvc.patch
@@ -1,0 +1,27 @@
+diff --git a/libheif/CMakeLists.txt b/libheif/CMakeLists.txt
+index 59b4719..38d6b35 100644
+--- a/libheif/CMakeLists.txt
++++ b/libheif/CMakeLists.txt
+@@ -54,10 +54,18 @@ set_target_properties(heif
+                           VERSION ${PROJECT_VERSION}
+                           SOVERSION ${PROJECT_VERSION_MAJOR})
+ 
+-target_compile_definitions(heif
+-                           PUBLIC
+-                               LIBHEIF_EXPORTS
+-                               HAVE_VISIBILITY)
++# Enable static linking when building from vcpkg
++if(NOT BUILD_SHARED_LIBS)
++    target_compile_definitions(heif
++                               PUBLIC
++                                LIBHEIF_STATIC_BUILD
++                                HAVE_VISIBILITY)
++else()
++    target_compile_definitions(heif
++                               PUBLIC
++                                LIBHEIF_EXPORTS
++                                HAVE_VISIBILITY)
++endif()
+ 
+ if(LIBDE265_FOUND)
+     target_compile_definitions(heif PRIVATE HAVE_LIBDE265=1)

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         dont_build_examples_and_gdk_pixbuf.patch
         remove_finding_pkgconfig.patch
         install-extra-headers.patch
+        fix-static-build-msvc.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
#13354 

- Which triplets are supported/not supported? Have you updated the CI baseline?
x86-windows
x86-windows-static
x64-windows
x64-windows-static

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes