### PR TITLE
[libsodium] use x64 specific gcc options only on x64 platform

### DIFF
--- a/ports/libsodium/CMakeLists.txt
+++ b/ports/libsodium/CMakeLists.txt
@@ -208,130 +208,111 @@ else ()
     sodium_check_func(posix_memalign HAVE_POSIX_MEMALIGN)
     sodium_check_func(getpid HAVE_GETPID)
 
-    check_c_source_runs(
-        "
-        #pragma GCC target(\"mmx\")
-        #include <mmintrin.h>
-        int main(void)
-        {
-          __m64 x = _mm_setzero_si64();
-        }
-        "
-        HAVE_MMINTRIN_H
-    )
+    if (VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+        check_c_source_runs(
+            "
+            #pragma GCC target(\"mmx\")
+            #include <mmintrin.h>
+            int main(void)
+            {
+              __m64 x = _mm_setzero_si64();
+            }
+            "
+            HAVE_MMINTRIN_H
+        )
 
-    if (HAVE_MMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_MMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mmmx)
-    endif ()
+        if (HAVE_MMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_MMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mmmx)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #pragma GCC target(\"sse2\")
-        #ifndef __SSE2__
-        # define __SSE2__
-        #endif
-        
-        #include <emmintrin.h>
-        int main(void) {
-          __m128d x = _mm_setzero_pd();
-          __m128i z = _mm_srli_epi64(_mm_setzero_si128(), 26);
-        }
-        "
-        HAVE_EMMINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #pragma GCC target(\"sse2\")
+            #ifndef __SSE2__
+            # define __SSE2__
+            #endif
+            
+            #include <emmintrin.h>
+            int main(void) {
+              __m128d x = _mm_setzero_pd();
+              __m128i z = _mm_srli_epi64(_mm_setzero_si128(), 26);
+            }
+            "
+            HAVE_EMMINTRIN_H
+        )
 
-    if (HAVE_EMMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_EMMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -msse2)
-    endif ()
+        if (HAVE_EMMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_EMMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -msse2)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #pragma GCC target(\"sse3\")
-        #include <pmmintrin.h>
-        int main(void) {
-          __m128 x = _mm_addsub_ps(_mm_cvtpd_ps(_mm_setzero_pd()), _mm_cvtpd_ps(_mm_setzero_pd()));
-        }
-        "
-        HAVE_PMMINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #pragma GCC target(\"sse3\")
+            #include <pmmintrin.h>
+            int main(void) {
+              __m128 x = _mm_addsub_ps(_mm_cvtpd_ps(_mm_setzero_pd()), _mm_cvtpd_ps(_mm_setzero_pd()));
+            }
+            "
+            HAVE_PMMINTRIN_H
+        )
 
-    if (HAVE_PMMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_PMMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -msse3)
-    endif ()
+        if (HAVE_PMMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_PMMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -msse3)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #pragma GCC target(\"ssse3\")
-        #include <tmmintrin.h>
-        int main(void) {
-          __m64 x = _mm_abs_pi32(_m_from_int(0));
-        }
-        "
-        HAVE_TMMINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #pragma GCC target(\"ssse3\")
+            #include <tmmintrin.h>
+            int main(void) {
+              __m64 x = _mm_abs_pi32(_m_from_int(0));
+            }
+            "
+            HAVE_TMMINTRIN_H
+        )
 
-    if (HAVE_TMMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_TMMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mssse3)
-    endif ()
+        if (HAVE_TMMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_TMMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mssse3)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #pragma GCC target(\"sse4.1\")
-        #include <smmintrin.h>
-        int main(void) {
-          __m128i x = _mm_minpos_epu16(_mm_setzero_si128());
-        }
-        "
-        HAVE_SMMINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #pragma GCC target(\"sse4.1\")
+            #include <smmintrin.h>
+            int main(void) {
+              __m128i x = _mm_minpos_epu16(_mm_setzero_si128());
+            }
+            "
+            HAVE_SMMINTRIN_H
+        )
 
-    if (HAVE_SMMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SMMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -msse4.1)
-    endif ()
+        if (HAVE_SMMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SMMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -msse4.1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #ifdef __native_client__
-        # error NativeClient detected - Avoiding AVX opcodes
-        #endif
-        #pragma GCC target(\"avx\")
-        #include <immintrin.h>
-        int main(void) {
-          _mm256_zeroall();
-        }
-        "
-        HAVE_AVXINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #ifdef __native_client__
+            # error NativeClient detected - Avoiding AVX opcodes
+            #endif
+            #pragma GCC target(\"avx\")
+            #include <immintrin.h>
+            int main(void) {
+              _mm256_zeroall();
+            }
+            "
+            HAVE_AVXINTRIN_H
+        )
 
-    if (HAVE_AVXINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVXINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mavx)
-    endif ()
-
-    check_c_source_runs(
-        "
-        #ifdef __native_client__
-        # error NativeClient detected - Avoiding AVX2 opcodes
-        #endif
-        #pragma GCC target(\"avx2\")
-        #include <immintrin.h>
-        int main(void) {
-          __m256 x = _mm256_set1_ps(3.14);
-          __m256 y = _mm256_permutevar8x32_ps(x, _mm256_set1_epi32(42));
-          return _mm256_movemask_ps(_mm256_cmp_ps(x, y, _CMP_NEQ_OQ));
-        }
-        "
-        HAVE_AVX2INTRIN_H
-    )
-
-    if (HAVE_AVX2INTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX2INTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mavx2)
+        if (HAVE_AVXINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVXINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mavx)
+        endif ()
 
         check_c_source_runs(
             "
@@ -341,229 +322,250 @@ else ()
             #pragma GCC target(\"avx2\")
             #include <immintrin.h>
             int main(void) {
-              __m256i y = _mm256_broadcastsi128_si256(_mm_setzero_si128());
+              __m256 x = _mm256_set1_ps(3.14);
+              __m256 y = _mm256_permutevar8x32_ps(x, _mm256_set1_epi32(42));
+              return _mm256_movemask_ps(_mm256_cmp_ps(x, y, _CMP_NEQ_OQ));
             }
             "
-            _mm256_broadcastsi128_si256_DEFINED
+            HAVE_AVX2INTRIN_H
         )
 
-        if (NOT _mm256_broadcastsi128_si256_DEFINED)
-            target_compile_definitions(${PROJECT_NAME}
-                PRIVATE
-                    _mm256_broadcastsi128_si256=_mm_broadcastsi128_si256
+        if (HAVE_AVX2INTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX2INTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mavx2)
+
+            check_c_source_runs(
+                "
+                #ifdef __native_client__
+                # error NativeClient detected - Avoiding AVX2 opcodes
+                #endif
+                #pragma GCC target(\"avx2\")
+                #include <immintrin.h>
+                int main(void) {
+                  __m256i y = _mm256_broadcastsi128_si256(_mm_setzero_si128());
+                }
+                "
+                _mm256_broadcastsi128_si256_DEFINED
             )
+
+            if (NOT _mm256_broadcastsi128_si256_DEFINED)
+                target_compile_definitions(${PROJECT_NAME}
+                    PRIVATE
+                        _mm256_broadcastsi128_si256=_mm_broadcastsi128_si256
+                )
+            endif ()
         endif ()
-    endif ()
 
-    check_c_source_runs(
-        "
-        #ifdef __native_client__
-        # error NativeClient detected - Avoiding AVX512F opcodes
-        #endif
-        #pragma GCC target(\"avx512f\")
-        #include <immintrin.h>
-        
-        #ifndef __AVX512F__
-        # error No AVX512 support
-        #elif defined(__clang__)
-        # if __clang_major__ < 4
-        #  error Compiler AVX512 support may be broken
-        # endif
-        #elif defined(__GNUC__)
-        # if __GNUC__ < 6
-        #  error Compiler AVX512 support may be broken
-        # endif
-        #endif
- 
-        int main(void) {
-          __m512i x = _mm512_setzero_epi32();
-          __m512i y = _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 1, 4, 5, 2, 3, 6, 7), x);
-        }
-        "
-        HAVE_AVX512FINTRIN_H
-    )
+        check_c_source_runs(
+            "
+            #ifdef __native_client__
+            # error NativeClient detected - Avoiding AVX512F opcodes
+            #endif
+            #pragma GCC target(\"avx512f\")
+            #include <immintrin.h>
+            
+            #ifndef __AVX512F__
+            # error No AVX512 support
+            #elif defined(__clang__)
+            # if __clang_major__ < 4
+            #  error Compiler AVX512 support may be broken
+            # endif
+            #elif defined(__GNUC__)
+            # if __GNUC__ < 6
+            #  error Compiler AVX512 support may be broken
+            # endif
+            #endif
+     
+            int main(void) {
+              __m512i x = _mm512_setzero_epi32();
+              __m512i y = _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 1, 4, 5, 2, 3, 6, 7), x);
+            }
+            "
+            HAVE_AVX512FINTRIN_H
+        )
 
-    if (HAVE_AVX512FINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX512FINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mavx512f)
-    else ()
-        target_compile_options(${PROJECT_NAME} PRIVATE -mno-avx512f)
-    endif ()
+        if (HAVE_AVX512FINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX512FINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mavx512f)
+        else ()
+            target_compile_options(${PROJECT_NAME} PRIVATE -mno-avx512f)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #ifdef __native_client__
-        # error NativeClient detected - Avoiding AESNI opcodes
-        #endif
-        #pragma GCC target(\"aes\")
-        #pragma GCC target(\"pclmul\")
-        #include <wmmintrin.h>
+        check_c_source_runs(
+            "
+            #ifdef __native_client__
+            # error NativeClient detected - Avoiding AESNI opcodes
+            #endif
+            #pragma GCC target(\"aes\")
+            #pragma GCC target(\"pclmul\")
+            #include <wmmintrin.h>
 
-        int main(void) {
-          __m128i x = _mm_aesimc_si128(_mm_setzero_si128());
-          __m128i y = _mm_clmulepi64_si128(_mm_setzero_si128(), _mm_setzero_si128(), 0);
-        }
-        "
-        HAVE_WMMINTRIN_H
-    )
+            int main(void) {
+              __m128i x = _mm_aesimc_si128(_mm_setzero_si128());
+              __m128i y = _mm_clmulepi64_si128(_mm_setzero_si128(), _mm_setzero_si128(), 0);
+            }
+            "
+            HAVE_WMMINTRIN_H
+        )
 
-    if (HAVE_WMMINTRIN_H)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_WMMINTRIN_H=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -maes -mpclmul)
-    endif ()
+        if (HAVE_WMMINTRIN_H)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_WMMINTRIN_H=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -maes -mpclmul)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #ifdef __native_client__
-        # error NativeClient detected - Avoiding RDRAND opcodes
-        #endif
-        #pragma GCC target(\"rdrnd\")
-        #include <immintrin.h>
+        check_c_source_runs(
+            "
+            #ifdef __native_client__
+            # error NativeClient detected - Avoiding RDRAND opcodes
+            #endif
+            #pragma GCC target(\"rdrnd\")
+            #include <immintrin.h>
 
-        int main(void) {
-          unsigned long long x;
-          _rdrand64_step(&x);
-        }
-        "
-        HAVE_RDRAND
-    )
+            int main(void) {
+              unsigned long long x;
+              _rdrand64_step(&x);
+            }
+            "
+            HAVE_RDRAND
+        )
 
-    if (HAVE_RDRAND)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_RDRAND=1)
-        target_compile_options(${PROJECT_NAME} PRIVATE -mrdrnd)
-    endif ()
+        if (HAVE_RDRAND)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_RDRAND=1)
+            target_compile_options(${PROJECT_NAME} PRIVATE -mrdrnd)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #include <intrin.h>
+        check_c_source_runs(
+            "
+            #include <intrin.h>
 
-        int main(void) {
-          (void) _xgetbv(0);
-        }
-        "
-        HAVE__XGETBV
-    )
+            int main(void) {
+              (void) _xgetbv(0);
+            }
+            "
+            HAVE__XGETBV
+        )
 
-    if (HAVE__XGETBV)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE__XGETBV=1)
-    endif ()
+        if (HAVE__XGETBV)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE__XGETBV=1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        int main(void) {
-          int a = 42;
-          int *pnt = &a;
-          __asm__ __volatile__ (\"\" : : \"r\"(pnt) : \"memory\");
-        }
-        "
-        HAVE_INLINE_ASM
-    )
+        check_c_source_runs(
+            "
+            int main(void) {
+              int a = 42;
+              int *pnt = &a;
+              __asm__ __volatile__ (\"\" : : \"r\"(pnt) : \"memory\");
+            }
+            "
+            HAVE_INLINE_ASM
+        )
 
-    if (HAVE_INLINE_ASM)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_INLINE_ASM=1)
-    endif ()
+        if (HAVE_INLINE_ASM)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_INLINE_ASM=1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        int main(void) {
-        #if defined(__amd64) || defined(__amd64__) || defined(__x86_64__)
-        # if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_WIN32) || defined(_WIN64)
-        #  error Windows x86_64 calling conventions are not supported yet
-        # endif
-        /* neat */
-        #else
-        # error !x86_64
-        #endif
-          unsigned char i = 0, o = 0, t;
-          __asm__ __volatile__ (\"pxor %%xmm12, %%xmm6 \n\"
-            \"movb (%[i]), %[t] \n\"
-            \"addb %[t], (%[o]) \n\"
-            : [t] \"=&r\"(t)
-            : [o] \"D\"(&o), [i] \"S\"(&i)
-            : \"memory\", \"flags\", \"cc\");
-        }
-        "
-        HAVE_AMD64_ASM
-    )
+        check_c_source_runs(
+            "
+            int main(void) {
+            #if defined(__amd64) || defined(__amd64__) || defined(__x86_64__)
+            # if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_WIN32) || defined(_WIN64)
+            #  error Windows x86_64 calling conventions are not supported yet
+            # endif
+            /* neat */
+            #else
+            # error !x86_64
+            #endif
+              unsigned char i = 0, o = 0, t;
+              __asm__ __volatile__ (\"pxor %%xmm12, %%xmm6 \n\"
+                \"movb (%[i]), %[t] \n\"
+                \"addb %[t], (%[o]) \n\"
+                : [t] \"=&r\"(t)
+                : [o] \"D\"(&o), [i] \"S\"(&i)
+                : \"memory\", \"flags\", \"cc\");
+            }
+            "
+            HAVE_AMD64_ASM
+        )
 
-    if (HAVE_AMD64_ASM)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AMD64_ASM=1)
-    endif ()
+        if (HAVE_AMD64_ASM)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AMD64_ASM=1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        int main(void) {
-        #if defined(__amd64) || defined(__amd64__) || defined(__x86_64__)
-        # if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_WIN32) || defined(_WIN64)
-        #  error Windows x86_64 calling conventions are not supported yet
-        # endif
-        /* neat */
-        #else
-        # error !x86_64
-        #endif
-          __asm__ __volatile__ (\"vpunpcklqdq %xmm0,%xmm13,%xmm0\");
-        }
-        "
-        HAVE_AVX_ASM
-    )
+        check_c_source_runs(
+            "
+            int main(void) {
+            #if defined(__amd64) || defined(__amd64__) || defined(__x86_64__)
+            # if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(_WIN32) || defined(_WIN64)
+            #  error Windows x86_64 calling conventions are not supported yet
+            # endif
+            /* neat */
+            #else
+            # error !x86_64
+            #endif
+              __asm__ __volatile__ (\"vpunpcklqdq %xmm0,%xmm13,%xmm0\");
+            }
+            "
+            HAVE_AVX_ASM
+        )
 
-    if (HAVE_AVX_ASM)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX_ASM=1)
-    endif ()
+        if (HAVE_AVX_ASM)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_AVX_ASM=1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        #if !defined(__clang__) && !defined(__GNUC__) && !defined(__SIZEOF_INT128__)
-        # error mode(TI) is a gcc extension, and __int128 is not available
-        #endif
-        #if defined(__clang__) && !defined(__x86_64__) && !defined(__aarch64__)
-        # error clang does not properly handle the 128-bit type on 32-bit systems
-        #endif
-        #ifndef NATIVE_LITTLE_ENDIAN
-        # error libsodium currently expects a little endian CPU for the 128-bit type
-        #endif
-        #ifdef __EMSCRIPTEN__
-        # error emscripten currently doesn't support some operations on integers larger than 64 bits
-        #endif
-        #include <stddef.h>
-        #include <stdint.h>
-        #if defined(__SIZEOF_INT128__)
-        typedef unsigned __int128 uint128_t;
-        #else
-        typedef unsigned uint128_t __attribute__((mode(TI)));
-        #endif
-        void fcontract(uint128_t *t) {
-          *t += 0x8000000000000 - 1;
-          *t *= *t;
-          *t >>= 84;
-        }
+        check_c_source_runs(
+            "
+            #if !defined(__clang__) && !defined(__GNUC__) && !defined(__SIZEOF_INT128__)
+            # error mode(TI) is a gcc extension, and __int128 is not available
+            #endif
+            #if defined(__clang__) && !defined(__x86_64__) && !defined(__aarch64__)
+            # error clang does not properly handle the 128-bit type on 32-bit systems
+            #endif
+            #ifndef NATIVE_LITTLE_ENDIAN
+            # error libsodium currently expects a little endian CPU for the 128-bit type
+            #endif
+            #ifdef __EMSCRIPTEN__
+            # error emscripten currently doesn't support some operations on integers larger than 64 bits
+            #endif
+            #include <stddef.h>
+            #include <stdint.h>
+            #if defined(__SIZEOF_INT128__)
+            typedef unsigned __int128 uint128_t;
+            #else
+            typedef unsigned uint128_t __attribute__((mode(TI)));
+            #endif
+            void fcontract(uint128_t *t) {
+              *t += 0x8000000000000 - 1;
+              *t *= *t;
+              *t >>= 84;
+            }
 
-        int main(void) {
-          (void) fcontract;
-        }
-        "
-        HAVE_TI_MODE
-    )
+            int main(void) {
+              (void) fcontract;
+            }
+            "
+            HAVE_TI_MODE
+        )
 
-    if (HAVE_TI_MODE)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_TI_MODE=1)
-    endif ()
+        if (HAVE_TI_MODE)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_TI_MODE=1)
+        endif ()
 
-    check_c_source_runs(
-        "
-        int main(void) {
-          unsigned int cpu_info[4];
-          __asm__ __volatile__ (\"xchgl %%ebx, %k1; cpuid; xchgl %%ebx, %k1\" :
-            \"=a\" (cpu_info[0]), \"=&r\" (cpu_info[1]),
-            \"=c\" (cpu_info[2]), \"=d\" (cpu_info[3]) :
-            \"0\" (0U), \"2\" (0U));
-        }
-        "
-        HAVE_CPUID
-    )
+        check_c_source_runs(
+            "
+            int main(void) {
+              unsigned int cpu_info[4];
+              __asm__ __volatile__ (\"xchgl %%ebx, %k1; cpuid; xchgl %%ebx, %k1\" :
+                \"=a\" (cpu_info[0]), \"=&r\" (cpu_info[1]),
+                \"=c\" (cpu_info[2]), \"=d\" (cpu_info[3]) :
+                \"0\" (0U), \"2\" (0U));
+            }
+            "
+            HAVE_CPUID
+        )
 
-    if (HAVE_CPUID)
-        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_CPUID=1)
+        if (HAVE_CPUID)
+            target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_CPUID=1)
+        endif ()
     endif ()
 
     check_c_source_runs(

--- a/ports/libsodium/CONTROL
+++ b/ports/libsodium/CONTROL
@@ -1,4 +1,5 @@
 Source: libsodium
-Version: 1.0.18-2
+Version: 1.0.18
+Port-Version: 3
 Description: A modern and easy-to-use crypto library
 Homepage: https://github.com/jedisct1/libsodium


### PR DESCRIPTION
fixes #15288 