### PR TITLE
[llvm] fix debug build

### DIFF
--- a/ports/llvm/CONTROL
+++ b/ports/llvm/CONTROL
@@ -1,6 +1,6 @@
 Source: llvm
 Version: 11.0.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -254,6 +254,8 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/tools)
+    
+    set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 endif()
 
 # LLVM still generates a few DLLs in the static build:

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3682,7 +3682,7 @@
     },
     "llvm": {
       "baseline": "11.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "lmdb": {
       "baseline": "0.9.24",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "308632b643c39d4e6871c550156d218b4cf8d968",
+      "git-tree": "8012fe9ce8874a41714fad23d8d367f8d2c1ebce",
+      "version-string": "11.0.0",
+      "port-version": 3
+    },
+    {
+      "git-tree": "e063ccc9a7bfca7223d4e5f49beb8a4bfc31b2d7",
       "version-string": "11.0.0",
       "port-version": 2
     },


### PR DESCRIPTION
LLVM did no build in debug because the include directory was removed.
I'm not sure this behavior is correct (llvm port). Yet I did add the policy so it builds.