### PR TITLE
[avisynthplus] Update to 3.7.0

### DIFF
--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -1,12 +1,10 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_LIBRARY_LINKAGE "static" ON_TARGET "UWP")
-
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AviSynth/AviSynthPlus
-    REF v3.6.1
-    SHA512 7104c334769aacf3b1c14491c2e0cdd6586d6ea68dae7d10e7955ac56c6277fe4ae189d30ebd161baeda80e65e80fc49d4b2aed476272dd1aa235e7c8f0209d9
+    REF v3.7.0
+    SHA512 0f2d5344c4472b810667b99d9e99a2ec8135923f4185dbd7e29ca65e696ce13500ea20ef09c995486573314149a671e1256a4dd0696c4ace8d3ec3716ffdcfc7
     HEAD_REF master
 )
 
@@ -18,6 +16,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(INSTALL ${SOURCE_PATH}/distrib/gpl.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -8,6 +8,16 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_download_distfile(GHC_ARCHIVE
+    URLS "https://github.com/gulrak/filesystem/archive/3f1c185ab414e764c694b8171d1c4d8c5c437517.zip"
+    FILENAME filesystem-3f1c185ab414e764c694b8171d1c4d8c5c437517.zip
+    SHA512 e3fe1e41b31f840ebc219fcd795e7be2973b80bb3843d6bb080786ad9e3e7f846a118673cb9e17d76bae66954e64e024a82622fb8cea7818d5d9357de661d3d1
+)
+
+file(REMOVE_RECURSE ${SOURCE_PATH}/filesystem)
+vcpkg_extract_source_archive(${GHC_ARCHIVE} ${SOURCE_PATH})
+file(RENAME ${SOURCE_PATH}/filesystem-3f1c185ab414e764c694b8171d1c4d8c5c437517 ${SOURCE_PATH}/filesystem)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/avisynthplus/vcpkg.json
+++ b/ports/avisynthplus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "avisynthplus",
-  "version-string": "3.6.1",
+  "version-string": "3.7.0",
   "description": "An improved version of the AviSynth frameserver, with improved features and developer friendliness",
   "homepage": "http://avs-plus.net/",
-  "supports": "!arm & !uwp & !static"
+  "supports": "!arm & !uwp"
 }

--- a/ports/avisynthplus/vcpkg.json
+++ b/ports/avisynthplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "avisynthplus",
-  "version-string": "3.7.0",
+  "version-semver": "3.7.0",
   "description": "An improved version of the AviSynth frameserver, with improved features and developer friendliness",
   "homepage": "http://avs-plus.net/",
   "supports": "!arm & !uwp"

--- a/versions/a-/avisynthplus.json
+++ b/versions/a-/avisynthplus.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c6fcfa304c80155f761128da54ffdf10f8863792",
-      "version-string": "3.7.0",
+      "git-tree": "3d573152a7d82faefcb525b1d6cf688a1465a71b",
+      "version-semver": "3.7.0",
       "port-version": 0
     },
     {

--- a/versions/a-/avisynthplus.json
+++ b/versions/a-/avisynthplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2a3310d35d1a195b32167130aaf76265f392a33",
+      "version-string": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "de073b58132bfad56e8b89ece1e9e4c995df607b",
       "version-string": "3.6.1",
       "port-version": 0

--- a/versions/a-/avisynthplus.json
+++ b/versions/a-/avisynthplus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e2a3310d35d1a195b32167130aaf76265f392a33",
+      "git-tree": "c6fcfa304c80155f761128da54ffdf10f8863792",
       "version-string": "3.7.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -205,7 +205,7 @@
       "port-version": 0
     },
     "avisynthplus": {
-      "baseline": "3.6.1",
+      "baseline": "3.7.0",
       "port-version": 0
     },
     "avro-c": {


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix?
Update AviSynth+ to 3.7.0.

- Which triplets are supported/not supported? Have you updated the CI baseline?
x64-windows-static is newly supported as upstream added static library support in 3.7.0. No need to update CI baseline.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.
