### PR TITLE
[c-ares] Update to 1.17.1.

### DIFF
--- a/ports/c-ares/CONTROL
+++ b/ports/c-ares/CONTROL
@@ -1,5 +1,5 @@
 Source: c-ares
-Version: 2019-5-2-1
+Version: 1.17.1
 Homepage: https://github.com/c-ares/c-ares
 Description: A C library for asynchronous DNS requests
 Supports: !uwp

--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -1,12 +1,10 @@
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-    message(FATAL_ERROR "c-ares does not currently support UWP.")
-endif()
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
-    REF 9f1fdbf5dd633f81352fac0d6bc0d0c4d45be459
-    SHA512 2bb3696e839e37c6f2be4b979ae6d0eab2914d6f0ca043f688e3bb3071d2348cb64424049f019c16bc05d472dd61d5071e865edd229dce023a50f556a1961766
+    REF cares-1_17_1
+    SHA512 e2a2a40118b128755571274d0cfe7cc822bc18392616378c6dd5f73f210571d7e5005a40ba0763658bdae7f2c7aadb324b2888ad8b4dcb54ad47dfaf97c2ebfc
     HEAD_REF master
 )
 
@@ -46,7 +44,7 @@ endif()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/c-ares)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/c-ares/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/c-ares/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Update c-ares to 1.17.1, the current version as of
2020-11-30.  The release announcement can be found at
https://c-ares.haxx.se/mail/c-ares-archive-2020-11/0008.shtml.
Fixes #14828.