### PR TITLE
[arcus] New port

### DIFF
--- a/ports/arcus/CONTROL
+++ b/ports/arcus/CONTROL
@@ -1,6 +1,6 @@
 Source: arcus
 Version: 4.8.0
 Homepage: https://github.com/Ultimaker/libArcus
-Description: This library contains C++ code and Python3 bindings for creating a socket in a thread and using this socket to send and receive messages based on the Protocol Buffers library.
+Description: This library contains C++ bindings for creating a socket in a thread and using this socket to send and receive messages based on the Protocol Buffers library.
 Supports: !uwp
 Build-Depends: protobuf

--- a/ports/arcus/CONTROL
+++ b/ports/arcus/CONTROL
@@ -1,4 +1,6 @@
 Source: arcus
 Version: 4.8.0
+Homepage: https://github.com/Ultimaker/libArcus
 Description: This library contains C++ code and Python3 bindings for creating a socket in a thread and using this socket to send and receive messages based on the Protocol Buffers library.
+Supports: !uwp
 Build-Depends: protobuf

--- a/ports/arcus/CONTROL
+++ b/ports/arcus/CONTROL
@@ -1,0 +1,4 @@
+Source: arcus
+Version: 4.8.0
+Description: This library contains C++ code and Python3 bindings for creating a socket in a thread and using this socket to send and receive messages based on the Protocol Buffers library.
+Build-Depends: protobuf

--- a/ports/arcus/portfile.cmake
+++ b/ports/arcus/portfile.cmake
@@ -8,11 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    set(ENABLE_STATIC ON)
-else()
-    set(ENABLE_STATIC OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/arcus/portfile.cmake
+++ b/ports/arcus/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Ultimaker/libArcus
+    REF 4.8.0
+    SHA512 44db9b48ab6be08c30f2121d68197a7347eaf3ee255649969a773afbe45ec2433e2cc082aa72f6d40dad7ea28345da858471fff9a129365a4e848df8c8c07689
+    HEAD_REF master
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(ENABLE_STATIC ON)
+else()
+    set(ENABLE_STATIC OFF)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_PYTHON=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_STATIC=${ENABLE_STATIC}
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Arcus TARGET_PATH share/arcus)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/arcus/copyright" COPYONLY)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -33,8 +33,6 @@ apr:arm64-windows=fail
 # Requires ATL for ARM64 to be installed in CI
 azure-storage-cpp:arm64-windows=fail
 
-arcus:arm-uwp=fail
-arcus:x64-uwp=fail
 blend2d:arm64-windows=fail
 blend2d:arm-uwp=fail
 blend2d:x64-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -33,6 +33,8 @@ apr:arm64-windows=fail
 # Requires ATL for ARM64 to be installed in CI
 azure-storage-cpp:arm64-windows=fail
 
+arcus:arm-uwp=fail
+arcus:x64-uwp=fail
 blend2d:arm64-windows=fail
 blend2d:arm-uwp=fail
 blend2d:x64-uwp=fail


### PR DESCRIPTION
Arcus is used by CuraEngine as a library for writing to sockets.
Adding this port helps with CuraEngine's build as well as any other
projects that depend on Arcus.

UWP is not supported by this library.
