### PR TITLE
[vcpkg] Improve docs for binarycaching

### DIFF
--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -84,6 +84,34 @@ More information about Azure DevOps Artifacts' NuGet support is available in the
 
 [devops-nuget]: https://docs.microsoft.com/en-us/azure/devops/artifacts/get-started-nuget?view=azure-devops
 
+### Azure Blob Storage (experimental)
+
+> Note: This is an experimental feature and may change or be removed at any time
+
+Vcpkg supports interfacing with Azure Blob Storage via the `x-azblob` source type.
+
+```
+x-azblob,<baseuri>,<sas>[,<rw>]
+```
+
+First, you need to create an Azure Storage Account as well as a container ([Quick Start Documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal)].
+
+Next, you will need to create a Shared Access Signature, which can be done from the storage account under Settings -> Shared access signature. This SAS will need:
+- Allowed services: Blob
+- Allowed resource types: Object
+- Allowed permissions: Read, Create (if using `write` or `readwrite`)
+
+The blob endpoint plus the container must be passed as the `<baseuri>` and the generated SAS without the `?` prefix must be passed as the `<sas>`.
+
+Example:
+```
+x-azblob,https://<storagename>.blob.core.windows.net/<containername>,sv=2019-12-12&ss=b&srt=o&sp=rcx&se=2020-12-31T06:20:36Z&st=2020-12-30T22:20:36Z&spr=https&sig=abcd,readwrite
+```
+
+Vcpkg will attempt to avoid revealing the SAS during normal operations, however:
+1. It will be printed in full if `--debug` is passed
+2. It will be passed as a command line parameter to subprocesses, such as `curl.exe`
+
 ## Configuration
 
 Binary caching is configured via a combination of defaults, the environment variable `VCPKG_BINARY_SOURCES` (set to `<source>;<source>;...`), and the command line option `--binarysource=<source>`. Source options are evaluated in order of defaults, then environment, then command line. Binary caching can be completely disabled by passing `--binarysource=clear` as the last command line option.

--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -62,3 +62,19 @@ This environment variable can be set to a list of environment variables, separat
 the build environment.
 
 Example: `FOO_SDK_DIR;BAR_SDK_DIR`
+
+#### VCPKG_MAX_CONCURRENCY
+
+This environment variables limits the amount of concurrency requested by underlying buildsystems. If unspecified, this defaults to logical cores + 1.
+
+#### VCPKG_DEFAULT_BINARY_CACHE
+
+This environment variable redirects the default location to store binary packages. See [Binary Caching](binarycaching.md#Configuration) for more details.
+
+#### VCPKG_BINARY_SOURCES
+
+This environment variable adds or removes binary sources. See [Binary Caching](binarycaching.md#Configuration) for more details.
+
+#### VCPKG_NUGET_REPOSITORY
+
+This environment variable changes the metadata of produced NuGet packages. See [Binary Caching](binarycaching.md#Configuration) for more details.


### PR DESCRIPTION
This PR adds docs for the experimental `x-azblob` provider as well as filling out some missing environment variables from `config-environment.md`.