### PR TITLE
 [matplotplusplus] Install extra 3rd libraries

### DIFF
--- a/ports/matplotplusplus/install-3rd-libraries.patch
+++ b/ports/matplotplusplus/install-3rd-libraries.patch
@@ -1,0 +1,13 @@
+diff --git a/source/3rd_party/CMakeLists.txt b/source/3rd_party/CMakeLists.txt
+index 52f20eb..ab58bbd 100644
+--- a/source/3rd_party/CMakeLists.txt
++++ b/source/3rd_party/CMakeLists.txt
+@@ -41,6 +41,8 @@ endif()
+ if(MASTER_PROJECT AND NOT BUILD_SHARED_LIBS)
+   install(TARGETS nodesoup
+       EXPORT Matplot++Targets
++      RUNTIME DESTINATION bin
++      LIBRARY DESTINATION lib
+       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
+ endif()
+ 

--- a/ports/matplotplusplus/portfile.cmake
+++ b/ports/matplotplusplus/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
     REF 36d8dc6c3b94b7a71c4f129763f2c6ad8fc0b54a
     SHA512 ac8902e953a2a9f6bd62e14e2eb0bd42e407bae6c0b2921ad16ce547e4921ba2c8d8a9cc68e75831676dce3cd89cdf8294862710e838510b68e20f8a6cdf806f
     HEAD_REF master
+    PATCHES install-3rd-libraries.patch # Remove this patch when nodesoup is added in vcpkg
 )
 
 vcpkg_check_features(

--- a/ports/matplotplusplus/vcpkg.json
+++ b/ports/matplotplusplus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "matplotplusplus",
   "version-date": "2021-04-11",
+  "port-version": 1,
   "description": "A C++ graphics library for data visualization",
   "homepage": "https://alandefreitas.github.io/matplotplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3850,7 +3850,7 @@
     },
     "matplotplusplus": {
       "baseline": "2021-04-11",
-      "port-version": 0
+      "port-version": 1
     },
     "matroska": {
       "baseline": "1.6.2",

--- a/versions/m-/matplotplusplus.json
+++ b/versions/m-/matplotplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1daed23f0dc56cccb47adb60cee246cac3d8cdbd",
+      "version-date": "2021-04-11",
+      "port-version": 1
+    },
+    {
       "git-tree": "e4cf18b9e9c16d294f966bae3d1d89ecd698a47f",
       "version-date": "2021-04-11",
       "port-version": 0


### PR DESCRIPTION
Install internal extra 3rd library nodesoup since it's not added in vcpkg.

Fixes #17416.