### PR TITLE
Fix CURL filesystem deadlock with corporate proxy

### DIFF
--- a/toolsrc/src/vcpkg/metrics.cpp
+++ b/toolsrc/src/vcpkg/metrics.cpp
@@ -498,7 +498,7 @@ namespace vcpkg::Metrics
 #else
         auto escaped_path = Strings::escape_string(fs::u8string(vcpkg_metrics_txt_path), '\'', '\\');
         const std::string cmd_line = Strings::format(
-            R"((curl "https://dc.services.visualstudio.com/v2/track" -H "Content-Type: application/json" -X POST --tlsv1.2 --data '@%s' >/dev/null 2>&1; rm '%s') &)",
+            R"((curl --max-time 0.2 "https://dc.services.visualstudio.com/v2/track" -H "Content-Type: application/json" -X POST --tlsv1.2 --data '@%s' >/dev/null 2>&1; rm '%s') &)",
             escaped_path,
             escaped_path);
         System::cmd_execute_clean(cmd_line);


### PR DESCRIPTION
The CURL call to the metrics  endpoint doesn't have a timeout. When executing this behind a corporate proxy that blocks this access the filesystem is in a deadlock until curl is killed. By adding a 200ms timeout we give ample time for CURL to finish its request, while also not stopping usage inside local network.

**Describe the pull request**

- What does your PR fix? Fixes #16476 

- Which triplets are supported/not supported? Have you updated the CI baseline? Affects non-Windows users. No update to CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? AFAIK, yes, but please edit the PR as necessary if there's something that doesn't conform to your guidelines.
