### PR TITLE
[vcpkg] fix X_VCPKG_APPLOCAL_DEPS_INSTALL

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -526,6 +526,9 @@ function(x_vcpkg_install_local_dependencies)
     if(_VCPKG_TARGET_TRIPLET_PLAT MATCHES "windows|uwp")
         cmake_parse_arguments(PARSE_ARGV 0 __VCPKG_APPINSTALL "" "DESTINATION" "TARGETS")
         _vcpkg_set_powershell_path()
+        if(NOT IS_ABSOLUTE ${__VCPKG_APPINSTALL_DESTINATION})
+            set(__VCPKG_APPINSTALL_DESTINATION "\${CMAKE_INSTALL_PREFIX}/${__VCPKG_APPINSTALL_DESTINATION}")
+        endif()
         foreach(TARGET IN LISTS __VCPKG_APPINSTALL_TARGETS)
             get_target_property(TARGETTYPE ${TARGET} TYPE)
             if(NOT TARGETTYPE STREQUAL "INTERFACE_LIBRARY")
@@ -535,7 +538,7 @@ function(x_vcpkg_install_local_dependencies)
                 endif()
                 install(CODE "message(\"-- Installing app dependencies for ${TARGET}...\")
                     execute_process(COMMAND \"${_VCPKG_POWERSHELL_PATH}\" -noprofile -executionpolicy Bypass -file \"${_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
-                        -targetBinary \"\${CMAKE_INSTALL_PREFIX}/${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
+                        -targetBinary \"${__VCPKG_APPINSTALL_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
                         -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
                         -OutVariable out)")
             endif()

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -553,7 +553,7 @@ if(X_VCPKG_APPLOCAL_DEPS_INSTALL)
             set(PARSED_TARGETS "")
 
             # Destination - [RUNTIME] DESTINATION argument overrides this
-            set(DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+            set(DESTINATION "bin")
 
             # Parse arguments given to the install function to find targets and (runtime) destination
             set(MODIFIER "") # Modifier for the command in the argument


### PR DESCRIPTION
**Describe the pull request**
This pull request fixes applocal.ps1 getting invoked with double `CMAKE_INSTALL_PREFIX` in install targets when `X_VCPKG_APPLOCAL_DEPS_INSTALL` is enabled:
```
C:/Users/David/Documents/hello/build/cmake_install.cmake(49):  message(-- Installing app dependencies for hello... )
-- Installing app dependencies for hello...
C:/Users/David/Documents/hello/build/cmake_install.cmake(50):  execute_process(COMMAND C:/Program Files/WindowsApps/Microsoft.PowerShell_7.1.1.0_x64__8wekyb3d8bbwe/pwsh.exe -noprofile -executionpolicy Bypass -file C:/Users/David/AppData/Local/Programs/vcpkg/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary ${CMAKE_INSTALL_PREFIX}/C:/Program Files (x86)/Hello/bin/hello.exe -installedDir C:/Users/David/Documents/hello/build/vcpkg_installed/x64-windows/debug/bin -OutVariable out )
```
