### PR TITLE
[prometheus-cpp] Update to version 0.12.1

### DIFF
--- a/ports/prometheus-cpp/CONTROL
+++ b/ports/prometheus-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: prometheus-cpp
-Version: 0.11.0
+Version: 0.12.1
 Description: Prometheus Client Library for Modern C++
 Default-Features: compression, pull
 

--- a/ports/prometheus-cpp/portfile.cmake
+++ b/ports/prometheus-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jupp0r/prometheus-cpp
-    REF bb017ec15a824d3301845a1274b4b46a01d6d871 # v0.11.0
-    SHA512 5ab3398842305bacf6cd65c700c6856f001bb998b62dea121c119484ccd376115a07afb7d62e6f87c8cbfe4f7ac05d4428121677eb8694eb9c9169465eb3518c
+    REF 38130aee330377d6289a076628dbe450d59ef3e9 # v0.12.1
+    SHA512 9daf12f482ba947e28ce0411cb75234865542e2c850d1173de98f2929c3eb8d02c7f38630d060829273ef57da0eee9ce3f3cb21b05abe1da7e64307253d57bba
     HEAD_REF master
 )
 
@@ -38,4 +38,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/prometheus-cpp)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/prometheus-cpp/copyright COPYONLY)
+configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4713,7 +4713,7 @@
       "port-version": 0
     },
     "prometheus-cpp": {
-      "baseline": "0.11.0",
+      "baseline": "0.12.1",
       "port-version": 0
     },
     "protobuf": {

--- a/versions/p-/prometheus-cpp.json
+++ b/versions/p-/prometheus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be1b7db5fe2c186c52cd074caa038874d27e245f",
+      "version-string": "0.12.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c86b33f02ac3a4e3c0fa288cf033a15238f24a7a",
       "version-string": "0.11.0",
       "port-version": 0


### PR DESCRIPTION
Update prometheus-cpp to 0.12.0. Locally tested on macOS.