### PR TITLE
[spdlog] Fix mingW build

### DIFF
--- a/ports/spdlog/fix-mingw-build.patch
+++ b/ports/spdlog/fix-mingw-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b969465..31e23cd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -136,7 +136,7 @@ if(SPDLOG_BUILD_SHARED OR BUILD_SHARED_LIBS)
+     endif()
+     add_library(spdlog SHARED ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
+     target_compile_definitions(spdlog PUBLIC SPDLOG_SHARED_LIB)
+-    if(MSVC)
++    if(MSVC AND NOT MINGW)
+         target_compile_options(spdlog PUBLIC 
+             $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/wd4251 /wd4275>)
+     endif()

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v1.8.5
     SHA512 77cc9df0c40bbdbfe1f3e5818dccf121918bfceac28f2608f39e5bf944968b7e8e24a6fc29f01bc58a9bae41b8892d49cfb59c196935ec9868884320b50f130c
     HEAD_REF v1.x
+    PATCHES fix-mingw-build.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.8.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5726,7 +5726,7 @@
     },
     "spdlog": {
       "baseline": "1.8.5",
-      "port-version": 1
+      "port-version": 2
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9aa80a12ad92e29cfc19df70b9fd615b4aa5997b",
+      "version-semver": "1.8.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "2e12349e1676bc1b9dce1f297789684a5ebd46c7",
       "version-semver": "1.8.5",
       "port-version": 1


### PR DESCRIPTION
The compile flag `/wd4251 /wd4275` can only be used on MSVC.

Fixes #17482.