### PR TITLE
[WinReg] update to v4.0.0

### DIFF
--- a/ports/winreg/CONTROL
+++ b/ports/winreg/CONTROL
@@ -1,5 +1,5 @@
 Source: winreg
-Version: 3.1.0
+Version: 4.0.0
 Homepage: https://github.com/GiovanniDicanio/WinReg
 Description: High-level C++ wrapper around the Windows Registry C API.
 Supports: windows|uwp

--- a/ports/winreg/portfile.cmake
+++ b/ports/winreg/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_fail_port_install(ON_TARGET "linux" "osx")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GiovanniDicanio/WinReg
-    REF d59fd46431f0c7ca5e3339918455b831c63bba25 #v3.1.0
-    SHA512 98dea669415dcb4e577c92506050a9defab5ac5f70e9d783d0b379297d84e0e2b56afc230b86ff190421a0d54b283e7abe72bb3cf53ecfe3fbe90f29c335e08c
+    REF 9b7ad93b366ffa1f6938c6685d1cfc50d9d0100b #v4.0.0
+    SHA512 dd68f92579ee6e0f7628023d4e2f52c79bf2a0e5624b2158078f827c7df6d207244ffd1f8347ad65475b276185314349aedc4f9ae4b5e3405ee5088efaf72734
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6249,7 +6249,7 @@
       "port-version": 4
     },
     "winreg": {
-      "baseline": "3.1.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "winsock2": {

--- a/versions/w-/winreg.json
+++ b/versions/w-/winreg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6243560127ca086b89812f77a6635c8cd38fcdc4",
+      "version-string": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8afef56a008634916bc97eb11ae79ba02c695c8",
       "version-string": "3.1.0",
       "port-version": 0

--- a/versions/w-/winreg.json
+++ b/versions/w-/winreg.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "6243560127ca086b89812f77a6635c8cd38fcdc4",
-      "version-string": "4.0.0",
+      "version-semver": "4.0.0",
       "port-version": 0
     },
     {

--- a/versions/w-/winreg.json
+++ b/versions/w-/winreg.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "6243560127ca086b89812f77a6635c8cd38fcdc4",
-      "version-semver": "4.0.0",
+      "version-string": "4.0.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Fix #16747

Update winreg  to the latest version 4.0.0

Note: no feature need to test 