### PR TITLE
[leptonica] add missing dependency

### DIFF
--- a/ports/leptonica/CONTROL
+++ b/ports/leptonica/CONTROL
@@ -1,5 +1,6 @@
 Source: leptonica
 Version: 1.80.0
+Port-Version: 1
 Homepage: https://github.com/DanBloomberg/leptonica
 Description: An open source library containing software that is broadly useful for image processing and image analysis applications
-Build-Depends: libjpeg-turbo, zlib, libpng, tiff, giflib, libwebp
+Build-Depends: libjpeg-turbo, zlib, libpng, tiff, giflib, libwebp, openjpeg


### PR DESCRIPTION
**Describe the pull request**
Add openjpeg to leptonica dependencies. Otherwise it complains about missing <openjpeg.h> headers