### PR TITLE
Better handling of DOS attempts (on-sight connection's termination, improved events)

### DIFF
--- a/ports/libssh/use-onconnection-bind-callback.patch
+++ b/ports/libssh/use-onconnection-bind-callback.patch
@@ -1,0 +1,108 @@
+diff --git a/include/libssh/server.h b/include/libssh/server.h
+index 41f89d5..aca6805 100644
+--- a/include/libssh/server.h
++++ b/include/libssh/server.h
+@@ -367,6 +367,44 @@ LIBSSH_API int ssh_channel_request_send_exit_signal(ssh_channel channel,
+
+ LIBSSH_API int ssh_send_keepalive(ssh_session session);
+
++/**
++     * @brief Accept an incoming ssh connection without initializing the session.
++     *
++     * @param  ssh_bind_o     The ssh server bind to accept a connection.
++     * @return client socket when a connection is established, or SSH_ERROR on failure.
++     */
++LIBSSH_API socket_t ssh_bind_accept_alone(ssh_bind ssh_bind_o);
++
++/**
++ * @brief Accept an incoming ssh connection on the given file descriptor
++ *        and initialize the session. Same as ssh_bind_accept_fd() with additional
++ *        freeing of memory associated with client socket should anything go wrong.
++ *
++ * @param  ssh_bind_o     The ssh server bind to accept a connection.
++ * @param  session        A preallocated ssh session
++ * @param  fd             A file descriptor of an already established TCP
++ *                          inbound connection
++ * @see ssh_new
++ * @see ssh_bind_accept
++ * @return SSH_OK when a connection is established
++ */
++LIBSSH_API int ssh_bind_session_init(socket_t clientSocket, ssh_bind sshbind, ssh_session session);
++
++/**
++ * @brief Kills a socket and frees associated memory.
++ *
++ * @param  ssh_bind_o     The ssh server bind to accept a connection.
++ * @param  session			A preallocated ssh session
++ * @see ssh_new
++ * @return SSH_OK when done, SSH_ERROR if not.
++ */
++LIBSSH_API int ssh_kill_socket(socket_t socket);
++
++/* deprecated functions */
++SSH_DEPRECATED LIBSSH_API int ssh_accept(ssh_session session);
++SSH_DEPRECATED LIBSSH_API int channel_write_stderr(ssh_channel channel,
++    const void* data, uint32_t len);
++
+ /* deprecated functions */
+ SSH_DEPRECATED LIBSSH_API int ssh_accept(ssh_session session);
+ SSH_DEPRECATED LIBSSH_API int channel_write_stderr(ssh_channel channel,
+diff --git a/src/bind.c b/src/bind.c
+index fa8df9e..50c96e1 100644
+--- a/src/bind.c
++++ b/src/bind.c
+@@ -580,6 +580,54 @@ int ssh_bind_accept(ssh_bind sshbind, ssh_session session) {
+   return rc;
+ }
+
++socket_t ssh_bind_accept_alone(ssh_bind sshbind) {
++
++    socket_t fd = SSH_INVALID_SOCKET;
++    int rc;
++    if (sshbind->bindfd == SSH_INVALID_SOCKET) {
++        ssh_set_error(sshbind, SSH_FATAL,
++            "Can't accept new clients on a not bound socket.");
++        return SSH_ERROR;
++    }
++
++    fd = accept(sshbind->bindfd, NULL, NULL);
++
++    if (fd == SSH_INVALID_SOCKET) {
++        ssh_set_error(sshbind, SSH_FATAL,
++            "Accepting a new connection: %s",
++            strerror(errno));
++
++        CLOSE_SOCKET(fd);
++        ssh_socket_free(fd);
++
++        return SSH_ERROR;
++    }
++    sshbind->bind_callbacks->incoming_connection(sshbind,
++        sshbind->bind_callbacks_userdata);
++    return fd;
++}
++
++int ssh_bind_session_init(socket_t clientSocket, ssh_bind sshbind, ssh_session session) {
++    int rc;
++    rc = ssh_bind_accept_fd(sshbind, session, clientSocket);
++
++    if (rc == SSH_ERROR) {
++        CLOSE_SOCKET(clientSocket);
++        ssh_socket_free(session->socket);
++    }
++    return rc;
++}
++
++int ssh_kill_socket(socket_t fd)
++{
++    if (socket == SSH_INVALID_SOCKET) {
++        return SSH_ERROR;
++    }
++
++    CLOSE_SOCKET(fd);//already freed
++    return SSH_OK;
++}
++
+
+ /**
+  * @}


### PR DESCRIPTION
That it to better handle situations described in here: [](https://www.reddit.com/r/gridnetproject/comments/md2a2m/denial_of_servicedos_attacks_weve_been_facing_and/)

The aim was to be able to abort a connection possibly as soon as the incoming connection had been accepted on the listening TCP socket. Thus we wanted to approach the usual way that to us would seem like

1)create ssh_bind

2)initialize ssh_bind_callbacks_struct with ssh_callbacks_init()

3)pass a pointer to a function with a footprint of void callbackConn (ssh_bind sshbind, void* userdata) to incoming_connection of ssh_bind_callbacks_struct which just got initialized (0ed out is seems)

call ssh_bind_set_callbacks() and with that set-up we would have expected for the callbackConn() function to fire.

It never happens. 'normally' we would have accepted the connection in such a function.

The usual accept_bind_accept works but as the practice shows, peers are able to exploit the timeout set (we could change the default timeout of infinity which as practice shows peers might exploit but not completing one of the handshake steps they participate in).

So with accept_bind_accept IF a timeout is set evil peers might still block the server-processing queue up to the timeout value; and if method like-keyboard interactive is enabled we cannot set the timeout to say 2sec as user wouldn't be able to type in credentials at all and if we set to to 10 seconds then the malicious attacker can block processing for all users for up to 10 seconds. By the way; when we disabled keyboard-interactive authentication, the keyboard interactive thing it the first to show up when connecting to server. ssh_bind_listen indeed doesn't seem to accomplish anything more than 'listening', no event processing logic seems to be invoked. ssh_bind_poll_callback never gets called.

We've added a couple of modifications that make the appropriate events fire and also making it possible to abort connection on sight without any reply at all.
