### PR TITLE
[libtasn1] Add Windows support, update to 4.17

### DIFF
--- a/ports/libtasn1/msvc_fixes.patch
+++ b/ports/libtasn1/msvc_fixes.patch
@@ -1,0 +1,86 @@
+diff --git a/src/asn1Coding.c b/src/asn1Coding.c
+index 86c1d07..6fcfc4d 100644
+--- a/src/asn1Coding.c
++++ b/src/asn1Coding.c
+@@ -23,7 +23,12 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#ifdef HAVE_UNISTD_H
+ #include <unistd.h>
++#endif
++#ifdef _MSC_VER
++#include <io.h>
++#endif
+ #include <getopt.h>
+ #include <assert.h>
+ 
+diff --git a/src/asn1Decoding.c b/src/asn1Decoding.c
+index c6f192e..3e4e21d 100644
+--- a/src/asn1Decoding.c
++++ b/src/asn1Decoding.c
+@@ -23,7 +23,12 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#ifdef HAVE_UNISTD_H
+ #include <unistd.h>
++#endif
++#ifdef _MSC_VER
++#include <io.h>
++#endif
+ #include <getopt.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+diff --git a/src/asn1Parser.c b/src/asn1Parser.c
+index b6844a8..445c716 100644
+--- a/src/asn1Parser.c
++++ b/src/asn1Parser.c
+@@ -23,7 +23,12 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <stdlib.h>
++#ifdef HAVE_UNISTD_H
+ #include <unistd.h>
++#endif
++#ifdef _MSC_VER
++#include <io.h>
++#endif
+ #include <getopt.h>
+ #include <assert.h>
+ 
+diff --git a/src/benchmark.c b/src/benchmark.c
+index 010d58e..6c613df 100644
+--- a/src/benchmark.c
++++ b/src/benchmark.c
+@@ -21,9 +21,16 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <signal.h>
++#ifndef _MSC_VER
+ #include <sys/time.h>
++#endif
+ #include <time.h>
++#ifdef HAVE_UNISTD_H
+ #include <unistd.h>
++#endif
++#ifdef _MSC_VER
++#include <io.h>
++#endif
+ #include "benchmark.h"
+ 
+ int benchmark_must_finish = 0;
+diff --git a/src/benchmark.h b/src/benchmark.h
+index 3272649..6b6bf32 100644
+--- a/src/benchmark.h
++++ b/src/benchmark.h
+@@ -21,7 +21,9 @@
+ # define BENCHMARK_H
+ 
+ #include <config.h>
++#ifndef _MSC_VER
+ #include <sys/time.h>
++#endif
+ #include <time.h>
+ #include <signal.h>
+ #if defined _WIN32

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -1,5 +1,9 @@
 set(VERSION 4.16.0)
 
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(PATCHES msvc_fixes.patch)
+endif()
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libtasn1/libtasn1-${VERSION}.tar.gz"
     FILENAME "libtasn1-${VERSION}.tar.gz"
@@ -11,7 +15,7 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
     REF ${VERSION}
     PATCHES
-        msvc_fixes.patch
+        ${PATCHES}
 )
 
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -43,5 +43,5 @@ vcpkg_configure_make(
 vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools" "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -41,6 +41,7 @@ endif()
 set(ENV{GTKDOCIZE} true)
 
 vcpkg_configure_make(
+    USE_WRAPPERS
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         --disable-gtk-doc

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -31,7 +31,7 @@ endif()
 
 if(VCPKG_TARGET_IS_WINDOWS)
     # These are hacks for MSVC since autoconf can't determine the absolute path correctly
-    foreach(H stdint limits string stddef)
+    foreach(H stdint limits string stddef sys_types)
         find_file(H_PATH "${H}.h" PATHS $ENV{INCLUDE} NO_DEFAULT_PATH)
         string(REPLACE "\\" "/" H_PATH "${H_PATH}")
         list(APPEND EXTRA_OPTS "gl_cv_next_${H}_h='\"${H_PATH}\"'")

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -1,4 +1,4 @@
-set(VERSION 4.16.0)
+set(VERSION 4.17.0)
 
 if(VCPKG_TARGET_IS_WINDOWS)
     set(PATCHES msvc_fixes.patch)
@@ -7,7 +7,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libtasn1/libtasn1-${VERSION}.tar.gz"
     FILENAME "libtasn1-${VERSION}.tar.gz"
-    SHA512 b356249535d5d592f9b59de39d21e26dd0f3f00ea47c9cef292cdd878042ea41ecbb7c8d2f02ac5839f5210092fe92a25acd343260ddf644887b031b167c2e71
+    SHA512 9cbd920196d1e4c8f5aa613259cded2510d40edb583ce20cc2702e2dee9bf32bee85a159c74600ffbebc2af2787e28ed0fe0adf15fc46839283747f4fe166d3d
 )
 
 vcpkg_extract_source_archive_ex(
@@ -44,4 +44,4 @@ vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/tools ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -29,21 +29,12 @@ else()
     set(VCPKG_CXX_FLAGS "-g -O2")
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    # These are hacks for MSVC since autoconf can't determine the absolute path correctly
-    foreach(H stdint limits string stddef sys_types)
-        find_file(H_PATH "${H}.h" PATHS $ENV{INCLUDE} NO_DEFAULT_PATH)
-        string(REPLACE "\\" "/" H_PATH "${H_PATH}")
-        list(APPEND EXTRA_OPTS "gl_cv_next_${H}_h='\"${H_PATH}\"'")
-    endforeach()
-endif()
-
 set(ENV{GTKDOCIZE} true)
-
 vcpkg_configure_make(
-    USE_WRAPPERS
+    AUTOCONFIG
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
+        --disable-doc
         --disable-gtk-doc
         --disable-gcc-warnings
         ${EXTRA_OPTS}

--- a/ports/libtasn1/vcpkg.json
+++ b/ports/libtasn1/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "libtasn1",
   "version": "4.16.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
-  "supports": "!windows"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "getopt",
+      "platform": "windows"
+    },
+    {
+      "name": "gettimeofday",
+      "platform": "windows"
+    }
+  ]
 }

--- a/ports/libtasn1/vcpkg.json
+++ b/ports/libtasn1/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libtasn1",
-  "version": "4.16.0",
-  "port-version": 2,
+  "version": "4.17.0",
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "supports": "!uwp",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -762,6 +762,7 @@ libssh:arm-uwp=fail
 libssh:x64-uwp=fail
 libstk:arm-uwp=fail
 libstk:x64-uwp=fail
+libtasn1:x64-windows-static-md=fail
 libtins:arm-uwp=fail
 libtins:x64-uwp=fail
 libtomcrypt:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3557,8 +3557,8 @@
       "port-version": 2
     },
     "libtasn1": {
-      "baseline": "4.16.0",
-      "port-version": 1
+      "baseline": "4.17.0",
+      "port-version": 0
     },
     "libtcod": {
       "baseline": "1.18.0",

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7fef52089ad061da2c53a3f3bfcecdb7bb9f3f3c",
+      "git-tree": "63ad8395545c61a38b7564108d2c1c4b7a6bbf12",
       "version": "4.17.0",
       "port-version": 0
     },

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fef52089ad061da2c53a3f3bfcecdb7bb9f3f3c",
+      "version": "4.17.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "11a07d986211ef12d636380ed414b1e2350b8041",
       "version": "4.16.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
Enables windows build

- Which triplets are supported/not supported? Have you updated the CI baseline?

static-md build is unsupported. CI baseline updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes. 
