### PR TITLE
[metrohash] support iOS triplets

### DIFF
--- a/ports/metrohash/CMakeLists.txt
+++ b/ports/metrohash/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(metrohash
             )
 list(APPEND metro_headers src/metrohash.h src/metrohash64.h src/metrohash128.h)
 
-if(NOT ANDROID)
+if(NOT VCPKG_TARGET_ARCHITECTURE MATCHES arm)
     list(APPEND metro_headers src/metrohash128crc.h)
     target_sources(metrohash PRIVATE src/metrohash128crc.cpp)
     if(CMAKE_CXX_COMPILER_ID MATCHES Clang)

--- a/ports/metrohash/CMakeLists.txt
+++ b/ports/metrohash/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(metrohash
             )
 list(APPEND metro_headers src/metrohash.h src/metrohash64.h src/metrohash128.h)
 
-if(NOT VCPKG_TARGET_ARCHITECTURE MATCHES arm)
+if(NOT ANDROID AND NOT IOS)
     list(APPEND metro_headers src/metrohash128crc.h)
     target_sources(metrohash PRIVATE src/metrohash128crc.cpp)
     if(CMAKE_CXX_COMPILER_ID MATCHES Clang)

--- a/ports/metrohash/vcpkg.json
+++ b/ports/metrohash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "metrohash",
   "version-string": "1.1.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "MetroHash is a set of state-of-the-art hash functions for non-cryptographic use cases",
   "homepage": "https://github.com/jandrewrogers/MetroHash",
   "supports": "!(uwp | arm | x86)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3710,7 +3710,7 @@
     },
     "metrohash": {
       "baseline": "1.1.3",
-      "port-version": 2
+      "port-version": 3
     },
     "mgnlibs": {
       "baseline": "2019-09-29",

--- a/versions/m-/metrohash.json
+++ b/versions/m-/metrohash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22416b3a0b51090a313beebd24de08f83d59d0f2",
+      "version-string": "1.1.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "0c764c9b22fa64b5194e65f69bfb28bc47dc20fc",
       "version-string": "1.1.3",
       "port-version": 2

--- a/versions/m-/metrohash.json
+++ b/versions/m-/metrohash.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52449d6735d6080ca8c584825b689f8e29347343",
+      "git-tree": "33078163f0311cfecce47b42c304650b602c9ddf",
       "version-string": "1.1.3",
       "port-version": 3
     },

--- a/versions/m-/metrohash.json
+++ b/versions/m-/metrohash.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "22416b3a0b51090a313beebd24de08f83d59d0f2",
+      "git-tree": "52449d6735d6080ca8c584825b689f8e29347343",
       "version-string": "1.1.3",
       "port-version": 3
     },


### PR DESCRIPTION
### What does your PR fix?

This is an enhancement of #15715

### Which triplets are supported/not supported? Have you updated the CI baseline?

Support 4 ios triplets
* `arm64-ios`
* `arm-ios`
* `x64-ios`
* `x86-ios`


```console
$ ./vcpkg install metrohash:arm64-ios metrohash:arm-ios metrohash:x64-ios metrohash:x86-ios
...

The package metrohash:arm-ios provides CMake targets:

    find_package(metrohash CONFIG REQUIRED)
    target_link_libraries(main PRIVATE metrohash::metrohash)

The package metrohash:arm64-ios provides CMake targets:

    find_package(metrohash CONFIG REQUIRED)
    target_link_libraries(main PRIVATE metrohash::metrohash)

The package metrohash:x64-ios provides CMake targets:

    find_package(metrohash CONFIG REQUIRED)
    target_link_libraries(main PRIVATE metrohash::metrohash)

The package metrohash:x86-ios provides CMake targets:

    find_package(metrohash CONFIG REQUIRED)
    target_link_libraries(main PRIVATE metrohash::metrohash)

```

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

* Versioning
   * [x] `"port-version"` update
   * [x] Update the version files in `versions/`
* Code format
   * [x] Manifests
