### PR TITLE
Libgcrypt add cflags to tool build command

### DIFF
--- a/ports/libgcrypt/CONTROL
+++ b/ports/libgcrypt/CONTROL
@@ -1,5 +1,6 @@
 Source: libgcrypt
 Version: 1.8.7
+Port-Version: 1
 Homepage: https://gnupg.org/software/libgcrypt/index.html
 Description: A library implementing the so-called Assuan protocol
 Build-Depends: libgpg-error

--- a/ports/libgcrypt/fix-flags.patch
+++ b/ports/libgcrypt/fix-flags.patch
@@ -1,0 +1,13 @@
+diff --git a/cipher/Makefile.am b/cipher/Makefile.am
+index 95c4510..d43350c 100644
+--- a/cipher/Makefile.am
++++ b/cipher/Makefile.am
+@@ -112,7 +112,7 @@ gost-sb.h: gost-s-box
+ 	./gost-s-box $@
+ 
+ gost-s-box: gost-s-box.c
+-	$(CC_FOR_BUILD) -o $@ $(srcdir)/gost-s-box.c
++	$(CC_FOR_BUILD) $(CFLAGS) -o $@ $(srcdir)/gost-s-box.c
+ 
+ 
+ if ENABLE_O_FLAG_MUNGING

--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-pkgconfig.patch
+        fix-flags.patch
 )
 
 vcpkg_configure_make(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3058,7 +3058,7 @@
     },
     "libgcrypt": {
       "baseline": "1.8.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libgd": {
       "baseline": "2.2.5-4",

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "394e5b7b433e4b18e9276c48b7331fbea30034ba",
+      "version-string": "1.8.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "3a7be352162b1187194ba75ff3514361213f77a6",
       "version-string": "1.8.7",
       "port-version": 0


### PR DESCRIPTION
Libgcrypt add cflags to tool build command

- What does your PR fix? Fixes for PR #15605 

- Which triplets are supported/not supported? same
- Have you updated the CI baseline? no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
