### PR TITLE
[vcpkg] Ignore toolsrc build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,6 +286,7 @@ __pycache__/
 /installed*/
 /packages/
 /scripts/buildsystems/tmp/
+/toolsrc/*
 #ignore custom triplets
 /triplets/*
 #add vcpkg-designed triplets back in


### PR DESCRIPTION
currently files like `toolsrc/build.rel/*.o` are shown if you do `git status`