### PR TITLE
[ffmpeg] fix dnn dependency

### DIFF
--- a/ports/ffmpeg/0016-configure-dnn-needs-avformat.patch
+++ b/ports/ffmpeg/0016-configure-dnn-needs-avformat.patch
@@ -1,0 +1,26 @@
+From e5f322be7b782a1d831b63662c849b2f04c212fd Mon Sep 17 00:00:00 2001
+From: "Matthias C. M. Troffaes" <matthias.troffaes@gmail.com>
+Date: Tue, 4 May 2021 13:47:58 +0100
+Subject: [PATCH] configure: dnn needs avformat
+
+The source file "libavfilter/dnn/dnn_backend_native.h" includes
+"libavformat/avio.h", so avformat needs to be declared as a dependency.
+---
+ configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure b/configure
+index 36713ab658..84f7980dc2 100755
+--- a/configure
++++ b/configure
+@@ -2621,6 +2621,7 @@ cbs_vp9_select="cbs"
+ dct_select="rdft"
+ dirac_parse_select="golomb"
+ dnn_suggest="libtensorflow"
++dnn_deps="avformat"
+ error_resilience_select="me_cmp"
+ faandct_deps="faan"
+ faandct_select="fdctdsp"
+-- 
+2.25.1
+

--- a/ports/ffmpeg/CONTROL
+++ b/ports/ffmpeg/CONTROL
@@ -1,6 +1,6 @@
 Source: ffmpeg
 Version: 4.3.2
-Port-Version: 8
+Port-Version: 9
 Homepage: https://ffmpeg.org
 Description: a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.
   FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations.

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -16,8 +16,9 @@ vcpkg_from_github(
         0011-Fix-x265-detection.patch
         0012-Fix-ssl-110-detection.patch
         0013-define-WINVER.patch
-        0014-avfilter-dependency-fix.patch
+        0014-avfilter-dependency-fix.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-February/275819.html
         0015-Fix-xml2-detection.patch
+        0016-configure-dnn-needs-avformat.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/279926.html
 )
 
 if (SOURCE_PATH MATCHES " ")

--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -13,7 +13,7 @@ Build-Depends: opencolorio
 Description: Enable opencolorio support for openimageio
 
 Feature: ffmpeg
-Build-Depends: ffmpeg[core,avcodec,avfilter]
+Build-Depends: ffmpeg[avresample]
 Description: Enable ffmpeg support for openimageio
 
 Feature: field3d

--- a/ports/openimageio/CONTROL
+++ b/ports/openimageio/CONTROL
@@ -13,7 +13,7 @@ Build-Depends: opencolorio
 Description: Enable opencolorio support for openimageio
 
 Feature: ffmpeg
-Build-Depends: ffmpeg[avresample]
+Build-Depends: ffmpeg[core,avcodec,avfilter]
 Description: Enable ffmpeg support for openimageio
 
 Feature: field3d

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1954,7 +1954,7 @@
     },
     "ffmpeg": {
       "baseline": "4.3.2",
-      "port-version": 8
+      "port-version": 9
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e497eda37bc7882949022c537489959d12c80f63",
+      "version-string": "4.3.2",
+      "port-version": 9
+    },
+    {
       "git-tree": "297aff4ad5a5110a5cb3cf6a118152722f2239ec",
       "version-string": "4.3.2",
       "port-version": 8


### PR DESCRIPTION
I promise I will be slowing down with these ffmpeg PRs eventually... 😄

- #### What does your PR fix?  
  The source file "libavfilter/dnn/dnn_backend_native.h" includes "libavformat/avio.h", so avformat needs to be declared as a dependency. This fixes linking errors in the build of ``ffmpeg[core,avfilter]:x64-windows``.

  Posted upstream here: http://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/279926.html

  Whilst at it, I've also added a link to the other avfilter patch: http://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/279927.html

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
