### PR TITLE
[ixwebsocket] build failure

### DIFF
--- a/ports/ixwebsocket/CONTROL
+++ b/ports/ixwebsocket/CONTROL
@@ -1,5 +1,6 @@
 Source: ixwebsocket
 Version: 11.0.4
+Port-Version: 1
 Build-Depends: zlib
 Homepage: https://github.com/machinezone/IXWebSocket
 Description: Lightweight WebSocket Client and Server + HTTP Client and Server

--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ixwebsocket TARGET_PATH share/${port})
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ixwebsocket TARGET_PATH share/${PORT})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15451 
The CMake targets after ixwebsocket install are
find_package(share CONFIG REQUIRED)
target_link_libraries(main PRIVATE ixwebsocket::ixwebsocket)
There is a problem, the correct one should be
find_package(ixwebsocket CONFIG REQUIRED)
target_link_libraries(main PRIVATE ixwebsocket::ixwebsocket)
After modification, the build can be used normally

All features are tested successfully in the following triplets:

- x86-windows
- x64-windows
- x64-windows-static

