### PR TITLE
[glib] fix build error for x64-linux-dynamic

### DIFF
--- a/ports/glib/CMakeLists.txt
+++ b/ports/glib/CMakeLists.txt
@@ -181,7 +181,7 @@ endif()
 # gmodule
 add_library(gmodule gmodule/gmodule.c)
 target_compile_definitions(gmodule PRIVATE G_LOG_DOMAIN="GModule")
-target_link_libraries(gmodule PRIVATE glib ${Intl_LIBRARIES})
+target_link_libraries(gmodule PRIVATE glib ${CMAKE_DL_LIBS} ${Intl_LIBRARIES})
 target_include_directories(gmodule PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gmodule>)
 target_include_directories(gmodule PRIVATE ${Intl_INCLUDE_DIRS} PUBLIC $<INSTALL_INTERFACE:include>)
 list(APPEND GLIB_TARGETS gmodule)

--- a/ports/glib/CONTROL
+++ b/ports/glib/CONTROL
@@ -1,6 +1,6 @@
 Source: glib
 Version: 2.52.3
-Port-Version: 25
+Port-Version: 26
 Homepage: https://developer.gnome.org/glib/
 Description: Portable, general-purpose utility library.
 Build-Depends: zlib, pcre, libffi, gettext, libiconv

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2246,7 +2246,7 @@
     },
     "glib": {
       "baseline": "2.52.3",
-      "port-version": 25
+      "port-version": 26
     },
     "glibmm": {
       "baseline": "2.52.1",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ae9d07c61fa6787bacd9402f61b416843e36867",
+      "version-string": "2.52.3",
+      "port-version": 26
+    },
+    {
       "git-tree": "5cadd8fd83d64bc11b551994268c796eabf629b6",
       "version-string": "2.52.3",
       "port-version": 25


### PR DESCRIPTION
fix glib build error for x64-linux-dynamic

- What does your PR fix? Fixes #15833

- Which triplets are supported/not supported? Have you updated the CI baseline?
- x64-linux-dynamic, x86-windows, x64-windows

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
