### PR TITLE
[aom] Add new port

### DIFF
--- a/ports/aom/aom-install.diff
+++ b/ports/aom/aom-install.diff
@@ -1,0 +1,75 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 18190f647..f4b1b359d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,9 @@ endif()
+ 
+ project(AOM C CXX)
+ 
++include(GNUInstallDirs)
++include(CMakePackageConfigHelpers)
++
+ if(NOT EMSCRIPTEN)
+   if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+     set(CMAKE_BUILD_TYPE
+@@ -289,6 +292,52 @@ if(BUILD_SHARED_LIBS)
+   set(AOM_LIB_TARGETS ${AOM_LIB_TARGETS} aom_static)
+ endif()
+ 
++set(PUBLIC_HEADERS
++    aom/aom.h
++    aom/aom_codec.h
++    aom/aom_decoder.h
++    aom/aom_encoder.h
++    aom/aom_frame_buffer.h
++    aom/aom_image.h
++    aom/aom_integer.h
++    aom/aomcx.h
++    aom/aomdx.h
++)
++
++set_target_properties(aom PROPERTIES
++                          PUBLIC_HEADER "${PUBLIC_HEADERS}")
++
++
++target_include_directories(aom
++                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                                   $<INSTALL_INTERFACE:include>)
++
++install(TARGETS aom
++        EXPORT unofficial-aom-targets
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aom")
++
++install(EXPORT unofficial-aom-targets
++        FILE unofficial-aom-targets.cmake
++        NAMESPACE unofficial::
++        DESTINATION lib/cmake/aom)
++
++configure_package_config_file(cmake/aom-config.cmake.in
++                              ${CMAKE_CURRENT_BINARY_DIR}/aom-config.cmake
++                              INSTALL_DESTINATION lib/cmake/aom
++                              NO_SET_AND_CHECK_MACRO
++                              NO_CHECK_REQUIRED_COMPONENTS_MACRO)
++
++write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/aom-config-version.cmake
++                                 VERSION ${SO_FILE_VERSION}
++                                 COMPATIBILITY SameMajorVersion)
++
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/aom-config.cmake
++              ${CMAKE_CURRENT_BINARY_DIR}/aom-config-version.cmake
++        DESTINATION lib/cmake/aom)
++
+ # Setup dependencies.
+ setup_aom_dsp_targets()
+ setup_aom_mem_targets()
+diff --git a/cmake/aom-config.cmake.in b/cmake/aom-config.cmake.in
+new file mode 100644
+index 000000000..91cac3b5b
+--- /dev/null
++++ b/cmake/aom-config.cmake.in
+@@ -0,0 +1,2 @@
++@PACKAGE_INIT@
++include(${CMAKE_CURRENT_LIST_DIR}/unofficial-aom-targets.cmake)

--- a/ports/aom/aom-rename-static.diff
+++ b/ports/aom/aom-rename-static.diff
@@ -1,0 +1,12 @@
+diff -pruN aom-3.0.0.o/CMakeLists.txt aom-3.0.0/CMakeLists.txt
+--- aom-3.0.0.o/CMakeLists.txt	2021-04-15 20:05:52.695181200 +0300
++++ aom-3.0.0/CMakeLists.txt	2021-04-15 22:34:16.147522600 +0300
+@@ -249,7 +249,7 @@ endif()
+ add_library(aom ${AOM_SOURCES} $<TARGET_OBJECTS:aom_rtcd>)
+ if(BUILD_SHARED_LIBS)
+   add_library(aom_static STATIC ${AOM_SOURCES} $<TARGET_OBJECTS:aom_rtcd>)
+-  set_target_properties(aom_static PROPERTIES OUTPUT_NAME aom)
++  set_target_properties(aom_static PROPERTIES OUTPUT_NAME aom_static)
+ 
+   if(NOT MSVC)
+     # Extract version string and set VERSION/SOVERSION for the aom target.

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -1,0 +1,49 @@
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "UWP")
+
+# NASM is required to build AOM
+vcpkg_find_acquire_program(NASM)
+get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+vcpkg_add_to_path(${NASM_EXE_PATH})
+
+# Perl is required to build AOM
+vcpkg_find_acquire_program(PERL)
+get_filename_component(PERL_PATH ${PERL} DIRECTORY)
+vcpkg_add_to_path(${PERL_PATH})
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://aomedia.googlesource.com/aom"
+    REF 33aff8586e35ffe385637f6aa2c991858c0fb58e
+    TAG v3.1.0
+    PATCHES
+        aom-rename-static.diff
+        aom-install.diff
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DENABLE_DOCS=OFF
+        -DENABLE_EXAMPLES=OFF
+        -DENABLE_TESTDATA=OFF
+        -DENABLE_TESTS=OFF
+        -DENABLE_TOOLS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+# Move cmake configs
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+# Remove duplicate files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle usage
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -43,8 +43,5 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/debug/share)
 
-# Handle usage
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_git(
     TAG v3.1.0
     PATCHES
         aom-rename-static.diff
+        # Can be dropped when https://bugs.chromium.org/p/aomedia/issues/detail?id=3029 is merged into the upstream
         aom-install.diff
 )
 

--- a/ports/aom/portfile.cmake
+++ b/ports/aom/portfile.cmake
@@ -23,7 +23,6 @@ vcpkg_from_git(
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DENABLE_DOCS=OFF
         -DENABLE_EXAMPLES=OFF

--- a/ports/aom/usage
+++ b/ports/aom/usage
@@ -1,4 +1,0 @@
-The package aom provides CMake targets:
-
-    find_package(aom CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::aom)

--- a/ports/aom/usage
+++ b/ports/aom/usage
@@ -1,0 +1,4 @@
+The package aom provides CMake targets:
+
+    find_package(aom CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::aom)

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "aom",
+  "version-semver": "3.1.0",
+  "description": "AV1 codec library",
+  "homepage": "https://aomedia.googlesource.com/aom",
+  "supports": "!uwp & !arm64",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/aom/vcpkg.json
+++ b/ports/aom/vcpkg.json
@@ -3,7 +3,7 @@
   "version-semver": "3.1.0",
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",
-  "supports": "!uwp & !arm64",
+  "supports": "!uwp & !arm",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dcc51db063666bbc6620325c722b16d0a40a60b0",
+      "git-tree": "f99c8c6e8b058829edd89bfc80a8bd2aaf0dee85",
       "version-semver": "3.1.0",
       "port-version": 0
     }

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "dcc51db063666bbc6620325c722b16d0a40a60b0",
+      "version-semver": "3.1.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5ad9e1ff21c8fd9790c08393b5eac5e3cf582b5d",
+      "git-tree": "b465c1a32eeac8dfe55239134d800c309b16b33f",
       "version-semver": "3.1.0",
       "port-version": 0
     }

--- a/versions/a-/aom.json
+++ b/versions/a-/aom.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f99c8c6e8b058829edd89bfc80a8bd2aaf0dee85",
+      "git-tree": "5ad9e1ff21c8fd9790c08393b5eac5e3cf582b5d",
       "version-semver": "3.1.0",
       "port-version": 0
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -92,6 +92,10 @@
       "baseline": "2020-01-13",
       "port-version": 2
     },
+    "aom": {
+      "baseline": "3.1.0",
+      "port-version": 0
+    },
     "apr": {
       "baseline": "1.7.0",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

Add AV1 codec library https://aomedia.googlesource.com/aom version 3.1.0.

- #### What does your PR fix?  

\-

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Triplets: Everything except UWP and ARM.

CI baseline is not updated.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.

Port peculiarity:

- Added missing CMake rules to install and export unofficial targets. Discussion is in #17332 .
- AOM always builds an extra static lib when `BUILD_SHARED_LIBS` is `ON` which is not installed by the rules added above. We simply don't need it.