### PR TITLE
[atomic-queue]: available in vcpkg!

### DIFF
--- a/ports/atomic-queue/portfile.cmake
+++ b/ports/atomic-queue/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO max0x7ba/atomic_queue
+    REF 7619054490efdbfe377bd528bc09b21f5cd38a02
+    SHA512 0d145f461a5c978c4d6f6d8ec1f06f0c61f3d009e65eac12db806c2aa7941461f881b34b9c4dd9aeebd3206a4598e6081f89f983c389b2f5aecefefcbddd94b6
+    HEAD_REF master
+)
+
+file(
+    COPY 
+        ${SOURCE_PATH}/include/atomic_queue/atomic_queue.h 
+        ${SOURCE_PATH}/include/atomic_queue/atomic_queue_mutex.h 
+        ${SOURCE_PATH}/include/atomic_queue/barrier.h 
+        ${SOURCE_PATH}/include/atomic_queue/defs.h 
+        ${SOURCE_PATH}/include/atomic_queue/spinlock.h 
+    DESTINATION 
+        ${CURRENT_PACKAGES_DIR}/include/atomic_queue
+)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/atomic-queue/vcpkg.json
+++ b/ports/atomic-queue/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "atomic-queue",
+  "version-date": "2021-05-03",
+  "description": "Minimalistic header-only thread-safe ultra-low-latency multiple-producer-multiple-consumer lockless queues based on circular buffer with std::atomic.",
+  "homepage": "https://github.com/max0x7ba/atomic_queue"
+}

--- a/versions/a-/atomic-queue.json
+++ b/versions/a-/atomic-queue.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "a32a426d9c16a0067532134ecb6680ee7928f7f7",
+      "version-date": "2021-05-03",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -188,6 +188,10 @@
       "baseline": "0",
       "port-version": 0
     },
+    "atomic-queue": {
+      "baseline": "2021-05-03",
+      "port-version": 0
+    },
     "aubio": {
       "baseline": "0.4.9",
       "port-version": 4


### PR DESCRIPTION
**atomic_queue port**

from https://github.com/max0x7ba/atomic_queue

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
    `all` (I'm assuming, I've only used it on linux and windows but it is header-only std C++14 with no dependencies).

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
