### PR TITLE
[vcpkg] Use objdump for dll dependencies

### DIFF
--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -90,8 +90,10 @@ function resolve([string]$targetBinary) {
         $a = $(dumpbin /DEPENDENTS $targetBinary | ? { $_ -match "^    [^ ].*\.dll" } | % { $_ -replace "^    ","" })
     } elseif (Get-Command "llvm-objdump" -ErrorAction SilentlyContinue) {
         $a = $(llvm-objdump -p $targetBinary| ? { $_ -match "^ {4}DLL Name: .*\.dll" } | % { $_ -replace "^ {4}DLL Name: ","" })
+    } elseif (Get-Command "objdump" -ErrorAction SilentlyContinue) {
+        $a = $(objdump -p $targetBinary| ? { $_ -match "^\tDLL Name: .*\.dll" } | % { $_ -replace "^\tDLL Name: ","" })
     } else {
-        Write-Error "Neither dumpbin nor llvm-objdump could be found. Can not take care of dll dependencies."
+        Write-Error "Neither dumpbin, llvm-objdump nor objdump could be found. Can not take care of dll dependencies."
     }
     $a | % {
         if ([string]::IsNullOrEmpty($_)) {


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR enables use of mingw `objdump` for app-local DLL deployment.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  mingw, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  -/-

- #### Known limitations
  - applocal.ps1 deploys libs which were built with vcpkg. For mingw, this will not include runtime libraries of gcc or pthreads.
  - This was not tested with plugins.