### PR TITLE
[libzippp] fix find lzma

### DIFF
--- a/ports/libzippp/CONTROL
+++ b/ports/libzippp/CONTROL
@@ -1,6 +1,6 @@
 Source: libzippp
 Version: 4.0-1.7.3
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/ctabin/libzippp
 Description: Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling
 Build-Depends: zlib, libzip[core,bzip2]

--- a/ports/libzippp/fix-find-lzma.patch
+++ b/ports/libzippp/fix-find-lzma.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/FindLIBZIP.cmake b/cmake/FindLIBZIP.cmake
+index c51c09a..a32bb13 100644
+--- a/cmake/FindLIBZIP.cmake
++++ b/cmake/FindLIBZIP.cmake
+@@ -50,7 +50,7 @@ if (LIBZIP_FOUND)
+             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES Nettle::Nettle)
+         endif()
+         if(_have_extra_libs MATCHES "-llzma")
+-            find_package(LibLZMA::LibLZMA REQUIRED)
++            find_package(LibLZMA REQUIRED)
+             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES LibLZMA::LibLZMA)
+         endif()
+         if(_have_extra_libs MATCHES "-lz")

--- a/ports/libzippp/portfile.cmake
+++ b/ports/libzippp/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 791bdc43eb18b87e3bdfa087493e3e32217e672c #v4.0-1.7.3 with CXX std version c++11
     SHA512 c6a90ecec21bb2d9e3af681c35d7eec0bee7b356fc1438004dc84be32ee7b94d047c35817d46b222237d54699ea54afa4fd3ae5deeba40dfce4fd2035a38b0e5
     HEAD_REF libzippp-v4.0-1.7.3
+    PATCHES fix-find-lzma.patch
 )
 
 vcpkg_check_features(
@@ -22,6 +23,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_copy_pdbs()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake/libzippp")


### PR DESCRIPTION
**Describe the pull request**
  * Adds patch to fix find lzma after port changes to use upstream CMakeLists.txt

- What does your PR fix? https://github.com/microsoft/vcpkg/issues/14679
  * Reference Issue: [libzippp] x64-windows build failure after liblzma use upstream CMakeLists.txt + Add pkgconfig. (#14615) #14679 
  * Reference Commit: PR [liblzma] use upstream CMakeLists.txt + Add pkgconfig. (#14615) https://github.com/microsoft/vcpkg/commit/eb895b95aac6fd7485373702f29f508c42a180a0
- Which triplets are supported/not supported? Have you updated the CI baseline? No Changes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
