### PR TITLE
[vcpkg] clarify the actions of vcpkg_check_linkage

### DIFF
--- a/docs/maintainers/vcpkg_check_linkage.md
+++ b/docs/maintainers/vcpkg_check_linkage.md
@@ -14,6 +14,8 @@ vcpkg_check_linkage(
 ### ONLY_STATIC_LIBRARY
 Indicates that this port can only be built with static library linkage.
 
+Note: If the user requested a dynamic build ONLY_STATIC_LIBRARY will result in a note being printed, not a fatal error.
+
 ### ONLY_DYNAMIC_LIBRARY
 Indicates that this port can only be built with dynamic/shared library linkage.
 

--- a/scripts/cmake/vcpkg_check_linkage.cmake
+++ b/scripts/cmake/vcpkg_check_linkage.cmake
@@ -15,6 +15,8 @@ vcpkg_check_linkage(
 ### ONLY_STATIC_LIBRARY
 Indicates that this port can only be built with static library linkage.
 
+Note: If the user requested a dynamic build ONLY_STATIC_LIBRARY will result in a note being printed, not a fatal error.
+
 ### ONLY_DYNAMIC_LIBRARY
 Indicates that this port can only be built with dynamic/shared library linkage.
 


### PR DESCRIPTION
**Describe the pull request**

I got confused by the behavior of `vcpkg_check_linkage(ONLY_STATIC_LIBRARY)` in triplets that request dynamic libraries, so I documented it's behavior in this case.
