### PR TITLE
[drogon] Upgrade to v1.3.0

### DIFF
--- a/ports/drogon/CONTROL
+++ b/ports/drogon/CONTROL
@@ -1,5 +1,8 @@
 Source: drogon
-Version: 1.1.0
+Version: 1.3.0
 Homepage: https://github.com/an-tao/drogon
 Description:Drogon: A C++14/17 based HTTP web application framework running on Linux/macOS/Unix/Windows
 Build-Depends: trantor, zlib, jsoncpp, libmariadb (!osx), libmariadb[iconv] (osx), libpq, sqlite3, brotli, libuuid (!windows)
+
+Feature: ctl
+Description: Build drogon_ctl tool. 

--- a/ports/drogon/portfile.cmake
+++ b/ports/drogon/portfile.cmake
@@ -1,11 +1,17 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO an-tao/drogon
-    REF v1.1.0
-    SHA512 00d7d64fc666b0b2c02afab899f622123883b62b274d33f3504da6250a6458fc56ab12b131c24f9a7e20284bc5c3604a4f2dd796f56ad00d454d9f8504d8f96e
+    REF v1.3.0
+    SHA512 cddda4b90d28c15319b9cd1dea561c429b804508fc40678b9906fb70153cb36d7a4fc1c13fee01ec1f49d747a722856ceee364aba4118d922afabc3629ba2115
     HEAD_REF master
     PATCHES
         vcpkg.patch
+        resolv.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    ctl BUILD_CTL
 )
 
 vcpkg_configure_cmake(
@@ -13,6 +19,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DBUILD_EXAMPLES=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
@@ -20,8 +27,11 @@ vcpkg_install_cmake()
 # Fix CMake files
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Drogon)
 # Copy drogon_ctl
-vcpkg_copy_tools(TOOL_NAMES drogon_ctl
-                 AUTO_CLEAN)
+if("ctl" IN_LIST FEATURES)
+    message("copying tools")
+    vcpkg_copy_tools(TOOL_NAMES drogon_ctl
+                     AUTO_CLEAN)
+endif()
 # # Remove includes in debug
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/drogon/resolv.patch
+++ b/ports/drogon/resolv.patch
@@ -1,0 +1,13 @@
+diff --git a/drogon_ctl/CMakeLists.txt b/drogon_ctl/CMakeLists.txt
+--- a/drogon_ctl/CMakeLists.txt
++++ b/drogon_ctl/CMakeLists.txt
+@@ -39,6 +39,9 @@
+ if(WIN32)
+   target_link_libraries(drogon_ctl PRIVATE ws2_32 Rpcrt4)
+ endif(WIN32)
++if(APPLE)
++  target_link_libraries(drogon_ctl PRIVATE resolv)
++endif()
+ message(STATUS "bin:" ${INSTALL_BIN_DIR})
+ install(TARGETS drogon_ctl RUNTIME DESTINATION ${INSTALL_BIN_DIR})
+ if(WIN32)

--- a/ports/drogon/vcpkg.patch
+++ b/ports/drogon/vcpkg.patch
@@ -57,14 +57,3 @@ index 6df5dac..b79036d 100755
  
    # Find mysql, only mariadb client liberary is supported
    find_package(MySQL)
-@@ -251,7 +249,10 @@ if(BUILD_EXAMPLES)
- endif(BUILD_EXAMPLES)
- 
- if(BUILD_CTL)
-+  message("BUILD_CTL")
-   add_subdirectory(drogon_ctl)
-+else()
-+  message("no BUILD_CTL")
- endif(BUILD_CTL)
- 
- if(COZ_PROFILING)

--- a/ports/drogon/vcpkg.patch
+++ b/ports/drogon/vcpkg.patch
@@ -1,8 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 96d6c6a..9d3dd24 100755
+index 6df5dac..b79036d 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -72,9 +72,9 @@ if(WIN32)
+@@ -5,13 +5,11 @@ project(drogon)
+ message(STATUS "compiler: " ${CMAKE_CXX_COMPILER_ID})
+ include(CheckCXXSourceRuns)
+ check_cxx_source_runs(
+-        ${PROJECT_SOURCE_DIR}/cmake/tests/binary_compatibility_test.cc
+-        cross_compiling)
++        "int main(){return 0;}"
++        not_cross_compiling)
+ 
+-if(cross_compiling)
++if(!not_cross_compiling)
+   set(BUILD_PROGRAMS OFF)
+-else(cross_compiling)
+-  set(BUILD_PROGRAMS ON)
+ endif()
+ 
+ option(BUILD_CTL "Build drogon_ctl" ${BUILD_PROGRAMS})
+@@ -84,9 +82,9 @@ if(WIN32)
      PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/mman-win32>)
  endif(WIN32)
  
@@ -13,8 +30,8 @@ index 96d6c6a..9d3dd24 100755
 +target_link_libraries(${PROJECT_NAME} PUBLIC Trantor::Trantor)
  
  if(NOT WIN32)
-   target_link_libraries(${PROJECT_NAME} PRIVATE dl)
-@@ -169,11 +169,11 @@ endif(NOT WIN32)
+   if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+@@ -183,11 +181,11 @@ endif(NOT WIN32)
  
  if(BUILD_ORM)
    # find postgres
@@ -31,3 +48,23 @@ index 96d6c6a..9d3dd24 100755
      set(DROGON_SOURCES ${DROGON_SOURCES}
                         orm_lib/src/postgresql_impl/PostgreSQLResultImpl.cc)
      if(LIBPQ_BATCH_MODE)
+@@ -206,7 +204,7 @@ if(BUILD_ORM)
+       set(DROGON_SOURCES ${DROGON_SOURCES}
+                          orm_lib/src/postgresql_impl/PgConnection.cc)
+     endif(libpq_supports_batch)
+-  endif(pg_FOUND)
++  endif(PostgreSQL_FOUND)
+ 
+   # Find mysql, only mariadb client liberary is supported
+   find_package(MySQL)
+@@ -251,7 +249,10 @@ if(BUILD_EXAMPLES)
+ endif(BUILD_EXAMPLES)
+ 
+ if(BUILD_CTL)
++  message("BUILD_CTL")
+   add_subdirectory(drogon_ctl)
++else()
++  message("no BUILD_CTL")
+ endif(BUILD_CTL)
+ 
+ if(COZ_PROFILING)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1661,7 +1661,7 @@
       "port-version": 0
     },
     "drogon": {
-      "baseline": "1.1.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "dtl": {

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3a5b10159091c6bf28fec5202810e8c5c213889",
+      "version-string": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f6370e6a96e12ad2fdd2cbefbe442e6b794091dc",
       "version-string": "1.1.0",
       "port-version": 0

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "46e66bff1be9afc354420f8e207e8c0b9ec5dfb9",
+      "git-tree": "bbe57dbdbffedb8cd5218f8dc76c1bbe35b59b5d",
       "version-string": "1.3.0",
       "port-version": 0
     },

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3a5b10159091c6bf28fec5202810e8c5c213889",
+      "git-tree": "46e66bff1be9afc354420f8e207e8c0b9ec5dfb9",
       "version-string": "1.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Upgrades `drogon` version.
Fix cross compiling on ARM64 by adding a feature switch to disable building `drogon_ctl` tools because they are required to run at build time.
Also it fixes a linking error on macOS since upstream library `c-ares` requires it. https://github.com/an-tao/drogon/issues/688

- Which triplets are supported/not supported? Have you updated the CI baseline?
I tested the following triplets:
```
drogon[ctl]:x64-windows
drogon:x64-windows
drogon[ctl]:x86-windows
drogon:x86-windows
drogon:arm64-windows (Cross compile with host x64)
drogon[ctl]:x64-osx
```

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes