### PR TITLE
[vcpkg] Restore x-upload-metrics command accidentally disabled by removing VCPKG_DISABLE_METRICS

### DIFF
--- a/toolsrc/src/vcpkg-test/commands.cpp
+++ b/toolsrc/src/vcpkg-test/commands.cpp
@@ -32,9 +32,9 @@ TEST_CASE ("get_available_basic_commands works", "[commands]")
     check_all_commands(Commands::get_available_basic_commands(), {
         "contact",
         "version",
-#if VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#if defined(_WIN32)
         "x-upload-metrics",
-#endif // VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#endif // defined(_WIN32)
         });
 }
 

--- a/toolsrc/src/vcpkg/commands.cpp
+++ b/toolsrc/src/vcpkg/commands.cpp
@@ -41,16 +41,16 @@ namespace vcpkg::Commands
     {
         static const Version::VersionCommand version{};
         static const Contact::ContactCommand contact{};
-#if VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#if defined(_WIN32)
         static const UploadMetrics::UploadMetricsCommand upload_metrics{};
-#endif // VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#endif // defined(_WIN32)
 
         static std::vector<PackageNameAndFunction<const BasicCommand*>> t = {
             {"version", &version},
             {"contact", &contact},
-#if VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#if defined(_WIN32)
             {"x-upload-metrics", &upload_metrics},
-#endif // VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#endif // defined(_WIN32)
         };
         return t;
     }

--- a/toolsrc/src/vcpkg/commands.upload-metrics.cpp
+++ b/toolsrc/src/vcpkg/commands.upload-metrics.cpp
@@ -1,6 +1,6 @@
 #include <vcpkg/commands.upload-metrics.h>
 
-#if VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#if defined(_WIN32)
 #include <vcpkg/base/checks.h>
 #include <vcpkg/base/files.h>
 
@@ -26,4 +26,4 @@ namespace vcpkg::Commands::UploadMetrics
         Checks::exit_success(VCPKG_LINE_INFO);
     }
 }
-#endif // VCPKG_ENABLE_X_UPLOAD_METRICS_COMMAND
+#endif // defined(_WIN32)


### PR DESCRIPTION
… in https://github.com/microsoft/vcpkg/pull/15470

I noticed this was messed up looking at the build log https://dev.azure.com/vcpkg/public/_build/results?buildId=48343&view=logs&j=0a61404f-5c45-5632-e83c-408b7fcca1d6&t=7cbd98da-c495-5b10-7ecd-f57aaa0a79d7 which has

```
commands.upload-metrics.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library [C:\a\1\s\build.x86.vs2017\vcpkglib.vcxproj]
```
