### PR TITLE
[openssl] Update to 1.1.1i

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,5 +1,4 @@
 Source: openssl
-Version: 1.1.1h
-Port-Version: 5
+Version: 1.1.1i
 Homepage: https://www.openssl.org
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -2,11 +2,11 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
   message(FATAL_ERROR "Can't build openssl if libressl/boringssl is installed. Please remove libressl/boringssl, and try install openssl again if you need it.")
 endif()
 
-set(OPENSSL_VERSION 1.1.1h)
+set(OPENSSL_VERSION 1.1.1i)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL_VERSION}.tar.gz"
     FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
-    SHA512 da50fd99325841ed7a4367d9251c771ce505a443a73b327d8a46b2c6a7d2ea99e43551a164efc86f8743b22c2bdb0020bf24a9cbd445e9d68868b2dc1d34033a
+    SHA512 fe12e0ab9e1688f24dd862ac633d0ab703b499c0f34b53c3560aa0d3879d81d647aa0678ed517dda5efb2711f669fcb1a1e0e24f6eac2efc2cf4eae6b62014d8
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -25,7 +25,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
     # disable that makes linkage error (e.g. require stderr usage)
     list(APPEND DISABLES no-stdio no-ui no-asm)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(PLATFORM darwin64-x86_64-cc)
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "arm64")
+        set(PLATFORM darwin64-arm64-cc)
+    else()
+        set(PLATFORM darwin64-x86_64-cc)
+    endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     set(PLATFORM BSD-generic64)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
@@ -213,4 +217,3 @@ install(
     FILES ${INSTALL_PKG_CONFIGS}
     DESTINATION lib/pkgconfig
 )
-


### PR DESCRIPTION
- Update openssl to 1.1.1i.
- Add support for arm64-osx triplet.