### PR TITLE
[lua]Update port to version 5.4.3

### DIFF
--- a/ports/lua/CONTROL
+++ b/ports/lua/CONTROL
@@ -1,5 +1,5 @@
 Source: lua
-Version: 5.4.2
+Version: 5.4.3
 Homepage: https://www.lua.org
 Description: a powerful, fast, lightweight, embeddable scripting language
 

--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.lua.org/ftp/lua-5.4.2.tar.gz"
-    FILENAME "lua-5.4.2.tar.gz"
-    SHA512 9454a6ffd973598f2f4a2399834c31c4d5090bd12e716776e3189aa57760319d114ee64a8338bbc2ef5e08150bf0adc2ad94a1b2677f38538a43359969d4d920
+    URLS "https://www.lua.org/ftp/lua-5.4.3.tar.gz"
+    FILENAME "lua-5.4.3.tar.gz"
+    SHA512 3a1a3ee8694b72b4ec9d3ce76705fe179328294353604ca950c53f41b41161b449877d43318ef4501fee44ecbd6c83314ce7468d7425ba9b2903c9c32a28bbc0
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3681,7 +3681,7 @@
       "port-version": 0
     },
     "lua": {
-      "baseline": "5.4.2",
+      "baseline": "5.4.3",
       "port-version": 0
     },
     "luabridge": {

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a52fbd7ff551d4c1b7e6d308283cfe92ca81758",
+      "version-string": "5.4.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f3de4a36739615d9ffba11571f50226b385721b",
       "version-string": "5.4.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #

Updates the Lua port to version 5.4.3

- Which triplets are supported/not supported? Have you updated the CI baseline?

Not aware of any unsupported triplets at this time.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes. I've submitted a previous update that was merged so I think I'm all set (hopefully).