### PR TITLE
[libgnutls] Disable tpm

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -35,6 +35,7 @@ vcpkg_configure_make(
         --disable-libdane
         --with-included-unistring
         --without-p11-kit
+        --without-tpm
         ${OPENSSL_COMPATIBILITY}
         "LDFLAGS=${LDFLAGS}"
 )

--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     REF ${GNUTLS_VERSION}
 )
 
@@ -25,7 +25,7 @@ if ("openssl" IN_LIST FEATURES)
 endif()
 
 vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         --disable-doc
         --disable-silent-rules
@@ -44,5 +44,5 @@ vcpkg_install_make()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgnutls",
   "version": "3.6.15",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "supports": "!windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3134,7 +3134,7 @@
     },
     "libgnutls": {
       "baseline": "3.6.15",
-      "port-version": 1
+      "port-version": 2
     },
     "libgo": {
       "baseline": "3.1-1",

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c03a1c452fa39d1b6d884aa3ef12c0c98a11f0a3",
+      "version": "3.6.15",
+      "port-version": 2
+    },
+    {
       "git-tree": "09f2d8c5e4e07d2076324767d251fef3bc4acb8c",
       "version": "3.6.15",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR disables TPM support in libgnutls. TPM support needs ltspi which has no port in vcpkg, but may happen to be found in the system environment.
  Fixes #17650.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes