### PR TITLE
[vcpkg_execute_build_process] Add warning message when memory or hard disk space is insufficient

### DIFF
--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -133,7 +133,7 @@ function(vcpkg_execute_build_process)
                 endif()
             endwhile()
         elseif(out_contents MATCHES "fatal error: ld terminated with signal 9 [Killed]")
-            message(WARNING "Insufficient memory or hard disk space is detected, please make sure there is enough space and try again.")
+            message(WARNING "ld was terminated with signal 9 [killed], please ensure your system has sufficient hard disk space and memory.")
         endif()
 
         if(error_code)

--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -132,6 +132,8 @@ function(vcpkg_execute_build_process)
                     break()
                 endif()
             endwhile()
+        elseif(out_contents MATCHES "fatal error: ld terminated with signal 9 [Killed]")
+            message(WARNING "Insufficient memory or hard disk space is detected, please make sure there is enough space and try again.")
         endif()
 
         if(error_code)


### PR DESCRIPTION
When building a port in linux, occasionally there will be insufficient memory or disk, we should extract this information and display it in the console.

Related #16586.