### PR TITLE
[vcpkg baseline][chartdir] Update version to 7.0.0

### DIFF
--- a/ports/chartdir/CONTROL
+++ b/ports/chartdir/CONTROL
@@ -1,5 +1,0 @@
-Source: chartdir
-Version: 6.3.1
-Port-Version: 2
-Homepage: https://www.advsofteng.com/
-Description: ChartDirector is a powerful chart component for creating professional looking charts for web and windows applications.

--- a/ports/chartdir/portfile.cmake
+++ b/ports/chartdir/portfile.cmake
@@ -8,14 +8,14 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
 
     vcpkg_download_distfile(ARCHIVE_FILE
         URLS "http://www.advsofteng.net/chartdir_cpp_win.zip"
-        FILENAME "chartdir_cpp_win-6.3.1.zip"
-        SHA512 e9841d4416c833f57439a36cb981a9c320884c655f8278a22690f05a215c87f0bba83406b45e03ea384c015a4619852c7a9b36dcc9dbd7d531dee1c07b5cffe9
+        FILENAME "chartdir_cpp_win-7.0.0.zip"
+        SHA512 38d9dae641c0341ccee4709138afd37ad4718c34def70a0dc569956bf9c3488d0d66072f604dca4663dc80bd09446a2ba27ef3806fc3b87dda6aaa5453a7316f
     )
 
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE ${ARCHIVE_FILE}
-        REF 6.3.1
+        REF 7.0.0
     )
 
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
@@ -24,31 +24,31 @@ elseif(VCPKG_TARGET_IS_WINDOWS)
         set(LIBDIR "${SOURCE_PATH}/lib32")
     endif()
 
-    file(COPY "${LIBDIR}/chartdir60.dll"  DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-    file(COPY "${LIBDIR}/chartdir60.lib"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    file(COPY "${LIBDIR}/chartdir60.dll"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(COPY "${LIBDIR}/chartdir60.lib"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+    file(COPY "${LIBDIR}/chartdir70.dll"  DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(COPY "${LIBDIR}/chartdir70.lib"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY "${LIBDIR}/chartdir70.dll"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(COPY "${LIBDIR}/chartdir70.lib"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 
-    set(CHARTDIR_LIB "chartdir60.lib")
+    set(CHARTDIR_LIB "chartdir70.lib")
 
 elseif(VCPKG_TARGET_IS_OSX)
 
     vcpkg_download_distfile(ARCHIVE_FILE
         URLS "https://www.advsofteng.net/chartdir_cpp_mac.tar.gz"
-        FILENAME "chartdir_cpp_mac-6.3.1.51483c1975.tar.gz"
-        SHA512 51483c197518203a24f652a4bfd9af1f933f8c59f3d7286e13c612cf09c5b850b4d1e9daa506379218797b5bb79bbc571b9e90b0fbb0f3ef4a3f455dd0de3848
+        FILENAME "chartdir_cpp_mac-7.0.0.tar.gz"
+        SHA512 3f00a4eb7c6b7fc1ebd4856c287ca9a76ca4ce813b4203350526c7ef10c946baa3768446178b664af8e8222275f10f9ee6f5f87cf1e23f23c4a221f431864744
     )
 
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE ${ARCHIVE_FILE}
-        REF 6.3.1
+        REF 7.0.0
     )
 
-    file(COPY "${SOURCE_PATH}/lib/libchartdir.6.dylib"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    file(COPY "${SOURCE_PATH}/lib/libchartdir.6.dylib"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+    file(COPY "${SOURCE_PATH}/lib/libchartdir.7.dylib"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY "${SOURCE_PATH}/lib/libchartdir.7.dylib"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 
-    set(CHARTDIR_LIB "libchartdir.6.dylib")
+    set(CHARTDIR_LIB "libchartdir.7.dylib")
 
 elseif(VCPKG_TARGET_IS_LINUX)
 
@@ -56,16 +56,16 @@ elseif(VCPKG_TARGET_IS_LINUX)
 
         vcpkg_download_distfile(ARCHIVE_FILE
             URLS "http://www.advsofteng.net/chartdir_cpp_linux_64.tar.gz"
-            FILENAME "chartdir_cpp_linux_64-6.3.1.tar.gz"
-            SHA512 e6a3acee3cc5f38304ffa0d3704b1365fcc7a60c8bb688f121caa31efa568b74598b4e10379e84200888d9d8dc3cd7a6a24a944c2d63ca5a146162854c6222a9
+            FILENAME "chartdir_cpp_linux_64-7.0.0.tar.gz"
+            SHA512 e7e71b64b3a756b6df174758c392ab4c9310b4d265e521dccbd009eeefd46e021a74572e7212de5564725df20ddf189e1599e88a116b426f1256f7d34b0131aa
         )
 
     else()
 
         vcpkg_download_distfile(ARCHIVE_FILE
             URLS "http://www.advsofteng.net/chartdir_cpp_linux.tar.gz"
-            FILENAME "chartdir_cpp_linux-6.3.1.tar.gz"
-            SHA512 0a2f2d7c8d53c2f06c302a837f286826b4f48cc5f5bdb55c4de23337bc4188d1652625aee2c8061561d9b5bdef5e0e2a4cdd176d44ca60c1f730e4f38299c5a0
+            FILENAME "chartdir_cpp_linux-7.0.0.tar.gz"
+            SHA512 bf749c9821a901a7071964f22aabb606f90dc853907720a05252165d63d27aa31d10f0aa62995ab92085bb790f3830063fd8042331195b0153a9d49e8a92e871
         )
 
     endif()
@@ -73,22 +73,22 @@ elseif(VCPKG_TARGET_IS_LINUX)
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE ${ARCHIVE_FILE}
-        REF 6.3.1
+        REF 7.0.0
     )
 
-    file(COPY "${SOURCE_PATH}/lib/libchartdir.so.6.0.3"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    file(COPY "${SOURCE_PATH}/lib/libchartdir.so.6.0.3"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+    file(COPY "${SOURCE_PATH}/lib/libchartdir.so.7.0.0"  DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY "${SOURCE_PATH}/lib/libchartdir.so.7.0.0"  DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
 
-    set(CHARTDIR_LIB "libchartdir.so.6.0.3")
+    set(CHARTDIR_LIB "libchartdir.so.7.0.0")
 
-    file(COPY ${SOURCE_PATH}/lib/fonts DESTINATION ${CURRENT_PACKAGES_DIR}/share/chartdir)
+    file(COPY ${SOURCE_PATH}/lib/fonts DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 
 endif()
 
 file(GLOB HEADERS "${SOURCE_PATH}/include/*.h")
-file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include/chartdir)
+file(COPY ${HEADERS} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/chartdir.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 
-configure_file(${SOURCE_PATH}/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/chartdir/copyright COPYONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in ${CURRENT_PACKAGES_DIR}/share/chartdir/chartdir-config.cmake @ONLY)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/chartdir)
+configure_file(${SOURCE_PATH}/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/Config.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/chartdir-config.cmake @ONLY)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/chartdir/vcpkg.json
+++ b/ports/chartdir/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "chartdir",
+  "version": "7.0.0",
+  "description": "ChartDirector is a powerful chart component for creating professional looking charts for web and windows applications.",
+  "homepage": "https://www.advsofteng.com/"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1189,8 +1189,8 @@
       "port-version": 0
     },
     "chartdir": {
-      "baseline": "6.3.1",
-      "port-version": 2
+      "baseline": "7.0.0",
+      "port-version": 0
     },
     "check": {
       "baseline": "0.15.2",

--- a/versions/c-/chartdir.json
+++ b/versions/c-/chartdir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "433c4a83452c8867b63d012a46109a4e3992e13f",
+      "version": "7.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "9fde410f21fe4ab0dfdc3980210c97a17d752380",
       "version-string": "6.3.1",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  In CI unstable test, `chartdir` build failed with wrong hash:
```
File does not have expected hash:
          File path: [ D:/downloads/temp/chartdir_cpp_win-6.3.1.zip ]
      Expected hash: [ e9841d4416c833f57439a36cb981a9c320884c655f8278a22690f05a215c87f0bba83406b45e03ea384c015a4619852c7a9b36dcc9dbd7d531dee1c07b5cffe9 ]
        Actual hash: [ 38d9dae641c0341ccee4709138afd37ad4718c34def70a0dc569956bf9c3488d0d66072f604dca4663dc80bd09446a2ba27ef3806fc3b87dda6aaa5453a7316f ]
```
Aftre checked the homepage of `chartdir`, the latest version 7.0 has been released, so I update this port to the latest version.

Note: No feature needs to test.