### PR TITLE
[fontconfig] Don't require uuid port for mingw

### DIFF
--- a/ports/fontconfig/CONTROL
+++ b/ports/fontconfig/CONTROL
@@ -1,6 +1,6 @@
 Source: fontconfig
 Version: 2.13.1
-Port-Version: 5
+Port-Version: 6
 Homepage: https://www.freedesktop.org/software/fontconfig/front.html
 Description: Library for configuring and customizing font access.
-Build-Depends: freetype, expat, libiconv, dirent, pthread, json-c, libuuid (!windows&!osx), gettext
+Build-Depends: freetype, expat, libiconv, dirent, pthread, json-c, libuuid (!windows&!osx&!mingw), gettext

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2026,7 +2026,7 @@
     },
     "fontconfig": {
       "baseline": "2.13.1",
-      "port-version": 5
+      "port-version": 6
     },
     "foonathan-memory": {
       "baseline": "2019-07-21-1",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b2332fd4b819725ae740da7023098294a7da7e8",
+      "version-string": "2.13.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "de83a21d912d9b87d8ad069d94dffcca201830a3",
       "version-string": "2.13.1",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixes a failing dependency of fontconfig on mingw: The libuuid port is `linux|osx`. On mingw as on a regular windows, there is a static uuid system library.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  mingw, -/-.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

(There is another fontconfig mingw issue due to the pthread dependency but I would like to resolve this there.)