### PR TITLE
[physx] Use /Z7 instead of /Zi to integrate the debug info when building static

### DIFF
--- a/ports/physx/CONTROL
+++ b/ports/physx/CONTROL
@@ -1,4 +1,4 @@
 Source: physx
 Version: 4.1.1
-Port-Version: 6
+Port-Version: 7
 Description: The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs

--- a/ports/physx/CONTROL
+++ b/ports/physx/CONTROL
@@ -1,4 +1,5 @@
 Source: physx
 Version: 4.1.1
 Port-Version: 7
+Homepage: https://github.com/NVIDIAGameWorks/PhysX
 Description: The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs

--- a/ports/physx/fix-compiler-flag.patch
+++ b/ports/physx/fix-compiler-flag.patch
@@ -1,0 +1,38 @@
+diff --git a/physx/source/compiler/cmake/uwp/CMakeLists.txt b/physx/source/compiler/cmake/uwp/CMakeLists.txt
+index 2abab31..e3cd075 100644
+--- a/physx/source/compiler/cmake/uwp/CMakeLists.txt
++++ b/physx/source/compiler/cmake/uwp/CMakeLists.txt
+@@ -40,10 +40,10 @@ ENDIF()
+ 
+ # Cache the CXX flags so the other CMakeLists.txt can use them if needed
+ SET(PHYSX_CXX_FLAGS "/Wall /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
+-SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
+-SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
+-SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
+-SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
++SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /Z7" CACHE INTERNAL "PhysX Debug CXX Flags")
++SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Checked CXX Flags")
++SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Profile CXX Flags")
++SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ # These flags are local to the directory the CMakeLists.txt is in, so don't get carried over to OTHER CMakeLists.txt (thus the CACHE variables above)
+ SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
+diff --git a/physx/source/compiler/cmake/windows/CMakeLists.txt b/physx/source/compiler/cmake/windows/CMakeLists.txt
+index c772333..a0b30d8 100644
+--- a/physx/source/compiler/cmake/windows/CMakeLists.txt
++++ b/physx/source/compiler/cmake/windows/CMakeLists.txt
+@@ -46,10 +46,10 @@ ELSE()
+ 	SET(PHYSX_CXX_FLAGS "/arch:SSE2 /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")	
+ ENDIF()
+ 
+-SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
+-SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
+-SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
+-SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
++SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Z7" CACHE INTERNAL "PhysX Debug CXX Flags")
++SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Checked CXX Flags")
++SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Profile CXX Flags")
++SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Release CXX Flags")
+ 
+ # cache lib type defs
+ IF(PX_GENERATE_STATIC_LIBRARIES)	

--- a/ports/physx/fix-compiler-flag.patch
+++ b/ports/physx/fix-compiler-flag.patch
@@ -1,38 +1,37 @@
-diff --git a/physx/source/compiler/cmake/uwp/CMakeLists.txt b/physx/source/compiler/cmake/uwp/CMakeLists.txt
-index 2abab31..e3cd075 100644
---- a/physx/source/compiler/cmake/uwp/CMakeLists.txt
-+++ b/physx/source/compiler/cmake/uwp/CMakeLists.txt
-@@ -40,10 +40,10 @@ ENDIF()
+diff --git a/physx/compiler/public/CMakeLists.txt b/physx/compiler/public/CMakeLists.txt
+index bd85eee..f32fe82 100644
+--- a/physx/compiler/public/CMakeLists.txt
++++ b/physx/compiler/public/CMakeLists.txt
+@@ -33,6 +33,8 @@ ENDIF()
  
- # Cache the CXX flags so the other CMakeLists.txt can use them if needed
- SET(PHYSX_CXX_FLAGS "/Wall /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
--SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
--SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
--SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
--SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
-+SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /Z7" CACHE INTERNAL "PhysX Debug CXX Flags")
-+SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Checked CXX Flags")
-+SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Profile CXX Flags")
-+SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Release CXX Flags")
+ project(PhysXSDK C CXX)
  
- # These flags are local to the directory the CMakeLists.txt is in, so don't get carried over to OTHER CMakeLists.txt (thus the CACHE variables above)
- SET(CMAKE_CXX_FLAGS ${PHYSX_CXX_FLAGS})
++SET(PHYSX_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE INTERNAL "PhysX Debug CXX Flags")
++
+ OPTION(PX_BUILDSNIPPETS "Generate the snippets" OFF)
+ OPTION(PX_BUILDPUBLICSAMPLES "Generate the samples" OFF)
+ OPTION(PX_CMAKE_SUPPRESS_REGENERATION "Disable zero_check projects" OFF)
 diff --git a/physx/source/compiler/cmake/windows/CMakeLists.txt b/physx/source/compiler/cmake/windows/CMakeLists.txt
-index c772333..a0b30d8 100644
+index c772333..e8a243c 100644
 --- a/physx/source/compiler/cmake/windows/CMakeLists.txt
 +++ b/physx/source/compiler/cmake/windows/CMakeLists.txt
-@@ -46,10 +46,10 @@ ELSE()
- 	SET(PHYSX_CXX_FLAGS "/arch:SSE2 /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")	
+@@ -41,15 +41,17 @@ ELSE()
+ 	SET(PHYSX_FP_MODE "/fp:fast")	
+ ENDIF()
+ IF(CMAKE_CL_64)
+-	SET(PHYSX_CXX_FLAGS "/d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
++	SET(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS} ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")
+ ELSE()
+-	SET(PHYSX_CXX_FLAGS "/arch:SSE2 /d2Zi+ /MP /WX /W4 /GF /GS- /GR- /Gd ${PHYSX_FP_MODE} /Oy ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")	
++	SET(PHYSX_CXX_FLAGS "${PHYSX_CXX_FLAGS} /arch:SSE2 ${PHYSX_FP_MODE} ${PHYSX_WARNING_DISABLES}" CACHE INTERNAL "PhysX CXX")	
  ENDIF()
  
--SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
--SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
--SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
--SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
-+SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Z7" CACHE INTERNAL "PhysX Debug CXX Flags")
-+SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Checked CXX Flags")
-+SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Profile CXX Flags")
-+SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Z7" CACHE INTERNAL "PhysX Release CXX Flags")
++if (0)
+ SET(PHYSX_CXX_FLAGS_DEBUG "/Od ${WINCRT_DEBUG} /RTCu /Zi" CACHE INTERNAL "PhysX Debug CXX Flags")
+ SET(PHYSX_CXX_FLAGS_CHECKED "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Checked CXX Flags")
+ SET(PHYSX_CXX_FLAGS_PROFILE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Profile CXX Flags")
+ SET(PHYSX_CXX_FLAGS_RELEASE "/Ox ${WINCRT_NDEBUG} /Zi" CACHE INTERNAL "PhysX Release CXX Flags")
++endif()
  
  # cache lib type defs
  IF(PX_GENERATE_STATIC_LIBRARIES)	

--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -79,9 +79,6 @@ else()
     list(APPEND OPTIONS "-DPX_OUTPUT_ARCH=x86")
 endif()
 
-# Replicate PhysX's CXX Flags here so we don't have to patch out /WX and -Wall
-list(APPEND OPTIONS "-DPHYSX_CXX_FLAGS:INTERNAL=${VCPKG_CXX_FLAGS}")
-
 vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}/physx/compiler/public"
     PREFER_NINJA

--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         msvc_142_bug_workaround.patch
         vs16_3_typeinfo_header_fix.patch
         fix_discarded_qualifiers.patch
+        fix-compiler-flag.patch
 )
 
 if(NOT DEFINED RELEASE_CONFIGURATION)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4518,7 +4518,7 @@
     },
     "physx": {
       "baseline": "4.1.1",
-      "port-version": 6
+      "port-version": 7
     },
     "picojson": {
       "baseline": "1.3.0-1",

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75090b4c055d1ddfb5a9e5663aa569ec7289f54c",
+      "git-tree": "61c80fbae2a59a689ceb9774b288dc6ffbdceac4",
       "version-string": "4.1.1",
       "port-version": 7
     },

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "44b0612e4b1e890e135a201e35c78a7d83dab1c1",
+      "version-string": "4.1.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "ff229b023b059806554bb8d9e6fbc2b4eb0fe139",
       "version-string": "4.1.1",
       "port-version": 6

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44b0612e4b1e890e135a201e35c78a7d83dab1c1",
+      "git-tree": "75090b4c055d1ddfb5a9e5663aa569ec7289f54c",
       "version-string": "4.1.1",
       "port-version": 7
     },


### PR DESCRIPTION
When building windows-static, we should always use Z7 to embed debugging information in the static library.

Related: #15929.