### PR TITLE
[xmlsec] add pkgconfig files

### DIFF
--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -3,9 +3,6 @@ project (xmlsec1 C)
 
 option(INSTALL_HEADERS_TOOLS "Install public header files and tools" ON)
 
-set(CMAKE_SHARED_LIBRARY_PREFIX)
-set(CMAKE_STATIC_LIBRARY_PREFIX)
-
 find_package(LibXml2 REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Iconv REQUIRED)
@@ -58,16 +55,16 @@ if(MSVC)
   add_compile_options(/wd4130 /wd4127 /wd4152)
 endif()
 
-add_library(libxmlsec1 ${SOURCESXMLSEC})
-add_library(libxmlsec1-openssl ${SOURCESXMLSECOPENSSL})
+add_library(xmlsec1 ${SOURCESXMLSEC})
+add_library(xmlsec1-openssl ${SOURCESXMLSECOPENSSL})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include include ${LIBXML2_INCLUDE_DIRS})
 
-target_link_libraries(libxmlsec1 PRIVATE
+target_link_libraries(xmlsec1 PRIVATE
     ${LIBXML2_LIBRARIES} OpenSSL::SSL
 )
-target_link_libraries(libxmlsec1-openssl PRIVATE
-    ${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec1
+target_link_libraries(xmlsec1-openssl PRIVATE
+    ${LIBXML2_LIBRARIES} OpenSSL::SSL xmlsec1
 )
 
 add_compile_definitions(inline=__inline)
@@ -89,12 +86,12 @@ add_compile_definitions(_UNICODE)
 add_compile_definitions(_MBCS)
 add_compile_definitions(_REENTRANT)
 
-target_compile_definitions(libxmlsec1-openssl PRIVATE
+target_compile_definitions(xmlsec1-openssl PRIVATE
     -DXMLSEC_CRYPTO_OPENSSL
 )
 
-set_target_properties(libxmlsec1 PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
-set_target_properties(libxmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
+set_target_properties(xmlsec1 PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
+set_target_properties(xmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
 
 if(NOT BUILD_SHARED_LIBS)
     set(XMLSEC_CORE_CFLAGS "-DLIBXML_STATIC -DLIBXSLT_STATIC -DXMLSEC_STATIC -DXMLSEC_NO_CRYPTO_DYNAMIC_LOADING")
@@ -104,10 +101,10 @@ else()
     set(XMLSEC_OPENSSL_CFLAGS ${XMLSEC_CORE_CFLAGS})
 endif()
 
-target_compile_definitions(libxmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
-target_compile_definitions(libxmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS})
+target_compile_definitions(xmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
+target_compile_definitions(xmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS})
 
-install(TARGETS libxmlsec1 libxmlsec1-openssl
+install(TARGETS xmlsec1 xmlsec1-openssl
     EXPORT xmlsecExport
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
@@ -142,7 +139,7 @@ if(INSTALL_HEADERS_TOOLS)
 	endif()
 
 	target_link_libraries(xmlsec PRIVATE
-		${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec1 libxmlsec1-openssl
+		${LIBXML2_LIBRARIES} OpenSSL::SSL xmlsec1 xmlsec1-openssl
 	)
     if(NOT Iconv_IS_BUILT_IN)
         target_link_libraries(xmlsec PRIVATE Iconv::Iconv)

--- a/ports/xmlsec/CMakeLists.txt
+++ b/ports/xmlsec/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.8)
-project (xmlsec C)
+project (xmlsec1 C)
 
 option(INSTALL_HEADERS_TOOLS "Install public header files and tools" ON)
 
@@ -58,20 +58,20 @@ if(MSVC)
   add_compile_options(/wd4130 /wd4127 /wd4152)
 endif()
 
-add_library(libxmlsec ${SOURCESXMLSEC})
-add_library(libxmlsec-openssl ${SOURCESXMLSECOPENSSL})
+add_library(libxmlsec1 ${SOURCESXMLSEC})
+add_library(libxmlsec1-openssl ${SOURCESXMLSECOPENSSL})
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include include ${LIBXML2_INCLUDE_DIRS})
 
-target_link_libraries(libxmlsec PRIVATE
+target_link_libraries(libxmlsec1 PRIVATE
     ${LIBXML2_LIBRARIES} OpenSSL::SSL
 )
-target_link_libraries(libxmlsec-openssl PRIVATE
-    ${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec
+target_link_libraries(libxmlsec1-openssl PRIVATE
+    ${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec1
 )
 
 add_compile_definitions(inline=__inline)
-add_compile_definitions(PACKAGE="xmlsec")
+add_compile_definitions(PACKAGE="xmlsec1")
 add_compile_definitions(XMLSEC_MSCRYPTO_NT4=1)
 add_compile_definitions(HAVE_STDIO_H)
 add_compile_definitions(HAVE_STDLIB_H)
@@ -89,22 +89,25 @@ add_compile_definitions(_UNICODE)
 add_compile_definitions(_MBCS)
 add_compile_definitions(_REENTRANT)
 
-target_compile_definitions(libxmlsec-openssl PRIVATE
+target_compile_definitions(libxmlsec1-openssl PRIVATE
     -DXMLSEC_CRYPTO_OPENSSL
 )
 
-set_target_properties(libxmlsec PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
-set_target_properties(libxmlsec-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
+set_target_properties(libxmlsec1 PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
+set_target_properties(libxmlsec1-openssl PROPERTIES VERSION ${XMLSEC_VERSION_MAJOR}.${XMLSEC_VERSION_MINOR})
 
 if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(libxmlsec PRIVATE -DLIBXML_STATIC -DLIBXSLT_STATIC -DXMLSEC_STATIC -DXMLSEC_NO_CRYPTO_DYNAMIC_LOADING)
-    target_compile_definitions(libxmlsec-openssl PRIVATE -DLIBXML_STATIC -DLIBXSLT_STATIC -DXMLSEC_STATIC -DXMLSEC_NO_CRYPTO_DYNAMIC_LOADING)
+    set(XMLSEC_CORE_CFLAGS "-DLIBXML_STATIC -DLIBXSLT_STATIC -DXMLSEC_STATIC -DXMLSEC_NO_CRYPTO_DYNAMIC_LOADING")
+    set(XMLSEC_OPENSSL_CFLAGS ${XMLSEC_CORE_CFLAGS})
 else()
-	target_compile_definitions(libxmlsec PRIVATE -DXMLSEC_DL_WIN32)
-	target_compile_definitions(libxmlsec-openssl PRIVATE -DXMLSEC_DL_WIN32)
+    set(XMLSEC_CORE_CFLAGS "-DXMLSEC_DL_WIN32")
+    set(XMLSEC_OPENSSL_CFLAGS ${XMLSEC_CORE_CFLAGS})
 endif()
 
-install(TARGETS libxmlsec libxmlsec-openssl
+target_compile_definitions(libxmlsec1 PRIVATE ${XMLSEC_CORE_CFLAGS})
+target_compile_definitions(libxmlsec1-openssl PRIVATE ${XMLSEC_OPENSSL_CFLAGS})
+
+install(TARGETS libxmlsec1 libxmlsec1-openssl
     EXPORT xmlsecExport
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
@@ -139,7 +142,7 @@ if(INSTALL_HEADERS_TOOLS)
 	endif()
 
 	target_link_libraries(xmlsec PRIVATE
-		${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec libxmlsec-openssl
+		${LIBXML2_LIBRARIES} OpenSSL::SSL libxmlsec1 libxmlsec1-openssl
 	)
     if(NOT Iconv_IS_BUILT_IN)
         target_link_libraries(xmlsec PRIVATE Iconv::Iconv)
@@ -158,3 +161,22 @@ if(INSTALL_HEADERS_TOOLS)
 	endif()
 	install(TARGETS xmlsec DESTINATION tools/xmlsec)
 endif()
+
+message(STATUS "Generating pkgconfig files")
+
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${prefix})
+set(libdir ${prefix}/${CMAKE_INSTALL_LIBDIR})
+set(includedir ${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
+set(VERSION ${XMLSEC_VERSION})
+set(LIBXML_MIN_VERSION ${LIBXML2_VERSION_STRING})
+set(OPENSSL_LIBS "-lssl -lcrypto")
+set(XMLSEC_CORE_CFLAGS "${XMLSEC_CORE_CFLAGS} -DXMLSEC_DL_LIBLTDL=1 -I\${includedir}/xmlsec1 -DXMLSEC_CRYPTO_OPENSSL=1")
+set(XMLSEC_CORE_LIBS "-lxmlsec1 -lltdl")
+set(XMLSEC_OPENSSL_CFLAGS "${XMLSEC_OPENSSL_CFLAGS} -I\${includedir}/xmlsec1")
+set(XMLSEC_OPENSSL_LIBS "-L\${libdir} -lxmlsec1-openssl ${XMLSEC_CORE_LIBS} ${OPENSSL_LIBS}")
+
+configure_file(${PROJECT_SOURCE_DIR}/xmlsec.pc.in ${PROJECT_BINARY_DIR}/xmlsec1.pc @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/xmlsec-openssl.pc.in ${PROJECT_BINARY_DIR}/xmlsec1-openssl.pc @ONLY)
+install(FILES ${PROJECT_BINARY_DIR}/xmlsec1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+install(FILES ${PROJECT_BINARY_DIR}/xmlsec1-openssl.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)

--- a/ports/xmlsec/CONTROL
+++ b/ports/xmlsec/CONTROL
@@ -1,5 +1,6 @@
 Source: xmlsec
 Version: 1.2.31
+Port-Version: 1
 Homepage: https://www.aleksey.com/xmlsec/
 Description: XML Security Library is a C library based on LibXML2. The library supports major XML security standards.
 Build-Depends: libxml2, openssl

--- a/ports/xmlsec/CONTROL
+++ b/ports/xmlsec/CONTROL
@@ -1,6 +1,0 @@
-Source: xmlsec
-Version: 1.2.31
-Port-Version: 1
-Homepage: https://www.aleksey.com/xmlsec/
-Description: XML Security Library is a C library based on LibXML2. The library supports major XML security standards.
-Build-Depends: libxml2, openssl

--- a/ports/xmlsec/pkgconfig_fixes.patch
+++ b/ports/xmlsec/pkgconfig_fixes.patch
@@ -1,0 +1,21 @@
+diff --git a/xmlsec-openssl.pc.in b/xmlsec-openssl.pc.in
+index af3ae29..40635cf 100644
+--- a/xmlsec-openssl.pc.in
++++ b/xmlsec-openssl.pc.in
+@@ -8,5 +8,4 @@ Version: @VERSION@
+ Description: XML Security Library implements XML Signature and XML Encryption standards
+ Requires: libxml-2.0 >= @LIBXML_MIN_VERSION@ @LIBXSLT_PC_FILE_COND@
+ Cflags: @XMLSEC_OPENSSL_CFLAGS@
+-Cflags.private: -DXMLSEC_STATIC
+ Libs: @XMLSEC_OPENSSL_LIBS@
+diff --git a/xmlsec.pc.in b/xmlsec.pc.in
+index 2d5a3ad..0f72d68 100644
+--- a/xmlsec.pc.in
++++ b/xmlsec.pc.in
+@@ -7,5 +7,5 @@ Name: xmlsec1
+ Version: @VERSION@
+ Description: XML Security Library implements XML Signature and XML Encryption standards
+ Requires: libxml-2.0 >= @LIBXML_MIN_VERSION@ @LIBXSLT_PC_FILE_COND@ 
+-Cflags: -DXMLSEC_CRYPTO_DYNAMIC_LOADING=1 @XMLSEC_CORE_CFLAGS@
++Cflags: @XMLSEC_CORE_CFLAGS@
+ Libs: -L${libdir} @XMLSEC_CORE_LIBS@ 

--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES 
         0001-uwp-fix.patch
+        pkgconfig_fixes.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
@@ -20,6 +21,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets()
+vcpkg_fixup_pkgconfig()
 
 file(INSTALL ${SOURCE_PATH}/Copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "xmlsec",
+  "version-string": "1.2.31",
+  "port-version": 1,
+  "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
+  "homepage": "https://www.aleksey.com/xmlsec/",
+  "dependencies": [
+    "libxml2",
+    "openssl"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6558,7 +6558,7 @@
     },
     "xmlsec": {
       "baseline": "1.2.31",
-      "port-version": 0
+      "port-version": 1
     },
     "xmsh": {
       "baseline": "0.5.2-1",

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ac432422644610294ad8d2873ea5e1b178dcb3d",
+      "version-string": "1.2.31",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f0df3480ea9d16e5857f7d6815ff6fb3107b05f",
       "version-string": "1.2.31",
       "port-version": 0

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1ac432422644610294ad8d2873ea5e1b178dcb3d",
+      "git-tree": "9bce4d43cc99b63c9be1b547fcede14a75a61447",
       "version-string": "1.2.31",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Fixes #16830 
Also fixes the library filename, which should actually be `libxmlsec1`. This follows the upstream naming scheme.
I believe this port in general should be renamed to `xmlsec1`, which is how vast majority of repositories call it: https://repology.org/project/xmlsec/versions . I did not, however, make that change as part of this PR.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No change

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes