### PR TITLE
[winsparkle] inital port

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(MESSAGE "winsparkle only supports Windows platforms" ON_TARGET "osx" "linux" "uwp")
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0-src.zip"
     FILENAME "winsparkle-070.zip"

--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,0 +1,44 @@
+vcpkg_fail_port_install(MESSAGE "winsparkle only supports Windows platforms" ON_TARGET "osx" "linux" "uwp")
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0-src.zip"
+    FILENAME "winsparkle-070.zip"
+    SHA512 58991c821b31bbc2e7af342af6cfce2fc095841200a2a2359d3fd784d804e1bfddcb640ba8427614732e43bc1608f203e2f03274d8f942e66ad40d5ac2554891
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+# build and install 
+vcpkg_install_msbuild(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PROJECT_SUBPATH "WinSparkle-2017.sln"
+    PLATFORM ${BUILD_ARCH}
+    TARGET_PLATFORM_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}
+    PLATFORM_TOOLSET ${VCPKG_PLATFORM_TOOLSET}
+    OPTIONS /t:restore /p:RestorePackagesConfig=true
+    USE_VCPKG_INTEGRATION
+)
+
+# These libraries are useless, so remove.
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libcharset-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libcharset-1.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libgcc_s_dw2-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libgcc_s_dw2-1.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libgettextlib-0-20-2.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libgettextlib-0-20-2.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libgettextpo-0.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libgettextpo-0.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libgettextsrc-0-20-2.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libgettextsrc-0-20-2.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libgomp-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libgomp-1.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libiconv-2.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libiconv-2.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libintl-8.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libintl-8.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libstdc++-6.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libstdc++-6.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libtextstyle-0.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libtextstyle-0.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libwinpthread-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libwinpthread-1.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libcharset-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libcharset-1.dll)
+
+# Install includes
+file(INSTALL ${SOURCE_PATH}/include/winsparkle.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/winsparkle.h)
+file(INSTALL ${SOURCE_PATH}/include/winsparkle-version.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/winsparkle-version.h)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/winsparkle RENAME copyright)

--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -13,6 +13,9 @@ vcpkg_extract_source_archive_ex(
 vcpkg_install_msbuild(
     SOURCE_PATH "${SOURCE_PATH}"
     PROJECT_SUBPATH "WinSparkle-2017.sln"
+    LICENSE_SUBPATH "COPYING"
+    INCLUDES_SUBPATH "include"
+    ALLOW_ROOT_INCLUDES
     PLATFORM ${BUILD_ARCH}
     TARGET_PLATFORM_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}
     PLATFORM_TOOLSET ${VCPKG_PLATFORM_TOOLSET}
@@ -33,10 +36,10 @@ file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libstdc++-6.dll ${CURRENT_PACKAGES_DIR}/
 file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libtextstyle-0.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libtextstyle-0.dll)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libwinpthread-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libwinpthread-1.dll)
 file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/libcharset-1.dll ${CURRENT_PACKAGES_DIR}/debug/bin/libcharset-1.dll)
+file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/COPYING.lib ${CURRENT_PACKAGES_DIR}/debug/lib/COPYING.lib)
 
-# Install includes
-file(INSTALL ${SOURCE_PATH}/include/winsparkle.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/winsparkle.h)
-file(INSTALL ${SOURCE_PATH}/include/winsparkle-version.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/winsparkle-version.h)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+

--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -39,4 +39,4 @@ file(INSTALL ${SOURCE_PATH}/include/winsparkle.h DESTINATION ${CURRENT_PACKAGES_
 file(INSTALL ${SOURCE_PATH}/include/winsparkle-version.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/winsparkle-version.h)
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/winsparkle RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "winsparkle",
   "version": "0.7.0",
-  "homepage": "https://winsparkle.org",
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
+  "homepage": "https://winsparkle.org",
   "supports": "windows & !(arm | uwp)"
 }

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "winsparkle",
+  "version": "0.7.0",
+  "homepage": "https://winsparkle.org",
+  "description": "WinSparkle is an easy-to-use software update library for Windows developers."
+}

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "winsparkle",
   "version": "0.7.0",
   "homepage": "https://winsparkle.org",
-  "description": "WinSparkle is an easy-to-use software update library for Windows developers."
+  "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
+  "supports": "windows & !(arm | uwp)"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1648,6 +1648,7 @@ v8:x64-windows-static-md=fail
 yato:x64-windows-static-md=fail
 zyre:x64-windows-static-md=fail
 usbmuxd:x64-windows-static-md=fail
+winsparkle:x64-windows-static-md=fail
 workflow:x64-uwp=fail
 workflow:arm-uwp=fail
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7268,6 +7268,10 @@
       "baseline": "0.0",
       "port-version": 3
     },
+    "winsparkle": {
+      "baseline": "0.7.0",
+      "port-version": 0
+    },
     "wintoast": {
       "baseline": "1.2.0",
       "port-version": 1

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e37cbdd793f6a4e11e3560cb69e41bd234b8d457",
+      "version": "0.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds winsparkle to the ports 

Fixes  #16607

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
- 
winsparkle:arm-uwp=fail
winsparkle:x64-linux=fail
winsparkle:x64-osx=fail
winsparkle:x64-uwp=fail

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
