### PR TITLE
[vcpkg] Fix find powershell

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -280,12 +280,13 @@ and places it in the variable Z_VCPKG_POWERSHELL_PATH.
 #]===]
 function(z_vcpkg_set_powershell_path)
     # Attempt to use pwsh if it is present; otherwise use powershell
+    set(PWSH_EXPECT_VER 7.1.0)
     if(NOT DEFINED Z_VCPKG_POWERSHELL_PATH)
-        find_program(Z_VCPKG_PWSH_PATH pwsh)
+        find_program(Z_VCPKG_PWSH_PATH NAMES pwsh PATHS "${Z_VCPKG_ROOT_DIR}/downloads/tools" PATH_SUFFIXES powershell-core-${PWSH_EXPECT_VER}-windows NO_DEFAULT_PATH)
         if(Z_VCPKG_PWSH_PATH)
             set(Z_VCPKG_POWERSHELL_PATH "${Z_VCPKG_PWSH_PATH}" CACHE INTERNAL "The path to the PowerShell implementation to use.")
         else()
-            message(DEBUG "vcpkg: Could not find PowerShell Core; falling back to PowerShell")
+            message("vcpkg: Could not find PowerShell Core; falling back to PowerShell")
             find_program(Z_VCPKG_BUILTIN_POWERSHELL_PATH powershell REQUIRED)
             if(Z_VCPKG_BUILTIN_POWERSHELL_PATH)
                 set(Z_VCPKG_POWERSHELL_PATH "${Z_VCPKG_BUILTIN_POWERSHELL_PATH}" CACHE INTERNAL "The path to the PowerShell implementation to use.")


### PR DESCRIPTION
Because the name of the powershell inside the system is powershell instead of pwsh, the first search for powershell fails.
https://github.com/microsoft/vcpkg/blob/9431133cd5e6c0ea48031d1d3bd11bcbebb1e243/scripts/buildsystems/vcpkg.cmake#L284
Change here to first find the powershell inside vcpkg.

This also affects the use of feature `X_VCPKG_APPLOCAL_DEPS_INSTALL` to install dependencies:
```
  -- Installing app dependencies for CMakeProject2...
  Resolve-Path : Illegal characters in path.
  At F:\vcpkg\scripts\buildsystems\msbuild\applocal.ps1:68 char:23
  +     $baseBinaryPath = Resolve-Path $targetBinary -erroraction stop
  +                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      + CategoryInfo          : InvalidArgument: (C:\Users\vzay\C...:CMakeProject2>:String) [Resolve-Path], ArgumentExce 
     ption
      + FullyQualifiedErrorId : ItemExistsArgumentError,Microsoft.PowerShell.Commands.ResolvePathCommand
```

Fixes #16721 #14339.