### PR TITLE
[vcpkg_build_msbuild][vcpkg_install_msbuild] Deduplicate and enable /MP for better performance

### DIFF
--- a/docs/maintainers/vcpkg_build_msbuild.md
+++ b/docs/maintainers/vcpkg_build_msbuild.md
@@ -16,6 +16,7 @@ vcpkg_build_msbuild(
     [OPTIONS_RELEASE </p:ZLIB_LIB=X>...]
     [OPTIONS_DEBUG </p:ZLIB_LIB=X>...]
     [USE_VCPKG_INTEGRATION]
+    [DISABLE_APPLOCAL_DEPS]
 )
 ```
 
@@ -24,6 +25,11 @@ vcpkg_build_msbuild(
 Apply the normal `integrate install` integration for building the project.
 
 By default, projects built with this command will not automatically link libraries or have header paths set.
+
+### DISABLE_APPLOCAL_DEPS
+Disables copying dependent DLLs to the output folder.
+
+This option is strongly recommended when passing `USE_VCPKG_INTEGRATION`.
 
 ### PROJECT_PATH
 The path to the solution (`.sln`) or project (`.vcxproj`) file.

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -14,6 +14,7 @@ set(PATCHES
     0004-dont-copy-vcruntime.patch
     0005-only-build-required-projects.patch
     0006-fix-duplicate-symbols.patch
+    pyproject-runtimelibrary.patch
 )
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(PREPEND PATCHES 0001-static-library.patch)
@@ -98,10 +99,18 @@ if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
         vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/debug/bin")
     endif()
 
+    if(VCPKG_CRT_LINKAGE STREQUAL "static")
+        set(RUNTIME_LIBRARY_SUFFIX)
+    else()
+        set(RUNTIME_LIBRARY_SUFFIX DLL)
+    endif()
+
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
         PROJECT_SUBPATH "PCbuild/pcbuild.proj"
         OPTIONS ${OPTIONS}
+        OPTIONS_RELEASE /p:RuntimeLibrary=MultiThreaded${RUNTIME_LIBRARY_SUFFIX}
+        OPTIONS_DEBUG /p:RuntimeLibrary=MultiThreadedDebug${RUNTIME_LIBRARY_SUFFIX}
         LICENSE_SUBPATH "LICENSE"
         SKIP_CLEAN
     )

--- a/ports/python3/pyproject-runtimelibrary.patch
+++ b/ports/python3/pyproject-runtimelibrary.patch
@@ -1,0 +1,21 @@
+diff --git a/PCbuild/pyproject.props b/PCbuild/pyproject.props
+index c659d14..9229d90 100644
+--- a/PCbuild/pyproject.props
++++ b/PCbuild/pyproject.props
+@@ -37,7 +37,7 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <StringPooling>true</StringPooling>
+       <ExceptionHandling></ExceptionHandling>
+-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <RuntimeLibrary>$(RuntimeLibrary)</RuntimeLibrary>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+@@ -50,7 +50,6 @@
+     <ClCompile Condition="$(Configuration) == 'Debug'">
+       <Optimization>Disabled</Optimization>
+       <WholeProgramOptimization>false</WholeProgramOptimization>
+-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+     </ClCompile>
+     <ClCompile Condition="$(ICCBuild) == 'true'">
+       <FloatingPointModel>Strict</FloatingPointModel>

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
-  "version-string": "3.9.0",
-  "port-version": 3,
+  "version-semver": "3.9.0",
+  "port-version": 4,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/scripts/cmake/vcpkg_install_msbuild.cmake
+++ b/scripts/cmake/vcpkg_install_msbuild.cmake
@@ -124,6 +124,7 @@ function(vcpkg_install_msbuild)
     endfunction()
 
     set(BUILD_MSBUILD_OPTIONS
+        _PASS_VCPKG_VARS
         OPTIONS ${_csc_OPTIONS}
         OPTIONS_RELEASE ${_csc_OPTIONS_RELEASE}
         OPTIONS_DEBUG ${_csc_OPTIONS_DEBUG}
@@ -137,11 +138,22 @@ function(vcpkg_install_msbuild)
     if(DEFINED _csc_PLATFORM_TOOLSET)
         list(APPEND BUILD_MSBUILD_OPTIONS PLATFORM_TOOLSET ${_csc_PLATFORM_TOOLSET})
     endif()
-    if(DEFINED _csc_PLATFORM)
-        list(APPEND BUILD_MSBUILD_OPTIONS PLATFORM ${_csc_PLATFORM})
+    if(NOT DEFINED _csc_PLATFORM)
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+            set(_csc_PLATFORM x64)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+            set(_csc_PLATFORM Win32)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL ARM)
+            set(_csc_PLATFORM ARM)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+            set(_csc_PLATFORM arm64)
+        else()
+            message(FATAL_ERROR "Unsupported target architecture")
+        endif()
     endif()
+    list(APPEND BUILD_MSBUILD_OPTIONS PLATFORM ${_csc_PLATFORM})
     if(DEFINED _csc_USE_VCPKG_INTEGRATION)
-        list(APPEND BUILD_MSBUILD_OPTIONS USE_VCPKG_INTEGRATION)
+        list(APPEND BUILD_MSBUILD_OPTIONS USE_VCPKG_INTEGRATION DISABLE_APPLOCAL_DEPS)
     endif()
     if(DEFINED _csc_DEBUG_CONFIGURATION)
         list(APPEND BUILD_MSBUILD_OPTIONS DEBUG_CONFIGURATION ${_csc_DEBUG_CONFIGURATION})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4722,7 +4722,7 @@
     },
     "python3": {
       "baseline": "3.9.0",
-      "port-version": 3
+      "port-version": 4
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3edecc2e2c0cc393f81690c73683d41394d72c7",
+      "version-semver": "3.9.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "b2f9a57528c88d1deef5b695e56edd7a671c97c2",
       "version-string": "3.9.0",
       "port-version": 3


### PR DESCRIPTION
This PR enables /MP parallelism for MSBuild-based ports and reduced code duplication by refactoring `vcpkg_install_msbuild()` to dispatch to `vcpkg_build_msbuild()`.

Replaces #12223.