### PR TITLE
[vcpkg] Output versions during install plans

### DIFF
--- a/toolsrc/include/vcpkg/sourceparagraph.h
+++ b/toolsrc/include/vcpkg/sourceparagraph.h
@@ -74,6 +74,8 @@ namespace vcpkg
 
         Json::Object extra_info;
 
+        VersionT to_versiont() const { return VersionT{version, port_version}; }
+
         friend bool operator==(const SourceParagraph& lhs, const SourceParagraph& rhs);
         friend bool operator!=(const SourceParagraph& lhs, const SourceParagraph& rhs) { return !(lhs == rhs); }
     };
@@ -104,6 +106,8 @@ namespace vcpkg
         Optional<std::string> check_against_feature_flags(const fs::path& origin,
                                                           const FeatureFlagSettings& flags) const;
 
+        VersionT to_versiont() const { return core_paragraph->to_versiont(); }
+
         friend bool operator==(const SourceControlFile& lhs, const SourceControlFile& rhs);
         friend bool operator!=(const SourceControlFile& lhs, const SourceControlFile& rhs) { return !(lhs == rhs); }
     };
@@ -131,6 +135,8 @@ namespace vcpkg
         {
             return {std::make_unique<SourceControlFile>(source_control_file->clone()), source_location};
         }
+
+        VersionT to_versiont() const { return source_control_file->to_versiont(); }
 
         std::unique_ptr<SourceControlFile> source_control_file;
         fs::path source_location;

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -311,47 +311,47 @@ namespace vcpkg::Dependencies
     static std::string to_output_string(RequestType request_type,
                                         const CStringView s,
                                         const Build::BuildPackageOptions& options,
-                                        const fs::path& install_port_path,
+                                        const SourceControlFileLocation* scfl,
                                         const fs::path& builtin_ports_dir)
     {
-        if (!builtin_ports_dir.empty() && !Strings::case_insensitive_ascii_starts_with(fs::u8string(install_port_path),
-                                                                                       fs::u8string(builtin_ports_dir)))
+        std::string ret;
+        switch (request_type)
         {
-            const char* const from_head = options.use_head_version == Build::UseHeadVersion::YES ? " (from HEAD)" : "";
-            switch (request_type)
+            case RequestType::AUTO_SELECTED: Strings::append(ret, "  * "); break;
+            case RequestType::USER_REQUESTED: Strings::append(ret, "    "); break;
+            default: Checks::unreachable(VCPKG_LINE_INFO);
+        }
+        Strings::append(ret, s);
+        if (scfl)
+        {
+            Strings::append(ret, " -> ", scfl->to_versiont());
+        }
+        if (options.use_head_version == Build::UseHeadVersion::YES)
+        {
+            Strings::append(ret, " (+HEAD)");
+        }
+        if (scfl)
+        {
+            const auto s_install_port_path = fs::u8string(scfl->source_location);
+            if (!builtin_ports_dir.empty() &&
+                !Strings::case_insensitive_ascii_starts_with(s_install_port_path, fs::u8string(builtin_ports_dir)))
             {
-                case RequestType::AUTO_SELECTED:
-                    return Strings::format("  * %s%s -- %s", s, from_head, fs::u8string(install_port_path));
-                case RequestType::USER_REQUESTED:
-                    return Strings::format("    %s%s -- %s", s, from_head, fs::u8string(install_port_path));
-                default: Checks::unreachable(VCPKG_LINE_INFO);
+                Strings::append(ret, " -- ", s_install_port_path);
             }
         }
-        return to_output_string(request_type, s, options);
+        return ret;
     }
 
     std::string to_output_string(RequestType request_type,
                                  const CStringView s,
                                  const Build::BuildPackageOptions& options)
     {
-        const char* const from_head = options.use_head_version == Build::UseHeadVersion::YES ? " (from HEAD)" : "";
-
-        switch (request_type)
-        {
-            case RequestType::AUTO_SELECTED: return Strings::format("  * %s%s", s, from_head);
-            case RequestType::USER_REQUESTED: return Strings::format("    %s%s", s, from_head);
-            default: Checks::unreachable(VCPKG_LINE_INFO);
-        }
+        return to_output_string(request_type, s, options, {}, {});
     }
 
     std::string to_output_string(RequestType request_type, const CStringView s)
     {
-        switch (request_type)
-        {
-            case RequestType::AUTO_SELECTED: return Strings::format("  * %s", s);
-            case RequestType::USER_REQUESTED: return Strings::format("    %s", s);
-            default: Checks::unreachable(VCPKG_LINE_INFO);
-        }
+        return to_output_string(request_type, s, {Build::UseHeadVersion::NO}, {}, {});
     }
 
     InstallPlanAction::InstallPlanAction() noexcept
@@ -1096,13 +1096,11 @@ namespace vcpkg::Dependencies
 
         static auto actions_to_output_string = [&](const std::vector<const InstallPlanAction*>& v) {
             return Strings::join("\n", v, [&](const InstallPlanAction* p) {
-                if (auto* pscfl = p->source_control_file_location.get())
-                {
-                    return to_output_string(
-                        p->request_type, p->displayname(), p->build_options, pscfl->source_location, builtin_ports_dir);
-                }
-
-                return to_output_string(p->request_type, p->displayname(), p->build_options);
+                return to_output_string(p->request_type,
+                                        p->displayname(),
+                                        p->build_options,
+                                        p->source_control_file_location.get(),
+                                        builtin_ports_dir);
             });
         };
 

--- a/toolsrc/src/vcpkg/dependencies.cpp
+++ b/toolsrc/src/vcpkg/dependencies.cpp
@@ -312,6 +312,7 @@ namespace vcpkg::Dependencies
                                         const CStringView s,
                                         const Build::BuildPackageOptions& options,
                                         const SourceControlFileLocation* scfl,
+                                        const InstalledPackageView* ipv,
                                         const fs::path& builtin_ports_dir)
     {
         std::string ret;
@@ -325,6 +326,10 @@ namespace vcpkg::Dependencies
         if (scfl)
         {
             Strings::append(ret, " -> ", scfl->to_versiont());
+        }
+        else if (ipv)
+        {
+            Strings::append(ret, " -> ", VersionT{ipv->core->package.version, ipv->core->package.port_version});
         }
         if (options.use_head_version == Build::UseHeadVersion::YES)
         {
@@ -346,12 +351,12 @@ namespace vcpkg::Dependencies
                                  const CStringView s,
                                  const Build::BuildPackageOptions& options)
     {
-        return to_output_string(request_type, s, options, {}, {});
+        return to_output_string(request_type, s, options, {}, {}, {});
     }
 
     std::string to_output_string(RequestType request_type, const CStringView s)
     {
-        return to_output_string(request_type, s, {Build::UseHeadVersion::NO}, {}, {});
+        return to_output_string(request_type, s, {Build::UseHeadVersion::NO}, {}, {}, {});
     }
 
     InstallPlanAction::InstallPlanAction() noexcept
@@ -1100,6 +1105,7 @@ namespace vcpkg::Dependencies
                                         p->displayname(),
                                         p->build_options,
                                         p->source_control_file_location.get(),
+                                        p->installed_package.get(),
                                         builtin_ports_dir);
             });
         };


### PR DESCRIPTION
With versioning, it is now possible for users to be confused about what versions are actually selected for install. This PR changes the plan printing behavior to include version information to improve transparency. The notation for "using HEAD" has changed to clarify that it is a modifier upon the displayed version, not that the displayed version is the HEAD version.

#### Example 1:
**Before**
```
> vcpkg-old install --feature-flags=manifests,versions --dry-run
Detecting compiler hash for triplet x86-windows...
The following packages will be removed:
    rapidjson:x86-windows
The following packages will be rebuilt:
    fmt[core]:x86-windows
    zlib[core]:x86-windows -- C:\src\vcpkg\buildtrees\versioning\versions\068430e3e24fa228c302c808ba99f8a48d126557\zlib
The following packages will be built and installed:
    brotli[core]:x86-windows
```
**After**
```
> vcpkg install --feature-flags=manifests,versions --dry-run
Detecting compiler hash for triplet x86-windows...
The following packages will be removed:
    rapidjson:x86-windows
The following packages will be rebuilt:
    fmt[core]:x86-windows -> 7.1.3
    zlib[core]:x86-windows -> 1.2.11#8 -- C:\src\vcpkg\buildtrees\versioning\versions\068430e3e24fa228c302c808ba99f8a48d126557\zlib
The following packages will be built and installed:
    brotli[core]:x86-windows -> 1.0.9
```

#### Example 2:
**Before**
```
> vcpkg-old install cpprestsdk --dry-run --head
Computing installation plan...
The following packages are already installed:
    zlib[core]:x86-windows
The following packages will be built and installed:
  * brotli[core]:x86-windows
    cpprestsdk[brotli,compression,core,default-features]:x86-windows (from HEAD)
Additional packages (*) will be modified to complete this operation.
```
**After**
```
> vcpkg install cpprestsdk --dry-run --head
Computing installation plan...
The following packages are already installed:
    zlib[core]:x86-windows -> 1.2.11#9
The following packages will be built and installed:
  * brotli[core]:x86-windows -> 1.0.9
    cpprestsdk[brotli,compression,core,default-features]:x86-windows -> 2.10.16-3 (+HEAD)
Additional packages (*) will be modified to complete this operation.
```