### PR TITLE
[vcpkg] set CMake policy CMP0087 for X_VCPKG_APPLOCAL_DEPS_INSTALL

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -529,6 +529,10 @@ function(x_vcpkg_install_local_dependencies)
         foreach(TARGET IN LISTS __VCPKG_APPINSTALL_TARGETS)
             get_target_property(TARGETTYPE ${TARGET} TYPE)
             if(NOT TARGETTYPE STREQUAL "INTERFACE_LIBRARY")
+                # Install CODE|SCRIPT allow the use of generator expressions
+                if(POLICY CMP0087)
+                    cmake_policy(SET CMP0087 NEW)
+                endif()
                 install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                     execute_process(COMMAND \"${_VCPKG_POWERSHELL_PATH}\" -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
                         -targetBinary \"\${CMAKE_INSTALL_PREFIX}/${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"


### PR DESCRIPTION
Without this, X_VCPKG_APPLOCAL_DEPS_INSTALL does not work and
CMake prints this warning at the configure step:

CMake Warning (dev) in CMakeLists.txt:
Policy CMP0087 is not set: Install CODE|SCRIPT allow the use of generator
expressions.  Run "cmake --help-policy CMP0087" for policy details.  Use
the cmake_policy command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

https://cmake.org/cmake/help/latest/policy/CMP0087.html

**Describe the pull request**

- Which triplets are supported/not supported? Have you updated the CI baseline?
Windows

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
AFAIK yes
