### PR TITLE
Include libtool as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ need to install:
 
 ```sh
 $ sudo apt-get update
-$ sudo apt-get install build-essential tar curl zip unzip
+$ sudo apt-get install build-essential tar curl zip unzip libtool
 ```
 
 - CentOS


### PR DESCRIPTION
**Add libtool as system dependency**

- What does your PR fix? #14827

- Which triplets are supported/not supported? Have you updated the CI baseline?
CI doesn't need to update as it was taken care of already? b8755728ab92f43d3056091324d7135b1c9fc390 seem to include libtool. @BillyONeal should all of those apt tools https://github.com/microsoft/vcpkg/blob/a2135fd97e834e83a705b1cff0d91a0e45a0fb00/scripts/azure-pipelines/linux/provision-image.sh#L9 be in README.md?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes? Once it's reviewed I'll update other translations.