### PR TITLE
[ci.baseline.txt] Add 'host' type

### DIFF
--- a/scripts/azure-pipelines/parse-baseline.ps1
+++ b/scripts/azure-pipelines/parse-baseline.ps1
@@ -1,0 +1,113 @@
+#! /usr/bin/env pwsh
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: MIT
+#
+
+<#
+.SYNOPSIS
+Parses the ci.baseline.txt file.
+
+.DESCRIPTION
+parse-baseline takes a triplet, and the path to the ci.baseline.txt file,
+and returns a map from port name to one of the following strings:
+
+* 'host' - This port should pass for triplets where HOST_TRIPLET == TARGET_TRIPLET
+* 'skip' - This port should be skipped for this triplet
+* 'fail' - This port should fail for this triplet
+* 'pass' - This port should pass for this triplet. Equivalent to the port not being in the map.
+
+.PARAMETER Triplet
+The triplet to find port kind for.
+
+.PARAMETER BaselineFile
+The path to the ci.baseline.txt file.
+#>
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory)]
+    [string]$Triplet,
+    [Parameter(Mandatory)]
+    [string]$BaselineFile
+)
+
+if (-not (Test-Path -Path $BaselineFile)) {
+    Write-Error "Unable to find baseline file $BaselineFile"
+    throw
+}
+
+#read in the file, strip out comments and blank lines and spaces
+$baselineListRaw = Get-Content -Path $BaselineFile `
+    | Where-Object { -not ($_ -match "\s*#") } `
+    | Where-Object { -not ( $_ -match "^\s*$") } `
+    | ForEach-Object { $_ -replace "\s" }
+
+###############################################################
+# This script is running at the beginning of the CI test, so do a little extra
+# checking so things can fail early.
+
+#verify everything has a valid value
+$missingValues = $baselineListRaw | Where-Object { -not ($_ -match "=\w") }
+
+if ($missingValues) {
+    Write-Error "The following are missing values: $missingValues"
+    throw
+}
+
+$invalidValues = $baselineListRaw `
+    | Where-Object { -not ($_ -match "=(skip|pass|fail|host)$") }
+
+if ($invalidValues) {
+    Write-Error "The following have invalid values: $invalidValues"
+    throw
+}
+
+$hostPortsWithTriplet = $baselineListRaw `
+    | Where-Object { $_ -match ":.*=host$" }
+
+if ($hostPortsWithTriplet) {
+    Write-Error "The following host ports have triplets: $hostPortsWithTriplet"
+    throw
+}
+
+# do the actual parsing
+
+$actualBaseline = $baselineListRaw | ForEach-Object {
+    if ($_ -match "^(.*):$Triplet=(.*)$") {
+        @{
+            port = $matches[1]
+            kind = $matches[2]
+        }
+    } elseif ($_ -match "^(.*)=host$") {
+        @{
+            port = $matches[1]
+            kind = 'host'
+        }
+    }
+}
+$result = @{}
+$actualBaseline | ForEach-Object {
+    $port = $_.port
+    $kind = $_.kind
+    switch -regex ($kind) {
+        '^host$' {
+            if ($port -notin $result) {
+                $result[$port] = 'host'
+            } elseif ($result[$port] -eq 'host') {
+                Write-Error `
+                    "${port}=host has multiple definitions in $baselineFile"
+                throw
+            }
+        }
+        '^(skip|pass|fail)$' {
+            if ($port -notin $result -or $result[$port] -eq 'host') {
+                $result[$port] = $kind
+            } else {
+                Write-Error `
+                    "${port}:${Triplet} has multiple definitions in $baselineFile"
+                throw
+            }
+        }
+    }
+}
+
+$result

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -14,6 +14,7 @@
 ##          ports.  Please comment for why a port is skipped so it can be
 ##          removed when the issue is resolved.
 ##
+## Additionally, a special case is $port=host; this means "skip on triplets where host != target"
 ##
 ## CI tested triplets:
 ##    arm64-windows
@@ -29,20 +30,9 @@
 
 # Add new items alphabetically
 
-# script ports
-vcpkg-cmake:arm64-windows=fail
-vcpkg-cmake:arm-uwp=fail
-vcpkg-cmake:x64-uwp=fail
-vcpkg-cmake:x64-windows-static=fail
-vcpkg-cmake:x64-windows-static-md=fail
-vcpkg-cmake:x86-windows=fail
-
-vcpkg-cmake-config:arm64-windows=fail
-vcpkg-cmake-config:arm-uwp=fail
-vcpkg-cmake-config:x64-uwp=fail
-vcpkg-cmake-config:x64-windows-static=fail
-vcpkg-cmake-config:x64-windows-static-md=fail
-vcpkg-cmake-config:x86-windows=fail
+# host ports
+vcpkg-cmake=host
+vcpkg-cmake-config=host
 
 # other ports
 # Cross compiling CI machine cannot run gen_test_char to generate apr_escape_test_char.h


### PR DESCRIPTION
port=host means "skip on non-host triplets"

this also pulls out baseline parsing from the behavior that the
baseline represents, which means we're not duplicating
extremely complex code twice.

Taken from work in #16478 