### PR TITLE
[many ports] Disambiguate Python usage.

### DIFF
--- a/ports/azure-kinect-sensor-sdk/CONTROL
+++ b/ports/azure-kinect-sensor-sdk/CONTROL
@@ -1,6 +1,6 @@
 Source: azure-kinect-sensor-sdk
 Version: 1.4.0-alpha.0
-Port-Version: 6
+Port-Version: 7
 Homepage: https://github.com/microsoft/Azure-Kinect-Sensor-SDK
 Description: Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.
 Build-Depends: azure-c-shared-utility, glfw3, gtest, imgui, libusb, spdlog, cjson, ebml, libjpeg-turbo, matroska, libsoundio, libyuv

--- a/ports/azure-kinect-sensor-sdk/portfile.cmake
+++ b/ports/azure-kinect-sensor-sdk/portfile.cmake
@@ -13,8 +13,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     docs K4A_BUILD_DOCS
@@ -31,6 +29,7 @@ vcpkg_configure_cmake(
     -DBUILD_EXAMPLES=OFF
     -DWITH_TEST=OFF
     -DIMGUI_EXTERNAL_PATH=${CURRENT_INSTALLED_DIR}/include/bindings
+    -DPython3_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_install_cmake()

--- a/ports/blitz/CONTROL
+++ b/ports/blitz/CONTROL
@@ -1,5 +1,6 @@
 Source: blitz
 Version: 2020-03-25
+Port-Version: 1
 Homepage: https://github.com/blitzpp/blitz
 Description: Blitz++ is a C++ template class library that provides high-performance multidimensional array containers for scientific computing.
 Supports: !(arm|arm64|uwp)

--- a/ports/blitz/portfile.cmake
+++ b/ports/blitz/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_find_acquire_program(PYTHON2)
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
         -DBUILD_DOC=OFF
         -DBUILD_TESTING=OFF
         -DPython_EXECUTABLE=${PYTHON2}

--- a/ports/blitz/portfile.cmake
+++ b/ports/blitz/portfile.cmake
@@ -9,14 +9,13 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path(${PYTHON2_DIR})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
         -DBUILD_DOC=OFF
-        -DBUILD_TESTING=OFF    
+        -DBUILD_TESTING=OFF
+        -DPython_EXECUTABLE=${PYTHON2}
 )
 
 vcpkg_install_cmake()

--- a/ports/coolprop/CONTROL
+++ b/ports/coolprop/CONTROL
@@ -1,5 +1,6 @@
 Source: coolprop
 Version: 6.4.1
+Port-Version: 1
 Homepage: https://github.com/CoolProp/CoolProp
 Description: Thermophysical properties for the masses
 Build-Depends: catch, eigen3, pybind11, if97, fmt, rapidjson, msgpack, refprop-headers

--- a/ports/coolprop/portfile.cmake
+++ b/ports/coolprop/portfile.cmake
@@ -13,8 +13,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR ${PYTHON2} DIRECTORY)
-vcpkg_add_to_path(${PYTHON2_DIR})
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/externals)
 
@@ -80,6 +78,7 @@ vcpkg_configure_cmake(
         -DCOOLPROP_STATIC_LIBRARY=${COOLPROP_STATIC_LIBRARY}
         -DCOOLPROP_MSVC_DYNAMIC=${COOLPROP_MSVC_DYNAMIC}
         -DCOOLPROP_MSVC_STATIC=${COOLPROP_MSVC_STATIC}
+        -DPYTHON_EXECUTABLE=${PYTHON2}
     OPTIONS_RELEASE
         -DCOOLPROP_INSTALL_PREFIX=${CURRENT_PACKAGES_DIR}
     OPTIONS_DEBUG

--- a/ports/cppcms/CONTROL
+++ b/ports/cppcms/CONTROL
@@ -1,5 +1,6 @@
 Source: cppcms
-Version: 1.2.1-1
+Version: 1.2.1
+Port-Version: 2
 Homepage: https://github.com/artyom-beilis/cppcms
 Description: CppCMS is a Free High Performance Web Development Framework (not a CMS) aimed at Rapid Web Application Development
 Build-Depends: icu, pcre, openssl, zlib

--- a/ports/cppcms/portfile.cmake
+++ b/ports/cppcms/portfile.cmake
@@ -10,12 +10,13 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR ${PYTHON2} DIRECTORY)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DCMAKE_PROGRAM_PATH=${PYTHON2_DIR} -DUSE_WINDOWS6_API=ON
+    OPTIONS
+        -DPYTHON=${PYTHON2}
+        -DUSE_WINDOWS6_API=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/folly/CONTROL
+++ b/ports/folly/CONTROL
@@ -1,5 +1,6 @@
 Source: folly
 Version: 2020.10.19.00
+Port-Version: 1
 Homepage: https://github.com/facebook/folly
 Description: An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows
 Build-Depends: openssl, libevent, double-conversion, glog, gflags, boost-chrono, boost-context, boost-conversion, boost-crc, boost-date-time, boost-filesystem, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-thread, boost-smart-ptr, fmt

--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -6,8 +6,6 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 # Required to run build/generate_escape_tables.py et al.
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -64,6 +62,7 @@ vcpkg_configure_cmake(
         -DLIBURCU_FOUND=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_LibURCU=ON
         -DCMAKE_INSTALL_DIR=share/folly
+        -DPython3_EXECUTABLE=${PYTHON3}
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/graphqlparser/CONTROL
+++ b/ports/graphqlparser/CONTROL
@@ -1,3 +1,4 @@
 Source: graphqlparser
-Version: 0.7.0-1
+Version: 0.7.0
+Port-Version: 2
 Description: A GraphQL query parser in C++ with C and C++ APIs

--- a/ports/graphqlparser/portfile.cmake
+++ b/ports/graphqlparser/portfile.cmake
@@ -16,20 +16,20 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL 
     )
 elseif(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     vcpkg_find_acquire_program(PYTHON2)
-    vcpkg_find_acquire_program(FLEX) #
+    vcpkg_find_acquire_program(FLEX)
     vcpkg_find_acquire_program(BISON)
 
-    get_filename_component(VCPKG_DOWNLOADS_PYTHON2_DIR "${PYTHON2}" DIRECTORY)
     get_filename_component(VCPKG_DOWNLOADS_FLEX_DIR "${FLEX}" DIRECTORY)
     get_filename_component(VCPKG_DOWNLOADS_BISON_DIR "${BISON}" DIRECTORY)
+
+    vcpkg_add_to_path(${VCPKG_DOWNLOADS_FLEX_DIR})
+    vcpkg_add_to_path(${VCPKG_DOWNLOADS_BISON_DIR})
 
     vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         PREFER_NINJA
         OPTIONS
-            -DVCPKG_DOWNLOADS_PYTHON2_DIR=${VCPKG_DOWNLOADS_PYTHON2_DIR}
-            -DVCPKG_DOWNLOADS_FLEX_DIR=${VCPKG_DOWNLOADS_FLEX_DIR}
-            -DVCPKG_DOWNLOADS_BISON_DIR=${VCPKG_DOWNLOADS_BISON_DIR}
+            -DPYTHON_EXECUTABLE=${PYTHON2}
     )
 endif()
 

--- a/ports/graphqlparser/win-cmake.patch
+++ b/ports/graphqlparser/win-cmake.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index c4c8b3e..3373d82 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3,9 +3,26 @@ PROJECT(libgraphqlparser C CXX)
+@@ -3,9 +3,17 @@ PROJECT(libgraphqlparser C CXX)
  
  SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
  
@@ -11,15 +11,6 @@ index c4c8b3e..3373d82 100644
 +  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 +  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h")
 +ELSEIF(WIN32)
-+  # If we're building this with vcpkg on Windows, let portfile.cmake tell us where it
-+  # stored these tools. Otherwise these variables should be empty and we'll fall back
-+  # to the normal CMake FIND_PACKAGE logic for each of these programs.
-+  SET(CMAKE_PROGRAM_PATH
-+    "${VCPKG_DOWNLOADS_PYTHON2_DIR}"
-+	"${VCPKG_DOWNLOADS_FLEX_DIR}"
-+	"${VCPKG_DOWNLOADS_BISON_DIR}"
-+	"${CMAKE_PROGRAM_PATH}")
-+
 +  SET(FLEX_COMPILE_FLAGS "--header-file=lexer.h --wincompat")
 +
 +  # Let CMake figure out the exports for the SHARED library (DLL) on Windows.

--- a/ports/libtorrent/CONTROL
+++ b/ports/libtorrent/CONTROL
@@ -1,5 +1,6 @@
 Source: libtorrent
 Version: 1.2.11
+Port-Version: 1
 Homepage: https://github.com/arvidn/libtorrent
 Description: An efficient feature complete C++ BitTorrent implementation
 Build-Depends: openssl, boost-system, boost-date-time, boost-chrono, boost-random, boost-asio, boost-crc, boost-config, boost-iterator, boost-scope-exit, boost-multiprecision, boost-pool, boost-variant

--- a/ports/libtorrent/portfile.cmake
+++ b/ports/libtorrent/portfile.cmake
@@ -27,8 +27,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # Note: the python feature currently requires `python3-dev` and `python3-setuptools` installed on the system
 if("python" IN_LIST FEATURES)
     vcpkg_find_acquire_program(PYTHON3)
-    get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
-    vcpkg_add_to_path(${PYTHON3_PATH})
+    list(APPEND FEATURE_OPTIONS -DPython3_EXECUTABLE=${PYTHON3})
 
     file(GLOB BOOST_PYTHON_LIB "${CURRENT_INSTALLED_DIR}/lib/*boost_python*")
     string(REGEX REPLACE ".*(python)([0-9])([0-9]+).*" "\\1\\2\\3" _boost-python-module-name "${BOOST_PYTHON_LIB}")

--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,6 @@
 Source: llvm
 Version: 11.0.0
+Port-Version: 1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -148,8 +148,6 @@ foreach(llvm_target IN LISTS known_llvm_targets)
 endforeach()
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR ${PYTHON3} DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_DIR})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/llvm
@@ -174,6 +172,7 @@ vcpkg_configure_cmake(
         -DLLVM_BUILD_LLVM_C_DYLIB=OFF
         # Path for binary subdirectory (defaults to 'bin')
         -DLLVM_TOOLS_INSTALL_DIR=tools/llvm
+        -DPython3_EXECUTABLE=${PYTHON3}
     OPTIONS_DEBUG
         -DCMAKE_DEBUG_POSTFIX=d
 )

--- a/ports/open62541/CONTROL
+++ b/ports/open62541/CONTROL
@@ -1,5 +1,6 @@
 Source: open62541
 Version: 1.1.2
+Port-Version: 1
 Homepage: https://open62541.org
 Description: open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.
 Supports: !uwp

--- a/ports/open62541/portfile.cmake
+++ b/ports/open62541/portfile.cmake
@@ -14,8 +14,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -23,6 +21,7 @@ vcpkg_configure_cmake(
     OPTIONS
         ${FEATURE_OPTIONS}
         -DOPEN62541_VERSION=${VERSION}
+        -DPYTHON_EXECUTABLE=${PYTHON3}
     OPTIONS_DEBUG
         -DCMAKE_DEBUG_POSTFIX=d
 )

--- a/ports/opencc/CONTROL
+++ b/ports/opencc/CONTROL
@@ -1,6 +1,6 @@
 Source: opencc
 Version: 2020-04-26
-Port-Version: 7
+Port-Version: 8
 Description: A project for conversion between Traditional and Simplified Chinese
 Homepage: https://github.com/BYVoid/OpenCC
 Supports: !(arm|arm64|uwp)

--- a/ports/opencc/portfile.cmake
+++ b/ports/opencc/portfile.cmake
@@ -9,14 +9,13 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR ${PYTHON3} DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_DIR})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_DOCUMENTATION=OFF
         -DENABLE_GTEST=OFF
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_install_cmake(

--- a/ports/opencolorio-tools/CONTROL
+++ b/ports/opencolorio-tools/CONTROL
@@ -1,5 +1,6 @@
 Source: opencolorio-tools
 Version: 1.1.1
+Port-Version: 1
 Homepage: https://opencolorio.org/
 Description: OpenColorIO applications, same source with port OpenColorIO.
 Build-Depends: openimageio[opencolorio]

--- a/ports/opencolorio-tools/portfile.cmake
+++ b/ports/opencolorio-tools/portfile.cmake
@@ -25,8 +25,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_PATH "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path(PREPEND ${PYTHON3_PATH})
 
 # TODO(theblackunknown) build additional targets based on feature
 
@@ -44,6 +42,7 @@ vcpkg_configure_cmake(
         -DOCIO_BUILD_PYGLUE:BOOL=OFF
         -DOCIO_BUILD_JNIGLUE:BOOL=OFF
         -DOCIO_STATIC_JNIGLUE:BOOL=OFF
+        -DPython_EXECUTABLE:FILEPATH=${PYTHON3}
         -DUSE_EXTERNAL_TINYXML:BOOL=ON
         -DUSE_EXTERNAL_YAML:BOOL=ON
 )

--- a/ports/opencolorio/CONTROL
+++ b/ports/opencolorio/CONTROL
@@ -1,6 +1,6 @@
 Source: opencolorio
 Version: 1.1.1
-Port-Version: 4
+Port-Version: 5
 Homepage: https://opencolorio.org/
 Description: OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.
 Build-Depends: glew[core], freeglut[core], lcms[core], yaml-cpp[core], tinyxml[core]

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -22,8 +22,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_PATH "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path(PREPEND ${PYTHON3_PATH})
 
 # TODO(theblackunknown) build additional targets based on feature
 
@@ -41,6 +39,7 @@ vcpkg_configure_cmake(
         -DOCIO_BUILD_PYGLUE:BOOL=OFF
         -DOCIO_BUILD_JNIGLUE:BOOL=OFF
         -DOCIO_STATIC_JNIGLUE:BOOL=OFF
+        -DPython_EXECUTABLE:FILEPATH=${PYTHON3}
         -DUSE_EXTERNAL_TINYXML:BOOL=ON
         -DUSE_EXTERNAL_YAML:BOOL=ON
 )

--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -1,6 +1,6 @@
 Source: openimageio
 Version: 2.1.16.0
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/OpenImageIO/oiio
 Description: A library for reading and writing images, and a bunch of related classes, utilities, and application
 Build-Depends: libjpeg-turbo, tiff, libpng, libheif, openexr, boost-thread, boost-smart-ptr, boost-foreach, boost-regex, boost-type-traits, boost-static-assert, boost-unordered, boost-config, boost-algorithm, boost-filesystem, boost-system, boost-thread, boost-asio, boost-random, robin-map, boost-stacktrace, fmt

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -44,8 +44,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -61,6 +59,7 @@ vcpkg_configure_cmake(
         -DBUILD_MISSING_PYBIND11=OFF
         -DBUILD_MISSING_DEPS=OFF
         -DVERBOSE=ON
+        -DPython_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_install_cmake()

--- a/ports/opensubdiv/portfile.cmake
+++ b/ports/opensubdiv/portfile.cmake
@@ -19,8 +19,6 @@ These can be installed on Ubuntu systems via sudo apt install libxinerama-dev")
 endif()
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
 
 if (VCPKG_CRT_LINKAGE STREQUAL static)
     set(STATIC_CRT_LNK ON)
@@ -39,6 +37,7 @@ vcpkg_configure_cmake(
         -DNO_REGRESSION=ON
         -DNO_TESTS=ON
         -DMSVC_STATIC_CRT=${STATIC_CRT_LNK}
+        -DPYTHON_EXECUTABLE=${PYTHON2}
 )
 
 vcpkg_install_cmake()

--- a/ports/opensubdiv/vcpkg.json
+++ b/ports/opensubdiv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opensubdiv",
   "version-string": "3.4.3",
+  "port-version": 1,
   "description": "An Open-Source subdivision surface library.",
   "homepage": "https://github.com/PixarAnimationStudios/OpenSubdiv",
   "supports": "!arm & !uwp"

--- a/ports/proxygen/CONTROL
+++ b/ports/proxygen/CONTROL
@@ -1,5 +1,6 @@
 Source: proxygen
 Version: 2020.10.19.00
+Port-Version: 1
 Homepage: https://github.com/facebook/proxygen
 Description: It comprises the core C++ HTTP abstractions used at Facebook.
 Build-Depends: folly, fizz, wangle, zstd, zlib, openssl, boost-iostreams, boost-context, boost-date-time, boost-filesystem, boost-program-options, boost-regex, boost-system, boost-thread

--- a/ports/proxygen/portfile.cmake
+++ b/ports/proxygen/portfile.cmake
@@ -9,8 +9,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_PATH})
 
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_find_acquire_program(GPERF)
@@ -26,6 +24,8 @@ endif()
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DPROXYGEN_PYTHON=${PYTHON3}
 )
 
 vcpkg_install_cmake()

--- a/ports/pybind11/CONTROL
+++ b/ports/pybind11/CONTROL
@@ -1,6 +1,6 @@
 Source: pybind11
 Version: 2.6.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/pybind/pybind11
 Description: pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.
 Build-Depends: python3 (windows)

--- a/ports/pybind11/portfile.cmake
+++ b/ports/pybind11/portfile.cmake
@@ -7,8 +7,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYPATH ${PYTHON3} PATH)
-vcpkg_add_to_path("${PYPATH}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -16,6 +14,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DPYBIND11_TEST=OFF
         -DPYTHONLIBS_FOUND=ON
+        -DPYTHON_EXECUTABLE=${PYTHON3}
         -DPYTHON_INCLUDE_DIRS=${CURRENT_INSTALLED_DIR}/include
         -DPYTHON_MODULE_EXTENSION=.dll
     OPTIONS_RELEASE

--- a/ports/shaderc/CONTROL
+++ b/ports/shaderc/CONTROL
@@ -1,5 +1,6 @@
 Source: shaderc
 Version: 2019-06-26-1
+Port-Version: 1
 Homepage: https://github.com/google/shaderc
 Description: A collection of tools, libraries and tests for shader compilation.
 Build-Depends: glslang, spirv-tools

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -25,13 +25,16 @@ endif()
 
 # shaderc uses python to manipulate copyright information
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_EXE_PATH ${PYTHON3} DIRECTORY)
-vcpkg_add_to_path(PREPEND "${PYTHON3_EXE_PATH}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DSHADERC_SKIP_TESTS=true ${OPTIONS} -Dglslang_SOURCE_DIR=${CURRENT_INSTALLED_DIR}/include -Dspirv-tools_SOURCE_DIR=${CURRENT_INSTALLED_DIR}/include 
+    OPTIONS
+        -DSHADERC_SKIP_TESTS=true
+        ${OPTIONS}
+        -Dglslang_SOURCE_DIR=${CURRENT_INSTALLED_DIR}/include
+        -Dspirv-tools_SOURCE_DIR=${CURRENT_INSTALLED_DIR}/include
+        -DPYTHON_EXECUTABLE=${PYTHON3}
     OPTIONS_DEBUG -DSUFFIX_D=true
     OPTIONS_RELEASE -DSUFFIX_D=false
 )

--- a/ports/shogun/CONTROL
+++ b/ports/shogun/CONTROL
@@ -1,6 +1,6 @@
 Source: shogun
 Version: 6.1.4
-Port-Version: 4
+Port-Version: 5
 Build-Depends: bzip2, eigen3, liblzma, libxml2, blas, nlopt, rxcpp, snappy, zlib, protobuf, curl, lzo, dirent
 Homepage: https://github.com/shogun-toolbox/shogun
 Description: Unified and efficient Machine Learning

--- a/ports/shogun/portfile.cmake
+++ b/ports/shogun/portfile.cmake
@@ -14,8 +14,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path(${PYTHON3_DIR})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -43,6 +41,7 @@ vcpkg_configure_cmake(
         -DCMAKE_DISABLE_FIND_PACKAGE_CURL=TRUE
         -DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE
         -DINSTALL_TARGETS=shogun-static
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_install_cmake()

--- a/ports/spirv-tools/CONTROL
+++ b/ports/spirv-tools/CONTROL
@@ -1,5 +1,6 @@
 Source: spirv-tools
 Version: 2020.1-1
+Port-Version: 1
 Homepage: https://github.com/KhronosGroup/SPIRV-Tools
 Description: API and commands for processing SPIR-V modules
 Build-Depends: spirv-headers

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -13,8 +13,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -23,6 +21,7 @@ vcpkg_configure_cmake(
         -DSPIRV-Headers_SOURCE_DIR=${CURRENT_INSTALLED_DIR}
         -DSPIRV_WERROR=OFF
         -DENABLE_SPIRV_TOOLS_INSTALL=ON
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_install_cmake()

--- a/ports/usd/CONTROL
+++ b/ports/usd/CONTROL
@@ -1,5 +1,6 @@
 Source: usd
 Version: 20.08
+Port-Version: 1
 Homepage: https://github.com/PixarAnimationStudios/USD
 Build-Depends: boost-assign, boost-crc, boost-date-time, boost-filesystem, boost-format, boost-multi-index, boost-program-options, boost-regex, boost-system, boost-vmd, tbb, zlib
 Description: Universal Scene Description (USD) is an efficient, scalable system for authoring, reading, and streaming time-sampled scene description for interchange between graphics applications.

--- a/ports/usd/portfile.cmake
+++ b/ports/usd/portfile.cmake
@@ -14,8 +14,6 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
 
 IF (VCPKG_TARGET_IS_WINDOWS)
 ELSE()
@@ -37,6 +35,7 @@ vcpkg_configure_cmake(
         -DPXR_BUILD_EXAMPLES:BOOL=OFF
         -DPXR_BUILD_TUTORIALS:BOOL=OFF
         -DPXR_BUILD_USD_TOOLS:BOOL=OFF
+        -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON2}
 )
 
 vcpkg_install_cmake()

--- a/ports/yasm-tool/portfile.cmake
+++ b/ports/yasm-tool/portfile.cmake
@@ -4,8 +4,6 @@ set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 set(VCPKG_LIBRARY_LINKAGE static)
 
 vcpkg_find_acquire_program(PYTHON3)
-get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -19,6 +17,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DENABLE_NLS=OFF
+        -DPYTHON_EXECUTABLE=${PYTHON3}
         -DYASM_BUILD_TESTS=OFF
 )
 

--- a/ports/yasm-tool/vcpkg.json
+++ b/ports/yasm-tool/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yasm-tool",
   "version-string": "2020-10-12",
+  "port-version": 1,
   "description": "A modular assembler. This port is intended to build other ports and should not be used directly.",
   "homepage": "http://yasm.tortall.net/",
   "supports": "windows & x86"

--- a/ports/yasm/CONTROL
+++ b/ports/yasm/CONTROL
@@ -1,5 +1,6 @@
 Source: yasm
 Version: 1.3.0
+Port-Version: 1
 Homepage: https://github.com/yasm/yasm
 Description: Yasm is a complete rewrite of the NASM assembler under the “new” BSD License.
 Supports: windows & !uwp & !arm

--- a/ports/yasm/portfile.cmake
+++ b/ports/yasm/portfile.cmake
@@ -15,12 +15,12 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON_PATH ${PYTHON2} DIRECTORY)
-vcpkg_add_to_path("${PYTHON_PATH}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DPYTHON_EXECUTABLE=${PYTHON2}
 )
 
 vcpkg_install_cmake()

--- a/ports/z3/CONTROL
+++ b/ports/z3/CONTROL
@@ -1,5 +1,6 @@
 Source: z3
 Version: 4.8.9
+Port-Version: 1
 Homepage: https://github.com/Z3Prover/z3
 Description: Z3 is a theorem prover from Microsoft Research.
 Supports: !arm64 && !uwp

--- a/ports/z3/portfile.cmake
+++ b/ports/z3/portfile.cmake
@@ -1,8 +1,6 @@
 vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "arm64")
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
@@ -23,6 +21,7 @@ vcpkg_configure_cmake(
   PREFER_NINJA
   OPTIONS
     ${BUILD_STATIC}
+    -DPYTHON_EXECUTABLE=${PYTHON2}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
In #15298 there are CI failures that appear to result from ports using the wrong Python interpreter, potentially the one built by #14891. This fixes all cmake based ports to correctly specify the path to the python executable instead of relying on magical fairy dust for finding the acquired python in the path.

- What does your PR fix?
See above

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
