### PR TITLE
[docs] fix "CMake script" -> "makefile" for vcpkg_(n)build_make

### DIFF
--- a/docs/maintainers/vcpkg_build_make.md
+++ b/docs/maintainers/vcpkg_build_make.md
@@ -38,7 +38,7 @@ Additional subdir to invoke make in. Useful if only parts of a port should be bu
 
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
-You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your CMake script supports the
+You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your makefile supports the
 "install" target
 
 ## Examples

--- a/docs/maintainers/vcpkg_build_nmake.md
+++ b/docs/maintainers/vcpkg_build_nmake.md
@@ -64,7 +64,7 @@ Adds the appropriate Release and Debug `bin\` directories to the path during the
 
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
-You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your CMake script supports the
+You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your makefile supports the
 "install" target
 
 ## Examples

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -39,7 +39,7 @@ Additional subdir to invoke make in. Useful if only parts of a port should be bu
 
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
-You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your CMake script supports the
+You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your makefile supports the
 "install" target
 
 ## Examples

--- a/scripts/cmake/vcpkg_build_nmake.cmake
+++ b/scripts/cmake/vcpkg_build_nmake.cmake
@@ -65,7 +65,7 @@ Adds the appropriate Release and Debug `bin\` directories to the path during the
 
 ## Notes:
 This command should be preceeded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
-You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your CMake script supports the
+You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your makefile supports the
 "install" target
 
 ## Examples


### PR DESCRIPTION
This patch replaces "your CMake script" with "your makefile" in the documentation of `vcpkg_build_(n)make.md`, which is probably copied from `vcpkg_build_cmake.md`.

I am not sure if such a small document fix would be accepted as a PR; if not, please feel free to squash it with others.