### PR TITLE
[taglib] Upgrade from 1.12-beta-2 to 1.12

### DIFF
--- a/ports/taglib/CONTROL
+++ b/ports/taglib/CONTROL
@@ -1,5 +1,0 @@
-Source: taglib
-Version: 1.12.0-20210123
-Description: TagLib Audio Meta-Data Library
-Homepage: https://github.com/taglib/taglib
-Build-Depends: zlib

--- a/ports/taglib/msvc-disable-deprecated-warnings.patch
+++ b/ports/taglib/msvc-disable-deprecated-warnings.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fc91cc6..6f57e4ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,10 +58,17 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+ endif()
+
+-if(MSVC AND ENABLE_STATIC_RUNTIME)
+-  foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+-    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+-  endforeach(flag_var)
++if(MSVC)
++  if(ENABLE_STATIC_RUNTIME)
++    foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
++      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
++    endforeach(flag_var)
++  endif()
++  # Disable warnings for internal invocations of API functions
++  # that have been marked with TAGLIB_DEPRECATED
++  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996
++  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
+ endif()
+
+ # Read version information from file taglib/toolkit/taglib.h into variables

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taglib/taglib
-    REF 4c14571647e3391dd8f59473903abc44707b4f1b
-    SHA512 2619013e38de4afce58d2c8a8fcb2fc34aeb4006c0657a942cb035a5b79ac1438609f89c31bc631b299eb270ac90f2d222c0ddeeb8151803cf7cda15ab3282b4
+    REF v1.12
+    SHA512 63c96297d65486450908bda7cc1583ec338fa5a56a7c088fc37d6e125e1ee76e6d20343556a8f3d36f5b7e5187c58a5d15be964c996e3586ea1438910152b1a6
     HEAD_REF master
 )
 
@@ -25,6 +25,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_pkgconfig()
 
 # remove the debug/include files
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -7,9 +7,9 @@ vcpkg_from_github(
     PATCHES msvc-disable-deprecated-warnings.patch
 )
 
-if(VCPKG_CRT_LINKAGE STREQUAL static)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(BUILD_SHARED_LIBS OFF)
-else()
+elseif(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     set(BUILD_SHARED_LIBS ON)
 endif()
 

--- a/ports/taglib/portfile.cmake
+++ b/ports/taglib/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v1.12
     SHA512 63c96297d65486450908bda7cc1583ec338fa5a56a7c088fc37d6e125e1ee76e6d20343556a8f3d36f5b7e5187c58a5d15be964c996e3586ea1438910152b1a6
     HEAD_REF master
+    PATCHES msvc-disable-deprecated-warnings.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)
@@ -14,8 +15,6 @@ endif()
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     set(WINRT_OPTIONS -DHAVE_VSNPRINTF=1 -DPLATFORM_WINRT=1)
-    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} /wd4996")
-    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} /wd4996")
 endif()
 
 vcpkg_configure_cmake(

--- a/ports/taglib/vcpkg.json
+++ b/ports/taglib/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "taglib",
+  "version-semver": "1.12.0",
+  "description": "TagLib Audio Meta-Data Library",
+  "homepage": "https://taglib.org/",
+  "license": "LGPL-2.1 OR MPL-1.1",
+  "dependencies": [
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5713,7 +5713,7 @@
       "port-version": 0
     },
     "taglib": {
-      "baseline": "1.12.0-20210123",
+      "baseline": "1.12.0",
       "port-version": 0
     },
     "taocpp-json": {

--- a/versions/t-/taglib.json
+++ b/versions/t-/taglib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4559ad74a4b1757cc6f7b11abce3b6c4cab66c7",
+      "version-semver": "1.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e9d856fb23e6cf5ad4b86f2098549ba88098a0cb",
       "version-string": "1.12.0-20210123",
       "port-version": 0


### PR DESCRIPTION
Follow-up of:
 - #16266 (original)
 - #16390 (merged beforehand)

Original changes:
- Replace CONTROL with vcpkg.json
- Use Git tag as REF
- Link official homepage instead of GitHub project page
- Add license string according to GitHub repo
- Add missing vcpkg_fixup_pkgconfig() in portfile

Additional changes:
- Switch to semantic versioning ("version-semver")
- Use VCPKG_LIBRARY_LINKAGE instead of VCPKG_CRT_LINKAGE to decide about static/dynamic build (https://github.com/microsoft/vcpkg/pull/16390/files#r591427047)
- Revert disabling of warnings in portfile.cmake and instead patch the original CMake build file. This ensures that the warnings are re-enabled when a fix from upstream becomes available.