### PR TITLE
[vcpkg baseline] [libass] Fix dependency issue in Linux

### DIFF
--- a/ports/libass/CMakeLists.txt
+++ b/ports/libass/CMakeLists.txt
@@ -20,7 +20,7 @@ add_compile_definitions(CONFIG_FRIBIDI)
 add_compile_definitions(CONFIG_HARFBUZZ)
 
 file (GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/libass/*.c)
-
+set(FONTCONFIG_LIBRARAY)
 if(WIN32)
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_fontconfig.c$")
@@ -30,6 +30,9 @@ elseif(APPLE)
 else()
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_coretext.c$")
   list(FILTER SOURCES EXCLUDE REGEX ".*ass_directwrite.c$")
+
+  find_package(Fontconfig REQUIRED)
+  set(FONTCONFIG_LIBRARAY Fontconfig::Fontconfig)
 endif()
 
 find_package(Freetype REQUIRED)
@@ -60,7 +63,8 @@ endif()
 target_link_libraries(ass PRIVATE
   Freetype::Freetype
   ${FRIBIDI_LIBRARY}
-  ${HARFBUZZ_LIBRARY})
+  ${HARFBUZZ_LIBRARY}
+  ${FONTCONFIG_LIBRARY})
 
 install(TARGETS ass
   RUNTIME DESTINATION bin

--- a/ports/libass/vcpkg.json
+++ b/ports/libass/vcpkg.json
@@ -9,12 +9,12 @@
       "name": "dirent",
       "platform": "windows"
     },
-    "freetype",
-    "fribidi",
-    "harfbuzz",
     {
       "name": "fontconfig",
       "platform": "linux"
-    }
+    },
+    "freetype",
+    "fribidi",
+    "harfbuzz"
   ]
 }

--- a/ports/libass/vcpkg.json
+++ b/ports/libass/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libass",
   "version-string": "0.14.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "libass is a portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format",
   "homepage": "https://github.com/libass/libass",
   "dependencies": [
@@ -11,6 +11,10 @@
     },
     "freetype",
     "fribidi",
-    "harfbuzz"
+    "harfbuzz",
+    {
+      "name": "fontconfig",
+      "platform": "linux"
+    }
   ]
 }


### PR DESCRIPTION
Relate to https://github.com/microsoft/vcpkg/pull/14640#issuecomment-734655799

Fixes failures:
```
/mnt/vcpkg-ci/buildtrees/libass/src/ebd911d5ca-39016ec3fc.clean/libass/ass_fontconfig.c:26:10: fatal error: fontconfig/fontconfig.h: No such file or directory
 #include <fontconfig/fontconfig.h>
```