### PR TITLE
[suitesparse] Copy shared library to build directory.

### DIFF
--- a/ports/suitesparse/portfile.cmake
+++ b/ports/suitesparse/portfile.cmake
@@ -46,6 +46,8 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/suitesparse)
 
+vcpkg_copy_pdbs()
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/suitesparse/vcpkg.json
+++ b/ports/suitesparse/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "suitesparse",
   "version-semver": "5.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A suite of sparse matrix algorithms. Also provides libcxsparse.",
   "homepage": "http://suitesparse.com",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5590,7 +5590,7 @@
     },
     "suitesparse": {
       "baseline": "5.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "sundials": {
       "baseline": "5.5.0",

--- a/versions/s-/suitesparse.json
+++ b/versions/s-/suitesparse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "805b5b9556d7ff63261dfde41b4cf3c54e540334",
+      "version-semver": "5.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "4c709290c9cc6e7635c120dbd5cd9d227408a0ab",
       "version-semver": "5.8.0",
       "port-version": 1


### PR DESCRIPTION
This PR fixes issue #14203 by copying the shared suitesparse library to the build directory.
