### PR TITLE
[sdl2] Update patch

### DIFF
--- a/ports/sdl2/0002-sdl2-skip-ibus-on-linux.patch
+++ b/ports/sdl2/0002-sdl2-skip-ibus-on-linux.patch
@@ -1,6 +1,8 @@
---- CMakeLists.orig.txt 2020-10-28 09:08:51.925900284 +0100
-+++ CMakeLists.txt      2020-10-28 09:09:10.034165780 +0100
-@@ -1240,12 +1240,6 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 06aa026..81d7645 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1240,12 +1240,6 @@ elseif(UNIX AND NOT APPLE AND NOT ANDROID AND NOT RISCOS)
          set(HAVE_FCITX TRUE)
        endif()
  

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2",
   "version-string": "2.0.14",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5282,7 +5282,7 @@
     },
     "sdl2": {
       "baseline": "2.0.14",
-      "port-version": 2
+      "port-version": 3
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07b3a3a427d35ed4ba0a154d7ff3e34be2f0ddfb",
+      "version-string": "2.0.14",
+      "port-version": 3
+    },
+    {
       "git-tree": "df27b00967d099fabd3b9315a02105bd3e1be3d1",
       "version-string": "2.0.14",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16349

Using manifests and verioning to build SDl2, it failed with applying patch failed.

```
-- Applying patch 0002-sdl2-skip-ibus-on-linux.patch
CMake Error at scripts/cmake/vcpkg_apply_patches.cmake:63 (message):
  Applying patch failed.  Checking patch CMakeLists.txt 2020-10-28
  09:09:10.034165780 +0100...

  error: CMakeLists.txt 2020-10-28 09:09:10.034165780 +0100: No such file or
  directory

Call Stack (most recent call first):
  scripts/cmake/vcpkg_extract_source_archive_ex.cmake:145 (vcpkg_apply_patches)
  buildtrees/versioning/versions/sdl2/df27b00967d099fabd3b9315a02105bd3e1be3d1/portfile.cmake:8 (vcpkg_extract_source_archive_ex)
  scripts/ports.cmake:133 (include)
```
Note: No need to test feature.

