### PR TITLE
[civetweb] Disable extensive log output for debug builds

### DIFF
--- a/ports/civetweb/CONTROL
+++ b/ports/civetweb/CONTROL
@@ -1,5 +1,6 @@
 Source: civetweb
 Version: 1.13
+Port-Version: 1
 Homepage: https://github.com/civetweb/civetweb
 Description: Easy to use, powerful, C/C++ embeddable web server.
 Supports: !uwp

--- a/ports/civetweb/add-option-to-disable-debug-tools.patch
+++ b/ports/civetweb/add-option-to-disable-debug-tools.patch
@@ -1,0 +1,36 @@
+From 111672d5437a3c7f02b66d730be5000dade58bff Mon Sep 17 00:00:00 2001
+From: Gregor Jasny <gjasny@googlemail.com>
+Date: Tue, 15 Dec 2020 14:38:37 +0100
+Subject: [PATCH] CMake: Add option to disable Debug tools
+Origin: https://github.com/civetweb/civetweb/pull/952
+
+Sometimes one needs the CMake `Debug` build type
+to select the Windows Debug runtime. But at the same
+time the verbose logging output might be unwanted.
+
+This PR adds the `CIVETWEB_ENABLE_DEBUG_TOOLS` option
+to disable extensive logging and assertion.
+---
+ CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 368e5640..000f7972 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -476,8 +476,11 @@ endif()
+ 
+ 
+ # Set up the definitions
++option(CIVETWEB_ENABLE_DEBUG_TOOLS "For Debug builds enable verbose logging and assertions" ON)
+ if (${CMAKE_BUILD_TYPE} MATCHES "[Dd]ebug")
+-  add_definitions(-DDEBUG)
++  if(CIVETWEB_ENABLE_DEBUG_TOOLS)
++    add_definitions(-DDEBUG)
++  endif()
+   add_definitions(-O0)
+   add_definitions(-g)
+ endif()
+-- 
+2.29.2
+

--- a/ports/civetweb/portfile.cmake
+++ b/ports/civetweb/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     REF 8e243456965c9be5212cb96519da69cd54550e3d # v1.13
     SHA512 6f9daf404975697c6b7a56cc71006aaf14442acf545e483d8a7b845f255d5e5d6e08194fe3350a667e0b737b6924c9d39b025b587af27e7f12cd7b64f314eb70
     HEAD_REF master
+    PATCHES "add-option-to-disable-debug-tools.patch"
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -19,6 +20,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DCIVETWEB_BUILD_TESTING=OFF
+        -DCIVETWEB_ENABLE_DEBUG_TOOLS=OFF
         -DCIVETWEB_ENABLE_ASAN=OFF
         -DCIVETWEB_ENABLE_CXX=ON
         -DCIVETWEB_ENABLE_IPV6=ON


### PR DESCRIPTION
Hello,

this patch removes overly verbose output of civetweb in `Debug` builds. This output is unconditionally printed to stdout.

```
*** 1608147558.169509000 4595015104 mg_start2:19608: [listening_ports] -> [127.0.0.1:0]
*** 1608147558.169531000 4595015104 mg_start2:19608: [num_threads] -> [2]
*** 1608147558.169817000 123145365999616 consume_socket:18713: going idle
*** 1608147558.169847000 123145366114304 consume_socket:18713: going idle
*** 1608147558.171559000 123145366228992 accept_new_connection:19032: Accepted socket 7
*** 1608147558.171584000 123145366228992 produce_socket:18771: queued socket 7
*** 1608147558.171621000 123145365999616 consume_socket:18727: grabbed socket 7, going busy
*** 1608147558.171676000 123145365999616 worker_thread_run:18881: Start processing connection from 127.0.0.1
*** 1608147558.171685000 123145365999616 process_new_connection:18442: Start processing connection from 127.0.0.1
*** 1608147558.171689000 123145365999616 process_new_connection:18449: calling get_request (1 times for this connection)
*** 1608147558.171747000 123145365999616 switch_domain_context:13818: HTTP Host: 127.0.0.1
*** 1608147558.171757000 123145365999616 process_new_connection:18536: http: 1.1, error: none
*** 1608147558.171764000 123145365999616 handle_request:14354: URL: /metrics
*** 1608147558.171796000 123145365999616 open_auth_file:8754: fopen(/.htpasswd): No such file or directory
*** 1608147558.171808000 123145365999616 mg_send_http_error_impl:4939: Error 404 - [Not Found]
*** 1608147558.173098000 123145365999616 process_new_connection:18556: handle_request done
*** 1608147558.173122000 123145365999616 process_new_connection:18630: Done processing connection from 127.0.0.1 (0.000000 sec)
*** 1608147558.173163000 123145365999616 worker_thread_run:18950: Connection closed
*** 1608147558.173167000 123145365999616 consume_socket:18713: going idle
*** 1608147558.376629000 123145366228992 master_thread_run:19164: stopping workers
*** 1608147558.376686000 123145366114304 worker_thread_run:18978: exiting
*** 1608147558.376691000 123145365999616 worker_thread_run:18978: exiting
*** 1608147558.376732000 123145366228992 master_thread_run:19203: exiting
```

I opened an upstream civetweb/civetweb#952 with the same patch as well.

Thanks,
Gregor