### PR TITLE
[google-cloud-cpp] update to the latest release (v1.24.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.23.0
-    SHA512 66c8bc6a878dbe23be0dd8fbe2580b725a2e5dab1b132a53f3454a32ec0cce706bdeae8b08b1922acc892f7983df5bc076e3d16993d5d0c1bda75e8a1195c882
+    REF v1.24.0
+    SHA512 06d53c1599ad60d5ec201f4fc9526f1bae6aee3c776423b9072c07030c840fb808c4e983b83ca58b7899f56e648b4a73846c8ecad0238e513979964f2d28d072
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version-string": "1.23.0",
+  "version-string": "1.24.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2213,7 +2213,7 @@
       "port-version": 3
     },
     "google-cloud-cpp": {
-      "baseline": "1.23.0",
+      "baseline": "1.24.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39f9bad63d71830d31bd827577e3c37621653d5e",
+      "version-string": "1.24.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ab2377218e8992e8aedf8fed757edb90cc390817",
       "version-string": "1.23.0",
       "port-version": 0


### PR DESCRIPTION
Upgrades `google-cloud-cpp` to the latest release (v1.24.0)

- What does your PR fix? Fixes #

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

I think so, still learning about the new `x-add-version` command.
