### PR TITLE
[geos] Update to 3.9.0

### DIFF
--- a/ports/geos/CONTROL
+++ b/ports/geos/CONTROL
@@ -1,5 +1,4 @@
 Source: geos
-Version: 3.8.1
-Port-Version: 1
+Version: 3.9.0
 Homepage: https://www.osgeo.org/projects/geos/
 Description: Geometry Engine Open Source

--- a/ports/geos/dont-build-astyle.patch
+++ b/ports/geos/dont-build-astyle.patch
@@ -1,10 +1,10 @@
 diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index 1f27b802..ecf836b4 100644
+index f0f616e..8a81a2a 100644
 --- a/tools/CMakeLists.txt
 +++ b/tools/CMakeLists.txt
-@@ -21,7 +21,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/geos-config
-         PERMISSIONS
-         OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+@@ -40,7 +40,6 @@ if(NOT MSVC)
+ 
+ endif()
  
 -add_subdirectory(astyle)
  

--- a/ports/geos/portfile.cmake
+++ b/ports/geos/portfile.cmake
@@ -1,9 +1,9 @@
-set(GEOS_VERSION 3.8.1)
+set(GEOS_VERSION 3.9.0)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2"
     FILENAME "geos-${GEOS_VERSION}.tar.bz2"
-    SHA512 1d8d8b3ece70eb388ea128f4135c7455899f01828223b23890ad3a2401e27104efce03987676794273a9b9d4907c0add2be381ff14b8420aaa9a858cc5941056
+    SHA512 1081f2aa20e671450953f7bb53b17c703804a1c9f4987c9da0987ff24339af5811b2c8b79c8e438d04ca38e4d06164dc5a4206f266f7efc19af3f9d9ea8f71f8
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2125,8 +2125,8 @@
       "port-version": 0
     },
     "geos": {
-      "baseline": "3.8.1",
-      "port-version": 1
+      "baseline": "3.9.0",
+      "port-version": 0
     },
     "geotrans": {
       "baseline": "3.8",

--- a/versions/g-/geos.json
+++ b/versions/g-/geos.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f0db53a1f1de01b660fe82145abc3f1208f7fc4",
+      "version-string": "3.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e71bfd0742035ab5630ea9849eeda3ecd1a71118",
       "version-string": "3.8.1",
       "port-version": 1


### PR DESCRIPTION
Update geos to 3.9.0 to fix the conflict between internal header file `io.h` and Windows SDK header(official PR https://github.com/libgeos/geos/pull/242).

Related: https://github.com/libgeos/geos/issues/262 https://github.com/microsoft/vcpkg/pull/15375