### PR TITLE
[flashlight-cpu] Update port to v0.3

### DIFF
--- a/ports/flashlight-cpu/portfile.cmake
+++ b/ports/flashlight-cpu/portfile.cmake
@@ -6,7 +6,7 @@ endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO facebookresearch/flashlight
+    REPO flashlight/flashlight
     REF 76f7fa7f5a162c73d6bf8befdb8e197a4dc7515d # 0.3 branch tip
     SHA512 87786f9443d27ac9b513cf582caea13dccfa344e55a4970c0c2c7df7530260ad38cc578690ebf2fa256e8ea943abea547e0e6d5ee0ba090b336c4f7af8d2f53f
     HEAD_REF master

--- a/ports/flashlight-cpu/portfile.cmake
+++ b/ports/flashlight-cpu/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO facebookresearch/flashlight
-    REF 81c4d8d5ea57e9ceaa6db3b17f0861491fd31383
-    SHA512 988da269be81f7b4897d72e52683259f4223029b5012150958b9b21c7103fe49a2458ffa5623ed53c125a98f7294541af46cd68b17e9213269e5a2aecfaabb67
+    REF 76f7fa7f5a162c73d6bf8befdb8e197a4dc7515d # 0.3 branch tip
+    SHA512 87786f9443d27ac9b513cf582caea13dccfa344e55a4970c0c2c7df7530260ad38cc578690ebf2fa256e8ea943abea547e0e6d5ee0ba090b336c4f7af8d2f53f
     HEAD_REF master
 )
 
@@ -30,6 +30,7 @@ vcpkg_check_features(
     asr FL_BUILD_APP_ASR
     imgclass FL_BUILD_APP_IMGCLASS
     lm FL_BUILD_APP_LM
+    objdet FL_BUILD_APP_OBJDET
 )
 
 # Build and install
@@ -48,7 +49,11 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 # Binaries/tools
 set(FLASHLIGHT_TOOLS "")
 if ("imgclass" IN_LIST FEATURES)
-  list(APPEND FLASHLIGHT_TOOLS fl_img_imagenet_resnet34)
+  list(APPEND FLASHLIGHT_TOOLS
+    fl_img_imagenet_resnet34
+    fl_img_imagenet_eval
+    fl_img_imagenet_vit
+  )
 endif()
 if ("asr" IN_LIST FEATURES)
   list(APPEND FLASHLIGHT_TOOLS
@@ -57,10 +62,15 @@ if ("asr" IN_LIST FEATURES)
     fl_asr_decode
     fl_asr_align
     fl_asr_voice_activity_detection_ctc
+    fl_asr_arch_benchmark
   )
 endif()
 if ("lm" IN_LIST FEATURES)
-  list(APPEND FLASHLIGHT_TOOLS fl_lm_train fl_lm_dictionary_builder)
+  list(APPEND FLASHLIGHT_TOOLS
+    fl_lm_dictionary_builder
+    fl_lm_train
+    fl_lm_test
+  )
 endif()
 list(LENGTH FLASHLIGHT_TOOLS NUM_TOOLS)
 if (NUM_TOOLS GREATER 0)

--- a/ports/flashlight-cpu/vcpkg.json
+++ b/ports/flashlight-cpu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flashlight-cpu",
-  "version-string": "0.3",
+  "version": "0.3",
   "description": "A C++ standalone library for machine learning. CPU backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
   "supports": "!(windows | osx)",

--- a/ports/flashlight-cpu/vcpkg.json
+++ b/ports/flashlight-cpu/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flashlight-cpu",
-  "version-string": "20210111",
+  "version-string": "0.3",
   "description": "A C++ standalone library for machine learning. CPU backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
   "supports": "!(windows | osx)",
@@ -71,6 +71,20 @@
           "name": "flashlight-cpu",
           "features": [
             "fl",
+            "lib"
+          ]
+        },
+        "gflags"
+      ]
+    },
+    "objdet": {
+      "description": "flashlight object detection app",
+      "dependencies": [
+        {
+          "name": "flashlight-cpu",
+          "features": [
+            "fl",
+            "imgclass",
             "lib"
           ]
         },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1981,7 +1981,7 @@
       "port-version": 1
     },
     "flashlight-cpu": {
-      "baseline": "20210111",
+      "baseline": "0.3",
       "port-version": 0
     },
     "flashlight-cuda": {

--- a/versions/f-/flashlight-cpu.json
+++ b/versions/f-/flashlight-cpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1cf96b6d845c7bac3b2034d8fcb291d1424180fe",
+      "git-tree": "63e05566899f6a034fb93cf6556cf3d5ca387f61",
       "version": "0.3",
       "port-version": 0
     },

--- a/versions/f-/flashlight-cpu.json
+++ b/versions/f-/flashlight-cpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cf96b6d845c7bac3b2034d8fcb291d1424180fe",
+      "version": "0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "d4a7e9f779d4cce7cc5fe65b83411fca53306f62",
       "version-string": "20210111",
       "port-version": 0


### PR DESCRIPTION
Updates to Flashlight v0.3 (release https://github.com/flashlight/flashlight/releases/tag/v0.3).

Tested on Ubuntu and CentOS with gcc 7 (min compiler supported)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

Same triplet support as before - no changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
