### PR TITLE
[opencv4] Fix OPTIONS BUILD_opencv_gapi

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -375,7 +375,7 @@ vcpkg_configure_cmake(
         -DBUILD_opencv_dnn=${BUILD_opencv_dnn}
         ###### The following modules are disabled for UWP
         -DBUILD_opencv_quality=${BUILD_opencv_quality}
-        -DBUILD_opencv_gapi=${DBUILD_opencv_gapi}
+        -DBUILD_opencv_gapi=${BUILD_opencv_gapi}
         ###### The following module is disabled because it's broken #https://github.com/opencv/opencv_contrib/issues/2307
         -DBUILD_opencv_rgbd=OFF
         ###### Additional build flags

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.1",
+  "port-version": 1,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4450,7 +4450,7 @@
     },
     "opencv4": {
       "baseline": "4.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "opendnp3": {
       "baseline": "3.1.0",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c719098632c388044e4cd242a1f5276e81727466",
+      "version": "4.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "ba505df8f61764e9b4667b04958c748237d12d23",
       "version": "4.5.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17345

https://github.com/microsoft/vcpkg/blob/414bec05f2a97cfc0ddb8e22fd4635dfe2a20ab8/ports/opencv4/portfile.cmake#L378

Fix this as `-DBUILD_opencv_gapi=${BUILD_opencv_gapi}`.