### PR TITLE
[spirv-tools] Update to v2021.1

### DIFF
--- a/ports/spirv-tools/0001-don-t-use-MP4.patch
+++ b/ports/spirv-tools/0001-don-t-use-MP4.patch
@@ -1,0 +1,58 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 8247f6f..e28f6ee 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -420,7 +420,3 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
+   install(FILES ${CMAKE_BINARY_DIR}/${SPIRV_TOOLS}Config.cmake DESTINATION ${PACKAGE_DIR})
+ endif(ENABLE_SPIRV_TOOLS_INSTALL)
+ 
+-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+-  # Enable parallel builds across four cores for this lib
+-  add_definitions(/MP4)
+-endif()
+diff --git a/source/fuzz/CMakeLists.txt b/source/fuzz/CMakeLists.txt
+index 804fcf0..4915f07 100644
+--- a/source/fuzz/CMakeLists.txt
++++ b/source/fuzz/CMakeLists.txt
+@@ -419,10 +419,6 @@ if(SPIRV_BUILD_FUZZER)
+         ${CMAKE_CURRENT_BINARY_DIR}/protobufs/spvtoolsfuzz.pb.cc
+         )
+ 
+-  if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+-    # Enable parallel builds across four cores for this lib
+-    add_definitions(/MP4)
+-  endif()
+ 
+   spvtools_pch(SPIRV_TOOLS_FUZZ_SOURCES pch_source_fuzz)
+ 
+diff --git a/source/opt/CMakeLists.txt b/source/opt/CMakeLists.txt
+index 88d5658..e3faab7 100644
+--- a/source/opt/CMakeLists.txt
++++ b/source/opt/CMakeLists.txt
+@@ -218,11 +218,6 @@ set(SPIRV_TOOLS_OPT_SOURCES
+   wrap_opkill.cpp
+ )
+ 
+-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+-  # Enable parallel builds across four cores for this lib
+-  add_definitions(/MP4)
+-endif()
+-
+ spvtools_pch(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)
+ 
+ add_library(SPIRV-Tools-opt ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_TOOLS_OPT_SOURCES})
+diff --git a/source/reduce/CMakeLists.txt b/source/reduce/CMakeLists.txt
+index e589ad5..b93a37b 100644
+--- a/source/reduce/CMakeLists.txt
++++ b/source/reduce/CMakeLists.txt
+@@ -71,10 +71,6 @@ set(SPIRV_TOOLS_REDUCE_SOURCES
+         simple_conditional_branch_to_branch_reduction_opportunity.cpp
+ )
+ 
+-if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+-  # Enable parallel builds across four cores for this lib
+-  add_definitions(/MP4)
+-endif()
+ 
+ spvtools_pch(SPIRV_TOOLS_REDUCE_SOURCES pch_source_reduce)
+

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         cmake-install.patch
         install-config-typo.patch
+        0001-don-t-use-MP4.patch
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KhronosGroup/SPIRV-Tools
-    REF v2020.7
-    SHA512 34d870e5aaaa2ad744369521efd43bdfba5e47208bb31bc0e325322e3a6edbe7686d3f4d9a6ebff6e85625e1a00811ab0162e2b8f39dd18603b7ff6548897950
+    REF v2021.1
+    SHA512 e8478eacb86415f75a1e5b3f66a0508b01a9f7e9d8b070eb0329ca56be137f5543dd42125a1033cb8552c01f46e11affd7fda866231b3742c66de9b4341930d5
     PATCHES
         cmake-install.patch
         install-config-typo.patch
@@ -24,6 +24,8 @@ else()
     set(SKIP_EXECUTABLES OFF)
 endif()
 
+string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static SPIRV_TOOLS_BUILD_STATIC)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -32,7 +34,7 @@ vcpkg_configure_cmake(
         -DSPIRV_WERROR=OFF
         -DSPIRV_SKIP_EXECUTABLES=${SKIP_EXECUTABLES} # option SPIRV_SKIP_TESTS follows this value
         -DENABLE_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
-        -DSPIRV_TOOLS_BUILD_STATIC=ON
+        -DSPIRV_TOOLS_BUILD_STATIC=${SPIRV_TOOLS_BUILD_STATIC}
 )
 
 vcpkg_install_cmake()

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -25,7 +25,6 @@ else()
     set(SKIP_EXECUTABLES OFF)
 endif()
 
-string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static SPIRV_TOOLS_BUILD_STATIC)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -35,7 +34,7 @@ vcpkg_configure_cmake(
         -DSPIRV_WERROR=OFF
         -DSPIRV_SKIP_EXECUTABLES=${SKIP_EXECUTABLES} # option SPIRV_SKIP_TESTS follows this value
         -DENABLE_SPIRV_TOOLS_INSTALL=${TOOLS_INSTALL}
-        -DSPIRV_TOOLS_BUILD_STATIC=${SPIRV_TOOLS_BUILD_STATIC}
+        -DSPIRV_TOOLS_BUILD_STATIC=ON
 )
 
 vcpkg_install_cmake()

--- a/ports/spirv-tools/portfile.cmake
+++ b/ports/spirv-tools/portfile.cmake
@@ -25,7 +25,6 @@ else()
     set(SKIP_EXECUTABLES OFF)
 endif()
 
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/spirv-tools/vcpkg.json
+++ b/ports/spirv-tools/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "spirv-tools",
-  "version-string": "2020.7",
+  "version-string": "2021.1",
   "description": "API and commands for processing SPIR-V modules",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Tools",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5781,7 +5781,7 @@
       "port-version": 0
     },
     "spirv-tools": {
-      "baseline": "2020.7",
+      "baseline": "2021.1",
       "port-version": 0
     },
     "sprout": {

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f68c9f6f448ff5f839c4b712f60c65d0051949f",
+      "version-string": "2021.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "03084f48c2608e410a438662bab2a68ab92a5c95",
       "version-string": "2020.7",
       "port-version": 0

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4f68c9f6f448ff5f839c4b712f60c65d0051949f",
+      "git-tree": "8aa72f897eca05f81b3c3ef42d8b28b114495ab5",
       "version-string": "2021.1",
       "port-version": 0
     },

--- a/versions/s-/spirv-tools.json
+++ b/versions/s-/spirv-tools.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8aa72f897eca05f81b3c3ef42d8b28b114495ab5",
+      "git-tree": "c18f04e12fa671a9067896ccdf8c932601f81115",
       "version-string": "2021.1",
       "port-version": 0
     },


### PR DESCRIPTION
Updates spirv-tools to v2021.1 and disables /MP4 (which was causing the compiler to bail on my high-corecount machine).

I've submitted the /MP4 removal patch to upstream.
