### PR TITLE
[wil] Use internal CMakeLists

### DIFF
--- a/ports/wil/CONTROL
+++ b/ports/wil/CONTROL
@@ -1,3 +1,5 @@
 Source: wil
 Version: 2020-05-19
+Port-Version: 1
+Homepage: https://github.com/microsoft/wil
 Description: The Windows Implementation Libraries (WIL) is a header-only C++ library created to make life easier for developers on Windows through readable type-safe C++ interfaces for common Windows coding patterns.

--- a/ports/wil/fix-install-headers.patch
+++ b/ports/wil/fix-install-headers.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 97a6737..4ae28fb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,4 +48,4 @@ install(EXPORT ${PROJECT_NAME}_targets
+ )
+ 
+ # Install the headers at a standard cmake location.
+-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+\ No newline at end of file
++install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/wil" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+\ No newline at end of file

--- a/ports/wil/portfile.cmake
+++ b/ports/wil/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     REF 3c00e7f1d8cf9930bbb8e5be3ef0df65c84e8928
     SHA512 c9c3b4a41f7523a6da6378def4a6b868e9f66438998d04ae8489b9784db91664af7af3ab6ef73c104b9ac100c0dc5ae6a13e9cb9f679ba428a4abc07b32a7dce
     HEAD_REF master
+    PATCHES fix-install-headers.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/wil/portfile.cmake
+++ b/ports/wil/portfile.cmake
@@ -7,5 +7,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/wil RENAME copyright)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DWIL_BUILD_TESTS=OFF
+        -DWIL_BUILD_PACKAGING=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/WIL)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/wil" RENAME copyright)


### PR DESCRIPTION
Since wil support official CMakeLists, use it instead.

Fixes #15431.