### PR TITLE
[arrayfire] Update port to fix cuSparse issue with CUDA 10.1

### DIFF
--- a/ports/arrayfire/build.patch
+++ b/ports/arrayfire/build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e1108c60..670f271b 100644
+index 1f30a5b3..f93e4ed9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -104,18 +104,11 @@ mark_as_advanced(
@@ -62,13 +62,6 @@ index 2c7b96ea..b5006ee0 100644
  endif()
  
  # Libraries
-diff --git a/assets b/assets
-index cd08d749..c53bfab9 160000
---- a/assets
-+++ b/assets
-@@ -1 +1 @@
--Subproject commit cd08d749611b324012555ad6f23fd76c5465bd6c
-+Subproject commit c53bfab909adfeed626f91ed419555711e20bca5
 diff --git a/src/api/unified/CMakeLists.txt b/src/api/unified/CMakeLists.txt
 index 967eaa63..ff04392c 100644
 --- a/src/api/unified/CMakeLists.txt
@@ -131,7 +124,7 @@ index 170bb0f3..c6e20177 100644
  arrayfire_set_default_cxx_flags(afcpu)
  
 diff --git a/src/backend/cuda/CMakeLists.txt b/src/backend/cuda/CMakeLists.txt
-index 7e3e4089..bbd8d838 100644
+index 7e3e4089..a3a53087 100644
 --- a/src/backend/cuda/CMakeLists.txt
 +++ b/src/backend/cuda/CMakeLists.txt
 @@ -110,7 +110,11 @@ cuda_include_directories(
@@ -147,6 +140,31 @@ index 7e3e4089..bbd8d838 100644
  endif()
  
  file(GLOB jit_src "kernel/jit.cuh")
+@@ -240,9 +244,14 @@ if(AF_WITH_NONFREE)
+   set(cxx_definitions -DAF_WITH_NONFREE_SIFT)
+ endif()
+ 
++# New API of cuSparse was introduced in 10.1.168 for Linux and the older
++# 10.1.105 fix version doesn't it. Unfortunately, the new API was introduced in
++# in a fix release of CUDA - unconventionally. As CMake's FindCUDA module
++# doesn't provide patch/fix version number, we use 10.2 as the minimum
++# CUDA version to enable this new cuSparse API.
+ if(CUDA_VERSION_MAJOR VERSION_GREATER 10 OR
+    (UNIX AND
+-    CUDA_VERSION_MAJOR VERSION_EQUAL 10 AND CUDA_VERSION_MINOR VERSION_GREATER 0))
++    CUDA_VERSION_MAJOR VERSION_EQUAL 10 AND CUDA_VERSION_MINOR VERSION_GREATER 1))
+   list(APPEND cxx_definitions -DAF_USE_NEW_CUSPARSE_API)
+ endif()
+ 
+@@ -301,7 +310,7 @@ set_target_properties(af_cuda_static_cuda_library
+ 
+ if(CUDA_VERSION_MAJOR VERSION_GREATER 10 OR
+    (UNIX AND
+-    CUDA_VERSION_MAJOR VERSION_EQUAL 10 AND CUDA_VERSION_MINOR VERSION_GREATER 0))
++    CUDA_VERSION_MAJOR VERSION_EQUAL 10 AND CUDA_VERSION_MINOR VERSION_GREATER 1))
+   target_compile_definitions(af_cuda_static_cuda_library PRIVATE AF_USE_NEW_CUSPARSE_API)
+ endif()
+ 
 diff --git a/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt b/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
 index 9a796c9e..d9864b00 100644
 --- a/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
@@ -191,10 +209,3 @@ index d618ff2f..9f517398 100644
        )
  
      set_target_properties(opencl_sort_by_key_${SBK_TYPE}
-diff --git a/test/data b/test/data
-index 408f4405..6a48c886 160000
---- a/test/data
-+++ b/test/data
-@@ -1 +1 @@
--Subproject commit 408f44059015c57a66e13b4c98df86ebcb427950
-+Subproject commit 6a48c88658bcd68392e99344714cb0dccd4ec285

--- a/ports/arrayfire/vcpkg.json
+++ b/ports/arrayfire/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrayfire",
   "version-string": "3.7.3",
+  "port-version": 2,
   "description": "ArrayFire is a general-purpose library that simplifies the process of developing software that targets parallel and massively-parallel architectures including CPUs, GPUs, and other hardware acceleration devices.",
   "supports": "x64",
   "dependencies": [


### PR DESCRIPTION
Patch the ArrayFire port to fix an issue with the cuSparse API in CUDA 10.1. See https://github.com/arrayfire/arrayfire/pull/3057. Since this isn't going to be grafted into the v3.7 branch or the 3.7.3 tip, fix the port manually for now since the vcpkg min CUDA version is 10.1 and users might install 10.1 pre update 2 when the API is broken.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Same as before - `x64`*. No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

cc @umar456 @9prady9 