### PR TITLE
[sdl2] Fix vulkan feature dependencies

### DIFF
--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "sdl2",
   "version-string": "2.0.14",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {
     "vulkan": {
-      "description": "Vulkan functionality for SDL",
-      "dependencies": [
-        "vulkan"
-      ]
+      "description": "Vulkan functionality for SDL"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5250,7 +5250,7 @@
     },
     "sdl2": {
       "baseline": "2.0.14",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df27b00967d099fabd3b9315a02105bd3e1be3d1",
+      "version-string": "2.0.14",
+      "port-version": 2
+    },
+    {
       "git-tree": "8d5fa523a69780e41605b585788d212d688f3c71",
       "version-string": "2.0.14",
       "port-version": 1


### PR DESCRIPTION
SDL2 ships with its own copy of required Vulkan headers, so the `vulkan` port dependency here is unneeded (and unused).