### PR TITLE
[boost-build] Fix cflags and c++flags for msvc

### DIFF
--- a/ports/boost-build/CONTROL
+++ b/ports/boost-build/CONTROL
@@ -1,5 +1,6 @@
 Source: boost-build
 Version: 1.75.0.beta1
+Port-Version: 1
 Homepage: https://github.com/boostorg/build
 Description: Boost.Build
 Build-Depends: boost-uninstall

--- a/ports/boost-build/fix_options.patch
+++ b/ports/boost-build/fix_options.patch
@@ -1,0 +1,236 @@
+diff --git a/src/tools/msvc.jam b/src/tools/msvc.jam
+index bf07a93..cf04eba 100644
+--- a/src/tools/msvc.jam
++++ b/src/tools/msvc.jam
+@@ -450,19 +450,19 @@ rule configure-version-specific ( toolset : version : conditions )
+     # version 7.* explicitly or if we auto-detected the version ourselves.
+     if ! [ MATCH ^(6\\.) : $(version) ]
+     {
+-        toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:forScope" "/Zc:wchar_t" ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions) : "/Zc:forScope" "/Zc:wchar_t" ;
+         toolset.flags $(toolset).compile.c++ C++FLAGS $(conditions) : /wd4675 ;
+ 
+         # Explicitly disable the 'function is deprecated' warning. Some msvc
+         # versions have a bug, causing them to emit the deprecation warning even
+         # with /W0.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<warnings>off : /wd4996 ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<warnings>off : /wd4996 ;
+ 
+         if [ MATCH "^([78]\\.)" : $(version) ]
+         {
+             # 64-bit compatibility warning deprecated since 9.0, see
+             # http://msdn.microsoft.com/en-us/library/yt4xw8fh.aspx
+-            toolset.flags $(toolset).compile CFLAGS $(conditions)/<warnings>all : /Wp64 ;
++            toolset.flags $(toolset).compile OPTIONS $(conditions)/<warnings>all : /Wp64 ;
+         }
+     }
+ 
+@@ -471,17 +471,17 @@ rule configure-version-specific ( toolset : version : conditions )
+     # variables and functions that have internal linkage
+     if ! [ version.version-less [ SPLIT_BY_CHARACTERS [ MATCH "^([0123456789.]+)" : $(version) ] : . ] : 12 ]
+     {
+-        toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:inline" ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions) : "/Zc:inline" ;
+ 
+         # /Gy analog for variables: https://devblogs.microsoft.com/cppblog/introducing-gw-compiler-switch/
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<optimization>speed $(conditions)/<optimization>space : /Gw ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<optimization>speed $(conditions)/<optimization>space : /Gw ;
+     }
+ 
+     # 14.0 introduced /Zc:throwingNew opt-in flag that disables a workaround
+     # for not throwing operator new in VC up to 6.0
+     if ! [ version.version-less [ SPLIT_BY_CHARACTERS [ MATCH "^([0123456789.]+)" : $(version) ] : . ] : 14 ]
+     {
+-        toolset.flags $(toolset).compile CFLAGS $(conditions) : "/Zc:throwingNew" ;
++        toolset.flags $(toolset).compile C++FLAGS $(conditions) : "/Zc:throwingNew" ;
+     }
+ 
+     #
+@@ -491,34 +491,34 @@ rule configure-version-specific ( toolset : version : conditions )
+     if [ MATCH "^([67])" : $(version) ]
+     {
+         # 8.0 deprecates some of the options.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<optimization>speed $(conditions)/<optimization>space : /Ogiy /Gs ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<optimization>speed : /Ot ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<optimization>space : /Os ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<optimization>speed $(conditions)/<optimization>space : /Ogiy /Gs ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<optimization>speed : /Ot ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<optimization>space : /Os ;
+ 
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-i386)/<instruction-set> : /GB ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-i386)/<instruction-set>i486 : /G4 ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g5) : /G5 ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g6) : /G6 ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g7) : /G7 ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-i386)/<instruction-set> : /GB ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-i386)/<instruction-set>i486 : /G4 ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g5) : /G5 ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g6) : /G6 ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-i386)/<instruction-set>$(.cpu-type-g7) : /G7 ;
+ 
+         # Improve floating-point accuracy. Otherwise, some of C++ Boost's "math"
+         # tests will fail.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions) : /Op ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions) : /Op ;
+ 
+         # 7.1 and below have single-threaded static RTL.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<runtime-debugging>off/<runtime-link>static/<threading>single : /ML ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<runtime-debugging>on/<runtime-link>static/<threading>single : /MLd ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<runtime-debugging>off/<runtime-link>static/<threading>single : /ML ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<runtime-debugging>on/<runtime-link>static/<threading>single : /MLd ;
+     }
+     else
+     {
+         # 8.0 and above adds some more options.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-amd64)/<instruction-set> : "/favor:blend" ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-amd64)/<instruction-set>$(.cpu-type-em64t) : "/favor:EM64T" ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/$(.cpu-arch-amd64)/<instruction-set>$(.cpu-type-amd64) : "/favor:AMD64" ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-amd64)/<instruction-set> : "/favor:blend" ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-amd64)/<instruction-set>$(.cpu-type-em64t) : "/favor:EM64T" ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/$(.cpu-arch-amd64)/<instruction-set>$(.cpu-type-amd64) : "/favor:AMD64" ;
+ 
+         # 8.0 and above only has multi-threaded static RTL.
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<runtime-debugging>off/<runtime-link>static/<threading>single : /MT ;
+-        toolset.flags $(toolset).compile CFLAGS $(conditions)/<runtime-debugging>on/<runtime-link>static/<threading>single : /MTd ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<runtime-debugging>off/<runtime-link>static/<threading>single : /MT ;
++        toolset.flags $(toolset).compile OPTIONS $(conditions)/<runtime-debugging>on/<runtime-link>static/<threading>single : /MTd ;
+ 
+         # Specify target machine type so the linker will not need to guess.
+         toolset.flags $(toolset).link LINKFLAGS $(conditions)/$(.cpu-arch-amd64) : "/MACHINE:X64" ;
+@@ -614,7 +614,7 @@ rule compile.c ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+     C++FLAGS on $(targets[1]) = ;
+-    get-rspline $(targets) : -TC ;
++    get-rspline $(targets) : -TC CFLAGS ;
+     compile-c-c++ $(<) : $(>) [ on $(<) return $(PCH_FILE) ] [ on $(<) return $(PCH_HEADER) ] ;
+ }
+ 
+@@ -623,7 +623,7 @@ rule compile.c.preprocess ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+     C++FLAGS on $(targets[1]) = ;
+-    get-rspline $(targets) : -TC ;
++    get-rspline $(targets) : -TC CFLAGS ;
+     preprocess-c-c++ $(<) : $(>) [ on $(<) return $(PCH_FILE) ] [ on $(<) return $(PCH_HEADER) ] ;
+ }
+ 
+@@ -632,8 +632,8 @@ rule compile.c.pch ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+     C++FLAGS on $(targets[1]) = ;
+-    get-rspline $(targets[1]) : -TC ;
+-    get-rspline $(targets[2]) : -TC ;
++    get-rspline $(targets[1]) : -TC CFLAGS ;
++    get-rspline $(targets[2]) : -TC CFLAGS ;
+     local pch-source = [ on $(<) return $(PCH_SOURCE) ] ;
+     if $(pch-source)
+     {
+@@ -716,14 +716,14 @@ actions compile-c-c++-pch-s
+ rule compile.c++ ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+-    get-rspline $(targets) : -TP ;
++    get-rspline $(targets) : -TP C++FLAGS ;
+     compile-c-c++ $(<) : $(>) [ on $(<) return $(PCH_FILE) ] [ on $(<) return $(PCH_HEADER) ] ;
+ }
+ 
+ rule compile.c++.preprocess ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+-    get-rspline $(targets) : -TP ;
++    get-rspline $(targets) : -TP C++FLAGS ;
+     preprocess-c-c++ $(<) : $(>) [ on $(<) return $(PCH_FILE) ] [ on $(<) return $(PCH_HEADER) ] ;
+ }
+ 
+@@ -731,8 +731,8 @@ rule compile.c++.preprocess ( targets + : sources * : properties * )
+ rule compile.c++.pch ( targets + : sources * : properties * )
+ {
+     set-setup-command $(targets) : $(properties) ;
+-    get-rspline $(targets[1]) : -TP ;
+-    get-rspline $(targets[2]) : -TP ;
++    get-rspline $(targets[1]) : -TP C++FLAGS ;
++    get-rspline $(targets[2]) : -TP C++FLAGS ;
+     local pch-source = [ on $(<) return $(PCH_SOURCE) ] ;
+     if $(pch-source)
+     {
+@@ -1691,10 +1691,10 @@ local rule default-path ( version )
+ 
+ 
+ 
+-rule get-rspline ( target : lang-opt )
++rule get-rspline ( target : lang-opt lang-flags )
+ {
+     CC_RSPLINE on $(target) = [ on $(target) return $(lang-opt) -U$(UNDEFS)
+-        $(CFLAGS) $(C++FLAGS) $(OPTIONS) -c $(.nl)-D$(DEFINES)
++        $($(lang-flags)) $(OPTIONS) -c $(.nl)-D$(DEFINES)
+         $(.nl)\"-I$(INCLUDES:W)\" $(.nl)\"-FI$(FORCE_INCLUDES:W)\" ] ;
+ }
+ 
+@@ -1830,25 +1830,25 @@ local rule register-toolset-really ( )
+     # Declare flags for compilation.
+     #
+ 
+-    toolset.flags msvc.compile CFLAGS <optimization>speed : /O2 ;
+-    toolset.flags msvc.compile CFLAGS <optimization>space : /O1 ;
++    toolset.flags msvc.compile OPTIONS <optimization>speed : /O2 ;
++    toolset.flags msvc.compile OPTIONS <optimization>space : /O1 ;
+ 
+-    toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium) : /G1 ;
+-    toolset.flags msvc.compile CFLAGS $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium2) : /G2 ;
++    toolset.flags msvc.compile OPTIONS  $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium) : /G1 ;
++    toolset.flags msvc.compile OPTIONS  $(.cpu-arch-ia64)/<instruction-set>$(.cpu-type-itanium2) : /G2 ;
+ 
+-    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>object : /Z7 ;
+-    toolset.flags msvc.compile CFLAGS <debug-symbols>on/<debug-store>database : /Zi ;
+-    toolset.flags msvc.compile CFLAGS <optimization>off : /Od ;
+-    toolset.flags msvc.compile CFLAGS <inlining>off : /Ob0 ;
+-    toolset.flags msvc.compile CFLAGS <inlining>on : /Ob1 ;
+-    toolset.flags msvc.compile CFLAGS <inlining>full : /Ob2 ;
++    toolset.flags msvc.compile OPTIONS <debug-symbols>on/<debug-store>object : /Z7 ;
++    toolset.flags msvc.compile OPTIONS <debug-symbols>on/<debug-store>database : /Zi ;
++    toolset.flags msvc.compile OPTIONS <optimization>off : /Od ;
++    toolset.flags msvc.compile OPTIONS <inlining>off : /Ob0 ;
++    toolset.flags msvc.compile OPTIONS <inlining>on : /Ob1 ;
++    toolset.flags msvc.compile OPTIONS <inlining>full : /Ob2 ;
+ 
+-    toolset.flags msvc.compile CFLAGS <warnings>on : /W3 ;
+-    toolset.flags msvc.compile CFLAGS <warnings>off : /W0 ;
+-    toolset.flags msvc.compile CFLAGS <warnings>all : /W4 ;
+-    toolset.flags msvc.compile CFLAGS <warnings>extra : /W4 ;
+-    toolset.flags msvc.compile CFLAGS <warnings>pedantic : /W4 ;
+-    toolset.flags msvc.compile CFLAGS <warnings-as-errors>on : /WX ;
++    toolset.flags msvc.compile OPTIONS <warnings>on : /W3 ;
++    toolset.flags msvc.compile OPTIONS <warnings>off : /W0 ;
++    toolset.flags msvc.compile OPTIONS <warnings>all : /W4 ;
++    toolset.flags msvc.compile OPTIONS <warnings>extra : /W4 ;
++    toolset.flags msvc.compile OPTIONS <warnings>pedantic : /W4 ;
++    toolset.flags msvc.compile OPTIONS <warnings-as-errors>on : /WX ;
+ 
+     toolset.flags msvc.compile C++FLAGS  <exception-handling>on/<asynch-exceptions>off/<extern-c-nothrow>off : /EHs ;
+     toolset.flags msvc.compile C++FLAGS  <exception-handling>on/<asynch-exceptions>off/<extern-c-nothrow>on : /EHsc ;
+@@ -1862,16 +1862,16 @@ local rule register-toolset-really ( )
+     # By default 8.0 enables rtti support while prior versions disabled it. We
+     # simply enable or disable it explicitly so we do not have to depend on this
+     # default behaviour.
+-    toolset.flags msvc.compile CFLAGS <rtti>on : /GR ;
+-    toolset.flags msvc.compile CFLAGS <rtti>off : /GR- ;
+-    toolset.flags msvc.compile CFLAGS <runtime-debugging>off/<runtime-link>shared : /MD ;
+-    toolset.flags msvc.compile CFLAGS <runtime-debugging>on/<runtime-link>shared : /MDd ;
++    toolset.flags msvc.compile C++FLAGS <rtti>on : /GR ;
++    toolset.flags msvc.compile C++FLAGS <rtti>off : /GR- ;
++    toolset.flags msvc.compile OPTIONS <runtime-debugging>off/<runtime-link>shared : /MD ;
++    toolset.flags msvc.compile OPTIONS <runtime-debugging>on/<runtime-link>shared : /MDd ;
+ 
+-    toolset.flags msvc.compile CFLAGS <runtime-debugging>off/<runtime-link>static/<threading>multi : /MT ;
+-    toolset.flags msvc.compile CFLAGS <runtime-debugging>on/<runtime-link>static/<threading>multi : /MTd ;
++    toolset.flags msvc.compile OPTIONS  <runtime-debugging>off/<runtime-link>static/<threading>multi : /MT ;
++    toolset.flags msvc.compile OPTIONS  <runtime-debugging>on/<runtime-link>static/<threading>multi : /MTd ;
+ 
+-    toolset.flags msvc.compile OPTIONS <cflags> : ;
+-    toolset.flags msvc.compile.c++ OPTIONS <cxxflags> : ;
++    toolset.flags msvc.compile CFLAGS <cflags> : ;
++    toolset.flags msvc.compile.c++ C++FLAGS <cxxflags> : ;
+ 
+     toolset.flags msvc.compile PDB_CFLAG <debug-symbols>on/<debug-store>database : /Fd ;
+ 

--- a/ports/boost-build/portfile.cmake
+++ b/ports/boost-build/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_from_github(
     REF boost-${BOOST_VERSION}
     SHA512 e5dd73ef41d341e2bce25677389502d22ca7f328e7fdbb91d95aac415f7b490008d75ff0a63f8e4bd9427215f863c161ec9573c29b663b727df4b60e25a3aac2
     HEAD_REF master
+    PATCHES
+        fix_options.patch
 )
 
 vcpkg_download_distfile(ARCHIVE


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/15232

B2 applied both cflags and c++flags when build with C++ source, which cause the 2 options are incompatible, related to Upstream issue https://github.com/boostorg/build/issues/690

Currently this issue has been fixed in boost-build, extract the patches from the 2 commits for fixing this issue:
https://github.com/boostorg/build/commit/ab341585995464332733d2852a50f9696867e711
https://github.com/boostorg/build/commit/f5584205b0ee93904a5f2a9921459f99a1caa515

Noted that the first commit caused a bunch of c++ options to disappear, so the second commit fixed missing C++ flags args for msvc.