### PR TITLE
[soil] Use cache source address temporary

### DIFF
--- a/ports/soil/CONTROL
+++ b/ports/soil/CONTROL
@@ -1,3 +1,4 @@
 Source: soil
-Version: 2008.07.07-2
+Version: 2008.07.07
+Port-Version: 3
 Description: Simple OpenGL Image Library

--- a/ports/soil/portfile.cmake
+++ b/ports/soil/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.lonesock.net/files/soil.zip"
-    FILENAME "soil-2008.07.07.zip"
+    URLS "https://web.archive.org/web/20200104042737/http://www.lonesock.net/files/soil.zip" #"http://www.lonesock.net/files/soil.zip"
+    FILENAME "soil.zip"
     SHA512 a575a84aa65b7556320779d635561341f5cf156418d0462473e5d1eb082829be3bcb30600b4887af75aeddd3715de16bdb3ca1668ebaa93eea62bacf22b79548
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5377,8 +5377,8 @@
       "port-version": 0
     },
     "soil": {
-      "baseline": "2008.07.07-2",
-      "port-version": 0
+      "baseline": "2008.07.07",
+      "port-version": 3
     },
     "soil2": {
       "baseline": "release-1.11-1",

--- a/versions/s-/soil.json
+++ b/versions/s-/soil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bd40ebe372c50d3b4bc61b8ca481e5bb5b4b4d0",
+      "version-string": "2008.07.07",
+      "port-version": 3
+    },
+    {
       "git-tree": "4d137f0a640e2e1628d22a6a57018582f4e472a4",
       "version-string": "2008.07.07-2",
       "port-version": 0


### PR DESCRIPTION
Since the official soil site is no longer available, use the cached address.

Fixes #15800.