### PR TITLE
[google-cloud-cpp] update to latest (v1.27.0) version

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.26.0
-    SHA512 686b6390c9b64075d4644db4c9b19c3f01d53a2385dc85028e3277361e21fe834ddc1248c5ac6c63ff3c87d3a21de229ea77d3bec8480a0904ed0126e2e619f6
+    REF v1.27.0
+    SHA512 8528dbdea21a1ca84b7e3b7768a6f6de42c86ed879a4332e646b6de382bf8012d832a2687d5c4560530b569fd79983c259c49852855422c798a63e1787cda328
     HEAD_REF master
     PATCHES
         disable-benchmarks.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2317,7 +2317,7 @@
       "port-version": 5
     },
     "google-cloud-cpp": {
-      "baseline": "1.26.0",
+      "baseline": "1.27.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e6a35577a3c0149939403d8aa0bb1ba3487398b",
+      "version": "1.27.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "249151585040064668071c55f2cd0e4ec1fae8c5",
       "version": "1.26.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release.

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 
Yes
