### PR TITLE
[vcpkg Readme] Added x64 triplet note for Windows Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ To install the libraries for your project, run:
 > .\vcpkg\vcpkg install [packages to install]
 ```
 
+Note: This will install x86 libraries by default. To install x64, run:
+
+```cmd
+> .\vcpkg\vcpkg install package:x64-windows
+```
+
+Or
+
+```cmd
+> .\vcpkg\vcpkg install [packages to install] --triplet=x64-windows
+```
+
 You can also search for the libraries you need with the `search` subcommand:
 
 ```cmd


### PR DESCRIPTION
**Describe the pull request**
Adds a note to the README.md about default installation being x86, and an example of how to target x64 instead.

- What does your PR fix? 
Not a fix, but inspired by #1254 and #12357

- Which triplets are supported/not supported? Have you updated the CI baseline?
N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes