### PR TITLE
[embree3] Fix Embree 3 static compilation patch

### DIFF
--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,6 +1,6 @@
 Source: embree3
 Version: 3.11.0
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/embree/embree
 Description: High Performance Ray Tracing Kernels.
 Build-Depends: tbb

--- a/ports/embree3/fix-static-usage.patch
+++ b/ports/embree3/fix-static-usage.patch
@@ -2,7 +2,7 @@ diff --git a/common/cmake/embree-config.cmake b/common/cmake/embree-config.cmake
 index 14ce929..7e2e8f5 100644
 --- a/common/cmake/embree-config.cmake
 +++ b/common/cmake/embree-config.cmake
-@@ -50,6 +50,16 @@ IF (EMBREE_STATIC_LIB)
+@@ -50,6 +50,22 @@ IF (EMBREE_STATIC_LIB)
    INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/simd-targets.cmake")
    INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/lexers-targets.cmake")
    INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/tasking-targets.cmake")
@@ -15,6 +15,12 @@ index 14ce929..7e2e8f5 100644
 +  ENDIF()
 +  IF(EMBREE_ISA_AVX2)
 +      INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_avx2-targets.cmake")
++  ENDIF()
++  IF(EMBREE_ISA_AVX512KNL)
++      INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_avx512knl-targets.cmake")
++  ENDIF()
++  IF(EMBREE_ISA_AVX512SKX)
++      INCLUDE("${EMBREE_ROOT_DIR}/@EMBREE_CMAKEEXPORT_DIR@/embree_avx512skx-targets.cmake")
 +  ENDIF()
  ENDIF()
  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1830,7 +1830,7 @@
     },
     "embree3": {
       "baseline": "3.11.0",
-      "port-version": 1
+      "port-version": 2
     },
     "enet": {
       "baseline": "1.3.16",

--- a/versions/e-/embree3.json
+++ b/versions/e-/embree3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "955eb7f17ebf475e96ee8fe283b56cbc3944da44",
+      "version-string": "3.11.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "c8355374d128022898e8694462f47103bd730684",
       "version-string": "3.11.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  ports/embree3/fix-static-usage.patch misses checks for AVX512KNL and AVX512SKX. Without these checks, finding the package in CMake will fail on systems enabling one of these two configurations. The pull request adds the missing checks.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
