### PR TITLE
[vcpkg] Remote-install (Github downloading and installing)

### DIFF
--- a/toolsrc/include/vcpkg/base/downloads.h
+++ b/toolsrc/include/vcpkg/base/downloads.h
@@ -24,11 +24,15 @@ namespace vcpkg::Downloads
                                      const fs::path& path,
                                      const std::string& sha512);
 
+    std::string download_file(Files::Filesystem& fs, View<std::string> urls, const fs::path& download_path);
+
     // Returns url that was successfully downloaded from
     std::string download_file(Files::Filesystem& fs,
                               View<std::string> urls,
                               const fs::path& download_path,
                               const std::string& sha512);
+
+    void download_file(Files::Filesystem& fs, const std::string& url, const fs::path& download_path);
 
     void download_file(Files::Filesystem& fs,
                        const std::string& url,

--- a/toolsrc/include/vcpkg/input.h
+++ b/toolsrc/include/vcpkg/input.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <vcpkg/base/cstringview.h>
+
 #include <vcpkg/packagespec.h>
+#include <vcpkg/triplet.h>
+#include <vcpkg/vcpkgpaths.h>
 
 namespace vcpkg::Input
 {

--- a/toolsrc/include/vcpkg/remote_install.h
+++ b/toolsrc/include/vcpkg/remote_install.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vcpkg/commands.interface.h>
+#include <vcpkg/vcpkgpaths.h>
+
+#include <string>
+
+namespace vcpkg::RemoteInstall
+{
+    extern const CommandStructure COMMAND_STRUCTURE;
+
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, Triplet default_triplet);
+
+    struct RemoteInstallCommand : Commands::TripletCommand
+    {
+        virtual void perform_and_exit(const VcpkgCmdArguments& args,
+                                      const VcpkgPaths& paths,
+                                      Triplet default_triplet) const override;
+    };
+}

--- a/toolsrc/include/vcpkg/vcpkgcmdarguments.h
+++ b/toolsrc/include/vcpkg/vcpkgcmdarguments.h
@@ -113,6 +113,17 @@ namespace vcpkg
                                                           const CommandLineCharType* const* const argv);
         static VcpkgCmdArguments create_from_arg_sequence(const std::string* arg_begin, const std::string* arg_end);
 
+        VcpkgCmdArguments() = default;
+
+        VcpkgCmdArguments(const VcpkgCmdArguments& val)
+            : command(val.command)
+            , command_arguments(val.command_arguments)
+            , m_is_recursive_invocation(val.m_is_recursive_invocation)
+            , command_switches(val.command_switches)
+            , command_options(val.command_options)
+        {
+        }
+
         static void append_common_options(HelpTableFormatter& target);
 
         constexpr static StringLiteral VCPKG_ROOT_DIR_ENV = "VCPKG_ROOT";
@@ -225,6 +236,10 @@ namespace vcpkg
 
         void debug_print_feature_flags() const;
         void track_feature_flag_metrics() const;
+
+        void remove_command_switches(const StringLiteral& command_switch) { command_switches.erase(command_switch); }
+
+        void remove_command_option(const StringLiteral& command_option) { command_options.erase(command_option); }
 
     private:
         bool m_is_recursive_invocation = false;

--- a/toolsrc/src/vcpkg-test/commands.cpp
+++ b/toolsrc/src/vcpkg-test/commands.cpp
@@ -78,6 +78,7 @@ TEST_CASE ("get_available_commands_type_a works", "[commands]")
         "build-external",
         "export",
         "depend-info",
+        "remote-install",
         });
 }
 // clang-format on

--- a/toolsrc/src/vcpkg/commands.cpp
+++ b/toolsrc/src/vcpkg/commands.cpp
@@ -32,6 +32,7 @@
 #include <vcpkg/export.h>
 #include <vcpkg/help.h>
 #include <vcpkg/install.h>
+#include <vcpkg/remote_install.h>
 #include <vcpkg/remove.h>
 #include <vcpkg/update.h>
 
@@ -116,6 +117,7 @@ namespace vcpkg::Commands
         static const BuildExternal::BuildExternalCommand build_external{};
         static const Export::ExportCommand export_command{};
         static const DependInfo::DependInfoCommand depend_info{};
+        static const RemoteInstall::RemoteInstallCommand remote_install{};
 
         static std::vector<PackageNameAndFunction<const TripletCommand*>> t = {
             {"install", &install},
@@ -128,6 +130,7 @@ namespace vcpkg::Commands
             {"build-external", &build_external},
             {"export", &export_command},
             {"depend-info", &depend_info},
+            {"remote-install", &remote_install},
         };
         return t;
     }

--- a/toolsrc/src/vcpkg/packagespec.cpp
+++ b/toolsrc/src/vcpkg/packagespec.cpp
@@ -102,7 +102,8 @@ namespace vcpkg
 
     static bool is_package_name_char(char32_t ch)
     {
-        return Parse::ParserBase::is_lower_alpha(ch) || Parse::ParserBase::is_ascii_digit(ch) || ch == '-';
+        return Parse::ParserBase::is_lower_alpha(ch) || Parse::ParserBase::is_ascii_digit(ch) || ch == '-' ||
+               ch == '/' || ch == '\\' || ch == '.';
     }
 
     static bool is_feature_name_char(char32_t ch)

--- a/toolsrc/src/vcpkg/packagespec.cpp
+++ b/toolsrc/src/vcpkg/packagespec.cpp
@@ -102,8 +102,7 @@ namespace vcpkg
 
     static bool is_package_name_char(char32_t ch)
     {
-        return Parse::ParserBase::is_lower_alpha(ch) || Parse::ParserBase::is_ascii_digit(ch) || ch == '-' ||
-               ch == '/' || ch == '\\' || ch == '.';
+        return Parse::ParserBase::is_lower_alpha(ch) || Parse::ParserBase::is_ascii_digit(ch) || ch == '-';
     }
 
     static bool is_feature_name_char(char32_t ch)

--- a/toolsrc/src/vcpkg/remote_install.cpp
+++ b/toolsrc/src/vcpkg/remote_install.cpp
@@ -1,0 +1,68 @@
+#include <vcpkg/base/downloads.h>
+#include <vcpkg/base/files.h>
+#include <vcpkg/base/system.print.h>
+#include <vcpkg/base/system.process.h>
+#include <vcpkg/base/util.h>
+
+#include <vcpkg/input.h>
+#include <vcpkg/packagespec.h>
+#include <vcpkg/remote_install.h>
+#include <vcpkg/vcpkgcmdarguments.h>
+#include <vcpkg/vcpkgpaths.h>
+
+namespace vcpkg::RemoteInstall
+{
+    const CommandStructure COMMAND_STRUCTURE = {
+        create_example_string("remote-install nnoops-long-arith-lib"),
+        1,
+        1,
+        {{}, {}},
+        nullptr,
+    };
+
+    void perform_and_exit(const VcpkgCmdArguments& args, const VcpkgPaths& paths, Triplet default_triplet)
+    {
+        const ParsedArguments options = args.parse_arguments(COMMAND_STRUCTURE);
+
+        const std::vector<FullPackageSpec> specs = Util::fmap(args.command_arguments, [&](auto&& arg) {
+            return Input::check_and_get_full_package_spec(
+                std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text);
+        });
+
+        for (auto&& spec : specs)
+        {
+            Input::check_triplet(spec.package_spec.triplet(), paths);
+        }
+
+        std::string str = "";
+        System::printf("command remote-install, %s \n", str);
+
+        // Files::Filesystem& fs = paths.get_filesystem();
+
+        // fs::path destination = paths.builtin_ports_directory() / "capture-example";
+
+        // std::error_code err;
+        // bool res = fs.create_directory(destination, err);
+        // Checks::check_exit(VCPKG_LINE_INFO,
+        //                    !err.value(),
+        //                    "Failed to create directory '%s', code: %d",
+        //                    fs::u8string(destination),
+        //                    err.value());
+
+        // System::printf("capture command. create directory : %d \n", res);
+
+        // Downloads::download_file(
+        //     fs,
+        //     "https://github.com/Mr-Leshiy/nnoops-long-arith-lib/raw/master/nnoops-long-arith-vcpkg.zip",
+        //     paths.builtin_ports_directory() / "nnoops-long-arith-lib" / "nnoops-long-arith-lib-vcpkg.zip");
+
+        Checks::exit_success(VCPKG_LINE_INFO);
+    }
+
+    void RemoteInstallCommand::perform_and_exit(const VcpkgCmdArguments& args,
+                                                const VcpkgPaths& paths,
+                                                Triplet default_triplet) const
+    {
+        RemoteInstall::perform_and_exit(args, paths, default_triplet);
+    }
+}

--- a/toolsrc/src/vcpkg/remote_install.cpp
+++ b/toolsrc/src/vcpkg/remote_install.cpp
@@ -29,27 +29,29 @@ namespace vcpkg::RemoteInstall
                 std::string(arg), default_triplet, COMMAND_STRUCTURE.example_text);
         });
 
+        // check triplets
         for (auto&& spec : specs)
         {
             Input::check_triplet(spec.package_spec.triplet(), paths);
+            System::printf("dir: %s, name: %s, triplet: %s \n",
+                           spec.package_spec.dir(),
+                           spec.package_spec.name(),
+                           spec.package_spec.triplet().to_string());
         }
 
-        std::string str = "";
-        System::printf("command remote-install, %s \n", str);
-
-        // Files::Filesystem& fs = paths.get_filesystem();
-
-        // fs::path destination = paths.builtin_ports_directory() / "capture-example";
-
-        // std::error_code err;
-        // bool res = fs.create_directory(destination, err);
-        // Checks::check_exit(VCPKG_LINE_INFO,
-        //                    !err.value(),
-        //                    "Failed to create directory '%s', code: %d",
-        //                    fs::u8string(destination),
-        //                    err.value());
-
-        // System::printf("capture command. create directory : %d \n", res);
+        Files::Filesystem& fs = paths.get_filesystem();
+        // create directories
+        for (auto&& spec : specs)
+        {
+            std::error_code err;
+            fs::path destination = paths.builtin_ports_directory() / spec.package_spec.name();
+            fs.create_directory(destination, err);
+            Checks::check_exit(VCPKG_LINE_INFO,
+                               !err.value(),
+                               "Failed to create directory '%s', code: %d",
+                               fs::u8string(destination),
+                               err.value());
+        }
 
         // Downloads::download_file(
         //     fs,


### PR DESCRIPTION
It is a new feature ```remote-install``` command.
The purpose to add such new functionality, is to make process if distribution of some new libraries with the vcpkg in the more easy way.  I am introducing a new way how it is possible to install library using vcpkg.

It is the first version of such feature, it is only works with the github repo, but of course it is also possible to extend it and make it more flexible.


**So how it works ?**
Lets analyze the following example of the usage of the new command ```remote-install```.
Example:
```
./vcpkg remote-install nnoops-long-arith-lib --author-name=Mr-Leshiy
```
1. So here it is we prvide a package name ```nnoops-long-arith-lib``` and the author of such package ```--author-name=Mr-Leshiy```.
Package name it is should be a github repository name and author name - an owner of this repository on the github. So it is directly corresponds to the github url of the repository ```https://github.com/Mr-Leshiy/nnoops-long-arith-lib```.
2. Vcpkg will go the such repository add try to download an archive with the concrete naming which should corresponds to the repository name, in our example it will find the ```nnoops-long-arith-lib-vcpkg.zip``` archive. In such archive should be description how to install your library with the vcpkg (examples of such instructions you can find in the ```ports``` directory of the vcpkg repository)
3. Next step is to create directory with the name of the package in our example ```nnoops-long-arith-lib``` in the ports folder. 
```vcpkg/ports/nnoops-long-arith-lib```
4. After that download an archive ```nnoops-long-arith-lib-vcpkg.zip``` from the github repository to the ```vcpkg/ports/nnoops-long-arith-lib``` and unarchive it in this directory.
5. The final step is just execute an install process for such package. Executes  ```Install::perform_and_exit(install_args, paths, default_triplet); ```. 

I was inspired of the Rust and Golang programming languages, how it is possible to manage dependencies and directly point the destination of the dependency for the Github.
I think it will help for the wide use of the vcpkg and for the faster integration process of the new libraries which are not part of the vcpkg at this time.

