### PR TITLE
[vcpkg baseline][gsoap] Update to 2.8.111

### DIFF
--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -1,5 +1,5 @@
 Source: gsoap
-Version: 2.8.105
+Version: 2.8.111
 Build-Depends: curl
 Homepage: https://sourceforge.net/projects/gsoap2/
 Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.

--- a/ports/gsoap/portfile.cmake
+++ b/ports/gsoap/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsoap2
     REF gsoap-2.8
-    FILENAME "gsoap_2.8.105.zip"
-    SHA512 3b7b66ef738e9ba78f0c9d5ec141faab102dc2ed7c528e84358d530ec8cb913c559438bb86ae0f22e0736c4cd9be9e74f364a44257189ccaa1e6d001317f99de
+    FILENAME "gsoap_2.8.111.zip"
+    SHA512 9cc7f0252f82ec18d19784aba2d913e70620fc09955d148a31e2c89bba4915d20a6b592bd7b6a747f89dc3ab17b2bc542d672933fa1a3acbf59bc3d1f49fe31b
     PATCHES fix-build-in-windows.patch
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2325,7 +2325,7 @@
       "port-version": 0
     },
     "gsoap": {
-      "baseline": "2.8.105",
+      "baseline": "2.8.111",
       "port-version": 0
     },
     "gtest": {

--- a/versions/g-/gsoap.json
+++ b/versions/g-/gsoap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "010523cbf786f4563ccef87dc0d28b13083f06f0",
+      "version-string": "2.8.111",
+      "port-version": 0
+    },
+    {
       "git-tree": "a376e6e1ce84fa44f521c1cd75ac61ad71d811d9",
       "version-string": "2.8.105",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

The current archive 2.8.105 doesn't exist now. So update it to the latest version.

Related #16268
