### PR TITLE
[vcpkg integrate install] Allow setting the vcpkg installed dir

### DIFF
--- a/docs/users/manifests.md
+++ b/docs/users/manifests.md
@@ -15,7 +15,7 @@ rather than global to a system or user.
 In manifest mode, an installed tree is associated with a particular project rather than the vcpkg installation.
 The set of installed ports is controlled by editing the project's "manifest file",
 and the installed tree is placed in the project directory or build directory.
-This mode acts more similarly to language package managers like Cargo, or npm. 
+This mode acts more similarly to language package managers like Cargo, or npm.
 We recommend using this manifest mode whenever possible,
 because it allows one to encode a project's dependencies explicitly in a project file,
 rather than in the documentation, making your project much easier to consume.
@@ -350,4 +350,8 @@ This property must be set to true in order to consume from a local vcpkg.json fi
 *(Requires `Use Vcpkg Manifest` set to `true`)*
 
 This property can be set to "false" to disable automatic dependency restoration on project build. Dependencies can be manually restored via the vcpkg command line.
+
+#### `VcpkgInstalledDirectory` (Installed Directory)
+
+This property defines the location where headers and binaries are consumed from. In manifest mode, this directory is created and populated based on your manifest.
 

--- a/scripts/buildsystems/msbuild/vcpkg-general.xml
+++ b/scripts/buildsystems/msbuild/vcpkg-general.xml
@@ -55,8 +55,8 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="VcpkgInstalledDir" DisplayName="vcpkg installed directory" Category="General" Subtype="folder" Visible="true"
-                  Description="The vcpkg installed directory: this is the place where vcpkg places all of the ports for installation.">
+  <StringProperty Name="VcpkgInstalledDir" DisplayName="Installed Directory" Category="General" Subtype="folder" Visible="true"
+                  Description="The location where headers and binaries will be consumed from. In manifest mode, this directory will be created and populated based on vcpkg.json.">
   </StringProperty>
 
   <BoolProperty Name="VcpkgUseStatic" DisplayName="Use Static Libraries" Category="Conditional" Default="false"

--- a/scripts/buildsystems/msbuild/vcpkg-general.xml
+++ b/scripts/buildsystems/msbuild/vcpkg-general.xml
@@ -55,11 +55,8 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="VcpkgCurrentInstalledDir" DisplayName="Package install directory" Category="General" Subtype="folder" Visible="false"
-                  Description="Defines the direct path to the installed Vcpkg packages.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Vcpkg" HasConfigurationCondition="false" />
-    </StringProperty.DataSource>
+  <StringProperty Name="VcpkgInstalledDir" DisplayName="vcpkg installed directory" Category="General" Subtype="folder" Visible="true"
+                  Description="The vcpkg installed directory: this is the place where vcpkg places all of the ports for installation.">
   </StringProperty>
 
   <BoolProperty Name="VcpkgUseStatic" DisplayName="Use Static Libraries" Category="Conditional" Default="false"

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -77,11 +77,12 @@
   <Target Name="VcpkgInstallManifestDependencies" BeforeTargets="ClCompile"
           Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'"
           Inputs="@(_ZVcpkgInstallManifestDependenciesInputs)"
-          Outputs="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog;$(VcpkgInstalledDir)">
+          Outputs="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog;$(VcpkgInstalledDir).msbuildstamp-$(VcpkgTriplet)">
     <Message Text="Installing vcpkg dependencies to $(VcpkgInstalledDir)" Importance="High" />
     <MakeDir Directories="$(TLogLocation)" />
     <ItemGroup>
       <_VcpkgItemToDelete Include="$(TLogLocation)VcpkgInstallManifest*.read.1u.tlog" />
+      <_VcpkgItemToDelete Include="$(VcpkgInstalledDir).msbuildstamp-*" />
     </ItemGroup>
     <Delete Files="@(_VcpkgItemToDelete)" />
     <Message Text="%22$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))%22 install --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
@@ -92,6 +93,7 @@
                       Lines="@(_VcpkgInstallManifestDependenciesInputs -> '^%(Identity)')"
                       Encoding="Unicode"
                       Overwrite="true"/>
+    <Touch Files="$(VcpkgInstalledDir).msbuildstamp-$(VcpkgTriplet)" AlwaysCreate="true" />
 
     <CreateProperty Value="false">
       <Output TaskParameter="ValueSetByTask" PropertyName="Link_MinimalRebuildFromTracking" />

--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -1,4 +1,4 @@
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="VcpkgConfigSubdir;VcpkgCurrentInstalledDir;VcpkgInstalledDir;VcpkgNormalizedConfiguration">
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="VcpkgConfigSubdir;_ZVcpkgCurrentInstalledDir;VcpkgNormalizedConfiguration">
 
   <!-- Import default properties if not done yet. This does not overwrite any previously defined properties. -->
   <Import Condition="'$(VcpkgPropsImported)' != 'true'" Project="vcpkg.props" />
@@ -18,12 +18,12 @@
     <VcpkgRoot Condition="'$(VcpkgRoot)' != '' and !$(VcpkgRoot.EndsWith('\'))">$(VcpkgRoot)\</VcpkgRoot>
     <VcpkgManifestRoot Condition="'$(VcpkgManifestRoot)' != '' and !$(VcpkgManifestRoot.EndsWith('\'))">$(VcpkgManifestRoot)\</VcpkgManifestRoot>
 
-    <VcpkgInstalledDir>$([System.IO.Path]::Combine($(VcpkgRoot), 'installed'))</VcpkgInstalledDir>
-    <VcpkgInstalledDir Condition="'$(VcpkgEnableManifest)' == 'true'">$([System.IO.Path]::Combine($(VcpkgManifestRoot), 'vcpkg_installed'))</VcpkgInstalledDir>
+    <VcpkgInstalledDir Condition="'$(VcpkgInstalledDir)' == '' and '$(VcpkgEnableManifest)' != 'true'">$([System.IO.Path]::Combine($(VcpkgRoot), 'installed'))</VcpkgInstalledDir>
+    <VcpkgInstalledDir Condition="'$(VcpkgInstalledDir)' == '' and '$(VcpkgEnableManifest)' == 'true'">$([System.IO.Path]::Combine($(VcpkgManifestRoot), 'vcpkg_installed'))</VcpkgInstalledDir>
     <VcpkgInstalledDir Condition="!$(VcpkgInstalledDir.EndsWith('\'))">$(VcpkgInstalledDir)\</VcpkgInstalledDir>
 
-    <VcpkgCurrentInstalledDir Condition="'$(VcpkgCurrentInstalledDir)' == ''">$([System.IO.Path]::Combine($(VcpkgInstalledDir), $(VcpkgTriplet)))</VcpkgCurrentInstalledDir>
-    <VcpkgCurrentInstalledDir Condition="!$(VcpkgCurrentInstalledDir.EndsWith('\'))">$(VcpkgCurrentInstalledDir)\</VcpkgCurrentInstalledDir>
+    <_ZVcpkgCurrentInstalledDir>$([System.IO.Path]::Combine($(VcpkgInstalledDir), $(VcpkgTriplet)))</_ZVcpkgCurrentInstalledDir>
+    <_ZVcpkgCurrentInstalledDir Condition="!$(_ZVcpkgCurrentInstalledDir.EndsWith('\'))">$(_ZVcpkgCurrentInstalledDir)\</_ZVcpkgCurrentInstalledDir>
 
     <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Debug'))">Debug</VcpkgNormalizedConfiguration>
     <VcpkgNormalizedConfiguration Condition="$(VcpkgConfiguration.StartsWith('Release')) or '$(VcpkgConfiguration)' == 'RelWithDebInfo' or '$(VcpkgConfiguration)' == 'MinSizeRel'">Release</VcpkgNormalizedConfiguration>
@@ -42,14 +42,14 @@
 
   <ItemDefinitionGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <Link>
-      <AdditionalDependencies Condition="'$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\*.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
+      <AdditionalDependencies Condition="'$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(_ZVcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\*.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(_ZVcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(_ZVcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(VcpkgCurrentInstalledDir)include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)include</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(VcpkgCurrentInstalledDir)include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(_ZVcpkgCurrentInstalledDir)include</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
 
@@ -61,7 +61,7 @@
   </Target>
 
   <Target Name="VcpkgTripletSelection" BeforeTargets="ClCompile">
-    <Message Text="Using triplet &quot;$(VcpkgTriplet)&quot; from &quot;$(VcpkgCurrentInstalledDir)&quot;"
+    <Message Text="Using triplet &quot;$(VcpkgTriplet)&quot; from &quot;$(_ZVcpkgCurrentInstalledDir)&quot;"
              Importance="Normal" Condition="'$(VcpkgEnabled)' == 'true'"/>
     <Message Text="Not using Vcpkg because VcpkgEnabled is &quot;$(VcpkgEnabled)&quot;"
              Importance="Normal" Condition="'$(VcpkgEnabled)' != 'true'"/>
@@ -70,20 +70,22 @@
   </Target>
 
   <ItemGroup>
-    <_VcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg.json"/>
-    <_VcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg-configuration.json" Condition="Exists('$(VcpkgManifestRoot)vcpkg-configuration.json')"/>
+    <_ZVcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg.json"/>
+    <_ZVcpkgInstallManifestDependenciesInputs Include="$(VcpkgManifestRoot)vcpkg-configuration.json" Condition="Exists('$(VcpkgManifestRoot)vcpkg-configuration.json')"/>
   </ItemGroup>
 
   <Target Name="VcpkgInstallManifestDependencies" BeforeTargets="ClCompile"
           Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgEnableManifest)' == 'true' and '$(VcpkgManifestInstall)' == 'true'"
-          Inputs="@(_VcpkgInstallManifestDependenciesInputs)"
-          Outputs="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog">
+          Inputs="@(_ZVcpkgInstallManifestDependenciesInputs)"
+          Outputs="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog;$(VcpkgInstalledDir)">
     <Message Text="Installing vcpkg dependencies to $(VcpkgInstalledDir)" Importance="High" />
     <MakeDir Directories="$(TLogLocation)" />
     <ItemGroup>
       <_VcpkgItemToDelete Include="$(TLogLocation)VcpkgInstallManifest*.read.1u.tlog" />
     </ItemGroup>
     <Delete Files="@(_VcpkgItemToDelete)" />
+    <Message Text="%22$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))%22 install --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
+          Importance="High" />
     <Exec Command="%22$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))%22 install --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
           StandardOutputImportance="High" />
     <WriteLinesToFile File="$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).read.1u.tlog"
@@ -100,7 +102,7 @@
           Condition="'$(VcpkgEnabled)' == 'true' and '$(VcpkgApplocalDeps)' == 'true' and '$(LinkSkippedExecution)' != 'true'">
     <Message Text="[vcpkg] Starting VcpkgApplocalDeps" Importance="low" />
     <PropertyGroup>
-      <_VcpkgAppLocalPowerShellCommonArguments>-ExecutionPolicy Bypass -noprofile -File "$(MSBuildThisFileDirectory)applocal.ps1" "$(TargetPath)" "$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)bin" "$(TLogLocation)$(ProjectName).write.1u.tlog" "$(IntDir)vcpkg.applocal.log"</_VcpkgAppLocalPowerShellCommonArguments>
+      <_VcpkgAppLocalPowerShellCommonArguments>-ExecutionPolicy Bypass -noprofile -File "$(MSBuildThisFileDirectory)applocal.ps1" "$(TargetPath)" "$(_ZVcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)bin" "$(TLogLocation)$(ProjectName).write.1u.tlog" "$(IntDir)vcpkg.applocal.log"</_VcpkgAppLocalPowerShellCommonArguments>
     </PropertyGroup>
     <!-- Search %PATH% for pwsh.exe if it is available. -->
     <Exec


### PR DESCRIPTION
Still to do: this breaks the no-op case where `vcpkg install` should not be called; however, this was necessary because otherwise changing the current installed dir would not work. cc @ras0219 for any ideas?