### PR TITLE
[curl] Fix linker flags in curl-config and libcurl.pc for osx

### DIFF
--- a/ports/curl/0020-fix-pc-file.patch
+++ b/ports/curl/0020-fix-pc-file.patch
@@ -5,7 +5,7 @@ diff -urw a/CMakeLists.txt b/CMakeLists.txt
        message(WARNING "Bad lib in library list: ${_libname}")
        continue()
      endif()
-+  elseif(CMAKE_VERSION VERSION_GREATER "3.8.99" AND _lib MATCHES "^(.*)/([^/]*)[.]framework$")
++  elseif(_lib MATCHES "^(.*)/([^/]*)[.]framework$")
 +    if(CMAKE_MATCH_1 IN_LIST CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES)
 +      set(_lib "-framework ${CMAKE_MATCH_2}")
 +    else()

--- a/ports/curl/0020-fix-pc-file.patch
+++ b/ports/curl/0020-fix-pc-file.patch
@@ -1,0 +1,16 @@
+diff -urw a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2021-05-10 20:46:52.204346972 +0200
++++ b/CMakeLists.txt	2021-05-11 19:39:00.065235266 +0200
+@@ -1482,6 +1482,12 @@
+       message(WARNING "Bad lib in library list: ${_libname}")
+       continue()
+     endif()
++  elseif(CMAKE_VERSION VERSION_GREATER "3.8.99" AND _lib MATCHES "^(.*)/([^/]*)[.]framework$")
++    if(CMAKE_MATCH_1 IN_LIST CMAKE_C_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES)
++      set(_lib "-framework ${CMAKE_MATCH_2}")
++    else()
++      set(_lib "-framework ${_lib}")
++    endif()
+   endif()
+   if(_lib MATCHES ".*/.*" OR _lib MATCHES "^-")
+     set(LIBCURL_LIBS          "${LIBCURL_LIBS} ${_lib}")

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         0010_fix_othertests_cmake.patch
         0011_fix_static_build.patch
         0012-fix-dependency-idn2.patch
+        0020-fix-pc-file.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "7.74.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "A library for transferring data with URLs",
   "homepage": "https://github.com/curl/curl",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1546,7 +1546,7 @@
     },
     "curl": {
       "baseline": "7.74.0",
-      "port-version": 7
+      "port-version": 8
     },
     "curlpp": {
       "baseline": "2018-06-15-3",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6f975156f39e2311de3d0f59ad99351cabf011a8",
+      "git-tree": "cd05855cc1cd2d0f221664f0bfbe639b685fa028",
       "version": "7.74.0",
       "port-version": 8
     },

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6f975156f39e2311de3d0f59ad99351cabf011a8",
+      "version": "7.74.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "2184d79bb98ed36af015203385175cade013d8af",
       "version": "7.74.0",
       "port-version": 7


### PR DESCRIPTION
- #### What does your PR fix?  
  Apply same library path fixup as for Linux, plus:
  Instead of just listing the absolute framework location with no flags, the flags are now:
  `-framework CoreFoundation -framework Security`

  Needed to to fix gdal for osx (#9068).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged (but targeting osx), no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
