### PR TITLE
[openmama] Modify the output path of the common header file

### DIFF
--- a/ports/openmama/CONTROL
+++ b/ports/openmama/CONTROL
@@ -1,6 +1,0 @@
-Source: openmama
-Version: 6.3.1
-Build-Depends: libevent, apr, qpid-proton
-Supports: windows&(x64|x86)
-Homepage: https://github.com/OpenMAMA/OpenMAMA
-Description: OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages.

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_find_acquire_program(FLEX)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO OpenMAMA/OpenMAMA
-    REF c4925ee103add1a51c1d27be45b46d97af347f36 # https://github.com/OpenMAMA/OpenMAMA/tree/OpenMAMA-6.3.1-release
+    REPO finos/OpenMAMA
+    REF c4925ee103add1a51c1d27be45b46d97af347f36 # https://github.com/finos/OpenMAMA/releases/tag/OpenMAMA-6.3.1-release
     SHA512 e2773d082dd28e073fe81223fc113b1a5db7cd0d95e150e9f3f02c8c9483b9219b5d10682a125dd792c3a7877e15b90fd908084a4c89af4ec8d8c0389c282de2
     HEAD_REF next
 )
@@ -41,7 +41,20 @@ endif()
 # Vcpkg does not expect include files to be in the debug directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Vcpkg does not like this header name and shouldn't be required anyway, so remove it
-file(REMOVE "${CURRENT_PACKAGES_DIR}/include/platform.h")
+foreach(OPENMAMA_ROOT_HEADER destroyhandle.h platform.h list.h lookup2.h property.h timers.h wlock.h windows)
+    if(EXISTS "${CURRENT_PACKAGES_DIR}/include/${OPENMAMA_ROOT_HEADER}")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/include/${OPENMAMA_ROOT_HEADER}" "${CURRENT_PACKAGES_DIR}/include/wombat/${OPENMAMA_ROOT_HEADER}")
+    endif()
+endforeach()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h" "list.h" "wombat/list.h")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h" "list.h" "wombat/list.h")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h" "property.h" "wombat/property.h")
+endif()
 
 vcpkg_copy_pdbs()

--- a/ports/openmama/portfile.cmake
+++ b/ports/openmama/portfile.cmake
@@ -47,14 +47,8 @@ foreach(OPENMAMA_ROOT_HEADER destroyhandle.h platform.h list.h lookup2.h propert
     endif()
 endforeach()
 
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h" "list.h" "wombat/list.h")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h" "list.h" "wombat/list.h")
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h" "property.h" "wombat/property.h")
-endif()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/transport.h" "list.h" "wombat/list.h")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/types.h" "list.h" "wombat/list.h")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/mama/integration/mama.h" "property.h" "wombat/property.h")
 
 vcpkg_copy_pdbs()

--- a/ports/openmama/vcpkg.json
+++ b/ports/openmama/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "openmama",
+  "version-semver": "6.3.1",
+  "port-version": 1,
+  "description": "OpenMAMA is a high performance vendor neutral lightweight wrapper that provides a common API interface to different middleware and messaging solutions across a variety of platforms and languages",
+  "homepage": "https://github.com/finos/OpenMAMA",
+  "supports": "windows & (x64 | x86)",
+  "dependencies": [
+    "apr",
+    "libevent",
+    "qpid-proton"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4362,7 +4362,7 @@
     },
     "openmama": {
       "baseline": "6.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openmesh": {
       "baseline": "8.1",

--- a/versions/o-/openmama.json
+++ b/versions/o-/openmama.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b397da5501e9745b87824351da9b25d365fb4c9e",
+      "version-semver": "6.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "6945e436fdfc5307d58f84ff5c76f6a34e2a8031",
       "version-string": "6.3.1",
       "port-version": 0

--- a/versions/o-/openmama.json
+++ b/versions/o-/openmama.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b397da5501e9745b87824351da9b25d365fb4c9e",
+      "git-tree": "74e126369c9ba45cf7105e1b72871738acd24de5",
       "version-semver": "6.3.1",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**
In CI Test, workflow installation failed with following errors:
```
error C2079: 'list' uses undefined struct 'list_head'
error C2198: 'list_for_each': too few arguments for call 
error C2143: syntax error: missing ';' before '{'
```
This issue occurs because there is a list.h file generated by openmama and saved in the vcpkg\installed{triplets}\include folder, it conflict with the list.h file of workflow. As a result, the structure and macro defined in the header file list.h(workflow) become undefined during compilation.
After communicatied with upstream, I moved these common header files into the wombat folder and modified header files those include the common header files.

BTW, update the REPO and homapage from OpenMAMA/OpenMAMA to finos/OpenMAMA, because OpenMAMA/OpenMAMA is no longer found.