### PR TITLE
[vcpkg baseline][hidapi] Disable hidapi check on OSX

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -454,6 +454,8 @@ healpix:x64-uwp=fail
 healpix:arm64-windows=fail
 healpix:arm-uwp=fail
 healpix:x64-osx=fail
+# https://github.com/libusb/hidapi/issues/264
+hidapi:x64-osx=fail
 hiredis:arm-uwp=fail
 hiredis:x64-uwp=fail
 hpx:x64-windows-static=fail


### PR DESCRIPTION
When building `hidapi:x64-osx`:
```
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
configure.ac:16: error: AC_CONFIG_MACRO_DIR can only be used once
./lib/autoconf/general.m4:1970: AC_CONFIG_MACRO_DIR is expanded from...
configure.ac:16: the top level
autom4te: error: /usr/local/opt/m4/bin/m4 failed with exit status: 1
aclocal: error: /usr/local/Cellar/autoconf/2.71/bin/autom4te failed with exit status: 1
autoreconf: error: aclocal failed with exit status: 1
```

This issue is due to the use of the newer autoconfig and the deprecation of this function in its new version (can only be used once).
The port was added in the PR https://github.com/microsoft/vcpkg/pull/17231. I guess this is caused by the installation of newer autotools after our osx machine was updated. Waiting for upstream fix.


See upstream issue: https://github.com/libusb/hidapi/issues/264