### PR TITLE
[vcpkg] Fix build for mingw

### DIFF
--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -48,14 +48,10 @@ namespace fs
     inline path u8path(std::initializer_list<char> il) { return u8path(vcpkg::StringView{il.begin(), il.end()}); }
     inline path u8path(const char* s) { return u8path(vcpkg::StringView{s, s + ::strlen(s)}); }
 
-    // this allows us to support implementations where std::is_same_v<std::string::const_iterator, const char*>
-    // otherwise, this would collide with u8path(const char*, const char*)
-    template <class T, class = std::enable_if_t<std::is_convertible_v<T, std::string::const_iterator>>>
-    inline path u8path(T first, T last)
+    inline path u8path(std::string::const_iterator first, std::string::const_iterator last)
     {
-        std::string::const_iterator first_it = first, last_it = last;
-        auto firstp = &*first_it;
-        return u8path(vcpkg::StringView{firstp, firstp + (last_it - first_it)});
+        auto firstp = &*first;
+        return u8path(vcpkg::StringView{firstp, firstp + (last - first)});
     }
 
     std::string u8string(const path& p);

--- a/toolsrc/include/vcpkg/base/files.h
+++ b/toolsrc/include/vcpkg/base/files.h
@@ -48,20 +48,15 @@ namespace fs
     inline path u8path(std::initializer_list<char> il) { return u8path(vcpkg::StringView{il.begin(), il.end()}); }
     inline path u8path(const char* s) { return u8path(vcpkg::StringView{s, s + ::strlen(s)}); }
 
-#if defined(_MSC_VER)
-    inline path u8path(std::string::const_iterator first, std::string::const_iterator last)
+    // this allows us to support implementations where std::is_same_v<std::string::const_iterator, const char*>
+    // otherwise, this would collide with u8path(const char*, const char*)
+    template <class T, class = std::enable_if_t<std::is_convertible_v<T, std::string::const_iterator>>>
+    inline path u8path(T first, T last)
     {
-        if (first == last)
-        {
-            return path{};
-        }
-        else
-        {
-            auto firstp = &*first;
-            return u8path(vcpkg::StringView{firstp, firstp + (last - first)});
-        }
+        std::string::const_iterator first_it = first, last_it = last;
+        auto firstp = &*first_it;
+        return u8path(vcpkg::StringView{firstp, firstp + (last_it - first_it)});
     }
-#endif
 
     std::string u8string(const path& p);
     std::string generic_u8string(const path& p);

--- a/toolsrc/src/vcpkg/base/files.cpp
+++ b/toolsrc/src/vcpkg/base/files.cpp
@@ -104,6 +104,11 @@ namespace
 
 fs::path fs::u8path(vcpkg::StringView s)
 {
+    if (s.size() == 0)
+    {
+        return fs::path();
+    }
+
 #if defined(_WIN32)
     return fs::path(vcpkg::Strings::to_utf16(s));
 #else


### PR DESCRIPTION
Change `u8path` to always allow `string::const_iterator`, even on non-MSVC. We had the split before because I thought that `std::is_same_v<char const*, string::const_iterator>` was an implementation choice made by some standard libraries, but that isn't accurate.

Fixes #10349 