### PR TITLE
[hazelcast-cpp-client] New version update to 4.0.1  

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF 57ece8e82c4380472b4acff948db6a86ff0648b1 # v4.0.0 + fixes
-    SHA512 eb11677883f237e27562dfcd0f0e7e19ed439f8b0e13ca02942d2351b99ec54d4496cbaf8c3aaa08304b799f921641d51286bb7b7d4c6a0f1ff58cf954f3596f
+    REF v4.0.1
+    SHA512 9d6e2fe890d5dc08b2ccc2e74c736c7ce014a03f5f020ccfc21f5accbfe39285898283e01e491cab1259badf983094b97b618230cb999480372aaf018d874457
     HEAD_REF master
 )
 

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version-semver": "4.0.0",
+  "version-semver": "4.0.1",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2385,7 +2385,7 @@
       "port-version": 0
     },
     "hazelcast-cpp-client": {
-      "baseline": "4.0.0",
+      "baseline": "4.0.1",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -4,6 +4,11 @@
       "git-tree": "1d4ad2dfd6a51e8867868bfa7a2ce80226d767c8",
       "version-semver": "4.0.1",
       "port-version": 0
+    },
+    {
+      "git-tree": "d0f516ea034e3c58e0c1621f4230445eb303a1b0",
+      "version-semver": "4.0.0",
+      "port-version": 0
     }
   ]
 }

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "d0f516ea034e3c58e0c1621f4230445eb303a1b0",
-      "version-semver": "4.0.0",
+      "git-tree": "027d56df46d770d8e2225693e4bbc91703451757",
+      "version-semver": "4.0.1",
       "port-version": 0
     }
   ]

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "027d56df46d770d8e2225693e4bbc91703451757",
+      "git-tree": "1d4ad2dfd6a51e8867868bfa7a2ce80226d767c8",
       "version-semver": "4.0.1",
       "port-version": 0
     }


### PR DESCRIPTION
Updated the `hazelcast-cpp-client` version to 4.0.1 since we released this new patch release.

**Describe the pull request**

- What does your PR fix? Fixes #
- It updates the hazelcast-cpp-client version from 4.0.0 to 4.0.1.

- Which triplets are supported/not supported? Have you updated the CI baseline?
- yes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
- yes
