### PR TITLE
[libusb] Fix the support for Visual Studio 2019

### DIFF
--- a/ports/libusb/CONTROL
+++ b/ports/libusb/CONTROL
@@ -1,6 +1,0 @@
-Source: libusb
-Version: 1.0.24
-Port-Version: 3
-Homepage: https://github.com/libusb/libusb
-Description: a cross-platform library to access USB devices
-Supports: !uwp

--- a/ports/libusb/portfile.cmake
+++ b/ports/libusb/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_from_github(
 
 if(VCPKG_TARGET_IS_WINDOWS)
   if(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
-    set(MSVS_VERSION 2017)  #they are abi compatible, so it should work
+    set(MSVS_VERSION 2019)
   elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
     set(MSVS_VERSION 2017)
   else()

--- a/ports/libusb/vcpkg.json
+++ b/ports/libusb/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libusb",
+  "version": "1.0.24",
+  "port-version": 4,
+  "description": "a cross-platform library to access USB devices",
+  "homepage": "https://github.com/libusb/libusb",
+  "supports": "!uwp"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3510,7 +3510,7 @@
     },
     "libusb": {
       "baseline": "1.0.24",
-      "port-version": 3
+      "port-version": 4
     },
     "libusb-win32": {
       "baseline": "1.2.6.0-6",

--- a/versions/l-/libusb.json
+++ b/versions/l-/libusb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d77c2046af91be18e4af15b3a9b3e7f0024fa18",
+      "version": "1.0.24",
+      "port-version": 4
+    },
+    {
       "git-tree": "419808531bfc5a58d7581dc700a2560a3ab7265e",
       "version-string": "1.0.24",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16832

Current version has supported Visual Studio 2019, so we should also support it.

Note: No feature needs to test.
