### PR TITLE
[podofo] Fix feature crypto

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -4554,7 +4554,7 @@
     },
     "podofo": {
       "baseline": "0.9.6",
-      "port-version": 12
+      "port-version": 13
     },
     "poly2tri": {
       "baseline": "2020-07-21",

--- a/port_versions/p-/podofo.json
+++ b/port_versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69967a79faa43c4d15f5fc533f44b3d095813d63",
+      "version-string": "0.9.6",
+      "port-version": 13
+    },
+    {
       "git-tree": "8ab65ed2018a120250dafbdeadc9ef87957d2cb4",
       "version-string": "0.9.6",
       "port-version": 12

--- a/ports/podofo/0005-fix-crypto.patch
+++ b/ports/podofo/0005-fix-crypto.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f23dd5a..fd9e8ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -315,11 +315,12 @@ ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+ FIND_PACKAGE(ZLIB REQUIRED)
+ MESSAGE("Found zlib headers in ${ZLIB_INCLUDE_DIR}, library at ${ZLIB_LIBRARIES}")
+ 
+-FIND_PACKAGE(LIBCRYPTO)
++FIND_PACKAGE(OpenSSL)
+ 
+-IF(LIBCRYPTO_FOUND)
++IF(OpenSSL_FOUND)
+ 	SET(PODOFO_HAVE_OPENSSL TRUE)
+-	INCLUDE_DIRECTORIES(${LIBCRYPTO_INCLUDE_DIR})
++    LIST(APPEND OPENSSL_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
++    ADD_DEFINITIONS(-DPODOFO_HAVE_OPENSSL_1_1)
+ 	MESSAGE("Found OpenSSL's libCrypto headers in ${LIBCRYPTO_INCLUDE_DIR}, library at ${LIBCRYPTO_LIBRARIES}")
+ ELSE(LIBCRYPTO_FOUND)
+ 	MESSAGE("OpenSSL's libCrypto not found. Encryption support will be disabled")
+@@ -396,8 +397,6 @@ ENDIF(CppUnit_FOUND)
+ 
+ ENDIF(NOT PODOFO_BUILD_LIB_ONLY)
+ 
+-FIND_PACKAGE(OpenSSL)
+-
+ FIND_PACKAGE(FREETYPE REQUIRED)
+ MESSAGE("Found freetype library at ${FREETYPE_LIBRARIES}, headers ${FREETYPE_INCLUDE_DIR}")
+ 

--- a/ports/podofo/CONTROL
+++ b/ports/podofo/CONTROL
@@ -1,6 +1,6 @@
 Source: podofo
 Version: 0.9.6
-Port-Version: 12
+Port-Version: 13
 Homepage: https://sourceforge.net/projects/podofo/
 Description: PoDoFo is a library to work with the PDF file format
 Build-Depends: zlib, libpng, libjpeg-turbo, tiff, openssl, freetype

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_sourceforge(
         0002-HAVE_UNISTD_H.patch
         freetype.patch
         ${ADDITIONAL_PATCH}
+        0005-fix-crypto.patch
 )
 
 set(PODOFO_NO_FONTMANAGER ON)


### PR DESCRIPTION
Since openssl generates `libssl` and `libcrypto` in vcpkg at the same time, change the method of finding crypto to the method in vcpkg.

Fixes #15663.