### PR TITLE
[curl] Use cmake_minimum_required() to ensure if(ON) works

### DIFF
--- a/ports/curl/CONTROL
+++ b/ports/curl/CONTROL
@@ -1,5 +1,5 @@
 Source: curl
-Port-Version: 1
+Port-Version: 2
 Version: 7.74.0
 Build-Depends: zlib
 Homepage: https://github.com/curl/curl

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -189,3 +189,7 @@ endif()
 
 file(INSTALL ${CURRENT_PORT_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+file(READ "${CURRENT_PACKAGES_DIR}/share/curl/CURLConfig.cmake" _contents)
+# CURL uses if(ON) in its config file, which requires cmake_minimum_required to function correctly
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/curl/CURLConfig.cmake" "cmake_minimum_required(VERSION 3.1)\n${_contents}")

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -24,8 +24,11 @@ vcpkg_configure_cmake(
         -DENABLE_UTILS=OFF
         -DENABLE_GLIB=OFF
         -DENABLE_GLOBJECT_INTROSPECTION=OFF
+        -DENABLE_GTK_DOC=OFF
         -DENABLE_QT5=OFF
         -DENABLE_QT6=OFF
+        -DENABLE_CMS=none
+        -DRUN_GPERF_IF_PRESENT=OFF
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "poppler",
   "version-string": "20.12.1",
+  "port-version": 1,
   "description": "a PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "dependencies": [
@@ -8,6 +9,7 @@
       "name": "cairo",
       "platform": "osx"
     },
+    "curl",
     {
       "name": "devil",
       "platform": "(windows | linux) & !arm"
@@ -15,7 +17,10 @@
     "fontconfig",
     "freetype",
     "libiconv",
-    "openjpeg"
+    "libjpeg-turbo",
+    "libpng",
+    "openjpeg",
+    "tiff"
   ],
   "default-features": [
     "zlib"


### PR DESCRIPTION
This fixes a baseline issue with poppler discovered in #15424