### PR TITLE
[vcpkg-cmake-config] Fix removal of files in `debug/share`

### DIFF
--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,5 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-02-26",
-  "port-version": 1
+  "version-date": "2021-05-22"
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -223,13 +223,13 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)]]
 
     # Remove /debug/<target_path>/ if it's empty.
     file(GLOB_RECURSE remaining_files "${debug_share}/*")
-    if(NOT remaining_files STREQUAL "")
+    if(remaining_files STREQUAL "")
         file(REMOVE_RECURSE "${debug_share}")
     endif()
 
     # Remove /debug/share/ if it's empty.
     file(GLOB_RECURSE remaining_files "${CURRENT_PACKAGES_DIR}/debug/share/*")
-    if(NOT remaining_files STREQUAL "")
+    if(remaining_files STREQUAL "")
         file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
     endif()
 endfunction()

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -136,9 +136,9 @@ function(vcpkg_cmake_config_fixup)
         "${debug_share}/*[Cc]onfigVersion.cmake"
         "${debug_share}/*[Cc]onfig-version.cmake"
     )
-    if(NOT unused_files STREQUAL "")
-        file(REMOVE "${unused_files}")
-    endif()
+    foreach(unused_file IN LISTS unused_files)
+        file(REMOVE "${unused_file}")
+    endforeach()
 
     file(GLOB_RECURSE release_targets
         "${release_share}/*-release.cmake"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6341,8 +6341,8 @@
       "port-version": 2
     },
     "vcpkg-cmake-config": {
-      "baseline": "2021-02-26",
-      "port-version": 1
+      "baseline": "2021-05-22",
+      "port-version": 0
     },
     "vcpkg-gfortran": {
       "baseline": "3",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d4f997a32b8e8bfe98d12beb2bfe6be713c7086",
+      "version-date": "2021-05-22",
+      "port-version": 0
+    },
+    {
       "git-tree": "46d60d4dd4297bedecdcd308167ad2492b269183",
       "version-date": "2021-02-26",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixes:
  - Broken removal of unused cmake files for the debug configuration.
  - Broken (inverted) logic of removing `debug/share` when it doesn't have any files left.
  
  The lack of proper removal triggered post-build policy checks to fail unless the portfile explicitly removed `debug/share`.
  This was found when porting `geos` to the new functions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
