### PR TITLE
[openblas] Force static linking on linux as findpackage only find static blas

### DIFF
--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_LINUX)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xianyi/OpenBLAS


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15192. This is more a workaround, but because I don't want to replace system FindBLAS, I didn't find a better way  than disabling dynamic linkage for BLAS.
- Which triplets are supported/not supported? Have you updated the CI baseline? This force linux to use static build, even with dynamic triplet
