### PR TITLE
[icu] Add support for macos rpath prefix macro

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,6 +1,6 @@
 Source: icu
 Version: 67.1
-Port-Version: 7
+Port-Version: 8
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -169,6 +169,127 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}"
         LOGNAME "make-build-${RELEASE_TRIPLET}")
 
+    # remove this block if https://unicode-org.atlassian.net/browse/ICU-21458
+    # is resolved and use the configure script instead
+    if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        if(DEFINED CMAKE_INSTALL_NAME_DIR)
+            set(ID_PREFIX "${CMAKE_INSTALL_NAME_DIR}")
+        else()
+            set(ID_PREFIX "@rpath")
+        endif()
+
+        # add ID_PREFIX to libicudata
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+            "libicudata.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicui18n
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+            "libicui18n.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicui18n dependencies
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicui18n.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicui18n.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicuio
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicuio.${ICU_VERSION_MAJOR}.dylib"
+            "libicuio.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicuio dependencies
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicuio.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicuio.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicuio.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicutu
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicutu.${ICU_VERSION_MAJOR}.dylib"
+            "libicutu.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicutu dependencies
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicutu.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicutu.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicutu.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicuuc
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+            "libicuuc.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+
+        # add ID_PREFIX to libicuuc dependencies
+        vcpkg_execute_build_process(
+            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                   "libicuuc.${VERSION}.dylib"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
+            LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
+        )
+    endif()
+
     vcpkg_execute_build_process(
         COMMAND ${BASH} --noprofile --norc -c "make install"
         WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}"

--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -178,9 +178,20 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
             set(ID_PREFIX "@rpath")
         endif()
 
+        # install_name_tool may be missing if cross-compiling
+        find_program(
+            INSTALL_NAME_TOOL
+            install_name_tool
+            HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin/
+            DOC "Absolute path of install_name_tool"
+            REQUIRED
+        )
+
+        message(STATUS "setting rpath prefix for macOS dynamic libraries")
+
         # add ID_PREFIX to libicudata
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -id "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
             "libicudata.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
@@ -188,7 +199,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
         # add ID_PREFIX to libicui18n
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -id "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
             "libicui18n.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
@@ -196,23 +207,23 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
         # add ID_PREFIX to libicui18n dependencies
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicui18n.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicui18n.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicui18n.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicui18n.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
 
         # add ID_PREFIX to libicuio
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicuio.${ICU_VERSION_MAJOR}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -id "${ID_PREFIX}/libicuio.${ICU_VERSION_MAJOR}.dylib"
             "libicuio.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
@@ -220,30 +231,30 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
         # add ID_PREFIX to libicuio dependencies
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicuio.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicuio.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicuio.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicuio.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicuio.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicuio.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
 
         # add ID_PREFIX to libicutu
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicutu.${ICU_VERSION_MAJOR}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -id "${ID_PREFIX}/libicutu.${ICU_VERSION_MAJOR}.dylib"
             "libicutu.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
@@ -251,30 +262,30 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
         # add ID_PREFIX to libicutu dependencies
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicutu.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicui18n.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicutu.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicutu.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicutu.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicutu.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicutu.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )
 
         # add ID_PREFIX to libicuuc
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -id "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -id "${ID_PREFIX}/libicuuc.${ICU_VERSION_MAJOR}.dylib"
             "libicuuc.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
@@ -282,9 +293,9 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
         # add ID_PREFIX to libicuuc dependencies
         vcpkg_execute_build_process(
-            COMMAND /usr/bin/install_name_tool -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
-                                                   "libicuuc.${VERSION}.dylib"
+            COMMAND ${INSTALL_NAME_TOOL} -change "libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "${ID_PREFIX}/libicudata.${ICU_VERSION_MAJOR}.dylib"
+                                                "libicuuc.${VERSION}.dylib"
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/lib"
             LOGNAME "make-build-fix-rpath-${RELEASE_TRIPLET}"
         )

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2386,7 +2386,7 @@
     },
     "icu": {
       "baseline": "67.1",
-      "port-version": 7
+      "port-version": 8
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23-1",

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a4ccf3436902853fc3532291321d4dfb542eee9",
+      "git-tree": "db2977707d68a8c04e0960b0965722f8e5bfda20",
       "version-string": "67.1",
       "port-version": 8
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a4ccf3436902853fc3532291321d4dfb542eee9",
+      "version-string": "67.1",
+      "port-version": 8
+    },
+    {
       "git-tree": "e224ca4ff2e2bcb1c4b72a1813ab886c1dfa2bfc",
       "version-string": "67.1",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
This PR implements a temporary solution for https://unicode-org.atlassian.net/browse/ICU-21458. It alters the ID fields of the built dylibs to add support for the @rpath macro on macOS. The new code is commented that it should be removed and replaced with calls to new configure options, if ICU-21458 is resolved.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Only macOS is affected.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes