### PR TITLE
[brotli] Fold common into dec and enc archives for static builds.

### DIFF
--- a/ports/brotli/fold-common-into-static-builds.patch
+++ b/ports/brotli/fold-common-into-static-builds.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ff3401..62d891f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,8 +171,8 @@ endif()
+ 
+ set(BROTLI_STATIC_LIBS brotlicommon-static brotlidec-static brotlienc-static)
+ add_library(brotlicommon-static STATIC ${BROTLI_COMMON_C})
+-add_library(brotlidec-static STATIC ${BROTLI_DEC_C})
+-add_library(brotlienc-static STATIC ${BROTLI_ENC_C})
++add_library(brotlidec-static STATIC ${BROTLI_DEC_C} ${BROTLI_COMMON_C})
++add_library(brotlienc-static STATIC ${BROTLI_ENC_C} ${BROTLI_COMMON_C})
+ 
+ # Older CMake versions does not understand INCLUDE_DIRECTORIES property.
+ include_directories(${BROTLI_INCLUDE_DIRS})

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix-arm-uwp.patch
         pkgconfig.patch
         fix-ios.patch
+        fold-common-into-static-builds.patch
 )
 
 vcpkg_configure_cmake(


### PR DESCRIPTION
This change allows downstream consumers of the archives to not worry
about ordering the link correctly when using this package, which can be
problematic when --as-needed is passed to the linker and the order isn't
otherwise known.

Keeping the brotlicommon-static archive as is allows for probing of the
brotli libraries to remain symmetric between dynamic and static links.

Fixes static linking issue discussed in
https://github.com/microsoft/vcpkg/issues/16991 which is blocking
rust-sdl2 CI dependent upon vcpkg discussed here
https://github.com/Rust-SDL2/rust-sdl2/pull/1085 .