### PR TITLE
[monkeys-audio] Update to 5.70

### DIFF
--- a/ports/monkeys-audio/CONTROL
+++ b/ports/monkeys-audio/CONTROL
@@ -1,5 +1,5 @@
 Source: monkeys-audio
-Version: 5.65
+Version: 5.70
 Homepage: https://monkeysaudio.com
 Description: Monkey's Audio is an excellent audio compression tool which has multiple advantages over traditional methods.
   Audio files compressed with it end with .ape extension.

--- a/ports/monkeys-audio/fix-project-config.patch
+++ b/ports/monkeys-audio/fix-project-config.patch
@@ -1,16 +1,16 @@
-diff --git a/Source/Projects/VS2019/MACDll/MACDll.vcxproj b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
-index 4e84b52..79882b0 100644
---- a/Source/Projects/VS2019/MACDll/MACDll.vcxproj
-+++ b/Source/Projects/VS2019/MACDll/MACDll.vcxproj
-@@ -75,10 +75,9 @@
+--- a/Source/Projects/VS2019/MACDll/MACDll.vcxproj	2020-12-23 21:42:15.830541000 +0100
++++ b/Source/Projects/VS2019/MACDll/MACDll.vcxproj	2020-12-29 06:07:36.101967600 +0100
+@@ -74,11 +74,9 @@
      <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
    </PropertyGroup>
    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
--    <OutDir>C:\Applications\Winamp\plugins\</OutDir>
+-    <OutDir>C:\Applications\Cool Edit Pro\</OutDir>
 +    <OutDir>$(Configuration)\</OutDir>
      <IntDir>$(Configuration)\</IntDir>
-     <LinkIncremental>true</LinkIncremental>
--    <TargetName>in_ape.dll</TargetName>
+-    <LinkIncremental>true</LinkIncremental>
+-    <TargetName>APE</TargetName>
+-    <TargetExt>.flt</TargetExt>
++    <LinkIncremental>false</LinkIncremental>
    </PropertyGroup>
    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
      <OutDir>$(Configuration)\</OutDir>

--- a/ports/monkeys-audio/portfile.cmake
+++ b/ports/monkeys-audio/portfile.cmake
@@ -2,21 +2,22 @@ vcpkg_fail_port_install(ON_TARGET "UWP" "OSX" "Linux")
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 
-set(MA_VERSION 565d)
+set(MA_VERSION 570)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://monkeysaudio.com/files/MAC_SDK_${MA_VERSION}.zip"
+         "https://web.archive.org/web/20201229182615if_/https://monkeysaudio.com/files/MAC_SDK_570.zip"
     FILENAME "MAC_SDK_${MA_VERSION}.zip"
-    SHA512 785273b4fe19dad284b2c51fb648b2cbae66af069fac75745909862e084e8bfe175703b0997b20cd15a54985e8d707810d8cdcc849692767e71ace924ddfd951
+    SHA512 d3b5a10574dde1ea90578959378b87f8a8c94b3cc7198bc51b86f7128d66117d706c191d56a699dce0c2a53b7722e0893cb614f96f9ad725a266a871da587fd4
 )
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL
-    PATCHES 
-	    fix-project-config.patch
-	    remove-certificate-step.patch
+    PATCHES
+        fix-project-config.patch
+        remove-certificate-step.patch
 )
 
 file(REMOVE_RECURSE
@@ -52,10 +53,10 @@ if ("tools" IN_LIST FEATURES)
         PROJECT_SUBPATH Source/Projects/VS2019/Console/Console.vcxproj
         PLATFORM ${PLATFORM}
     )
-    
+
     file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/Console.lib ${CURRENT_PACKAGES_DIR}/debug/lib/Console.lib)
     file(RENAME ${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/Console.exe ${CURRENT_PACKAGES_DIR}/tools/monkeys-audio/mac.exe)
-    
+
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
 endif()
 

--- a/ports/monkeys-audio/remove-certificate-step.patch
+++ b/ports/monkeys-audio/remove-certificate-step.patch
@@ -1,25 +1,23 @@
-diff --git a/Source/Projects/VS2019/Console/Console.vcxproj b/Source/Projects/VS2019/Console/Console.vcxproj
-index 164608f..feeb163 100644
---- a/Source/Projects/VS2019/Console/Console.vcxproj
-+++ b/Source/Projects/VS2019/Console/Console.vcxproj
+--- a/Source/Projects/VS2019/Console/Console.vcxproj	2020-12-23 21:42:15.672211100 +0100
++++ b/Source/Projects/VS2019/Console/Console.vcxproj	2020-12-29 05:29:53.916306700 +0100
 @@ -180,10 +180,6 @@
        <DataExecutionPrevention />
        <TargetMachine>MachineX86</TargetMachine>
      </Link>
 -    <PostBuildEvent>
--      <Command>C:\MAC\Current\Source\Certificate\signtool.exe sign /t http://timestamp.digicert.com /f C:\MAC\Current\Source\Certificate\MAC2.crt /v "$(TargetPath)"
--C:\MAC\Current\Source\Certificate\signtool.exe sign /f C:\MAC\Current\Source\Certificate\MAC2.crt /tr http://timestamp.comodoca.com /td sha256 /fd sha256 /a /as "$(TargetPath)"</Command>
+-      <Command>C:\MAC\Current\Source\Certificate\signtool.exe sign /t http://timestamp.digicert.com /f C:\MAC\Current\Source\Certificate\MAC3.pfx /p password /v "$(TargetPath)"
+-C:\MAC\Current\Source\Certificate\signtool.exe sign /f C:\MAC\Current\Source\Certificate\MAC3.pfx /tr http://sha256timestamp.ws.symantec.com/sha256/timestamp /td sha256 /fd sha256 /a /as /p password "$(TargetPath)"</Command>
 -    </PostBuildEvent>
    </ItemDefinitionGroup>
    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
      <Midl>
-@@ -273,10 +269,6 @@ C:\MAC\Current\Source\Certificate\signtool.exe sign /f C:\MAC\Current\Source\Cer
+@@ -273,10 +269,6 @@
        <DataExecutionPrevention />
        <TargetMachine>MachineX64</TargetMachine>
      </Link>
 -    <PostBuildEvent>
--      <Command>C:\MAC\Current\Source\Certificate\signtool.exe sign /t http://timestamp.digicert.com /f C:\MAC\Current\Source\Certificate\MAC2.crt /v "$(TargetPath)"
--C:\MAC\Current\Source\Certificate\signtool.exe sign /f C:\MAC\Current\Source\Certificate\MAC2.crt /tr http://timestamp.comodoca.com /td sha256 /fd sha256 /a /as "$(TargetPath)"</Command>
+-      <Command>C:\MAC\Current\Source\Certificate\signtool.exe sign /t http://timestamp.digicert.com /f C:\MAC\Current\Source\Certificate\MAC3.pfx /p password /v "$(TargetPath)"
+-C:\MAC\Current\Source\Certificate\signtool.exe sign /f C:\MAC\Current\Source\Certificate\MAC3.pfx /tr http://sha256timestamp.ws.symantec.com/sha256/timestamp /td sha256 /fd sha256 /a /as /p password "$(TargetPath)"</Command>
 -    </PostBuildEvent>
    </ItemDefinitionGroup>
    <ItemGroup>


### PR DESCRIPTION
**Describe the pull request**
- What does your PR fix? Fixes #
  - Update to current version 5.70
  - Released MAC_SDK files are currently only provided for download for a
short period of time and replaced frequently by newer versions.
See: https://monkeysaudio.com/files/
  - Add alternative download URL from Internet Archive
  - The feature `tools` was tested the following way:
`.\vcpkg.exe install monkeys-audio[tools]:x86-windows`
`.\vcpkg.exe install monkeys-audio[tools]:x64-windows`

- Which triplets are supported/not supported? Have you updated the CI baseline?
`!(uwp|osx|linux)`
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
