### PR TITLE
[draco] Fix build failure on gcc 11

### DIFF
--- a/ports/draco/fix-build-error-in-gcc11.patch
+++ b/ports/draco/fix-build-error-in-gcc11.patch
@@ -1,3 +1,19 @@
+diff --git a/src/draco/core/hash_utils.h b/src/draco/core/hash_utils.h
+index dd910d0..aa61523 100644
+--- a/src/draco/core/hash_utils.h
++++ b/src/draco/core/hash_utils.h
+@@ -17,10 +17,9 @@
+ 
+ #include <stdint.h>
+ 
++#include <cstddef>
+ #include <functional>
+ 
+-// TODO(fgalligan): Move this to core.
+-
+ namespace draco {
+ 
+ template <typename T1, typename T2>
 diff --git a/src/draco/io/parser_utils.cc b/src/draco/io/parser_utils.cc
 index 3c302b9..adca2ac 100644
 --- a/src/draco/io/parser_utils.cc

--- a/ports/draco/vcpkg.json
+++ b/ports/draco/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "draco",
   "version": "1.3.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": " A library for compressing and decompressing 3D geometric meshes and point clouds. It is intended to improve the storage and transmission of 3D graphics.",
   "homepage": "https://github.com/google/draco"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1726,7 +1726,7 @@
     },
     "draco": {
       "baseline": "1.3.6",
-      "port-version": 1
+      "port-version": 2
     },
     "drlibs": {
       "baseline": "2019-08-12",

--- a/versions/d-/draco.json
+++ b/versions/d-/draco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d306b49fab537cd9980ce5de0c994372a1300777",
+      "version": "1.3.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "c3690271c81d83c2016d5710acaa76a94d6d78b8",
       "version": "1.3.6",
       "port-version": 1


### PR DESCRIPTION
Fix build failure:
```
[snip]
In file included from hash_utils.cc:15:
draco/core/hash_utils.h:27:1: error: 'size_t' does not name a type
   27 | size_t HashCombine(T1 a, T2 b) {
      | ^~~~~~
draco/core/hash_utils.h:21:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
   20 | #include <functional>
  +++ |+#include <cstddef>
   21 | 
draco/core/hash_utils.h:34:1: error: 'size_t' does not name a type
   34 | size_t HashCombine(T a, size_t hash) {
      | ^~~~~~
draco/core/hash_utils.h:34:1: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
draco/core/hash_utils.h:44:43: error: 'size_t' has not been declared
   44 | uint64_t FingerprintString(const char *s, size_t len);
      |                                           ^~~~~~
draco/core/hash_utils.h:49:3: error: 'size_t' does not name a type
   49 |   size_t operator()(const T &a) const {
      |   ^~~~~~
draco/core/hash_utils.h:49:3: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
draco/core/hash_utils.h:58:3: error: 'size_t' does not name a type
   58 |   size_t ValueHash(const V &val) const {
      |   ^~~~~~
draco/core/hash_utils.h:58:3: note: 'size_t' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
[snap]
```
Use the official commit https://github.com/google/draco/pull/636.

Fixes #17963.