### PR TITLE
[glbinding] Improve usage information

### DIFF
--- a/ports/glbinding/CONTROL
+++ b/ports/glbinding/CONTROL
@@ -1,5 +1,0 @@
-Source: glbinding
-Version: 3.1.0-2
-Description: glbinding is an MIT licensed, cross-platform C++ binding for the OpenGL API
-Homepage: https://github.com/cginternals/glbinding
-Build-Depends: egl-registry

--- a/ports/glbinding/portfile.cmake
+++ b/ports/glbinding/portfile.cmake
@@ -56,3 +56,4 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/KHR)
 
 # Handle copyright
 file(RENAME ${CURRENT_PACKAGES_DIR}/share/glbinding/LICENSE ${CURRENT_PACKAGES_DIR}/share/glbinding/copyright)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/glbinding/usage @ONLY)

--- a/ports/glbinding/usage
+++ b/ports/glbinding/usage
@@ -1,0 +1,4 @@
+The package glbinding:@TARGET_TRIPLET@ provides CMake targets:
+
+    find_package(glbinding CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE glbinding::glbinding glbinding::glbinding-aux)

--- a/ports/glbinding/vcpkg.json
+++ b/ports/glbinding/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "glbinding",
+  "version-string": "3.1.0",
+  "port-version": 3,
+  "description": "glbinding is an MIT licensed, cross-platform C++ binding for the OpenGL API",
+  "homepage": "https://github.com/cginternals/glbinding",
+  "dependencies": [
+    "egl-registry"
+  ]
+}


### PR DESCRIPTION
Current vcpkg heuristics fail to correctly detect the usage information for glbinding, suggesting that the user run `find_package()` for packages that don't exist.
