### PR TITLE
[gettext] Fix building for android

### DIFF
--- a/ports/gettext/android.patch
+++ b/ports/gettext/android.patch
@@ -1,0 +1,12 @@
+diff --color -ruN a/gettext-runtime/intl/dcigettext.c src/gettext-runtime/intl/dcigettext.c
+--- a/gettext-runtime/intl/dcigettext.c	2021-05-26 16:27:55.420544597 +0200
++++ src/gettext-runtime/intl/dcigettext.c	2021-05-26 16:29:14.546516701 +0200
+@@ -143,7 +143,7 @@
+ # else
+ #  if VMS
+ #   define getcwd(buf, max) (getcwd) (buf, max, 0)
+-#  else
++#  elif !(defined(__clang__) && defined(__BIONIC_FORTIFY))
+ char *getcwd ();
+ #  endif
+ # endif

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_extract_source_archive_ex(
         0002-Fix-uwp-build.patch
         0003-Fix-win-unicode-paths.patch
         rel_path.patch
+        android.patch
         ${PATCHES}
 )
 vcpkg_find_acquire_program(BISON)

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The GNU gettext utilities are a set of tools that provides a framework to help other GNU packages produce multi-lingual messages. Provides libintl.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 2
+      "port-version": 3
     },
     "gettimeofday": {
       "baseline": "2017-10-14-3",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33c7af8451faeef94c8a06cb41b71dce144d6fba",
+      "version": "0.21",
+      "port-version": 3
+    },
+    {
       "git-tree": "7aba831bc44964ac3d3767392b037e30b06d897e",
       "version": "0.21",
       "port-version": 2


### PR DESCRIPTION
Taken from https://github.com/navit-gps/navit/pull/1087/files

**Describe the pull request**

- #### What does your PR fix?  
  Fixes building gettext for android

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  +android, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

