### PR TITLE
[hidapi] Support static build

### DIFF
--- a/ports/hidapi/CONTROL
+++ b/ports/hidapi/CONTROL
@@ -1,4 +1,0 @@
-Source: hidapi
-Version: 2019-08-30
-Description: A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.
-Homepage: https://github.com/libusb/hidapi

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "linux" "osx" "uwp")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
@@ -7,26 +9,46 @@ vcpkg_from_github(
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    if(TRIPLET_SYSTEM_ARCH MATCHES "arm")
-        message(FATAL_ERROR "ARM builds are currently not supported!")
-    elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore)
-        message(FATAL_ERROR "UWP builds are currently not supported!")
+    file(READ "${SOURCE_PATH}/windows/hidapi.vcxproj" _contents)
+    if(${VCPKG_CRT_LINKAGE} STREQUAL "dynamic")
+        string(REGEX REPLACE
+            "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"
+            "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>"
+            _contents "${_contents}")
+        string(REGEX REPLACE
+            "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>"
+            "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>"
+            _contents "${_contents}")
+    else()
+        string(REGEX REPLACE
+            "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>"
+            "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>"
+            _contents "${_contents}")
+        string(REGEX REPLACE
+            "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>"
+            "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>"
+            _contents "${_contents}")
     endif()
+
+    if(${VCPKG_LIBRARY_LINKAGE} STREQUAL "dynamic")
+        string(REPLACE
+            "<ConfigurationType>StaticLibrary</ConfigurationType>"
+            "<ConfigurationType>DynamicLibrary</ConfigurationType>"
+            _contents "${_contents}")
+    else()
+        string(REPLACE
+            "<ConfigurationType>DynamicLibrary</ConfigurationType>"
+            "<ConfigurationType>StaticLibrary</ConfigurationType>"
+            _contents "${_contents}")
+    endif()
+    file(WRITE "${SOURCE_PATH}/windows/hidapi.vcxproj" "${_contents}")
 
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
-        PROJECT_SUBPATH windows/hidapi.sln
+        PROJECT_SUBPATH windows/hidapi.vcxproj
         INCLUDES_SUBPATH hidapi ALLOW_ROOT_INCLUDES
         LICENSE_SUBPATH LICENSE-bsd.txt # use BSD license
     )
 
-    file(COPY
-        ${CMAKE_CURRENT_LIST_DIR}/hidapi-config.cmake
-        DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    endif()
-else()
-    message(FATAL_ERROR "Non-Windows builds are currently not supported!")
+    file(COPY {CMAKE_CURRENT_LIST_DIR}/hidapi-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 endif()

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -50,5 +50,5 @@ if(VCPKG_TARGET_IS_WINDOWS)
         LICENSE_SUBPATH LICENSE-bsd.txt # use BSD license
     )
 
-    file(COPY {CMAKE_CURRENT_LIST_DIR}/hidapi-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+    file(COPY ${CMAKE_CURRENT_LIST_DIR}/hidapi-config.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 endif()

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "hidapi",
+  "version-string": "2019-08-30",
+  "port-version": 1,
+  "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
+  "homepage": "https://github.com/libusb/hidapi",
+  "supports": "windows & !(arm | arm64 | uwp)"
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/15422

hidapi doesn't configure with static build in poject files, it generates dynamic library when build with static, and simiply remove the bin directory in vcpkg, which is wrong.

Fix the issue and supports the static build.