### PR TITLE
[vcpkg baseline][cppcms] Fix issue with detecting Python 2.

### DIFF
--- a/ports/cppcms/CONTROL
+++ b/ports/cppcms/CONTROL
@@ -1,5 +1,6 @@
 Source: cppcms
-Version: 1.2.1-1
+Version: 1.2.1
+Port-Version: 2
 Homepage: https://github.com/artyom-beilis/cppcms
 Description: CppCMS is a Free High Performance Web Development Framework (not a CMS) aimed at Rapid Web Application Development
 Build-Depends: icu, pcre, openssl, zlib

--- a/ports/cppcms/portfile.cmake
+++ b/ports/cppcms/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DPYTHON=${PYTHON2}
+        -DPYTHON=${PYTHON2} # Switch to python3 on the next update
         -DUSE_WINDOWS6_API=ON
 )
 

--- a/ports/cppcms/portfile.cmake
+++ b/ports/cppcms/portfile.cmake
@@ -10,12 +10,13 @@ vcpkg_from_github(
 )
 
 vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR ${PYTHON2} DIRECTORY)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DCMAKE_PROGRAM_PATH=${PYTHON2_DIR} -DUSE_WINDOWS6_API=ON
+    OPTIONS
+        -DPYTHON=${PYTHON2}
+        -DUSE_WINDOWS6_API=ON
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This fixes an issue with detection of Python 2 in the cppcms port. Ping @JackBoosY 

- What does your PR fix?
The upstream CMakeLists were using `find_program()` to find the Python executable instead of `find_package()`. This can result in the Python 3 interpreter built by the python3 port to be selected in some situations. We fix this by passing the path to Python directly to the CMake cache.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
