### PR TITLE
[opencascade] Fix OpenCASCADE_INSTALL_PREFIX path in config

### DIFF
--- a/ports/opencascade/CONTROL
+++ b/ports/opencascade/CONTROL
@@ -1,6 +1,6 @@
 Source: opencascade
 Version: 7.4.0
-Port-Version: 2
+Port-Version: 3
 Build-Depends: freetype
 Description: Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.
 Supports: !(uwp|osx|linux|arm)

--- a/ports/opencascade/fix-install-prefix-path.patch
+++ b/ports/opencascade/fix-install-prefix-path.patch
@@ -1,0 +1,12 @@
+diff --git a/adm/templates/OpenCASCADEConfig.cmake.in b/adm/templates/OpenCASCADEConfig.cmake.in
+index 4937103b..cd35e07d 100644
+--- a/adm/templates/OpenCASCADEConfig.cmake.in
++++ b/adm/templates/OpenCASCADEConfig.cmake.in
+@@ -23,6 +23,7 @@ set (OpenCASCADE_DEVELOPMENT_VERSION "@OCC_VERSION_DEVELOPMENT@")
+ # - in Windows style: $INSTALL_DIR/cmake
+ get_filename_component (OpenCASCADE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
++get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
+ if (OpenCASCADE_INSTALL_PREFIX MATCHES "/cmake$")
+   get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
+ endif()

--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         fix-msvc-32bit-builds.patch
         fix-build-with-vs2017.patch
         fix-static-build.patch
+        fix-install-prefix-path.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #14636

Currently,  OpenCASCADE_INSTALL_PREFIX path is like this:

`OpenCASCADE_INSTALL_PREFIX=D:/vcpkg/installed/x64-windows/share`

This causes `OpenCASCADE_INCLUDE_DIR `and `OpenCASCADE_LIBRARY_DIR` are wrong.

```
OpenCASCADE_INCLUDE_DIR =D:/vcpkg/installed/x64-windows/share/include/opencascade

OpenCASCADE_LIBRARY_DIR=D:/vcpkg/installed/x64-windows/share/lib
```
So need to fix `OpenCASCADE_INSTALL_PREFIX `path.

Note: All features are not needed to test.