### PR TITLE
[vcpkg baseline][gdk-pixbuf] Fix build error on windows

### DIFF
--- a/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -12,7 +12,7 @@ index b39c55d..3abf53b 100644
 +    int main () {
 +        return round(0);
 +    }''',
-+    name : 'round Support')
++    name : 'round Support', dependencies: mathlib_dep)
    gdk_pixbuf_conf.set('HAVE_ROUND', 1)
  endif
  
@@ -22,7 +22,7 @@ index b39c55d..3abf53b 100644
 +    int main () {
 +        return lrint(0);
 +    }''',
-+    name : 'lrint Support')
++    name : 'lrint Support', dependencies: mathlib_dep)
    gdk_pixbuf_conf.set('HAVE_LRINT', 1)
  endif
  

--- a/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -1,41 +1,28 @@
-diff --git a/gdk-pixbuf/fallback-c89.c b/gdk-pixbuf/fallback-c89.c
-index f2078ff..8def6a6 100644
---- a/gdk-pixbuf/fallback-c89.c
-+++ b/gdk-pixbuf/fallback-c89.c
-@@ -34,7 +34,7 @@ round (double x)
- /* Workaround for lrint() for non-GCC/non-C99 compilers */
- #ifndef HAVE_LRINT
- static inline long
--lrint (double x)
-+opj_lrint (double x)
- {
-   if (ceil (x + 0.5) == floor (x + 0.5))
-     {
-diff --git a/gdk-pixbuf/pixops/pixops.c b/gdk-pixbuf/pixops/pixops.c
-index 623dbd0..c435f67 100644
---- a/gdk-pixbuf/pixops/pixops.c
-+++ b/gdk-pixbuf/pixops/pixops.c
-@@ -1769,8 +1769,8 @@ prescale (const guchar     **src_bufp,
-   /* Scale the whole source image into a top-left-aligned temporary pixbuf.
-    * render_[xy][01] are done in the final scaling, not here, as they are
-    * measured in the coordinate system of the scaled image. */
--  tmp_width = lrint (src_width * prescale_x);
--  tmp_height = lrint (src_height * prescale_y);
-+  tmp_width = opj_lrint (src_width * prescale_x);
-+  tmp_height = opj_lrint (src_height * prescale_y);
- 
-   /* We are below the gdk_ interface, so create the temp image manually.
-    * Code copied from gdk_pixbuf_new() */
 diff --git a/meson.build b/meson.build
-index b39c55d..bb67d3f 100644
+index b39c55d..3abf53b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -89,7 +89,7 @@ if cc.has_function('round', dependencies: mathlib_dep)
+@@ -85,11 +85,21 @@ endforeach
+ mathlib_dep = cc.find_library('m', required: false)
+ 
+ # XXX: Remove the checks for round() and lrint() once GDK-Pixbuf is declared C99
+-if cc.has_function('round', dependencies: mathlib_dep)
++if cc.compiles('''
++    #include <math.h>
++    int main () {
++        return round(0);
++    }''',
++    name : 'round Support')
    gdk_pixbuf_conf.set('HAVE_ROUND', 1)
  endif
  
 -if cc.has_function('lrint', dependencies: mathlib_dep)
-+if cc.has_function('opj_lrint', dependencies: mathlib_dep)
++if cc.compiles('''
++    #include <math.h>
++    int main () {
++        return lrint(0);
++    }''',
++    name : 'lrint Support')
    gdk_pixbuf_conf.set('HAVE_LRINT', 1)
  endif
  

--- a/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -1,0 +1,41 @@
+diff --git a/gdk-pixbuf/fallback-c89.c b/gdk-pixbuf/fallback-c89.c
+index f2078ff..8def6a6 100644
+--- a/gdk-pixbuf/fallback-c89.c
++++ b/gdk-pixbuf/fallback-c89.c
+@@ -34,7 +34,7 @@ round (double x)
+ /* Workaround for lrint() for non-GCC/non-C99 compilers */
+ #ifndef HAVE_LRINT
+ static inline long
+-lrint (double x)
++opj_lrint (double x)
+ {
+   if (ceil (x + 0.5) == floor (x + 0.5))
+     {
+diff --git a/gdk-pixbuf/pixops/pixops.c b/gdk-pixbuf/pixops/pixops.c
+index 623dbd0..c435f67 100644
+--- a/gdk-pixbuf/pixops/pixops.c
++++ b/gdk-pixbuf/pixops/pixops.c
+@@ -1769,8 +1769,8 @@ prescale (const guchar     **src_bufp,
+   /* Scale the whole source image into a top-left-aligned temporary pixbuf.
+    * render_[xy][01] are done in the final scaling, not here, as they are
+    * measured in the coordinate system of the scaled image. */
+-  tmp_width = lrint (src_width * prescale_x);
+-  tmp_height = lrint (src_height * prescale_y);
++  tmp_width = opj_lrint (src_width * prescale_x);
++  tmp_height = opj_lrint (src_height * prescale_y);
+ 
+   /* We are below the gdk_ interface, so create the temp image manually.
+    * Code copied from gdk_pixbuf_new() */
+diff --git a/meson.build b/meson.build
+index b39c55d..bb67d3f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -89,7 +89,7 @@ if cc.has_function('round', dependencies: mathlib_dep)
+   gdk_pixbuf_conf.set('HAVE_ROUND', 1)
+ endif
+ 
+-if cc.has_function('lrint', dependencies: mathlib_dep)
++if cc.has_function('opj_lrint', dependencies: mathlib_dep)
+   gdk_pixbuf_conf.set('HAVE_LRINT', 1)
+ endif
+ 

--- a/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -1,17 +1,21 @@
 diff --git a/meson.build b/meson.build
-index b39c55d5d..e1c5018a6 100644
+index b39c55d..4b050c7 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -89,7 +89,11 @@ if cc.has_function('round', dependencies: mathlib_dep)
+@@ -89,8 +89,14 @@ if cc.has_function('round', dependencies: mathlib_dep)
    gdk_pixbuf_conf.set('HAVE_ROUND', 1)
  endif
  
 -if cc.has_function('lrint', dependencies: mathlib_dep)
-+function_check_args =''
+-  gdk_pixbuf_conf.set('HAVE_LRINT', 1)
 +if cc.get_id() == 'msvc'
-+  function_check_args ='-Oi-'
-+endif
-+if cc.has_function('lrint', dependencies: mathlib_dep, args: function_check_args)
-   gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++    if cc.has_function('lrint', dependencies: mathlib_dep, args: '-Oi-')
++        gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++    endif
++else
++    if cc.has_function('lrint', dependencies: mathlib_dep)
++      gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++    endif
  endif
  
+ if cc.has_function('bind_textdomain_codeset', prefix: '#include <libintl.h>')

--- a/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -1,28 +1,17 @@
 diff --git a/meson.build b/meson.build
-index b39c55d..3abf53b 100644
+index b39c55d5d..e1c5018a6 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -85,11 +85,21 @@ endforeach
- mathlib_dep = cc.find_library('m', required: false)
- 
- # XXX: Remove the checks for round() and lrint() once GDK-Pixbuf is declared C99
--if cc.has_function('round', dependencies: mathlib_dep)
-+if cc.compiles('''
-+    #include <math.h>
-+    int main () {
-+        return round(0);
-+    }''',
-+    name : 'round Support', dependencies: mathlib_dep)
+@@ -89,7 +89,11 @@ if cc.has_function('round', dependencies: mathlib_dep)
    gdk_pixbuf_conf.set('HAVE_ROUND', 1)
  endif
  
 -if cc.has_function('lrint', dependencies: mathlib_dep)
-+if cc.compiles('''
-+    #include <math.h>
-+    int main () {
-+        return lrint(0);
-+    }''',
-+    name : 'lrint Support', dependencies: mathlib_dep)
++function_check_args =''
++if cc.get_id() == 'msvc'
++  function_check_args ='-Oi-'
++endif
++if cc.has_function('lrint', dependencies: mathlib_dep, args: function_check_args)
    gdk_pixbuf_conf.set('HAVE_LRINT', 1)
  endif
  

--- a/ports/gdk-pixbuf/portfile.cmake
+++ b/ports/gdk-pixbuf/portfile.cmake
@@ -10,7 +10,9 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
-    PATCHES fix_build.patch
+    PATCHES
+        fix_build.patch
+        fix_build_error_windows.patch
 )
 if(VCPKG_TARGET_IS_WINDOWS)
     #list(APPEND OPTIONS -Dnative_windows_loaders=true) # Use Windows system components to handle BMP, EMF, GIF, ICO, JPEG, TIFF and WMF images, overriding jpeg and tiff.  To build this into gdk-pixbuf, pass in windows" with the other loaders to build in or use "all" with the builtin_loaders option

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.2",
+  "port-version": 1
   "description": "Image loading library.",
   "homepage": "https://developer.gnome.org/gdk-pixbuf/",
   "dependencies": [

--- a/ports/gdk-pixbuf/vcpkg.json
+++ b/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.2",
-  "port-version": 1
+  "port-version": 1,
   "description": "Image loading library.",
   "homepage": "https://developer.gnome.org/gdk-pixbuf/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2170,7 +2170,7 @@
     },
     "gdk-pixbuf": {
       "baseline": "2.42.2",
-      "port-version": 0
+      "port-version": 1
     },
     "genann": {
       "baseline": "2019-07-10",

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6b39f217d5336b508a27ca1d56769285de4069cb",
+      "git-tree": "f90cd0dd11fd312fe803519706f422a9207336d0",
       "version": "2.42.2",
       "port-version": 1
     },

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7d3a1830065f2ca29f0df5a704c13a46cc5af8e0",
+      "git-tree": "bd1dbe2aeb1e9aa06b5723c62970f3c81392205c",
       "version": "2.42.2",
       "port-version": 1
     },

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd1dbe2aeb1e9aa06b5723c62970f3c81392205c",
+      "git-tree": "6b39f217d5336b508a27ca1d56769285de4069cb",
       "version": "2.42.2",
       "port-version": 1
     },

--- a/versions/g-/gdk-pixbuf.json
+++ b/versions/g-/gdk-pixbuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d3a1830065f2ca29f0df5a704c13a46cc5af8e0",
+      "version": "2.42.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "609b77f244ec0d76aac5616cd8654dfcbc608297",
       "version": "2.42.2",
       "port-version": 0


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/17431

It looks 'has_function' in https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/blob/master/meson.build#L93 generate wrong check code here with vs2019.  just replace the functions with correct check code. this issue occurred on vs2019, it compiles fine with vs2017.

Fix the failures:
E:\vcpkg\clean\vcpkg\buildtrees\gdk-pixbuf\src\k-pixbuf-2-c86079bed6\gdk-pixbuf\pixops\../fallback-c89.c(38): error C2169: 'lrint': intrinsic function, cannot be defined

Upstream issue https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/issues/187.
Meson issue: https://github.com/mesonbuild/meson/issues/8703 https://github.com/mesonbuild/meson/issues/8702.