### PR TITLE
[protobuf] Fix the default proto file path

### DIFF
--- a/ports/protobuf/CONTROL
+++ b/ports/protobuf/CONTROL
@@ -1,5 +1,6 @@
 Source: protobuf
 Version: 3.14.0
+Port-Version: 1
 Homepage: https://github.com/protocolbuffers/protobuf
 Description: Protocol Buffers - Google's data interchange format
 

--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -6,7 +6,7 @@ index f192ae6..22900ed 100644
      return;
    }
    // Check if the upper level directory has an "include" subdirectory.
-+  // Suitable for vcpkg directory structure
++  // change "'$/bin' is next to 'include'" assumption to "'$/bin/tools' is next to 'include'"
 +  for (int i = 0; i < 2; i++)
 +  {
    pos = path.find_last_of("/\\");

--- a/ports/protobuf/fix-default-proto-file-path.patch
+++ b/ports/protobuf/fix-default-proto-file-path.patch
@@ -1,0 +1,20 @@
+diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
+index f192ae6..22900ed 100644
+--- a/src/google/protobuf/compiler/command_line_interface.cc
++++ b/src/google/protobuf/compiler/command_line_interface.cc
+@@ -260,11 +260,15 @@ void AddDefaultProtoPaths(
+     return;
+   }
+   // Check if the upper level directory has an "include" subdirectory.
++  // Suitable for vcpkg directory structure
++  for (int i = 0; i < 2; i++)
++  {
+   pos = path.find_last_of("/\\");
+   if (pos == std::string::npos || pos == 0) {
+     return;
+   }
+   path = path.substr(0, pos);
++  }
+   if (IsInstalledProtoPath(path + "/include")) {
+     paths->push_back(
+         std::pair<std::string, std::string>("", path + "/include"));

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-static-build.patch
+        fix-default-proto-file-path.patch
 )
 
 if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")


### PR DESCRIPTION
Because the vcpkg policy is that all tools should be installed in the _tools_ directory, this is inconsistent with the default installation path of protobuf itself(_bin_), which leads to the problem of protobuf automatically finding the include path.
Fix this.

See source code:
https://github.com/protocolbuffers/protobuf/blob/64dd751868d633421563e53e68da831a0a02c923/src/google/protobuf/compiler/command_line_interface.cc#L256-L272

fixes #15217.

Note: already tested the executable usage manually.