### PR TITLE
[quill] Uncomment QUILL_FMT_EXTERNAL macro

### DIFF
--- a/ports/quill/CONTROL
+++ b/ports/quill/CONTROL
@@ -1,5 +1,6 @@
 Source: quill
 Version: 1.6.1
+Port-Version: 1
 Homepage: https://github.com/odygrd/quill/
 Description: C++14 Asynchronous Low Latency Logging Library
 Supports: !(arm|uwp|android)

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -20,9 +20,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/quill)
 
-file(READ ${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h QUILLCONFIG)
-string(REGEX REPLACE "// #define QUILL_FMT_EXTERNAL" "#define QUILL_FMT_EXTERNAL" QUILLCONFIG "${QUILLCONFIG}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h "${QUILLCONFIG}")
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h "// #define QUILL_FMT_EXTERNAL" "#define QUILL_FMT_EXTERNAL")
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -10,10 +10,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# remove bundled fmt
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/quill/quill/include/quill/bundled/fmt)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/quill/quill/src/bundled/fmt)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -22,9 +18,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/quill)
 
+file(READ ${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h QUILLCONFIG)
+string(REGEX REPLACE "// #define QUILL_FMT_EXTERNAL" "#define QUILL_FMT_EXTERNAL" QUILLCONFIG "${QUILLCONFIG}")
+file(WRITE ${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h "${QUILLCONFIG}")
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5006,7 +5006,7 @@
     },
     "quill": {
       "baseline": "1.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "quirc": {
       "baseline": "1.1",

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a29a0dd1467a5224f7838e8b1c9f63d263702e87",
+      "version-string": "1.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "51f728199fde5bc02ecc29588236bb509cc4bb10",
       "version-string": "1.6.1",
       "port-version": 0

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a29a0dd1467a5224f7838e8b1c9f63d263702e87",
+      "git-tree": "aa542e38f0f2480e495b785840e919d46a1d58d5",
       "version-string": "1.6.1",
       "port-version": 1
     },


### PR DESCRIPTION
As we build using the vcpkg fmt port instead of the one bundled in Quill, this macro needs to be defined.