### PR TITLE
[speexdsp] Fix include directories for Linux builds

### DIFF
--- a/ports/speexdsp/CMakeLists.txt
+++ b/ports/speexdsp/CMakeLists.txt
@@ -94,6 +94,7 @@ configure_file("${CMAKE_CURRENT_LIST_DIR}/include/speex/speexdsp_config_types.h.
 list(APPEND LIBSPEEXDSP_HEADERS_PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/speexdsp_config_types.h")
 
 include_directories("${CMAKE_CURRENT_LIST_DIR}/include")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 add_library(speexdsp ${LIBSPEEXDSP_SOURCES} ${LIBSPEEXDSP_HEADERS})
 set_target_properties(speexdsp PROPERTIES PUBLIC_HEADER "${LIBSPEEXDSP_HEADERS_PUBLIC}")

--- a/ports/speexdsp/CONTROL
+++ b/ports/speexdsp/CONTROL
@@ -1,6 +1,6 @@
 Source: speexdsp
 Version: 1.2.0
-Port-Version: 3
+Port-Version: 4
 Homepage: https://speex.org/
 Description: A patent-free, Open Source/Free Software DSP library.
 Build-Depends:

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1446,7 +1446,6 @@ spdk-isal:x64-uwp=fail
 spdk-isal:x64-windows=fail
 spdk-isal:x64-windows-static=fail
 spdk-isal:x86-windows=fail
-speexdsp:x64-linux=fail
 spirv-tools:arm-uwp=fail
 spirv-tools:x64-uwp=fail
 stormlib:arm-uwp=fail


### PR DESCRIPTION
In the comments of #14758, @BillyONeal pointed out there was a build error when compiling on Linux. As it turns out, when I was dealing with [an error in the CI tests](https://github.com/microsoft/vcpkg/pull/14758#issuecomment-733984344) (that wasn't appearing for me locally), I changed the location where the configured header file `speexdsp_config_types.h` gets written to before installing, but forgot to add the new location to the project's include directories. This is a quick fix for that mistake that fixes the Linux build (I tested it in Docker).