### PR TITLE
[vcpkg baseline][gsoap] Update to 2.8.112

### DIFF
--- a/ports/gsoap/CONTROL
+++ b/ports/gsoap/CONTROL
@@ -1,6 +1,0 @@
-Source: gsoap
-Version: 2.8.111
-Build-Depends: curl
-Homepage: https://sourceforge.net/projects/gsoap2/
-Description: The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.
-Supports: !(linux|osx|arm|uwp)

--- a/ports/gsoap/portfile.cmake
+++ b/ports/gsoap/portfile.cmake
@@ -1,3 +1,5 @@
+message(FATAL_ERROR "gsoap does not offer permanent public downloads of its sources; all versions except the latest are removed from sourceforge. Therefore, vcpkg cannot support this library directly in the central catalog. If you would like to use gsoap, you can use this port as a starting point (${CMAKE_CURRENT_LIST_DIR}) and update it to use a permanent commercial copy or the latest public download. Do not report issues with this library to the vcpkg GitHub.")
+
 vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP" ON_ARCH "arm" "arm64")
 
 vcpkg_from_sourceforge(

--- a/ports/gsoap/portfile.cmake
+++ b/ports/gsoap/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsoap2
     REF gsoap-2.8
-    FILENAME "gsoap_2.8.111.zip"
-    SHA512 9cc7f0252f82ec18d19784aba2d913e70620fc09955d148a31e2c89bba4915d20a6b592bd7b6a747f89dc3ab17b2bc542d672933fa1a3acbf59bc3d1f49fe31b
+    FILENAME "gsoap_2.8.112.zip"
+    SHA512 0c2562891a738916235f1d4b19d8419d96d0466ca4b729766551183c7b9b90cbe35bbf7fe126b3ea6b18138cbf591c9a9b5b73ddea7152ccdd2f790777c2b6d8
     PATCHES fix-build-in-windows.patch
 )
 
@@ -14,7 +14,7 @@ set(BUILD_ARCH "Win32")
 # Handle binary files and includes
 file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/gsoap ${CURRENT_PACKAGES_DIR}/debug/tools)
 
-if (NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_build_msbuild(
         USE_VCPKG_INTEGRATION
         PROJECT_PATH ${SOURCE_PATH}/gsoap/VisualStudio2005/soapcpp2/soapcpp2.sln

--- a/ports/gsoap/vcpkg.json
+++ b/ports/gsoap/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "gsoap",
+  "version": "2.8.112",
+  "description": "The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.",
+  "homepage": "https://sourceforge.net/projects/gsoap2/",
+  "supports": "windows & !(arm | uwp)"
+}

--- a/ports/gsoap/vcpkg.json
+++ b/ports/gsoap/vcpkg.json
@@ -3,5 +3,5 @@
   "version": "2.8.112",
   "description": "The gSOAP toolkit is a C and C++ software development toolkit for SOAP and REST XML Web services and generic C/C++ XML data bindings.",
   "homepage": "https://sourceforge.net/projects/gsoap2/",
-  "supports": "windows & !(arm | uwp)"
+  "supports": "!(linux | osx | arm | uwp)"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -368,6 +368,11 @@ gasol:x64-uwp=fail
 geos:arm-uwp=fail
 geos:x64-uwp=fail
 
+# gsoap does not offer stable public source downloads
+gsoap:x64-windows        = skip
+gsoap:x86-windows        = skip
+gsoap:x64-windows-static = skip
+
 # Port geotrans source ftp://ftp.nga.mil server
 # extremely slow may take several hours to download
 geotrans:x64-linux           = skip

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -372,6 +372,7 @@ geos:x64-uwp=fail
 gsoap:x64-windows        = skip
 gsoap:x86-windows        = skip
 gsoap:x64-windows-static = skip
+gsoap:x64-windows-static-md = skip
 
 # Port geotrans source ftp://ftp.nga.mil server
 # extremely slow may take several hours to download

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2337,7 +2337,7 @@
       "port-version": 0
     },
     "gsoap": {
-      "baseline": "2.8.111",
+      "baseline": "2.8.112",
       "port-version": 0
     },
     "gtest": {

--- a/versions/g-/gsoap.json
+++ b/versions/g-/gsoap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f441794d1a89b0f7a25bb7d4743f22096b9c1b58",
+      "git-tree": "9b9c63ec0048c9b58ae9aa3bf3d1b3245c7f5281",
       "version": "2.8.112",
       "port-version": 0
     },

--- a/versions/g-/gsoap.json
+++ b/versions/g-/gsoap.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9b9c63ec0048c9b58ae9aa3bf3d1b3245c7f5281",
+      "git-tree": "3f3950a7c522535f3095358a298f7af276894a94",
       "version": "2.8.112",
       "port-version": 0
     },

--- a/versions/g-/gsoap.json
+++ b/versions/g-/gsoap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f441794d1a89b0f7a25bb7d4743f22096b9c1b58",
+      "version": "2.8.112",
+      "port-version": 0
+    },
+    {
       "git-tree": "010523cbf786f4563ccef87dc0d28b13083f06f0",
       "version-string": "2.8.111",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #
```
-- Downloading https://sourceforge.net/projects/gsoap2/files//gsoap-2.8/gsoap_2.8.111.zip/download... Failed. Status: 22;"HTTP response code said error"
CMake Warning at scripts/cmake/vcpkg_download_distfile.cmake:202 (message):
      
      Failed to download file.
```
The current archive gsoap_2.8.111.zip doesn't exist now. So update it to the latest version 2.8.112.

Note: No feature needs to test.



