### PR TITLE
[vcpkg] Teach vcpkg.targets to emit a .tlog, enabling up-to-date checks

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -30,6 +30,7 @@
 
     <VcpkgConfigSubdir Condition="'$(VcpkgNormalizedConfiguration)' == 'Debug'">debug\</VcpkgConfigSubdir>
     <VcpkgApplocalDeps Condition="'$(VcpkgApplocalDeps)' == ''">true</VcpkgApplocalDeps>
+    <ProjectStateLine>VcpkgTriplet=$(VcpkgTriplet):$(ProjectStateLine)</ProjectStateLine>
   </PropertyGroup>
 
   <!-- Import property page 'Vcpkg' -->
@@ -68,15 +69,35 @@
              Importance="High" Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgNormalizedConfiguration)' == ''"/>
   </Target>
 
+  <ItemGroup>
+    <_VcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg.json"/>
+    <_VcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg-configuration.json" Condition="Exists('$(VcpkgManifestRoot)vcpkg-configuration.json')"/>
+  </ItemGroup>
+
   <Target Name="VcpkgInstallManifestDependencies" BeforeTargets="ClCompile"
-          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'">
-    <Message Text="Installing vcpkg dependencies" Importance="High" />
-    <Exec Command="%22$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))%22 install --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22"
+          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'"
+          Inputs="@(_VcpkgInstallManifestDependenciesInputs)"
+          Outputs="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog">
+    <Message Text="Installing vcpkg dependencies to $(VcpkgInstalledDir)" Importance="High" />
+    <MakeDir Directories="$(TLogLocation)" />
+    <ItemGroup>
+      <_VcpkgItemToDelete Include="$(TLogLocation)VcpkgInstallManifest*.read.1u.tlog" />
+    </ItemGroup>
+    <Delete Files="@(_VcpkgItemToDelete)" />
+    <Exec Command="%22$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))%22 install --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22" 
           StandardOutputImportance="High" />
+    <WriteLinesToFile File="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog"
+                      Lines="@(_VcpkgInstallManifestDependenciesInputs -> '^%(Identity)')"
+                      Encoding="Unicode"
+                      Overwrite="true"/>
+
+    <CreateProperty Value="false">
+      <Output TaskParameter="ValueSetByTask" PropertyName="Link_MinimalRebuildFromTracking" />
+    </CreateProperty>
   </Target>
 
   <Target Name="AppLocalFromInstalled" AfterTargets="CopyFilesToOutputDirectory" BeforeTargets="CopyLocalFilesOutputGroup;RegisterOutput"
-          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgApplocalDeps)' == 'true'">
+          Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgApplocalDeps)' == 'true' and '$(LinkSkippedExecution)' != 'true'">
     <Message Text="[vcpkg] Starting VcpkgApplocalDeps" Importance="low" />
     <PropertyGroup>
       <_VcpkgAppLocalPowerShellCommonArguments>-ExecutionPolicy Bypass -noprofile -File "$(MSBuildThisFileDirectory)applocal.ps1" "$(TargetPath)" "$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)bin" "$(TLogLocation)$(ProjectName).write.1u.tlog" "$(IntDir)vcpkg.applocal.log"</_VcpkgAppLocalPowerShellCommonArguments>


### PR DESCRIPTION
See title.

Even a no-op check on Windows can take several seconds due to running `vcvars.bat`. This change fixes this in two ways:

1. Add `Inputs` and `Outputs` to `VcpkgInstallManifestDependencies`, causing it to not execute `vcpkg.exe` if the manifest has not been changed.
2. Add steps to emit a `.tlog` file, plugging in to the VCTools/MSBuild "fast up to date" system. Without this step, modifying only `vcpkg.json` will not cause `Ctrl-B` to actually build anything; with this step, it will correctly invoke vcpkg.exe and rebuild anything that has changed (due to header changes etc).

Due to limitations in the fast up-to-date system, vcpkg.json will be compared against any `.ilk` files. We therefore need to always trigger a re-link via `Link_MinimalRebuildFromTracking=false` if vcpkg.json is modified.

@strega-nil @yuehuang010 