### PR TITLE
[CGAL] Restore boost dependencies

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,8 +1,7 @@
 Source: cgal
 Version: 5.2
 Port-Version: 2
-Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-archive, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric, boost-optional, boost-parameter, boost-pending, boost-pool, boost-preprocessor, boost-property_map, boost-property_tree, boost-ptr_container, boost-random, boost-range, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
-
+Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric-conversion, boost-optional, boost-parameter, boost-pool, boost-preprocessor, boost-property-map, boost-property-tree, boost-ptr-container, boost-random, boost-range, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 

--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,6 +1,6 @@
 Source: cgal
 Version: 5.2
-Port-Version: 1
+Port-Version: 2
 Build-Depends: mpfr, gmp, zlib, boost
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.

--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,7 +1,7 @@
 Source: cgal
 Version: 5.2
 Port-Version: 2
-Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric-conversion, boost-optional, boost-parameter, boost-pool, boost-preprocessor, boost-property-map, boost-property-tree, boost-ptr-container, boost-random, boost-range, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
+Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric-conversion, boost-optional, boost-parameter, boost-pool, boost-preprocessor, boost-property-map, boost-property-tree, boost-ptr-container, boost-random, boost-range, boost-serialization, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 

--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,7 +1,7 @@
 Source: cgal
 Version: 5.2
 Port-Version: 1
-Build-Depends: mpfr, gmp, zlib, boost-format, boost-container, boost-ptr-container, boost-iterator, boost-variant, boost-any, boost-unordered, boost-random, boost-foreach, boost-graph, boost-heap, boost-logic, boost-multiprecision, boost-interval
+Build-Depends: mpfr, gmp, zlib, boost
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 

--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,7 +1,8 @@
 Source: cgal
 Version: 5.2
 Port-Version: 2
-Build-Depends: mpfr, gmp, zlib, boost
+Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-archive, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric, boost-optional, boost-parameter, boost-pending, boost-pool, boost-preprocessor, boost-property_map, boost-property_tree, boost-ptr_container, boost-random, boost-range, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
+
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1142,7 +1142,7 @@
     },
     "cgal": {
       "baseline": "5.2",
-      "port-version": 1
+      "port-version": 2
     },
     "cgicc": {
       "baseline": "3.2.19-4",

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "005c2dedaba604aa23a5c35c800b25590bbe3ba5",
+      "version-string": "5.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "5cbb2f2a60d864bd36098d71a050aeef43e52eff",
       "version-string": "5.2",
       "port-version": 1

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "005c2dedaba604aa23a5c35c800b25590bbe3ba5",
+      "git-tree": "6d5aeedca6a3ace515272f0d3a1fc150efde9076",
       "version-string": "5.2",
       "port-version": 2
     },


### PR DESCRIPTION
 The boost packages listed in the dependencies are unsufficient. We need the whole boost as a dependency, not just a few modules.

