### PR TITLE
[vcpkg] Allow to use Nuget's cache for Nuget binary caching sources (fix #15169)

### DIFF
--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -197,6 +197,10 @@ or
 ```
 if the appropriate environment variables are defined and non-empty. This is specifically used to associate packages in GitHub Packages with the _building_ project and not intended to associate with the original package sources.
 
+#### NuGet's cache
+
+NuGet's cache is not used by default. To use it for every nuget-based source, set the [environment variable](config-environment.md) `VCPKG_USE_NUGET_CACHE` to `true` (case-insensitive) or `1`.
+
 ## Implementation Notes (internal details subject to change without notice)
 
 Binary caching relies on hashing everything that contributes to a particular package build. This includes:

--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -78,3 +78,7 @@ This environment variable adds or removes binary sources. See [Binary Caching](b
 #### VCPKG_NUGET_REPOSITORY
 
 This environment variable changes the metadata of produced NuGet packages. See [Binary Caching](binarycaching.md#Configuration) for more details.
+
+#### VCPKG_USE_NUGET_CACHE
+
+This environment variable allows using NuGet's cache for every nuget-based binary source. See [Binary Caching](binarycaching.md#NuGets-cache) for more details.

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -2,6 +2,7 @@
 #include <vcpkg/base/downloads.h>
 #include <vcpkg/base/files.h>
 #include <vcpkg/base/parse.h>
+#include <vcpkg/base/strings.h>
 #include <vcpkg/base/system.debug.h>
 #include <vcpkg/base/system.print.h>
 #include <vcpkg/base/system.process.h>
@@ -411,7 +412,11 @@ namespace
             , m_read_configs(std::move(read_configs))
             , m_write_configs(std::move(write_configs))
             , m_interactive(interactive)
+            , m_use_nuget_cache(false)
         {
+            const std::string use_nuget_cache = System::get_environment_variable("VCPKG_USE_NUGET_CACHE").value_or("");
+            m_use_nuget_cache = Strings::case_insensitive_ascii_equals(use_nuget_cache, "true") ||
+                                Strings::case_insensitive_ascii_equals(use_nuget_cache, "1");
         }
 
         int run_nuget_commandline(const std::string& cmdline)
@@ -525,9 +530,7 @@ namespace
                     .string_arg("-Source")
                     .string_arg(Strings::join(";", m_read_sources))
                     .string_arg("-ExcludeVersion")
-                    .string_arg("-NoCache")
                     .string_arg("-PreRelease")
-                    .string_arg("-DirectDownload")
                     .string_arg("-PackageSaveMode")
                     .string_arg("nupkg")
                     .string_arg("-Verbosity")
@@ -536,6 +539,10 @@ namespace
                 if (!m_interactive)
                 {
                     cmdline.string_arg("-NonInteractive");
+                }
+                if (!m_use_nuget_cache)
+                {
+                    cmdline.string_arg("-DirectDownload").string_arg("-NoCache");
                 }
 
                 cmdlines.push_back(cmdline.extract());
@@ -555,9 +562,7 @@ namespace
                     .string_arg("-ConfigFile")
                     .path_arg(cfg)
                     .string_arg("-ExcludeVersion")
-                    .string_arg("-NoCache")
                     .string_arg("-PreRelease")
-                    .string_arg("-DirectDownload")
                     .string_arg("-PackageSaveMode")
                     .string_arg("nupkg")
                     .string_arg("-Verbosity")
@@ -566,6 +571,10 @@ namespace
                 if (!m_interactive)
                 {
                     cmdline.string_arg("-NonInteractive");
+                }
+                if (!m_use_nuget_cache)
+                {
+                    cmdline.string_arg("-DirectDownload").string_arg("-NoCache");
                 }
 
                 cmdlines.push_back(cmdline.extract());
@@ -729,6 +738,7 @@ namespace
 
         std::set<PackageSpec> m_restored;
         bool m_interactive;
+        bool m_use_nuget_cache;
     };
 }
 

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -1433,6 +1433,9 @@ void vcpkg::help_topic_binary_caching(const VcpkgPaths&)
              "\n"
              "if the appropriate environment variables are defined and non-empty.\n");
     tbl.blank();
+    tbl.text("NuGet's cache is not used by default. To use it for every nuget-based source, set the environment "
+             "variable `VCPKG_USE_NUGET_CACHE` to `true` (case-insensitive) or `1`.\n");
+    tbl.blank();
     System::print2(tbl.m_str);
     const auto& maybe_cachepath = default_cache_path();
     if (auto p = maybe_cachepath.get())

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -52,12 +52,6 @@ namespace vcpkg::Commands::PortHistory
             return run_git_command_inner(paths, dot_git_dir, work_dir, cmd);
         }
 
-        bool is_date(const std::string& version_string)
-        {
-            std::regex re("^([0-9]{4,}[-][0-9]{2}[-][0-9]{2})$");
-            return std::regex_match(version_string, re);
-        }
-
         vcpkg::Optional<HistoryVersion> get_version_from_text(const std::string& text,
                                                               const std::string& git_tree,
                                                               const std::string& commit_id,


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15169

I also fixed a warning on `Fix warning on clang version 10.0.0-4ubuntu1` so that I could compile `toolsrc` (the function `is_date` was not used anymore).

I should probably add documentation, but I wanted feedback before writing the doc. I fixed the issue I raise in #15169 by introducing an environment variable `VCPKG_USE_NUGET_CACHE`. This is the simplest solution I could think of, and it has the advantage of requiring a very small changeset/pull request.

I'm looking forward for your feedback. :slightly_smiling_face: 

- Which triplets are supported/not supported? Have you updated the CI baseline? The same. No.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes.
