### PR TITLE
[quill] Upgrade to 1.6.2

### DIFF
--- a/ports/quill/CONTROL
+++ b/ports/quill/CONTROL
@@ -1,7 +1,7 @@
 Source: quill
-Version: 1.6.1
-Port-Version: 1
+Version: 1.6.2
+Port-Version: 0
 Homepage: https://github.com/odygrd/quill/
 Description: C++14 Asynchronous Low Latency Logging Library
-Supports: !(arm|uwp|android)
+Supports: !(uwp|android)
 Build-Depends: fmt

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -1,12 +1,12 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v1.6.1
-    SHA512 108a93108b0e8fa99a9d76ec4bcadd3ad477d871f274ad832fc0d15538c632a787b83b8a8134f750b613eb08a2742aebf3e79726ac430a7e1dd16c42a62f57f3
+    REF v1.6.2
+    SHA512 c1db04c96c70b6bced38ecc83b4bba9e60b02cf13ff48ab92132ceb828414fcf046cb2c41337a4ae321b0bad8598eb280a7edcc30e0720d7609898e15d514380
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5081,8 +5081,8 @@
       "port-version": 0
     },
     "quill": {
-      "baseline": "1.6.1",
-      "port-version": 1
+      "baseline": "1.6.2",
+      "port-version": 0
     },
     "quirc": {
       "baseline": "1.1",

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e3b811db3b65c4239a657bfd1a2fae470a8096a",
+      "version-string": "1.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa542e38f0f2480e495b785840e919d46a1d58d5",
       "version-string": "1.6.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
Upgrade quill to 1.6.2

- Which triplets are supported/not supported? Have you updated the CI baseline? 
Same triplets as before. Support for triplet `arm` has been added.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes