### PR TITLE
[infoware] Bump version to 0.6.0

### DIFF
--- a/ports/infoware/portfile.cmake
+++ b/ports/infoware/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ThePhD/infoware
-    REF v0.5.5
-    SHA512 06aea2c3a51df30cfc220eafb603620c3cf5f00b0d5935486ac46c6c2333972910af2b53fc1e2187b5fce0aa9650323a0dff526d768ff54888bfc549a8173903
+    REF v0.6.0
+    SHA512 38be9e375508c7fdee4be3540d80c95bf14dbef68c7880d3dc98de3128b43680c18ceb09fb0da33b6d31064d8cdbf0672671d6b4be4f0a4208a0b99d0224bd2e
     HEAD_REF master
 )
 

--- a/ports/infoware/vcpkg.json
+++ b/ports/infoware/vcpkg.json
@@ -1,8 +1,7 @@
 {
   "$reason": "Note that independent usage and testing may work, but it seems to fail in CI environments for potential cross-compilation, and is thusly noted here to note break how vcpkg builds things!",
   "name": "infoware",
-  "version-string": "0.5.5",
-  "port-version": 1,
+  "version-string": "0.6.0",
   "description": "C++ Library for pulling system and hardware information, without hitting the command line.",
   "homepage": "https://github.com/ThePhD/infoware",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2633,8 +2633,8 @@
       "port-version": 0
     },
     "infoware": {
-      "baseline": "0.5.5",
-      "port-version": 1
+      "baseline": "0.6.0",
+      "port-version": 0
     },
     "inih": {
       "baseline": "51",

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -1,23 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "5b7cda9f7b8eb929162ab979be0d2a6a01d37292",
-      "version-string": "0.5.5",
-      "port-version": 1
-    },
-    {
-      "git-tree": "ed2c00122823b77b0ef74a94031a6cacbb015ffb",
-      "version-string": "0.5.5",
-      "port-version": 0
-    },
-    {
-      "git-tree": "8bfd4af8d1a7f17e086f2e1a8c205f38b4c4b255",
-      "version-string": "0.5.4",
-      "port-version": 0
-    },
-    {
-      "git-tree": "263f7da8f2331a6e6891af54268f2f7bf0df9ca6",
-      "version-string": "0.5.3",
+      "git-tree": "ea6cdef830ceb71bfa0d850127931972603d5695",
+      "version-string": "0.6.0",
       "port-version": 0
     }
   ]

--- a/versions/i-/infoware.json
+++ b/versions/i-/infoware.json
@@ -4,6 +4,26 @@
       "git-tree": "ea6cdef830ceb71bfa0d850127931972603d5695",
       "version-string": "0.6.0",
       "port-version": 0
+    },
+    {
+      "git-tree": "5b7cda9f7b8eb929162ab979be0d2a6a01d37292",
+      "version-string": "0.5.5",
+      "port-version": 1
+    },
+    {
+      "git-tree": "ed2c00122823b77b0ef74a94031a6cacbb015ffb",
+      "version-string": "0.5.5",
+      "port-version": 0
+    },
+    {
+      "git-tree": "8bfd4af8d1a7f17e086f2e1a8c205f38b4c4b255",
+      "version-string": "0.5.4",
+      "port-version": 0
+    },
+    {
+      "git-tree": "263f7da8f2331a6e6891af54268f2f7bf0df9ca6",
+      "version-string": "0.5.3",
+      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
**Describe the pull request**

- What does your PR fix? The infoware version being out of date.

- Which triplets are supported/not supported? Same ones. Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)? Still pretty sure I didn't.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  Likewise I hope it still does.

- If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result? No, I just updated it.