### PR TITLE
[devil] Fix pkgconfig on Windows

### DIFF
--- a/ports/devil/0005-fix-pkgconfig.patch
+++ b/ports/devil/0005-fix-pkgconfig.patch
@@ -1,0 +1,52 @@
+diff --git a/DevIL/src-IL/CMakeLists.txt b/DevIL/src-IL/CMakeLists.txt
+index 4accaa1..c3a1874 100644
+--- a/DevIL/src-IL/CMakeLists.txt
++++ b/DevIL/src-IL/CMakeLists.txt
+@@ -160,6 +160,27 @@ if(WIN32)
+ 	# Linux uses libIL.so, libILU.so, and libILUT.so, but Windows uses
+ 	#  DevIL.dll, ILU.dll, and ILUT.dll.
+ 	set_target_properties(IL PROPERTIES OUTPUT_NAME "DevIL")
++    
++    configure_file(${CMAKE_CURRENT_LIST_DIR}/pkgconfig/IL.pc.cmake.in ${CMAKE_CURRENT_LIST_DIR}/pkgconfig/DevIL.pc.cmake.in COPYONLY)
++    
++    file(READ ${CMAKE_CURRENT_LIST_DIR}/pkgconfig/DevIL.pc.cmake.in PKGCONFIG_FILE)
++    string(REPLACE "IL" "DevIL" PKGCONFIG_FILE "${PKGCONFIG_FILE}")
++    file(WRITE ${CMAKE_CURRENT_LIST_DIR}/pkgconfig/DevIL.pc.cmake.in "${PKGCONFIG_FILE}")
++    
++    file(READ ${CMAKE_CURRENT_LIST_DIR}/../src-ILU/pkgconfig/ILU.pc.cmake.in PKGCONFIG_FILE)
++    string(REPLACE "Requires: IL" "Requires: DevIL" PKGCONFIG_FILE "${PKGCONFIG_FILE}")
++    string(REPLACE "Libs.private: -lIL" "Libs.private: -lDevIL" PKGCONFIG_FILE "${PKGCONFIG_FILE}")
++    file(WRITE ${CMAKE_CURRENT_LIST_DIR}/../src-ILU/pkgconfig/ILU.pc.cmake.in "${PKGCONFIG_FILE}")
++    
++    file(READ ${CMAKE_CURRENT_LIST_DIR}/../src-ILUT/pkgconfig/ILUT.pc.cmake.in PKGCONFIG_FILE)
++    string(REPLACE "Requires: IL" "Requires: DevIL" PKGCONFIG_FILE "${PKGCONFIG_FILE}")
++    string(REPLACE "Libs.private: -lIL" "Libs.private: -lDevIL" PKGCONFIG_FILE "${PKGCONFIG_FILE}")
++    file(WRITE ${CMAKE_CURRENT_LIST_DIR}/../src-ILUT/pkgconfig/ILUT.pc.cmake.in "${PKGCONFIG_FILE}")
++    set(PKGCFG_IN_FILE pkgconfig/DevIL.pc.cmake.in)
++    set(PKGCFG_FILE DevIL.pc)
++else(WIN32)
++    set(PKGCFG_IN_FILE pkgconfig/IL.pc.cmake.in)
++    set(PKGCFG_FILE IL.pc)
+ endif(WIN32)
+ 
+ if(UNICODE)
+@@ -246,8 +267,8 @@ endif()
+ # TODO: add Requires.private or Libs.private
+ # (needed to support static linking?)
+ # TODO: sort out version number
+-configure_file( pkgconfig/IL.pc.cmake.in
+-		${CMAKE_CURRENT_BINARY_DIR}/IL.pc @ONLY)
++configure_file( ${PKGCFG_IN_FILE}
++		${CMAKE_CURRENT_BINARY_DIR}/${PKGCFG_FILE} @ONLY)
+ 
+ 
+ # Installation
+@@ -259,7 +280,7 @@ install (TARGETS IL
+ install (FILES ../include/IL/il.h DESTINATION include/IL)
+ 
+ install(FILES
+-    ${CMAKE_CURRENT_BINARY_DIR}/IL.pc
++    ${CMAKE_CURRENT_BINARY_DIR}/${PKGCFG_FILE}
+ 	DESTINATION lib/pkgconfig
+ )
+ 

--- a/ports/devil/CONTROL
+++ b/ports/devil/CONTROL
@@ -1,6 +1,6 @@
 Source: devil
 Version: 1.8.0
-Port-Version: 6
+Port-Version: 7
 Build-Depends:
 Homepage: https://github.com/DentonW/DevIL
 Description: A full featured cross-platform image library

--- a/ports/devil/portfile.cmake
+++ b/ports/devil/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         0003_fix-openexr.patch
         enable-static.patch
         0004_compatible-jasper-2-0-20.patch
+        0005-fix-pkgconfig.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/DevIL/src-IL/cmake/FindOpenEXR.cmake)
@@ -38,6 +39,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
In _SOURCE/DevIL/src-IL/CMakeLists.txt_:
```cmake
if(WIN32)
	# Linux uses libIL.so, libILU.so, and libILUT.so, but Windows uses
	#  DevIL.dll, ILU.dll, and ILUT.dll.
	set_target_properties(IL PROPERTIES OUTPUT_NAME "DevIL")
endif(WIN32)
```
This will caused the wrong name in its pkgconfig files.

Fixes #14775.