### PR TITLE
[hyperscan] Remove erroneous python3 dependency.

### DIFF
--- a/ports/hyperscan/CONTROL
+++ b/ports/hyperscan/CONTROL
@@ -1,5 +1,7 @@
 Source: hyperscan
 Version: 5.3.0
+Port-Version: 1
 Homepage: https://www.hyperscan.io
 Description: A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.
-Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-crc, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, pcre, python3, ragel
+Build-Depends: boost-array, boost-chrono, boost-config, boost-core, boost-crc, boost-detail, boost-functional, boost-regex, boost-system, boost-thread, boost-type-traits, boost-unordered, boost-utility, boost-dynamic-bitset, boost-random, boost-graph, boost-multi-array, boost-icl, boost-ptr-container, pcre, ragel
+Supports: !arm

--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -13,12 +13,11 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_PATH})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS "-DPYTHON_EXECUTABLE=${PYTHON3}"
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This removes the dependency on the python3 port from hyperscan. Hyperscan uses python as part of its build process only.

- What does your PR fix?
See above.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Hyperscan does not support ARM, being an Intel library. Originally, hyperscan skipped ARM due to its dependency on python3.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
