### PR TITLE
[rubberband] Add new port

### DIFF
--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_download_distfile(
+  ARCHIVE URLS "https://breakfastquay.com/files/releases/rubberband-1.9.1.tar.bz2"
+  FILENAME "rubberband-1.9.1.tar.bz2"
+  SHA512 cb20ef8fb717a9e6b5b0b921541bd701e94326e12cdb20d50bed344d12fa1b4fd731335c3a0a7f2d2a5ce96031d965b209e7667c4d55fd8494b8e20d3409f0d3
+)
+
+vcpkg_extract_source_archive_ex(
+  OUT_SOURCE_PATH SOURCE_PATH
+  ARCHIVE ${ARCHIVE}
+)
+
+vcpkg_configure_meson(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_install_meson()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(
+  INSTALL ${SOURCE_PATH}/COPYING
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/rubberband
+  RENAME copyright
+)

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "rubberband",
+  "version": "1.9.1",
+  "description": "High quality software library for audio time-stretching and pitch-shifting.",
+  "homepage": "https://www.breakfastquay.com/rubberband/",
+  "dependencies": [
+    "kissfft"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5376,6 +5376,10 @@
       "baseline": "0.9.6-2",
       "port-version": 0
     },
+    "rubberband": {
+      "baseline": "1.9.1",
+      "port-version": 0
+    },
     "rxcpp": {
       "baseline": "4.1.0-1",
       "port-version": 0

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c06335400a1eb701be1e862e021c42420c457530",
+      "version": "1.9.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
[rubberband](https://www.breakfastquay.com/rubberband/) is a small
library for stretching sounds.
This is the minimal portfile to make vcpkg happy, but probably still
needs some improvement, i.e. not picking up system libraries.

I do have some questions on how to improve this port (BTW: I am not familiar with meson and this is my first port):
- Should I delete the binaries (the rubberband "example" executable), as done in this port, or would it be better to patch the meson build file to disable building the executable in the first place?
- rubberband can use different FFT implementations. I have read that features would not be a good solution to handle this, as these would not  be strictly additive. Should I just pick one? The project itself uses a different one on macOS than all other platforms by default. Should this be reflected in this port?
- rubberband does have a VAMP plugin which is optional and in my opinion not as interesting as the library itself (in the context of vcpkg), do I need to provide a feature for that? Or is this something, that could be done in a later PR, if somebody would even be interested in it.
- Do I need to take extra steps in order to avoid picking up system libraries during the build of this package or would that be fine?

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17768 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)? 
  I have so far only tested it on my machine (linux). No I have not updated the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  To the best of my knowledge ;)

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
Opened it as a draft PR.