### PR TITLE
[vcpkg baseline][libheif] Fix build failure on OSX

### DIFF
--- a/ports/libheif/disable-depend-dav1d.patch
+++ b/ports/libheif/disable-depend-dav1d.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 05afd5d..1e7f36f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,7 +65,9 @@ if (WITH_AOM)
+     find_package(LibAOM)
+ endif()
+ find_package(Rav1e)
++if (WITH_DAV1D)
+ find_package(Dav1d)
++endif()
+ 
+ if (LIBDE265_FOUND)
+     message("HEIF decoder, libde265: found")

--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 667eeabb553ce73094eb29faea3f31fb8610fec2 #v1.10.0
     SHA512 937290310ec6dda8840262d4bad5e3628033fa2caa6e9cc4a0df7a372cacf38c9b55cf29d2cb7ea2183641e263298fc2e87167c1b0f04f8697023f123d78aa9d
     HEAD_REF master
-    PATCHES gdk-pixbuf.patch
+    PATCHES
+        gdk-pixbuf.patch
+        disable-depend-dav1d.patch
 )
 
 vcpkg_configure_cmake(
@@ -12,6 +14,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -DWITH_EXAMPLES=OFF
+        -DWITH_DAV1D=OFF
 )
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libheif",
   "version": "1.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3170,7 +3170,7 @@
     },
     "libheif": {
       "baseline": "1.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libhsplasma": {
       "baseline": "2020.08.30",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a05aafcbf48befb78710d61cee5d64aa37788a83",
+      "version": "1.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "ba05813e40676056ca9a267270a62c4001635db0",
       "version": "1.10.0",
       "port-version": 2


### PR DESCRIPTION
Libheif will find dav1d automaticlly in its CMakeLists.txt, and when it use dav1d, we will got some link errors:
```
[19/20] : && /Library/Developer/CommandLineTools/usr/bin/c++ -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk -bundle -Wl,-headerpad_max_install_names -pthread /Users/vagrant/Data/installed/x64-osx/debug/lib/pkgconfig/../../lib/libintl.a -Wl,-framework,CoreFoundation -Wl,-framework,Carbon -Wl,-framework,Foundation -Wl,-framework,AppKit -o gdk-pixbuf/libpixbufloader-heif.so gdk-pixbuf/CMakeFiles/pixbufloader-heif.dir/pixbufloader-heif.c.o  libheif/libheif.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgdk_pixbuf-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libm.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgio-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libresolv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgobject-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libffi.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmodule-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglib-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpcre.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libm.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgio-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libresolv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgobject-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libffi.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmodule-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglib-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpcre.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblibde265.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libx265.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libdav1d.a && :
FAILED: gdk-pixbuf/libpixbufloader-heif.so 
: && /Library/Developer/CommandLineTools/usr/bin/c++ -fPIC -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk -bundle -Wl,-headerpad_max_install_names -pthread /Users/vagrant/Data/installed/x64-osx/debug/lib/pkgconfig/../../lib/libintl.a -Wl,-framework,CoreFoundation -Wl,-framework,Carbon -Wl,-framework,Foundation -Wl,-framework,AppKit -o gdk-pixbuf/libpixbufloader-heif.so gdk-pixbuf/CMakeFiles/pixbufloader-heif.dir/pixbufloader-heif.c.o  libheif/libheif.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgdk_pixbuf-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libm.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgio-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libresolv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgobject-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libffi.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmodule-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglib-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpcre.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libm.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgio-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libresolv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgobject-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libffi.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmodule-2.0.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglib-2.0.a  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpcre.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblibde265.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libx265.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libdav1d.a && :
Undefined symbols for architecture x86_64:
  "_dav1d_avg_avx2", referenced from:
      _dav1d_mc_dsp_init_x86_8bpc in libdav1d.a(x86_mc_init_tmpl.c.o)
  "_dav1d_avg_avx512icl", referenced from:
      _dav1d_mc_dsp_init_x86_8bpc in libdav1d.a(x86_mc_init_tmpl.c.o)
  "_dav1d_avg_ssse3", referenced from:
      _dav1d_mc_dsp_init_x86_8bpc in libdav1d.a(x86_mc_init_tmpl.c.o)
  "_dav1d_blend_avx2", referenced from:
      _dav1d_mc_dsp_init_x86_8bpc in libdav1d.a(x86_mc_init_tmpl.c.o)
  "_dav1d_blend_h_avx2", referenced from:
```
After checking dav1d's library, I found these symbols are external: 
```
vcpkg@vcpkg % nm packages/dav1d_x64-osx/lib/libdav1d.a| grep _dav1d_avg_avx2
0000000000006bf0 T _dav1d_avg_avx2
0000000000006ce1 t _dav1d_avg_avx2.ret
0000000000006eaa t _dav1d_avg_avx2.w128
0000000000006e87 t _dav1d_avg_avx2.w128_loop
0000000000006d60 t _dav1d_avg_avx2.w16
0000000000006d34 t _dav1d_avg_avx2.w16_loop
0000000000006ddb t _dav1d_avg_avx2.w32
0000000000006daf t _dav1d_avg_avx2.w32_loop
0000000000006c33 t _dav1d_avg_avx2.w4
0000000000006e47 t _dav1d_avg_avx2.w64
0000000000006e1c t _dav1d_avg_avx2.w64_loop
0000000000006d11 t _dav1d_avg_avx2.w8
0000000000006ce5 t _dav1d_avg_avx2.w8_loop
                 U _dav1d_avg_avx2
```
But I couldn't find these implement anywhere:
```
vcpkg@vcpkg % find buildtrees/dav1d/x64-osx-dbg -name "*.a"
buildtrees/dav1d/x64-osx-dbg/src/libdav1d.a
```
So disable it temporary to fix the baseline issue.

Related: https://github.com/microsoft/vcpkg/pull/17845.