### PR TITLE
[libpq] Change compile flag /Zi to /Z7 when building Windows

### DIFF
--- a/ports/libpq/CONTROL
+++ b/ports/libpq/CONTROL
@@ -1,6 +1,6 @@
 Source: libpq
 Version: 12.2
-Port-Version: 9
+Port-Version: 10
 Build-Depends: libpq[core,bonjour] (osx)
 Supports: !uwp
 Homepage: https://www.postgresql.org/

--- a/ports/libpq/patches/windows/fix-compile-flag-Zi.patch
+++ b/ports/libpq/patches/windows/fix-compile-flag-Zi.patch
@@ -11,3 +11,23 @@ index b93992f..2397511 100644
        <CompileAs>Default</CompileAs>
      </ClCompile>
      <Link>
+diff --git a/src/tools/msvc/Install.pm b/src/tools/msvc/Install.pm
+index e0c9a88..98f9e67 100644
+--- a/src/tools/msvc/Install.pm
++++ b/src/tools/msvc/Install.pm
+@@ -341,9 +341,12 @@ sub CopySolutionOutput
+ 				  || croak "Could not copy $pf.$ext\n";
+ 			}
+ 		}
+-		lcopy("$conf\\$pf\\$pf.pdb", "$target\\bin\\$pf.pdb")
+-		  || croak "Could not copy $pf.pdb\n";
+-		print ".";
++        if ($1 eq 'DynamicLibrary')
++        {
++            lcopy("$conf\\$pf\\$pf.pdb", "$target\\bin\\$pf.pdb")
++            || croak "Could not copy $pf.pdb\n";
++            print ".";
++        }
+ 	}
+ 	print "\n";
+ 	return;

--- a/ports/libpq/patches/windows/fix-compile-flag-Zi.patch
+++ b/ports/libpq/patches/windows/fix-compile-flag-Zi.patch
@@ -1,0 +1,13 @@
+diff --git a/src/tools/msvc/MSBuildProject.pm b/src/tools/msvc/MSBuildProject.pm
+index b93992f..2397511 100644
+--- a/src/tools/msvc/MSBuildProject.pm
++++ b/src/tools/msvc/MSBuildProject.pm
+@@ -333,7 +333,7 @@ sub WriteItemDefinitionGroup
+       <BrowseInformation>false</BrowseInformation>
+       <WarningLevel>Level3</WarningLevel>
+       <SuppressStartupBanner>true</SuppressStartupBanner>
+-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -42,6 +42,7 @@ set(PATCHES
         patches/windows/MSBuildProject_fix_gendef_perl.patch
         patches/windows/msgfmt.patch
         patches/windows/python_lib.patch
+        patches/windows/fix-compile-flag-Zi.patch
         patches/linux/configure.patch)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)


### PR DESCRIPTION
Set compile flag `/Z7` instead of `/Zi`.

Fixes #10113.