### PR TITLE
[kinectsdk1] Update hash

### DIFF
--- a/ports/kinectsdk1/CONTROL
+++ b/ports/kinectsdk1/CONTROL
@@ -1,4 +1,0 @@
-Source: kinectsdk1
-Version: 1.8-2
-Description: Kinect for Windows SDK for Kinect v1 sensor.
-Supports: !arm

--- a/ports/kinectsdk1/portfile.cmake
+++ b/ports/kinectsdk1/portfile.cmake
@@ -1,12 +1,10 @@
-if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
-    message(FATAL_ERROR "This port does not currently support architecture: ${VCPKG_TARGET_ARCHITECTURE}")
-endif()
+vcpkg_fail_port_install(ON_ARCH "arm")
 
 set(KINECTSDK10_VERSION "v1.8")
 vcpkg_download_distfile(KINECTSDK10_INSTALLER
     URLS "https://download.microsoft.com/download/E/1/D/E1DEC243-0389-4A23-87BF-F47DE869FC1A/KinectSDK-${KINECTSDK10_VERSION}-Setup.exe"
     FILENAME "KinectSDK-${KINECTSDK10_VERSION}-Setup.exe"
-    SHA512 ee8a0f70c86aad80fe214108e315e4550a90ed39f278ce00a7137532174ee5bf3bdeb1d0b499fc5ffdb5e176adecfd68963ee3731e1d2f00d69d32d1b8a3c555
+    SHA512 d7e886d639b4310addc7c1350311f81289ffbcd653237882da7bf3d4074281ed35d217cb8be101579cac880c574dd89c62cd6a87772d60905c446d0be5fd1932
 )
 
 vcpkg_find_acquire_program(DARK)
@@ -65,5 +63,4 @@ file(
 )
 
 # Handle copyright
-file(COPY "${KINECTSDK10_DIR}/SDKEula.rtf" DESTINATION ${CURRENT_PACKAGES_DIR}/share/kinectsdk1)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/kinectsdk1/SDKEula.rtf ${CURRENT_PACKAGES_DIR}/share/kinectsdk1/copyright)
+file(INSTALL ${KINECTSDK10_DIR}/SDKEula.rtf DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/kinectsdk1/vcpkg.json
+++ b/ports/kinectsdk1/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "kinectsdk1",
+  "version-string": "1.8",
+  "port-version: "3",
+  "description": "Kinect for Windows SDK for Kinect v1 sensor.",
+  "Supports: "!arm"
+}

--- a/ports/kinectsdk1/vcpkg.json
+++ b/ports/kinectsdk1/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kinectsdk1",
   "version-string": "1.8",
-  "port-version: "3",
+  "port-version": 3,
   "description": "Kinect for Windows SDK for Kinect v1 sensor.",
-  "Supports: "!arm"
+  "supports": "!arm"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2729,8 +2729,8 @@
       "port-version": 0
     },
     "kinectsdk1": {
-      "baseline": "1.8-2",
-      "port-version": 0
+      "baseline": "1.8",
+      "port-version": 3
     },
     "kinectsdk2": {
       "baseline": "2.0-2",

--- a/versions/k-/kinectsdk1.json
+++ b/versions/k-/kinectsdk1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b48f4bf28923981e5a8ad549daa4dc8ee64dac83",
+      "version-string": "1.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "6f1b6079d522449e9e015c19c96b021bef51d3f8",
       "version-string": "1.8-2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
Kinectsdk1 installation failed with error:
File does not have expected hash:
      File path: [ D:/downloads/temp/KinectSDK-v1.8-Setup.exe ]
      Expected hash: [ ee8a0f70c86aad80fe214108e315e4550a90ed39f278ce00a7137532174ee5bf3bdeb1d0b499fc5ffdb5e176adecfd68963ee3731e1d2f00d69d32d1b8a3c555 ]
        Actual hash: [ d7e886d639b4310addc7c1350311f81289ffbcd653237882da7bf3d4074281ed35d217cb8be101579cac880c574dd89c62cd6a87772d60905c446d0be5fd1932 ]

So update the hash to the correct one.