### PR TITLE
[angle] Include EGL/eglext_angle.h in ANGLE

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -391,6 +391,8 @@ add_library(libEGL
     "src/libEGL/libEGL.cpp"
     "src/libEGL/libEGL.rc"
     "src/libEGL/resource.h"
+    "src/libEGL/egl_loader_autogen.cpp"
+    "src/libEGL/egl_loader_autogen.h"
 )
 target_link_libraries(libEGL PRIVATE angle::common angle::libANGLE libGLESv2)
 target_include_directories(libEGL PUBLIC "$<INSTALL_INTERFACE:include>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
@@ -469,7 +471,9 @@ if(NOT DISABLE_INSTALL_HEADERS)
         PATTERN "*.h"
         PATTERN "*.inc"
         PATTERN "GLSLANG" EXCLUDE
-        PATTERN "EGL" EXCLUDE
+        PATTERN "egl.h" EXCLUDE
+        PATTERN "eglext.h" EXCLUDE
+        PATTERN "eglplatform.h" EXCLUDE
         PATTERN "KHR" EXCLUDE
         PATTERN "export.h" EXCLUDE
     )

--- a/ports/angle/CONTROL
+++ b/ports/angle/CONTROL
@@ -1,5 +1,6 @@
 Source: angle
-Version: 2020-05-15-2
+Version: 2020-05-15
+Port-Version: 2
 Homepage: https://github.com/google/angle
 Description: A conformant OpenGL ES implementation for Windows, Mac and Linux.
   The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support.

--- a/ports/angle/CONTROL
+++ b/ports/angle/CONTROL
@@ -1,5 +1,5 @@
 Source: angle
-Version: 2020-05-15-1
+Version: 2020-05-15-2
 Homepage: https://github.com/google/angle
 Description: A conformant OpenGL ES implementation for Windows, Mac and Linux.
   The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support.

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "973f13d1ce406b7c4058315d33ce9f3ba4c771f0",
+      "git-tree": "48342ccfb3565a61cc9ed878a2ff422e294b4e56",
       "version-string": "2020-05-15",
       "port-version": 2
     },

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "973f13d1ce406b7c4058315d33ce9f3ba4c771f0",
+      "version-string": "2020-05-15",
+      "port-version": 2
+    },
+    {
       "git-tree": "936af02bc2517e092035c23ca444a3d638b9a713",
       "version-string": "2020-05-15-1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -77,8 +77,8 @@
       "port-version": 0
     },
     "angle": {
-      "baseline": "2020-05-15-1",
-      "port-version": 0
+      "baseline": "2020-05-15",
+      "port-version": 2
     },
     "antlr4": {
       "baseline": "4.8",


### PR DESCRIPTION
**Describe the pull request**
Stops excluding eglext_angle.h from ANGLE. #14890 

- What does your PR fix? Fixes #
eglext_angle.h includes entry points to angle-specific EGL extension functions and this PR exposes them.

- Which triplets are supported/not supported? Have you updated the CI baseline?
I tested it on x64-windows and arm64-uwp.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I think so. I updated the version of the port at least.