### PR TITLE
[libxml2] Improve pc file

### DIFF
--- a/ports/libxml2/CMakeLists.txt
+++ b/ports/libxml2/CMakeLists.txt
@@ -166,6 +166,13 @@ install(TARGETS libxml2
 )
 
 # pkgconfig
+if(NOT Iconv_IS_BUILT_IN)
+    set(ICONV_LIBS "-liconv")
+endif()
+if(UNIX)
+    set(M_LIBS "-lm")
+    set(THREAD_LIBS "-pthread")
+endif()
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\${prefix}")
 set(libdir ${prefix}/${CMAKE_INSTALL_LIBDIR})

--- a/ports/libxml2/CMakeLists.txt
+++ b/ports/libxml2/CMakeLists.txt
@@ -138,7 +138,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsSt
         _WINSOCK_DEPRECATED_NO_WARNINGS
     )
     target_sources(libxml2 PRIVATE win32/libxml2.rc)
-    configure_file(rcVersion.h.in include/rcVersion.h @ONLY)
+    configure_file("${PORT_DIR}/rcVersion.h.in" include/rcVersion.h @ONLY)
 endif()
 
 target_compile_definitions(libxml2 PRIVATE

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -15,12 +15,6 @@ else()
     set(ENABLE_NETWORK 1)
 endif()
 
-x_vcpkg_pkgconfig_get_modules(
-    PREFIX PKGFCONFIG
-    MODULES liblzma zlib
-    LIBS
-)
-
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -28,10 +22,7 @@ vcpkg_configure_cmake(
         -DPORT_DIR=${CMAKE_CURRENT_LIST_DIR}
         -DWITH_HTTP=${ENABLE_NETWORK}
         -DWITH_FTP=${ENABLE_NETWORK}
-    OPTIONS_RELEASE
-        "-DLIBS=${PKGFCONFIG_LIBS_RELEASE}"
     OPTIONS_DEBUG
-        "-DLIBS=${PKGFCONFIG_LIBS_DEBUG}"
         -DINSTALL_HEADERS=OFF
 )
 
@@ -43,6 +34,10 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endif()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libxml-2.0.pc" "-lxml2" "-llibxml2")
 endif ()
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libxml-2.0.pc" "\nRequires:\n" "\nRequires.private: liblzma zlib\n")
+endif()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libxml-2.0.pc" "\nRequires:\n" "\nRequires.private: liblzma zlib\n")
 vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -15,6 +15,12 @@ else()
     set(ENABLE_NETWORK 1)
 endif()
 
+x_vcpkg_pkgconfig_get_modules(
+    PREFIX PKGFCONFIG
+    MODULES liblzma zlib
+    LIBS
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -22,7 +28,10 @@ vcpkg_configure_cmake(
         -DPORT_DIR=${CMAKE_CURRENT_LIST_DIR}
         -DWITH_HTTP=${ENABLE_NETWORK}
         -DWITH_FTP=${ENABLE_NETWORK}
+    OPTIONS_RELEASE
+        "-DLIBS=${PKGFCONFIG_LIBS_RELEASE}"
     OPTIONS_DEBUG
+        "-DLIBS=${PKGFCONFIG_LIBS_DEBUG}"
         -DINSTALL_HEADERS=OFF
 )
 

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -7,7 +7,6 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/rcVersion.h.in DESTINATION ${SOURCE_PATH})
 
 if (VCPKG_TARGET_IS_UWP)
     message(WARNING "Feature network couldn't be enabled on UWP, disable http and ftp automatically.")

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "libxml2",
   "version-semver": "2.9.10",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://xmlsoft.org/",
   "dependencies": [
     "libiconv",
     "liblzma",
+    "vcpkg-pkgconfig-get-modules",
     "zlib"
   ]
 }

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -7,7 +7,6 @@
   "dependencies": [
     "libiconv",
     "liblzma",
-    "vcpkg-pkgconfig-get-modules",
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3654,7 +3654,7 @@
     },
     "libxml2": {
       "baseline": "2.9.10",
-      "port-version": 6
+      "port-version": 7
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "828fccc07beb722b28194fc6a8a43257c16ae78a",
+      "git-tree": "f86ba7081b940af77e935875fbdf9cbf69446b9f",
       "version-semver": "2.9.10",
       "port-version": 7
     },

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "828fccc07beb722b28194fc6a8a43257c16ae78a",
+      "version-semver": "2.9.10",
+      "port-version": 7
+    },
+    {
       "git-tree": "306378bea94b3a4b3c5992510b992b3690b87f52",
       "version-semver": "2.9.10",
       "port-version": 6


### PR DESCRIPTION
- #### What does your PR fix?  
  The pc file did not list any extra libraries needed for static linking. This PR adds them, e.g. for x64-linux-dbg:  
  `Libs.private:  -pthread    -lm  -L/vcpkg/installed/x64-linux/debug/lib/pkgconfig/../../lib -llzmad -pthread -lz`
  This ~helps with~ fixes the libxml2 test in gdal `configure`.

  In addition, the PR also shortcuts a copying step introduced in my previous PR.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

- ### Remarks

  - Similar configuration is done in upstream HEAD's CMakeLists.txt. CC @JackBoosY 
  - Some requirements are collected via `x_vcpkg_pkgconfig_get_modules`, in order to easily to resolve recursively and with debug postfixes as needed. CC @Neumann-A 