### PR TITLE
[jxrlib] Add usage and fix FindJXR.cmake

### DIFF
--- a/ports/jxrlib/CONTROL
+++ b/ports/jxrlib/CONTROL
@@ -1,5 +1,0 @@
-Source: jxrlib
-Version: 2019.10.9
-Port-Version: 2
-Homepage: https://github.com/4creators/jxrlib
-Description: Open source implementation of the jpegxr image format standard.

--- a/ports/jxrlib/FindJXR.cmake
+++ b/ports/jxrlib/FindJXR.cmake
@@ -21,7 +21,7 @@ find_library(JXRGLUE_LIBRARY_RELEASE NAMES jxrglue PATH_SUFFIXES lib)
 find_library(JXRGLUE_LIBRARY_DEBUG NAMES jxrglued PATH_SUFFIXES lib)
 select_library_configurations(JXRGLUE)
 
-set(JXR_LIBRARIES ${JPEGXR_LIBRARY} ${JXRGLUE_LIBRARY})
+set(JXR_LIBRARIES ${JXRGLUE_LIBRARY} ${JPEGXR_LIBRARY})
 mark_as_advanced(JXR_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)

--- a/ports/jxrlib/portfile.cmake
+++ b/ports/jxrlib/portfile.cmake
@@ -26,9 +26,10 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
 #install FindJXR.cmake file
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/FindJXR.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/jxr)
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/jxr)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/jxr)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/jxrlib/usage
+++ b/ports/jxrlib/usage
@@ -1,0 +1,5 @@
+The package jxrlib provides CMake integration:
+
+    find_package(JXR REQUIRED)
+    target_include_directories(main PRIVATE ${JXR_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE ${JXR_LIBRARIES})

--- a/ports/jxrlib/vcpkg.json
+++ b/ports/jxrlib/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "jxrlib",
+  "version": "2019.10.9",
+  "port-version": 3,
+  "description": "Open source implementation of the jpegxr image format standard.",
+  "homepage": "https://github.com/4creators/jxrlib"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2774,7 +2774,7 @@
     },
     "jxrlib": {
       "baseline": "2019.10.9",
-      "port-version": 2
+      "port-version": 3
     },
     "kangaru": {
       "baseline": "4.2.4",

--- a/versions/j-/jxrlib.json
+++ b/versions/j-/jxrlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2070ec06331c3cf93574ec82fa22791e3ba6172f",
+      "version": "2019.10.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "c24ffcc58c1c28bef405da5b56adad3a25cd441b",
       "version-string": "2019.10.9",
       "port-version": 2


### PR DESCRIPTION
Fix bug:
```
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlue.c.o): in function `PKCreateFactory':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlue.c:367: undefined reference to `CreateWS_File'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlue.c:368: undefined reference to `CreateWS_Memory'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlue.c.o): in function `PKCodecFactory_CreateDecoderFromFile':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlue.c:419: undefined reference to `CreateWS_File'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeContent_Init':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:812: undefined reference to `ImageStrEncInit'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeContent_Encode':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:836: undefined reference to `ImageStrEncEncode'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeContent_Term':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:848: undefined reference to `ImageStrEncTerm'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeAlpha_Init':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:938: undefined reference to `ImageStrEncInit'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeAlpha_Encode':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:960: undefined reference to `ImageStrEncEncode'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_EncodeAlpha_Term':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:972: undefined reference to `ImageStrEncTerm'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageEncode_Transcode_WMP':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:1413: undefined reference to `WMPhotoTranscode'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:1425: undefined reference to `WMPhotoTranscode'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageDecode_Initialize_WMP':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:1855: undefined reference to `ImageStrDecGetInfo'
[build] /usr/bin/ld: ../../vcpkg/installed/x64-linux/debug/lib/libjxrglued.a(JXRGlueJxr.c.o): in function `PKImageDecode_Copy_WMP':
[build] /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:1984: undefined reference to `ImageStrDecInit'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:1998: undefined reference to `ImageStrDecTerm'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2000: undefined reference to `ImageStrDecInit'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2026: undefined reference to `ImageStrDecDecode'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2049: undefined reference to `ImageStrDecTerm'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2105: undefined reference to `ImageStrDecInit'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2117: undefined reference to `ImageStrDecTerm'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2118: undefined reference to `ImageStrDecInit'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2126: undefined reference to `ImageStrDecDecode'
[build] /usr/bin/ld: /home/roeber/_repos/sw_test/build/vcpkg/buildtrees/jxrlib/src/0dd9dbbdb4-4d68cbd583.clean/jxrgluelib/JXRGlueJxr.c:2131: undefined reference to `ImageStrDecTerm'
```
```bash
root@usr:/home/usr/vcpkg# nm packages/jxrlib_x64-linux/debug/lib/libjxrglued.a -g | grep CreateWS_File
                 U CreateWS_File
                 U CreateWS_File
root@usr:/home/usr/vcpkg# nm packages/jxrlib_x64-linux/debug/lib/libjpegxrd.a -g | grep CreateWS_File
                 U CreateWS_File
0000000000000882 T CreateWS_File
```
Obviously, due to the order of links in linux, we should link `libjxrglued.a` first, then link `libjpegxrd.a`.
Fix this.
Also add usage file.

Related: https://github.com/microsoft/vcpkg/issues/14498