### PR TITLE
[curl] Update to 7.74.0

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,6 +1,5 @@
 Source: curl
-Version: 7.73.0
-Port-Version: 4
+Version: 7.74.0
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl
 Description: A library for transferring data with URLs

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
-    REF 315ee3fe75dade912b48a21ceec9ccda0230d937 #curl-7_73_0
-    SHA512 db9385d63688256c335f08fe044c67e7c17e2fbcbb47df234d5f9a1586b259edb07a37845c2ad85d2da00738b19dc0e718d91d05b2881c2828fec2660f858444
+    REF e052859759b34d0e05ce0f17244873e5cd7b457b #curl-7_74_0
+    SHA512 3dbbab00dda4f0e7d012fab358d2dd1362ff0c0f59c81f638fb547acba6f74a61c306906892447af3b18e8b0ebb93ebb8e0ac77e92247864bfa3a9c4ce7ea1d0
     HEAD_REF master
     PATCHES
         0002_fix_uwp.patch


### PR DESCRIPTION
Updated curl to version 7.74.0

Fixes clang-cl builds on Windows, which are failing in current version.
