### PR TITLE
[spdlog] Use external fmt header

### DIFF
--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -40,6 +40,11 @@ vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/ostr.h
     "#if 0 // !defined(SPDLOG_FMT_EXTERNAL)"
 )
 
+vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/chrono.h
+    "#if !defined(SPDLOG_FMT_EXTERNAL)"
+    "#if 0 // !defined(SPDLOG_FMT_EXTERNAL)"
+)
+
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/debug/share)
 

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.8.5",
+  "port-version": 1,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -332,12 +332,12 @@
       "baseline": "4.8.30",
       "port-version": 5
     },
-    "bext-ut": {
-      "baseline": "1.1.8",
-      "port-version": 0
-    },
     "bext-di": {
       "baseline": "1.2.0",
+      "port-version": 0
+    },
+    "bext-ut": {
+      "baseline": "1.1.8",
       "port-version": 0
     },
     "bfgroup-lyra": {
@@ -5702,7 +5702,7 @@
     },
     "spdlog": {
       "baseline": "1.8.5",
-      "port-version": 0
+      "port-version": 1
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2e12349e1676bc1b9dce1f297789684a5ebd46c7",
+      "version-semver": "1.8.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "a2f8d7856c8821fb685f99873f5e058dc6136c2b",
       "version-semver": "1.8.5",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes #17134

Since we have used external `fmt`, the headers should also be the external one instead of the bundled one . Currently. `include/spdlog/fmt/ostr.h` and `include/spdlog/fmt/fmt.h` has been changed, `include/spdlog/fmt/chrono.h` should be updated as the same way.

```
vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/chrono.h
    "#if !defined(SPDLOG_FMT_EXTERNAL)"
    "#if 0 // !defined(SPDLOG_FMT_EXTERNAL)"
)
```
Note: No need to test features.

