### PR TITLE
[brotli] add iOS support

### DIFF
--- a/ports/brotli/CONTROL
+++ b/ports/brotli/CONTROL
@@ -1,4 +1,5 @@
 Source: brotli
 Version: 1.0.9
+Port-Version: 1
 Homepage: https://github.com/google/brotli
 Description: a generic-purpose lossless compression algorithm that compresses data using a combination of a modern variant of the LZ77 algorithm, Huffman coding and 2nd order context modeling.

--- a/ports/brotli/fix-ios.patch
+++ b/ports/brotli/fix-ios.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fcd9024..a717b87 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -225,6 +225,7 @@ if(NOT BROTLI_BUNDLED_MODE)
+   install(
+     TARGETS brotli
+     RUNTIME DESTINATION tools/brotli
++    BUNDLE DESTINATION tools/brotli
+     CONFIGURATIONS Release
+   )
+ 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         install.patch
         fix-arm-uwp.patch
         pkgconfig.patch
+        fix-ios.patch
 )
 
 vcpkg_configure_cmake(

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f55fe158d8bd753a6e6908164e03ae4f0b73cea",
+      "version-string": "1.0.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "4aaf6f174ede5bc58872943a5e32d96c5e0d45da",
       "version-string": "1.0.9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1014,7 +1014,7 @@
     },
     "brotli": {
       "baseline": "1.0.9",
-      "port-version": 0
+      "port-version": 1
     },
     "brpc": {
       "baseline": "0.9.7",


### PR DESCRIPTION
This adds support for building brotli on iOS triplets.

For iOS the `BUNDLE DESTINATION` parameter must be specified when calling `install` in `CMakeLists.txt`, and so this PR sets it to the same path as the `RUNTIME DESTINATION`.

Triplets that now compile with this change:

arm64-ios
x64-ios