### PR TITLE
[curl] Fix mingw to default to winssl (matching windows builds)

### DIFF
--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "7.74.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "A library for transferring data with URLs",
   "homepage": "https://github.com/curl/curl",
   "dependencies": [
@@ -110,7 +110,7 @@
           "features": [
             "winssl"
           ],
-          "platform": "windows & !uwp"
+          "platform": "(windows & !uwp) | mingw"
         },
         {
           "name": "curl",
@@ -118,7 +118,7 @@
           "features": [
             "openssl"
           ],
-          "platform": "(uwp | !windows) & !osx"
+          "platform": "(uwp | !windows) & !osx & !mingw"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1546,7 +1546,7 @@
     },
     "curl": {
       "baseline": "7.74.0",
-      "port-version": 5
+      "port-version": 6
     },
     "curlpp": {
       "baseline": "2018-06-15-3",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73eb56fb6fa870b5959ba36b931817fc85208efe",
+      "version": "7.74.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "8be2f3a1be62244a892aeba05026579fbf7200b4",
       "version": "7.74.0",
       "port-version": 5


### PR DESCRIPTION
**Describe the pull request**
Fixes the default ssl backend when using mingw to match the backend used for windows builds (`winssl`).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  only impacts community mingw triplets
