### PR TITLE
[spdlog] Support build shared library

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,6 +1,6 @@
 Source: spdlog
 Version: 1.8.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -11,11 +11,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	benchmark SPDLOG_BUILD_BENCH
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    set(SPDLOG_BUILD_SHARED_LIBS ON)
-else()
-    set(SPDLOG_BUILD_SHARED_LIBS OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SPDLOG_BUILD_SHARED)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -24,7 +20,7 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
         -DSPDLOG_FMT_EXTERNAL=ON
         -DSPDLOG_INSTALL=ON
-        -DSPDLOG_BUILD_SHARED=${SPDLOG_BUILD_SHARED_LIBS}
+        -DSPDLOG_BUILD_SHARED=${SPDLOG_BUILD_SHARED}
 )
 
 vcpkg_install_cmake()

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -11,6 +11,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 	benchmark SPDLOG_BUILD_BENCH
 )
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(SPDLOG_BUILD_SHARED_LIBS ON)
+else()
+    set(SPDLOG_BUILD_SHARED_LIBS OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -18,6 +24,7 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
         -DSPDLOG_FMT_EXTERNAL=ON
         -DSPDLOG_INSTALL=ON
+        -DSPDLOG_BUILD_SHARED=${SPDLOG_BUILD_SHARED_LIBS}
 )
 
 vcpkg_install_cmake()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5510,7 +5510,7 @@
     },
     "spdlog": {
       "baseline": "1.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7b92922f96d83b3fe37142b9e0de0d8a04f8ecd",
+      "version-string": "1.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "51a19e55194fc03004bf1584612eb50cce1b4ec2",
       "version-string": "1.8.0",
       "port-version": 1

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f7b92922f96d83b3fe37142b9e0de0d8a04f8ecd",
+      "git-tree": "83277d69ee0f37839d9f06c9fb658a3dd457e3eb",
       "version-string": "1.8.0",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16075 
Currently spdlog port always builds static library even when VCPKG_LIBRARY_LINKAGE=dynamic,After adding SPDLOG_BUILD_SHARED_LIBS OPTION, the shared library can be compiled normally.

All feature are tested successfully in the following triplets:
- x86-windows
- x64-windows
- x64-windows-static

