### PR TITLE
[proj4] Allow enabling tiff support for static builds

### DIFF
--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -14,6 +14,8 @@ vcpkg_extract_source_archive_ex(
 )
 
 if (VCPKG_TARGET_IS_WINDOWS)
+  # TODO: This should be updated to use the knowledge from the base packages
+  #       instead of manually maintaining this knowledge here
   if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
       set(GEOS_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/geos_c.lib")
       set(GEOS_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/geos_cd.lib")
@@ -21,6 +23,8 @@ if (VCPKG_TARGET_IS_WINDOWS)
       set(LIBXML2_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/libxml2.lib")
       set(LIBRTTOPO_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/librttopo.lib")
       set(LIBRTTOPO_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/librttopo.lib")
+      set(PROJ_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/proj.lib")
+      set(PROJ_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/proj_d.lib")
   else()
       set(GEOS_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/geos_c.lib ${CURRENT_INSTALLED_DIR}/lib/geos.lib")
       set(GEOS_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/geos_cd.lib ${CURRENT_INSTALLED_DIR}/debug/lib/geosd.lib")
@@ -28,6 +32,8 @@ if (VCPKG_TARGET_IS_WINDOWS)
       set(LIBXML2_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/libxml2.lib ${CURRENT_INSTALLED_DIR}/debug/lib/lzmad.lib ws2_32.lib")
       set(LIBRTTOPO_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/librttopo.lib")
       set(LIBRTTOPO_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/librttopo.lib")
+      set(PROJ_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/proj.lib ${CURRENT_INSTALLED_DIR}/lib/tiff.lib ${CURRENT_INSTALLED_DIR}/lib/jpeg.lib ole32.lib shell32.lib")
+      set(PROJ_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/proj_d.lib ${CURRENT_INSTALLED_DIR}/debug/lib/tiffd.lib ${CURRENT_INSTALLED_DIR}/debug/lib/jpegd.lib ole32.lib shell32.lib")
   endif()
 
   set(LIBS_ALL_DBG
@@ -39,7 +45,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
       ${LIBXML2_LIBS_DBG} \
       ${GEOS_LIBS_DBG} \
       ${LIBRTTOPO_LIBS_DBG} \
-      ${CURRENT_INSTALLED_DIR}/debug/lib/proj_d.lib ole32.lib shell32.lib"
+      ${PROJ_LIBS_DBG}"
   )
   set(LIBS_ALL_REL
       "${CURRENT_INSTALLED_DIR}/lib/iconv.lib \
@@ -50,7 +56,7 @@ if (VCPKG_TARGET_IS_WINDOWS)
       ${LIBXML2_LIBS_REL} \
       ${GEOS_LIBS_REL} \
       ${LIBRTTOPO_LIBS_REL} \
-      ${CURRENT_INSTALLED_DIR}/lib/proj.lib ole32.lib shell32.lib"
+      ${PROJ_LIBS_REL}"
   )
 
   string(REPLACE "/" "\\\\" INST_DIR ${CURRENT_PACKAGES_DIR})

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
   set(VCPKG_BUILD_SHARED_LIBS ON)
-  set(EXTRA_FEATURES tiff ENABLE_TIFF tools BUILD_PROJSYNC tools ENABLE_CURL)
+  set(EXTRA_FEATURES tools BUILD_PROJSYNC tools ENABLE_CURL)
   set(TOOL_NAMES cct cs2cs geod gie proj projinfo projsync)
 else()
   set(VCPKG_BUILD_SHARED_LIBS OFF)
@@ -33,8 +33,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-  message(WARNING "ENABLE_TIFF ENABLE_CURL and BUILD_PROJSYNC will be off when building static")
-  set(FEATURE_OPTIONS ${FEATURE_OPTIONS} -DENABLE_TIFF=OFF -DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF)
+  message(WARNING "ENABLE_CURL and BUILD_PROJSYNC will be off when building static")
+  set(FEATURE_OPTIONS ${FEATURE_OPTIONS} -DENABLE_CURL=OFF -DBUILD_PROJSYNC=OFF)
 endif()
 
 if ("database" IN_LIST FEATURES)

--- a/ports/proj4/vcpkg.json
+++ b/ports/proj4/vcpkg.json
@@ -1,17 +1,21 @@
 {
   "name": "proj4",
   "version-string": "7.2.1",
+  "port-version": 1,
   "description": "PROJ.4 library for cartographic projections",
   "homepage": "https://github.com/OSGeo/PROJ",
   "dependencies": [
     {
       "name": "sqlite3",
       "default-features": false
+    },
+    {
+      "name": "tiff",
+      "default-features": false
     }
   ],
   "default-features": [
-    "database",
-    "tiff"
+    "database"
   ],
   "features": {
     "database": {
@@ -24,12 +28,6 @@
           ],
           "platform": "!uwp & !arm"
         }
-      ]
-    },
-    "tiff": {
-      "description": "Enable TIFF support to read some grids",
-      "dependencies": [
-        "tiff"
       ]
     },
     "tools": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4718,7 +4718,7 @@
     },
     "proj4": {
       "baseline": "7.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "prometheus-cpp": {
       "baseline": "0.12.1",

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a63c1523c7bb2f3a6be34f485b41f99c82988650",
+      "version-string": "7.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5106324dbb2ce3a08bb9603c5f458aabb67d2a27",
       "version-string": "7.2.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Before this patch building proj in static or static-md triplets always disabled tiff support unconditionally. This patch moves the enable/disable tiff support to the already declared tiff feature flag.

Enabling/disabling tiff support enables/disables certain grid shift operations in proj[4], so with this enabled higher precision transformations may be used for several operations.

This patch leaves curl disabled, so the tiff flag doesn't allow using the CDN for transforms directly, unless a custom handler is installed (uncommon) or the data is available/cached locally (common).

- Which triplets are supported/not supported? Have you updated the CI baseline?
Nothing changed.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?