### PR TITLE
[libzip] Relative pkgconfig paths

### DIFF
--- a/ports/libzip/CONTROL
+++ b/ports/libzip/CONTROL
@@ -1,5 +1,6 @@
 Source: libzip
 Version: 1.7.3
+Port-Version: 1
 Homepage: https://github.com/nih-at/libzip
 Build-Depends: zlib
 Default-Features: bzip2,default-aes

--- a/ports/libzip/portfile.cmake
+++ b/ports/libzip/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share/libzip)
+vcpkg_fixup_pkgconfig()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
  
 # Remove include directories from lib


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #2973
libzip.pc currently builds with absolute paths. This adds the missing call to `vcpkg_fixup_pkgconfig`.
