### PR TITLE
[PCL] add a way to disable SSE

### DIFF
--- a/ports/pcl/CONTROL
+++ b/ports/pcl/CONTROL
@@ -1,6 +1,6 @@
 Source: pcl
 Version: 1.11.1
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/PointCloudLibrary/pcl
 Description: Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.
 Build-Depends: eigen3, flann, qhull, libpng, boost-system, boost-filesystem, boost-thread, boost-date-time, boost-iostreams, boost-random, boost-foreach, boost-dynamic-bitset, boost-property-map, boost-graph, boost-multi-array, boost-signals2, boost-sort, boost-ptr-container, boost-uuid, boost-interprocess, boost-asio
@@ -32,3 +32,6 @@ Description: OpenGL support for PCL
 Feature: vtk
 Description: VTK-Visualizations support for PCL
 Build-Depends: vtk
+
+Feature: disable-sse
+Description: Disables SSE support

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -29,15 +29,18 @@ if ("tools" IN_LIST FEATURES AND VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    openni2     WITH_OPENNI2
-    qt          WITH_QT
-    pcap        WITH_PCAP
-    cuda        WITH_CUDA
-    cuda        BUILD_CUDA
-    cuda        BUILD_GPU
-    tools       BUILD_tools
-    opengl      WITH_OPENGL
-    vtk         WITH_VTK
+    FEATURES
+        openni2     WITH_OPENNI2
+        qt          WITH_QT
+        pcap        WITH_PCAP
+        cuda        WITH_CUDA
+        cuda        BUILD_CUDA
+        cuda        BUILD_GPU
+        tools       BUILD_tools
+        opengl      WITH_OPENGL
+        vtk         WITH_VTK
+    INVERTED_FEATURES
+        disable-sse PCL_ENABLE_SSE
 )
 
 vcpkg_configure_cmake(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -332,12 +332,12 @@
       "baseline": "4.8.30",
       "port-version": 5
     },
-    "bext-ut": {
-      "baseline": "1.1.8",
-      "port-version": 0
-    },
     "bext-di": {
       "baseline": "1.2.0",
+      "port-version": 0
+    },
+    "bext-ut": {
+      "baseline": "1.1.8",
       "port-version": 0
     },
     "bfgroup-lyra": {
@@ -4654,7 +4654,7 @@
     },
     "pcl": {
       "baseline": "1.11.1",
-      "port-version": 2
+      "port-version": 3
     },
     "pcre": {
       "baseline": "8.44",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,7 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "7efe6bc9f411b5669ec8ae76407a1250318f3772",
+      "git-tree": "0e13d4046052222f0135999a05aa72875d2647a4",
+      "version-string": "1.11.1",
+      "port-version": 3
+    },
+    {
+      "git-tree": "965ac7e810b04459a8060a73273f924cf8d7f317",
       "version-string": "1.11.1",
       "port-version": 2
     },


### PR DESCRIPTION
PCL adds `-march=native` and other flags to the whole project making it harder to make binaries that work across different instruction sets. This PR add a feature flag to be able to disable SSE optimizations