### PR TITLE
[vcpkg baseline][poppler] Add feature splash and add its dependency boost-container and boost-move

### DIFF
--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_add_to_path(${GPERF_PATH})
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     curl ENABLE_CURL
     zlib ENABLE_ZLIB
+    splash ENABLE_SPLASH
 )
 
 vcpkg_configure_cmake(

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -5,8 +5,6 @@
   "description": "a PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "dependencies": [
-    "boost-container",
-    "boost-move",
     {
       "name": "cairo",
       "platform": "osx"
@@ -21,6 +19,7 @@
     "openjpeg"
   ],
   "default-features": [
+    "splash",
     "zlib"
   ],
   "features": {
@@ -28,6 +27,13 @@
       "description": "curl for poppler",
       "dependencies": [
         "curl"
+      ]
+    },
+    "splash": {
+      "description": "Build the Splash graphics backend",
+      "dependencies": [
+        "boost-container",
+        "boost-move"
       ]
     },
     "zlib": {

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "poppler",
   "version-string": "20.12.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "a PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "dependencies": [
+    "boost-container",
+    "boost-move",
     {
       "name": "cairo",
       "platform": "osx"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4686,7 +4686,7 @@
     },
     "poppler": {
       "baseline": "20.12.1",
-      "port-version": 3
+      "port-version": 4
     },
     "portable-snippets": {
       "baseline": "2019-09-20",

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39df7895fae1b7440dd7c453679f6e0d782a8a5a",
+      "version-string": "20.12.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "a6d078aca2d1c5803ddd287701692b891856c3fd",
       "version-string": "20.12.1",
       "port-version": 3


### PR DESCRIPTION
If `ENABLE_SPLASH` is enabled (the default is `ON`), poppler will look for `boost`, and when ANY component of boost is found, boost will be enabled, but the source code does not add the name of the component to look for boost, resulting in compilation failure:
```
D:\buildtrees\poppler\src\er-20.12.1-8a8a8b28c3.clean\splash\SplashXPathScanner.h(31): fatal error C1083: Cannot open include file: 'boost/container/small_vector.hpp': No such file or directory
```

See source code https://github.com/freedesktop/poppler/blob/061bae27a04684bdb0a1b4a6c3a8adf7fddcb7db/splash/SplashXPathScanner.h#L30-L32