### PR TITLE
[vcpkg] Rewriting CmdLineBuilder (2/n)

### DIFF
--- a/test.cmake
+++ b/test.cmake
@@ -1,0 +1,1 @@
+execute_process(COMMAND "bash" "-c" "echo \$TEST_ENV_VAR")

--- a/toolsrc/include/vcpkg/base/cache.h
+++ b/toolsrc/include/vcpkg/base/cache.h
@@ -4,7 +4,7 @@
 
 namespace vcpkg
 {
-    template<class Key, class Value>
+    template<class Key, class Value, class Less = std::less<Key>>
     struct Cache
     {
         template<class F>
@@ -16,6 +16,6 @@ namespace vcpkg
         }
 
     private:
-        mutable std::map<Key, Value> m_cache;
+        mutable std::map<Key, Value, Less> m_cache;
     };
 }

--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -20,10 +20,6 @@ namespace vcpkg::System
         std::string s;
     };
 
-    std::string make_basic_cmake_cmd(const fs::path& cmake_tool_path,
-                                     const fs::path& cmake_script,
-                                     const std::vector<CMakeVariable>& pass_variables);
-
     struct CmdLineBuilder
     {
         CmdLineBuilder() = default;
@@ -46,14 +42,27 @@ namespace vcpkg::System
         CmdLineBuilder&& raw_arg(StringView s) && { return std::move(raw_arg(s)); }
 
         std::string&& extract() && { return std::move(buf); }
-        operator StringView() noexcept { return buf; }
+        operator StringView() const noexcept { return buf; }
         StringView command_line() const { return buf; }
 
         void clear() { buf.clear(); }
+        bool empty() const { return buf.empty(); }
 
     private:
         std::string buf;
     };
+
+    struct CmdLineBuilderMapLess
+    {
+        bool operator()(const CmdLineBuilder& lhs, const CmdLineBuilder& rhs) const
+        {
+            return lhs.command_line() < rhs.command_line();
+        }
+    };
+
+    CmdLineBuilder make_basic_cmake_cmd(const fs::path& cmake_tool_path,
+                                        const fs::path& cmake_script,
+                                        const std::vector<CMakeVariable>& pass_variables);
 
     fs::path get_exe_path_of_current_process();
 
@@ -79,48 +88,48 @@ namespace vcpkg::System
         const fs::path& working_directory;
     };
 
-    int cmd_execute(StringView cmd_line, InWorkingDirectory wd, const Environment& env = {});
-    inline int cmd_execute(StringView cmd_line, const Environment& env = {})
+    int cmd_execute(const CmdLineBuilder& cmd_line, InWorkingDirectory wd, const Environment& env = {});
+    inline int cmd_execute(const CmdLineBuilder& cmd_line, const Environment& env = {})
     {
         return cmd_execute(cmd_line, InWorkingDirectory{fs::path()}, env);
     }
 
-    int cmd_execute_clean(StringView cmd_line, InWorkingDirectory wd);
-    inline int cmd_execute_clean(StringView cmd_line)
+    int cmd_execute_clean(const CmdLineBuilder& cmd_line, InWorkingDirectory wd);
+    inline int cmd_execute_clean(const CmdLineBuilder& cmd_line)
     {
         return cmd_execute_clean(cmd_line, InWorkingDirectory{fs::path()});
     }
 
 #if defined(_WIN32)
-    Environment cmd_execute_modify_env(StringView cmd_line, const Environment& env = {});
+    Environment cmd_execute_modify_env(const CmdLineBuilder& cmd_line, const Environment& env = {});
 
-    void cmd_execute_background(const StringView cmd_line);
+    void cmd_execute_background(const CmdLineBuilder& cmd_line);
 #endif
 
-    ExitCodeAndOutput cmd_execute_and_capture_output(StringView cmd_line,
+    ExitCodeAndOutput cmd_execute_and_capture_output(const CmdLineBuilder& cmd_line,
                                                      InWorkingDirectory wd,
                                                      const Environment& env = {});
-    inline ExitCodeAndOutput cmd_execute_and_capture_output(StringView cmd_line, const Environment& env = {})
+    inline ExitCodeAndOutput cmd_execute_and_capture_output(const CmdLineBuilder& cmd_line, const Environment& env = {})
     {
         return cmd_execute_and_capture_output(cmd_line, InWorkingDirectory{fs::path()}, env);
     }
 
-    int cmd_execute_and_stream_lines(StringView cmd_line,
+    int cmd_execute_and_stream_lines(const CmdLineBuilder& cmd_line,
                                      InWorkingDirectory wd,
                                      std::function<void(StringView)> per_line_cb,
                                      const Environment& env = {});
-    inline int cmd_execute_and_stream_lines(StringView cmd_line,
+    inline int cmd_execute_and_stream_lines(const CmdLineBuilder& cmd_line,
                                             std::function<void(StringView)> per_line_cb,
                                             const Environment& env = {})
     {
         return cmd_execute_and_stream_lines(cmd_line, InWorkingDirectory{fs::path()}, std::move(per_line_cb), env);
     }
 
-    int cmd_execute_and_stream_data(StringView cmd_line,
+    int cmd_execute_and_stream_data(const CmdLineBuilder& cmd_line,
                                     InWorkingDirectory wd,
                                     std::function<void(StringView)> data_cb,
                                     const Environment& env = {});
-    inline int cmd_execute_and_stream_data(StringView cmd_line,
+    inline int cmd_execute_and_stream_data(const CmdLineBuilder& cmd_line,
                                            std::function<void(StringView)> data_cb,
                                            const Environment& env = {})
     {

--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -42,7 +42,6 @@ namespace vcpkg::System
         CmdLineBuilder&& raw_arg(StringView s) && { return std::move(raw_arg(s)); }
 
         std::string&& extract() && { return std::move(buf); }
-        operator StringView() const noexcept { return buf; }
         StringView command_line() const { return buf; }
 
         void clear() { buf.clear(); }

--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -232,7 +232,7 @@ namespace vcpkg::Build
         const VcpkgPaths& m_paths;
     };
 
-    std::string make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
+    System::CmdLineBuilder make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
 
     struct ExtendedBuildResult
     {
@@ -369,7 +369,7 @@ namespace vcpkg::Build
         struct EnvMapEntry
         {
             std::unordered_map<std::string, std::string> env_map;
-            Cache<std::string, System::Environment> cmd_cache;
+            Cache<System::CmdLineBuilder, System::Environment, System::CmdLineBuilderMapLess> cmd_cache;
         };
 
         Cache<std::vector<std::string>, EnvMapEntry> envs;

--- a/toolsrc/include/vcpkg/buildenvironment.h
+++ b/toolsrc/include/vcpkg/buildenvironment.h
@@ -9,7 +9,7 @@
 
 namespace vcpkg
 {
-    std::string make_cmake_cmd(const VcpkgPaths& paths,
-                               const fs::path& cmake_script,
-                               std::vector<System::CMakeVariable>&& pass_variables);
+    System::CmdLineBuilder make_cmake_cmd(const VcpkgPaths& paths,
+                                          const fs::path& cmake_script,
+                                          std::vector<System::CMakeVariable>&& pass_variables);
 }

--- a/toolsrc/src/vcpkg/archives.cpp
+++ b/toolsrc/src/vcpkg/archives.cpp
@@ -44,13 +44,21 @@ namespace vcpkg::Archives
             const std::string nugetid = match[1];
             const std::string version = match[2];
 
-            const auto code_and_output = System::cmd_execute_and_capture_output(Strings::format(
-                R"("%s" install %s -Version %s -OutputDirectory "%s" -Source "%s" -nocache -DirectDownload -NonInteractive -ForceEnglishOutput -PackageSaveMode nuspec)",
-                fs::u8string(nuget_exe),
-                nugetid,
-                version,
-                fs::u8string(to_path_partial),
-                fs::u8string(paths.downloads)));
+            const auto code_and_output = System::cmd_execute_and_capture_output(System::CmdLineBuilder{nuget_exe}
+                                                                                    .string_arg("install")
+                                                                                    .string_arg(nugetid)
+                                                                                    .string_arg("-Version")
+                                                                                    .string_arg(version)
+                                                                                    .string_arg("-OutputDirectory")
+                                                                                    .path_arg(to_path_partial)
+                                                                                    .string_arg("-Source")
+                                                                                    .path_arg(paths.downloads)
+                                                                                    .string_arg("-nocache")
+                                                                                    .string_arg("-DirectDownload")
+                                                                                    .string_arg("-NonInteractive")
+                                                                                    .string_arg("-ForceEnglishOutput")
+                                                                                    .string_arg("-PackageSaveMode")
+                                                                                    .string_arg("nuspec"));
 
             Checks::check_exit(VCPKG_LINE_INFO,
                                code_and_output.exit_code == 0,
@@ -65,11 +73,12 @@ namespace vcpkg::Archives
             Checks::check_exit(VCPKG_LINE_INFO, !recursion_limiter_sevenzip);
             recursion_limiter_sevenzip = true;
             const auto seven_zip = paths.get_tool_exe(Tools::SEVEN_ZIP);
-            const auto code_and_output =
-                System::cmd_execute_and_capture_output(Strings::format(R"("%s" x "%s" -o"%s" -y)",
-                                                                       fs::u8string(seven_zip),
-                                                                       fs::u8string(archive),
-                                                                       fs::u8string(to_path_partial)));
+            const auto code_and_output = System::cmd_execute_and_capture_output(
+                System::CmdLineBuilder{seven_zip}
+                    .string_arg("x")
+                    .path_arg(archive)
+                    .string_arg(Strings::format("-o%s", fs::u8string(to_path_partial)))
+                    .string_arg("-y"));
             Checks::check_exit(VCPKG_LINE_INFO,
                                code_and_output.exit_code == 0,
                                "7zip failed while extracting '%s' with message:\n%s",

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -569,7 +569,7 @@ namespace vcpkg
         auto timer = Chrono::ElapsedTimer::create_started();
 
         auto process_info =
-            windows_create_windowless_process(cmd_line,
+            windows_create_windowless_process(cmd_line.command_line(),
                                               InWorkingDirectory{fs::path()},
                                               {},
                                               CREATE_NEW_CONSOLE | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB);
@@ -623,7 +623,7 @@ namespace vcpkg
 #if defined(_WIN32)
         using vcpkg::g_ctrl_c_state;
         g_ctrl_c_state.transition_to_spawn_process();
-        auto proc_info = windows_create_windowless_process(cmd_line, wd, env, 0);
+        auto proc_info = windows_create_windowless_process(cmd_line.command_line(), wd, env, 0);
         auto long_exit_code = [&]() -> unsigned long {
             if (auto p = proc_info.get())
                 return p->wait();
@@ -698,7 +698,7 @@ namespace vcpkg
         using vcpkg::g_ctrl_c_state;
 
         g_ctrl_c_state.transition_to_spawn_process();
-        auto maybe_proc_info = windows_create_process_redirect(cmd_line, wd, env, 0);
+        auto maybe_proc_info = windows_create_process_redirect(cmd_line.command_line(), wd, env, 0);
         auto exit_code = [&]() -> unsigned long {
             if (auto p = maybe_proc_info.get())
                 return p->wait_and_stream_output(data_cb);

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -647,12 +647,15 @@ namespace vcpkg
         std::string real_command_line;
         if (wd.working_directory.empty())
         {
-            real_command_line.assign(cmd_line.begin(), cmd_line.end());
+            real_command_line = cmd_line.command_line().to_string();
         }
         else
         {
-            real_command_line =
-                System::CmdLineBuilder("cd").path_arg(wd.working_directory).raw_arg("&&").raw_arg(cmd_line).extract();
+            real_command_line = System::CmdLineBuilder("cd")
+                                    .path_arg(wd.working_directory)
+                                    .raw_arg("&&")
+                                    .raw_arg(cmd_line.command_line())
+                                    .extract();
         }
         Debug::print("system(", real_command_line, ")\n");
         fflush(nullptr);
@@ -717,14 +720,14 @@ namespace vcpkg
         std::string actual_cmd_line;
         if (wd.working_directory.empty())
         {
-            actual_cmd_line = Strings::format(R"(%s 2>&1)", cmd_line);
+            actual_cmd_line = Strings::format(R"(%s 2>&1)", cmd_line.command_line());
         }
         else
         {
             actual_cmd_line = System::CmdLineBuilder("cd")
                                   .path_arg(wd.working_directory)
                                   .raw_arg("&&")
-                                  .raw_arg(cmd_line)
+                                  .raw_arg(cmd_line.command_line())
                                   .raw_arg("2>&1")
                                   .extract();
         }

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -420,7 +420,7 @@ namespace
         {
         }
 
-        int run_nuget_commandline(StringView cmdline)
+        int run_nuget_commandline(const System::CmdLineBuilder& cmdline)
         {
             if (m_interactive)
             {
@@ -450,7 +450,9 @@ namespace
             }
             else if (res.output.find("for example \"-ApiKey AzureDevOps\"") != std::string::npos)
             {
-                auto res2 = System::cmd_execute_and_capture_output(Strings::concat(cmdline, " -ApiKey AzureDevOps"));
+                auto real_cmdline = cmdline;
+                real_cmdline.string_arg("-ApiKey").string_arg("AzureDevOps");
+                auto res2 = System::cmd_execute_and_capture_output(real_cmdline);
                 if (Debug::g_debugging)
                 {
                     System::print2(res2.output);
@@ -514,7 +516,7 @@ namespace
             };
 
             const auto& nuget_exe = paths.get_tool_exe("nuget");
-            std::vector<std::string> cmdlines;
+            std::vector<System::CmdLineBuilder> cmdlines;
 
             if (!m_read_sources.empty())
             {
@@ -544,7 +546,7 @@ namespace
                     cmdline.string_arg("-NonInteractive");
                 }
 
-                cmdlines.push_back(std::move(cmdline).extract());
+                cmdlines.push_back(std::move(cmdline));
             }
             for (auto&& cfg : m_read_configs)
             {
@@ -574,7 +576,7 @@ namespace
                     cmdline.string_arg("-NonInteractive");
                 }
 
-                cmdlines.push_back(std::move(cmdline).extract());
+                cmdlines.push_back(std::move(cmdline));
             }
 
             const size_t current_restored = m_restored.size();

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -452,7 +452,7 @@ namespace vcpkg::Build
         const auto arch = to_vcvarsall_toolchain(pre_build_info.target_architecture, toolset);
         const auto target = to_vcvarsall_target(pre_build_info.cmake_system_name);
 
-        return System::CmdLineBuilder{"cmd"}.string_arg("/c").string_arg(
+        return System::CmdLineBuilder{"cmd"}.string_arg("/c").raw_arg(
             Strings::format(R"("%s" %s %s %s %s 2>&1 <NUL)",
                             fs::u8string(toolset.vcvarsall),
                             Strings::join(" ", toolset.vcvarsall_options),

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -328,7 +328,7 @@ namespace vcpkg::Build
 #if defined(_WIN32)
     const System::Environment& EnvCache::get_action_env(const VcpkgPaths& paths, const AbiInfo& abi_info)
     {
-        std::string build_env_cmd =
+        auto build_env_cmd =
             make_build_env_cmd(*abi_info.pre_build_info, abi_info.toolset.value_or_exit(VCPKG_LINE_INFO));
 
         const auto& base_env = envs.get_lazy(abi_info.pre_build_info->passthrough_env_vars, [&]() -> EnvMapEntry {
@@ -439,9 +439,9 @@ namespace vcpkg::Build
         });
     }
 
-    std::string make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
+    System::CmdLineBuilder make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
     {
-        if (!pre_build_info.using_vcvars()) return "";
+        if (!pre_build_info.using_vcvars()) return {};
 
         const char* tonull = " >nul";
         if (Debug::g_debugging)
@@ -452,12 +452,13 @@ namespace vcpkg::Build
         const auto arch = to_vcvarsall_toolchain(pre_build_info.target_architecture, toolset);
         const auto target = to_vcvarsall_target(pre_build_info.cmake_system_name);
 
-        return Strings::format(R"(cmd /c ""%s" %s %s %s %s 2>&1 <NUL")",
-                               fs::u8string(toolset.vcvarsall),
-                               Strings::join(" ", toolset.vcvarsall_options),
-                               arch,
-                               target,
-                               tonull);
+        return System::CmdLineBuilder{"cmd"}.string_arg("/c").string_arg(
+            Strings::format(R"("%s" %s %s %s %s 2>&1 <NUL)",
+                            fs::u8string(toolset.vcvarsall),
+                            Strings::join(" ", toolset.vcvarsall_options),
+                            arch,
+                            target,
+                            tonull));
     }
 
     static std::unique_ptr<BinaryControlFile> create_binary_control_file(

--- a/toolsrc/src/vcpkg/buildenvironment.cpp
+++ b/toolsrc/src/vcpkg/buildenvironment.cpp
@@ -4,9 +4,9 @@
 
 namespace vcpkg
 {
-    std::string make_cmake_cmd(const VcpkgPaths& paths,
-                               const fs::path& cmake_script,
-                               std::vector<System::CMakeVariable>&& pass_variables)
+    System::CmdLineBuilder make_cmake_cmd(const VcpkgPaths& paths,
+                                          const fs::path& cmake_script,
+                                          std::vector<System::CMakeVariable>&& pass_variables)
     {
         auto local_variables = std::move(pass_variables);
         local_variables.emplace_back("VCPKG_ROOT_DIR", paths.root);

--- a/toolsrc/src/vcpkg/commands.contact.cpp
+++ b/toolsrc/src/vcpkg/commands.contact.cpp
@@ -45,7 +45,7 @@ namespace vcpkg::Commands::Contact
             }
 
 #if defined(_WIN32)
-            System::cmd_execute("start https://aka.ms/NPS_vcpkg");
+            System::cmd_execute(System::CmdLineBuilder("start").string_arg("https://aka.ms/NPS_vcpkg"));
             System::print2("Default browser launched to https://aka.ms/NPS_vcpkg; thank you for your feedback!\n");
 #else
             System::print2("Please navigate to https://aka.ms/NPS_vcpkg in your preferred browser. Thank you for your "

--- a/toolsrc/src/vcpkg/commands.create.cpp
+++ b/toolsrc/src/vcpkg/commands.create.cpp
@@ -51,7 +51,7 @@ namespace vcpkg::Commands::Create
             cmake_args.emplace_back("FILENAME", zip_file_name);
         }
 
-        const std::string cmd_launch_cmake = make_cmake_cmd(paths, paths.ports_cmake, std::move(cmake_args));
+        auto cmd_launch_cmake = make_cmake_cmd(paths, paths.ports_cmake, std::move(cmake_args));
         return System::cmd_execute_clean(cmd_launch_cmake);
     }
 

--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -262,8 +262,8 @@ namespace vcpkg::Commands::Edit
         if (editor_exe == "Code.exe" || editor_exe == "Code - Insiders.exe")
         {
             // note that we are invoking cmd silently but Code.exe is relaunched from there
-            cmd_line = System::CmdLineBuilder("cmd").string_arg("/c").string_arg(cmd_line).raw_arg("<NUL");
-            System::cmd_execute_background(cmd_line);
+            System::cmd_execute_background(
+                System::CmdLineBuilder("cmd").string_arg("/c").string_arg(cmd_line.command_line()).raw_arg("<NUL"));
             Checks::exit_success(VCPKG_LINE_INFO);
         }
 #endif

--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -219,14 +219,15 @@ namespace vcpkg::Commands::Edit
         candidate_paths.push_back(fs::path{"/usr/share/code/bin/code"});
         candidate_paths.push_back(fs::path{"/usr/bin/code"});
 
-        if (System::cmd_execute("command -v xdg-mime") == 0)
+        if (System::cmd_execute(System::CmdLineBuilder("command").string_arg("-v").string_arg("xdg-mime")) == 0)
         {
-            auto mime_qry = Strings::format(R"(xdg-mime query default text/plain)");
+            auto mime_qry =
+                System::CmdLineBuilder("xdg-mime").string_arg("query").string_arg("default").string_arg("text/plain");
             auto execute_result = System::cmd_execute_and_capture_output(mime_qry);
             if (execute_result.exit_code == 0 && !execute_result.output.empty())
             {
-                mime_qry = Strings::format(R"(command -v %s)",
-                                           execute_result.output.substr(0, execute_result.output.find('.')));
+                mime_qry = System::CmdLineBuilder("command").string_arg("-v").string_arg(
+                    execute_result.output.substr(0, execute_result.output.find('.')));
                 execute_result = System::cmd_execute_and_capture_output(mime_qry);
                 if (execute_result.exit_code == 0 && !execute_result.output.empty())
                 {

--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -254,7 +254,7 @@ namespace vcpkg::Commands::Edit
         const fs::path env_editor = *it;
         const std::vector<std::string> arguments = create_editor_arguments(paths, options, ports);
         const auto args_as_string = Strings::join(" ", arguments);
-        const auto cmd_line = Strings::format(R"("%s" %s -n)", fs::u8string(env_editor), args_as_string);
+        auto cmd_line = System::CmdLineBuilder(env_editor).raw_arg(args_as_string).string_arg("-n");
 
         auto editor_exe = fs::u8string(env_editor.filename());
 
@@ -262,7 +262,8 @@ namespace vcpkg::Commands::Edit
         if (editor_exe == "Code.exe" || editor_exe == "Code - Insiders.exe")
         {
             // note that we are invoking cmd silently but Code.exe is relaunched from there
-            System::cmd_execute_background(Strings::concat("cmd /c \"", cmd_line, " <NUL\""));
+            cmd_line = System::CmdLineBuilder("cmd").string_arg("/c").string_arg(cmd_line).raw_arg("<NUL");
+            System::cmd_execute_background(cmd_line);
             Checks::exit_success(VCPKG_LINE_INFO);
         }
 #endif

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -98,7 +98,11 @@ namespace vcpkg::Commands::Env
             }
         }();
 
-        std::string cmd = args.command_arguments.empty() ? "cmd" : ("cmd /c " + args.command_arguments.at(0));
+        System::CmdLineBuilder cmd("cmd");
+        if (!args.command_arguments.empty())
+        {
+            cmd.string_arg("/c").raw_arg(args.command_arguments.at(0));
+        }
 #ifdef _WIN32
         System::enter_interactive_subprocess();
 #endif

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -379,10 +379,11 @@ CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=%s"
             nuspec_file_path, create_nuspec_file_contents(paths.root, nuget_id, nupkg_version), VCPKG_LINE_INFO);
 
         // Using all forward slashes for the command line
-        const std::string cmd_line = Strings::format(R"("%s" pack -OutputDirectory "%s" "%s")",
-                                                     fs::u8string(nuget_exe),
-                                                     fs::u8string(buildsystems_dir),
-                                                     fs::u8string(nuspec_file_path));
+        auto cmd_line = System::CmdLineBuilder(nuget_exe)
+                            .string_arg("pack")
+                            .string_arg("-OutputDirectory")
+                            .path_arg(buildsystems_dir)
+                            .path_arg(nuspec_file_path);
 
         const int exit_code =
             System::cmd_execute_and_capture_output(cmd_line, System::get_clean_environment()).exit_code;
@@ -414,9 +415,12 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         const fs::path script_path = paths.scripts / "addPoshVcpkgToPowershellProfile.ps1";
 
         const auto& ps = paths.get_tool_exe("powershell-core");
-        const std::string cmd = Strings::format(R"("%s" -NoProfile -ExecutionPolicy Bypass -Command "& {& '%s' }")",
-                                                fs::u8string(ps),
-                                                fs::u8string(script_path));
+        auto cmd = System::CmdLineBuilder(ps)
+                       .string_arg("-NoProfile")
+                       .string_arg("-ExecutionPolicy")
+                       .string_arg("Bypass")
+                       .string_arg("-Command")
+                       .string_arg(Strings::format("& {& '%s' }", fs::u8string(script_path)));
         const int rc = System::cmd_execute(cmd);
         if (rc)
         {

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -34,13 +34,12 @@ namespace vcpkg::Commands::PortHistory
         {
             const fs::path& git_exe = paths.get_tool_exe(Tools::GIT);
 
-            System::CmdLineBuilder builder;
-            builder.path_arg(git_exe)
-                .string_arg(Strings::concat("--git-dir=", fs::u8string(dot_git_directory)))
-                .string_arg(Strings::concat("--work-tree=", fs::u8string(working_directory)));
-            const std::string full_cmd = Strings::concat(std::move(builder).extract(), " ", cmd);
+            auto full_cmd = System::CmdLineBuilder(git_exe)
+                                .string_arg(Strings::concat("--git-dir=", fs::u8string(dot_git_directory)))
+                                .string_arg(Strings::concat("--work-tree=", fs::u8string(working_directory)))
+                                .raw_arg(cmd);
 
-            const auto output = System::cmd_execute_and_capture_output(full_cmd);
+            auto output = System::cmd_execute_and_capture_output(full_cmd);
             return output;
         }
 

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -85,7 +85,8 @@ namespace vcpkg::Commands::PortHistory
                                                                 const std::string& commit_date,
                                                                 const std::string& port_name)
         {
-            auto rev_parse_cmd = System::CmdLineBuilder("rev-parse").string_arg(Strings::concat(commit_id, ":ports/", port_name));
+            auto rev_parse_cmd =
+                System::CmdLineBuilder("rev-parse").string_arg(Strings::concat(commit_id, ":ports/", port_name));
             auto rev_parse_output = run_git_command(paths, rev_parse_cmd);
             if (rev_parse_output.exit_code == 0)
             {

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -30,20 +30,20 @@ namespace vcpkg::Commands::PortHistory
         const System::ExitCodeAndOutput run_git_command_inner(const VcpkgPaths& paths,
                                                               const fs::path& dot_git_directory,
                                                               const fs::path& working_directory,
-                                                              StringView cmd)
+                                                              const System::CmdLineBuilder& cmd)
         {
             const fs::path& git_exe = paths.get_tool_exe(Tools::GIT);
 
             auto full_cmd = System::CmdLineBuilder(git_exe)
                                 .string_arg(Strings::concat("--git-dir=", fs::u8string(dot_git_directory)))
                                 .string_arg(Strings::concat("--work-tree=", fs::u8string(working_directory)))
-                                .raw_arg(cmd);
+                                .raw_arg(cmd.command_line());
 
             auto output = System::cmd_execute_and_capture_output(full_cmd);
             return output;
         }
 
-        const System::ExitCodeAndOutput run_git_command(const VcpkgPaths& paths, StringView cmd)
+        const System::ExitCodeAndOutput run_git_command(const VcpkgPaths& paths, const System::CmdLineBuilder& cmd)
         {
             const fs::path& work_dir = paths.root;
             const fs::path dot_git_dir = paths.root / ".git";
@@ -85,7 +85,7 @@ namespace vcpkg::Commands::PortHistory
                                                                 const std::string& commit_date,
                                                                 const std::string& port_name)
         {
-            const std::string rev_parse_cmd = Strings::format("rev-parse %s:ports/%s", commit_id, port_name);
+            auto rev_parse_cmd = System::CmdLineBuilder("rev-parse").string_arg(Strings::concat(commit_id, ":ports/", port_name));
             auto rev_parse_output = run_git_command(paths, rev_parse_cmd);
             if (rev_parse_output.exit_code == 0)
             {
@@ -93,7 +93,7 @@ namespace vcpkg::Commands::PortHistory
                 const auto git_tree = Strings::trim(std::move(rev_parse_output.output));
 
                 // Do we have a manifest file?
-                const std::string manifest_cmd = Strings::format(R"(show %s:vcpkg.json)", git_tree, port_name);
+                auto manifest_cmd = System::CmdLineBuilder("show").string_arg(Strings::concat(git_tree, ":vcpkg.json"));
                 auto manifest_output = run_git_command(paths, manifest_cmd);
                 if (manifest_output.exit_code == 0)
                 {
@@ -101,7 +101,7 @@ namespace vcpkg::Commands::PortHistory
                         manifest_output.output, git_tree, commit_id, commit_date, port_name, true);
                 }
 
-                const std::string cmd = Strings::format(R"(show %s:CONTROL)", git_tree, commit_id, port_name);
+                auto cmd = System::CmdLineBuilder("show").string_arg(Strings::concat(git_tree, ":CONTROL"));
                 auto control_output = run_git_command(paths, cmd);
 
                 if (control_output.exit_code == 0)

--- a/toolsrc/src/vcpkg/commands.portsdiff.cpp
+++ b/toolsrc/src/vcpkg/commands.portsdiff.cpp
@@ -91,15 +91,18 @@ namespace vcpkg::Commands::PortsDiff
         const auto checkout_this_dir =
             Strings::format(R"(.\%s)", ports_dir_name_as_string); // Must be relative to the root of the repository
 
-        const std::string cmd = Strings::format(R"("%s" --git-dir="%s" --work-tree="%s" checkout %s -f -q -- %s %s)",
-                                                fs::u8string(git_exe),
-                                                fs::u8string(dot_git_dir),
-                                                fs::u8string(temp_checkout_path),
-                                                git_commit_id,
-                                                checkout_this_dir,
-                                                ".vcpkg-root");
+        auto cmd = System::CmdLineBuilder(git_exe)
+                       .string_arg(Strings::format("--git-dir=%s", fs::u8string(dot_git_dir)))
+                       .string_arg(Strings::format("--work-tree=%s", fs::u8string(temp_checkout_path)))
+                       .string_arg("checkout")
+                       .string_arg(git_commit_id)
+                       .string_arg("-f")
+                       .string_arg("-q")
+                       .string_arg("--")
+                       .string_arg(checkout_this_dir)
+                       .string_arg(".vcpkg-root");
         System::cmd_execute_and_capture_output(cmd, System::get_clean_environment());
-        System::cmd_execute_and_capture_output(Strings::format(R"("%s" reset)", fs::u8string(git_exe)),
+        System::cmd_execute_and_capture_output(System::CmdLineBuilder(git_exe).string_arg("reset"),
                                                System::get_clean_environment());
         const auto ports_at_commit =
             Paragraphs::load_overlay_ports(paths, temp_checkout_path / ports_dir_name_as_string);
@@ -117,7 +120,7 @@ namespace vcpkg::Commands::PortsDiff
     {
         static const std::string VALID_COMMIT_OUTPUT = "commit\n";
 
-        const auto cmd = Strings::format(R"("%s" cat-file -t %s)", fs::u8string(git_exe), git_commit_id);
+        auto cmd = System::CmdLineBuilder(git_exe).string_arg("cat-file").string_arg("-t").string_arg(git_commit_id);
         const System::ExitCodeAndOutput output = System::cmd_execute_and_capture_output(cmd);
         Checks::check_exit(
             VCPKG_LINE_INFO, output.output == VALID_COMMIT_OUTPUT, "Invalid commit id %s", git_commit_id);

--- a/toolsrc/src/vcpkg/export.chocolatey.cpp
+++ b/toolsrc/src/vcpkg/export.chocolatey.cpp
@@ -216,10 +216,12 @@ if (Test-Path $installedDir)
             const fs::path chocolatey_uninstall_file_path = per_package_dir_path / "tools" / "chocolateyUninstall.ps1";
             fs.write_contents(chocolatey_uninstall_file_path, chocolatey_uninstall_content, VCPKG_LINE_INFO);
 
-            const auto cmd_line = Strings::format(R"("%s" pack -OutputDirectory "%s" "%s" -NoDefaultExcludes)",
-                                                  fs::u8string(nuget_exe),
-                                                  fs::u8string(exported_dir_path),
-                                                  fs::u8string(nuspec_file_path));
+            auto cmd_line = System::CmdLineBuilder(nuget_exe)
+                                .string_arg("pack")
+                                .string_arg("-OutputDirectory")
+                                .path_arg(exported_dir_path)
+                                .path_arg(nuspec_file_path)
+                                .string_arg("-NoDefaultExcludes");
 
             const int exit_code =
                 System::cmd_execute_and_capture_output(cmd_line, System::get_clean_environment()).exit_code;

--- a/toolsrc/src/vcpkg/export.ifw.cpp
+++ b/toolsrc/src/vcpkg/export.ifw.cpp
@@ -370,10 +370,10 @@ namespace vcpkg::Export::IFW
                                fs::generic_u8string(repository_dir),
                                failure_point.string());
 
-            const auto cmd_line = Strings::format(R"("%s" --packages "%s" "%s")",
-                                                  fs::u8string(repogen_exe),
-                                                  fs::u8string(packages_dir),
-                                                  fs::u8string(repository_dir));
+            auto cmd_line = System::CmdLineBuilder(repogen_exe)
+                                .string_arg("--packages")
+                                .path_arg(packages_dir)
+                                .path_arg(repository_dir);
 
             const int exit_code =
                 System::cmd_execute_and_capture_output(cmd_line, System::get_clean_environment()).exit_code;
@@ -393,24 +393,27 @@ namespace vcpkg::Export::IFW
 
             System::printf("Generating installer %s...\n", fs::generic_u8string(installer_file));
 
-            std::string cmd_line;
+            System::CmdLineBuilder cmd_line;
 
             std::string ifw_repo_url = ifw_options.maybe_repository_url.value_or("");
             if (!ifw_repo_url.empty())
             {
-                cmd_line = Strings::format(R"("%s" --online-only --config "%s" --repository "%s" "%s")",
-                                           fs::u8string(binarycreator_exe),
-                                           fs::u8string(config_file),
-                                           fs::u8string(repository_dir),
-                                           fs::u8string(installer_file));
+                cmd_line = System::CmdLineBuilder(binarycreator_exe)
+                               .string_arg("--online-only")
+                               .string_arg("--config")
+                               .path_arg(config_file)
+                               .string_arg("--repository")
+                               .path_arg(repository_dir)
+                               .path_arg(installer_file);
             }
             else
             {
-                cmd_line = Strings::format(R"("%s" --config "%s" --packages "%s" "%s")",
-                                           fs::u8string(binarycreator_exe),
-                                           fs::u8string(config_file),
-                                           fs::u8string(packages_dir),
-                                           fs::u8string(installer_file));
+                cmd_line = System::CmdLineBuilder(binarycreator_exe)
+                               .string_arg("--config")
+                               .path_arg(config_file)
+                               .string_arg("--packages")
+                               .path_arg(packages_dir)
+                               .path_arg(installer_file);
             }
 
             const int exit_code =

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -263,7 +263,7 @@ namespace vcpkg::Metrics
             return "{}";
         }
 
-        auto getmac = System::cmd_execute_and_capture_output("getmac");
+        auto getmac = System::cmd_execute_and_capture_output(System::CmdLineBuilder("getmac"));
 
         if (getmac.exit_code != 0) return "0";
 

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -493,11 +493,21 @@ namespace vcpkg::Metrics
         builder.path_arg(vcpkg_metrics_txt_path);
         System::cmd_execute_background(builder);
 #else
-        auto escaped_path = Strings::escape_string(fs::u8string(vcpkg_metrics_txt_path), '\'', '\\');
-        const std::string cmd_line = Strings::format(
-            R"((curl "https://dc.services.visualstudio.com/v2/track" -H "Content-Type: application/json" -X POST --tlsv1.2 --data '@%s' >/dev/null 2>&1; rm '%s') &)",
-            escaped_path,
-            escaped_path);
+        // TODO: convert to cmd_execute_background or something.
+        auto curl = System::CmdLineBuilder("curl")
+                        .string_arg("https://dc.services.visualstudio.com/v2/track")
+                        .string_arg("-H")
+                        .string_arg("Content-Type: application/json")
+                        .string_arg("-X")
+                        .string_arg("POST")
+                        .string_arg("--tlsv1.2")
+                        .string_arg("--data")
+                        .string_arg(Strings::concat("@", fs::u8string(vcpkg_metrics_txt_path)))
+                        .string_arg(">/dev/null")
+                        .string_arg("2>&1");
+        auto remove = System::CmdLineBuilder("rm").path_arg(escaped_path);
+        System::CmdLineBuilder cmd_line;
+        cmd_line.raw_arg("(").raw_arg(curl.command_line()).raw_arg(";").raw_arg(remove.command_line()).raw_arg(") &");
         System::cmd_execute_clean(cmd_line);
 #endif
     }

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -503,8 +503,8 @@ namespace vcpkg::Metrics
                         .string_arg("--tlsv1.2")
                         .string_arg("--data")
                         .string_arg(Strings::concat("@", fs::u8string(vcpkg_metrics_txt_path)))
-                        .string_arg(">/dev/null")
-                        .string_arg("2>&1");
+                        .raw_arg(">/dev/null")
+                        .raw_arg("2>&1");
         auto remove = System::CmdLineBuilder("rm").path_arg(vcpkg_metrics_txt_path);
         System::CmdLineBuilder cmd_line;
         cmd_line.raw_arg("(").raw_arg(curl.command_line()).raw_arg(";").raw_arg(remove.command_line()).raw_arg(") &");

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -505,7 +505,7 @@ namespace vcpkg::Metrics
                         .string_arg(Strings::concat("@", fs::u8string(vcpkg_metrics_txt_path)))
                         .string_arg(">/dev/null")
                         .string_arg("2>&1");
-        auto remove = System::CmdLineBuilder("rm").path_arg(escaped_path);
+        auto remove = System::CmdLineBuilder("rm").path_arg(vcpkg_metrics_txt_path);
         System::CmdLineBuilder cmd_line;
         cmd_line.raw_arg("(").raw_arg(curl.command_line()).raw_arg(";").raw_arg(remove.command_line()).raw_arg(") &");
         System::cmd_execute_clean(cmd_line);

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -390,10 +390,10 @@ namespace vcpkg::PostBuildLint
         std::vector<fs::path> dlls_with_no_exports;
         for (const fs::path& dll : dlls)
         {
-            const std::string cmd_line =
-                Strings::format(R"("%s" /exports "%s")", fs::u8string(dumpbin_exe), fs::u8string(dll));
+            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/exports").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
-            Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
+            Checks::check_exit(
+                VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());
 
             if (ec_data.output.find("ordinal hint RVA      name") == std::string::npos)
             {
@@ -428,10 +428,10 @@ namespace vcpkg::PostBuildLint
         std::vector<fs::path> dlls_with_improper_uwp_bit;
         for (const fs::path& dll : dlls)
         {
-            const std::string cmd_line =
-                Strings::format(R"("%s" /headers "%s")", fs::u8string(dumpbin_exe), fs::u8string(dll));
+            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/headers").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
-            Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
+            Checks::check_exit(
+                VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());
 
             if (ec_data.output.find("App Container") == std::string::npos)
             {
@@ -720,13 +720,12 @@ namespace vcpkg::PostBuildLint
 
         for (const fs::path& lib : libs)
         {
-            const std::string cmd_line =
-                Strings::format(R"("%s" /directives "%s")", fs::u8string(dumpbin_exe), fs::u8string(lib));
+            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/directives").path_arg(lib);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
             Checks::check_exit(VCPKG_LINE_INFO,
                                ec_data.exit_code == 0,
                                "Running command:\n   %s\n failed with message:\n%s",
-                               cmd_line,
+                               cmd_line.command_line(),
                                ec_data.output);
 
             for (const BuildType& bad_build_type : bad_build_types)
@@ -775,10 +774,10 @@ namespace vcpkg::PostBuildLint
 
         for (const fs::path& dll : dlls)
         {
-            const auto cmd_line =
-                Strings::format(R"("%s" /dependents "%s")", fs::u8string(dumpbin_exe), fs::u8string(dll));
+            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/dependents").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
-            Checks::check_exit(VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line);
+            Checks::check_exit(
+                VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());
 
             for (const OutdatedDynamicCrt& outdated_crt : get_outdated_dynamic_crts(pre_build_info.platform_toolset))
             {

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -297,7 +297,7 @@ namespace vcpkg
         }
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
+            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -326,7 +326,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
+            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -414,7 +414,7 @@ Type 'NuGet help <command>' for help on a specific command.
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const std::string cmd = Strings::format(R"("%s" --version)", fs::u8string(path_to_exe));
+            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -443,8 +443,8 @@ git version 2.17.1.windows.2
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto rc = System::cmd_execute_and_capture_output(
-                System::CmdLineBuilder().path_arg(path_to_exe).string_arg("--version").extract());
+            auto rc =
+                System::cmd_execute_and_capture_output(System::CmdLineBuilder(path_to_exe).string_arg("--version"));
             if (rc.exit_code != 0)
             {
                 return {Strings::concat(
@@ -485,7 +485,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            const std::string cmd = Strings::format(R"("%s" --framework-version)", fs::u8string(path_to_exe));
+            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--framework-version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -512,8 +512,8 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto rc = System::cmd_execute_and_capture_output(
-                System::CmdLineBuilder().path_arg(path_to_exe).string_arg("--version").extract());
+            auto rc =
+                System::cmd_execute_and_capture_output(System::CmdLineBuilder(path_to_exe).string_arg("--version"));
             if (rc.exit_code != 0)
             {
                 return {Strings::concat(

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -573,8 +573,7 @@ If you wish to silence this error and use classic mode, you can:
                                  .string_arg("-d")
                                  .string_arg("HEAD")
                                  .string_arg("--")
-                                 .path_arg(path_with_separator)
-                                 .extract();
+                                 .path_arg(path_with_separator);
 
         auto output = System::cmd_execute_and_capture_output(git_cmd);
         if (output.exit_code != 0)
@@ -589,19 +588,22 @@ If you wish to silence this error and use classic mode, you can:
             // <mode> SP <type> SP <object> TAB <file>
             auto split_line = Strings::split(line, '\t');
             if (split_line.size() != 2)
-                return Strings::format(
-                    "Error: Unexpected output from command `%s`. Couldn't split by `\\t`.\n%s", git_cmd, line);
+                return Strings::format("Error: Unexpected output from command `%s`. Couldn't split by `\\t`.\n%s",
+                                       git_cmd.command_line(),
+                                       line);
 
             auto file_info_section = Strings::split(split_line[0], ' ');
             if (file_info_section.size() != 3)
-                return Strings::format(
-                    "Error: Unexepcted output from command `%s`. Couldn't split by ` `.\n%s", git_cmd, line);
+                return Strings::format("Error: Unexepcted output from command `%s`. Couldn't split by ` `.\n%s",
+                                       git_cmd.command_line(),
+                                       line);
 
             const auto index = split_line[1].find_last_of('/');
             if (index == std::string::npos)
             {
-                return Strings::format(
-                    "Error: Unexpected output from command `%s`. Couldn't split by `/`.\n%s", git_cmd, line);
+                return Strings::format("Error: Unexpected output from command `%s`. Couldn't split by `/`.\n%s",
+                                       git_cmd.command_line(),
+                                       line);
             }
 
             ret.emplace(split_line[1].substr(index + 1), file_info_section.back());

--- a/toolsrc/src/vcpkg/visualstudio.cpp
+++ b/toolsrc/src/vcpkg/visualstudio.cpp
@@ -84,8 +84,14 @@ namespace vcpkg::VisualStudio
         const fs::path vswhere_exe = program_files_32_bit / "Microsoft Visual Studio" / "Installer" / "vswhere.exe";
         if (fs.exists(vswhere_exe))
         {
-            const auto code_and_output = System::cmd_execute_and_capture_output(
-                Strings::format(R"("%s" -all -prerelease -legacy -products * -format xml)", fs::u8string(vswhere_exe)));
+            const auto code_and_output = System::cmd_execute_and_capture_output(System::CmdLineBuilder(vswhere_exe)
+                                                                                    .string_arg("-all")
+                                                                                    .string_arg("-prerelease")
+                                                                                    .string_arg("-legacy")
+                                                                                    .string_arg("-products")
+                                                                                    .string_arg("*")
+                                                                                    .string_arg("-format")
+                                                                                    .string_arg("xml"));
             Checks::check_exit(VCPKG_LINE_INFO,
                                code_and_output.exit_code == 0,
                                "Running vswhere.exe failed with message:\n%s",


### PR DESCRIPTION
I would like, and I think the team would like generally,
to switch to using stuff like `posix_spawn`, as opposed to the
existing use of `system` and `popen`.

This requires a pretty large change to how we use CmdLineBuilder.
The first change we have to make is that the execute functions
_cannot_ take a StringView anymore.
This PR makes that change.