### PR TITLE
[libgwenhywfar] new port

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -14,8 +14,17 @@ vcpkg_extract_source_archive_ex(
     REF ${GNUTLS_VERSION}
 )
 
+if(VCPKG_TARGET_IS_OSX)
+    set(LDFLAGS "-framework CoreFoundation")
+else()
+    set(LDFLAGS "")
+endif()
+
+if ("openssl" IN_LIST FEATURES)
+  set(OPENSSL_COMPATIBILITY "--enable-openssl-compatibility")
+endif()
+
 vcpkg_configure_make(
-    AUTOCONFIG
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         --disable-doc
@@ -23,8 +32,11 @@ vcpkg_configure_make(
         --disable-tests
         --disable-maintainer-mode
         --disable-rpath
+        --disable-libdane
         --with-included-unistring
         --without-p11-kit
+        ${OPENSSL_COMPATIBILITY}
+        "LDFLAGS=${LDFLAGS}"
 )
 
 vcpkg_install_make()

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "name": "libgnutls",
   "version": "3.6.15",
+  "port-version": 1,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "supports": "!windows",
   "dependencies": [
+    "gettext",
     "gmp",
     "libidn2",
     "libtasn1",
     "nettle"
-  ]
+  ],
+  "features": {
+    "openssl": {
+      "description": "enables the OpenSSL compatibility library"
+    }
+  }
 }

--- a/ports/libgwenhywfar/portfile.cmake
+++ b/ports/libgwenhywfar/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports unix platforms" ON_TARGET "Windows")
+
 set(VERSION_MAJOR 5)
 set(VERSION_MINOR 6)
 set(VERSION_PATCH 0)

--- a/ports/libgwenhywfar/portfile.cmake
+++ b/ports/libgwenhywfar/portfile.cmake
@@ -1,0 +1,65 @@
+set(VERSION_MAJOR 5)
+set(VERSION_MINOR 6)
+set(VERSION_PATCH 0)
+set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.aquamaniac.de/rdm/attachments/download/364/gwenhywfar-${VERSION}.tar.gz"
+    FILENAME "gwenhywfar-${VERSION}.tar.gz"
+    SHA512 9875d677f49fc0a46f371fd1954d15d99c7d5994e90b16f1be7a5b8a1cbcd74ae9733e4541afd6d8251a2ba1a0a37c28e0f248952b7c917313fbf5b38b1d8d11
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+    REF ${VERSION}
+)
+
+if ("libxml2" IN_LIST FEATURES)
+   set(WITH_LIBXML2_CODE "--with-libxml2-code=yes")
+endif()
+if ("cpp" IN_LIST FEATURES)
+   list(APPEND FEATURES_GUI "cpp")
+endif()
+if ("qt5" IN_LIST FEATURES)
+   list(APPEND FEATURES_GUI "qt5")
+endif()
+
+list(JOIN FEATURES_GUI " " GUIS)
+
+if(VCPKG_TARGET_IS_OSX)
+    set(LDFLAGS "-framework CoreFoundation -framework Security")
+else()
+    set(LDFLAGS "")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        --disable-silent-rules
+        --disable-binreloc 
+        --with-guis=${GUIS}
+        --with-libgpg-error-prefix=${CURRENT_INSTALLED_DIR}/tools/libgpg-error
+        --with-libgcrypt-prefix=${CURRENT_INSTALLED_DIR}/tools/libgcrypt
+        --with-qt5-qmake=${CURRENT_INSTALLED_DIR}/tools/qt5/bin/qmake
+        --with-qt5-moc=${CURRENT_INSTALLED_DIR}/tools/qt5/bin/moc
+        --with-qt5-uic=${CURRENT_INSTALLED_DIR}/tools/qt5/bin/uic
+        ${WITH_LIBXML2_CODE}
+        "LDFLAGS=${LDFLAGS}"
+)
+
+vcpkg_install_make()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+foreach(GUI IN LISTS FEATURES_GUI)
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/gwengui-${GUI}-${VERSION_MAJOR}.${VERSION_MINOR} TARGET_PATH share/gwengui-${GUI}-${VERSION_MAJOR}.${VERSION_MINOR} DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/gwenhywfar-${VERSION_MAJOR}.${VERSION_MINOR})
+
+if ("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(SEARCH_DIR ${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin TOOL_NAMES gct-tool gsa mklistdoc typemaker typemaker2 xmlmerge AUTO_CLEAN)
+endif()    
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libgwenhywfar/vcpkg.json
+++ b/ports/libgwenhywfar/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgwenhywfar",
-  "version-string": "5.6.0",
+  "version-semver": "5.6.0",
   "description": "A helper library for networking and security applications and libraries",
   "homepage": "https://www.aquamaniac.de/rdm/",
   "supports": "!windows",

--- a/ports/libgwenhywfar/vcpkg.json
+++ b/ports/libgwenhywfar/vcpkg.json
@@ -1,0 +1,40 @@
+{
+  "name": "libgwenhywfar",
+  "version-string": "5.6.0",
+  "description": "A helper library for networking and security applications and libraries",
+  "homepage": "https://www.aquamaniac.de/rdm/",
+  "supports": "!windows",
+  "dependencies": [
+    "libgcrypt",
+    {
+      "name": "libgnutls",
+      "features": [
+        "openssl"
+      ]
+    }
+  ],
+  "default-features": [
+    "cpp",
+    "libxml2"
+  ],
+  "features": {
+    "cpp": {
+      "description": "C++ bindings"
+    },
+    "libxml2": {
+      "description": "Enables libXML2-depending functionality",
+      "dependencies": [
+        "libxml2"
+      ]
+    },
+    "qt5": {
+      "description": "Qt bindings",
+      "dependencies": [
+        "qt5-base"
+      ]
+    },
+    "tools": {
+      "description": "Some helper tools provided by Gwenhywfar and useful for applications using it"
+    }
+  }
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -605,7 +605,6 @@ libfreenect2:x64-linux=fail
 libfreenect2:x64-osx=fail
 libgit2:arm-uwp=fail
 libgit2:x64-uwp=fail
-libgnutls:x64-osx=fail
 libgo:arm-uwp=fail
 libgo:x64-uwp=fail
 libgo:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3068,6 +3068,10 @@
       "baseline": "2019-08-27-1",
       "port-version": 0
     },
+    "libgwenhywfar": {
+      "baseline": "5.6.0",
+      "port-version": 0
+    },
     "libharu": {
       "baseline": "2017-08-15-9",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3046,7 +3046,7 @@
     },
     "libgnutls": {
       "baseline": "3.6.15",
-      "port-version": 0
+      "port-version": 1
     },
     "libgo": {
       "baseline": "3.1-1",

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09f2d8c5e4e07d2076324767d251fef3bc4acb8c",
+      "version": "3.6.15",
+      "port-version": 1
+    },
+    {
       "git-tree": "089f1c103a3f2c52e6ae54e8956a98345502e286",
       "version": "3.6.15",
       "port-version": 0

--- a/versions/l-/libgwenhywfar.json
+++ b/versions/l-/libgwenhywfar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2fc9244d4836dbb7d33a79af53e4a97b81b7d246",
+      "git-tree": "5be9e6060d67e8aad23d1de86effb0ce52605ec4",
       "version-semver": "5.6.0",
       "port-version": 0
     }

--- a/versions/l-/libgwenhywfar.json
+++ b/versions/l-/libgwenhywfar.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "41f377a6c0059a62e17a181e8390add8b52dc363",
-      "version-string": "5.6.0",
+      "version-semver": "5.6.0",
       "port-version": 0
     }
   ]

--- a/versions/l-/libgwenhywfar.json
+++ b/versions/l-/libgwenhywfar.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "41f377a6c0059a62e17a181e8390add8b52dc363",
+      "version-string": "5.6.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libgwenhywfar.json
+++ b/versions/l-/libgwenhywfar.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "41f377a6c0059a62e17a181e8390add8b52dc363",
+      "git-tree": "2fc9244d4836dbb7d33a79af53e4a97b81b7d246",
       "version-semver": "5.6.0",
       "port-version": 0
     }


### PR DESCRIPTION
Adds new port for libgwenhywfar

- Which triplets are supported/not supported? Have you updated the CI baseline?

Standard osx and linux. Windows currently unsupported due to a missing Windows libgnutls port.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

**Note** that this requires libgnutls fixes from https://github.com/microsoft/vcpkg/pull/16807, and is built on top of it.