### PR TITLE
[libjpeg-turbo] update to 2.0.6

### DIFF
--- a/ports/libjpeg-turbo/CONTROL
+++ b/ports/libjpeg-turbo/CONTROL
@@ -1,6 +1,5 @@
 Source: libjpeg-turbo
-Version: 2.0.5
-Port-Version: 4
+Version: 2.0.6
 Homepage: https://github.com/libjpeg-turbo/libjpeg-turbo
 Description: libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, NEON, AltiVec) to accelerate baseline JPEG compression and decompression on x86, x86-64, ARM, and PowerPC systems.
 

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libjpeg-turbo/libjpeg-turbo
-    REF ae87a958613b69628b92088b313ded0d4f59a716 # 2.0.5
-    SHA512 25e8857a3542cc74c48775959f11811529fe6a853990cb285f91a6218c1cde5dd1e58043208e81709fb7a71c376396b2de1f20b53b2c5b8595ca097fa02992fd
+    REF 10ba6ed3365615ed5c2995fe2d240cb2d5000173 # 2.0.6
+    SHA512 219d01907e66dd0fc20ea13cfa51a8efee305810f1245d0648b6ad8ee3cf11bf0bbd43b1ceeeb142a6ebbbfa281ec6a3b4e283b2fc343c360cd3ad29e9d42528
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3045,8 +3045,8 @@
       "port-version": 0
     },
     "libjpeg-turbo": {
-      "baseline": "2.0.5",
-      "port-version": 4
+      "baseline": "2.0.6",
+      "port-version": 0
     },
     "libjuice": {
       "baseline": "0.6.0",

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "42aed1a37d04ecdc437a4f52c6dd71740339f478",
+      "version-string": "2.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "0c5889f679a9404504230cb568df8f1f1263cbba",
       "version-string": "2.0.5",
       "port-version": 4


### PR DESCRIPTION
Fix #15904

Update libjpeg-turbo to the latest version 2.0.6

All features are tested successfully in the following triplets:
- x86-windows
- x64-windows
- x64-windows-static