### PR TITLE
[libui] Export system libs on OSX

### DIFF
--- a/ports/libui/003-fix-system-link.patch
+++ b/ports/libui/003-fix-system-link.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a23b84d..9892dfc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -172,6 +172,12 @@ if(BUILD_SHARED_LIBS)
+ 	target_link_libraries(libui
+ 		PRIVATE ${_LIBUI_LIBS})
+ endif()
++
++if (APPLE)
++    find_library(Foundation Foundation)
++    find_library(AppKit AppKit)
++    target_link_libraries(libui PUBLIC $<$<PLATFORM_ID:Darwin>:${Foundation};${AppKit}>)
++endif()
+ # TODO INTERFACE libs don't inherit to grandhcildren?
+ # on Windows the linker for static libraries is different; don't give it the flags
+ if(BUILD_SHARED_LIBS)

--- a/ports/libui/CONTROL
+++ b/ports/libui/CONTROL
@@ -1,3 +1,0 @@
-Source: libui
-Version: 2018-11-03-1
-Description: Simple and portable (but not inflexible) native GUI library in C.

--- a/ports/libui/portfile.cmake
+++ b/ports/libui/portfile.cmake
@@ -24,4 +24,4 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libui TARGET_PATH share/unoffici
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/libui/copyright" COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/libui/portfile.cmake
+++ b/ports/libui/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         "001-fix-cmake.patch"
         "002-fix-macosx-build.patch"
+        "003-fix-system-link.patch"
 )
 
 vcpkg_configure_cmake(
@@ -16,11 +17,11 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+vcpkg_copy_pdbs()
+
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libui TARGET_PATH share/unofficial-libui)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/libui/copyright COPYONLY)
-
-vcpkg_copy_pdbs()
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/libui/copyright" COPYONLY)

--- a/ports/libui/vcpkg.json
+++ b/ports/libui/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "libui",
+  "version-date": "2018-11-03",
+  "port-version": 2,
+  "description": "Simple and portable (but not inflexible) native GUI library in C.",
+  "homepage": "https://github.com/andlabs/libui"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3537,8 +3537,8 @@
       "port-version": 0
     },
     "libui": {
-      "baseline": "2018-11-03-1",
-      "port-version": 0
+      "baseline": "2018-11-03",
+      "port-version": 2
     },
     "libunibreak": {
       "baseline": "4.3-0",

--- a/versions/l-/libui.json
+++ b/versions/l-/libui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "302766b82a15672a75618bad9bb8e8be58ef6ba8",
+      "git-tree": "941bfc035a8cfa6020be3475769732b027249a1d",
       "version-date": "2018-11-03",
       "port-version": 2
     },

--- a/versions/l-/libui.json
+++ b/versions/l-/libui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "302766b82a15672a75618bad9bb8e8be58ef6ba8",
+      "version-date": "2018-11-03",
+      "port-version": 2
+    },
+    {
       "git-tree": "c3d3ba8694ca2465c505735531cd10dfc8cf150d",
       "version-string": "2018-11-03-1",
       "port-version": 0


### PR DESCRIPTION
Export OSX system libraries `Foundation` and `AppKit` to cmake config file to fix the usage issue.

Fixes #17054.