### PR TITLE
[LLGL] installs header files in the wrong directory

### DIFF
--- a/ports/llgl/CONTROL
+++ b/ports/llgl/CONTROL
@@ -1,5 +1,6 @@
 Source: llgl
 Version: 2019-08-15
+Port-Version: 1
 Homepage: https://github.com/LukasBanana/LLGL
 Description: Low Level Graphics Library (LLGL) is a thin abstraction layer for the modern graphics APIs OpenGL, Direct3D, Vulkan, and Metal.
 Supports: !uwp

--- a/ports/llgl/fix-install-error.patch
+++ b/ports/llgl/fix-install-error.patch
@@ -39,6 +39,6 @@ index f440884..d1b0c2f 100644
 +  ARCHIVE DESTINATION lib
 +)
 +# Install headers
-+install(DIRECTORY ${PROJECT_INCLUDE_DIR} DESTINATION include)
++install(DIRECTORY ${PROJECT_INCLUDE_DIR} DESTINATION .)
 +
  

--- a/ports/llgl/portfile.cmake
+++ b/ports/llgl/portfile.cmake
@@ -35,5 +35,4 @@ endif()
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15216 
When LLGL is successfully built, the include file should be in ....\vcpkg\installed\x86-windows\include\LLGL, but it is actually in ....\vcpkg\installed\x86-windows\include\include\LLGL, The path is wrong. Modify the path of install in the CMakeLists.txt file to solve this problem.

All the features are tested successfully in the following triplets:
- x86-windows
- x64-windows
- x64-windows-static


