### PR TITLE
[libdjinterop] add new port with version 0.14.6

### DIFF
--- a/ports/libdjinterop/portfile.cmake
+++ b/ports/libdjinterop/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xsco/libdjinterop
+    REF 0.14.6
+    SHA512 3d05bc882ddc309a1b0d5e97572ede1aa826b662a19ffd8ee874c13ead668d1c3f14d59bf861ae3880588e1a9b94e4a92ccdbb5df71bfb7ffe28f57a1b123f18
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libdjinterop/vcpkg.json
+++ b/ports/libdjinterop/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libdjinterop",
+  "version-string": "0.14.6",
+  "description": "C++ library for access to DJ record libraries. Currently only supports Denon Engine Prime databases",
+  "homepage": "https://github.com/xsco/libdjinterop",
+  "license": "LGPL-3.0-or-later",
+  "dependencies": [
+    "sqlite3",
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2908,6 +2908,10 @@
       "baseline": "3.0",
       "port-version": 0
     },
+    "libdjinterop": {
+      "baseline": "0.14.6",
+      "port-version": 0
+    },
     "libdshowcapture": {
       "baseline": "0.6.0-1",
       "port-version": 0

--- a/versions/l-/libdjinterop.json
+++ b/versions/l-/libdjinterop.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f880d97fbd6043537231fcd201e5df71dc8b51f6",
+      "version-string": "0.14.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- What does your PR fix?
Add new port for [libdjinterop](https://github.com/xsco/libdjinterop)

- Which triplets are supported/not supported? Have you updated the CI baseline?
all

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes