### PR TITLE
Add missing autoconf dependencies to Linux provisioning

### DIFF
--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -12,7 +12,10 @@ APT_PACKAGES="at curl unzip tar libxt-dev gperf libxaw7-dev cifs-utils \
   libxcursor-dev yasm libnuma1 libnuma-dev python-six python3-six python-yaml \
   flex libbison-dev autoconf libudev-dev libncurses5-dev libtool libxrandr-dev \
   xutils-dev dh-autoreconf autoconf-archive libgles2-mesa-dev ruby-full \
-  pkg-config meson"
+  pkg-config meson autopoint"
+
+# Required by libgpod
+APT_PACKAGES="$APT_PACKAGES gtk-doc-tools"
 
 # Additionally required by qt5-base
 APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \


### PR DESCRIPTION
- #### What does your PR fix?  
This PR is to install dependencies which are required by autoconf when building ports such as libtasn1 or libidn2. The lack of these dependencies breaks a number of PRs (e.g. #17215, #17205, #17137, #17098, #17057).
It is broken out of #17227 (which is osx only now)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  linux, -/-

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  -/-

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  -/-
