### PR TITLE
[rtaudio] Add new port

### DIFF
--- a/ports/rtaudio/CONTROL
+++ b/ports/rtaudio/CONTROL
@@ -1,4 +1,0 @@
-Source: rtaudio
-Version: 5.1.0
-Description: A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.
-Homepage: https://github.com/thestk/rtaudio

--- a/ports/rtaudio/CONTROL
+++ b/ports/rtaudio/CONTROL
@@ -1,0 +1,4 @@
+Source: rtaudio
+Version: 5.1.0
+Description: A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.
+Homepage: https://github.com/thestk/rtaudio

--- a/ports/rtaudio/LICENSE
+++ b/ports/rtaudio/LICENSE
@@ -1,0 +1,26 @@
+RtAudio: a set of realtime audio i/o C++ classes
+Copyright (c) 2001-2019 Gary P. Scavone
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+Any person wishing to distribute modifications to the Software is
+asked to send the modifications to the original developer so that
+they can be incorporated into the canonical version.  This is,
+however, not a binding provision of this license.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ports/rtaudio/portfile.cmake
+++ b/ports/rtaudio/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thestk/rtaudio

--- a/ports/rtaudio/portfile.cmake
+++ b/ports/rtaudio/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO thestk/rtaudio
+    REF 5.1.0
+    SHA512 338a3a14cd4ea665ac7e94a275cb017bffd87cb10eb8ab6784fad320345ee828b8874439edd08c39efa48736edf9aa0622620784adc320473b03a8f81e17fff6
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Version 5.1.0 has the license text embedded in the README.md, so we are including it as a standalone file in the vcpkg port
+# Current master version of rtaudio has a LICENSE file which should be used instead for ports of future releases
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+

--- a/ports/rtaudio/vcpkg.json
+++ b/ports/rtaudio/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "rtaudio",
   "version-string": "5.1.0",
   "description": "A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.",
-  "homepage": "https://github.com/thestk/rtaudio"
+  "homepage": "https://github.com/thestk/rtaudio",
+  "supports": "!uwp"
 }

--- a/ports/rtaudio/vcpkg.json
+++ b/ports/rtaudio/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "rtaudio",
+  "version-string": "5.1.0",
+  "description": "A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.",
+  "homepage": "https://github.com/thestk/rtaudio"
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1335,6 +1335,7 @@ rpclib:arm-uwp=fail
 rpclib:x64-uwp=fail
 rsocket:x64-windows=fail
 rsocket:x64-windows-static=fail
+rtaudio:x64-linux=fail
 rtlsdr:x64-uwp=fail
 rtlsdr:arm64-windows=fail
 rtlsdr:arm-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

This adds a new port for the latest release of [RtAudio](https://github.com/thestk/rtaudio). Fixes #11183.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Triplets x86-windows, x86-windows-static, x64-windows and x64-windows-static have been tested. Other platforms are untested.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
