### PR TITLE
[taglib] Upgrade to 1.12

### DIFF
--- a/ports/taglib/CONTROL
+++ b/ports/taglib/CONTROL
@@ -1,5 +1,0 @@
-Source: taglib
-Version: 1.11.1-20190531
-Description: TagLib Audio Meta-Data Library
-Homepage: https://github.com/taglib/taglib
-Build-Depends: zlib

--- a/ports/taglib/msvc-disable-deprecated-warnings.patch
+++ b/ports/taglib/msvc-disable-deprecated-warnings.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fc91cc6..6f57e4ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,10 +58,17 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+ endif()
+
+-if(MSVC AND ENABLE_STATIC_RUNTIME)
+-  foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+-    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+-  endforeach(flag_var)
++if(MSVC)
++  if(ENABLE_STATIC_RUNTIME)
++    foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
++      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
++    endforeach(flag_var)
++  endif()
++  # Disable warnings for internal invocations of API functions
++  # that have been marked with TAGLIB_DEPRECATED
++  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996
++  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
+ endif()
+
+ # Read version information from file taglib/toolkit/taglib.h into variables

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v1.12
     SHA512 63c96297d65486450908bda7cc1583ec338fa5a56a7c088fc37d6e125e1ee76e6d20343556a8f3d36f5b7e5187c58a5d15be964c996e3586ea1438910152b1a6
     HEAD_REF master
+    PATCHES msvc-disable-deprecated-warnings.patch
 )
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taglib/taglib
-    REF ba7adc2bc261ed634c2a964185bcffb9365ad2f4
-    SHA512 faf516f40f12031a37414ce9246ec409e64e570faebe2d604afdefbb7d665e0a0c9c68bec0e6dcb1c5ceb8fa8e1c3477f5ac75029f17beedd679fa3ea735ce6d
+    REF v1.12
+    SHA512 63c96297d65486450908bda7cc1583ec338fa5a56a7c088fc37d6e125e1ee76e6d20343556a8f3d36f5b7e5187c58a5d15be964c996e3586ea1438910152b1a6
     HEAD_REF master
 )
 
@@ -17,6 +17,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_pkgconfig()
 
 # remove the debug/include files
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "taglib",
+  "version-string": "1.12",
+  "description": "TagLib Audio Meta-Data Library",
+  "homepage": "https://taglib.org/",
+  "license": "LGPL-2.1 AND MPL-1.1",
+  "dependencies": [
+    "zlib"
+  ]
+}

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "1.12",
   "description": "TagLib Audio Meta-Data Library",
   "homepage": "https://taglib.org/",
-  "license": "LGPL-2.1 AND MPL-1.1",
+  "license": "LGPL-2.1 OR MPL-1.1",
   "dependencies": [
     "zlib"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5685,7 +5685,7 @@
       "port-version": 0
     },
     "taglib": {
-      "baseline": "1.11.1-20190531",
+      "baseline": "1.12",
       "port-version": 0
     },
     "taocpp-json": {

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb511f3c77beba553608ca77c9561e9bd8e7edda",
+      "version-string": "1.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "8aee2b399d4cd5af999057cbbe5e9476272b5a24",
       "version-string": "1.11.1-20190531",
       "port-version": 0

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bb511f3c77beba553608ca77c9561e9bd8e7edda",
+      "git-tree": "a8855c21b8e75b485552ff17d8d77ee5477143f9",
       "version-string": "1.12",
       "port-version": 0
     },


### PR DESCRIPTION
- Replace CONTROL with vcpkg.json
- Use Git tag as REF
- Use official version number (without the date suffix)
- Link official homepage instead of GitHub project page
- Add license string according to GitHub repo
  https://github.com/taglib/taglib/issues/999
- Add missing vcpkg_fixup_pkgconfig() in portfile