### PR TITLE
[vcpkg] Move x-ci-verify-versions tests into the "formatting" tests.

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
 
 stages:
 - stage: FormatChecks
-  displayName: 'Formatting and Documentation Checks'
+  displayName: 'Version Database, Formatting, and Documentation Checks'
   pool: $(windows-pool)
   jobs:
   - job:
@@ -35,6 +35,13 @@ stages:
       inputs:
         filePath: scripts/azure-pipelines/Create-PRDiff.ps1
         arguments: '-DiffFile $(DiffFile)'
+        pwsh: true
+    - task: PowerShell@2
+      displayName: 'Validate version files'
+      inputs:
+        targetType: inline
+        script: |
+          ./vcpkg.exe --feature-flags=versions x-ci-verify-versions --verbose
         pwsh: true
     - task: PublishBuildArtifacts@1
       condition: failed()

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -33,14 +33,6 @@ jobs:
       arguments: '-Triplet ${{ parameters.triplet }} -BuildReason $(Build.Reason) -UseEnvironmentSasToken -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
       pwsh: true
   - task: PowerShell@2
-    displayName: 'Validate version files'
-    condition: eq('${{ parameters.triplet }}', 'x86-windows')
-    inputs:
-      targetType: inline
-      script: |
-        ./vcpkg.exe --feature-flags=versions x-ci-verify-versions --verbose
-      pwsh: true
-  - task: PowerShell@2
     displayName: 'Report on Disk Space After Build'
     condition: always()
     inputs:


### PR DESCRIPTION
(Note that previously this was done in a later step because bootstrap was more expensive; now that bootstrap just downloads a vcpkg.exe we can report problems to the user earlier)

This is to avoid cases where a version update triggers full-rebuild like situations like occurred in https://github.com/microsoft/vcpkg/pull/17431