### PR TITLE
[llvm] Fix resource path when building tools

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,5 +1,6 @@
 Source: llvm
 Version: 11.0.0
+Port-Version: 1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -119,6 +119,10 @@ if("polly" IN_LIST FEATURES)
     list(APPEND LLVM_ENABLE_PROJECTS "polly")
 endif()
 
+if("tools" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -DCLANG_RESOURCE_DIR=../../lib/clang/11.0.0)
+endif()
+
 set(known_llvm_targets
     AArch64
     AMDGPU

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3594,7 +3594,7 @@
     },
     "llvm": {
       "baseline": "11.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "lmdb": {
       "baseline": "0.9.24",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a8e86d3dc793c4404435e87c04470da6d9cccce",
+      "version-string": "11.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0188d318ae61d867088f8717bc5ed178479f14a1",
       "version-string": "11.0.0",
       "port-version": 0


### PR DESCRIPTION
> Default resource directory for clang is constructed relative to the location of the clang executable:
> 
> From `clang/lib/Driver/Driver.cpp`:
> 
> ```
> std::string Driver::GetResourcesPath(StringRef BinaryPath,
>                                      StringRef CustomResourceDir) {
> ...
>   // Dir is bin/ or lib/, depending on where BinaryPath is.
>   std::string Dir = llvm::sys::path::parent_path(BinaryPath);
> ...
>     P = llvm::sys::path::parent_path(Dir);
>     llvm::sys::path::append(P, Twine("lib") + CLANG_LIBDIR_SUFFIX, "clang",
>                             CLANG_VERSION_STRING);
> ...
> }
> ```
> 
> Vcpkg moves clang to `tools/llvm` adding a subdirectory. As a result the above code produces `tools/lib/clang/11.0.0` which does not exist. Clang is therefore unable to find header files under `lib/clang/11.0.0`.
> 
> From `clang/lib/Driver/ToolChains/Clang.cpp`:
> 
> ```
>   // Pass the path to compiler resource files.
>   CmdArgs.push_back("-resource-dir");
>   CmdArgs.push_back(D.ResourceDir.c_str());
> ```
> 
> I have worked around the problem by adding this to my `ports/llvm/portfile.cmake`
> 
> ```
> list(APPEND FEATURE_OPTIONS
>      -DCLANG_RESOURCE_DIR=../../lib/clang/11.0.0
> )
> ```

Fix this.

Fixes #16284.