### PR TITLE
[boost] /safeseh

### DIFF
--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -307,6 +307,11 @@ function(boost_modular_build)
         list(APPEND B2_OPTIONS address-model=64 architecture=power)
     else()
         list(APPEND B2_OPTIONS address-model=32 architecture=x86)
+
+        if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+            list(APPEND B2_OPTIONS "asmflags=/safeseh")
+        endif()
+
     endif()
 
     file(TO_CMAKE_PATH "${_bm_DIR}/nothing.bat" NOTHING_BAT)

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.75.0",
-  "port-version": 5,
+  "port-version": 6,
   "dependencies": [
     "boost-uninstall"
   ]

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "71c0db71c5cdc6d6516ba3c15dfd4ad8d5e3834d",
+      "version-string": "1.75.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "b88a7b8df97734c03d2abaa3c562dfbfab07dbea",
       "version-string": "1.75.0",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -698,7 +698,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.75.0",
-      "port-version": 5
+      "port-version": 6
     },
     "boost-move": {
       "baseline": "1.75.0",


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?  
 Builds boost on windows x86 with `/safeseh`. Otherwise you get linker errors if you build your application with `/safeseh` but boost is not build with `/safeseh`.

- Should boost always be built with `/safeseh` for all users in all circumstances?  
  Yes! It improves the security of the resulting application (see [here](https://stackoverflow.com/questions/25081033/what-safesehno-option-actually-do)) and has no downsides.