### PR TITLE
[psimd] add a new port

### DIFF
--- a/ports/psimd/portfile.cmake
+++ b/ports/psimd/portfile.cmake
@@ -1,0 +1,15 @@
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Maratyszcza/psimd
+    REF 072586a71b55b7f8c584153d223e95687148a900
+    SHA512 a18faea093423dd9fe19ece8b228e011dccce0a2a22222f777ea19b023a13173966d4a8aea01147e8fc58de5d39cffcedeb2221a1572ae52bd5aba1295f86a94
+)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+vcpkg_install_cmake()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)

--- a/ports/psimd/vcpkg.json
+++ b/ports/psimd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "psimd",
   "version-string": "2021-02-21",
-  "homepage": "https://github.com/Maratyszcza/psimd",
-  "description": "Portable 128-bit SIMD intrinsics"
+  "description": "Portable 128-bit SIMD intrinsics",
+  "homepage": "https://github.com/Maratyszcza/psimd"
 }

--- a/ports/psimd/vcpkg.json
+++ b/ports/psimd/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "psimd",
+  "version-string": "2021-02-21",
+  "homepage": "https://github.com/Maratyszcza/psimd",
+  "description": "Portable 128-bit SIMD intrinsics"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4752,6 +4752,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "psimd": {
+      "baseline": "2021-02-21",
+      "port-version": 0
+    },
     "ptex": {
       "baseline": "2.3.2",
       "port-version": 2

--- a/versions/p-/psimd.json
+++ b/versions/p-/psimd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c54624730c6c8ae43a4d77d74a9771543863ba4d",
+      "git-tree": "d96e70295af788d6abe87bdad2a48d80f24ecfb5",
       "version-string": "2021-02-21",
       "port-version": 0
     }

--- a/versions/p-/psimd.json
+++ b/versions/p-/psimd.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c54624730c6c8ae43a4d77d74a9771543863ba4d",
+      "version-string": "2021-02-21",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

### What does your PR fix?

There was no port request for this project.

This is one of the 3rd party libraries for [the PyTorch project](https://github.com/pytorch/pytorch/blob/master/.gitmodules). The PR will be used for future support of the `libtorch` port.

### Which triplets are supported/not supported? Have you updated the CI baseline?

This port is a header-only library, so every triplet must be available.

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

The library doesn't have a tag/release.
 
* Manifests and CONTROL files
    * [x] `vcpkg format-manifest`
* Versioning
    * [x] Follow common conventions for the "version" field  
      [... we use the date that the commit was accessed by you, formatted as `YYYY-MM-DD`.](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/manifest-files.md#version-fields)
