### PR TITLE
[google-cloud-cpp] use 'version' for version numbers

### DIFF
--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "google-cloud-cpp",
-  "version-string": "1.24.0",
-  "port-version": 1,
+  "version": "1.24.0",
+  "port-version": 2,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2258,7 +2258,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.24.0",
-      "port-version": 1
+      "port-version": 2
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "720f34d5340392fe35e2ed3553b378225c8bb211",
+      "version": "1.24.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "16ca3b8eae830e46a951f7e5dc10408ee0517f6d",
       "version-string": "1.24.0",
       "port-version": 1


### PR DESCRIPTION
`google-cloud-cpp` versions can take advantage of the [version sorting](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#version), so let's do.

- What does your PR fix? Fixes #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
