### PR TITLE
[libgnutls] macOS fix; additional optimizations

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -14,8 +14,17 @@ vcpkg_extract_source_archive_ex(
     REF ${GNUTLS_VERSION}
 )
 
+if(VCPKG_TARGET_IS_OSX)
+    set(LDFLAGS "-framework CoreFoundation")
+else()
+    set(LDFLAGS "")
+endif()
+
+if ("openssl" IN_LIST FEATURES)
+  set(OPENSSL_COMPATIBILITY "--enable-openssl-compatibility")
+endif()
+
 vcpkg_configure_make(
-    AUTOCONFIG
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         --disable-doc
@@ -23,8 +32,11 @@ vcpkg_configure_make(
         --disable-tests
         --disable-maintainer-mode
         --disable-rpath
+        --disable-libdane
         --with-included-unistring
         --without-p11-kit
+        ${OPENSSL_COMPATIBILITY}
+        "LDFLAGS=${LDFLAGS}"
 )
 
 vcpkg_install_make()

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "name": "libgnutls",
   "version": "3.6.15",
+  "port-version": 1,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "supports": "!windows",
   "dependencies": [
+    "gettext",
     "gmp",
     "libidn2",
     "libtasn1",
     "nettle"
-  ]
+  ],
+  "features": {
+    "openssl": {
+      "description": "enables the OpenSSL compatibility library"
+    }
+  }
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -605,7 +605,6 @@ libfreenect2:x64-linux=fail
 libfreenect2:x64-osx=fail
 libgit2:arm-uwp=fail
 libgit2:x64-uwp=fail
-libgnutls:x64-osx=fail
 libgo:arm-uwp=fail
 libgo:x64-uwp=fail
 libgo:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3046,7 +3046,7 @@
     },
     "libgnutls": {
       "baseline": "3.6.15",
-      "port-version": 0
+      "port-version": 1
     },
     "libgo": {
       "baseline": "3.1-1",

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09f2d8c5e4e07d2076324767d251fef3bc4acb8c",
+      "version": "3.6.15",
+      "port-version": 1
+    },
+    {
       "git-tree": "089f1c103a3f2c52e6ae54e8956a98345502e286",
       "version": "3.6.15",
       "port-version": 0


### PR DESCRIPTION
Add missing macOS SDK CoreFoundation framework reference
Add OpenSSL compatibility feature
Explicitly disable libdane (was already disabled implicitly due to  a missing libunbound)
No need for autoconfig

- What does your PR fix? 
Fixes gnutls regression (https://github.com/microsoft/vcpkg/pull/16776)

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes