### PR TITLE
[vcpkg] Fix windres-rc wrapper

### DIFF
--- a/scripts/buildsystems/make_wrapper/windres-rc
+++ b/scripts/buildsystems/make_wrapper/windres-rc
@@ -1,7 +1,7 @@
 #! /bin/sh
 # Wrapper for windres to rc which do not understand '-i -o --output-format'.
 # cvtres is invoked by the linker
-scriptversion=2020-08-17.03; # UTC
+scriptversion=2021-04-02.18; # UTC
 
 
 nl='
@@ -58,8 +58,6 @@ func_file_conv ()
 # Adjust compile command to suit rc instead of windres
 func_windres_wrapper ()
 {
-  echo "FROM WINDRESWRAPPER FUNCTION:$@"
-  echo "RCFLAGS:$(RCFLAGS)"
   # Assume a capable shell
   in=
   out=


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
  It fixes logged error messages about not being able to execute `RCFLAGS`, and actually output the contents of this variable.
  **If the output of "RCFLAGS:..." is used, this will change behaviour.**

- Which triplets are supported/not supported? Have you updated the CI baseline?
  AFAICT this is used for MSVC windows triplets, when building packages based on autotools, such as `libiconv`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  No relevant guidelines for this script.

**Note:**
I'm not using MSVC, so **I couldn't test** with this toolchain.
Maybe this should be run with, or `set`, `-e`.