### PR TITLE
[ngspice] fix win32 codemodel glob

### DIFF
--- a/ports/ngspice/CONTROL
+++ b/ports/ngspice/CONTROL
@@ -1,5 +1,6 @@
 Source: ngspice
 Version: 34
+Port-Version: 1
 Homepage: http://ngspice.sourceforge.net/
 Description: Ngspice is a mixed-level/mixed-signal electronic circuit simulator. It is a successor of the latest stable release of Berkeley SPICE
 Supports: !(linux|osx|arm|uwp)

--- a/ports/ngspice/portfile.cmake
+++ b/ports/ngspice/portfile.cmake
@@ -55,15 +55,25 @@ if("codemodels" IN_LIST FEATURES)
         PLATFORM ${TRIPLET_SYSTEM_ARCH}
         TARGET Build
     )
-    
+
+    # ngspice oddly has solution configs of x64 and x86 but
+    # output folders of x64 and win32
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+        set(OUT_ARCH  x64)
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
+        set(OUT_ARCH  Win32)
+    else()
+        message(FATAL_ERROR "Unsupported target architecture")
+    endif()
+        
     #put the code models in the intended location
     file(GLOB NGSPICE_CODEMODELS_DEBUG
-        ${BUILDTREE_PATH}/visualc/codemodels/${TRIPLET_SYSTEM_ARCH}/Debug/*.cm
+        ${BUILDTREE_PATH}/visualc/codemodels/${OUT_ARCH}/Debug/*.cm
     )
     file(COPY ${NGSPICE_CODEMODELS_DEBUG} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/ngspice)
     
     file(GLOB NGSPICE_CODEMODELS_RELEASE
-        ${BUILDTREE_PATH}/visualc/codemodels/${TRIPLET_SYSTEM_ARCH}/Release/*.cm
+        ${BUILDTREE_PATH}/visualc/codemodels/${OUT_ARCH}/Release/*.cm
     )
     file(COPY ${NGSPICE_CODEMODELS_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/lib/ngspice)
     

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4066,7 +4066,7 @@
     },
     "ngspice": {
       "baseline": "34",
-      "port-version": 0
+      "port-version": 1
     },
     "nifticlib": {
       "baseline": "2020-04-30",

--- a/versions/n-/ngspice.json
+++ b/versions/n-/ngspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "249a0e9bafd17932e3d46a0f979a2983b8a78b0d",
+      "version-string": "34",
+      "port-version": 1
+    },
+    {
       "git-tree": "2a9bd9cf0045f6a35080bf13ea51abba65bd49a6",
       "version-string": "34",
       "port-version": 0


### PR DESCRIPTION
Sorry for yet another MR.

I overlooked this last time, the glob to copy codemodels was working on x64 but I accidentally removed the arch substitute for globbing win32. (The upstream solution uses x64 and x86, but the output directories are x64 and Win32 :/)