### PR TITLE
 [log4cxx] Fix dependency and pkgconfig

### DIFF
--- a/ports/log4cxx/CONTROL
+++ b/ports/log4cxx/CONTROL
@@ -1,7 +1,7 @@
 Source: log4cxx
 Version: 0.11.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://logging.apache.org/log4cxx
 Description: Apache log4cxx is a logging framework for C++ patterned after Apache log4j, which uses Apache Portable Runtime for most platform-specific code and should be usable on any platform supported by APR
 Supports: !uwp
-Build-Depends: apr, apr-util
+Build-Depends: apr, apr-util, expat

--- a/ports/log4cxx/expat.patch
+++ b/ports/log4cxx/expat.patch
@@ -7,7 +7,7 @@ index d30a71b..3ecf5f0 100644
  find_package(APR-Util REQUIRED)
  
 +# Find expat for XML parsing
-+find_package(EXPAT REQUIRED)
++find_package(expat CONFIG REQUIRED)
 +
  # Building
  add_subdirectory(src)
@@ -21,7 +21,7 @@ index 3e0cb17..9a450b7 100644
  target_compile_definitions(log4cxx PRIVATE ${LOG4CXX_COMPILE_DEFINITIONS} ${APR_COMPILE_DEFINITIONS} ${APR_UTIL_COMPILE_DEFINITIONS} )
  target_include_directories(log4cxx INTERFACE $<INSTALL_INTERFACE:include> PRIVATE ${APR_INCLUDE_DIR} ${APR_UTIL_INCLUDE_DIR})
 -target_link_libraries(log4cxx PRIVATE ${APR_UTIL_LIBRARIES} ${XMLLIB_LIBRARIES} ${APR_LIBRARIES} ${APR_SYSTEM_LIBS})
-+target_link_libraries(log4cxx PRIVATE ${APR_UTIL_LIBRARIES} EXPAT::EXPAT ${APR_LIBRARIES} ${APR_SYSTEM_LIBS})
++target_link_libraries(log4cxx PRIVATE ${APR_UTIL_LIBRARIES} expat::expat ${APR_LIBRARIES} ${APR_SYSTEM_LIBS})
  if(WIN32)
  # The ODBC appender is always enabled in the Windows configuration
  target_link_libraries(log4cxx PRIVATE odbc32.lib)
@@ -55,5 +55,5 @@ index bddfe48..138c489 100644
  )
  
 -target_link_libraries(xmltests PRIVATE ${APR_UTIL_LIBRARIES} ${XMLLIB_LIBRARIES})
-+target_link_libraries(xmltests PRIVATE ${APR_UTIL_LIBRARIES} EXPAT::EXPAT)
++target_link_libraries(xmltests PRIVATE ${APR_UTIL_LIBRARIES} expat::expat)
  set(ALL_LOG4CXX_TESTS ${ALL_LOG4CXX_TESTS} xmltests PARENT_SCOPE)

--- a/ports/log4cxx/pkgconfig.patch
+++ b/ports/log4cxx/pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 523fbd9..0467470 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,7 +66,7 @@ if(UNIX)
+   )
+ 
+   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblog4cxx.pc" 
+-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ endif(UNIX)
+ 
+ # Support for find_package(log4cxx) in consuming CMake projects using

--- a/ports/log4cxx/portfile.cmake
+++ b/ports/log4cxx/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         expat.patch
         linux.patch
+        pkgconfig.patch
 )
 
 vcpkg_configure_cmake(
@@ -25,6 +26,17 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/log4cxx)
+
+if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
+    vcpkg_fixup_pkgconfig()
+endif()
+
+file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/log4cxxConfig.cmake _contents)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/log4cxxConfig.cmake
+"include(CMakeFindDependencyMacro)
+find_dependency(expat CONFIG)
+${_contents}")
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
 
 vcpkg_copy_pdbs()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3562,7 +3562,7 @@
     },
     "log4cxx": {
       "baseline": "0.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "loguru": {
       "baseline": "2.1.0-1",

--- a/versions/l-/log4cxx.json
+++ b/versions/l-/log4cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e84807f759e37781d7ce7bfc3b7485609a0feb7c",
+      "version-string": "0.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "a584f921462afb2f1b269dc9a7b361b17445028b",
       "version-string": "0.11.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16006

Update expat usage in expat.patch like this:
```
 find_package(expat CONFIG REQUIRED) 
 target_link_libraries(main PRIVARE expat::expat) 
```
Add dependency in log4cxxConfig.cmake

Fix pkgconfig path

Note: No feature needs to test.

