### PR TITLE
[libvpx] Fix arm-uwp builds for v142 toolset

### DIFF
--- a/ports/libvpx/0003-add-uwp-and-v142-support.patch
+++ b/ports/libvpx/0003-add-uwp-and-v142-support.patch
@@ -1,0 +1,162 @@
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index 49cd13e..819948d 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -987,6 +987,8 @@ EOF
+           asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
+ 
+           case ${tgt_os} in
++            uwp)
++              ;&
+             win*)
+               asm_conversion_cmd="$asm_conversion_cmd -noelf"
+               AS="$CC -c"
+@@ -1005,7 +1007,7 @@ EOF
+           # A number of ARM-based Windows platforms are constrained by their
+           # respective SDKs' limitations. Fortunately, these are all 32-bit ABIs
+           # and so can be selected as 'win32'.
+-          if [ ${tgt_os} = "win32" ]; then
++          if [ ${tgt_os} = "win32" ] || [ ${tgt_isa} = "armv7" ]; then
+             asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
+             AS_SFX=.S
+             msvs_arch_dir=arm-msvs
+@@ -1237,6 +1239,8 @@ EOF
+         android)
+           soft_enable realtime_only
+           ;;
++        uwp)
++          ;&
+         win*)
+           enabled gcc && add_cflags -fno-common
+           ;;
+@@ -1359,6 +1363,16 @@ EOF
+       fi
+       AS_SFX=.asm
+       case  ${tgt_os} in
++        uwp)
++          if [ {$tgt_isa} = "x86" ] || {$tgt_isa} = "armv7" ]; then
++            add_asflags -f win32
++          else
++            add_asflags -f win64
++          fi
++          enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
++          enabled debug && [ "${AS}" = nasm ] && add_asflags -gcv8
++          EXE_SFX=.exe
++          ;;
+         win32)
+           add_asflags -f win32
+           enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
+@@ -1479,6 +1493,8 @@ EOF
+   # Almost every platform uses pthreads.
+   if enabled multithread; then
+     case ${toolchain} in
++      *-uwp-vs*)
++        ;;
+       *-win*-vs*)
+         ;;
+       *-android-gcc)
+diff --git a/build/make/gen_msvs_vcxproj.sh b/build/make/gen_msvs_vcxproj.sh
+index b634b06..99839dc 100644
+--- a/build/make/gen_msvs_vcxproj.sh
++++ b/build/make/gen_msvs_vcxproj.sh
+@@ -294,7 +294,22 @@ generate_vcxproj() {
+         tag_content ProjectGuid "{${guid}}"
+         tag_content RootNamespace ${name}
+         tag_content Keyword ManagedCProj
+-        if [ $vs_ver -ge 12 ] && [ "${platforms[0]}" = "ARM" ]; then
++        if [ $vs_ver -ge 16 ]; then
++            if [[ $target =~ [^-]*-uwp-.* ]]; then
++                # Universal Windows Applications
++                tag_content AppContainerApplication true
++                tag_content ApplicationType "Windows Store"
++                tag_content ApplicationTypeRevision 10.0
++            fi
++            if [[ $target =~ [^-]*-uwp-.* ]] || [ "${platforms[0]}" = "ARM" ] || [ "${platforms[0]}" = "ARM64" ]; then
++                # Default to the latest Windows 10 SDK
++                tag_content WindowsTargetPlatformVersion 10.0
++            else
++                # Minimum supported version of Windows for the desktop
++                tag_content WindowsTargetPlatformVersion 8.1
++            fi
++            tag_content MinimumVisualStudioVersion 16.0
++        elif [ $vs_ver -ge 12 ] && [ "${platforms[0]}" = "ARM" ]; then
+             tag_content AppContainerApplication true
+             # The application type can be one of "Windows Store",
+             # "Windows Phone" or "Windows Phone Silverlight". The
+@@ -389,7 +404,7 @@ generate_vcxproj() {
+                 Condition="'\$(Configuration)|\$(Platform)'=='$config|$plat'"
+             if [ "$name" == "vpx" ]; then
+                 hostplat=$plat
+-                if [ "$hostplat" == "ARM" ]; then
++                if [ "$hostplat" == "ARM" ] && [ $vs_ver -le 15 ]; then
+                     hostplat=Win32
+                 fi
+             fi
+diff --git a/configure b/configure
+index 32272ce..84ab38f 100644
+--- a/configure
++++ b/configure
+@@ -100,16 +100,20 @@ EOF
+ all_platforms="${all_platforms} arm64-android-gcc"
+ all_platforms="${all_platforms} arm64-darwin-gcc"
+ all_platforms="${all_platforms} arm64-linux-gcc"
++all_platforms="${all_platforms} arm64-uwp-vs16"
+ all_platforms="${all_platforms} arm64-win64-gcc"
+ all_platforms="${all_platforms} arm64-win64-vs15"
++all_platforms="${all_platforms} arm64-win64-vs16"
+ all_platforms="${all_platforms} armv7-android-gcc"   #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-darwin-gcc"    #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-linux-rvct"    #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-linux-gcc"     #neon Cortex-A8
+ all_platforms="${all_platforms} armv7-none-rvct"     #neon Cortex-A8
++all_platforms="${all_platforms} armv7-uwp-vs16"
+ all_platforms="${all_platforms} armv7-win32-gcc"
+ all_platforms="${all_platforms} armv7-win32-vs14"
+ all_platforms="${all_platforms} armv7-win32-vs15"
++all_platforms="${all_platforms} armv7-win32-vs16"
+ all_platforms="${all_platforms} armv7s-darwin-gcc"
+ all_platforms="${all_platforms} armv8-linux-gcc"
+ all_platforms="${all_platforms} mips32-linux-gcc"
+@@ -134,6 +138,7 @@ all_platforms="${all_platforms} x86-linux-gcc"
+ all_platforms="${all_platforms} x86-linux-icc"
+ all_platforms="${all_platforms} x86-os2-gcc"
+ all_platforms="${all_platforms} x86-solaris-gcc"
++all_platforms="${all_platforms} x86-uwp-vs16"
+ all_platforms="${all_platforms} x86-win32-gcc"
+ all_platforms="${all_platforms} x86-win32-vs14"
+ all_platforms="${all_platforms} x86-win32-vs15"
+@@ -154,6 +159,7 @@ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+ all_platforms="${all_platforms} x86_64-linux-gcc"
+ all_platforms="${all_platforms} x86_64-linux-icc"
+ all_platforms="${all_platforms} x86_64-solaris-gcc"
++all_platforms="${all_platforms} x86_64-uwp-vs16"
+ all_platforms="${all_platforms} x86_64-win64-gcc"
+ all_platforms="${all_platforms} x86_64-win64-vs14"
+ all_platforms="${all_platforms} x86_64-win64-vs15"
+@@ -475,6 +481,8 @@ process_targets() {
+     ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
+     DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
+     case "${tgt_os}" in
++    uwp)
++          ;&
+     win*) enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
+           DIST_DIR="${DIST_DIR}-${tgt_cc}"
+           ;;
+@@ -567,6 +575,8 @@ process_detect() {
+ 
+             # Specialize windows and POSIX environments.
+             case $toolchain in
++                *-uwp-*)
++                ;&
+                 *-win*-*)
+                     # Don't check for any headers in Windows builds.
+                     false
+@@ -742,6 +752,8 @@ process_toolchain() {
+             check_add_cxxflags -std=c++11 && soft_enable webm_io
+             soft_enable libyuv
+         ;;
++        *-uwp-*)
++        ;&
+         *-win*)
+             # Some mingw toolchains don't have pthread available by default.
+             # Treat these more like visual studio where threading in gtest

--- a/ports/libvpx/0003-add-uwp-and-v142-support.patch
+++ b/ports/libvpx/0003-add-uwp-and-v142-support.patch
@@ -1,17 +1,8 @@
 diff --git a/build/make/configure.sh b/build/make/configure.sh
-index 49cd13e..819948d 100644
+index 49cd13e..a627a02 100644
 --- a/build/make/configure.sh
 +++ b/build/make/configure.sh
-@@ -987,6 +987,8 @@ EOF
-           asm_conversion_cmd="${source_path}/build/make/ads2gas.pl"
- 
-           case ${tgt_os} in
-+            uwp)
-+              ;&
-             win*)
-               asm_conversion_cmd="$asm_conversion_cmd -noelf"
-               AS="$CC -c"
-@@ -1005,7 +1007,7 @@ EOF
+@@ -1005,7 +1005,7 @@ EOF
            # A number of ARM-based Windows platforms are constrained by their
            # respective SDKs' limitations. Fortunately, these are all 32-bit ABIs
            # and so can be selected as 'win32'.
@@ -20,21 +11,22 @@ index 49cd13e..819948d 100644
              asm_conversion_cmd="${source_path}/build/make/ads2armasm_ms.pl"
              AS_SFX=.S
              msvs_arch_dir=arm-msvs
-@@ -1237,6 +1239,8 @@ EOF
+@@ -1237,6 +1237,9 @@ EOF
          android)
            soft_enable realtime_only
            ;;
 +        uwp)
-+          ;&
++          enabled gcc && add_cflags -fno-common
++          ;;
          win*)
            enabled gcc && add_cflags -fno-common
            ;;
-@@ -1359,6 +1363,16 @@ EOF
+@@ -1359,6 +1362,16 @@ EOF
        fi
        AS_SFX=.asm
        case  ${tgt_os} in
 +        uwp)
-+          if [ {$tgt_isa} = "x86" ] || {$tgt_isa} = "armv7" ]; then
++          if [ {$tgt_isa} = "x86" ] || [ {$tgt_isa} = "armv7" ]; then
 +            add_asflags -f win32
 +          else
 +            add_asflags -f win64
@@ -46,7 +38,7 @@ index 49cd13e..819948d 100644
          win32)
            add_asflags -f win32
            enabled debug && [ "${AS}" = yasm ] && add_asflags -g cv8
-@@ -1479,6 +1493,8 @@ EOF
+@@ -1479,6 +1492,8 @@ EOF
    # Almost every platform uses pthreads.
    if enabled multithread; then
      case ${toolchain} in
@@ -93,7 +85,7 @@ index b634b06..99839dc 100644
                  fi
              fi
 diff --git a/configure b/configure
-index 32272ce..84ab38f 100644
+index 32272ce..e2231b4 100644
 --- a/configure
 +++ b/configure
 @@ -100,16 +100,20 @@ EOF
@@ -133,30 +125,30 @@ index 32272ce..84ab38f 100644
  all_platforms="${all_platforms} x86_64-win64-gcc"
  all_platforms="${all_platforms} x86_64-win64-vs14"
  all_platforms="${all_platforms} x86_64-win64-vs15"
-@@ -475,6 +481,8 @@ process_targets() {
+@@ -474,11 +480,10 @@ process_targets() {
+     ! enabled multithread && DIST_DIR="${DIST_DIR}-nomt"
      ! enabled install_docs && DIST_DIR="${DIST_DIR}-nodocs"
      DIST_DIR="${DIST_DIR}-${tgt_isa}-${tgt_os}"
-     case "${tgt_os}" in
-+    uwp)
-+          ;&
-     win*) enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
-           DIST_DIR="${DIST_DIR}-${tgt_cc}"
-           ;;
-@@ -567,6 +575,8 @@ process_detect() {
+-    case "${tgt_os}" in
+-    win*) enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
+-          DIST_DIR="${DIST_DIR}-${tgt_cc}"
+-          ;;
+-    esac
++    if [[ ${tgt_os} =~ win.* ]] || [ "${tgt_os}" = "uwp" ]; then
++        enabled static_msvcrt && DIST_DIR="${DIST_DIR}mt" || DIST_DIR="${DIST_DIR}md"
++        DIST_DIR="${DIST_DIR}-${tgt_cc}"
++    fi
+     if [ -f "${source_path}/build/make/version.sh" ]; then
+         ver=`"$source_path/build/make/version.sh" --bare "$source_path"`
+         DIST_DIR="${DIST_DIR}-${ver}"
+@@ -567,6 +572,10 @@ process_detect() {
  
              # Specialize windows and POSIX environments.
              case $toolchain in
 +                *-uwp-*)
-+                ;&
++                    # Don't check for any headers in UWP builds.
++                    false
++                ;;
                  *-win*-*)
                      # Don't check for any headers in Windows builds.
                      false
-@@ -742,6 +752,8 @@ process_toolchain() {
-             check_add_cxxflags -std=c++11 && soft_enable webm_io
-             soft_enable libyuv
-         ;;
-+        *-uwp-*)
-+        ;&
-         *-win*)
-             # Some mingw toolchains don't have pthread available by default.
-             # Treat these more like visual studio where threading in gtest

--- a/ports/libvpx/CONTROL
+++ b/ports/libvpx/CONTROL
@@ -1,6 +1,6 @@
 Source: libvpx
 Version: 1.9.0
-Port-Version: 5
+Port-Version: 6
 Homepage: https://github.com/webmproject/libvpx
 Description: The reference software implementation for the video coding formats VP8 and VP9.
 Supports: !(uwp&arm)

--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         0001-vcxproj-nasm.patch
         0002-Fix-nasm-debug-format-flag.patch
+        0003-add-uwp-and-v142-support.patch
 )
 
 vcpkg_find_acquire_program(PERL)
@@ -41,21 +42,33 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         set(LIBVPX_CRT_SUFFIX md)
     endif()
 
+    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL WindowsStore AND VCPKG_PLATFORM_TOOLSET STREQUAL v142)
+        set(LIBVPX_TARGET_OS "uwp")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x86 OR VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
+        set(LIBVPX_TARGET_OS "win32")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64 OR VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+        set(LIBVPX_TARGET_OS "win64")
+    endif()
+
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
-        set(LIBVPX_TARGET_ARCH "x86-win32")
+        set(LIBVPX_TARGET_ARCH "x86-${LIBVPX_TARGET_OS}")
         set(LIBVPX_ARCH_DIR "Win32")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
-        set(LIBVPX_TARGET_ARCH "x86_64-win64")
+        set(LIBVPX_TARGET_ARCH "x86_64-${LIBVPX_TARGET_OS}")
         set(LIBVPX_ARCH_DIR "x64")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
-        set(LIBVPX_TARGET_ARCH "arm64-win64")
+        set(LIBVPX_TARGET_ARCH "arm64-${LIBVPX_TARGET_OS}")
         set(LIBVPX_ARCH_DIR "ARM64")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL arm)
-        set(LIBVPX_TARGET_ARCH "armv7-win32")
+        set(LIBVPX_TARGET_ARCH "armv7-${LIBVPX_TARGET_OS}")
         set(LIBVPX_ARCH_DIR "ARM")
     endif()
 
-    set(LIBVPX_TARGET_VS "vs15")
+    if(VCPKG_PLATFORM_TOOLSET STREQUAL v142)
+        set(LIBVPX_TARGET_VS "vs16")
+    else()
+        set(LIBVPX_TARGET_VS "vs15")
+    endif()
 
     message(STATUS "Generating makefile")
     file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3442,7 +3442,7 @@
     },
     "libvpx": {
       "baseline": "1.9.0",
-      "port-version": 5
+      "port-version": 6
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f7104cf754bab559718bee308d2e7be4ea94f36",
+      "git-tree": "017466933d1b0a427b79b86b61129fb5cf12f05f",
       "version-string": "1.9.0",
       "port-version": 6
     },

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f7104cf754bab559718bee308d2e7be4ea94f36",
+      "version-string": "1.9.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "7f96abd4953072c5949e4eae823b7d5af27d8f13",
       "version-string": "1.9.0",
       "port-version": 5


### PR DESCRIPTION
This adds improved support for targeting UWP as well as ARM/ARM64 for regular Windows Desktop with the v142 toolset. Without this change, libvpx for the arm-uwp triplet currently fails to build with v142. This change does not modify the existing behavior for v141 and earlier.

Supported triplets when VCPKG_PLATFORM_TOOLSET is set to v142:

arm-uwp*
arm64-uwp*
x86-uwp*
x64-uwp*
arm-windows*
arm64-windows*
x86-windows*
x64-windows*