### PR TITLE
[scripts] Fix Perl download link

### DIFF
--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -73,7 +73,6 @@ function(vcpkg_find_acquire_program VAR)
     set(APT_PACKAGE_NAME "perl")
     set(URL
       "https://strawberryperl.com/download/${PERL_VERSION}/strawberry-perl-${PERL_VERSION}-32bit.zip"
-      "http://strawberryperl.com/download/${PERL_VERSION}/strawberry-perl-${PERL_VERSION}-32bit.zip"
     )
     set(ARCHIVE "strawberry-perl-${PERL_VERSION}-32bit.zip")
     set(HASH d353d3dc743ebdc6d1e9f6f2b7a6db3c387c1ce6c890bae8adc8ae5deae8404f4c5e3cf249d1e151e7256d4c5ee9cd317e6c41f3b6f244340de18a24b938e0c4)

--- a/scripts/cmake/vcpkg_find_acquire_program.cmake
+++ b/scripts/cmake/vcpkg_find_acquire_program.cmake
@@ -72,7 +72,7 @@ function(vcpkg_find_acquire_program VAR)
     set(BREW_PACKAGE_NAME "perl")
     set(APT_PACKAGE_NAME "perl")
     set(URL
-      "https://strawberry.perl.bot/download/${PERL_VERSION}/strawberry-perl-${PERL_VERSION}-32bit.zip"
+      "https://strawberryperl.com/download/${PERL_VERSION}/strawberry-perl-${PERL_VERSION}-32bit.zip"
       "http://strawberryperl.com/download/${PERL_VERSION}/strawberry-perl-${PERL_VERSION}-32bit.zip"
     )
     set(ARCHIVE "strawberry-perl-${PERL_VERSION}-32bit.zip")


### PR DESCRIPTION
Domain https://strawberry.perl.bot is not available now.
During download the Perl from https://strawberry.perl.bot/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip I always get the same error: `Failed. Status: 22;"HTTP response code said error"`.
Downloading from http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip is to slow and sometimes fails.

Steps to reproduce:
```
> vcpkg install openssl
Computing installation plan...
The following packages will be built and installed:
    openssl[core]:x86-windows -> 1.1.1j
Starting package 1/1: openssl:x86-windows
Building package openssl[core]:x86-windows...
-- Downloading https://www.openssl.org/source/openssl-1.1.1j.tar.gz -> openssl-1.1.1j.tar.gz...
-- Downloading https://strawberry.perl.bot/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip -> strawberry-perl-5.30.0.1-32bit.zip...
-- Downloading https://strawberry.perl.bot/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip... Failed. Status: 22;"HTTP response code said error"
-- Downloading http://strawberryperl.com/download/5.30.0.1/strawberry-perl-5.30.0.1-32bit.zip -> strawberry-perl-5.30.0.1-32bit.zip...
```
