### PR TITLE
[boost-modular-build-helper] Specify msvc version in user-config.jam

### DIFF
--- a/ports/boost-modular-build-helper/CONTROL
+++ b/ports/boost-modular-build-helper/CONTROL
@@ -1,4 +1,4 @@
 Source: boost-modular-build-helper
 Version: 1.74.0
-Port-Version: 1
+Port-Version: 2
 Build-Depends: boost-uninstall

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -318,13 +318,16 @@ function(boost_modular_build)
         set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <cflags>-Zl <compileflags> /AI\"${PLATFORM_WINMD_DIR}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
     endif()
 
-    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/user-config.jam @ONLY)
-    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/user-config.jam @ONLY)
-
+    set(MSVC_VERSION)
     if(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
         list(APPEND _bm_OPTIONS toolset=msvc)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v14.")
+        set(MSVC_VERSION 14.2)
+    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
         list(APPEND _bm_OPTIONS toolset=msvc)
+        set(MSVC_VERSION 14.1)
+    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v140")
+        list(APPEND _bm_OPTIONS toolset=msvc)
+        set(MSVC_VERSION 14.0)
     elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v120")
         list(APPEND _bm_OPTIONS toolset=msvc)
     elseif(VCPKG_PLATFORM_TOOLSET MATCHES "external")
@@ -332,6 +335,9 @@ function(boost_modular_build)
     else()
         message(FATAL_ERROR "Unsupported value for VCPKG_PLATFORM_TOOLSET: '${VCPKG_PLATFORM_TOOLSET}'")
     endif()
+
+    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/user-config.jam @ONLY)
+    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/user-config.jam @ONLY)
 
     ######################
     # Perform build + Package

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -2,7 +2,7 @@ import toolset ;
 
 if "@VCPKG_PLATFORM_TOOLSET@" != "external"
 {
-    using msvc : : cl.exe
+    using msvc : @MSVC_VERSION@ : cl.exe
         :
         <setup>"@NOTHING_BAT@"
         @TOOLSET_OPTIONS@


### PR DESCRIPTION
This PR fixes an issue with generated user-config.jam files for non-system-wide copies of MSVC. If the version of MSVC is not specified, boost-build assumes an extremely old version and fails to build.