### PR TITLE
[vcpkg] Fix issue in vcpkg.targets that introduced in 13755

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -4,14 +4,16 @@
   <Import Condition="'$(VcpkgPropsImported)' != 'true'" Project="vcpkg.props" />
 
   <!-- Define properties derived from those defined in vcpkg.props, in the project file or specified on the command line. -->
+   <PropertyGroup>
+    <!-- Note: Overwrite VcpkgPageSchema with a non-existing path to disable the VcPkg property sheet in your projects -->
+    <VcpkgPageSchema Condition="'$(VcpkgPageSchema)' == ''">$([System.IO.Path]::Combine($(VcpkgRoot), 'scripts\buildsystems\msbuild\vcpkg-general.xml'))</VcpkgPageSchema>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <!-- Triplet defining platform, OS, and linkage -->
     <VcpkgLinkage />
     <VcpkgLinkage Condition="'$(VcpkgUseStatic)' == 'true'">-static</VcpkgLinkage>
     <VcpkgTriplet Condition="'$(VcpkgTriplet)' == ''">$(VcpkgPlatformTarget)-$(VcpkgOSTarget)$(VcpkgLinkage)</VcpkgTriplet>
-
-    <!-- Note: Overwrite VcpkgPageSchema with a non-existing path to disable the VcPkg property sheet in your projects -->
-    <VcpkgPageSchema Condition="'$(VcpkgPageSchema)' == ''">$([System.IO.Path]::Combine($(VcpkgRoot), 'scripts\buildsystems\msbuild\vcpkg-general.xml'))</VcpkgPageSchema>
 
     <VcpkgRoot Condition="'$(VcpkgRoot)' != '' and !$(VcpkgRoot.EndsWith('\'))">$(VcpkgRoot)\</VcpkgRoot>
     <VcpkgManifestRoot Condition="'$(VcpkgManifestRoot)' != '' and !$(VcpkgManifestRoot.EndsWith('\'))">$(VcpkgManifestRoot)\</VcpkgManifestRoot>


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14729

Fix issue: 
When 'Use vcpkg' set to No, the vcpkg tab disappear, user can't enable it again. That due the PropertyGroup condition, which is wrong for the VcpkgPageSchema.

Test with latest vcpkg and vs16.8.2