### PR TITLE
[minizip-ng] Modify the output include path of the header file

### DIFF
--- a/ports/minizip-ng/Modify-header-file-path.patch
+++ b/ports/minizip-ng/Modify-header-file-path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ef8023..ec1ee55 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,7 +81,7 @@ include(FeatureSummary)
+ 
+ set(INSTALL_BIN_DIR ${CMAKE_INSTALL_FULL_BINDIR} CACHE PATH "Installation directory for executables")
+ set(INSTALL_LIB_DIR ${CMAKE_INSTALL_FULL_LIBDIR} CACHE PATH "Installation directory for libraries")
+-set(INSTALL_INC_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR} CACHE PATH "Installation directory for headers")
++set(INSTALL_INC_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR}/minizip-ng CACHE PATH "Installation directory for headers")
+ set(INSTALL_MAN_DIR ${CMAKE_INSTALL_FULL_MANDIR} CACHE PATH "Installation directory for manual pages")
+ 
+ set(STDLIB_DEF)

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 3.0.1
     SHA512 98c9bdcea79a88a2dd69cec6c49f8565edf78ab9cddbf0e85e08b049b300b187f176bf57d5a894bf777bec0a097e46ecc05f78dab9cd5726fd473ffd8718dce0
     HEAD_REF master
+    PATCHES Modify-header-file-path.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "3.0.1",
+  "port-version": 1,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3946,7 +3946,7 @@
     },
     "minizip-ng": {
       "baseline": "3.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "mio": {
       "baseline": "2019-02-10",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3f833fb14771ffd8f32496aa12035c86ab1cb9a",
+      "version": "3.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "0512bceae574c70ea907a8ebfc88709dc196164e",
       "version": "3.0.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
On CI unstable test, `minizip-ng` failed with the following errors:

```
The following files are already installed in D:/installed/x64-windows and are in conflict with minizip-ng:x64-windows

Installed by libzip:x64-windows
    include/zip.h
```

Since there is no relationship between `libzip` and `minizip-ng`, and the content of the generated zip.h file is not the same.
So modify the output include path of `minizip-ng` from `include` to `include/minizip-ng` to avoid the conflicts.

Note: No feature needs to test.
