### PR TITLE
[harfbuzz] work around upstream SameFileError

### DIFF
--- a/ports/harfbuzz/0001-circumvent-samefile-error.patch
+++ b/ports/harfbuzz/0001-circumvent-samefile-error.patch
@@ -1,0 +1,43 @@
+diff --git a/src/gen-harfbuzzcc.py b/src/gen-harfbuzzcc.py
+index b25bcc7..97bf2ab 100644
+--- a/src/gen-harfbuzzcc.py
++++ b/src/gen-harfbuzzcc.py
+@@ -15,4 +15,8 @@ with open (OUTPUT, "wb") as f:
+        f.write ("".join ('#include "{}"\n'.format (os.path.basename (x)) for x in sources if x.endswith (".cc")).encode ())
+ 
+ # copy it also to src/
+-shutil.copyfile (OUTPUT, os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT)))
++src = OUTPUT
++dst = os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT))
++# Avoid SameFileError
++if not os.path.samefile(src, dst):
++    shutil.copyfile (src, dst)
+diff --git a/src/gen-hb-version.py b/src/gen-hb-version.py
+index 5ec2024..59d4754 100644
+--- a/src/gen-hb-version.py
++++ b/src/gen-hb-version.py
+@@ -33,4 +33,8 @@ with open (INPUT, "r", encoding='utf-8') as template:
+                        .encode ())
+ 
+ # copy it also to src/
+-shutil.copyfile (OUTPUT, os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT)))
++src = OUTPUT
++dst = os.path.join(CURRENT_SOURCE_DIR, os.path.basename (OUTPUT))
++# Avoid SameFileError if src and dst is the same
++if not os.path.samefile(src, dst):
++    shutil.copyfile (src, dst)
+diff --git a/src/gen-ragel-artifacts.py b/src/gen-ragel-artifacts.py
+index b60ec3b..288e224 100644
+--- a/src/gen-ragel-artifacts.py
++++ b/src/gen-ragel-artifacts.py
+@@ -22,4 +22,8 @@ hh = rl.replace ('.rl', '.hh')
+ subprocess.Popen ([ragel, '-e', '-F1', '-o', hh, rl], cwd=outdir).wait ()
+ 
+ # copy it also to src/
+-shutil.copyfile (os.path.join (outdir, hh), os.path.join (CURRENT_SOURCE_DIR, hh))
++src = os.path.join (outdir, hh)
++dst = os.path.join (CURRENT_SOURCE_DIR, hh)
++# Avoid SameFileError
++if not os.path.samefile(src, dst):
++    shutil.copyfile (src, dst)
+

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -5,6 +5,11 @@ vcpkg_from_github(
     SHA512 d231a788ea4e52231d4c363c1eca76424cb82ed0952b5c24d0b082e88b3dddbda967e7fffe67fffdcb22c7ebfbf0ec923365eb4532be772f2e61fa7d29b51998
     HEAD_REF master
     PATCHES
+		# This patch is a workaround that is needed until the following issues are resolved upstream:
+		# - https://github.com/mesonbuild/meson/issues/8375
+		# - https://github.com/harfbuzz/harfbuzz/issues/2870
+		# Details: https://github.com/microsoft/vcpkg/issues/16262
+		0001-circumvent-samefile-error.patch
         0002-fix-uwp-build.patch
 )
 

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "harfbuzz",
   "version-string": "2.7.4",
+  "port-version": 1,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2378,7 +2378,7 @@
     },
     "harfbuzz": {
       "baseline": "2.7.4",
-      "port-version": 0
+      "port-version": 1
     },
     "hayai": {
       "baseline": "2019-08-10",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e985af9b39fb57ee491c1a773c43334665ddb3d3",
+      "version-string": "2.7.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "bb9ea75cd35a35e57fb0bf79ff78818c95148fcf",
       "version-string": "2.7.4",
       "port-version": 0


### PR DESCRIPTION
During the configuration of harfbuzz several Python scripts are invoked
that are supposed to copy some files. For some reason however the
scripts end up being instructed to copy files to themselves at which
point a SameFileError is risen, causing the build to fail.

This is a workaround for the underlaying issue that is deemed to be
usptream. The upstream issues are
- https://github.com/mesonbuild/meson/issues/8375
- https://github.com/harfbuzz/harfbuzz/issues/2870

The workaround is to add a patch that makes sure these scripts check
whether source and target file are the same and only invoking the copy
action if they are not.

Fixes #16262