### PR TITLE
[openssl/unix] Run `make` with 'VCPKG_CONCURRENCY' parallelism

### DIFF
--- a/ports/openssl/CONTROL
+++ b/ports/openssl/CONTROL
@@ -1,5 +1,5 @@
 Source: openssl
 Version: 1.1.1j
-Port-Version: 1
+Port-Version: 2
 Homepage: https://www.openssl.org
 Description: OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.

--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -178,7 +178,7 @@ add_custom_command(
 add_custom_target(build_libs ALL
     COMMAND ${ENV_COMMAND} "PATH=${MSYS_BIN_DIR}${PATH_VAR}"
     COMMAND "${CMAKE_COMMAND}" -E touch "${BUILDDIR}/krb5.h"
-    COMMAND "${MAKE}" build_libs
+    COMMAND "${MAKE}" -j ${VCPKG_CONCURRENCY} build_libs
     VERBATIM
     WORKING_DIRECTORY "${BUILDDIR}"
     DEPENDS "${BUILDDIR}/Makefile"

--- a/ports/openssl/unix/portfile.cmake
+++ b/ports/openssl/unix/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
         -DSOURCE_PATH=${MASTER_COPY_SOURCE_PATH}
         -DPERL=${PERL}
         -DMAKE=${MAKE}
+        -DVCPKG_CONCURRENCY=${VCPKG_CONCURRENCY}
     OPTIONS_RELEASE
         -DINSTALL_HEADERS=ON
 )

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4522,7 +4522,7 @@
     },
     "openssl": {
       "baseline": "1.1.1j",
-      "port-version": 1
+      "port-version": 2
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "47f6dd2398634984759b609529bf35482957da54",
+      "version-string": "1.1.1j",
+      "port-version": 2
+    },
+    {
       "git-tree": "2695b5d292f012836d962b22293d4dc081f75bff",
       "version-string": "1.1.1j",
       "port-version": 1


### PR DESCRIPTION
This PR modifies the `openssl/unix` port to invoke `make` with `-j ${VCPKG_CONCURRENCY}` to enable parallel builds.

As called out in the Issue, I see significant improvements in build times: building `openssl:arm-android` goes from ~12 minutes, to ~2 minutes. In our cloud build, the build goes from ~18 minutes to ~4 minutes.

- #### What does your PR fix?  
Fixes #17267.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
