### PR TITLE
[opencolorio] Install OpenColorIOConfig.cmake

### DIFF
--- a/port_versions/baseline.json
+++ b/port_versions/baseline.json
@@ -4190,7 +4190,7 @@
     },
     "opencolorio": {
       "baseline": "1.1.1",
-      "port-version": 4
+      "port-version": 5
     },
     "opencolorio-tools": {
       "baseline": "1.1.1",

--- a/port_versions/o-/opencolorio.json
+++ b/port_versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c011ef89b247b0bc54a08016fe23793defd398a5",
+      "version-semver": "1.1.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "6f60ef16979a651554f0b59663f4180229b5c662",
       "version-string": "1.1.1",
       "port-version": 4

--- a/ports/opencolorio/CONTROL
+++ b/ports/opencolorio/CONTROL
@@ -1,6 +1,0 @@
-Source: opencolorio
-Version: 1.1.1
-Port-Version: 4
-Homepage: https://opencolorio.org/
-Description: OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.
-Build-Depends: glew[core], freeglut[core], lcms[core], yaml-cpp[core], tinyxml[core]

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -51,14 +51,23 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake")
 
 vcpkg_copy_pdbs()
 
-# Clean redundant files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(READ "${CURRENT_PACKAGES_DIR}/OpenColorIOConfig.cmake" _contents)
+string(REPLACE
+    [=[get_filename_component(OpenColorIO_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)]=]
+    [=[get_filename_component(OpenColorIO_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(OpenColorIO_DIR "${OpenColorIO_DIR}" PATH)
+get_filename_component(OpenColorIO_DIR "${OpenColorIO_DIR}" PATH)]=]
+    _contents
+    "${_contents}")
+string(REPLACE "/cmake/OpenColorIO.cmake" "/share/opencolorio/OpenColorIO.cmake" _contents "${_contents}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/opencolorio/OpenColorIOConfig.cmake" "${_contents}")
 
-# CMake Configs leftovers
-file(REMOVE
-    ${CURRENT_PACKAGES_DIR}/OpenColorIOConfig.cmake
+# Clean redundant files
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/debug/include
+    ${CURRENT_PACKAGES_DIR}/debug/share
     ${CURRENT_PACKAGES_DIR}/debug/OpenColorIOConfig.cmake
+    ${CURRENT_PACKAGES_DIR}/OpenColorIOConfig.cmake
 )
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "opencolorio",
+  "version-semver": "1.1.1",
+  "port-version": 5,
+  "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
+  "homepage": "https://opencolorio.org/",
+  "dependencies": [
+    {
+      "name": "freeglut",
+      "default-features": false
+    },
+    {
+      "name": "glew",
+      "default-features": false
+    },
+    {
+      "name": "lcms",
+      "default-features": false
+    },
+    {
+      "name": "tinyxml",
+      "default-features": false
+    },
+    {
+      "name": "yaml-cpp",
+      "default-features": false
+    }
+  ]
+}


### PR DESCRIPTION
Enable `find_package(OpenColorIO CONFIG REQUIRED)`.

Fixes #15765 

As a drive by, this also changes the version scheme to semver based on observation of upstream's release naming.