### PR TITLE
[g3log] update to 1.3.4

### DIFF
--- a/ports/g3log/CONTROL
+++ b/ports/g3log/CONTROL
@@ -1,4 +1,0 @@
-Source: g3log
-Version: 2019-07-29
-Description: Asynchronous logger with Dynamic Sinks
-Homepage: https://github.com/KjellKod/g3log

--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KjellKod/g3log
-    REF f1491791785101d4ae948f8ecee7e9cc3e6b0be8
-    SHA512 852ed7c9eb2345f02414be7fb7dfbd4be340dcbf8abc4e6ba6327d181cf10e33969279166151b4eeab78b290d3fecbf4a5094696c412f7b2ab815df415652bd8
+    REF 2fca06ff6da5c67465b591f4d45e8fd14d531142 #v1.3.4
+    SHA512 8dba89e5a08e44d585478470725e25e37486685d8fe4d3cb5e97c81013389c95d96bdde658244e425008169bc8a9fc2d34a065b83b110c62e73d3ccab9b2b9e1
     HEAD_REF master
 )
 
@@ -10,7 +10,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" G3_SHARED_LIB)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" G3_SHARED_RUNTIME)
 
 # https://github.com/KjellKod/g3log#prerequisites
-set(VERSION "1.3.2-80")
+set(VERSION "1.3.4")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -28,7 +28,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/g3logger TARGET_PATH share/g3logger)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/g3log TARGET_PATH share/g3log)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/g3log/portfile.cmake
+++ b/ports/g3log/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/g3log TARGET_PATH share/g3log)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/g3log)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/g3log/vcpkg.json
+++ b/ports/g3log/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "g3log",
+  "version": "1.3.4",
+  "description": "Asynchronous logger with Dynamic Sinks",
+  "homepage": "https://github.com/KjellKod/g3log"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2093,7 +2093,7 @@
       "port-version": 1
     },
     "g3log": {
-      "baseline": "2019-07-29",
+      "baseline": "1.3.4",
       "port-version": 0
     },
     "gainput": {

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87577189ec7b093294cd4137f1bd7c1620a2163d",
+      "version": "1.3.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "dea4491e152ae900d6677244552b14be3bf4c125",
       "version-string": "2019-07-29",
       "port-version": 0

--- a/versions/g-/g3log.json
+++ b/versions/g-/g3log.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87577189ec7b093294cd4137f1bd7c1620a2163d",
+      "git-tree": "2d5c7967292d8363c14af69e0b4d37fa9d48dd0e",
       "version": "1.3.4",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #16425

Update g3log to the latest version 1.3.4

Note : no feature need to test