### PR TITLE
[ffmpeg] fix up the pkgconfig files

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
 Version: 4.3.1
-Port-Version: 8
+Port-Version: 9
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -511,6 +511,47 @@ endif()
 
 vcpkg_copy_pdbs()
 
+if (VCPKG_TARGET_IS_WINDOWS)
+    # Translate cygpath to local path
+    set(CYGPATH_CMD ${MSYS_ROOT}/usr/bin/cygpath.exe -w)
+    
+    foreach(PKGCONFIG_PATH ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
+        file(GLOB PKGCONFIG_FILES ${PKGCONFIG_PATH}/*.pc)
+        foreach(PKGCONFIG_FILE ${PKGCONFIG_FILES})
+            file(READ ${PKGCONFIG_FILE} PKGCONFIG_CONTENT)
+            foreach(PATH_NAME prefix libdir includedir)
+                string(REGEX MATCH "${PATH_NAME}=[^\n]*\n" PATH_VALUE ${PKGCONFIG_CONTENT})
+                string(REPLACE "${PATH_NAME}=" "" PATH_VALUE ${PATH_VALUE})
+                string(REPLACE "\n" "" PATH_VALUE ${PATH_VALUE})
+                set(${PATH_NAME}_cygpath ${PATH_VALUE})
+            endforeach()
+            execute_process(
+                COMMAND ${CYGPATH_CMD} "${prefix_dir}"
+                OUTPUT_VARIABLE FIXED_PREFIX_PATH
+            )
+            string(REPLACE "\n" "" FIXED_PREFIX_PATH ${FIXED_PREFIX_PATH})
+			file(TO_CMAKE_PATH ${FIXED_PREFIX_PATH} FIXED_PREFIX_PATH)
+            execute_process(
+                COMMAND ${CYGPATH_CMD} "${libdir_dir}"
+                OUTPUT_VARIABLE FIXED_LIBDIR_PATH
+            )
+            string(REPLACE "\n" "" FIXED_LIBDIR_PATH ${FIXED_LIBDIR_PATH})
+			file(TO_CMAKE_PATH ${FIXED_LIBDIR_PATH} FIXED_LIBDIR_PATH)
+            execute_process(
+                COMMAND ${CYGPATH_CMD} "${includedir_dir}"
+                OUTPUT_VARIABLE FIXED_INCLUDE_PATH
+            )
+            string(REPLACE "\n" "" FIXED_INCLUDE_PATH ${FIXED_INCLUDE_PATH})
+			file(TO_CMAKE_PATH ${FIXED_INCLUDE_PATH} FIXED_INCLUDE_PATH)
+            vcpkg_replace_string(${PKGCONFIG_FILE} "${prefix_cygpath}" "${FIXED_PREFIX_PATH}")
+            vcpkg_replace_string(${PKGCONFIG_FILE} "${libdir_cygpath}" "${FIXED_LIBDIR_PATH}")
+            vcpkg_replace_string(${PKGCONFIG_FILE} "${includedir_cygpath}" "${FIXED_INCLUDE_PATH}")
+        endforeach()
+    endforeach()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
 # Handle copyright
 file(STRINGS ${CURRENT_BUILDTREES_DIR}/build-${TARGET_TRIPLET}-rel-out.log LICENSE_STRING REGEX "License: .*" LIMIT_COUNT 1)
 if(LICENSE_STRING STREQUAL "License: LGPL version 2.1 or later")

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -526,23 +526,24 @@ if (VCPKG_TARGET_IS_WINDOWS)
                 set(${PATH_NAME}_cygpath ${PATH_VALUE})
             endforeach()
             execute_process(
-                COMMAND ${CYGPATH_CMD} "${prefix_dir}"
+                COMMAND ${CYGPATH_CMD} "${prefix_cygpath}"
                 OUTPUT_VARIABLE FIXED_PREFIX_PATH
             )
             string(REPLACE "\n" "" FIXED_PREFIX_PATH ${FIXED_PREFIX_PATH})
-			file(TO_CMAKE_PATH ${FIXED_PREFIX_PATH} FIXED_PREFIX_PATH)
+            file(TO_CMAKE_PATH ${FIXED_PREFIX_PATH} FIXED_PREFIX_PATH)
             execute_process(
-                COMMAND ${CYGPATH_CMD} "${libdir_dir}"
+                COMMAND ${CYGPATH_CMD} "${libdir_cygpath}"
                 OUTPUT_VARIABLE FIXED_LIBDIR_PATH
             )
             string(REPLACE "\n" "" FIXED_LIBDIR_PATH ${FIXED_LIBDIR_PATH})
-			file(TO_CMAKE_PATH ${FIXED_LIBDIR_PATH} FIXED_LIBDIR_PATH)
+            file(TO_CMAKE_PATH ${FIXED_LIBDIR_PATH} FIXED_LIBDIR_PATH)
             execute_process(
-                COMMAND ${CYGPATH_CMD} "${includedir_dir}"
+                COMMAND ${CYGPATH_CMD} "${includedir_cygpath}"
                 OUTPUT_VARIABLE FIXED_INCLUDE_PATH
             )
             string(REPLACE "\n" "" FIXED_INCLUDE_PATH ${FIXED_INCLUDE_PATH})
-			file(TO_CMAKE_PATH ${FIXED_INCLUDE_PATH} FIXED_INCLUDE_PATH)
+            file(TO_CMAKE_PATH ${FIXED_INCLUDE_PATH} FIXED_INCLUDE_PATH)
+            
             vcpkg_replace_string(${PKGCONFIG_FILE} "${prefix_cygpath}" "${FIXED_PREFIX_PATH}")
             vcpkg_replace_string(${PKGCONFIG_FILE} "${libdir_cygpath}" "${FIXED_LIBDIR_PATH}")
             vcpkg_replace_string(${PKGCONFIG_FILE} "${includedir_cygpath}" "${FIXED_INCLUDE_PATH}")

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -513,24 +513,24 @@ vcpkg_copy_pdbs()
 
 if (VCPKG_TARGET_IS_WINDOWS)
     # Translate cygpath to local path
-    set(CYGPATH_CMD ${MSYS_ROOT}/usr/bin/cygpath.exe -w)
+    set(CYGPATH_CMD "${MSYS_ROOT}/usr/bin/cygpath.exe" -w)
     
-    foreach(PKGCONFIG_PATH ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
-        file(GLOB PKGCONFIG_FILES ${PKGCONFIG_PATH}/*.pc)
-        foreach(PKGCONFIG_FILE ${PKGCONFIG_FILES})
-            file(READ ${PKGCONFIG_FILE} PKGCONFIG_CONTENT)
+    foreach(PKGCONFIG_PATH "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+        file(GLOB PKGCONFIG_FILES "${PKGCONFIG_PATH}/*.pc")
+        foreach(PKGCONFIG_FILE IN LISTS PKGCONFIG_FILES)
+            file(READ "${PKGCONFIG_FILE}" PKGCONFIG_CONTENT)
             foreach(PATH_NAME prefix libdir includedir)
-                string(REGEX MATCH "${PATH_NAME}=[^\n]*\n" PATH_VALUE ${PKGCONFIG_CONTENT})
-                string(REPLACE "${PATH_NAME}=" "" PATH_VALUE ${PATH_VALUE})
-                string(REPLACE "\n" "" PATH_VALUE ${PATH_VALUE})
-                set(${PATH_NAME}_cygpath ${PATH_VALUE})
+                string(REGEX MATCH "${PATH_NAME}=[^\n]*\n" PATH_VALUE "${PKGCONFIG_CONTENT}")
+                string(REPLACE "${PATH_NAME}=" "" PATH_VALUE "${PATH_VALUE}")
+                string(REPLACE "\n" "" PATH_VALUE "${PATH_VALUE}")
+                set("${PATH_NAME}_cygpath" "${PATH_VALUE}")
             endforeach()
             execute_process(
                 COMMAND ${CYGPATH_CMD} "${prefix_cygpath}"
                 OUTPUT_VARIABLE FIXED_PREFIX_PATH
             )
-            string(REPLACE "\n" "" FIXED_PREFIX_PATH ${FIXED_PREFIX_PATH})
-            file(TO_CMAKE_PATH ${FIXED_PREFIX_PATH} FIXED_PREFIX_PATH)
+            string(REPLACE "\n" "" FIXED_PREFIX_PATH "${FIXED_PREFIX_PATH}")
+            file(TO_CMAKE_PATH "${FIXED_PREFIX_PATH}" FIXED_PREFIX_PATH)
             execute_process(
                 COMMAND ${CYGPATH_CMD} "${libdir_cygpath}"
                 OUTPUT_VARIABLE FIXED_LIBDIR_PATH
@@ -541,12 +541,12 @@ if (VCPKG_TARGET_IS_WINDOWS)
                 COMMAND ${CYGPATH_CMD} "${includedir_cygpath}"
                 OUTPUT_VARIABLE FIXED_INCLUDE_PATH
             )
-            string(REPLACE "\n" "" FIXED_INCLUDE_PATH ${FIXED_INCLUDE_PATH})
+            string(REPLACE "\n" "" FIXED_INCLUDE_PATH "${FIXED_INCLUDE_PATH}")
             file(TO_CMAKE_PATH ${FIXED_INCLUDE_PATH} FIXED_INCLUDE_PATH)
             
-            vcpkg_replace_string(${PKGCONFIG_FILE} "${prefix_cygpath}" "${FIXED_PREFIX_PATH}")
-            vcpkg_replace_string(${PKGCONFIG_FILE} "${libdir_cygpath}" "${FIXED_LIBDIR_PATH}")
-            vcpkg_replace_string(${PKGCONFIG_FILE} "${includedir_cygpath}" "${FIXED_INCLUDE_PATH}")
+            vcpkg_replace_string("${PKGCONFIG_FILE}" "${prefix_cygpath}" "${FIXED_PREFIX_PATH}")
+            vcpkg_replace_string("${PKGCONFIG_FILE}" "${libdir_cygpath}" "${FIXED_LIBDIR_PATH}")
+            vcpkg_replace_string("${PKGCONFIG_FILE}" "${includedir_cygpath}" "${FIXED_INCLUDE_PATH}")
         endforeach()
     endforeach()
 endif()


### PR DESCRIPTION
Since ffmpeg is built using cygin on windows, cygpath format is used instead of local path format when generating pkgconfig, fix this issue.

Fixes #15111.