### PR TITLE
[vcpkg baseline][libtasn1] Fix static build

### DIFF
--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -29,6 +29,12 @@ else()
     set(VCPKG_CXX_FLAGS "-g -O2")
 endif()
 
+# The upstream doesn't add this macro to the configure
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(VCPKG_C_FLAGS ${VCPKG_C_FLAGS} -DASN1_STATIC)
+    set(VCPKG_CXX_FLAGS ${VCPKG_CXX_FLAGS} -DASN1_STATIC)
+endif()
+
 set(ENV{GTKDOCIZE} true)
 vcpkg_configure_make(
     AUTOCONFIG

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -31,8 +31,7 @@ endif()
 
 # The upstream doesn't add this macro to the configure
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(VCPKG_C_FLAGS ${VCPKG_C_FLAGS} -DASN1_STATIC)
-    set(VCPKG_CXX_FLAGS ${VCPKG_CXX_FLAGS} -DASN1_STATIC)
+    set(EXTRA_OPTS "${EXTRA_OPTS} CFLAGS=\"$CFLAGS -DASN1_STATIC\"")
 endif()
 
 set(ENV{GTKDOCIZE} true)

--- a/ports/libtasn1/portfile.cmake
+++ b/ports/libtasn1/portfile.cmake
@@ -30,7 +30,8 @@ else()
 endif()
 
 # The upstream doesn't add this macro to the configure
-if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL static)
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+
     set(EXTRA_OPTS "${EXTRA_OPTS} CFLAGS=\"$CFLAGS -DASN1_STATIC\"")
 endif()
 

--- a/ports/libtasn1/vcpkg.json
+++ b/ports/libtasn1/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libtasn1",
   "version": "4.17.0",
+  "port-version": 1,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
   "supports": "!uwp",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -761,7 +761,6 @@ libssh:arm-uwp=fail
 libssh:x64-uwp=fail
 libstk:arm-uwp=fail
 libstk:x64-uwp=fail
-libtasn1:x64-windows-static-md=fail
 libtins:arm-uwp=fail
 libtins:x64-uwp=fail
 libtomcrypt:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3558,7 +3558,7 @@
     },
     "libtasn1": {
       "baseline": "4.17.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libtcod": {
       "baseline": "1.18.0",

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4969c8ddb39ae78f59999f2e94e6f0c8d8e81aaa",
+      "version": "4.17.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "63ad8395545c61a38b7564108d2c1c4b7a6bbf12",
       "version": "4.17.0",
       "port-version": 0

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "04828737d466a23ff937ef771c49e861ded218c2",
+      "git-tree": "3554f6c03cdac32ddf68540d62c04f6f4644ec94",
       "version": "4.17.0",
       "port-version": 1
     },

--- a/versions/l-/libtasn1.json
+++ b/versions/l-/libtasn1.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4969c8ddb39ae78f59999f2e94e6f0c8d8e81aaa",
+      "git-tree": "04828737d466a23ff937ef771c49e861ded218c2",
       "version": "4.17.0",
       "port-version": 1
     },


### PR DESCRIPTION
Fix static build on Windows:
```
   Creating library asn1Parser.lib and object asn1Parser.exp
asn1Parser.obj : error LNK2019: unresolved external symbol __imp_asn1_parser2tree referenced in function main
asn1Parser.obj : error LNK2019: unresolved external symbol __imp_asn1_parser2array referenced in function main
asn1Parser.obj : error LNK2019: unresolved external symbol __imp_asn1_delete_structure referenced in function main
asn1Parser.obj : error LNK2019: unresolved external symbol __imp_asn1_strerror referenced in function main
asn1Parser.exe : fatal error LNK1120: 4 unresolved externals
   Creating library asn1Coding.lib and object asn1Coding.exp
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_parser2tree referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_print_structure referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_create_element referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_delete_structure referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_write_value referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_der_coding referenced in function main
asn1Coding.obj : error LNK2019: unresolved external symbol __imp_asn1_strerror referenced in function main
...
```
Add `ASN1_STATIC` to `C_FLAGS` / `CXX_FLAGS` because this macro does not exist in the source configuration file.

Related: https://github.com/microsoft/vcpkg/pull/16953