### PR TITLE
Add VCPKG_BUILD_TYPE environment variable

### DIFF
--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -88,3 +88,14 @@ This environment variable changes the metadata of produced NuGet packages. See [
 #### VCPKG_USE_NUGET_CACHE
 
 This environment variable allows using NuGet's cache for every nuget-based binary source. See [Binary Caching](binarycaching.md#NuGets-cache) for more details.
+
+#### VCPKG_BUILD_TYPE
+
+This environment variable allows to select a single build type configuration.
+This allows to reduce build times and disk storage requirements locally or in
+continuous integration setups.
+The environment variable overrides settings in triplet files.
+Note that some ports do not support single build type configurations.
+
+At the moment, the only supported value is: `release`.
+

--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -139,6 +139,9 @@ if(CMD MATCHES "^BUILD$")
     include("${SCRIPTS}/cmake/z_vcpkg_apply_patches.cmake")
     include("${SCRIPTS}/cmake/z_vcpkg_prettify_command_line.cmake")
 
+    include("${SCRIPTS}/vcpkg_get_tags.cmake")
+    z_vcpkg_select_build_type()
+
     include("${CURRENT_PORT_DIR}/portfile.cmake")
     if(DEFINED PORT)
         include("${SCRIPTS}/build_info.cmake")

--- a/scripts/vcpkg_get_tags.cmake
+++ b/scripts/vcpkg_get_tags.cmake
@@ -1,4 +1,18 @@
+macro(z_vcpkg_select_build_type)
+    if(DEFINED ENV{VCPKG_BUILD_TYPE})
+        if(NOT "$ENV{VCPKG_BUILD_TYPE}" STREQUAL "release")
+            # Cf. https://github.com/microsoft/vcpkg/pull/16110
+            message(FATAL_ERROR "The only supported value for VCPKG_BUILD_TYPE is 'release'.")
+        endif()
+        set(VCPKG_BUILD_TYPE "$ENV{VCPKG_BUILD_TYPE}")
+        if(NOT "VCPKG_BUILD_TYPE" IN_LIST VCPKG_ENV_PASSTHROUGH)
+            # This is for tracking, not for usage by ports.
+            list(APPEND VCPKG_ENV_PASSTHROUGH "VCPKG_BUILD_TYPE")
+        endif()
+    endif()
+endmacro()
 function(vcpkg_get_tags PORT FEATURES VCPKG_TRIPLET_ID VCPKG_ABI_SETTINGS_FILE)
+    z_vcpkg_select_build_type()
     message("d8187afd-ea4a-4fc3-9aa4-a6782e1ed9af")
     vcpkg_triplet_file(${VCPKG_TRIPLET_ID})
 


### PR DESCRIPTION
- #### What does your PR fix?  

  This PR adds an environment variable which allows to select a single build type configuration.
This helps to cut build times and disk storage requirements in local development and in
continuous integration setups, without requiring modification to triplet files.

  However, ATM the only supported value is `release` (cf. https://github.com/microsoft/vcpkg/pull/15983#issuecomment-826555806, #16110). I still think it might be useful. Issues and PRs show that the release-only configuration is used. Removing barriers to test release-only builds locally can improve PR quality even in absence of CI coverage.

  The placement of the new macro was chosen to interact with ABI tracking without needing changes to vcpkg tool. When accessing `vcpkg_get_tags.cmake`, vcpkg tool [modifies `CMAKE_CURRENT_LIST_DIR`](https://github.com/microsoft/vcpkg-tool/blob/096e217509a649eccb060623b2c0e046086b6615/src/vcpkg/cmakevars.cpp#L93-L95) so I didn't want to include another file from that cmake file.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, -/-

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  -/-
