### PR TITLE
[oatpp] update to 1.2.5 

### DIFF
--- a/ports/oatpp/fix-identifier-not-found.patch
+++ b/ports/oatpp/fix-identifier-not-found.patch
@@ -1,0 +1,13 @@
+diff --git a/src/oatpp/core/base/Environment.cpp b/src/oatpp/core/base/Environment.cpp
+index b870835..a596172 100644
+--- a/src/oatpp/core/base/Environment.cpp
++++ b/src/oatpp/core/base/Environment.cpp
+@@ -96,7 +96,7 @@ void DefaultLogger::log(v_uint32 priority, const std::string& tag, const std::st
+     default:
+       std::cout << " " << priority << " |";
+   }
+-
++struct tm* localtime_r(time_t *_clock, struct tm *_result);
+   if (m_config.timeFormat) {
+ 	time_t seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
+     struct tm now;

--- a/ports/oatpp/portfile.cmake
+++ b/ports/oatpp/portfile.cmake
@@ -1,13 +1,15 @@
-set(OATPP_VERSION "1.2.0")
+set(OATPP_VERSION "1.2.5")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO oatpp/oatpp
-    REF 8f1c11ae534e1f03646de8efcc9b2505fb1881cc  # 1.2.0
-    SHA512 4661aefe89be8153b08be0eb95ce688d5af3abd80e8f92fe3b2f1ac9dc76228383b05f7b33314de5f25d433013d6d287650ed156b69244b0d9ba8b604df8aaa3
+    REF 9899786b235b2d987c8b131cdb01909727b98d4f  # 1.2.5
+    SHA512 b5d1d6e2e2927f929aa3c7ac7fbc8afd491c28391d54d77647700982217ed17a00b96886cd314058003e103d3d7992f30fd0ab26f6cfce4ed26e12e0b6c9fd4c
     HEAD_REF master
+    PATCHES
+        fix-identifier-not-found.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/oatpp/vcpkg.json
+++ b/ports/oatpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "oatpp",
-  "version-string": "1.2.0",
-  "port-version": 1,
+  "version": "1.2.5",
   "description": "Modern web framework.",
   "homepage": "https://github.com/oatpp/oatpp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4309,8 +4309,8 @@
       "port-version": 1
     },
     "oatpp": {
-      "baseline": "1.2.0",
-      "port-version": 1
+      "baseline": "1.2.5",
+      "port-version": 0
     },
     "oatpp-consul": {
       "baseline": "1.2.0",

--- a/versions/o-/oatpp.json
+++ b/versions/o-/oatpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b64337c83dbed9eb12ad8dadb9404d80941c307e",
+      "version": "1.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "5c36b3d62c498e43f74d403b8f8020fbc2a06611",
       "version-string": "1.2.0",
       "port-version": 1


### PR DESCRIPTION
Fix #17504 

Update oatpp to the latest version 1.2.5

Note: no feature need to test