### PR TITLE
[abseil] Remove link flag '-ignore:4221'

### DIFF
--- a/ports/abseil/fix-msvc-flags.patch
+++ b/ports/abseil/fix-msvc-flags.patch
@@ -1,0 +1,12 @@
+diff --git a/absl/copts/AbseilConfigureCopts.cmake b/absl/copts/AbseilConfigureCopts.cmake
+index acd46d0..6081527 100644
+--- a/absl/copts/AbseilConfigureCopts.cmake
++++ b/absl/copts/AbseilConfigureCopts.cmake
+@@ -41,7 +41,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+     # clang-cl is half MSVC, half LLVM
+     set(ABSL_DEFAULT_COPTS "${ABSL_CLANG_CL_FLAGS}")
+     set(ABSL_TEST_COPTS "${ABSL_CLANG_CL_FLAGS};${ABSL_CLANG_CL_TEST_FLAGS}")
+-    set(ABSL_DEFAULT_LINKOPTS "${ABSL_MSVC_LINKOPTS}")
+   else()
+     set(ABSL_DEFAULT_COPTS "${ABSL_LLVM_FLAGS}")
+     set(ABSL_TEST_COPTS "${ABSL_LLVM_FLAGS};${ABSL_LLVM_TEST_FLAGS}")

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -8,12 +8,15 @@ vcpkg_from_github(
     REF 0f3bb466b868b523cf1dc9b2aaaed65c77b28862 #LTS 20200923, Patch 2
     SHA512 17e766a2f7a655a3877eb3accc5745a910b69a5e2426b7ce7f6d31095523dd32d48a709c5f8380488b4cb93ce9faadedc08f0481dbdbd00cf68831541d724b4d
     HEAD_REF master
-    # in C++17 mode, use std::any, std::optional, std::string_view, std::variant
-    # instead of the library replacement types
-    # in C++11 mode, force use of library replacement types, otherwise the automatic
-    # detection can cause ABI issues depending on which compiler options
-    # are enabled for consuming user code
-    PATCHES fix-cxx-standard.patch
+    PATCHES
+        # in C++17 mode, use std::any, std::optional, std::string_view, std::variant
+        # instead of the library replacement types
+        # in C++11 mode, force use of library replacement types, otherwise the automatic
+        # detection can cause ABI issues depending on which compiler options
+        # are enabled for consuming user code
+        fix-cxx-standard.patch
+        # Official patch https://github.com/abseil/abseil-cpp/commit/58a9c6d53f93078101c2c0bd98d2951e74328a55
+        fix-msvc-flags.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "abseil",
   "version-string": "2020-09-23",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1558fdc71dd0f0988cd2a53ba439bed3cc899247",
+      "version-string": "2020-09-23",
+      "port-version": 2
+    },
+    {
       "git-tree": "3d9d65e41e314658c5e18839117ebf7f060b9cb7",
       "version-string": "2020-09-23",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,7 +10,7 @@
     },
     "abseil": {
       "baseline": "2020-09-23",
-      "port-version": 1
+      "port-version": 2
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
Use [official patch](https://github.com/abseil/abseil-cpp/commit/58a9c6d53f93078101c2c0bd98d2951e74328a55) to fix the build failure:
```
clang : error : unknown argument: '-ignore:4221'
```

Fixes #13945.