### PR TITLE
[libwebp] release build fix

### DIFF
--- a/ports/libwebp/CONTROL
+++ b/ports/libwebp/CONTROL
@@ -1,6 +1,6 @@
 Source: libwebp
 Version: 1.1.0
-Port-Version: 2
+Port-Version: 3
 Homepage: https://github.com/webmproject/libwebp
 Description: WebP codec: library to encode and decode images in WebP format
 Default-Features: simd, nearlossless

--- a/ports/libwebp/portfile.cmake
+++ b/ports/libwebp/portfile.cmake
@@ -61,10 +61,12 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/WebP/cmake TARGET_PATH share/WebP) # find_package is called with WebP not libwebp
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebp.pc" "-lwebp" "-lwebpd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdecoder.pc" "-lwebpdecoder" "-lwebpdecoderd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdemux.pc" "-lwebpdemux" "-lwebpdemuxd")
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpmux.pc" "-lwebpmux" "-lwebpmuxd")
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebp.pc" "-lwebp" "-lwebpd")
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdecoder.pc" "-lwebpdecoder" "-lwebpdecoderd")
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpdemux.pc" "-lwebpdemux" "-lwebpdemuxd")
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libwebpmux.pc" "-lwebpmux" "-lwebpmuxd")
+endif()
 vcpkg_fixup_pkgconfig()
 
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3602,7 +3602,7 @@
     },
     "libwebp": {
       "baseline": "1.1.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libwebsockets": {
       "baseline": "4.1.6",

--- a/versions/l-/libwebp.json
+++ b/versions/l-/libwebp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06805ddd46c901db8e808a9b703f7fbdac2f8e99",
+      "version-string": "1.1.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "8e1a0ef8ea8d864f10f3ad1604f3d0e920534ecd",
       "version-string": "1.1.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? Fixes builds that have VCPKG_BUILD_TYPE equal to release. In such case, the current portfile attempts to  change some strings in some files that have not been installed, resulting in an error. This patch fixes this behaviour.

- Which triplets are supported/not supported? Have you updated the CI baseline? No changes.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? Yes, to the best of my knowledge.
