### PR TITLE
[vcpkg baseline][vcpkg_configure_make] Fix arm64-windows, arm-uwp

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -392,8 +392,10 @@ function(vcpkg_configure_make)
         list(APPEND _csc_OPTIONS gl_cv_double_slash_root=yes
                                  ac_cv_func_memmove=yes)
         #list(APPEND _csc_OPTIONS lt_cv_deplibs_check_method=pass_all) # Just ignore libtool checks 
-        if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        if(VCPKG_TARGET_ARCHITECTURE MATCHES "^[Aa][Rr][Mm]64$")
             list(APPEND _csc_OPTIONS gl_cv_host_cpu_c_abi=no)
+            # Currently needed for arm64 because objdump yields: "unrecognised machine type (0xaa64) in Import Library Format archive"
+            list(APPEND _csc_OPTIONS lt_cv_deplibs_check_method=pass_all)
         endif()
     else()
         string(REPLACE " " "\ " _VCPKG_PREFIX ${CURRENT_INSTALLED_DIR})

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -396,6 +396,9 @@ function(vcpkg_configure_make)
             list(APPEND _csc_OPTIONS gl_cv_host_cpu_c_abi=no)
             # Currently needed for arm64 because objdump yields: "unrecognised machine type (0xaa64) in Import Library Format archive"
             list(APPEND _csc_OPTIONS lt_cv_deplibs_check_method=pass_all)
+        elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "^[Aa][Rr][Mm]$")
+            # Currently needed for arm because objdump yields: "unrecognised machine type (0x1c4) in Import Library Format archive"
+            list(APPEND _csc_OPTIONS lt_cv_deplibs_check_method=pass_all)
         endif()
     else()
         string(REPLACE " " "\ " _VCPKG_PREFIX ${CURRENT_INSTALLED_DIR})


### PR DESCRIPTION
**Describe the pull request**
Since https://github.com/microsoft/vcpkg/commit/af3c99bc65d46e77900ae4e826866f134dc903ae various ports have been failing on `arm64-windows`.

Investigation yielded the cause: `objdump` is failing to deal with arm64 arch libraries:
```
usr/bin/objdump: installed\arm64-windows\lib\iconv.lib(iconv-2.dll): unrecognised machine type (0xaa64) in Import Library Format archive
```

@Neumann-A Suggested that the best option, for now, is to add a workaround with a comment (reverting af3c99bc65d46e77900ae4e826866f134dc903ae would have its own issues) - so that's what this PR does.

- What does your PR fix? Fixes #15737

- Which triplets are supported/not supported? Have you updated the CI baseline?

`arm64` Windows triplet(s) are impacted.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
