### PR TITLE
[vcpkg_*_cmake] remove deprecation message

### DIFF
--- a/docs/maintainers/maintainer-guide.md
+++ b/docs/maintainers/maintainer-guide.md
@@ -43,7 +43,6 @@ At this time, the following helpers are deprecated:
 2. `vcpkg_apply_patches()` should be replaced by the `PATCHES` arguments to the "extract" helpers (e.g. [`vcpkg_from_github()`](vcpkg_from_github.md))
 3. `vcpkg_build_msbuild()` should be replaced by [`vcpkg_install_msbuild()`](vcpkg_install_msbuild.md)
 4. `vcpkg_copy_tool_dependencies()` should be replaced by [`vcpkg_copy_tools()`](vcpkg_copy_tools.md)
-5. `vcpkg_configure_cmake()`, `vcpkg_build_cmake()`, and `vcpkg_install_cmake()` should be replaced by the helper functions in [`vcpkg-cmake`](ports/vcpkg-cmake.md).
 
 ### Avoid excessive comments in portfiles
 

--- a/docs/maintainers/maintainer-guide.md
+++ b/docs/maintainers/maintainer-guide.md
@@ -43,6 +43,7 @@ At this time, the following helpers are deprecated:
 2. `vcpkg_apply_patches()` should be replaced by the `PATCHES` arguments to the "extract" helpers (e.g. [`vcpkg_from_github()`](vcpkg_from_github.md))
 3. `vcpkg_build_msbuild()` should be replaced by [`vcpkg_install_msbuild()`](vcpkg_install_msbuild.md)
 4. `vcpkg_copy_tool_dependencies()` should be replaced by [`vcpkg_copy_tools()`](vcpkg_copy_tools.md)
+5. `vcpkg_configure_cmake()`, `vcpkg_build_cmake()`, and `vcpkg_install_cmake()` should be replaced by the helper functions in [`vcpkg-cmake`](ports/vcpkg-cmake.md).
 
 ### Avoid excessive comments in portfiles
 
@@ -229,7 +230,7 @@ If you're updating multiple ports at the same time, instead you can run:
 vcpkg x-add-version --all
 ```
 
-To update the files for all modified ports at once.  
+To update the files for all modified ports at once.
 
 _NOTE: These commands require you to have committed your changes to the ports before running them. The reason is that the Git SHA of the port directory is required in these version files. But don't worry, the `x-add-version` command will warn you if you have local changes that haven't been committed._
 

--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -36,14 +36,11 @@ You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) functi
 
 function(vcpkg_build_cmake)
     cmake_parse_arguments(PARSE_ARGV 0 "arg"
-        "DISABLE_PARALLEL;ADD_BIN_TO_PATH;Z_VCPKG_DISABLE_DEPRECATION_MESSAGE"
+        "DISABLE_PARALLEL;ADD_BIN_TO_PATH"
         "TARGET;LOGFILE_ROOT"
         ""
     )
 
-    if(NOT arg_Z_VCPKG_DISABLE_DEPRECATION_MESSAGE)
-        message(DEPRECATION "vcpkg_build_cmake has been deprecated in favor of vcpkg_cmake_build from the vcpkg-cmake port.")
-    endif()
     if(Z_VCPKG_CMAKE_BUILD_GUARD)
         message(FATAL_ERROR "The ${PORT} port already depends on vcpkg-cmake; using both vcpkg-cmake and vcpkg_build_cmake in the same port is unsupported.")
     endif()

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -69,7 +69,6 @@ This command supplies many common arguments to CMake. To see the full list, exam
 #]===]
 
 function(vcpkg_configure_cmake)
-    message(DEPRECATION "vcpkg_configure_cmake has been deprecated in favor of vcpkg_cmake_configure from the vcpkg-cmake port.")
     if(Z_VCPKG_CMAKE_CONFIGURE_GUARD)
         message(FATAL_ERROR "The ${PORT} port already depends on vcpkg-cmake; using both vcpkg-cmake and vcpkg_configure_cmake in the same port is unsupported.")
     endif()

--- a/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
+++ b/scripts/cmake/vcpkg_fixup_cmake_targets.cmake
@@ -53,7 +53,6 @@ Replace `${CURRENT_INSTALLED_DIR}` with `${_IMPORT_PREFIX}` in configs and targe
 #]===]
 
 function(vcpkg_fixup_cmake_targets)
-    message(DEPRECATION "vcpkg_fixup_cmake_targets has been deprecated in favor of vcpkg_cmake_config_fixup from the vcpkg-cmake-config port.")
     if(Z_VCPKG_CMAKE_CONFIG_FIXUP_GUARD)
         message(FATAL_ERROR "The ${PORT} port already depends on vcpkg-cmake-config; using both vcpkg-cmake-config and vcpkg_fixup_cmake_targets in the same port is unsupported.")
     endif()

--- a/scripts/cmake/vcpkg_install_cmake.cmake
+++ b/scripts/cmake/vcpkg_install_cmake.cmake
@@ -26,7 +26,6 @@ parameter.
 #]===]
 
 function(vcpkg_install_cmake)
-    message(DEPRECATION "vcpkg_install_cmake has been deprecated in favor of vcpkg_cmake_install from the vcpkg-cmake port.")
     if(Z_VCPKG_CMAKE_INSTALL_GUARD)
         message(FATAL_ERROR "The ${PORT} port already depends on vcpkg-cmake; using both vcpkg-cmake and vcpkg_install_cmake in the same port is unsupported.")
     endif()


### PR DESCRIPTION
to be replaced by a note in the maintainer-guide
this allows existing ports to build without warnings, so as to avoid warning people unnecessarily,
while still making sure people update when they update ports.

Fixes #16463 