### PR TITLE
[python2] Add feature tools

### DIFF
--- a/ports/cppcms/CONTROL
+++ b/ports/cppcms/CONTROL
@@ -1,6 +1,7 @@
 Source: cppcms
-Version: 1.2.1-1
+Version: 1.2.1
+Port-Version: 2
 Homepage: https://github.com/artyom-beilis/cppcms
 Description: CppCMS is a Free High Performance Web Development Framework (not a CMS) aimed at Rapid Web Application Development
-Build-Depends: icu, pcre, openssl, zlib
+Build-Depends: icu, pcre, openssl, zlib, python2[tools]
 Supports: !(linux|osx)

--- a/ports/graphqlparser/CONTROL
+++ b/ports/graphqlparser/CONTROL
@@ -1,3 +1,5 @@
 Source: graphqlparser
-Version: 0.7.0-1
+Version: 0.7.0
+Port-Version: 2
+Build-Depends: python2[tools]
 Description: A GraphQL query parser in C++ with C and C++ APIs

--- a/ports/open62541/CONTROL
+++ b/ports/open62541/CONTROL
@@ -1,7 +1,9 @@
 Source: open62541
 Version: 1.1.2
+Port-Version: 1
 Homepage: https://open62541.org
 Description: open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.
+Build-Depends: python2[tools]
 Supports: !uwp
 Default-Features: openssl
 

--- a/ports/python2/CONTROL
+++ b/ports/python2/CONTROL
@@ -1,3 +1,8 @@
 Source: python2
-Version: 2.7.15-2
+Version: 2.7.15
+Port-Version: 3
+Homepage: https://www.python.org
 Description: The Python programming language as an embeddable library
+
+Feature: tools
+Description: Build python2 executable


### PR DESCRIPTION
Add feature `tools` to build and install python executables.
To fix the issue:
```
Traceback (most recent call last):
  File "D:\buildtrees\cppcms\src\20a4ad93d4-26c9d29282.clean\bin\cppcms_tmpl_cc", line 14, in <module>
    import StringIO
ModuleNotFoundError: No module named 'StringIO'
```

