### PR TITLE
[gtest] Add a patch to fix build error in GCC 11

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -2270,7 +2270,7 @@
     },
     "gtest": {
       "baseline": "1.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gtk": {
       "baseline": "3.22.19-4",

--- a/port_versions/g-/gtest.json
+++ b/port_versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e94f8c09a8fa6ed7fc618734d412878d83069bfb",
+      "version-string": "1.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "88de073e86bcae80206fca0ff4f4f8e6c165f43a",
       "version-string": "1.10.0",
       "port-version": 2

--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,5 +1,5 @@
 Source: gtest
 Version: 1.10.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/fix-build-failure-in-gcc-11.patch
+++ b/ports/gtest/fix-build-failure-in-gcc-11.patch
@@ -1,0 +1,22 @@
+diff --git a/googletest/src/gtest-death-test.cc b/googletest/src/gtest-death-test.cc
+index da09a1cf..43cbd78a 100644
+--- a/googletest/src/gtest-death-test.cc
++++ b/googletest/src/gtest-death-test.cc
+@@ -1288,7 +1288,7 @@ static void StackLowerThanAddress(const void* ptr,
+ // making comparison result unpredictable.
+ GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
+ static void StackLowerThanAddress(const void* ptr, bool* result) {
+-  int dummy;
++  int dummy = 0;
+   *result = (&dummy < ptr);
+ }
+ 
+@@ -1296,7 +1296,7 @@ static void StackLowerThanAddress(const void* ptr, bool* result) {
+ GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
+ GTEST_ATTRIBUTE_NO_SANITIZE_HWADDRESS_
+ static bool StackGrowsDown() {
+-  int dummy;
++  int dummy = 0;
+   bool result;
+   StackLowerThanAddress(&dummy, &result);
+   return result;

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         0002-Fix-z7-override.patch
         fix-main-lib-path.patch
+        fix-build-failure-in-gcc-11.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" GTEST_FORCE_SHARED_CRT)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Fixes #15617.
To summarize, gtest 1.10.0 failed to compile in GCC 11, and no other versions will be released due to their policy (live in head, no release tags), so a patch is the only way to solve it.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.