### PR TITLE
[vtk] fix find lz4 hdf5 pegl

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 6
+Port-Version: 7
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2

--- a/ports/vtk/FindLZ4.patch
+++ b/ports/vtk/FindLZ4.patch
@@ -1,8 +1,8 @@
 diff --git a/CMake/FindLZ4.cmake b/CMake/FindLZ4.cmake
-index 8c94e3bcd..ade3f9451 100644
+index 8c94e3b..034e43e 100644
 --- a/CMake/FindLZ4.cmake
 +++ b/CMake/FindLZ4.cmake
-@@ -1,38 +1,3 @@
+@@ -1,38 +1,5 @@
 -find_path(LZ4_INCLUDE_DIR
 -  NAMES lz4.h
 -  DOC "lz4 include directory")
@@ -42,6 +42,8 @@ index 8c94e3bcd..ade3f9451 100644
 -  endif ()
 -endif ()
 +find_package(LZ4 CONFIG REQUIRED)
-+set_target_properties(lz4::lz4 PROPERTIES IMPORTED_GLOBAL TRUE)
-+add_library(LZ4::LZ4 ALIAS lz4::lz4)
++if(NOT TARGET LZ4::LZ4)
++  add_library(LZ4::LZ4 INTERFACE IMPORTED)
++  set_property(TARGET LZ4::LZ4 APPEND PROPERTY INTERFACE_LINK_LIBRARIES lz4::lz4)
++endif()
 \ No newline at end of file

--- a/ports/vtk/pegtl.patch
+++ b/ports/vtk/pegtl.patch
@@ -13,10 +13,10 @@ index 73eee02f7..22d8bc159 100644
 -mark_as_advanced(PEGTL_INCLUDE_DIR)
 +message(STATUS "Searching for PEGTL")
 +find_package(PEGTL CONFIG NAMES PEGTL-2)
-+if(TARGET taocpp::pegtl)
++if(TARGET taocpp::pegtl AND NOT TARGET PEGTL::PEGTL)
 +    message(STATUS "Searching for PEGTL - found target taocpp::pegtl")
-+    set_target_properties(taocpp::pegtl PROPERTIES IMPORTED_GLOBAL TRUE)
-+    add_library(PEGTL::PEGTL ALIAS taocpp::pegtl)
++    add_library(PEGTL::PEGTL INTERFACE IMPORTED)
++    set_property(TARGET PEGTL::PEGTL APPEND PROPERTY INTERFACE_LINK_LIBRARIES taocpp::pegtl)
 +else()
 +    find_path(PEGTL_INCLUDE_DIR
 +      NAMES pegtl/version.hpp

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -346,3 +346,6 @@ endforeach()
 # =============================================================================
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/Copyright.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+# This is a workaround for bug #15502: HDF5 targets are not the same between VTK and ITK, and HDF5 prevent double inclusion with a fatal error
+file(REMOVE ${CURRENT_PACKAGES_DIR}/share/${PORT}/patches/99/FindHDF5.cmake)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6350,7 +6350,7 @@
     },
     "vtk": {
       "baseline": "9.0.1",
-      "port-version": 6
+      "port-version": 7
     },
     "vtk-dicom": {
       "baseline": "0.8.12-1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "533b7c3d28bbcb1b2d0eb0a56c94ea1ba5939139",
+      "version-string": "9.0.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "78be7ee36f34395e4d5511fd61457c4f7178a438",
       "version-string": "9.0.1",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #15502

Basically it fixes LZ4, HDF5, PEGL import problems, allowing to use VTK / ITK with FindPackage.
