### PR TITLE
[vcpkg] Improve error reporting for vcpkg_abi_info.txt copy failure.

### DIFF
--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -1134,7 +1134,7 @@ namespace vcpkg::Build
                                       const IBuildLogsRecorder& build_logs_recorder,
                                       const StatusParagraphs& status_db)
     {
-        auto& fs = paths.get_filesystem();
+        auto& filesystem = paths.get_filesystem();
         auto& spec = action.spec;
         const std::string& name = action.source_control_file_location.value_or_exit(VCPKG_LINE_INFO)
                                       .source_control_file->core_paragraph->name;
@@ -1177,7 +1177,6 @@ namespace vcpkg::Build
 
         auto& abi_file = *abi_info.abi_tag_file.get();
 
-        std::error_code ec;
         const fs::path abi_package_dir = paths.package_dir(spec) / "share" / spec.name();
         const fs::path abi_file_in_package = paths.package_dir(spec) / "share" / spec.name() / "vcpkg_abi_info.txt";
         if (action.has_package_abi())
@@ -1204,17 +1203,34 @@ namespace vcpkg::Build
         }
 
         ExtendedBuildResult result = do_build_package_and_clean_buildtrees(args, paths, action);
+        build_logs_recorder.record_build_result(paths, spec, result.code);
 
-        fs.create_directories(abi_package_dir, ec);
-        fs.copy_file(abi_file, abi_file_in_package, fs::copy_options::none, ec);
-        Checks::check_exit(VCPKG_LINE_INFO, !ec, "Could not copy into file: %s", fs::u8string(abi_file_in_package));
+        std::error_code ec;
+        filesystem.create_directories(abi_package_dir, ec);
+        if (!ec)
+        {
+            Checks::exit_with_message(VCPKG_LINE_INFO,
+                                      Strings::format("Could not create %s: %d %s",
+                                                      fs::u8string(abi_package_dir).c_str(),
+                                                      ec.value(),
+                                                      ec.message().c_str()));
+        }
+
+        filesystem.copy_file(abi_file, abi_file_in_package, fs::copy_options::none, ec);
+        if (!ec)
+        {
+            Checks::exit_with_message(VCPKG_LINE_INFO,
+                                      Strings::format("Could not copy %s -> %s: %d %s",
+                                                      fs::u8string(abi_file).c_str(),
+                                                      fs::u8string(abi_file_in_package).c_str(),
+                                                      ec.value(),
+                                                      ec.message().c_str()));
+        }
 
         if (action.has_package_abi() && result.code == BuildResult::SUCCEEDED)
         {
             binaries_provider.push_success(paths, action);
         }
-
-        build_logs_recorder.record_build_result(paths, spec, result.code);
 
         return result;
     }

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -1207,7 +1207,7 @@ namespace vcpkg::Build
 
         std::error_code ec;
         filesystem.create_directories(abi_package_dir, ec);
-        if (!ec)
+        if (ec)
         {
             Checks::exit_with_message(VCPKG_LINE_INFO,
                                       Strings::format("Could not create %s: %d %s",
@@ -1217,7 +1217,7 @@ namespace vcpkg::Build
         }
 
         filesystem.copy_file(abi_file, abi_file_in_package, fs::copy_options::none, ec);
-        if (!ec)
+        if (ec)
         {
             Checks::exit_with_message(VCPKG_LINE_INFO,
                                       Strings::format("Could not copy %s -> %s: %d %s",

--- a/toolsrc/src/vcpkg/build.cpp
+++ b/toolsrc/src/vcpkg/build.cpp
@@ -1210,21 +1210,21 @@ namespace vcpkg::Build
         if (ec)
         {
             Checks::exit_with_message(VCPKG_LINE_INFO,
-                                      Strings::format("Could not create %s: %d %s",
+                                      Strings::format("Could not create %s: %s (%d)",
                                                       fs::u8string(abi_package_dir).c_str(),
-                                                      ec.value(),
-                                                      ec.message().c_str()));
+                                                      ec.message().c_str(),
+                                                      ec.value()));
         }
 
         filesystem.copy_file(abi_file, abi_file_in_package, fs::copy_options::none, ec);
         if (ec)
         {
             Checks::exit_with_message(VCPKG_LINE_INFO,
-                                      Strings::format("Could not copy %s -> %s: %d %s",
+                                      Strings::format("Could not copy %s -> %s: %s (%d)",
                                                       fs::u8string(abi_file).c_str(),
                                                       fs::u8string(abi_file_in_package).c_str(),
-                                                      ec.value(),
-                                                      ec.message().c_str()));
+                                                      ec.message().c_str(),
+                                                      ec.value()));
         }
 
         if (action.has_package_abi() && result.code == BuildResult::SUCCEEDED)


### PR DESCRIPTION
In build https://dev.azure.com/vcpkg/public/_build/results?buildId=48398

we are getting output like:

```
Error: Building package v-hacd:x64-windows-static failed with: BUILD_FAILED
Elapsed time for package v-hacd:x64-windows-static: 4.156 s
Starting package 1396/1464: v8:x64-windows-static
Building package v8[core]:x64-windows-static...
-- Using msys root at D:/downloads/tools/msys2/969c0913b9df89e1
-- Fetching https://chromium.googlesource.com/v8/v8.git...
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:108 (message):
    Command failed: C:/agent/externals/git/cmd/git.exe fetch https://chromium.googlesource.com/v8/v8.git 7565e93eb72cea4268028fc20186d415c22b1cff --depth 1 -n
    Working Directory: D:/downloads/git-tmp
    Error code: 128
    See logs for more information:
      D:\buildtrees\v8\git-fetch-x64-windows-static-err.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_from_git.cmake:91 (vcpkg_execute_required_process)
  ports/v8/portfile.cmake:71 (vcpkg_from_git)
  scripts/ports.cmake:128 (include)

Could not copy into file: D:\packages\v8_x64-windows-static\share\v8\vcpkg_abi_info.txt
```

(followed by a crash of vcpkg)

but aren't printing the reason for the copy failure. Added printing of that reason.
