### PR TITLE
[cryptopp] Update to 8.5.0

### DIFF
--- a/ports/cryptopp/CONTROL
+++ b/ports/cryptopp/CONTROL
@@ -1,5 +1,5 @@
 Source: cryptopp
-Version: 8.2.0-2
+Version: 8.5.0
 Homepage: https://github.com/weidai11/cryptopp
 Description: Crypto++ is a free C++ class library of cryptographic schemes.
 

--- a/ports/cryptopp/cmake.patch
+++ b/ports/cryptopp/cmake.patch
@@ -1,13 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8cf9fa2..86a756b 100644
+index 1683961..f63c71e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -336,9 +336,13 @@ if (MSVC)
-   if (CMAKE_SYSTEM_VERSION MATCHES "10\\.0.*")
-     list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "_WIN32_WINNT=0x0A00")
-   endif ()
--  list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FI\"winapifamily.h\"")
-+  list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FIwinapifamily.h")
+@@ -395,6 +395,10 @@ if (MSVC)
+   list(APPEND CRYPTOPP_COMPILE_OPTIONS /FI winapifamily.h)
  endif ()
  
 +if(WINDOWS_STORE)

--- a/ports/cryptopp/patch.patch
+++ b/ports/cryptopp/patch.patch
@@ -1,8 +1,8 @@
-diff --git a/config.h b/config.h
-index f06992a2..be6eda31 100644
---- a/config.h
-+++ b/config.h
-@@ -814,6 +814,7 @@ NAMESPACE_END
+diff --git a/config_os.h b/config_os.h
+index da27de22..9703f77d 100644
+--- a/config_os.h
++++ b/config_os.h
+@@ -126,6 +126,7 @@
  #endif
  
  #ifdef CRYPTOPP_WIN32_AVAILABLE

--- a/ports/cryptopp/portfile.cmake
+++ b/ports/cryptopp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH CMAKE_SOURCE_PATH
   REPO noloader/cryptopp-cmake
-  REF 6d0666c457fbbf6f81819fd2b80f0cb5b6646593
-  SHA512 0341f14ce734afaee8bcc1db1716684f241499c692a5478c83a3df3fd2e5331cd04b2f4f51d43cce231ca1d9fbe76220639573c05ef06be0cf33081a1ef7ab30
+  REF CRYPTOPP_8_5_0
+  SHA512 758633786c81f5a34ade0ab99983b3262bb3a028b086e734b1f8ddb618c801453d517f67176178936f87ec36a91fca93fba9bcaec4301705138954e6eb49d136
   HEAD_REF master
   PATCHES
     cmake.patch
@@ -13,8 +13,8 @@ vcpkg_from_github(
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO weidai11/cryptopp
-  REF CRYPTOPP_8_2_0
-  SHA512 d2dcc107091d00800de243abdce8286ccd7fcc5707eebf88b97675456a021e62002e942b862db0465f72142951f631c0c1f0b2ba56028b96461780a17f2dfdf9
+  REF CRYPTOPP_8_5_0
+  SHA512 e8dd210c9e9d4925edc456e4d68780deaa224d85e11394ad5da835dcb1a1e6b3e899aa473acf20449f9721116960884b6d88b29335479b305bb7e29faa87e6c0
   HEAD_REF master
   PATCHES patch.patch
 )
@@ -38,15 +38,12 @@ if("pem-pack" IN_LIST FEATURES)
     file(COPY ${PEM_PACK_FILES} DESTINATION ${SOURCE_PATH})
 endif()
 
-# disable assembly on OSX and ARM Windows to fix broken build
-if (VCPKG_TARGET_IS_OSX)
-    set(CRYPTOPP_DISABLE_ASM "ON")
-elseif (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
+# disable assembly on ARM Windows to fix broken build
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
     set(CRYPTOPP_DISABLE_ASM "ON")
 else()
     set(CRYPTOPP_DISABLE_ASM "OFF")
 endif()
-
 
 # Dynamic linking should be avoided for Crypto++ to reduce the attack surface,
 # so generate a static lib for both dynamic and static vcpkg targets.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1493,7 +1493,7 @@
       "port-version": 0
     },
     "cryptopp": {
-      "baseline": "8.2.0-2",
+      "baseline": "8.5.0",
       "port-version": 0
     },
     "cspice": {

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2139babc473c8cb03dfa4f96b31a83bb70cdcf2c",
+      "version-string": "8.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ad41b9e4eb55001f640b5aab811f288862829d70",
       "version-string": "8.2.0-2",
       "port-version": 0

--- a/versions/c-/cryptopp.json
+++ b/versions/c-/cryptopp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2139babc473c8cb03dfa4f96b31a83bb70cdcf2c",
+      "git-tree": "c8aee6279ffed7e7e1f9037c15937643c315a999",
       "version-string": "8.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
This PR updates Crypto++ to 8.5.0. It also re-enables assembly in macOS builds, which appears to be working correctly now.

- #### What does your PR fix?  
  Updates Crypto++ to version 8.5.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Tested on Windows (x86/x64/ARM64), macOS (x64/ARM64), Linux (Debian 10 x86_64)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes