### PR TITLE
[vcpkg] vcpkg_configure_meson: Support macOS cross-compile

### DIFF
--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -91,6 +91,11 @@ function(vcpkg_internal_meson_generate_native_file _additional_binaries) #https:
     file(WRITE "${_file}" "${NATIVE}")
 endfunction()
 
+function(vcpkg_internal_meson_convert_compiler_flags_to_list _out_var _compiler_flags)
+    string(REGEX REPLACE [=[( +|^)((\"(\\\"|[^"])+\"|\\\"|\\ |[^ ])+)]=] ";\\2" ${_out_var} "${_compiler_flags}")
+    set(${_out_var} "${${_out_var}}" PARENT_SCOPE)
+endfunction()
+
 function(vcpkg_internal_meson_generate_native_file_config _config) #https://mesonbuild.com/Native-environments.html
     if(VCPKG_TARGET_IS_WINDOWS)
         set(L_FLAG /LIBPATH:)
@@ -101,7 +106,7 @@ function(vcpkg_internal_meson_generate_native_file_config _config) #https://meso
     set(LIBPATH_${_config} "'${L_FLAG}${CURRENT_INSTALLED_DIR}${PATH_SUFFIX_${_config}}/lib'")
     
     set(NATIVE_${_config} "[properties]\n") #https://mesonbuild.com/Builtin-options.html
-    string(REGEX REPLACE "( |^)(-|/)" ";\\2" MESON_CFLAGS_${_config} "${VCPKG_DETECTED_CMAKE_C_FLAGS_${_config}}")
+    vcpkg_internal_meson_convert_compiler_flags_to_list(MESON_CFLAGS_${_config} "${VCPKG_DETECTED_CMAKE_C_FLAGS_${_config}}")
     list(TRANSFORM MESON_CFLAGS_${_config} APPEND "'")
     list(TRANSFORM MESON_CFLAGS_${_config} PREPEND "'")
     #list(APPEND MESON_CFLAGS_${_config} "${LIBPATH_${_config}}")
@@ -109,7 +114,7 @@ function(vcpkg_internal_meson_generate_native_file_config _config) #https://meso
     list(JOIN MESON_CFLAGS_${_config} ", " MESON_CFLAGS_${_config})
     string(REPLACE "'', " "" MESON_CFLAGS_${_config} "${MESON_CFLAGS_${_config}}")
     string(APPEND NATIVE_${_config} "c_args = [${MESON_CFLAGS_${_config}}]\n")
-    string(REGEX REPLACE "( |^)(-|/)" ";\\2" MESON_CXXFLAGS_${_config} "${VCPKG_DETECTED_CMAKE_CXX_FLAGS_${_config}}")
+    vcpkg_internal_meson_convert_compiler_flags_to_list(MESON_CXXFLAGS_${_config} "${VCPKG_DETECTED_CMAKE_CXX_FLAGS_${_config}}")
     list(TRANSFORM MESON_CXXFLAGS_${_config} APPEND "'")
     list(TRANSFORM MESON_CXXFLAGS_${_config} PREPEND "'")
     #list(APPEND MESON_CXXFLAGS_${_config} "${LIBPATH_${_config}}")
@@ -278,15 +283,6 @@ function(vcpkg_internal_meson_generate_cross_file _additional_binaries) #https:/
         set(VCPKG_MESON_CROSS_FILE "${_file}" PARENT_SCOPE)
         file(WRITE "${_file}" "${CROSS}")
     endif()
-endfunction()
-
-function(vcpkg_internal_meson_convert_compiler_flags_to_list _out_var _compiler_flags)
-    string(REGEX REPLACE "( +|^)(--?|/)" ";\\2" ${_out_var} "${_compiler_flags}")
-    if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
-        # special-case handling for "-arch <arm64/etc>" on macOS/iOS - this must be split into separate list entries
-        string(REGEX REPLACE "-arch ([^;]+)" "-arch;\\1" ${_out_var} "${${_out_var}}")
-    endif()
-    set(${_out_var} "${${_out_var}}" PARENT_SCOPE)
 endfunction()
 
 function(vcpkg_internal_meson_generate_cross_file_config _config) #https://mesonbuild.com/Native-environments.html

--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -281,7 +281,7 @@ function(vcpkg_internal_meson_generate_cross_file _additional_binaries) #https:/
 endfunction()
 
 function(vcpkg_internal_meson_convert_compiler_flags_to_list _out_var _compiler_flags)
-    string(REGEX REPLACE "( |^)(-|/)" ";\\2" ${_out_var} "${_compiler_flags}")
+    string(REGEX REPLACE "( +|^)(--?|/)" ";\\2" ${_out_var} "${_compiler_flags}")
     if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
         # special-case handling for "-arch <arm64/etc>" on macOS/iOS - this must be split into separate list entries
         string(REGEX REPLACE "-arch ([^;]+)" "-arch;\\1" ${_out_var} "${${_out_var}}")


### PR DESCRIPTION
**Describe the pull request**

NOTE: Depends on #15659 ~~(the first 3 commits in this PR are from #15659, for running CI)~~ - now merged!

Based on discussion on Discord with @ras0219, this takes the approach of a minimal fix to the meson cross-compile config.

While this fixes cross-compiling *many* meson-based ports, there is one exception:

Meson-based ports that require "native" architecture tools to be built as part of their build process may still have issues. But as @ras0219 noted (on Discord), that is best fixed by port-level fixes after PR https://github.com/microsoft/vcpkg/pull/15424 is merged that take advantage of that new "host triplet dependency" functionality. Regardless, this fix is needed for the rest.

- What does your PR fix?

Fixes `arm64-osx` cross-compile of meson-based ports.

(Building meson-based ports for `arm64-osx` would previously build them for the native architecture - i.e. building `harfbuzz:arm64-osx` on an Intel 64-bit Mac, would seemingly succeed **but** actually build an `x86_64` architecture library.)

- Which triplets are supported/not supported? Have you updated the CI baseline?

`arm64-osx`