### PR TITLE
[gettext] Add "autopoint" tool to gettext[core]

### DIFF
--- a/ports/gettext/install-autopoint.cmake
+++ b/ports/gettext/install-autopoint.cmake
@@ -1,0 +1,49 @@
+function(install_autopoint)
+    # variables for configuring autopoint.in
+    set(PACKAGE "gettext-tools")
+    set(VERSION "${GETTEXT_VERSION}")
+    set(ARCHIVE_VERSION "${GETTEXT_VERSION}")
+    set(ARCHIVE_FORMAT "dirgz")
+    set(bindir [[${prefix}/tools/gettext/bin]])
+    set(datadir [[${datarootdir}]])
+    set(exec_prefix [[${prefix}]])
+    set(PATH_SEPARATOR ":")
+    set(RELOCATABLE "yes")
+
+    file(STRINGS "${SOURCE_PATH}/gettext-tools/configure"
+        VERSIONS_FROM_CONFIGURE
+        REGEX "^ *(ARCHIVE_VERSION|VERSION)=.*$"
+    )
+    foreach(LINE IN LISTS VERSIONS_FROM_CONFIGURE)
+        if(LINE MATCHES "^ *(ARCHIVE_VERSION|VERSION)='?([0-9.]+)'?$")
+            set(${CMAKE_MATCH_1} "${CMAKE_MATCH_2}")
+        endif()
+    endforeach()
+
+    set(WORKING_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")
+    file(MAKE_DIRECTORY "${WORKING_DIR}")
+
+    # autopoint script
+    configure_file("${SOURCE_PATH}/gettext-tools/misc/autopoint.in" "${WORKING_DIR}/autopoint" @ONLY)
+
+    # data tarball
+    if(WIN32)
+        vcpkg_acquire_msys(MSYS_ROOT PACKAGES gzip)
+        vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+    endif()
+    file(COPY "${SOURCE_PATH}/gettext-tools/misc/archive.dir.tar" DESTINATION "${WORKING_DIR}")
+    vcpkg_execute_required_process(
+        COMMAND gzip -f archive.dir.tar
+        WORKING_DIRECTORY "${WORKING_DIR}"
+        LOGNAME gzip-${TARGET_TRIPLET}
+    )
+
+    # installation
+    file(INSTALL "${WORKING_DIR}/autopoint" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin"
+      FILE_PERMISSIONS
+        OWNER_WRITE OWNER_READ OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+    )
+    file(INSTALL "${WORKING_DIR}/archive.dir.tar.gz" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gettext/gettext")
+endfunction()

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -1,13 +1,7 @@
-if(VCPKG_TARGET_IS_LINUX)
-    if (NOT EXISTS "/usr/include/libintl.h")
-        message(FATAL_ERROR "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
-                            "Please use \"sudo apt-get install libc-dev\" or the equivalent to install development files."
-        )
-    endif()
-    if(NOT "tools" IN_LIST FEATURES)
-        set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
-        return()
-    endif()
+if(VCPKG_TARGET_IS_LINUX AND NOT EXISTS "/usr/include/libintl.h")
+    message(FATAL_ERROR "When targeting Linux, `libintl.h` is expected to come from the C Runtime Library (glibc). "
+                        "Please use \"sudo apt-get install libc-dev\" or the equivalent to install development files."
+    )
 endif()
 
 set(VCPKG_POLICY_ALLOW_RESTRICTED_HEADERS enabled)
@@ -134,8 +128,15 @@ if("tools" IN_LIST FEATURES)
         file(RENAME "${CURRENT_PACKAGES_DIR}.release" "${CURRENT_PACKAGES_DIR}")
     endif()
 else()
-    list(APPEND OPTIONS "--config-cache")
-    build_libintl_only()
+    if(VCPKG_TARGET_IS_LINUX)
+        set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    else()
+        list(APPEND OPTIONS "--config-cache")
+        build_libintl_only()
+    endif()
+    # A fast installation of the autopoint tool and data, needed for autotools
+    include("${CMAKE_CURRENT_LIST_DIR}/install-autopoint.cmake")
+    install_autopoint()
 endif()
 
 # Handle copyright

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 4,
-  "description": "The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.",
+  "port-version": 5,
+  "description": "GNU gettext provides libintl and a set of tools to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [
     "libiconv"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2266,7 +2266,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 4
+      "port-version": 5
     },
     "gettimeofday": {
       "baseline": "2017-10-14-3",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1089dfcf335a94ca47c5b918c56a7ab6fc0ae92",
+      "version": "0.21",
+      "port-version": 5
+    },
+    {
       "git-tree": "b6cde01ab4095a258993eaf85eb31c1e845c64a6",
       "version": "0.21",
       "port-version": 4


### PR DESCRIPTION
"autopoint" is needed for building some packages, when running `autoreconf`. It is included in the "tools" feature of gettext, but this feature has a longer buildtime, and only a tiny part of this feature is actually needed.

- #### What does your PR fix?  
  ~This PR adds an explicit "autopoint" feature to gettext. Other than the slow build of "tools", it uses a custom cmake script to create the output.~
  ~In addition, it updates the libidn2 port to use this feature, resolving #17057.~
  ~It is an alternative to adding to adding autopoint to CI provisioning. Related discussion is in #17227.~
  This PR adds a lightweight (cmake-based) installation of `autopoint` to the core feature of gettext. This makes it available for the autoconf step of all ports that use gettext at runtime.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, -/-

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
