### PR TITLE
[docs] vcpkg_from_github beast moved to boost-beast

### DIFF
--- a/docs/maintainers/vcpkg_from_github.md
+++ b/docs/maintainers/vcpkg_from_github.md
@@ -70,7 +70,7 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 
 * [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
 * [ms-gsl](https://github.com/Microsoft/vcpkg/blob/master/ports/ms-gsl/portfile.cmake)
-* [beast](https://github.com/Microsoft/vcpkg/blob/master/ports/beast/portfile.cmake)
+* [boost-beast](https://github.com/Microsoft/vcpkg/blob/master/ports/boost-beast/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_from\_github.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_from_github.cmake)

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -69,7 +69,7 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 
 * [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
 * [ms-gsl](https://github.com/Microsoft/vcpkg/blob/master/ports/ms-gsl/portfile.cmake)
-* [beast](https://github.com/Microsoft/vcpkg/blob/master/ports/beast/portfile.cmake)
+* [boost-beast](https://github.com/Microsoft/vcpkg/blob/master/ports/boost-beast/portfile.cmake)
 #]===]
 
 function(vcpkg_from_github)


### PR DESCRIPTION
**Describe the pull request**

Came across the [webpage on vcpkg.io](https://vcpkg.io/en/docs/maintainers/vcpkg_from_github.html) which took me to an empty beast file.
boost-beast has moved from beast to boost-beast