### PR TITLE
[cudnn] Fix port: install find module, add usage

### DIFF
--- a/ports/cudnn/CONTROL
+++ b/ports/cudnn/CONTROL
@@ -1,6 +1,6 @@
 Source: cudnn
 Version: 7.6.5
-Port-Version: 2
+Port-Version: 3
 Description: NVIDIA's cuDNN deep neural network acceleration library
 Build-Depends: cuda
 Supports: (windows|linux)&x64

--- a/ports/cudnn/portfile.cmake
+++ b/ports/cudnn/portfile.cmake
@@ -70,3 +70,6 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
 else()
   message(FATAL_ERROR "Please install CUDNN using your system package manager (the same way you installed CUDA). For example: apt install libcudnn8-dev.")
 endif()
+
+file(INSTALL "${CURRENT_PORT_DIR}/FindCUDNN.cmake" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/cudnn/usage
+++ b/ports/cudnn/usage
@@ -1,0 +1,10 @@
+The package cudnn provides CMake variables:
+
+    find_package(CUDNN REQUIRED)
+    target_link_libraries(main PRIVATE ${CUDNN_LIBRARIES})
+    target_include_directories(main PRIVATE ${CUDNN_INCLUDE_DIRS})
+
+Or the following CMake target:
+
+    find_package(CUDNN REQUIRED)
+    target_link_libraries(main PRIVATE CuDNN::CuDNN)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1526,7 +1526,7 @@
     },
     "cudnn": {
       "baseline": "7.6.5",
-      "port-version": 2
+      "port-version": 3
     },
     "cunit": {
       "baseline": "2.1.3-6",

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5083fb9e3d717ff2d4d678f9ecda78985122ce02",
+      "git-tree": "00e54079329e9cc4f1f623dce3bc39b0f19e958d",
       "version-string": "7.6.5",
       "port-version": 3
     },

--- a/versions/c-/cudnn.json
+++ b/versions/c-/cudnn.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5083fb9e3d717ff2d4d678f9ecda78985122ce02",
+      "version-string": "7.6.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "5581791a9ad35390ed30629985b3863cf8b85bba",
       "version-string": "7.6.5",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?  

https://github.com/microsoft/vcpkg/pull/17331 removed the installation of `FindCUDNN.cmake`, which breaks the port for downstream projects that have `find_dependency` calls that might require a `FindCUDNN` module. cc @BillyONeal 

Add back the installation of the module in addition to a `usage`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
