### PR TITLE
[catch2] Fix share/catch2 directory name conflict

### DIFF
--- a/ports/catch2/CONTROL
+++ b/ports/catch2/CONTROL
@@ -1,4 +1,5 @@
 Source: catch2
 Version: 2.13.1
+Port-Version: 1
 Description: A modern, header-only test framework for unit testing.
 Homepage: https://github.com/catchorg/Catch2

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -16,13 +16,16 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/Catch2" "${CURRENT_PACKAGES_DIR}/share/catch2")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/Catch2" "${CURRENT_PACKAGES_DIR}/debug/share/catch2")
+
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Catch2)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
-if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp)
+if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp")
     message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
 endif()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/catch.hpp "#include <catch2/catch.hpp>")
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/catch.hpp" "#include <catch2/catch.hpp>")
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1110,7 +1110,7 @@
     },
     "catch2": {
       "baseline": "2.13.1",
-      "port-version": 0
+      "port-version": 1
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e-1",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47ba2c2a9ed12b317550ed102374cd13554fe9ac",
+      "version-string": "2.13.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "519a6fcb84ac66fdffb75f3d5555496228e43e5f",
       "version-string": "2.13.1",
       "port-version": 0


### PR DESCRIPTION
Catch2 installs into share/Catch2/ and lib/cmake/Catch2.
The vcpkg_fixup_cmake_targets() function tries to move the contents from
the latter directory to share/catch2, i.e. differing in case w.r.t. the
former.

On Linux this results in both names being present. On pure Windows the
first name "wins". It breaks in a Linux Docker container where the
installation root is located on a bound directory that is on a
case-insensitive file system, such as from a host running Windows.

- #### What does your PR fix?  
  Fixes: #17228.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  `N/A`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `to the best of my knowledge...`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`
