### PR TITLE
[opencv4] set LD_LIBRARY_PATH to fix dynamic build

### DIFF
--- a/docs/maintainers/vcpkg_build_cmake.md
+++ b/docs/maintainers/vcpkg_build_cmake.md
@@ -18,6 +18,9 @@ be passed.
 ### ADD_BIN_TO_PATH
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
 
+### ADD_LIB_TO_LD_LIBRARY_PATH
+Adds the appropriate Release and Debug `lib\` directories to the LD_LIBRARY_PATH on Unix during the build such that executables can run against the in-tree .so.
+
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
 You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -359,7 +359,7 @@ vcpkg_configure_cmake(
         ${ADDITIONAL_BUILD_FLAGS}
 )
 
-vcpkg_install_cmake()
+vcpkg_install_cmake(ADD_LIB_TO_LD_LIBRARY_PATH)
 vcpkg_fixup_cmake_targets(CONFIG_PATH "share/opencv" TARGET_PATH "share/opencv")
 vcpkg_copy_pdbs()
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 

Fixes #15101

The idea is to add a special option (`ADD_LIB_TO_LD_LIBRARY_PATH`) to `vcpkg_build_cmake()`, so it can handle, as it does for `PATH`, dynamic .so used by tools. The name of the option has been arbitrary chosen, feel free to suggest anything better.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Only Unix builds should be impacted.

