### PR TITLE
[vcpkg-cmake] Fix typo in vcpkg_cmake_configure that prevented custom triplets from working

### DIFF
--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2021-02-26"
+  "version-date": "2021-02-28"
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -222,7 +222,7 @@ function(vcpkg_cmake_configure)
     endif()
 
     z_vcpkg_cmake_configure_both_set_or_unset(VCPKG_CXX_FLAGS_DEBUG VCPKG_C_FLAGS_DEBUG)
-    z_vcpkg_cmake_configure_both_set_or_unset(VCPKG_CXX_FLAGS_RELEASE VCPKG_C_FLAGS_RELASE)
+    z_vcpkg_cmake_configure_both_set_or_unset(VCPKG_CXX_FLAGS_RELEASE VCPKG_C_FLAGS_RELEASE)
     z_vcpkg_cmake_configure_both_set_or_unset(VCPKG_CXX_FLAGS VCPKG_C_FLAGS)
 
     set(VCPKG_SET_CHARSET_FLAG ON)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6113,7 +6113,7 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2021-02-26",
+      "baseline": "2021-02-28",
       "port-version": 0
     },
     "vcpkg-cmake-config": {

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b627b47898864ee5a880cea03b4dea64b9d81953",
+      "version-date": "2021-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "51896aa8073adb5c8450daa423d03eedf0dfc61f",
       "version-date": "2021-02-26",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? A typo that prevents triplets overriding release build flags from working.

- Which triplets are supported/not supported? Have you updated the CI baseline? Yes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
