### PR TITLE
boost-modular-build-helper] Add system library dl for boost-regex[icu] and boost-locale[icu] on linux

### DIFF
--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -68,8 +68,9 @@ else
     }
     else
     {
-        lib icuuc : : <name>icuuc <search>"@CURRENT_INSTALLED_DIR@/lib" <variant>release : : ;
-        lib icuuc : : <name>icuuc <search>"@CURRENT_INSTALLED_DIR@/debug/lib" <variant>debug : : ;
+        lib dl ;
+        lib icuuc : : <name>icuuc <search>"@CURRENT_INSTALLED_DIR@/lib" <variant>release : : <library>dl ;
+        lib icuuc : : <name>icuuc <search>"@CURRENT_INSTALLED_DIR@/debug/lib" <variant>debug : : <library>dl ;
 
         lib icuin : : <name>icui18n <search>"@CURRENT_INSTALLED_DIR@/lib" <variant>release : : ;
         lib icuin : : <name>icui18n <search>"@CURRENT_INSTALLED_DIR@/debug/lib" <variant>debug : : ;

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.75.0",
-  "port-version": 6,
+  "port-version": 7,
   "dependencies": [
     "boost-uninstall"
   ]

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "108d63ed0f26b1db432bb3ba7bcecf7ff18cafed",
+      "version-string": "1.75.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "71c0db71c5cdc6d6516ba3c15dfd4ad8d5e3834d",
       "version-string": "1.75.0",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -698,7 +698,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.75.0",
-      "port-version": 6
+      "port-version": 7
     },
     "boost-move": {
       "baseline": "1.75.0",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/16851

It requires system library 'dl' on linux when build with icu feature for boost-locale and boost-regex.

Failures:
```
gcc.link /home/josue/Projects/vcpkg/buildtrees/boost-locale/x64-linux-dbg/boost/build/807d196849ea9393cd67ccebca5daf06/has_icu64
/usr/bin/ld: /home/josue/Projects/vcpkg/installed/x64-linux/debug/lib/libicuuc.a(putil.ao): in function `uprv_dl_open_67':
/home/josue/Projects/vcpkg/buildtrees/icu/src/c-67_1-src-52188c6db3.clean/source/common/putil.cpp:2306: undefined reference to `dlopen'
/usr/bin/ld: /home/josue/Projects/vcpkg/installed/x64-linux/debug/lib/libicuuc.a(putil.ao): in function `uprv_dl_close_67':
/home/josue/Projects/vcpkg/buildtrees/icu/src/c-67_1-src-52188c6db3.clean/source/common/putil.cpp:2319: undefined reference to `dlclose'
/usr/bin/ld: /home/josue/Projects/vcpkg/installed/x64-linux/debug/lib/libicuuc.a(putil.ao): in function `uprv_dlsym_func_67':
/home/josue/Projects/vcpkg/buildtrees/icu/src/c-67_1-src-52188c6db3.clean/source/common/putil.cpp:2330: undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
```