### PR TITLE
[vcpkg] Add parse checking for version fields and enable non-string versions outside 'versions' flag

### DIFF
--- a/toolsrc/src/vcpkg-test/manifests.cpp
+++ b/toolsrc/src/vcpkg-test/manifests.cpp
@@ -136,6 +136,25 @@ TEST_CASE ("manifest versioning", "[manifests]")
         "version-semver": "abcd#1"
     })json",
                         true);
+
+    SECTION ("version syntax")
+    {
+        test_parse_manifest(R"json({
+        "name": "zlib",
+        "version-semver": "2020-01-01"
+    })json",
+                            true);
+        test_parse_manifest(R"json({
+        "name": "zlib",
+        "version-date": "1.1.1"
+    })json",
+                            true);
+        test_parse_manifest(R"json({
+        "name": "zlib",
+        "version": "1.2.3-rc3"
+    })json",
+                            true);
+    }
 }
 
 TEST_CASE ("manifest constraints error hash", "[manifests]")

--- a/toolsrc/src/vcpkg/sourceparagraph.cpp
+++ b/toolsrc/src/vcpkg/sourceparagraph.cpp
@@ -1009,14 +1009,6 @@ namespace vcpkg
     {
         if (!flags.versions)
         {
-            if (core_paragraph->version_scheme != Versions::Scheme::String)
-            {
-                return Strings::concat(fs::u8string(origin),
-                                       " was rejected because it uses a non-string version scheme and the `",
-                                       VcpkgCmdArguments::VERSIONS_FEATURE,
-                                       "` feature flag is disabled.\nThis can be fixed by using \"version-string\".");
-            }
-
             auto check_deps = [&](View<Dependency> deps) -> Optional<std::string> {
                 for (auto&& dep : deps)
                 {

--- a/toolsrc/src/vcpkg/versiondeserializers.cpp
+++ b/toolsrc/src/vcpkg/versiondeserializers.cpp
@@ -97,15 +97,40 @@ namespace vcpkg
         else
         {
             if (has_exact)
+            {
                 version_scheme = Versions::Scheme::String;
+            }
             else if (has_relax)
+            {
                 version_scheme = Versions::Scheme::Relaxed;
+                auto v = Versions::RelaxedVersion::from_string(version);
+                if (!v.has_value())
+                {
+                    r.add_generic_error(parent_type, "'version' text was not a relaxed version:\n", v.error());
+                }
+            }
             else if (has_semver)
+            {
                 version_scheme = Versions::Scheme::Semver;
+                auto v = Versions::SemanticVersion::from_string(version);
+                if (!v.has_value())
+                {
+                    r.add_generic_error(parent_type, "'version-semver' text was not a semantic version:\n", v.error());
+                }
+            }
             else if (has_date)
+            {
                 version_scheme = Versions::Scheme::Date;
+                auto v = Versions::DateVersion::from_string(version);
+                if (!v.has_value())
+                {
+                    r.add_generic_error(parent_type, "'version-date' text was not a date version:\n", v.error());
+                }
+            }
             else
+            {
                 Checks::unreachable(VCPKG_LINE_INFO);
+            }
         }
 
         return SchemedVersion(version_scheme, VersionT{version, port_version});


### PR DESCRIPTION
See title.

This enables PRs to the vcpkg repository to begin converting ports to use version schemes besides `version-string`.