### PR TITLE
[curl] Correct feature non-http description and add warning message

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -10,7 +10,7 @@ Feature: tool
 Description: Builds curl executable
 
 Feature: non-http
-Description: Enables protocols beyond HTTP/HTTPS/HTTP2
+Description: Enable all protocols except HTTP
 
 Feature: http2
 Build-Depends: nghttp2, curl[core,ssl]

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -15,6 +15,10 @@ vcpkg_from_github(
         0011_fix_static_build.patch
 )
 
+if ("non-http" IN_LIST FEATURES)
+    message(WARNING "Using feature \"non-http\", if you wish to enable http, please install curl using command `./vcpkg install curl[core]:${TARGET_TRIPLET}`")
+endif()
+
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)
 
 # schannel will enable sspi, but sspi do not support uwp


### PR DESCRIPTION
Since `non-http` is a default feature of curl and it's description is incorrect, fix the description and add warning message.

Fixes #14030.

Note: notify user to update this port is not needed, so don't update the port version.