### PR TITLE
[sdl2-image] Fix usage

### DIFF
--- a/ports/sdl2-image/CMakeLists.txt
+++ b/ports/sdl2-image/CMakeLists.txt
@@ -110,12 +110,19 @@ install(TARGETS SDL2_image
 
 install(FILES SDL_image.h DESTINATION include/SDL2 CONFIGURATIONS Release)
 
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/sdl2-image-config.cmake"
+[[include(CMakeFindDependencyMacro)
+find_dependency(SDL2 CONFIG)
+include("${CMAKE_CURRENT_LIST_DIR}/sdl2-image-targets.cmake")
+]])
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdl2-image-config.cmake DESTINATION share/sdl2-image)
+
 install(EXPORT SDL2_image
     DESTINATION share/sdl2-image/
-    FILE sdl2-image-config.cmake
+    FILE sdl2-image-targets.cmake
     NAMESPACE SDL2::
 )
-
 
 message(STATUS "Link-time dependencies:")
 message(STATUS "  " SDL2::SDL2)

--- a/ports/sdl2-image/CONTROL
+++ b/ports/sdl2-image/CONTROL
@@ -1,5 +1,6 @@
 Source: sdl2-image
 Version: 2.0.5
+Port-Version: 1
 Build-Depends: sdl2, libpng
 Homepage: https://www.libsdl.org/projects/SDL_image
 Description: SDL_image is an image file loading library. It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, WEBP, XCF, XPM, XV


### PR DESCRIPTION
Missing `find_dependency` in sdl2-image's cmake configure file.

Fixes #14789.