### PR TITLE
[boost-dynamic-bitset] Update dependencies

### DIFF
--- a/ports/boost-dynamic-bitset/vcpkg.json
+++ b/ports/boost-dynamic-bitset/vcpkg.json
@@ -1,10 +1,18 @@
 {
   "name": "boost-dynamic-bitset",
   "version-string": "1.75.0",
+  "port-version": 1,
   "description": "Boost dynamic_bitset module",
   "homepage": "https://github.com/boostorg/dynamic_bitset",
   "dependencies": [
+    "boost-assert",
+    "boost-config",
+    "boost-container-hash",
     "boost-core",
+    "boost-integer",
+    "boost-move",
+    "boost-static-assert",
+    "boost-throw-exception",
     "boost-vcpkg-helpers"
   ]
 }

--- a/versions/b-/boost-dynamic-bitset.json
+++ b/versions/b-/boost-dynamic-bitset.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8c99c0940c770de59d33f1dc952214245f4a5987",
+      "version-string": "1.75.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8616ee67880d16f75306371c1c1be70f8df9a189",
       "version-string": "1.75.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -558,7 +558,7 @@
     },
     "boost-dynamic-bitset": {
       "baseline": "1.75.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-endian": {
       "baseline": "1.75.0",


### PR DESCRIPTION
Fixes the dependencies of the [boost dynamic bitset library](https://github.com/boostorg/dynamic_bitset)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  N.A.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
