### PR TITLE
[doc] Update manifest to reference versioning spec

### DIFF
--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -79,7 +79,7 @@ Manifest property | Versioning scheme
 `version-string`  | For arbitrary strings
 
 
-See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions, for more details.
+See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions for more details.
 
 Additionally, `"port-version"` is used to differentiate between port changes that don't change the underlying library version.
 

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -74,6 +74,7 @@ however, more version kinds will be added later. Additionally,
 `"port-version"` is used to differentiate between port changes that don't change the underlying library version.
 
 #### `"version-string"`
+See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions , for further cases (semantic versioning etc.)
 
 This field is an ascii string, and may contain alphanumeric characters, `.`, `_`, or `-`. No attempt at ordering versions is made; all versions are treated as byte strings and are only evaluated for equality.
 

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -69,12 +69,13 @@ numbers, and hyphens, and it must not begin nor end with a hyphen.
 
 ### Version fields
 
+See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions, for further cases (semantic versioning etc.)
+
 The library version. There is currently only one kind of version, a `"version-string"` -
 however, more version kinds will be added later. Additionally,
 `"port-version"` is used to differentiate between port changes that don't change the underlying library version.
 
 #### `"version-string"`
-See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions , for further cases (semantic versioning etc.)
 
 This field is an ascii string, and may contain alphanumeric characters, `.`, `_`, or `-`. No attempt at ordering versions is made; all versions are treated as byte strings and are only evaluated for equality.
 

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -78,7 +78,6 @@ Manifest property | Versioning scheme
 `version-date`    | For dates in the format YYYY-MM-DD
 `version-string`  | For arbitrary strings
 
-
 See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions for more details.
 
 Additionally, `"port-version"` is used to differentiate between port changes that don't change the underlying library version.

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -69,11 +69,19 @@ numbers, and hyphens, and it must not begin nor end with a hyphen.
 
 ### Version fields
 
-See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions, for further cases (semantic versioning etc.)
+Currently there are different fields for special versioning. Namely:
 
-The library version. There is currently only one kind of version, a `"version-string"` -
-however, more version kinds will be added later. Additionally,
-`"port-version"` is used to differentiate between port changes that don't change the underlying library version.
+Manifest property | Versioning scheme
+------------------|------------------------------------
+`version`         | For dot-separated numeric versions
+`version-semver`  | For SemVer compliant versions
+`version-date`    | For dates in the format YYYY-MM-DD
+`version-string`  | For arbitrary strings
+
+
+See https://github.com/microsoft/vcpkg/blob/master/docs/specifications/versioning.md#22-package-versions, for more details.
+
+Additionally, `"port-version"` is used to differentiate between port changes that don't change the underlying library version.
 
 #### `"version-string"`
 


### PR DESCRIPTION
Currently only `version-string` is included in the manifest-files.md. However there are more variants of this field. This PR adds a cross link to the versioning specification. 

fixes #17548
