### PR TITLE
[google-cloud-cpp] update to v1.23.0

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -2201,7 +2201,7 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "1.22.0",
+      "baseline": "1.23.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/port_versions/g-/google-cloud-cpp.json
+++ b/port_versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab2377218e8992e8aedf8fed757edb90cc390817",
+      "version-string": "1.23.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "85ed59dd339159f0600765d49cb7e1e723e67fec",
       "version-string": "1.22.0",
       "port-version": 0

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.22.0
-    SHA512 bf5554009d4dddef8782fa7a6ea9790e47169c1558dda4b2bd3caf83efe25c7b04d5d6b7b4dbbc3540790b243b7c9496ebc79f07e21a310c83e952c3596f0536
+    REF v1.23.0
+    SHA512 66c8bc6a878dbe23be0dd8fbe2580b725a2e5dab1b132a53f3454a32ec0cce706bdeae8b08b1922acc892f7983df5bc076e3d16993d5d0c1bda75e8a1195c882
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version-string": "1.22.0",
+  "version-string": "1.23.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "supports": "!uwp",


### PR DESCRIPTION
Update `google-cloud-cpp` to the latest release (v1.23.0)

- What does your PR fix? Fixes #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

No change.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
