### PR TITLE
[sentry-native] Fix sentry-config-cmake.in

### DIFF
--- a/ports/sentry-native/CONTROL
+++ b/ports/sentry-native/CONTROL
@@ -1,5 +1,6 @@
 Source: sentry-native
 Version: 0.4.4
+Port-Version: 1
 Homepage: https://sentry.io/
 Description: Sentry SDK for C, C++ and native applications.
 Build-Depends: curl (!windows)

--- a/ports/sentry-native/fix-config-cmake.patch
+++ b/ports/sentry-native/fix-config-cmake.patch
@@ -1,0 +1,23 @@
+diff --git a/sentry-config.cmake.in b/sentry-config.cmake.in
+index 89ea345..21d8732 100644
+--- a/sentry-config.cmake.in
++++ b/sentry-config.cmake.in
+@@ -5,7 +5,7 @@ set(SENTRY_TRANSPORT @SENTRY_TRANSPORT@)
+ 
+ if(SENTRY_BACKEND STREQUAL "crashpad")
+ 	if(@SENTRY_CRASHPAD_SYSTEM@)
+-		find_package(crashpad REQUIRED)
++		find_dependency(crashpad)
+ 	else()
+ 		include("${CMAKE_CURRENT_LIST_DIR}/sentry_crashpad-targets.cmake")
+ 	endif()
+@@ -14,7 +14,7 @@ endif()
+ include("${CMAKE_CURRENT_LIST_DIR}/sentry-targets.cmake")
+ 
+ if(SENTRY_TRANSPORT STREQUAL "curl" AND NOT @BUILD_SHARED_LIBS@)
+-	find_package(CURL REQUIRED)
++	find_dependency(CURL)
+ 	set_property(TARGET sentry::sentry APPEND
+-		PROPERTY INTERFACE_LINK_LIBRARIES ${CURL_LIBRARIES})
++		PROPERTY INTERFACE_LINK_LIBRARIES CURL::libcurl)
+ endif()

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -9,8 +9,10 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
-    PATCHES fix-warningC5105.patch
     NO_REMOVE_ONE_LEVEL
+    PATCHES
+        fix-warningC5105.patch
+        fix-config-cmake.patch
 )
 
 if (NOT DEFINED SENTRY_BACKEND)


### PR DESCRIPTION
- In `*-config.cmake`, we should use `find_dependency` instead of `find_package`.
- Fix curl target name.

Fixes #15023.