### PR TITLE
[libebur128] add new port with version 1.2.5

### DIFF
--- a/ports/libebur128/portfile.cmake
+++ b/ports/libebur128/portfile.cmake
@@ -1,0 +1,20 @@
+if((VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64") AND VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "${PORT} does not support Windows ARM")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jiixyj/libebur128
+    REF v1.2.5
+    SHA512 5f53c64f47bbad224840eef978bbc357f3fab091ef45f849749e5fabba0035d074451bc6e60240d3ff2c56b96faaf66fb91f32f96dcaacd9d81d3c148688c2f7
+)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DENABLE_INTERNAL_QUEUE_H=ON
+)
+vcpkg_install_cmake()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libebur128/vcpkg.json
+++ b/ports/libebur128/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libebur128",
+  "version-string": "1.2.5",
+  "description": "A library implementing the EBU R128 audio loudness standard",
+  "homepage": "https://github.com/jiixyj/libebur128",
+  "license": "MIT",
+  "supports": "!(arm & windows)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2912,6 +2912,10 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
+    "libebur128": {
+      "baseline": "1.2.5",
+      "port-version": 0
+    },
     "libepoxy": {
       "baseline": "1.5.5",
       "port-version": 0

--- a/versions/l-/libebur128.json
+++ b/versions/l-/libebur128.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9bfff5d49e34c3ff392662fca4b0ab398a4148b3",
+      "version-string": "1.2.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- What does your PR fix?
Adding port for [libebur128](https://github.com/jiixyj/libebur128)

- Which triplets are supported/not supported? Have you updated the CI baseline?
all except Windows ARM

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes