### PR TITLE
[vcpkg_acquire_msys] add findutils as a dependency to libtool

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -185,7 +185,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
     msys_package(
         URL "https://repo.msys2.org/msys/x86_64/libtool-2.4.6-9-x86_64.pkg.tar.xz"
         SHA512 b309799e5a9d248ef66eaf11a0bd21bf4e8b9bd5c677c627ec83fa760ce9f0b54ddf1b62cbb436e641fbbde71e3b61cb71ff541d866f8ca7717a3a0dbeb00ebf
-        DEPS grep sed coreutils file 
+        DEPS grep sed coreutils file findutils
     )
     msys_package(
         URL "https://repo.msys2.org/msys/x86_64/file-5.39-1-x86_64.pkg.tar.zst"


### PR DESCRIPTION
libtool sometimes requires `find` to be available. 
Without this dependency libtool is partly unuseable. 