### PR TITLE
[boost-regex] fix build with icu on osx

### DIFF
--- a/ports/boost-regex/b2-options.cmake
+++ b/ports/boost-regex/b2-options.cmake
@@ -1,3 +1,4 @@
 if("icu" IN_LIST FEATURES)
     set(B2_REQUIREMENTS "<library>/user-config//icuuc <library>/user-config//icudt <library>/user-config//icuin <define>BOOST_HAS_ICU=1")
+    set(B2_OPTIONS cxxstd=11)
 endif()

--- a/ports/boost-regex/b2-options.cmake
+++ b/ports/boost-regex/b2-options.cmake
@@ -1,4 +1,6 @@
 if("icu" IN_LIST FEATURES)
     set(B2_REQUIREMENTS "<library>/user-config//icuuc <library>/user-config//icudt <library>/user-config//icuin <define>BOOST_HAS_ICU=1")
-    set(B2_OPTIONS cxxstd=11)
+    if(APPLE)
+        list(APPEND B2_OPTIONS cxxstd=11)
+    endif()
 endif()

--- a/ports/boost-regex/vcpkg.json
+++ b/ports/boost-regex/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-regex",
   "version-string": "1.75.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost regex module",
   "homepage": "https://github.com/boostorg/regex",
   "dependencies": [

--- a/versions/b-/boost-regex.json
+++ b/versions/b-/boost-regex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1eb139e3e57925a27b750c521cd2a9909dd9c73b",
+      "version-string": "1.75.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "bacde176dddb776105f9b7996de34a3a051ff324",
       "version-string": "1.75.0",
       "port-version": 1

--- a/versions/b-/boost-regex.json
+++ b/versions/b-/boost-regex.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1eb139e3e57925a27b750c521cd2a9909dd9c73b",
+      "git-tree": "9b5c6faa967ec00a8f3ed0aa1bb1f82564e3e064",
       "version-string": "1.75.0",
       "port-version": 2
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -838,7 +838,7 @@
     },
     "boost-regex": {
       "baseline": "1.75.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-safe-numerics": {
       "baseline": "1.75.0",


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes pipeline (discussed on discord)

- Which triplets are supported/not supported? Have you updated the CI baseline? All supported

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes

Edit: 
Failures in PR #14628 pipeline:
```
In file included from ../build/../src/icu.cpp:23:
In file included from ../include/boost/regex/icu.hpp:25:
In file included from /Users/vagrant/Data/installed/x64-osx/include/unicode/coll.h:62:
In file included from /Users/vagrant/Data/installed/x64-osx/include/unicode/ucol.h:17:
In file included from /Users/vagrant/Data/installed/x64-osx/include/unicode/unorm.h:25:
In file included from /Users/vagrant/Data/installed/x64-osx/include/unicode/unorm2.h:34:
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:71:51: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
    static void* U_EXPORT2 operator new(size_t) = delete;
                                                  ^
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:72:53: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
    static void* U_EXPORT2 operator new[](size_t) = delete;
                                                    ^
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:74:58: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
    static void* U_EXPORT2 operator new(size_t, void*) = delete;
                                                         ^
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:224:34: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
    LocalPointer(LocalPointer<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
                                 ^
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:224:40: error: expected ';' at end of declaration list
    LocalPointer(LocalPointer<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
                                       ^
                                       ;
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:399:30: warning: rvalue references are a C++11 extension [-Wc++11-extensions]
    LocalArray(LocalArray<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
                             ^
/Users/vagrant/Data/installed/x64-osx/include/unicode/localpointer.h:399:36: error: expected ';' at end of declaration list
    LocalArray(LocalArray<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
                                   ^
                                   ;
```