### PR TITLE
[xaudio2redist] Add new port

### DIFF
--- a/ports/xaudio2redist/CONTROL
+++ b/ports/xaudio2redist/CONTROL
@@ -1,5 +1,0 @@
-Source: xaudio2redist
-Version: 1.2.6
-Homepage: https://aka.ms/XAudio2Redist
-Description: Redistributable version of XAudio 2.9 for Windows 7 SP1 or later
-Supports: windows & !arm & !uwp & !static

--- a/ports/xaudio2redist/CONTROL
+++ b/ports/xaudio2redist/CONTROL
@@ -1,0 +1,5 @@
+Source: xaudio2redist
+Version: 1.2.6
+Homepage: https://aka.ms/XAudio2Redist
+Description: Redistributable version of XAudio 2.9 for Windows 7 SP1 or later
+Supports: windows & !arm & !uwp & !static

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp" "linux" "osx")
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/1.2.6"
+    FILENAME "xaudio2redist.1.2.6.zip"
+    SHA512 f9b0bacb5787e0239cbf1ffed8e1e8896aa32f69755b084995b2fd1bfe4d49a876d9a69e26469e8779a461e8ff74dc9d5ea86e1ff045dfe2770dfb08b8ba16c3
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(GLOB HEADER_FILES ${PACKAGE_PATH}/build/native/include/*.h)
+file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+
+if(VCPKG_CRT_LINKAGE STREQUAL "static")
+    file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+    file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+else()
+    file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+    file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+endif()
+
+file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+
+file(INSTALL ${PACKAGE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -1,4 +1,8 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp" "linux" "osx")
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "${PORT} only supports Windows.")
+endif()
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -20,13 +20,10 @@ file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT}
 file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
 file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
 
-if(VCPKG_CRT_LINKAGE STREQUAL "static")
-    file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-    file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
-else()
-    file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-    file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
-endif()
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/xapobaseredist_md.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
 
 file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
 file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/xaudio2_9redist.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "xaudio2redist",
+  "version-string": "1.2.6",
+  "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
+  "homepage": "https://aka.ms/XAudio2Redist",
+  "supports": "windows & !arm & !uwp & !static"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6456,6 +6456,10 @@
       "baseline": "1.11-12",
       "port-version": 0
     },
+    "xaudio2redist": {
+      "baseline": "1.2.6",
+      "port-version": 0
+    },
     "xbyak": {
       "baseline": "5.991",
       "port-version": 0

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d75aefb437498db3cf248396e2c98c517eed0a62",
+      "git-tree": "e33a929ddbf8ebc95959d6650a38d351aafea07c",
       "version-string": "1.2.6",
       "port-version": 0
     }

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a995bc8b9b03b4e540caba802992bd8117040bb",
+      "git-tree": "194becc7207699429a8a3c6dbf53caf1e6c0c53b",
       "version-string": "1.2.6",
       "port-version": 0
     }

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4a995bc8b9b03b4e540caba802992bd8117040bb",
+      "version-string": "1.2.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "194becc7207699429a8a3c6dbf53caf1e6c0c53b",
+      "git-tree": "d75aefb437498db3cf248396e2c98c517eed0a62",
       "version-string": "1.2.6",
       "port-version": 0
     }


### PR DESCRIPTION
Adds a vcpkg port for the NuGet package Microsoft.XAudio2.Redist. This provides XAudio 2.9 in a form you can use on Windows 7 SP1, Windows 8.0, Windows 8.1, and Windows 10.

It does not support UWP or ARM/ARM64. You can use XAudio2.9 directly in those scenarios.

> None of the lib or dll names collide with the Windows SDK. The headers do, but they are in a ``include/xaudio2redist`` folder.