### PR TITLE
[vcpkg] Convert env vars slash if host is Win32

### DIFF
--- a/scripts/get_cmake_vars/CMakeLists.txt
+++ b/scripts/get_cmake_vars/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(VAR IN LISTS VCPKG_VARS_TO_CHECK)
 endforeach()
 
 foreach(_env IN LISTS VCPKG_ENV_VARS_TO_CHECK)
-    IF(WIN32)
+    if(CMAKE_HOST_WIN32)
         string(REPLACE "\\" "/" ENV_${_env} "$ENV{${_env}}")
         string(APPEND OUTPUT_STRING "set(${VCPKG_VAR_PREFIX}_ENV_${_env} \"${ENV_${_env}}\")\n")
     else()


### PR DESCRIPTION
Environment variables are host properties rather than target.