### PR TITLE
[fdk-aac] make patent-encumbered HE-AAC optional

### DIFF
--- a/ports/fdk-aac/portfile.cmake
+++ b/ports/fdk-aac/portfile.cmake
@@ -1,23 +1,36 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
-vcpkg_from_github(
-  OUT_SOURCE_PATH SOURCE_PATH
-  REPO mstorsjo/fdk-aac
-  REF v2.0.2
-  SHA512 616207e85035d1659a2b7808ca6ec02ef53c1c4b39eb280fe861f82a4cf548e5db2ac381c496bad37dfc2b8c6677fe704d9fd8449e43d1f93d3e636239e0191b
-  HEAD_REF master
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES
+    FEATURES
+        he-aac HE_AAC
 )
 
-vcpkg_configure_cmake(
+if(HE_AAC)
+    vcpkg_from_github(
+        REPO mstorsjo/fdk-aac
+        REF v2.0.2
+        SHA512 616207e85035d1659a2b7808ca6ec02ef53c1c4b39eb280fe861f82a4cf548e5db2ac381c496bad37dfc2b8c6677fe704d9fd8449e43d1f93d3e636239e0191b
+        HEAD_REF master
+        OUT_SOURCE_PATH SOURCE_PATH
+    )
+else()
+    vcpkg_from_gitlab(
+        GITLAB_URL https://gitlab.freedesktop.org/
+        REPO wtaymans/fdk-aac-stripped
+        REF 585981a49f2186b0d2e47c64bf6b5abf539395f8 # corresponds to v2.0.2 tag in mstorsjo/fdk-aac GitHub repository
+        HEAD_REF stripped4
+        SHA512 e0e56396ed0be427302ed4b54fc6e8dc522a172c288b7c1ec40cc3a9ceb13518ca7bbb874bc71b88b2a91e0bbbe4ad0bab6910efa1db63d91e6370976641bac4
+        OUT_SOURCE_PATH SOURCE_PATH
+    )
+endif()
+
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS_RELEASE -DBUILD_PROGRAMS=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
-file(INSTALL ${SOURCE_PATH}/NOTICE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(INSTALL "${SOURCE_PATH}/NOTICE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/fdk-aac/vcpkg.json
+++ b/ports/fdk-aac/vcpkg.json
@@ -1,6 +1,22 @@
 {
   "name": "fdk-aac",
   "version-semver": "2.0.2",
-  "description": "A standalone library of the Fraunhofer FDK AAC code",
-  "homepage": "https://github.com/mstorsjo/fdk-aac"
+  "port-version": 1,
+  "description": "A standalone Third-Party Modified Version of the Fraunhofer FDK AAC Codec Library for Android. Uses a fork without HE-AAC, HE-AACv2, or xHE-AAC support to avoid patent licensing and GPL compatibility issues when built without the he-aac option.",
+  "homepage": "https://gitlab.freedesktop.org/wtaymans/fdk-aac-stripped",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "he-aac": {
+      "description": "Support patent-encumbered HE-AAC, HE-AACv2, and xHE-AAC codec profiles. Do not distribute binaries with this option without the relevant patent licenses if you are in a jurisdiction that recognizes software patents. Might not be compatible with the GPL depending on legal interpretation. Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1501522#c112"
+    }
+  }
 }

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 12,
+  "port-version": 13,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -299,9 +299,15 @@
       ]
     },
     "fdk-aac": {
-      "description": "AAC de/encoding via libfdk-aac",
+      "description": "AAC de/encoding via libfdk-aac, **including GPL-incompatible patent-encumbered HE-AAC**. If you do not require HE-AAC, use the built-in FFmpeg AAC codec.",
       "dependencies": [
-        "fdk-aac",
+        {
+          "name": "fdk-aac",
+          "default-features": false,
+          "features": [
+            "he-aac"
+          ]
+        },
         {
           "name": "ffmpeg",
           "default-features": false,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1990,7 +1990,7 @@
     },
     "fdk-aac": {
       "baseline": "2.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "fdlibm": {
       "baseline": "5.3-4",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1998,7 +1998,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 12
+      "port-version": 13
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/fdk-aac.json
+++ b/versions/f-/fdk-aac.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "56f6b0699ef8d63059cd4ecb1bdc7613104d7cf8",
+      "version-semver": "2.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "01ec3a3ac30a2128fb45b82c526e9fcf4d87de9a",
       "version-semver": "2.0.2",
       "port-version": 0

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "26e3d87d6b3049b45355f36a34402b938d5b486d",
+      "version": "4.4",
+      "port-version": 13
+    },
+    {
       "git-tree": "4d910207840ec65730eb972e472dab548fb8b5d2",
       "version": "4.4",
       "port-version": 12


### PR DESCRIPTION
By default, use a fork of fdk-aac (which was originally written
by Fraunhofer for the Android Open Source Project) which has
support for the patent-encumbered HE-AAC, HE-AACv2, and xHE-AAC
profiles removed. This fork is used by Fedora and Arch Linux to
provide support for most AAC use cases without patent licensing
fees and to permit combining it with GPL software. The upstream
fdk-aac with support for all AAC profiles can be built with the
new 'he-aac' option for this port.

Fedora Legal's opinion, from
https://bugzilla.redhat.com/show_bug.cgi?id=1501522#c112 :
The Fedora Project is aware that the Free Software Foundation
has stated that the Fraunhofer FDK AAC license is GPL
incompatible, specifically, because of Clause 3.

We believe that the fdk-aac software codec implementation that we
wish to include in Fedora is no longer encumbered by AAC patents.
This fact means that Clause 3 in the FDK AAC license is a "no op",
or to put it plainly, if no patents are in play, there are no
patent licenses to disclaim. For this (and only this) specific
implementation of fdk-aac, we believe that the FDK AAC license is
GPL compatible.