### PR TITLE
[baseline][colmap] Fix find dependency freeimage

### DIFF
--- a/ports/colmap/fix-dependency-freeimage.patch
+++ b/ports/colmap/fix-dependency-freeimage.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b05097c..cdd8ca4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,7 +96,8 @@ find_package(Boost REQUIRED COMPONENTS
+ 
+ find_package(Eigen3 REQUIRED)
+ 
+-find_package(FreeImage REQUIRED)
++find_package(freeimage CONFIG REQUIRED)
++set(FREEIMAGE_LIBRARIES freeimage::FreeImage)
+ 
+ find_package(Glog REQUIRED)
+ 

--- a/ports/colmap/portfile.cmake
+++ b/ports/colmap/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF ${COLMAP_REF}
     SHA512 9a4b4f2a49891ce8ac32ab1f2e9b859336326bada889e6de49c017a069884bb6c8ab8a2ae430d955e58fc22377c63e8fba9ce80ff959713e2878e29814d44632
     HEAD_REF dev
+    PATCHES fix-dependency-freeimage.patch
 )
 
 if (NOT TRIPLET_SYSTEM_ARCH STREQUAL "x64" AND ("cuda" IN_LIST FEATURES OR "cuda-redist" IN_LIST FEATURES))

--- a/ports/colmap/vcpkg.json
+++ b/ports/colmap/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "colmap",
   "version-string": "3.6",
+  "port-version": 1,
   "description": "COLMAP is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline with a graphical and command-line interface. It offers a wide range of features for reconstruction of ordered and unordered image collections. The software is licensed under the new BSD license.",
   "homepage": "https://colmap.github.io/",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1266,7 +1266,7 @@
     },
     "colmap": {
       "baseline": "3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "comms": {
       "baseline": "3.1.3",

--- a/versions/c-/colmap.json
+++ b/versions/c-/colmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f88c10f0bc3819bae7c197375bba335106726f1",
+      "version-string": "3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "e2d108b4334d41c2cc500c5dfe4c389127a46220",
       "version-string": "3.6",
       "port-version": 0


### PR DESCRIPTION
The default find method only find the release version of freeimage.

Related: #15860.