### PR TITLE
[ignition-msgs*] Fix flaky CI tests for ignition-msgs* ports (take 2)

### DIFF
--- a/ports/ignition-modularscripts/CONTROL
+++ b/ports/ignition-modularscripts/CONTROL
@@ -1,4 +1,3 @@
 Source: ignition-modularscripts
-Version: 2020-05-16
-Port-Version: 2
+Version: 2020-11-23
 Description: Vcpkg helpers to package ignition libraries

--- a/ports/ignition-modularscripts/ignition_modular_library.cmake
+++ b/ports/ignition-modularscripts/ignition_modular_library.cmake
@@ -7,7 +7,7 @@ function(ignition_modular_build_library NAME MAJOR_VERSION SOURCE_PATH CMAKE_PAC
         OPTIONS -DBUILD_TESTING=OFF
     )
 
-    vcpkg_install_cmake()
+    vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
     # If necessary, move the CMake config files
     if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake")

--- a/ports/ignition-msgs1/CONTROL
+++ b/ports/ignition-msgs1/CONTROL
@@ -1,5 +1,5 @@
 Source: ignition-msgs1
 Version: 1.0.0
-Port-Version: 2
+Port-Version: 3
 Build-Depends: ignition-cmake0, ignition-math4, protobuf
 Description: Middleware protobuf messages for robotics

--- a/ports/ignition-msgs1/portfile.cmake
+++ b/ports/ignition-msgs1/portfile.cmake
@@ -14,12 +14,6 @@ if(ignition_msgs_CROSSCOMPILING)
     message(FATAL_ERROR "This port does not currently support triplets that require cross-compilation.")
 endif()
 
-# This port needs  to generate protobuf messages with a custom plugin generator,
-# so it needs to have in Windows the relative protobuf dll available in the PATH
-set(path_backup $ENV{PATH})
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/bin)
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
-
 ignition_modular_library(NAME msgs
                          VERSION "1.0.0"
                          # See https://bitbucket.org/ignitionrobotics/ign-msgs/issues/33/the-ignition-msgs1_100-tag-does-not-match
@@ -27,7 +21,3 @@ ignition_modular_library(NAME msgs
                          SHA512 3a270f0ac988b947091d4626be48fe8cfed5ddfde5a37b9d0f08fddcbf278099ab231fca11e2dd2296ca54e0350ea14e3f685dc238f0827f18f10ab7b75039de
                          # Fix linking order of protobuf libraries (backport of https://bitbucket.org/ignitionrobotics/ign-msgs/pull-requests/151)
                          PATCHES fix-protobuf-static-link-order.patch)
-
-
-# Restore old path
-set(ENV{PATH} ${path_backup})

--- a/ports/ignition-msgs5/CONTROL
+++ b/ports/ignition-msgs5/CONTROL
@@ -1,6 +1,6 @@
 Source: ignition-msgs5
 Version: 5.3.0
-Port-Version: 1
+Port-Version: 2
 Build-Depends: ignition-modularscripts, ignition-cmake2, ignition-math6, protobuf, tinyxml2
 Description: Middleware protobuf messages for robotics
 Supports: !(arm|uwp)

--- a/ports/ignition-msgs5/portfile.cmake
+++ b/ports/ignition-msgs5/portfile.cmake
@@ -4,17 +4,9 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 
 include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
 
-# This port needs  to generate protobuf messages with a custom plugin generator,
-# so it needs to have in Windows the relative protobuf dll available in the PATH
-set(path_backup $ENV{PATH})
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/bin)
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
-
 ignition_modular_library(NAME msgs
                          VERSION "5.3.0"
                          SHA512 55c167d00b60ae6da0144a9495e9ac8aed61fcbdc61e057e75d31261e335c573543d60e28a7dc195a7c9849c5c6eb0e088d4f4e79fd927e83470a3f1fabef60e
                          PATCHES
                            "01-protobuf.patch")
 
-# Restore old path
-set(ENV{PATH} "${path_backup}")

--- a/ports/ignition-msgs6/CONTROL
+++ b/ports/ignition-msgs6/CONTROL
@@ -1,5 +1,6 @@
 Source: ignition-msgs6
 Version: 6.0.0
+Port-Version: 1
 Build-Depends: ignition-modularscripts, ignition-cmake2, ignition-math6, protobuf, tinyxml2
 Description: Middleware protobuf messages for robotics
 Supports: !(arm|uwp)

--- a/ports/ignition-msgs6/portfile.cmake
+++ b/ports/ignition-msgs6/portfile.cmake
@@ -4,15 +4,7 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 
 include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
 
-# This port needs  to generate protobuf messages with a custom plugin generator,
-# so it needs to have in Windows the relative protobuf dll available in the PATH
-set(path_backup $ENV{PATH})
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/bin)
-vcpkg_add_to_path(${CURRENT_INSTALLED_DIR}/debug/bin)
-
 ignition_modular_library(NAME msgs
                          VERSION "6.0.0"
                          SHA512 d1d6f6602ae33ec95b36c5df7815b06970f349492ef0309d8aacbaf2dca0c3e7314bbd64890a2554485fbd52f148a90b7bf54dceb0b3a1dd40eeb1f5bdb9613c)
 
-# Restore old path
-set(ENV{PATH} "${path_backup}")


### PR DESCRIPTION
Pass `ADD_BIN_TO_PATH` to `vcpkg_install_cmake` and remove custom `PATH` hacks. Less invasive version of https://github.com/microsoft/vcpkg/pull/14464 thanks to @Neumann-A feedback. 

**Describe the pull request**

- What does your PR fix? Fixes the problem mentioned in https://github.com/microsoft/vcpkg/pull/14324#discussion_r517128792, not sure if there is a corresponding issue.

- Which triplets are supported/not supported? Have you updated the CI baseline? The PR should not change the supported triplets. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes

cc @BillyONeal 

