### PR TITLE
[poco] Fix dependency libmariadb

### DIFF
--- a/ports/libmariadb/CONTROL
+++ b/ports/libmariadb/CONTROL
@@ -1,6 +1,6 @@
 Source: libmariadb
 Version: 3.1.10
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/MariaDB/mariadb-connector-c
 Description: MariaDB Connector/C is used to connect C/C++ applications to MariaDB and MySQL databases
 Default-Features: zlib, openssl

--- a/ports/libmariadb/export-cmake-targets.patch
+++ b/ports/libmariadb/export-cmake-targets.patch
@@ -1,8 +1,16 @@
 diff --git a/libmariadb/CMakeLists.txt b/libmariadb/CMakeLists.txt
-index 083a863..d911fa7 100644
+index 083a863..6c8d932 100644
 --- a/libmariadb/CMakeLists.txt
 +++ b/libmariadb/CMakeLists.txt
-@@ -457,13 +457,25 @@ ENDIF()
+@@ -405,6 +405,7 @@ ELSE()
+   TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE mariadbclient)
+   SET_TARGET_PROPERTIES(libmariadb PROPERTIES LINKER_LANGUAGE C)
+ ENDIF()
++TARGET_INCLUDE_DIRECTORIES(libmariadb PUBLIC $<INSTALL_INTERFACE:include/mysql>)
+ 
+ TARGET_LINK_LIBRARIES(libmariadb LINK_PRIVATE ${SYSTEM_LIBS})
+ 
+@@ -457,13 +458,25 @@ ENDIF()
  
  INSTALL(TARGETS mariadbclient
            COMPONENT Development

--- a/ports/poco/CONTROL
+++ b/ports/poco/CONTROL
@@ -1,6 +1,6 @@
 Source: poco
 Version: 1.10.1
-Port-Version: 2
+Port-Version: 3
 Build-Depends: expat, pcre, zlib
 Description: Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.
 Homepage: https://github.com/pocoproject/poco

--- a/ports/poco/fix_dependency.patch
+++ b/ports/poco/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b664afd..e08b6c2 100644
+index b664afd..aafbf4a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -82,8 +82,6 @@ option(FORCE_OPENSSL "Force usage of OpenSSL even under windows" OFF)
@@ -11,7 +11,7 @@ index b664afd..e08b6c2 100644
  endif()
  
  if(OPENSSL_FOUND)
-@@ -113,24 +111,18 @@ else()
+@@ -113,24 +111,19 @@ else()
  	option(ENABLE_APACHECONNECTOR "Enable ApacheConnector" OFF)
  endif()
  
@@ -33,6 +33,7 @@ index b664afd..e08b6c2 100644
 +    find_package(libmysql)
 +    if (NOT libmysql_FOUND)
 +        find_package(unofficial-libmariadb CONFIG REQUIRED)
++        set(MYSQL_LIBRARIES libmariadb)
 +    endif()
  endif()
  
@@ -43,7 +44,7 @@ index b664afd..e08b6c2 100644
  endif()
  
  if(PostgreSQL_FOUND)
-@@ -200,6 +192,9 @@ include(DefinePlatformSpecifc)
+@@ -200,6 +193,9 @@ include(DefinePlatformSpecifc)
  # Collect the built libraries and include dirs, the will be used to create the PocoConfig.cmake file
  set(Poco_COMPONENTS "")
  
@@ -53,7 +54,7 @@ index b664afd..e08b6c2 100644
  if(ENABLE_TESTS)
  	add_subdirectory(CppUnit)
  	set(ENABLE_XML ON CACHE BOOL "Enable XML" FORCE)
-@@ -327,8 +322,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Redis AND ENABLE_REDIS)
+@@ -327,8 +323,11 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/Redis AND ENABLE_REDIS)
  	list(APPEND Poco_COMPONENTS "Redis")
  endif()
  
@@ -67,7 +68,7 @@ index b664afd..e08b6c2 100644
  	list(APPEND Poco_COMPONENTS "PDF")
  endif()
  
-@@ -457,15 +455,6 @@ install(
+@@ -457,15 +456,6 @@ install(
  		Devel
  )
  
@@ -83,6 +84,19 @@ index b664afd..e08b6c2 100644
  message(STATUS "CMake ${CMAKE_VERSION} successfully configured ${PROJECT_NAME} using ${CMAKE_GENERATOR} generator")
  message(STATUS "${PROJECT_NAME} package version: ${PROJECT_VERSION}")
  if(BUILD_SHARED_LIBS)
+diff --git a/Data/CMakeLists.txt b/Data/CMakeLists.txt
+index 7d1e99e..9d0a85c 100644
+--- a/Data/CMakeLists.txt
++++ b/Data/CMakeLists.txt
+@@ -45,7 +45,7 @@ else(ENABLE_DATA_SQLITE)
+ 	message(STATUS "SQLite Support Disabled")
+ endif()
+ 
+-if(MYSQL_FOUND AND ENABLE_DATA_MYSQL)
++if((MYSQL_FOUND OR unofficial-libmariadb_FOUND) AND ENABLE_DATA_MYSQL)
+ 	message(STATUS "MySQL Support Enabled")
+ 	add_subdirectory(MySQL)
+ else()
 diff --git a/Data/MySQL/CMakeLists.txt b/Data/MySQL/CMakeLists.txt
 index f71b145..7034974 100644
 --- a/Data/MySQL/CMakeLists.txt

--- a/ports/poco/fix_dependency.patch
+++ b/ports/poco/fix_dependency.patch
@@ -229,3 +229,15 @@ index 173eacd..936edf4 100644
  
  foreach(module ${Poco_FIND_COMPONENTS})
      find_package(Poco${module}
+diff --git a/Data/MySQL/include/Poco/Data/MySQL/MySQL.h b/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
+index b533c9f..e2bb2d3 100644
+--- a/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
++++ b/Data/MySQL/include/Poco/Data/MySQL/MySQL.h
+@@ -54,7 +54,6 @@
+ 	#if !defined(MySQL_EXPORTS)
+ 		#pragma comment(lib, "PocoDataMySQL" POCO_LIB_SUFFIX)
+ 	#endif
+-	#pragma comment(lib, "libmysql")
+ #endif
+ 
+ 


### PR DESCRIPTION
- Export `INTERFACE_INCLUDE_DIRECTORIES` in libmariadb
- Fix using libmariadb on option `ENABLE_DATA_MYSQL`

Fixes #14713.