### PR TITLE
[paho-mqtt] wrong include path

### DIFF
--- a/ports/paho-mqtt/CONTROL
+++ b/ports/paho-mqtt/CONTROL
@@ -1,5 +1,6 @@
 Source: paho-mqtt
 Version: 1.3.5
+Port-Version: 1
 Homepage: https://github.com/eclipse/paho.mqtt.c
 Description: Paho project provides open-source client implementations of MQTT and MQTT-SN messaging protocols aimed at new, existing, and emerging applications for the Internet of Things
 Build-Depends: openssl

--- a/ports/paho-mqtt/fix-install-path.patch
+++ b/ports/paho-mqtt/fix-install-path.patch
@@ -13,16 +13,3 @@ index 3df385a..1ee7be0 100644
  ENDIF()
  
  ADD_SUBDIRECTORY(src)
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 20b578a..75dc833 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -183,7 +183,7 @@ IF (PAHO_BUILD_STATIC)
- ENDIF()
- 
- INSTALL(FILES MQTTAsync.h MQTTClient.h MQTTClientPersistence.h MQTTProperties.h MQTTReasonCodes.h MQTTSubscribeOpts.h MQTTExportDeclarations.h
--    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/paho-mqtt)
- 
- IF (PAHO_WITH_SSL)
-     SET(OPENSSL_ROOT_DIR "" CACHE PATH "Directory containing OpenSSL libraries and includes")


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15349 
If I link to the target eclipse-paho-mqtt-c::paho-mqtt3as the header files can't be found. The INTERFACE_INCLUDE_DIRECTORIES point to /home/sandro/vcpkg/installed/x64-linux/include whereas the headers are located in /home/sandro/vcpkg/installed/x64-linux/include/paho-mqtt

Note: No featyre need to test

