### PR TITLE
[python3] Disable registry access to determine WinSDK

### DIFF
--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -88,6 +88,11 @@ if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
             "/p:ForceImportBeforeCppTargets=${SOURCE_PATH}/PCbuild/python_vcpkg.props"
         )
     endif()
+    string(REPLACE "\\" "" WindowsSDKVersion "$ENV{WindowsSDKVersion}")
+    list(APPEND OPTIONS
+        "/p:WindowsTargetPlatformVersion=${WindowsSDKVersion}"
+        "/p:DefaultWindowsSDKVersion=${WindowsSDKVersion}"
+    )
     if(VCPKG_TARGET_IS_UWP)
         list(APPEND OPTIONS "/p:IncludeUwp=true")
     else()

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-string": "3.9.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4966,7 +4966,7 @@
     },
     "python3": {
       "baseline": "3.9.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ebb4ed9ed737c672ca5462a4019a704b6461e91d",
+      "version-string": "3.9.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "025737aca98a8b23d4ea8de388dacfba6b844eca",
       "version-string": "3.9.2",
       "port-version": 1


### PR DESCRIPTION
Currently, `python3` uses code like the following to get the Windows SDK Version:
```xml
  <PropertyGroup Condition="$(DefaultWindowsSDKVersion) == ''">
    <!--
    Attempt to select the latest installed WinSDK. If we don't find any, then we will
    let the MSBuild targets determine which one it wants to use (typically the earliest
    possible version). Since we limit WINVER to Windows 7 anyway, it doesn't really
    matter which WinSDK version we use.
    -->
    <_RegistryVersion>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
    <_RegistryVersion Condition="$(_RegistryVersion) == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
    <_RegistryVersion Condition="$(_RegistryVersion) != '' and !$(_RegistryVersion.EndsWith('.0'))">$(_RegistryVersion).0</_RegistryVersion>

    <!-- The minimum allowed SDK version to use for building -->
    <DefaultWindowsSDKVersion>10.0.10586.0</DefaultWindowsSDKVersion>
    <DefaultWindowsSDKVersion Condition="$([System.Version]::Parse($(_RegistryVersion))) > $([System.Version]::Parse($(DefaultWindowsSDKVersion)))">$(_RegistryVersion)</DefaultWindowsSDKVersion>
  </PropertyGroup>
```

This is bad for a variety of reasons, but specifically we want to avoid registry access.