### PR TITLE
[proj4] Update to 8.0.0

### DIFF
--- a/ports/mapnik/portfile.cmake
+++ b/ports/mapnik/portfile.cmake
@@ -7,6 +7,8 @@ vcpkg_from_github(
     REF 14f913d6ab3b0903dd36a1cb2d22f7d5493b8bb8
     SHA512 f90762594d46946ddc512bb19b21c4d6a2f1ce81b7500a326ad512fae3a3f77e49ef3eb727ff8f98a31596e4132528212e0fa146e2eee0a9965a16551cfd0386
     HEAD_REF master
+    PATCHES
+        proj-find-fix.patch # Quiet search with version range somehow fails for proj8+
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/mapnik/proj-find-fix.patch
+++ b/ports/mapnik/proj-find-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 47bbaa1..43f384d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -304,7 +304,7 @@ if(USE_WEBP)
+ 
+ if(USE_PROJ)
+     #https://proj.org/development/cmake.html
+-    mapnik_find_package(PROJ ${PROJ_MIN_VERSION} QUIET)
++    mapnik_find_package(PROJ REQUIRED)
+     # currently the cmake files are not installed, when installing proj via apt-get. So search via pkg-config
+     if(NOT PROJ_FOUND)
+         message(STATUS "PROJ not found via FindPROJ. Searching via pkg-config...")

--- a/ports/mapnik/vcpkg.json
+++ b/ports/mapnik/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mapnik",
   "version-date": "2021-11-15",
+  "port-version": 1,
   "description": "Mapnik is an open source toolkit for developing mapping applications.",
   "homepage": "https://github.com/mapnik/mapnik",
   "supports": "!(static & windows)",

--- a/ports/proj4/portfile.cmake
+++ b/ports/proj4/portfile.cmake
@@ -1,9 +1,9 @@
-set(VERSION 7.2.1) # Variable used for pc file
+set(VERSION 8.0.0) # Variable used for pc file
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO OSGeo/PROJ
     REF "${VERSION}"
-    SHA512 e6e77266dcd70c939c16667c916cccab8de161221d2ef600cfca43382f50da2dc8d790561556b4416adbb4ac6fba939004e0cc936c278e0e808dc3566e9a70d4
+    SHA512 353f0e14ba6c11bfcec8a30b3f322842e8a3103546e0fd40871e341c859ca7ae2b9411425be5b588eb45cc5716255d2ea81d6357407bcfb9506a0edb161376f5
     HEAD_REF master
     PATCHES
         fix-filemanager-uwp.patch

--- a/ports/proj4/vcpkg.json
+++ b/ports/proj4/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "proj4",
-  "version-semver": "7.2.1",
-  "port-version": 7,
+  "version-semver": "8.0.0",
   "description": "PROJ.4 library for cartographic projections",
   "homepage": "https://github.com/OSGeo/PROJ",
   "dependencies": [

--- a/ports/vtk/UseProj5Api.patch
+++ b/ports/vtk/UseProj5Api.patch
@@ -1,0 +1,149 @@
+From 0325638832e35c8c8c6fc96e2c1d887aeea3dd43 Mon Sep 17 00:00:00 2001
+From: Julien Schueller <schueller@phimeca.com>
+Date: Mon, 8 Mar 2021 10:57:46 +0100
+Subject: [PATCH] Geovis: Use proj>=5 api
+
+Closes #18130
+---
+ Geovis/Core/vtkGeoProjection.cxx    | 17 ++++++++++++++++-
+ Geovis/Core/vtkGeoTransform.cxx     | 28 ++++++++++++++--------------
+ ThirdParty/libproj/vtk_libproj.h.in |  7 +------
+ 3 files changed, 31 insertions(+), 21 deletions(-)
+
+diff --git a/Geovis/Core/vtkGeoProjection.cxx b/Geovis/Core/vtkGeoProjection.cxx
+index 7ff6526a5d..0a0d06eba1 100644
+--- a/Geovis/Core/vtkGeoProjection.cxx
++++ b/Geovis/Core/vtkGeoProjection.cxx
+@@ -121,7 +121,11 @@ vtkGeoProjection::~vtkGeoProjection()
+   this->SetPROJ4String(nullptr);
+   if (this->Projection)
+   {
++#if PROJ_VERSION_MAJOR >= 5
++    proj_destroy(this->Projection);
++#else
+     pj_free(this->Projection);
++#endif
+   }
+   delete this->Internals;
+   this->Internals = nullptr;
+@@ -185,13 +189,21 @@ int vtkGeoProjection::UpdateProjection()
+ 
+   if (this->Projection)
+   {
++#if PROJ_VERSION_MAJOR >= 5
++    proj_destroy(this->Projection);
++#else
+     pj_free(this->Projection);
++#endif
+     this->Projection = nullptr;
+   }
+ 
+   if (this->PROJ4String && strlen(this->PROJ4String))
+   {
++#if PROJ_VERSION_MAJOR >= 5
++    this->Projection = proj_create(PJ_DEFAULT_CTX, this->PROJ4String);
++#else
+     this->Projection = pj_init_plus(this->PROJ4String);
++#endif
+     if (!this->Projection)
+     {
+       vtkErrorMacro("Cannot set projection with string " << this->PROJ4String);
+@@ -234,8 +246,11 @@ int vtkGeoProjection::UpdateProjection()
+       stringHolder[i] = param.str();
+       pjArgs[3 + i] = stringHolder[i].c_str();
+     }
+-
++#if PROJ_VERSION_MAJOR >= 5
++    this->Projection = proj_create_argv(PJ_DEFAULT_CTX, argSize, const_cast<char**>(pjArgs));
++#else
+     this->Projection = pj_init(argSize, const_cast<char**>(pjArgs));
++#endif
+     delete[] pjArgs;
+   }
+   this->ProjectionMTime = this->GetMTime();
+diff --git a/Geovis/Core/vtkGeoTransform.cxx b/Geovis/Core/vtkGeoTransform.cxx
+index 5c2c74279d..1c99b6b11b 100644
+--- a/Geovis/Core/vtkGeoTransform.cxx
++++ b/Geovis/Core/vtkGeoTransform.cxx
+@@ -163,8 +163,12 @@ void vtkGeoTransform::InternalTransformPoints(double* x, vtkIdType numPts, int s
+   projPJ src = this->SourceProjection ? this->SourceProjection->GetProjection() : nullptr;
+   projPJ dst = this->DestinationProjection ? this->DestinationProjection->GetProjection() : nullptr;
+   int delta = stride - 2;
++#if PROJ_VERSION_MAJOR >= 5
++  PJ_COORD c, c_out;
++#else
+   projLP lp;
+   projXY xy;
++#endif
+   if (src)
+   {
+     // Convert from src system to lat/long using inverse of src transform
+@@ -172,17 +176,15 @@ void vtkGeoTransform::InternalTransformPoints(double* x, vtkIdType numPts, int s
+     for (vtkIdType i = 0; i < numPts; ++i)
+     {
+ #if PROJ_VERSION_MAJOR >= 5
+-      xy.x = coord[0];
+-      xy.y = coord[1];
++      c.xy.x = coord[0];
++      c.xy.y = coord[1];
++      c_out = proj_trans(src, PJ_INV, c);
++      coord[0] = c_out.lp.lam;
++      coord[1] = c_out.lp.phi;
+ #else
+       xy.u = coord[0];
+       xy.v = coord[1];
+-#endif
+       lp = pj_inv(xy, src);
+-#if PROJ_VERSION_MAJOR >= 5
+-      coord[0] = lp.lam;
+-      coord[1] = lp.phi;
+-#else
+       coord[0] = lp.u;
+       coord[1] = lp.v;
+ #endif
+@@ -208,17 +210,15 @@ void vtkGeoTransform::InternalTransformPoints(double* x, vtkIdType numPts, int s
+     for (vtkIdType i = 0; i < numPts; ++i)
+     {
+ #if PROJ_VERSION_MAJOR >= 5
+-      lp.lam = coord[0];
+-      lp.phi = coord[1];
++      c.lp.lam = coord[0];
++      c.lp.phi = coord[1];
++      c_out = proj_trans(src, PJ_FWD, c);
++      coord[0] = c_out.xy.x;
++      coord[1] = c_out.xy.y;
+ #else
+       lp.u = coord[0];
+       lp.v = coord[1];
+-#endif
+       xy = pj_fwd(lp, dst);
+-#if PROJ_VERSION_MAJOR >= 5
+-      coord[0] = xy.x;
+-      coord[1] = xy.y;
+-#else
+       coord[0] = xy.u;
+       coord[1] = xy.v;
+ #endif
+diff --git a/ThirdParty/libproj/vtk_libproj.h.in b/ThirdParty/libproj/vtk_libproj.h.in
+index 4d8ffc3c5d..c4182c4db2 100644
+--- a/ThirdParty/libproj/vtk_libproj.h.in
++++ b/ThirdParty/libproj/vtk_libproj.h.in
+@@ -28,14 +28,9 @@
+ #if VTK_MODULE_USE_EXTERNAL_vtklibproj
+ # if VTK_LibPROJ_MAJOR_VERSION >= 5
+ #  include <proj.h>
+-# endif
+-# if VTK_LibPROJ_MAJOR_VERSION < 6
++# else
+ #  include <projects.h>
+ # endif
+-# if VTK_LibPROJ_MAJOR_VERSION >= 6
+-#  define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H 1
+-# endif
+-# include <proj_api.h>
+ # include <geodesic.h>
+ #else
+ # include <vtklibproj/src/projects.h>
+-- 
+2.32.0.windows.1
+

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -29,6 +29,7 @@ vcpkg_from_github(
         d107698a.patch
         fix-gdal.patch
         missing-limits.patch # This patch can be removed in next version. Since it has been merged to upstream via https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7611
+        UseProj5Api.patch # Allow Proj 8.0+ (commit b66e4a7, backported). Should be in soon after 9.0.3
 )
 
 # =============================================================================

--- a/ports/vtk/vcpkg.json
+++ b/ports/vtk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vtk",
   "version-semver": "9.0.3-pv5.9.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Software system for 3D computer graphics, image processing, and visualization",
   "homepage": "https://github.com/Kitware/VTK",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4246,7 +4246,7 @@
     },
     "mapnik": {
       "baseline": "2021-11-15",
-      "port-version": 0
+      "port-version": 1
     },
     "marble": {
       "baseline": "19.08.2",
@@ -5365,8 +5365,8 @@
       "port-version": 1
     },
     "proj4": {
-      "baseline": "7.2.1",
-      "port-version": 7
+      "baseline": "8.0.0",
+      "port-version": 0
     },
     "prometheus-cpp": {
       "baseline": "0.13.0",
@@ -7074,7 +7074,7 @@
     },
     "vtk": {
       "baseline": "9.0.3-pv5.9.1",
-      "port-version": 4
+      "port-version": 5
     },
     "vtk-dicom": {
       "baseline": "0.8.12",

--- a/versions/m-/mapnik.json
+++ b/versions/m-/mapnik.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f8eb08ffc7a02dd08de30c0851587d9537fc72e",
+      "version-date": "2021-11-15",
+      "port-version": 1
+    },
+    {
       "git-tree": "d1ae6b45aea26d1bbed2716beaaaeaf3719fbefa",
       "version-date": "2021-11-15",
       "port-version": 0

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1939ed4483f6f1d75f6ddacb6a741090144bcfb",
+      "version-semver": "8.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "991dc069b2b9acb50da346e27f48100d5d8f8186",
       "version-semver": "7.2.1",
       "port-version": 7

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd6ac57e684fd8a2234509813248f64a6cb522d5",
+      "version-semver": "9.0.3-pv5.9.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "223022edbe63b3ecdb3e9204a4ad63ab61b36ece",
       "version-semver": "9.0.3-pv5.9.1",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Upgrade proj[4] to 8.0.0

Minimal change to bump the version. Removes the legacy (proj4 like) api, and therefore fixes some dependencies.

Originally this pull request contained some work to unconditonally enable tiff support, but this part is now removed. This same support is now independently(?) added to [#20443](https://github.com/microsoft/vcpkg/pull/20443) by @dg0yt.

This pull request (now open for half a year) re-opens the proj project for bumping to more recent versions (2021-11-15: last version 8.2.0)

- Which triplets are supported/not supported? Have you updated the CI baseline?
All existing triplets supported (Windows, Linux, OS/X, UWP)

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
