### PR TITLE
[google-cloud-cpp] populate license field

### DIFF
--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version-string": "1.24.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -3,6 +3,7 @@
   "version-string": "1.24.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
+  "license": "Apache-2.0",
   "supports": "!uwp",
   "dependencies": [
     "abseil",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2250,7 +2250,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.24.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "16ca3b8eae830e46a951f7e5dc10408ee0517f6d",
+      "version-string": "1.24.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "39f9bad63d71830d31bd827577e3c37621653d5e",
       "version-string": "1.24.0",
       "port-version": 0


### PR DESCRIPTION
Populate the `license` field in the `google-cloud-cpp` manifest file.
 
- What does your PR fix? Fixes #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
