### PR TITLE
[hdf5] threadsafe support

### DIFF
--- a/ports/hdf5/CONTROL
+++ b/ports/hdf5/CONTROL
@@ -1,5 +1,6 @@
 Source: hdf5
 Version: 1.12.0
+Port-Version: 1
 Homepage: https://www.hdfgroup.org/downloads/hdf5/
 Description: HDF5 is a data model, library, and file format for storing and managing data
 Default-Features: szip, zlib
@@ -26,4 +27,8 @@ Build-Depends: zlib
 Feature: fortran
 Description: Build with fortran
 Build-Depends: 
+
+Feature: threadsafe
+Description: thread safety for HDF5
+Build-Depends: pthreads
 

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -30,6 +30,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
      szip         HDF5_ENABLE_SZIP_ENCODING
      zlib         HDF5_ENABLE_Z_LIB_SUPPORT
      fortran      HDF5_BUILD_FORTRAN
+     threadsafe   HDF5_ENABLE_THREADSAFE 
 )
 
 file(REMOVE ${SOURCE_PATH}/config/cmake_ext_mod/FindSZIP.cmake)#Outdated; does not find debug szip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2422,7 +2422,7 @@
     },
     "hdf5": {
       "baseline": "1.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "healpix": {
       "baseline": "1.12.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "44e842d3e953523fb313d56e4af9bb51af40e507",
+      "git-tree": "702697dde6af133b36ea056ffb5d99f83d09a86d",
       "version-string": "1.12.0",
       "port-version": 1
     },

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -3,6 +3,11 @@
     {
       "git-tree": "44e842d3e953523fb313d56e4af9bb51af40e507",
       "version-string": "1.12.0",
+      "port-version": 1
+    },
+    {
+      "git-tree": "44e842d3e953523fb313d56e4af9bb51af40e507",
+      "version-string": "1.12.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
- #### What does your PR fix?  
fixes #17260

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
no changes to support - updated baseline for port version.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes

