### PR TITLE
[Azure pipeline] Upload file list logs for unstable testing

### DIFF
--- a/scripts/azure-pipelines/windows-unstable/job.yml
+++ b/scripts/azure-pipelines/windows-unstable/job.yml
@@ -83,3 +83,18 @@ jobs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\failure-logs'
       ArtifactName: 'failure logs for ${{ parameters.triplet }}'
     condition: always()
+ - task: PowerShell@2
+    displayName: 'Build a file list for all packages'
+    condition: always()
+    inputs:
+      targetType: inline
+      script: |
+        ./vcpkg.exe fetch python3
+        & $(.\vcpkg fetch python3) .\scripts\file_script.py D:\installed\vcpkg\info\
+      pwsh: true
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: file lists for ${{ parameters.triplet }}'
+    condition: always()
+    inputs:
+      PathtoPublish: scripts/list_files
+      ArtifactName: 'file lists for ${{ parameters.triplet }}'

--- a/scripts/azure-pipelines/windows-unstable/job.yml
+++ b/scripts/azure-pipelines/windows-unstable/job.yml
@@ -83,7 +83,7 @@ jobs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)\failure-logs'
       ArtifactName: 'failure logs for ${{ parameters.triplet }}'
     condition: always()
- - task: PowerShell@2
+  - task: PowerShell@2
     displayName: 'Build a file list for all packages'
     condition: always()
     inputs:


### PR DESCRIPTION
 'File list' logs is very important for investigating the conflicts issue in unstable testing, so upload the logs as well.

The Changes from https://github.com/microsoft/vcpkg/blob/master/scripts/azure-pipelines/windows/azure-pipelines.yml