### PR TITLE
[hidapi] fix mac build

### DIFF
--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
     REF hidapi-0.10.1
     SHA512 0479706c631775483378070ff7170542725678eabc202a5bd07436c951fd766e01743417999ac3fb2b5436c865f6ace2cfced1f210fa3a3e88c19ceb3bbe0534
     HEAD_REF master
-    patch remove-duplicate-AC_CONFIG_MACRO_DIR.patch
+    PATCHES remove-duplicate-AC_CONFIG_MACRO_DIR.patch
 )
 
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hidapi",
   "version-semver": "0.10.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
   "homepage": "https://github.com/libusb/hidapi",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2466,7 +2466,7 @@
     },
     "hidapi": {
       "baseline": "0.10.1",
-      "port-version": 1
+      "port-version": 2
     },
     "highfive": {
       "baseline": "2.2.2",

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8ddfc714e198b19f67260bfeb2e5ae58e37fd909",
+      "version-semver": "0.10.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "5322c7526edb02f08688e2831978b2be542755c9",
       "version-semver": "0.10.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes the mac build of hidapi introduced in  #17231

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  now all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
