### PR TITLE
Include "zip" as required apt dependency in bootstrap error message

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -74,7 +74,7 @@ vcpkgCheckRepoTool()
     __tool=$1
     if ! command -v "$__tool" >/dev/null 2>&1 ; then
         echo "Could not find $__tool. Please install it (and other dependencies) with:"
-        echo "sudo apt-get install curl unzip tar"
+        echo "sudo apt-get install curl zip unzip tar"
         exit 1
     fi
 }


### PR DESCRIPTION
When running `bootstrap.sh` on a new Ubuntu installation, it currently fails with the message:
```
Could not find unzip. Please install it (and other dependencies) with:
sudo apt-get install curl unzip tar
```

The mentioned dependencies are enough to bootstrap vcpkg but when actually installing packages, it turns out that also `zip` is required:
```
...
-- Configuring x64-linux-dbg
-- Configuring x64-linux-rel
-- Building x64-linux-dbg
-- Building x64-linux-rel
-- Installing: /mnt/d/vcpkg/packages/rtaudio_x64-linux/share/rtaudio/README.md
-- Installing: /mnt/d/vcpkg/packages/rtaudio_x64-linux/share/rtaudio/copyright
-- Performing post-build validation
-- Performing post-build validation done
sh: 1: zip: not found
```

So I suggest to also include `zip` in the error message in the bootstrap script.