### PR TITLE
[vcpkg] Format JSON output of `x-add-version` to minimize diffs

### DIFF
--- a/toolsrc/src/vcpkg/commands.add-version.cpp
+++ b/toolsrc/src/vcpkg/commands.add-version.cpp
@@ -97,7 +97,8 @@ namespace
         }
 
         std::error_code ec;
-        fs.write_contents(output_path, Json::stringify(serialize_baseline(baseline_map), {}), ec);
+        fs.write_contents(
+            output_path, Json::stringify(serialize_baseline(baseline_map), Json::JsonStyle::with_spaces(2)), ec);
         if (ec)
         {
             System::printf(
@@ -127,7 +128,8 @@ namespace
 
         std::error_code ec;
         fs.create_directories(output_path.parent_path(), VCPKG_LINE_INFO);
-        fs.write_contents(output_path, Json::stringify(serialize_versions(versions), {}), ec);
+        fs.write_contents(
+            output_path, Json::stringify(serialize_versions(versions), Json::JsonStyle::with_spaces(2)), ec);
         if (ec)
         {
             System::printf(

--- a/toolsrc/src/vcpkg/commands.civerifyversions.cpp
+++ b/toolsrc/src/vcpkg/commands.civerifyversions.cpp
@@ -373,9 +373,13 @@ namespace vcpkg::Commands::CIVerifyVersions
             {
                 System::printf(System::Color::error, "FAIL: %s\n", port_name);
                 errors.emplace(Strings::format("Error: While validating port %s.\n"
-                                               "       Missing expected versions file at: %s",
+                                               "       Missing expected versions file at: %s\n"
+                                               "       Run:\n\n"
+                                               "           vcpkg x-add-version %s\n\n"
+                                               "       to create the versions file.",
                                                port_name,
-                                               fs::u8string(versions_file_path)));
+                                               fs::u8string(versions_file_path),
+                                               port_name));
                 continue;
             }
 


### PR DESCRIPTION
Break JSON file output into multiple lines to avoid large diffs when using `x-add-version`.