### PR TITLE
Libgpg-error add cflags to tools build commands

### DIFF
--- a/ports/libgpg-error/CONTROL
+++ b/ports/libgpg-error/CONTROL
@@ -1,5 +1,6 @@
 Source: libgpg-error
 Version: 1.39
+Port-Version: 1
 Homepage: https://gnupg.org/software/libgpg-error/index.html
 Description: A common dependency of all GnuPG components
 Supports: !windows

--- a/ports/libgpg-error/add_cflags_to_tools.patch
+++ b/ports/libgpg-error/add_cflags_to_tools.patch
@@ -1,0 +1,30 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index fc3acc3..9a86251 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -279,14 +279,14 @@ gpg-error.def: Makefile gpg-error.def.in
+ # It is correct to use $(CC_FOR_BUILD) here.  We want to run the
+ # program at build time.
+ mkerrcodes$(EXEEXT_FOR_BUILD): mkerrcodes.c mkerrcodes.h Makefile
+-	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) \
++	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CFLAGS) $(LDFLAGS_FOR_BUILD) \
+ 	$(CPPFLAGS_FOR_BUILD) -I. -I$(srcdir) -o $@ $(srcdir)/mkerrcodes.c
+ 
+ if HAVE_W32CE_SYSTEM
+ # It is correct to use $(CC_FOR_BUILD) here.  We want to run the
+ # program at build time.
+ mkw32errmap$(EXEEXT_FOR_BUILD): mkw32errmap.c mkw32errmap.tab.h Makefile
+-	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) \
++	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CFLAGS) $(LDFLAGS_FOR_BUILD) \
+ 	$(CPPFLAGS_FOR_BUILD) -I. -I$(srcdir) -o $@ $(srcdir)/mkw32errmap.c
+ endif
+ 
+@@ -300,7 +300,7 @@ errnos-sym.h: Makefile mkstrtable.awk errnos.in
+ 
+ 
+ mkheader$(EXEEXT_FOR_BUILD): mkheader.c Makefile
+-	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) \
++	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CFLAGS) $(LDFLAGS_FOR_BUILD) \
+ 	$(CPPFLAGS_FOR_BUILD) -g -I. -I$(srcdir) -o $@ $(srcdir)/mkheader.c
+ 
+ parts_of_gpg_error_h = 	 	\

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF libgpg-error-1.39
     SHA512 c8ca3fc9f1bec90a84214c8fed6073f5a0f6f6880c166a8737a24e0eee841ed5f0f3c94028b50b76535cb2e06f0362b19638e429b4cdc399487d6001b977bbbe
     HEAD_REF master
+    PATCHES
+        add_cflags_to_tools.patch
 )
 
 vcpkg_configure_make(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3082,7 +3082,7 @@
     },
     "libgpg-error": {
       "baseline": "1.39",
-      "port-version": 0
+      "port-version": 1
     },
     "libgpod": {
       "baseline": "2019-08-29",

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "36b77502b20b311f354f24c02f27fd5dd4896663",
+      "version-string": "1.39",
+      "port-version": 1
+    },
+    {
       "git-tree": "e5779f2d8e3f5c155d4b2e0b05661a9e0032c00a",
       "version-string": "1.39",
       "port-version": 0


### PR DESCRIPTION
Libgpg-error add cflags to tools build commands

- What does your PR fix? Fixes for PR #15605 

- Which triplets are supported/not supported? same
- Have you updated the CI baseline? no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
