### PR TITLE
[ogre] Do not use strict mode by default in ogre for backward compatibility

### DIFF
--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ogre",
   "version-string": "1.12.9",
-  "port-version": 4,
+  "port-version": 5,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [
@@ -13,7 +13,6 @@
     "assimp",
     "freeimage",
     "overlay",
-    "strict",
     "zziplib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4142,7 +4142,7 @@
     },
     "ogre": {
       "baseline": "1.12.9",
-      "port-version": 4
+      "port-version": 5
     },
     "ogre-next": {
       "baseline": "2019-10-20-1",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "322b9a5290ce1656aa66b684b07d1e327b18eeeb",
+      "version-string": "1.12.9",
+      "port-version": 5
+    },
+    {
       "git-tree": "7bd4cd10abb70cc91306e834cb8f7831bc33c8a0",
       "version-string": "1.12.9",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? All versions of ogre since it was added in vcpkg had the strict resource mode disabled by default. https://github.com/microsoft/vcpkg/pull/15194 added support to enable it as a feature, that is great for user interested in it, but also added it as a default feature, meaning that downstream users of the ogre library may break (see for example https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/39#issuecomment-764457000) without any change at all in the Ogre version, just a bump in the vcpkg port version. This PR just removes the `strict` feature from the default enabled features, but any interested user can still enable it if interested. 

- Which triplets are supported/not supported? Have you updated the CI baseline? The change should not affect the CI baseline. 

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
