### PR TITLE
[catch2] Add patch to lower-case cmake config dir name

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,4 +1,5 @@
 Source: catch2
 Version: 2.13.1
+Port-Version: 1
 Description: A modern, header-only test framework for unit testing.
 Homepage: https://github.com/catchorg/Catch2

--- a/ports/catch2/lowercase-cmake-config-dir.patch
+++ b/ports/catch2/lowercase-cmake-config-dir.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b515105..c69c96e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -108,7 +108,7 @@ add_library(Catch2::Catch2 ALIAS Catch2)
+ # see https://github.com/catchorg/Catch2/issues/1373
+ if (NOT_SUBPROJECT)
+     include(CMakePackageConfigHelpers)
+-    set(CATCH_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Catch2")
++    set(CATCH_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/catch2")
+ 
+     configure_package_config_file(
+         ${CMAKE_CURRENT_LIST_DIR}/CMake/Catch2Config.cmake.in
+@@ -199,7 +199,7 @@ if (NOT_SUBPROJECT)
+         "contrib/gdbinit"
+         "contrib/lldbinit"
+       DESTINATION
+-        ${CMAKE_INSTALL_DATAROOTDIR}/Catch2
++        ${CMAKE_INSTALL_DATAROOTDIR}/catch2
+     )
+     endif()
+ 

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF fd9f5ac661f87335ecd70d39849c1d3a90f1c64d # v2.13.1
     SHA512 4fafd06006034cc02dddd22c381b5817549834dae0aff29ed598edd21a3c67f8ac61a77f51b06f3c59baa96a114ecb19c6df09126215bfc00bef94f8f77b810d
     HEAD_REF master
+    PATCHES
+        lowercase-cmake-config-dir.patch
 )
 
 vcpkg_configure_cmake(
@@ -16,7 +18,7 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/catch2)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1110,7 +1110,7 @@
     },
     "catch2": {
       "baseline": "2.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e-1",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d58b238b2ed75f9497db8f301295e53787c23479",
+      "version-string": "2.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "519a6fcb84ac66fdffb75f3d5555496228e43e5f",
       "version-string": "2.13.1",
       "port-version": 0


### PR DESCRIPTION
Otherwise on Linux there will be both share/Catch2 and
share/catch2 and when developing on Windows inside a Linux
dev-container, installation in the mapped file system fails in
vcpkg_fixup_targets() because vcpkg is trying to make the directory
share/cmake/catch2 but share/cmake/Catch2 already exists.

**Describe the pull request**

- What does your PR fix? Fixes #17228

- Which triplets are supported/not supported? Have you updated the CI baseline? N/A

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? to the best of my knowledge...
