### PR TITLE
[libtcod] Update to 1.16.7

### DIFF
--- a/ports/libtcod/portfile.cmake
+++ b/ports/libtcod/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtcod/libtcod
-    REF 1.16.7-1-g2311b47
+    REF 2311b47028f0879c1d3fc44e11d8352052b8d8b0
     SHA512  7b3ab6daf6847d2d0993a1aa73d6d4b9b56684ac5f44cdf7d4ae551600c5354c72afdfa40abd837dda66b3bb1e4c0d50c8c9a7bf5a7e4915cbdc703211c7c917
     HEAD_REF develop
 )

--- a/ports/libtcod/portfile.cmake
+++ b/ports/libtcod/portfile.cmake
@@ -1,18 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libtcod/libtcod
-    REF 1.16.6
-    SHA512  88777acd89d5ab2541d8b5d2f6db966059b76501b591d6e1d782d0d39b0adbcb38be25c49716b6e581b4b0488bf2dbfc5b07452b80495365861cee97e5279bfd
+    REF 1.16.7-1-g2311b47
+    SHA512  7b3ab6daf6847d2d0993a1aa73d6d4b9b56684ac5f44cdf7d4ae551600c5354c72afdfa40abd837dda66b3bb1e4c0d50c8c9a7bf5a7e4915cbdc703211c7c917
     HEAD_REF develop
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
         -DCMAKE_INSTALL_INCLUDEDIR=${CURRENT_PACKAGES_DIR}/include
-        -DCMAKE_INSTALL_CONFIGDIR=share/libtcod
         -DLIBTCOD_SDL2=find_package
         -DLIBTCOD_ZLIB=find_package
         -DLIBTCOD_GLAD=find_package
@@ -21,14 +19,10 @@ vcpkg_configure_cmake(
         -DLIBTCOD_STB=vcpkg
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
-file(
-    INSTALL "${SOURCE_PATH}/LICENSE.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
-    RENAME copyright
-)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtcod",
-  "version-string": "1.16.7",
+  "version-semver": "1.16.7",
+  "port-version": 1,
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libtcod",
-  "version-string": "1.16.6",
+  "version-string": "1.16.7",
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",
@@ -11,6 +11,14 @@
     "sdl2",
     "stb",
     "utf8proc",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/ports/libtcod/vcpkg.json
+++ b/ports/libtcod/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtcod",
   "version-semver": "1.16.7",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Kyle Benesch <4b796c65+github@gmail.com>",
   "description": "Common algorithms and tools for roguelikes.",
   "homepage": "https://github.com/libtcod/libtcod",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3509,7 +3509,7 @@
       "port-version": 0
     },
     "libtcod": {
-      "baseline": "1.16.6",
+      "baseline": "1.16.7",
       "port-version": 0
     },
     "libtheora": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3510,7 +3510,7 @@
     },
     "libtcod": {
       "baseline": "1.16.7",
-      "port-version": 1
+      "port-version": 2
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3510,7 +3510,7 @@
     },
     "libtcod": {
       "baseline": "1.16.7",
-      "port-version": 0
+      "port-version": 1
     },
     "libtheora": {
       "baseline": "1.2.0alpha1-20170719",

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d7bdb2a149f1fa7d4daa37fd02e9655273f503f",
+      "version-semver": "1.16.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "40587cd0b117a21791c1da332c89c6e1a820e2a9",
       "version-semver": "1.16.7",
       "port-version": 1

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8498087d7b87609436a7c5fb85c391592add740",
+      "version-string": "1.16.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "e2de0a47f3776252b6e04681c92d67b0730587ef",
       "version-string": "1.16.6",
       "port-version": 0

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40587cd0b117a21791c1da332c89c6e1a820e2a9",
+      "version-semver": "1.16.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "c8498087d7b87609436a7c5fb85c391592add740",
       "version-string": "1.16.7",
       "port-version": 0


### PR DESCRIPTION
- What does your PR fix?
  - Updates libtcod port to the latest release.
  - Fixed handling of the `share` directory upstream, so `-DCMAKE_INSTALL_CONFIGDIR=share/libtcod` is no longer needed.
  - The copyright file is now handled upstream.
  - Deprecated helper functions replaced with `vcpkg-cmake` and `vcpkg-cmake-config` functions.

- Which triplets are supported/not supported? Have you updated the CI baseline?

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  - Yes.