### PR TITLE
Avoid C4819 warning during bootstrap-vcpkg.bat

### DIFF
--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -335,32 +335,32 @@ namespace vcpkg::Export::Prefab
 
         /*
         prefab
-        └── <name>
-            ├── aar
-            │   ├── AndroidManifest.xml
-            │   ├── META-INF
-            │   │   └── LICENCE
-            │   └── prefab
-            │       ├── modules
-            │       │   └── <module>
-            │       │       ├── include
-            │       │       ├── libs
-            │       │       │   ├── android.arm64-v8a
-            │       │       │   │   ├── abi.json
-            │       │       │   │   └── lib<module>.so
-            │       │       │   ├── android.armeabi-v7a
-            │       │       │   │   ├── abi.json
-            │       │       │   │   └── lib<module>.so
-            │       │       │   ├── android.x86
-            │       │       │   │   ├── abi.json
-            │       │       │   │   └── lib<module>.so
-            │       │       │   └── android.x86_64
-            │       │       │       ├── abi.json
-            │       │       │       └── lib<module>.so
-            │       │       └── module.json
-            │       └── prefab.json
-            ├── <name>-<version>.aar
-            └── pom.xml
+        +-- <name>
+            +-- aar
+            |   +-- AndroidManifest.xml
+            |   +-- META-INF
+            |   |   +-- LICENCE
+            |   +-- prefab
+            |       +-- modules
+            |       |   +-- <module>
+            |       |       +-- include
+            |       |       +-- libs
+            |       |       |   +-- android.arm64-v8a
+            |       |       |   |   +-- abi.json
+            |       |       |   |   +-- lib<module>.so
+            |       |       |   +-- android.armeabi-v7a
+            |       |       |   |   +-- abi.json
+            |       |       |   |   +-- lib<module>.so
+            |       |       |   +-- android.x86
+            |       |       |   |   +-- abi.json
+            |       |       |   |   +-- lib<module>.so
+            |       |       |   +-- android.x86_64
+            |       |       |       +-- abi.json
+            |       |       |       +-- lib<module>.so
+            |       |       +-- module.json
+            |       +-- prefab.json
+            +-- <name>-<version>.aar
+            +-- pom.xml
         */
 
         std::unordered_map<std::string, std::string> version_map;

--- a/toolsrc/src/vcpkg/registries.cpp
+++ b/toolsrc/src/vcpkg/registries.cpp
@@ -243,7 +243,7 @@ namespace
         fs::path path_to_registry_database(const VcpkgPaths& paths) const
         {
             fs::path path_to_db = paths.config_root_dir / path;
-            path_to_db /= fs::u8path({'\xF0', '\x9F', '\x98', '\x87'}); // utf-8 for 😇
+            path_to_db /= fs::u8path({'\xF0', '\x9F', '\x98', '\x87'}); // utf-8 for https://emojipedia.org/smiling-face-with-halo/
             return path_to_db;
         }
 

--- a/toolsrc/src/vcpkg/registries.cpp
+++ b/toolsrc/src/vcpkg/registries.cpp
@@ -243,7 +243,8 @@ namespace
         fs::path path_to_registry_database(const VcpkgPaths& paths) const
         {
             fs::path path_to_db = paths.config_root_dir / path;
-            path_to_db /= fs::u8path({'\xF0', '\x9F', '\x98', '\x87'}); // utf-8 for https://emojipedia.org/smiling-face-with-halo/
+            path_to_db /= fs::u8path(
+                {'\xF0', '\x9F', '\x98', '\x87'}); // utf-8 for https://emojipedia.org/smiling-face-with-halo/
             return path_to_db;
         }
 


### PR DESCRIPTION
Comment-only modification but fixes #15093 .

The C4819 warnings are introduced by UTF-8 characters in the comments.
So, I converted UTF-8 characters into Laten-1 ASCII characters.
