### PR TITLE
Fix #15395: libarchive build fails for x86_windows_v120

### DIFF
--- a/ports/libarchive/fix-xxhash-inline-for-visual-studio.patch
+++ b/ports/libarchive/fix-xxhash-inline-for-visual-studio.patch
@@ -1,0 +1,17 @@
+diff --git a/libarchive/xxhash.c b/libarchive/xxhash.c
+index 70750bae..f96e9d93 100644
+--- a/libarchive/xxhash.c
++++ b/libarchive/xxhash.c
+@@ -150,7 +150,11 @@ typedef struct _U32_S { U32 v; } _PACKED U32_S;
+ #if GCC_VERSION >= 409
+ __attribute__((__no_sanitize_undefined__))
+ #endif
+-static inline U32 A32(const void * x)
++#if defined(_MSC_VER)
++static __inline U32 A32(const void * x)
++#else
++static inline U32 A32(const void* x)
++#endif
+ {
+     return (((const U32_S *)(x))->v);
+ }

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         fix-dependencies.patch
         fix-cpu-set.patch
         disable-warnings.patch
+        fix-xxhash-inline-for-visual-studio.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
Build fails on compiling xxhash.c having a fuction with "inline" specifier.
"inline" is a c99 keyword and c99 is not yet (fully) supported with MSVC toolset v120:
"The inline keyword is available only in C++. The __inline and __forceinline
keywords are available in both C and C++. For compatibility with previous versions,
_inline is a synonym for __inline."
(Source: http://msdn.microsoft.com/en-us/library/z8y1yy88.aspx)

This fix adds a patch that replaces "inline" with "__inline" in xxhash.c

**Describe the pull request**

- What does your PR fix? Fixes #

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
