### PR TITLE
[vcpkg] Adhere to older draft schema to improve compatibility with editors (such as VS)

### DIFF
--- a/scripts/vcpkg.schema.json
+++ b/scripts/vcpkg.schema.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "title": "Vcpkg manifest",
   "description": "Vcpkg manifest file. See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/manifests.md.",
   "definitions": {


### PR DESCRIPTION
Visual Studio does not yet support the newer JSON Schema Draft 07. By reducing the draft requirement of our schema to version 4, it can now be handled by both Visual Studio and Visual Studio Code.