### PR TITLE
[vcpkg] Add tar support for gettext

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -310,7 +310,7 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
         SHA512 7306dec7859edc27d70a24ab4b396728481484a426c5aa2f7e9fed2635b3b25548b05b7d37a161a86a8edaa5922948bee8c99b1e8a078606e69ca48a433fe321
         DEPS libintl msys2-runtime
     )
-msys_package(
+    msys_package(
         URL "https://repo.msys2.org/msys/x86_64/gettext-devel-0.19.8.1-1-x86_64.pkg.tar.xz"
         SHA512 648f74c23e4f92145cdd0d45ff5285c2df34e855a9e75e5463dd6646967f8cf34a18ce357c6f498a4680e6d7b84e2d1697ba9deee84da8ea6bb14bbdb594ee22
         DEPS gettext
@@ -318,7 +318,12 @@ msys_package(
     msys_package(
         URL "https://repo.msys2.org/msys/x86_64/gettext-0.19.8.1-1-x86_64.pkg.tar.xz"
         SHA512 c8c42d084c297746548963f7ec7a7df46241886f3e637e779811ee4a8fee6058f892082bb2658f6777cbffba2de4bcdfd68e846ba63c6a6552c9efb0c8c1de50
-        DEPS libintl libgettextpo libasprintf
+        DEPS libintl libgettextpo libasprintf tar
+    )
+    msys_package(
+        URL "https://repo.msys2.org/msys/x86_64/tar-1.32-1-x86_64.pkg.tar.xz"
+        SHA512 379525f4b8a3f21d67d6506647aec8367724e1b4c896039f46845d9e834298280381e7261a87440925ee712794d43074f4ffb5e09e67a5195af810bbc107ad9a
+        DEPS libiconv libintl
     )
     msys_package(
         URL "https://repo.msys2.org/msys/x86_64/libgettextpo-0.19.8.1-1-x86_64.pkg.tar.xz"


### PR DESCRIPTION
Add `tar` dependency for `gettext`, which requires `tar` when running `autopoint`.

I believe this should resolve #15508 and #14830 - I was able to build `fontconfig` on Windows 7 with this change.

**However**: Keep in mind that I have not tinkered with `vcpkg` before, so I have no idea if this is the 'right' way to do things. Also, I do not know if this will cause conflicts for Windows 10 which apparently has native `tar` support.