### PR TITLE
[magnum/magnum-plugins] fix magnum-plugins building all magnum dependencies

### DIFF
--- a/ports/magnum-plugins/CONTROL
+++ b/ports/magnum-plugins/CONTROL
@@ -1,6 +1,6 @@
 Source: magnum-plugins
 Version: 2020.06
-Port-Version: 3
+Port-Version: 4
 Build-Depends: magnum[core]
 Description: Plugins for magnum, C++11/C++14 graphics middleware for games and data visualization
 Homepage: https://magnum.graphics/
@@ -8,118 +8,118 @@ Default-Features: ddsimporter, icoimporter, miniexrimageconverter, opengeximport
 
 Feature: assimpimporter
 Description: AssimpImporter plugin
-Build-Depends: assimp, magnum[anyimageimporter], magnum[trade]
+Build-Depends: assimp, magnum[core,anyimageimporter], magnum[core,trade]
 
 Feature: openddl
 Description: OpenDdl library
 
 Feature: basisimageconverter
 Description: BasisImageConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: basisimporter
 Description: BasisImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: ddsimporter
 Description: DdsImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: devilimageimporter
 Description: DevIlImageImporter plugin
-Build-Depends: devil, magnum[trade]
+Build-Depends: devil, magnum[core,trade]
 
 Feature: drflacaudioimporter
 Description: DrFlacAudioImporter plugin
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 
 Feature: drmp3audioimporter
 Description: DrMp3AudioImporter plugin
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 
 Feature: drwavaudioimporter
 Description: DrWavAudioImporter plugin
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 #Feature: faad2audioimporter
 #Description: Faad2AudioImporter plugin
-#Build-Depends: magnum[audio], faad2
+#Build-Depends: magnum[core,audio], faad2
 
 Feature: freetypefont
 Description: FreeTypeFont plugin
-Build-Depends: freetype, magnum[text]
+Build-Depends: freetype, magnum[core,text]
 
 Feature: glslangshaderconverter
 Description: GlslangShaderConverter plugin
-Build-Depends: glslang, magnum[shadertools]
+Build-Depends: glslang, magnum[core,shadertools]
 
 Feature: harfbuzzfont
 Description: HarfBuzzFont plugin
-Build-Depends: harfbuzz, magnum-plugins[freetypefont]
+Build-Depends: harfbuzz, magnum-plugins[core,freetypefont]
 
 Feature: icoimporter
 Description: IcoImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: jpegimporter
 Description: JpegImporter plugin
-Build-Depends: libjpeg-turbo, magnum[trade]
+Build-Depends: libjpeg-turbo, magnum[core,trade]
 
 Feature: jpegimageconverter
 Description: JpegImageConverter plugin
-Build-Depends: libjpeg-turbo, magnum[trade]
+Build-Depends: libjpeg-turbo, magnum[core,trade]
 
 Feature: meshoptimizersceneconverter
 Description: MeshOptimizerSceneConverter plugin
-Build-Depends: magnum[trade], meshoptimizer
+Build-Depends: magnum[core,trade], meshoptimizer
 
 Feature: miniexrimageconverter
 Description: MiniExrImageConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: opengeximporter
 Description: OpenGexImporter plugin
-Build-Depends: magnum[anyimageimporter], magnum[trade], magnum-plugins[openddl]
+Build-Depends: magnum[core,anyimageimporter], magnum[core,trade], magnum-plugins[core,openddl]
 
 Feature: pngimageconverter
 Description: PngImageConverter plugin
-Build-Depends: libpng, magnum[trade]
+Build-Depends: libpng, magnum[core,trade]
 
 Feature: pngimporter
 Description: PngImporter plugin
-Build-Depends: libpng, magnum[trade]
+Build-Depends: libpng, magnum[core,trade]
 
 Feature: spirvtoolsshaderconverter
 Description: SpirvToolsShaderConverter plugin
-Build-Depends: spirv-tools, magnum[shadertools]
+Build-Depends: spirv-tools, magnum[core,shadertools]
 
 Feature: stanfordimporter
 Description: StanfordImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: stanfordsceneconverter
 Description: StanfordSceneConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: stbimageconverter
 Description: StbImageConverter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: stbimageimporter
 Description: StbImageImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: stbtruetypefont
 Description: StbTrueTypeFont plugin
-Build-Depends: magnum[text]
+Build-Depends: magnum[core,text]
 
 Feature: stbvorbisaudioimporter
 Description: StbVorbisAudioImporter plugin
-Build-Depends: magnum[audio]
+Build-Depends: magnum[core,audio]
 
 Feature: stlimporter
 Description: StlImporter plugin
-Build-Depends: magnum[trade]
+Build-Depends: magnum[core,trade]
 
 Feature: tinygltfimporter
 Description: TinyGltfImporter plugin
-Build-Depends: magnum[anyimageimporter], magnum-plugins[stbimageimporter], magnum[trade]
+Build-Depends: magnum[core,anyimageimporter], magnum-plugins[core,stbimageimporter], magnum[core,trade]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3706,7 +3706,7 @@
     },
     "magnum-plugins": {
       "baseline": "2020.06",
-      "port-version": 3
+      "port-version": 4
     },
     "mapbox-variant": {
       "baseline": "1.2.0",

--- a/versions/m-/magnum-plugins.json
+++ b/versions/m-/magnum-plugins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "05b4c54140907b0b46926c50e0b56bc80051b218",
+      "version-string": "2020.06",
+      "port-version": 4
+    },
+    {
       "git-tree": "79988d3cd16038434cacef0e4423f3b2e64f0a1b",
       "version-string": "2020.06",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

Fixes error:

```
  By not providing "FindAssimp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Assimp", but
  CMake did not find one.
  Could not find a package configuration file provided by "Assimp" with any
  of the following names:
    AssimpConfig.cmake
    assimp-config.cmake
  Add the installation prefix of "Assimp" to CMAKE_PREFIX_PATH or set
  "Assimp_DIR" to a directory containing one of the above files.  If "Assimp"
  provides a separate development package or SDK, be sure it has been
  installed.
```

The assimp library in vcpkg is all lower case and Magnum expects it camel case.

Also installing magnum-plugins triggers the installation of all the features in magnum.