### PR TITLE
[behaviortree-cpp] update to 3.5.6

### DIFF
--- a/ports/behaviortree-cpp/001_port_fixes.patch
+++ b/ports/behaviortree-cpp/001_port_fixes.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 75dea11..4eea781 100644
+index a390aed..658f994 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -229,7 +229,7 @@ if( ZMQ_FOUND )
+@@ -233,7 +233,7 @@ if( ZMQ_FOUND )
  endif()
  
  if(MSVC)
--    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W4 /WX)
-+    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W4 /wd4702)
+-    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W3 /WX)
++    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W3 /wd4702)
  else()
      target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE
          -Wall -Wextra -Werror=return-type)

--- a/ports/behaviortree-cpp/002_fix_dependencies.patch
+++ b/ports/behaviortree-cpp/002_fix_dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 75dea11..23053ca 100644
+index 658f994..a04cf27 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -14,7 +14,7 @@ if(MSVC)
@@ -8,27 +8,26 @@ index 75dea11..23053ca 100644
  #---- Include boost to add coroutines ----
 -find_package(Boost COMPONENTS coroutine QUIET)
 +find_package(Boost REQUIRED) # coroutine2 is header-only
+ 
  if(Boost_FOUND)
-     include_directories(${Boost_INCLUDE_DIRS})
      string(REPLACE "." "0" Boost_VERSION_NODOT ${Boost_VERSION})
-@@ -45,18 +45,18 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+@@ -46,17 +46,18 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
  
  #---- Find other packages ----
  find_package(Threads)
 -find_package(ZMQ)
 +find_package(cppzmq)
  
- list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES
+ list(APPEND BEHAVIOR_TREE_PUBLIC_LIBRARIES
      ${CMAKE_THREAD_LIBS_INIT}
      ${CMAKE_DL_LIBS}
-     ${Boost_LIBRARIES} )
+ )
  
 -if( ZMQ_FOUND )
 +if( ZMQ_FOUND OR ON )
      message(STATUS "ZeroMQ found.")
      add_definitions( -DZMQ_FOUND )
      list(APPEND BT_SOURCE src/loggers/bt_zmq_publisher.cpp)
--    list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES ${ZMQ_LIBRARIES})
 +    list(APPEND BEHAVIOR_TREE_EXTERNAL_LIBRARIES cppzmq)
  else()
      message(WARNING "ZeroMQ NOT found. Skipping the build of [PublisherZMQ] and [bt_recorder].")

--- a/ports/behaviortree-cpp/portfile.cmake
+++ b/ports/behaviortree-cpp/portfile.cmake
@@ -3,9 +3,9 @@ vcpkg_fail_port_install(ON_TARGET "UWP")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/3.5.1.tar.gz"
-    FILENAME "BehaviorTree.CPP.3.5.1.tar.gz"
-    SHA512 66db43225e692fa0f9073e63bdff765c037440372478792a9b442103a8bed945f5c3ae1d66266b86cb41d0006404a8297708a799ec0c7286c2beec6f964a4ac6
+    URLS "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/3.5.6.tar.gz"
+    FILENAME "BehaviorTree.CPP.3.5.6.tar.gz"
+    SHA512 cd3b15eb7c5bab68239b697da166220b4df8dd7e6cf5e831f316d411e24be56c9ed74e54a3e3dd332164d740159eaf9ce62d005601fd65133809dab29430c9b7
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version-string": "3.5.1",
-  "port-version": 2,
+  "version-string": "3.5.6",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp & !osx",

--- a/ports/behaviortree-cpp/vcpkg.json
+++ b/ports/behaviortree-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "behaviortree-cpp",
-  "version-string": "3.5.6",
+  "version": "3.5.6",
   "description": "Behavior Trees Library in C++.",
   "homepage": "https://www.behaviortree.dev",
   "supports": "!uwp & !osx",

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "773b51211bbb4916d2c9dd182aca7c3339520762",
-      "version-string": "3.5.6",
+      "git-tree": "32f97d9bfd43e38949f858a9ce271117b0380c85",
+      "version": "3.5.6",
       "port-version": 0
     },
     {

--- a/versions/b-/behaviortree-cpp.json
+++ b/versions/b-/behaviortree-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "773b51211bbb4916d2c9dd182aca7c3339520762",
+      "version-string": "3.5.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "450257131642541acbb14602fc6f2b2b83d1c2c1",
       "version-string": "3.5.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -317,8 +317,8 @@
       "port-version": 0
     },
     "behaviortree-cpp": {
-      "baseline": "3.5.1",
-      "port-version": 2
+      "baseline": "3.5.6",
+      "port-version": 0
     },
     "benchmark": {
       "baseline": "1.5.2",


### PR DESCRIPTION
Fix #17150 

Update behaviortree-cpp to the latest version 3.5.6

Note: no feature need to test