### PR TITLE
[hexl] Add new port

### DIFF
--- a/ports/hexl/disable_downloading_cpu_features.patch
+++ b/ports/hexl/disable_downloading_cpu_features.patch
@@ -1,0 +1,101 @@
+From 16095678843dadf13b0f786ddf53c726e837bc74 Mon Sep 17 00:00:00 2001
+From: Wei Dai <wei.dai@microsoft.com>
+Date: Tue, 8 Jun 2021 15:55:18 -0700
+Subject: [PATCH] Disabled downloading cpu-features.
+
+---
+ CMakeLists.txt      |  9 ++++++++-
+ hexl/CMakeLists.txt | 15 ++++++---------
+ 2 files changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 05e42f9..a7ad993 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,7 +183,14 @@ message(STATUS "CMAKE_INSTALL_PREFIX:     ${CMAKE_INSTALL_PREFIX}")
+ #------------------------------------------------------------------------------
+ # Third-party code...
+ #------------------------------------------------------------------------------
+-add_subdirectory(cmake/cpu-features)
++find_package(CpuFeatures CONFIG REQUIRED)
++if(CpuFeatures_FOUND)
++  add_library(cpu_features ALIAS CpuFeatures::cpu_features)
++  get_target_property(
++    CpuFeatures_INCLUDE_DIR
++    CpuFeatures::cpu_features
++    INTERFACE_INCLUDE_DIRECTORIES)
++endif()
+
+ if (HEXL_TESTING OR HEXL_BENCHMARK OR HEXL_DEBUG)
+   if(NOT TARGET Threads::Threads)
+diff --git a/hexl/CMakeLists.txt b/hexl/CMakeLists.txt
+index 7e603e3..b83a94e 100644
+--- a/hexl/CMakeLists.txt
++++ b/hexl/CMakeLists.txt
+@@ -44,6 +44,7 @@ target_include_directories(hexl
+     PUBLIC  $<BUILD_INTERFACE:${HEXL_INC_ROOT_DIR}>            # Public headers
+     PUBLIC  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>   # Public headers
+     )
++target_include_directories(hexl PUBLIC ${CpuFeatures_INCLUDE_DIR}) # Public headers
+
+ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+     target_compile_options(hexl PRIVATE -Wall -Wconversion -Wshadow -pedantic -Wextra
+@@ -74,7 +75,7 @@ else ()
+     # For proper export of IntelHEXLConfig.cmake / IntelHEXLTargts.cmake,
+     # we avoid explicitly linking dependencies via target_link_libraries, since
+     # this would add dependencies to the exported hexl target.
+-    add_dependencies(hexl cpu_features)
++    target_link_libraries(hexl PRIVATE cpu_features)
+     if (HEXL_DEBUG)
+         add_dependencies(hexl gflags)
+         # Manually add logging include directory
+@@ -95,42 +96,38 @@ else ()
+         if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+             add_custom_command(TARGET hexl POST_BUILD
+                 COMMAND ar -x $<TARGET_FILE:hexl>
+-                COMMAND ar -x $<TARGET_FILE:cpu_features>
+                 COMMAND ar -x $<TARGET_FILE:gflags>
+                 COMMAND ar -x $<TARGET_FILE:easyloggingpp>
+                 COMMAND ar -qcs $<TARGET_FILE:hexl> *.o
+                 COMMAND rm -f *.o
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-                DEPENDS hexl cpu_features gflags easyloggingpp
++                DEPENDS hexl gflags easyloggingpp
+             )
+         elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+              add_custom_command(TARGET hexl POST_BUILD
+                 COMMAND lib.exe /OUT:$<TARGET_FILE:hexl>
+                     $<TARGET_FILE:hexl>
+-                    $<TARGET_FILE:cpu_features>
+                     $<TARGET_FILE:gflags>
+                     $<TARGET_FILE:easyloggingpp>
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-                DEPENDS hexl cpu_features gflags easyloggingpp
++                DEPENDS hexl gflags easyloggingpp
+              )
+         endif()
+     else()
+         if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+             add_custom_command(TARGET hexl POST_BUILD
+                 COMMAND ar -x $<TARGET_FILE:hexl>
+-                COMMAND ar -x $<TARGET_FILE:cpu_features>
+                 COMMAND ar -qcs $<TARGET_FILE:hexl> *.o
+                 COMMAND rm -f *.o
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-                DEPENDS hexl cpu_features
++                DEPENDS hexl
+         )
+         elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+             add_custom_command(TARGET hexl POST_BUILD
+                 COMMAND lib.exe /OUT:$<TARGET_FILE:hexl>
+                     $<TARGET_FILE:hexl>
+-                    $<TARGET_FILE:cpu_features>
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-                DEPENDS hexl cpu_features
++                DEPENDS hexl
+             )
+       endif()
+     endif()
+--
+2.25.1
+

--- a/ports/hexl/portfile.cmake
+++ b/ports/hexl/portfile.cmake
@@ -1,0 +1,41 @@
+# This library only supports "x64" architecture
+vcpkg_fail_port_install(ON_ARCH "x86" "arm" "arm64")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/hexl
+    REF 2dc1db6824be3fc89d13740efd0270ec9afec77e
+    SHA512 aaa80dc53a21586d763a2b84b40d60062020470988422601bc5e9c2b31c6263847a97ea8f956d002a95e2d5e843cafa96fabdfd8b8ee892c7a7b9747133adebb
+    HEAD_REF main
+    PATCHES disable_downloading_cpu_features.patch
+)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(HEXL_SHARED OFF)
+else()
+    set(HEXL_SHARED ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        "-DHEXL_DEBUG=OFF"
+        "-DHEXL_BENCHMARK=OFF"
+        "-DHEXL_EXPORT=ON"
+        "-DHEXL_COVERAGE=OFF"
+        "-DHEXL_TESTING=OFF"
+        "-DHEXL_SHARED_LIB=${HEXL_SHARED}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "HEXL" CONFIG_PATH "lib/cmake")
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
+
+vcpkg_copy_pdbs()

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "hexl",
+  "version": "1.1.0",
+  "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
+  "homepage": "https://github.com/intel/hexl",
+  "supports": "x64 & !(windows & !static)",
+  "dependencies": [
+    "cpu-features",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2480,6 +2480,10 @@
       "baseline": "15",
       "port-version": 0
     },
+    "hexl": {
+      "baseline": "1.1.0",
+      "port-version": 0
+    },
     "hffix": {
       "baseline": "1.0.0",
       "port-version": 0

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7f5bcef6355a0cb88d04f4a3664568c74e2fd6bb",
+      "version": "1.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Added a new port "hexl".

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
x64 & (windows | linux | osx) & static
No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
I ran `./vcpkg x-add-version hexl` for this new port only.
