### PR TITLE
[qscintilla] Update to 2.12

### DIFF
--- a/ports/qscintilla/CONTROL
+++ b/ports/qscintilla/CONTROL
@@ -1,5 +1,5 @@
 Source: qscintilla
-Version: 2.11.4-2
+Version: 2.12.0
 Homepage: https://www.riverbankcomputing.com/software/qscintilla
 Description: QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)
 Build-Depends: qt5-base[core], qt5-macextras (osx), qt5-winextras (windows)

--- a/ports/qscintilla/fix-static.patch
+++ b/ports/qscintilla/fix-static.patch
@@ -1,12 +1,3 @@
-From fd83f64efb35eb9dac6be67d1dcabfbae67d441a Mon Sep 17 00:00:00 2001
-From: Matthias Kuhn <matthias@opengis.ch>
-Date: Sun, 28 Feb 2021 09:25:08 +0100
-Subject: [PATCH] Fix staticlib
-
----
- src/qscintilla.pro | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
 diff --git a/src/qscintilla.pro b/src/qscintilla.pro
 index 8d0acd2..2246442 100644
 --- a/src/qscintilla.pro
@@ -36,6 +27,3 @@ index 8d0acd2..2246442 100644
      features.files = $$PWD/features_staticlib/qscintilla2.prf
  } else {
      features.files = $$PWD/features/qscintilla2.prf
--- 
-2.30.1.windows.1
-

--- a/ports/qscintilla/fix-static.patch
+++ b/ports/qscintilla/fix-static.patch
@@ -1,7 +1,16 @@
-diff --git a/Qt4Qt5/qscintilla.pro b/Qt4Qt5/qscintilla.pro
-index 075079c32..8ff8678b6 100644
---- a/Qt4Qt5/qscintilla.pro
-+++ b/Qt4Qt5/qscintilla.pro
+From fd83f64efb35eb9dac6be67d1dcabfbae67d441a Mon Sep 17 00:00:00 2001
+From: Matthias Kuhn <matthias@opengis.ch>
+Date: Sun, 28 Feb 2021 09:25:08 +0100
+Subject: [PATCH] Fix staticlib
+
+---
+ src/qscintilla.pro | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/qscintilla.pro b/src/qscintilla.pro
+index 8d0acd2..2246442 100644
+--- a/src/qscintilla.pro
++++ b/src/qscintilla.pro
 @@ -37,13 +37,13 @@ CONFIG(debug, debug|release) {
      TARGET = qscintilla2_qt$${QT_MAJOR_VERSION}
  }
@@ -11,19 +20,22 @@ index 075079c32..8ff8678b6 100644
      QMAKE_POST_LINK += install_name_tool -id @rpath/$(TARGET1) $(TARGET)
  }
  
- INCLUDEPATH += . ../include ../lexlib ../src
+ INCLUDEPATH += . ../scintilla/include ../scintilla/lexlib ../scintilla/src
  
 -!CONFIG(staticlib) {
 +!CONFIG(static) {
      DEFINES += QSCINTILLA_MAKE_DLL
  }
  DEFINES += SCINTILLA_QT SCI_LEXER INCLUDE_DEPRECATED_FEATURES
-@@ -90,7 +90,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
- } else {
-     features.path = $$[QT_INSTALL_DATA]/mkspecs/features
- }
+@@ -82,7 +82,7 @@ qsci.files = ../qsci
+ INSTALLS += qsci
+ 
+ features.path = $$[QT_HOST_DATA]/mkspecs/features
 -CONFIG(staticlib) {
 +CONFIG(static) {
      features.files = $$PWD/features_staticlib/qscintilla2.prf
  } else {
      features.files = $$PWD/features/qscintilla2.prf
+-- 
+2.30.1.windows.1
+

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.4/QScintilla-2.11.4.tar.gz"
-    FILENAME "QScintilla-2.11.4.tar.gz"
-    SHA512 90fc2427121ca9ae55e34cf636460099bbdadd844318d9ef05f86790a36e25fb64528264bb7bb99e46b7add96378eff0cc69bb692940c6a1bddfadf86a9abdbd
+    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.zip"
+    FILENAME "QScintilla-2.12.0.zip"
+    SHA512 94e826a68cfc313f7fe6caf47ca43fb43070869e698a9a4f266e0b472393c1dcaeedf33a2ecc6c7687af3f12a3b564ec160b580207311672368f9c8c28b0308e
 )
 
 vcpkg_extract_source_archive_ex(
@@ -18,7 +18,7 @@ get_filename_component(PYTHON3_PATH ${PYTHON3} DIRECTORY)
 vcpkg_add_to_path(${PYTHON3_PATH})
 
 vcpkg_configure_qmake(
-    SOURCE_PATH ${SOURCE_PATH}/Qt4Qt5
+    SOURCE_PATH ${SOURCE_PATH}/src
     OPTIONS
         CONFIG+=build_all
         CONFIG-=hide_symbols
@@ -34,7 +34,7 @@ else()
     vcpkg_install_qmake()
 endif()
 
-file(GLOB HEADER_FILES ${SOURCE_PATH}/Qt4Qt5/Qsci/*)
+file(GLOB HEADER_FILES ${SOURCE_PATH}/src/Qsci/*)
 file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/Qsci)
 
 vcpkg_copy_pdbs()

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.zip"
-    FILENAME "QScintilla-2.12.0.zip"
-    SHA512 94e826a68cfc313f7fe6caf47ca43fb43070869e698a9a4f266e0b472393c1dcaeedf33a2ecc6c7687af3f12a3b564ec160b580207311672368f9c8c28b0308e
+    URLS "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
+    FILENAME "QScintilla-2.12.0.tar.gz"
+    SHA512 9bdaba5c33c1b11ccad83eb1fda72142758afc50c955a62d5a8ff102b41d4b67d897bf96ce0540e16bc5a7fae2ce1acbf06931d5f0ae6768759c9ff072c03daa
 )
 
 vcpkg_extract_source_archive_ex(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4813,7 +4813,7 @@
       "port-version": 0
     },
     "qscintilla": {
-      "baseline": "2.11.4-2",
+      "baseline": "2.12.0",
       "port-version": 0
     },
     "qt-advanced-docking-system": {

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1db621e9fbf4db9d7e58e0d61301525184b01672",
+      "version-string": "2.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3279799f70de1a88e50db50b7e99dcdf1b08ac31",
       "version-string": "2.11.4-2",
       "port-version": 0

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1db621e9fbf4db9d7e58e0d61301525184b01672",
+      "git-tree": "753c09c98e94157f9998e6528d5bb7dce4337ced",
       "version-string": "2.12.0",
       "port-version": 0
     },


### PR DESCRIPTION
Library name: qsctintilla

New version number: 2.12

The changelog is here https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/ChangeLog

~It builds fine here without the static patch, I am not sure about the reason for this patch, so I left it out. It can be updated and reintroduced if there is a need for it.~ Reintroduced, osx build failed

Doesn't solve any immediate problems (except some local build issues which may well have been introduced by me tampering with [things])