### PR TITLE
[fontconfig] Avoid error on cross-compile building the fontconfig cache

### DIFF
--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -87,7 +87,7 @@ file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share
 
 
 ## Build the fontconfig cache
-if(NOT VCPKG_TARGET_IS_WINDOWS)
+if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT CMAKE_CROSSCOMPILING)
     set(ENV{FONTCONFIG_PATH} "${CURRENT_PACKAGES_DIR}/etc/fonts")
     set(ENV{FONTCONFIG_FILE} "${CURRENT_PACKAGES_DIR}/etc/fonts/fonts.conf")
     vcpkg_execute_required_process(COMMAND "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin/fc-cache${VCPKG_TARGET_EXECUTABLE_SUFFIX}" --verbose


### PR DESCRIPTION
**Describe the pull request**

Fix fontconfig cross-compile by not attempting to execute the non-native architecture `fc-cache` tool.

- What does your PR fix?

Avoid `fontconfig` build failure on cross-compile.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Impacts cross-compilation triplets (ex. `arm64-osx`).
