### PR TITLE
[vcpkg] Fix the wrong slash

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -45,7 +45,7 @@ while (!($vcpkgRootDir -eq "") -and !(Test-Path "$vcpkgRootDir\.vcpkg-root"))
 
 Write-Verbose "Examining $vcpkgRootDir for .vcpkg-root - Found"
 
-& "$scriptsDir/tls12-download.exe" github.com "/microsoft/vcpkg-tool/releases/download/2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e/vcpkg.exe" "$vcpkgRootDir/vcpkg.exe"
+& "$scriptsDir/tls12-download.exe" github.com "/microsoft/vcpkg-tool/releases/download/2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e/vcpkg.exe" "$vcpkgRootDir\vcpkg.exe"
 Write-Host ""
 
 if ($LASTEXITCODE -ne 0)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/17255

Fix the wrong slash in bootstrap.

Previously:
```
Downloading https://github.com/microsoft/vcpkg-tool/releases/download/2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e/vcpkg.exe -> F:\PhoebeHui\vcpkg/vcpkg.exe
```
Currently:
```
Downloading https://github.com/microsoft/vcpkg-tool/releases/download/2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e/vcpkg.exe -> F:\PhoebeHui\vcpkg\vcpkg.exe
```