### PR TITLE
[glm] Add namespace to export target

### DIFF
--- a/ports/glm/CMakeLists.txt
+++ b/ports/glm/CMakeLists.txt
@@ -15,7 +15,9 @@ install(
 )
 
 install(
-    EXPORT glm-config DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/glm
+    EXPORT glm-config
+    NAMESPACE glm::
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/glm
 )
 
 install(

--- a/ports/glm/CONTROL
+++ b/ports/glm/CONTROL
@@ -1,4 +1,0 @@
-Source: glm
-Version: 0.9.9.8
-Description: OpenGL Mathematics (GLM)
-Homepage: https://glm.g-truc.net

--- a/ports/glm/vcpkg.json
+++ b/ports/glm/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "glm",
+  "version-string": "0.9.9.8",
+  "port-version": 1,
+  "description": "OpenGL Mathematics (GLM)",
+  "homepage": "https://glm.g-truc.net"
+}

--- a/ports/globjects/CONTROL
+++ b/ports/globjects/CONTROL
@@ -1,5 +1,0 @@
-Source: globjects
-Version: 1.1.0-3
-Build-Depends: glbinding, glm
-Description: C++ library strictly wrapping OpenGL objects.
-Homepage: https://github.com/cginternals/globjects

--- a/ports/globjects/fix-dependency-glm.patch
+++ b/ports/globjects/fix-dependency-glm.patch
@@ -1,0 +1,13 @@
+diff --git a/source/globjects/CMakeLists.txt b/source/globjects/CMakeLists.txt
+index 71e92d8..b8b4408 100644
+--- a/source/globjects/CMakeLists.txt
++++ b/source/globjects/CMakeLists.txt
+@@ -359,7 +359,7 @@ target_link_libraries(${target}
+ 
+     PUBLIC
+     ${DEFAULT_LIBRARIES}
+-    glm
++    glm::glm
+     glbinding::glbinding
+     glbinding::glbinding-aux
+ 

--- a/ports/globjects/portfile.cmake
+++ b/ports/globjects/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF dc68b09a53ec20683d3b3a12ed8d9cb12602bb9a
     SHA512 5145df795a73a8d74e983e143fd57441865f3082860efb89a3aa8c4d64c2eb6f0256a8049ccd5479dd77e53ef6638d9c903b29a8ef2b41a076003d9595912500
     HEAD_REF master
-    PATCHES system-install.patch
+    PATCHES
+        system-install.patch
+        fix-dependency-glm.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/globjects/vcpkg.json
+++ b/ports/globjects/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "globjects",
+  "version-string": "1.1.0",
+  "port-version": 4,
+  "description": "C++ library strictly wrapping OpenGL objects",
+  "homepage": "https://github.com/cginternals/globjects",
+  "dependencies": [
+    "glbinding",
+    "glm"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2233,8 +2233,8 @@
       "port-version": 1
     },
     "globjects": {
-      "baseline": "1.1.0-3",
-      "port-version": 0
+      "baseline": "1.1.0",
+      "port-version": 4
     },
     "glog": {
       "baseline": "0.4.0-3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "glm": {
       "baseline": "0.9.9.8",
-      "port-version": 0
+      "port-version": 1
     },
     "globjects": {
       "baseline": "1.1.0-3",

--- a/versions/g-/glm.json
+++ b/versions/g-/glm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4aafac80f39a72fadaf6a31afb961790678062de",
+      "version-string": "0.9.9.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "14a7c57c30809e4f4c953dd60fa335bb194d0be5",
       "version-string": "0.9.9.8",
       "port-version": 0

--- a/versions/g-/globjects.json
+++ b/versions/g-/globjects.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d9e98af47d7eb383a98e39c5661e573b1197e8c",
+      "version-string": "1.1.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "b2e73ec8949205afcdcf9c8b7f5e536275f0ed19",
       "version-string": "1.1.0-3",
       "port-version": 0


### PR DESCRIPTION
Add namespace `glm::` to the export target `glm` to improve compatibility.

Fixes #16427.