### PR TITLE
[flashlight-cuda] Update port

### DIFF
--- a/ports/flashlight-cuda/portfile.cmake
+++ b/ports/flashlight-cuda/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/flashlight
-    REF 94486a1108fd0511a05523bfa1cf734bc14022f7
-    SHA512 73a7547a26020be21d26393c2758cc235b452a0fb5d8537777bdbcc556f71846e07eca649167902dd7d0743cb7d10738b4e38cd7fe69b51b6122f3241e2edd84
+    REF 0948e97dbff23d474500a5f55bcf59d3b3589cf4
+    SHA512 89c2efdebc6688a38f9fc3ebb8442c8fe2ad3d51c0e60c5dd8e7ca283715e07f48083543f09eed0db9929d86b765a898d9b3960a9b6f9844b20260f94cf71fdf
     HEAD_REF master
 )
 
@@ -14,23 +14,24 @@ set(FL_DEFAULT_VCPKG_CMAKE_FLAGS
   -DFL_BACKEND=CUDA # this port is CUDA-backend only
   -DFL_BUILD_STANDALONE=OFF
   -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
-  )
+)
 
-# Determine which backend to build via specified feature
+# Determine which components to build via specified feature
 vcpkg_check_features(
-  OUT_FEATURE_OPTIONS FL_BACKEND_FEATURE_OPTIONS
+  OUT_FEATURE_OPTIONS FL_FEATURE_OPTIONS
   FEATURES
     lib FL_BUILD_LIBRARIES
     fl FL_BUILD_CORE
     asr FL_BUILD_APP_ASR
-    imgclass FL_BUILD_APP_IMG_CLASS
+    imgclass FL_BUILD_APP_IMGCLASS
+    lm FL_BUILD_APP_LM
 )
 
 # Build and install
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS ${FL_DEFAULT_VCPKG_CMAKE_FLAGS} ${FL_BACKEND_FEATURE_OPTIONS}
+    OPTIONS ${FL_DEFAULT_VCPKG_CMAKE_FLAGS} ${FL_FEATURE_OPTIONS}
 )
 vcpkg_install_cmake()
 
@@ -40,16 +41,24 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 # Binaries/tools
 set(FLASHLIGHT_TOOLS "")
 if ("imgclass" IN_LIST FEATURES)
-  list(APPEND FLASHLIGHT_TOOLS fl_imageNetResnet34)
+  list(APPEND FLASHLIGHT_TOOLS fl_img_imagenet_resnet34)
 endif()
 if ("asr" IN_LIST FEATURES)
-  list(APPEND FLASHLIGHT_TOOLS fl_asr_train fl_asr_test fl_asr_decode)
+  list(APPEND FLASHLIGHT_TOOLS
+    fl_asr_train
+    fl_asr_test
+    fl_asr_decode
+    fl_asr_align
+    fl_asr_voice_activity_detection_ctc
+  )
+endif()
+if ("lm" IN_LIST FEATURES)
+  list(APPEND FLASHLIGHT_TOOLS fl_lm_train fl_lm_dictionary_builder)
 endif()
 list(LENGTH FLASHLIGHT_TOOLS NUM_TOOLS)
 if (NUM_TOOLS GREATER 0)
   vcpkg_copy_tools(TOOL_NAMES ${FLASHLIGHT_TOOLS} AUTO_CLEAN)
 endif()
 
-# Copyright and license
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/flashlight-cuda RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/flashlight-cuda RENAME license)
+# Copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/flashlight-cuda/vcpkg.json
+++ b/ports/flashlight-cuda/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "flashlight-cuda",
   "version-string": "20201201",
   "description": "A C++ standalone library for machine learning. CUDA backend.",
+  "homepage": "https://github.com/facebookresearch/flashlight",
   "supports": "!(windows | osx)",
   "default-features": [
     "fl"
@@ -12,9 +13,9 @@
       "dependencies": [
         {
           "name": "flashlight-cuda",
-          "default-features": false,
           "features": [
-            "fl"
+            "fl",
+            "lib"
           ]
         },
         "gflags",
@@ -34,13 +35,6 @@
         "cereal",
         "cuda",
         "cudnn",
-        {
-          "name": "flashlight-cuda",
-          "default-features": false,
-          "features": [
-            "lib"
-          ]
-        },
         "nccl",
         "openmpi",
         "stb"
@@ -51,9 +45,9 @@
       "dependencies": [
         {
           "name": "flashlight-cuda",
-          "default-features": false,
           "features": [
-            "fl"
+            "fl",
+            "lib"
           ]
         },
         "gflags"
@@ -66,6 +60,19 @@
         "fftw3",
         "intel-mkl",
         "kenlm"
+      ]
+    },
+    "lm": {
+      "description": "flashlight lm app",
+      "dependencies": [
+        {
+          "name": "flashlight-cuda",
+          "features": [
+            "fl",
+            "lib"
+          ]
+        },
+        "gflags"
       ]
     }
   }


### PR DESCRIPTION
Update the `flashlight-cuda` port.
- Add the `lm` feature
- Ensure compatibility with gcc >= 8
- Rename and add additional tools
- Remove `fl` feature dependence on the `lib` feature

- What does your PR fix? Fixes #

Will hopefully fix https://github.com/microsoft/vcpkg/issues/15208 and https://github.com/facebookresearch/flashlight/issues/369. 


- Which triplets are supported/not supported? Have you updated the CI baseline?

`x64-linux` -- no changes here. Tested.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes