### PR TITLE
[osgearth] Fix undefined references due to openjp2 and xml2

### DIFF
--- a/ports/osgearth/fix-dependency-osg.patch
+++ b/ports/osgearth/fix-dependency-osg.patch
@@ -25,7 +25,7 @@ index b7dff11..d1ec2ff 100644
 +    if (UNIX)
 +        list(APPEND OSG_DEPENDS_LIBRARY ${OSG_DEPENDS_LIBRARY} -pthread)
 +        # Due to Linux Linker dependency issues these need to included again
-+        set(DEPEND_LIB_LIST fontconfig freetype uuid gdal json-c expat zstd proj sqlite3 webp gif cfitsio openjp2)
++        set(DEPEND_LIB_LIST fontconfig freetype uuid gdal json-c expat zstd proj sqlite3 webp gif cfitsio openjp2 xml2)
 +    else(UNIX)
 +        set(DEPEND_LIB_LIST cfitsio)
 +    endif()

--- a/ports/osgearth/fix-dependency-osg.patch
+++ b/ports/osgearth/fix-dependency-osg.patch
@@ -25,7 +25,7 @@ index b7dff11..d1ec2ff 100644
 +    if (UNIX)
 +        list(APPEND OSG_DEPENDS_LIBRARY ${OSG_DEPENDS_LIBRARY} -pthread)
 +        # Due to Linux Linker dependency issues these need to included again
-+        set(DEPEND_LIB_LIST fontconfig freetype uuid gdal json-c expat zstd proj sqlite3 webp gif cfitsio)
++        set(DEPEND_LIB_LIST fontconfig freetype uuid gdal json-c expat zstd proj sqlite3 webp gif cfitsio openjp2)
 +    else(UNIX)
 +        set(DEPEND_LIB_LIST cfitsio)
 +    endif()

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2015 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "supports": "!(x86 | wasm32)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4622,7 +4622,7 @@
     },
     "osgearth": {
       "baseline": "3.1",
-      "port-version": 3
+      "port-version": 4
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d12ff3ef1419ab8813b430101fb6dbcc96861671",
+      "version": "3.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "d2483eb1bb083bdcf0b4de24f0f8c0d77825dc56",
       "version": "3.1",
       "port-version": 3


### PR DESCRIPTION
Add additional dependencies (for GDAL) openjp2 and xml2 in the explicit linking list

- #### What does your PR fix?  
  Fixes #17992 17992

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
