### PR TITLE
[google-cloud-cpp] update to the latest release (v1.26.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.25.0
-    SHA512 db1803b9de38028a171d3b295b85da5dd36f150c78f2ec523f24eb67998c27d06584aa26e572cab8508841cb469c980304501b87f4157a8020f85bc733f968b5
+    REF v1.26.0
+    SHA512 686b6390c9b64075d4644db4c9b19c3f01d53a2385dc85028e3277361e21fe834ddc1248c5ac6c63ff3c87d3a21de229ea77d3bec8480a0904ed0126e2e619f6
     HEAD_REF master
     PATCHES
         disable-benchmarks.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
   "version": "1.26.0",
-  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.25.0",
-  "port-version": 3,
+  "version": "1.26.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2281,8 +2281,8 @@
       "port-version": 4
     },
     "google-cloud-cpp": {
-      "baseline": "1.25.0",
-      "port-version": 3
+      "baseline": "1.26.0",
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2282,7 +2282,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.26.0",
-      "port-version": 1
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "34762ed0a0b85a8851a423a9336acedb06ce83a3",
+      "git-tree": "249151585040064668071c55f2cd0e4ec1fae8c5",
       "version": "1.26.0",
-      "port-version": 1
+      "port-version": 0
     },
     {
       "git-tree": "83200cc9220f1d5da7d7367321597708cf4ee044",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34762ed0a0b85a8851a423a9336acedb06ce83a3",
+      "version": "1.26.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "83200cc9220f1d5da7d7367321597708cf4ee044",
       "version": "1.25.0",
       "port-version": 3


### PR DESCRIPTION
Update google-cloud-cpp to v1.16.0, the latest release.

- What does your PR fix?

N/A

- Which triplets are supported/not supported? Have you updated the CI baseline?

N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.
