### PR TITLE
[vcpkg_build_make] remove libtool artifacts

### DIFF
--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -238,6 +238,12 @@ function(vcpkg_build_make)
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}_tmp")
     endif()
 
+    # Remove libtool files since they contain absolute paths and are not necessary. 
+    file(GLOB_RECURSE LIBTOOL_FILES "${CURRENT_PACKAGES_DIR}/**/*.la")
+    if(LIBTOOL_FILES)
+        file(REMOVE ${LIBTOOL_FILES})
+    endif()
+
     if (CMAKE_HOST_WIN32)
         set(ENV{PATH} "${PATH_GLOBAL}")
     endif()


### PR DESCRIPTION
- current status from the x window pr #9966 is that they are seemingly unnecessary
- also solid evidence that if the file exists and has been moved will lead to a dependent build error. 