### PR TITLE
direcxtsdk port updated to use MS Downloads

### DIFF
--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -4,7 +4,7 @@ message(WARNING "Build ${PORT} is deprecated, untested in CI, and requires the u
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.microsoft.com/download/A/E/7/AE743F1F-632B-4809-87A9-AA1BB3458E31/DXSDK_Jun10.exe"
-    FILENAME "DXSDK_Jun10_24e1e9bda.exe"
+    FILENAME "DXSDK_Jun10_SHA256.exe"
     SHA512 24e1e9bda319b780124b865f4640822cfc44e4d18fbdcc8456d48fe54081652ce4ddb63d3bd8596351057cbae50fc824b8297e99f0f7c97547153162562ba73f
 )
 

--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -3,9 +3,9 @@ vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 message(WARNING "Build ${PORT} is deprecated, untested in CI, and requires the use of the DirectSetup legacy REDIST solution. See https://aka.ms/dxsdk for more information.")
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://archive.org/download/dxsdk_2010/DXSDK_Jun10.exe"
+    URLS "https://download.microsoft.com/download/A/E/7/AE743F1F-632B-4809-87A9-AA1BB3458E31/DXSDK_Jun10.exe"
     FILENAME "DXSDK_Jun10.exe"
-    SHA512 4869ac947a35cd0d6949fbda17547256ea806fef36f48474dda63651f751583e9902641087250b6e8ccabaab85e51effccd9235dc6cdf64e21ec2b298227fe19
+    SHA512 24e1e9bda319b780124b865f4640822cfc44e4d18fbdcc8456d48fe54081652ce4ddb63d3bd8596351057cbae50fc824b8297e99f0f7c97547153162562ba73f
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -4,7 +4,7 @@ message(WARNING "Build ${PORT} is deprecated, untested in CI, and requires the u
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://download.microsoft.com/download/A/E/7/AE743F1F-632B-4809-87A9-AA1BB3458E31/DXSDK_Jun10.exe"
-    FILENAME "DXSDK_Jun10.exe"
+    FILENAME "DXSDK_Jun10_24e1e9bda.exe"
     SHA512 24e1e9bda319b780124b865f4640822cfc44e4d18fbdcc8456d48fe54081652ce4ddb63d3bd8596351057cbae50fc824b8297e99f0f7c97547153162562ba73f
 )
 

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directxsdk",
   "version-string": "jun10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Legacy DirectX SDK",
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
   "supports": "windows & !windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1622,7 +1622,7 @@
     },
     "directxsdk": {
       "baseline": "jun10",
-      "port-version": 1
+      "port-version": 2
     },
     "directxtex": {
       "baseline": "jan2021b",

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "666e70ebfe4e96b44fba991aa40b16e6186fa270",
+      "git-tree": "1bc75766eb1ace518c8c85f8ffda0c627d714edd",
       "version-string": "jun10",
       "port-version": 2
     },

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce484a5467c86e1bf8e572ba0f2b60f036c50608",
+      "git-tree": "666e70ebfe4e96b44fba991aa40b16e6186fa270",
       "version-string": "jun10",
       "port-version": 2
     },

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce484a5467c86e1bf8e572ba0f2b60f036c50608",
+      "version-string": "jun10",
+      "port-version": 2
+    },
+    {
       "git-tree": "7656b85e1c390a41e14d9e5b96b1b0f093c1d1f1",
       "version-string": "jun10",
       "port-version": 1


### PR DESCRIPTION
The legacy DirectX SDK has been republished to [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkId=226640). This version of the EXE is identical to the one before, but the 'outer container' has been resigned with SHA-256 to meet DLC requirements.

This port switches the **directxsdk** port over to use the MSDLC instead of archive.org because it's *much* faster to download.

The legacy DirectXSDK is still end-of-life, deprecated, legacy, etc., etc., etc.