### PR TITLE
[date] Fix vcpkg_fixup_cmake_targets for mingw

### DIFF
--- a/ports/date/CONTROL
+++ b/ports/date/CONTROL
@@ -1,6 +1,6 @@
 Source: date
 Version: 3.0.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/HowardHinnant/date
 Description: A date and time library based on the C++17 <chrono> header
 

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
+if(VCPKG_TARGET_IS_WINDOWS)
   vcpkg_fixup_cmake_targets(CONFIG_PATH CMake TARGET_PATH share/date)
 else()
   vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/date TARGET_PATH share/date)

--- a/ports/date/portfile.cmake
+++ b/ports/date/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "MinGW")
   vcpkg_fixup_cmake_targets(CONFIG_PATH CMake TARGET_PATH share/date)
 else()
   vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/date TARGET_PATH share/date)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1530,7 +1530,7 @@
     },
     "date": {
       "baseline": "3.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "dav1d": {
       "baseline": "0.8.1",

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1bba93caf610b4684625beadedd56be6928d371a",
+      "git-tree": "6223ca4908ce9896c0d17ac21dac600e7f4d54e1",
       "version-string": "3.0.0",
       "port-version": 2
     },

--- a/versions/d-/date.json
+++ b/versions/d-/date.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1bba93caf610b4684625beadedd56be6928d371a",
+      "version-string": "3.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "42976b85736114e38204b7d8cd5ea5e74a73c7cd",
       "version-string": "3.0.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
Make `vcpkg_fixup_cmake_targets` point to the correct folder for mingw
- Which triplets are supported/not supported? Have you updated the CI baseline?
All mingw triplets. CI baseline updated.
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes