### PR TITLE
[sdl2] Don't propagate shared link options

### DIFF
--- a/ports/sdl2/no-propagate-shared-link-options.patch
+++ b/ports/sdl2/no-propagate-shared-link-options.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7dfd35389..648218cc5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2062,7 +2062,7 @@ if(SDL_SHARED)
+     set_target_properties(SDL2 PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB")
+   endif()
+   set(_INSTALL_LIBS "SDL2" ${_INSTALL_LIBS})
+-  target_link_libraries(SDL2 ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
++  target_link_libraries(SDL2 PRIVATE ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
+   target_include_directories(SDL2 PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
+   if (NOT ANDROID)
+     set_target_properties(SDL2 PROPERTIES DEBUG_POSTFIX "${SDL_CMAKE_DEBUG_POSTFIX}")

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_extract_source_archive_ex(
         0006-sdl2-Enable-creation-of-pkg-cfg-file-on-windows.patch
         0007-sdl2-skip-ibus-on-linux.patch
         0008-fix-macos-metal-test.patch
+        no-propagate-shared-link-options.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version-string": "2.0.12",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {


### PR DESCRIPTION
**Describe the pull request**
This is a patch so that SDL2 doesn't propagate link flags for shared builds. This can be problematic in certain cases, for example, SDL2 specifies `-Wl,--no-undefined` as a linker flag and this will get propagated to all dependent projects.

There are upstream issues
* [https://bugzilla.libsdl.org/show_bug.cgi?id=5249](https://bugzilla.libsdl.org/show_bug.cgi?id=5249)
* [https://bugzilla.libsdl.org/show_bug.cgi?id=2992](https://bugzilla.libsdl.org/show_bug.cgi?id=2992)

It's worth noting that this problem __IS__ fixed in SDL 2.0.13 which hasn't been released yet. See [https://github.com/spurious/SDL-mirror/commit/07d40b7290f28996aff23c8588772ca3f6e99ffb](https://github.com/spurious/SDL-mirror/commit/07d40b7290f28996aff23c8588772ca3f6e99ffb) for the specific commit / more info. When 2.0.13 is released we can get rid of this patch.

- What does your PR fix? Fixes #14743

- Which triplets are supported/not supported? Have you updated the CI baseline?
This fixes dynamic triplets, so any community-supported triplets like `x64-linux-dynamic`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
