### PR TITLE
[fltk] Fix link to system libs

### DIFF
--- a/ports/fltk/CONTROL
+++ b/ports/fltk/CONTROL
@@ -1,6 +1,0 @@
-Source: fltk
-Version: 1.3.5
-Port-Version: 3
-Homepage: https://www.fltk.org/
-Description: FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.
-Build-Depends: zlib, libpng, libjpeg-turbo

--- a/ports/fltk/fix-system-link.patch
+++ b/ports/fltk/fix-system-link.patch
@@ -1,0 +1,18 @@
+diff --git a/CMake/macros.cmake b/CMake/macros.cmake
+index 0c2586f..eb77510 100644
+--- a/CMake/macros.cmake
++++ b/CMake/macros.cmake
+@@ -37,6 +37,13 @@ macro(FL_ADD_LIBRARY LIBNAME LIBTYPE LIBFILES)
+     add_library(${LIBRARY_NAME} ${LIBTYPE} ${LIBFILES})
+ 
+     target_include_directories(${LIBRARY_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
++    
++    if (APPLE)
++        find_library(Cocoa Cocoa)
++        target_link_libraries(${LIBRARY_NAME} PUBLIC $<$<PLATFORM_ID:Darwin>:${Cocoa}>)
++    elseif (WIN32)
++        target_link_libraries(${LIBRARY_NAME} PUBLIC gdi32 gdiplus user32 advapi32 ole32 shell32 comdlg32)
++    endif()
+ 
+     set_target_properties(${LIBRARY_NAME}
+         PROPERTIES

--- a/ports/fltk/portfile.cmake
+++ b/ports/fltk/portfile.cmake
@@ -1,11 +1,11 @@
+# FLTK has many improperly shared global variables that get duplicated into every DLL
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_download_distfile(ARCHIVE
     URLS "https://fltk.org/pub/fltk/1.3.5/fltk-1.3.5-source.tar.gz"
     FILENAME "fltk-1.3.5.tar.gz"
     SHA512 db7ea7c5f3489195a48216037b9371a50f1119ae7692d66f71b6711e5ccf78814670581bae015e408dee15c4bba921728309372c1cffc90113cdc092e8540821
 )
-
-# FLTK has many improperly shared global variables that get duplicated into every DLL
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive_ex(
         add-link-libraries.patch
         config-path.patch
         include.patch
+        fix-system-link.patch
 )
 
 if (VCPKG_TARGET_ARCHITECTURE MATCHES "arm" OR VCPKG_TARGET_ARCHITECTURE MATCHES "arm64")
@@ -42,6 +43,8 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/fltk)
 
+vcpkg_copy_pdbs()
+
 if(VCPKG_TARGET_IS_OSX)
     vcpkg_copy_tools(TOOL_NAMES fluid.app fltk-config AUTO_CLEAN)
 elseif(VCPKG_TARGET_IS_WINDOWS)
@@ -50,8 +53,6 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
 else()
     vcpkg_copy_tools(TOOL_NAMES fluid fltk-config AUTO_CLEAN)
 endif()
-
-vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE
@@ -74,4 +75,4 @@ foreach(FILE Fl_Export.H fl_utf8.h)
     file(WRITE ${CURRENT_PACKAGES_DIR}/include/FL/${FILE} "${FLTK_HEADER}")
 endforeach()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "fltk",
+  "version": "1.3.5",
+  "port-version": 4,
+  "description": "FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.",
+  "homepage": "https://www.fltk.org/",
+  "dependencies": [
+    "libjpeg-turbo",
+    "libpng",
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1982,7 +1982,7 @@
     },
     "fltk": {
       "baseline": "1.3.5",
-      "port-version": 3
+      "port-version": 4
     },
     "fluidlite": {
       "baseline": "2020-08-27",

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09b2ceac638353fa15310751f007a9e868087460",
+      "version": "1.3.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "4f56d4551d634591725cc016e804323a7a793faa",
       "version-string": "1.3.5",
       "port-version": 3


### PR DESCRIPTION
fltk forgot to export some system libraries in the cmake configuration file on Windows and OSX, fix this.

Fixes #17053.