### PR TITLE
[libwebp] Fix release-only builds

### DIFF
--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,6 +1,6 @@
 Source: libwebp
 Version: 1.1.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/webmproject/libwebp
 Description: WebP codec: library to encode and decode images in WebP format
 Default-Features: simd, nearlossless

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -61,10 +61,12 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/WebP/cmake TARGET_PATH share/WebP) # find_package is called with WebP not libwebp
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebp.pc" "-lwebp" "-lwebpd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdecoder.pc" "-lwebpdecoder" "-lwebpdecoderd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdemux.pc" "-lwebpdemux" "-lwebpdemuxd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpmux.pc" "-lwebpmux" "-lwebpmuxd")
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebp.pc" "-lwebp" "-lwebpd")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdecoder.pc" "-lwebpdecoder" "-lwebpdecoderd")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdemux.pc" "-lwebpdemux" "-lwebpdemuxd")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpmux.pc" "-lwebpmux" "-lwebpmuxd")
+endif()
 vcpkg_fixup_pkgconfig()
 
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3602,7 +3602,7 @@
     },
     "libwebp": {
       "baseline": "1.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libwebsockets": {
       "baseline": "4.1.6",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a3bfc774b61126901f0f9524de41ef864918f35",
+      "version-string": "1.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "8e1a0ef8ea8d864f10f3ad1604f3d0e920534ecd",
       "version-string": "1.1.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
  This PR makes it possible to build libwebp with `VCPKG_BUILD_TYPE` "release". Error before this change:
~~~
-- Building x86-windows-rel
CMake Error at scripts/cmake/vcpkg_replace_string.cmake:13 (file):
  file failed to open for reading (No such file or directory):

    D:/a/1/s/packages/libwebp_x86-windows/debug/lib/pkgconfig/libwebp.pc
Call Stack (most recent call first):
  ports/libwebp/portfile.cmake:64 (vcpkg_replace_string)
  scripts/ports.cmake:142 (include)
~~~

- Which triplets are supported/not supported? Have you updated the CI baseline?
  All triplets, in particular with `VCPKG_BUILD_TYPE` added.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  -/-