### PR TITLE
[mpg123] Upgrade to 1.26.3-1

### DIFF
--- a/ports/mpg123/portfile.cmake
+++ b/ports/mpg123/portfile.cmake
@@ -36,6 +36,12 @@ vcpkg_from_sourceforge(
 include(${CURRENT_INSTALLED_DIR}/share/yasm-tool-helper/yasm-tool-helper.cmake)
 yasm_tool_helper(APPEND_TO_PATH)
 
+macro(read_api_version)
+    file(READ "${SOURCE_PATH}/configure.ac" configure_ac)
+    string(REGEX MATCH "API_VERSION=([0-9]+)" result ${configure_ac})
+    set(API_VERSION ${CMAKE_MATCH_1})
+endmacro()
+
 if(VCPKG_TARGET_IS_UWP)
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
@@ -45,12 +51,19 @@ if(VCPKG_TARGET_IS_UWP)
         RELEASE_CONFIGURATION Release_uwp
         DEBUG_CONFIGURATION Debug_uwp
     )
+
     file(INSTALL
         ${SOURCE_PATH}/ports/MSVC++/mpg123.h
         ${SOURCE_PATH}/src/libmpg123/fmt123.h
-        ${SOURCE_PATH}/src/libmpg123/mpg123.h.in
         DESTINATION ${CURRENT_PACKAGES_DIR}/include
     )
+
+    read_api_version()
+    configure_file(
+        ${SOURCE_PATH}/src/libmpg123/mpg123.h.in
+        ${CURRENT_PACKAGES_DIR}/include/mpg123.h.in @ONLY
+    )
+
 elseif(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_install_msbuild(
         SOURCE_PATH ${SOURCE_PATH}
@@ -59,12 +72,19 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
         RELEASE_CONFIGURATION Release${MPG123_CONFIGURATION}${MPG123_CONFIGURATION_SUFFIX}
         DEBUG_CONFIGURATION Debug${MPG123_CONFIGURATION}${MPG123_CONFIGURATION_SUFFIX}
     )
+
     file(INSTALL
         ${SOURCE_PATH}/ports/MSVC++/mpg123.h
         ${SOURCE_PATH}/src/libmpg123/fmt123.h
-        ${SOURCE_PATH}/src/libmpg123/mpg123.h.in
         DESTINATION ${CURRENT_PACKAGES_DIR}/include
     )
+
+    read_api_version()
+    configure_file(
+        ${SOURCE_PATH}/src/libmpg123/mpg123.h.in
+        ${CURRENT_PACKAGES_DIR}/include/mpg123.h.in @ONLY
+    )
+
 elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
     set(MPG123_OPTIONS
         --disable-dependency-tracking

--- a/ports/mpg123/vcpkg.json
+++ b/ports/mpg123/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mpg123",
   "version-string": "1.26.3",
+  "port-version": 1,
   "description": "mpg123 is a real time MPEG 1.0/2.0/2.5 audio player/decoder for layers 1, 2 and 3 (MPEG 1.0 layer 3 also known as MP3).",
   "homepage": "https://sourceforge.net/projects/mpg123/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3974,7 +3974,7 @@
     },
     "mpg123": {
       "baseline": "1.26.3",
-      "port-version": 0
+      "port-version": 1
     },
     "mpi": {
       "baseline": "1",

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "713170246145d9711bb80f639355ea3a6bb58b85",
+      "version-string": "1.26.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "19e2118fcd63fde61be2fd29d54a7bc8699ffa75",
       "version-string": "1.26.3",
       "port-version": 0

--- a/versions/m-/mpg123.json
+++ b/versions/m-/mpg123.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "713170246145d9711bb80f639355ea3a6bb58b85",
+      "git-tree": "b143abaf1493952c9a04569e7d8379dac8ff8c1c",
       "version-string": "1.26.3",
       "port-version": 1
     },


### PR DESCRIPTION
Fix invalid `MPG123_API_VERSION` value in `mpg123.h.in` for Windows platform. It was equal to `@API_VERSION@`, now it is read from `configure.ac` and set to correct value.

See also libsndfile/libsndfile#499.