### PR TITLE
[dxsdk-d3dx] Add new port

### DIFF
--- a/ports/dxsdk-d3dx/CONTROL
+++ b/ports/dxsdk-d3dx/CONTROL
@@ -1,0 +1,5 @@
+Source: dxsdk-d3dx
+Version: 9.29.952.8
+Homepage: https://walbourn.github.io/legacy-d3dx-on-nuget/
+Description: Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.
+Supports: windows & !arm & !uwp & !static

--- a/ports/dxsdk-d3dx/CONTROL
+++ b/ports/dxsdk-d3dx/CONTROL
@@ -1,5 +1,0 @@
-Source: dxsdk-d3dx
-Version: 9.29.952.8
-Homepage: https://walbourn.github.io/legacy-d3dx-on-nuget/
-Description: Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.
-Supports: windows & !arm & !uwp & !static

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -1,5 +1,7 @@
 vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp" "linux" "osx")
 
+message(WARNING "Use of ${PORT} is not recommended for new projects. See https://aka.ms/dxsdk for more information.")
+
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 set(VCPKG_POLICY_ALLOW_OBSOLETE_MSVCRT enabled)

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -1,4 +1,8 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp" "linux" "osx")
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "${PORT} only supports Windows.")
+endif()
 
 message(WARNING "Use of ${PORT} is not recommended for new projects. See https://aka.ms/dxsdk for more information.")
 

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp" "linux" "osx")
+
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+set(VCPKG_POLICY_ALLOW_OBSOLETE_MSVCRT enabled)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.DXSDK.D3DX/9.29.952.8"
+    FILENAME "dxsdk-d3dx.9.29.952.8.zip"
+    SHA512 9f6a95ed858555c1c438a85219ede32c82729068b21dd7ecf11de01cf3cdd525b2f04a58643bfcc14c48a29403dc1c80246f0a12a1ef4377b91b855f6d6d7986
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH PACKAGE_PATH
+    ARCHIVE ${ARCHIVE}
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(GLOB HEADER_FILES ${PACKAGE_PATH}/build/native/include/*.h ${PACKAGE_PATH}/build/native/include/*.inl)
+file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx9.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx10.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx11.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx9d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx10d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx11d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+
+file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DCompiler_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX9_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/d3dx10_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/d3dx11_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DCompiler_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX9d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX10d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX11d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+
+file(INSTALL ${PACKAGE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "dxsdk-d3dx",
+  "version-string": "9.29.952.8",
+  "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
+  "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
+  "supports": "windows & !arm & !uwp & !static"
+}

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dxsdk-d3dx",
-  "version-string": "9.29.952.8",
+  "version": "9.29.952.8",
   "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
   "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
   "supports": "windows & !arm & !uwp & !static"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1744,6 +1744,10 @@
       "baseline": "1.0.1-1",
       "port-version": 0
     },
+    "dxsdk-d3dx": {
+      "baseline": "9.29.952.8",
+      "port-version": 0
+    },
     "dxut": {
       "baseline": "11.25",
       "port-version": 0

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9146df5201edaad77f44c79d997ba2fd0521a04c",
+      "git-tree": "86d44bc042b1f750661bf3556672560fce61a776",
       "version-string": "9.29.952.8",
       "port-version": 0
     }

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "86d44bc042b1f750661bf3556672560fce61a776",
-      "version-string": "9.29.952.8",
+      "git-tree": "38ff04dcf269c835a7f5c03d50a1a457350bde49",
+      "version": "9.29.952.8",
       "port-version": 0
     }
   ]

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55546c3cf4e67e97bf5054b71a47fc87943fad49",
+      "git-tree": "9146df5201edaad77f44c79d997ba2fd0521a04c",
       "version-string": "9.29.952.8",
       "port-version": 0
     }

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "55546c3cf4e67e97bf5054b71a47fc87943fad49",
+      "version-string": "9.29.952.8",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a vcpkg port for the NuGet package Microsoft.DXSDK.D3DX. This provides the D3DX9, D3DX10, and D3DX11 utility libraries, their headers, and SHA-2 signed DLLs which can be redistributed side-by-side with the application per a new license.

Use of these legacy libraries is still not recommended for new projects, but this is a much more supportable way to use legacy D3DX libraries for existing projects that rely on it.

These headers are compatible with the modern Windows SDK, but are located in ``include/dxsdk-d3dx`` to isolate them.