### PR TITLE
[scintilla] update to 4.4.6

### DIFF
--- a/ports/scintilla/CONTROL
+++ b/ports/scintilla/CONTROL
@@ -1,5 +1,0 @@
-Source: scintilla
-Version: 4.4.5
-Homepage: https://www.scintilla.org/
-Description: A free source code editing component for Win32, GTK+, and OS X
-Supports: !(uwp|linux|osx)

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -17,7 +17,7 @@ endif()
 vcpkg_extract_source_archive_ex(
   OUT_SOURCE_PATH SOURCE_PATH
   ARCHIVE ${ARCHIVE}
-  REF 4.4.5
+  REF 4.4.6
   PATCHES ${PATCHES}
 )
 
@@ -27,4 +27,4 @@ vcpkg_install_msbuild(
   LICENSE_SUBPATH License.txt
 )
 
-file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/scintilla)
+file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} FILES_MATCHING PATTERN "*.*")

--- a/ports/scintilla/portfile.cmake
+++ b/ports/scintilla/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP")
 
 vcpkg_download_distfile(ARCHIVE
-  URLS "https://www.scintilla.org/scintilla445.zip"
-  FILENAME "scintilla445.zip"
-  SHA512 bac25ee6e9b1ab3602a6fbf2f28f046f6da5c45dfd6e882df250760a254517ee9b05d95b816234b5145553f0a8da92016d7839a50624543c52fde7539ea08259
+  URLS "https://www.scintilla.org/scintilla446.zip"
+  FILENAME "scintilla446.zip"
+  SHA512 db6fa38283401497d8331f97dc5b57ea11d998988001f06b95892de769de5829b9f567635f3c1f2d9cfbc4384024d11666d28224ce90c5813ceef865b0dec255
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
@@ -24,7 +24,7 @@ vcpkg_extract_source_archive_ex(
 vcpkg_install_msbuild(
   SOURCE_PATH ${SOURCE_PATH}
   PROJECT_SUBPATH Win32/SciLexer.vcxproj
-  INCLUDES_SUBPATH include
   LICENSE_SUBPATH License.txt
-  ALLOW_ROOT_INCLUDES
 )
+
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR}/include/scintilla)

--- a/ports/scintilla/vcpkg.json
+++ b/ports/scintilla/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "scintilla",
+  "version": "4.4.6",
+  "description": "A free source code editing component for Win32, GTK+, and OS X",
+  "homepage": "https://www.scintilla.org/",
+  "supports": "!(uwp | linux | osx)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5269,7 +5269,7 @@
       "port-version": 0
     },
     "scintilla": {
-      "baseline": "4.4.5",
+      "baseline": "4.4.6",
       "port-version": 0
     },
     "sciter": {

--- a/versions/s-/scintilla.json
+++ b/versions/s-/scintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6d51bc777316bdb73bfdd4fa57d58571b1f1aad1",
+      "version": "4.4.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "1bb13f73af518651e5dafcd0767ca409d3219ac3",
       "version-string": "4.4.5",
       "port-version": 0

--- a/versions/s-/scintilla.json
+++ b/versions/s-/scintilla.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6d51bc777316bdb73bfdd4fa57d58571b1f1aad1",
+      "git-tree": "725d3e47a1e30713a272b1ef12251b65696f8a3e",
       "version": "4.4.6",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #16465 
 
Update scintilla to the latest version 4.4.6,
Both tesseract and scintilla included platform.h, which causes the conflict.

So move the headers for scintilla to include/scintilla .

Note: no feature need to test.