### PR TITLE
[libffi] Added armv7-a to allowed architectures for Android 32 bit arm builds

### DIFF
--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # config variables for ffi.h.in
 set(VERSION 3.3)
 
-set(KNOWN_PROCESSORS x86 x86_64 AMD64 ARM ARM64 i386 armv7l aarch64)
+set(KNOWN_PROCESSORS x86 x86_64 AMD64 ARM ARM64 i386 armv7l armv7-a ZZaarch64)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR IN_LIST KNOWN_PROCESSORS)
     message(FATAL_ERROR "Unknown processor: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -20,6 +20,8 @@ endif()
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "ARM")
     set(TARGET ARM)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "armv7l")
+    set(TARGET ARM)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a")
     set(TARGET ARM)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     set(TARGET ARM64)

--- a/ports/libffi/CMakeLists.txt
+++ b/ports/libffi/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # config variables for ffi.h.in
 set(VERSION 3.3)
 
-set(KNOWN_PROCESSORS x86 x86_64 AMD64 ARM ARM64 i386 armv7l armv7-a ZZaarch64)
+set(KNOWN_PROCESSORS x86 x86_64 AMD64 ARM ARM64 i386 armv7l armv7-a aarch64)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR IN_LIST KNOWN_PROCESSORS)
     message(FATAL_ERROR "Unknown processor: ${CMAKE_SYSTEM_PROCESSOR}")

--- a/ports/libffi/CONTROL
+++ b/ports/libffi/CONTROL
@@ -1,5 +1,5 @@
 Source: libffi
 Version: 3.3
-Port-Version: 6
+Port-Version: 7
 Homepage: https://github.com/libffi/libffi
 Description: Portable, high level programming interface to various calling conventions

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2934,7 +2934,7 @@
     },
     "libffi": {
       "baseline": "3.3",
-      "port-version": 6
+      "port-version": 7
     },
     "libflac": {
       "baseline": "1.3.3",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7582c1b20c576263d22b8429155ead9117cc7c95",
+      "version-string": "3.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "d656f226f68b97173701d07c53633a3d05702abb",
       "version-string": "3.3",
       "port-version": 6


### PR DESCRIPTION
Closes #15820

**Fixes target processor for 32 bit ARM using Android toolchain file**

- What does your PR fix? Fixes#15820

- Which triplets are supported/not supported? Have you updated the CI baseline?
   - Only will effect `arm-android` community triplet

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
   - Yes?
