### PR TITLE
[vcpkg] Improve diagnostics around compiler tracking and toolset errors. 'Fixes' #15823.

### DIFF
--- a/toolsrc/include/vcpkg/build.h
+++ b/toolsrc/include/vcpkg/build.h
@@ -232,7 +232,9 @@ namespace vcpkg::Build
         const VcpkgPaths& m_paths;
     };
 
-    System::Command make_build_env_cmd(const PreBuildInfo& pre_build_info, const Toolset& toolset);
+    System::Command make_build_env_cmd(const PreBuildInfo& pre_build_info,
+                                       const Toolset& toolset,
+                                       View<Toolset> all_toolsets);
 
     struct ExtendedBuildResult
     {

--- a/toolsrc/include/vcpkg/vcpkgpaths.h
+++ b/toolsrc/include/vcpkg/vcpkgpaths.h
@@ -148,6 +148,8 @@ namespace vcpkg
         /// </remarks>
         const Toolset& get_toolset(const Build::PreBuildInfo& prebuildinfo) const;
 
+        View<Toolset> get_all_toolsets() const;
+
         Files::Filesystem& get_filesystem() const;
 
         const System::Environment& get_action_env(const Build::AbiInfo& abi_info) const;

--- a/toolsrc/src/vcpkg/commands.env.cpp
+++ b/toolsrc/src/vcpkg/commands.env.cpp
@@ -48,7 +48,7 @@ namespace vcpkg::Commands::Env
         const Build::PreBuildInfo pre_build_info(
             paths, triplet, var_provider.get_generic_triplet_vars(triplet).value_or_exit(VCPKG_LINE_INFO));
         const Toolset& toolset = paths.get_toolset(pre_build_info);
-        auto build_env_cmd = Build::make_build_env_cmd(pre_build_info, toolset);
+        auto build_env_cmd = Build::make_build_env_cmd(pre_build_info, toolset, paths.get_all_toolsets());
 
         std::unordered_map<std::string, std::string> extra_env = {};
         const bool add_bin = Util::Sets::contains(options.switches, OPTION_BIN);

--- a/toolsrc/src/vcpkg/vcpkgpaths.cpp
+++ b/toolsrc/src/vcpkg/vcpkgpaths.cpp
@@ -980,8 +980,7 @@ If you wish to silence this error and use classic mode, you can:
 #if !defined(_WIN32)
         Checks::exit_maybe_upgrade(VCPKG_LINE_INFO, "Cannot build windows triplets from non-windows.");
 #else
-        const std::vector<Toolset>& vs_toolsets = m_pimpl->toolsets.get_lazy(
-            [this]() { return VisualStudio::find_toolset_instances_preferred_first(*this); });
+        View<Toolset> vs_toolsets = get_all_toolsets();
 
         std::vector<const Toolset*> candidates = Util::fmap(vs_toolsets, [](auto&& x) { return &x; });
         const auto tsv = prebuildinfo.platform_toolset.get();
@@ -1026,6 +1025,16 @@ If you wish to silence this error and use classic mode, you can:
         Checks::check_exit(VCPKG_LINE_INFO, !candidates.empty(), "No suitable Visual Studio instances were found");
         return *candidates.front();
 
+#endif
+    }
+
+    View<Toolset> VcpkgPaths::get_all_toolsets() const
+    {
+#if defined(_WIN32)
+        return m_pimpl->toolsets.get_lazy(
+            [this]() { return VisualStudio::find_toolset_instances_preferred_first(*this); });
+#else
+        return {};
 #endif
     }
 


### PR DESCRIPTION
This PR improves the diagnostics presented during toolchain misconfiguration by enumerating to the user's VS instances. As a drive by, we also print the error output (along with log path) when compiler detection fails.

Before:
```
PS C:\src\vcpkg> .\vcpkg.exe install tinyxml2:x64-windows
Computing installation plan...
The following packages will be built and installed:
    tinyxml2[core]:x64-windows -> 8.0.0-1
Detecting compiler hash for triplet x64-windows...
Unsupported toolchain combination. Target was: s390x but supported ones were:
x86,amd64,x86_amd64,x86_arm,x86_arm64,amd64_x86,amd64_arm,amd64_arm64
Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```
After:
```
PS C:\src\vcpkg> .\toolsrc\out\build\x64-Debug\vcpkg.exe install tinyxml2:x64-windows
Computing installation plan...
The following packages will be built and installed:
    tinyxml2[core]:x64-windows -> 8.0.0-1
Detecting compiler hash for triplet x64-windows...
Error: Unsupported toolchain combination.
Target was s390x but the chosen Visual Studio instance supports:
    x86, amd64, x86_amd64, x86_arm, x86_arm64, amd64_x86, amd64_arm, amd64_arm64
Vcpkg selected C:\Program Files (x86)\Microsoft Visual Studio\2019\Community as the Visual Studio instance.
Detected instances:
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community
    C:\Program Files (x86)\Microsoft Visual Studio 14.0\
    C:\Program Files (x86)\Microsoft Visual Studio 14.0
    C:\Program Files (x86)\Microsoft Visual Studio 14.0

See https://github.com/microsoft/vcpkg/blob/master/docs/users/triplets.md#VCPKG_VISUAL_STUDIO_PATH for more information.
Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```