### PR TITLE
[boost] build boost on windows x86 with /safeseh

### DIFF
--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -307,6 +307,11 @@ function(boost_modular_build)
         list(APPEND B2_OPTIONS address-model=64 architecture=power)
     else()
         list(APPEND B2_OPTIONS address-model=32 architecture=x86)
+    
+        if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+            list(APPEND B2_OPTIONS "asmflags=/safeseh")
+        endif()
+
     endif()
 
     file(TO_CMAKE_PATH "${_bm_DIR}/nothing.bat" NOTHING_BAT)

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.75.0",
-  "port-version": 4,
+  "port-version": 5,
   "dependencies": [
     "boost-uninstall"
   ]

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd22d72081419af2762f4a5d59ba123619129e38",
+      "version-string": "1.75.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "b261a1bd3ff03916f10c4a157b670c3c4e7e7326",
       "version-string": "1.75.0",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -698,7 +698,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.75.0",
-      "port-version": 4
+      "port-version": 5
     },
     "boost-move": {
       "baseline": "1.75.0",


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Build boost on windows x86 with `/safeseh`. Otherwise you get linker errors if you build your application with `/safeseh` but boost is not build with `/safeseh`.

- Which triplets are supported/not supported? Have you updated the CI baseline? No Changes. Tested with x86-windows-static locally.
