### PR TITLE
Change Nuget binary cache pre-release info to always start with letters

### DIFF
--- a/toolsrc/src/vcpkg-test/binarycaching.cpp
+++ b/toolsrc/src/vcpkg-test/binarycaching.cpp
@@ -29,28 +29,28 @@ using namespace vcpkg;
 
 TEST_CASE ("reformat_version semver-ish", "[reformat_version]")
 {
-    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1-abitag");
-    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0-abitag");
-    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0-abitag");
-    REQUIRE(reformat_version("v52", "abitag") == "52.0.0-abitag");
-    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2-abitag");
-    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1-abitag");
-    REQUIRE(reformat_version("1", "abitag") == "1.0.0-abitag");
+    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0-vcpkgabitag");
+    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1-vcpkgabitag");
+    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0-vcpkgabitag");
+    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0-vcpkgabitag");
+    REQUIRE(reformat_version("v52", "abitag") == "52.0.0-vcpkgabitag");
+    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2-vcpkgabitag");
+    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1-vcpkgabitag");
+    REQUIRE(reformat_version("1", "abitag") == "1.0.0-vcpkgabitag");
 }
 
 TEST_CASE ("reformat_version date", "[reformat_version]")
 {
-    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26-abitag");
-    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26-abitag");
-    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26-abitag");
+    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26-vcpkgabitag");
+    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0-vcpkgabitag");
+    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26-vcpkgabitag");
+    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26-vcpkgabitag");
 }
 
 TEST_CASE ("reformat_version generic", "[reformat_version]")
 {
-    REQUIRE(reformat_version("apr", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("", "abitag") == "0.0.0-abitag");
+    REQUIRE(reformat_version("apr", "abitag") == "0.0.0-vcpkgabitag");
+    REQUIRE(reformat_version("", "abitag") == "0.0.0-vcpkgabitag");
 }
 
 TEST_CASE ("generate_nuspec", "[generate_nuspec]")
@@ -96,7 +96,7 @@ Build-Depends: bzip
 
     NugetReference ref(ipa);
 
-    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-packageabi.nupkg");
+    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-vcpkgpackageabi.nupkg");
 
     {
         auto nuspec = generate_nuspec(paths, ipa, ref, {});
@@ -108,7 +108,7 @@ Build-Depends: bzip
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0-vcpkgpackageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -140,7 +140,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0-vcpkgpackageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -172,7 +172,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0-vcpkgpackageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -267,7 +267,7 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
+  <package id="zlib_x64-android" version="1.5.0-vcpkgpackageabi"/>
 </packages>
 )");
 
@@ -290,8 +290,8 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
-  <package id="zlib2_x64-android" version="1.52.0-packageabi2"/>
+  <package id="zlib_x64-android" version="1.5.0-vcpkgpackageabi"/>
+  <package id="zlib2_x64-android" version="1.52.0-vcpkgpackageabi2"/>
 </packages>
 )");
 }

--- a/toolsrc/src/vcpkg-test/binarycaching.cpp
+++ b/toolsrc/src/vcpkg-test/binarycaching.cpp
@@ -29,28 +29,28 @@ using namespace vcpkg;
 
 TEST_CASE ("reformat_version semver-ish", "[reformat_version]")
 {
-    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1-abitag");
-    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0-abitag");
-    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0-abitag");
-    REQUIRE(reformat_version("v52", "abitag") == "52.0.0-abitag");
-    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2-abitag");
-    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1-abitag");
-    REQUIRE(reformat_version("1", "abitag") == "1.0.0-abitag");
+    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0+abitag");
+    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1+abitag");
+    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0+abitag");
+    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0+abitag");
+    REQUIRE(reformat_version("v52", "abitag") == "52.0.0+abitag");
+    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2+abitag");
+    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1+abitag");
+    REQUIRE(reformat_version("1", "abitag") == "1.0.0+abitag");
 }
 
 TEST_CASE ("reformat_version date", "[reformat_version]")
 {
-    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26-abitag");
-    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26-abitag");
-    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26-abitag");
+    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26+abitag");
+    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0+abitag");
+    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26+abitag");
+    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26+abitag");
 }
 
 TEST_CASE ("reformat_version generic", "[reformat_version]")
 {
-    REQUIRE(reformat_version("apr", "abitag") == "0.0.0-abitag");
-    REQUIRE(reformat_version("", "abitag") == "0.0.0-abitag");
+    REQUIRE(reformat_version("apr", "abitag") == "0.0.0+abitag");
+    REQUIRE(reformat_version("", "abitag") == "0.0.0+abitag");
 }
 
 TEST_CASE ("generate_nuspec", "[generate_nuspec]")
@@ -96,7 +96,7 @@ Build-Depends: bzip
 
     NugetReference ref(ipa);
 
-    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-packageabi.nupkg");
+    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0+packageabi.nupkg");
 
     {
         auto nuspec = generate_nuspec(paths, ipa, ref, {});
@@ -108,7 +108,7 @@ Build-Depends: bzip
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0+packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -140,7 +140,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0+packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -172,7 +172,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0-packageabi</version>
+    <version>1.5.0+packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -267,7 +267,7 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
+  <package id="zlib_x64-android" version="1.5.0+packageabi"/>
 </packages>
 )");
 
@@ -290,8 +290,8 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
-  <package id="zlib2_x64-android" version="1.52.0-packageabi2"/>
+  <package id="zlib_x64-android" version="1.5.0+packageabi"/>
+  <package id="zlib2_x64-android" version="1.52.0+packageabi2"/>
 </packages>
 )");
 }

--- a/toolsrc/src/vcpkg-test/binarycaching.cpp
+++ b/toolsrc/src/vcpkg-test/binarycaching.cpp
@@ -29,28 +29,28 @@ using namespace vcpkg;
 
 TEST_CASE ("reformat_version semver-ish", "[reformat_version]")
 {
-    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0+abitag");
-    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1+abitag");
-    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0+abitag");
-    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0+abitag");
-    REQUIRE(reformat_version("v52", "abitag") == "52.0.0+abitag");
-    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2+abitag");
-    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1+abitag");
-    REQUIRE(reformat_version("1", "abitag") == "1.0.0+abitag");
+    REQUIRE(reformat_version("0.0.0", "abitag") == "0.0.0-abitag");
+    REQUIRE(reformat_version("1.0.1", "abitag") == "1.0.1-abitag");
+    REQUIRE(reformat_version("1.01.000", "abitag") == "1.1.0-abitag");
+    REQUIRE(reformat_version("1.2", "abitag") == "1.2.0-abitag");
+    REQUIRE(reformat_version("v52", "abitag") == "52.0.0-abitag");
+    REQUIRE(reformat_version("v09.01.02", "abitag") == "9.1.2-abitag");
+    REQUIRE(reformat_version("1.1.1q", "abitag") == "1.1.1-abitag");
+    REQUIRE(reformat_version("1", "abitag") == "1.0.0-abitag");
 }
 
 TEST_CASE ("reformat_version date", "[reformat_version]")
 {
-    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26+abitag");
-    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0+abitag");
-    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26+abitag");
-    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26+abitag");
+    REQUIRE(reformat_version("2020-06-26", "abitag") == "2020.6.26-abitag");
+    REQUIRE(reformat_version("20-06-26", "abitag") == "0.0.0-abitag");
+    REQUIRE(reformat_version("2020-06-26-release", "abitag") == "2020.6.26-abitag");
+    REQUIRE(reformat_version("2020-06-26000", "abitag") == "2020.6.26-abitag");
 }
 
 TEST_CASE ("reformat_version generic", "[reformat_version]")
 {
-    REQUIRE(reformat_version("apr", "abitag") == "0.0.0+abitag");
-    REQUIRE(reformat_version("", "abitag") == "0.0.0+abitag");
+    REQUIRE(reformat_version("apr", "abitag") == "0.0.0-abitag");
+    REQUIRE(reformat_version("", "abitag") == "0.0.0-abitag");
 }
 
 TEST_CASE ("generate_nuspec", "[generate_nuspec]")
@@ -96,7 +96,7 @@ Build-Depends: bzip
 
     NugetReference ref(ipa);
 
-    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0+packageabi.nupkg");
+    REQUIRE(ref.nupkg_filename() == "zlib2_x64-windows.1.5.0-packageabi.nupkg");
 
     {
         auto nuspec = generate_nuspec(paths, ipa, ref, {});
@@ -108,7 +108,7 @@ Build-Depends: bzip
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0+packageabi</version>
+    <version>1.5.0-packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -140,7 +140,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0+packageabi</version>
+    <version>1.5.0-packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -172,7 +172,7 @@ Dependencies:
         std::string expected = R"(<package>
   <metadata>
     <id>zlib2_x64-windows</id>
-    <version>1.5.0+packageabi</version>
+    <version>1.5.0-packageabi</version>
     <authors>vcpkg</authors>
     <description>NOT FOR DIRECT USE. Automatically generated cache package.
 
@@ -267,7 +267,7 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0+packageabi"/>
+  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
 </packages>
 )");
 
@@ -290,8 +290,8 @@ Description: a spiffy compression library wrapper
     packageconfig = generate_nuget_packages_config(plan);
     REQUIRE(packageconfig == R"(<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib_x64-android" version="1.5.0+packageabi"/>
-  <package id="zlib2_x64-android" version="1.52.0+packageabi2"/>
+  <package id="zlib_x64-android" version="1.5.0-packageabi"/>
+  <package id="zlib2_x64-android" version="1.52.0-packageabi2"/>
 </packages>
 )");
 }

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -1179,7 +1179,7 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
         auto major = trim_leading_zeroes(sm.str(1));
         auto minor = sm.size() > 2 && !sm.str(2).empty() ? trim_leading_zeroes(sm.str(2).substr(1)) : "0";
         auto patch = sm.size() > 3 && !sm.str(3).empty() ? trim_leading_zeroes(sm.str(3).substr(1)) : "0";
-        return Strings::concat(major, '.', minor, '.', patch, "-", abi_tag);
+        return Strings::concat(major, '.', minor, '.', patch, "-vcpkg", abi_tag);
     }
 
     static const std::regex date_matcher(R"((\d\d\d\d)-(\d\d)-(\d\d).*)");
@@ -1190,11 +1190,11 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
                                trim_leading_zeroes(sm.str(2)),
                                '.',
                                trim_leading_zeroes(sm.str(3)),
-                               "-",
+                               "-vcpkg",
                                abi_tag);
     }
 
-    return Strings::concat("0.0.0-", abi_tag);
+    return Strings::concat("0.0.0-vcpkg", abi_tag);
 }
 
 details::NuGetRepoInfo details::get_nuget_repo_info_from_env()

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -1179,7 +1179,7 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
         auto major = trim_leading_zeroes(sm.str(1));
         auto minor = sm.size() > 2 && !sm.str(2).empty() ? trim_leading_zeroes(sm.str(2).substr(1)) : "0";
         auto patch = sm.size() > 3 && !sm.str(3).empty() ? trim_leading_zeroes(sm.str(3).substr(1)) : "0";
-        return Strings::concat(major, '.', minor, '.', patch, "+", abi_tag);
+        return Strings::concat(major, '.', minor, '.', patch, "-", abi_tag);
     }
 
     static const std::regex date_matcher(R"((\d\d\d\d)-(\d\d)-(\d\d).*)");
@@ -1190,11 +1190,11 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
                                trim_leading_zeroes(sm.str(2)),
                                '.',
                                trim_leading_zeroes(sm.str(3)),
-                               "+",
+                               "-",
                                abi_tag);
     }
 
-    return Strings::concat("0.0.0+", abi_tag);
+    return Strings::concat("0.0.0-", abi_tag);
 }
 
 details::NuGetRepoInfo details::get_nuget_repo_info_from_env()

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -1179,7 +1179,7 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
         auto major = trim_leading_zeroes(sm.str(1));
         auto minor = sm.size() > 2 && !sm.str(2).empty() ? trim_leading_zeroes(sm.str(2).substr(1)) : "0";
         auto patch = sm.size() > 3 && !sm.str(3).empty() ? trim_leading_zeroes(sm.str(3).substr(1)) : "0";
-        return Strings::concat(major, '.', minor, '.', patch, "-", abi_tag);
+        return Strings::concat(major, '.', minor, '.', patch, "+", abi_tag);
     }
 
     static const std::regex date_matcher(R"((\d\d\d\d)-(\d\d)-(\d\d).*)");
@@ -1190,11 +1190,11 @@ std::string vcpkg::reformat_version(const std::string& version, const std::strin
                                trim_leading_zeroes(sm.str(2)),
                                '.',
                                trim_leading_zeroes(sm.str(3)),
-                               "-",
+                               "+",
                                abi_tag);
     }
 
-    return Strings::concat("0.0.0-", abi_tag);
+    return Strings::concat("0.0.0+", abi_tag);
 }
 
 details::NuGetRepoInfo details::get_nuget_repo_info_from_env()


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14542

- Which triplets are supported/not supported? Have you updated the CI baseline? Not applicable, this PR affects the "tool" vcpkg.exe

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes. I ran the full test suite and everything passes.
