### PR TITLE
[yomm2] new port

### DIFF
--- a/ports/yomm2/fix_find_boost.patch
+++ b/ports/yomm2/fix_find_boost.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b7b88b1..02297e7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,7 +11,7 @@ project(YOMM2 VERSION 1.0)
+ # Find Boost dependency
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+ include(find_or_download_package)
+-find_or_download_package(Boost INSTALL_WITH_YOMM)
++find_package(Boost REQUIRED)
+ message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index 7272504..9f8b2ae 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,7 +1,7 @@
+ include(CMakeFindDependencyMacro)
+ 
+ # Tell library users about the Boost dependency
+-find_dependency(Boost 1.53 HINTS ${CMAKE_CURRENT_LIST_DIR}/..)
++find_dependency(Boost 1.53)
+ 
+ # Add the targets file
+ include("${CMAKE_CURRENT_LIST_DIR}/YOMM2Targets.cmake")

--- a/ports/yomm2/fix_uwp_osx.patch
+++ b/ports/yomm2/fix_uwp_osx.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f16eb6..a46c8b7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,14 +15,15 @@ find_package(Boost)
+ message(STATUS "Using Boost libraries from ${Boost_INCLUDE_DIRS}")
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -save-temps")
+   endif()
+ endif()
+ 
+ if(MSVC)
+-  set(CMAKE_CXX_FLAGS "/std:c++17 -D_SCL_SECURE_NO_WARNINGS /EHsc")
++  set(CMAKE_CXX_FLAGS "/std:c++17 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS /EHsc")
++else()
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+ endif()
+ 
+ add_subdirectory(src)

--- a/ports/yomm2/portfile.cmake
+++ b/ports/yomm2/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jll63/yomm2
+    REF v1.1.2
+    SHA512  f45c3f3d267dedaa3c76f9dab1a75be01941e3715e71b30b878be49157a5ba97f2188c9e635272be3ca396019b161bb21a30199ca504c94a18673685f5dbf06d
+    HEAD_REF master
+    PATCHES "fix_find_boost.patch" "fix_uwp_osx.patch"
+)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS -DYOMM2_ENABLE_EXAMPLES=OFF
+)
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/YOMM2)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/yomm2/vcpkg.json
+++ b/ports/yomm2/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "yomm2",
+  "version-string": "1.1.2",
+  "description": "YOMM2 is an implementation of open multi-methods.",
+  "homepage": "https://github.com/jll63/yomm2",
+  "dependencies": [
+    "boost-dynamic-bitset",
+    "boost-integer",
+    "boost-move",
+    "boost-preprocessor",
+    "boost-type-traits"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6616,6 +6616,10 @@
       "baseline": "1.18.0-1",
       "port-version": 0
     },
+    "yomm2": {
+      "baseline": "1.1.2",
+      "port-version": 0
+    },
     "yyjson": {
       "baseline": "2021-04-12",
       "port-version": 0

--- a/versions/y-/yomm2.json
+++ b/versions/y-/yomm2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5d025f5bb550c4a43b070841b8a48936d0644017",
+      "version-string": "1.1.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new port for library [yomm2](https://github.com/jll63/yomm2). Note that dependency of Boost libs are not resolved properly (#17882 #17848)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Normally all, waiting for CI

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
