### PR TITLE
[prometheus-cpp] Update to version 0.12.2

### DIFF
--- a/ports/prometheus-cpp/CONTROL
+++ b/ports/prometheus-cpp/CONTROL
@@ -1,5 +1,5 @@
 Source: prometheus-cpp
-Version: 0.12.1
+Version: 0.12.2
 Description: Prometheus Client Library for Modern C++
 Default-Features: compression, pull
 
@@ -12,7 +12,7 @@ Build-Depends: gtest
 Description: Additional testing support
 
 Feature: pull
-Build-Depends: civetweb, cppcodec
+Build-Depends: civetweb
 Description: Support for regular pull mode
 
 Feature: push

--- a/ports/prometheus-cpp/portfile.cmake
+++ b/ports/prometheus-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jupp0r/prometheus-cpp
-    REF 38130aee330377d6289a076628dbe450d59ef3e9 # v0.12.1
-    SHA512 9daf12f482ba947e28ce0411cb75234865542e2c850d1173de98f2929c3eb8d02c7f38630d060829273ef57da0eee9ce3f3cb21b05abe1da7e64307253d57bba
+    REF 2412990ee9ad89245e7d1df9ec85ab19b24674d3 # v0.12.2
+    SHA512 52ecf1984c709dab749f2b4b0010796be49b9db5416678baf77f645054f85b1cae4d67f06ffb1643c0fbcfbf2e65c81f2157a22c0b75a346f9b1feba6537b87d
     HEAD_REF master
 )
 
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DUSE_THIRDPARTY_LIBRARIES=OFF # use vcpkg packages
+        -DGENERATE_PKGCONFIG=OFF
         ${FEATURE_OPTIONS}
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4741,7 +4741,7 @@
       "port-version": 1
     },
     "prometheus-cpp": {
-      "baseline": "0.12.1",
+      "baseline": "0.12.2",
       "port-version": 0
     },
     "protobuf": {

--- a/versions/p-/prometheus-cpp.json
+++ b/versions/p-/prometheus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bcbc7c9c58b3cfd8b1559bab7816b46edf8f2af6",
+      "version-string": "0.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "be1b7db5fe2c186c52cd074caa038874d27e245f",
       "version-string": "0.12.1",
       "port-version": 0


### PR DESCRIPTION
Update prometheus-cpp to `0.12.2`. Locally tested all the features on macOS.