### PR TITLE
 [clamav] Fix the conflicts with libmspack

### DIFF
--- a/ports/clamav/CONTROL
+++ b/ports/clamav/CONTROL
@@ -1,6 +1,0 @@
-Source: clamav
-Version: 0.103.0
-Homepage: https://www.clamav.net
-Description: ClamAV is an open-source anti-virus toolkit.
-Build-Depends: openssl, json-c, libxml2, pcre2, pthreads, zlib, bzip2
-Supports: !uwp & !static

--- a/ports/clamav/mspack.patch
+++ b/ports/clamav/mspack.patch
@@ -1,0 +1,44 @@
+diff --git a/cmake/FindMSPack.cmake b/cmake/FindMSPack.cmake
+index cad448f..4ce4f87 100644
+--- a/cmake/FindMSPack.cmake
++++ b/cmake/FindMSPack.cmake
+@@ -50,7 +50,7 @@ find_path(MSPack_INCLUDE_DIR
+   PATH_SUFFIXES mspack
+ )
+ find_library(MSPack_LIBRARY
+-  NAMES mspack
++  NAMES libmspack
+   PATHS ${PC_MSPack_LIBRARY_DIRS}
+ )
+ 
+diff --git a/libclamav/CMakeLists.txt b/libclamav/CMakeLists.txt
+index 136ea30..72db826 100644
+--- a/libclamav/CMakeLists.txt
++++ b/libclamav/CMakeLists.txt
+@@ -504,7 +504,7 @@ target_link_libraries( clamav_obj
+         yara
+         tomsfastmath
+         bytecode_runtime
+-        ClamAV::libmspack
++        ${MSPack_LIBRARIES}
+         ClamAV::libclamunrar_iface_iface
+         OpenSSL::SSL
+         OpenSSL::Crypto
+@@ -547,7 +547,7 @@ if(ENABLE_SHARED_LIB)
+             yara
+             tomsfastmath
+             bytecode_runtime
+-            ClamAV::libmspack
++            ${MSPack_LIBRARIES}
+             ClamAV::libclamunrar_iface_iface
+             OpenSSL::SSL
+             OpenSSL::Crypto
+@@ -588,7 +588,7 @@ if(ENABLE_STATIC_LIB)
+             yara
+             tomsfastmath
+             bytecode_runtime
+-            ClamAV::libmspack
++            ${MSPack_LIBRARIES}
+             ClamAV::libclamunrar_iface_iface
+             OpenSSL::SSL
+             OpenSSL::Crypto

--- a/ports/clamav/portfile.cmake
+++ b/ports/clamav/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
       "build.patch"
       "cmakefiles.patch"
       "curl.patch"
+      "mspack.patch"
 )
 
 vcpkg_configure_cmake(
@@ -21,6 +22,7 @@ vcpkg_configure_cmake(
       -DENABLE_DOCS=OFF
       -DENABLE_SHARED_LIB=ON
       -DENABLE_STATIC_LIB=OFF
+      -DENABLE_EXTERNAL_MSPACK=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/clamav/vcpkg.json
+++ b/ports/clamav/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "clamav",
+  "version-semver": "0.103.0",
+  "port-version": 1,
+  "description": "ClamAV is an open-source anti-virus toolkit.",
+  "homepage": "https://www.clamav.net",
+  "supports": "!uwp & !static",
+  "dependencies": [
+    "bzip2",
+    "json-c",
+    "libmspack",
+    "libxml2",
+    "openssl",
+    "pcre2",
+    "pthreads",
+    "zlib"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1222,7 +1222,7 @@
     },
     "clamav": {
       "baseline": "0.103.0",
-      "port-version": 0
+      "port-version": 1
     },
     "clapack": {
       "baseline": "3.2.1",

--- a/versions/c-/clamav.json
+++ b/versions/c-/clamav.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6b4287e62ba66791d4f3b1af99f795f7cd8df15",
+      "version-semver": "0.103.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "30eb9215db50ee898f34f2405682017ac2424e58",
       "version-string": "0.103.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?

On CI unstable test, `libmspack `failed with the following errors:

```
The following files are already installed in D:/installed/x64-windows and are in conflict with libmspack:x64-windows

Installed by clamav:x64-windows
    bin/libmspack.dll
    bin/libmspack.pdb
    debug/bin/libmspack.dll
    debug/bin/libmspack.pdb
```
Since `clamav ` has bundled `libmspack`, which will also generate the same libraries with `libmspack` provided by vcpkg.

So update to use external `libmspack` in `clamav `and also add it as the dependency of `clamav `to avoid the conflicts.

Note: No feature needs to test.