### PR TITLE
[vtk] enables openvr module when openvr is listed

### DIFF
--- a/ports/vtk/CONTROL
+++ b/ports/vtk/CONTROL
@@ -1,6 +1,6 @@
 Source: vtk
 Version: 9.0.1
-Port-Version: 5
+Port-Version: 6
 Description: Software system for 3D computer graphics, image processing, and visualization
 Homepage: https://github.com/Kitware/VTK
 Build-Depends: zlib, libpng, tiff, libxml2, jsoncpp, glew, freetype, expat, hdf5[core], libjpeg-turbo, proj4, lz4, liblzma, libtheora, eigen3, double-conversion, pugixml, libharu[notiffsymbols], sqlite3, netcdf-c, utfcpp, libogg, pegtl-2

--- a/ports/vtk/portfile.cmake
+++ b/ports/vtk/portfile.cmake
@@ -91,6 +91,12 @@ if("opengl" IN_LIST FEATURES)
         )
 endif()
 
+if ("openvr" IN_LIST FEATURES)
+    list(APPEND ADDITIONAL_OPTIONS    
+        -DVTK_MODULE_ENABLE_VTK_RenderingOpenVR=YES
+    )
+endif()
+
 if("cuda" IN_LIST FEATURES AND CMAKE_HOST_WIN32)
     vcpkg_add_to_path("$ENV{CUDA_PATH}/bin")
 endif()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2552,7 +2552,7 @@
       "baseline": "9.0.0",
       "port-version": 0
     },
-	"iir1": {
+    "iir1": {
       "baseline": "1.8.0",
       "port-version": 0
     },
@@ -6254,7 +6254,7 @@
     },
     "vtk": {
       "baseline": "9.0.1",
-      "port-version": 5
+      "port-version": 6
     },
     "vtk-dicom": {
       "baseline": "0.8.12-1",

--- a/versions/v-/vtk.json
+++ b/versions/v-/vtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "78be7ee36f34395e4d5511fd61457c4f7178a438",
+      "version-string": "9.0.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "88d95daae73bf5c3413bb18188c81f9ea752e418",
       "version-string": "9.0.1",
       "port-version": 5


### PR DESCRIPTION
This PR sets the `VTK_MODULE_ENABLE_VTK_RenderingOpenVR` flag when `openvr` is in the feature list. Previously, adding this feature did nothing other than changing the dependencies. 