### PR TITLE
[vcpkg] Avoid duplication of Libs in vcpkg_fixup_pkgconfig

### DIFF
--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -158,6 +158,13 @@ function(vcpkg_fixup_pkgconfig)
             # Once this transformation is complete, users of vcpkg should never need to pass
             # --static.
             if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+                if(_contents MATCHES "\nLibs.private: *([^\n]*[^ \n])")
+                    # If the software already merges Libs.private into Libs (e.g. curl), avoid duplication.
+                    set(_libs_private "${CMAKE_MATCH_1}")
+                    string(REGEX REPLACE "\nLibs: *([^\n]*[^ \n])" "\nLibs: @VCPKG_FIXUP_LIBS@" _contents "${_contents}")
+                    string(REPLACE " ${_libs_private} " " " _libs " ${CMAKE_MATCH_1} ")
+                    string(REPLACE "@VCPKG_FIXUP_LIBS@" "${_libs}" _contents "${_contents}")
+                endif()
                 # Libs comes before Libs.private
                 string(REGEX REPLACE "(^|\n)(Libs: [^\n]*)(.*)\nLibs.private:( [^\n]*)" "\\1\\2\\4\\3" _contents "${_contents}")
                 # Libs.private comes before Libs


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR modifies `vcpkg_fixup_pkgconfig`, static linkage, to not duplicate Libs.private in Libs if its already present there.

  E.g. for curl, x64-linux, instead of 
  `Libs: -L"${libdir}" -lcurl-d  -lgcc -lgcc_s -lc -lgcc -lgcc_s -ldl -lpthread -lssl -lcrypto -lz  -lgcc -lgcc_s -lc -lgcc -lgcc_s -ldl -lpthread -lssl -lcrypto -lz` 
  curl.pc is now: 
  `Libs:  -L"${libdir}" -lcurl-d    -lgcc -lgcc_s -lc -lgcc -lgcc_s -ldl -lpthread -lssl -lcrypto -lz` 

  This helps when reviewing build logs (as I'm doing for gdal at the moment).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  -/-