### PR TITLE
[ignition-fuel-tools4] Add new port 🤖

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -2416,6 +2416,10 @@
       "baseline": "1.2.0-2",
       "port-version": 0
     },
+    "ignition-fuel-tools4": {
+      "baseline": "4.3.0",
+      "port-version": 0
+    },
     "ignition-math4": {
       "baseline": "4.0.0-1",
       "port-version": 0

--- a/port_versions/i-/ignition-fuel-tools4.json
+++ b/port_versions/i-/ignition-fuel-tools4.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f151bec5a2340e8531307d7b205f8d78f56a7513",
+      "version-string": "4.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/ports/ignition-fuel-tools4/CONTROL
+++ b/ports/ignition-fuel-tools4/CONTROL
@@ -1,0 +1,5 @@
+Source: ignition-fuel-tools4
+Version: 4.3.0
+Homepage: https://ignitionrobotics.org/libs/fuel_tools
+Build-Depends: curl, ignition-cmake2, ignition-common3, ignition-modularscripts, ignition-msgs5, libyaml, libzip, jsoncpp, tinyxml2
+Description: Tools for using fuel API to download robot models

--- a/ports/ignition-fuel-tools4/portfile.cmake
+++ b/ports/ignition-fuel-tools4/portfile.cmake
@@ -1,0 +1,7 @@
+include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_library.cmake)
+
+ignition_modular_library(NAME fuel-tools
+                         VERSION "4.3.0"
+                         CMAKE_PACKAGE_NAME ignition-fuel_tools4
+                         SHA512 451d7bcd195a8ce41c3a7d64ad936c8c0812cbc7af03dbe75cbdc359599bf1f828595833c1758d4de8e37c37730bb852de95b2256ff9134af4ab197df2b66a8b
+                         )


### PR DESCRIPTION
- What does your PR fix? 
  - This PR adds a new port for the new major  version of the [ignition-fuel-tools](https://ignitionrobotics.org/libs/fuel_tools) library. 

- Which triplets are supported/not supported?
  - All tested triplet (for which the dependency are actually available) should be supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - I hope.

As discussed in https://github.com/microsoft/vcpkg/pull/7781, different major version of ignition robotics libraries (https://ignitionrobotics.org/) can be installed side by side, so each new major version is added as a new port. 

In particular, ignition-fuel-tools4 is a dependency for Gazebo 11 (http://gazebosim.org/blog/gazebo11) and for Ignition Robotics Citadel (that contains Ignition Gazebo 3, see https://www.openrobotics.org/blog/2019/12/11/ignition-citadel-released).
