### PR TITLE
[duktape] Add VERSION and SOVERSION properties CMake build

### DIFF
--- a/ports/duktape/CMakeLists.txt
+++ b/ports/duktape/CMakeLists.txt
@@ -17,6 +17,8 @@ file(GLOB_RECURSE DUKTAPE_HEADERS "${CMAKE_CURRENT_LIST_DIR}/src/*.h")
 add_library(duktape ${DUKTAPE_SOURCES} ${DUKTAPE_HEADERS})
 target_include_directories(duktape PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
 set_target_properties(duktape PROPERTIES PUBLIC_HEADER "${DUKTAPE_HEADERS}")
+set_target_properties(duktape PROPERTIES VERSION ${duktape_VERSION})
+set_target_properties(duktape PROPERTIES SOVERSION ${duktape_MAJOR_VERSION})
 
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(duktape PRIVATE -DDUK_F_DLL_BUILD)

--- a/ports/duktape/CONTROL
+++ b/ports/duktape/CONTROL
@@ -1,4 +1,5 @@
 Source: duktape
 Version: 2.5.0
+Port-Version: 1
 Homepage: https://github.com/svaarala/duktape
 Description: Embeddable Javascript engine with a focus on portability and compact footprint.


### PR DESCRIPTION
This is a fairly simple change that should have minimal impact. The biggest change is that it will add the version numbers to the dynamic libraries built for macOS and Linux using custom or community triplets. The `SOVERSION` is set to the major version, as the project's [semantic versioning](https://duktape.org/guide.html#versioning) indicates this is the API compatibility value.