### PR TITLE
 [libwebsockets] Update dependency

### DIFF
--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,17 +1,14 @@
 {
   "name": "libwebsockets",
   "version-semver": "4.1.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://github.com/warmcat/libwebsockets",
   "supports": "!(arm | uwp)",
   "dependencies": [
     "libuv",
     "openssl",
-    {
-      "name": "pthreads",
-      "platform": "!windows"
-    },
+    "pthreads",
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3610,7 +3610,7 @@
     },
     "libwebsockets": {
       "baseline": "4.1.6",
-      "port-version": 1
+      "port-version": 2
     },
     "libxdiff": {
       "baseline": "0.23",

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa509ae21580082ef8aea72e394bb7005f689371",
+      "version-semver": "4.1.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "1846ac46a72330104a9a4c13042cdb19ae8a42c4",
       "version-semver": "4.1.6",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17202

`pthreads `is also required on Windows platform, so remove the platform conditions for `pthreads` in dependency lists.

Note: No feature needs to test.
