### PR TITLE
[vcpkg] Improve error messages for incomplete Mono

### DIFF
--- a/toolsrc/include/vcpkg/base/expected.h
+++ b/toolsrc/include/vcpkg/base/expected.h
@@ -110,7 +110,10 @@ namespace vcpkg
         // Constructors are intentionally implicit
 
         ExpectedT(const S& s, ExpectedRightTag = {}) : m_s(s) { }
-        ExpectedT(S&& s, ExpectedRightTag = {}) : m_s(std::move(s)) { }
+        template<class = std::enable_if<!std::is_reference<S>::value>>
+        ExpectedT(S&& s, ExpectedRightTag = {}) : m_s(std::move(s))
+        {
+        }
 
         ExpectedT(const T& t, ExpectedLeftTag = {}) : m_t(t) { }
         template<class = std::enable_if<!std::is_reference<T>::value>>

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -361,11 +361,13 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
             if (rc.exit_code != 0)
             {
 #ifndef _WIN32
-                return {Strings::concat(std::move(rc.output),
-                                        "\n\nFailed to get version of ",
-                                        fs::u8string(path_to_exe),
-                                        "\nThis may be caused by an incomplete mono installation. Full mono is "
-                                        "available on some systems via `sudo apt install mono-complete`."),
+                return {Strings::concat(
+                            std::move(rc.output),
+                            "\n\nFailed to get version of ",
+                            fs::u8string(path_to_exe),
+                            "\nThis may be caused by an incomplete mono installation. Full mono is "
+                            "available on some systems via `sudo apt install mono-complete`. Ubuntu 18.04 users may "
+                            "need a newer version of mono, available at https://www.mono-project.com/download/stable/"),
                         expected_right_tag};
 #else
                 return {Strings::concat(

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -83,12 +83,22 @@ namespace vcpkg
         const bool has_tool_entry = std::regex_search(XML.cbegin(), XML.cend(), match_tool_entry, tool_regex);
         if (!has_tool_entry)
         {
+            StringLiteral add_info = "";
+            if (tool == "mono")
+            {
+#if defined(__APPLE__)
+                add_info = " (brew install mono)";
+#else
+                add_info = " (sudo apt install mono-complete)";
+#endif
+            }
             return Strings::format("Could not automatically acquire %s because there is no entry in %s for os=%s. You "
-                                   "may be able to install %s via your system package manager.",
+                                   "may be able to install %s via your system package manager%s.",
                                    tool,
                                    fs::u8string(XML_PATH),
                                    OS_STRING,
-                                   tool);
+                                   tool,
+                                   add_info);
         }
 
         const std::string tool_data =
@@ -139,7 +149,7 @@ namespace vcpkg
         virtual std::array<int, 3> default_min_version() const = 0;
 
         virtual void add_special_paths(std::vector<fs::path>& out_candidate_paths) const { (void)out_candidate_paths; }
-        virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const = 0;
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const = 0;
     };
 
     static Optional<PathAndVersion> find_first_with_sufficient_version(const VcpkgPaths& paths,
@@ -222,10 +232,9 @@ namespace vcpkg
                                      const ToolProvider& tool_provider,
                                      const ToolData& tool_data)
     {
-        const auto downloaded_path = fetch_tool(paths, tool_provider.tool_data_name(), tool_data);
-        const auto downloaded_version =
-            tool_provider.get_version(paths, downloaded_path).value_or_exit(VCPKG_LINE_INFO);
-        return {downloaded_path, downloaded_version};
+        auto downloaded_path = fetch_tool(paths, tool_provider.tool_data_name(), tool_data);
+        auto downloaded_version = tool_provider.get_version(paths, downloaded_path).value_or_exit(VCPKG_LINE_INFO);
+        return {std::move(downloaded_path), std::move(downloaded_version)};
     }
 
     static PathAndVersion get_path(const VcpkgPaths& paths, const ToolProvider& tool)
@@ -285,13 +294,15 @@ namespace vcpkg
             (void)out_candidate_paths;
 #endif
         }
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
-            const auto rc = System::cmd_execute_and_capture_output(cmd);
+            auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             /* Sample output:
@@ -311,19 +322,21 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {3, 5, 1}; }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
-            const auto rc = System::cmd_execute_and_capture_output(cmd);
+            auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             /* Sample output:
 1.8.2
                 */
-            return rc.output;
+            return {std::move(rc.output), expected_left_tag};
         }
     };
 
@@ -335,7 +348,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {4, 6, 2}; }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const override
         {
             System::CmdLineBuilder cmd;
 #ifndef _WIN32
@@ -344,10 +357,21 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
             (void)paths;
 #endif
             cmd.path_arg(path_to_exe);
-            const auto rc = System::cmd_execute_and_capture_output(cmd.extract());
+            auto rc = System::cmd_execute_and_capture_output(cmd.extract());
             if (rc.exit_code != 0)
             {
-                return nullopt;
+#ifndef _WIN32
+                return {Strings::concat(std::move(rc.output),
+                                        "\n\nFailed to get version of ",
+                                        fs::u8string(path_to_exe),
+                                        "\nThis may be caused by an incomplete mono installation. Full mono is "
+                                        "available on some systems via `sudo apt install mono-complete`."),
+                        expected_right_tag};
+#else
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
+#endif
             }
 
             /* Sample output:
@@ -357,7 +381,8 @@ Type 'NuGet help <command>' for help on a specific command.
 
 [[[List of available commands follows]]]
                 */
-            return StringView::find_exactly_one_enclosed(rc.output, "NuGet Version: ", "\n").to_string();
+            return {StringView::find_exactly_one_enclosed(rc.output, "NuGet Version: ", "\n").to_string(),
+                    expected_left_tag};
         }
     };
 
@@ -383,13 +408,15 @@ Type 'NuGet help <command>' for help on a specific command.
 #endif
         }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
-            const auto rc = System::cmd_execute_and_capture_output(cmd);
+            auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             /* Sample output:
@@ -398,7 +425,7 @@ git version 2.17.1.windows.2
             const auto idx = rc.output.find("git version ");
             Checks::check_exit(
                 VCPKG_LINE_INFO, idx != std::string::npos, "Unexpected format of git version string: %s", rc.output);
-            return rc.output.substr(idx);
+            return {rc.output.substr(idx), expected_left_tag};
         }
     };
 
@@ -410,13 +437,15 @@ git version 2.17.1.windows.2
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {0, 0, 0}; }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const auto rc = System::cmd_execute_and_capture_output(
+            auto rc = System::cmd_execute_and_capture_output(
                 System::CmdLineBuilder().path_arg(path_to_exe).string_arg("--version").extract());
             if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             /* Sample output:
@@ -425,7 +454,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
             const auto idx = rc.output.find("Mono JIT compiler version ");
             Checks::check_exit(
                 VCPKG_LINE_INFO, idx != std::string::npos, "Unexpected format of mono version string: %s", rc.output);
-            return rc.output.substr(idx);
+            return {rc.output.substr(idx), expected_left_tag};
         }
     };
 
@@ -450,19 +479,21 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
             // "Qt" / "QtIFW-3.1.0" / "bin" / "installerbase.exe");
         }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
             const std::string cmd = Strings::format(R"("%s" --framework-version)", fs::u8string(path_to_exe));
-            const auto rc = System::cmd_execute_and_capture_output(cmd);
+            auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             /* Sample output:
 3.1.81
                 */
-            return rc.output;
+            return {std::move(rc.output), expected_left_tag};
         }
     };
 
@@ -475,17 +506,19 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
         virtual const std::string& exe_stem() const override { return m_exe; }
         virtual std::array<int, 3> default_min_version() const override { return {7, 0, 3}; }
 
-        virtual Optional<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
+        virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const auto pwsh_invocation = System::cmd_execute_and_capture_output(
+            auto rc = System::cmd_execute_and_capture_output(
                 System::CmdLineBuilder().path_arg(path_to_exe).string_arg("--version").extract());
-            if (pwsh_invocation.exit_code != 0)
+            if (rc.exit_code != 0)
             {
-                return nullopt;
+                return {Strings::concat(
+                            std::move(rc.output), "\n\nFailed to get version of ", fs::u8string(path_to_exe), "\n"),
+                        expected_right_tag};
             }
 
             // Sample output: PowerShell 7.0.3\r\n
-            auto output = std::move(pwsh_invocation.output);
+            auto output = std::move(rc.output);
             if (!Strings::starts_with(output, "PowerShell "))
             {
                 Checks::exit_with_message(
@@ -493,7 +526,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
             }
 
             output.erase(0, 11);
-            return Strings::trim(std::move(output));
+            return {Strings::trim(std::move(output)), expected_left_tag};
         }
     };
 

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -310,7 +310,8 @@ cmake version 3.10.2
 
 CMake suite maintained and supported by Kitware (kitware.com/cmake).
                 */
-            return StringView::find_exactly_one_enclosed(rc.output, "cmake version ", "\n").to_string();
+            return {StringView::find_exactly_one_enclosed(rc.output, "cmake version ", "\n").to_string(),
+                    expected_left_tag};
         }
     };
 

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -89,7 +89,8 @@ namespace vcpkg
 #if defined(__APPLE__)
                 add_info = " (brew install mono)";
 #else
-                add_info = " (sudo apt install mono-complete)";
+                add_info = " (e.g. sudo apt install mono-complete). Ubuntu 18.04 users may "
+                           "need a newer version of mono, available at https://www.mono-project.com/download/stable/";
 #endif
             }
             return Strings::format("Could not automatically acquire %s because there is no entry in %s for os=%s. You "


### PR DESCRIPTION
This PR fixes #14784 by providing better error information when the user has an incomplete mono installation (i.e. just `mono-runtime` instead of `mono-complete`). It also partially improves #14304 for Ubuntu 18.04 users, noting that they will need to get a newer version of `mono` than is available in apt.

#### Example 1
Before:
>root@0b923fc8e7fa:/vcpkg# ./vcpkg export --nuget zlib:x86-windows
The following packages are already built and will be exported:
    zlib:x86-windows
Exporting package zlib:x86-windows...
Packing nuget package...
Could not automatically acquire mono because there is no entry in /vcpkg/scripts/vcpkgTools.xml for os=linux. You may be able to install mono via your system package manager.

After
>root@0b923fc8e7fa:/vcpkg# ./vcpkg.new export --nuget zlib:x86-windows
The following packages are already built and will be exported:
    zlib:x86-windows
Exporting package zlib:x86-windows...
Packing nuget package...
Could not automatically acquire mono because there is no entry in /vcpkg/scripts/vcpkgTools.xml for os=linux. You may be able to install mono via your system package manager (e.g. sudo apt install mono-complete). Ubuntu 18.04 users may need a newer version of mono, available at https://www.mono-project.com/download/stable/.

#### Example 2
Before:
>root@0b923fc8e7fa:/vcpkg# ./vcpkg export --nuget zlib:x86-windows
The following packages are already built and will be exported:
    zlib:x86-windows
Exporting package zlib:x86-windows...
Packing nuget package...
A suitable version of nuget was not found (required v5.5.1). Downloading portable nuget v5.5.1...
Downloading nuget...
  https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe -> /vcpkg/downloads/22ea847d-nuget.exe
Value was null

After:
>root@0b923fc8e7fa:/vcpkg# ./vcpkg.new export --nuget zlib:x86-windows
The following packages are already built and will be exported:
    zlib:x86-windows
Exporting package zlib:x86-windows...
Packing nuget package...
A suitable version of nuget was not found (required v5.5.1). Downloading portable nuget v5.5.1...
Downloading nuget...
  https://dist.nuget.org/win-x86-commandline/v5.5.1/nuget.exe -> /vcpkg/downloads/22ea847d-nuget.exe
Failed at [../src/vcpkg/tools.cpp(236)] with message:
Could not load file or assembly 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' or one of its dependencies.
System.IO.FileNotFoundException: Could not load file or assembly 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' or one of its dependencies.
File name: 'System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
  at NuGet.CommandLine.Program.MainCore (System.String workingDirectory, System.String[] args) [0x000d8] in <94d83393be9c41c48c8dff90a7cc668d>:0
>
>
>Failed to get version of /vcpkg/downloads/tools/nuget-5.5.1-linux/nuget.exe
This may be caused by an incomplete mono installation. Full mono is available on some systems via `sudo apt install mono-complete`. Ubuntu 18.04 users may need a newer version of mono, available at https://www.mono-project.com/download/stable/
