### PR TITLE
[geographiclib] Update to version 1.51

### DIFF
--- a/ports/geographiclib/cxx-library-only.patch
+++ b/ports/geographiclib/cxx-library-only.patch
@@ -1,8 +1,6 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 30875ddb..34aa6515 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -464,12 +464,12 @@ endif ()
+--- CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
++++ CMakeLists.txt	2020-11-22 12:12:35.314649815 -0500
+@@ -434,12 +434,12 @@
  # documentation files into the source tree.  Skip Apple here because
  # man/makeusage.sh uses "head --lines -4" to drop the last 4 lines of a
  # file and there's no simple equivalent for MacOSX
@@ -17,7 +15,7 @@ index 30875ddb..34aa6515 100644
    set (MAINTAINER ON)
  else ()
    set (MAINTAINER OFF)
-@@ -496,25 +496,34 @@ if (WIN32)
+@@ -466,25 +466,34 @@
    set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
  endif ()
  
@@ -52,11 +50,9 @@ index 30875ddb..34aa6515 100644
  if (MSVC AND BUILD_NETGEOGRAPHICLIB)
    if (GEOGRAPHICLIB_PRECISION EQUAL 2)
      set (NETGEOGRAPHICLIB_LIBRARIES NETGeographicLib)
-diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 90e773ba..c9a303b0 100644
---- a/cmake/CMakeLists.txt
-+++ b/cmake/CMakeLists.txt
-@@ -33,10 +33,10 @@ configure_file (project-config.cmake.in
+--- cmake/CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
++++ cmake/CMakeLists.txt	2020-11-22 12:15:14.370006356 -0500
+@@ -33,10 +33,10 @@
  configure_file (project-config-version.cmake.in
    "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake" @ONLY)
  export (TARGETS
@@ -69,7 +65,7 @@ index 90e773ba..c9a303b0 100644
    NAMESPACE ${PROJECT_NAME}::
    FILE "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-namespace-targets.cmake")
  
-@@ -44,15 +44,9 @@ export (TARGETS
+@@ -44,13 +44,7 @@
  # ${INSTALL_CMAKE_DIR} and @PROJECT_ROOT_DIR@ is the relative
  # path to the root from there.  (Note that the whole install tree can
  # be relocated.)
@@ -77,21 +73,15 @@ index 90e773ba..c9a303b0 100644
 -  # Install under lib${LIB_SUFFIX} so that 32-bit and 64-bit packages
 -  # can be installed on a single machine.
 -  set (INSTALL_CMAKE_DIR "lib${LIB_SUFFIX}/cmake/${PROJECT_NAME}")
--  set (PROJECT_ROOT_DIR "../../..")
 -else ()
 -  set (INSTALL_CMAKE_DIR "cmake")
--  set (PROJECT_ROOT_DIR "..")
 -endif ()
-+  set (INSTALL_CMAKE_DIR "share/${PROJECT_NAME_LOWER}")
-+  set (PROJECT_ROOT_DIR "../..")
-+
- # @PROJECT_INCLUDE_DIRS@ is not used in the install tree; reset
- # it to prevent the source and build paths appearing in the installed
- # config files
-diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index b8c028c7..26e4ba14 100644
---- a/tools/CMakeLists.txt
-+++ b/tools/CMakeLists.txt
++set (INSTALL_CMAKE_DIR "share/${PROJECT_NAME_LOWER}")
+ # Find root of install tree relative to INSTALL_CMAKE_DIR
+ file (RELATIVE_PATH PROJECT_ROOT_DIR
+   "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_PREFIX}")
+--- tools/CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
++++ tools/CMakeLists.txt	2020-11-22 12:12:35.322649933 -0500
 @@ -1,7 +1,7 @@
  # Build the tools...
  
@@ -101,7 +91,7 @@ index b8c028c7..26e4ba14 100644
  # Only needed if target_compile_definitions is not supported
  add_definitions (${PROJECT_DEFINITIONS})
  
-@@ -16,7 +16,7 @@ foreach (TOOL ${TOOLS})
+@@ -16,7 +16,7 @@
    add_dependencies (tools ${TOOL})
  
    set_source_files_properties (${TOOL}.cpp PROPERTIES
@@ -110,7 +100,7 @@ index b8c028c7..26e4ba14 100644
  
    target_link_libraries (${TOOL} ${PROJECT_LIBRARIES} ${HIGHPREC_LIBRARIES})
  
-@@ -35,7 +35,7 @@ if (APPLE)
+@@ -35,7 +35,7 @@
  endif ()
  
  # Specify where the tools are installed, adding them to the export targets
@@ -119,7 +109,7 @@ index b8c028c7..26e4ba14 100644
  
  if (MSVC AND PACKAGE_DEBUG_LIBS)
    # Possibly don't EXPORT the debug versions of the tools and then this
-@@ -55,7 +55,7 @@ set_property (TARGET tools ${TOOLS} PROPERTY FOLDER tools)
+@@ -55,7 +55,7 @@
  # systems.  This needs to substitute ${GEOGRAPHICLIB_DATA} as the
  # default data directory.  These are installed under sbin, because it is
  # expected to be run with write access to /usr/local.

--- a/ports/geographiclib/cxx-library-only.patch
+++ b/ports/geographiclib/cxx-library-only.patch
@@ -1,8 +1,29 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 345df69b..aba8cff7 100644
+index 345df69b..cb891034 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -434,12 +434,12 @@ endif ()
+@@ -196,6 +196,11 @@ else ()
+   set (DEVELOPER OFF)
+ endif ()
+ 
++set (INSTALL_TOOL_DIR "tools/geographiclib")
++file (RELATIVE_PATH PROJECT_LIB_DIR
++  "${CMAKE_INSTALL_PREFIX}/${INSTALL_TOOL_DIR}"
++  "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
++
+ if (NOT MSVC)
+   # Set the run time path for shared libraries for non-Windows machines.
+   # (1) include link path for external packages (not needed with
+@@ -207,7 +212,7 @@ if (NOT MSVC)
+   # (2) include installed path for GeographicLib.
+   if (NOT APPLE)
+     # Use relative path so that package is relocatable
+-    set (CMAKE_INSTALL_RPATH "\$ORIGIN/../lib${LIB_SUFFIX}")
++    set (CMAKE_INSTALL_RPATH "\$ORIGIN/${PROJECT_LIB_DIR}")
+   else ()
+     # cmake 2.8.12 introduced a way to make the package relocatable.
+     # See also INSTALL_RPATH property on the tools.
+@@ -434,12 +439,12 @@ endif ()
  # documentation files into the source tree.  Skip Apple here because
  # man/makeusage.sh uses "head --lines -4" to drop the last 4 lines of a
  # file and there's no simple equivalent for MacOSX
@@ -17,7 +38,7 @@ index 345df69b..aba8cff7 100644
    set (MAINTAINER ON)
  else ()
    set (MAINTAINER OFF)
-@@ -466,25 +466,34 @@ if (WIN32)
+@@ -466,25 +471,34 @@ if (WIN32)
    set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
  endif ()
  
@@ -85,7 +106,7 @@ index cbc21961..69c923bc 100644
  file (RELATIVE_PATH PROJECT_ROOT_DIR
    "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_PREFIX}")
 diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index 3fa8ec6a..f772b77c 100644
+index 3fa8ec6a..92c73946 100644
 --- a/tools/CMakeLists.txt
 +++ b/tools/CMakeLists.txt
 @@ -1,7 +1,7 @@
@@ -106,12 +127,17 @@ index 3fa8ec6a..f772b77c 100644
  
    target_link_libraries (${TOOL} ${PROJECT_LIBRARIES} ${HIGHPREC_LIBRARIES})
  
-@@ -35,7 +35,7 @@ if (APPLE)
+@@ -31,11 +31,11 @@ endif ()
+ if (APPLE)
+   # Ensure that the package is relocatable
+   set_target_properties (${TOOLS} PROPERTIES
+-    INSTALL_RPATH "@loader_path/../lib${LIB_SUFFIX}")
++    INSTALL_RPATH "@loader_path/${PROJECT_LIB_DIR}")
  endif ()
  
  # Specify where the tools are installed, adding them to the export targets
 -install (TARGETS ${TOOLS} EXPORT targets DESTINATION bin)
-+install (TARGETS ${TOOLS} DESTINATION tools)
++install (TARGETS ${TOOLS} DESTINATION "${INSTALL_TOOL_DIR}")
  
  if (MSVC AND PACKAGE_DEBUG_LIBS)
    # Possibly don't EXPORT the debug versions of the tools and then this

--- a/ports/geographiclib/cxx-library-only.patch
+++ b/ports/geographiclib/cxx-library-only.patch
@@ -1,6 +1,8 @@
---- CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
-+++ CMakeLists.txt	2020-11-22 12:12:35.314649815 -0500
-@@ -434,12 +434,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 345df69b..aba8cff7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -434,12 +434,12 @@ endif ()
  # documentation files into the source tree.  Skip Apple here because
  # man/makeusage.sh uses "head --lines -4" to drop the last 4 lines of a
  # file and there's no simple equivalent for MacOSX
@@ -15,7 +17,7 @@
    set (MAINTAINER ON)
  else ()
    set (MAINTAINER OFF)
-@@ -466,25 +466,34 @@
+@@ -466,25 +466,34 @@ if (WIN32)
    set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
  endif ()
  
@@ -50,9 +52,11 @@
  if (MSVC AND BUILD_NETGEOGRAPHICLIB)
    if (GEOGRAPHICLIB_PRECISION EQUAL 2)
      set (NETGEOGRAPHICLIB_LIBRARIES NETGeographicLib)
---- cmake/CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
-+++ cmake/CMakeLists.txt	2020-11-22 12:15:14.370006356 -0500
-@@ -33,10 +33,10 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index cbc21961..69c923bc 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -33,10 +33,10 @@ configure_file (project-config.cmake.in
  configure_file (project-config-version.cmake.in
    "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-config-version.cmake" @ONLY)
  export (TARGETS
@@ -65,7 +69,7 @@
    NAMESPACE ${PROJECT_NAME}::
    FILE "${PROJECT_BINARY_DIR}/${PROJECT_NAME_LOWER}-namespace-targets.cmake")
  
-@@ -44,13 +44,7 @@
+@@ -44,13 +44,7 @@ export (TARGETS
  # ${INSTALL_CMAKE_DIR} and @PROJECT_ROOT_DIR@ is the relative
  # path to the root from there.  (Note that the whole install tree can
  # be relocated.)
@@ -80,8 +84,10 @@
  # Find root of install tree relative to INSTALL_CMAKE_DIR
  file (RELATIVE_PATH PROJECT_ROOT_DIR
    "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_PREFIX}")
---- tools/CMakeLists.txt.orig	2020-11-22 09:00:22.000000000 -0500
-+++ tools/CMakeLists.txt	2020-11-22 12:12:35.322649933 -0500
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 3fa8ec6a..f772b77c 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
 @@ -1,7 +1,7 @@
  # Build the tools...
  
@@ -91,7 +97,7 @@
  # Only needed if target_compile_definitions is not supported
  add_definitions (${PROJECT_DEFINITIONS})
  
-@@ -16,7 +16,7 @@
+@@ -16,7 +16,7 @@ foreach (TOOL ${TOOLS})
    add_dependencies (tools ${TOOL})
  
    set_source_files_properties (${TOOL}.cpp PROPERTIES
@@ -100,7 +106,7 @@
  
    target_link_libraries (${TOOL} ${PROJECT_LIBRARIES} ${HIGHPREC_LIBRARIES})
  
-@@ -35,7 +35,7 @@
+@@ -35,7 +35,7 @@ if (APPLE)
  endif ()
  
  # Specify where the tools are installed, adding them to the export targets
@@ -109,7 +115,7 @@
  
  if (MSVC AND PACKAGE_DEBUG_LIBS)
    # Possibly don't EXPORT the debug versions of the tools and then this
-@@ -55,7 +55,7 @@
+@@ -55,7 +55,7 @@ set_property (TARGET tools ${TOOLS} PROPERTY FOLDER tools)
  # systems.  This needs to substitute ${GEOGRAPHICLIB_DATA} as the
  # default data directory.  These are installed under sbin, because it is
  # expected to be run with write access to /usr/local.

--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -38,13 +38,8 @@ vcpkg_install_cmake ()
 vcpkg_fixup_cmake_targets (CONFIG_PATH share/geographiclib)
 vcpkg_copy_pdbs ()
 
-file (GLOB TOOL_LIST LIST_DIRECTORIES false
-  ${CURRENT_PACKAGES_DIR}/tools/*)
-if (TOOL_LIST)
-  file (COPY ${TOOL_LIST}
-    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+if (tools IN_LIST FEATURES)
   vcpkg_copy_tool_dependencies (${CURRENT_PACKAGES_DIR}/tools/${PORT})
-  file (REMOVE ${TOOL_LIST})
 endif ()
 
 file (REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -41,7 +41,7 @@ vcpkg_copy_pdbs ()
 file (GLOB TOOL_LIST LIST_DIRECTORIES false
   ${CURRENT_PACKAGES_DIR}/tools/*)
 if (TOOL_LIST)
-  file (INSTALL ${TOOL_LIST}
+  file (COPY ${TOOL_LIST}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
   vcpkg_copy_tool_dependencies (${CURRENT_PACKAGES_DIR}/tools/${PORT})
   file (REMOVE ${TOOL_LIST})

--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_sourceforge (
     OUT_SOURCE_PATH SOURCE_PATH
     REPO geographiclib
     REF distrib
-    FILENAME "GeographicLib-1.50.1.tar.gz"
-    SHA512 1db874f30957a0edb8a1df3eee6db73cc993629e3005fe912e317a4ba908e7d7580ce483bb0054c4b46370b8edaec989609fb7e4eb6ba00c80182db43db436f1
+    FILENAME "GeographicLib-1.51.tar.gz"
+    SHA512 34487a09fa94a34d24179cfe9fd2e5fdda28675966703ca137cbfe6cc88760c2fbde55f76c464de060b58bfe0a516e22c0f59318cf85ae7cc01c5c6a73dd6ead
     PATCHES cxx-library-only.patch
 )
 

--- a/ports/geographiclib/vcpkg.json
+++ b/ports/geographiclib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "geographiclib",
-  "version-string": "1.50.1",
+  "version-string": "1.51",
   "description": "GeographicLib, a C++ library for performing geographic conversions",
   "homepage": "https://geographiclib.sourceforge.io",
   "features": {


### PR DESCRIPTION
This is just a routine upgrade.

- What does your PR fix? Routine upgrade to 1.51

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
