### PR TITLE
[aws-sdk-cpp] Restore AWSSDKConfig.cmake and add usage

### DIFF
--- a/ports/aws-sdk-cpp/CONTROL
+++ b/ports/aws-sdk-cpp/CONTROL
@@ -1,6 +1,6 @@
 Source: aws-sdk-cpp
 Version: 1.8.83
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/aws/aws-sdk-cpp
 Description: AWS SDK for C++
 Build-Depends: openssl (!uwp&!windows), curl (!uwp&!windows), aws-c-event-stream

--- a/ports/aws-sdk-cpp/fix-AWSSDKCONFIG.patch
+++ b/ports/aws-sdk-cpp/fix-AWSSDKCONFIG.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/AWSSDKConfig.cmake b/cmake/AWSSDKConfig.cmake
+index c2f643e..5a4d8d2 100644
+--- a/cmake/AWSSDKConfig.cmake
++++ b/cmake/AWSSDKConfig.cmake
+@@ -43,7 +43,6 @@ endif()
+ 
+ # On Windows, dlls are treated as runtime target and installed in bindir
+ if (WIN32 AND AWSSDK_INSTALL_AS_SHARED_LIBS)
+-    set(AWSSDK_INSTALL_LIBDIR "${AWSSDK_INSTALL_BINDIR}")
+     # If installed CMake scripts are associated with dll library, define USE_IMPORT_EXPORT for customers
+     add_definitions(-DUSE_IMPORT_EXPORT)
+ endif()
+@@ -54,7 +53,6 @@ endif()
+ get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${AWSSDK_DEFAULT_ROOT_DIR}" PATH)
+ get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${AWSSDK_DEFAULT_ROOT_DIR}" PATH)
+-get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${AWSSDK_DEFAULT_ROOT_DIR}" PATH)
+ get_filename_component(AWS_NATIVE_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+ 
+ set(CPP_STANDARD "11" CACHE STRING "Flag to upgrade the C++ standard used. The default is 11. The minimum is 11.")

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF e98e5732ec7319051f162f7314ae361c85d0a8c9 # 1.8.83
     SHA512 da540db60551be833ea0315dd93241f9740ab953ed5657c1c7a8c401ae52a4e75b116758420b0a8a4ebb79358dff8377f5e052b180b36f0af27a36003f28bd56
     HEAD_REF master
-    PATCHES patch-relocatable-rpath.patch
+    PATCHES
+        patch-relocatable-rpath.patch
+        fix-AWSSDKCONFIG.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" FORCE_SHARED_CRT)
@@ -60,7 +62,6 @@ endforeach()
 file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include
     ${CURRENT_PACKAGES_DIR}/debug/share
-    ${CURRENT_PACKAGES_DIR}/share/AWSSDK
     ${CURRENT_PACKAGES_DIR}/lib/pkgconfig
     ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig
     ${CURRENT_PACKAGES_DIR}/nuget
@@ -81,6 +82,8 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
 
     file(APPEND ${CURRENT_PACKAGES_DIR}/include/aws/core/SDKConfig.h "#ifndef USE_IMPORT_EXPORT\n#define USE_IMPORT_EXPORT\n#endif")
 endif()
+
+configure_file(${CURRENT_PORT_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/aws-sdk-cpp/usage
+++ b/ports/aws-sdk-cpp/usage
@@ -1,0 +1,17 @@
+The package @PORT@:@TARGET_TRIPLET@ provides CMake targets:
+
+    find_package(AWSSDK CONFIG COMPONENTS core dynamodb kinesis s3 REQUIRED)
+    target_include_directories(main PRVATE ${AWSSDK_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE ${AWSSDK_LIBRARIES})
+
+    find_package(aws-cpp-sdk-core CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE aws-cpp-sdk-core)
+
+    find_package(aws-cpp-sdk-dynamodb CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE aws-cpp-sdk-dynamodb)
+
+    find_package(aws-cpp-sdk-kinesis CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE aws-cpp-sdk-kinesis)
+
+    find_package(aws-cpp-sdk-s3 CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE aws-cpp-sdk-s3)


### PR DESCRIPTION
- Don't remove `AWSSDKConfig.cmake`
- Fix `AWSSDKConfig.cmake`
- Add usage, because vcpkg cannot analyze cmake files correctly

Fixes #14817.

Already test the usage locally.