### PR TITLE
[robin-hood-hashing] update to 3.10.0

### DIFF
--- a/ports/robin-hood-hashing/CONTROL
+++ b/ports/robin-hood-hashing/CONTROL
@@ -1,4 +1,0 @@
-Source: robin-hood-hashing
-Version: 3.9.1
-Homepage: https://github.com/martinus/robin-hood-hashing
-Description: Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20

--- a/ports/robin-hood-hashing/portfile.cmake
+++ b/ports/robin-hood-hashing/portfile.cmake
@@ -1,12 +1,26 @@
-# header-only library
-
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO martinus/robin-hood-hashing
-    REF 3.9.1
-    SHA512 dbd614b772171d3e1d47e01513b3aa56d086a0530bad80931dbee4c3674e08c31cb023ac2cd3e9cadd86db76856ccc4c7a0fa9f7cd653044cd68c82e1a4c9c9c
-    HEAD_REF master
+	OUT_SOURCE_PATH SOURCE_PATH
+	REPO martinus/robin-hood-hashing
+	REF 3.10.0
+	SHA512 38ab7fa33a1516933155dda06e3b83860810c33cc6ae4fa48e31389da870bb8037a210a4596576061ef67b51e791d2c7ab5a02dad5e323612e53dff7561801ff
+	HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/src/include/robin_hood.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+vcpkg_cmake_configure(
+	SOURCE_PATH ${SOURCE_PATH}
+	OPTIONS
+		-DRH_STANDALONE_PROJECT=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+	PACKAGE_NAME robin_hood
+	CONFIG_PATH lib/cmake/robin_hood
+)
+
+file(REMOVE_RECURSE
+	${CURRENT_PACKAGES_DIR}/debug
+	${CURRENT_PACKAGES_DIR}/lib
+)
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/robin-hood-hashing/vcpkg.json
+++ b/ports/robin-hood-hashing/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "robin-hood-hashing",
-  "version-string": "3.10.0",
+  "version": "3.10.0",
   "description": "Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20",
   "homepage": "https://github.com/martinus/robin-hood-hashing",
   "dependencies": [

--- a/ports/robin-hood-hashing/vcpkg.json
+++ b/ports/robin-hood-hashing/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "robin-hood-hashing",
+  "version-string": "3.10.0",
+  "description": "Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20",
+  "homepage": "https://github.com/martinus/robin-hood-hashing",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5189,7 +5189,7 @@
       "port-version": 0
     },
     "robin-hood-hashing": {
-      "baseline": "3.9.1",
+      "baseline": "3.10.0",
       "port-version": 0
     },
     "robin-map": {

--- a/versions/r-/robin-hood-hashing.json
+++ b/versions/r-/robin-hood-hashing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979b52c12dc816fe086bb501f6dfa6a50dbf6029",
+      "version-string": "3.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2025e5ad11f6546769a99e68bfcec0b3f18086c",
       "version-string": "3.9.1",
       "port-version": 0

--- a/versions/r-/robin-hood-hashing.json
+++ b/versions/r-/robin-hood-hashing.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "979b52c12dc816fe086bb501f6dfa6a50dbf6029",
-      "version-string": "3.10.0",
+      "git-tree": "0f8facd0d45a81d17c839ec9b8cce03d718b9bd7",
+      "version": "3.10.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
**Describe the pull request**

Updates `robin-hood-hashing` to `3.10.0`
https://github.com/martinus/robin-hood-hashing/releases/tag/3.10.0