### PR TITLE
[msbuild]Fix incorrect triplet configuration for Project Reunion apps

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.props
+++ b/scripts/buildsystems/msbuild/vcpkg.props
@@ -4,7 +4,7 @@
   <!-- Set default OS Target-->
   <PropertyGroup Condition="'$(VcpkgOSTarget)' == ''">
     <VcpkgOSTarget>windows</VcpkgOSTarget>
-    <VcpkgOSTarget Condition="'$(AppContainerApplication)' != '' And $(AppContainerApplication)">uwp</VcpkgOSTarget>
+    <VcpkgOSTarget Condition="'$(AppContainerApplication)' == 'true'">uwp</VcpkgOSTarget>
   </PropertyGroup>
 
   <!-- Set default Platform Target. $(PlatformTarget) is not available at the top of the .vcxproj file. -->

--- a/scripts/buildsystems/msbuild/vcpkg.props
+++ b/scripts/buildsystems/msbuild/vcpkg.props
@@ -4,7 +4,7 @@
   <!-- Set default OS Target-->
   <PropertyGroup Condition="'$(VcpkgOSTarget)' == ''">
     <VcpkgOSTarget>windows</VcpkgOSTarget>
-    <VcpkgOSTarget Condition="'$(ApplicationType)|$(ApplicationTypeRevision)' == 'Windows Store|10.0'">uwp</VcpkgOSTarget>
+    <VcpkgOSTarget Condition="'$(AppContainerApplication)' != '' And $(AppContainerApplication)">uwp</VcpkgOSTarget>
   </PropertyGroup>
 
   <!-- Set default Platform Target. $(PlatformTarget) is not available at the top of the .vcxproj file. -->


### PR DESCRIPTION
Fixes incorrect triplet configuration for Project Reunion apps.

- What does your PR fix? 
Fixes #15409

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes