### PR TITLE
[vcpkg_configure_make][vcpkg_build_make] Use prefix without DESTDIR

### DIFF
--- a/ports/apr-util/CONTROL
+++ b/ports/apr-util/CONTROL
@@ -1,6 +1,0 @@
-Source: apr-util
-Version: 1.6.1
-Port-Version: 3
-Homepage: https://apr.apache.org/
-Description: Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation
-Build-Depends: expat, apr, openssl

--- a/ports/apr-util/portfile.cmake
+++ b/ports/apr-util/portfile.cmake
@@ -65,11 +65,25 @@ else(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
         NO_DEBUG
-        OPTIONS 
+        OPTIONS
             "--prefix=${CURRENT_INSTALLED_DIR}"
             "--with-apr=${CURRENT_INSTALLED_DIR}/tools/apr"
             "--with-openssl=${CURRENT_INSTALLED_DIR}"
             "-with-expat=${CURRENT_INSTALLED_DIR}"
+            --without-nss
+            --without-commoncrypto
+            --without-lber
+            --without-ldap
+            --without-gdbm
+            --without-ndbm
+            --without-berkeley-db
+            --without-sqlite3
+            --without-sqlite2
+            --without-mysql
+            --without-pgsql
+            --without-oracle
+            --without-odbc
+            --without-iconv
             "${CONFIGURE_PARAMETER_1}"
             "${CONFIGURE_PARAMETER_2}"
             "${CONFIGURE_PARAMETER_3}"

--- a/ports/apr-util/vcpkg.json
+++ b/ports/apr-util/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "apr-util",
+  "version": "1.6.1",
+  "port-version": 4,
+  "description": "Apache Portable Runtime (APR) project  mission is to create and maintain software libraries that provide a predictable and consistent interface to underlying platform-specific implementation",
+  "homepage": "https://apr.apache.org/",
+  "dependencies": [
+    "apr",
+    "expat",
+    "openssl"
+  ]
+}

--- a/ports/apr/CONTROL
+++ b/ports/apr/CONTROL
@@ -1,9 +1,0 @@
-Source: apr
-Version: 1.7.0
-Port-Version: 3
-Homepage: https://apr.apache.org/
-Description: The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.
-Supports: !uwp
-
-Feature: private-headers
-Description: Install non-standard files required for building Apache httpd

--- a/ports/apr/portfile.cmake
+++ b/ports/apr/portfile.cmake
@@ -84,6 +84,16 @@ else()
         "-lapr-\${APR_MAJOR_VERSION}" "-lapr-1"
     )
     vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES pthread rt dl uuid crypt)
+
+    foreach(SUBPATH "" "/debug")
+        if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/apr${SUBPATH}/bin/apr-1-config")
+            file(READ "${CURRENT_PACKAGES_DIR}/tools/apr${SUBPATH}/bin/apr-1-config" _contents)
+            string(REGEX REPLACE "\nprefix=[^\n]*\n" "\nprefix=\"\$(dirname \"\$0\")/../../..${SUBPATH}\"\n" _contents "${_contents}")
+            string(REGEX REPLACE "\nAPR_SOURCE_DIR=[^\n]*\n" "\nAPR_SOURCE_DIR=\"\"\n" _contents "${_contents}")
+            string(REGEX REPLACE "\nAPR_BUILD_DIR=[^\n]*\n" "\nAPR_BUILD_DIR=\"\"\n" _contents "${_contents}")
+            file(WRITE "${CURRENT_PACKAGES_DIR}/tools/apr${SUBPATH}/bin/apr-1-config" "${_contents}")
+        endif()
+    endforeach()
 endif()
 
 # Handle copyright

--- a/ports/apr/vcpkg.json
+++ b/ports/apr/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "apr",
+  "version": "1.7.0",
+  "port-version": 4,
+  "description": "The Apache Portable Runtime (APR) is a C library that forms a system portability layer that covers many operating systems.",
+  "homepage": "https://apr.apache.org/",
+  "supports": "!uwp",
+  "features": {
+    "private-headers": {
+      "description": "Install non-standard files required for building Apache httpd"
+    }
+  }
+}

--- a/ports/mpc/CONTROL
+++ b/ports/mpc/CONTROL
@@ -1,5 +1,0 @@
-Source: mpc
-Version: 1.2.0
-Homepage: http://www.multiprecision.org/mpc/
-Description: GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.
-Build-Depends: gmp, mpfr

--- a/ports/mpc/gmpd.patch
+++ b/ports/mpc/gmpd.patch
@@ -1,15 +1,15 @@
 diff --git a/configure.ac b/configure.ac
-index ab3da6092..2533df1d8 100644
+index ab3da60..1e5fc78 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -151,7 +151,9 @@ AC_CHECK_FUNCS([dup dup2],,
+@@ -149,8 +149,8 @@ AC_CHECK_FUNCS([gettimeofday localeconv setlocale getrusage])
+ AC_CHECK_FUNCS([dup dup2],,
+         [AC_DEFINE([MPC_NO_STREAM_REDIRECTION],1,[Do not check mpc_out_str on stdout])])
  
- AC_CHECK_LIB([gmp], [__gmpz_init],
-              [LIBS="-lgmp $LIBS"],
--             [AC_MSG_ERROR([libgmp not found or uses a different ABI (including static vs shared).])])
-+             [AC_CHECK_LIB([gmpd], [__gmpz_init],
-+             [LIBS="-lgmpd $LIBS"],
-+             [AC_MSG_ERROR([libgmp not found or uses a different ABI (including static vs shared).])])])
+-AC_CHECK_LIB([gmp], [__gmpz_init],
+-             [LIBS="-lgmp $LIBS"],
++PKG_CHECK_MODULES([GMP], [gmp],
++             [LIBS="$GMP_LIBS $LIBS"],
+              [AC_MSG_ERROR([libgmp not found or uses a different ABI (including static vs shared).])])
  
  AC_MSG_CHECKING(for MPFR)
- LIBS="-lmpfr $LIBS"

--- a/ports/mpc/vcpkg.json
+++ b/ports/mpc/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "mpc",
+  "version": "1.2.0",
+  "port-version": 1,
+  "description": "GNU MPC is a C library for the arithmetic of complex numbers with arbitrarily high precision and correct rounding of the result.",
+  "homepage": "http://www.multiprecision.org/mpc/",
+  "dependencies": [
+    "gmp",
+    "mpfr"
+  ]
+}

--- a/ports/openmpi/CONTROL
+++ b/ports/openmpi/CONTROL
@@ -1,6 +1,0 @@
-Source: openmpi
-Version: 4.0.3
-Port-Version: 3
-Homepage: https://www.open-mpi.org/
-Description: The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.
-Supports: !(windows|uwp)

--- a/ports/openmpi/opal_wrapper.dbg.sh
+++ b/ports/openmpi/opal_wrapper.dbg.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+export OPAL_PREFIX="$( cd "$DIR/../../.." && pwd )"
+export OPAL_INCLUDEDIR="$( cd "$DIR/../../../../include" && pwd )"
+exec -a "$0" "$DIR/opal_wrapper_real" "$@"

--- a/ports/openmpi/opal_wrapper.rel.sh
+++ b/ports/openmpi/opal_wrapper.rel.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+export OPAL_PREFIX="$( cd "$DIR/../../.." && pwd )"
+exec -a "$0" "$DIR/opal_wrapper_real" "$@"

--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -35,4 +35,15 @@ vcpkg_install_make(DISABLE_PARALLEL)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
+# Use shell script wrappers to make the executables relocatable; see https://www.open-mpi.org/faq/?category=building#installdirs
+# All executables are symlinks to `opal_wrapper`, so we only need to replace that. This will not work on systems that don't support symlinks.
+if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/openmpi/debug/bin/opal_wrapper")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/openmpi/debug/bin/opal_wrapper" "${CURRENT_PACKAGES_DIR}/tools/openmpi/debug/bin/opal_wrapper_real")
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/opal_wrapper.dbg.sh" "${CURRENT_PACKAGES_DIR}/tools/openmpi/debug/bin/opal_wrapper" COPYONLY)
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/openmpi/bin/opal_wrapper")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/tools/openmpi/bin/opal_wrapper" "${CURRENT_PACKAGES_DIR}/tools/openmpi/bin/opal_wrapper_real")
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/opal_wrapper.rel.sh" "${CURRENT_PACKAGES_DIR}/tools/openmpi/bin/opal_wrapper" COPYONLY)
+endif()
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/openmpi/vcpkg.json
+++ b/ports/openmpi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "openmpi",
+  "version-semver": "4.0.3",
+  "port-version": 5,
+  "description": "The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.",
+  "homepage": "https://www.open-mpi.org/",
+  "supports": "!(windows | uwp)"
+}

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -99,7 +99,7 @@ function(vcpkg_build_make)
         string(REPLACE " " "\\\ " _VCPKG_PACKAGE_PREFIX ${CURRENT_PACKAGES_DIR})
         # Don't know why '/cygdrive' is suddenly a requirement here. (at least for x264)
         string(REGEX REPLACE "([a-zA-Z]):/" "/cygdrive/\\1/" _VCPKG_PACKAGE_PREFIX "${_VCPKG_PACKAGE_PREFIX}")
-        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} --trace -f ${_bc_MAKEFILE} ${_bc_INSTALL_TARGET} DESTDIR=${_VCPKG_PACKAGE_PREFIX})
+        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} --trace -f ${_bc_MAKEFILE} ${_bc_INSTALL_TARGET})
         #TODO: optimize for install-data (release) and install-exec (release/debug)
     else()
         # Compiler requriements
@@ -112,7 +112,7 @@ function(vcpkg_build_make)
         # Set make command and install command
         set(MAKE_OPTS ${_bc_MAKE_OPTIONS} V=1 -j ${VCPKG_CONCURRENCY} -f ${_bc_MAKEFILE} ${_bc_BUILD_TARGET})
         set(NO_PARALLEL_MAKE_OPTS ${_bc_MAKE_OPTIONS} V=1 -j 1 -f ${_bc_MAKEFILE} ${_bc_BUILD_TARGET})
-        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} -f ${_bc_MAKEFILE} ${_bc_INSTALL_TARGET} DESTDIR=${CURRENT_PACKAGES_DIR})
+        set(INSTALL_OPTS -j ${VCPKG_CONCURRENCY} -f ${_bc_MAKEFILE} ${_bc_INSTALL_TARGET})
     endif()
 
     # Since includes are buildtype independent those are setup by vcpkg_configure_make
@@ -229,14 +229,6 @@ function(vcpkg_build_make)
             endif()
         endif()
     endforeach()
-
-    if (_bc_ENABLE_INSTALL)
-        string(REGEX REPLACE "([a-zA-Z]):/" "/\\1/" _VCPKG_INSTALL_PREFIX "${CURRENT_INSTALLED_DIR}")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}_tmp")
-        file(RENAME "${CURRENT_PACKAGES_DIR}" "${CURRENT_PACKAGES_DIR}_tmp")
-        file(RENAME "${CURRENT_PACKAGES_DIR}_tmp${_VCPKG_INSTALL_PREFIX}/" "${CURRENT_PACKAGES_DIR}")
-        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}_tmp")
-    endif()
 
     # Remove libtool files since they contain absolute paths and are not necessary. 
     file(GLOB_RECURSE LIBTOOL_FILES "${CURRENT_PACKAGES_DIR}/**/*.la")

--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -403,8 +403,8 @@ function(vcpkg_configure_make)
         # CXXLINK  The command used to actually link a C++ program. 
     
         #Some PATH handling for dealing with spaces....some tools will still fail with that!
-        string(REPLACE " " "\\\ " _VCPKG_PREFIX ${CURRENT_INSTALLED_DIR})
-        string(REGEX REPLACE "([a-zA-Z]):/" "/\\1/" _VCPKG_PREFIX "${_VCPKG_PREFIX}")
+        string(REPLACE " " "\\\ " _VCPKG_PREFIX "${CURRENT_PACKAGES_DIR}")
+        string(REGEX REPLACE "^([a-zA-Z]):/" "/cygdrive/\\1/" _VCPKG_PREFIX "${_VCPKG_PREFIX}")
         set(_VCPKG_INSTALLED ${CURRENT_INSTALLED_DIR})
         set(prefix_var "'\${prefix}'") # Windows needs extra quotes or else the variable gets expanded in the makefile!
 
@@ -421,8 +421,8 @@ function(vcpkg_configure_make)
             list(APPEND _csc_OPTIONS lt_cv_deplibs_check_method=pass_all)
         endif()
     else()
-        string(REPLACE " " "\ " _VCPKG_PREFIX ${CURRENT_INSTALLED_DIR})
-        string(REPLACE " " "\ " _VCPKG_INSTALLED ${CURRENT_INSTALLED_DIR})
+        string(REPLACE " " "\ " _VCPKG_PREFIX "${CURRENT_PACKAGES_DIR}")
+        string(REPLACE " " "\ " _VCPKG_INSTALLED "${CURRENT_INSTALLED_DIR}")
         set(EXTRA_QUOTES)
         set(prefix_var "\${prefix}")
     endif()


### PR DESCRIPTION
**This PR has been superceded by https://github.com/microsoft/vcpkg/pull/16775 and remains open as a draft for the other improvements to be picked out**

Because vcpkg requires packages to be relocatable, there's no functional difference between `DESTDIR` and `--prefix`. By assigning `--prefix` to `packages\`, we can simplify the build process and avoid doubling path lengths.