### PR TITLE
[libilbc] New port

### DIFF
--- a/ports/libilbc/CONTROL
+++ b/ports/libilbc/CONTROL
@@ -1,0 +1,4 @@
+Source: libilbc
+Version: 3.0.3
+Description: Open source implementation of the Internet Low Bit Rate Codec (iLBC) / RFC 3951 codec from the WebRTC project.
+Homepage: https://github.com/TimothyGu/libilbc

--- a/ports/libilbc/CONTROL
+++ b/ports/libilbc/CONTROL
@@ -2,3 +2,4 @@ Source: libilbc
 Version: 3.0.3
 Description: Open source implementation of the Internet Low Bit Rate Codec (iLBC) / RFC 3951 codec from the WebRTC project.
 Homepage: https://github.com/TimothyGu/libilbc
+Supports: !(arm&uwp)

--- a/ports/libilbc/do-not-build-ilbc_test.patch
+++ b/ports/libilbc/do-not-build-ilbc_test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 671ded64d1..1d01f737c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -332,7 +332,7 @@ install(FILES ilbc.h ${CMAKE_CURRENT_BINARY_DIR}/ilbc_export.h
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES CONTRIBUTING.md NEWS.md README.md
+         DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-install(TARGETS ilbc ilbc_test
++install(TARGETS ilbc
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/ports/libilbc/portfile.cmake
+++ b/ports/libilbc/portfile.cmake
@@ -9,15 +9,23 @@ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF ${ILBC_VERSION}
+    PATCHES do-not-build-ilbc_test.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DCMAKE_INSTALL_DOCDIR=share/${PORT}
 )
+
 vcpkg_install_cmake()
 
-vcpkg_copy_tools(TOOL_NAMES ilbc_test AUTO_CLEAN)
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/ilbc_export.h "#ifdef ILBC_STATIC_DEFINE" "#if 1")
+endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libilbc/portfile.cmake
+++ b/ports/libilbc/portfile.cmake
@@ -11,8 +11,6 @@ vcpkg_extract_source_archive_ex(
     REF ${ILBC_VERSION}
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/libilbc/portfile.cmake
+++ b/ports/libilbc/portfile.cmake
@@ -1,0 +1,39 @@
+set(ILBC_VERSION 3.0.3)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/TimothyGu/libilbc/releases/download/v${ILBC_VERSION}/libilbc-${ILBC_VERSION}.zip"
+    FILENAME "libilbc-${ILBC_VERSION}.zip"
+    SHA512 a5755db093529f6a3fd8fd47da63b57cffff1d3babef443d92f7c5a250ce8d1585adfba525c4037b142d9f00f1675a5054c172bf936be280dfcc22ed553c94c6
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${ILBC_VERSION}
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+)
+vcpkg_install_cmake()
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
+if(EXES)
+    file(REMOVE ${EXES})
+endif()
+
+file(GLOB DEBUG_EXES "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
+if(DEBUG_EXES)
+    file(REMOVE ${DEBUG_EXES})
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/libilbc/portfile.cmake
+++ b/ports/libilbc/portfile.cmake
@@ -16,20 +16,10 @@ vcpkg_configure_cmake(
     PREFER_NINJA
 )
 vcpkg_install_cmake()
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
-file(GLOB EXES "${CURRENT_PACKAGES_DIR}/bin/*.exe")
-if(EXES)
-    file(REMOVE ${EXES})
-endif()
-
-file(GLOB DEBUG_EXES "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
-if(DEBUG_EXES)
-    file(REMOVE ${DEBUG_EXES})
-endif()
+vcpkg_copy_tools(TOOL_NAMES ilbc_test AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
+
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libilbc/portfile.cmake
+++ b/ports/libilbc/portfile.cmake
@@ -14,8 +14,6 @@ vcpkg_extract_source_archive_ex(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS
-        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
 )
 vcpkg_install_cmake()
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -598,7 +598,6 @@ libics:x64-uwp=fail
 libigl:arm64-windows=fail
 libigl:arm-uwp=fail
 libigl:x64-uwp=fail
-libilbc:arm-uwp=fail
 liblemon:arm-uwp=fail
 liblemon:x64-uwp=fail
 liblo:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -598,6 +598,7 @@ libics:x64-uwp=fail
 libigl:arm64-windows=fail
 libigl:arm-uwp=fail
 libigl:x64-uwp=fail
+libilbc:arm-uwp=fail
 liblemon:arm-uwp=fail
 liblemon:x64-uwp=fail
 liblo:arm-uwp=fail


### PR DESCRIPTION
**Describe the pull request**

This adds a port for libilbc, an implementation of the Internet Low Bit Rate Codec (iLBC).

- What does your PR fix? Fixes #14836

- Which triplets are supported/not supported?

Tested with x64-osx, but should work with *-windows and *-linux.

- Have you updated the CI baseline?

Yes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.