### PR TITLE
Libspatialite remove cflags from vcpkg_configure_make options

### DIFF
--- a/ports/libspatialite/CONTROL
+++ b/ports/libspatialite/CONTROL
@@ -1,5 +1,6 @@
 Source: libspatialite
 Version: 5.0.0
+Port-Version: 1
 Homepage: https://www.gaia-gis.it/gaia-sins/libspatialite-sources
 Description: SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities.
 Build-Depends: libxml2, sqlite3, geos, proj4, zlib, freexl, libiconv, librttopo

--- a/ports/libspatialite/portfile.cmake
+++ b/ports/libspatialite/portfile.cmake
@@ -105,7 +105,6 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX) # Build in UNIX
       SOURCE_PATH ${SOURCE_PATH}
       AUTOCONFIG
       OPTIONS
-          "CFLAGS=-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
           "LIBS=-lpthread -ldl -lm -l${STDLIB}"
           "LIBXML2_CFLAGS=-I\"${CURRENT_INSTALLED_DIR}/include\""
           "--enable-rttopo"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3458,7 +3458,7 @@
     },
     "libspatialite": {
       "baseline": "5.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libspnav": {
       "baseline": "0.2.3",

--- a/versions/l-/libspatialite.json
+++ b/versions/l-/libspatialite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b713a9368a0d53629cd8497cc82107ea6a33e980",
+      "version-string": "5.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f63638cb7e228e76cebf7e4a6c28902b4738f907",
       "version-string": "5.0.0",
       "port-version": 0


### PR DESCRIPTION
Libspatialite remove cflags from vcpkg_configure_make options
This flag do not mentioned in sources 

- What does your PR fix? Fixes for PR #15605

- Which triplets are supported/not supported? same
- Have you updated the CI baseline? no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
