### PR TITLE
[libffi] Update patch to fix apply patch failure

### DIFF
--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libffi",
   "version": "3.3",
-  "port-version": 8,
+  "port-version": 9,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi"
 }

--- a/ports/libffi/win32-disable-stackframe-check.patch
+++ b/ports/libffi/win32-disable-stackframe-check.patch
@@ -1,32 +1,11 @@
-Rolf Gebhardt <rolf.gebhardt@lbs-sw.de>
-22 Jul 2020
-[PATCH] x86/win32: disable runtime stack frame checks with msvc
- around built assembly
-
-based on the patch for x86/win64:
-
-From 53291b332b1bc061a3409d3b60c38f313609b98e Mon Sep 17 00:00:00 2001
-From: Matthew Waters <matthew@centricular.com>
-Date: Fri, 16 Mar 2018 15:10:04 +1100
-Subject: [PATCH] x86/win64: disable runtime stack frame checks with msvc
- around built assembly
-
-MSVC can add truntime code that checks if a stack frame is mismanaged
-however our custom assembly delibrately accesses and modifies the parent
-stack frame.  Fortunately we can disable that specific check for the
-function call so do that.
----
- src/x86/ffi.c | 11 +++++++++++
- 1 file changed, 11 insertions(+)
-
 diff --git a/src/x86/ffi.c b/src/x86/ffi.c
 index 9a59218..9f5d703 100644
 --- a/src/x86/ffi.c
 +++ b/src/x86/ffi.c
 @@ -255,6 +255,14 @@ static const struct abi_params abi_params[FFI_LAST_ABI] = {
-
+ 
  extern void FFI_DECLARE_FASTCALL ffi_call_i386(struct call_frame *, char *) FFI_HIDDEN;
-
+ 
 +/* we perform some black magic here to use some of the parent's
 + * stack frame in ff_call_win() that breaks with the msvc compiler
 + * with the /RTCs or /GZ flags.  Disable the 'Stack frame run time
@@ -37,14 +16,14 @@ index 9a59218..9f5d703 100644
 +#endif
  static void
  ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
-              void **avalue, void *closure)
+ 	      void **avalue, void *closure)
 @@ -390,6 +398,9 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
-
+ 
    ffi_call_i386 (frame, stack);
  }
 +#if defined(_MSC_VER)
 +#pragma runtime_checks("s", restore)
 +#endif
-
+ 
  void
  ffi_call (ffi_cif *cif, void (*fn)(void), void *rvalue, void **avalue)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3070,7 +3070,7 @@
     },
     "libffi": {
       "baseline": "3.3",
-      "port-version": 8
+      "port-version": 9
     },
     "libflac": {
       "baseline": "1.3.3",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c40f59f0527e2336818bd5d6b0d14ae2bdc5c286",
+      "version": "3.3",
+      "port-version": 9
+    },
+    {
       "git-tree": "ea2ed30397fc14caf66d8f7290306cfc5c5aa424",
       "version": "3.3",
       "port-version": 8


### PR DESCRIPTION
Fixes bug when using featrure versioning:
```
Starting package 1/2: libffi:x64-windows
Building package libffi[core]:x64-windows...
-- Installing port from location: F:\vcpkg\buildtrees\versioning\versions\libffi\ea2ed30397fc14caf66d8f7290306cfc5c5aa424
-- Using cached F:/vcpkg/downloads/libffi-libffi-v3.3.tar.gz
-- Extracting source F:/vcpkg/downloads/libffi-libffi-v3.3.tar.gz
-- Applying patch win64-disable-stackframe-check.patch
-- Applying patch win32-disable-stackframe-check.patch
CMake Error at scripts/cmake/z_vcpkg_apply_patches.cmake:57 (message):
  Applying patch failed: error: corrupt patch at line 27
```