### PR TITLE
[collada-dom] Add REMOVE_RECURSE to solve DLLs error path

### DIFF
--- a/ports/collada-dom/CONTROL
+++ b/ports/collada-dom/CONTROL
@@ -1,6 +1,6 @@
 Source: collada-dom
 Version: 2.5.0
 Port-Version: 4
-Homepage: https://github.com/GiovanniDicanio/WinReg
+Homepage: https://github.com/rdiankov/collada-dom
 Description: The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.
 Build-Depends: zlib, libxml2, minizip, pcre, uriparser, boost-filesystem, boost-system

--- a/ports/collada-dom/CONTROL
+++ b/ports/collada-dom/CONTROL
@@ -1,4 +1,6 @@
 Source: collada-dom
 Version: 2.5.0-3
+Homepage: https://github.com/mongodb/mongo-cxx-driver
+Port-Version: 1
 Description: The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.
 Build-Depends: zlib, libxml2, minizip, pcre, uriparser, boost-filesystem, boost-system

--- a/ports/collada-dom/CONTROL
+++ b/ports/collada-dom/CONTROL
@@ -1,6 +1,6 @@
 Source: collada-dom
-Version: 2.5.0-3
+Version: 2.5.0
+Port-Version: 4
 Homepage: https://github.com/mongodb/mongo-cxx-driver
-Port-Version: 1
 Description: The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.
 Build-Depends: zlib, libxml2, minizip, pcre, uriparser, boost-filesystem, boost-system

--- a/ports/collada-dom/CONTROL
+++ b/ports/collada-dom/CONTROL
@@ -1,6 +1,6 @@
 Source: collada-dom
 Version: 2.5.0
 Port-Version: 4
-Homepage: https://github.com/mongodb/mongo-cxx-driver
+Homepage: https://github.com/GiovanniDicanio/WinReg
 Description: The COLLADA Document Object Model (DOM) is an application programming interface (API) that provides a C++ object representation of a COLLADA XML instance document.
 Build-Depends: zlib, libxml2, minizip, pcre, uriparser, boost-filesystem, boost-system

--- a/ports/collada-dom/fix-shared-keyword.patch
+++ b/ports/collada-dom/fix-shared-keyword.patch
@@ -1,0 +1,13 @@
+diff --git a/dom/CMakeLists.txt b/dom/CMakeLists.txt
+index 62e1b8a..7ff49b5 100644
+--- a/dom/CMakeLists.txt
++++ b/dom/CMakeLists.txt
+@@ -28,7 +28,7 @@ if( OPT_COLLADA14 )
+   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/1.4 DESTINATION ${COLLADA_DOM_INCLUDE_INSTALL_DIR} COMPONENT ${COMPONENT_PREFIX}-dev  PATTERN ".svn" EXCLUDE PATTERN ".~" EXCLUDE)
+ endif()
+ 
+-add_library(collada-dom SHARED ${COLLADA_BASE_SOURCES})
++add_library(collada-dom ${COLLADA_BASE_SOURCES})
+ target_link_libraries(collada-dom ${COLLADA_LIBS})
+ set_target_properties(collada-dom PROPERTIES
+   COMPILE_FLAGS "${COLLADA_COMPILE_FLAGS}"

--- a/ports/collada-dom/portfile.cmake
+++ b/ports/collada-dom/portfile.cmake
@@ -19,9 +19,12 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/collada_dom-2.5)
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/licenses/license_e.txt DESTINATION
-             ${CURRENT_PACKAGES_DIR}/share/collada-dom
+             ${CURRENT_PACKAGES_DIR}/share/${PORT}
              RENAME copyright)

--- a/ports/collada-dom/portfile.cmake
+++ b/ports/collada-dom/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         vs-version-detection.patch
         use-uriparser.patch
         use-vcpkg-minizip.patch
+        fix-shared-keyword.patch
 )
 
 vcpkg_configure_cmake(
@@ -19,9 +20,6 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/collada_dom-2.5)
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright

--- a/ports/collada-dom/portfile.cmake
+++ b/ports/collada-dom/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     PATCHES
         vs-version-detection.patch
         use-uriparser.patch
-		use-vcpkg-minizip.patch
+        use-vcpkg-minizip.patch
 )
 
 vcpkg_configure_cmake(
@@ -25,6 +25,4 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/licenses/license_e.txt DESTINATION
-             ${CURRENT_PACKAGES_DIR}/share/${PORT}
-             RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/licenses/license_e.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -137,7 +137,6 @@ cmcstl2:x86-windows        = skip
 coin:arm64-windows=fail
 coin:arm-uwp=fail
 coin:x64-uwp=fail
-collada-dom:x64-windows-static=fail
 collada-dom:x64-windows-static-md=fail
 constexpr-contracts:x64-linux=fail
 coolprop:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -137,7 +137,6 @@ cmcstl2:x86-windows        = skip
 coin:arm64-windows=fail
 coin:arm-uwp=fail
 coin:x64-uwp=fail
-collada-dom:x64-windows-static-md=fail
 constexpr-contracts:x64-linux=fail
 coolprop:arm-uwp=fail
 coolprop:x64-linux=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1289,8 +1289,8 @@
       "port-version": 0
     },
     "collada-dom": {
-      "baseline": "2.5.0-3",
-      "port-version": 1
+      "baseline": "2.5.0",
+      "port-version": 4
     },
     "colmap": {
       "baseline": "3.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1290,7 +1290,7 @@
     },
     "collada-dom": {
       "baseline": "2.5.0-3",
-      "port-version": 0
+      "port-version": 1
     },
     "colmap": {
       "baseline": "3.6",

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "414ae19359fcd9b4b0ac7633234a1d8c20e098a1",
+      "version-string": "2.5.0-3",
+      "port-version": 1
+    },
+    {
       "git-tree": "f53be121329578c16d057a2019a9ced1bbb24457",
       "version-string": "2.5.0-3",
       "port-version": 0

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b59347647a93d20067b154f56201252bb783ba14",
+      "git-tree": "0a87dad472402c697bfed87281e1c86b892f72cd",
       "version-string": "2.5.0",
       "port-version": 4
     },

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "21f5cbf9fc6fbacb4df5bff59f213116918c3d32",
+      "git-tree": "b59347647a93d20067b154f56201252bb783ba14",
       "version-string": "2.5.0",
       "port-version": 4
     },

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21f5cbf9fc6fbacb4df5bff59f213116918c3d32",
+      "version-string": "2.5.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "414ae19359fcd9b4b0ac7633234a1d8c20e098a1",
       "version-string": "2.5.0-3",
       "port-version": 1

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -6,11 +6,6 @@
       "port-version": 4
     },
     {
-      "git-tree": "414ae19359fcd9b4b0ac7633234a1d8c20e098a1",
-      "version-string": "2.5.0-3",
-      "port-version": 1
-    },
-    {
       "git-tree": "f53be121329578c16d057a2019a9ced1bbb24457",
       "version-string": "2.5.0-3",
       "port-version": 0

--- a/versions/c-/collada-dom.json
+++ b/versions/c-/collada-dom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0a87dad472402c697bfed87281e1c86b892f72cd",
+      "git-tree": "f4daab646db5e1ac2332133fd45ef8dc98b0a017",
       "version-string": "2.5.0",
       "port-version": 4
     },


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16720 
When install colladda-dom:x64-windows-static ，The error shows that DLL files are generated in the bin directory during static install, use REMOVE_RECURSE in the portfile to remove them,

Note: no feature need to test
