### PR TITLE
[spdlog] Fix build for Android

### DIFF
--- a/ports/spdlog/CONTROL
+++ b/ports/spdlog/CONTROL
@@ -1,6 +1,6 @@
 Source: spdlog
 Version: 1.8.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/gabime/spdlog
 Description: Very fast, header only, C++ logging library
 Build-Depends: fmt

--- a/ports/spdlog/fix-androidbuild.patch
+++ b/ports/spdlog/fix-androidbuild.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	(revision 4a9ccf7e38e257feecce0c579a782741254eaeef)
++++ b/CMakeLists.txt	(date 1616381634500)
+@@ -188,6 +188,11 @@
+     set(PKG_CONFIG_REQUIRES fmt) # add dependency to pkg-config
+ endif ()
+ 
++if (ANDROID)
++    target_link_libraries(spdlog PUBLIC log)
++    target_link_libraries(spdlog_header_only INTERFACE log)
++endif ()
++
+ # ---------------------------------------------------------------------------------------
+ # Misc definitions according to tweak options
+ # ---------------------------------------------------------------------------------------

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,10 +4,11 @@ vcpkg_from_github(
     REF 4a9ccf7e38e257feecce0c579a782741254eaeef # v1.8.0
     SHA512 333f14704e0d0aa88abbe4ddd29aeb009de2f845440559d463f1b7f9c7da32b2fbdba0f2abf97ec2a5c479d2d62bb2220b21a1bc423d62fbbb93952cf829d532
     HEAD_REF v1.x
-    PATCHES fix-featurebuild.patch
+    PATCHES fix-featurebuild.patch fix-androidbuild.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
 	benchmark SPDLOG_BUILD_BENCH
 )
 

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 4a9ccf7e38e257feecce0c579a782741254eaeef # v1.8.0
     SHA512 333f14704e0d0aa88abbe4ddd29aeb009de2f845440559d463f1b7f9c7da32b2fbdba0f2abf97ec2a5c479d2d62bb2220b21a1bc423d62fbbb93952cf829d532
     HEAD_REF v1.x
-    PATCHES fix-featurebuild.patch fix-androidbuild.patch
+    PATCHES 
+        fix-featurebuild.patch 
+        fix-androidbuild.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5590,7 +5590,7 @@
     },
     "spdlog": {
       "baseline": "1.8.0",
-      "port-version": 2
+      "port-version": 3
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea95a70eb662591583aac9ed5329a691823c9c38",
+      "git-tree": "aa6f400b5acd74dd5071a1419d4fce8ccaa3981c",
       "version-string": "1.8.0",
       "port-version": 3
     },

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea95a70eb662591583aac9ed5329a691823c9c38",
+      "version-string": "1.8.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "83277d69ee0f37839d9f06c9fb658a3dd457e3eb",
       "version-string": "1.8.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**
Fix building spdlog for Android

- What does your PR fix? Fixes #
Adds log library to the target libraries list

- Which triplets are supported/not supported? Have you updated the CI baseline?
All Android triplets

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes