### PR TITLE
[qt5-base] Improve the warning message on Linux

### DIFF
--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,6 +1,6 @@
 Source: qt5-base
 Version: 5.15.1
-Port-Version: 5
+Port-Version: 4
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, zstd, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl, angle (!windows), egl-registry, icu (!uwp), fontconfig (!windows)

--- a/ports/qt5-base/CONTROL
+++ b/ports/qt5-base/CONTROL
@@ -1,6 +1,6 @@
 Source: qt5-base
 Version: 5.15.1
-Port-Version: 4
+Port-Version: 5
 Homepage: https://www.qt.io/
 Description: Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.
 Build-Depends: zlib, zstd, libjpeg-turbo, libpng, freetype, pcre2, harfbuzz, sqlite3, libpq, double-conversion, openssl, angle (!windows), egl-registry, icu (!uwp), fontconfig (!windows)

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -16,9 +16,41 @@ endif()
 
 
 if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libx11-xcb-dev\n\nThese can be installed on Ubuntu systems via apt-get install libx11-xcb-dev.")
-    message(WARNING "${PORT} for qt5-x11extras requires the following libraries from the system package manager:\n    libxkbcommon-x11-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxkbcommon-x11-dev.")
-    #
+    message(WARNING
+[[
+qt5-base currently requires the following libraries from the system package manager:
+    libx11-xcb-dev
+    libx11-dev
+    libxext-dev
+    libxfixes-dev
+    libxi-dev
+    libxrender-dev
+    libxcb1-dev
+    libxcb-glx0-dev
+    libxcb-keysyms1-dev
+    libxcb-image0-dev
+    libxcb-shm0-dev
+    libxcb-icccm4-dev
+    libxcb-sync-dev
+    libxcb-xfixes0-dev
+    libxcb-shape0-dev
+    libxcb-randr0-dev
+    libxcb-render-util0-dev
+    libxcb-xinerama0-dev
+    libxkbcommon-dev
+    libxkbcommon-x11-dev
+
+These can be installed on Ubuntu systems via apt-get install PACKAGE_NAME.
+]]
+    )
+    message(WARNING 
+[[
+qt5-base for qt5-x11extras requires the following libraries from the system package manager:
+    libxkbcommon-x11-dev
+
+These can be installed on Ubuntu systems via apt-get install libxkbcommon-x11-dev.
+]]
+    )
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -16,33 +16,7 @@ endif()
 
 
 if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING
-[[
-qt5-base currently requires the following libraries from the system package manager:
-    libx11-xcb-dev
-    libx11-dev
-    libxext-dev
-    libxfixes-dev
-    libxi-dev
-    libxrender-dev
-    libxcb1-dev
-    libxcb-glx0-dev
-    libxcb-keysyms1-dev
-    libxcb-image0-dev
-    libxcb-shm0-dev
-    libxcb-icccm4-dev
-    libxcb-sync-dev
-    libxcb-xfixes0-dev
-    libxcb-shape0-dev
-    libxcb-randr0-dev
-    libxcb-render-util0-dev
-    libxcb-xinerama0-dev
-    libxkbcommon-dev
-    libxkbcommon-x11-dev
-
-These can be installed on Ubuntu systems via apt-get install PACKAGE_NAME.
-]]
-    )
+    message(WARNING "qt5-base currently requires some packages from the system package manager, see https://doc.qt.io/qt-5/linux-requirements.html")
     message(WARNING 
 [[
 qt5-base for qt5-x11extras requires the following libraries from the system package manager:


### PR DESCRIPTION
According to [the users reply](https://github.com/microsoft/vcpkg/issues/15150#issuecomment-745958851), improve the warning message to notify users to install more dependent packages on Linux.

Fixes #15150.