### PR TITLE
[physx] Install PDBs for static library.

### DIFF
--- a/ports/physx/CONTROL
+++ b/ports/physx/CONTROL
@@ -1,4 +1,4 @@
 Source: physx
 Version: 4.1.1
-Port-Version: 6
+Port-Version: 7
 Description: The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs

--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -112,9 +112,14 @@ function(fixup_physx_artifacts)
     _fixup("debug/bin" "debug/${_fpa_DIRECTORY}")
 endfunction()
 
+set(_PHYSX_LIB_SUFFIXES ${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX})
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND _PHYSX_LIB_SUFFIXES ".pdb")
+endif()
+
 fixup_physx_artifacts(
     DIRECTORY "lib"
-    SUFFIXES ${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX} ${VCPKG_TARGET_IMPORT_LIBRARY_SUFFIX}
+    SUFFIXES ${_PHYSX_LIB_SUFFIXES}
 )
 fixup_physx_artifacts(
     DIRECTORY "bin"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4514,7 +4514,7 @@
     },
     "physx": {
       "baseline": "4.1.1",
-      "port-version": 6
+      "port-version": 7
     },
     "picojson": {
       "baseline": "1.3.0-1",

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc6bb3fc504ec508b1b6a0624870b6001ee54131",
+      "version-string": "4.1.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "ff229b023b059806554bb8d9e6fbc2b4eb0fe139",
       "version-string": "4.1.1",
       "port-version": 6


### PR DESCRIPTION
The physx pdbs are copied into the `bin` directory, which is deleted under static configurations. This prevents debug information from being available to users in this configuration. This PR ensures pdbs are copied into `lib` when the library is built statically.

- What does your PR fix?
See above

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
