### PR TITLE
[vcpkg baseline] Skip libgnutls:x64-osx in Ci testing

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -607,6 +607,7 @@ libfreenect2:x64-linux=fail
 libfreenect2:x64-osx=fail
 libgit2:arm-uwp=fail
 libgit2:x64-uwp=fail
+libgnutls:x64-osx=fail
 libgo:arm-uwp=fail
 libgo:x64-uwp=fail
 libgo:arm64-windows=fail


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/16596#issuecomment-802405156

The libgnutls:x64-osx failed with following failures which is expected, skip it in CI testing.
```
Undefined symbols for architecture x86_64:
  "_libintl_dgettext", referenced from:
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
  "_libintl_gettext", referenced from:
      _aoGetsText in libcmd-serv.a(serv-args.o)
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [gnutls-serv] Error 1
ld: warning: directory not found for option '-L/Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link'
ld: warning: directory not found for option '-L/Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/'
Undefined symbols for architecture x86_64:
  "_libintl_dgettext", referenced from:
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
  "_libintl_gettext", referenced from:
      _aoGetsText in libcmd-cli.a(cli-args.o)
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
ld: warning: directory not found for option '-L/Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link'
ld: warning: directory not found for option '-L/Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/'
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [gnutls-cli] Error 1
Undefined symbols for architecture x86_64:
  "_libintl_dgettext", referenced from:
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
  "_libintl_gettext", referenced from:
      _print_one_paragraph in libopts.a(libopts_la-libopts.o)
      _aoGetsText in libcmd-srp.a(srptool-args.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [srptool] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2

```
