### PR TITLE
[yasm-tool] Add msg to ports gmp, mpg123 and nettle to install yasm-tool:x86-windows from issue #16600

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -1,3 +1,9 @@
+if((VCPKG_HOST_IS_WINDOWS)
+  AND ((VCPKG_TARGET_ARCHITECTURE MATCHES "(x|X)64") OR (VCPKG_TARGET_ARCHITECTURE MATCHES "(arm|ARM)"))
+  AND NOT (EXISTS "${CURRENT_INSTALLED_DIR}/../x86-windows/tools/yasm-tool/yasm.exe"))
+    message(FATAL_ERROR "\nFatal Error: You can not build port ${PORT} without port 'yasm-tool:x86-windows' being installed.\nFirst: Please run: 'vcpkg install yasm-tool:x86-windows'\nSecond: Try to install port ${PORT} again if you need it.\n")
+endif()
+
 if(EXISTS "${CURRENT_INSTALLED_DIR}/include/gmp.h" OR "${CURRENT_INSTALLED_DIR}/include/gmpxx.h")
     message(FATAL_ERROR "Can't build ${PORT} if mpir is installed. Please remove mpir, and try install ${PORT} again if you need it.")
 endif()
@@ -9,10 +15,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
         REF 0018c44e8dfcc3b64b43e0aea4b3f419f0b65fd0 #v6.2.1-2
         SHA512 2405e2536ca9fe0b890f44f54c936ac0e4b5a9ebe6a19e1c48a9c21b7211d2a1b45865852e3c65a98a6735216a4e27bea75c0fd6e52efeed4baecd95da9895a5
         HEAD_REF master
-        PATCHES 
+        PATCHES
             vs.build.patch
             runtime.patch
-            adddef.patch 
+            adddef.patch
     )
 
     include(${CURRENT_INSTALLED_DIR}/share/yasm-tool-helper/yasm-tool-helper.cmake)

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version-string": "6.2.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "supports": "windows & !(arm | arm64)",

--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -1,3 +1,9 @@
+if((VCPKG_HOST_IS_WINDOWS)
+  AND ((VCPKG_TARGET_ARCHITECTURE MATCHES "(x|X)64") OR (VCPKG_TARGET_ARCHITECTURE MATCHES "(arm|ARM)"))
+  AND NOT (EXISTS "${CURRENT_INSTALLED_DIR}/../x86-windows/tools/yasm-tool/yasm.exe"))
+    message(FATAL_ERROR "\nFatal Error: You can not build port ${PORT} without port 'yasm-tool:x86-windows' being installed.\nFirst: Please run: 'vcpkg install yasm-tool:x86-windows'\nSecond: Try to install port ${PORT} again if you need it.\n")
+endif()
+
 set(MPG123_VERSION 1.26.3)
 set(MPG123_HASH 7574331afaecf3f867455df4b7012e90686ad6ac8c5b5e820244204ea7088bf2b02c3e75f53fe71c205f9eca81fef93f1d969c8d0d1ee9775dc05482290f7b2d)
 

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mpg123",
   "version-string": "1.26.3",
+  "port-version": 1,
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "dependencies": [

--- a/ports/nettle/portfile.cmake
+++ b/ports/nettle/portfile.cmake
@@ -1,3 +1,9 @@
+if((VCPKG_HOST_IS_WINDOWS)
+  AND ((VCPKG_TARGET_ARCHITECTURE MATCHES "(x|X)64") OR (VCPKG_TARGET_ARCHITECTURE MATCHES "(arm|ARM)"))
+  AND NOT (EXISTS "${CURRENT_INSTALLED_DIR}/../x86-windows/tools/yasm-tool/yasm.exe"))
+    message(FATAL_ERROR "\nFatal Error: You can not build port ${PORT} without port 'yasm-tool:x86-windows' being installed.\nFirst: Please run: 'vcpkg install yasm-tool:x86-windows'\nSecond: Try to install port ${PORT} again if you need it.\n")
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/nettle/vcpkg.json
+++ b/ports/nettle/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nettle",
   "version-string": "3.6",
+  "port-version": 1,
   "description": "Nettle is a low-level cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.",
   "homepage": "https://git.lysator.liu.se/nettle/nettle",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2262,7 +2262,7 @@
     },
     "gmp": {
       "baseline": "6.2.1",
-      "port-version": 3
+      "port-version": 4
     },
     "google-cloud-cpp": {
       "baseline": "1.25.0",
@@ -3938,7 +3938,7 @@
     },
     "mpg123": {
       "baseline": "1.26.3",
-      "port-version": 0
+      "port-version": 1
     },
     "mpi": {
       "baseline": "1",
@@ -4094,7 +4094,7 @@
     },
     "nettle": {
       "baseline": "3.6",
-      "port-version": 0
+      "port-version": 1
     },
     "networkdirect-sdk": {
       "baseline": "2.0.1",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9fb6c032a85cdea3a8bf246ef83dfd23b59978d",
+      "version-string": "6.2.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "3b7459d7ea886b86c9c80890c0b697df9df3cce1",
       "version-string": "6.2.1",
       "port-version": 3

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8493c9bc4ad38eac3313e2cdf87cbb06d8119f7",
+      "version-string": "1.26.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "19e2118fcd63fde61be2fd29d54a7bc8699ffa75",
       "version-string": "1.26.3",
       "port-version": 0

--- a/versions/n-/nettle.json
+++ b/versions/n-/nettle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c43244b158062d78dbfe1034f857b463270b1f01",
+      "version-string": "3.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "c5667fa4f9c8aae21162042f6193069cdb994337",
       "version-string": "3.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
1. Add message to portfile.cmake for ports gmp, mpg123 and nettle 
   - If Host is Windows 
   - and Target Architecture is x64 or arm
   - and [vcpkg-root]\installed\x86-windows\tools\yasm-tool\yasm.exe  does not exist
   - Fatal Error displays user needs to install yasm-tool:x86-windows 
2. Incremented port-version for ports gmp, mpg123 and nettle 
3. Cleaned up <Carriage-Return><Line-Feed> <CR><LF> to just <Line-Feed> <LF>
    (Unix/Linux) standard. Somehow I added <CR><LF> to all files edited. 
4. Ran ./vcpkg.exe format-manifest --all to ensure all vcpkg.json files formatted correctly.
5. Updated json files for versioning
6. Ran tests for x86 and x64 windows [yasm-tool-msg-16600-tests.log](https://github.com/microsoft/vcpkg/files/6132734/yasm-tool-msg-16600-tests.log)
    - without yasm-tool:x86-windows installed (Errors Displayed) for x64-windows for each port gmp, mpg123 and nettle
    - without yasm-tool:x86-windows installed (No Errors Displayed) for x86-windows 
       - yasm-tool:x86-windows was installed automatically first
       - ports gmp, mpg123 and nettle for triplet x86-windows installed successfully
    - with yasm-tool:x86-windows installed (No Errors Displayed) for x86-windows and all ports installed 
       - ports gmp, mpg123 and nettle for triplet x64-windows installed successfully

- What does your PR fix? Fixes #16600

- Which triplets are supported/not supported? No changes should effect supported/not support triplets.
- Have you updated the CI baseline? No changes should effect the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? To the best of my ability, yes

/cc: @JackBoosY