### PR TITLE
[vcpkg baseline][qt5-location] Update patch

### DIFF
--- a/ports/qt5-location/CONTROL
+++ b/ports/qt5-location/CONTROL
@@ -1,5 +1,5 @@
 Source: qt5-location
 Version: 5.15.1
-Port-Version: 1
+Port-Version: 2
 Description: Qt5 Location Module - Displays map, navigation, and place content in a QML application.
 Build-Depends: qt5-base[core], qt5-declarative, qt5-quickcontrols, qt5-quickcontrols2, qt5-serialport

--- a/ports/qt5-location/portfile.cmake
+++ b/ports/qt5-location/portfile.cmake
@@ -1,10 +1,3 @@
-vcpkg_download_distfile(
-    PATCH
-    URLS "https://codereview.qt-project.org/gitweb?p=qt%2Fqtlocation.git;a=commitdiff_plain;h=6b2cf7e9d150b7be709fcd688c5045949cedc3d9;hp=7769ea903f87efc4ad55530a2749f104eddff2e4"
-    SHA512 99d16fb0e88a2250de3896815abbb22ff5aa4d3920397610cf37be701fe03a7241e0586aae5b85755aeb958926183c96a0482a8837335d20a2171ebb2a66e640
-    FILENAME qt5-location-rename-99d16fb0.patch
-)
-
 message(STATUS "${PORT} has a spurious failure in which it is unable to create a parent directory! Just retry.")
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation(PATCHES "${PATCH}")
+qt_submodule_installation(PATCHES rename_third_party_libs_conflicts.patch)

--- a/ports/qt5-location/rename_third_party_libs_conflicts.patch
+++ b/ports/qt5-location/rename_third_party_libs_conflicts.patch
@@ -1,0 +1,68 @@
+diff --git a/src/3rdparty/clip2tri/clip2tri.pro b/src/3rdparty/clip2tri/clip2tri.pro
+index 802c040..4059a63 100644
+--- a/src/3rdparty/clip2tri/clip2tri.pro
++++ b/src/3rdparty/clip2tri/clip2tri.pro
+@@ -1,4 +1,4 @@
+-TARGET = clip2tri
++TARGET = qt_clip2tri
+ 
+ CONFIG += staticlib exceptions warn_off optimize_full
+ 
+@@ -18,5 +18,5 @@ gcc {
+ HEADERS += clip2tri.h
+ SOURCES += clip2tri.cpp
+ 
+-LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lpoly2tri$$qtPlatformTargetSuffix() -lclipper$$qtPlatformTargetSuffix()
++LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lqt_poly2tri$$qtPlatformTargetSuffix() -lqt_clipper$$qtPlatformTargetSuffix()
+ 
+diff --git a/src/3rdparty/clipper/clipper.pro b/src/3rdparty/clipper/clipper.pro
+index 874d55c..a518d24 100644
+--- a/src/3rdparty/clipper/clipper.pro
++++ b/src/3rdparty/clipper/clipper.pro
+@@ -1,4 +1,4 @@
+-TARGET = clipper
++TARGET = qt_clipper
+ 
+ CONFIG += staticlib exceptions warn_off optimize_full
+ 
+diff --git a/src/3rdparty/poly2tri/poly2tri.pro b/src/3rdparty/poly2tri/poly2tri.pro
+index 76f2779..6c5f769 100644
+--- a/src/3rdparty/poly2tri/poly2tri.pro
++++ b/src/3rdparty/poly2tri/poly2tri.pro
+@@ -1,4 +1,4 @@
+-TARGET = poly2tri
++TARGET = qt_poly2tri
+ 
+ CONFIG += staticlib warn_off optimize_full
+ 
+diff --git a/src/location/declarativemaps/declarativemaps.pri b/src/location/declarativemaps/declarativemaps.pri
+index e2a922f..12199ee 100644
+--- a/src/location/declarativemaps/declarativemaps.pri
++++ b/src/location/declarativemaps/declarativemaps.pri
+@@ -68,5 +68,5 @@ SOURCES += \
+         declarativemaps/qquickgeomapgesturearea.cpp
+ 
+ load(qt_build_paths)
+-LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lpoly2tri$$qtPlatformTargetSuffix() -lclip2tri$$qtPlatformTargetSuffix()
++LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lqt_poly2tri$$qtPlatformTargetSuffix() -lqt_clip2tri$$qtPlatformTargetSuffix()
+ 
+diff --git a/src/location/location.pro b/src/location/location.pro
+index 1b541b9..b0e2c3f 100644
+--- a/src/location/location.pro
++++ b/src/location/location.pro
+@@ -45,4 +45,4 @@ HEADERS += $$PUBLIC_HEADERS $$PRIVATE_HEADERS
+ 
+ load(qt_module)
+ 
+-LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lclip2tri$$qtPlatformTargetSuffix()
++LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lqt_clip2tri$$qtPlatformTargetSuffix()
+diff --git a/src/positioning/positioning.pro b/src/positioning/positioning.pro
+index 6535090..db49921 100644
+--- a/src/positioning/positioning.pro
++++ b/src/positioning/positioning.pro
+@@ -95,4 +95,4 @@ HEADERS += $$PUBLIC_HEADERS $$PRIVATE_HEADERS
+ 
+ load(qt_module)
+ 
+-LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lclip2tri$$qtPlatformTargetSuffix()
++LIBS_PRIVATE += -L$$MODULE_BASE_OUTDIR/lib -lqt_clip2tri$$qtPlatformTargetSuffix()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14630

The patch https://codereview.qt-project.org/gitweb?p=qt%2Fqtlocation.git;a=commitdiff_plain;h=6b2cf7e9d150b7be709fcd688c5045949cedc3d9;hp=7769ea903f87efc4ad55530a2749f104eddff2e4 from upstream has gone, so make the patch manually.

The patch content from here https://code.qt.io/cgit/qt/qtlocation.git/commit/?h=6b2cf7e9d150b7be709fcd688c5045949cedc3d9

Related PR #14642, #14622, #14615.

Note: No feature needs to test.