### PR TITLE
[protobuf] fix rpath for linux dynamic build

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -112,6 +112,11 @@ else()
         file(INSTALL ${E} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}
                 PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ)
     endforeach()
+
+    if(protobuf_BUILD_PROTOC_BINARIES)
+        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    endif()
+
     protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
     protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
 endif()

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -40,5 +40,23 @@ function(vcpkg_copy_tool_dependencies TOOL_DIR)
         endmacro()
         search_for_dependencies("${CURRENT_PACKAGES_DIR}/bin")
         search_for_dependencies("${CURRENT_INSTALLED_DIR}/bin")
+    elseif (VCPKG_TARGET_IS_LINUX AND ("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic"))
+        # Fix RPATH: works but requires patchelf
+        find_program(PATCHELF_FOUND NAMES patchelf)
+        if(PATCHELF_FOUND)
+            file(GLOB TOOLS 
+                LIST_DIRECTORIES FALSE
+                "${TOOL_DIR}/*"
+            )
+            foreach(TOOL IN LISTS TOOLS)
+                execute_process(
+                    COMMAND  patchelf --set-rpath "\$ORIGIN/../../lib" "${TOOL}"
+                    OUTPUT_QUIET
+                    ERROR_QUIET
+                )
+            endforeach()
+        else()
+            message(FATAL_ERROR "`patchelf` is not available. You can install it with `apt install patchelf`")
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
**Describe the pull request**

This is not a definitive PR. It is mostly to discuss about the general issue of dynamic linkage support.

- What does your PR fix? 

It fixes #15101, but not only. Most of the tools won't work or use in reality the system libraries (liblzma "xz" for exemple), because they don't have rpath or an incorrect one. This patch use a tool `patchelf` to patch the appropriate rpath so the tools will find and use the right libraries located at `$ORIGIN/../../lib`

It works, at least for liblzma and protobuf, but need of course to be tested for all tools. Since it requires an external program (I did not found a way in pure CMake..), a better way to acquire it may be needed. Please, I'm open to suggestion for that.

Another option, is to mimic the Windows way, by `BundleUtilities`, something like
```cmake
# Search for all installed libraries
include(BundleUtilities)
file(GLOB_RECURSE LIBS FOLLOW_SYMLINKS "${CURRENT_INSTALLED_DIR}/*${CMAKE_SHARED_LIBRARY_SUFFIX}*")
file(GLOB_RECURSE PACKAGE_LIBS FOLLOW_SYMLINKS "${CURRENT_PACKAGES_DIR}/*${CMAKE_SHARED_LIBRARY_SUFFIX}*")
list(APPEND LIBS ${PACKAGE_LIBS})

...
foreach(tool_name IN LISTS _vct_TOOL_NAMES)
    ...
    # Copy dependencies according to new location
    # Seems to do what vcpkg_copy_tool_dependencies is supposed to do but unfortunately, is not enough to fix RPATH
    fixup_bundle(
        "${CURRENT_PACKAGES_DIR}/tools/${PORT}/${tool_bin}"
        "${LIB}"
        "${CURRENT_PACKAGES_DIR}/lib"
    )
....
```

The rpath patch is still needed, but you can now give "$ORIGIN" as rpath since all .so are locally copied. It mimics the windows way a bit.

What are your though ?

- Which triplets are supported/not supported? 
Only valid for Linux shared build
