### PR TITLE
[vcpkg] Don't require native tools on arm64 macOS

### DIFF
--- a/toolsrc/src/vcpkg.cpp
+++ b/toolsrc/src/vcpkg.cpp
@@ -239,7 +239,7 @@ int main(const int argc, const char* const* const argv)
     load_config(fs);
 
 #if (defined(__aarch64__) || defined(__arm__) || defined(__s390x__) || defined(_M_ARM) || defined(_M_ARM64)) &&        \
-    !defined(_WIN32)
+    !defined(_WIN32) && !defined(__APPLE__)
     if (!System::get_environment_variable("VCPKG_FORCE_SYSTEM_BINARIES").has_value())
     {
         Checks::exit_with_message(


### PR DESCRIPTION
I've been building on macOS (Apple Silicon) and vcpkg has started saying:

"Environment variable VCPKG_FORCE_SYSTEM_BINARIES must be set on arm and s390x platforms."

I assume it's now being built as native code instead of x86_64 - however, I see no reason that we need to use system binaries on Apple Silicon. We can still run x86_64 binaries of cmake, etc.

As such I propose this patch to exclude macOS from this error, in the same way Windows is excluded.