### PR TITLE
Add mingw documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS. This too
 - [Binary Caching](users/binarycaching.md)
 - [Versioning](users/versioning.md)
 - [Usage with Android](users/android.md)
+- [Usage with MinGW](users/mingw.md)
 - [Host Dependencies](users/host-dependencies.md)
 
 ### Maintainer Help

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Vcpkg helps you manage C and C++ libraries on Windows, Linux and MacOS. This too
 - [Binary Caching](users/binarycaching.md)
 - [Versioning](users/versioning.md)
 - [Usage with Android](users/android.md)
-- [Usage with MinGW](users/mingw.md)
+- [Usage with Mingw-w64](users/mingw.md)
 - [Host Dependencies](users/host-dependencies.md)
 
 ### Maintainer Help

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -2,6 +2,15 @@
 
 **The latest version of this documentation is available on [GitHub](https://github.com/Microsoft/vcpkg/tree/master/docs/users/mingw.md).**
 
+*MinGW is community-supported and not tested as part of vcpkg repository's CI process.*
+
+## Table of Contents
+
+ - [Mingw-w64 community triplets](#Mingw-w64-community-triplets)
+ - [Using Mingw-w64 natively on Windows](#Using-Mingw-w64-natively-on-Windows)
+   - [How to avoid mixing different installations](#How-to-avoid-mixing-different-installations)
+ - [Using Mingw-w64 to build Windows programs on other systems](#Using-Mingw-w64-to-build-Windows-programs-on-other-systems)
+
 ## Mingw-w64 community triplets
 
 Vcpkg includes
@@ -100,9 +109,9 @@ try to keep the directories of the msys subsystem (`/usr/bin`, `bin`)
 out of the `PATH` environment variable as found by vcpkg. In bash, you
 may modify the `PATH` just for a single call of vcpkg:
 
-~~~
+```bash
 PATH="${PATH/:\/usr\/bin:\/bin:/:}" ./vcpkg install libpq
-~~~
+```
 
 Alternatively, you may run vcpkg from a regular Command Prompt, after
 adding *only* the desired mingw directory (e.g. `C:\msys64\mingw64\bin`)
@@ -133,7 +142,7 @@ might be older releases which lack some useful features or bug fixes.
 An alternative independent toolchain is offered by [MXE](https://mxe.cc/).
 
 For vcpkg bootstrapping, clone the github repository and run the
-bootstrap-vcpkg.sh script:
+`bootstrap-vcpkg.sh` script:
 
 ```bash
 git clone https://github.com/microsoft/vcpkg.git

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -41,7 +41,7 @@ must use a mingw subsystem of MSYS2, and install some packages
 | x64          | x64-mingw-dynamic, x64-mingw-static | mingw64   | mingw-w64-x86_64- |
 | x86          | x86-mingw-dynamic, x86-mingw-static | mingw32   | mingw-w64-i686-   |
 
-After the basic installation if MSYS2, you will need to install a few
+After the basic installation of MSYS2, you will need to install a few
 additional packages for software development, e.g. for x64:
 
 ```bash

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -1,24 +1,23 @@
-# Vcpkg and MinGW
+# Vcpkg and Mingw-w64
 
 **The latest version of this documentation is available on [GitHub](https://github.com/Microsoft/vcpkg/tree/master/docs/users/mingw.md).**
 
-## MinGW community triplets
+## Mingw-w64 community triplets
 
 Vcpkg includes
-[community triplets for MinGW](https://github.com/microsoft/vcpkg/tree/master/triplets/community)
-for x64, x86, arm64 and arm. They don't depend on Visual Studio and
+[x64, x86, arm64 and arm community triplets](https://github.com/microsoft/vcpkg/tree/master/triplets/community)
+for [Mingw-w64](http://mingw-w64.org/). They don't depend on Visual Studio and
 can be used natively on Windows as well as for cross-compiling on
 other operating systems. There are two variants of each triplet,
-selecting between static and dynamic linking:
+selecting between static and dynamic linking. The actual tools
+(g++ etc.) are expected to be named with particular prefixes.
 
-- arm64-mingw-dynamic
-- arm64-mingw-static
-- arm-mingw-dynamic
-- arm-mingw-static
-- x64-mingw-dynamic
-- x64-mingw-static
-- x86-mingw-dynamic
-- x86-mingw-static
+| architecture | vcpkg community triplets                | tool name prefix     |
+|--------------|-----------------------------------------|----------------------|
+| x64          | x64-mingw-dynamic, x64-mingw-static     | x86_64-w64-mingw32-  |
+| x86          | x86-mingw-dynamic, x86-mingw-static     | i686-w64-mingw32-    |
+| arm64        | arm64-mingw-dynamic, arm64-mingw-static | aarch64-w64-mingw32- |
+| arm          | arm-mingw-dynamic, arm-mingw-static     | armv7-w64-mingw32-   |
 
 These triplets are not tested by continuous integration, so many ports
 do not build, and even existing ports may break on port updates.
@@ -28,10 +27,10 @@ Because of this, community involvement is paramount!
 - [Open issues](https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+mingw)
 - [Open pull requests](https://github.com/microsoft/vcpkg/pulls?q=is%3Apr+is%3Aopen+mingw)
 
-## Using MinGW natively on Windows
+## Using Mingw-w64 natively on Windows
 
 With [MSYS2](https://www.msys2.org/), it is possible to easily create
-a full environment for building ports with MinGW on a Windows PC.
+a full environment for building ports with Mingw-w64 on a Windows PC.
 
 Note that for building software for native windows environments, you
 must use a mingw subsystem of MSYS2, and install some packages 
@@ -66,7 +65,7 @@ cd vcpkg
 ```
 
 For building packages, you need to tell vcpkg that you want to use the
-MinGW triplet. This can be done in different ways. When Visual Studio
+mingw triplet. This can be done in different ways. When Visual Studio
 is not installed, you must also set the host triplet to mingw. This is
 needed to resolve host dependencies. For convenience, you can use
 environment variables to set both triplets:
@@ -82,21 +81,21 @@ Now you can test your setup:
 ./vcpkg install zlib
 ```
 
-## Using MinGW to build Windows programs on other systems
+## Using Mingw-w64 to build Windows programs on other systems
 
 You can use the vcpkg mingw community triplets with toolchains on
 non-Windows computers to cross-compile software to be run on Windows.
 Many Linux distributions offer such toolchains in optional packages
-with a special [suffix](https://repology.org/projects/?search=-mingw-w64)
+with a mingw-w64 [suffix](https://repology.org/projects/?search=-mingw-w64)
 or [prefix](https://repology.org/projects/?search=mingw-w64-).
 As an example, for Debian-based distributions, you would start with
-these installation commands for the x64 targets:
+this installation command for the x64 toolchain:
 
 ```
 sudo apt-get install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 ```
 
-Note that the packaged versions of MinGW and GCC on Linux distributions
+Note that the packaged versions of Mingw-w64 toolchains on Linux distributions
 might be older releases which lack some useful features or bug fixes.
 An alternative independent toolchain is offered by [MXE](https://mxe.cc/).
 

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -49,7 +49,7 @@ additional packages for software development, e.g. for x64:
 pacman -S git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
 ```
 
-The active subsystem is select by running the MSYS2 MinGW app, or
+The active subsystem is selected by running the MSYS2 MinGW app, or
 changed in a running terminal by
 
 ```bash
@@ -89,7 +89,7 @@ non-Windows computers to cross-compile software to be run on Windows.
 Many Linux distributions offer such toolchains in optional packages
 with a special [suffix](https://repology.org/projects/?search=-mingw-w64)
 or [prefix](https://repology.org/projects/?search=mingw-w64-).
-As an example, for on Debian-based distributions, you would start with
+As an example, for Debian-based distributions, you would start with
 these installation commands for the x64 targets:
 
 ```

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -4,7 +4,7 @@
 
 ## MinGW community triplets
 
-vcpkg includes
+Vcpkg includes
 [community triplets for MinGW](https://github.com/microsoft/vcpkg/tree/master/triplets/community)
 for x64, x86, arm64 and arm. They don't depend on Visual Studio and
 can be used natively on Windows as well as for cross-compiling on
@@ -56,7 +56,7 @@ changed in a running terminal by
 source shell mingw64   # or mingw32
 ```
 
-The bootstrapping of vcpkg shall be done by running bootstrap_vcpkg.exe.
+The bootstrapping of vcpkg shall be done by running bootstrap-vcpkg.bat.
 This will download the official vcpkg.exe.
 
 ```bash
@@ -84,13 +84,25 @@ Now you can test your setup:
 
 ## Using MinGW to build Windows programs on other systems
 
-Many Linux distributions come with MinGW toolchains which allow to
-cross-compile software on Linux to be run on Windows. You can use
-such toolchains with vcpkg by setting the desired mingw triplet.
+You can use the vcpkg mingw community triplets with toolchains on
+non-Windows computers to cross-compile software to be run on Windows.
+Many Linux distributions offer such toolchains in optional packages
+with a special [suffix](https://repology.org/projects/?search=-mingw-w64)
+or [prefix](https://repology.org/projects/?search=mingw-w64-).
+As an example, for on Debian-based distributions, you would start with
+these installation commands for the x64 targets:
 
-Note that the pre-installed cmake might be too old for vcpkg.
+```
+sudo apt-get install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
+```
 
-For bootstrapping, clone the github repository and run the shell script:
+Note that the pre-installed cmake might be too old for vcpkg. Also the
+packaged versions of MinGW and GCC might be older releases which lack
+some useful features or bug fixes. An alternative independent toolchain
+is offered by [MXE](https://mxe.cc/).
+
+For vcpkg bootstrapping, clone the github repository and run the
+bootstrap-vcpkg.sh script:
 
 ```bash
 git clone https://github.com/microsoft/vcpkg.git

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -1,0 +1,101 @@
+# Vcpkg and MinGW
+
+**The latest version of this documentation is available on [GitHub](https://github.com/Microsoft/vcpkg/tree/master/docs/users/mingw.md).**
+
+## MinGW community triplets
+
+vcpkg includes
+[community triplets for MinGW](https://github.com/microsoft/vcpkg/tree/master/triplets/community)
+for x64, x86, arm64 and arm. They don't depend on Visual Studio and
+can be used natively on Windows as well as for cross-compiling on
+other operating systems. There are two variants of each triplet,
+selecting between static and dynamic linking:
+
+- arm64-mingw-dynamic
+- arm64-mingw-static
+- arm-mingw-dynamic
+- arm-mingw-static
+- x64-mingw-dynamic
+- x64-mingw-static
+- x86-mingw-dynamic
+- x86-mingw-static
+
+These triplets are not tested by continuous integration, so many ports
+do not build, and even existing ports may break on port updates.
+Because of this, community involvement is paramount!
+
+- [Discussions](https://github.com/microsoft/vcpkg/discussions?discussions_q=mingw)
+- [Open issues](https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+mingw)
+- [Open pull requests](https://github.com/microsoft/vcpkg/pulls?q=is%3Apr+is%3Aopen+mingw)
+
+## Using MinGW natively on Windows
+
+With [MSYS2](https://www.msys2.org/), it is possible to easily create
+a full environment for building ports with MinGW on a Windows PC.
+
+Note that for building software for native windows environments, you
+must use a mingw subsystem of MSYS2, and install some packages 
+(with a specific prefix) for this subsystem.
+
+| architecture | vcpkg triplets                      | subsystem | package prefix    |
+|--------------|-------------------------------------|-----------|-------------------|
+| x64          | x64-mingw-dynamic, x64-mingw-static | mingw64   | mingw-w64-x86_64- |
+| x86          | x86-mingw-dynamic, x86-mingw-static | mingw32   | mingw-w64-i686-   |
+
+After the basic installation if MSYS2, you will need to install a few
+additional packages for software development, e.g. for x64:
+
+```bash
+pacman -S git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+```
+
+The active subsystem is select by running the MSYS2 MinGW app, or
+changed in a running terminal by
+
+```bash
+source shell mingw64   # or mingw32
+```
+
+The bootstrapping of vcpkg shall be done by running bootstrap_vcpkg.exe.
+This will download the official vcpkg.exe.
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.bat
+```
+
+For building packages, you need to tell vcpkg that you want to use the
+MinGW triplet. This can be done in different ways. When Visual Studio
+is not installed, you must also set the host triplet to mingw. This is
+needed to resolve host dependencies. For convenience, you can use
+environment variables to set both triplets:
+
+```bash
+export VCPKG_DEFAULT_TRIPLET=x64-mingw-dynamic
+export VCPKG_DEFAULT_HOST_TRIPLET=x64-mingw-dynamic
+```
+
+Now you can test your setup:
+
+```bash
+./vcpkg install zlib
+```
+
+## Using MinGW to build Windows programs on other systems
+
+Many Linux distributions come with MinGW toolchains which allow to
+cross-compile software on Linux to be run on Windows. You can use
+such toolchains with vcpkg by setting the desired mingw triplet.
+
+Note that the pre-installed cmake might be too old for vcpkg.
+
+For bootstrapping, clone the github repository and run the shell script:
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg install zlib:x64-mingw-dynamic
+```
+

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -46,14 +46,14 @@ After the basic installation if MSYS2, you will need to install a few
 additional packages for software development, e.g. for x64:
 
 ```bash
-pacman -S git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+pacman -S --needed git base-devel mingw-w64-x86_64-toolchain
 ```
 
 The active subsystem is selected by running the MSYS2 MinGW app, or
 changed in a running terminal by
 
 ```bash
-source shell mingw64   # or mingw32
+source shell mingw64   # for x64, or "mingw32" for x86
 ```
 
 The bootstrapping of vcpkg shall be done by running bootstrap-vcpkg.bat.
@@ -96,10 +96,9 @@ these installation commands for the x64 targets:
 sudo apt-get install gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
 ```
 
-Note that the pre-installed cmake might be too old for vcpkg. Also the
-packaged versions of MinGW and GCC might be older releases which lack
-some useful features or bug fixes. An alternative independent toolchain
-is offered by [MXE](https://mxe.cc/).
+Note that the packaged versions of MinGW and GCC on Linux distributions
+might be older releases which lack some useful features or bug fixes.
+An alternative independent toolchain is offered by [MXE](https://mxe.cc/).
 
 For vcpkg bootstrapping, clone the github repository and run the
 bootstrap-vcpkg.sh script:

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -81,6 +81,39 @@ Now you can test your setup:
 ./vcpkg install zlib
 ```
 
+### How to avoid mixing different installations
+
+[The MSYS2 project explicitly warns](https://www.msys2.org/wiki/MSYS2-introduction/#path)
+that "mixing in programs from other MSYS2 installations, Cygwin installations,
+compiler toolchains or even various other programs is not supported and will
+probably break things in unexpected ways." For example, the proper passing of
+command line arguments with quoting and escaping may fail.
+
+But Vcpkg ports implicitly create MSYS2 installations, e.g. for `pkg-config`
+and for various other build tools needed to deal with packages based on
+autoconf. In particular, when ports prepend the directory of tools to the
+`PATH` environment variable, this may change which tool with a particular
+name is actually invoked, and how arguments are passed between tools.
+
+To mitigate such issues when working with a full MSYS2 installation,
+try to keep the directory of the msys subsystem (`/usr/bin`) out of the
+`PATH` environment variable as found by vcpkg. In bash, you may modify
+the `PATH` just for the call of vcpkg:
+
+~~~
+PATH="${PATH/:\/usr\/bin:/:}" ./vcpkg install libpq
+~~~
+
+Alternatively, you may run vcpkg from a regular Command Prompt, after
+adding *only* the desired mingw directory (e.g. `C:\msys64\mingw64\bin`)
+to the `PATH`.
+
+When using vcpkg for CI with standard images on Azure Pipelines, Github Actions
+or similar, note that the default `PATH` might contain more directories
+which create a mix of MSYS2 programs from different installations. You may
+want to set the desired `PATH` manually, or remove directories which contain
+`sh.exe`, `bash.exe`, `msys-2.0.dll` or `cygwin1.dll`.
+
 ## Using Mingw-w64 to build Windows programs on other systems
 
 You can use the vcpkg mingw community triplets with toolchains on

--- a/docs/users/mingw.md
+++ b/docs/users/mingw.md
@@ -96,12 +96,12 @@ autoconf. In particular, when ports prepend the directory of tools to the
 name is actually invoked, and how arguments are passed between tools.
 
 To mitigate such issues when working with a full MSYS2 installation,
-try to keep the directory of the msys subsystem (`/usr/bin`) out of the
-`PATH` environment variable as found by vcpkg. In bash, you may modify
-the `PATH` just for the call of vcpkg:
+try to keep the directories of the msys subsystem (`/usr/bin`, `bin`)
+out of the `PATH` environment variable as found by vcpkg. In bash, you
+may modify the `PATH` just for a single call of vcpkg:
 
 ~~~
-PATH="${PATH/:\/usr\/bin:/:}" ./vcpkg install libpq
+PATH="${PATH/:\/usr\/bin:\/bin:/:}" ./vcpkg install libpq
 ~~~
 
 Alternatively, you may run vcpkg from a regular Command Prompt, after

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -190,5 +190,5 @@ We recommend using a systematic naming scheme when creating new triplets. The An
 ## Android triplets
 See [android.md](android.md)
 
-## MinGW triplets
+## Mingw-w64 triplets
 See [mingw.md](mingw.md)

--- a/docs/users/triplets.md
+++ b/docs/users/triplets.md
@@ -189,3 +189,6 @@ We recommend using a systematic naming scheme when creating new triplets. The An
 
 ## Android triplets
 See [android.md](android.md)
+
+## MinGW triplets
+See [mingw.md](mingw.md)


### PR DESCRIPTION
This PR adds basic documentation for using vcpkg with mingw.

The instructions weren't tested line by line from scratch. But they are based on recent work with vcpkg.