### PR TITLE
set pangolin:x64-linux=fail in ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1210,6 +1210,7 @@ orocos-kdl:arm-uwp=fail
 orocos-kdl:x64-uwp=fail
 paho-mqtt:arm-uwp=fail
 paho-mqtt:x64-uwp=fail
+pangolin:x64-linux=fail
 pangomm:x64-osx=fail
 pangomm:arm64-windows=fail
 paraview:x64-linux=fail


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes pipeline fail in #16994

- Which triplets are supported/not supported? Have you updated the CI baseline? Yes

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes
