### PR TITLE
[ncurses] Add new port

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -1,0 +1,59 @@
+vcpkg_fail_port_install(ON_TARGET "Windows" "UWP")
+
+vcpkg_download_distfile(
+    ARCHIVE_PATH
+    URLS
+        "https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz"
+        "ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz"
+        "ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz"
+    FILENAME "ncurses-6.2.tgz"
+    SHA512 4c1333dcc30e858e8a9525d4b9aefb60000cfc727bc4a1062bace06ffc4639ad9f6e54f6bdda0e3a0e5ea14de995f96b52b3327d9ec633608792c99a1e8d840d
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE_PATH}
+)
+
+set(OPTIONS
+    --disable-db-install
+    --enable-pc-files
+    --without-manpages
+    --without-progs
+    --without-tack
+    --without-tests
+)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    list(APPEND OPTIONS
+        --with-shared
+        --with-cxx-shared
+        --without-normal
+    )
+endif()
+
+set(OPTIONS_DEBUG
+    --with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig
+    --with-debug
+)
+set(OPTIONS_RELEASE
+    --with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig
+    --without-debug
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS ${OPTIONS}
+    OPTIONS_DEBUG ${OPTIONS_DEBUG}
+    OPTIONS_RELEASE ${OPTIONS_RELEASE}
+    NO_ADDITIONAL_PATHS
+)
+vcpkg_install_make()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "ncurses",
+  "version-string": "6.2",
+  "description": "free software emulation of curses in System V Release 4.0",
+  "supports": "!(windows | uwp)"
+}

--- a/scripts/test_ports/cmake/portfile.cmake
+++ b/scripts/test_ports/cmake/portfile.cmake
@@ -10,6 +10,10 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
+if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_UWP)
+    set(BUILD_CURSES_DIALOG ON)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -26,6 +30,7 @@ vcpkg_configure_cmake(
         -DCMAKE_USE_SYSTEM_JSONCPP=ON
         -DCMAKE_USE_SYSTEM_LIBRHASH=OFF # not yet in VCPKG
         -DCMAKE_USE_SYSTEM_LIBUV=ON
+        -DBUILD_CursesDialog=${BUILD_CURSES_DIALOG}
         -DBUILD_QtDialog=ON # Just to test Qt with CMake
 )
 
@@ -36,6 +41,9 @@ if(NOT VCPKG_TARGET_IS_OSX)
     set(_tools cmake cmake-gui ctest cpack)
     if(VCPKG_TARGET_IS_WINDOWS)
         list(APPEND _tools cmcldeps)
+    endif()
+    if(BUILD_CURSES_DIALOG)
+        list(APPEND _tools ccmake)
     endif()
     vcpkg_copy_tools(TOOL_NAMES ${_tools} AUTO_CLEAN)
 else()

--- a/scripts/test_ports/cmake/vcpkg.json
+++ b/scripts/test_ports/cmake/vcpkg.json
@@ -11,6 +11,10 @@
     "libarchive",
     "liblzma",
     "libuv",
+    {
+      "name": "ncurses",
+      "platform": "!(windows | uwp)"
+    },
     "nghttp2",
     "qt5-base",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4176,6 +4176,10 @@
       "baseline": "2.4.6",
       "port-version": 0
     },
+    "ncurses": {
+      "baseline": "6.2",
+      "port-version": 0
+    },
     "neargye-semver": {
       "baseline": "0.2.2",
       "port-version": 0

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ab8de39c1659867da459ac0bec7e09bee5762819",
+      "version-string": "6.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds the port ncurses.

- What does your PR fix?
Fixes #7110
Fixes #17167
Closes #17164

- Which triplets are supported/not supported? Have you updated the CI baseline?
Windows (MSVC) is not supported.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes