### PR TITLE
[wxwidgets] Update to 3.1.5

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -3,12 +3,11 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxWidgets/wxWidgets
-    REF v3.1.4
-    SHA512 108e35220de10afbfc58762498ada9ece0b3166f56a6d11e11836d51bfbaed1de3033c32ed4109992da901fecddcf84ce8a1ba47303f728c159c638dac77d148
+    REF v3.1.5
+    SHA512 69111e8424148dd75255190f692e82edcc49eccf60d5e9d3ab35e114065f7183c54385583188b8156a59f6632a70f8ec69cc078174b860074904ba1a7b273ba5
     HEAD_REF master
     PATCHES
         disable-platform-lib-dir.patch
-        fix-stl-build-vs2019-16.6.patch
 )
 
 set(OPTIONS)

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
-  "version-semver": "3.1.4",
-  "port-version": 8,
+  "version-semver": "3.1.5",
+  "port-version": 0,
   "description": "a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.",
   "homepage": "https://github.com/wxWidgets/wxWidgets",
   "supports": "!uwp",

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wxwidgets",
   "version-semver": "3.1.5",
-  "port-version": 0,
   "description": "a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.",
   "homepage": "https://github.com/wxWidgets/wxWidgets",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6493,8 +6493,8 @@
       "port-version": 1
     },
     "wxwidgets": {
-      "baseline": "3.1.4",
-      "port-version": 8
+      "baseline": "3.1.5",
+      "port-version": 0
     },
     "x-plane": {
       "baseline": "3.0.3",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8dfc1eda7d6f7304d642d0a8dfe5da53dc5eba95",
+      "version-semver": "3.1.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8fc2d91de4a0a86698c67e6bb662c14cbfd29732",
       "version-semver": "3.1.4",
       "port-version": 8


### PR DESCRIPTION
**Describe the pull request**

The following commit updated wxwidgets to 3.1.5

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all supported except UWP

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes