### PR TITLE
vcpkg_configure_meson: mingw build fix

### DIFF
--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -113,7 +113,7 @@ endfunction()
 
 # Generates the required compiler properties for meson
 function(vcpkg_internal_meson_generate_flags_properties_string _out_var _config)
-    if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         set(L_FLAG /LIBPATH:)
     else()
         set(L_FLAG -L)


### PR DESCRIPTION
**Describe the pull request**
This fixes an issue that was preventing certain meson-based ports (ex. `harfbuzz`) from successfully building with the `mingw` community triplets.