### PR TITLE
[luasec] new port

### DIFF
--- a/ports/luasec/CMakeLists.txt
+++ b/ports/luasec/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.20.0)
+project(luasec)
+
+find_path(LUA_INCLUDE_DIR lua.h PATH_SUFFIXES lua)
+find_library(LUA_LIBRARY lua)
+find_package(OpenSSL)
+
+set(LUASEC_INCLUDES ${LUA_INCLUDE_DIR} src)
+set(LUASEC_LIBRARIES
+    ${LUA_LIBRARY}
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    OpenSSL::applink
+    ws2_32)
+
+add_library(lua-ssl
+    src/config.c
+    src/ssl.c
+    src/context.c
+    src/x509.c
+    src/ec.c
+    src/options.c
+    src/luasocket/buffer.c
+    src/luasocket/io.c
+    src/luasocket/timeout.c
+    src/luasocket/wsocket.c)
+
+target_include_directories(lua-ssl PRIVATE ${LUASEC_INCLUDES})
+target_link_libraries(lua-ssl PRIVATE ${LUASEC_LIBRARIES})
+set_target_properties(lua-ssl PROPERTIES PREFIX "")
+
+install(TARGETS lua-ssl
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
+install(FILES src/ssl.lua DESTINATION share/lua)
+install(FILES src/https.lua DESTINATION share/lua/ssl)

--- a/ports/luasec/portfile.cmake
+++ b/ports/luasec/portfile.cmake
@@ -1,0 +1,33 @@
+set(LUASEC_REVISION v1.0.1)
+set(LUASEC_HASH 21ae200e40f13a35eebca95cdac25ae13532a3008b2f9ec97a079033b9efde69e81954354453623eb77340368f482d3c69adb26881a6c0d7c4897df31301af93)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO brunoos/luasec
+    REF ${LUASEC_REVISION}
+    SHA512 ${LUASEC_HASH}
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+
+# Remove debug share
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+# Allow empty include directory
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)

--- a/ports/luasec/vcpkg.json
+++ b/ports/luasec/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "luasec",
+  "version": "1.0.1",
+  "maintainers": "Stephen Baker <baker.stephen.e@gmail.com>",
+  "description": "LuaSec depends on OpenSSL, and integrates with LuaSocket to make it easy to add secure connections to any Lua applications or scripts.",
+  "homepage": "https://github.com/brunoos/luasec",
+  "dependencies": [
+    "lua",
+    "luasocket",
+    "openssl"
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -867,6 +867,7 @@ luajit:x64-windows        = skip
 luajit:x64-windows-static = skip
 luajit:x64-windows-static-md=skip
 luajit:x86-windows        = skip
+luasec:x64-windows-static=fail
 luasocket:x64-linux=fail
 luasocket:x64-osx=fail
 lzfse:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3796,6 +3796,10 @@
       "baseline": "2.0.5-3",
       "port-version": 0
     },
+    "luasec": {
+      "baseline": "1.0.1",
+      "port-version": 0
+    },
     "luasocket": {
       "baseline": "2020-09-14",
       "port-version": 0

--- a/versions/l-/luasec.json
+++ b/versions/l-/luasec.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "2529ee34af0b23fb576f0e8ed672ceba83c4c305",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds luasec, a lua library for networking over TLS.

https://github.com/brunoos/luasec/

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
