### PR TITLE
[speexdsp] fix dll exports

### DIFF
--- a/ports/speexdsp/CMakeLists.txt
+++ b/ports/speexdsp/CMakeLists.txt
@@ -39,6 +39,7 @@ set(LIBSPEEXDSP_HEADERS
     "${CMAKE_CURRENT_LIST_DIR}/include/speex/speex_buffer.h"
 )
 set(LIBSPEEXDSP_HEADERS_PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include/speex/speex_buffer.h"
     "${CMAKE_CURRENT_LIST_DIR}/include/speex/speex_echo.h"
     "${CMAKE_CURRENT_LIST_DIR}/include/speex/speex_jitter.h"
     "${CMAKE_CURRENT_LIST_DIR}/include/speex/speex_preprocess.h"

--- a/ports/speexdsp/CONTROL
+++ b/ports/speexdsp/CONTROL
@@ -1,6 +1,6 @@
 Source: speexdsp
 Version: 1.2.0
-Port-Version: 4
+Port-Version: 5
 Homepage: https://speex.org/
 Description: A patent-free, Open Source/Free Software DSP library.
 Build-Depends:

--- a/ports/speexdsp/portfile.cmake
+++ b/ports/speexdsp/portfile.cmake
@@ -16,6 +16,7 @@ else()
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${ARCHIVE}"
         REF "1.2.0"
+        PATCHES "win-exports.patch"
     )
 endif()
 

--- a/ports/speexdsp/win-exports.patch
+++ b/ports/speexdsp/win-exports.patch
@@ -1,0 +1,41 @@
+--- a/win32/libspeexdsp.def	2018-09-08 00:49:31.000000000 +0300
++++ b/win32/libspeexdsp.def	2021-01-11 03:17:12.864767700 +0300
+@@ -1,4 +1,4 @@
+-LIBRARY libspeexdsp
++LIBRARY speexdsp
+ EXPORTS
+ 
+ 
+@@ -23,6 +23,7 @@
+ speex_echo_cancel
+ speex_echo_capture
+ speex_echo_playback
++speex_echo_state_destroy
+ speex_echo_state_reset
+ speex_echo_ctl
+ speex_decorrelate_new
+@@ -32,12 +33,15 @@
+ ;
+ ;	speex_jitter.h
+ ;
++jitter_buffer_ctl
+ jitter_buffer_init
+ jitter_buffer_reset
+ jitter_buffer_destroy
+ jitter_buffer_put
+ jitter_buffer_get
++jitter_buffer_get_another
+ jitter_buffer_get_pointer_timestamp
++jitter_buffer_remaining_span
+ jitter_buffer_tick
+ jitter_buffer_update_delay
+ 
+@@ -71,6 +75,8 @@
+ speex_resampler_get_input_stride
+ speex_resampler_set_output_stride
+ speex_resampler_get_output_stride
++speex_resampler_get_input_latency
++speex_resampler_get_output_latency
+ speex_resampler_skip_zeros
+ speex_resampler_reset_mem
+ speex_resampler_strerror


### PR DESCRIPTION
* Fixes some missing exports in `speexdsp` library
* Fixes missing `speexdsp_buffer.h` header
* Fixes .dll name

Tested on {arm,arm64,x86,x64}-windows.