### PR TITLE
[libraw] Fix non-determinant openmp behavior.

### DIFF
--- a/ports/libraw/CONTROL
+++ b/ports/libraw/CONTROL
@@ -1,5 +1,6 @@
 Source: libraw
 Version: 201903-3
+Port-Version: 1
 Build-Depends: lcms, jasper
 Homepage: https://www.libraw.org
 Description: raw image decoder library

--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DINSTALL_CMAKE_MODULE_PATH=${CURRENT_PACKAGES_DIR}/share/libraw
         -DCMAKE_DEBUG_POSTFIX=d
+        -DENABLE_OPENMP=OFF
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
This fixes an issue by which libraw may be built with or without support for `openmp` depending on the currently installed packages. This has been observed to cause a non-determinant build error in the `openimageio` port. Since `openmp` is not listed as a dependency of libraw, I have explicitly disabled it in the portfile to prevent these kinds of errors.

- What does your PR fix?
See above.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
