### PR TITLE
[cuda] Add ENV CUDA_HOME to path hints

### DIFF
--- a/ports/cuda/CONTROL
+++ b/ports/cuda/CONTROL
@@ -1,5 +1,5 @@
 Source: cuda
 Version: 10.1
-Port-Version: 4
+Port-Version: 5
 Description: A parallel computing platform and programming model
 Homepage: https://developer.nvidia.com/cuda-toolkit

--- a/ports/cuda/vcpkg_find_cuda.cmake
+++ b/ports/cuda/vcpkg_find_cuda.cmake
@@ -9,6 +9,7 @@ function(vcpkg_find_cuda)
 
     set(CUDA_PATHS 
             ENV CUDA_PATH
+            ENV CUDA_HOME
             ENV CUDA_BIN_PATH
             ENV CUDA_PATH_V11_0
             ENV CUDA_PATH_V10_2


### PR DESCRIPTION
Adds `CUDA_HOME` as a env var from which to add a search path when looking for CUDA.

`CUDA_HOME` is a common env var name used for specifying a CUDA path used by a litany of projects.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Same as before. No substantive changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes