### PR TITLE
[doc] Fix example code.

### DIFF
--- a/docs/examples/manifest-mode-cmake.md
+++ b/docs/examples/manifest-mode-cmake.md
@@ -30,6 +30,7 @@ find_package(range-v3 REQUIRED)
 find_package(cxxopts REQUIRED)
 
 add_executable(fibo src/main.cxx)
+target_compile_features(fibo PRIVATE cxx_std_17)
 
 target_link_libraries(fibo
   PRIVATE
@@ -45,7 +46,7 @@ And then we should add `main.cxx`:
 #include <fmt/format.h>
 #include <range/v3/view.hpp>
 
-namespace view = ranges::view;
+namespace view = ranges::views;
 
 int fib(int x) {
   int a = 0, b = 1;


### PR DESCRIPTION
I was experimenting with Manifest Mode and the code from [Manifest Mode: CMake Example](https://github.com/microsoft/vcpkg/blob/master/docs/examples/manifest-mode-cmake.md) does not compile with Clang and MSVC. It needs C++17.

```
G:\dev\testing-vcpkg\project1\build\msvc\vcpkg_installed\x64-windows\include\range/v3/detail/config.hpp(223,1): fatal error C1189: #error:  ra
nge-v3 requires Visual Studio 2019 with the /std:c++17 (or /std:c++latest) and /permissive- options. [G:\dev\testing-vcpkg\project1\build\msvc
\fibo.vcxproj]

../src/main.cxx:11:17: warning: 'begin' and 'end' returning different types ('ranges::counted_iterator<ranges::basic_iterator<ranges::repeat_view<int>::cursor>>' and 'ranges::default_sentinel_t') is a C++17 extension [-Wc++17-extensions]
  for (int it : view::repeat(0) | view::take(x))

../src/main.cxx:29:16: warning: 'begin' and 'end' returning different types ('ranges::counted_iterator<ranges::basic_iterator<ranges::iota_view<int>::cursor>>' and 'ranges::default_sentinel_t') is a C++17 extension [-Wc++17-extensions]
  for (int x : view::iota(1) | view::take(n))
```
  

This PR fixes it, as well as a deprecated warning in range-v3 lib.
```
../src/main.cxx:5:26: warning: 'view' is deprecated: The ranges::view namespace has been renamed to ranges::views. (Sorry!) [-Wdeprecated-declarations]
namespace view = ranges::view;
```
