### PR TITLE
Add shell.nix for building on NixOS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,46 @@
+{ pkgs ? import <nixpkgs> {}, withX11 ? false }:
+
+(pkgs.buildFHSUserEnv {
+  name = "vcpkg";
+  targetPkgs = pkgs: (with pkgs; [
+      autoconf
+      automake
+      cmake
+      gcc
+      gettext
+      glibc.dev
+      gperf
+      libtool
+      libxkbcommon.dev
+      m4
+      ninja
+      pkgconfig
+      zip
+      zstd.dev
+    ] ++ pkgs.lib.optionals withX11 [
+      freetds
+      libdrm.dev
+      libglvnd.dev
+      mesa_drivers
+      mesa_glu.dev
+      mesa.dev
+      xlibs.libxcb.dev
+      xlibs.xcbutilimage.dev
+      xlibs.xcbutilwm.dev
+      xlibs.xorgserver.dev
+      xorg.libpthreadstubs
+      xorg.libX11.dev
+      xorg.libxcb.dev
+      xorg.libXext.dev
+      xorg.libXi.dev
+      xorg.xcbproto
+      xorg.xcbutil.dev
+      xorg.xcbutilcursor.dev
+      xorg.xcbutilerrors
+      xorg.xcbutilkeysyms.dev
+      xorg.xcbutilrenderutil.dev
+      xorg.xcbutilwm.dev
+      xorg.xorgproto
+    ]);
+  runScript = "bash";
+}).env


### PR DESCRIPTION
NixOS does not follow the FHS/LSB convention and building vcpkg therefore
fails. In general, vcpkg is of very limited use for a Nix system.
This shell.nix however, allows a developer to enter a environment
suitable for building vcpkg and developing packages for use on
other platforms.
Running with argument withX11 will allow building most packages that require
X11 libraries.

$ nix-shell --arg withX11 true

**Describe the pull request**

- What does your PR fix?

Allows to develop vcpkg packages on NixOS or when the nix package manager is installed.

- Which triplets are supported/not supported? Have you updated the CI baseline?


- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

yes
