### PR TITLE
[vcpkg] Fix CMAKE_CURRENT_LIST_DIR in load_dep_info_vars()

### DIFF
--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -184,6 +184,10 @@ namespace vcpkg::Files
                                  std::error_code& ec) = 0;
         void write_contents(const fs::path& path, const std::string& data, LineInfo linfo);
         virtual void write_contents(const fs::path& file_path, const std::string& data, std::error_code& ec) = 0;
+        void write_contents_and_dirs(const fs::path& path, const std::string& data, LineInfo linfo);
+        virtual void write_contents_and_dirs(const fs::path& file_path,
+                                             const std::string& data,
+                                             std::error_code& ec) = 0;
         void rename(const fs::path& oldpath, const fs::path& newpath, LineInfo linfo);
         virtual void rename(const fs::path& oldpath, const fs::path& newpath, std::error_code& ec) = 0;
         virtual void rename_or_copy(const fs::path& oldpath,

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -465,6 +465,14 @@ namespace vcpkg::Files
         this->write_contents(path, data, ec);
         if (ec) Checks::exit_with_message(linfo, "error writing file: %s: %s", fs::u8string(path), ec.message());
     }
+    void Filesystem::write_contents_and_dirs(const fs::path& path, const std::string& data, LineInfo linfo)
+    {
+        std::error_code ec;
+        this->write_contents_and_dirs(path, data, ec);
+        if (ec)
+            Checks::exit_with_message(
+                linfo, "error writing file and creating directories: %s: %s", fs::u8string(path), ec.message());
+    }
     void Filesystem::rename(const fs::path& oldpath, const fs::path& newpath, LineInfo linfo)
     {
         std::error_code ec;
@@ -1146,6 +1154,22 @@ namespace vcpkg::Files
                 {
                     ec = std::make_error_code(std::errc::no_space_on_device);
                 }
+            }
+        }
+
+        virtual void write_contents_and_dirs(const fs::path& file_path,
+                                             const std::string& data,
+                                             std::error_code& ec) override
+        {
+            write_contents(file_path, data, ec);
+            if (ec)
+            {
+                create_directories(file_path.parent_path(), ec);
+                if (ec)
+                {
+                    return;
+                }
+                write_contents(file_path, data, ec);
             }
         }
 

--- a/toolsrc/src/vcpkg/cmakevars.cpp
+++ b/toolsrc/src/vcpkg/cmakevars.cpp
@@ -34,9 +34,9 @@ namespace vcpkg::CMakeVars
 
             void load_generic_triplet_vars(Triplet triplet) const override;
 
-            void load_dep_info_vars(Span<const PackageSpec> specs) const override;
+            void load_dep_info_vars(View<PackageSpec> specs) const override;
 
-            void load_tag_vars(Span<const FullPackageSpec> specs,
+            void load_tag_vars(View<FullPackageSpec> specs,
                                const PortFileProvider::PortFileProvider& port_provider) const override;
 
             Optional<const std::unordered_map<std::string, std::string>&> get_generic_triplet_vars(
@@ -50,9 +50,9 @@ namespace vcpkg::CMakeVars
 
         public:
             fs::path create_tag_extraction_file(
-                const Span<const std::pair<const FullPackageSpec*, std::string>>& spec_abi_settings) const;
+                const View<std::pair<const FullPackageSpec*, std::string>> spec_abi_settings) const;
 
-            fs::path create_dep_info_extraction_file(const Span<const PackageSpec> specs) const;
+            fs::path create_dep_info_extraction_file(const View<PackageSpec> specs) const;
 
             void launch_and_split(const fs::path& script_path,
                                   std::vector<std::vector<std::pair<std::string, std::string>>>& vars) const;
@@ -71,26 +71,16 @@ namespace vcpkg::CMakeVars
         return std::make_unique<TripletCMakeVarProvider>(paths);
     }
 
-    fs::path TripletCMakeVarProvider::create_tag_extraction_file(
-        const Span<const std::pair<const FullPackageSpec*, std::string>>& spec_abi_settings) const
+    static std::string create_extraction_file_prelude(const VcpkgPaths& paths,
+                                                      const std::map<Triplet, int>& emitted_triplets)
     {
-        Files::Filesystem& fs = paths.get_filesystem();
-        static int tag_extract_id = 0;
+        const auto& fs = paths.get_filesystem();
+        std::string extraction_file("macro(vcpkg_triplet_file VCPKG_TRIPLET_ID)\n");
 
-        std::string extraction_file("include(\"" + fs::generic_u8string(get_tags_path) + "\")\n\n");
-
-        std::map<Triplet, int> emitted_triplets;
-        int emitted_triplet_id = 0;
-        for (const auto& spec_abi_setting : spec_abi_settings)
-        {
-            emitted_triplets[spec_abi_setting.first->package_spec.triplet()] = emitted_triplet_id++;
-        }
-
-        Strings::append(extraction_file, "macro(vcpkg_triplet_file VCPKG_TRIPLET_ID)\n");
         Strings::append(extraction_file,
                         "set(_vcpkg_triplet_file_BACKUP_CURRENT_LIST_FILE \"${CMAKE_CURRENT_LIST_FILE}\")\n");
 
-        for (auto& p : emitted_triplets)
+        for (auto&& p : emitted_triplets)
         {
             auto path_to_triplet = paths.get_triplet_file_path(p.first);
             Strings::append(extraction_file, "if(VCPKG_TRIPLET_ID EQUAL ", p.second, ")\n");
@@ -99,14 +89,33 @@ namespace vcpkg::CMakeVars
             Strings::append(
                 extraction_file,
                 "get_filename_component(CMAKE_CURRENT_LIST_DIR \"${CMAKE_CURRENT_LIST_FILE}\" DIRECTORY)\n");
-            Strings::append(extraction_file, fs.read_contents(paths.get_triplet_file_path(p.first), VCPKG_LINE_INFO));
+            Strings::append(extraction_file, fs.read_contents(path_to_triplet, VCPKG_LINE_INFO));
             Strings::append(extraction_file, "\nendif()\n");
         }
         Strings::append(extraction_file,
-                        "set(CMAKE_CURRENT_LIST_FILE \"${_vcpkg_triplet_file_BACKUP_CURRENT_LIST_FILE}\")\n");
-        Strings::append(extraction_file,
-                        "get_filename_component(CMAKE_CURRENT_LIST_DIR \"${CMAKE_CURRENT_LIST_FILE}\" DIRECTORY)\n");
-        Strings::append(extraction_file, "endmacro()\n");
+                        R"(
+set(CMAKE_CURRENT_LIST_FILE "${_vcpkg_triplet_file_BACKUP_CURRENT_LIST_FILE}")
+get_filename_component(CMAKE_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+endmacro()
+)");
+        return extraction_file;
+    }
+
+    fs::path TripletCMakeVarProvider::create_tag_extraction_file(
+        const View<std::pair<const FullPackageSpec*, std::string>> spec_abi_settings) const
+    {
+        Files::Filesystem& fs = paths.get_filesystem();
+        static int tag_extract_id = 0;
+
+        std::map<Triplet, int> emitted_triplets;
+        int emitted_triplet_id = 0;
+        for (const auto& spec_abi_setting : spec_abi_settings)
+        {
+            emitted_triplets[spec_abi_setting.first->package_spec.triplet()] = emitted_triplet_id++;
+        }
+        std::string extraction_file = create_extraction_file_prelude(paths, emitted_triplets);
+
+        Strings::append(extraction_file, "\ninclude(\"" + fs::generic_u8string(get_tags_path) + "\")\n\n");
 
         for (const auto& spec_abi_setting : spec_abi_settings)
         {
@@ -125,19 +134,14 @@ namespace vcpkg::CMakeVars
         }
 
         fs::path path = paths.buildtrees / Strings::concat(tag_extract_id++, ".vcpkg_tags.cmake");
-
-        fs.create_directories(paths.buildtrees, ignore_errors);
-        fs.write_contents(path, extraction_file, VCPKG_LINE_INFO);
-
+        fs.write_contents_and_dirs(path, extraction_file, VCPKG_LINE_INFO);
         return path;
     }
 
-    fs::path TripletCMakeVarProvider::create_dep_info_extraction_file(const Span<const PackageSpec> specs) const
+    fs::path TripletCMakeVarProvider::create_dep_info_extraction_file(const View<PackageSpec> specs) const
     {
         static int dep_info_id = 0;
         Files::Filesystem& fs = paths.get_filesystem();
-
-        std::string extraction_file("include(\"" + fs::generic_u8string(get_dep_info_path) + "\")\n\n");
 
         std::map<Triplet, int> emitted_triplets;
         int emitted_triplet_id = 0;
@@ -145,17 +149,10 @@ namespace vcpkg::CMakeVars
         {
             emitted_triplets[spec.triplet()] = emitted_triplet_id++;
         }
-        Strings::append(extraction_file, "macro(vcpkg_triplet_file VCPKG_TRIPLET_ID)\n");
-        for (auto& p : emitted_triplets)
-        {
-            Strings::append(extraction_file,
-                            "if(VCPKG_TRIPLET_ID EQUAL ",
-                            p.second,
-                            ")\n",
-                            fs.read_contents(paths.get_triplet_file_path(p.first), VCPKG_LINE_INFO),
-                            "\nendif()\n");
-        }
-        Strings::append(extraction_file, "endmacro()\n");
+
+        std::string extraction_file = create_extraction_file_prelude(paths, emitted_triplets);
+
+        Strings::append(extraction_file, "\ninclude(\"" + fs::generic_u8string(get_dep_info_path) + "\")\n\n");
 
         for (const PackageSpec& spec : specs)
         {
@@ -164,11 +161,7 @@ namespace vcpkg::CMakeVars
         }
 
         fs::path path = paths.buildtrees / Strings::concat(dep_info_id++, ".vcpkg_dep_info.cmake");
-
-        std::error_code ec;
-        fs.create_directories(paths.buildtrees, ec);
-        fs.write_contents(path, extraction_file, VCPKG_LINE_INFO);
-
+        fs.write_contents_and_dirs(path, extraction_file, VCPKG_LINE_INFO);
         return path;
     }
 
@@ -237,7 +230,7 @@ namespace vcpkg::CMakeVars
                                              std::make_move_iterator(vars.front().end()));
     }
 
-    void TripletCMakeVarProvider::load_dep_info_vars(Span<const PackageSpec> specs) const
+    void TripletCMakeVarProvider::load_dep_info_vars(View<PackageSpec> specs) const
     {
         if (specs.size() == 0) return;
         std::vector<std::vector<std::pair<std::string, std::string>>> vars(specs.size());
@@ -260,7 +253,7 @@ namespace vcpkg::CMakeVars
         }
     }
 
-    void TripletCMakeVarProvider::load_tag_vars(Span<const FullPackageSpec> specs,
+    void TripletCMakeVarProvider::load_tag_vars(View<FullPackageSpec> specs,
                                                 const PortFileProvider::PortFileProvider& port_provider) const
     {
         if (specs.size() == 0) return;


### PR DESCRIPTION
#14661 fixed `CMAKE_CURRENT_LIST_DIR` for tags but not for dep_info_vars. This PR extracts the common sequence to fix the issue for both.