### PR TITLE
[kuku] Add new port

### DIFF
--- a/ports/kuku/CMakeLists-windows.patch
+++ b/ports/kuku/CMakeLists-windows.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c4a87db..10d3eb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,10 +13,6 @@ cmake_minimum_required(VERSION 3.12)
+ 
+ project(Kuku VERSION 2.0.0 LANGUAGES CXX C)
+ 
+-if(${MSVC})
+-    message(FATAL_ERROR "Please build using the attached Visual Studio solution/project files.")
+-endif()
+-
+ ########################
+ # Global configuration #
+ ########################

--- a/ports/kuku/CONTROL
+++ b/ports/kuku/CONTROL
@@ -1,0 +1,4 @@
+Source: kuku
+Version: 2.0
+Homepage: https://github.com/microsoft/Kuku
+Description: Kuku is a simple open-source (MIT licensed) cuckoo hashing library developed by the Cryptography and Privacy Research group at Microsoft.

--- a/ports/kuku/CONTROL
+++ b/ports/kuku/CONTROL
@@ -2,4 +2,3 @@ Source: kuku
 Version: 2.0
 Homepage: https://github.com/microsoft/Kuku
 Description: Kuku is a simple open-source (MIT licensed) cuckoo hashing library developed by the Cryptography and Privacy Research group at Microsoft.
-Default-Features:

--- a/ports/kuku/CONTROL
+++ b/ports/kuku/CONTROL
@@ -2,3 +2,4 @@ Source: kuku
 Version: 2.0
 Homepage: https://github.com/microsoft/Kuku
 Description: Kuku is a simple open-source (MIT licensed) cuckoo hashing library developed by the Cryptography and Privacy Research group at Microsoft.
+Default-Features:

--- a/ports/kuku/portfile.cmake
+++ b/ports/kuku/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO microsoft/Kuku
+    REF e7cd2d6ad7f8886061c8e4b85890ede69cec3929
+    SHA512 8220a8e839bd247d6a8d1049562028c620353d0cabee0681383d1457bda544ff1394709eeaa82a92a8c0d3491cc9f15de1a14b78a86e8f97ee1da68eb50c982e
+    HEAD_REF master
+    PATCHES CMakeLists-windows.patch
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Kuku-2.0)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
Add new port for kuku library:
https://github.com/microsoft/Kuku

- What does your PR fix?
This is a new port

- Which triplets are supported/not supported? Have you updated the CI baseline?
Tested x86-windows, x86-windows-static, x64-windows, x64-windows-static, x64-linux, x64-osx. Other triplets should be supported as well.
I have not updated the CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
