### PR TITLE
[poppler] Fix error gperf is not recognized as an internal or externa command

### DIFF
--- a/ports/poppler/0003-fix-gperf-not-recognized.patch
+++ b/ports/poppler/0003-fix-gperf-not-recognized.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cce875a..0b04be7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -530,8 +530,8 @@ endif()
+ if (GPERF AND RUN_GPERF_IF_PRESENT)
+     macro(ADD_GPERF_FILE input)
+         add_custom_command(OUTPUT poppler/${input}.c
+-                       COMMAND gperf poppler/${input}.gperf > ${CMAKE_CURRENT_BINARY_DIR}/poppler/${input}.c
+-                       COMMAND gperf poppler/${input}.gperf > ${CMAKE_CURRENT_SOURCE_DIR}/poppler/${input}.pregenerated.c
++                       COMMAND ${GPERF} poppler/${input}.gperf > ${CMAKE_CURRENT_BINARY_DIR}/poppler/${input}.c
++                       COMMAND ${GPERF} poppler/${input}.gperf > ${CMAKE_CURRENT_SOURCE_DIR}/poppler/${input}.pregenerated.c
+                        COMMAND clang-format -i ${CMAKE_CURRENT_SOURCE_DIR}/poppler/${input}.pregenerated.c || true
+                        DEPENDS poppler/${input}.gperf
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -7,7 +7,12 @@ vcpkg_from_github(
     PATCHES
         0001-remove-CMAKE_CXX_STANDARD.patch
         0002-remove-test-subdirectory.patch
+        0003-fix-gperf-not-recognized.patch
 )
+
+vcpkg_find_acquire_program(GPERF)
+get_filename_component(GPERF_PATH ${GPERF} DIRECTORY)
+vcpkg_add_to_path(${GPERF_PATH})
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     curl ENABLE_CURL

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "poppler",
   "version-string": "20.12.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "a PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "dependencies": [


### PR DESCRIPTION
**Describe the pull request**
Poppler installation failed with error "gperf is not recognized as an internal or externa command" in the internal CI test.
For fix this issue:
1. Replace the gperf.exe as the variable ${GPERF} which from find_program(GPERF gperf);
2. Since poppler used gperf, adding vcpkg_find_acquire_program(GPERF) into the porffile.cmake file.  BTW, fontconfig is the dependence of the poppler, and it include the vcpkg_find_acquire_program(GPERF) in its portfile.cmake file.

