### PR TITLE
[freetype] Update to 2.10.4

### DIFF
--- a/ports/freetype/CONTROL
+++ b/ports/freetype/CONTROL
@@ -1,6 +1,5 @@
 Source: freetype
-Version: 2.10.2
-Port-Version: 7
+Version: 2.10.4
 Homepage: https://www.freetype.org/
 Description: A library to render fonts.
 Default-Features: zlib, bzip2, png, brotli

--- a/ports/freetype/fix-exports.patch
+++ b/ports/freetype/fix-exports.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 04ce73a..ee3cc05 100644
+index 2314c79..994c602 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -454,7 +454,7 @@ endif ()
+@@ -446,7 +446,7 @@ endif ()
  set(PKG_CONFIG_REQUIRED_PRIVATE "")
  
  if (ZLIB_FOUND)
@@ -11,12 +11,17 @@ index 04ce73a..ee3cc05 100644
    target_include_directories(freetype PRIVATE ${ZLIB_INCLUDE_DIRS})
    list(APPEND PKG_CONFIG_REQUIRED_PRIVATE "zlib")
  endif ()
-@@ -562,8 +562,21 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+@@ -560,12 +560,26 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    install(
      EXPORT freetype-targets
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freetype
 -      FILE freetype-config.cmake
        COMPONENT headers)
+   install(
+     FILES ${PROJECT_BINARY_DIR}/freetype-config-version.cmake
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/freetype
+     COMPONENT headers)
++
 +
 +  if(ZLIB_FOUND)
 +    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/freetype-config.cmake"

--- a/ports/freetype/pkgconfig.patch
+++ b/ports/freetype/pkgconfig.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 65839ac58..54f2ce8ec 100644
---- a/CMakeLists.txt	
+index 61b174e..2314c79 100644
+--- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -517,7 +517,6 @@ endif ()
+@@ -509,7 +509,6 @@ endif ()
  
  if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
    # Generate the pkg-config file
@@ -10,11 +10,11 @@ index 65839ac58..54f2ce8ec 100644
      file(READ "${PROJECT_SOURCE_DIR}/builds/unix/freetype2.in" FREETYPE2_PC_IN)
  
      string(REPLACE ";" ", " PKG_CONFIG_REQUIRED_PRIVATE "${PKG_CONFIG_REQUIRED_PRIVATE}")
-@@ -551,7 +550,6 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+@@ -543,7 +542,6 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
        FILES ${PROJECT_BINARY_DIR}/freetype2.pc
        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
        COMPONENT pkgconfig)
 -  endif ()
  
-   install(
-     TARGETS freetype
+   include(CMakePackageConfigHelpers)
+   write_basic_package_version_file(

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -1,11 +1,11 @@
-set(FT_VERSION 2.10.2)
+set(FT_VERSION 2.10.4)
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO freetype/freetype2
     REF ${FT_VERSION}
     FILENAME freetype-${FT_VERSION}.tar.xz
-    SHA512 cf45089bd8893d7de2cdcb59d91bbb300e13dd0f0a9ef80ed697464ba7aeaf46a5a81b82b59638e6b21691754d8f300f23e1f0d11683604541d77f0f581affaa
+    SHA512 827cda734aa6b537a8bcb247549b72bc1e082a5b32ab8d3cccb7cc26d5f6ee087c19ce34544fa388a1eb4ecaf97600dbabc3e10e950f2ba692617fee7081518f
     PATCHES
         0001-Fix-install-command.patch
         0003-Fix-UWP.patch

--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 2
+Port-Version: 3
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2

--- a/ports/vtk/fix-freetype.patch
+++ b/ports/vtk/fix-freetype.patch
@@ -1,0 +1,26 @@
+diff --git a/Rendering/FreeType/vtkFreeTypeTools.cxx b/Rendering/FreeType/vtkFreeTypeTools.cxx
+index c54289dc..e6d9b14f 100644
+--- a/Rendering/FreeType/vtkFreeTypeTools.cxx
++++ b/Rendering/FreeType/vtkFreeTypeTools.cxx
+@@ -378,7 +378,7 @@ FTC_CMapCache* vtkFreeTypeTools::GetCMapCache()
+ }
+ 
+ //----------------------------------------------------------------------------
+-FT_CALLBACK_DEF(FT_Error)
++FT_Error
+ vtkFreeTypeToolsFaceRequester(
+   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
+ {
+diff --git a/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx b/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
+index 5c1908cf..41ed97e7 100644
+--- a/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
++++ b/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
+@@ -29,7 +29,7 @@ vtkStandardNewMacro(vtkFontConfigFreeTypeTools);
+ namespace
+ {
+ // The FreeType face requester callback:
+-FT_CALLBACK_DEF(FT_Error)
++static FT_Error
+ vtkFontConfigFreeTypeToolsFaceRequester(
+   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
+ {

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -129,6 +129,7 @@ vcpkg_from_github(
         module-name-mangling.patch
         # Last patch TODO: Patch out internal loguru
         FindExpat.patch # The find_library calls are taken care of by vcpkg-cmake-wrapper.cmake of expat
+        fix-freetype.patch # Should be fixed next version, !7367 + !7434
 )
 
 # =============================================================================


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

Regular port update https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/ with major security vulnerability fix, plus the upstream vtk patch for compatibility with this revision from https://discourse.vtk.org/t/building-opencascade-7-5-0-with-vtk-9-0-1

Closes #14008. I made a new PR due to the changes on `master` and branched off the last commit that affected freetype and vtk since I could not build anything on HEAD #15332 but I could on 191e01f 

- Which triplets are supported/not supported? Have you updated the CI baseline?
It should work everywhere but since vtk takes really long to build, I've only tested against x86-windows.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
