### PR TITLE
[vcpkg baseline][osgearth] Fix and add dependency tinyxml

### DIFF
--- a/ports/osgearth/fix-tinyxml.patch
+++ b/ports/osgearth/fix-tinyxml.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c78bd16..bf31091 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -193,7 +193,9 @@ OPTION(OSGEARTH_INSTALL_SHADERS "Whether to deploy GLSL shaders when doing a Mak
+ # TinyXML is an XML parsing library
+ SET (WITH_EXTERNAL_TINYXML FALSE CACHE BOOL "Use bundled or system wide version of TinyXML")
+ IF (WITH_EXTERNAL_TINYXML)
+-    find_package(TinyXML REQUIRED)
++    find_package(tinyxml CONFIG REQUIRED)
++    set(TINYXML_FOUND 1)
++    set(TINYXML_LIBRARY unofficial-tinyxml::unofficial-tinyxml)
+ ENDIF (WITH_EXTERNAL_TINYXML)
+ 
+ # postfix settings for various configs

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -15,7 +15,11 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         make-all-find-packages-required.patch
+        fix-tinyxml.patch
 )
+
+# Upstream bug, see https://github.com/gwaldron/osgearth/issues/1002
+file(REMOVE ${SOURCE_PATH}/src/osgEarth/tinyxml.h)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "supports": "!(x86 | wasm32) & !staticcrt",
@@ -20,6 +20,7 @@
       ]
     },
     "protobuf",
-    "sqlite3"
+    "sqlite3",
+    "tinyxml"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4370,7 +4370,7 @@
     },
     "osgearth": {
       "baseline": "3.1",
-      "port-version": 1
+      "port-version": 2
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9355b8ad52fcf4998fe4c262f29a4e01fa83b9fa",
+      "version": "3.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "d194c647fcf69fe345c13ae7b6da3451e4bbddb6",
       "version": "3.1",
       "port-version": 1


### PR DESCRIPTION
Since osgearth has built-in tinyxml and put its codes in the same source path, osgearth always uses the internal tinyxml symbol declaration first, no matter whether you choose to use internal or external tinyxml.

Related: https://github.com/gwaldron/osgearth/issues/1002