### PR TITLE
[libqcow] Fix build issues by updating to 20210419

### DIFF
--- a/ports/libqcow/CONTROL
+++ b/ports/libqcow/CONTROL
@@ -1,5 +1,5 @@
 Source: libqcow
-Version: 20200928
+Version: 20210419
 Homepage: https://github.com/libyal/libqcow
 Build-Depends: gettext,openssl,zlib
 Description: Library and tools to access the QEMU Copy-On-Write (QCOW) image format.

--- a/ports/libqcow/portfile.cmake
+++ b/ports/libqcow/portfile.cmake
@@ -1,14 +1,14 @@
 vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-set(LIB_VERSION 20200928)
+set(LIB_VERSION 20210419)
 set(LIB_FILENAME libqcow-alpha-${LIB_VERSION}.tar.gz)
 
 # Release distribution file contains configured sources, while the source code in the repository does not.
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libyal/libqcow/releases/download/${LIB_VERSION}/${LIB_FILENAME}"
     FILENAME "${LIB_FILENAME}"
-    SHA512 c0112bb26924b82ea84eb14a5d5b2ec53a421159de97a6136b3af0940453fba1ca46a7f8130429d5f812ccb3625e93aa3e4237278575fe439b918bc14b0565a5
+    SHA512 911d29bd880df95288e552356d128d18c924fcd0d61d166fbeaf09936f11bf27b984d8ffd4cdc4bc285e7df295a1fe64ff595b0dfdd10b6fcfbdc6586d6bd3b0
 )
 
 vcpkg_extract_source_archive_ex(
@@ -27,7 +27,7 @@ vcpkg_configure_cmake(
 )
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libqcow" TARGET_PATH "share/libqcow")
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/libqcow")
 
 vcpkg_copy_pdbs()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3329,7 +3329,7 @@
       "port-version": 0
     },
     "libqcow": {
-      "baseline": "20200928",
+      "baseline": "20210419",
       "port-version": 0
     },
     "libqglviewer": {

--- a/versions/l-/libqcow.json
+++ b/versions/l-/libqcow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de588945b39a3e022991df3289a71fab3162474d",
+      "version-string": "20210419",
+      "port-version": 0
+    },
+    {
       "git-tree": "236cb89ed2aaf88e94409fc2f91b82c6c2b4cd49",
       "version-string": "20200928",
       "port-version": 0


### PR DESCRIPTION
The author behind https://github.com/libyal/libqcow has removed tags/releases that we needed to successfully build on Windows, since the releases contained headers pre-configured for Windows that are not present in the master branch.

This PR solves the issue by bumping to the latest version.
