### PR TITLE
Don't copy svm-toy if not on Windows

### DIFF
--- a/ports/libsvm/CONTROL
+++ b/ports/libsvm/CONTROL
@@ -1,7 +1,0 @@
-Source: libsvm
-Version: 323-1
-Description: A library for Support Vector Machines
-Homepage: https://www.csie.ntu.edu.tw/~cjlin/libsvm/
-
-Feature: tools
-Description: Build libsvm tools

--- a/ports/libsvm/portfile.cmake
+++ b/ports/libsvm/portfile.cmake
@@ -29,7 +29,11 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
 
 if ("tools" IN_LIST FEATURES)
-    vcpkg_copy_tools(TOOL_NAMES svm-predict svm-scale svm-toy svm-train AUTO_CLEAN)
+    if (WIN32)
+        vcpkg_copy_tools(TOOL_NAMES svm-predict svm-scale svm-toy svm-train AUTO_CLEAN)
+    else ()
+        vcpkg_copy_tools(TOOL_NAMES svm-predict svm-scale svm-train AUTO_CLEAN)
+    endif ()
 endif ()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/libsvm/vcpkg.json
+++ b/ports/libsvm/vcpkg.json
@@ -1,13 +1,12 @@
 {
-    "name": "libsvm",
-    "version-string": "323-1",
-    "homepage": "https://www.csie.ntu.edu.tw/~cjlin/libsvm/",
-    "description": "A library for Support Vector Machines.",
-    "features": [
-        {
-            "name": "tools",
-            "description": "build libsvm CLI tools."
-        }
-    ],
-    "port-version": 1
+  "name": "libsvm",
+  "version-string": "323",
+  "port-version": 2,
+  "description": "A library for Support Vector Machines.",
+  "homepage": "https://www.csie.ntu.edu.tw/~cjlin/libsvm/",
+  "features": {
+    "tools": {
+      "description": "build libsvm CLI tools."
+    }
+  }
 }

--- a/ports/libsvm/vcpkg.json
+++ b/ports/libsvm/vcpkg.json
@@ -1,0 +1,13 @@
+{
+    "name": "libsvm",
+    "version-string": "323-1",
+    "homepage": "https://www.csie.ntu.edu.tw/~cjlin/libsvm/",
+    "description": "A library for Support Vector Machines.",
+    "features": [
+        {
+            "name": "tools",
+            "description": "build libsvm CLI tools."
+        }
+    ],
+    "port-version": 1
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3445,8 +3445,8 @@
       "port-version": 0
     },
     "libsvm": {
-      "baseline": "323-1",
-      "port-version": 1
+      "baseline": "323",
+      "port-version": 2
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3446,7 +3446,7 @@
     },
     "libsvm": {
       "baseline": "323-1",
-      "port-version": 0
+      "port-version": 1
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",

--- a/versions/l-/libsvm.json
+++ b/versions/l-/libsvm.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "f1a2a08d154eb8240cb58c5a23c8a1452334563e",
-      "version-string": "323-1",
-      "port-version": 1
+      "git-tree": "14f75f50d38f27beddb27fb54bf0927942db9954",
+      "version-string": "323",
+      "port-version": 2
     },
     {
       "git-tree": "81c8a12b8a8abcbfe0eefa7ea1643ea3118b49a2",

--- a/versions/l-/libsvm.json
+++ b/versions/l-/libsvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1a2a08d154eb8240cb58c5a23c8a1452334563e",
+      "version-string": "323-1",
+      "port-version": 1
+    },
+    {
       "git-tree": "81c8a12b8a8abcbfe0eefa7ea1643ea3118b49a2",
       "version-string": "323-1",
       "port-version": 0


### PR DESCRIPTION
svm-toy is only compiled on Windows, so should only be copied on Windows.

**Describe the pull request**

- What does your PR fix? Fixes platform dependence on libsvm with tool feature enabled.

- Which triplets are supported/not supported? Have you updated the CI baseline? x64-linux

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
