### PR TITLE
[protobuf] Update to 3.15.8

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF 2514f0bd7da7e2af1bed4c5d1b84f031c4d12c10    #v3.14.0
-    SHA512 765fd12786b405eb8b7365f1117fa16d0e268f8677e829e0a91635bb4278295c5e488949726394f84d0993f8ea8205ca66eb1f79c88cc89ad5ac4a2df483d473
+    REF 436bd7880e458532901c58f4d9d1ea23fa7edd52    #v3.15.8
+    SHA512 88bb9a965bccfe11a07aee2c0c16eb9cc1845ea2d7500ef6def3e1c0a8155ac4eadd0ceef4b12552960dffe95a0fc82549d1abba71ca073ab86ec5de57d9cafb
     HEAD_REF master
     PATCHES
         fix-static-build.patch
@@ -78,7 +78,7 @@ if(protobuf_BUILD_PROTOC_BINARIES)
     if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR NOT VCPKG_CMAKE_SYSTEM_NAME)
         vcpkg_copy_tools(TOOL_NAMES protoc AUTO_CLEAN)
     else()
-        vcpkg_copy_tools(TOOL_NAMES protoc protoc-3.14.0.0 AUTO_CLEAN)
+        vcpkg_copy_tools(TOOL_NAMES protoc protoc-3.15.8.0 AUTO_CLEAN)
     endif()
 else()
     file(COPY ${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "protobuf",
-  "version-string": "3.14.0",
-  "port-version": 4,
+  "version-semver": "3.15.8",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4873,8 +4873,8 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.14.0",
-      "port-version": 4
+      "baseline": "3.15.8",
+      "port-version": 0
     },
     "protobuf-c": {
       "baseline": "1.3.2-2",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ffb8fef5a5ded5a0350fee3550cad324017e89a",
+      "version-semver": "3.15.8",
+      "port-version": 0
+    },
+    {
       "git-tree": "d60f4db7f63f55aa3b9be8c8848f2d492cab577f",
       "version-string": "3.14.0",
       "port-version": 4


### PR DESCRIPTION
Library name: protobuf

New version number: 3.15.3

See https://github.com/protocolbuffers/protobuf/releases for release notes.
3.15 makes "optional" available and contains a number of enhancements, bugfixes and security fixes for  c++