### PR TITLE
[etcd-cpp-apiv3] Add etcd-cpp-vpiv3 port.

### DIFF
--- a/ports/etcd-cpp-apiv3/CONTROL
+++ b/ports/etcd-cpp-apiv3/CONTROL
@@ -1,0 +1,6 @@
+Source: etcd-cpp-apiv3
+Version: etcd-cpp-apiv3-7e280ec
+Homepage: https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3
+Description: The etcd-cpp-apiv3 is a C++ API for etcd's v3 client API, i.e., ETCDCTL_API=3.
+Build-Depends: boost-system, boost-thread, boost-locale, boost-random,
+               cpprestsdk, grpc, openssl, protobuf

--- a/ports/etcd-cpp-apiv3/portfile.cmake
+++ b/ports/etcd-cpp-apiv3/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO etcd-cpp-apiv3/etcd-cpp-apiv3
+    REF 7e280ec8a49aaf26976d72a4080f2e2c6756f2b7
+    SHA512 1e1d525f79840731102e6400ff2582807e0626b58fa60726e49bea6ca51868a6b8bf3a34c7bf1d1266e156daa1e741bbfa2acce42b54680a23426bc00192dc6d
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_ETCD_TESTS=OFF
+)
+set(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+vcpkg_copy_pdbs()
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/etcd-cpp-apiv3 RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -260,6 +260,7 @@ epsilon:arm-uwp=fail
 epsilon:x64-linux=fail
 epsilon:x64-osx=fail
 epsilon:x64-uwp=fail
+etcd-cpp-apiv3:arm64-windows=fail
 faad2:x64-linux=fail
 faad2:x64-osx=fail
 fann:arm-uwp=fail


### PR DESCRIPTION
- What does your PR fix? Fixes #

Add the [etcd-cpp-apiv3](https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3) library.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Any platforms/triplets that [cpprestsdk](https://github.com/microsoft/vcpkg/tree/master/ports/cpprestsdk) and [grpc](https://github.com/microsoft/vcpkg/tree/master/ports/grpc) are supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.