### PR TITLE
[gtest] fix builds when using --head

### DIFF
--- a/ports/gtest/CONTROL
+++ b/ports/gtest/CONTROL
@@ -1,5 +1,5 @@
 Source: gtest
 Version: 1.10.0
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/google/googletest
 Description: GoogleTest and GoogleMock testing frameworks.

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -76,4 +76,4 @@ endif()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/googletest/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2310,7 +2310,7 @@
     },
     "gtest": {
       "baseline": "1.10.0",
-      "port-version": 3
+      "port-version": 4
     },
     "gtk": {
       "baseline": "3.22.19-4",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "963ff8673900c86aabd3e7e24d61abacd4e959f4",
+      "git-tree": "9f4e8f94a3fe61d4abcc1929129b2e21ad6cc066",
       "version-string": "1.10.0",
       "port-version": 4
     },

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "963ff8673900c86aabd3e7e24d61abacd4e959f4",
+      "version-string": "1.10.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "e94f8c09a8fa6ed7fc618734d412878d83069bfb",
       "version-string": "1.10.0",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Fixes an issue where the license couldn't be found, by switching to the LICENSE file in the root of the repo. Release 1.10.0 also included this file, so the updated script builds both --head and 1.10.0.
gtest follows the "live at head" philosophy so there isn't going to be any fixed release anymore, making it important for --head to build so that the user is able to consume newer features.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
