### PR TITLE
[doc] document vcpkg_fixup_pkgconfig merging behaviour

### DIFF
--- a/docs/maintainers/vcpkg_fixup_pkgconfig.md
+++ b/docs/maintainers/vcpkg_fixup_pkgconfig.md
@@ -2,7 +2,11 @@
 
 The latest version of this document lives in the [vcpkg repo](https://github.com/Microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_fixup_pkgconfig.md).
 
-Fix common paths in *.pc files and make everything relative to $(prefix)
+Fix common paths in *.pc files and make everything relative to $(prefix).
+Additionally, on static triplets, private entries are merged with their non-private counterparts,
+allowing pkg-config to be called without the ``--static`` flag.
+Note that vcpkg is designed to never have to call pkg-config with the ``--static`` flag,
+since a consumer cannot know if a dependent library has been built statically or not.
 
 ## Usage
 ```cmake

--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
@@ -1,7 +1,11 @@
 #[===[.md:
 # vcpkg_fixup_pkgconfig
 
-Fix common paths in *.pc files and make everything relative to $(prefix)
+Fix common paths in *.pc files and make everything relative to $(prefix).
+Additionally, on static triplets, private entries are merged with their non-private counterparts,
+allowing pkg-config to be called without the ``--static`` flag.
+Note that vcpkg is designed to never have to call pkg-config with the ``--static`` flag,
+since a consumer cannot know if a dependent library has been built statically or not.
 
 ## Usage
 ```cmake


### PR DESCRIPTION
This also documents the fact that pkg-config is never to be called with the --static flag. Maybe something should be added to the maintainer guide as well (i.e. .pc files should always work without ``--static``), but for now, this seems like a good pace to add it.

See discussion in #17748.

cc @Neumann-A