### PR TITLE
[cimg] update to 2.9.4

### DIFF
--- a/ports/cimg/CONTROL
+++ b/ports/cimg/CONTROL
@@ -1,4 +1,4 @@
 Source: cimg
-Version: 2.6.2
+Version: 2.9.4
 Homepage: https://github.com/dtschump/CImg
 Description: The CImg Library is a small, open-source, and modern C++ toolkit for image processing

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     REPO "dtschump/CImg"
-    REF v.2.6.2
+    REF a0e7ecb55130bdf90756033c1e1470eae4b88c1a #v2.9.4
     HEAD_REF master
-    SHA512 6571c646c2d1c007212b3c8cd6794ff1722a0ffc4fcbbe26499cf1e74d3490e893cac5868c5b513602b336b5609316cd7f67c2e1f89b04fe79df5f93b9c6be7a)
+    SHA512 0fc814b67ce9f035a68308850117b40cb54d731cb559bf1b6f46e1ec1e29d473e805818018ac411529b51510468cfbe4427aa52a354f919d7f1ce84bd285a47d)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
@@ -14,8 +14,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 # Move cmake files, ensuring they will be 3 directories up the import prefix
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/cimg)
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
 
-file(INSTALL ${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/cimg RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/Licence_CeCILL_V2-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/cimg RENAME copyright2)
+file(INSTALL ${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/Licence_CeCILL_V2-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright2)

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_fixup_cmake_targets()
+
 # Move cmake files, ensuring they will be 3 directories up the import prefix
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)

--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -13,8 +13,6 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets()
-
 # Move cmake files, ensuring they will be 3 directories up the import prefix
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)


### PR DESCRIPTION
Fix #14821

Update cimg to the latest version 2.9.4

Note: No feature need to test 