### PR TITLE
[libbson] fix cmake find

### DIFF
--- a/ports/libbson/portfile.cmake
+++ b/ports/libbson/portfile.cmake
@@ -43,9 +43,9 @@ vcpkg_copy_pdbs()
 set(PORT_POSTFIX "1.0")
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libbson-static-${PORT_POSTFIX} TARGET_PATH share/bson-${PORT_POSTFIX})
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libbson-static-${PORT_POSTFIX} TARGET_PATH share/libbson-${PORT_POSTFIX})
 else()
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libbson-${PORT_POSTFIX} TARGET_PATH share/bson-${PORT_POSTFIX})
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libbson-${PORT_POSTFIX} TARGET_PATH share/libbson-${PORT_POSTFIX})
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
@@ -66,20 +66,20 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/bson/bson-macros.h
         "define BSON_API __declspec(dllimport)" "define BSON_API")
         
-     file(RENAME ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/libbson-static-${PORT_POSTFIX}-config.cmake
-        ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/bson-${PORT_POSTFIX}-config.cmake)
-     file(RENAME ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/libbson-static-${PORT_POSTFIX}-config-version.cmake
-        ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/bson-${PORT_POSTFIX}-config-version.cmake)
+     file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-static-${PORT_POSTFIX}-config.cmake
+        ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config.cmake)
+     file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-static-${PORT_POSTFIX}-config-version.cmake
+        ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config-version.cmake)
 
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
 else()
-     file(RENAME ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config.cmake
-        ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/bson-${PORT_POSTFIX}-config.cmake)
-     file(RENAME ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config-version.cmake
-        ${CURRENT_PACKAGES_DIR}/share/bson-${PORT_POSTFIX}/bson-${PORT_POSTFIX}-config-version.cmake)
+     file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config.cmake
+        ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config.cmake)
+     file(RENAME ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config-version.cmake
+        ${CURRENT_PACKAGES_DIR}/share/libbson-${PORT_POSTFIX}/libbson-${PORT_POSTFIX}-config-version.cmake)
 endif()
 
-vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/bson-1.0/bson-1.0-config.cmake
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/libbson-1.0/libbson-1.0-config.cmake
     "include/libbson-1.0" "include/")
 
 file(COPY ${SOURCE_PATH}/THIRD_PARTY_NOTICES DESTINATION ${CURRENT_PACKAGES_DIR}/share/libbson)

--- a/ports/mongo-c-driver/CONTROL
+++ b/ports/mongo-c-driver/CONTROL
@@ -1,6 +1,6 @@
 Source: mongo-c-driver
 Version: 1.16.1
-Port-Version: 3
+Port-Version: 4
 Build-Depends: libbson, openssl (!windows), zlib
 Description: Client library written in C for MongoDB.
 Homepage: https://github.com/mongodb/mongo-c-driver

--- a/ports/mongo-c-driver/fix-dependency-libbson.patch
+++ b/ports/mongo-c-driver/fix-dependency-libbson.patch
@@ -1,8 +1,28 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1a2b7ba..7c939d6 100644
+index 1a2b7bad7..7ff8bbf32 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -169,14 +169,6 @@ if (ENABLE_BSON STREQUAL SYSTEM)
+@@ -151,16 +151,15 @@ if (ENABLE_BSON STREQUAL SYSTEM)
+    # The input variable BSON_ROOT_DIR is respected for backwards compatibility,
+    # but you should use the standard CMAKE_PREFIX_PATH instead.
+    message (STATUS "Searching for libbson CMake packages")
+-   find_package (bson-1.0
+-      "${MONGOC_MAJOR_VERSION}.${MONGOC_MINOR_VERSION}.${MONGOC_MICRO_VERSION}"
++   find_package (libbson-1.0 CONFIG
+       HINTS
+       ${BSON_ROOT_DIR})
+ 
+-   if (NOT bson-1.0_FOUND)
++   if (NOT libbson-1.0_FOUND)
+       message (FATAL_ERROR "System libbson not found")
+    endif ()
+ 
+-   message ("--   libbson found version \"${bson-1.0_VERSION}\"")
++   message ("--   libbson found version \"${libbson-1.0_VERSION}\"")
+    message ("--   disabling test-libmongoc since using system libbson")
+    SET (ENABLE_TESTS OFF)
+ 
+@@ -169,14 +168,6 @@ if (ENABLE_BSON STREQUAL SYSTEM)
     endif ()
  
     set (USING_SYSTEM_BSON TRUE)
@@ -50,19 +70,6 @@ index 0f9e50c..797aaec 100644
  target_link_libraries (mongoc-stat mongoc_shared ${LIBRARIES})
  
  # mongoc-stat works if shared memory performance counters are enabled.
-diff --git a/src/libmongoc/build/cmake/libmongoc-1.0-config.cmake.in b/src/libmongoc/build/cmake/libmongoc-1.0-config.cmake.in
-index feeca02..62aa21a 100644
---- a/src/libmongoc/build/cmake/libmongoc-1.0-config.cmake.in
-+++ b/src/libmongoc/build/cmake/libmongoc-1.0-config.cmake.in
-@@ -19,7 +19,7 @@ set (MONGOC_MINOR_VERSION @MONGOC_MINOR_VERSION@)
- set (MONGOC_MICRO_VERSION @MONGOC_MICRO_VERSION@)
- set (MONGOC_VERSION @MONGOC_VERSION@)
- 
--find_package (libbson-1.0 "@MONGOC_MAJOR_VERSION@.@MONGOC_MINOR_VERSION@" REQUIRED)
-+find_package (bson-1.0 "@MONGOC_MAJOR_VERSION@.@MONGOC_MINOR_VERSION@" REQUIRED)
- 
- @PACKAGE_INIT@
- 
 diff --git a/src/libmongoc/build/cmake/libmongoc-static-1.0-config.cmake.in b/src/libmongoc/build/cmake/libmongoc-static-1.0-config.cmake.in
 index 6f05b0c..113804e 100644
 --- a/src/libmongoc/build/cmake/libmongoc-static-1.0-config.cmake.in
@@ -72,7 +79,7 @@ index 6f05b0c..113804e 100644
  set (MONGOC_STATIC_VERSION @MONGOC_VERSION@)
  
 -find_package (libbson-static-1.0 "@MONGOC_MAJOR_VERSION@.@MONGOC_MINOR_VERSION@" REQUIRED)
-+find_package (bson-1.0 "@MONGOC_MAJOR_VERSION@.@MONGOC_MINOR_VERSION@" REQUIRED)
++find_package (libbson-1.0 "@MONGOC_MAJOR_VERSION@.@MONGOC_MINOR_VERSION@" REQUIRED)
  
  @PACKAGE_INIT@
  

--- a/ports/mongo-cxx-driver/CONTROL
+++ b/ports/mongo-cxx-driver/CONTROL
@@ -1,6 +1,6 @@
 Source: mongo-cxx-driver
 Version: 3.4.0-5
-Port-Version: 1
+Port-Version: 2
 Build-Depends: libbson, mongo-c-driver, boost-smart-ptr, boost-optional, boost-utility
 Homepage: https://github.com/mongodb/mongo-cxx-driver
 Description: MongoDB C++ Driver.

--- a/ports/mongo-cxx-driver/fix-dependency-libbson.patch
+++ b/ports/mongo-cxx-driver/fix-dependency-libbson.patch
@@ -7,7 +7,7 @@ index 69b53b3..655b33a 100644
  
  if (BUILD_SHARED_LIBS)
 -    find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} REQUIRED)
-+    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} CONFIG REQUIRED)
++    find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} CONFIG REQUIRED)
      set(libbson_libraries ${BSON_LIBRARIES})
      set(libbson_include_directories ${BSON_INCLUDE_DIRS})
      set(libbson_definitions ${BSON_DEFINITIONS})
@@ -16,7 +16,7 @@ index 69b53b3..655b33a 100644
 -    set(libbson_libraries ${BSON_STATIC_LIBRARIES})
 -    set(libbson_include_directories ${BSON_STATIC_INCLUDE_DIRS})
 -    set(libbson_definitions ${BSON_STATIC_DEFINITIONS})
-+    find_package(bson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} CONFIG REQUIRED)
++    find_package(libbson-${LIBBSON_REQUIRED_ABI_VERSION} ${LIBBSON_REQUIRED_VERSION} CONFIG REQUIRED)
 +    set(libbson_libraries ${BSON_LIBRARIES})
 +    set(libbson_include_directories ${BSON_INCLUDE_DIRS})
 +    set(libbson_definitions ${BSON_DEFINITIONS})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3826,11 +3826,11 @@
     },
     "mongo-c-driver": {
       "baseline": "1.16.1",
-      "port-version": 3
+      "port-version": 4
     },
     "mongo-cxx-driver": {
       "baseline": "3.4.0-5",
-      "port-version": 1
+      "port-version": 2
     },
     "mongoose": {
       "baseline": "6.15-2",

--- a/versions/l-/libbson.json
+++ b/versions/l-/libbson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b26ca651117f7c38660c6a08d643aba7d6248ab0",
+      "git-tree": "9988ee3812d5134cb3ebe09af0178e77518a1368",
       "version-string": "1.16.1",
       "port-version": 2
     },

--- a/versions/m-/mongo-c-driver.json
+++ b/versions/m-/mongo-c-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6b948f7f7ff67f47481c2630ba40ab300bceee01",
+      "version-string": "1.16.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "7f42fe8e15fb11c2ef5c63723edcd29a2be93062",
       "version-string": "1.16.1",
       "port-version": 3

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d0b0f339d4533201003aefd28a57efc827414434",
+      "version-string": "3.4.0-5",
+      "port-version": 2
+    },
+    {
       "git-tree": "604e80750b83ac609caa6acca73b09307900a9cd",
       "version-string": "3.4.0-5",
       "port-version": 1


### PR DESCRIPTION
Fixes this error when calling `find_package(libbson-1.0 CONFIG REQUIRED)` in linux
```
CMake Error at vcpkg/scripts/buildsystems/vcpkg.cmake:622 (_find_package):
  Could not find a package configuration file provided by "libbson-1.0" with
  any of the following names:

    libbson-1.0Config.cmake
    libbson-1.0-config.cmake

  Add the installation prefix of "libbson-1.0" to CMAKE_PREFIX_PATH or set
  "libbson-1.0_DIR" to a directory containing one of the above files.  If
  "libbson-1.0" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:17 (find_package)
```