### PR TITLE
[vcpkg] Don't override pkg-config prefix

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -721,7 +721,7 @@ function(vcpkg_configure_make)
             set(_LINK_CONFIG_BACKUP "$ENV{_LINK_}")
             set(ENV{_LINK_} "${LINK_ENV_${_VAR_SUFFIX}}")
         endif()
-        set(ENV{PKG_CONFIG} "${PKGCONFIG} --define-variable=prefix=${_VCPKG_INSTALLED}${PATH_SUFFIX_${_buildtype}}")
+        set(ENV{PKG_CONFIG} "${PKGCONFIG}")
 
         set(_lib_env_vars LIB LIBPATH LIBRARY_PATH LD_LIBRARY_PATH)
         foreach(_lib_env_var IN LISTS _lib_env_vars)


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? 
  This PR fixes breaking builds when pkg-config picks up .pc files from system directories: Overriding the prefix will invalidate include and lib paths. 
  Example case: gdal, picking up system OpenEXR in Azure Pipelines' Ubuntu image.

- Which triplets are supported/not supported? Have you updated the CI baseline?
  -/-

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 -/-

.pc file from vcpkg ports should be safe when properly using `$(pcfiledir)` and `vcpkg_fixup_pkgconfig`.
Related discussion: https://github.com/microsoft/vcpkg/pull/10402#issuecomment-817085769