### PR TITLE
[new/updated port] frugally-deep and updated fplus

### DIFF
--- a/ports/fplus/portfile.cmake
+++ b/ports/fplus/portfile.cmake
@@ -1,15 +1,17 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/FunctionalPlus
-    REF 916abce0787da6c6c373d06c453a2cd684594dc2 #v0.2.13-p0
-    SHA512 40aa090fc96794e1255416fba84b4afae6b52fe66dc9b810d863da78f387238054e743ba775921b1387b10b00ce6d1500df97806018181f26fcbc925758ef0f6
+    REF v0.2.14-p0
+    SHA512 f6232140fc343521bc484c7fa1a9d4942fbfc078be1cefa7b34c33632ec23d55827d13319f7b7a5535c5eedeb3161e15f84ecb80aa110685dbfc2c932c57284b
     HEAD_REF master
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    -DFPLUS_BUILD_EXAMPLES=OFF
+    OPTIONS
+        -DFPLUS_BUILD_EXAMPLES=OFF
+        -DFunctionalPlus_INSTALL_CMAKEDIR=share/FunctionalPlus
 )
 
 vcpkg_install_cmake()

--- a/ports/fplus/vcpkg.json
+++ b/ports/fplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fplus",
-  "version-semver": "0.2.13-p0",
+  "version-semver": "0.2.14-p0",
   "description": "Functional Programming Library for C++. Write concise and readable C++ code",
   "homepage": "https://github.com/Dobiasd/FunctionalPlus"
 }

--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -6,6 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        double FDEEP_USE_DOUBLE
+)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -13,8 +17,8 @@ vcpkg_configure_cmake(
     OPTIONS
     -DFDEEP_BUILD_UNITTEST=OFF
     -DFDEEP_USE_TOOLCHAIN=ON
+    ${FEATURE_OPTIONS}
 )
-# feature FDEEP_USE_DOUBLE
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/frugally-deep TARGET_PATH share/${PORT})

--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Dobiasd/frugally-deep

--- a/ports/frugally-deep/portfile.cmake
+++ b/ports/frugally-deep/portfile.cmake
@@ -1,0 +1,26 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Dobiasd/frugally-deep
+    REF v0.15.2-p0
+    SHA512 2237c139c217cc9e338c854505009e85cea6658888e0d97c0c7957b58e0e53e2add555b81fa276c2ec9f794d5356bdb267c1e0b05090c83627916d954d2a11ba
+    HEAD_REF master
+)
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+    -DFDEEP_BUILD_UNITTEST=OFF
+    -DFDEEP_USE_TOOLCHAIN=ON
+)
+# feature FDEEP_USE_DOUBLE
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/frugally-deep TARGET_PATH share/${PORT})
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "frugally-deep",
+  "version-semver": "v0.15.2-p0",
+  "description": "Header-only library for using Keras models in C++.",
+  "homepage": "https://github.com/Dobiasd/frugally-deep",
+  "dependencies": [
+    "eigen3",
+    "nlohmann-json",
+    "fplus"
+  ]
+}

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -7,5 +7,10 @@
     "eigen3",
     "fplus",
     "nlohmann-json"
-  ]
+  ],
+  "features": {
+    "double": {
+      "description": "Use double precision"
+    }
+  }
 }

--- a/ports/frugally-deep/vcpkg.json
+++ b/ports/frugally-deep/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "frugally-deep",
-  "version-semver": "v0.15.2-p0",
+  "version-semver": "0.15.2-p0",
   "description": "Header-only library for using Keras models in C++.",
   "homepage": "https://github.com/Dobiasd/frugally-deep",
   "dependencies": [
     "eigen3",
-    "nlohmann-json",
-    "fplus"
+    "fplus",
+    "nlohmann-json"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2096,6 +2096,10 @@
       "baseline": "1.0.0",
       "port-version": 0
     },
+    "frugally-deep": {
+      "baseline": "0.15.2-p0",
+      "port-version": 0
+    },
     "fruit": {
       "baseline": "3.6.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2053,7 +2053,7 @@
       "port-version": 0
     },
     "fplus": {
-      "baseline": "0.2.13-p0",
+      "baseline": "0.2.14-p0",
       "port-version": 0
     },
     "freeglut": {

--- a/versions/f-/fplus.json
+++ b/versions/f-/fplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d76810dad7926ef832d9f75966f99a763ed40cfb",
+      "version-semver": "0.2.14-p0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3c2d60588fe82f0001bd8bdf1a7b765c7e51eb6d",
       "version-semver": "0.2.13-p0",
       "port-version": 0

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "54dcbfae1016ead7a92e3100ede872804b50e70b",
+      "git-tree": "b53df71f90baedbb8e1d9c05ad4d437756c289d3",
       "version-semver": "0.15.2-p0",
       "port-version": 0
     }

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f2a8477b8761d7fd67e44ba01c5987c295a1b58e",
+      "version-semver": "0.15.2-p0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/f-/frugally-deep.json
+++ b/versions/f-/frugally-deep.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2a8477b8761d7fd67e44ba01c5987c295a1b58e",
+      "git-tree": "54dcbfae1016ead7a92e3100ede872804b50e70b",
       "version-semver": "0.15.2-p0",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17556

additionally the port fplus was incorrectly exported. Upstream requires the name for `find_package` to be `FunctionalPlus` instead of `fplus`. In the same run it was updated to the next version.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes
