### PR TITLE
[vcpkg baseline] [embree2/embree3] Set cmake policy

### DIFF
--- a/ports/embree2/CONTROL
+++ b/ports/embree2/CONTROL
@@ -1,5 +1,0 @@
-Source: embree2
-Version: 2.17.7
-Homepage: https://github.com/embree/embree
-Description: High Performance Ray Tracing Kernels.
-Build-Depends: tbb

--- a/ports/embree2/cmake_policy.patch
+++ b/ports/embree2/cmake_policy.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index afa704d..96dc4f8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,6 +57,9 @@ IF(COMMAND cmake_policy)
+   if (POLICY CMP0042)
+     cmake_policy(SET CMP0042 OLD)
+   endif()
++  if (POLICY CMP0001)
++    cmake_policy(SET CMP0001 OLD)
++  endif()
+ ENDIF(COMMAND cmake_policy)
+ 
+ MARK_AS_ADVANCED(CMAKE_BACKWARDS_COMPATIBILITY)

--- a/ports/embree2/portfile.cmake
+++ b/ports/embree2/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v2.17.7
     SHA512 3ea548e5ed85f68dc1f9dfe864711f9b731e0df8a2258257f77db08bbdbe3a9014a626313e3ff41174f3b26f09dc8ff523900119ff4c8465bfff53f621052873
     HEAD_REF devel2
+    PATCHES
+        cmake_policy.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/common/cmake/FindTBB.cmake)

--- a/ports/embree2/vcpkg.json
+++ b/ports/embree2/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "embree2",
+  "version-semver": "2.17.7",
+  "port-version": 1,
+  "description": "High Performance Ray Tracing Kernels.",
+  "homepage": "https://github.com/embree/embree",
+  "dependencies": [
+    "tbb"
+  ]
+}

--- a/ports/embree3/CONTROL
+++ b/ports/embree3/CONTROL
@@ -1,6 +1,0 @@
-Source: embree3
-Version: 3.11.0
-Port-Version: 2
-Homepage: https://github.com/embree/embree
-Description: High Performance Ray Tracing Kernels.
-Build-Depends: tbb

--- a/ports/embree3/cmake_policy.patch
+++ b/ports/embree3/cmake_policy.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 06f49a8..fdaaee7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -69,6 +69,9 @@ IF(COMMAND cmake_policy)
+   if(POLICY CMP0074)
+     cmake_policy(SET CMP0074 NEW)
+   endif()
++  if (POLICY CMP0001)
++    cmake_policy(SET CMP0001 OLD)
++  endif()
+ ENDIF(COMMAND cmake_policy)
+ 
+ MARK_AS_ADVANCED(CMAKE_BACKWARDS_COMPATIBILITY)

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-path.patch
         fix-static-usage.patch
+        cmake_policy.patch
 )
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static EMBREE_STATIC_LIB)

--- a/ports/embree3/vcpkg.json
+++ b/ports/embree3/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "embree3",
+  "version-semver": "3.11.0",
+  "port-version": 4,
+  "description": "High Performance Ray Tracing Kernels.",
+  "homepage": "https://github.com/embree/embree",
+  "dependencies": [
+    "tbb"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1830,11 +1830,11 @@
     },
     "embree2": {
       "baseline": "2.17.7",
-      "port-version": 0
+      "port-version": 1
     },
     "embree3": {
       "baseline": "3.11.0",
-      "port-version": 2
+      "port-version": 4
     },
     "enet": {
       "baseline": "1.3.16",

--- a/versions/e-/embree2.json
+++ b/versions/e-/embree2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "234d3da49438399d5df9e1a105401bc930ae22fe",
+      "version-semver": "2.17.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "3a87d7af065343c7a78620fa2f432272cb56c117",
       "version-string": "2.17.7",
       "port-version": 0

--- a/versions/e-/embree3.json
+++ b/versions/e-/embree3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6ab4d3d622de45be9755e48843b6adfada70e8a",
+      "version-semver": "3.11.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "955eb7f17ebf475e96ee8fe283b56cbc3944da44",
       "version-string": "3.11.0",
       "port-version": 2


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/17978

Set cmake policy for fixing failures:

```
CMake Error in CMakeLists.txt:
  You have set CMAKE_BACKWARDS_COMPATIBILITY to a CMake version less than
  2.4.  This version of CMake only supports backwards compatibility with
  CMake 2.4 or later.  For compatibility with older versions please use any
  CMake 2.8.x release or lower.
```

Reference https://cmake.org/cmake/help/latest/policy/CMP0001.html#policy:CMP0001
