### PR TITLE
[ginkgo] Create new port

### DIFF
--- a/ports/ginkgo/cmake-fixes.patch
+++ b/ports/ginkgo/cmake-fixes.patch
@@ -1,73 +1,44 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e2413dd29e..c835b0dc6e 100644
+index e75f7d6..63685f2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -20,6 +20,13 @@ include(cmake/hip_path.cmake)
+@@ -20,6 +20,12 @@ include(cmake/hip_path.cmake)
  include(cmake/autodetect_executors.cmake)
  include(cmake/build_type_helpers.cmake)
-
+ 
 +if (MSVC)
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-+endif()
-+if (MINGW OR CYGWIN)
-+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
++    add_compile_options(/bigobj)
++elseif (MINGW OR CYGWIN)
++    add_compile_options("-Wa,-mbig-obj")
 +endif()
 +
  # Ginkgo configuration options
  option(GINKGO_DEVEL_TOOLS "Add development tools to the build system" OFF)
  option(GINKGO_BUILD_TESTS "Generate build files for unit tests" ON)
 diff --git a/cmake/GinkgoConfig.cmake.in b/cmake/GinkgoConfig.cmake.in
-index 961949822e..51a2e8a724 100644
+index 0348f95..3b8be0f 100644
 --- a/cmake/GinkgoConfig.cmake.in
 +++ b/cmake/GinkgoConfig.cmake.in
-@@ -140,8 +140,12 @@ set(GINKGO_OPENMP_LIBRARIES @OpenMP_CXX_LIBRARIES@)
+@@ -129,8 +129,6 @@ set(GINKGO_OPENMP_LIBRARIES @OpenMP_CXX_LIBRARIES@)
  set(GINKGO_OPENMP_FLAGS "@OpenMP_CXX_FLAGS@")
  
  # Provide useful HIP helper functions
 -include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
 -include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
-+if(GINKGO_BUILD_HIP)
-+    include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
-+endif()
-+if (WIN32 OR CYGWIN)
-+    include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
-+endif()
  
  # NOTE: we do not export benchmarks, examples, tests or devel tools
  #     so `third_party` libraries are currently unneeded.
 diff --git a/cmake/install_helpers.cmake b/cmake/install_helpers.cmake
-index 68a75a5f9a..74ae6f8b6b 100644
+index ba7ea3f..7cc3ba8 100644
 --- a/cmake/install_helpers.cmake
 +++ b/cmake/install_helpers.cmake
-@@ -2,28 +2,29 @@ include(CMakePackageConfigHelpers)
- include(GNUInstallDirs)
- 
- 
--set(GINKGO_INSTALL_INCLUDE_DIR "include")
--set(GINKGO_INSTALL_LIBRARY_DIR "lib")
--set(GINKGO_INSTALL_PKGCONFIG_DIR "lib/pkgconfig")
--set(GINKGO_INSTALL_CONFIG_DIR "lib/cmake/Ginkgo")
--set(GINKGO_INSTALL_MODULE_DIR "lib/cmake/Ginkgo/Modules")
-+set(GINKGO_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
-+set(GINKGO_INSTALL_LIBRARY_DIR "${CMAKE_INSTALL_LIBDIR}")
-+set(GINKGO_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}")
-+set(GINKGO_INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-+set(GINKGO_INSTALL_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo")
-+set(GINKGO_INSTALL_MODULE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo/Modules")
- 
- function(ginkgo_install_library name subdir)
--    
-+
-     if (WIN32 OR CYGWIN)
+@@ -14,16 +14,11 @@ function(ginkgo_install_library name subdir)
          # dll is considered as runtime
          install(TARGETS "${name}"
              EXPORT Ginkgo
 -            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
 -            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
 -            RUNTIME DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
-+            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
-+            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
-+            RUNTIME DESTINATION "${GINKGO_INSTALL_RUNTIME_DIR}"
              )
      else ()
          # install .so and .a files
@@ -75,12 +46,10 @@ index 68a75a5f9a..74ae6f8b6b 100644
              EXPORT Ginkgo
 -            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
 -            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
-+            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
-+            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
          )
      endif ()
  endfunction()
-@@ -37,9 +37,8 @@ function(ginkgo_install)
+@@ -37,9 +32,8 @@ function(ginkgo_install)
          DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}"
          FILES_MATCHING PATTERN "*.hpp"
          )
@@ -92,16 +61,7 @@ index 68a75a5f9a..74ae6f8b6b 100644
          )
      if (GINKGO_HAVE_PAPI_SDE)
          install(FILES "${Ginkgo_SOURCE_DIR}/third_party/papi_sde/papi_sde_interface.h"
-@@ -60,7 +59,7 @@ function(ginkgo_install)
-     write_basic_package_version_file(
-         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
-         VERSION "${PROJECT_VERSION}"
--        COMPATIBILITY AnyNewerVersion
-+        COMPATIBILITY SameMajorVersion
-         )
-     configure_package_config_file(
-         "${Ginkgo_SOURCE_DIR}/cmake/GinkgoConfig.cmake.in"
-@@ -75,11 +74,21 @@ function(ginkgo_install)
+@@ -70,8 +64,6 @@ function(ginkgo_install)
      install(FILES
          "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
          "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
@@ -109,20 +69,18 @@ index 68a75a5f9a..74ae6f8b6b 100644
 -        "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
          DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
          )
--      install(EXPORT Ginkgo
-+    if (WIN32 OR CYGWIN)
-+        install(FILES
-+            "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
-+            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
-+            )
-+    endif()
-+    if (GINKGO_BUILD_HIP)
-+        install(FILES
-+            "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
-+            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
-+            )
-+    endif()
-+    install(EXPORT Ginkgo
-         NAMESPACE Ginkgo::
-         FILE GinkgoTargets.cmake
-         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}")
+       install(EXPORT Ginkgo
+diff --git a/cmake/windows_helpers.cmake b/cmake/windows_helpers.cmake
+index 5f517a5..46d31ba 100644
+--- a/cmake/windows_helpers.cmake
++++ b/cmake/windows_helpers.cmake
+@@ -14,9 +14,7 @@ function(ginkgo_switch_windows_link lang from to)
+ endfunction()
+ 
+ macro(ginkgo_switch_to_windows_static lang)
+-    ginkgo_switch_windows_link(${lang} "MD" "MT")
+ endmacro()
+ 
+ macro(ginkgo_switch_to_windows_dynamic lang)
+-    ginkgo_switch_windows_link(${lang} "MT" "MD")
+ endmacro()

--- a/ports/ginkgo/cmake-fixes.patch
+++ b/ports/ginkgo/cmake-fixes.patch
@@ -1,0 +1,128 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e2413dd29e..c835b0dc6e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,6 +20,13 @@ include(cmake/hip_path.cmake)
+ include(cmake/autodetect_executors.cmake)
+ include(cmake/build_type_helpers.cmake)
+
++if (MSVC)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
++endif()
++if (MINGW OR CYGWIN)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
++endif()
++
+ # Ginkgo configuration options
+ option(GINKGO_DEVEL_TOOLS "Add development tools to the build system" OFF)
+ option(GINKGO_BUILD_TESTS "Generate build files for unit tests" ON)
+diff --git a/cmake/GinkgoConfig.cmake.in b/cmake/GinkgoConfig.cmake.in
+index 961949822e..51a2e8a724 100644
+--- a/cmake/GinkgoConfig.cmake.in
++++ b/cmake/GinkgoConfig.cmake.in
+@@ -140,8 +140,12 @@ set(GINKGO_OPENMP_LIBRARIES @OpenMP_CXX_LIBRARIES@)
+ set(GINKGO_OPENMP_FLAGS "@OpenMP_CXX_FLAGS@")
+ 
+ # Provide useful HIP helper functions
+-include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
+-include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
++if(GINKGO_BUILD_HIP)
++    include(${CMAKE_CURRENT_LIST_DIR}/hip_helpers.cmake)
++endif()
++if (WIN32 OR CYGWIN)
++    include(${CMAKE_CURRENT_LIST_DIR}/windows_helpers.cmake)
++endif()
+ 
+ # NOTE: we do not export benchmarks, examples, tests or devel tools
+ #     so `third_party` libraries are currently unneeded.
+diff --git a/cmake/install_helpers.cmake b/cmake/install_helpers.cmake
+index 68a75a5f9a..74ae6f8b6b 100644
+--- a/cmake/install_helpers.cmake
++++ b/cmake/install_helpers.cmake
+@@ -2,28 +2,29 @@ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+ 
+ 
+-set(GINKGO_INSTALL_INCLUDE_DIR "include")
+-set(GINKGO_INSTALL_LIBRARY_DIR "lib")
+-set(GINKGO_INSTALL_PKGCONFIG_DIR "lib/pkgconfig")
+-set(GINKGO_INSTALL_CONFIG_DIR "lib/cmake/Ginkgo")
+-set(GINKGO_INSTALL_MODULE_DIR "lib/cmake/Ginkgo/Modules")
++set(GINKGO_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
++set(GINKGO_INSTALL_LIBRARY_DIR "${CMAKE_INSTALL_LIBDIR}")
++set(GINKGO_INSTALL_RUNTIME_DIR "${CMAKE_INSTALL_BINDIR}")
++set(GINKGO_INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++set(GINKGO_INSTALL_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo")
++set(GINKGO_INSTALL_MODULE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/Ginkgo/Modules")
+ 
+ function(ginkgo_install_library name subdir)
+-    
++
+     if (WIN32 OR CYGWIN)
+         # dll is considered as runtime
+         install(TARGETS "${name}"
+             EXPORT Ginkgo
+-            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
+-            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
+-            RUNTIME DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
++            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
++            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
++            RUNTIME DESTINATION "${GINKGO_INSTALL_RUNTIME_DIR}"
+             )
+     else ()
+         # install .so and .a files
+         install(TARGETS "${name}"
+             EXPORT Ginkgo
+-            LIBRARY DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
+-            ARCHIVE DESTINATION ${GINKGO_INSTALL_LIBRARY_DIR}
++            LIBRARY DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
++            ARCHIVE DESTINATION "${GINKGO_INSTALL_LIBRARY_DIR}"
+         )
+     endif ()
+ endfunction()
+@@ -37,9 +37,8 @@ function(ginkgo_install)
+         DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}"
+         FILES_MATCHING PATTERN "*.hpp"
+         )
+-    install(DIRECTORY "${Ginkgo_BINARY_DIR}/include/"
+-        DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}"
+-        FILES_MATCHING PATTERN "*.hpp"
++    install(FILES "${Ginkgo_BINARY_DIR}/include/ginkgo/config.hpp"
++        DESTINATION "${GINKGO_INSTALL_INCLUDE_DIR}/ginkgo"
+         )
+     if (GINKGO_HAVE_PAPI_SDE)
+         install(FILES "${Ginkgo_SOURCE_DIR}/third_party/papi_sde/papi_sde_interface.h"
+@@ -60,7 +59,7 @@ function(ginkgo_install)
+     write_basic_package_version_file(
+         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
+         VERSION "${PROJECT_VERSION}"
+-        COMPATIBILITY AnyNewerVersion
++        COMPATIBILITY SameMajorVersion
+         )
+     configure_package_config_file(
+         "${Ginkgo_SOURCE_DIR}/cmake/GinkgoConfig.cmake.in"
+@@ -75,11 +74,21 @@ function(ginkgo_install)
+     install(FILES
+         "${Ginkgo_BINARY_DIR}/GinkgoConfig.cmake"
+         "${Ginkgo_BINARY_DIR}/GinkgoConfigVersion.cmake"
+-        "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
+-        "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
+         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
+         )
+-      install(EXPORT Ginkgo
++    if (WIN32 OR CYGWIN)
++        install(FILES
++            "${Ginkgo_SOURCE_DIR}/cmake/windows_helpers.cmake"
++            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
++            )
++    endif()
++    if (GINKGO_BUILD_HIP)
++        install(FILES
++            "${Ginkgo_SOURCE_DIR}/cmake/hip_helpers.cmake"
++            DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}"
++            )
++    endif()
++    install(EXPORT Ginkgo
+         NAMESPACE Ginkgo::
+         FILE GinkgoTargets.cmake
+         DESTINATION "${GINKGO_INSTALL_CONFIG_DIR}")

--- a/ports/ginkgo/portfile.cmake
+++ b/ports/ginkgo/portfile.cmake
@@ -25,11 +25,16 @@ vcpkg_cmake_configure(
         -DGINKGO_BUILD_HIP=OFF
         -DGINKGO_BUILD_BENCHMARKS=OFF
         -DGINKGO_DEVEL_TOOLS=OFF
+        -DGINKGO_SKIP_DEPENDENCY_UPDATE=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_Git=ON
+        -DGinkgo_NAME=ginkgo
         ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Ginkgo)
+vcpkg_fixup_pkgconfig()
+
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/ginkgo" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/ginkgo/portfile.cmake
+++ b/ports/ginkgo/portfile.cmake
@@ -1,0 +1,35 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ginkgo-project/ginkgo
+    REF v1.3.0
+    SHA512 40db39666730a2120d0c5e197518f784aab71655781c037fb83302a346f6bf717e5c58491e9b29b9adacb492328e11bc60960f99323c220d53505ecab6489871
+    HEAD_REF master
+    PATCHES
+        cmake-fixes.patch
+        windows-iterator.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    openmp    GINKGO_BUILD_OMP
+    cuda      GINKGO_BUILD_CUDA
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+    OPTIONS
+        -DGINKGO_BUILD_REFERENCE=ON
+        -DGINKGO_BUILD_TESTS=OFF
+        -DGINKGO_BUILD_EXAMPLES=OFF
+        -DGINKGO_BUILD_HIP=OFF
+        -DGINKGO_BUILD_BENCHMARKS=OFF
+        -DGINKGO_DEVEL_TOOLS=OFF
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Ginkgo)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/ginkgo" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/ginkgo/vcpkg.json
+++ b/ports/ginkgo/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "ginkgo",
+  "version-semver": "1.3.0",
+  "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems.",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Build the CUDA backend of Ginkgo",
+      "dependencies": [
+        "cuda"
+      ]
+    },
+    "openmp": {
+      "description": "Build the OpenMP backend of Ginkgo"
+    }
+  }
+}

--- a/ports/ginkgo/vcpkg.json
+++ b/ports/ginkgo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ginkgo",
   "version-semver": "1.3.0",
-  "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems.",
+  "description": "Ginkgo is a high-performance linear algebra library for manycore systems, with a focus on sparse solution of linear systems. Note that the OpenMP feature is not available on Windows, and the CUDA feature on Windows requires the CUDACXX environment variable to point to the CUDA nvcc.exe compiler with VCPKG_KEEP_ENV_VARS set to CUDACXX to pass its value through to the vcpkg environment.",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/ginkgo/windows-iterator.patch
+++ b/ports/ginkgo/windows-iterator.patch
@@ -1,0 +1,117 @@
+diff --git a/core/base/iterator_factory.hpp b/core/base/iterator_factory.hpp
+index b7efd21dfe..5e4bddeb17 100644
+--- a/core/base/iterator_factory.hpp
++++ b/core/base/iterator_factory.hpp
+@@ -110,7 +110,7 @@ class IteratorFactory {
+ 
+         ~Reference() {}
+ 
+-        Reference(IteratorFactory &parent, array_index_type array_index)
++        Reference(IteratorFactory *parent, array_index_type array_index)
+             : parent_(parent), arr_index_(array_index)
+         {}
+ 
+@@ -143,10 +143,10 @@ class IteratorFactory {
+         {
+             // In C++11, it is legal for a nested class to access private
+             // members of the parent class.
+-            parent_.dominant_values_[arr_index_] =
+-                std::move(other.parent_.dominant_values_[other.arr_index_]);
+-            parent_.secondary_values_[arr_index_] =
+-                std::move(other.parent_.secondary_values_[other.arr_index_]);
++            parent_->dominant_values_[arr_index_] =
++                std::move(other.parent_->dominant_values_[other.arr_index_]);
++            parent_->secondary_values_[arr_index_] =
++                std::move(other.parent_->secondary_values_[other.arr_index_]);
+             return *this;
+         }
+ 
+@@ -174,25 +174,25 @@ class IteratorFactory {
+             return left.dominant < right.dominant();
+         }
+ 
+-        ToSortType &dominant() { return parent_.dominant_values_[arr_index_]; }
++        ToSortType &dominant() { return parent_->dominant_values_[arr_index_]; }
+ 
+         const ToSortType &dominant() const
+         {
+-            return parent_.dominant_values_[arr_index_];
++            return parent_->dominant_values_[arr_index_];
+         }
+ 
+         SecondaryType &secondary()
+         {
+-            return parent_.secondary_values_[arr_index_];
++            return parent_->secondary_values_[arr_index_];
+         }
+ 
+         const SecondaryType &secondary() const
+         {
+-            return parent_.secondary_values_[arr_index_];
++            return parent_->secondary_values_[arr_index_];
+         }
+ 
+     private:
+-        IteratorFactory &parent_;
++        IteratorFactory *parent_;
+         array_index_type arr_index_;
+     };
+ 
+@@ -214,9 +214,11 @@ class IteratorFactory {
+         using reference = Reference;
+         using iterator_category = std::random_access_iterator_tag;
+ 
++        Iterator() = default;
++
+         ~Iterator() {}
+ 
+-        Iterator(IteratorFactory &parent, difference_type array_index)
++        Iterator(IteratorFactory *parent, difference_type array_index)
+             : parent_(parent), arr_index_(array_index)
+         {}
+ 
+@@ -298,12 +300,12 @@ class IteratorFactory {
+         }
+ 
+         // Comparable operators
+-        bool operator==(const Iterator &other)
++        bool operator==(const Iterator &other) const
+         {
+             return arr_index_ == other.arr_index_;
+         }
+ 
+-        bool operator!=(const Iterator &other)
++        bool operator!=(const Iterator &other) const
+         {
+             return arr_index_ != other.arr_index_;
+         }
+@@ -329,8 +331,8 @@ class IteratorFactory {
+         }
+ 
+     private:
+-        IteratorFactory &parent_;
+-        difference_type arr_index_;
++        IteratorFactory *parent_{};
++        difference_type arr_index_{};
+     };
+ 
+ public:
+@@ -363,7 +365,7 @@ class IteratorFactory {
+      * Creates an iterator pointing to the beginning of both arrays
+      * @returns  an iterator pointing to the beginning of both arrays
+      */
+-    Iterator begin() { return {*this, 0}; }
++    Iterator begin() { return {this, 0}; }
+ 
+     /**
+      * Creates an iterator pointing to the (excluding) end of both arrays
+@@ -371,7 +373,7 @@ class IteratorFactory {
+      */
+     Iterator end()
+     {
+-        return {*this, static_cast<typename Iterator::difference_type>(size_)};
++        return {this, static_cast<typename Iterator::difference_type>(size_)};
+     }
+ 
+ private:
+

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2192,6 +2192,10 @@
       "baseline": "5.1.4-6",
       "port-version": 0
     },
+    "ginkgo": {
+      "baseline": "1.3.0",
+      "port-version": 0
+    },
     "gl2ps": {
       "baseline": "1.4.2",
       "port-version": 0

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9748b66062d3e27d5310f578953c6aa80adb034f",
+      "version-semver": "1.3.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cbe8587a0e52ff2991e4f56cb9004933f88a450",
+      "git-tree": "b204eef5f779c05c2160e28cc07f411258ddcbfc",
       "version-semver": "1.3.0",
       "port-version": 0
     }

--- a/versions/g-/ginkgo.json
+++ b/versions/g-/ginkgo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9748b66062d3e27d5310f578953c6aa80adb034f",
+      "git-tree": "7cbe8587a0e52ff2991e4f56cb9004933f88a450",
       "version-semver": "1.3.0",
       "port-version": 0
     }


### PR DESCRIPTION
This PR adds a port for the [Ginkgo](https://github.com/ginkgo-project/ginkgo) numerical linear algebra library with support for its Reference, OpenMP and CUDA backends. It does have a HIP backend for ROCm GPUs as well, but since the HIP ecosystem can still be a bit fragile, I left it out of the port.

We support and test compilation as a static and dynamic library for Linux (GCC/Clang/Intel), Windows (MSVC, MinGW, Cygwin) and Mac (AppleClang).

As far as I can tell, there is only one other library called Ginkgo, which is a Go testing framework, so name collisions should not be an issue here.
