### PR TITLE
[hypodermic] Add new port (v2.5.2)

### DIFF
--- a/ports/hypodermic/disable_hypodermic_tests.patch
+++ b/ports/hypodermic/disable_hypodermic_tests.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9b6358a..5f55bc2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -76,7 +76,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_FLAGS} ${WARNING_FLAGS}")
+ 
+ 
+ add_subdirectory(Hypodermic)
+-add_subdirectory(Hypodermic.Tests)
++#add_subdirectory(Hypodermic.Tests)
+ 
+ 
+ # uninstall target

--- a/ports/hypodermic/portfile.cmake
+++ b/ports/hypodermic/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ybainier/Hypodermic
+    REF 3e86a5a1fd5e8279d6ca461f9f398fa3f3c2eddc # v2.5.2
+    SHA512 1af2a94037aa5bf8c65aceb4a2e941f7f6d016422d345f86280085115e9bb871387370158b1a83891be8efdadd4eea0a1f8905225ebee64c000ec9023a9f212e
+    HEAD_REF master
+    PATCHES
+        "disable_hypodermic_tests.patch"
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/lib
+    ${CURRENT_PACKAGES_DIR}/debug
+)
+
+
+# Put the license file where vcpkg expects it
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/hypodermic/)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/hypodermic/LICENSE ${CURRENT_PACKAGES_DIR}/share/hypodermic/copyright)

--- a/ports/hypodermic/vcpkg.json
+++ b/ports/hypodermic/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "hypodermic",
+  "version-string": "2.5.2",
+  "description": "Hypodermic is a non-intrusive header only IoC container for C++",
+  "homepage": "https://github.com/ybainier/Hypodermic",
+  "license": "MIT",
+  "dependencies": [
+    "boost-algorithm",
+    "boost-config",
+    "boost-format",
+    "boost-range",
+    "boost-signals2",
+    "boost-system",
+    "boost-test"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2476,6 +2476,10 @@
       "baseline": "5.3.0",
       "port-version": 1
     },
+    "hypodermic": {
+      "baseline": "2.5.2",
+      "port-version": 0
+    },
     "hypre": {
       "baseline": "2.19.0",
       "port-version": 0

--- a/versions/h-/hypodermic.json
+++ b/versions/h-/hypodermic.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "94648decd2043ffd566f58a1d5c826835bb33aca",
+      "version-string": "2.5.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a new package called "hypodermic" which is a header-only IoC container for C++.
See also the homepage of the original author: https://github.com/ybainier/Hypodermic

- Which triplets are supported/not supported? Have you updated the CI baseline?
It's header-only and should work with all triplets. Tested with x64-linux and x64-windows. The CI baseline has not been updated.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
