### PR TITLE
[libgcrypt] Update libgcrypt

### DIFF
--- a/ports/libgcrypt/CONTROL
+++ b/ports/libgcrypt/CONTROL
@@ -1,5 +1,5 @@
 Source: libgcrypt
-Version: 1.8.6
+Version: 1.8.7
 Homepage: https://gnupg.org/software/libgcrypt/index.html
 Description: A library implementing the so-called Assuan protocol
 Build-Depends: libgpg-error

--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports unix platform" 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gpg/libgcrypt
-    REF libgcrypt-1.8.6
-    SHA512 85005b159048b7b47b3fc77e8be5b5b317b1ae73ef536d4e2d78496763b7b8c4f80c70016ed27fc60e998cbc7642d3cf487bd4c5e5a5d8abc8f8d51e02f330d1
+    REF libgcrypt-1.8.7
+    SHA512 43e50a1b8a3cdbf420171c785fe558f443b414b708defa585277ac5ea59f9d8ae7f4555ed291c16fa004e7d4dd93a5ab2011c3c591e784ce3c6662a3193fd3e1
     HEAD_REF master
     PATCHES
         fix-pkgconfig.patch

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2957,7 +2957,7 @@
       "port-version": 0
     },
     "libgcrypt": {
-      "baseline": "1.8.6",
+      "baseline": "1.8.7",
       "port-version": 0
     },
     "libgd": {

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a7be352162b1187194ba75ff3514361213f77a6",
+      "version-string": "1.8.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "4fd1f0fdf10d205488c813a331b0547e9ab9bbc0",
       "version-string": "1.8.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
Update libgcrypt to 1.8.7
https://github.com/gpg/libgcrypt/blob/libgcrypt-1.8.7/NEWS
Small number of fixes, support opaque mpi.

- Which triplets are supported/not supported? Have you updated the CI baseline? No change from previous version. CI baseline is updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? I think so.. there's a lot there, so please let me know if I've missed something.
