### PR TITLE
[breakpad] add support for Android triplets

### DIFF
--- a/ports/breakpad/CMakeLists.txt
+++ b/ports/breakpad/CMakeLists.txt
@@ -42,6 +42,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
             $<INSTALL_INTERFACE:include>
     )
+
+    set(TARGETS libbreakpad)
 endif()
 
 # libbreakpad_client target

--- a/ports/breakpad/CMakeLists.txt
+++ b/ports/breakpad/CMakeLists.txt
@@ -11,7 +11,6 @@ add_definitions(
     -D_CRT_SECURE_NO_WARNINGS
     -D_CRT_SECURE_NO_DEPRECATE
     -D_CRT_NONSTDC_NO_DEPRECATE
-    -D_LIBCPP_VERSION
 )
 
 set(CMAKE_DEBUG_POSTFIX d)
@@ -20,42 +19,70 @@ string(COMPARE EQUAL "${CMAKE_BUILD_TYPE}" "Release" DEFAULT_INSTALL_HEADERS)
 option(INSTALL_HEADERS "Install header files" ${DEFAULT_INSTALL_HEADERS})
 
 # libbreakpad target
-file(GLOB_RECURSE LIBBREAKPAD_SOURCES src/processor/*.cc)
-if(WIN32)
-    list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-        "_unittest|synth_minidump|/tests|/testdata|/linux|/mac|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
-elseif(APPLE)
-    list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-        "_unittest|synth_minidump|/tests|/testdata|/linux|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
-else()
-    list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
-        "_unittest|synth_minidump|/tests|/testdata|/mac|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Android)
+    file(GLOB_RECURSE LIBBREAKPAD_SOURCES src/processor/*.cc)
+    if(WIN32)
+        list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
+            "_unittest|synth_minidump|/tests|/testdata|/linux|/mac|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+    elseif(APPLE)
+        list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
+            "_unittest|synth_minidump|/tests|/testdata|/linux|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+    else()
+        list(FILTER LIBBREAKPAD_SOURCES EXCLUDE REGEX
+            "_unittest|synth_minidump|/tests|/testdata|/mac|/windows|/android|/solaris|microdump_stackwalk|minidump_dump|minidump_stackwalk")
+    endif()
+
+    find_library(LIBDISASM_LIB NAMES libdisasmd libdisasm)
+
+    add_library(libbreakpad ${LIBBREAKPAD_SOURCES})
+    target_link_libraries(libbreakpad PRIVATE ${LIBDISASM_LIB})
+
+    target_include_directories(libbreakpad
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+            $<INSTALL_INTERFACE:include>
+    )
 endif()
 
-find_library(LIBDISASM_LIB NAMES libdisasmd libdisasm)
-
-add_library(libbreakpad ${LIBBREAKPAD_SOURCES})
-target_link_libraries(libbreakpad PRIVATE ${LIBDISASM_LIB})
-
-target_include_directories(libbreakpad
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        $<INSTALL_INTERFACE:include>
-)
-
-set(TARGETS libbreakpad)
-if(WIN32)
-    file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/windows/*.cc src/common/windows/*.cc)
-    include_directories("$ENV{VSINSTALLDIR}/DIA SDK/include")
-elseif(APPLE)
-    add_definitions(-DHAVE_MACH_O_NLIST_H)
-    file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/mac/*.cc src/common/mac/*.cc)
-    list(APPEND LIBBREAKPAD_CLIENT_SOURCES src/common/mac/MachIPC.mm)
+# libbreakpad_client target
+if(CMAKE_SYSTEM_NAME STREQUAL Android)
+    set(LIBBREAKPAD_CLIENT_SOURCES
+        src/client/minidump_file_writer.cc
+        src/client/linux/crash_generation/crash_generation_client.cc
+        src/client/linux/dump_writer_common/thread_info.cc
+        src/client/linux/dump_writer_common/ucontext_reader.cc
+        src/client/linux/handler/exception_handler.cc
+        src/client/linux/handler/minidump_descriptor.cc
+        src/client/linux/log/log.cc
+        src/client/linux/microdump_writer/microdump_writer.cc
+        src/client/linux/minidump_writer/linux_dumper.cc
+        src/client/linux/minidump_writer/linux_ptrace_dumper.cc
+        src/client/linux/minidump_writer/minidump_writer.cc)
+    set(LIBBREAKPAD_COMMON_SOURCES
+        src/common/convert_UTF.cc
+        src/common/md5.cc
+        src/common/string_conversion.cc
+        src/common/linux/breakpad_getcontext.S
+        src/common/linux/elfutils.cc
+        src/common/linux/file_id.cc
+        src/common/linux/guid_creator.cc
+        src/common/linux/linux_libc_support.cc
+        src/common/linux/memory_mapped_file.cc
+        src/common/linux/safe_readlink.cc)
 else()
-    add_definitions(-DHAVE_A_OUT_H)
-    file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/linux/*.cc src/common/linux/*.cc)
+    if(WIN32)
+        file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/windows/*.cc src/common/windows/*.cc)
+        include_directories("$ENV{VSINSTALLDIR}/DIA SDK/include")
+    elseif(APPLE)
+        add_definitions(-DHAVE_MACH_O_NLIST_H)
+        file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/mac/*.cc src/common/mac/*.cc)
+        list(APPEND LIBBREAKPAD_CLIENT_SOURCES src/common/mac/MachIPC.mm)
+    else()
+        add_definitions(-DHAVE_A_OUT_H)
+        file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/linux/*.cc src/common/linux/*.cc)
+    endif()
+    file(GLOB LIBBREAKPAD_COMMON_SOURCES src/common/*.cc src/common/*.c src/client/*.cc)
 endif()
-file(GLOB LIBBREAKPAD_COMMON_SOURCES src/common/*.cc src/common/*.c src/client/*.cc)
 list(APPEND LIBBREAKPAD_CLIENT_SOURCES ${LIBBREAKPAD_COMMON_SOURCES})
 list(FILTER LIBBREAKPAD_CLIENT_SOURCES EXCLUDE REGEX "/sender|/tests|/unittests|/testcases|_unittest|_test")
 if(WIN32)
@@ -76,7 +103,9 @@ elseif(APPLE)
     target_link_libraries(libbreakpad_client PRIVATE ${CoreFoundation_FRAMEWORK})
 else()
     find_library(PTHREAD_LIBRARIES pthread)
-    target_link_libraries(libbreakpad_client PRIVATE ${PTHREAD_LIBRARIES})
+    if(PTHREAD_LIBRARIES)
+        target_link_libraries(libbreakpad_client PRIVATE ${PTHREAD_LIBRARIES})
+    endif()
     if (HAVE_GETCONTEXT)
         target_compile_definitions(libbreakpad_client PRIVATE HAVE_GETCONTEXT=1)
     endif()

--- a/ports/breakpad/CMakeLists.txt
+++ b/ports/breakpad/CMakeLists.txt
@@ -48,29 +48,8 @@ endif()
 
 # libbreakpad_client target
 if(CMAKE_SYSTEM_NAME STREQUAL Android)
-    set(LIBBREAKPAD_CLIENT_SOURCES
-        src/client/minidump_file_writer.cc
-        src/client/linux/crash_generation/crash_generation_client.cc
-        src/client/linux/dump_writer_common/thread_info.cc
-        src/client/linux/dump_writer_common/ucontext_reader.cc
-        src/client/linux/handler/exception_handler.cc
-        src/client/linux/handler/minidump_descriptor.cc
-        src/client/linux/log/log.cc
-        src/client/linux/microdump_writer/microdump_writer.cc
-        src/client/linux/minidump_writer/linux_dumper.cc
-        src/client/linux/minidump_writer/linux_ptrace_dumper.cc
-        src/client/linux/minidump_writer/minidump_writer.cc)
-    set(LIBBREAKPAD_COMMON_SOURCES
-        src/common/convert_UTF.cc
-        src/common/md5.cc
-        src/common/string_conversion.cc
-        src/common/linux/breakpad_getcontext.S
-        src/common/linux/elfutils.cc
-        src/common/linux/file_id.cc
-        src/common/linux/guid_creator.cc
-        src/common/linux/linux_libc_support.cc
-        src/common/linux/memory_mapped_file.cc
-        src/common/linux/safe_readlink.cc)
+    file(READ "android/google_breakpad/Android.mk" android_mk)
+    string(REGEX MATCHALL "src/[^\n]*\\.cc" LIBBREAKPAD_CLIENT_SOURCES "${android_mk}")
 else()
     if(WIN32)
         file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/windows/*.cc src/common/windows/*.cc)
@@ -84,8 +63,8 @@ else()
         file(GLOB_RECURSE LIBBREAKPAD_CLIENT_SOURCES src/client/linux/*.cc src/common/linux/*.cc)
     endif()
     file(GLOB LIBBREAKPAD_COMMON_SOURCES src/common/*.cc src/common/*.c src/client/*.cc)
+    list(APPEND LIBBREAKPAD_CLIENT_SOURCES ${LIBBREAKPAD_COMMON_SOURCES})
 endif()
-list(APPEND LIBBREAKPAD_CLIENT_SOURCES ${LIBBREAKPAD_COMMON_SOURCES})
 list(FILTER LIBBREAKPAD_CLIENT_SOURCES EXCLUDE REGEX "/sender|/tests|/unittests|/testcases|_unittest|_test")
 if(WIN32)
     list(FILTER LIBBREAKPAD_CLIENT_SOURCES EXCLUDE REGEX "language.cc|path_helper.cc|stabs_to_module.cc|stabs_reader.cc|minidump_file_writer.cc")

--- a/ports/breakpad/CONTROL
+++ b/ports/breakpad/CONTROL
@@ -1,6 +1,6 @@
 Source: breakpad
 Version: 2020-09-14
-Port-Version: 1
+Port-Version: 2
 Build-Depends: libdisasm
 Homepage: https://github.com/google/breakpad
 Description: a set of client and server components which implement a crash-reporting system.

--- a/ports/breakpad/fix-unordered_map.patch
+++ b/ports/breakpad/fix-unordered_map.patch
@@ -1,0 +1,14 @@
+diff --git a/src/common/unordered.h b/src/common/unordered.h
+index c9cbd58..7743eda 100644
+--- a/src/common/unordered.h
++++ b/src/common/unordered.h
+@@ -46,7 +46,8 @@ struct unordered_map : public __gnu_cxx::hash_map<T, U, H> {};
+ template <class T, class H = __gnu_cxx::hash<T> >
+ struct unordered_set : public __gnu_cxx::hash_set<T, H> {};
+ 
+-#elif defined(_LIBCPP_VERSION)  // c++11
++#elif (__cplusplus >= 201103L) || defined(_LIBCPP_VERSION) || \
++    (defined(_MSC_VER) && (_MSC_VER >= 1800))  // c++11
+ #include <unordered_map>
+ #include <unordered_set>
+ using std::unordered_map;

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-unique_ptr.patch
+        fix-unordered_map.patch
 )
 
 if(VCPKG_HOST_IS_LINUX OR VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_ANDROID)

--- a/ports/breakpad/portfile.cmake
+++ b/ports/breakpad/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
         fix-unique_ptr.patch
 )
 
-if(VCPKG_HOST_IS_LINUX)
+if(VCPKG_HOST_IS_LINUX OR VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_ANDROID)
     vcpkg_from_git(
         OUT_SOURCE_PATH LSS_SOURCE_PATH
         URL https://chromium.googlesource.com/linux-syscall-support

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f0fd7d08d1321da3729f672e323fb14e4f5e00da",
+      "git-tree": "724ca1cc38bbb2414d1efe91f8a95353235ede58",
       "version-string": "2020-09-14",
       "port-version": 2
     },

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "037bab839723792c3436564f32feae2aad8dbf7d",
+      "git-tree": "a73f6bbc8c8215e5a3f19dc6c5107bce5fccffc2",
       "version-string": "2020-09-14",
       "port-version": 2
     },

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a73f6bbc8c8215e5a3f19dc6c5107bce5fccffc2",
+      "git-tree": "f0fd7d08d1321da3729f672e323fb14e4f5e00da",
       "version-string": "2020-09-14",
       "port-version": 2
     },

--- a/versions/b-/breakpad.json
+++ b/versions/b-/breakpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "037bab839723792c3436564f32feae2aad8dbf7d",
+      "version-string": "2020-09-14",
+      "port-version": 2
+    },
+    {
       "git-tree": "e266c29cb65ac51e96422f0788dae07529f1f493",
       "version-string": "2020-09-14",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1006,7 +1006,7 @@
     },
     "breakpad": {
       "baseline": "2020-09-14",
-      "port-version": 1
+      "port-version": 2
     },
     "brigand": {
       "baseline": "1.3.0",


### PR DESCRIPTION
This changes vcpkg's custom CMakeLists.txt file for Breakpad so that it correctly builds libbreakpad_client for Android. It follows the same source file layout for Android as seen in [./android/google_breakpad/Android.mk](https://github.com/google/breakpad/blob/main/android/google_breakpad/Android.mk). Additionally, the -D_LIBCPP_VERSION preprocessor definition was removed, since this is defined when including libc++ headers.

Linux and Windows target triplets are unaffected by this change. This has been tested with Android NDK r21e and Android NDK r22.