### PR TITLE
Openmpi keep -isystem flags in configure scripts

### DIFF
--- a/ports/openmpi/CONTROL
+++ b/ports/openmpi/CONTROL
@@ -1,6 +1,5 @@
 Source: openmpi
-Version: 4.0.3
-Port-Version: 3
+Version: 4.1.0
 Homepage: https://www.open-mpi.org/
 Description: The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.
 Supports: !(windows|uwp)

--- a/ports/openmpi/keep_isystem.patch
+++ b/ports/openmpi/keep_isystem.patch
@@ -1,0 +1,283 @@
+diff --git a/configure b/configure
+index b2451c4..a7fb4da 100755
+--- a/configure
++++ b/configure
+@@ -19562,6 +19562,10 @@ $as_echo "$as_me: WARNING: This usually indicates an error in configure." >&2;}
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -19653,6 +19657,10 @@ $as_echo "$as_me: WARNING: This usually indicates an error in configure." >&2;}
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -19759,6 +19767,10 @@ $as_echo "$as_me: WARNING: Code coverage functionality is currently available on
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -19946,6 +19958,10 @@ $as_echo "$opal_cv_cc_wno_long_double" >&6; }
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -20127,6 +20143,10 @@ $as_echo "$opal_cv_cc_fno_strict_aliasing" >&6; }
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -20267,6 +20287,10 @@ $as_echo "$opal_cv_cc_restrict_cflags" >&6; }
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -26120,6 +26144,10 @@ $as_echo "$as_me: WARNING: Code coverage functionality is currently available on
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -26297,6 +26325,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -26441,6 +26473,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -27799,6 +27835,10 @@ $as_echo "$as_me: WARNING: Code coverage functionality is currently available on
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -27973,6 +28013,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -28117,6 +28161,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -44127,6 +44175,10 @@ fi
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -60612,6 +60664,10 @@ $as_echo_n "checking if intel compiler _Quad == REAL*16... " >&6; }
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+@@ -60842,6 +60898,10 @@ $as_echo_n "checking if gnu compiler __float128 == REAL*16... " >&6; }
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+                 ;;
++        -isystem)
++                opal_found=0
++                opal_i=`expr $opal_count + 1`
++                ;;
+         --param)
+                 opal_found=0
+                 opal_i=`expr $opal_count + 1`
+diff --git a/opal/mca/pmix/pmix3x/pmix/configure b/opal/mca/pmix/pmix3x/pmix/configure
+index 0326a68..07df146 100755
+--- a/opal/mca/pmix/pmix3x/pmix/configure
++++ b/opal/mca/pmix/pmix3x/pmix/configure
+@@ -19386,6 +19386,10 @@ $as_echo "$pmix_cv_cc_coverage" >&6; }
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -19477,6 +19481,10 @@ $as_echo "$pmix_cv_cc_coverage" >&6; }
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -19583,6 +19591,10 @@ $as_echo "$as_me: WARNING: Code coverage functionality is currently available on
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -19770,6 +19782,10 @@ $as_echo "$pmix_cv_cc_wno_long_double" >&6; }
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -19951,6 +19967,10 @@ $as_echo "$pmix_cv_cc_fno_strict_aliasing" >&6; }
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -20091,6 +20111,10 @@ $as_echo "$pmix_cv_cc_restrict_cflags" >&6; }
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -53914,6 +53938,10 @@ fi
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -54005,6 +54033,10 @@ fi
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -54096,6 +54128,10 @@ fi
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+@@ -54187,6 +54223,10 @@ fi
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`
+                 ;;
++        -isystem)
++                pmix_found=0
++                pmix_i=`expr $pmix_count + 1`
++                ;;
+         --param)
+                 pmix_found=0
+                 pmix_i=`expr $pmix_count + 1`

--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -2,18 +2,20 @@ vcpkg_fail_port_install(ON_TARGET "Windows" "UWP")
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-set(OpenMPI_FULL_VERSION "4.0.3")
-set(OpenMPI_SHORT_VERSION "4.0")
+set(OpenMPI_FULL_VERSION "4.1.0")
+set(OpenMPI_SHORT_VERSION "4.1")
 
 vcpkg_download_distfile(ARCHIVE
   URLS "https://download.open-mpi.org/release/open-mpi/v${OpenMPI_SHORT_VERSION}/openmpi-${OpenMPI_FULL_VERSION}.tar.gz"
   FILENAME "openmpi-${OpenMPI_FULL_VERSION}.tar.gz"
-  SHA512 23a9dfb7f4a63589b82f4e073a825550d3bc7e6b34770898325323ef4a28ed90b47576acaae6be427eb2007b37a88e18c1ea44d929b8ca083fe576ef1111fef6
+  SHA512 1f8117b11c5279d34194b4f5652b0223cf1258a4ac0efd40bab78f31f203068e027235a92a87e546b1b35c5b369bc90788b109c05a7068c75533a03649410e99
 )
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES 
+	keep_isystem.patch
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4441,8 +4441,8 @@
       "port-version": 0
     },
     "openmpi": {
-      "baseline": "4.0.3",
-      "port-version": 3
+      "baseline": "4.1.0",
+      "port-version": 0
     },
     "openmvg": {
       "baseline": "1.6",

--- a/versions/o-/openmpi.json
+++ b/versions/o-/openmpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ada9b58df7928b49218b4b932e37b343a2047273",
+      "version-string": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "54178d2df9f03298fa293753786c0ddbb1fbf2c4",
       "version-string": "4.0.3",
       "port-version": 3


### PR DESCRIPTION
Openmpi keep -isystem flags in configure scripts

- What does your PR fix? Fixes for PR #15605 

- Which triplets are supported/not supported? same
-  Have you updated the CI baseline? no

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? yes
