### PR TITLE
[libevent] Fix library cannot be found

### DIFF
--- a/ports/libevent/CONTROL
+++ b/ports/libevent/CONTROL
@@ -1,5 +1,6 @@
 Source: libevent
 Version: 2.1.12
+Port-Version: 1
 Homepage: https://github.com/libevent/libevent
 Description: An event notification library
 Supports: !uwp

--- a/ports/libevent/fix-LibeventConfig_cmake_in_path.patch
+++ b/ports/libevent/fix-LibeventConfig_cmake_in_path.patch
@@ -1,13 +1,22 @@
 diff --git a/cmake/LibeventConfig.cmake.in b/cmake/LibeventConfig.cmake.in
-index 7b808c3..fbf67be 100644
+index 7b808c3..9376a5a 100644
 --- a/cmake/LibeventConfig.cmake.in
 +++ b/cmake/LibeventConfig.cmake.in
 @@ -58,7 +58,7 @@ endif()
-
+ 
  # Get the path of the current file.
  get_filename_component(LIBEVENT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 -get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../../.." ABSOLUTE)
 +get_filename_component(_INSTALL_PREFIX "${LIBEVENT_CMAKE_DIR}/../.." ABSOLUTE)
-
+ 
  macro(message_if_needed _flag _msg)
      if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+@@ -131,7 +131,7 @@ if(CONFIG_FOR_INSTALL_TREE)
+         find_library(_event_lib
+                     NAMES "event_${_comp}"
+                     PATHS "${_INSTALL_PREFIX}/lib"
+-                    NO_DEFAULT_PATH)
++                    )
+         if(_event_lib)
+             list(APPEND LIBEVENT_LIBRARIES "libevent::${_comp}")
+             set_case_insensitive_found(${_comp})

--- a/ports/libevent/portfile.cmake
+++ b/ports/libevent/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(MESSAGE "${PORT} does not currently support UWP" ON_TARGET "uwp")
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

```
CMake Error at F:/vcpkg/installed/x86-windows/share/libevent/LibeventConfig.cmake:172 (message):
  Can not find any libraries for libevent.
Call Stack (most recent call first):
  F:/vcpkg/scripts/buildsystems/vcpkg.cmake:536 (_find_package)
  examples/CMakeLists.txt:22 (FIND_PACKAGE)
```
Related https://github.com/microsoft/vcpkg/pull/14734#issuecomment-732764851

The issue from upstream https://github.com/libevent/libevent/issues/1107
