### PR TITLE
yaml-cpp: Fix visibility attribute for ubuntu

### DIFF
--- a/ports/yaml-cpp/CONTROL
+++ b/ports/yaml-cpp/CONTROL
@@ -1,4 +1,5 @@
 Source: yaml-cpp
 Version: 0.6.3
+Port-Version: 1
 Homepage: https://github.com/jbeder/yaml-cpp
 Description: yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.

--- a/ports/yaml-cpp/portfile.cmake
+++ b/ports/yaml-cpp/portfile.cmake
@@ -36,7 +36,7 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 file(READ ${CURRENT_PACKAGES_DIR}/include/yaml-cpp/dll.h DLL_H)
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS)
     string(REPLACE "#ifdef YAML_CPP_DLL" "#if 1" DLL_H "${DLL_H}")
 else()
     string(REPLACE "#ifdef YAML_CPP_DLL" "#if 0" DLL_H "${DLL_H}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6530,7 +6530,7 @@
     },
     "yaml-cpp": {
       "baseline": "0.6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "yara": {
       "baseline": "4.0.2",

--- a/versions/y-/yaml-cpp.json
+++ b/versions/y-/yaml-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "045045b2d5b8cb6166b6d0d548effc0764623341",
+      "version-string": "0.6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "fabfdd85c28d751aa769d2e743bf0e9ccd8dd178",
       "version-string": "0.6.3",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

I'm building the libraries as shared libraries as shown in [overlay-triplets-linux-dynamic](https://github.com/microsoft/vcpkg/blob/master/docs/examples/overlay-triplets-linux-dynamic.md) which cause the `dll.h` header in `yaml-cpp` package to always define `YAML_CPP_API` as `__declspec(dllexport)` or `__declspec(dllimport)` ([link](https://github.com/microsoft/vcpkg/blob/master/ports/yaml-cpp/portfile.cmake#L39-L43)) which is causing compile errors when built on gcc/clang in ubuntu, this PR replaces `__declspec(dllexport)`/`__declspec(dllimport)` with `__attribute__ ((visibility ("default")))` as shown in [GNU C++ visibility](https://gcc.gnu.org/wiki/Visibility#Step-by-step_guide)

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
