### PR TITLE
[vcpkg] Emit parse errors to match '<file>:<line>:<col>: error: <text>' for better IDE compatibility

### DIFF
--- a/toolsrc/src/vcpkg-test/json.cpp
+++ b/toolsrc/src/vcpkg-test/json.cpp
@@ -234,7 +234,7 @@ TEST_CASE ("JSON track newlines", "[json]")
     auto res = Json::parse("{\n,", fs::u8path("filename"));
     REQUIRE(!res);
     REQUIRE(res.error()->format() ==
-            R"(Error: filename:2:1: Unexpected character; expected property name
+            R"(filename:2:1: error: Unexpected character; expected property name
    on expression: ,
                   ^
 )");

--- a/toolsrc/src/vcpkg/base/json.cpp
+++ b/toolsrc/src/vcpkg/base/json.cpp
@@ -1062,7 +1062,7 @@ namespace vcpkg::Json
     ExpectedT<std::pair<Value, JsonStyle>, std::unique_ptr<Parse::IParseError>> parse(StringView json,
                                                                                       const fs::path& filepath) noexcept
     {
-        return Parser::parse(json, fs::generic_u8string(filepath));
+        return Parser::parse(json, fs::u8string(filepath));
     }
     ExpectedT<std::pair<Value, JsonStyle>, std::unique_ptr<Parse::IParseError>> parse(StringView json,
                                                                                       StringView origin) noexcept

--- a/toolsrc/src/vcpkg/base/parse.cpp
+++ b/toolsrc/src/vcpkg/base/parse.cpp
@@ -34,13 +34,12 @@ namespace vcpkg::Parse
             caret_spacing.push_back(cp == '\t' ? '\t' : ' ');
         }
 
-        return Strings::concat("Error: ",
-                               origin,
+        return Strings::concat(origin,
                                ":",
                                row,
                                ":",
                                column,
-                               ": ",
+                               ": error: ",
                                message,
                                "\n"
                                "   on expression: ", // 18 columns


### PR DESCRIPTION
See title.

The built-in error log parsers in Visual Studio (MSBuild) expect the filename to come first on the error line. With this change, vcpkg parse errors are picked up by the error log and you can jump directly to the offending file location via double-click.

https://github.com/dotnet/msbuild/blob/ec6ed832e6a4adf94a2e6ff7e2f34d8e2da1cc05/src/Shared/CanonicalError.cs#L78