### PR TITLE
[spdlog] Prevents MSVC warning flags to propagate in CUDA

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,6 +1,6 @@
 Source: spdlog
 Version: 1.8.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/fix-prevent-msvc-warning-in-cuda.patch
+++ b/ports/spdlog/fix-prevent-msvc-warning-in-cuda.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e554d6..4261c3c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -131,7 +131,7 @@ if (SPDLOG_BUILD_SHARED)
+     add_library(spdlog SHARED ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
+     target_compile_definitions(spdlog PUBLIC SPDLOG_SHARED_LIB)
+     if (MSVC)
+-        target_compile_options(spdlog PUBLIC /wd4251 /wd4275)
++        target_compile_options(spdlog PUBLIC $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/wd4251 /wd4275>)
+     endif ()
+     if (NOT SPDLOG_FMT_EXTERNAL AND NOT SPDLOG_FMT_EXTERNAL_HO)
+         target_compile_definitions(spdlog PRIVATE FMT_EXPORT PUBLIC FMT_SHARED)

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 4a9ccf7e38e257feecce0c579a782741254eaeef # v1.8.0
     SHA512 333f14704e0d0aa88abbe4ddd29aeb009de2f845440559d463f1b7f9c7da32b2fbdba0f2abf97ec2a5c479d2d62bb2220b21a1bc423d62fbbb93952cf829d532
     HEAD_REF v1.x
-    PATCHES fix-featurebuild.patch
+    PATCHES 
+        fix-featurebuild.patch
+        fix-prevent-msvc-warning-in-cuda.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     HEAD_REF v1.x
     PATCHES 
         fix-featurebuild.patch
-        fix-prevent-msvc-warning-in-cuda.patch
+        fix-prevent-msvc-warning-in-cuda.patch # Remove this patch in the next update
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5538,7 +5538,7 @@
     },
     "spdlog": {
       "baseline": "1.8.0",
-      "port-version": 2
+      "port-version": 3
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78821eaa76c9a7dba6fc07c0b81f1e4554c4fa7b",
+      "version-string": "1.8.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "83277d69ee0f37839d9f06c9fb658a3dd457e3eb",
       "version-string": "1.8.0",
       "port-version": 2

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "78821eaa76c9a7dba6fc07c0b81f1e4554c4fa7b",
+      "git-tree": "c0e2b63131855b012c682ba9b23f37cfc642cdde",
       "version-string": "1.8.0",
       "port-version": 3
     },


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16153

Upstream issue https://github.com/gabime/spdlog/issues/1825


Use the patch from upstream PR https://github.com/gabime/spdlog/pull/1829 to fix the warning.

Note: There is no need to test features.


