### PR TITLE
Fixing link in maintainers doc

### DIFF
--- a/docs/maintainers/vcpkg_build_make.md
+++ b/docs/maintainers/vcpkg_build_make.md
@@ -36,7 +36,7 @@ Additional subdir to invoke make in. Useful if only parts of a port should be bu
 
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
-You can use the alias [`vcpkg_install_make()`](vcpkg_configure_make.md) function if your CMake script supports the
+You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your CMake script supports the
 "install" target
 
 ## Examples


### PR DESCRIPTION
This fixes a link in the maintainer document. The link to `vcpkg_install_make.md` was linking to `vcpkg_configure_make.md`

The line ending change was automatically done by the Github. Not sure if this is a problem.