### PR TITLE
[antlr4,python3] Resolve cross port conflicts

### DIFF
--- a/ports/antlr4/CONTROL
+++ b/ports/antlr4/CONTROL
@@ -1,5 +1,6 @@
 Source: antlr4
 Version: 4.8
+Port-Version: 1
 Homepage: https://www.antlr.org
 Description: ANother Tool for Language Recognition
 Build-Depends: libuuid (!uwp&!windows&!osx)

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -78,12 +78,6 @@ else()
     endif()
 endif()
 
-file(GLOB HDRS LIST_DIRECTORIES true ${CURRENT_PACKAGES_DIR}/include/antlr4-runtime/*)
-file(COPY ${HDRS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/antlr4-runtime)
-
 vcpkg_copy_pdbs()
 
 file(INSTALL ${LICENSE} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-message(STATUS "Installing done")

--- a/ports/python3/python_vcpkg.props.in
+++ b/ports/python3/python_vcpkg.props.in
@@ -6,7 +6,7 @@
       <PreprocessorDefinitions>_Py_HAVE_ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="${VCPKG_LIBRARY_LINKAGE} == 'static'">XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>
-        ${CURRENT_INSTALLED_DIR}/include;%(AdditionalIncludeDirectories)
+        %(AdditionalIncludeDirectories);${CURRENT_INSTALLED_DIR}/include
       </AdditionalIncludeDirectories>
 
       <RuntimeLibrary Condition="'${VCPKG_CRT_LINKAGE}|$(Configuration)' == 'static|Debug'">MultiThreadedDebug</RuntimeLibrary>

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-string": "3.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",


### PR DESCRIPTION
This is safe because vcpkg never hydrates python3's $(PySrcDir)\externals directory, so it wasn't using vendored dependencies at all.

Fixes https://github.com/microsoft/vcpkg/issues/15377