### PR TITLE
[libidn2] Fix cross-compile (non-Windows)

### DIFF
--- a/ports/libidn2/CONTROL
+++ b/ports/libidn2/CONTROL
@@ -1,6 +1,0 @@
-Source: libidn2
-Version: 2.3.0
-Port-Version: 1
-Build-Depends: libiconv
-Homepage: https://www.gnu.org/software/libidn/
-Description: GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.

--- a/ports/libidn2/portfile.cmake
+++ b/ports/libidn2/portfile.cmake
@@ -50,6 +50,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
 else()
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
+        AUTOCONFIG
         COPY_SOURCE
         OPTIONS
             --with-libiconv-prefix=${CURRENT_INSTALLED_DIR}

--- a/ports/libidn2/vcpkg.json
+++ b/ports/libidn2/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "libidn2",
+  "version-string": "2.3.0",
+  "port-version": 2,
+  "description": "GNU Libidn is an implementation of the Stringprep, Punycode and IDNA 2003 specifications. Libidn's purpose is to encode and decode internationalized domain names.",
+  "homepage": "https://www.gnu.org/software/libidn/",
+  "dependencies": [
+    "libiconv"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3026,7 +3026,7 @@
     },
     "libidn2": {
       "baseline": "2.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libigl": {
       "baseline": "2.2.0",

--- a/versions/l-/libidn2.json
+++ b/versions/l-/libidn2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f5a62105488c9eb440e97c4d49a1ac6c8fa996c",
+      "version-string": "2.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "6d198421acf88e8196da7f2d1389100307f92133",
       "version-string": "2.3.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

Add missing `AUTOCONFIG` option to `vcpkg_configure_make` for `libidn2` port.

- What does your PR fix?

Fixes non-Windows cross-compile of `libidn2`.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Non-Windows cross-compilation triplet scenarios are potentially affected (ex: `arm64-osx`).
