### PR TITLE
[vcpkg_check_features] Document variables set in the parent scope

### DIFF
--- a/docs/maintainers/vcpkg_check_features.md
+++ b/docs/maintainers/vcpkg_check_features.md
@@ -48,6 +48,8 @@ Arguments passed to `FEATURES` and `INVERTED_FEATURES` are not validated to prev
 If the same (`FEATURE_NAME`, `OPTION_NAME`) pair is passed to both lists,
 two conflicting definitions are added to `OUT_FEATURE_OPTIONS`.
 
+For each definition added to `OUT_FEATURE_OPTIONS`, the corresponding variable will also be set in
+the parent scope, so they are immediately available after calling this function.
 
 ## Examples
 

--- a/scripts/cmake/vcpkg_check_features.cmake
+++ b/scripts/cmake/vcpkg_check_features.cmake
@@ -49,6 +49,8 @@ Arguments passed to `FEATURES` and `INVERTED_FEATURES` are not validated to prev
 If the same (`FEATURE_NAME`, `OPTION_NAME`) pair is passed to both lists,
 two conflicting definitions are added to `OUT_FEATURE_OPTIONS`.
 
+For each definition added to `OUT_FEATURE_OPTIONS`, the corresponding variable will also be set in
+the parent scope, so they are immediately available after calling this function.
 
 ## Examples
 


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

This behavior is already used in existing ports: https://github.com/microsoft/vcpkg/pull/16082#discussion_r571577415. So I think it's better to document it.

- Which triplets are supported/not supported? Have you updated the CI baseline?

Not relevant.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
