### PR TITLE
[pcl] Fix build when librealsense2 is present

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,5 +1,6 @@
 Source: pcl
 Version: 1.11.1
+Port-Version: 1
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-sort, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-link-libpng.patch
         remove-broken-targets.patch
         fix-check-sse.patch
+        realsense2.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/Modules/FindFLANN.cmake)

--- a/ports/pcl/realsense2.patch
+++ b/ports/pcl/realsense2.patch
@@ -1,0 +1,13 @@
+diff --git a/io/src/real_sense_2_grabber.cpp b/io/src/real_sense_2_grabber.cpp
+index d13231e..06d1238 100644
+--- a/io/src/real_sense_2_grabber.cpp
++++ b/io/src/real_sense_2_grabber.cpp
+@@ -287,7 +287,7 @@ namespace pcl
+     cloud->width = sp.width ();
+     cloud->height = sp.height ();
+     cloud->is_dense = false;
+-    cloud->points.resize ( size () );
++    cloud->points.resize ( points.size () );
+ 
+     const auto cloud_vertices_ptr = points.get_vertices ();
+     const auto cloud_texture_ptr = points.get_texture_coordinates ();


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 

When librealsens2 is installed, PCL want to build realsense2 grabber. The file `io/src/real_sense_2_grabber.cpp` miscompile and this patch fix it. (Upstream's master have the same modification)

- Which triplets are supported/not supported? Have you updated the CI baseline?

Should support everything, since the problem is present in `real_sense_2_grabber.cpp` and it is used in all triplets. However, the autodetection of librealsense is curious and this should be a feature that set a dependency to the librealsense2 package. Anyway, this patch will be still required, so it can be already applied. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Not sure, but it should.
