### PR TITLE
[vcpkg baseline][libmicrohttpd] Control dependencies, doc, examples, test

### DIFF
--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,6 +1,0 @@
-Source: libmicrohttpd
-Version: 0.9.63
-Port-Version: 5
-Homepage: https://www.gnu.org/software/libmicrohttpd/
-Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application
-Supports: !(arm|uwp)

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -38,6 +38,11 @@ else()
     endif()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            --disable-doc
+            --disable-examples
+            --disable-curl
+            --disable-https
     )
 
     vcpkg_install_make()

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_download_distfile(ARCHIVE
 )
 
 vcpkg_extract_source_archive_ex(
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     OUT_SOURCE_PATH SOURCE_PATH
     PATCHES fix-msvc-project.patch
 )
@@ -30,8 +30,8 @@ if (VCPKG_TARGET_IS_WINDOWS)
         DEBUG_CONFIGURATION "Debug-${CFG_SUFFIX}"
     )
     
-    file(GLOB MICROHTTPD_HEADERS ${SOURCE_PATH}/src/include/microhttpd*.h)
-    file(COPY ${MICROHTTPD_HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+    file(GLOB MICROHTTPD_HEADERS "${SOURCE_PATH}/src/include/microhttpd*.h")
+    file(COPY ${MICROHTTPD_HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 else()
     if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         set(ENV{LIBS} "$ENV{LIBS} -framework Foundation -framework AppKit") # TODO: Get this from the extracted cmake vars somehow
@@ -42,7 +42,7 @@ else()
 
     vcpkg_install_make()
     
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 endif()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES fix-msvc-project.patch
 )
 
-if (VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
         set(CFG_SUFFIX "dll")
     else()

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -43,6 +43,7 @@ else()
             --disable-examples
             --disable-curl
             --disable-https
+            --with-gnutls=no
     )
 
     vcpkg_install_make()

--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libmicrohttpd",
+  "version": "0.9.63",
+  "port-version": 6,
+  "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
+  "homepage": "https://www.gnu.org/software/libmicrohttpd/",
+  "supports": "!(arm | uwp)",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "platform": "!windows"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3270,7 +3270,7 @@
     },
     "libmicrohttpd": {
       "baseline": "0.9.63",
-      "port-version": 5
+      "port-version": 6
     },
     "libmikmod": {
       "baseline": "3.3.11.1-8",

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad5715c86bbc6b5431d84fd5c26d27babaab4ca8",
+      "version": "0.9.63",
+      "port-version": 6
+    },
+    {
       "git-tree": "da43ec88147e3aa99a5d4e7378f0011a92a25ad2",
       "version-string": "0.9.63",
       "port-version": 5

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad5715c86bbc6b5431d84fd5c26d27babaab4ca8",
+      "git-tree": "c221d15de1cc1eedc33f912269d69d5ade11e3c1",
       "version": "0.9.63",
       "port-version": 6
     },


### PR DESCRIPTION
- #### What does your PR fix?  
  - Fixes #17636 by explicitly
    - disabling https (was inactive on Windows; was used randomly when libgnutls happened to be found in the system; has issues when linking the static build of port libgnutls, #17650)
    - disabling curl (used for tests)
    - declaring gettext dependency (if not windows)
  - Disables building of doc and examples (common practice in vcpkg)
  - Adds mingw support

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no 
  Note that CI baseline contains: `libmicrohttpd:x64-windows-static-md=fail`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

CC @NancyLi1013 
