### PR TITLE
[librtmp] Switch to GitHub mirror

### DIFF
--- a/ports/librtmp/CONTROL
+++ b/ports/librtmp/CONTROL
@@ -1,5 +1,0 @@
-Source: librtmp
-Version: 2019-11-11_1
-Build-Depends: zlib, openssl
-Homepage: https://rtmpdump.mplayerhq.hu
-Description: RTMPDump Real-Time Messaging Protocol API

--- a/ports/librtmp/portfile.cmake
+++ b/ports/librtmp/portfile.cmake
@@ -1,9 +1,8 @@
-set(RTMPDUMP_REVISION c5f04a58fc2aeea6296ca7c44ee4734c18401aa3)
-
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.ffmpeg.org/rtmpdump
-    REF ${RTMPDUMP_REVISION}
+    REPO mirror/rtmpdump
+    REF c5f04a58fc2aeea6296ca7c44ee4734c18401aa3
+    SHA512 d97ac38672898a96412baa5f03d1e64d512ccefe15ead0a055ca039dc6057e2e620e046c28f4d7468e132b0b5a9eb9bd171250c1afa14da53760a0d7aae3c9e9
     PATCHES
         dh.patch                #Openssl 1.1.1 patch
         handshake.patch         #Openssl 1.1.1 patch

--- a/ports/librtmp/vcpkg.json
+++ b/ports/librtmp/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "librtmp",
+  "version-date": "2019-11-11",
+  "port-version": 2,
+  "description": "RTMPDump Real-Time Messaging Protocol API",
+  "homepage": "https://rtmpdump.mplayerhq.hu",
+  "dependencies": [
+    "openssl",
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3349,8 +3349,8 @@
       "port-version": 1
     },
     "librtmp": {
-      "baseline": "2019-11-11_1",
-      "port-version": 0
+      "baseline": "2019-11-11",
+      "port-version": 2
     },
     "librttopo": {
       "baseline": "1.1.0-2",

--- a/versions/l-/librtmp.json
+++ b/versions/l-/librtmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3b156fff5f461b63a2665c4ec4a9a805e5a5447",
+      "version-date": "2019-11-11",
+      "port-version": 2
+    },
+    {
       "git-tree": "b6470730f086d7c4e4ba3fd890ce17ec95084b41",
       "version-string": "2019-11-11_1",
       "port-version": 0


### PR DESCRIPTION
Fixes issue with gitlab not providing archives for unreferenced SHAs