### PR TITLE
[jsonnet] Incorporate md5.cpp into jsonnet library

### DIFF
--- a/ports/jsonnet/0004-incorporate-md5.patch
+++ b/ports/jsonnet/0004-incorporate-md5.patch
@@ -1,0 +1,42 @@
+diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index d4e77a8..5d36314 100644
+--- a/core/CMakeLists.txt
++++ b/core/CMakeLists.txt
+@@ -15,7 +15,8 @@ set(LIBJSONNET_HEADERS
+     static_error.h
+     string_utils.h
+     unicode.h
+-    vm.h)
++    vm.h
++    ../third_party/md5/md5.h)
+ 
+ set(LIBJSONNET_SOURCE
+     desugarer.cpp
+@@ -26,12 +27,13 @@ set(LIBJSONNET_SOURCE
+     pass.cpp
+     static_analysis.cpp
+     string_utils.cpp
+-    vm.cpp)
++    vm.cpp
++    ../third_party/md5/md5.cpp)
+ 
+ if (BUILD_SHARED_BINARIES)
+ add_library(libjsonnet ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
+-add_dependencies(libjsonnet md5 stdlib)
+-target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
++add_dependencies(libjsonnet stdlib)
++target_link_libraries(libjsonnet nlohmann_json::nlohmann_json)
+ 
+ file(STRINGS ${CMAKE_CURRENT_SOURCE_DIR}/../include/libjsonnet.h JSONNET_VERSION_DEF
+      REGEX "[#]define[ \t]+LIB_JSONNET_VERSION[ \t]+")
+@@ -54,8 +56,8 @@ endif()
+ if (BUILD_STATIC_LIBS)
+     # Static library for jsonnet command-line tool.
+     add_library(libjsonnet_static STATIC ${LIBJSONNET_SOURCE})
+-    add_dependencies(libjsonnet_static md5 stdlib)
+-    target_link_libraries(libjsonnet_static md5 nlohmann_json::nlohmann_json)
++    add_dependencies(libjsonnet_static stdlib)
++    target_link_libraries(libjsonnet_static nlohmann_json::nlohmann_json)
+     set_target_properties(libjsonnet_static PROPERTIES OUTPUT_NAME jsonnet)
+     install(TARGETS libjsonnet_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+ endif()

--- a/ports/jsonnet/CONTROL
+++ b/ports/jsonnet/CONTROL
@@ -1,6 +1,6 @@
 Source: jsonnet
 Version: 0.16.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/google/jsonnet
 Description: Jsonnet - The data templating language
 Build-Depends: nlohmann-json

--- a/ports/jsonnet/portfile.cmake
+++ b/ports/jsonnet/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     001-enable-msvc.patch
     002-fix-dependency-and-install.patch
     0003-use-upstream-nlohmann-json.patch
+    0004-incorporate-md5.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2686,7 +2686,7 @@
     },
     "jsonnet": {
       "baseline": "0.16.0",
-      "port-version": 1
+      "port-version": 2
     },
     "jwt-cpp": {
       "baseline": "0.4.0",

--- a/versions/j-/jsonnet.json
+++ b/versions/j-/jsonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53efaebae6e8131ee43960d0d58a5f110298a9c1",
+      "version-string": "0.16.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "77e5fa13bd74db46bf2626d82e8b9f88805031b6",
       "version-string": "0.16.0",
       "port-version": 1


### PR DESCRIPTION
Resolve the issue of libjsonnet.a not including md5.cpp, previously discussed in #5914.

This is also a problem in the original [jsonnet](https://github.com/google/jsonnet/) repository, where the make build includes md5.cpp in libjsonnet, but the CMake build separates it into libjsonnet and libmd.

This is better solved with upstream, but I would like to use jsonnet sooner, and only vcpkg developers care about CMakeLists.txt..., so please allow patches to be added to vcpkg.  
Since vcpkg already applies patches to CMakeLists.txt for Visual Studio build, this doesn't really change.

One thing to note is the mixing of licenses.
[jsonnet](https://github.com/google/jsonnet/) and [third_party/md5](https://github.com/google/jsonnet/tree/master/third_party/md5) are under different licenses. jsonnet is under the apache license, while md5.cpp is under a different license belonging to RSA Data Security, Inc.  
However, since Linux distributions (including debian) offer libjsonnet as a mixed license as well, this should not be a problem.

This patch is expected to work triplet-independently.
