### PR TITLE
[termcolor] update to 2.0.0

### DIFF
--- a/ports/termcolor/portfile.cmake
+++ b/ports/termcolor/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ikalnytskyi/termcolor
-    REF v1.0.1
-    SHA512 15deaa7d225fa7934c207e6a57d89fd4c0ea5ebef38c4ff58ff27e19f444b030c265406a525f545592d67cff2b24ed839992693bb6d043cb3d8bca986c53fd95
+    REF 67eb0aa55e48ead9fe2aab049f0b1aa7943ba0ea #v2.0.0
+    SHA512 c076f0acafa455fb3ed58bca5f0a0989dc3824e9b4f264fc5aa5b599068cc6551ccc2cfe1180a4ff0f8424e6adbfbbfeed50d395ab5f288b8c678cfa42e8fa17
     HEAD_REF master
 )
 

--- a/ports/termcolor/vcpkg.json
+++ b/ports/termcolor/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "termcolor",
-  "version-string": "1.0.1",
+  "version-semver": "2.0.0",
   "description": "Termcolor is a header-only C++ library for printing colored messages to the terminal.",
   "homepage": "https://github.com/ikalnytskyi/termcolor"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5785,7 +5785,7 @@
       "port-version": 1
     },
     "termcolor": {
-      "baseline": "1.0.1",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "tesseract": {

--- a/versions/t-/termcolor.json
+++ b/versions/t-/termcolor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a357134080b4f2553d91d289f167cc23ddc8c102",
+      "version-semver": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0f9f8a1daeb0ba36dc2333e9d7a99a8da3cf0a78",
       "version-string": "1.0.1",
       "port-version": 0


### PR DESCRIPTION
Fix #16771 

Update termcolor to the latest version 2.0.0

Note: no feature need to test