### PR TITLE
[magic-enum] Update to v0.7.2

### DIFF
--- a/ports/magic-enum/CONTROL
+++ b/ports/magic-enum/CONTROL
@@ -1,4 +1,4 @@
 Source: magic-enum
-Version: 0.7.1
+Version: 0.7.2
 Description: Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.
 Homepage: https://github.com/Neargye/magic_enum

--- a/ports/magic-enum/portfile.cmake
+++ b/ports/magic-enum/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Neargye/magic_enum
-    REF v0.7.1
-    SHA512 0eff2901d9829289fa36811fd428a9a6b66d6b88971948a385c9e74e5bbe3f52f4b80321c96a4d002bfe2c9b3d45e9bae8fbe17d718643fa318ab845b887be09
+    REF v0.7.2
+    SHA512 53991ccc890548a81a410e274ec2deaf0f153ec15d154ac802452235dc5b913b56da64fddc6aeed9882206fd2abe7250423d36f5e72bdba54b622b8dfdfa9dad
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3609,7 +3609,7 @@
       "port-version": 0
     },
     "magic-enum": {
-      "baseline": "0.7.1",
+      "baseline": "0.7.2",
       "port-version": 0
     },
     "magic-get": {

--- a/versions/m-/magic-enum.json
+++ b/versions/m-/magic-enum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "237d596c8e4341629912912346075a1d9f65096b",
+      "version-string": "0.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "b216fb15c94a2693a2fe1f7fa350a8f13d11f53f",
       "version-string": "0.7.1",
       "port-version": 0


### PR DESCRIPTION
Update magic-enum to v0.7.2

Changelog:
https://github.com/Neargye/magic_enum/releases/tag/v0.7.2