### PR TITLE
[flashlight-cpu] Fix installation

### DIFF
--- a/ports/flashlight-cpu/fix-dependencies.patch
+++ b/ports/flashlight-cpu/fix-dependencies.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d9eacb..b530743 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,7 +183,7 @@ if (FL_BUILD_CORE)
+ 
+   # If cereal is found in a user-defined location, use it rather than
+   # downloading from source
+-  find_package(cereal)
++  find_package(cereal CONFIG REQUIRED)
+   if (NOT TARGET cereal AND NOT cereal_FOUND AND FL_BUILD_STANDALONE)
+     message(STATUS "cereal NOT found. Will download from source")
+     set(CEREAL_INSTALL_PATH ${FL_INSTALL_INC_DIR}/cereal)
+@@ -206,7 +206,6 @@ if (FL_BUILD_CORE)
+     message(STATUS "Found cereal")
+     target_link_libraries(flashlight PRIVATE cereal)
+   endif()
+-  setup_install_find_module(${CMAKE_MODULE_PATH}/Findcereal.cmake)
+ 
+   # -------------------- Locate Backend-specific Dependencies --------------------
+   # TODO: rather than conditionally searching for backend-specific dependencies,
+diff --git a/cmake/flashlightConfig.cmake.in b/cmake/flashlightConfig.cmake.in
+index 00f9442..f265b8f 100644
+--- a/cmake/flashlightConfig.cmake.in
++++ b/cmake/flashlightConfig.cmake.in
+@@ -36,6 +36,7 @@ if (@FL_BUILD_LIBRARIES@)
+ endif()
+ # Core dependencies
+ if (@FL_BUILD_CORE@)
++  find_dependency(cereal CONFIG)
+   find_dependency(ArrayFire 3.7.1)
+ endif()
+ if (@FL_BUILD_DISTRIBUTED@)

--- a/ports/flashlight-cpu/portfile.cmake
+++ b/ports/flashlight-cpu/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     REF 626914e79073c5547513de649af706f7e2b796ad # 0.3 branch tip
     SHA512 a22057cfa4cfe7acd95cbc5445a30870cce3cdde89066d1d75f40be0d73b069a49e89b226fe5337488cfe5618dd25958679c0636a3e4008312f01606328becfa
     HEAD_REF master
+    PATCHES fix-dependencies.patch
 )
 
 ################################### Build ###################################
@@ -41,13 +42,13 @@ vcpkg_configure_cmake(
         ${FL_DEFAULT_VCPKG_CMAKE_FLAGS} 
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
-        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/${PORT}
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/flashlight
     OPTIONS_RELEASE
-        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/flashlight
 )
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/flashlight-cpu TARGET_PATH share/flashlight)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/flashlight TARGET_PATH share/flashlight)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/flashlight-cpu/portfile.cmake
+++ b/ports/flashlight-cpu/portfile.cmake
@@ -19,7 +19,6 @@ set(FL_DEFAULT_VCPKG_CMAKE_FLAGS
   -DFL_BUILD_EXAMPLES=OFF
   -DFL_BACKEND=CPU # this port is CPU-backend only
   -DFL_BUILD_STANDALONE=OFF
-  -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
 )
 
 # Determine which components to build via specified feature
@@ -41,6 +40,10 @@ vcpkg_configure_cmake(
     OPTIONS 
         ${FL_DEFAULT_VCPKG_CMAKE_FLAGS} 
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/${PORT}
+    OPTIONS_RELEASE
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT}
 )
 vcpkg_install_cmake()
 

--- a/ports/flashlight-cpu/vcpkg.json
+++ b/ports/flashlight-cpu/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "flashlight-cpu",
   "version": "0.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C++ standalone library for machine learning. CPU backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
   "supports": "!(windows | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1998,7 +1998,7 @@
     },
     "flashlight-cpu": {
       "baseline": "0.3",
-      "port-version": 1
+      "port-version": 2
     },
     "flashlight-cuda": {
       "baseline": "0.3",

--- a/versions/f-/flashlight-cpu.json
+++ b/versions/f-/flashlight-cpu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9a558cf97b737e75e612869995b498709b5a330e",
+      "git-tree": "b37aa1e8b06ce24319b6969ed0fa87664e4ec308",
       "version": "0.3",
       "port-version": 2
     },

--- a/versions/f-/flashlight-cpu.json
+++ b/versions/f-/flashlight-cpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a558cf97b737e75e612869995b498709b5a330e",
+      "version": "0.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "9de5ce0a5763ebc2b46378a46172b8cda7ac95c5",
       "version": "0.3",
       "port-version": 1


### PR DESCRIPTION
Fix installation bug:
```
CMake Error at scripts/cmake/vcpkg_fixup_cmake_targets.cmake:95 (message):

'/home/skrrohit/my_repos/projects/vcpkg/packages/flashlight-cpu_x64-linux/debug/share/flashlight-cpu'
does not exist.
Call Stack (most recent call first):
```

Fixes #18064.