### PR TITLE
[x265] Allow release-only build.

### DIFF
--- a/ports/x265/CONTROL
+++ b/ports/x265/CONTROL
@@ -1,6 +1,6 @@
 Source: x265
 Version: 3.4
-Port-Version: 3
+Port-Version: 4
 Homepage: https://github.com/videolan/x265
 Description: x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.
 Supports: !(uwp | arm)

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -32,8 +32,9 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 # remove duplicated include files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+endif()
 vcpkg_copy_tools(TOOL_NAMES x265 AUTO_CLEAN)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR VCPKG_TARGET_IS_LINUX)
@@ -42,24 +43,36 @@ endif()
 
 if(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_TARGET_IS_MINGW))
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc" "-lx265" "-lx265-static")
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc" "-lx265" "-lx265-static")
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc" "-lx265" "-lx265-static")
+        endif()
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc" "-lx265" "-lx265-static")
+        endif()
     endif()
 endif()
 
 # maybe create vcpkg_regex_replace_string?
 
-file(READ ${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc _contents)
-string(REGEX REPLACE "-l(std)?c\\+\\+" "" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc "${_contents}")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(READ ${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc _contents)
+    string(REGEX REPLACE "-l(std)?c\\+\\+" "" _contents "${_contents}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig/x265.pc "${_contents}")
+endif()
 
-file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc _contents)
-string(REGEX REPLACE "-l(std)?c\\+\\+" "" _contents "${_contents}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc "${_contents}")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc _contents)
+    string(REGEX REPLACE "-l(std)?c\\+\\+" "" _contents "${_contents}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/x265.pc "${_contents}")
+endif()
 
 if(VCPKG_TARGET_IS_MINGW AND ENABLE_SHARED)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libx265.a)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libx265.a)
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/libx265.a)
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/libx265.a)
+    endif()
 endif()
 
 if(UNIX)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6466,7 +6466,7 @@
     },
     "x265": {
       "baseline": "3.4",
-      "port-version": 3
+      "port-version": 4
     },
     "xalan-c": {
       "baseline": "1.11-12",

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39318069e894d5dd6ff63112fd707c31b13be88b",
+      "version-string": "3.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "aa119fefeb5d57dd2b34ec63ea94942f868f1d94",
       "version-string": "3.4",
       "port-version": 3


### PR DESCRIPTION
When doing a release-only build, conditionally disable commands
for debug builds


When doing a release only build with the following triplet:

set(VCPKG_BUILD_TYPE release)

x265 will fail to install as it is assuming debug files exist to be copied.

This patch disables the copy commands for debug files when building in release mode

Note that this patch does not enable a debug-only build