### PR TITLE
[minizip-ng] made cmake installs relative

### DIFF
--- a/ports/minizip-ng/made_cmake_install_relative.patch
+++ b/ports/minizip-ng/made_cmake_install_relative.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ef8023..524ba60 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -686,7 +686,7 @@ endif()
+ set(MINIZIP_PC ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc)
+ configure_file(minizip.pc.cmakein ${MINIZIP_PC} @ONLY)
+ 
+-set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${PROJECT_NAME}"
++set(INSTALL_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+     CACHE PATH "Installation directory for cmake files.")
+ set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig"
+     CACHE PATH "Installation directory for pkgconfig (.pc) files")

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 3.0.1
     SHA512 98c9bdcea79a88a2dd69cec6c49f8565edf78ab9cddbf0e85e08b049b300b187f176bf57d5a894bf777bec0a097e46ecc05f78dab9cd5726fd473ffd8718dce0
     HEAD_REF master
-    PATCHES Modify-header-file-path.patch
+    PATCHES 
+        Modify-header-file-path.patch
+        made_cmake_install_relative.patch
 )
 
 vcpkg_cmake_configure(

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3f833fb14771ffd8f32496aa12035c86ab1cb9a",
+      "git-tree": "d047922e281f34a18be55988dd2362fb204e6bd3",
       "version": "3.0.1",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  After installation minizip cmake installs had some absolute paths which were making them unusable, this PR makes them relative

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes