### PR TITLE
[vcpkg/docs] Add Missing Links in Spanish Readme

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -1,5 +1,10 @@
 # Vcpkg
 
+[中文总览](README_zh_CN.md)
+[English](README.md)
+[한국어](README_ko_KR.md)
+[Français](README_fr.md)
+
 Vcpkg ayuda a manejar librerías de C y C++ en Windows, Linux y MacOS.
 Esta herramienta y ecosistema se encuentran en constante evolución ¡Siempre apreciamos contribuciones nuevas!
 


### PR DESCRIPTION
This Pull Request add the missing links from the other readme files


- What does your PR fix? Add the missing links for the spanish readme

- Which triplets are supported/not supported? 
N/A it is a fix for the spanish readme / Documentation Related