### PR TITLE
[magnum,-plugins] Fix deprecated use of vcpkg_check_features

### DIFF
--- a/ports/magnum-plugins/CONTROL
+++ b/ports/magnum-plugins/CONTROL
@@ -1,6 +1,6 @@
 Source: magnum-plugins
 Version: 2020.06
-Port-Version: 4
+Port-Version: 5
 Build-Depends: magnum[core]
 Description: Plugins for magnum, C++11/C++14 graphics middleware for games and data visualization
 Homepage: https://magnum.graphics/

--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -64,7 +64,7 @@ foreach(_feature IN LISTS ALL_SUPPORTED_FEATURES)
     endif()
 endforeach()
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS ${_COMPONENTS})
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES ${_COMPONENTS})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/magnum/CONTROL
+++ b/ports/magnum/CONTROL
@@ -1,6 +1,6 @@
 Source: magnum
 Version: 2020.06
-Port-Version: 4
+Port-Version: 5
 Build-Depends: corrade[utility]
 Description: C++11/C++14 graphics middleware for games and data visualization
 Homepage: https://magnum.graphics/

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -69,7 +69,7 @@ foreach(_feature IN LISTS ALL_SUPPORTED_FEATURES)
     endif()
 endforeach()
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS ${_COMPONENTS})
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES ${_COMPONENTS})
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3758,7 +3758,7 @@
     },
     "magnum": {
       "baseline": "2020.06",
-      "port-version": 4
+      "port-version": 5
     },
     "magnum-extras": {
       "baseline": "2020.06",
@@ -3770,7 +3770,7 @@
     },
     "magnum-plugins": {
       "baseline": "2020.06",
-      "port-version": 4
+      "port-version": 5
     },
     "mailio": {
       "baseline": "0.20.0",

--- a/versions/m-/magnum-plugins.json
+++ b/versions/m-/magnum-plugins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "457d2fb07dd06abe61d8bdee77bc5dc1ff9391a5",
+      "version-string": "2020.06",
+      "port-version": 5
+    },
+    {
       "git-tree": "05b4c54140907b0b46926c50e0b56bc80051b218",
       "version-string": "2020.06",
       "port-version": 4

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb97c301133d04f205cb1547e5559341474f842e",
+      "version-string": "2020.06",
+      "port-version": 5
+    },
+    {
       "git-tree": "96fbedbdb7cac5cb1624af746d6e4b2cb4b57cc8",
       "version-string": "2020.06",
       "port-version": 4


### PR DESCRIPTION
Hey all,

this fixes build of magnum-plugins and magnum with recent versions of vcpkg, where `vcpkg_check_features` is no longer supported. 

Best,
Jonathan
