### PR TITLE
[directxsdk] Update DirectX SDK port

### DIFF
--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -1,6 +1,6 @@
 vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 
-message(WARNING "Build ${PORT} is deprecated, and requires the use of the DirectSetup legacy REDIST solution. See https://aka.ms/dxsdk for more information.")
+message(WARNING "Build ${PORT} is deprecated, untested in CI, and requires the use of the DirectSetup legacy REDIST solution. See https://aka.ms/dxsdk for more information.")
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://archive.org/download/dxsdk_2010/DXSDK_Jun10.exe"

--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -13,7 +13,6 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-
 # See https://walbourn.github.io/the-zombie-directx-sdk/
 set(INC_DIR "${SOURCE_PATH}/Include")
 set(LIB_DIR "${SOURCE_PATH}/Lib/${VCPKG_TARGET_ARCHITECTURE}")

--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -1,7 +1,9 @@
 vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 
+message(WARNING "Build ${PORT} is deprecated, and requires the use of the DirectSetup legacy REDIST solution. See https://aka.ms/dxsdk for more information.")
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.microsoft.com/download/a/e/7/ae743f1f-632b-4809-87a9-aa1bb3458e31/DXSDK_Jun10.exe"
+    URLS "https://archive.org/download/dxsdk_2010/DXSDK_Jun10.exe"
     FILENAME "DXSDK_Jun10.exe"
     SHA512 4869ac947a35cd0d6949fbda17547256ea806fef36f48474dda63651f751583e9902641087250b6e8ccabaab85e51effccd9235dc6cdf64e21ec2b298227fe19
 )
@@ -12,49 +14,136 @@ vcpkg_extract_source_archive_ex(
 )
 
 
+# See https://walbourn.github.io/the-zombie-directx-sdk/
+set(INC_DIR "${SOURCE_PATH}/Include")
 set(LIB_DIR "${SOURCE_PATH}/Lib/${VCPKG_TARGET_ARCHITECTURE}")
+
+set(HEADERS
+    ${INC_DIR}/audiodefs.h
+    ${INC_DIR}/comdecl.h
+    ${INC_DIR}/D3DX10.h
+    ${INC_DIR}/d3dx10async.h
+    ${INC_DIR}/D3DX10core.h
+    ${INC_DIR}/D3DX10math.h
+    ${INC_DIR}/D3DX10math.inl
+    ${INC_DIR}/D3DX10mesh.h
+    ${INC_DIR}/D3DX10tex.h
+    ${INC_DIR}/D3DX11.h
+    ${INC_DIR}/D3DX11async.h
+    ${INC_DIR}/D3DX11core.h
+    ${INC_DIR}/D3DX11tex.h
+    ${INC_DIR}/d3dx9.h
+    ${INC_DIR}/d3dx9anim.h
+    ${INC_DIR}/d3dx9core.h
+    ${INC_DIR}/d3dx9effect.h
+    ${INC_DIR}/d3dx9math.h
+    ${INC_DIR}/d3dx9math.inl
+    ${INC_DIR}/d3dx9mesh.h
+    ${INC_DIR}/d3dx9shader.h
+    ${INC_DIR}/d3dx9shape.h
+    ${INC_DIR}/d3dx9tex.h
+    ${INC_DIR}/d3dx9xof.h
+    ${INC_DIR}/D3DX_DXGIFormatConvert.inl
+    ${INC_DIR}/dsetup.h
+    ${INC_DIR}/dxdiag.h
+    ${INC_DIR}/DxErr.h
+    ${INC_DIR}/dxfile.h
+    ${INC_DIR}/dxsdkver.h
+    ${INC_DIR}/PIXPlugin.h
+    ${INC_DIR}/rmxfguid.h
+    ${INC_DIR}/rmxftmpl.h
+    ${INC_DIR}/xact3.h
+    ${INC_DIR}/xact3d3.h
+    ${INC_DIR}/xact3wb.h
+    ${INC_DIR}/XDSP.h
+    ${INC_DIR}/xma2defs.h)
+
 set(DEBUG_LIBS
-    ${LIB_DIR}/D3DCSXd.lib
     ${LIB_DIR}/d3dx10d.lib
     ${LIB_DIR}/d3dx11d.lib
     ${LIB_DIR}/d3dx9d.lib
-    ${LIB_DIR}/xapobased.lib
 )
 set(RELEASE_LIBS
-    ${LIB_DIR}/D3DCSX.lib
     ${LIB_DIR}/d3dx10.lib
     ${LIB_DIR}/d3dx11.lib
     ${LIB_DIR}/d3dx9.lib
-    ${LIB_DIR}/xapobase.lib
 )
-# Libs without a debug part
 set(OTHER_LIBS
-    ${LIB_DIR}/d2d1.lib
-    ${LIB_DIR}/d3d10.lib
-    ${LIB_DIR}/d3d10_1.lib
-    ${LIB_DIR}/d3d11.lib
-    ${LIB_DIR}/d3d9.lib
-    ${LIB_DIR}//d3dcompiler.lib
     ${LIB_DIR}/d3dxof.lib
-    ${LIB_DIR}/dinput8.lib
-    ${LIB_DIR}/dsound.lib
-    ${LIB_DIR}/dwrite.lib
     ${LIB_DIR}/DxErr.lib
-    ${LIB_DIR}/dxgi.lib
-    ${LIB_DIR}/dxguid.lib
-    ${LIB_DIR}/X3DAudio.lib
-    ${LIB_DIR}/XAPOFX.lib
-    ${LIB_DIR}/XInput.lib
 )
 if(${VCPKG_TARGET_ARCHITECTURE} STREQUAL "x86")
     list(APPEND OTHER_LIBS ${LIB_DIR}/dsetup.lib)
 endif()
 
+set(XINPUT13_HEADER ${INC_DIR}/XInput.h)
+set(XINPUT13_LIB ${LIB_DIR}/XInput.lib)
+
+set(XAUDIO27_HEADERS
+    ${INC_DIR}/X3DAudio.h
+    ${INC_DIR}/XAPO.h
+    ${INC_DIR}/XAPOBase.h
+    ${INC_DIR}/XAPOFX.h
+    ${INC_DIR}/XAudio2.h
+    ${INC_DIR}/XAudio2fx.h)
+set(XAUDIO27_DEBUG_LIBS ${LIB_DIR}/xapobased.lib)
+set(XAUDIO27_RELEASE_LIBS ${LIB_DIR}/xapobase.lib)
+set(XAUDIO27_OTHER_LIBS
+    ${LIB_DIR}/X3DAudio.lib
+    ${LIB_DIR}/XAPOFX.lib
+)
+
+set(XP_HEADERS
+    ${INC_DIR}/D3D10.h
+    ${INC_DIR}/D3D10effect.h
+    ${INC_DIR}/d3d10misc.h
+    ${INC_DIR}/d3d10sdklayers.h
+    ${INC_DIR}/D3D10shader.h
+    ${INC_DIR}/D3D10_1.h
+    ${INC_DIR}/D3D10_1shader.h
+    ${INC_DIR}/D3D11.h
+    ${INC_DIR}/D3D11SDKLayers.h
+    ${INC_DIR}/D3D11Shader.h
+    ${INC_DIR}/D3Dcommon.h
+    ${INC_DIR}/D3Dcompiler.h
+    ${INC_DIR}/D3DCSX.h
+    ${INC_DIR}/D3DX_DXGIFormatConvert.inl
+    ${INC_DIR}/xnamath.h
+    ${INC_DIR}/xnamathconvert.inl
+    ${INC_DIR}/xnamathmatrix.inl
+    ${INC_DIR}/xnamathmisc.inl
+    ${INC_DIR}/xnamathvector.inl)
+
+set(XP_DEBUG_LIBS ${LIB_DIR}/D3DCSXd.lib)
+set(XP_RELEASE_LIBS ${LIB_DIR}/D3DCSX.lib)
+set(XP_OTHER_LIBS
+    ${LIB_DIR}/d3dcompiler.lib
+    ${LIB_DIR}/dxguid.lib
+)
+
+
 #install(DIRECTORY "${SOURCE_PATH}/Include" DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(COPY "${SOURCE_PATH}/Include/" DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
 file(COPY ${RELEASE_LIBS} ${OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
 file(COPY ${DEBUG_LIBS} ${OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 
+if(("xinput1-3" IN_LIST FEATURES) OR ("xp" IN_LIST FEATURES))
+   file(COPY ${XINPUT13_HEADER} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+   file(COPY ${XINPUT13_LIB} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+   file(COPY ${XINPUT13_LIB} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+endif()
+
+if(("xaudio2-7" IN_LIST FEATURES) OR ("xp" IN_LIST FEATURES))
+   file(COPY ${XAUDIO27_HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+   file(COPY ${XAUDIO27_RELEASE_LIBS} ${XAUDIO27_OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+   file(COPY ${XAUDIO27_DEBUG_LIBS} ${XAUDIO27_OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+endif()
+
+if("xp" IN_LIST FEATURES)
+    file(COPY ${XP_HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+    file(COPY ${XP_RELEASE_LIBS} ${XP_OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY ${XP_DEBUG_LIBS} ${XP_OTHER_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+endif()
 
 # # Handle copyright
 file(INSTALL "${SOURCE_PATH}/Documentation/License Agreements/DirectX SDK EULA.txt" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -5,11 +5,11 @@
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
   "supports": "windows & !arm & !uwp",
   "features": {
-    "xinput1-3": {
-      "description": "Include headers for legacy XInput 1.3 (prefer use of XInput 9.1.0 or 1.4)"
-    },
     "xaudio2-7": {
       "description": "Include headers for legacy XAudio 2.7 (prefer use of XAudio2Redist)"
+    },
+    "xinput1-3": {
+      "description": "Include headers for legacy XInput 1.3 (prefer use of XInput 9.1.0 or 1.4)"
     },
     "xp": {
       "description": "Include headers needed for Windows 7.1A targeting Windows XP / Server 2003"

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "Legacy DirectX SDK",
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
-  "supports": "windows & !arm & !uwp",
+  "supports": "windows & !windows",
   "features": {
     "xaudio2-7": {
       "description": "Include headers/libs for legacy XAudio 2.7 (prefer use of XAudio2Redist)"

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "directxsdk",
-  "version-string": "jun10b",
+  "version-string": "jun10",
+  "port-version": 1,
   "description": "Legacy DirectX SDK",
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
   "supports": "windows & !arm & !uwp",

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -6,13 +6,13 @@
   "supports": "windows & !arm & !uwp",
   "features": {
     "xinput1-3": {
-      "description": "Include headers for legacy XInput 1.3 (prefer use of XInput 9.1.0 or 1.4)"
+      "description": "Include headers/libs for legacy XInput 1.3 (prefer use of XInput 9.1.0 or 1.4)"
     },
     "xaudio2-7": {
-      "description": "Include headers for legacy XAudio 2.7 (prefer use of XAudio2Redist)"
+      "description": "Include headers/libs for legacy XAudio 2.7 (prefer use of XAudio2Redist)"
     },
     "xp": {
-      "description": "Include headers needed for Windows 7.1A targeting Windows XP / Server 2003"
+      "description": "Include headers/libs needed for Windows 7.1A targeting Windows XP / Server 2003"
     }
   }
 }

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "directxsdk",
-  "version-string": "jun10",
-  "description": "DirectX SDK",
-  "homepage": "https://www.microsoft.com/en-us/download/details.aspx?id=6812",
-  "supports": "windows & !arm & !uwp"
+  "version-string": "jun10b",
+  "description": "Legacy DirectX SDK",
+  "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
+  "supports": "windows & !arm & !uwp",
+  "features": {
+    "xinput1-3": {
+      "description": "Include headers for legacy XInput 1.3 (prefer use of XInput 9.1.0 or 1.4)"
+    },
+    "xaudio2-7": {
+      "description": "Include headers for legacy XAudio 2.7 (prefer use of XAudio2Redist)"
+    },
+    "xp": {
+      "description": "Include headers needed for Windows 7.1A targeting Windows XP / Server 2003"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1593,7 +1593,7 @@
       "port-version": 0
     },
     "directxsdk": {
-      "baseline": "jun10",
+      "baseline": "jun10b",
       "port-version": 0
     },
     "directxtex": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1593,8 +1593,8 @@
       "port-version": 0
     },
     "directxsdk": {
-      "baseline": "jun10b",
-      "port-version": 0
+      "baseline": "jun10",
+      "port-version": 1
     },
     "directxtex": {
       "baseline": "jan2021b",

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "195047d88a2f4c953b4149e143e811922dc78622",
+      "version-string": "jun10",
+      "port-version": 1
+    },
+    {
       "git-tree": "b3a7a8a22c780726a74fb673c31454ef83e9ea79",
       "version-string": "jun10b",
       "port-version": 0

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "195047d88a2f4c953b4149e143e811922dc78622",
+      "git-tree": "7656b85e1c390a41e14d9e5b96b1b0f093c1d1f1",
       "version-string": "jun10",
       "port-version": 1
     },

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3a7a8a22c780726a74fb673c31454ef83e9ea79",
+      "version-string": "jun10b",
+      "port-version": 0
+    },
+    {
       "git-tree": "dc3241d51d057a92ef8db501c80a749a46ed4461",
       "version-string": "jun10",
       "port-version": 0


### PR DESCRIPTION
The legacy DirectX SDK is no longer hosted on Microsoft Downloads due to the [retirement of SHA-1 signed](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/sha-1-windows-content-to-be-retired-august-3-2020/ba-p/1544373) content.

This port does a number of things:

* It uses the archive.org copy. That has been verified to be genuine, and the SHA-256 hash inside this port has not changed.
* There's a warning from the port noting this is deprecated
* Per the guidance in this [blog post](https://walbourn.github.io/the-zombie-directx-sdk/), I trimmed out the headers/libs known to conflict with the Windows SDK
* Added optional features to add legacy **xinput1-3** and **xaudio2-7** which conflicts with the Windows 8 SDK / Windows 10 SDK headers -and- requires legacy setup. This supports opt-in use of the legacy bits.
* Added optional feature **xp** to add all the content needed to build with the Windows 7.1A SDK

> Note that the download speeds from archive.org are noticeably slower than they were on Microsoft Downloads.