### PR TITLE
[vcpkg] Pass no parallel build command to execute_process when parallel build is disabled

### DIFF
--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -187,7 +187,7 @@ function(vcpkg_build_make)
 
             if (_bc_DISABLE_PARALLEL)
                 vcpkg_execute_build_process(
-                        COMMAND ${MAKE_BASH} ${MAKE_CMD_LINE}
+                        COMMAND ${MAKE_BASH} ${NO_PARALLEL_MAKE_CMD_LINE}
                         WORKING_DIRECTORY "${WORKING_DIRECTORY}"
                         LOGNAME "${_bc_LOGFILE_ROOT}-${TARGET_TRIPLET}${SHORT_BUILDTYPE}"
                 )


### PR DESCRIPTION
Really run non parallel build when DISABLE_PARALLEL was set

- Which triplets are supported/not supported? all
- Have you updated the CI baseline? no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
