### PR TITLE
[libpng] Fix cross-compilation on macOS

### DIFF
--- a/ports/libpng/CONTROL
+++ b/ports/libpng/CONTROL
@@ -1,6 +1,6 @@
 Source: libpng
 Version: 1.6.37
-Port-Version: 13
+Port-Version: 14
 Build-Depends: zlib
 Homepage: https://github.com/glennrp/libpng
 Description: libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files.

--- a/ports/libpng/macos-arch-fix.patch
+++ b/ports/libpng/macos-arch-fix.patch
@@ -1,0 +1,62 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6451fcf1b..dbd5016ca 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -63,11 +63,22 @@ option(PNG_HARDWARE_OPTIMIZATIONS "Enable hardware optimizations" ON)
+ set(PNG_PREFIX "" CACHE STRING "Prefix to add to the API function names")
+ set(DFA_XTRA "" CACHE FILEPATH "File containing extra configuration settings")
+ 
++# CMake currently sets CMAKE_SYSTEM_PROCESSOR to one of x86_64 or arm64 on macOS,
++# based upon the OS architecture, not the target architecture. As such, we need
++# to check CMAKE_OSX_ARCHITECTURES to identify which hardware-specific flags to
++# enable. Note that this will fail if you attempt to build a universal binary in
++# a single cmake invokation.
++if (APPLE AND CMAKE_OSX_ARCHITECTURES)
++  set(TARGET_ARCH ${CMAKE_OSX_ARCHITECTURES})
++else()
++  set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
++endif()
++
+ if(PNG_HARDWARE_OPTIMIZATIONS)
+ 
+ # set definitions and sources for arm
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
+-  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
++if(TARGET_ARCH MATCHES "^arm" OR
++  TARGET_ARCH MATCHES "^aarch64")
+   set(PNG_ARM_NEON_POSSIBLE_VALUES check on off)
+   set(PNG_ARM_NEON "check" CACHE STRING "Enable ARM NEON optimizations:
+      check: (default) use internal checking code;
+@@ -121,8 +132,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
+ endif()
+ 
+ # set definitions and sources for intel
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
+-   CMAKE_SYSTEM_PROCESSOR MATCHES "^x86_64*")
++if(TARGET_ARCH MATCHES "^i?86" OR
++   TARGET_ARCH MATCHES "^x86_64*")
+   set(PNG_INTEL_SSE_POSSIBLE_VALUES on off)
+   set(PNG_INTEL_SSE "on" CACHE STRING "Enable INTEL_SSE optimizations:
+      off: disable the optimizations")
+@@ -171,8 +182,8 @@ endif()
+ else(PNG_HARDWARE_OPTIMIZATIONS)
+ 
+ # set definitions and sources for arm
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
+-   CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
++if(TARGET_ARCH MATCHES "^arm" OR
++  TARGET_ARCH MATCHES "^aarch64")
+   add_definitions(-DPNG_ARM_NEON_OPT=0)
+ endif()
+ 
+@@ -183,8 +194,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
+ endif()
+ 
+ # set definitions and sources for intel
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
+-   CMAKE_SYSTEM_PROCESSOR MATCHES "^x86_64*")
++if(TARGET_ARCH MATCHES "^i?86" OR
++   TARGET_ARCH MATCHES "^x86_64")
+   add_definitions(-DPNG_INTEL_SSE_OPT=0)
+ endif()
+ 

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -43,6 +43,7 @@ vcpkg_from_github(
         pkgconfig.2.patch
         ${APNG_EXTRA_PATCH}
         fix-export-targets.patch
+        macos-arch-fix.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
libpng does not build correctly for arm64 on macOS, as the CMakeLists.txt supplied with libpng checks CMAKE_SYSTEM_PROCESSOR. vcpkg currently uses an x86_64 version of cmake, and cmake always sets CMAKE_SYSTEM_PROCESSOR to x86_64 in this situation, when run under Rosetta. Updated versions of cmake (see https://github.com/microsoft/vcpkg/pull/15001) do report arm64 correctly, but in this case if we're cross-compiling we are not wanting to know the system processor, but the target architecture.

Ideally a fix may be submitted upstream, but for the time being I propose this patch, which should only be applied for macOS triplets, and will detect the target architecture and will then compile libpng with appropriate hardware-specific optimisations.