### PR TITLE
[sqlcipher] Update to 4.4.1

### DIFF
--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install( ON_TARGET "UWP" "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
-    REF v4.4.0
-    SHA512 e6e7b09cc079d75ac0b9e15a256bfe479ce97cfdece3244ca53e2e04b7f1dc1afdc1ee76d07f2629e614c7532cc80eeef6b85ba5952d31a2eaed8d6e84414628
+    REF v4.4.1
+    SHA512 6bf53c697a1ae1a2714e135ee0645978706f6ee6c0500de9a9953314eda8fc84dc5a4f0beeebb390f14e4552833f11f869ba9846896d40e2e45e483edea09fe5
     HEAD_REF master
 )
 

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "sqlcipher",
   "version-string": "4.4.1",
-  "port-version": 1,
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "supports": "windows & !uwp & !static",

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlcipher",
-  "version-string": "4.4.0",
+  "version-string": "4.4.1",
   "port-version": 1,
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",


### PR DESCRIPTION
Updated sqlcipher to 4.4.1, which itself followed sqlite to 3.33.0. 