### PR TITLE
[pybind11] Use vcpkg Python3.

### DIFF
--- a/ports/pybind11/CONTROL
+++ b/ports/pybind11/CONTROL
@@ -1,6 +1,6 @@
 Source: pybind11
 Version: 2.6.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/pybind/pybind11
 Description: pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa, mainly to create Python bindings of existing C++ code.
-Build-Depends: python3 (windows)
+Build-Depends: python3


### PR DESCRIPTION
This fixes an issue in which pybind11 might use system Python instead of the vcpkg python3 port. On a clean install of vcpkg in Ubuntu 20.04, this has been observed to cause the port to fail to build.

- What does your PR fix?
See above.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
