### PR TITLE
[mdnsresponder] Change compile flag /Zi to /Z7

### DIFF
--- a/ports/mdnsresponder/CONTROL
+++ b/ports/mdnsresponder/CONTROL
@@ -1,5 +1,6 @@
 Source: mdnsresponder
-Version: 765.30.11-2
+Version: 765.30.11
+Port-Version: 3
 Description: The mDNSResponder project is a component of Bonjour, Apple's ease-of-use IP networking initiative.
 Homepage: https://developer.apple.com/bonjour/
 Supports: !arm

--- a/ports/mdnsresponder/portfile.cmake
+++ b/ports/mdnsresponder/portfile.cmake
@@ -49,6 +49,11 @@ function(FIX_VCXPROJ VCXPROJ_PATH)
       "<ConfigurationType>StaticLibrary</ConfigurationType>"
       ORIG "${ORIG}")
   endif()
+  
+  string(REPLACE
+    "<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>"
+    "<DebugInformationFormat>OldStyle</DebugInformationFormat>"
+    ORIG "${ORIG}")
   file(WRITE ${VCXPROJ_PATH} "${ORIG}")
 endfunction()
 


### PR DESCRIPTION
In order to embed debugging information in the static library, set `/Z7` instead of `/Zi` to sync with `vcpkg_configure_cmake`.

Fixes #13955.