### PR TITLE
[speex] Add linux and macOS support.

### DIFF
--- a/ports/speex/CONTROL
+++ b/ports/speex/CONTROL
@@ -1,6 +1,5 @@
 Source: speex
 Version: 1.2.0
-Port-Version: 7
+Port-Version: 8
 Homepage: https://github.com/xiph/speex
 Description: Speex is an Open Source/Free Software patent-free audio compression format designed for speech.
-Supports: !(linux | osx)

--- a/ports/speex/portfile.cmake
+++ b/ports/speex/portfile.cmake
@@ -1,4 +1,7 @@
-vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
+  set(USE_CMAKE_BUILDSYSTEM TRUE)
+  list(APPEND PATCHES "0001-make-pkg-config-lib-name-configurable.patch")
+endif()
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
@@ -6,24 +9,34 @@ vcpkg_from_github(
   REF Speex-1.2.0
   SHA512  612dfd67a9089f929b7f2a613ed3a1d2fda3d3ec0a4adafe27e2c1f4542de1870b42b8042f0dcb16d52e08313d686cc35b76940776419c775417f5bad18b448f
   HEAD_REF master
-  PATCHES
-    0001-make-pkg-config-lib-name-configurable.patch
+  PATCHES ${PATCHES}
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+if(USE_CMAKE_BUILDSYSTEM)
+  file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+  vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
+  )
+  vcpkg_install_cmake()
 
-vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
-  OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
-)
+  if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(READ "${CURRENT_PACKAGES_DIR}/include/speex/speex.h" _contents)
+    string(REPLACE "extern const SpeexMode" "__declspec(dllimport) extern const SpeexMode" _contents "${_contents}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/include/speex/speex.h" "${_contents}")
+  endif()
+else()
+  message("\
+${PORT} currently requires the following libraries from the system package manager:
+    autoconf libtool
+These can be installed on Ubuntu systems via sudo apt install autoconf libtool\
+  ")
 
-vcpkg_install_cmake()
+  vcpkg_configure_make(SOURCE_PATH ${SOURCE_PATH} AUTOCONFIG)
+  vcpkg_install_make()
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-  file(READ "${CURRENT_PACKAGES_DIR}/include/speex/speex.h" _contents)
-  string(REPLACE "extern const SpeexMode" "__declspec(dllimport) extern const SpeexMode" _contents "${_contents}")
-  file(WRITE "${CURRENT_PACKAGES_DIR}/include/speex/speex.h" "${_contents}")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 endif()
 
 vcpkg_fixup_pkgconfig()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5470,7 +5470,7 @@
     },
     "speex": {
       "baseline": "1.2.0",
-      "port-version": 7
+      "port-version": 8
     },
     "speexdsp": {
       "baseline": "1.2.0",

--- a/versions/s-/speex.json
+++ b/versions/s-/speex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eaa4e7b1a075051d8ba02bc67a89ae035be1b28c",
+      "version-string": "1.2.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "ee8363b22602ef2b0f74d4d43de88ed32457c4ba",
       "version-string": "1.2.0",
       "port-version": 7


### PR DESCRIPTION
This adds support for Linux and macOS to the speex port.

- What does your PR fix?
See above.

- Which triplets are supported/not supported? Have you updated the CI baseline?
Adds support for x64-linux and x64-osx.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
