### PR TITLE
[openh264] only build shared or static library

### DIFF
--- a/ports/openh264/0001-respect-default-library-option.patch
+++ b/ports/openh264/0001-respect-default-library-option.patch
@@ -1,0 +1,57 @@
+From 328b15a962caa928373b55d85f9911f45442886e Mon Sep 17 00:00:00 2001
+From: Xavier Claessens <xavier.claessens@collabora.com>
+Date: Mon, 19 Oct 2020 17:03:25 -0400
+Subject: [PATCH] meson: Respect default_library option
+
+When using library() instead of shared_library() and static_library,
+meson will build shared, static, or both depending on the
+value of static_library option.
+
+As far as I know extract_all_objects() was uses as workaround for Meson
+bugs fixed a while ago when using not installed static libraries.
+---
+ meson.build | 19 +++----------------
+ 1 file changed, 3 insertions(+), 16 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 283413375b..65641508de 100644
+--- a/meson.build
++++ b/meson.build
+@@ -184,26 +184,13 @@ api_header_deps = []
+ subdir ('codec')
+ subdir ('test')
+ 
+-all_objects = [
+-  libcommon.extract_all_objects(),
+-  libprocessing.extract_all_objects(),
+-  libencoder.extract_all_objects(),
+-  libdecoder.extract_all_objects()
+-]
+-
+-libopenh264_shared = shared_library('openh264',
+-  objects: all_objects,
++libopenh264 = library('openh264',
++  link_whole: [libcommon, libprocessing, libencoder, libdecoder],
+   install: true,
+   soversion: major_version,
+-  version: meson.project_version(),
+   vs_module_defs: 'openh264.def',
+   dependencies: deps)
+ 
+-libopenh264_static = static_library('openh264',
+-  objects: all_objects,
+-  install: true,
+-  dependencies: deps)
+-
+ pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
+ 
+ foreach t : ['', '-static']
+@@ -235,7 +222,7 @@ foreach t : ['', '-static']
+ endforeach
+ 
+ openh264_dep = declare_dependency(
+-  link_with: libopenh264_shared,
++  link_with: libopenh264,
+   include_directories: include_directories('include'),
+   dependencies: deps + api_header_deps)
+ 

--- a/ports/openh264/portfile.cmake
+++ b/ports/openh264/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO cisco/openh264
     REF f15f940425eebf24ce66984db2445733cf500b7b
     SHA512 361003296e9cef2956aeff76ae4df7a949a585710facd84a92c1b4164c5a4522d6615fcc485ebc2e50be8a13feb942b870efdd28837307467081cb1eba1f17d2
+    PATCHES
+        0001-respect-default-library-option.patch  # https://github.com/cisco/openh264/pull/3351
 )
 
 if((VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x64"))

--- a/ports/openh264/vcpkg.json
+++ b/ports/openh264/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openh264",
   "version-date": "2021-03-16",
+  "port-version": 1,
   "description": "OpenH264 is a codec library which supports H.264 encoding and decoding. It is suitable for use in real time applications such as WebRTC.",
   "homepage": "https://www.openh264.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4486,7 +4486,7 @@
     },
     "openh264": {
       "baseline": "2021-03-16",
-      "port-version": 0
+      "port-version": 1
     },
     "openigtlink": {
       "baseline": "3.0",

--- a/versions/o-/openh264.json
+++ b/versions/o-/openh264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07352ebe168754b537e6ed23cc64e17e7b22ac9e",
+      "version-date": "2021-03-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "e541fb33857fd6401459e1f0fdc617d47fa3094e",
       "version-date": "2021-03-16",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Currently, when installing openh264, both the static and shared library get built and potentially installed, even though only a static or shared one is requested by vcpkg. For example, on x64-linux:

  ```bash
  # before patch
  $ ./vcpkg install openh264
  $ ls installed/x64-linux/lib/
  libopenh264.a  libopenh264.so  libopenh264.so.2.1.0  libopenh264.so.6  pkgconfig
  # after patch
  $ ./vcpkg install openh264
  $ ls installed/x64-linux/lib/
  libopenh264.a  pkgconfig
  ```

  This PR incorporates an upstream patch from https://github.com/cisco/openh264/pull/3351 to ensure that openh264 respects meson's default_library option, resolving this issue (since this is the mechanism also used by vcpkg to request either the static or shared library).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
