### PR TITLE
[ompl] upgrade to v1.5.1

### DIFF
--- a/ports/ompl/CONTROL
+++ b/ports/ompl/CONTROL
@@ -1,7 +1,7 @@
 Source: ompl
-Version: 1.5.0
-Port-Version: 1
-Homepage: https://bitbucket.org/ompl
+Version: 1.5.1
+Port-Version: 0
+Homepage: https://ompl.kavrakilab.org/
 Description: The Open Motion Planning Library, consists of many state-of-the-art sampling-based motion planning algorithms
 Build-Depends: boost-dynamic-bitset, boost-filesystem, boost-graph, boost-odeint, boost-program-options, boost-serialization, boost-system, boost-test, boost-ublas, boost-timer, eigen3
 

--- a/ports/ompl/fix_dependency.patch
+++ b/ports/ompl/fix_dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 24be873..3b916d7 100644
+index 4c7e6901..a433b7da 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -136,7 +136,7 @@ find_package(Drawstuff QUIET)
@@ -21,9 +21,9 @@ index 24be873..3b916d7 100644
  
  # ROS installs fcl in /usr. In /usr/include/fcl/config.h it says octomap was
  # enabled. Octomap is installed in /opt/ros/${ROS_DISTRO}/include (most
-@@ -199,7 +198,7 @@ set(OMPLAPP_LIBRARIES
-     ${Boost_FILESYSTEM_LIBRARY}
-     ${Boost_SYSTEM_LIBRARY}
+@@ -195,7 +194,7 @@ set(OMPLAPP_MODULE_LIBRARIES
+     ${FCL_LIBRARIES})
+ set(OMPLAPP_LIBRARIES
      ${OPENGL_LIBRARIES}
 -    ${ASSIMP_LIBRARIES}
 +    assimp::assimp

--- a/ports/ompl/portfile.cmake
+++ b/ports/ompl/portfile.cmake
@@ -1,21 +1,21 @@
 vcpkg_buildpath_length_warning(37)
 
-set(OMPL_VERSION 1.5.0)
+set(OMPL_VERSION 1.5.1)
 
 set(FEATURE_PATCHES)
 
 if("app" IN_LIST FEATURES)
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://github.com/ompl/omplapp/releases/download/1.5.0/omplapp-1.5.0-Source.tar.gz"
+        URLS "https://github.com/ompl/omplapp/releases/download/1.5.1/omplapp-1.5.1-Source.tar.gz"
         FILENAME "omplapp-${OMPL_VERSION}.tar.gz"
-        SHA512 ad221b67146915cb63be6731ca2fa7d827d85b7fd175d87ee64c799311dfe4878935881b1ae6447357fdd178f70c9aa01b178e857261a8d8769affa1e58ed72b
+        SHA512 83b1b09d6be776f7e15a748402f0c2f072459921de61a92731daf5171bd1f91a829fbeb6e10a489b92fba0297f6272e7bb6b8f07830c387bb29ccdbc7b3731f3
     )
     list(APPEND FEATURE_PATCHES fix_dependency.patch)
 else()
     vcpkg_download_distfile(ARCHIVE
-        URLS "https://github.com/ompl/ompl/archive/1.5.0.tar.gz"
+        URLS "https://github.com/ompl/ompl/archive/1.5.1.tar.gz"
         FILENAME "ompl-${OMPL_VERSION}.tar.gz"
-        SHA512 a300682fa0af40768c93e44b819c677b6121812e4f968ad89b5ae4044f3171a7febca63fa5645f2ad0f99ec3dfb3b02fe8c7443c4e389bf19a4a4bc9c7a5d013
+        SHA512 2f28d29f32f3bb03e67b29ce251e4786364847a25e3c4cf66d7663ed38dca4da71d4e03cf9ce647710d9524a3907c76c09795e77f041cb8822f695d28f5ca570
     )
 endif()
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Upgrade OMPL to 1.5.1.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I don't expect this change will make any regression on CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
