### PR TITLE
[manif] Add new port

### DIFF
--- a/ports/manif/cmake-fix.patch
+++ b/ports/manif/cmake-fix.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a50fd0c..2a5cdde 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101,6 +101,13 @@ else(TARGET Eigen3::Eigen)
+   target_include_directories(${PROJECT_NAME} SYSTEM INTERFACE ${EIGEN3_INCLUDE_DIRS})
+ endif(TARGET Eigen3::Eigen)
+ 
++# Add tl-optional interface dependency if enabled
++if(tl-optional_FOUND)
++  set(tl-optional_DEPENDENCY "find_dependency(tl-optional)")
++else()
++  set(tl-optional_DEPENDENCY "")
++endif()
++
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+   target_compile_options(${PROJECT_NAME} INTERFACE -ftemplate-depth=512)
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+diff --git a/cmake/manifConfig.cmake.in b/cmake/manifConfig.cmake.in
+index bbbc698..863d5b5 100644
+--- a/cmake/manifConfig.cmake.in
++++ b/cmake/manifConfig.cmake.in
+@@ -2,6 +2,7 @@
+ 
+ include(CMakeFindDependencyMacro)
+ @Eigen3_DEPENDENCY@
++@tl-optional_DEPENDENCY@
+ 
+ if(NOT TARGET @PROJECT_NAME@)
+   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/ports/manif/portfile.cmake
+++ b/ports/manif/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO artivis/manif
+    REF 0.0.4
+    SHA512 c6e0a333421d4bd3bf81f558bfc20b566960798281b6b95d234fa4e4e25fb323ad544876b1196aaf33fd335d61bf1a49d3fca4f3da24f417b04348b877199bec
+    HEAD_REF master
+    PATCHES
+        cmake-fix.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DUSE_SYSTEM_WIDE_TL_OPTIONAL=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+# Add the copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/manif/vcpkg.json
+++ b/ports/manif/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "manif",
+  "version": "0.0.4",
+  "description": "A small header-only library for Lie theory.",
+  "homepage": "https://github.com/artivis/manif",
+  "dependencies": [
+    "eigen3",
+    "tl-optional"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4000,6 +4000,10 @@
       "baseline": "1.0.4",
       "port-version": 0
     },
+    "manif": {
+      "baseline": "0.0.4",
+      "port-version": 0
+    },
     "mapbox-variant": {
       "baseline": "1.2.0",
       "port-version": 0

--- a/versions/m-/manif.json
+++ b/versions/m-/manif.json
@@ -1,0 +1,14 @@
+{
+  "versions": [
+    {
+      "git-tree": "c746acaed5b62a4913c582d48e95e0f224b2a16a",
+      "version": "0.0.4",
+      "port-version": 0
+    },
+    {
+      "git-tree": "928042a0efc9b239ff00b07a585fd2fdd468701f",
+      "version-string": "0.0.3",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces the `manif` library. 

`manif` is a header-only library based on `eigen3`


- What does your PR fix? Fixes #16058 

- Which triplets are supported/not supported? Have you updated the CI baseline? All the triplets should be supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
