### PR TITLE
[lapack-reference] enable fortran if possible for find blas

### DIFF
--- a/ports/lapack-reference/CONTROL
+++ b/ports/lapack-reference/CONTROL
@@ -1,6 +1,6 @@
 Source: lapack-reference
 Version: 3.8.0
-Port-Version: 3
+Port-Version: 4
 Description: LAPACK — Linear Algebra PACKage http://www.netlib.org/lapack/
 Default-Features: blas-select
 Build-Depends: vcpkg-gfortran (windows)

--- a/ports/lapack-reference/FindLAPACK.cmake
+++ b/ports/lapack-reference/FindLAPACK.cmake
@@ -86,6 +86,12 @@ This module defines the following variables:
     find_package(LAPACK)
 #]=======================================================================]
 
+include(${CMAKE_ROOT}/Modules/CheckLanguage.cmake)
+check_language(Fortran)
+if (CMAKE_Fortran_COMPILER)
+    enable_language(Fortran)
+endif()
+
 enable_language(C)
 # Check the language being used
 if(NOT (CMAKE_C_COMPILER_LOADED OR CMAKE_CXX_COMPILER_LOADED OR CMAKE_Fortran_COMPILER_LOADED))


### PR DESCRIPTION
**Describe the pull request**
If Fortran language not enabled FindLAPACK fails on default configuration. 

- What does your PR fix? Fixes #
FindLAPACK.cmake

- Which triplets are supported/not supported? Have you updated the CI baseline?
as previous, no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes