### PR TITLE
[boost-modular-build-helper] Bugfix/boost arm64 ios

### DIFF
--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -99,7 +99,7 @@ function(boost_modular_build)
         vcpkg_install_cmake()
     endfunction()
 
-    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND NOT (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" AND (VCPKG_CMAKE_SYSTEM_NAME STREQUAL "iOS" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")))
         set(build_flag 0)
         if(NOT DEFINED VCPKG_BUILD_TYPE)
             set(build_flag 1)

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -99,7 +99,7 @@ function(boost_modular_build)
         vcpkg_install_cmake()
     endfunction()
 
-    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    if(VCPKG_CMAKE_SYSTEM_NAME AND NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
         set(build_flag 0)
         if(NOT DEFINED VCPKG_BUILD_TYPE)
             set(build_flag 1)

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -8,7 +8,7 @@ if "@VCPKG_PLATFORM_TOOLSET@" != "external"
         @TOOLSET_OPTIONS@
         ;
 }
-else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64"
+else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64" && "@VCPKG_CMAKE_SYSTEM_NAME@" = "iOS"
 {
     using gcc : 12.0.0 : @CMAKE_CXX_COMPILER@
         :

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -19,10 +19,23 @@ else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64" && "@VCPKG_CMAKE_SYSTEM_NAME@" =
         @LDFLAGS@
         # MINGW here causes b2 to not run cygpath
         <flavor>mingw
-        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -mmacosx-version-min=10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
+        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
         ;        
 }
-
+else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64" && "@VCPKG_CMAKE_SYSTEM_NAME@" = "Darwin"
+{
+    using gcc : 12.0.0 : @CMAKE_CXX_COMPILER@
+        :
+        <ranlib>@CMAKE_RANLIB@
+        <archiver>@CMAKE_AR@
+        @CXXFLAGS@
+        @CFLAGS@
+        @LDFLAGS@
+        # MINGW here causes b2 to not run cygpath
+        <flavor>mingw
+        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -mmacosx-version-min=10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+        ; 
+}
 else
 {
     using gcc : 12.0.0 : @CMAKE_CXX_COMPILER@

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -19,7 +19,7 @@ else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64"
         @LDFLAGS@
         # MINGW here causes b2 to not run cygpath
         <flavor>mingw
-        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -mmacosx-version-min=10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
+        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -mmacosx-version-min=10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
         ;        
 }
 

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -8,9 +8,24 @@ if "@VCPKG_PLATFORM_TOOLSET@" != "external"
         @TOOLSET_OPTIONS@
         ;
 }
+else if "@VCPKG_TARGET_ARCHITECTURE@" = "arm64"
+{
+    using gcc : 12.0.0 : @CMAKE_CXX_COMPILER@
+        :
+        <ranlib>@CMAKE_RANLIB@
+        <archiver>@CMAKE_AR@
+        @CXXFLAGS@
+        @CFLAGS@
+        @LDFLAGS@
+        # MINGW here causes b2 to not run cygpath
+        <flavor>mingw
+        <compileflags>"-std=c++14 -stdlib=libc++ -DNDEBUG -arch arm64 -fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness -mmacosx-version-min=10.12 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
+        ;        
+}
+
 else
 {
-    using gcc : 5.4.1 : @CMAKE_CXX_COMPILER@
+    using gcc : 12.0.0 : @CMAKE_CXX_COMPILER@
         :
         <ranlib>@CMAKE_RANLIB@
         <archiver>@CMAKE_AR@

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.75.0",
-  "port-version": 9,
+  "port-version": 10,
   "dependencies": [
     "boost-build",
     "boost-uninstall"

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac3d5070ffc8f8ed8a1e6d260fc864e451e49a2d",
+      "version-string": "1.75.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "c475b268ac42e886acfdc783944e1e3a988b0ac8",
       "version-string": "1.75.0",
       "port-version": 9

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -722,7 +722,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.75.0",
-      "port-version": 9
+      "port-version": 10
     },
     "boost-move": {
       "baseline": "1.75.0",


### PR DESCRIPTION
Building boost for arm64 ios created x86_64 .a libraries. This is fixed by using a different modular builder, using gcc 12.0.0 and adding compiler options to the user-config.jam file.
