### PR TITLE
[libodb-mysql] Fix usage

### DIFF
--- a/ports/libodb-mysql/CMakeLists.txt
+++ b/ports/libodb-mysql/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(libodb-mysql
 
 )
 
-target_link_libraries(libodb-mysql PUBLIC odb::libodb ${MYSQL_LIB})
+target_link_libraries(libodb-mysql PRIVATE odb::libodb ${MYSQL_LIB})
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(libodb-mysql PRIVATE
         -DLIBODB_MYSQL_DYNAMIC_LIB
@@ -27,7 +27,7 @@ else()
         -DLIBODB_MYSQL_STATIC_LIB
         -DLIBODB_MYSQL_HAVE_UNLOCK_NOTIFY)
 endif()
-install(TARGETS libodb-mysql EXPORT odb_mysqlTargets
+install(TARGETS libodb-mysql EXPORT odb_mysqlConfig
     COMPONENT mysql
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
@@ -43,12 +43,5 @@ install(DIRECTORY odb DESTINATION include/
         PATTERN "*.txx"
 )
 endif()
-install(EXPORT odb_mysqlTargets NAMESPACE odb:: COMPONENT mysql DESTINATION share/odb_mysql)
-export(TARGETS libodb-mysql NAMESPACE odb:: FILE odb_mysqlTargets.cmake)
-
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/odb_mysql-config.cmake"
-[[include(CMakeFindDependencyMacro)
-find_dependency(odb CONFIG COMPONENTS libodb)
-include("${CMAKE_CURRENT_LIST_DIR}/odb_mysqlTargets.cmake")
-]])
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/odb_mysql-config.cmake DESTINATION share/odb_mysql)
+install(EXPORT odb_mysqlConfig NAMESPACE odb:: COMPONENT mysql DESTINATION share/odb)
+export(TARGETS libodb-mysql NAMESPACE odb:: FILE odb_mysqlConfig.cmake)

--- a/ports/libodb-mysql/CMakeLists.txt
+++ b/ports/libodb-mysql/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(libodb-mysql
 
 )
 
-target_link_libraries(libodb-mysql PRIVATE odb::libodb ${MYSQL_LIB})
+target_link_libraries(libodb-mysql PUBLIC odb::libodb ${MYSQL_LIB})
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(libodb-mysql PRIVATE
         -DLIBODB_MYSQL_DYNAMIC_LIB
@@ -27,7 +27,7 @@ else()
         -DLIBODB_MYSQL_STATIC_LIB
         -DLIBODB_MYSQL_HAVE_UNLOCK_NOTIFY)
 endif()
-install(TARGETS libodb-mysql EXPORT odb_mysqlConfig
+install(TARGETS libodb-mysql EXPORT odb_mysqlTargets
     COMPONENT mysql
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
@@ -43,5 +43,12 @@ install(DIRECTORY odb DESTINATION include/
         PATTERN "*.txx"
 )
 endif()
-install(EXPORT odb_mysqlConfig NAMESPACE odb:: COMPONENT mysql DESTINATION share/odb)
-export(TARGETS libodb-mysql NAMESPACE odb:: FILE odb_mysqlConfig.cmake)
+install(EXPORT odb_mysqlTargets NAMESPACE odb:: COMPONENT mysql DESTINATION share/odb_mysql)
+export(TARGETS libodb-mysql NAMESPACE odb:: FILE odb_mysqlTargets.cmake)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/odb_mysql-config.cmake"
+[[include(CMakeFindDependencyMacro)
+find_dependency(odb CONFIG COMPONENTS libodb)
+include("${CMAKE_CURRENT_LIST_DIR}/odb_mysqlTargets.cmake")
+]])
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/odb_mysql-config.cmake DESTINATION share/odb_mysql)

--- a/ports/libodb-mysql/CONTROL
+++ b/ports/libodb-mysql/CONTROL
@@ -1,5 +1,0 @@
-Source: libodb-mysql
-Version: 2.4.0-7
-Homepage: https://www.codesynthesis.com/products/odb/
-Description: MySQL support for the ODB ORM library
-Build-Depends: libodb, libmysql

--- a/ports/libodb-mysql/portfile.cmake
+++ b/ports/libodb-mysql/portfile.cmake
@@ -18,8 +18,9 @@ file(COPY
   DESTINATION ${SOURCE_PATH})
 
 set(MYSQL_INCLUDE_DIR "${CURRENT_INSTALLED_DIR}/include/mysql")
-set(MYSQL_LIB "${CURRENT_INSTALLED_DIR}/lib/libmysql.lib")
-set(MYSQL_LIB_DEBUG "${CURRENT_INSTALLED_DIR}/debug/lib/libmysql.lib")
+find_library(MYSQL_LIB NAMES libmysql mysqlclient PATH_SUFFIXES lib PATHS "${CURRENT_INSTALLED_DIR}" NO_DEFAULT_PATH REQUIRED)
+find_library(MYSQL_LIB_DEBUG NAMES libmysql mysqlclient PATH_SUFFIXES lib PATHS "${CURRENT_INSTALLED_DIR}/debug" NO_DEFAULT_PATH REQUIRED)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     DISABLE_PARALLEL_CONFIGURE
@@ -35,10 +36,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-file(READ ${CURRENT_PACKAGES_DIR}/debug/share/odb/odb_mysqlConfig-debug.cmake LIBODB_DEBUG_TARGETS)
-string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" LIBODB_DEBUG_TARGETS "${LIBODB_DEBUG_TARGETS}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/odb/odb_mysqlConfig-debug.cmake "${LIBODB_DEBUG_TARGETS}")
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/odb_mysql TARGET_PATH share/odb_mysql)
 
 vcpkg_copy_pdbs()
 

--- a/ports/libodb-mysql/portfile.cmake
+++ b/ports/libodb-mysql/portfile.cmake
@@ -36,8 +36,9 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/odb_mysql TARGET_PATH share/odb_mysql)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/odb TARGET_PATH share/odb)
 
 vcpkg_copy_pdbs()
 
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libodb-mysql/usage
+++ b/ports/libodb-mysql/usage
@@ -1,0 +1,4 @@
+The package libodb-mysql provides CMake integration:
+
+    find_package(odb CONFIG COMPONENTS libodb mysql REQUIRED)
+    target_link_libraries(main PRIVATE odb::libodb-mysql)

--- a/ports/libodb-mysql/vcpkg.json
+++ b/ports/libodb-mysql/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libodb-mysql",
+  "version": "2.4.0",
+  "port-version": 8,
+  "description": "MySQL support for the ODB ORM library",
+  "homepage": "https://www.codesynthesis.com/products/odb/",
+  "dependencies": [
+    "libmysql",
+    "libodb"
+  ]
+}

--- a/ports/libodb/CONTROL
+++ b/ports/libodb/CONTROL
@@ -1,4 +1,0 @@
-Source: libodb
-Version: 2.4.0-6
-Homepage: https://www.codesynthesis.com/products/odb/
-Description: ODB library, base runtime for the ODB ORM solution

--- a/ports/libodb/odbConfig.cmake
+++ b/ports/libodb/odbConfig.cmake
@@ -1,4 +1,4 @@
-set(_supported_components libodb sqlite pgsql)
+set(_supported_components libodb sqlite mysql pgsql)
 
 foreach(_comp ${odb_FIND_COMPONENTS})
     if(NOT ";${_supported_components};" MATCHES _comp)

--- a/ports/libodb/vcpkg.json
+++ b/ports/libodb/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "libodb",
+  "version": "2.4.0",
+  "port-version": 7,
+  "description": "ODB library, base runtime for the ODB ORM solution",
+  "homepage": "https://www.codesynthesis.com/products/odb/"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2552,7 +2552,7 @@
       "baseline": "9.0.0",
       "port-version": 0
     },
-	"iir1": {
+    "iir1": {
       "baseline": "1.8.0",
       "port-version": 0
     },
@@ -3289,8 +3289,8 @@
       "port-version": 0
     },
     "libodb-mysql": {
-      "baseline": "2.4.0-7",
-      "port-version": 0
+      "baseline": "2.4.0",
+      "port-version": 8
     },
     "libodb-pgsql": {
       "baseline": "2.4.0-3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3281,8 +3281,8 @@
       "port-version": 0
     },
     "libodb": {
-      "baseline": "2.4.0-6",
-      "port-version": 0
+      "baseline": "2.4.0",
+      "port-version": 7
     },
     "libodb-boost": {
       "baseline": "2.4.0-3",

--- a/versions/l-/libodb-mysql.json
+++ b/versions/l-/libodb-mysql.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "86ce95eaa94f518ad0693a9a24a1330736a24a6d",
+      "git-tree": "208d05d2a1a41329632318e2950c1300cf75eb51",
       "version": "2.4.0",
       "port-version": 8
     },

--- a/versions/l-/libodb-mysql.json
+++ b/versions/l-/libodb-mysql.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86ce95eaa94f518ad0693a9a24a1330736a24a6d",
+      "version": "2.4.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "684fea6cb54563fb4d54b05b259ecb6b5cbd0266",
       "version-string": "2.4.0-7",
       "port-version": 0

--- a/versions/l-/libodb.json
+++ b/versions/l-/libodb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6be9a8547e11c2b30077c90504c6dc714f854076",
+      "version": "2.4.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "cc5f10b9764952399ce497cf82615ea730dace28",
       "version-string": "2.4.0-6",
       "port-version": 0


### PR DESCRIPTION
Fix usage issue:
```
[build] CMake Error at /vcpkg/scripts/buildsystems/vcpkg.cmake:418 (_add_executable):
[build]   Target "main" links to target "odb::libodb-mysql" but the target
[build]   was not found.
```

Fixes #16896