### PR TITLE
Don't try to install dependencies not managed by vcpkg

### DIFF
--- a/scripts/buildsystems/osx/applocal.py
+++ b/scripts/buildsystems/osx/applocal.py
@@ -259,6 +259,11 @@ def fix_dependency(binary, dep):
     else:
         return True
 
+    # if the source path doesn't exist it's probably not a dependency
+    # originating with vcpkg and we should leave it alone
+    if not os.path.exists(qtnamesrc):
+        return True
+
     dep_ok = True
     # check that rpath of 'dep' inside binary has been correctly set
     # (ie: relative to exepath using '@executable_path' syntax)


### PR DESCRIPTION
This fixes build failures on osx when using dependencies not coming
from vcpkg (e.g. closed binaries). vcpkg tried to install those
dependencies (which fails because they're not where vcpkg expects them).

Fixes issue #8203

**Describe the pull request**

- What does your PR fix? Fixes #8203

- Which triplets are supported/not supported? Have you updated the CI baseline?
Not applicable

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
