### PR TITLE
[functions-framework-cpp] populate license field

### DIFF
--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "functions-framework-cpp",
   "version-string": "0.3.0",
+  "port-version": 1,
   "description": "Functions Framework for C++.",
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
+  "license": "Apache-2.0",
   "dependencies": [
     "abseil",
     "boost-beast",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2066,7 +2066,7 @@
     },
     "functions-framework-cpp": {
       "baseline": "0.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "fuzzylite": {
       "baseline": "6.0",

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1506acc2df21c0b49e93d73da7229d524ace0fb3",
+      "version-string": "0.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "35de9501f7e2c91bb35da41cffac790008330a3c",
       "version-string": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
Populates the `license` field in the `functions-framework-cpp` manifest file

- What does your PR fix? Fixes #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
