### PR TITLE
[physfs] Fix arm64-windows

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -4466,7 +4466,7 @@
     },
     "physfs": {
       "baseline": "3.0.2",
-      "port-version": 3
+      "port-version": 4
     },
     "physx": {
       "baseline": "4.1.1",

--- a/port_versions/p-/physfs.json
+++ b/port_versions/p-/physfs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bef97b95b7c30545c4ec9d0a55f672c3a6e3325f",
+      "version-string": "3.0.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "e46ccc22c717ad69bb6b6730669da403c86178d5",
       "version-string": "3.0.2",
       "port-version": 3

--- a/ports/physfs/fix-lzmasdk-arm64-windows.patch
+++ b/ports/physfs/fix-lzmasdk-arm64-windows.patch
@@ -1,0 +1,20 @@
+diff --git a/src/physfs_lzmasdk.h b/src/physfs_lzmasdk.h
+--- a/src/physfs_lzmasdk.h
++++ b/src/physfs_lzmasdk.h
+@@ -506,6 +506,7 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
+ #endif
+ 
+ #if defined(MY_CPU_AMD64) \
++    || defined(_M_ARM64) \
+     || defined(_M_IA64) \
+     || defined(__AARCH64EL__) \
+     || defined(__AARCH64EB__)
+@@ -531,6 +532,8 @@ MY_CPU_LE_UNALIGN means that CPU is LITTLE ENDIAN and CPU supports unaligned mem
+ 
+ #if defined(_WIN32) && defined(_M_ARM)
+ #define MY_CPU_ARM_LE
++#elif defined(_WIN64) && defined(_M_ARM64)
++#define MY_CPU_ARM_LE
+ #endif
+ 
+ #if defined(_WIN32) && defined(_M_IA64)

--- a/ports/physfs/portfile.cmake
+++ b/ports/physfs/portfile.cmake
@@ -1,6 +1,3 @@
-if(VCPKG_TARGET_IS_WINDOWS AND ${VCPKG_TARGET_ARCHITECTURE} MATCHES "arm64")
-	message(FATAL_ERROR "Architecture 'arm64' not supported on target 'Windows' by physfs!\n")
-endif()
 set(PHYSFS_VERSION 3.0.2)
 
 vcpkg_download_distfile(ARCHIVE
@@ -14,6 +11,8 @@ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     REF ${PHYSFS_VERSION}
+    PATCHES
+        "fix-lzmasdk-arm64-windows.patch"
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PHYSFS_STATIC)

--- a/ports/physfs/vcpkg.json
+++ b/ports/physfs/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "physfs",
   "version-string": "3.0.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "a library to provide abstract access to various archives",
   "homepage": "https://icculus.org/physfs/",
-  "supports": "!(arm64 & windows)",
   "dependencies": [
     "zlib"
   ]

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1234,7 +1234,6 @@ pfring:x64-osx=fail
 # pfring on Linux currently fails because its build scripts enable warnings as
 # errors, and warnings trigger with the Linux kernel headers in the Azure images.
 pfring:x64-linux=fail
-physfs:arm64-windows=fail
 physx:arm64-windows=fail
 piex:x64-osx=fail
 pistache:arm64-windows=fail


### PR DESCRIPTION
**Describe the pull request**

Fixes a minor issue that was blocking `arm64-windows` builds of the `physfs` port

- Which triplets are supported/not supported? Have you updated the CI baseline?

`physfs:arm64-windows` now compiles. Baseline updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
