### PR TITLE
[vcpkg baseline] Fix baseline regression

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5241,7 +5241,7 @@
       "port-version": 0
     },
     "seal": {
-      "baseline": "3.6.0",
+      "baseline": "3.6.1",
       "port-version": 0
     },
     "secp256k1": {

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f0e988ad7a2c1b8c2c0d39f9954d1782886dd93",
+      "version-string": "3.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "df71d4b4ab6cc7c95c3c5eaec90cc413d508b1ea",
       "version-string": "3.6.0",
       "port-version": 0


### PR DESCRIPTION
#15015 update seal to 3.6.1, but forgot to update the version record.