### PR TITLE
Properly index package actions in log

### DIFF
--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -435,13 +435,14 @@ namespace vcpkg::Install
         SpecSummary* current_summary = nullptr;
         Chrono::ElapsedTimer build_timer = Chrono::ElapsedTimer::create_started();
 
-        TrackedPackageInstallGuard(const size_t package_count,
+        TrackedPackageInstallGuard(const size_t action_count,
+                                   const size_t action_index,
                                    std::vector<SpecSummary>& results,
                                    const PackageSpec& spec)
         {
             results.emplace_back(spec, nullptr);
             current_summary = &results.back();
-            System::printf("Starting package %zd/%zd: %s\n", results.size(), package_count, spec.to_string());
+            System::printf("Starting package %zd/%zd: %s\n", action_index, action_count, spec.to_string());
         }
 
         ~TrackedPackageInstallGuard()
@@ -465,12 +466,13 @@ namespace vcpkg::Install
                            const CMakeVars::CMakeVarProvider& var_provider)
     {
         std::vector<SpecSummary> results;
-        const size_t package_count = action_plan.remove_actions.size() + action_plan.install_actions.size();
+        const size_t action_count = action_plan.remove_actions.size() + action_plan.install_actions.size();
+        size_t action_index = 1;
 
         const auto timer = Chrono::ElapsedTimer::create_started();
         for (auto&& action : action_plan.remove_actions)
         {
-            TrackedPackageInstallGuard this_install(package_count, results, action.spec);
+            TrackedPackageInstallGuard this_install(action_index++, action_count, results, action.spec);
             Remove::perform_remove_plan_action(paths, action, Remove::Purge::YES, &status_db);
         }
 
@@ -488,7 +490,7 @@ namespace vcpkg::Install
 
         for (auto&& action : action_plan.install_actions)
         {
-            TrackedPackageInstallGuard this_install(package_count, results, action.spec);
+            TrackedPackageInstallGuard this_install(action_index++, action_count, results, action.spec);
             auto result =
                 perform_install_plan_action(args, paths, action, status_db, binaryprovider, build_logs_recorder);
             if (result.code != BuildResult::SUCCEEDED && keep_going == KeepGoing::NO)

--- a/toolsrc/src/vcpkg/install.cpp
+++ b/toolsrc/src/vcpkg/install.cpp
@@ -435,8 +435,8 @@ namespace vcpkg::Install
         SpecSummary* current_summary = nullptr;
         Chrono::ElapsedTimer build_timer = Chrono::ElapsedTimer::create_started();
 
-        TrackedPackageInstallGuard(const size_t action_count,
-                                   const size_t action_index,
+        TrackedPackageInstallGuard(const size_t action_index,
+                                   const size_t action_count,
                                    std::vector<SpecSummary>& results,
                                    const PackageSpec& spec)
         {


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

When running `vcpkg install` with some packages already installed, invalid message of type `Starting package 3/2: opencl:x64-linux` may occur. It happens because `results` vector might contain already installed actions, while they are not counted in the total number of actions.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Tested myself on `x64-linux`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
