### PR TITLE
[ocilib] fix wrong solution filename

### DIFF
--- a/ports/ocilib/CONTROL
+++ b/ports/ocilib/CONTROL
@@ -1,5 +1,0 @@
-Source: ocilib
-Version: 4.7.1
-Homepage: https://vrogier.github.io/ocilib/
-Description: OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.
-Supports: !(arm|uwp)

--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -9,33 +9,19 @@ vcpkg_from_github(
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    if(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
-        set(OCILIB_ARCH_X86 x86)
-        set(OCILIB_ARCH_X64 x64)
-    else()
-        set(OCILIB_ARCH_X86 Win32)
-        set(OCILIB_ARCH_X64 Win64)
-    endif()
-    
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-        set(PLATFORM ${OCILIB_ARCH_X86})
-    else()
-        set(PLATFORM ${OCILIB_ARCH_X64})
-    endif()
-    
     # There is no debug configuration
     # As it is a C library, build the release configuration and copy its output to the debug folder
     set(VCPKG_BUILD_TYPE release)
+    
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
         PROJECT_SUBPATH proj/dll/ocilib_dll_vs2019.sln
         INCLUDES_SUBPATH include
         LICENSE_SUBPATH LICENSE
         RELEASE_CONFIGURATION "Release - ANSI"
-        PLATFORM ${PLATFORM}
         USE_VCPKG_INTEGRATION
         ALLOW_ROOT_INCLUDES)
-
+    
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug)
     file(COPY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -10,15 +10,9 @@ vcpkg_from_github(
 
 if(VCPKG_TARGET_IS_WINDOWS)
     if(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
-        set(SOLUTION_TYPE vs2019)
         set(OCILIB_ARCH_X86 x86)
         set(OCILIB_ARCH_X64 x64)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
-        set(SOLUTION_TYPE vs2017)
-        set(OCILIB_ARCH_X86 Win32)
-        set(OCILIB_ARCH_X64 Win64)
     else()
-        set(SOLUTION_TYPE vs2015)
         set(OCILIB_ARCH_X86 Win32)
         set(OCILIB_ARCH_X64 Win64)
     endif()
@@ -34,7 +28,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     set(VCPKG_BUILD_TYPE release)
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
-        PROJECT_SUBPATH proj/dll/ocilib_dll_${SOLUTION_TYPE}.sln
+        PROJECT_SUBPATH proj/dll/ocilib_dll_vs2019.sln
         INCLUDES_SUBPATH include
         LICENSE_SUBPATH LICENSE
         RELEASE_CONFIGURATION "Release - ANSI"

--- a/ports/ocilib/portfile.cmake
+++ b/ports/ocilib/portfile.cmake
@@ -9,19 +9,25 @@ vcpkg_from_github(
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        set(PLATFORM x86)
+    else()
+        set(PLATFORM x64)
+    endif()
+    
     # There is no debug configuration
     # As it is a C library, build the release configuration and copy its output to the debug folder
     set(VCPKG_BUILD_TYPE release)
-    
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
         PROJECT_SUBPATH proj/dll/ocilib_dll_vs2019.sln
         INCLUDES_SUBPATH include
         LICENSE_SUBPATH LICENSE
         RELEASE_CONFIGURATION "Release - ANSI"
+        PLATFORM ${PLATFORM}
         USE_VCPKG_INTEGRATION
         ALLOW_ROOT_INCLUDES)
-    
+
     file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug)
     file(COPY ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/ocilib/vcpkg.json
+++ b/ports/ocilib/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "ocilib",
+  "version-string": "4.7.1",
+  "port-version": 1,
+  "description": "OCILIB is an open source and cross platform Oracle Driver that delivers efficient access to Oracle databases.",
+  "homepage": "https://vrogier.github.io/ocilib/",
+  "supports": "!(arm | uwp)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4222,7 +4222,7 @@
     },
     "ocilib": {
       "baseline": "4.7.1",
-      "port-version": 0
+      "port-version": 1
     },
     "octomap": {
       "baseline": "1.9.5",

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b98e984c8943acdb9a1fb8fe363270c7c4c61b5f",
+      "version-string": "4.7.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a956cde150fe4a95f62c4586788dafd6587e00e6",
       "version-string": "4.7.1",
       "port-version": 0

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b98e984c8943acdb9a1fb8fe363270c7c4c61b5f",
+      "git-tree": "44c1d213a0b3ed6d47894dd1e5f2ea7f12897ed1",
       "version-string": "4.7.1",
       "port-version": 1
     },

--- a/versions/o-/ocilib.json
+++ b/versions/o-/ocilib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44c1d213a0b3ed6d47894dd1e5f2ea7f12897ed1",
+      "git-tree": "a3316dc22d7227e1886297c9471dcb737412bc84",
       "version-string": "4.7.1",
       "port-version": 1
     },


### PR DESCRIPTION
There is only a single file in proj/dll and that is ocilib_dll_vs2019.sln.

**Describe the pull request**

I have checked with upstream (https://github.com/vrogier/ocilib/tree/v4.7.1/proj/dll) and there is only a single .sln file there, while the current portfile tries to use ocilib_dll_vs2017.sln and ocilib_dll_vs2015.sln, which fails to build.

- What does your PR fix? Fixes #

Since this is a small fix, I did not make an issue. Should I?

- Which triplets are supported/not supported? Have you updated the CI baseline?

I'm not sure how to do this properly. This should only be a port-version bump, I think.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
