### PR TITLE
[vcpkg] Add missing autoconf dependencies to osx provisioning

### DIFF
--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -12,10 +12,7 @@ APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
   libxcursor-dev yasm libnuma1 libnuma-dev python-six python3-six python-yaml \
   flex libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
-  pkg-config meson autopoint"
-
-# Required by libgpod
-APT_PACKAGES="$APT_PACKAGES gtk-doc-tools"
+  pkg-config meson"
 
 # Additionally required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -12,7 +12,7 @@ APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
   libxcursor-dev yasm libnuma1 libnuma-dev python-six python3-six python-yaml \
   flex libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
-  pkg-config meson"
+  pkg-config meson autopoint"
 
 # Additionally required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -14,6 +14,9 @@ APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
   pkg-config meson autopoint"
 
+# Required by libgpod
+APT_PACKAGES="$APT_PACKAGES gtk-doc-tools"
+
 # Additionally required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
   libxcb1-dev libx11-xcb-dev libxcb-glx0-dev libxcb-util0-dev"

--- a/scripts/azure-pipelines/osx/configuration/Vagrantfile
+++ b/scripts/azure-pipelines/osx/configuration/Vagrantfile
@@ -18,6 +18,7 @@ brew_formulas = [
   'autoconf',
   'automake',
   'bison',
+  'gettext',
   'gfortran',
   'gperf',
   'gtk-doc',

--- a/scripts/azure-pipelines/osx/configuration/Vagrantfile
+++ b/scripts/azure-pipelines/osx/configuration/Vagrantfile
@@ -20,6 +20,7 @@ brew_formulas = [
   'bison',
   'gfortran',
   'gperf',
+  'gtk-doc',
   'libtool',
   'meson',
   'mono',


### PR DESCRIPTION
- What does your PR fix?
  This PR is to install dependencies which are required by autoconf when building ports such as libtasn1 or libidn2. The lack of these dependencies breaks a number of PRs (e.g. #17215, #17205, #17137, #17098, #17057).

- Which triplets are supported/not supported? Have you updated the CI baseline?
  ~linux,~ osx

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  -/-