### PR TITLE
[libid3tag] add new port with version 0.15.1b

### DIFF
--- a/ports/libid3tag/10_utf16.diff
+++ b/ports/libid3tag/10_utf16.diff
@@ -1,0 +1,48 @@
+#! /bin/sh -e
+## 10_utf16.dpatch by  <kurt@roeckx.be>
+##
+## All lines beginning with `## DP:' are a description of the patch.
+## DP: Handle bogus UTF16 sequences that have a length that is not
+## DP: an even number of 8 bit characters.
+
+if [ $# -lt 1 ]; then
+    echo "`basename $0`: script expects -patch|-unpatch as argument" >&2
+    exit 1
+fi
+
+[ -f debian/patches/00patch-opts ] && . debian/patches/00patch-opts
+patch_opts="${patch_opts:--f --no-backup-if-mismatch} ${2:+-d $2}"
+
+case "$1" in
+    -patch) patch -p1 ${patch_opts} < $0;;
+    -unpatch) patch -R -p1 ${patch_opts} < $0;;
+    *)
+        echo "`basename $0`: script expects -patch|-unpatch as argument" >&2
+        exit 1;;
+esac
+
+exit 0
+
+@DPATCH@
+diff -urNad utf16.c utf16.c
+--- utf16.c	2006-01-13 15:26:29.000000000 +0100
++++ utf16.c	2006-01-13 15:27:19.000000000 +0100
+@@ -282,5 +282,18 @@
+ 
+   free(utf16);
+ 
++  if (end == *ptr && length % 2 != 0)
++  {
++     /* We were called with a bogus length.  It should always
++      * be an even number.  We can deal with this in a few ways:
++      * - Always give an error.
++      * - Try and parse as much as we can and
++      *   - return an error if we're called again when we
++      *     already tried to parse everything we can.
++      *   - tell that we parsed it, which is what we do here.
++      */
++     (*ptr)++;
++  }
++
+   return ucs4;
+ }

--- a/ports/libid3tag/11_unknown_encoding.diff
+++ b/ports/libid3tag/11_unknown_encoding.diff
@@ -1,0 +1,37 @@
+#! /bin/sh /usr/share/dpatch/dpatch-run
+## 11_unknown_encoding.dpatch by Andreas Henriksson <andreas@fatal.se>
+##
+## All lines beginning with `## DP:' are a description of the patch.
+## DP: In case of an unknown/invalid encoding, id3_parse_string() will
+## DP: return NULL, but the return value wasn't checked resulting
+## DP: in segfault in id3_ucs4_length().  This is the only place
+## DP: the return value wasn't checked.
+
+@DPATCH@
+diff -urNad compat.gperf compat.gperf
+--- compat.gperf	2004-01-23 09:41:32.000000000 +0000
++++ compat.gperf	2007-01-14 14:36:53.000000000 +0000
+@@ -236,6 +236,10 @@
+ 
+     encoding = id3_parse_uint(&data, 1);
+     string   = id3_parse_string(&data, end - data, encoding, 0);
++    if (!string)
++    {
++	continue;
++    }
+ 
+     if (id3_ucs4_length(string) < 4) {
+       free(string);
+diff -urNad parse.c parse.c
+--- parse.c	2004-01-23 09:41:32.000000000 +0000
++++ parse.c	2007-01-14 14:37:34.000000000 +0000
+@@ -165,6 +165,9 @@
+   case ID3_FIELD_TEXTENCODING_UTF_8:
+     ucs4 = id3_utf8_deserialize(ptr, length);
+     break;
++  default:
++  	/* FIXME: Unknown encoding! Print warning? */
++	return NULL;
+   }
+ 
+   if (ucs4 && !full) {

--- a/ports/libid3tag/CMakeLists.txt
+++ b/ports/libid3tag/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.1.0)
+project(id3tag VERSION 0.15.1)
+
+option(BUILD_SHARED_LIBS "Build dynamic library" ON)
+
+include(GNUInstallDirs)
+
+#
+# Build
+#
+
+add_library(id3tag
+    compat.c
+    crc.c
+    debug.c
+    field.c
+    file.c
+    frame.c
+    frametype.c
+    genre.c
+    latin1.c
+    parse.c
+    render.c
+    tag.c
+    ucs4.c
+    utf16.c
+    utf8.c
+    util.c
+    version.c
+)
+target_include_directories(id3tag PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+if(UNIX)
+    target_compile_definitions(id3tag PRIVATE HAVE_UNISTD_H=1)
+endif()
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set_target_properties(id3tag PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+find_package(ZLIB REQUIRED)
+target_link_libraries(id3tag PRIVATE ZLIB::ZLIB)
+
+#
+# Installation
+#
+
+include(CMakePackageConfigHelpers)
+
+# Library files
+install(TARGETS id3tag
+  EXPORT id3tagTargets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+# Header files
+install(
+  FILES "${CMAKE_CURRENT_SOURCE_DIR}/id3tag.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+# CMake config
+set(ID3TAG_INSTALL_CMAKEDIR "lib/cmake/id3tag")
+install(
+  EXPORT id3tagTargets
+  FILE id3tagTargets.cmake
+  NAMESPACE id3tag::
+  DESTINATION "${ID3TAG_INSTALL_CMAKEDIR}"
+)
+configure_package_config_file(id3tagConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/id3tagConfig.cmake"
+  INSTALL_DESTINATION "${ID3TAG_INSTALL_CMAKEDIR}"
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/id3tagConfigVersion.cmake"
+  VERSION "${CMAKE_PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion
+)
+install(
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/id3tagConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/id3tagConfigVersion.cmake"
+  DESTINATION "${ID3TAG_INSTALL_CMAKEDIR}"
+)

--- a/ports/libid3tag/CVE-2008-2109.patch
+++ b/ports/libid3tag/CVE-2008-2109.patch
@@ -1,0 +1,11 @@
+--- field.c.orig	2008-05-05 09:49:15.000000000 -0400
++++ field.c	2008-05-05 09:49:25.000000000 -0400
+@@ -291,7 +291,7 @@
+ 
+       end = *ptr + length;
+ 
+-      while (end - *ptr > 0) {
++      while (end - *ptr > 0 && **ptr != '\0') {
+ 	ucs4 = id3_parse_string(ptr, end - *ptr, *encoding, 0);
+ 	if (ucs4 == 0)
+ 	  goto fail;

--- a/ports/libid3tag/id3tagConfig.cmake.in
+++ b/ports/libid3tag/id3tagConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/id3tagTargets.cmake")
+
+check_required_components(id3tag)

--- a/ports/libid3tag/portfile.cmake
+++ b/ports/libid3tag/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_fail_port_install(ON_TARGET "uwp")
+if((VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64") AND VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "${PORT} does not support Windows ARM")
+endif()
+
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mad/libid3tag
+    REF 0.15.1b
+    FILENAME libid3tag-0.15.1b.tar.gz
+    SHA512 ade7ce2a43c3646b4c9fdc642095174b9d4938b078b205cd40906d525acd17e87ad76064054a961f391edcba6495441450af2f68be69f116549ca666b069e6d3
+    PATCHES
+        10_utf16.diff
+        11_unknown_encoding.diff
+        CVE-2008-2109.patch
+)
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${SOURCE_PATH}/CMakeLists.txt" COPYONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/id3tagConfig.cmake.in" "${SOURCE_PATH}/id3tagConfig.cmake.in" COPYONLY)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/id3tag TARGET_PATH share/id3tag)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libid3tag/vcpkg.json
+++ b/ports/libid3tag/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libid3tag",
+  "version-string": "0.15.1b",
+  "description": "ID3 tag manipulation library",
+  "homepage": "https://www.underbit.com/products/mad/",
+  "license": "GPL-2.0-or-later",
+  "supports": "!(arm & windows) & !uwp",
+  "dependencies": [
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3020,6 +3020,10 @@
       "baseline": "1.6.4",
       "port-version": 0
     },
+    "libid3tag": {
+      "baseline": "0.15.1b",
+      "port-version": 0
+    },
     "libideviceactivation": {
       "baseline": "1.2.235",
       "port-version": 0

--- a/versions/l-/libid3tag.json
+++ b/versions/l-/libid3tag.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3794939f2cffcee91c3d42e82aa65463b0b6563d",
+      "version-string": "0.15.1b",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- What does your PR fix?
Add new port for [libid3tag](https://www.underbit.com/products/mad/)

- Which triplets are supported/not supported? Have you updated the CI baseline?
all except Windows ARM and UWP

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes