### PR TITLE
[asio] Add inline dummy return patch

### DIFF
--- a/ports/asio/inline_dummy_return.patch
+++ b/ports/asio/inline_dummy_return.patch
@@ -1,0 +1,13 @@
+diff --git a/asio/include/asio/impl/use_awaitable.hpp b/asio/include/asio/impl/use_awaitable.hpp
+index 60a6f5cd..af7be635 100644
+--- a/asio/include/asio/impl/use_awaitable.hpp
++++ b/asio/include/asio/impl/use_awaitable.hpp
+@@ -236,7 +236,7 @@ T dummy_return()
+ }
+ 
+ template <>
+-void dummy_return()
++inline void dummy_return()
+ {
+ }
+ #endif // defined(_MSC_VER)

--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF asio-1-18-1
     SHA512 c84e6fca448ed419a976756840f3f4543291a5a7d4f62d4de7c06945b2cd9ececca6633049ad5e36367d60f67a4f2735be017445514ae9fa9497d4af2a4d48f8
     HEAD_REF master
+    PATCHES
+        inline_dummy_return.patch
 )
 
 # Always use "ASIO_STANDALONE" to avoid boost dependency

--- a/ports/asio/vcpkg.json
+++ b/ports/asio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "asio",
   "version": "1.18.1",
+  "port-version": 1,
   "description": "Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.",
   "homepage": "https://github.com/chriskohlhoff/asio",
   "documentation": "https://think-async.com/Asio/asio-1.18.0/doc/",

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09afe8ce875f1c4e5e46d54c7c8bd5d0b9b512fc",
+      "version": "1.18.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "f564160afbc91228b0fe5c48f8f4c0b7dcd99b31",
       "version": "1.18.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -154,7 +154,7 @@
     },
     "asio": {
       "baseline": "1.18.1",
-      "port-version": 0
+      "port-version": 1
     },
     "asiosdk": {
       "baseline": "2.3.3-1",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes dummy_return bug which affects ASIO  
For further details, check https://github.com/conan-io/conan-center-index/issues/4008 and https://github.com/chriskohlhoff/asio/pull/584  
This fix is already present in Boost-Asio

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
