### PR TITLE
[bfgroup-lyra] Install CMake Targets

### DIFF
--- a/ports/bfgroup-lyra/CONTROL
+++ b/ports/bfgroup-lyra/CONTROL
@@ -1,4 +1,0 @@
-Source: bfgroup-lyra
-Version: 1.5
-Homepage: https://bfgroup.github.io/Lyra/
-Description: A simple to use, composable, command line parser for C++ 11 and beyond

--- a/ports/bfgroup-lyra/portfile.cmake
+++ b/ports/bfgroup-lyra/portfile.cmake
@@ -6,6 +6,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/include/lyra DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(
+    CONFIG_PATH share/lyra/cmake
+    TARGET_PATH share/lyra
+)
 
-configure_file(${SOURCE_PATH}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+# Library is header-only, so no debug content.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/bfgroup-lyra/vcpkg.json
+++ b/ports/bfgroup-lyra/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "bfgroup-lyra",
+  "version-string": "1.5",
+  "port-version": 1,
+  "description": "A simple to use, composable, command line parser for C++ 11 and beyond",
+  "homepage": "https://bfgroup.github.io/Lyra/"
+}

--- a/versions/b-/bfgroup-lyra.json
+++ b/versions/b-/bfgroup-lyra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0cfb523191016e3f686356b2d522034a2b7a47da",
+      "version-string": "1.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "c4a41ae13598868ce4257c7791ea89665d8104b8",
       "version-string": "1.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -334,7 +334,7 @@
     },
     "bfgroup-lyra": {
       "baseline": "1.5",
-      "port-version": 0
+      "port-version": 1
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
Per a report in discord, the `bfgroup-lyra` port is not installing its CMake targets. This fixes that issue.