### PR TITLE
[vcpkg baseline][libmicrohttpd] Disable feature libgnutls

### DIFF
--- a/ports/libmicrohttpd/CONTROL
+++ b/ports/libmicrohttpd/CONTROL
@@ -1,6 +1,0 @@
-Source: libmicrohttpd
-Version: 0.9.63
-Port-Version: 5
-Homepage: https://www.gnu.org/software/libmicrohttpd/
-Description: GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application
-Supports: !(arm|uwp)

--- a/ports/libmicrohttpd/portfile.cmake
+++ b/ports/libmicrohttpd/portfile.cmake
@@ -38,6 +38,8 @@ else()
     endif()
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            --with-gnutls=no
     )
 
     vcpkg_install_make()

--- a/ports/libmicrohttpd/vcpkg.json
+++ b/ports/libmicrohttpd/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "libmicrohttpd",
+  "version-semver": "0.9.63",
+  "port-version": 6,
+  "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
+  "homepage": "https://www.gnu.org/software/libmicrohttpd/",
+  "supports": "!(arm | uwp)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3274,7 +3274,7 @@
     },
     "libmicrohttpd": {
       "baseline": "0.9.63",
-      "port-version": 5
+      "port-version": 6
     },
     "libmikmod": {
       "baseline": "3.3.11.1-8",

--- a/versions/l-/libmicrohttpd.json
+++ b/versions/l-/libmicrohttpd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb112eb78c0fb2dc196637ee22175a2267039aae",
+      "version-semver": "0.9.63",
+      "port-version": 6
+    },
+    {
       "git-tree": "da43ec88147e3aa99a5d4e7378f0011a92a25ad2",
       "version-string": "0.9.63",
       "port-version": 5


### PR DESCRIPTION
Fix bug on our pipeline test:
```
Undefined symbols for architecture x86_64:
  "_SecCopyErrorMessageString", referenced from:
      _osstatus_error in libgnutls.a(certs.o)
  "_SecItemExport", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
  "_SecTrustSettingsCopyCertificates", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
Undefined symbols for architecture x86_64:
  "_SecCopyErrorMessageString", referenced from:
      _osstatus_error in libgnutls.a(certs.o)
  "_SecItemExport", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
  "_SecTrustSettingsCopyCertificates", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
Undefined symbols for architecture x86_64:
  "_SecCopyErrorMessageString", referenced from:
      _osstatus_error in libgnutls.a(certs.o)
ld: symbol(s) not found for architecture x86_64
  "_SecItemExport", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
  "_SecTrustSettingsCopyCertificates", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
Undefined symbols for architecture x86_64:
  "_SecCopyErrorMessageString", referenced from:
      _osstatus_error in libgnutls.a(certs.o)
  "_SecItemExport", referenced from:
clang: error: linker command failed with exit code 1 (use -v to see invocation)
      _add_system_trust in libgnutls.a(certs.o)
  "_SecTrustSettingsCopyCertificates", referenced from:
      _add_system_trust in libgnutls.a(certs.o)
```


Related: https://github.com/microsoft/vcpkg/issues/17636