### PR TITLE
[nsync] create a new port

### DIFF
--- a/ports/nsync/fix-install.patch
+++ b/ports/nsync/fix-install.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b1f1dc..328f9b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,7 +80,7 @@ set (NSYNC_OS_CPP_SRC
+ #    https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
+ 
+ # Pick the include directory for the operating system.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX" OR "${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX")
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/win32")
+ 	set (NSYNC_CPP_FLAGS "/TP")
+ 
+@@ -230,7 +230,7 @@ elseif (("${CMAKE_SYSTEM_PROCESSOR}X" STREQUAL "ppc64X"))
+ endif ()
+ 
+ # Windows uses some include files from the posix directory also.
+-if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX")
++if ("${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsX" OR "${CMAKE_SYSTEM_NAME}X" STREQUAL "WindowsStoreX")
+ 	include_directories ("${PROJECT_SOURCE_DIR}/platform/posix")
+ endif ()
+ 
+@@ -396,7 +396,8 @@ if (NSYNC_ENABLE_TESTS)
+ 	endforeach (t)
+ endif ()
+ 
+-set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
++# By default, install nsync always
++# set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+ 
+ install (TARGETS nsync
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -8,11 +8,8 @@ vcpkg_from_github(
     REF 1.24.0
     SHA512 14dd582488072123a353c967664ed9a3f636865bb35e64d7256dcc809539129fa47c7979a4009fd45c9341cac537a4ca6b4b617ba2cae1d3995a7c251376339f
     HEAD_REF master
-)
-
-vcpkg_replace_string(${SOURCE_PATH}/CMakeLists.txt
-    "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\")"
-    "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\" OR \"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsStoreX\" )"
+    PATCHES
+        fix-install.patch
 )
 
 vcpkg_configure_cmake(
@@ -21,7 +18,6 @@ vcpkg_configure_cmake(
     OPTIONS
         -DNSYNC_ENABLE_TESTS=OFF
 )
-vcpkg_build_cmake(TARGET nsync)
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -1,0 +1,24 @@
+if(VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO    google/nsync
+    REF     1.24.0
+    SHA512  14dd582488072123a353c967664ed9a3f636865bb35e64d7256dcc809539129fa47c7979a4009fd45c9341cac537a4ca6b4b617ba2cae1d3995a7c251376339f
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+    -DNSYNC_ENABLE_TESTS=OFF
+)
+vcpkg_build_cmake(TARGET nsync)
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nsync RENAME copyright)

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -26,4 +26,4 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/nsync RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -4,22 +4,22 @@ endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO    google/nsync
-    REF     1.24.0
-    SHA512  14dd582488072123a353c967664ed9a3f636865bb35e64d7256dcc809539129fa47c7979a4009fd45c9341cac537a4ca6b4b617ba2cae1d3995a7c251376339f
+    REPO google/nsync
+    REF 1.24.0
+    SHA512 14dd582488072123a353c967664ed9a3f636865bb35e64d7256dcc809539129fa47c7979a4009fd45c9341cac537a4ca6b4b617ba2cae1d3995a7c251376339f
     HEAD_REF master
 )
 
 vcpkg_replace_string(${SOURCE_PATH}/CMakeLists.txt
-  "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\")"
-  "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\" OR \"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsStoreX\" )"
+    "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\")"
+    "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\" OR \"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsStoreX\" )"
 )
 
 vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
-  OPTIONS
-    -DNSYNC_ENABLE_TESTS=OFF
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DNSYNC_ENABLE_TESTS=OFF
 )
 vcpkg_build_cmake(TARGET nsync)
 vcpkg_install_cmake()

--- a/ports/nsync/portfile.cmake
+++ b/ports/nsync/portfile.cmake
@@ -10,6 +10,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_replace_string(${SOURCE_PATH}/CMakeLists.txt
+  "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\")"
+  "if (\"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsX\" OR \"\${CMAKE_SYSTEM_NAME}X\" STREQUAL \"WindowsStoreX\" )"
+)
+
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA

--- a/ports/nsync/vcpkg.json
+++ b/ports/nsync/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nsync",
-  "version-string": "1.24.0",
+  "version": "1.24.0",
   "description": "nsync is a C library that exports various synchronization primitives, such as mutexes",
   "homepage": "https://github.com/google/nsync"
 }

--- a/ports/nsync/vcpkg.json
+++ b/ports/nsync/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "nsync",
+  "version-string": "1.24.0",
+  "description": "nsync is a C library that exports various synchronization primitives, such as mutexes",
+  "homepage": "https://github.com/google/nsync"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4048,6 +4048,10 @@
       "baseline": "4.1.2",
       "port-version": 0
     },
+    "nsync": {
+      "baseline": "1.24.0",
+      "port-version": 0
+    },
     "nt-wrapper": {
       "baseline": "2019-08-10",
       "port-version": 0

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5d185c8b6cdc647aa2695a70a509a11d3f188c1d",
+      "git-tree": "577f79d93c71820a6c8d768b93949fbcc8647966",
       "version": "1.24.0",
       "port-version": 0
     }

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "edaf8315863657a5ca8ff8cf8f55c3afd39a37f1",
+      "git-tree": "5d185c8b6cdc647aa2695a70a509a11d3f188c1d",
       "version": "1.24.0",
       "port-version": 0
     }

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "577f79d93c71820a6c8d768b93949fbcc8647966",
+      "git-tree": "65f07dbc95a609c95de7befffbf37da598652cee",
       "version": "1.24.0",
       "port-version": 0
     }

--- a/versions/n-/nsync.json
+++ b/versions/n-/nsync.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "edaf8315863657a5ca8ff8cf8f55c3afd39a37f1",
+      "version": "1.24.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
### What does your PR fix?

This is a rework of #7614

### Triplet support
  
The library's CMakeLists checks `Windows`, `Darwin`, `Linux`, `FreeBSD`, etc. And it seems there is no hack for each platform.
Currently working on Windows. Failure in the other platforms will be fixed in the next commits.

For Windows,
* There is no `__declspec(dllexport)` in the source code. IMO it intends to be `STATIC`.

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes. Wish for any kind of feedback :)
