### PR TITLE
[vcpkg] Add versioning fields to schema

### DIFF
--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -21,6 +21,69 @@
         }
       ]
     },
+    "version-text": {
+      "type": "string",
+      "pattern": "[^#]+"
+    },
+    "has-schemed-version": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "version-string": {
+              "description": "Text used to identify an arbitrary version",
+              "type": "string",
+              "pattern": "^[^#]+$"
+            }
+          },
+          "required": [
+            "version-string"
+          ]
+        },
+        {
+          "properties": {
+            "version": {
+              "description": "A relaxed version string (1.2.3.4...)",
+              "type": "string",
+              "pattern": "^\\d+(\\.\\d+)*$"
+            }
+          },
+          "required": [
+            "version"
+          ]
+        },
+        {
+          "properties": {
+            "version-semver": {
+              "description": "A semantic version string. See https://semver.org/",
+              "type": "string",
+              "pattern": "^\\d+\\.\\d+\\.\\d+([+-].+)?$"
+            }
+          },
+          "required": [
+            "version-semver"
+          ]
+        },
+        {
+          "properties": {
+            "version-date": {
+              "description": "A date version string (e.g. 2020-01-20)",
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}(\\.\\d+)*$"
+            }
+          },
+          "required": [
+            "version-date"
+          ]
+        }
+      ]
+    },
+    "port-version": {
+      "description": "A non-negative integer indicating the port revision. If this field doesn't exist, it's assumed to be `0`.",
+      "type": "integer",
+      "minimum": 0,
+      "default": 0
+    },
     "package-name": {
       "description": "Name of a package.",
       "allOf": [
@@ -71,6 +134,14 @@
         },
         "platform": {
           "$ref": "#/definitions/platform-expression"
+        },
+        "version>=": {
+          "description": "Minimum required port version",
+          "$ref": "#/definitions/version-text"
+        },
+        "port-version": {
+          "description": "Minimum port revision (defaults to 0)",
+          "$ref": "#/definitions/port-version"
         }
       },
       "patternProperties": {
@@ -90,6 +161,28 @@
         {
           "$ref": "#/definitions/dependency-object"
         }
+      ]
+    },
+    "override": {
+      "description": "A version override.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/identifier"
+        },
+        "version": {
+          "$ref": "#/definitions/version-text"
+        },
+        "port-version": {
+          "$ref": "#/definitions/port-version"
+        }
+      },
+      "patternProperties": {
+        "^\\$": {}
+      },
+      "required": [
+        "name",
+        "version"
       ]
     },
     "platform-expression": {
@@ -125,82 +218,93 @@
     }
   },
   "type": "object",
-  "properties": {
-    "name": {
-      "$ref": "#/definitions/package-name"
+  "allOf": [
+    {
+      "properties": {
+        "name": {
+          "description": "The name of the top-level package",
+          "$ref": "#/definitions/package-name"
+        },
+        "version-string": {},
+        "version": {},
+        "version-date": {},
+        "version-semver": {},
+        "port-version": {
+          "$ref": "#/definitions/port-version"
+        },
+        "maintainers": {
+          "description": "An array of strings which contain the authors of a package",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/description-field"
+        },
+        "homepage": {
+          "description": "A url which points to the homepage of a package.",
+          "type": "string",
+          "format": "uri"
+        },
+        "documentation": {
+          "description": "A url which points to the documentation of a package.",
+          "type": "string",
+          "format": "uri"
+        },
+        "license": {
+          "description": "An SPDX license expression at version 3.9.",
+          "type": "string"
+        },
+        "dependencies": {
+          "description": "Dependencies that are always required.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "overrides": {
+          "description": "Version overrides for dependencies.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/override"
+          }
+        },
+        "dev-dependencies": {
+          "description": "Dependencies only required for developers (testing and the like).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dependency"
+          }
+        },
+        "features": {
+          "description": "An array of features supported by the package",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/feature"
+          }
+        },
+        "default-features": {
+          "description": "Features enabled by default with the package.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/identifier"
+          }
+        },
+        "supports": {
+          "$ref": "#/definitions/platform-expression"
+        }
+      },
+      "patternProperties": {
+        "^\\$": {}
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
     },
-    "version-string": {
-      "description": "A string without semantic meaning, equivalent to `CONTROL`'s `Version` field.",
-      "type": "string"
-    },
-    "port-version": {
-      "description": "A non-negative integer. If this field doesn't exist, it's assumed to be `0`.",
-      "type": "integer",
-      "minimum": 0,
-      "default": 0
-    },
-    "maintainers": {
-      "description": "An array of strings which contain the authors of a package",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "description": {
-      "$ref": "#/definitions/description-field"
-    },
-    "homepage": {
-      "description": "A url which points to the homepage of a package.",
-      "type": "string",
-      "format": "uri"
-    },
-    "documentation": {
-      "description": "A url which points to the documentation of a package.",
-      "type": "string",
-      "format": "uri"
-    },
-    "license": {
-      "description": "An SPDX license expression at version 3.9.",
-      "type": "string"
-    },
-    "dependencies": {
-      "description": "Dependencies that are always required.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/dependency"
-      }
-    },
-    "dev-dependencies": {
-      "description": "Dependencies only required for developers (testing and the like).",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/dependency"
-      }
-    },
-    "features": {
-      "description": "An array of features supported by the package",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/feature"
-      }
-    },
-    "default-features": {
-      "description": "Features enabled by default with the package.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/identifier"
-      }
-    },
-    "supports": {
-      "$ref": "#/definitions/platform-expression"
+    {
+      "$ref": "#/definitions/has-schemed-version"
     }
-  },
-  "patternProperties": {
-    "^\\$": {}
-  },
-  "required": [
-    "name",
-    "version-string"
-  ],
-  "additionalProperties": false
+  ]
 }


### PR DESCRIPTION
This PR expands `vcpkg.schema.json` to cover the new versioning fields.
