### PR TITLE
[tesseract] Enable dynamic build, format portfile.cmake

### DIFF
--- a/ports/tesseract/CONTROL
+++ b/ports/tesseract/CONTROL
@@ -1,6 +1,6 @@
 Source: tesseract
 Version: 4.1.1
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/tesseract-ocr/tesseract
 Description: An OCR Engine that was developed at HP Labs between 1985 and 1995... and now at Google.
 Build-Depends: leptonica

--- a/ports/tesseract/fix-training-tools.patch
+++ b/ports/tesseract/fix-training-tools.patch
@@ -1,0 +1,40 @@
+diff --git a/src/training/CMakeLists.txt b/src/training/CMakeLists.txt
+index af291a5..f2e2ceb 100644
+--- a/src/training/CMakeLists.txt
++++ b/src/training/CMakeLists.txt
+@@ -63,7 +63,7 @@ endif()
+ # LIBRARY tessopt
+ ########################################
+ 
+-add_library                 (tessopt tessopt.cpp tessopt.h)
++add_library                 (tessopt STATIC tessopt.cpp tessopt.h)
+ project_group               (tessopt "Training Tools")
+ 
+ 
+@@ -81,7 +81,7 @@ set(common_training_src
+     mastertrainer.cpp
+     mastertrainer.h
+ )
+-add_library                 (common_training ${common_training_src})
++add_library                 (common_training STATIC ${common_training_src})
+ target_link_libraries       (common_training libtesseract tessopt)
+ project_group               (common_training "Training Tools")
+ 
+@@ -196,7 +196,7 @@ set(unicharset_training_src
+     validate_javanese.cpp validate_myanmar.cpp validator.cpp
+ 
+ )
+-add_library                 (unicharset_training ${unicharset_training_src})
++add_library                 (unicharset_training STATIC ${unicharset_training_src})
+ if(UNIX)
+     list(APPEND ICU_LIBRARIES ${CMAKE_DL_LIBS})
+ endif()
+@@ -270,7 +270,7 @@ endif()
+ 
+ find_package(unofficial-cairo CONFIG REQUIRED)
+ find_package(unofficial-glib CONFIG REQUIRED)
+-find_package(Intl CONFIG REQUIRED)
++find_package(Intl REQUIRED)
+ find_package(Fontconfig REQUIRED)
+ find_package(Freetype REQUIRED)
+ if(UNIX OR BUILD_SHARED_LIBS)

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -39,8 +39,10 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
+vcpkg_copy_tools(TOOL_NAMES tesseract AUTO_CLEAN)
+
 if("training_tools" IN_LIST FEATURES)
-    list(APPEND TRAINING_TOOLS tesseract ambiguous_words classifier_tester
+    list(APPEND TRAINING_TOOLS ambiguous_words classifier_tester
         combine_tessdata cntraining dawg2wordlistmftraining shapeclustering
         wordlist2dawg combine_lang_model lstmeval lstmtraining
         set_unicharset_properties unicharset_extractor text2image
@@ -50,10 +52,7 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
-                    ${CURRENT_PACKAGES_DIR}/bin
-                    ${CURRENT_PACKAGES_DIR}/debug/bin
-)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     PATCHES
         fix-tiff-linkage.patch
         fix-text2image.patch
+        fix-training-tools.patch
 )
 
 # The built-in cmake FindICU is better
@@ -41,9 +42,10 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
 vcpkg_copy_tools(TOOL_NAMES tesseract AUTO_CLEAN)
 
-if("training_tools" IN_LIST FEATURES)
-    list(APPEND TRAINING_TOOLS ambiguous_words classifier_tester
-        combine_tessdata cntraining dawg2wordlistmftraining shapeclustering
+if("training-tools" IN_LIST FEATURES)
+    list(APPEND TRAINING_TOOLS
+        ambiguous_words classifier_tester combine_tessdata
+        cntraining dawg2wordlist mftraining shapeclustering
         wordlist2dawg combine_lang_model lstmeval lstmtraining
         set_unicharset_properties unicharset_extractor text2image
     )

--- a/ports/tesseract/portfile.cmake
+++ b/ports/tesseract/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tesseract-ocr/tesseract
@@ -13,73 +11,49 @@ vcpkg_from_github(
 # The built-in cmake FindICU is better
 file(REMOVE ${SOURCE_PATH}/cmake/FindICU.cmake)
 
-# Handle Static Library Output
-if(VCPKG_LIBRARY_LINKAGE EQUAL "static")
-    list(APPEND OPTIONS_LIST -DSTATIC=ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
 
-# Handle CONTROL
-if("training-tools" IN_LIST FEATURES)
-    list(APPEND OPTIONS_LIST -DBUILD_TRAINING_TOOLS=ON)
-else()
-    list(APPEND OPTIONS_LIST -DBUILD_TRAINING_TOOLS=OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    training-tools  BUILD_TRAINING_TOOLS
+)
+
 if("cpu-independed" IN_LIST FEATURES)
-    list(APPEND OPTIONS_LIST -DTARGET_ARCHITECTURE=none)
+    set(TARGET_ARCHITECTURE none)
 else()
-    list(APPEND OPTIONS_LIST -DTARGET_ARCHITECTURE=auto)
+    set(TARGET_ARCHITECTURE auto)
 endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-        -DSTATIC=ON
+    OPTIONS ${FEATURE_OPTIONS}
+        -DSTATIC=${BUILD_STATIC}
         -DUSE_SYSTEM_ICU=True
         -DCMAKE_DISABLE_FIND_PACKAGE_LibArchive=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_OpenCL=ON
         -DLeptonica_DIR=YES
-        ${OPTIONS_LIST}
+        -DTARGET_ARCHITECTURE=${TARGET_ARCHITECTURE}
 )
 
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-# Install tool
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/tesseract)
-set(EXTENSION)
-if(WIN32)
-    set(EXTENSION ".exe")
-endif()
-
-# copy training tools
-set(TRAINING_TOOLS_DIR ${CURRENT_PACKAGES_DIR}/tools/tesseract/training)
 if("training_tools" IN_LIST FEATURES)
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/ambiguous_words${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/classifier_tester${EXTENSION} 	DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/combine_tessdata${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/cntraining${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/dawg2wordlist${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/mftraining${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/shapeclustering${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/wordlist2dawg${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/combine_lang_model${EXTENSION} 	DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/lstmeval${EXTENSION} 			DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/lstmtraining${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/set_unicharset_properties${EXTENSION} DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/unicharset_extractor${EXTENSION} 	DESTINATION ${TRAINING_TOOLS_DIR})
-    file(COPY ${CURRENT_PACKAGES_DIR}/bin/text2image${EXTENSION} 		DESTINATION ${TRAINING_TOOLS_DIR})
+    list(APPEND TRAINING_TOOLS tesseract ambiguous_words classifier_tester
+        combine_tessdata cntraining dawg2wordlistmftraining shapeclustering
+        wordlist2dawg combine_lang_model lstmeval lstmtraining
+        set_unicharset_properties unicharset_extractor text2image
+    )
+    vcpkg_copy_tools(TOOL_NAMES ${TRAINING_TOOLS} AUTO_CLEAN)
 endif()
-
-file(COPY ${CURRENT_PACKAGES_DIR}/bin/tesseract${EXTENSION} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/tesseract)
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/tesseract)
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/bin
+                    ${CURRENT_PACKAGES_DIR}/debug/bin
+)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
- Enable dynamic build
- Since some libraries required by training tools doesn't export any symbols, set them build as a static libraries
- Format `portfile.cmake`

Fixes #10174.

All features are tested succesfully on the following triplets:
- `x86-windows`
- `x64-windows-static` (since dependency glib doesn's support this triplet, skip)