### PR TITLE
[freeimage] Fix for FreeImage incorrect image format enum after disabling vendor plugins

### DIFF
--- a/ports/freeimage/CONTROL
+++ b/ports/freeimage/CONTROL
@@ -1,6 +1,6 @@
 Source: freeimage
 Version: 3.18.0
-Port-Version: 17
+Port-Version: 18
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openjpeg, libwebp (!uwp), libraw, jxrlib, openexr
 Homepage: https://sourceforge.net/projects/freeimage/
 Description: Support library for graphics image formats

--- a/ports/freeimage/portfile.cmake
+++ b/ports/freeimage/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_sourceforge(
         fix-function-overload.patch
         use-typedef-as-already-declared.patch
         use-functions-to-override-libtiff-warning-error-handlers.patch
+        update_format_enum_values.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/freeimage/update_format_enum_values.patch
+++ b/ports/freeimage/update_format_enum_values.patch
@@ -1,0 +1,33 @@
+diff --git a/Source/FreeImage.h b/Source/FreeImage.h
+index 59de277..224877f 100644
+--- a/Source/FreeImage.h
++++ b/Source/FreeImage.h
+@@ -420,15 +420,19 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
+ #if 0
+  	FIF_FAXG3	= 27,
+ #endif
+-	FIF_SGI		= 28,
+-	FIF_EXR		= 29,
+-	FIF_J2K		= 30,
+-	FIF_JP2		= 31,
+-	FIF_PFM		= 32,
+-	FIF_PICT	= 33,
+-	FIF_RAW		= 34,
+-	FIF_WEBP	= 35,
+-	FIF_JXR		= 36
++/* vcpkg: removal of G3 fax format messes up the format enum numbering due to FreeImage
++   relying on the list of plugins as created in AddNode(). Enum values have been
++   corrected to compensate. This is similar to the reported bug:
++   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841089 */
++	FIF_SGI		= 27,
++	FIF_EXR		= 28,
++	FIF_J2K		= 29,
++	FIF_JP2		= 30,
++	FIF_PFM		= 31,
++	FIF_PICT	= 32,
++	FIF_RAW		= 33,
++	FIF_WEBP	= 34,
++	FIF_JXR		= 35
+ };
+ 
+ /** Image type used in FreeImage.


### PR DESCRIPTION
**Describe the pull request**

This PR fixes an issue that arise from a separate patch being applied as part of the port: disable-plugins-depending-on-internal-third-party-libraries.patch. 

When ascertaining the format of an image, FreeImage returns and enum value, `FREE_IMAGE_FORMAT`. The above patch commented out one of the enum values, `FIF_FAXG3`, while leaving the enum values following it unchanged: `FIF_SGI, FIF_EXR, FIF_J2K, FIF_JP2, FIF_PFM, FIF_PICT, FIF_RAW, FIF_WEBP, FIF_JXR`. It also commented out adding the plugin to the list via AddNode().

FreeImage has a one-to-one relationship between this enum and its list of available plugins. Therefore, since one plugin is missing from the list, there is an offset of -1 for the above formats when trying to ascertain an image's format. For example, when trying to find the format of a WEBP image, we receive `FIF_RAW`. 

The PR fixes the issue by applying a new patch, subtracting 1 from each of the enum values after `FIF_FAXG3`. We tested it using WEBP images, and quite certain it will work for the rest.

