### PR TITLE
[vcpkg baseline][stxxl] Skip baseline check for windows build

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1511,6 +1511,11 @@ stormlib:arm-uwp=fail
 stormlib:x64-uwp=fail
 stxxl:arm-uwp=fail
 stxxl:x64-uwp=fail
+# upstream issue https://github.com/stxxl/stxxl/issues/99
+stxxl:x86-windows=skip
+stxxl:x64-windows=skip
+stxxl:x64-windows-static=skip
+stxxl:x64-windows-static-md=skip
 symengine:arm64-windows=fail
 symengine:arm-uwp=fail
 systemc:arm64-windows=fail


### PR DESCRIPTION
Since there is a baseline error when building stxxl:windows:
```
[9/47] "C:\PROGRA~2\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29333\bin\Hostx64\x86\cl.exe"   /TP -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -D_SCL_SECURE_NO_WARNINGS -ID:\installed\x86-windows\include -ID:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\include -Iinclude /nologo /DWIN32 /D_WINDOWS /W4 /utf-8 /GR /EHsc /MP  /wd4127 /wd4290 /wd4250 /wd4512 /wd4355 -openmp /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1 /showIncludes /Folib\CMakeFiles\stxxl.dir\io\fileperblock_file.cpp.obj /Fdlib\CMakeFiles\stxxl.dir\stxxl.pdb /FS -c D:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\lib\io\fileperblock_file.cpp
FAILED: lib/CMakeFiles/stxxl.dir/io/fileperblock_file.cpp.obj 
"C:\PROGRA~2\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29333\bin\Hostx64\x86\cl.exe"   /TP -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -D_SCL_SECURE_NO_WARNINGS -ID:\installed\x86-windows\include -ID:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\include -Iinclude /nologo /DWIN32 /D_WINDOWS /W4 /utf-8 /GR /EHsc /MP  /wd4127 /wd4290 /wd4250 /wd4512 /wd4355 -openmp /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1 /showIncludes /Folib\CMakeFiles\stxxl.dir\io\fileperblock_file.cpp.obj /Fdlib\CMakeFiles\stxxl.dir\stxxl.pdb /FS -c D:\buildtrees\stxxl\src\53f2b75236-bdc19ed4a0.clean\lib\io\fileperblock_file.cpp
D:\installed\x86-windows\include\boost/system/detail/system_category_message_win32.hpp(53): error C2039: '_snprintf': is not a member of 'std'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29333\include\mutex(30): note: see declaration of 'std'
```
and I think that's a upstream bug (https://github.com/stxxl/stxxl/issues/99) and this regression is occasional, skip its baseline check.
