### PR TITLE
[cudnn] add other locations to find lib already installed

### DIFF
--- a/ports/cudnn/CONTROL
+++ b/ports/cudnn/CONTROL
@@ -1,5 +1,6 @@
 Source: cudnn
 Version: 7.6.5
+Port-Version: 1
 Description: NVIDIA's cuDNN deep neural network acceleration library
 Build-Depends: cuda
 Supports: (windows|linux)&x64

--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -25,10 +25,10 @@
 include(FindPackageHandleStandardArgs)
 
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
+  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
   PATH_SUFFIXES cuda/include include)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
+  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)

--- a/ports/cudnn/FindCUDNN.cmake
+++ b/ports/cudnn/FindCUDNN.cmake
@@ -25,10 +25,10 @@
 include(FindPackageHandleStandardArgs)
 
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR}
+  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
   PATH_SUFFIXES cuda/include include)
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR}
+  HINTS ${CUDA_HOME} ${CUDA_PATH} ${CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -13,11 +13,11 @@ set(MINIMUM_CUDNN_VERSION "7.6.5")
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
+  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
   PATH_SUFFIXES cuda/include include)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
+  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -11,13 +11,16 @@ set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # only release bits are 
 
 set(MINIMUM_CUDNN_VERSION "7.6.5")
 
+include(${CURRENT_INSTALLED_DIR}/share/cuda/vcpkg_find_cuda.cmake)
+vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VERSION)
+
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
   PATH_SUFFIXES cuda/include include)
 message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
+  HINTS ${CUDA_TOOLKIT_ROOT} $ENV{CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
 message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
@@ -65,9 +68,6 @@ if (CUDNN_INCLUDE_DIR AND CUDNN_LIBRARY AND _CUDNN_VERSION VERSION_GREATER_EQUAL
 else()
   set(CUDNN_FOUND FALSE)
 endif()
-
-include(${CURRENT_INSTALLED_DIR}/share/cuda/vcpkg_find_cuda.cmake)
-vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT OUT_CUDA_VERSION CUDA_VERSION)
 
 # Download CUDNN if not found
 if (CUDNN_FOUND)

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -13,11 +13,13 @@ set(MINIMUM_CUDNN_VERSION "7.6.5")
 
 # Try to find CUDNN if it exists; only download if it doesn't exist
 find_path(CUDNN_INCLUDE_DIR NAMES cudnn.h cudnn_v8.h cudnn_v7.h
-  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR}
+  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/include
   PATH_SUFFIXES cuda/include include)
+message(STATUS "CUDNN_INCLUDE_DIR: ${CUDNN_INCLUDE_DIR}")
 find_library(CUDNN_LIBRARY NAMES cudnn cudnn8 cudnn7
-  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR}
+  HINTS ${CUDA_HOME} ${CUDA_PATH} $ENV{CUDA_TOOLKIT_ROOT_DIR} $ENV{cudnn} $ENV{CUDNN} $ENV{CUDNN_ROOT_DIR} /usr/lib/x86_64-linux-gnu/
   PATH_SUFFIXES lib lib64 cuda/lib cuda/lib64 lib/x64)
+message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
 if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn.h")
   file(READ ${CUDNN_INCLUDE_DIR}/cudnn.h CUDNN_HEADER_CONTENTS)
 elseif(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_v8.h")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1526,7 +1526,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 0
+      "port-version": 1
     },
     "cunit": {
       "baseline": "2.1.3-6",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28746f8bce3e6e4fcd37eb050877b66e4ec31e22",
+      "git-tree": "adb739692bd28713a0a88ad48548c877a3df895d",
       "version-string": "7.6.5",
       "port-version": 1
     },

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28746f8bce3e6e4fcd37eb050877b66e4ec31e22",
+      "version-string": "7.6.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "681f177cf063d3c8e655a18011c158ffad49fdbd",
       "version-string": "7.6.5",
       "port-version": 0

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "adb739692bd28713a0a88ad48548c877a3df895d",
+      "git-tree": "495cc586b4bfdb28c3c339d3f471b9fbfc8bc481",
       "version-string": "7.6.5",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17283 
  Without this PR, CUDNN cannot be found in some default linux folders when installed with apt-get. Also, moved all reasonable variables to ENV, since CMake has to look for them, otherwise they are unuseful

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
