### PR TITLE
[icu] support Mac/ARM build

### DIFF
--- a/ports/icu/CONTROL
+++ b/ports/icu/CONTROL
@@ -1,6 +1,6 @@
 Source: icu
 Version: 67.1
-Port-Version: 8
+Port-Version: 9
 Homepage: http://icu-project.org/apiref/icu4c/
 Description: Mature and widely used Unicode and localization library.
 Supports: !(arm|uwp)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2470,7 +2470,7 @@
     },
     "icu": {
       "baseline": "67.1",
-      "port-version": 8
+      "port-version": 9
     },
     "ideviceinstaller": {
       "baseline": "1.1.2.23-1",
@@ -2552,7 +2552,7 @@
       "baseline": "9.0.0",
       "port-version": 0
     },
-	"iir1": {
+    "iir1": {
       "baseline": "1.8.0",
       "port-version": 0
     },

--- a/versions/i-/icu.json
+++ b/versions/i-/icu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bcc60b62792397b3a6572a29618c4622645a81b",
+      "version-string": "67.1",
+      "port-version": 9
+    },
+    {
       "git-tree": "db2977707d68a8c04e0960b0965722f8e5bfda20",
       "version-string": "67.1",
       "port-version": 8


### PR DESCRIPTION
### What does your PR fix? Fixes

Support `arm64` cross-compile in Mac OS `x86_64` host system.

### Which triplets are supported/not supported? Have you updated the CI baseline?

* `arm64-osx`

The above triplet must become available when `uname` result is like below.

```console
user@host$ uname -msp
Darwin x86_64 i386
```

After changing `VCPKG_LIBRARY_LINKAGE` to `dynamic`, the build output should be arm64 shared.

```console
user@host$ ./vcpkg install icu:arm64-osx
Computing installation plan...
The following packages will be built and installed:
    icu[core]:arm64-osx -> 67.1#9
Detecting compiler hash for triplet arm64-osx...
...

user@host$ file ./installed/arm64-osx/lib/libicuio.dylib 
./installed/arm64-osx/lib/libicuio.dylib: Mach-O 64-bit dynamically linked shared library arm64
```

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yeah.  
It was quite complicated to make it work. Wish this can save people's time.
