### PR TITLE
[functions-framework-cpp] add new port with version 0.3.0

### DIFF
--- a/ports/functions-framework-cpp/portfile.cmake
+++ b/ports/functions-framework-cpp/portfile.cmake
@@ -1,3 +1,6 @@
+# TODO(coryan) - fix support for DLLs
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GoogleCloudPlatform/functions-framework-cpp

--- a/ports/functions-framework-cpp/portfile.cmake
+++ b/ports/functions-framework-cpp/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GoogleCloudPlatform/functions-framework-cpp
+    REF v0.3.0
+    SHA512 28594c275b7ac85ccbdcd9a1ab8e3a7c26932006f0da6ede4aab29f303305536b111cbcf99e9f8558f71f56876bc3e3b790f0627bd708ec9b09999f27ef37f3b
+    HEAD_REF main
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(
+    INSTALL ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+    RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "functions-framework-cpp",
+  "version-string": "0.3.0",
+  "description": "Functions Framework for C++.",
+  "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
+  "dependencies": [
+    "abseil",
+    "boost-beast",
+    "boost-program-options",
+    "boost-serialization",
+    "nlohmann-json"
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -336,6 +336,8 @@ fribidi:arm64-windows=fail
 fribidi:arm-uwp=fail
 fribidi:x64-uwp=fail
 ftgl:x64-uwp=fail
+# https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/207
+functions-framework-cpp:x64-uwp=fail
 fuzzylite:arm-uwp=fail
 fuzzylite:x64-linux=fail
 fuzzylite:x64-osx=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -336,12 +336,6 @@ fribidi:arm64-windows=fail
 fribidi:arm-uwp=fail
 fribidi:x64-uwp=fail
 ftgl:x64-uwp=fail
-# https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/207
-functions-framework-cpp:x64-uwp=fail
-# https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/208
-functions-framework-cpp:arm64-windows=fail
-functions-framework-cpp:x64-windows=fail
-functions-framework-cpp:x86-windows=fail
 fuzzylite:arm-uwp=fail
 fuzzylite:x64-linux=fail
 fuzzylite:x64-osx=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -336,6 +336,12 @@ fribidi:arm64-windows=fail
 fribidi:arm-uwp=fail
 fribidi:x64-uwp=fail
 ftgl:x64-uwp=fail
+# https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/207
+functions-framework-cpp:x64-uwp=fail
+# https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/208
+functions-framework-cpp:arm64-windows=fail
+functions-framework-cpp:x64-windows=fail
+functions-framework-cpp:x86-windows=fail
 fuzzylite:arm-uwp=fail
 fuzzylite:x64-linux=fail
 fuzzylite:x64-osx=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2036,6 +2036,10 @@
       "baseline": "4.1.0",
       "port-version": 0
     },
+    "functions-framework-cpp": {
+      "baseline": "0.3.0",
+      "port-version": 0
+    },
     "fuzzylite": {
       "baseline": "6.0",
       "port-version": 3

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "446ad258643bda063c56f6ec28fa157f00e8b132",
+      "git-tree": "35de9501f7e2c91bb35da41cffac790008330a3c",
       "version-string": "0.3.0",
       "port-version": 0
     }

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "446ad258643bda063c56f6ec28fa157f00e8b132",
+      "version-string": "0.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- What does your PR fix?

Add a new port [functions-framework-cpp](https://github.com/GoogleCloudPlatform/functions-framework-cpp)

- Which triplets are supported/not supported? Have you updated the CI baseline?

I updated the baseline, and opened bugs to fix the non-static windows and UWP builds in a future version of this library

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
