### PR TITLE
[vcpkg] Fix redefinition for OVERLAY_TRIPLETS_ENV

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -922,7 +922,6 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ARG;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ARG;
-    //constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::BINARY_SOURCES_ARG;
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -922,7 +922,7 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ARG;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ARG;
-    constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
+    //constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::BINARY_SOURCES_ARG;
 


### PR DESCRIPTION
Fix the bug  for master branch, the var of OVERLAY_TRIPLETS_ENV  be defined two times (the lines of 923 and 925 )


[69/83] Building CXX object CMakeFiles/vcpkglib.dir/src/vcpkg/vcpkgcmdarguments.cpp.o
FAILED: CMakeFiles/vcpkglib.dir/src/vcpkg/vcpkgcmdarguments.cpp.o
/usr/local/bin/g++-6 -DVCPKG_USE_STD_FILESYSTEM=0 -I../include -O3 -DNDEBUG -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk -include /Users/lizhipeng/develop/project/git_project/opensource/c++/vcpkg/toolsrc/include/pch.h -std=c++1z -MD -MT CMakeFiles/vcpkglib.dir/src/vcpkg/vcpkgcmdarguments.cpp.o -MF CMakeFiles/vcpkglib.dir/src/vcpkg/vcpkgcmdarguments.cpp.o.d -o CMakeFiles/vcpkglib.dir/src/vcpkg/vcpkgcmdarguments.cpp.o -c ../src/vcpkg/vcpkgcmdarguments.cpp
../src/vcpkg/vcpkgcmdarguments.cpp:925:48: error: redefinition of 'constexpr const vcpkg::StringLiteral vcpkg::VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV'
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
                                                ^~~~~~~~~~~~~~~~~~~~
In file included from ../src/vcpkg/vcpkgcmdarguments.cpp:9:0:
../include/vcpkg/vcpkgcmdarguments.h:145:40: note: 'constexpr const vcpkg::StringLiteral vcpkg::VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV' previously defined here
         constexpr static StringLiteral OVERLAY_TRIPLETS_ENV = "VCPKG_OVERLAY_TRIPLETS";

**Describe the pull request**

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
