### PR TITLE
[mailio] does not support uwp

### DIFF
--- a/ports/mailio/vcpkg.json
+++ b/ports/mailio/vcpkg.json
@@ -1,10 +1,12 @@
 {
   "name": "mailio",
   "version": "0.20.0",
+  "port-version": 1,
   "maintainers": "Tomislav Karastojković <contact@alepho.com>",
   "description": "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols. It is based on the standard C++ 17 and Boost library.",
   "homepage": "https://github.com/karastojko/mailio",
   "license": "BSD-2-clause",
+  "supports": "!uwp",
   "dependencies": [
     "boost-asio",
     "boost-date-time",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3726,7 +3726,7 @@
     },
     "mailio": {
       "baseline": "0.20.0",
-      "port-version": 0
+      "port-version": 1
     },
     "mapbox-variant": {
       "baseline": "1.2.0",

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "819040f9644957f597a2429bb3365cbf4f58e35d",
+      "version": "0.20.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d0031c324fcbf44f0af73cb045551c01c5cc21e3",
       "version": "0.20.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

The [mailio](https://github.com/microsoft/vcpkg/pull/16696) port does not support uwp. See the failing pipeline in #16788