### PR TITLE
[WIP] Add x-usage command

### DIFF
--- a/toolsrc/include/vcpkg/commands.usage.h
+++ b/toolsrc/include/vcpkg/commands.usage.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vcpkg/commands.interface.h>
+
+namespace vcpkg::Commands::Usage
+{
+    struct UsageCommand : TripletCommand
+    {
+        virtual void perform_and_exit(const VcpkgCmdArguments& args,
+                                      const VcpkgPaths& paths,
+                                      Triplet default_triplet) const override;
+    };
+}

--- a/toolsrc/src/vcpkg-test/commands.cpp
+++ b/toolsrc/src/vcpkg-test/commands.cpp
@@ -76,6 +76,7 @@ TEST_CASE ("get_available_commands_type_a works", "[commands]")
         "build-external",
         "export",
         "depend-info",
+        "x-usage",
         });
 }
 // clang-format on

--- a/toolsrc/src/vcpkg/commands.cpp
+++ b/toolsrc/src/vcpkg/commands.cpp
@@ -25,6 +25,7 @@
 #include <vcpkg/commands.setinstalled.h>
 #include <vcpkg/commands.upgrade.h>
 #include <vcpkg/commands.upload-metrics.h>
+#include <vcpkg/commands.usage.h>
 #include <vcpkg/commands.version.h>
 #include <vcpkg/commands.xvsinstances.h>
 #include <vcpkg/export.h>
@@ -110,6 +111,7 @@ namespace vcpkg::Commands
         static const BuildExternal::BuildExternalCommand build_external{};
         static const Export::ExportCommand export_command{};
         static const DependInfo::DependInfoCommand depend_info{};
+        static const Usage::UsageCommand usage{};
 
         static std::vector<PackageNameAndFunction<const TripletCommand*>> t = {
             {"install", &install},
@@ -122,6 +124,7 @@ namespace vcpkg::Commands
             {"build-external", &build_external},
             {"export", &export_command},
             {"depend-info", &depend_info},
+            {"x-usage", &usage},
         };
         return t;
     }

--- a/toolsrc/src/vcpkg/commands.usage.cpp
+++ b/toolsrc/src/vcpkg/commands.usage.cpp
@@ -1,0 +1,57 @@
+#include <vcpkg/commands.usage.h>
+#include <vcpkg/input.h>
+#include <vcpkg/install.h>
+#include <vcpkg/statusparagraphs.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkglib.h>
+
+namespace vcpkg::Commands::Usage
+{
+    const CommandStructure COMMAND_STRUCTURE = {
+        Strings::format("Display usage information for packages.\n%s", create_example_string("x-usage zlib openssl")),
+        1,
+        SIZE_MAX,
+        {},
+        nullptr,
+    };
+
+    void UsageCommand::perform_and_exit(const VcpkgCmdArguments& args,
+                                        const VcpkgPaths& paths,
+                                        Triplet default_triplet) const
+    {
+        const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
+
+        const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
+            return Input::check_and_get_full_package_spec(
+                std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text);
+        });
+
+        const StatusParagraphs status_paragraphs = database_load_check(paths);
+
+        std::set<std::string> not_installed;
+        for (auto&& spec : specs)
+        {
+            auto maybe_ipv = status_paragraphs.get_installed_package_view(spec.package_spec);
+            if (vcpkg::InstalledPackageView* ipv = maybe_ipv.get())
+            {
+                auto&& usage_info = Install::get_cmake_usage(ipv->core->package, paths);
+
+                if (!usage_info.message.empty())
+                {
+                    System::print2(usage_info.message);
+                }
+            }
+            else
+            {
+                not_installed.emplace(spec.package_spec.to_string());
+            }
+        }
+
+        for (auto&& package : not_installed)
+        {
+            System::printf(System::Color::error, "Package %s is not installed.\n", package);
+        }
+
+        Checks::exit_success(VCPKG_LINE_INFO);
+    }
+}

--- a/toolsrc/src/vcpkg/commands.usage.cpp
+++ b/toolsrc/src/vcpkg/commands.usage.cpp
@@ -8,7 +8,8 @@
 namespace vcpkg::Commands::Usage
 {
     const CommandStructure COMMAND_STRUCTURE = {
-        Strings::format("Display usage information for packages.\n%s", create_example_string("x-usage zlib openssl")),
+        Strings::format("Display usage information for installed packages.\n%s",
+                        create_example_string("x-usage zlib openssl")),
         1,
         SIZE_MAX,
         {},

--- a/toolsrc/windows-bootstrap/vcpkg.vcxproj
+++ b/toolsrc/windows-bootstrap/vcpkg.vcxproj
@@ -236,6 +236,7 @@
     <ClInclude Include="..\include\vcpkg\commands.search.h" />
     <ClInclude Include="..\include\vcpkg\commands.setinstalled.h" />
     <ClInclude Include="..\include\vcpkg\commands.upgrade.h" />
+    <ClInclude Include="..\include\vcpkg\commands.usage.h" />
     <ClInclude Include="..\include\vcpkg\commands.version.h" />
     <ClInclude Include="..\include\vcpkg\commands.xvsinstances.h" />
     <ClInclude Include="..\include\vcpkg\dependencies.h" />
@@ -326,6 +327,7 @@
     <ClCompile Include="..\src\vcpkg\commands.search.cpp" />
     <ClCompile Include="..\src\vcpkg\commands.setinstalled.cpp" />
     <ClCompile Include="..\src\vcpkg\commands.upgrade.cpp" />
+    <ClCompile Include="..\src\vcpkg\commands.usage.cpp" />
     <ClCompile Include="..\src\vcpkg\commands.upload-metrics.cpp" />
     <ClCompile Include="..\src\vcpkg\commands.version.cpp" />
     <ClCompile Include="..\src\vcpkg\commands.xvsinstances.cpp" />


### PR DESCRIPTION
Partial implementation of feature request in #15242

Packages need to be installed in order to extract usage information.

### Examples

#### In classic mode
```
PS D:\vpckg> ./vcpkg x-set-installed fmt zlib rapidjson
...
PS D:\vcpkg> ./vcpkg x-usage fmt zlib rapidjson --triplet-x64-windows
The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

The package fmt provides CMake targets:

    find_package(fmt CONFIG REQUIRED)
    target_link_libraries(main PRIVATE fmt::fmt)

    # Or use the header-only version
    target_link_libraries(main PRIVATE fmt::fmt-header-only)

The package rapidjson provides CMake integration:

    find_package(RapidJSON CONFIG REQUIRED)
    target_include_directories(main PRIVATE ${RAPIDJSON_INCLUDE_DIRS})

```


#### In a folder containing a manifest file (`vcpkg.json`)
```powershell
PS D:\test-project> ../vcpkg/vcpkg install --triplet x64-windows
...
PS D:\test-project> ../vcpkg/vcpkg x-usage fmt zlib rapidjson--triplet x64-windows
The package fmt provides CMake targets:

    find_package(fmt CONFIG REQUIRED)
    target_link_libraries(main PRIVATE fmt::fmt)

    # Or use the header-only version
    target_link_libraries(main PRIVATE fmt::fmt-header-only)

The package zlib is compatible with built-in CMake targets:

    find_package(ZLIB REQUIRED)
    target_link_libraries(main PRIVATE ZLIB::ZLIB)

Package rapidjson:x64-windows is not installed.
```

_Note: The `x-usage` command does not work properly when the `vcpkg.json` file and the `vcpkg_installed` directory are not at the same level._

Unfortunately, this means that this won't work on projects that rely on CMake automatically installing the dependencies from the manifest file by passing the toolchain in their invocation. Since they get installed in `build/vcpkg_installed`.  