### PR TITLE
[Catch2] update to 2.13.4

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,4 +1,4 @@
 Source: catch2
-Version: 2.13.1
+Version: 2.13.4
 Description: A modern, header-only test framework for unit testing.
 Homepage: https://github.com/catchorg/Catch2

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
-    REF fd9f5ac661f87335ecd70d39849c1d3a90f1c64d # v2.13.1
-    SHA512 4fafd06006034cc02dddd22c381b5817549834dae0aff29ed598edd21a3c67f8ac61a77f51b06f3c59baa96a114ecb19c6df09126215bfc00bef94f8f77b810d
+    REF de6fe184a9ac1a06895cdd1c9b437f0a0bdf14ad # v2.13.4
+    SHA512 a4cabb21e220dfe7882b082ce9eac563e2b1d44552fcb221ef0140049fdfe2aa87001e7a15d7f3ff377ceec5046930d2b666868ddbd19cc6b017df7b78c2fa03
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1101,7 +1101,7 @@
       "port-version": 0
     },
     "catch2": {
-      "baseline": "2.13.1",
+      "baseline": "2.13.4",
       "port-version": 0
     },
     "cccapstone": {
@@ -2552,7 +2552,7 @@
       "baseline": "9.0.0",
       "port-version": 0
     },
-	"iir1": {
+    "iir1": {
       "baseline": "1.8.0",
       "port-version": 0
     },

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96e3322ac6c9a04f7d21cf5f03fbcf5b71837805",
+      "version-string": "2.13.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "519a6fcb84ac66fdffb75f3d5555496228e43e5f",
       "version-string": "2.13.1",
       "port-version": 0


### PR DESCRIPTION
Fix #16938 

Update catch2 to the latest version 2.13.4

Note: no feature need to test