### PR TITLE
[vcpkg] Allow compilation of HEAD_REF-only ports in manifest mode

### DIFF
--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -129,6 +129,11 @@ function(vcpkg_from_github)
         set(VCPKG_USE_HEAD_VERSION OFF)
     endif()
 
+    if(VCPKG_MANIFEST_MODE AND NOT VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_REF)
+        message(STATUS "Package specifies HEAD_REF but not REF, and --head was not passed to vcpkg. Manifest mode is active, so HEAD_REF is being used.")
+        set(VCPKG_USE_HEAD_VERSION ON)
+    endif()
+
     # Handle --no-head scenarios
     if(NOT VCPKG_USE_HEAD_VERSION)
         if(NOT _vdud_REF)


### PR DESCRIPTION
**Requires https://github.com/microsoft/vcpkg-tool/pull/24 to work, otherwise it does nothing.**

Sort of addresses https://github.com/microsoft/vcpkg/issues/12504. More specifically, supports my desired use case:
* I have a registry with very, very frequently touched package. It does not make sense for me to version this package in any way, I am the only one using it, and I only ever want to use the latest version. Therefore, I have it [available on my vcpkg registry as a HEAD_REF-only port](https://github.com/PazerOP/vcpkg-registry/blob/397dc9e361f0727da46e45333940558c192f7b6c/ports/mh-stuff/portfile.cmake#L4).
* I have a project that consumes previously mentioned package, as well as many others from the official vcpkg registry. I do not want `--head` behavior for all those packages. 
* I want to use manifest mode, which means I cannot currently specify per-port build options (here's where #12504 comes into play)

With the given conditions, it is impossible to build my project. vcpkg will run the manifest install step, then hit my `--head`-requiring port, [and abort](https://github.com/microsoft/vcpkg/blob/0dc27b9b672cb9d069cf58c48f3ae3f7395d108b/scripts/cmake/vcpkg_from_github.cmake#L135).

I cannot use `--head`, because not all my vcpkg dependencies are built from source (discord-game-sdk). I also have no desire to be living on the bleeding edge for any third-party dependencies anyway. 

Theoretically, this change should not break any existing behavior (unless people were relying on vcpkg not working in this situation). It takes a previously non-working scenario (HEAD_REF-only port, manifests, and no `--head`) and makes it work in a (in my opinion) reasonable way.

- **What does your PR fix?** Somewhat related to #12504

- **Which triplets are supported/not supported? Have you updated the CI baseline?**
I do not believe this has any affect for CI pipelines, but I have not studied them in detail. Please correct me if this is wrong.

- **Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?** 
To the best of my understanding, yes.