### PR TITLE
[ghc-filesystem] Fix port/package name discrepancy

### DIFF
--- a/ports/ghc-filesystem/portfile.cmake
+++ b/ports/ghc-filesystem/portfile.cmake
@@ -14,7 +14,10 @@ vcpkg_cmake_configure(
         -DGHC_FILESYSTEM_WITH_INSTALL=ON
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ghc_filesystem)
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ghc_filesystem
+    CONFIG_PATH lib/cmake/ghc_filesystem
+)
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug

--- a/ports/ghc-filesystem/vcpkg.json
+++ b/ports/ghc-filesystem/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ghc-filesystem",
   "version": "1.5.4",
+  "port-version": 1,
   "description": "An implementation of C++17 std::filesystem for C++11 /C++14/C++17/C++20 on Windows, macOS, Linux and FreeBSD",
   "homepage": "https://github.com/gulrak/filesystem",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2222,7 +2222,7 @@
     },
     "ghc-filesystem": {
       "baseline": "1.5.4",
-      "port-version": 0
+      "port-version": 1
     },
     "gherkin-c": {
       "baseline": "2019-10-07-1",

--- a/versions/g-/ghc-filesystem.json
+++ b/versions/g-/ghc-filesystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b793d2816cd9bd4d242e09b3d9638d760216797",
+      "version": "1.5.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "bacddfca1f950fd501d4774332039f9be3e4d620",
       "version": "1.5.4",
       "port-version": 0


### PR DESCRIPTION
The package name uses `_` but the port name uses `-` meaning that `find-package` will not work

- #### What does your PR fix?  
This uses the `PACKAGE_NAME` in `vcpkg_cmake_config_fixup` to fix that 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Header only so All 
  Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

I tried updating the port-version but I was getting CI failures