### PR TITLE
[vcpkg baseline] [gdal] Fix build errors on linux and osx

### DIFF
--- a/ports/gdal/CONTROL
+++ b/ports/gdal/CONTROL
@@ -1,5 +1,6 @@
 Source: gdal
 Version: 3.1.3
+Port-Version: 1
 Homepage: https://gdal.org/
 Description: The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data.
 Build-Depends: proj4, libpng, geos, sqlite3, curl, expat, libpq, openjpeg, libwebp, libxml2, liblzma, netcdf-c, hdf5, zlib, libgeotiff, cfitsio, json-c (!windows)

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -186,6 +186,7 @@ else()
     
     set(CONF_OPTS --enable-shared=${BUILD_DYNAMIC} --enable-static=${BUILD_STATIC})
     list(APPEND CONF_OPTS --with-proj=${CURRENT_INSTALLED_DIR} --with-libjson-c=${CURRENT_INSTALLED_DIR})
+    list(APPEND CONF_OPTS --without-jasper)
     
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/14785#issuecomment-736248743

Building gdal --without-jasper
When installing jasper before gdal, gdal will fail on linux and osx, this is source issue https://github.com/OSGeo/gdal/issues/2981, and jasper has updaged to 2.0.20 in vcpkg, this issue still exist. 

```
jpeg2000dataset.cpp: In member function ‘int JPEG2000Dataset::DecodeImage()’:
jpeg2000dataset.cpp:516:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             if (poBand->iDepth != jas_image_cmptprec( psImage, iBand ) ||
                                ^
jpeg2000_vsil_io.cpp:154:1: error: invalid conversion from ‘int (*)(jas_stream_obj_t*, char*, unsigned int) {aka int (*)(void*, char*, unsigned int)}’ to ‘int (*)(jas_stream_obj_t*, const char*, unsigned int) {aka int (*)(void*, const char*, unsigned int)}’ [-fpermissive]
 };
 ^
make[2]: *** [../o/jpeg2000_vsil_io.lo] Error 1
make[1]: *** [jpeg2000-install-obj] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [frmts-target] Error 2
```

It doesn't need to test features.