### PR TITLE
[exiv2] Add pkgconfig to fix the path

### DIFF
--- a/ports/exiv2/CONTROL
+++ b/ports/exiv2/CONTROL
@@ -1,6 +1,6 @@
 Source: exiv2
 Version: 0.27.3
-Port-Version: 3
+Port-Version: 4
 Build-Depends: zlib, libiconv, gettext
 Description: Image metadata library and tools
 Homepage: https://www.exiv2.org

--- a/ports/exiv2/portfile.cmake
+++ b/ports/exiv2/portfile.cmake
@@ -31,6 +31,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/exiv2)
+vcpkg_fixup_pkgconfig()
 
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fix #15320

Currently, exiv2.pc contains absolute path, so add `vcpkg_fixup_pkgconfig() `to fix the path problem.

Note: Features are not needed to test.
