### PR TITLE
[protobuf] Fix deprecation warning in vcpkg_check_feature()

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -14,7 +14,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" protobuf_BUILD_SHARED_
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" protobuf_MSVC_STATIC_RUNTIME)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURE
+    FEATURES
         zlib protobuf_WITH_ZLIB
 )
 

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -14,7 +14,8 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" protobuf_BUILD_SHARED_
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" protobuf_MSVC_STATIC_RUNTIME)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    zlib protobuf_WITH_ZLIB
+    FEATURE
+        zlib protobuf_WITH_ZLIB
 )
 
 if(VCPKG_TARGET_IS_UWP)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version-string": "3.14.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4830,7 +4830,7 @@
     },
     "protobuf": {
       "baseline": "3.14.0",
-      "port-version": 3
+      "port-version": 4
     },
     "protobuf-c": {
       "baseline": "1.3.2-2",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "13bd967e6e6e32388efdcc63f9468b5b930828f3",
+      "git-tree": "d60f4db7f63f55aa3b9be8c8848f2d492cab577f",
       "version-string": "3.14.0",
       "port-version": 4
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13bd967e6e6e32388efdcc63f9468b5b930828f3",
+      "version-string": "3.14.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "9f8c80db7cf8a925199facba3ba0c6c8436c41c8",
       "version-string": "3.14.0",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #16988

In latest function vcpkg_check_features(), it will post deprecation warning when calling `vcpkg_check_features` without 
`FEATURES` keyword.

So adding `FEATURES` to solve the deprecation warning.