### PR TITLE
[openexr] Remove python dependency of openexr.

### DIFF
--- a/ports/openexr/CONTROL
+++ b/ports/openexr/CONTROL
@@ -1,7 +1,0 @@
-Source: openexr
-Version: 2.5.0
-Port-Version: 1
-Homepage: https://www.openexr.com/
-Description: OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications
-Build-Depends: zlib, python3
-Supports: !uwp

--- a/ports/openexr/vcpkg.json
+++ b/ports/openexr/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "openexr",
+  "version-string": "2.5.0",
+  "port-version": 2,
+  "description": "OpenEXR is a high dynamic-range (HDR) image file format developed by Industrial Light & Magic for use in computer imaging applications",
+  "homepage": "https://www.openexr.com/",
+  "supports": "!uwp",
+  "dependencies": [
+    "zlib"
+  ]
+}


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/14891 @Hoikas points out that the port depends on Python but the portfile.cmake explicitly disables it with `-DPYILMBASE_ENABLE=FALSE`.