### PR TITLE
[vcpkg baseline] Disable forest in ci baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -332,6 +332,15 @@ fontconfig:arm64-windows=fail
 foonathan-memory:arm64-windows=fail
 foonathan-memory:arm-uwp=fail
 foonathan-memory:x64-uwp=fail
+# forest is removed by upstream, see https://github.com/microsoft/vcpkg/pull/16836
+forest:arm-uwp=fail
+forest:arm64-windows=fail
+forest:x64-linux=fail
+forest:x64-uwp=fail
+forest:x64-windows-static-md=fail
+forest:x64-windows-static=fail
+forest:x64-windows=fail
+forest:x86-windows=fail
 forge:x86-windows=fail
 freeglut:arm64-windows=fail
 freeglut:arm-uwp=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -341,6 +341,7 @@ forest:x64-windows-static-md=fail
 forest:x64-windows-static=fail
 forest:x64-windows=fail
 forest:x86-windows=fail
+forest:x64-osx=fail
 forge:x86-windows=fail
 freeglut:arm64-windows=fail
 freeglut:arm-uwp=fail


### PR DESCRIPTION
Extract the changes from https://github.com/microsoft/vcpkg/pull/17331, since it blocks other PRs, so disable forest in ci baseline and this PR could be merged quickly.

https://github.com/microsoft/vcpkg/pull/16111
https://github.com/microsoft/vcpkg/pull/17331
https://github.com/microsoft/vcpkg/pull/17376

PR https://github.com/microsoft/vcpkg/pull/16836 would remove the port.