### PR TITLE
Updates links to documentation in repo's root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you can run `vcpkg help`, or `vcpkg help [command]` for command-specific help.
 * Github: [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/), the #vcpkg channel
 * Discord: [\#include \<C++\>](https://www.includecpp.org), the #🌏vcpkg channel
-* Docs: [Documentation](docs/index.md)
+* Docs: [Documentation](docs/README.md)
 
 [![Build Status](https://dev.azure.com/vcpkg/public/_apis/build/status/microsoft.vcpkg.ci?branchName=master)](https://dev.azure.com/vcpkg/public/_build/latest?definitionId=29&branchName=master)
 
@@ -307,7 +307,7 @@ depending on the shell you use, then restart your console.
 
 # Examples
 
-See the [documentation](docs/index.md) for specific walkthroughs,
+See the [documentation](docs/README.md) for specific walkthroughs,
 including [installing and using a package](docs/examples/installing-and-using-packages.md),
 [adding a new package from a zipfile](docs/examples/packaging-zipfiles.md),
 and [adding a new package from a GitHub repo](docs/examples/packaging-github-repos.md).


### PR DESCRIPTION
**Describe the pull request**
The links to docs are broken in README.md (even  the  "Quickstart" link on https://docs.microsoft.com/en-us/cpp/build/vcpkg)

In this PR I've updated the links from `docs/index.md` to `docs/README.md`

The breaking change was made in PR #16758 

- What does your PR fix? Fixes #
None, didn't create an issue because it's a minor fix. Please let me know if I should create one.

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes, but there was no guidance for docs/README
