### PR TITLE
[rtaudio] add ASIO backend as a feature

### DIFF
--- a/ports/rtaudio/portfile.cmake
+++ b/ports/rtaudio/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 34a3752e0c8249dc1780d196cd24e745425f0c77
     SHA512 00fea107f409f6dc43154aaf69aeffa1a3385031778b5f7d1ae1cc8337ed4ab92a7917cc9eade848dedd746016b6eff6234088619cb8d6a9a3f26a63efde493e
     HEAD_REF master
+    PATCHES remove-unused-variable.patch
 )
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)
@@ -14,10 +15,15 @@ else()
     set(RTAUDIO_STATIC_MSVCRT OFF)
 endif()
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        asio  RTAUDIO_API_ASIO
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DRTAUDIO_STATIC_MSVCRT=${RTAUDIO_STATIC_MSVCRT}
+    OPTIONS -DRTAUDIO_STATIC_MSVCRT=${RTAUDIO_STATIC_MSVCRT} ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()

--- a/ports/rtaudio/remove-unused-variable.patch
+++ b/ports/rtaudio/remove-unused-variable.patch
@@ -1,0 +1,20 @@
+diff --git a/include/asiolist.cpp b/include/asiolist.cpp
+index e4c73c2..333a662 100644
+--- a/include/asiolist.cpp
++++ b/include/asiolist.cpp
+@@ -166,7 +166,6 @@ AsioDriverList::AsioDriverList ()
+ 	LPASIODRVSTRUCT	pdl;
+ 	LONG 			cr;
+ 	DWORD			index = 0;
+-	BOOL			fin = FALSE;
+ 
+ 	numdrv		= 0;
+ 	lpdrvlist	= 0;
+@@ -184,7 +183,6 @@ AsioDriverList::AsioDriverList ()
+ #endif
+ 			lpdrvlist = newDrvStruct (hkEnum,keyname,0,lpdrvlist);
+ 		}
+-		else fin = TRUE;
+ 	}
+ 	if (hkEnum) RegCloseKey(hkEnum);
+ 

--- a/ports/rtaudio/vcpkg.json
+++ b/ports/rtaudio/vcpkg.json
@@ -1,7 +1,12 @@
 {
   "name": "rtaudio",
-  "version-date": "2021-01-25",
+  "version-date": "2021-04-30",
   "description": "A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.",
   "homepage": "https://github.com/thestk/rtaudio",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "features": {
+    "asio": {
+      "description": "Build with ASIO backend"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5381,7 +5381,7 @@
       "port-version": 1
     },
     "rtaudio": {
-      "baseline": "2021-01-25",
+      "baseline": "2021-04-30",
       "port-version": 0
     },
     "rtlsdr": {

--- a/versions/r-/rtaudio.json
+++ b/versions/r-/rtaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59166c851bb292b52492034aa3167e1be5142663",
+      "version-date": "2021-04-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "088d877f612f5f77cb47a93b0854491baebb5178",
       "version-date": "2021-01-25",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  My PR adds ASIO support as a feature to the RtAudio library. 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <!-- <all / linux, windows, ...>, <Yes/No> -->
  No change (new feature is available on windows only though)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

<!-- **If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/** -->
