### PR TITLE
[vcpkg] Rewriting CmdLineBuilder/Command (3/n)

### DIFF
--- a/toolsrc/include/vcpkg/base/system.process.h
+++ b/toolsrc/include/vcpkg/base/system.process.h
@@ -20,26 +20,26 @@ namespace vcpkg::System
         std::string s;
     };
 
-    struct CmdLineBuilder
+    struct Command
     {
-        CmdLineBuilder() = default;
-        explicit CmdLineBuilder(const fs::path& p) { path_arg(p); }
-        explicit CmdLineBuilder(StringView s) { string_arg(s); }
-        explicit CmdLineBuilder(const std::string& s) { string_arg(s); }
-        explicit CmdLineBuilder(const char* s) { string_arg({s, ::strlen(s)}); }
+        Command() = default;
+        explicit Command(const fs::path& p) { path_arg(p); }
+        explicit Command(StringView s) { string_arg(s); }
+        explicit Command(const std::string& s) { string_arg(s); }
+        explicit Command(const char* s) { string_arg({s, ::strlen(s)}); }
 
-        CmdLineBuilder& path_arg(const fs::path& p) & { return string_arg(fs::u8string(p)); }
-        CmdLineBuilder& string_arg(StringView s) &;
-        CmdLineBuilder& raw_arg(StringView s) &
+        Command& path_arg(const fs::path& p) & { return string_arg(fs::u8string(p)); }
+        Command& string_arg(StringView s) &;
+        Command& raw_arg(StringView s) &
         {
             buf.push_back(' ');
             buf.append(s.data(), s.size());
             return *this;
         }
 
-        CmdLineBuilder&& path_arg(const fs::path& p) && { return std::move(path_arg(p)); }
-        CmdLineBuilder&& string_arg(StringView s) && { return std::move(string_arg(s)); };
-        CmdLineBuilder&& raw_arg(StringView s) && { return std::move(raw_arg(s)); }
+        Command&& path_arg(const fs::path& p) && { return std::move(path_arg(p)); }
+        Command&& string_arg(StringView s) && { return std::move(string_arg(s)); };
+        Command&& raw_arg(StringView s) && { return std::move(raw_arg(s)); }
 
         std::string&& extract() && { return std::move(buf); }
         StringView command_line() const { return buf; }
@@ -51,17 +51,17 @@ namespace vcpkg::System
         std::string buf;
     };
 
-    struct CmdLineBuilderMapLess
+    struct CommandLess
     {
-        bool operator()(const CmdLineBuilder& lhs, const CmdLineBuilder& rhs) const
+        bool operator()(const Command& lhs, const Command& rhs) const
         {
             return lhs.command_line() < rhs.command_line();
         }
     };
 
-    CmdLineBuilder make_basic_cmake_cmd(const fs::path& cmake_tool_path,
-                                        const fs::path& cmake_script,
-                                        const std::vector<CMakeVariable>& pass_variables);
+    Command make_basic_cmake_cmd(const fs::path& cmake_tool_path,
+                                 const fs::path& cmake_script,
+                                 const std::vector<CMakeVariable>& pass_variables);
 
     fs::path get_exe_path_of_current_process();
 
@@ -87,48 +87,48 @@ namespace vcpkg::System
         const fs::path& working_directory;
     };
 
-    int cmd_execute(const CmdLineBuilder& cmd_line, InWorkingDirectory wd, const Environment& env = {});
-    inline int cmd_execute(const CmdLineBuilder& cmd_line, const Environment& env = {})
+    int cmd_execute(const Command& cmd_line, InWorkingDirectory wd, const Environment& env = {});
+    inline int cmd_execute(const Command& cmd_line, const Environment& env = {})
     {
         return cmd_execute(cmd_line, InWorkingDirectory{fs::path()}, env);
     }
 
-    int cmd_execute_clean(const CmdLineBuilder& cmd_line, InWorkingDirectory wd);
-    inline int cmd_execute_clean(const CmdLineBuilder& cmd_line)
+    int cmd_execute_clean(const Command& cmd_line, InWorkingDirectory wd);
+    inline int cmd_execute_clean(const Command& cmd_line)
     {
         return cmd_execute_clean(cmd_line, InWorkingDirectory{fs::path()});
     }
 
 #if defined(_WIN32)
-    Environment cmd_execute_modify_env(const CmdLineBuilder& cmd_line, const Environment& env = {});
+    Environment cmd_execute_modify_env(const Command& cmd_line, const Environment& env = {});
 
-    void cmd_execute_background(const CmdLineBuilder& cmd_line);
+    void cmd_execute_background(const Command& cmd_line);
 #endif
 
-    ExitCodeAndOutput cmd_execute_and_capture_output(const CmdLineBuilder& cmd_line,
+    ExitCodeAndOutput cmd_execute_and_capture_output(const Command& cmd_line,
                                                      InWorkingDirectory wd,
                                                      const Environment& env = {});
-    inline ExitCodeAndOutput cmd_execute_and_capture_output(const CmdLineBuilder& cmd_line, const Environment& env = {})
+    inline ExitCodeAndOutput cmd_execute_and_capture_output(const Command& cmd_line, const Environment& env = {})
     {
         return cmd_execute_and_capture_output(cmd_line, InWorkingDirectory{fs::path()}, env);
     }
 
-    int cmd_execute_and_stream_lines(const CmdLineBuilder& cmd_line,
+    int cmd_execute_and_stream_lines(const Command& cmd_line,
                                      InWorkingDirectory wd,
                                      std::function<void(StringView)> per_line_cb,
                                      const Environment& env = {});
-    inline int cmd_execute_and_stream_lines(const CmdLineBuilder& cmd_line,
+    inline int cmd_execute_and_stream_lines(const Command& cmd_line,
                                             std::function<void(StringView)> per_line_cb,
                                             const Environment& env = {})
     {
         return cmd_execute_and_stream_lines(cmd_line, InWorkingDirectory{fs::path()}, std::move(per_line_cb), env);
     }
 
-    int cmd_execute_and_stream_data(const CmdLineBuilder& cmd_line,
+    int cmd_execute_and_stream_data(const Command& cmd_line,
                                     InWorkingDirectory wd,
                                     std::function<void(StringView)> data_cb,
                                     const Environment& env = {});
-    inline int cmd_execute_and_stream_data(const CmdLineBuilder& cmd_line,
+    inline int cmd_execute_and_stream_data(const Command& cmd_line,
                                            std::function<void(StringView)> data_cb,
                                            const Environment& env = {})
     {

--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -232,7 +232,7 @@ namespace vcpkg::Build
         const VcpkgPaths& m_paths;
     };
 
-    System::CmdLineBuilder make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
+    System::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
 
     struct ExtendedBuildResult
     {
@@ -369,7 +369,7 @@ namespace vcpkg::Build
         struct EnvMapEntry
         {
             std::unordered_map<std::string, std::string> env_map;
-            Cache<System::CmdLineBuilder, System::Environment, System::CmdLineBuilderMapLess> cmd_cache;
+            Cache<System::Command, System::Environment, System::CommandLess> cmd_cache;
         };
 
         Cache<std::vector<std::string>, EnvMapEntry> envs;

--- a/toolsrc/include/vcpkg/buildenvironment.h
+++ b/toolsrc/include/vcpkg/buildenvironment.h
@@ -9,7 +9,7 @@
 
 namespace vcpkg
 {
-    System::CmdLineBuilder make_cmake_cmd(const VcpkgPaths& paths,
-                                          const fs::path& cmake_script,
-                                          std::vector<System::CMakeVariable>&& pass_variables);
+    System::Command make_cmake_cmd(const VcpkgPaths& paths,
+                                   const fs::path& cmake_script,
+                                   std::vector<System::CMakeVariable>&& pass_variables);
 }

--- a/toolsrc/src/vcpkg-test/system.cpp
+++ b/toolsrc/src/vcpkg-test/system.cpp
@@ -127,9 +127,9 @@ TEST_CASE ("guess_visual_studio_prompt", "[system]")
 
 TEST_CASE ("cmdlinebuilder", "[system]")
 {
-    using vcpkg::System::CmdLineBuilder;
+    using vcpkg::System::Command;
 
-    CmdLineBuilder cmd;
+    Command cmd;
     cmd.path_arg(fs::u8path("relative/path.exe"));
     cmd.string_arg("abc");
     cmd.string_arg("hello world!");

--- a/toolsrc/src/vcpkg/archives.cpp
+++ b/toolsrc/src/vcpkg/archives.cpp
@@ -44,7 +44,7 @@ namespace vcpkg::Archives
             const std::string nugetid = match[1];
             const std::string version = match[2];
 
-            const auto code_and_output = System::cmd_execute_and_capture_output(System::CmdLineBuilder{nuget_exe}
+            const auto code_and_output = System::cmd_execute_and_capture_output(System::Command{nuget_exe}
                                                                                     .string_arg("install")
                                                                                     .string_arg(nugetid)
                                                                                     .string_arg("-Version")
@@ -74,7 +74,7 @@ namespace vcpkg::Archives
             recursion_limiter_sevenzip = true;
             const auto seven_zip = paths.get_tool_exe(Tools::SEVEN_ZIP);
             const auto code_and_output = System::cmd_execute_and_capture_output(
-                System::CmdLineBuilder{seven_zip}
+                System::Command{seven_zip}
                     .string_arg("x")
                     .path_arg(archive)
                     .string_arg(Strings::format("-o%s", fs::u8string(to_path_partial)))
@@ -89,13 +89,13 @@ namespace vcpkg::Archives
 #else
         if (ext == ".gz" && ext.extension() != ".tar")
         {
-            const auto code = System::cmd_execute(System::CmdLineBuilder{"tar"}.string_arg("xzf").path_arg(archive),
+            const auto code = System::cmd_execute(System::Command{"tar"}.string_arg("xzf").path_arg(archive),
                                                   System::InWorkingDirectory{to_path_partial});
             Checks::check_exit(VCPKG_LINE_INFO, code == 0, "tar failed while extracting %s", fs::u8string(archive));
         }
         else if (ext == ".zip")
         {
-            const auto code = System::cmd_execute(System::CmdLineBuilder{"unzip"}.string_arg("-qqo").path_arg(archive),
+            const auto code = System::cmd_execute(System::Command{"unzip"}.string_arg("-qqo").path_arg(archive),
                                                   System::InWorkingDirectory{to_path_partial});
             Checks::check_exit(VCPKG_LINE_INFO, code == 0, "unzip failed while extracting %s", fs::u8string(archive));
         }

--- a/toolsrc/src/vcpkg/base/downloads.cpp
+++ b/toolsrc/src/vcpkg/base/downloads.cpp
@@ -220,7 +220,7 @@ namespace vcpkg::Downloads
     {
         static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
         cmd.string_arg("curl")
             .string_arg("--head")
             .string_arg("--location")
@@ -260,7 +260,7 @@ namespace vcpkg::Downloads
     {
         static constexpr StringLiteral guid_marker = "8a1db05f-a65d-419b-aa72-037fb4d0672e";
 
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
         cmd.string_arg("curl")
             .string_arg("--location")
             .string_arg("-w")
@@ -298,7 +298,7 @@ namespace vcpkg::Downloads
     {
         static constexpr StringLiteral guid_marker = "9a1db05f-a65d-419b-aa72-037fb4d0672e";
 
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
         cmd.string_arg("curl").string_arg("-X").string_arg("PUT");
         cmd.string_arg("-w").string_arg(Strings::concat("\\n", guid_marker, "%{http_code}"));
         cmd.string_arg(url);
@@ -443,7 +443,7 @@ namespace vcpkg::Downloads
                 }
             }
 #endif
-            System::CmdLineBuilder cmd;
+            System::Command cmd;
             cmd.string_arg("curl")
                 .string_arg("--fail")
                 .string_arg("-L")

--- a/toolsrc/src/vcpkg/base/system.process.cpp
+++ b/toolsrc/src/vcpkg/base/system.process.cpp
@@ -184,11 +184,11 @@ namespace vcpkg
     }
     System::CMakeVariable::CMakeVariable(std::string var) : s(std::move(var)) { }
 
-    System::CmdLineBuilder System::make_basic_cmake_cmd(const fs::path& cmake_tool_path,
-                                                        const fs::path& cmake_script,
-                                                        const std::vector<CMakeVariable>& pass_variables)
+    System::Command System::make_basic_cmake_cmd(const fs::path& cmake_tool_path,
+                                                 const fs::path& cmake_script,
+                                                 const std::vector<CMakeVariable>& pass_variables)
     {
-        System::CmdLineBuilder cmd{cmake_tool_path};
+        System::Command cmd{cmake_tool_path};
         for (auto&& var : pass_variables)
         {
             cmd.string_arg(var.s);
@@ -197,7 +197,7 @@ namespace vcpkg
         return cmd;
     }
 
-    System::CmdLineBuilder& System::CmdLineBuilder::string_arg(StringView s) &
+    System::Command& System::Command::string_arg(StringView s) &
     {
         if (!buf.empty()) buf.push_back(' ');
         if (Strings::find_first_of(s, " \t\n\r\"\\,;&`^|'") != s.end())
@@ -383,7 +383,7 @@ namespace vcpkg
         return clean_env;
     }
 
-    int System::cmd_execute_clean(const CmdLineBuilder& cmd_line, InWorkingDirectory wd)
+    int System::cmd_execute_clean(const Command& cmd_line, InWorkingDirectory wd)
     {
         return cmd_execute(cmd_line, wd, get_clean_environment());
     }
@@ -564,7 +564,7 @@ namespace vcpkg
 #endif
 
 #if defined(_WIN32)
-    void System::cmd_execute_background(const CmdLineBuilder& cmd_line)
+    void System::cmd_execute_background(const Command& cmd_line)
     {
         auto timer = Chrono::ElapsedTimer::create_started();
 
@@ -581,7 +581,7 @@ namespace vcpkg
         Debug::print("cmd_execute_background() took ", static_cast<int>(timer.microseconds()), " us\n");
     }
 
-    Environment System::cmd_execute_modify_env(const CmdLineBuilder& cmd_line, const Environment& env)
+    Environment System::cmd_execute_modify_env(const Command& cmd_line, const Environment& env)
     {
         static StringLiteral magic_string = "cdARN4xjKueKScMy9C6H";
 
@@ -623,7 +623,7 @@ namespace vcpkg
     }
 #endif
 
-    int System::cmd_execute(const CmdLineBuilder& cmd_line, System::InWorkingDirectory wd, const Environment& env)
+    int System::cmd_execute(const Command& cmd_line, System::InWorkingDirectory wd, const Environment& env)
     {
         auto timer = Chrono::ElapsedTimer::create_started();
 #if defined(_WIN32)
@@ -651,7 +651,7 @@ namespace vcpkg
         }
         else
         {
-            real_command_line = System::CmdLineBuilder("cd")
+            real_command_line = System::Command("cd")
                                     .path_arg(wd.working_directory)
                                     .raw_arg("&&")
                                     .raw_arg(cmd_line.command_line())
@@ -667,7 +667,7 @@ namespace vcpkg
         return exit_code;
     }
 
-    int System::cmd_execute_and_stream_lines(const CmdLineBuilder& cmd_line,
+    int System::cmd_execute_and_stream_lines(const Command& cmd_line,
                                              System::InWorkingDirectory wd,
                                              std::function<void(StringView)> per_line_cb,
                                              const Environment& env)
@@ -696,7 +696,7 @@ namespace vcpkg
         return rc;
     }
 
-    int System::cmd_execute_and_stream_data(const CmdLineBuilder& cmd_line,
+    int System::cmd_execute_and_stream_data(const Command& cmd_line,
                                             System::InWorkingDirectory wd,
                                             std::function<void(StringView)> data_cb,
                                             const Environment& env)
@@ -724,7 +724,7 @@ namespace vcpkg
         }
         else
         {
-            actual_cmd_line = System::CmdLineBuilder("cd")
+            actual_cmd_line = System::Command("cd")
                                   .path_arg(wd.working_directory)
                                   .raw_arg("&&")
                                   .raw_arg(cmd_line.command_line())
@@ -763,7 +763,7 @@ namespace vcpkg
         return exit_code;
     }
 
-    ExitCodeAndOutput System::cmd_execute_and_capture_output(const CmdLineBuilder& cmd_line,
+    ExitCodeAndOutput System::cmd_execute_and_capture_output(const Command& cmd_line,
                                                              System::InWorkingDirectory wd,
                                                              const Environment& env)
     {

--- a/toolsrc/src/vcpkg/binarycaching.cpp
+++ b/toolsrc/src/vcpkg/binarycaching.cpp
@@ -59,7 +59,7 @@ namespace
                                                         const fs::path& dst,
                                                         const fs::path& archive_path)
     {
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
 #if defined(_WIN32)
         auto&& seven_zip_exe = paths.get_tool_exe(Tools::SEVEN_ZIP);
         cmd.path_arg(seven_zip_exe)
@@ -96,13 +96,11 @@ namespace
 #if defined(_WIN32)
         auto&& seven_zip_exe = paths.get_tool_exe(Tools::SEVEN_ZIP);
 
-        System::cmd_execute_and_capture_output(System::CmdLineBuilder{seven_zip_exe}
-                                                   .string_arg("a")
-                                                   .path_arg(destination)
-                                                   .path_arg(source / fs::u8path("*")),
-                                               System::get_clean_environment());
+        System::cmd_execute_and_capture_output(
+            System::Command{seven_zip_exe}.string_arg("a").path_arg(destination).path_arg(source / fs::u8path("*")),
+            System::get_clean_environment());
 #else
-        System::cmd_execute_clean(System::CmdLineBuilder{"zip"}
+        System::cmd_execute_clean(System::Command{"zip"}
                                       .string_arg("--quiet")
                                       .string_arg("-y")
                                       .string_arg("-r")
@@ -420,7 +418,7 @@ namespace
         {
         }
 
-        int run_nuget_commandline(const System::CmdLineBuilder& cmdline)
+        int run_nuget_commandline(const System::Command& cmdline)
         {
             if (m_interactive)
             {
@@ -516,12 +514,12 @@ namespace
             };
 
             const auto& nuget_exe = paths.get_tool_exe("nuget");
-            std::vector<System::CmdLineBuilder> cmdlines;
+            std::vector<System::Command> cmdlines;
 
             if (!m_read_sources.empty())
             {
                 // First check using all sources
-                System::CmdLineBuilder cmdline;
+                System::Command cmdline;
 #ifndef _WIN32
                 cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif
@@ -551,7 +549,7 @@ namespace
             for (auto&& cfg : m_read_configs)
             {
                 // Then check using each config
-                System::CmdLineBuilder cmdline;
+                System::Command cmdline;
 #ifndef _WIN32
                 cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif
@@ -642,7 +640,7 @@ namespace
                 nuspec_path, generate_nuspec(paths, action, nuget_ref), VCPKG_LINE_INFO);
 
             const auto& nuget_exe = paths.get_tool_exe("nuget");
-            System::CmdLineBuilder cmdline;
+            System::Command cmdline;
 #ifndef _WIN32
             cmdline.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif
@@ -666,7 +664,7 @@ namespace
                 auto nupkg_path = paths.buildtrees / nuget_ref.nupkg_filename();
                 for (auto&& write_src : m_write_sources)
                 {
-                    System::CmdLineBuilder cmd;
+                    System::Command cmd;
 #ifndef _WIN32
                     cmd.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif
@@ -695,7 +693,7 @@ namespace
                 }
                 for (auto&& write_cfg : m_write_configs)
                 {
-                    System::CmdLineBuilder cmd;
+                    System::Command cmd;
 #ifndef _WIN32
                     cmd.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -439,7 +439,7 @@ namespace vcpkg::Build
         });
     }
 
-    System::CmdLineBuilder make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
+    System::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset)
     {
         if (!pre_build_info.using_vcvars()) return {};
 
@@ -452,7 +452,7 @@ namespace vcpkg::Build
         const auto arch = to_vcvarsall_toolchain(pre_build_info.target_architecture, toolset);
         const auto target = to_vcvarsall_target(pre_build_info.cmake_system_name);
 
-        return System::CmdLineBuilder{"cmd"}.string_arg("/c").raw_arg(
+        return System::Command{"cmd"}.string_arg("/c").raw_arg(
             Strings::format(R"("%s" %s %s %s %s 2>&1 <NUL)",
                             fs::u8string(toolset.vcvarsall),
                             Strings::join(" ", toolset.vcvarsall_options),

--- a/toolsrc/src/vcpkg/buildenvironment.cpp
+++ b/toolsrc/src/vcpkg/buildenvironment.cpp
@@ -4,9 +4,9 @@
 
 namespace vcpkg
 {
-    System::CmdLineBuilder make_cmake_cmd(const VcpkgPaths& paths,
-                                          const fs::path& cmake_script,
-                                          std::vector<System::CMakeVariable>&& pass_variables)
+    System::Command make_cmake_cmd(const VcpkgPaths& paths,
+                                   const fs::path& cmake_script,
+                                   std::vector<System::CMakeVariable>&& pass_variables)
     {
         auto local_variables = std::move(pass_variables);
         local_variables.emplace_back("VCPKG_ROOT_DIR", paths.root);

--- a/toolsrc/src/vcpkg/commands.contact.cpp
+++ b/toolsrc/src/vcpkg/commands.contact.cpp
@@ -45,7 +45,7 @@ namespace vcpkg::Commands::Contact
             }
 
 #if defined(_WIN32)
-            System::cmd_execute(System::CmdLineBuilder("start").string_arg("https://aka.ms/NPS_vcpkg"));
+            System::cmd_execute(System::Command("start").string_arg("https://aka.ms/NPS_vcpkg"));
             System::print2("Default browser launched to https://aka.ms/NPS_vcpkg; thank you for your feedback!\n");
 #else
             System::print2("Please navigate to https://aka.ms/NPS_vcpkg in your preferred browser. Thank you for your "

--- a/toolsrc/src/vcpkg/commands.edit.cpp
+++ b/toolsrc/src/vcpkg/commands.edit.cpp
@@ -219,14 +219,14 @@ namespace vcpkg::Commands::Edit
         candidate_paths.push_back(fs::path{"/usr/share/code/bin/code"});
         candidate_paths.push_back(fs::path{"/usr/bin/code"});
 
-        if (System::cmd_execute(System::CmdLineBuilder("command").string_arg("-v").string_arg("xdg-mime")) == 0)
+        if (System::cmd_execute(System::Command("command").string_arg("-v").string_arg("xdg-mime")) == 0)
         {
             auto mime_qry =
-                System::CmdLineBuilder("xdg-mime").string_arg("query").string_arg("default").string_arg("text/plain");
+                System::Command("xdg-mime").string_arg("query").string_arg("default").string_arg("text/plain");
             auto execute_result = System::cmd_execute_and_capture_output(mime_qry);
             if (execute_result.exit_code == 0 && !execute_result.output.empty())
             {
-                mime_qry = System::CmdLineBuilder("command").string_arg("-v").string_arg(
+                mime_qry = System::Command("command").string_arg("-v").string_arg(
                     execute_result.output.substr(0, execute_result.output.find('.')));
                 execute_result = System::cmd_execute_and_capture_output(mime_qry);
                 if (execute_result.exit_code == 0 && !execute_result.output.empty())
@@ -255,7 +255,7 @@ namespace vcpkg::Commands::Edit
         const fs::path env_editor = *it;
         const std::vector<std::string> arguments = create_editor_arguments(paths, options, ports);
         const auto args_as_string = Strings::join(" ", arguments);
-        auto cmd_line = System::CmdLineBuilder(env_editor).raw_arg(args_as_string).string_arg("-n");
+        auto cmd_line = System::Command(env_editor).raw_arg(args_as_string).string_arg("-n");
 
         auto editor_exe = fs::u8string(env_editor.filename());
 
@@ -264,7 +264,7 @@ namespace vcpkg::Commands::Edit
         {
             // note that we are invoking cmd silently but Code.exe is relaunched from there
             System::cmd_execute_background(
-                System::CmdLineBuilder("cmd").string_arg("/c").string_arg(cmd_line.command_line()).raw_arg("<NUL"));
+                System::Command("cmd").string_arg("/c").string_arg(cmd_line.command_line()).raw_arg("<NUL"));
             Checks::exit_success(VCPKG_LINE_INFO);
         }
 #endif

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -98,7 +98,7 @@ namespace vcpkg::Commands::Env
             }
         }();
 
-        System::CmdLineBuilder cmd("cmd");
+        System::Command cmd("cmd");
         if (!args.command_arguments.empty())
         {
             cmd.string_arg("/c").raw_arg(args.command_arguments.at(0));

--- a/toolsrc/src/vcpkg/commands.integrate.cpp
+++ b/toolsrc/src/vcpkg/commands.integrate.cpp
@@ -379,7 +379,7 @@ CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=%s"
             nuspec_file_path, create_nuspec_file_contents(paths.root, nuget_id, nupkg_version), VCPKG_LINE_INFO);
 
         // Using all forward slashes for the command line
-        auto cmd_line = System::CmdLineBuilder(nuget_exe)
+        auto cmd_line = System::Command(nuget_exe)
                             .string_arg("pack")
                             .string_arg("-OutputDirectory")
                             .path_arg(buildsystems_dir)
@@ -415,7 +415,7 @@ With a project open, go to Tools->NuGet Package Manager->Package Manager Console
         const fs::path script_path = paths.scripts / "addPoshVcpkgToPowershellProfile.ps1";
 
         const auto& ps = paths.get_tool_exe("powershell-core");
-        auto cmd = System::CmdLineBuilder(ps)
+        auto cmd = System::Command(ps)
                        .string_arg("-NoProfile")
                        .string_arg("-ExecutionPolicy")
                        .string_arg("Bypass")

--- a/toolsrc/src/vcpkg/commands.porthistory.cpp
+++ b/toolsrc/src/vcpkg/commands.porthistory.cpp
@@ -31,11 +31,11 @@ namespace vcpkg::Commands::PortHistory
         const System::ExitCodeAndOutput run_git_command_inner(const VcpkgPaths& paths,
                                                               const fs::path& dot_git_directory,
                                                               const fs::path& working_directory,
-                                                              const System::CmdLineBuilder& cmd)
+                                                              const System::Command& cmd)
         {
             const fs::path& git_exe = paths.get_tool_exe(Tools::GIT);
 
-            auto full_cmd = System::CmdLineBuilder(git_exe)
+            auto full_cmd = System::Command(git_exe)
                                 .string_arg(Strings::concat("--git-dir=", fs::u8string(dot_git_directory)))
                                 .string_arg(Strings::concat("--work-tree=", fs::u8string(working_directory)))
                                 .raw_arg(cmd.command_line());
@@ -44,7 +44,7 @@ namespace vcpkg::Commands::PortHistory
             return output;
         }
 
-        const System::ExitCodeAndOutput run_git_command(const VcpkgPaths& paths, const System::CmdLineBuilder& cmd)
+        const System::ExitCodeAndOutput run_git_command(const VcpkgPaths& paths, const System::Command& cmd)
         {
             const fs::path& work_dir = paths.root;
             const fs::path dot_git_dir = paths.root / ".git";
@@ -89,7 +89,7 @@ namespace vcpkg::Commands::PortHistory
                                                                 const std::string& port_name)
         {
             auto rev_parse_cmd =
-                System::CmdLineBuilder("rev-parse").string_arg(Strings::concat(commit_id, ":ports/", port_name));
+                System::Command("rev-parse").string_arg(Strings::concat(commit_id, ":ports/", port_name));
             auto rev_parse_output = run_git_command(paths, rev_parse_cmd);
             if (rev_parse_output.exit_code == 0)
             {
@@ -97,7 +97,7 @@ namespace vcpkg::Commands::PortHistory
                 const auto git_tree = Strings::trim(std::move(rev_parse_output.output));
 
                 // Do we have a manifest file?
-                auto manifest_cmd = System::CmdLineBuilder("show").string_arg(Strings::concat(git_tree, ":vcpkg.json"));
+                auto manifest_cmd = System::Command("show").string_arg(Strings::concat(git_tree, ":vcpkg.json"));
                 auto manifest_output = run_git_command(paths, manifest_cmd);
                 if (manifest_output.exit_code == 0)
                 {
@@ -105,7 +105,7 @@ namespace vcpkg::Commands::PortHistory
                         manifest_output.output, git_tree, commit_id, commit_date, port_name, true);
                 }
 
-                auto cmd = System::CmdLineBuilder("show").string_arg(Strings::concat(git_tree, ":CONTROL"));
+                auto cmd = System::Command("show").string_arg(Strings::concat(git_tree, ":CONTROL"));
                 auto control_output = run_git_command(paths, cmd);
 
                 if (control_output.exit_code == 0)
@@ -121,7 +121,7 @@ namespace vcpkg::Commands::PortHistory
         std::vector<HistoryVersion> read_versions_from_log(const VcpkgPaths& paths, const std::string& port_name)
         {
             // log --format="%H %cd" --date=short --left-only -- ports/{port_name}/.
-            System::CmdLineBuilder builder;
+            System::Command builder;
             builder.string_arg("log");
             builder.string_arg("--format=%H %cd");
             builder.string_arg("--date=short");

--- a/toolsrc/src/vcpkg/commands.portsdiff.cpp
+++ b/toolsrc/src/vcpkg/commands.portsdiff.cpp
@@ -91,7 +91,7 @@ namespace vcpkg::Commands::PortsDiff
         const auto checkout_this_dir =
             Strings::format(R"(.\%s)", ports_dir_name_as_string); // Must be relative to the root of the repository
 
-        auto cmd = System::CmdLineBuilder(git_exe)
+        auto cmd = System::Command(git_exe)
                        .string_arg(Strings::format("--git-dir=%s", fs::u8string(dot_git_dir)))
                        .string_arg(Strings::format("--work-tree=%s", fs::u8string(temp_checkout_path)))
                        .string_arg("checkout")
@@ -102,7 +102,7 @@ namespace vcpkg::Commands::PortsDiff
                        .string_arg(checkout_this_dir)
                        .string_arg(".vcpkg-root");
         System::cmd_execute_and_capture_output(cmd, System::get_clean_environment());
-        System::cmd_execute_and_capture_output(System::CmdLineBuilder(git_exe).string_arg("reset"),
+        System::cmd_execute_and_capture_output(System::Command(git_exe).string_arg("reset"),
                                                System::get_clean_environment());
         const auto ports_at_commit =
             Paragraphs::load_overlay_ports(paths, temp_checkout_path / ports_dir_name_as_string);
@@ -120,7 +120,7 @@ namespace vcpkg::Commands::PortsDiff
     {
         static const std::string VALID_COMMIT_OUTPUT = "commit\n";
 
-        auto cmd = System::CmdLineBuilder(git_exe).string_arg("cat-file").string_arg("-t").string_arg(git_commit_id);
+        auto cmd = System::Command(git_exe).string_arg("cat-file").string_arg("-t").string_arg(git_commit_id);
         const System::ExitCodeAndOutput output = System::cmd_execute_and_capture_output(cmd);
         Checks::check_exit(
             VCPKG_LINE_INFO, output.output == VALID_COMMIT_OUTPUT, "Invalid commit id %s", git_commit_id);

--- a/toolsrc/src/vcpkg/export.chocolatey.cpp
+++ b/toolsrc/src/vcpkg/export.chocolatey.cpp
@@ -216,7 +216,7 @@ if (Test-Path $installedDir)
             const fs::path chocolatey_uninstall_file_path = per_package_dir_path / "tools" / "chocolateyUninstall.ps1";
             fs.write_contents(chocolatey_uninstall_file_path, chocolatey_uninstall_content, VCPKG_LINE_INFO);
 
-            auto cmd_line = System::CmdLineBuilder(nuget_exe)
+            auto cmd_line = System::Command(nuget_exe)
                                 .string_arg("pack")
                                 .string_arg("-OutputDirectory")
                                 .path_arg(exported_dir_path)

--- a/toolsrc/src/vcpkg/export.cpp
+++ b/toolsrc/src/vcpkg/export.cpp
@@ -162,7 +162,7 @@ namespace vcpkg::Export
         fs.write_contents(nuspec_file_path, nuspec_file_content, VCPKG_LINE_INFO);
 
         // -NoDefaultExcludes is needed for ".vcpkg-root"
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
 #ifndef _WIN32
         cmd.path_arg(paths.get_tool_exe(Tools::MONO));
 #endif
@@ -223,7 +223,7 @@ namespace vcpkg::Export
             Strings::format("%s.%s", exported_dir_filename, format.extension());
         const fs::path exported_archive_path = (output_dir / exported_archive_filename);
 
-        System::CmdLineBuilder cmd;
+        System::Command cmd;
         cmd.path_arg(cmake_exe)
             .string_arg("-E")
             .string_arg("tar")

--- a/toolsrc/src/vcpkg/export.ifw.cpp
+++ b/toolsrc/src/vcpkg/export.ifw.cpp
@@ -370,10 +370,8 @@ namespace vcpkg::Export::IFW
                                fs::generic_u8string(repository_dir),
                                failure_point.string());
 
-            auto cmd_line = System::CmdLineBuilder(repogen_exe)
-                                .string_arg("--packages")
-                                .path_arg(packages_dir)
-                                .path_arg(repository_dir);
+            auto cmd_line =
+                System::Command(repogen_exe).string_arg("--packages").path_arg(packages_dir).path_arg(repository_dir);
 
             const int exit_code =
                 System::cmd_execute_and_capture_output(cmd_line, System::get_clean_environment()).exit_code;
@@ -393,12 +391,12 @@ namespace vcpkg::Export::IFW
 
             System::printf("Generating installer %s...\n", fs::generic_u8string(installer_file));
 
-            System::CmdLineBuilder cmd_line;
+            System::Command cmd_line;
 
             std::string ifw_repo_url = ifw_options.maybe_repository_url.value_or("");
             if (!ifw_repo_url.empty())
             {
-                cmd_line = System::CmdLineBuilder(binarycreator_exe)
+                cmd_line = System::Command(binarycreator_exe)
                                .string_arg("--online-only")
                                .string_arg("--config")
                                .path_arg(config_file)
@@ -408,7 +406,7 @@ namespace vcpkg::Export::IFW
             }
             else
             {
-                cmd_line = System::CmdLineBuilder(binarycreator_exe)
+                cmd_line = System::Command(binarycreator_exe)
                                .string_arg("--config")
                                .path_arg(config_file)
                                .string_arg("--packages")

--- a/toolsrc/src/vcpkg/export.prefab.cpp
+++ b/toolsrc/src/vcpkg/export.prefab.cpp
@@ -206,14 +206,12 @@ namespace vcpkg::Export::Prefab
 #if defined(_WIN32)
         auto&& seven_zip_exe = paths.get_tool_exe(Tools::SEVEN_ZIP);
 
-        System::cmd_execute_and_capture_output(System::CmdLineBuilder(seven_zip_exe)
-                                                   .string_arg("a")
-                                                   .path_arg(destination)
-                                                   .path_arg(source / fs::u8path("*")),
-                                               System::get_clean_environment());
+        System::cmd_execute_and_capture_output(
+            System::Command(seven_zip_exe).string_arg("a").path_arg(destination).path_arg(source / fs::u8path("*")),
+            System::get_clean_environment());
 #else
         System::cmd_execute_clean(
-            System::CmdLineBuilder{"zip"}.string_arg("--quiet").string_arg("-r").path_arg(destination).string_arg("*"),
+            System::Command{"zip"}.string_arg("--quiet").string_arg("-r").path_arg(destination).string_arg("*"),
             System::InWorkingDirectory{source});
 #endif
     }
@@ -224,7 +222,7 @@ namespace vcpkg::Export::Prefab
         {
             System::print2("\n[DEBUG] Installing POM and AAR file to ~/.m2\n\n");
         }
-        auto cmd_line = System::CmdLineBuilder(Tools::MAVEN);
+        auto cmd_line = System::Command(Tools::MAVEN);
         if (!prefab_options.enable_debug)
         {
             cmd_line.string_arg("-q");

--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -257,7 +257,7 @@ namespace vcpkg::Metrics
             return "{}";
         }
 
-        auto getmac = System::cmd_execute_and_capture_output(System::CmdLineBuilder("getmac"));
+        auto getmac = System::cmd_execute_and_capture_output(System::Command("getmac"));
 
         if (getmac.exit_code != 0) return "0";
 
@@ -474,14 +474,14 @@ namespace vcpkg::Metrics
         if (ec) return;
 
 #if defined(_WIN32)
-        System::CmdLineBuilder builder;
+        System::Command builder;
         builder.path_arg(temp_folder_path_exe);
         builder.string_arg("x-upload-metrics");
         builder.path_arg(vcpkg_metrics_txt_path);
         System::cmd_execute_background(builder);
 #else
         // TODO: convert to cmd_execute_background or something.
-        auto curl = System::CmdLineBuilder("curl")
+        auto curl = System::Command("curl")
                         .string_arg("https://dc.services.visualstudio.com/v2/track")
                         .string_arg("-H")
                         .string_arg("Content-Type: application/json")
@@ -492,8 +492,8 @@ namespace vcpkg::Metrics
                         .string_arg(Strings::concat("@", fs::u8string(vcpkg_metrics_txt_path)))
                         .raw_arg(">/dev/null")
                         .raw_arg("2>&1");
-        auto remove = System::CmdLineBuilder("rm").path_arg(vcpkg_metrics_txt_path);
-        System::CmdLineBuilder cmd_line;
+        auto remove = System::Command("rm").path_arg(vcpkg_metrics_txt_path);
+        System::Command cmd_line;
         cmd_line.raw_arg("(").raw_arg(curl.command_line()).raw_arg(";").raw_arg(remove.command_line()).raw_arg(") &");
         System::cmd_execute_clean(cmd_line);
 #endif

--- a/toolsrc/src/vcpkg/postbuildlint.cpp
+++ b/toolsrc/src/vcpkg/postbuildlint.cpp
@@ -390,7 +390,7 @@ namespace vcpkg::PostBuildLint
         std::vector<fs::path> dlls_with_no_exports;
         for (const fs::path& dll : dlls)
         {
-            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/exports").path_arg(dll);
+            auto cmd_line = System::Command(dumpbin_exe).string_arg("/exports").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
             Checks::check_exit(
                 VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());
@@ -428,7 +428,7 @@ namespace vcpkg::PostBuildLint
         std::vector<fs::path> dlls_with_improper_uwp_bit;
         for (const fs::path& dll : dlls)
         {
-            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/headers").path_arg(dll);
+            auto cmd_line = System::Command(dumpbin_exe).string_arg("/headers").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
             Checks::check_exit(
                 VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());
@@ -720,7 +720,7 @@ namespace vcpkg::PostBuildLint
 
         for (const fs::path& lib : libs)
         {
-            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/directives").path_arg(lib);
+            auto cmd_line = System::Command(dumpbin_exe).string_arg("/directives").path_arg(lib);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
             Checks::check_exit(VCPKG_LINE_INFO,
                                ec_data.exit_code == 0,
@@ -774,7 +774,7 @@ namespace vcpkg::PostBuildLint
 
         for (const fs::path& dll : dlls)
         {
-            auto cmd_line = System::CmdLineBuilder(dumpbin_exe).string_arg("/dependents").path_arg(dll);
+            auto cmd_line = System::Command(dumpbin_exe).string_arg("/dependents").path_arg(dll);
             System::ExitCodeAndOutput ec_data = System::cmd_execute_and_capture_output(cmd_line);
             Checks::check_exit(
                 VCPKG_LINE_INFO, ec_data.exit_code == 0, "Running command:\n   %s\n failed", cmd_line.command_line());

--- a/toolsrc/src/vcpkg/tools.cpp
+++ b/toolsrc/src/vcpkg/tools.cpp
@@ -297,7 +297,7 @@ namespace vcpkg
         }
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
+            auto cmd = System::Command(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -326,7 +326,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
+            auto cmd = System::Command(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -352,7 +352,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths& paths, const fs::path& path_to_exe) const override
         {
-            System::CmdLineBuilder cmd;
+            System::Command cmd;
 #ifndef _WIN32
             cmd.path_arg(paths.get_tool_exe(Tools::MONO));
 #else
@@ -414,7 +414,7 @@ Type 'NuGet help <command>' for help on a specific command.
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--version");
+            auto cmd = System::Command(path_to_exe).string_arg("--version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -443,8 +443,7 @@ git version 2.17.1.windows.2
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto rc =
-                System::cmd_execute_and_capture_output(System::CmdLineBuilder(path_to_exe).string_arg("--version"));
+            auto rc = System::cmd_execute_and_capture_output(System::Command(path_to_exe).string_arg("--version"));
             if (rc.exit_code != 0)
             {
                 return {Strings::concat(
@@ -485,7 +484,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto cmd = System::CmdLineBuilder(path_to_exe).string_arg("--framework-version");
+            auto cmd = System::Command(path_to_exe).string_arg("--framework-version");
             auto rc = System::cmd_execute_and_capture_output(cmd);
             if (rc.exit_code != 0)
             {
@@ -512,8 +511,7 @@ Mono JIT compiler version 6.8.0.105 (Debian 6.8.0.105+dfsg-2 Wed Feb 26 23:23:50
 
         virtual ExpectedS<std::string> get_version(const VcpkgPaths&, const fs::path& path_to_exe) const override
         {
-            auto rc =
-                System::cmd_execute_and_capture_output(System::CmdLineBuilder(path_to_exe).string_arg("--version"));
+            auto rc = System::cmd_execute_and_capture_output(System::Command(path_to_exe).string_arg("--version"));
             if (rc.exit_code != 0)
             {
                 return {Strings::concat(

--- a/toolsrc/src/vcpkg/visualstudio.cpp
+++ b/toolsrc/src/vcpkg/visualstudio.cpp
@@ -84,7 +84,7 @@ namespace vcpkg::VisualStudio
         const fs::path vswhere_exe = program_files_32_bit / "Microsoft Visual Studio" / "Installer" / "vswhere.exe";
         if (fs.exists(vswhere_exe))
         {
-            const auto code_and_output = System::cmd_execute_and_capture_output(System::CmdLineBuilder(vswhere_exe)
+            const auto code_and_output = System::cmd_execute_and_capture_output(System::Command(vswhere_exe)
                                                                                     .string_arg("-all")
                                                                                     .string_arg("-prerelease")
                                                                                     .string_arg("-legacy")


### PR DESCRIPTION
Rename CmdLineBuilder to Command, since it's no longer a builder but an actual data type.

This is the 3rd PR in the "rewrite CmdLineBuilder" saga; at this point, we need a new type name :)