### PR TITLE
[libpqxx] Fix build with Visual Studio 2017

### DIFF
--- a/ports/libpqxx/CONTROL
+++ b/ports/libpqxx/CONTROL
@@ -1,5 +1,6 @@
 Source: libpqxx
 Version: 7.3.1
+Port-Version: 1
 Homepage: https://github.com/jtv/libpqxx
 Description: The official C++ client API for PostgreSQL
 Build-Depends: libpq[core]

--- a/ports/libpqxx/fix-build-with-vs2017.patch
+++ b/ports/libpqxx/fix-build-with-vs2017.patch
@@ -1,0 +1,275 @@
+diff --git a/include/pqxx/binarystring.hxx b/include/pqxx/binarystring.hxx
+index 780cd6e..50865d3 100644
+--- a/include/pqxx/binarystring.hxx
++++ b/include/pqxx/binarystring.hxx
+@@ -65,31 +65,31 @@ public:
+   using const_iterator = const_pointer;
+   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+ 
+-  [[deprecated("Use std::byte for binary data.")]] binarystring(
+-    binarystring const &) = default;
++  PQXX_DEPRECATED("Use std::byte for binary data.")
++  binarystring(binarystring const &) = default;
+ 
+   /// Read and unescape bytea field.
+   /** The field will be zero-terminated, even if the original bytea field
+    * isn't.
+    * @param F the field to read; must be a bytea field
+    */
+-  [[deprecated("Use std::byte for binary data.")]] explicit binarystring(
+-    field const &);
++  PQXX_DEPRECATED("Use std::byte for binary data.")
++  explicit binarystring(field const &);
+ 
+   /// Copy binary data from std::string_view on binary data.
+   /** This is inefficient in that it copies the data to a buffer allocated on
+    * the heap.
+    */
+-  [[deprecated("Use std::byte for binary data.")]] explicit binarystring(
+-    std::string_view);
++  PQXX_DEPRECATED("Use std::byte for binary data.")
++  explicit binarystring(std::string_view);
+ 
+   /// Copy binary data of given length straight out of memory.
+-  [[deprecated("Use std::byte for binary data.")]] binarystring(
+-    void const *, std::size_t);
++  PQXX_DEPRECATED("Use std::byte for binary data.")
++  binarystring(void const *, std::size_t);
+ 
+   /// Efficiently wrap a buffer of binary data in a @c binarystring.
+-  [[deprecated("Use std::byte for binary data.")]] binarystring(
+-    std::shared_ptr<value_type> ptr, size_type size) :
++  PQXX_DEPRECATED("Use std::byte for binary data.")
++  binarystring(std::shared_ptr<value_type> ptr, size_type size) :
+           m_buf{std::move(ptr)}, m_size{size}
+   {}
+ 
+diff --git a/include/pqxx/compiler-public.hxx b/include/pqxx/compiler-public.hxx
+index 08d7ac9..8f01755 100644
+--- a/include/pqxx/compiler-public.hxx
++++ b/include/pqxx/compiler-public.hxx
+@@ -43,6 +43,11 @@
+ // Workarounds for Microsoft Visual C++
+ #  ifdef _MSC_VER
+ 
++// Workarounds for deprecated attribute syntax error in Visual Studio 2017.
++#    if _MSC_VER < 1920
++#      define PQXX_DEPRECATED(MESSAGE) __declspec(deprecated(#      MESSAGE))
++#    endif
++
+ // Suppress vtables on abstract classes.
+ #    define PQXX_NOVTABLE __declspec(novtable)
+ 
+@@ -112,4 +117,8 @@
+ #  define PQXX_NOVTABLE
+ #endif
+ 
++#ifndef PQXX_DEPRECATED
++#  define PQXX_DEPRECATED(MESSAGE) [[deprecated(#  MESSAGE)]]
++#endif
++
+ #endif
+diff --git a/include/pqxx/largeobject.hxx b/include/pqxx/largeobject.hxx
+index 072a490..40ab51b 100644
+--- a/include/pqxx/largeobject.hxx
++++ b/include/pqxx/largeobject.hxx
+@@ -36,20 +36,20 @@ public:
+ 
+   /// Refer to a nonexistent large object (similar to what a null pointer
+   /// does).
+-  [[deprecated("Use blob instead.")]] largeobject() noexcept = default;
++  PQXX_DEPRECATED("Use blob instead.") largeobject() noexcept = default;
+ 
+   /// Create new large object.
+   /** @param t Backend transaction in which the object is to be created.
+    */
+-  [[deprecated("Use blob instead.")]] explicit largeobject(dbtransaction &t);
++  PQXX_DEPRECATED("Use blob instead.") explicit largeobject(dbtransaction &t);
+ 
+   /// Wrap object with given oid.
+   /** Convert combination of a transaction and object identifier into a
+    * large object identity.  Does not affect the database.
+    * @param o Object identifier for the given object.
+    */
+-  [[deprecated("Use blob instead.")]] explicit largeobject(oid o) noexcept :
+-          m_id{o}
++  PQXX_DEPRECATED("Use blob instead.")
++  explicit largeobject(oid o) noexcept : m_id{o}
+   {}
+ 
+   /// Import large object from a local file.
+@@ -57,16 +57,16 @@ public:
+    * @param t Backend transaction in which the large object is to be created.
+    * @param file A filename on the client program's filesystem.
+    */
+-  [[deprecated("Use blob instead.")]] largeobject(
+-    dbtransaction &t, std::string_view file);
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobject(dbtransaction &t, std::string_view file);
+ 
+   /// Take identity of an opened large object.
+   /** Copy identity of already opened large object.  Note that this may be done
+    * as an implicit conversion.
+    * @param o Already opened large object to copy identity from.
+    */
+-  [[deprecated("Use blob instead.")]] largeobject(
+-    largeobjectaccess const &o) noexcept;
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobject(largeobjectaccess const &o) noexcept;
+ 
+   /// Object identifier.
+   /** The number returned by this function identifies the large object in the
+@@ -179,8 +179,8 @@ public:
+    * @param mode Access mode, defaults to ios_base::in | ios_base::out |
+    * ios_base::binary.
+    */
+-  [[deprecated("Use blob instead.")]] explicit largeobjectaccess(
+-    dbtransaction &t, openmode mode = default_mode);
++  PQXX_DEPRECATED("Use blob instead.")
++  explicit largeobjectaccess(dbtransaction &t, openmode mode = default_mode);
+ 
+   /// Open large object with given oid.
+   /** Convert combination of a transaction and object identifier into a
+@@ -190,8 +190,8 @@ public:
+    * @param mode Access mode, defaults to ios_base::in | ios_base::out |
+    * ios_base::binary.
+    */
+-  [[deprecated("Use blob instead.")]] largeobjectaccess(
+-    dbtransaction &t, oid o, openmode mode = default_mode);
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobjectaccess(dbtransaction &t, oid o, openmode mode = default_mode);
+ 
+   /// Open given large object.
+   /** Open a large object with the given identity for reading and/or writing.
+@@ -200,7 +200,8 @@ public:
+    * @param mode Access mode, defaults to ios_base::in | ios_base::out |
+    * ios_base::binary.
+    */
+-  [[deprecated("Use blob instead.")]] largeobjectaccess(
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobjectaccess(
+     dbtransaction &t, largeobject o, openmode mode = default_mode);
+ 
+   /// Import large object from a local file and open it.
+@@ -209,7 +210,8 @@ public:
+    * @param file A filename on the client program's filesystem.
+    * @param mode Access mode, defaults to ios_base::in | ios_base::out.
+    */
+-  [[deprecated("Use blob instead.")]] largeobjectaccess(
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobjectaccess(
+     dbtransaction &t, std::string_view file, openmode mode = default_mode);
+ 
+   ~largeobjectaccess() noexcept { close(); }
+@@ -386,7 +388,8 @@ public:
+   static constexpr auto default_mode{
+     std::ios::in | std::ios::out | std::ios::binary};
+ 
+-  [[deprecated("Use blob instead.")]] largeobject_streambuf(
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobject_streambuf(
+     dbtransaction &t, largeobject o, openmode mode = default_mode,
+     size_type buf_size = 512) :
+           m_bufsize{buf_size}, m_obj{t, o, mode}, m_g{nullptr}, m_p{nullptr}
+@@ -394,7 +397,8 @@ public:
+     initialize(mode);
+   }
+ 
+-  [[deprecated("Use blob instead.")]] largeobject_streambuf(
++  PQXX_DEPRECATED("Use blob instead.")
++  largeobject_streambuf(
+     dbtransaction &t, oid o, openmode mode = default_mode,
+     size_type buf_size = 512) :
+           m_bufsize{buf_size}, m_obj{t, o, mode}, m_g{nullptr}, m_p{nullptr}
+@@ -556,7 +560,8 @@ public:
+    * @param o Large object to access.
+    * @param buf_size Size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_ilostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_ilostream(
+     dbtransaction &t, largeobject o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{t, o, std::ios::in | std::ios::binary, buf_size}
+@@ -570,7 +575,8 @@ public:
+    * @param o Identifier of a large object to access.
+    * @param buf_size Size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_ilostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_ilostream(
+     dbtransaction &t, oid o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{t, o, std::ios::in | std::ios::binary, buf_size}
+@@ -612,7 +618,8 @@ public:
+    * @param o a large object to access.
+    * @param buf_size size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_olostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_olostream(
+     dbtransaction &t, largeobject o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{t, o, std::ios::out | std::ios::binary, buf_size}
+@@ -626,7 +633,8 @@ public:
+    * @param o a large object to access.
+    * @param buf_size size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_olostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_olostream(
+     dbtransaction &t, oid o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{t, o, std::ios::out | std::ios::binary, buf_size}
+@@ -682,7 +690,8 @@ public:
+    * @param o Large object to access.
+    * @param buf_size Size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_lostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_lostream(
+     dbtransaction &t, largeobject o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{
+@@ -697,7 +706,8 @@ public:
+    * @param o Large object to access.
+    * @param buf_size Size of buffer to use internally (optional).
+    */
+-  [[deprecated("Use blob instead.")]] basic_lostream(
++  PQXX_DEPRECATED("Use blob instead.")
++  basic_lostream(
+     dbtransaction &t, oid o, largeobject::size_type buf_size = 512) :
+           super{nullptr},
+           m_buf{
+diff --git a/include/pqxx/stream_from.hxx b/include/pqxx/stream_from.hxx
+index 7d05966..2e484bb 100644
+--- a/include/pqxx/stream_from.hxx
++++ b/include/pqxx/stream_from.hxx
+@@ -128,21 +128,23 @@ public:
+     Columns const &columns);
+ 
+   /// @deprecated Use the @c from_table_t overload instead.
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
+-    transaction_base &tx, std::string_view table) :
++  PQXX_DEPRECATED("Use the from_table_t overload instead.")
++  stream_from(transaction_base &tx, std::string_view table) :
+           stream_from{tx, from_table, table}
+   {}
+ 
+   /// @deprecated Use the @c from_table_t overload instead.
+   template<typename Columns>
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
++  PQXX_DEPRECATED("Use the from_table_t overload instead.")
++  stream_from(
+     transaction_base &tx, std::string_view table, Columns const &columns) :
+           stream_from{tx, from_table, table, columns}
+   {}
+ 
+   /// @deprecated Use the @c from_table_t overload instead.
+   template<typename Iter>
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
++  PQXX_DEPRECATED("Use the from_table_t overload instead.")
++  stream_from(
+     transaction_base &, std::string_view table, Iter columns_begin,
+     Iter columns_end);
+   //@}

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 9e55cea0116febb5c536ed18ede9a7b2c647e631 # 7.3.1
     SHA512 22da46c1c4ef798e7aa2db4f5094f8d4c3a965d755ae72a1cfae6282264c0d974317849f8db0bf34ff6aebd1ede5e5086cf74bff8bc3c6a21b3149a94d30c04f
     HEAD_REF master
+    PATCHES
+        fix-build-with-vs2017.patch #https://github.com/jtv/libpqxx/pull/406
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/config-public-compiler.h.in DESTINATION ${SOURCE_PATH})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3242,7 +3242,7 @@
     },
     "libpqxx": {
       "baseline": "7.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.0",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac2255ecfdb7a6d5b6307413f181117d005a4989",
+      "version-string": "7.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "66295fd2998b54f3f4fd43702c0f402fef16fccd",
       "version-string": "7.3.1",
       "port-version": 0


### PR DESCRIPTION
```
C:\dev\vcpkg\buildtrees\libpqxx\src\b2c647e631-5d91723e5b.clean\include\pqxx/stream_from.hxx(138): error C2061: syntax error: identifier 'stream_from'
C:\dev\vcpkg\buildtrees\libpqxx\src\b2c647e631-5d91723e5b.clean\include\pqxx/stream_from.hxx(139): error C2334: unexpected token(s) preceding ':'; skipping apparent function body
C:\dev\vcpkg\buildtrees\libpqxx\src\b2c647e631-5d91723e5b.clean\include\pqxx/stream_from.hxx(264): error C2039: '>>': is not a member of 'pqxx::stream_from'
```

This issue was fixed in the upstream, use official patch https://github.com/jtv/libpqxx/pull/406.

Fixes #15979.