### PR TITLE
[vcpkg_configure_qmake] add PATCHES to parse

### DIFF
--- a/scripts/cmake/vcpkg_configure_qmake.cmake
+++ b/scripts/cmake/vcpkg_configure_qmake.cmake
@@ -21,7 +21,7 @@ The options passed to qmake.
 
 function(vcpkg_configure_qmake)
     # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _csc "" "SOURCE_PATH" "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG")
+    cmake_parse_arguments(PARSE_ARGV 0 _csc "" "SOURCE_PATH" "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG;PATCHES")
      
     # Find qmake executable
     set(_triplet_hostbindir ${CURRENT_INSTALLED_DIR}/tools/qt5/bin)


### PR DESCRIPTION
When build qt5-webengine, `PATCHES` was consumed by `qt_download_submodule`, but will passed to `vcpkg_config_qmake` which does not recongize `PATCHES`.
