### PR TITLE
[websocketpp] Add features to build without Boost

### DIFF
--- a/ports/websocketpp/CONTROL
+++ b/ports/websocketpp/CONTROL
@@ -1,5 +1,0 @@
-Source: websocketpp
-Version: 0.8.2
-Build-Depends: zlib, openssl, boost-asio
-Homepage: https://github.com/zaphoyd/websocketpp
-Description: Library that implements RFC6455 The WebSocket Protocol

--- a/ports/websocketpp/vcpkg.json
+++ b/ports/websocketpp/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "websocketpp",
+  "version": "0.8.2",
+  "port-version": 1,
+  "description": "Library that implements RFC6455 The WebSocket Protocol",
+  "homepage": "https://github.com/zaphoyd/websocketpp",
+  "documentation": "http://docs.websocketpp.org/",
+  "default-features": [
+    "recommended"
+  ],
+  "features": {
+    "recommended": {
+      "description": "Use recommended dependencies",
+      "dependencies": [
+        "boost-asio",
+        "openssl",
+        "zlib"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6234,7 +6234,7 @@
     },
     "websocketpp": {
       "baseline": "0.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "wepoll": {
       "baseline": "1.5.8",

--- a/versions/w-/websocketpp.json
+++ b/versions/w-/websocketpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "495a31980417d3ca202b50c1951012d699af21f6",
+      "version": "0.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c717c6c7fe929ef1c9cc7b2250e78700326940c4",
       "version-string": "0.8.2",
       "port-version": 0


### PR DESCRIPTION
This creates features for websocketpp so that the consumer can choose the ASIO library and whether openssl and zlib are used (since these are all optional).

This should be a transparent change for existing users.