### PR TITLE
[vcpkg] Remove redefinition for OVERLAY_TRIPLETS_ENV

### DIFF
--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -922,7 +922,6 @@ namespace vcpkg
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_PORTS_ARG;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
     constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ARG;
-    constexpr StringLiteral VcpkgCmdArguments::OVERLAY_TRIPLETS_ENV;
 
     constexpr StringLiteral VcpkgCmdArguments::BINARY_SOURCES_ARG;
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14728

Currently `OVERLAY_TRIPLETS_ENV` is defined twice in gcc6.

Remove one of them to fix build error in gcc6.

Since this definition is added twice via these two PRs
#14616 ,#14436

