### PR TITLE
[vtk] Add support for unicode path for VTK reader/writer

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 4
+Port-Version: 5
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2
@@ -41,6 +41,10 @@ Feature: opengl
 Description: All opengl related modules
 Build-Depends: vtk[core]
 
+Feature: utf8
+Description: Enables vtk reader/writer with utf-8 path support
+Build-Depends: vtk[core]
+
 Feature: all
 Description: Build all vtk modules
-Build-Depends: libmysql, ffmpeg, gdal, vtk[core, qt, python, mpi], vtk[core, atlmfc] (windows)
+Build-Depends: libmysql, ffmpeg, gdal, vtk[core, qt, python, mpi], vtk[core, atlmfc, utf8] (windows)

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -95,6 +95,12 @@ if("cuda" IN_LIST FEATURES AND CMAKE_HOST_WIN32)
     vcpkg_add_to_path("$ENV{CUDA_PATH}/bin")
 endif()
 
+if("utf8" IN_LIST FEATURES)
+    list(APPEND ADDITIONAL_OPTIONS
+        -DKWSYS_ENCODING_DEFAULT_CODEPAGE=CP_UTF8
+    )
+endif()
+
 if("all" IN_LIST FEATURES)
     list(APPEND ADDITIONAL_OPTIONS
         -DVTK_USE_TK=OFF # TCL/TK currently not included in vcpkg

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6186,7 +6186,7 @@
     },
     "vtk": {
       "baseline": "9.0.1",
-      "port-version": 4
+      "port-version": 5
     },
     "vtk-dicom": {
       "baseline": "0.8.12-1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "88d95daae73bf5c3413bb18188c81f9ea752e418",
+      "version-string": "9.0.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "94667926df104c70c0229cc96b36ec41f3911853",
       "version-string": "9.0.1",
       "port-version": 4


### PR DESCRIPTION
**Add support for unicode path for VTK reader/writer**

- What does your PR fix? Fixes #
N/A
- Which triplets are supported/not supported? Have you updated the CI baseline?
tested with x64-windows, x64-windows-static-md
- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes