### PR TITLE
[boost-concept-check] Fix warning C4834 when install pagmo2

### DIFF
--- a/ports/boost-concept-check/fix-warning-c4834.patch
+++ b/ports/boost-concept-check/fix-warning-c4834.patch
@@ -7,7 +7,7 @@ index abbadb7..cab58e5 100644
        void test(boost::false_type)
        {
 -          f(first,second);
-+          //f(first,second);
++          std::ignore = f(first,second);
            Return r = f(first, second); // require operator()
            (void)r;
        }

--- a/ports/boost-concept-check/fix-warning-c4834.patch
+++ b/ports/boost-concept-check/fix-warning-c4834.patch
@@ -7,7 +7,7 @@ index abbadb7..cab58e5 100644
        void test(boost::false_type)
        {
 -          f(first,second);
-+          std::ignore = f(first,second);
++          (void) f(first,second);
            Return r = f(first, second); // require operator()
            (void)r;
        }

--- a/ports/boost-concept-check/fix-warning-c4834.patch
+++ b/ports/boost-concept-check/fix-warning-c4834.patch
@@ -1,0 +1,13 @@
+diff --git a/include/boost/concept_check.hpp b/include/boost/concept_check.hpp
+index abbadb7..cab58e5 100644
+--- a/include/boost/concept_check.hpp
++++ b/include/boost/concept_check.hpp
+@@ -352,7 +352,7 @@ namespace boost
+    private:
+       void test(boost::false_type)
+       {
+-          f(first,second);
++          //f(first,second);
+           Return r = f(first, second); // require operator()
+           (void)r;
+       }

--- a/ports/boost-concept-check/portfile.cmake
+++ b/ports/boost-concept-check/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF boost-1.75.0
     SHA512 823e3af47881c98f864c70686a3a2f6c9b7d5e6bf0ae61f2983f6c2ba26a70aaa888b683a74ef504ec7f5f479609731e35fad3518f1731954e01e7d67636e5d4
     HEAD_REF master
+    PATCHES
+        fix-warning-c4834.patch
 )
 
 include(${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost-modular-headers.cmake)

--- a/ports/boost-concept-check/vcpkg.json
+++ b/ports/boost-concept-check/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-concept-check",
   "version-string": "1.75.0",
+  "port-version": 1,
   "description": "Boost concept_check module",
   "homepage": "https://github.com/boostorg/concept_check",
   "dependencies": [

--- a/versions/b-/boost-concept-check.json
+++ b/versions/b-/boost-concept-check.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "266868f1b825d13692e9d42998c9f0c821a078b2",
+      "version-string": "1.75.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d3dcbf8caf23130b9b3bdbe0f896d4db4b87e362",
       "version-string": "1.75.0",
       "port-version": 0

--- a/versions/b-/boost-concept-check.json
+++ b/versions/b-/boost-concept-check.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eab8dcb2f52b027965122a0c04d921e669ad65f6",
+      "git-tree": "ee8e9890d2909b5afc0ade5315cb3d4f49164539",
       "version-string": "1.75.0",
       "port-version": 1
     },

--- a/versions/b-/boost-concept-check.json
+++ b/versions/b-/boost-concept-check.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "266868f1b825d13692e9d42998c9f0c821a078b2",
+      "git-tree": "eab8dcb2f52b027965122a0c04d921e669ad65f6",
       "version-string": "1.75.0",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -454,7 +454,7 @@
     },
     "boost-concept-check": {
       "baseline": "1.75.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-config": {
       "baseline": "1.75.0",


### PR DESCRIPTION
**Describe the pull request**
Since the change: https://github.com/microsoft/STL/pull/1474 , [nodiscard] was added before some operator() function, this change causes the warning C4834: discarding return value of function with 'nodiscard' attribute occurs when install port pagmo2. 

The change of STL is by design.
The warning was reported in the concept_check.hpp file, which comes from the dependency boost-concept-check of pagmo2，so I add a patch to modify the source code of boost-concept-check.
