### PR TITLE
[nanodbc] Allow specifing the ODBC version for nanodbc

### DIFF
--- a/ports/nanodbc/CONTROL
+++ b/ports/nanodbc/CONTROL
@@ -1,6 +1,6 @@
 Source: nanodbc
 Version: 2.13.0
-Port-Version: 2
-Homepage: https://github.com/lexicalunit/nanodbc
+Port-Version: 3
+Homepage: https://github.com/nanodbc/nanodbc
 Description: A small C++ wrapper for the native C ODBC API.
 Build-Depends: unixodbc(!windows)

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -1,7 +1,7 @@
 # Only static libraries are supported.
 # See https://github.com/nanodbc/nanodbc/issues/13
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-	
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nanodbc/nanodbc
@@ -10,6 +10,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if(DEFINED NANODBC_ODBC_VERSION)
+    set(NANODBC_ODBC_VERSION -DNANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION})
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -17,6 +21,7 @@ vcpkg_configure_cmake(
         -DNANODBC_DISABLE_EXAMPLES=ON
         -DNANODBC_DISABLE_TESTS=ON
         -DNANODBC_ENABLE_UNICODE=OFF
+        ${NANODBC_ODBC_VERSION}
 )
 
 vcpkg_install_cmake()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4178,7 +4178,7 @@
     },
     "nanodbc": {
       "baseline": "2.13.0",
-      "port-version": 2
+      "port-version": 3
     },
     "nanoflann": {
       "baseline": "1.3.1",

--- a/versions/n-/nanodbc.json
+++ b/versions/n-/nanodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c22ba3957ee9a1a2c6d893c746b6a51bf38435c",
+      "version-string": "2.13.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "4610c5bd3b7d399b683bea63cb00fe277bbcb3f8",
       "version-string": "2.13.0",
       "port-version": 2


### PR DESCRIPTION
This patch adds the option to specify an ODBC version directly to the nanodbc library, which up to this point has been looking for ODBC versions itself (see [here](https://github.com/nanodbc/nanodbc/blob/master/nanodbc/nanodbc.cpp#L103)). It only passes in the `NANODBC_ODBC_VERSION` option to nanodbc's cmake script if this flag has been set by the user.

- #### What does your PR fix?  
  See the following comment on what this PR is fixing: https://github.com/nanodbc/nanodbc/issues/114#issuecomment-358361843
  I experienced this issue on a CentOS box with unixODBC 2.3.1. In summary: unixODBC 2.3.1 reports an incorrect ODBC version which nanodbc picks up, but should be overridden with the version passed in through `NANODBC_ODBC_VERSION`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not sure I need to update the baseline file; please let me know if I do.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
