### PR TITLE
[scripts-audit] z_vcpkg_apply_patches, z_vcpkg_escape_regex_control_characters

### DIFF
--- a/scripts/cmake/vcpkg_internal_escape_regex_control_characters.cmake
+++ b/scripts/cmake/vcpkg_internal_escape_regex_control_characters.cmake
@@ -1,4 +1,0 @@
-function(vcpkg_internal_escape_regex_control_characters out_var string_with_regex_characters)
-  string(REGEX REPLACE "[][+.*()^\\$?|]" "\\\\\\0" _escaped_content "${string_with_regex_characters}")
-  set(${out_var} "${_escaped_content}" PARENT_SCOPE)
-endfunction()

--- a/scripts/cmake/z_vcpkg_apply_patches.cmake
+++ b/scripts/cmake/z_vcpkg_apply_patches.cmake
@@ -31,9 +31,13 @@ This should only be used for edge cases, such as patches that are known to fail 
 function(z_vcpkg_apply_patches)
     cmake_parse_arguments(PARSE_ARGV 0 "arg" "QUIET" "SOURCE_PATH" "PATCHES")
 
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "internal error: z_vcpkg_apply_patches was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
     find_program(GIT NAMES git git.cmd REQUIRED)
     if(DEFINED ENV{GIT_CONFIG_NOSYSTEM})
-        set(git_config_nosystem_backuP "$ENV{GIT_CONFIG_NOSYSTEM}")
+        set(git_config_nosystem_backup "$ENV{GIT_CONFIG_NOSYSTEM}")
     else()
         unset(git_config_nosystem_backup)
     endif()
@@ -43,7 +47,7 @@ function(z_vcpkg_apply_patches)
     foreach(patch IN LISTS arg_PATCHES)
         get_filename_component(absolute_patch "${patch}" ABSOLUTE BASE_DIR "${CURRENT_PORT_DIR}")
         message(STATUS "Applying patch ${patch}")
-        set(logname patch-${TARGET_TRIPLET}-${patchnum})
+        set(logname "patch-${TARGET_TRIPLET}-${patchnum}")
         vcpkg_execute_in_download_mode(
             COMMAND "${GIT}" -c core.longpaths=true -c core.autocrlf=false --work-tree=. --git-dir=.git apply "${absolute_patch}" --ignore-whitespace --whitespace=nowarn --verbose
             OUTPUT_FILE "${CURRENT_BUILDTREES_DIR}/${logname}-out.log"

--- a/scripts/cmake/z_vcpkg_escape_regex_control_characters.cmake
+++ b/scripts/cmake/z_vcpkg_escape_regex_control_characters.cmake
@@ -1,0 +1,8 @@
+function(z_vcpkg_escape_regex_control_characters out_var string)
+    if(ARGC GREATER "2")
+        message(FATAL_ERROR "z_vcpkg_escape_regex_control_characters passed extra arguments: ${ARGN}")
+    endif()
+    # uses | instead of [] to avoid confusion; additionally, CMake doesn't support `]` in a `[]`
+    string(REGEX REPLACE [[\[|\]|\(|\)|\.|\+|\*|\^|\\|\$|\?|\|]] [[\\\0]] escaped_content "${string}")
+    set("${out_var}" "${escaped_content}" PARENT_SCOPE)
+endfunction()

--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -1,3 +1,4 @@
+# rebuild: 0
 cmake_minimum_required(VERSION 3.5)
 
 set(SCRIPTS "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Location to stored scripts")


### PR DESCRIPTION
fixes a minor bug as well, where `GIT_CONFIG_NOSYSTEM` is never reset.