### PR TITLE
[vcpkg] Expose alpha end-to-end versioning

### DIFF
--- a/toolsrc/include/vcpkg/portfileprovider.h
+++ b/toolsrc/include/vcpkg/portfileprovider.h
@@ -73,7 +73,8 @@ namespace vcpkg::PortFileProvider
 
     struct BaselineProvider : IBaselineProvider, Util::ResourceBase
     {
-        explicit BaselineProvider(const vcpkg::VcpkgPaths& paths, const std::string& baseline);
+        explicit BaselineProvider(const vcpkg::VcpkgPaths& paths);
+        BaselineProvider(const vcpkg::VcpkgPaths& paths, const std::string& baseline);
         ~BaselineProvider();
 
         Optional<VersionT> get_baseline_version(StringView port_name) const override;

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -118,6 +118,7 @@ namespace vcpkg
         // Git manipulation
         fs::path git_checkout_baseline(Files::Filesystem& filesystem, StringView commit_sha) const;
         fs::path git_checkout_port(Files::Filesystem& filesystem, StringView port_name, StringView git_tree) const;
+        ExpectedS<std::string> git_show(const std::string& treeish, const fs::path& dot_git_dir) const;
 
         Optional<const Json::Object&> get_manifest() const;
         Optional<const fs::path&> get_manifest_path() const;

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -832,25 +832,67 @@ namespace vcpkg::Install
                 // remove "core" because resolve_deps_as_top_level uses default-inversion
                 features.erase(core_it);
             }
-            auto specs = resolve_deps_as_top_level(manifest_scf, default_triplet, features, var_provider);
 
-            auto install_plan = Dependencies::create_feature_install_plan(provider, var_provider, specs, {});
-
-            for (InstallPlanAction& action : install_plan.install_actions)
+            if (args.versions_enabled())
             {
-                action.build_options = install_plan_options;
-                action.build_options.use_head_version = Build::UseHeadVersion::NO;
-                action.build_options.editable = Build::Editable::NO;
-            }
+                PortFileProvider::VersionedPortfileProvider verprovider(paths);
+                auto baseprovider = [&]() -> PortFileProvider::BaselineProvider {
+                    if (auto p_baseline = manifest_scf.core_paragraph->extra_info.get("$x-default-baseline"))
+                    {
+                        return PortFileProvider::BaselineProvider(paths, p_baseline->string().to_string());
+                    }
+                    else
+                    {
+                        return PortFileProvider::BaselineProvider(paths);
+                    }
+                }();
 
-            Commands::SetInstalled::perform_and_exit_ex(args,
-                                                        paths,
-                                                        provider,
-                                                        *binaryprovider,
-                                                        var_provider,
-                                                        std::move(install_plan),
-                                                        dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
-                                                        pkgsconfig);
+                auto install_plan =
+                    Dependencies::create_versioned_install_plan(verprovider,
+                                                                baseprovider,
+                                                                var_provider,
+                                                                manifest_scf.core_paragraph->dependencies,
+                                                                manifest_scf.core_paragraph->overrides,
+                                                                {manifest_scf.core_paragraph->name, default_triplet})
+                        .value_or_exit(VCPKG_LINE_INFO);
+
+                for (InstallPlanAction& action : install_plan.install_actions)
+                {
+                    action.build_options = install_plan_options;
+                    action.build_options.use_head_version = Build::UseHeadVersion::NO;
+                    action.build_options.editable = Build::Editable::NO;
+                }
+
+                Commands::SetInstalled::perform_and_exit_ex(args,
+                                                            paths,
+                                                            provider,
+                                                            *binaryprovider,
+                                                            var_provider,
+                                                            std::move(install_plan),
+                                                            dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
+                                                            pkgsconfig);
+            }
+            else
+            {
+                auto specs = resolve_deps_as_top_level(manifest_scf, default_triplet, features, var_provider);
+                auto install_plan = Dependencies::create_feature_install_plan(provider, var_provider, specs, {});
+
+                for (InstallPlanAction& action : install_plan.install_actions)
+                {
+                    action.build_options = install_plan_options;
+                    action.build_options.use_head_version = Build::UseHeadVersion::NO;
+                    action.build_options.editable = Build::Editable::NO;
+                }
+
+                Commands::SetInstalled::perform_and_exit_ex(args,
+                                                            paths,
+                                                            provider,
+                                                            *binaryprovider,
+                                                            var_provider,
+                                                            std::move(install_plan),
+                                                            dry_run ? Commands::DryRun::Yes : Commands::DryRun::No,
+                                                            pkgsconfig);
+            }
         }
 
         const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {


### PR DESCRIPTION
* Check for the 'versions' feature flag while installing a manifest; if present, trigger version-based installation
* Implement two-level fallback for Baselines:
  * First, fall back to current repo's `port_versions/baseline.json`
  * Second, fall back to the current ports in `ports/`
* Optimize checking out baseline.json via `git show`
* Detect presence of `"$x-default-baseline"` in the manifest and use that as the baseline commit (temporary hack to be replaced by Federation functionality)
* If `port_versions/x-/xyz.json` is not found while requesting versioned port files, fall back to current ports in `ports/`. Note that this fallback only triggers if the version database is missing -- it does not always consider the current port files.

This set of changes enables transitional functionality that smoothly switches between current behavior (if all version-related files are missing) to fully versioned (baseline + version info for ports). It also enables partial experiments to be run with a subset of version information; any missing version databases can be worked around by overriding back to the current port version.