### PR TITLE
[ffmpeg] soxr dependency fix

### DIFF
--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
 Version: 4.3.2
-Port-Version: 7
+Port-Version: 8
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -155,7 +155,7 @@ Build-Depends: snappy
 Description: Snappy compression, needed for hap encoding
 
 Feature: soxr
-Build-Depends: soxr
+Build-Depends: soxr, ffmpeg[core,swresample]
 Description: Include libsoxr resampling
 
 Feature: speex

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1950,7 +1950,7 @@
     },
     "ffmpeg": {
       "baseline": "4.3.2",
-      "port-version": 7
+      "port-version": 8
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "297aff4ad5a5110a5cb3cf6a118152722f2239ec",
+      "version-string": "4.3.2",
+      "port-version": 8
+    },
+    {
       "git-tree": "bb3d01a7b00d6fe90592750d48e18049eb93215d",
       "version-string": "4.3.2",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix? Fixes #17270 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Triplets unchanged, baseline updated.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes to the best of my knowledge.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
