### PR TITLE
[vc] Update HEAD_REF and fix CMake configure options

### DIFF
--- a/ports/vc/CONTROL
+++ b/ports/vc/CONTROL
@@ -1,5 +1,6 @@
 Source: vc
 Version: 1.4.1
+Port-Version: 1
 Homepage: https://github.com/VcDevel/Vc
 Description: SIMD Vector Classes for C++ .
 Supports: !arm64

--- a/ports/vc/portfile.cmake
+++ b/ports/vc/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO  VcDevel/Vc 
     REF 1.4.1
     SHA512 dd17e214099796c41d70416d365ea038c00c5fda285b05e48d7ee4fe03f4db2671d2be006ca7b98b0d4133bfcb57faf04cecfe35c29c3b006cd91c9a185cc04a
-    HEAD_REF master
+    HEAD_REF 1.4
     PATCHES
         "correct_cmake_config_path.patch"
 )

--- a/ports/vc/portfile.cmake
+++ b/ports/vc/portfile.cmake
@@ -13,8 +13,7 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    -DBUILD_TESTING=OFF
-    -DBUILD_EXAMPLES=OFF
+    OPTIONS -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF
 )
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Vc/)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6114,7 +6114,7 @@
     },
     "vc": {
       "baseline": "1.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "vcglib": {
       "baseline": "1.0.1",

--- a/versions/v-/vc.json
+++ b/versions/v-/vc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ab229fb781ff549e05917c4ec46a1fcd6bd1a3a",
+      "version-string": "1.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "62edb04d91a2e37739c935e832dfa75f311089f8",
       "version-string": "1.4.1",
       "port-version": 0


### PR DESCRIPTION
Change the `HEAD_REF` of `vc` from `master` to `1.4`, because the development on `master` moved to a new repository focusing on `std::simd` (https://github.com/VcDevel/std-simd). The branch `1.4` contains the newest developments which are still the `vc` library. I have contacted the maintainer of vc and he now deleted the `master` branch.

Furthermore, the CMake configure options were not correctly passed. Please tell me if this is done correctly now!

With these changes I can now successfully run `vcpkg install vc --head` and `vcpkg install vc` with the triplet `x64-windows` defined via an environment variable.