### PR TITLE
[openigtlink] Fix cmake config location

### DIFF
--- a/ports/openigtlink/CONTROL
+++ b/ports/openigtlink/CONTROL
@@ -1,3 +1,5 @@
 Source: openigtlink
 Version: 3.0
+Port-Version: 1
+Homepage: https://github.com/openigtlink/OpenIGTLink
 Description: OpenIGTLink is an open-source network communication interface specifically designed for image-guided interventions.

--- a/ports/openigtlink/portfile.cmake
+++ b/ports/openigtlink/portfile.cmake
@@ -11,14 +11,12 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
          -DBUILD_TESTING=OFF
+         -DOpenIGTLink_INSTALL_PACKAGE_DIR=share/${PORT}
 )
 
 vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/igtl/cmake)
-
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 vcpkg_copy_pdbs()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4242,7 +4242,7 @@
     },
     "openigtlink": {
       "baseline": "3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "openimageio": {
       "baseline": "2.2.10.0",

--- a/versions/o-/openigtlink.json
+++ b/versions/o-/openigtlink.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f814a06b22cc250df4eb31553c6df7a803567b7",
+      "version-string": "3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "df766287f1c9c4d379143fab2456a64ae7ae8452",
       "version-string": "3.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 

Currently the openigtlink config files are generated in a igtl-3.0 subdirectory making the standard cmake `find_package(OpenIGTLink CONFIG REQUIRED)` fail. Even worse, the `OpenIGTLinkConfig.cmake` contained wrong hard coded path, set during build time. The package was just unusable.

This PR address this issues.
