### PR TITLE
[glslang] support iOS triplets

### DIFF
--- a/ports/glslang/CONTROL
+++ b/ports/glslang/CONTROL
@@ -1,5 +1,0 @@
-Source: glslang
-Version: 2019-03-05
-Port-Version: 3
-Homepage: https://github.com/KhronosGroup/glslang
-Description: Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator

--- a/ports/glslang/CONTROL
+++ b/ports/glslang/CONTROL
@@ -1,5 +1,5 @@
 Source: glslang
 Version: 2019-03-05
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/KhronosGroup/glslang
 Description: Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator

--- a/ports/glslang/portfile.cmake
+++ b/ports/glslang/portfile.cmake
@@ -11,12 +11,20 @@ vcpkg_from_github(
     CMakeLists-windows.patch
 )
 
+if(VCPKG_TARGET_IS_IOS)
+  # this case will report error since all executable will require BUNDLE DESTINATION
+  set(BUILD_BINARIES OFF)
+else()
+  set(BUILD_BINARIES ON)  
+endif()
+
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
   OPTIONS
     -DCMAKE_DEBUG_POSTFIX=d
     -DSKIP_GLSLANG_INSTALL=OFF
+    -DENABLE_GLSLANG_BINARIES=${BUILD_BINARIES}
 )
 
 vcpkg_install_cmake()
@@ -25,9 +33,13 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/glslang)
 
 vcpkg_copy_pdbs()
 
-file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools")
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+if(NOT BUILD_BINARIES)
+  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
+else()
+  file(RENAME ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/tools)
+endif()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/debug/bin)
 
 # Handle copyright
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/glslang)

--- a/ports/glslang/vcpkg.json
+++ b/ports/glslang/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "glslang",
+  "version-string": "2019-03-05",
+  "port-version": 3,
+  "description": "Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator",
+  "homepage": "https://github.com/KhronosGroup/glslang"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2198,7 +2198,7 @@
     },
     "glslang": {
       "baseline": "2019-03-05",
-      "port-version": 2
+      "port-version": 3
     },
     "glui": {
       "baseline": "2019-11-30",

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "facab59a26a7a41a3317ab60899b70ecb81b9afc",
+      "git-tree": "238bbf3091b944505d3c9fbad698023f852bd5eb",
       "version-string": "2019-03-05",
       "port-version": 3
     },

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "facab59a26a7a41a3317ab60899b70ecb81b9afc",
+      "version-string": "2019-03-05",
+      "port-version": 3
+    },
+    {
       "git-tree": "29f2d736c8273c412c4fcf0fd50da379d1ec9a0b",
       "version-string": "2019-03-05",
       "port-version": 2

--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "238bbf3091b944505d3c9fbad698023f852bd5eb",
+      "git-tree": "a7d9b6a3d936d273c6b1966eb3b8fe8cb1ba28d1",
       "version-string": "2019-03-05",
       "port-version": 3
     },


### PR DESCRIPTION
### What does your PR fix?

The port fails to build with iOS triplets since it generates some executables without `BUNDLE DESTINATION`.
The change disables `add_executable` usage by providing `OFF` to the built-in `option` of the project's `CMakeLists.txt`

The `CONTROL` file is converted to `vcpkg.json`

### Which triplets are supported/not supported? Have you updated the CI baseline?

Support 4 ios triplets
* `arm64-ios`
* `arm-ios`
* `x64-ios`
* `x86-ios`


### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

* Versioning
   * [x] `"port-version"` update
   * [x] Update the version files in `versions/`
* Code format
   * [x] Manifests
