### PR TITLE
[vcpkg] Remove non-existing 'import' command in vcpkg help information

### DIFF
--- a/toolsrc/src/vcpkg/commands.autocomplete.cpp
+++ b/toolsrc/src/vcpkg/commands.autocomplete.cpp
@@ -76,7 +76,6 @@ namespace vcpkg::Commands::Autocomplete
                 "ci",
                 "depend-info",
                 "env",
-                "import",
                 "portsdiff",
             };
 

--- a/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
+++ b/toolsrc/src/vcpkg/vcpkgcmdarguments.cpp
@@ -560,7 +560,6 @@ namespace vcpkg
         table.format("vcpkg export <pkg>... [opt]...", "Exports a package");
         table.format("vcpkg edit <pkg>",
                      "Open up a port for editing (uses " + format_environment_variable("EDITOR") + ", default 'code')");
-        table.format("vcpkg import <pkg>", "Import a pre-built library");
         table.format("vcpkg create <pkg> <url> [archivename]", "Create a new package");
         table.format("vcpkg owns <pat>", "Search for files in installed packages");
         table.format("vcpkg depend-info <pkg>...", "Display a list of dependencies for packages");


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14748

Remove non-existing 'import' command in vcpkg help information.