### PR TITLE
[clapack] Remove broken host-arithchk

### DIFF
--- a/ports/clapack/arith_linux64.h
+++ b/ports/clapack/arith_linux64.h
@@ -1,0 +1,9 @@
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Long int
+#define Intcast (int)(long)
+#define Double_Align
+#define X64_bit_pointers
+#define NO_LONG_LONG
+#define QNaN0 0x0
+#define QNaN1 0xfff80000

--- a/ports/clapack/arith_osx.h
+++ b/ports/clapack/arith_osx.h
@@ -1,0 +1,12 @@
+/* Suitable for macOS on x86_64 and arm64 */
+/* Not suitable for 32-bit macOS */
+
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Long int
+#define Intcast (int)(long)
+#define Double_Align
+#define X64_bit_pointers
+#define NANCHECK
+#define QNaN0 0x0
+#define QNaN1 0x7ff80000

--- a/ports/clapack/arith_win32.h
+++ b/ports/clapack/arith_win32.h
@@ -1,0 +1,8 @@
+/* Windows 32-bit */
+
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Double_Align
+#define NANCHECK
+#define QNaN0 0x0
+#define QNaN1 0x7ff80000

--- a/ports/clapack/arith_win64.h
+++ b/ports/clapack/arith_win64.h
@@ -1,0 +1,9 @@
+/* Windows 64-bit */
+
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Double_Align
+#define X64_bit_pointers
+#define NANCHECK
+#define QNaN0 0x0
+#define QNaN1 0x7ff80000

--- a/ports/clapack/portfile.cmake
+++ b/ports/clapack/portfile.cmake
@@ -20,10 +20,27 @@ vcpkg_extract_source_archive_ex(
       support-uwp.patch
 )
 
-if(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)
-  set(ARITHCHK_PATH ${CURRENT_HOST_INSTALLED_DIR}/tools/clapack/arithchk${VCPKG_HOST_EXECUTABLE_SUFFIX})
-  if(NOT EXISTS "${ARITHCHK_PATH}")
-    message(FATAL_ERROR "Expected ${ARITHCHK_PATH} to exist.")
+set(ARITH_PATH)
+if(DEFINED CLAPACK_ARITH_PATH)
+  set(ARITH_PATH "-DARITH_PATH=${CLAPACK_ARITH_PATH}")
+elseif(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)
+  if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "^x64$|^arm64$")
+      set(ARITH_PATH "-DARITH_PATH=${CMAKE_CURRENT_LIST_DIR}/arith_win64.h")
+    else()
+      set(ARITH_PATH "-DARITH_PATH=${CMAKE_CURRENT_LIST_DIR}/arith_win32.h")
+    endif()
+  elseif(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    set(ARITH_PATH "-DARITH_PATH=${CMAKE_CURRENT_LIST_DIR}/arith_osx.h")
+  elseif(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(ARITH_PATH "-DARITH_PATH=${CMAKE_CURRENT_LIST_DIR}/arith_linux64.h")
+  else()
+    message(WARNING
+"Unable to cross-compile clapack for ${VCPKG_TARGET_ARCHITECTURE}-${VCPKG_CMAKE_SYSTEM_NAME}.
+No arith.h is available and arithchk must be executed for the target.
+To fix this issue, define CLAPACK_ARITH_PATH in your triplet to the location of a pre-generated arith.h file.
+
+Continuing with trying to run arithchk anyway.")
   endif()
 endif()
 
@@ -32,7 +49,7 @@ vcpkg_configure_cmake(
   PREFER_NINJA
   OPTIONS
     -DCMAKE_DEBUG_POSTFIX=d
-    -DARITHCHK_PATH=${ARITHCHK_PATH}
+    ${ARITH_PATH}
 )
 
 vcpkg_install_cmake()

--- a/ports/clapack/support-uwp.patch
+++ b/ports/clapack/support-uwp.patch
@@ -6,7 +6,7 @@ index db58b4e..0fb61a0 100644
  # _zrotg_ seems to be missing in the wrap header
    add_definitions(-DNO_BLAS_WRAP)
  endif()
-+if (ARITHCHK_PATH)
++if (MSVC)
 +  add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 +endif()
  include_directories(${CLAPACK_SOURCE_DIR}/INCLUDE)
@@ -21,11 +21,11 @@ index 094614a..e5b40ab 100644
  set_target_properties(arithchk PROPERTIES COMPILE_DEFINITIONS 
    "NO_FPINIT;NO_LONG_LONG")
 +  
-+if (ARITHCHK_PATH)
-+ADD_CUSTOM_COMMAND(
-+   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arith.h
-+   COMMAND ${ARITHCHK_PATH} > ${CMAKE_CURRENT_BINARY_DIR}/arith.h
-+   )
++if (ARITH_PATH)
++configure_file(
++   "${ARITH_PATH}"
++   "${CMAKE_CURRENT_BINARY_DIR}/arith.h"
++   COPYONLY)
 +else()
  ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arith.h
@@ -37,14 +37,6 @@ index 094614a..e5b40ab 100644
  
  set(OFILES  ${MISC} ${POW} ${CX} ${DCX} ${REAL} ${DBL} ${INT} 
    ${HALF} ${CMP} ${EFL} ${CHAR} ${I77} ${TIME})
-@@ -69,3 +76,6 @@ install(TARGETS f2c EXPORT clapack-targets
-         ARCHIVE DESTINATION lib
-         INCLUDES DESTINATION include)
- 
-+if (NOT ARITHCHK_PATH)
-+    install(TARGETS arithchk RUNTIME DESTINATION tools/clapack)
-+endif()
-\ No newline at end of file
 diff --git a/F2CLIBS/libf2c/inquire.c b/F2CLIBS/libf2c/inquire.c
 index 5936a67..4846d41 100644
 --- a/F2CLIBS/libf2c/inquire.c

--- a/ports/clapack/vcpkg.json
+++ b/ports/clapack/vcpkg.json
@@ -1,14 +1,10 @@
 {
   "name": "clapack",
   "version-string": "3.2.1",
-  "port-version": 17,
+  "port-version": 18,
   "description": "CLAPACK (f2c'ed version of LAPACK)",
   "homepage": "https://www.netlib.org/clapack",
   "dependencies": [
-    "blas",
-    {
-      "name": "clapack",
-      "host": true
-    }
+    "blas"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1234,7 +1234,7 @@
     },
     "clapack": {
       "baseline": "3.2.1",
-      "port-version": 17
+      "port-version": 18
     },
     "clara": {
       "baseline": "1.1.5",

--- a/versions/c-/clapack.json
+++ b/versions/c-/clapack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "229447785643f09b1a4ef53bab355ff3757e178e",
+      "version-string": "3.2.1",
+      "port-version": 18
+    },
+    {
       "git-tree": "a75c0e3b1dbe8fa6cd276b2a6fc5b61b19e9ea45",
       "version-string": "3.2.1",
       "port-version": 17


### PR DESCRIPTION
As part of host dependencies, I moved `arithchk` to be built for the host and executed for the target. Unfortunately that's not how `arithchk` works. `arithchk` _must_ be built for the target platform, because the detected information is fundamentally baked in at compile time.

I've lifted the pre-generated files from #17311 to handle all our official targets, plus added an triplet extension point "CLAPACK_ARITH_PATH" which will allow cross-compiling users to supply their own custom `arith.h` based on their system information. The logic is:

1. If the user supplied arith.h, use that.
2. If we're native-targeting, run `arithchk`.
3. If we're cross-targeting a known platform, use that `arith.h`
4. Otherwise, print a warning and run `arithchk`. This is likely to fail in the case of android, but it would succeed for "minor variants" like `arm64-linux-dynamic`.

As a bonus, this significantly improves compile times for `clapack`, since it no longer requires the host build.

@Neumann-A @cenit @szhorvat I'd appreciate any input you could provide as users of numeric libraries.