### PR TITLE
[vtk] use patch for QT_NO_KEYWORDS support from upstream

### DIFF
--- a/ports/vtk/0002-Qt-enforce-QT_NO_KEYWORDS-builds-by-VTK-itself.patch
+++ b/ports/vtk/0002-Qt-enforce-QT_NO_KEYWORDS-builds-by-VTK-itself.patch
@@ -1,0 +1,33 @@
+From 20dd0370d7ad685b7fbdb1625ffec60c940980f3 Mon Sep 17 00:00:00 2001
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Fri, 17 Apr 2020 15:02:15 -0400
+Subject: [PATCH 2/2] Qt: enforce QT_NO_KEYWORDS builds by VTK itself
+
+---
+ GUISupport/Qt/CMakeLists.txt | 1 +
+ Views/Qt/CMakeLists.txt      | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/GUISupport/Qt/CMakeLists.txt b/GUISupport/Qt/CMakeLists.txt
+index bfa63a94f1..3fc6fe4bd9 100644
+--- a/GUISupport/Qt/CMakeLists.txt
++++ b/GUISupport/Qt/CMakeLists.txt
+@@ -47,4 +47,5 @@ vtk_module_add_module(VTK::GUISupportQt
+   HEADERS ${headers}
+   PRIVATE_HEADERS ${private_headers})
+ 
++vtk_module_definitions(VTK::GUISupportQt PRIVATE QT_NO_KEYWORDS)
+ vtk_module_link(VTK::GUISupportQt PUBLIC Qt5::Widgets)
+diff --git a/Views/Qt/CMakeLists.txt b/Views/Qt/CMakeLists.txt
+index 7684118e40..b697571dd2 100644
+--- a/Views/Qt/CMakeLists.txt
++++ b/Views/Qt/CMakeLists.txt
+@@ -17,4 +17,5 @@ set(CMAKE_AUTOMOC 1)
+ vtk_module_add_module(VTK::ViewsQt
+   CLASSES ${classes})
+ 
++vtk_module_definitions(VTK::ViewsQt PRIVATE QT_NO_KEYWORDS)
+ vtk_module_link(VTK::ViewsQt PRIVATE Qt5::Widgets)
+-- 
+2.30.0.windows.1
+

--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 3
+Port-Version: 4
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -109,6 +109,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 # =============================================================================
 # Clone & patch
+
+# This patch is huge, we prefer to download it on demand
+vcpkg_download_distfile(QT_NO_KEYWORDS_PATCH
+  URLS "https://github.com/Kitware/VTK/commit/64265c5fd1a8e26a6a81241284dea6b3272f6db6.diff"
+  FILENAME 64265c5fd1a8e26a6a81241284dea6b3272f6db6.diff
+  SHA512 08991f07b30b893b14e906017b77fb700a8298a3a8906086a0c4b67688c1c0431b3d6bf890df70bd3ebf963cbb9c035b5dbcb9d7593e8c716c3a594ccb9a0fc7
+)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Kitware/VTK
@@ -130,6 +138,9 @@ vcpkg_from_github(
         # Last patch TODO: Patch out internal loguru
         FindExpat.patch # The find_library calls are taken care of by vcpkg-cmake-wrapper.cmake of expat
         fix-freetype.patch # Should be fixed next version, !7367 + !7434
+        # Remove these 2 official patches in the next update
+        ${QT_NO_KEYWORDS_PATCH}
+        0002-Qt-enforce-QT_NO_KEYWORDS-builds-by-VTK-itself.patch
 )
 
 # =============================================================================

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6038,7 +6038,7 @@
     },
     "vtk": {
       "baseline": "9.0.1",
-      "port-version": 3
+      "port-version": 4
     },
     "vtk-dicom": {
       "baseline": "0.8.12-1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94667926df104c70c0229cc96b36ec41f3911853",
+      "version-string": "9.0.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "6f325c609afb0c171d6d70c965e041f8c7288bd3",
       "version-string": "9.0.1",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? It apply upstream patches (already merged), to support QT_NO_KEYWORDS. This is absolutely mandatory if you use VTK with other frameworks that define `slots, signals, ...` keywords. This doesn't change anything in VTK itself