### PR TITLE
[doc] Fix spelling errors

### DIFF
--- a/docs/about/privacy.md
+++ b/docs/about/privacy.md
@@ -9,7 +9,7 @@ We explicitly ONLY collect information from invocations of the tool itself; we d
 
 ## How to opt out
 
-The vcpkg telemetry feature is enabled by default. In order to opt-out of data collection, you can re-run the boostrap script with the following flag, for Windows and Linux/OSX, respectively:
+The vcpkg telemetry feature is enabled by default. In order to opt-out of data collection, you can re-run the bootstrap script with the following flag, for Windows and Linux/OSX, respectively:
 
 ```PS> .\bootstrap-vcpkg.bat -disableMetrics```
 

--- a/docs/examples/modify-baseline-to-pin-old-boost.md
+++ b/docs/examples/modify-baseline-to-pin-old-boost.md
@@ -147,7 +147,7 @@ git rev-parse HEAD
 The output of that command will be the commit SHA you need to put as the `"builtin-baseline"` in your project's manifest file. Copy the 40-hex digits and save them to use later in your manifest file.
 
 ### Step 5: (Optional) Go back to the main repository branch
-Once your changes have been commited locally, you can refer to the commit SHA regardless of the repository branch you're working on. So, let's go back to the main vcpkg repository branch.
+Once your changes have been committed locally, you can refer to the commit SHA regardless of the repository branch you're working on. So, let's go back to the main vcpkg repository branch.
 
 ```
 git checkout master

--- a/docs/examples/vcpkg_android_example_cmake_script/cmake/vcpkg_android.cmake
+++ b/docs/examples/vcpkg_android_example_cmake_script/cmake/vcpkg_android.cmake
@@ -57,7 +57,7 @@ if (VCPKG_TARGET_ANDROID)
     # |x64-android                | x86_64               |
     # |x86-android                | x86                  |
     #
-    # The variable must be stored in the cache in order to successfuly the two toolchains. 
+    # The variable must be stored in the cache in order to successfully the two toolchains. 
     #
     if (ANDROID_ABI MATCHES "arm64-v8a")
         set(VCPKG_TARGET_TRIPLET "arm64-android" CACHE STRING "" FORCE)

--- a/docs/examples/versioning.getting-started.md
+++ b/docs/examples/versioning.getting-started.md
@@ -42,7 +42,7 @@ project(myapp)
 
 ## Using versions with manifests
 
-With the `versions` feature flag enabled you can start addding version constraints to your dependencies.
+With the `versions` feature flag enabled you can start adding version constraints to your dependencies.
 
 Let's start with creating a simple CMake project that depends on `fmt` and `zlib`.
 

--- a/docs/maintainers/control-files.md
+++ b/docs/maintainers/control-files.md
@@ -106,7 +106,7 @@ Vcpkg does not distinguish between build-only dependencies and runtime dependenc
 
 *For example: websocketpp is a header only library, and thus does not require any dependencies at install time. However, downstream users need boost and openssl to make use of the library. Therefore, websocketpp lists boost and openssl as dependencies*
 
-If the port is dependent on optional features of another library those can be specified using the `portname[featurelist]` syntax. If the port does not require any features from the dependency, this should be specifed as `portname[core]`.
+If the port is dependent on optional features of another library those can be specified using the `portname[featurelist]` syntax. If the port does not require any features from the dependency, this should be specified as `portname[core]`.
 
 Dependencies can be filtered based on the target triplet to support differing requirements. These filters use the same syntax as the Supports field below and are surrounded in parentheses following the portname and feature list.
 

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -185,7 +185,7 @@ for example the dependency object `{ "name": "zlib" }` is equivalent to just wri
 If the port is dependent on optional features of another library,
 those can be specified using the `"features"` field of the dependency object.
 If the port does not require any features from the dependency,
-this should be specifed with the `"default-features"` fields set to `false`.
+this should be specified with the `"default-features"` fields set to `false`.
 
 Dependencies can also be filtered based on the target triplet to support differing requirements.
 These filters use the same syntax as the `"supports"` field below,

--- a/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_configure.md
+++ b/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_configure.md
@@ -31,7 +31,7 @@ that build type.
 
 Use the `OPTIONS` argument to set the configure settings for both release and debug,
 and use `OPTIONS_RELEASE` and `OPTIONS_DEBUG` to set the configure settings for
-release only and debug only repsectively.
+release only and debug only respectively.
 
 By default, when possible, `vcpkg_cmake_configure` uses [ninja-build]
 as its build system. If the `WINDOWS_USE_MSBUILD` argument is passed, then

--- a/docs/maintainers/vcpkg_build_cmake.md
+++ b/docs/maintainers/vcpkg_build_cmake.md
@@ -23,7 +23,7 @@ be passed.
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+This command should be preceded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
 You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the
 "install" target
 

--- a/docs/maintainers/vcpkg_build_make.md
+++ b/docs/maintainers/vcpkg_build_make.md
@@ -39,7 +39,7 @@ The underlying buildsystem will be instructed to not parallelize
 Additional subdir to invoke make in. Useful if only parts of a port should be built. 
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
+This command should be preceded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
 You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your makefile supports the
 "install" target
 

--- a/docs/maintainers/vcpkg_build_nmake.md
+++ b/docs/maintainers/vcpkg_build_nmake.md
@@ -65,7 +65,7 @@ be passed.
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
+This command should be preceded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
 You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your makefile supports the
 "install" target
 

--- a/docs/maintainers/vcpkg_copy_tools.md
+++ b/docs/maintainers/vcpkg_copy_tools.md
@@ -18,10 +18,10 @@ vcpkg_copy_tools(
 A list of tool filenames without extension.
 
 ### SEARCH_DIR
-The path to the directory containing the tools. This will be set to `${CURRENT_PACKAGES_DIR}/bin` if ommited.
+The path to the directory containing the tools. This will be set to `${CURRENT_PACKAGES_DIR}/bin` if omitted.
 
 ### DESTINATION
-Destination to copy the tools to. This will be set to `${CURRENT_PACKAGES_DIR}/tools/${PORT}` if ommited.
+Destination to copy the tools to. This will be set to `${CURRENT_PACKAGES_DIR}/tools/${PORT}` if omitted.
 
 ### AUTO_CLEAN
 Auto clean executables in `${CURRENT_PACKAGES_DIR}/bin` and `${CURRENT_PACKAGES_DIR}/debug/bin`.

--- a/docs/specifications/prefab.md
+++ b/docs/specifications/prefab.md
@@ -50,7 +50,7 @@ Note:
 ./vcpkg export --triplet x64-android jsoncpp --prefab --prefab-maven --prefab-debug
 ```
 
-You will see an ouput like this:
+You will see an output like this:
 ```
 The following packages are already built and will be exported:
     jsoncpp:arm64-android
@@ -102,7 +102,7 @@ In gradle.properties
     android.enableParallelJsonGen=false
     android.prefabVersion=${prefab.version}
 
-Successfuly exported jsoncpp. Checkout .../vcpkg/prefab 
+Successfully exported jsoncpp. Checkout .../vcpkg/prefab 
 
 ```
 

--- a/docs/specifications/registries-2.md
+++ b/docs/specifications/registries-2.md
@@ -459,7 +459,7 @@ This means that, even across different machines, the same registries will be use
 We will also be able to write down version resolution in this file as soon as that feature is added.
 
 It is recommended that one adds this `vcpkg-lock.json` to one's version control.
-This file is machine generated, and it is not specified how it's layed out;
+This file is machine generated, and it is not specified how it's laid out;
 however, for purposes of this RFC, we will define how it relates to git registries.
 
 In `vcpkg-lock.json`, in the top level object,

--- a/docs/specifications/registries.md
+++ b/docs/specifications/registries.md
@@ -182,7 +182,7 @@ and then run the following algorithm on each dependency:
 
 vcpkg will also rerun this algorithm whenever an install is run with different configuration.
 
-### How Registries are Layed Out
+### How Registries are Laid Out
 
 There are three kinds of registries, but they only differ in how the registry gets onto one's filesystem.
 Once the registry is there, package lookup runs the same, with each kind having it's own way of defining its

--- a/docs/specifications/versioning.md
+++ b/docs/specifications/versioning.md
@@ -32,7 +32,7 @@ This feature requires the use of manifests to declare project dependencies. To a
 * Ability for a top-level manifest to override all other version constraints.
 * Ability to declare a baseline for all versions.
 
-Example: A manifeset (`vcpkg.json`) using versioning features.
+Example: A manifest (`vcpkg.json`) using versioning features.
 ```json
 {
   "name": "versions-test",

--- a/docs/users/android.md
+++ b/docs/users/android.md
@@ -2,7 +2,7 @@
 
 **The latest version of this documentation is available on [GitHub](https://github.com/Microsoft/vcpkg/tree/master/docs/users/android.md).**
 
-Android is not officialy supported, and there are no official android triplets at the moment.
+Android is not officially supported, and there are no official android triplets at the moment.
 
 However, some packages can compile to Android, and the situation is improving: see the list of [PR related to Android](https://github.com/Microsoft/vcpkg/pulls?q=+android+).
 
@@ -149,7 +149,7 @@ Starting package 1/2: vulkan:arm64-android
 Building package vulkan[core]:arm64-android...
 -- Using community triplet arm64-android. This triplet configuration is not guaranteed to succeed.
 -- [COMMUNITY] Loading triplet configuration from: /.../vcpkg/triplets/community/arm64-android.cmake
--- Querying VULKAN_SDK Enviroment variable
+-- Querying VULKAN_SDK Environment variable
 -- Searching /.../Library/Android/sdk/ndk/22.1.7171670/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/vulkan/ for vulkan.h
 -- Found vulkan.h
 -- Performing post-build validation
@@ -208,7 +208,7 @@ cmake \
   ...
 ````
 
-2. Specifiy the android abi and vcpkg triplet
+2. Specify the android abi and vcpkg triplet
 
 When compiling for android, you need to select a matching "android abi" / "vcpkg triplet" pair.
 

--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -48,7 +48,7 @@ This environment variable can be set to a triplet name which will be used for un
 
 This environment variable allows users to override ports with alternate versions according to the
 [ports overlay](../specifications/ports-overlay.md) specification. List paths to overlays using
-the platform dependent PATH seperator (Windows `;` | others `:`)
+the platform dependent PATH separator (Windows `;` | others `:`)
 
 Example (Windows): `C:\custom-ports\boost;C:\custom-ports\sqlite3`
 
@@ -56,7 +56,7 @@ Example (Windows): `C:\custom-ports\boost;C:\custom-ports\sqlite3`
 
 This environment variable allows users to add directories to search for triplets.
 [Example: overlay triplets](../examples/overlay-triplets-linux-dynamic.md).
-List paths to overlays using the platform dependent PATH seperator (Windows `;`, others `:`)
+List paths to overlays using the platform dependent PATH separator (Windows `;`, others `:`)
 
 #### VCPKG_FORCE_SYSTEM_BINARIES
 

--- a/docs/users/versioning.implementation-details.md
+++ b/docs/users/versioning.implementation-details.md
@@ -67,7 +67,7 @@ Version constraints come in the following flavors:
 * **Declared constraints**: Constraints declared explicitly in the top-level manifest using `version>=`.
 * **Baseline constraints**: Constraints added implicitly by the `builtin-baseline`.
 * **Transitive constraints**: Constraints added indirectly by dependencies of your dependencies.
-* **Overriden constraints**: Constraints overriden in the top-level manifest using `overrides` declarations.
+* **Overridden constraints**: Constraints overridden in the top-level manifest using `overrides` declarations.
 
 To compute an installation plan, vcpkg follows roughly these steps:
 

--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "name": "vcpkg-cmake",
   "version-date": "2021-02-28",
-  "port-version": 1
+  "port-version": 2
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -30,7 +30,7 @@ that build type.
 
 Use the `OPTIONS` argument to set the configure settings for both release and debug,
 and use `OPTIONS_RELEASE` and `OPTIONS_DEBUG` to set the configure settings for
-release only and debug only repsectively.
+release only and debug only respectively.
 
 By default, when possible, `vcpkg_cmake_configure` uses [ninja-build]
 as its build system. If the `WINDOWS_USE_MSBUILD` argument is passed, then

--- a/scripts/cmake/vcpkg_build_cmake.cmake
+++ b/scripts/cmake/vcpkg_build_cmake.cmake
@@ -22,7 +22,7 @@ be passed.
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
+This command should be preceded by a call to [`vcpkg_configure_cmake()`](vcpkg_configure_cmake.md).
 You can use the alias [`vcpkg_install_cmake()`](vcpkg_configure_cmake.md) function if your CMake script supports the
 "install" target
 

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -38,7 +38,7 @@ The underlying buildsystem will be instructed to not parallelize
 Additional subdir to invoke make in. Useful if only parts of a port should be built. 
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
+This command should be preceded by a call to [`vcpkg_configure_make()`](vcpkg_configure_make.md).
 You can use the alias [`vcpkg_install_make()`](vcpkg_install_make.md) function if your makefile supports the
 "install" target
 

--- a/scripts/cmake/vcpkg_build_nmake.cmake
+++ b/scripts/cmake/vcpkg_build_nmake.cmake
@@ -64,7 +64,7 @@ be passed.
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
 
 ## Notes:
-This command should be preceeded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
+This command should be preceded by a call to [`vcpkg_configure_nmake()`](vcpkg_configure_nmake.md).
 You can use the alias [`vcpkg_install_nmake()`](vcpkg_install_nmake.md) function if your makefile supports the
 "install" target
 

--- a/scripts/cmake/vcpkg_copy_tools.cmake
+++ b/scripts/cmake/vcpkg_copy_tools.cmake
@@ -17,10 +17,10 @@ vcpkg_copy_tools(
 A list of tool filenames without extension.
 
 ### SEARCH_DIR
-The path to the directory containing the tools. This will be set to `${CURRENT_PACKAGES_DIR}/bin` if ommited.
+The path to the directory containing the tools. This will be set to `${CURRENT_PACKAGES_DIR}/bin` if omitted.
 
 ### DESTINATION
-Destination to copy the tools to. This will be set to `${CURRENT_PACKAGES_DIR}/tools/${PORT}` if ommited.
+Destination to copy the tools to. This will be set to `${CURRENT_PACKAGES_DIR}/tools/${PORT}` if omitted.
 
 ### AUTO_CLEAN
 Auto clean executables in `${CURRENT_PACKAGES_DIR}/bin` and `${CURRENT_PACKAGES_DIR}/debug/bin`.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "vcpkg-cmake": {
       "baseline": "2021-02-28",
-      "port-version": 1
+      "port-version": 2
     },
     "vcpkg-cmake-config": {
       "baseline": "2021-02-26",

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02fbd92ab46d1512b22280f1264e4e8f8d076ef4",
+      "version-date": "2021-02-28",
+      "port-version": 2
+    },
+    {
       "git-tree": "4abdcc88bd5ec2c76e320eb2ff4db665ee9913ac",
       "version-date": "2021-02-28",
       "port-version": 1


### PR DESCRIPTION
This PR fixes spelling errors in the documentation. The errors were found by `codespell`.

I have a second commit locally, updating the documentation headers of
- scripts/cmake/vcpkg_build_cmake.cmake
- scripts/cmake/vcpkg_build_make.cmake
- scripts/cmake/vcpkg_build_nmake.cmake
- scripts/cmake/vcpkg_copy_tools.cmake

This needs to be merged, too, but I guess it will give a very long CI run. So I'm holding this back until explicitly invited, and this PR in draft state.