### PR TITLE
[qscintilla] Modify macro QSCINTILLA_DLL to 1 in qscintilla header

### DIFF
--- a/ports/qscintilla/CONTROL
+++ b/ports/qscintilla/CONTROL
@@ -1,5 +1,0 @@
-Source: qscintilla
-Version: 2.12.0
-Homepage: https://www.riverbankcomputing.com/software/qscintilla
-Description: QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)
-Build-Depends: qt5-base[core], qt5-macextras (osx), qt5-winextras (windows)

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -30,6 +30,13 @@ if(VCPKG_TARGET_IS_WINDOWS)
         RELEASE_TARGETS release
         DEBUG_TARGETS debug
     )
+    
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/Qsci/qsciglobal.h
+            "#if defined(QSCINTILLA_DLL)"
+            "#if 1"
+        )
+    endif()
 else()
     vcpkg_install_qmake()
 endif()

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -30,19 +30,19 @@ if(VCPKG_TARGET_IS_WINDOWS)
         RELEASE_TARGETS release
         DEBUG_TARGETS debug
     )
-    
-    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-        vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/Qsci/qsciglobal.h
-            "#if defined(QSCINTILLA_DLL)"
-            "#if 1"
-        )
-    endif()
 else()
     vcpkg_install_qmake()
 endif()
 
 file(GLOB HEADER_FILES ${SOURCE_PATH}/src/Qsci/*)
 file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/Qsci)
+
+if (VCPKG_TARGET_IS_WINDOWS AND (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic))
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/Qsci/qsciglobal.h
+        "#if defined(QSCINTILLA_DLL)"
+        "#if 1"
+    )
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "qscintilla",
+  "version": "2.12.0",
+  "port-version": 1,
+  "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
+  "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
+  "supports": "!(windows & (arm | arm64))",
+  "dependencies": [
+    {
+      "name": "qt5-base",
+      "default-features": false
+    },
+    {
+      "name": "qt5-macextras",
+      "platform": "osx"
+    },
+    {
+      "name": "qt5-winextras",
+      "platform": "windows"
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5010,7 +5010,7 @@
     },
     "qscintilla": {
       "baseline": "2.12.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qt-advanced-docking-system": {
       "baseline": "3.6.3",

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63f2d1f0287a6d61b5c85b428920b0fbe102adec",
+      "version": "2.12.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "753c09c98e94157f9998e6528d5bb7dce4337ced",
       "version-string": "2.12.0",
       "port-version": 0


### PR DESCRIPTION
The macro `QSCINTILLA_DLL` shoud be change to `1` / `true` in the header file `qsciglobal.h` when building dynmaic on Windows.

Fixes #5198 partly.