### PR TITLE
[d3dx12] update port

### DIFF
--- a/ports/d3dx12/portfile.cmake
+++ b/ports/d3dx12/portfile.cmake
@@ -1,14 +1,21 @@
-set(VERSION may2020)
+set(VERSION may2021)
+
+# The official D3DX12.H is hosted on https://github.com/microsoft/DirectX-Headers.
+#
+# This port uses the version from directx-vs-templates instead because it is compatible with multiple
+# versions of the Windows 10 SDK. The official version only supports the 'latest' Windows 10 SDK.
+
+message(NOTICE "Consider using the 'directx-headers' port instead. See https://aka.ms/directx12agility")
 
 vcpkg_download_distfile(D3DX12_H
     URLS "https://raw.githubusercontent.com/walbourn/directx-vs-templates/${VERSION}/d3d12game_win32_dr/d3dx12.h"
     FILENAME "directx-vs-templates-${VERSION}-d3dx12.h"
-    SHA512 "829b72ddf861652bd96518b7d54f7a103c95b4434ec022e1551fb085e4dfc8f804e01ccdb4677e3f64367553c56d35291b305e10c2ea6186ddadaaa071c6d7a2"
+    SHA512 b053a8e6593c701a0827f8a52f20e160070b8b71242fd60a57617e46b87e909e11f814fc15b084b4f83b7ff5b9a562280da64a77cee3a171ef17839315df4245
 )
 vcpkg_download_distfile(LICENSE
     URLS "https://raw.githubusercontent.com/walbourn/directx-vs-templates/${VERSION}/LICENSE"
     FILENAME "directx-vs-templates-${VERSION}-LICENSE"
-    SHA512 "f1c9c9b83627d00ec98c9e54c4b708716731e4b0b27f38e95d21b01f8fe4e1f27eeade5d802f93caa83ede17610411ca082ea1ce79150c372f3abdceaaa9a4a3"
+    SHA512 ce7d8ec7bfb58ef36a95b20f6f0fc4e3cd4923bb3ac6bd1f62e8215df2ee83d2a594ce84b15951310f05a819a0370468af781e73a10e536d23965421466851f4
 )
 
 file(INSTALL "${D3DX12_H}" DESTINATION ${CURRENT_PACKAGES_DIR}/include RENAME d3dx12.h)

--- a/ports/d3dx12/vcpkg.json
+++ b/ports/d3dx12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "d3dx12",
-  "version-string": "may2020",
+  "version-string": "may2021",
   "description": "The D3D12 Helper Library",
-  "homepage": "https://github.com/microsoft/DirectX-Graphics-Samples/tree/master/Libraries/D3DX12"
+  "homepage": "https://docs.microsoft.com/en-us/windows/win32/direct3d12/helper-structures-and-functions-for-d3d12"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1561,7 +1561,7 @@
       "port-version": 0
     },
     "d3dx12": {
-      "baseline": "may2020",
+      "baseline": "may2021",
       "port-version": 0
     },
     "darknet": {

--- a/versions/d-/d3dx12.json
+++ b/versions/d-/d3dx12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34415699a49eb16898e8190a101c6f6e026b1b3d",
+      "version-string": "may2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "8ee92f85b281f540bb897404333cd300bd02e015",
       "version-string": "may2020",
       "port-version": 0


### PR DESCRIPTION
The ``d3dx12`` port was added by the community as a way to get just the ``D3DX12.H`` utility header from vcpkg. This updates the port to use the latest version of this header available today.

This port makes use of a 'mirror' or 'fork' of D3DX12.H that I maintain at [directx-vs-templates](https://github.com/walbourn/directx-vs-templates). The reason to use this version over the 'official' version is that the 'official' version *only works* with the latest Windows 10 SDK (19041). If you are using an older Windows 10 SDK the header fails to build. My version just adds the appropriate ``#ifdef`` statements to make it compile all the way back to Windows 10 SDK (14393)--the last version that supported VS 2015.

In addition to updating the port, the 'official' home of D3DX12.H has moved from [DirectX-Graphics-Samples](https://github.com/Microsoft/DirectX-Graphics-Samples) to [DirectX-Headers](https://github.com/microsoft/DirectX-Headers). An option for switching from this port to the 'official' version is to use the full header set via the ``directx-headers`` port instead of the locally installed Windows 10 SDK plus the ``d3dx12`` port. I added a message to note this.