### PR TITLE
[dav1d] Add dav1d AV1 decoder port

### DIFF
--- a/ports/dav1d/patch_underscore_prefix.patch
+++ b/ports/dav1d/patch_underscore_prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 07b2586..02acd91 100644
+--- a/meson.build
++++ b/meson.build
+@@ -370,7 +370,7 @@ endif
+ 
+ cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
+ 
+-if cc.symbols_have_underscore_prefix()
++if cc.symbols_have_underscore_prefix() or (host_machine.cpu_family() == 'x86' and host_machine.system() == 'windows')
+     cdata.set10('PREFIX', true)
+     cdata_asm.set10('PREFIX', true)
+ endif

--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -2,8 +2,10 @@ vcpkg_from_gitlab(
     GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO videolan/dav1d
-    REF 0.7.1
-    SHA512 355a021df537f24b39e54ca77c167cdebe1c6739a1f97500ceb522526b9d1fb51aeee8d8c729ed14907c5796de8a99a0e83ac306182f8cef5be90d3b5aec7b37
+    REF 0.8.1
+    SHA512 dd40b82b65e4be37a27ab11e7116f7a244b0da4469915ead3922ac31724fb6da3910a78629a32a669031fe08d4323ab135174afb7462f6ea4adf96c111841c1c
+    PATCHES
+        "patch_underscore_prefix.patch"
 )
 
 vcpkg_find_acquire_program(NASM)
@@ -19,6 +21,8 @@ vcpkg_configure_meson(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         --default-library=${LIBRARY_TYPE}
+        -Denable_tests=false
+        -Denable_tools=false
 )
 
 vcpkg_install_meson()

--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_ARCH "arm" "x86" ON_TARGET "uwp")
+
 vcpkg_from_gitlab(
     GITLAB_URL https://code.videolan.org
     OUT_SOURCE_PATH SOURCE_PATH
@@ -28,5 +30,4 @@ vcpkg_configure_meson(
 vcpkg_install_meson()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/dav1d/portfile.cmake
+++ b/ports/dav1d/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://code.videolan.org
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO videolan/dav1d
+    REF 0.7.1
+    SHA512 355a021df537f24b39e54ca77c167cdebe1c6739a1f97500ceb522526b9d1fb51aeee8d8c729ed14907c5796de8a99a0e83ac306182f8cef5be90d3b5aec7b37
+)
+
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+vcpkg_add_to_path(${NASM_EXE_PATH})
+
+set(LIBRARY_TYPE ${VCPKG_LIBRARY_LINKAGE})
+if (LIBRARY_TYPE STREQUAL "dynamic")
+    set(LIBRARY_TYPE "shared")
+endif(LIBRARY_TYPE STREQUAL "dynamic")
+
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        --default-library=${LIBRARY_TYPE}
+)
+
+vcpkg_install_meson()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+configure_file("${SOURCE_PATH}/COPYING" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "dav1d",
-  "version-string": "0.7.1",
+  "version-string": "0.8.1",
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
-  "supports": "!(uwp | x86)",
+  "supports": "!(uwp | arm)",
   "dependencies": [
     "tool-meson"
   ]

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "dav1d",
+  "version-string": "0.7.1",
+  "port-version": 1,
+  "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
+  "homepage": "https://code.videolan.org/videolan/dav1d",
+  "supports": "!(uwp | x86)",
+  "dependencies": [
+    "tool-meson"
+  ]
+}

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "0.8.1",
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
-  "supports": "!(uwp | arm)",
+  "supports": "!(uwp | arm | x86)",
   "dependencies": [
     "tool-meson"
   ]

--- a/ports/dav1d/vcpkg.json
+++ b/ports/dav1d/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dav1d",
   "version-string": "0.7.1",
-  "port-version": 1,
   "description": "dav1d is a new open-source AV1 decoder developed by the VideoLAN and FFmpeg communities and sponsored by the Alliance for Open Media.",
   "homepage": "https://code.videolan.org/videolan/dav1d",
   "supports": "!(uwp | x86)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1532,6 +1532,10 @@
       "baseline": "3.0.0",
       "port-version": 1
     },
+    "dav1d": {
+      "baseline": "0.8.1",
+      "port-version": 0
+    },
     "dbg-macro": {
       "baseline": "2019-07-11",
       "port-version": 0

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2aeddda3b79505665e1c47ac56a92524b27c838f",
+      "git-tree": "1c30fb68cde7004f37eb289c95fb9823331fe571",
       "version-string": "0.8.1",
       "port-version": 0
     }

--- a/versions/d-/dav1d.json
+++ b/versions/d-/dav1d.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2aeddda3b79505665e1c47ac56a92524b27c838f",
+      "version-string": "0.8.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds `dav1d` AV1 decoder port

- Which triplets are supported/not supported? Have you updated the CI baseline?

Struggling with MSVC underscore prefixes on x86-windows. Disabled support in manifest for now. 
