### PR TITLE
[vcpkg] Output the filepath on hash error. 

### DIFF
--- a/toolsrc/include/vcpkg/base/hash.h
+++ b/toolsrc/include/vcpkg/base/hash.h
@@ -43,7 +43,8 @@ namespace vcpkg::Hash
         const auto result = get_file_hash(fs, path, algo, ec);
         if (ec)
         {
-            Checks::exit_with_message(li, "Failure to read file for hashing: %s", ec.message());
+            Checks::exit_with_message(
+                li, "Failure to read file '%s' for hashing: %s", fs::generic_u8string(path), ec.message());
         }
 
         return result;

--- a/toolsrc/include/vcpkg/base/hash.h
+++ b/toolsrc/include/vcpkg/base/hash.h
@@ -44,7 +44,7 @@ namespace vcpkg::Hash
         if (ec)
         {
             Checks::exit_with_message(
-                li, "Failure to read file '%s' for hashing: %s", fs::generic_u8string(path), ec.message());
+                li, "Failure to read file '%s' for hashing: %s", fs::u8string(path), ec.message());
         }
 
         return result;


### PR DESCRIPTION
to have a simple and meaninful error message instead of a simple file not found error without any information about which file it actually tried to read. 