### PR TITLE
[usockets] Fix build issue with feature ssl

### DIFF
--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 project(uSockets C CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+
 option(INSTALL_HEADERS "Install header files" ON)
 
 # To enable this feature, OpenSSL 1.1+ is required and is currently disabled due to issue 4267
@@ -25,7 +27,7 @@ set(USOCKETS_EXT_LIBS )
 
 if (CMAKE_USE_OPENSSL)
     find_package(OpenSSL REQUIRED)
-    file(GLOB SSL_SOURCES src/crypto/*.c)
+    file(GLOB SSL_SOURCES src/crypto/*.c*)
     list(APPEND SOURCES ${SSL_SOURCES})
     list(APPEND USOCKETS_EXT_LIBS OpenSSL::SSL OpenSSL::Crypto)
 endif()

--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -24,6 +24,7 @@ set(USOCKETS_EXT_INCLUDE_DIR )
 set(USOCKETS_EXT_LIBS )
 
 if (CMAKE_USE_OPENSSL)
+    # It requires C++17 or later, see https://github.com/uNetworking/uSockets/blob/master/Makefile#L43
     set(CMAKE_CXX_STANDARD 17)
     find_package(OpenSSL REQUIRED)
     file(GLOB SSL_SOURCES src/crypto/*.c*)

--- a/ports/usockets/CMakeLists.txt
+++ b/ports/usockets/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 project(uSockets C CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-
 option(INSTALL_HEADERS "Install header files" ON)
 
 # To enable this feature, OpenSSL 1.1+ is required and is currently disabled due to issue 4267
@@ -26,6 +24,7 @@ set(USOCKETS_EXT_INCLUDE_DIR )
 set(USOCKETS_EXT_LIBS )
 
 if (CMAKE_USE_OPENSSL)
+    set(CMAKE_CXX_STANDARD 17)
     find_package(OpenSSL REQUIRED)
     file(GLOB SSL_SOURCES src/crypto/*.c*)
     list(APPEND SOURCES ${SSL_SOURCES})

--- a/ports/usockets/CONTROL
+++ b/ports/usockets/CONTROL
@@ -1,5 +1,6 @@
 Source: usockets
 Version: 0.6.0
+Port-Version: 1
 Build-Depends:libuv
 Description: Miniscule cross-platform eventing, networking & crypto for async applications
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/14933

 _sni_*  are in sni_tree.cpp, which not built in vcpkg, including this file, and it requires c++17 or later. See https://github.com/uNetworking/uSockets/blob/master/Makefile#L43

All features test pass with x64-windows and x64-windows-static

Failures:
```
openssl.c.obj : error LNK2019: unresolved external symbol _sni_new referenced in function _us_internal_create_ssl_socket_context
openssl.c.obj : error LNK2019: unresolved external symbol _sni_free referenced in function _us_internal_ssl_socket_context_free
openssl.c.obj : error LNK2019: unresolved external symbol _sni_add referenced in function _us_internal_ssl_socket_context_add_server_name
openssl.c.obj : error LNK2019: unresolved external symbol _sni_remove referenced in function _us_internal_ssl_socket_context_remove_server_name
openssl.c.obj : error LNK2019: unresolved external symbol _sni_find referenced in function _resolve_context
uSockets.dll : fatal error LNK1120: 5 unresolved externals
```