### PR TITLE
[pthreadpool] remove unused dependency

### DIFF
--- a/ports/pthreadpool/vcpkg.json
+++ b/ports/pthreadpool/vcpkg.json
@@ -1,13 +1,10 @@
 {
   "name": "pthreadpool",
   "version-date": "2020-04-10",
+  "port-version": 1,
   "description": "Portable (POSIX/Windows/Emscripten) thread pool for C/C++",
   "homepage": "https://github.com/Maratyszcza/pthreadpool",
   "dependencies": [
-    "fxdiv",
-    {
-      "name": "pthreads",
-      "platform": "windows & uwp"
-    }
+    "fxdiv"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4958,7 +4958,7 @@
     },
     "pthreadpool": {
       "baseline": "2020-04-10",
-      "port-version": 0
+      "port-version": 1
     },
     "pthreads": {
       "baseline": "3.0.0",

--- a/versions/p-/pthreadpool.json
+++ b/versions/p-/pthreadpool.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37e004fa65e21e9ffb647d6ff92cd834a46777cf",
+      "version-date": "2020-04-10",
+      "port-version": 1
+    },
+    {
       "git-tree": "da641f8e198df6999638e7a2f0a95e3f143cb595",
       "version-date": "2020-04-10",
       "port-version": 0


### PR DESCRIPTION
### What does your PR fix?  

Please check  https://github.com/microsoft/vcpkg/pull/17196#discussion_r624683392

At first, I thought the port needs the port `pthreads` because of its name.  
But the implementation uses Win32 API for Windows/UWP build.
I forgot to remove this part after the build check... This PR removes it.

### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No changes for triplet coverage.

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes
