### PR TITLE
[libkeyfinder] add new port with libkeyfinder 2.2.4

### DIFF
--- a/ports/libkeyfinder/portfile.cmake
+++ b/ports/libkeyfinder/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mixxxdj/libkeyfinder
+    REF v2.2.4
+    SHA512 6673b9a81dbfa3693fc4e7af4e5fc0f351f0c60b00fdafeb9e3437e2f77b5fec7d1e78e3989ff1daca72770a1d3cdbe3837508718b8e8aba3ac3f3d56af81a56
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    test BUILD_TESTING
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KeyFinder TARGET_PATH share/KeyFinder)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libkeyfinder/vcpkg.json
+++ b/ports/libkeyfinder/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libkeyfinder",
+  "version-string": "2.2.4",
+  "description": "Musical key detection for digital audio",
+  "homepage": "https://github.com/mixxxdj/libkeyfinder",
+  "license": "GPL-3.0-or-later",
+  "dependencies": [
+    "fftw3"
+  ],
+  "features": {
+    "test": {
+      "description": "Build tests",
+      "dependencies": [
+        "catch2"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3052,6 +3052,10 @@
       "baseline": "0.6.0",
       "port-version": 0
     },
+    "libkeyfinder": {
+      "baseline": "2.2.4",
+      "port-version": 0
+    },
     "libkml": {
       "baseline": "1.3.0",
       "port-version": 6

--- a/versions/l-/libkeyfinder.json
+++ b/versions/l-/libkeyfinder.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0ea7e74c79c626ed0185ee546a684293663cf651",
+      "version-string": "2.2.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- Which triplets are supported/not supported? Have you updated the CI baseline?
All platforms are supported. It's just a small C++ library that only depends on FFTW.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
AFAIK yes