### PR TITLE
Add disable-exceptions feature to portfile for tbb

### DIFF
--- a/ports/tbb/CMakeLists.txt
+++ b/ports/tbb/CMakeLists.txt
@@ -1,9 +1,13 @@
 project(tbb CXX)
 
+option(DISABLE_EXCEPTIONS "Set exceptions=0 for make to turn off exception support in TBB" OFF)
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*)
 file(COPY ${SOURCES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src)
 
 include(${CMAKE_CURRENT_BINARY_DIR}/src/cmake/TBBBuild.cmake REQUIRED)
+if(DISABLE_EXCEPTIONS)
+    set(DISABLE_EXCEPTIONS_ARG exceptions=0)
+endif()
 if(NOT BUILD_SHARED_LIBS)
     set(TBB_STATIC_INCLUDE extra_inc=big_iron.inc)
 endif()
@@ -26,7 +30,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   endif()
 endif()
 
-tbb_build(TBB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/src MAKE_ARGS ${arch} ${CPLUS} ${CONLY} ${TBB_STATIC_INCLUDE} ${FORWARD_SDK_ROOT})
+tbb_build(TBB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/src MAKE_ARGS ${arch} ${CPLUS} ${CONLY} ${DISABLE_EXCEPTIONS_ARG} ${TBB_STATIC_INCLUDE} ${FORWARD_SDK_ROOT})
 
 set(SUBDIR ${CMAKE_CURRENT_BINARY_DIR}/tbb_cmake_build/tbb_cmake_build_subdir)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/ports/tbb/CONTROL
+++ b/ports/tbb/CONTROL
@@ -4,6 +4,3 @@ Port-Version: 4
 Homepage: https://github.com/01org/tbb
 Description: Intel's Threading Building Blocks.
 Supports: !(uwp|arm|arm64) | linux | osx
-
-Feature: disable-exceptions
-Description: sets TBB_USE_EXCEPTIONS=0. This is useful if you want an unhandled exception in your tbb code to crash and yield a dump at the point where the exception is thrown, instead of being rethrown at the invocation of the associated TBB algorithm, at which point the original stack of the thrown exception is gone.

--- a/ports/tbb/CONTROL
+++ b/ports/tbb/CONTROL
@@ -1,6 +1,9 @@
 Source: tbb
 Version: 2020_U3
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/01org/tbb
 Description: Intel's Threading Building Blocks.
 Supports: !(uwp|arm|arm64) | linux | osx
+
+Feature: disable-exceptions
+Description: sets TBB_USE_EXCEPTIONS=0. This is useful if you want an unhandled exception in your tbb code to crash and yield a dump at the point where the exception is thrown, instead of being rethrown at the invocation of the associated TBB algorithm, at which point the original stack of the thrown exception is gone.

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -14,9 +14,14 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+if (TBB_DISABLE_EXCEPTIONS)
+    message(STATUS "Building TBB with exception-handling constructs disabled because TBB_DISABLE_EXCEPTIONS is set to ON.")
+else()
+    message(STATUS "TBB uses exception-handling constructs by default (if supported by the compiler). This use can be disabled with 'SET(TBB_DISABLE_EXCEPTIONS ON)' in your custom triplet.")
+endif()
 
 if (NOT VCPKG_TARGET_IS_WINDOWS)
-    if ("disable-exceptions" IN_LIST FEATURES)
+    if (TBB_DISABLE_EXCEPTIONS)
         set(DISABLE_EXCEPTIONS ON)
     else()
         set(DISABLE_EXCEPTIONS OFF)
@@ -68,7 +73,7 @@ else()
             string(REPLACE "\/D_CRT_SECURE_NO_DEPRECATE"
                         "\/D_CRT_SECURE_NO_DEPRECATE \/DIN_CILK_RUNTIME" SLN_CONFIGURE "${SLN_CONFIGURE}")
         endif()
-        if ("disable-exceptions" IN_LIST FEATURES)
+        if (TBB_DISABLE_EXCEPTIONS)
             string(REPLACE "<PreprocessorDefinitions>%(PreprocessorDefinitions)<\/PreprocessorDefinitions>"
                         "<PreprocessorDefinitions>TBB_USE_EXCEPTIONS=0;%(PreprocessorDefinitions)<\/PreprocessorDefinitions>" SLN_CONFIGURE "${SLN_CONFIGURE}")
         endif()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5674,7 +5674,7 @@
     },
     "tbb": {
       "baseline": "2020_U3",
-      "port-version": 3
+      "port-version": 4
     },
     "tcl": {
       "baseline": "core-9-0-a1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5674,7 +5674,7 @@
     },
     "tbb": {
       "baseline": "2020_U3",
-      "port-version": 4
+      "port-version": 3
     },
     "tcl": {
       "baseline": "core-9-0-a1",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e6228578b0ca40358f584aa1ea8b4a9ac2d4ed9",
+      "version-string": "2020_U3",
+      "port-version": 4
+    },
+    {
       "git-tree": "eb2f60732524f07ea5effc9aeda3472fd0bbe243",
       "version-string": "2020_U3",
       "port-version": 3

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f6bce30a0952827e86efb6f76bd85555623c10c7",
+      "version-string": "2020_U3",
+      "port-version": 4
+    },
+    {
       "git-tree": "eb2f60732524f07ea5effc9aeda3472fd0bbe243",
       "version-string": "2020_U3",
       "port-version": 3

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "f6bce30a0952827e86efb6f76bd85555623c10c7",
-      "version-string": "2020_U3",
-      "port-version": 4
-    },
-    {
       "git-tree": "eb2f60732524f07ea5effc9aeda3472fd0bbe243",
       "version-string": "2020_U3",
       "port-version": 3


### PR DESCRIPTION
I had forgotten to rev the port version in the last PR. Trying again, starting with a draft PR.

This feature passes `exceptions=0` to tbbbuild in the non-windows case (which eventually defines `TBB_USE_EXCEPTIONS` as `0` in cpp code), and sets `TBB_USE_EXCEPTIONS=0` in the `vcxproj` files in the windows case. I wasn't sure if this counts as exposing an "alternative", but expect a decent number of tbb clients would want this option available. Happy to discuss as this is my first portfile modification attempt.

The effect of the feature is that it removes the `try`/`catch(...)` wrappers around user code run by TBB. While these exception facilities can be nice in some cases, their removal allows for much easier debugging of a crash due to an unhandled exception in code that a TBB client provides to a TBB algorithm. With the `try`/`catch(...)` wrappers removed, the unhandled exception and crash dump are generated at the point of the thrown exception, versus significantly later in a different thread with the originally throwing thread no longer having the stack from when the exception was thrown.

All triplets should be supported with this feature.
