### PR TITLE
[imgui] Fix feature allegro5 usage

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -24,8 +24,20 @@ target_sources(
 )
 
 if(IMGUI_BUILD_ALLEGRO5_BINDING)
-    find_path(ALLEGRO5_INCLUDE_DIRS allegro5/allegro.h)
-    target_include_directories(${PROJECT_NAME} PRIVATE ${ALLEGRO5_INCLUDE_DIRS})
+    include(FindPackageHandleStandardArgs)
+    include(SelectLibraryConfigurations)
+    
+    find_path(ALLEGRO_INCLUDE_DIRS allegro5/allegro.h)
+    find_library(ALLEGRO_LIBRARY_DEBUG NAMES allegro-debug allegro-debug-static liballegro-debug-static  PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH REQUIRED)
+    find_library(ALLEGRO_LIBRARY_RELEASE NAMES allegro allegro-static liballegro-static PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH REQUIRED)
+    find_library(ALLEGRO_PRIMITIVES_LIBRARY_DEBUG allegro_primitives-debug allegro_primitives-debug-static liballegro_primitives-debug-static PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH REQUIRED)
+    find_library(ALLEGRO_PRIMITIVES_LIBRARY_RELEASE allegro_primitives allegro_primitives-static liballegro_primitives-static PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH REQUIRED)
+
+    select_library_configurations(ALLEGRO)
+    select_library_configurations(ALLEGRO_PRIMITIVES)
+
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${ALLEGRO_LIBRARY} ${ALLEGRO_PRIMITIVES_LIBRARY})
+    target_include_directories(${PROJECT_NAME} PRIVATE ${ALLEGRO_INCLUDE_DIRS})
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.cpp)
 endif()
 

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.82",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2574,7 +2574,7 @@
     },
     "imgui": {
       "baseline": "1.82",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.1-2",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "574a2583b113c474eb2aaf729b5bf349691fcd89",
+      "version": "1.82",
+      "port-version": 1
+    },
+    {
       "git-tree": "5b15b89409f5835f3ff13a7e725eb447dddeabab",
       "version": "1.82",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #17058

Using ` imgui[allegro5-binding]` will fail with the link error. Since there is no `allegro5` linked to `imgui` if `IMGUI_BUILD_ALLEGRO5_BINDING` is enabled.

Note: Feature `allegro5-binding` have passed with the following triplets:

- x86-windows
- x64-windows-static
