### PR TITLE
[x265] x265 Main10 and Main12 support

### DIFF
--- a/ports/x265/CONTROL
+++ b/ports/x265/CONTROL
@@ -1,6 +1,12 @@
 Source: x265
 Version: 3.4
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/videolan/x265
 Description: x265 is a H.265 / HEVC video encoder application library, designed to encode video or images into an H.265 / HEVC encoded bitstream.
 Supports: !(uwp | arm)
+
+Feature: bit10
+Description: 10-bit support
+
+Feature: bit12
+Description: 12-bit support

--- a/ports/x265/portfile.cmake
+++ b/ports/x265/portfile.cmake
@@ -11,16 +11,6 @@ vcpkg_from_github(
         disable-install-pdb.patch
 )
 
-set(ENABLE_ASSEMBLY OFF)
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_find_acquire_program(NASM)
-    get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
-    set(ENV{PATH} "$ENV{PATH};${NASM_EXE_PATH}")
-    set(ENABLE_ASSEMBLY ON)
-endif ()
-
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
-
 set(HAS_10_BIT OFF)
 if("bit10" IN_LIST FEATURES)
     set(HAS_10_BIT ON)
@@ -30,17 +20,29 @@ set(HAS_12_BIT OFF)
 if("bit12" IN_LIST FEATURES)
     set(HAS_12_BIT ON)
 endif()
+
+set(ENABLE_ASSEMBLY OFF)
+if (VCPKG_TARGET_IS_WINDOWS AND (NOT HAS_12_BIT AND NOT HAS_10_BIT))
+    vcpkg_find_acquire_program(NASM)
+    get_filename_component(NASM_EXE_PATH ${NASM} DIRECTORY)
+    set(ENV{PATH} "$ENV{PATH};${NASM_EXE_PATH}")
+    set(ENABLE_ASSEMBLY ON)
+endif ()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ENABLE_SHARED)
+
 set(FEATURE_OPT_DBG "")
 set(FEATURE_OPT_REL "")
 set(EXTRA_LIB_DBG "")
 set(EXTRA_LIB_REL "")
+
+set(ADDITIONAL_NAME "")
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(x265_lib_name "x265-static.lib")
-    set(x265_lib_name_main "x265-static-main.lib")
-elseif(VCPKG_TARGET_IS_LINUX)
-    set(x265_lib_name "libx265.a")
-    set(x265_lib_name_main "libx265-main.a")
+    set(ADDITIONAL_NAME "-static")
 endif()
+
+set(x265_lib_name "${VCPKG_TARGET_STATIC_LIBRARY_PREFIX}x265${ADDITIONAL_NAME}${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+set(x265_lib_name_main "${VCPKG_TARGET_STATIC_LIBRARY_PREFIX}x265${ADDITIONAL_NAME}-main${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
 
 ## Usage
 #  build_x265(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6658,7 +6658,7 @@
     },
     "x265": {
       "baseline": "3.4",
-      "port-version": 4
+      "port-version": 5
     },
     "xalan-c": {
       "baseline": "1.12",

--- a/versions/x-/x265.json
+++ b/versions/x-/x265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66da1e12dcb3cea0a762d2a74a4495995a7573d1",
+      "version-string": "3.4",
+      "port-version": 5
+    },
+    {
       "git-tree": "39318069e894d5dd6ff63112fd707c31b13be88b",
       "version-string": "3.4",
       "port-version": 4


### PR DESCRIPTION
Added two new features to support main10 and main12 profile of x265, tested on windows and linux

- #### What does your PR fix?  
  Fixes #13875

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
x64-linux x86-windows x86-windows-static

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

