### PR TITLE
[cppmicroservices] Fix warning C4834

### DIFF
--- a/ports/cppmicroservices/CONTROL
+++ b/ports/cppmicroservices/CONTROL
@@ -1,5 +1,6 @@
 Source: cppmicroservices
-Version: 3.4.0-1
+Version: 3.4.0
+Port-Version: 2
 Homepage: https://github.com/CppMicroServices/CppMicroServices
 Description: An OSGi-like C++ dynamic module system and service registry
 Build-Depends: gtest

--- a/ports/cppmicroservices/fix-warning-c4834.patch
+++ b/ports/cppmicroservices/fix-warning-c4834.patch
@@ -1,0 +1,25 @@
+diff --git a/httpservice/src/ServletContainer.cpp b/httpservice/src/ServletContainer.cpp
+index b4af8c9..8713066 100644
+--- a/httpservice/src/ServletContainer.cpp
++++ b/httpservice/src/ServletContainer.cpp
+@@ -279,7 +279,9 @@ void ServletContainer::SetContextPath(const std::string& path)
+ 
+ std::string ServletContainer::GetContextPath() const
+ {
+-  return Lock(d->m_Mutex), d->m_ContextPath;
++  Lock l(d->m_Mutex);
++  US_UNUSED(l);
++  return d->m_ContextPath;
+ }
+ 
+ void ServletContainer::Start()
+@@ -306,6 +308,8 @@ std::shared_ptr<ServletContext> ServletContainer::GetContext(
+ std::string ServletContainer::GetContextPath(
+   const ServletContext* /*context*/) const
+ {
+-  return Lock(d->m_Mutex), d->m_ContextPath;
++  Lock l(d->m_Mutex);
++  US_UNUSED(l);
++  return d->m_ContextPath;
+ }
+ }

--- a/ports/cppmicroservices/portfile.cmake
+++ b/ports/cppmicroservices/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         werror.patch
         fix-dependency-gtest.patch
+        fix-warning-c4834.patch
 )
 
 vcpkg_configure_cmake(
@@ -21,7 +22,6 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
 
 vcpkg_fixup_cmake_targets()
 


### PR DESCRIPTION
**Describe the pull request**
Since the change: https://github.com/microsoft/STL/pull/1495 , [nodiscard] was added before some constructors, this change causes the warning C4834: discarding return value of function with 'nodiscard' attribute occurs when install port cppmicroservices. 

The change of STL is by design, so I add a patch to modify the source code. 

