### PR TITLE
[CGAL] Fix the configuration file

### DIFF
--- a/ports/cgal/CONTROL
+++ b/ports/cgal/CONTROL
@@ -1,6 +1,6 @@
 Source: cgal
 Version: 5.2
-Port-Version: 2
+Port-Version: 3
 Build-Depends: mpfr, gmp, zlib, boost-accumulators, boost-algorithm, boost-bimap, boost-callable-traits, boost-concept-check, boost-container, boost-core, boost-detail, boost-filesystem, boost-functional, boost-fusion, boost-geometry, boost-graph, boost-heap, boost-intrusive, boost-iostreams, boost-iterator, boost-lambda, boost-logic, boost-math, boost-mpl, boost-multi-index, boost-multiprecision, boost-numeric-conversion, boost-optional, boost-parameter, boost-pool, boost-preprocessor, boost-property-map, boost-property-tree, boost-ptr-container, boost-random, boost-range, boost-serialization, boost-spirit, boost-thread, boost-tuple, boost-type-traits, boost-units, boost-utility, boost-variant
 Homepage: https://github.com/CGAL/cgal
 Description: The Computational Geometry Algorithms Library (CGAL) is a C++ library that aims to provide easy access to efficient and reliable algorithms in computational geometry.

--- a/ports/cgal/portfile.cmake
+++ b/ports/cgal/portfile.cmake
@@ -41,8 +41,6 @@ else()
     endforeach()
 endif()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/lib/cgal/CGALConfig.cmake "include (\$\{CMAKE_CURRENT_LIST_DIR\}/../../share/cgal/CGALConfig.cmake)")
-
 file(INSTALL ${SOURCE_PATH}/Installation/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 file(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1150,7 +1150,7 @@
     },
     "cgal": {
       "baseline": "5.2",
-      "port-version": 2
+      "port-version": 3
     },
     "cgicc": {
       "baseline": "3.2.19-4",

--- a/versions/c-/cgal.json
+++ b/versions/c-/cgal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14e2dc513d60c6c31b5fd94c6e891ac33fcb328f",
+      "version-string": "5.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "6d5aeedca6a3ace515272f0d3a1fc150efde9076",
       "version-string": "5.2",
       "port-version": 2


### PR DESCRIPTION
Remove the creation of the `/lib/cgal/CGALConfig.cmake` file, to only keep the right installation in `share/cgal`.

- #### What does your PR fix?  
It will at least fix the missing definition for PACKAGE_VERSION in cmake.

