### PR TITLE
[osg] Update dependency

### DIFF
--- a/ports/osg/CONTROL
+++ b/ports/osg/CONTROL
@@ -1,9 +1,9 @@
 Source: osg
 Version: 3.6.5
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/openscenegraph/OpenSceneGraph
 Description:  The OpenSceneGraph is an open source high performance 3D graphics toolkit.
-Build-Depends: zlib, fontconfig, boost-asio (!windows), boost-core (!windows), boost-logic (!windows), boost-lexical-cast (!windows), boost-smart-ptr (!windows), boost-tuple (!windows), boost-bind (!windows), freeglut (windows), expat (windows), openimageio (osx)
+Build-Depends: zlib, fontconfig, freeglut (windows), expat (windows), openimageio (osx)
 
 Feature: collada
 Description: Support for Collada (.dae) files
@@ -19,7 +19,7 @@ Build-Depends: freetype, sdl1, sdl2, libiconv (windows)
 
 Feature: plugins
 Description: Build OSG Plugins - Disable for compile testing examples on a time limit
-Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt, coin
+Build-Depends: freetype, sdl1, curl, openexr, ilmbase, gdal, giflib (windows), jasper, libjpeg-turbo, libpng, tiff, libxml2 (windows), libiconv (windows), libgta, liblas, nvtt (!x86), coin, boost-asio (!windows), boost-core (!windows), boost-logic (!windows), boost-lexical-cast (!windows), boost-smart-ptr (!windows), boost-tuple (!windows), boost-bind (!windows)
 
 Feature: packages
 Description: Set to ON to generate CPack configuration files and packaging targets


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14756 #14663

Remove `boost `from base dependency lists.

Add `boost `as the dependency lists of feature `plugins`

Update the dependencies of feature `plugins`(Change `nvtt `as `nvtt (!x86)`).

Note:

Feature plugins has passed with the following triplets:

- x86-windows


