### PR TITLE
[spirv-cross,spirv-tools] support iOS triplets

### DIFF
--- a/ports/spirv-cross/CONTROL
+++ b/ports/spirv-cross/CONTROL
@@ -1,4 +1,0 @@
-Source: spirv-cross
-Version: 2020-02-26
-Homepage: https://github.com/KhronosGroup/SPIRV-Cross
-Description: SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.

--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -9,10 +9,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if(VCPKG_TARGET_IS_IOS)
+    message(STATUS "Using iOS trplet. Executables won't be created...")
+    set(BUILD_CLI OFF)
+else()
+    set(BUILD_CLI ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=OFF
+    OPTIONS
+        -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=OFF
+        -DSPIRV_CROSS_CLI=${BUILD_CLI}
 )
 
 vcpkg_install_cmake()

--- a/ports/spirv-cross/vcpkg.json
+++ b/ports/spirv-cross/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "spirv-cross",
+  "version-string": "2020-02-26",
+  "port-version": 1,
+  "description": "SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.",
+  "homepage": "https://github.com/KhronosGroup/SPIRV-Cross",
+  "dependencies": [
+    "spirv-headers"
+  ]
+}

--- a/ports/spirv-tools/CONTROL
+++ b/ports/spirv-tools/CONTROL
@@ -1,5 +1,0 @@
-Source: spirv-tools
-Version: 2020.1-1
-Homepage: https://github.com/KhronosGroup/SPIRV-Tools
-Description: API and commands for processing SPIR-V modules
-Build-Depends: spirv-headers

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -32,7 +32,7 @@ vcpkg_configure_cmake(
         -DSPIRV-Headers_SOURCE_DIR=${CURRENT_INSTALLED_DIR}
         -DSPIRV_WERROR=OFF
         -DSPIRV_SKIP_EXECUTABLES=${SKIP_EXECUTABLES} # option SPIRV_SKIP_TESTS follows this value
-        -DSKIP_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
+        -DENABLE_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
 )
 
 vcpkg_install_cmake()

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -16,13 +16,23 @@ vcpkg_find_acquire_program(PYTHON3)
 get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
 vcpkg_add_to_path("${PYTHON3_DIR}")
 
+if(VCPKG_TARGET_IS_IOS)
+    message(STATUS "Using iOS trplet. Executables won't be created...")
+    set(TOOLS_INSTALL OFF)
+    set(SKIP_EXECUTABLES ON) 
+else()
+    set(TOOLS_INSTALL ON)
+    set(SKIP_EXECUTABLES OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         -DSPIRV-Headers_SOURCE_DIR=${CURRENT_INSTALLED_DIR}
         -DSPIRV_WERROR=OFF
-        -DENABLE_SPIRV_TOOLS_INSTALL=ON
+        -DSPIRV_SKIP_EXECUTABLES=${SKIP_EXECUTABLES} # option SPIRV_SKIP_TESTS follows this value
+        -DSKIP_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
 )
 
 vcpkg_install_cmake()
@@ -34,7 +44,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH share/SPIRV-Tools-reduce TARGET_PATH share
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin") # only static linkage, i.e. no need to preserve .dll/.so files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
-file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+if(TOOLS_INSTALL)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+endif()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/spirv-tools/vcpkg.json
+++ b/ports/spirv-tools/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "spirv-tools",
+  "version-string": "2020.1",
+  "port-version": 2,
+  "description": "API and commands for processing SPIR-V modules",
+  "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
+  "dependencies": [
+    "spirv-headers"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5530,15 +5530,15 @@
     },
     "spirv-cross": {
       "baseline": "2020-02-26",
-      "port-version": 0
+      "port-version": 1
     },
     "spirv-headers": {
       "baseline": "1.5.1",
       "port-version": 0
     },
     "spirv-tools": {
-      "baseline": "2020.1-1",
-      "port-version": 0
+      "baseline": "2020.1",
+      "port-version": 2
     },
     "sprout": {
       "baseline": "2019-06-20",

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ad1238ca2e8ac10608f992a317ee3108ddb3272",
+      "version-string": "2020-02-26",
+      "port-version": 1
+    },
+    {
       "git-tree": "b1d5c5737acb40490b9cf38a538ecc91d588be03",
       "version-string": "2020-02-26",
       "port-version": 0

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52f9eebd3f9c33c98cb33fb5694956bc631c5cfc",
+      "git-tree": "cebc581ce190b91f63b06fd7a4807ef1cc2b9c52",
       "version-string": "2020.1",
       "port-version": 2
     },

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52f9eebd3f9c33c98cb33fb5694956bc631c5cfc",
+      "version-string": "2020.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "f6e770ef4164d3a7a518eca97aa2e3fdbe2f79cb",
       "version-string": "2020.1-1",
       "port-version": 0


### PR DESCRIPTION
### What does your PR fix?

The port fails to build with iOS triplets since it generates some executables without `BUNDLE DESTINATION`.
The change disables `add_executable` usage by providing `OFF` to the built-in `option` of the project's `CMakeLists.txt`

The `CONTROL` file is converted to `vcpkg.json`

### Which triplets are supported/not supported? Have you updated the CI baseline?

Support 4 ios triplets
* `arm64-ios`
* `arm-ios`
* `x64-ios`
* `x86-ios`


### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

* Versioning
   * [x] `"port-version"` update
   * [x] Update the version files in `versions/`
* Code format
   * [x] Manifests
