### PR TITLE
[embree3] Fix target files cannot be found

### DIFF
--- a/ports/embree3/fix-targets-file-not-found.patch
+++ b/ports/embree3/fix-targets-file-not-found.patch
@@ -1,0 +1,18 @@
+diff --git a/common/cmake/package.cmake b/common/cmake/package.cmake
+index 8c89f5b..55cb2af 100644
+--- a/common/cmake/package.cmake
++++ b/common/cmake/package.cmake
+@@ -114,10 +114,10 @@ ENDIF()
+ #  SET(EMBREE_CMAKEEXPORT_DIR "cmake")
+ #  SET(EMBREE_RELATIVE_ROOT_DIR ".")
+ #ELSE()
+-SET(EMBREE_CMAKECONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/embree-${EMBREE_VERSION}")
+-SET(EMBREE_CMAKEEXPORT_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/embree-${EMBREE_VERSION}")
++SET(EMBREE_CMAKECONFIG_DIR "share/embree")
++SET(EMBREE_CMAKEEXPORT_DIR "share/embree")
+ IF (WIN32)
+-  SET(EMBREE_RELATIVE_ROOT_DIR "../../../")
++  SET(EMBREE_RELATIVE_ROOT_DIR "../..")
+ ELSE()
+   FILE(RELATIVE_PATH EMBREE_RELATIVE_ROOT_DIR "/${EMBREE_CMAKECONFIG_DIR}" "/")
+ ENDIF()

--- a/ports/embree3/portfile.cmake
+++ b/ports/embree3/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         fix-path.patch
         fix-static-usage.patch
         cmake_policy.patch
+        fix-targets-file-not-found.patch
 )
 
 string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} static EMBREE_STATIC_LIB)
@@ -22,11 +23,11 @@ if (NOT VCPKG_TARGET_IS_OSX)
 
     vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         FEATURES
-        avx     EMBREE_ISA_AVX
-        avx2    EMBREE_ISA_AVX2
-        avx512  EMBREE_ISA_AVX512
-        sse2    EMBREE_ISA_SSE2
-        sse42   EMBREE_ISA_SSE42
+            avx     EMBREE_ISA_AVX
+            avx2    EMBREE_ISA_AVX2
+            avx512  EMBREE_ISA_AVX512
+            sse2    EMBREE_ISA_SSE2
+            sse42   EMBREE_ISA_SSE42
     )
 elseif (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     list(LENGTH FEATURES FEATURE_COUNT)
@@ -59,18 +60,18 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/embree-${EMBREE3_VERSION} TARGET_PATH share/embree)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/embree TARGET_PATH share/embree)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 if(APPLE)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/uninstall.command ${CURRENT_PACKAGES_DIR}/debug/uninstall.command)
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/uninstall.command" "${CURRENT_PACKAGES_DIR}/debug/uninstall.command")
 endif()
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/${PORT}/)
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/doc" "${CURRENT_PACKAGES_DIR}/share/${PORT}/")
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/embree3/vcpkg.json
+++ b/ports/embree3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "embree3",
   "version-semver": "3.12.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High Performance Ray Tracing Kernels.",
   "homepage": "https://github.com/embree/embree",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1842,7 +1842,7 @@
     },
     "embree3": {
       "baseline": "3.12.2",
-      "port-version": 1
+      "port-version": 2
     },
     "enet": {
       "baseline": "1.3.16",

--- a/versions/e-/embree3.json
+++ b/versions/e-/embree3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04c9ff8d31137bc08cd37662050a41dd5f1d8ecf",
+      "version-semver": "3.12.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0b90c66c1c8be2574ff610fe1fda718e8b87b78",
       "version-semver": "3.12.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18096
 
```
 CMake Error at C:/Users/KazutakaNakashima/Documents/git/vcpkg/installed/x64-windows/share/embree/embree-config.cmake:72 (INCLUDE):
  INCLUDE could not find requested file:

    C:/Users/KazutakaNakashima/Documents/git/vcpkg/installed/lib/cmake/embree-3.12.2/embree-targets.cmake
Call Stack (most recent call first):
  C:/Users/KazutakaNakashima/Documents/git/vcpkg/scripts/buildsystems/vcpkg.cmake:861 (_find_package)
  CMakeLists.txt:5 (find_package)
```
Note: There is no need to test features.

 
