### PR TITLE
[wxwidgets] Fix include path in UNIX

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -88,7 +88,16 @@ foreach(INC IN LISTS INCLUDES)
 endforeach()
 
 if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/wx/setup.h)
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/setup.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/wx)
+    file(GLOB_RECURSE WX_SETUP_H_FILES_DBG ${CURRENT_PACKAGES_DIR}/debug/lib/*.h)
+    file(GLOB_RECURSE WX_SETUP_H_FILES_REL ${CURRENT_PACKAGES_DIR}/lib/*.h)
+    
+    string(REPLACE "${CURRENT_PACKAGES_DIR}/debug/lib/" "" WX_SETUP_H_FILES_DBG "${WX_SETUP_H_FILES_DBG}")
+    string(REPLACE "/setup.h" "" WX_SETUP_H_DBG_RELATIVE "${WX_SETUP_H_FILES_DBG}")
+    
+    string(REPLACE "${CURRENT_PACKAGES_DIR}/lib/" "" WX_SETUP_H_FILES_REL "${WX_SETUP_H_FILES_REL}")
+    string(REPLACE "/setup.h" "" WX_SETUP_H_REL_RELATIVE "${WX_SETUP_H_FILES_REL}")
+    
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/setup.h.in ${CURRENT_PACKAGES_DIR}/include/wx/setup.h @ONLY)
 endif()
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/wxwidgets)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/wxwidgets/usage COPYONLY)

--- a/ports/wxwidgets/setup.h
+++ b/ports/wxwidgets/setup.h
@@ -1,5 +1,0 @@
-#ifdef _DEBUG
-#include "../../debug/lib/mswud/wx/setup.h"
-#else
-#include "../../lib/mswu/wx/setup.h"
-#endif

--- a/ports/wxwidgets/setup.h.in
+++ b/ports/wxwidgets/setup.h.in
@@ -1,0 +1,5 @@
+#ifdef _DEBUG
+#include "../../debug/lib/@WX_SETUP_H_DBG_RELATIVE@/setup.h"
+#else
+#include "../../lib/@WX_SETUP_H_REL_RELATIVE@/setup.h"
+#endif

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
   "version-semver": "3.1.4",
-  "port-version": 6,
+  "port-version": 7,
   "description": "a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.",
   "homepage": "https://github.com/wxWidgets/wxWidgets",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6246,7 +6246,7 @@
     },
     "wxwidgets": {
       "baseline": "3.1.4",
-      "port-version": 6
+      "port-version": 7
     },
     "x-plane": {
       "baseline": "3.0.3",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12acbc593b35e2d327b6fc665c8eed6e25745431",
+      "version-semver": "3.1.4",
+      "port-version": 7
+    },
+    {
       "git-tree": "eed8ba1dc939b1c1a17a05bf409142664015ad4d",
       "version-semver": "3.1.4",
       "port-version": 6


### PR DESCRIPTION
The `setup.h` content in UNIX is incorrect:
```
#ifdef _DEBUG
#include "../../debug/lib/mswud/wx/setup.h"
#else
#include "../../lib/mswu/wx/setup.h"
#endif
```
it should be _VCPKG_ROOT/installed/TRIPLET/lib/wx/include/osx_cocoa-unicode-static-3.1/wx/setup.h_ and _VCPKG_ROOT/installed/TRIPLET/debug/lib/wx/include/osx_cocoa-unicode-static-3.1/wx/setup.h_.

Fixes #16338.