### PR TITLE
[functions-framework-cpp] use 'version' for version numbers

### DIFF
--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "functions-framework-cpp",
-  "version-string": "0.3.0",
-  "port-version": 1,
+  "version": "0.3.0",
+  "port-version": 2,
   "description": "Functions Framework for C++.",
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2074,7 +2074,7 @@
     },
     "functions-framework-cpp": {
       "baseline": "0.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "fuzzylite": {
       "baseline": "6.0",

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c99280d0ee9b2e57960d13b54521a2305c1f85a8",
+      "version": "0.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1506acc2df21c0b49e93d73da7229d524ace0fb3",
       "version-string": "0.3.0",
       "port-version": 1


### PR DESCRIPTION
`functions-framework-cpp` versions can take advantage of the [version sorting](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#version), so let's do.

- What does your PR fix? Fixes #
N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes
