### PR TITLE
[directxtex,directxmesh, directxtk, directxtk12, uvatlas] updated for April 2021 releases

### DIFF
--- a/ports/directxmesh/CONTROL
+++ b/ports/directxmesh/CONTROL
@@ -1,8 +1,8 @@
 Source: directxmesh
-Version: jan2021b
-Homepage: https://walbourn.github.io/directxmesh
+Version: apr2021
+Homepage: https://github.com/microsoft/DirectXMesh
 Description: DirectXMesh geometry processing library
-Build-Depends: directxmath(linux), directx-headers(linux)
+Build-Depends: directxmath, directx-headers
 Supports: windows|linux
 
 Feature: dx12

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF jan2021b
-    SHA512 dab353d5033c32cf5667b95820cf3048e4773fa3fed16d24b25a515fbf4b6f6792ab5955dc9bb790c911b4cae1af1166aa0fdc4f5a639b3f4c3c81a2451a9a40
+    REF apr2021
+    SHA512 9e125c1b00c03cb0ff2f5297567e3d5c885acf5c3309208b7f846543eb4114129733676fe6f77b9c33adeb2ad50504927fff9fe48b7fe3f2c042432d0737564c
     HEAD_REF master
 )
 
@@ -35,18 +35,12 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-if((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
-  vcpkg_copy_tools(
-        TOOL_NAMES meshconvert
-        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
-    )
-
-elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/jan2021/meshconvert.exe"
-    FILENAME "meshconvert-jan2021.exe"
-    SHA512 7df51baa495859aab418d194fd885cf37945ec2927122c18718b3a1a7d7ceb08c6853d084d74bf2bf2bc9ace47a351fd6b8d03706507f4966111ec1cb83f43a2
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/apr2021/meshconvert.exe"
+    FILENAME "meshconvert-apr2021.exe"
+    SHA512 0b2dd64f89d884734ad0c58690f50b84acbcd3ab61db79a5b2edf8effb9a756e38862cf599da9969cd30adc9a8f8fe6c8a3c0a3a4b4beef9be87dee8ad496871
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -55,7 +49,15 @@ elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+
+elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
+
+  vcpkg_copy_tools(
+        TOOL_NAMES meshconvert
+        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
+    )
+
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtex/CONTROL
+++ b/ports/directxtex/CONTROL
@@ -1,8 +1,8 @@
 Source: directxtex
-Version: jan2021b
-Homepage: https://walbourn.github.io/directxtex
+Version: apr2021
+Homepage: https://github.com/microsoft/DirectXTex
 Description: DirectXTex texture processing library
-Build-Depends: directxmath(linux), directx-headers(linux)
+Build-Depends: directxmath, directx-headers
 Supports: windows|linux
 
 Feature: dx12

--- a/ports/directxtex/enable_openexr_support.patch
+++ b/ports/directxtex/enable_openexr_support.patch
@@ -1,5 +1,5 @@
-diff --git a/DirectXTex/DirectXTexEXR.cpp b/DirectXTex/DirectXTexEXR.cpp
-index c78f1d1..e073539 100644
+diff --git a/DirectXTexEXR.cpp b/DirectXTexEXR.cpp
+index 9ac601f..204bde2 100644
 --- a/DirectXTex/DirectXTexEXR.cpp
 +++ b/DirectXTex/DirectXTexEXR.cpp
 @@ -8,7 +8,7 @@
@@ -11,10 +11,10 @@ index c78f1d1..e073539 100644
  
  #include "DirectXTexEXR.h"
  
-@@ -55,7 +55,7 @@ using namespace DirectX;
+@@ -56,7 +56,7 @@ using namespace DirectX;
  using PackedVector::XMHALF4;
  
- // Comment out this anonymous namespace if you add the include of DirectXTexP.h above
+ // Comment out this first anonymous namespace if you add the include of DirectXTexP.h above
 -#ifdef WIN32
 +#if 0
  namespace

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF jan2021b
-    SHA512 bd327d0629bbae199f1b3fd80c0470b15edf221f204a4958b4e47b2b1a155b5c0e0af1cc1c39229d582363798f82efa91a3f63ec118fdb0e9255098a576b98ef
+    REF apr2021
+    SHA512 0f2624d7ca6f30e75e5a394c3f4730b068dac256f3571df024d5421f2ce777ee1bf3d90984e93d4ed881d2364dc7bd0dc6b2b48c0abe50a5bc5c2071ce2ba711
     HEAD_REF master
 )
 
@@ -14,20 +14,21 @@ if("openexr" IN_LIST FEATURES)
     vcpkg_download_distfile(
         DIRECTXTEX_EXR_HEADER
         URLS "https://raw.githubusercontent.com/wiki/Microsoft/DirectXTex/DirectXTexEXR.h"
-        FILENAME "DirectXTexEXR.h"
-        SHA512 94ec71069949c8daa616d241ade0c771c448adab3e401a935d5462e7cac382cfbef47534072fc4b9706e086f5021de78a51fd4e2a6850cd3629c932592f9a168
+        FILENAME "DirectXTexEXR-2.h"
+        SHA512 54163820996f7f3c47d0e34da7d717ba51a4363458d77e8f3750d2b6b38bcf803f199b913b4fd7b8dcdd3f520cd0c2bb42a9f79d30f5805fccdece6af368dd12
     )
 
     vcpkg_download_distfile(
         DIRECTXTEX_EXR_SOURCE
         URLS "https://raw.githubusercontent.com/wiki/Microsoft/DirectXTex/DirectXTexEXR.cpp"
-        FILENAME "DirectXTexEXR-1.cpp"
-        SHA512 770fc0325b49139079b0bceb50619f93887e87a3dcf264b10dc01be16209fa51ba03d8273d4d4f84e596ac014376db96b7fed0afabe08c32394ed92495168ea6
+        FILENAME "DirectXTexEXR-2.cpp"
+        SHA512 fbf5a330961f3ac80e4425e8451e9a696240cd89fabca744a19f1f110ae188bae7d8eb5b058aaf66015066d919d4f581b14494d78d280147b23355d8a32745b9
     )
 
     file(COPY ${DIRECTXTEX_EXR_HEADER} DESTINATION ${SOURCE_PATH}/DirectXTex)
     file(COPY ${DIRECTXTEX_EXR_SOURCE} DESTINATION ${SOURCE_PATH}/DirectXTex)
-    file(RENAME ${SOURCE_PATH}/DirectXTex/DirectXTexEXR-1.cpp ${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp)
+    file(RENAME ${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.h ${SOURCE_PATH}/DirectXTex/DirectXTexEXR.h)
+    file(RENAME ${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.cpp ${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp)
     vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES enable_openexr_support.patch)
 endif()
 
@@ -61,32 +62,26 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-if((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
-  vcpkg_copy_tools(
-        TOOL_NAMES texassemble texconv texdiag
-        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
-    )
-
-elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jan2021/texassemble.exe"
-    FILENAME "texassemble-jan2021.exe"
-    SHA512 0def8873358234ea4cd16acd59cb1dda2a8ad132f362502d643caed43e9aef19f9c7e7248494093cbd61e7501a9b44f545d3fbd5f50972ebcee3d01598a7c3b7
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/apr2021/texassemble.exe"
+    FILENAME "texassemble-apr2021.exe"
+    SHA512 1ab77d057d859600cd74632cd236b4ba619ec3538fae2871488bfbe3434bf1acb3ea594b034d5bc7e631954f83e5170b2edb9bc9f228e9216771762ed971a4a2
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jan2021/texconv.exe"
-    FILENAME "texconv-jan2021.exe"
-    SHA512 77559db65406ad0343901ff22f7647c4f270674f7b0c31b12d8dc26c718f410708ebe95bdc0ddba4049fa6cefd52ff856174530fc4170f9e725b30aacb78249c
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/apr2021/texconv.exe"
+    FILENAME "texconv-apr2021.exe"
+    SHA512 6e4f0b775097cd45b54b9b024b6e2f7783d7b3af8cf0e120fb01d69318b30857506260be35b571e873300403acec3c325be6357d05a1fa5971c14ce3065343bc
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jan2021/texdiag.exe"
-    FILENAME "texdiag-jan2021.exe"
-    SHA512 1b9e733050b5f92af86a9a2f415205acbff62f0708e491a3846d7b6e480a9c57086eff636be163d42a40a6d34dafc622cc53940797e7f6f77e739f3a66365f57
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/apr2021/texdiag.exe"
+    FILENAME "texdiag-apr2021.exe"
+    SHA512 f35b2719d47ed36159a7572b632da26179db8d6b2a0164cd6cf917e5220ff04e6179987ca605d8d534cbc76fc8c5204c87748ed5be3dfb393413d5e1e7a58895
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -97,9 +92,17 @@ elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${TEXDIAG_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtex/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
+
+elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
+
+  vcpkg_copy_tools(
+        TOOL_NAMES texassemble texconv texdiag
+        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
+    )
+
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk/CONTROL
+++ b/ports/directxtk/CONTROL
@@ -1,7 +1,8 @@
 Source: directxtk
-Version: jan2021b
-Homepage: https://walbourn.github.io/directxtk
+Version: apr2021
+Homepage: https://github.com/microsoft/DirectXTK
 Description: A collection of helper classes for writing DirectX 11.x code in C++.
+Build-Depends: directxmath
 Supports: windows
 
 Feature: xaudio2-9

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF jan2021b
-    SHA512 87cac6f3ea9e16b5b2d195fd363d5da45d99a08b4bb7be8261a7347ec0e316604acc130129cabc24d635be77ec2487341eca1c5f46238d3ce27fbde1a2e817d1
+    REF apr2021
+    SHA512 d64b5a6c39e9ecc4609a1db4c3121880b4e40431ec2e785aefff8e11615444485b0ffa68169cff6a5dda52f38bb2ce22161644e5fa4b757b9a84e682a458f846
     HEAD_REF master
 )
 
@@ -32,7 +32,33 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-if(NOT VCPKG_TARGET_IS_UWP)
+if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+  vcpkg_download_distfile(
+    MAKESPRITEFONT_EXE
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/apr2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-apr2021.exe"
+    SHA512 f958dc0a88ff931182914ebb4b935d4ed71297d59a61fb70dbf7769d22350abc712acfdbbfbba658781600c83ac7e390eac0663ade747f749194addd209c5bfa
+  )
+
+  vcpkg_download_distfile(
+    XWBTOOL_EXE
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/apr2021/XWBTool.exe"
+    FILENAME "xwbtool-apr2021.exe"
+    SHA512 8918fe7f5c996a54c6a5032115c9b82c6fe9b61688da3cde11c0282061c17a829639b219b8ff5ac623986507338c927eb926f2c42ba3c98563dfe7e162e22305
+  )
+
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
+
+  file(INSTALL
+    ${MAKESPRITEFONT_EXE}
+    ${XWBTOOL_EXE}
+    DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
+
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
+
+elseif(NOT VCPKG_TARGET_IS_UWP)
+
   vcpkg_copy_tools(
         TOOL_NAMES XWBTool
         SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
@@ -44,30 +70,6 @@ if(NOT VCPKG_TARGET_IS_UWP)
       PLATFORM AnyCPU
   )
 
-elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
-  vcpkg_download_distfile(
-    MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jan2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jan2021.exe"
-    SHA512 0cca19694fd3625c5130a85456f7bf1dabc8c5f893223c19da134a0c4d64de853f7871644365dcec86012543f3a59a96bfabd9e51947648f6d82480602116fc4
-  )
-
-  vcpkg_download_distfile(
-    XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jan2021/XWBTool.exe"
-    FILENAME "xwbtool-jan2021.exe"
-    SHA512 91c9d0da90697ba3e0ebe4afcc4c8e084045b76b26e94d7acd4fd87e5965b52dd61d26038f5eb749a3f6de07940bf6e3af8e9f19d820bf904fbdb2752b78fce9
-  )
-
-  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
-
-  file(INSTALL
-    ${MAKESPRITEFONT_EXE}
-    ${XWBTOOL_EXE}
-    DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
-
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/CONTROL
+++ b/ports/directxtk12/CONTROL
@@ -1,6 +1,7 @@
 Source: directxtk12
-Version: jan2021b
-Homepage: https://walbourn.github.io/directx-tool-kit-for-directx-12
+Version: apr2021
+Homepage: https://github.com/microsoft/DirectXTK12
 Description: A collection of helper classes for writing DirectX 12 code in C++.
+Build-Depends: directxmath
 Supports: windows
 

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF jan2021b
-    SHA512 19e017f11fb6cd25a10fbf2597d1a0fe133a339781f5b1b333eb52224fcf5869c5e5bb5a3f3a2f57ffad527076e6780cccccfbae09c48abfce3010be688b87b5
+    REF apr2021
+    SHA512 5bca666815567f681420c4b4e8b1b801a3bdfaf8f00f0910c9d697c90d6c75d74d0ecf9f8c820cca5f94756c5e3796bc3fd936a8b695953af20ffd0c0c0b1b96
     HEAD_REF master
 )
 
@@ -22,16 +22,16 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jan2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jan2021.exe"
-    SHA512 0cca19694fd3625c5130a85456f7bf1dabc8c5f893223c19da134a0c4d64de853f7871644365dcec86012543f3a59a96bfabd9e51947648f6d82480602116fc4
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/apr2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-apr2021.exe"
+    SHA512 f958dc0a88ff931182914ebb4b935d4ed71297d59a61fb70dbf7769d22350abc712acfdbbfbba658781600c83ac7e390eac0663ade747f749194addd209c5bfa
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jan2021/XWBTool.exe"
-    FILENAME "xwbtool-jan2021.exe"
-    SHA512 91c9d0da90697ba3e0ebe4afcc4c8e084045b76b26e94d7acd4fd87e5965b52dd61d26038f5eb749a3f6de07940bf6e3af8e9f19d820bf904fbdb2752b78fce9
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/apr2021/XWBTool.exe"
+    FILENAME "xwbtool-apr2021.exe"
+    SHA512 8918fe7f5c996a54c6a5032115c9b82c6fe9b61688da3cde11c0282061c17a829639b219b8ff5ac623986507338c927eb926f2c42ba3c98563dfe7e162e22305
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -41,8 +41,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk12/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/uvatlas/CONTROL
+++ b/ports/uvatlas/CONTROL
@@ -1,6 +1,6 @@
 Source: uvatlas
-Version: jan2021b
+Version: apr2021
 Homepage: https://github.com/Microsoft/UVAtlas
 Description: UVAtlas isochart texture atlas
-Build-Depends: directxmesh(!(uwp|linux)), directxtex(!(uwp|linux)), directxmath(linux), directx-headers(linux)
+Build-Depends: directxmesh(!(uwp|linux)), directxtex(!(uwp|linux)), directxmath, directx-headers
 Supports: windows|linux

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF jan2021b
-    SHA512 6ed43dbe4ea33857ed96a2c05a4618ae935eb9bc0778118af6c791f794c2ad843fe1b52a2aa484914f8aaf3534a282ab80af95350eab2c340bb6b401dc9743b0
+    REF apr2021
+    SHA512 cbbcb5ca38d5ad27b1f355dba7d71cd605ab6a7588c1886d47f6426e932cdc62376f8fc85033010c2e742336aba632fd4f70b726340ab4ff4eb0343ddecac7db
     HEAD_REF master
 )
 
@@ -29,18 +29,12 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-if((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
-  vcpkg_copy_tools(
-        TOOL_NAMES uvatlastool
-        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
-    )
-
-elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/jan2021/uvatlastool.exe"
-    FILENAME "uvatlastool-jan2021.exe"
-    SHA512 8727510f3ec41c2fa7ed75100b8c0f4daa41e93a1b812e5ec3c265dc87c3f48651da37a18af5d8b57a0aa096c42232b58a50a00c036ec7c04dcae4767a2691f9
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/apr2021/uvatlastool.exe"
+    FILENAME "uvatlastool-apr2021.exe"
+    SHA512 a54d8de9a94dbfb29e3e200b60ce177a56c3c3b2907f7903564168af9da9969efc2abdc7c8107f323cc808fc04648751a51cd4c6cafaeb72174967fdd300e489
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -49,7 +43,15 @@ elseif((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-jan2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-apr2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+
+elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
+
+  vcpkg_copy_tools(
+        TOOL_NAMES uvatlastool
+        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
+    )
+
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1629,7 +1629,7 @@
       "port-version": 0
     },
     "directxmesh": {
-      "baseline": "jan2021b",
+      "baseline": "apr2021",
       "port-version": 0
     },
     "directxsdk": {
@@ -1637,15 +1637,15 @@
       "port-version": 2
     },
     "directxtex": {
-      "baseline": "jan2021b",
+      "baseline": "apr2021",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "jan2021b",
+      "baseline": "apr2021",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "jan2021b",
+      "baseline": "apr2021",
       "port-version": 0
     },
     "dirent": {
@@ -6209,7 +6209,7 @@
       "port-version": 0
     },
     "uvatlas": {
-      "baseline": "jan2021b",
+      "baseline": "apr2021",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec7046a3aaada7fed843b0769bcb50ec78a47555",
+      "version-string": "apr2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d476e8f15e28c928fc9de9898951a9eeeb5b2ae",
       "version-string": "jan2021b",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "af7a4042d884e4cf4f85fbfc49fe928949f53aeb",
+      "version-string": "apr2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "ddb9174d08513e8ad6a9ffc4cedc024fc1b6f68d",
       "version-string": "jan2021b",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9502cb93d3227fa8a77cd99a9f321447eb420300",
+      "version-string": "apr2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "d27a700ccc7ce75a1f7d79665795a042d6bd5df5",
       "version-string": "jan2021b",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49e5974a7aee2ea6a1d4639e7bf885947db11ea0",
+      "version-string": "apr2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "5f5b3546a9e14c89e73ebe317d01c00833f6345f",
       "version-string": "jan2021b",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39b1594645ffd005dc96b8201297e02cae54ed93",
+      "version-string": "apr2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "7ec0056d64ec3888a78610302a348cb5bf65cd78",
       "version-string": "jan2021b",
       "port-version": 0


### PR DESCRIPTION
There are now April 2021 releases of all these libraries on GitHub. This PR updates the vcpkg ports to use the latest versions.

> The upstream CMakeLists.txt now always use directxmath and/or directx-headers when building in vcpkg contexts, not just with linux.