### PR TITLE
[vcpkg] Fix lib uuid handling for x64-mingw-dynamic

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -545,6 +545,11 @@ function(vcpkg_configure_make)
         list(TRANSFORM ALL_LIBS_LIST REPLACE "^(${_lprefix})" "")
     endif()
     list(JOIN ALL_LIBS_LIST " ${_lprefix}" ALL_LIBS_STRING)
+    if(VCPKG_TARGET_IS_MINGW AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        # libtool must be told explicitly that there is no dynamic linkage for uuid.
+        # The "-Wl,..." syntax is understood by libtool and gcc, but no by ld.
+        string(REPLACE " -luuid" " -Wl,-Bstatic,-luuid,-Bdynamic" ALL_LIBS_STRING "${ALL_LIBS_STRING}")
+    endif()
 
     if(ALL_LIBS_STRING)
         set(ALL_LIBS_STRING "${_lprefix}${ALL_LIBS_STRING}")


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
  This PR fixes the build of gettext (and possibly other packages) on Windows when triplet, host triplet and cmake are mingw. Here, the cmake-detected standard libraries come with `-luuid`, not `uuid`, so it is not removed from LIBS by vcpkg. However, libtool refuses to create shared libraries for mingw because there is no shared library uuid. This change explicitly instructs libtool (or gcc) to statically link uuid. 

- Which triplets are supported/not supported? Have you updated the CI baseline?
  These flags do not work with plain `ld`.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  -/-