### PR TITLE
[netcdf-c] Fix usage

### DIFF
--- a/ports/netcdf-c/CONTROL
+++ b/ports/netcdf-c/CONTROL
@@ -1,6 +1,6 @@
 Source: netcdf-c
 Version: 4.7.4
-Port-Version: 1
+Port-Version: 2
 Build-Depends: hdf5, curl
 Homepage: https://github.com/Unidata/netcdf-c
 Description: a set of self-describing, machine-independent data formats that support the creation, access, and sharing of array-oriented scientific data.

--- a/ports/netcdf-c/portfile.cmake
+++ b/ports/netcdf-c/portfile.cmake
@@ -41,7 +41,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/netcdf)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/netcdf TARGET_PATH share/netcdf)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin ${CURRENT_PACKAGES_DIR}/bin)
@@ -50,5 +50,4 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/netcdf-c/usage
+++ b/ports/netcdf-c/usage
@@ -1,4 +1,0 @@
-The package netcdf-c provides CMake targets:
-
-    find_package(netCDF CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE netcdf)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4030,7 +4030,7 @@
     },
     "netcdf-c": {
       "baseline": "4.7.4",
-      "port-version": 1
+      "port-version": 2
     },
     "netcdf-cxx4": {
       "baseline": "4.3.1",

--- a/versions/n-/netcdf-c.json
+++ b/versions/n-/netcdf-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa42781f00db0c2de52798f0345801b667977c79",
+      "version-string": "4.7.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "725a87fc08fed5789a9a4a3308b2a80f4906a400",
       "version-string": "4.7.4",
       "port-version": 1


### PR DESCRIPTION
- `netcdf-c` generates cmake configure files in directory `netcdf`, not `netcdf-c`. Fix this.
- Remove usage since vcpkg can automatic generate it.

Related: #15375.