### PR TITLE
[onednn] Fix share path infix to match find_package() name

### DIFF
--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -17,7 +17,9 @@ vcpkg_configure_cmake(
 )
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake)
+# The port name and the find_package() name are different (onednn versus dnnl)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/dnnl TARGET_PATH share/dnnl)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/onednn/portfile.cmake
+++ b/ports/onednn/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_ARCH "x86" "arm" ON_TARGET "uwp")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oneapi-src/oneDNN

--- a/ports/onednn/vcpkg.json
+++ b/ports/onednn/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "onednn",
   "version-string": "2.0",
+  "port-version": 1,
   "description": "oneAPI Deep Neural Network Library (oneDNN)",
   "supports": "x64 & !uwp"
 }


### PR DESCRIPTION
I forgot to check in this line when sending https://github.com/microsoft/vcpkg/pull/15068. My mistake.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Same triplets as before. No change.

My initial tests on the PR adding the port were using this change. I've confirmed that this works on `x64-linux`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.