### PR TITLE
[vcpkg baseline][marble] Disable dependency KF5

### DIFF
--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5i18n",
   "version": "5.75.0",
+  "port-version": 1,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kf5i18n",
   "version": "5.75.0",
-  "port-version": 1,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [

--- a/ports/marble/portfile.cmake
+++ b/ports/marble/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DCMAKE_DISABLE_FIND_PACKAGE_I18n=ON
+        -DWITH_KF5=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/marble/vcpkg.json
+++ b/ports/marble/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "marble",
   "version-string": "19.08.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Marble KDE library",
   "homepage": "https://marble.kde.org",
   "supports": "windows & x64 & !static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3826,7 +3826,7 @@
     },
     "marble": {
       "baseline": "19.08.2",
-      "port-version": 1
+      "port-version": 2
     },
     "marl": {
       "baseline": "2020-10-10",

--- a/versions/m-/marble.json
+++ b/versions/m-/marble.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "882d37f618c122d3484dcb02cb4f35ead8580768",
+      "version-string": "19.08.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "753693b3e64d7baedd61a8f57b62e467267bc741",
       "version-string": "19.08.2",
       "port-version": 1


### PR DESCRIPTION
Re-fix issue:
```
CMake Error at D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find Gettext (missing: GETTEXT_MSGMERGE_EXECUTABLE
  GETTEXT_MSGFMT_EXECUTABLE)
Call Stack (most recent call first):
  D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:582 (_FPHSA_FAILURE_MESSAGE)
  D:/downloads/tools/cmake-3.19.2-windows/cmake-3.19.2-win32-x86/share/cmake-3.19/Modules/FindGettext.cmake:81 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  D:/installed/x64-windows/share/kf5i18n/KF5I18nMacros.cmake:5 (find_package)
  D:/installed/x64-windows/share/kf5i18n/KF5I18nConfig.cmake:33 (include)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  D:/installed/x64-windows/share/ECM/find-modules/FindKF5.cmake:53 (find_package)
  C:/a/1/s/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  MarbleMacros.cmake:124 (find_package)
  src/apps/marble-kde/CMakeLists.txt:14 (macro_optional_find_package)
```

Related: https://github.com/microsoft/vcpkg/pull/13100