### PR TITLE
[jsoncons] Update to 0.162.1

### DIFF
--- a/ports/jsoncons/CONTROL
+++ b/ports/jsoncons/CONTROL
@@ -1,4 +1,4 @@
 Source: jsoncons
-Version: 0.162.0
+Version: 0.162.1
 Description: A C++, header-only library for constructing JSON and JSON-like text and binary data formats, with JSON Pointer, JSON Patch, JSON Schema, JSONPath, JMESPath, CSV, MessagePack, CBOR, BSON, UBJSON
 Homepage: https://github.com/danielaparker/jsoncons

--- a/ports/jsoncons/portfile.cmake
+++ b/ports/jsoncons/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO danielaparker/jsoncons
-    REF ec6ff7a71f4a526c39f8ea4e4298f5a2ab3dead7 # v0.162.0
-    SHA512 02236badc9b1e3e64dcdeea11ecbc5faa0bfe664e51b97619ad9ceb77124b7f1c496fddb4c002fcdd86d73b3f1587ca01e5fefa39830d74af3d82119c1adbbef
+    REF f45be36e9db94900ee2d4e090ca732375ece763c # v0.162.1
+    SHA512 d4a7d2db41ef25cb5958203e2c715077b613c000ea4106ae00d309aa8e428811ae344924879cb73ceb47e071fc0a933c49b068c71fa836f3222a86d58280c1fb
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2677,7 +2677,7 @@
       "port-version": 2
     },
     "jsoncons": {
-      "baseline": "0.162.0",
+      "baseline": "0.162.1",
       "port-version": 0
     },
     "jsoncpp": {

--- a/versions/j-/jsoncons.json
+++ b/versions/j-/jsoncons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad7aa2c6b95e393547c142c07a26e42e6bd9b4e3",
+      "version-string": "0.162.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "662642b7a6219f7f9f8ec3b4e094899a8e4f89f6",
       "version-string": "0.162.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes 

danielaparker/jsoncons#307

- Which triplets are supported/not supported? Have you updated the CI baseline?

All are supported. CI baseline has been updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
