### PR TITLE
[vcpkg baseline][marble] Disable find I18n

### DIFF
--- a/ports/marble/CONTROL
+++ b/ports/marble/CONTROL
@@ -1,6 +1,0 @@
-Source: marble
-Version: 19.08.2
-Homepage: https://marble.kde.org
-Description: Marble KDE library
-Supports: windows & x64 & !static
-Build-Depends: qt5-base, qt5-svg, qt5-quickcontrols, qt5-webchannel

--- a/ports/marble/portfile.cmake
+++ b/ports/marble/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_I18n=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/marble/vcpkg.json
+++ b/ports/marble/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "marble",
+  "version-string": "19.08.2",
+  "port-version": 1,
+  "description": "Marble KDE library",
+  "homepage": "https://marble.kde.org",
+  "supports": "windows & x64 & !static",
+  "dependencies": [
+    "qt5-base",
+    "qt5-quickcontrols",
+    "qt5-svg",
+    "qt5-webchannel"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3822,7 +3822,7 @@
     },
     "marble": {
       "baseline": "19.08.2",
-      "port-version": 0
+      "port-version": 1
     },
     "marl": {
       "baseline": "2020-10-10",

--- a/versions/m-/marble.json
+++ b/versions/m-/marble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "753693b3e64d7baedd61a8f57b62e467267bc741",
+      "version-string": "19.08.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "6da05bd09e0eb41ee05e3269fab2283c5dab2d4c",
       "version-string": "19.08.2",
       "port-version": 0


### PR DESCRIPTION
Configure error when building marble:x64-windows on pipeline test:
```
CMake Error at D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find Gettext (missing: GETTEXT_MSGMERGE_EXECUTABLE
  GETTEXT_MSGFMT_EXECUTABLE)
Call Stack (most recent call first):
  D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:582 (_FPHSA_FAILURE_MESSAGE)
  D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindGettext.cmake:81 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  D:/installed/x64-windows/share/kf5i18n/KF5I18nMacros.cmake:5 (find_package)
  D:/installed/x64-windows/share/kf5i18n/KF5I18nConfig.cmake:33 (include)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  D:/installed/x64-windows/share/ECM/find-modules/FindKF5.cmake:53 (find_package)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  MarbleMacros.cmake:124 (find_package)
  src/apps/marble-kde/CMakeLists.txt:14 (macro_optional_find_package)
```

Fixes #17340.