### PR TITLE
[openssl] Restore Blowfish cipher in OpenSSL

### DIFF
--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -205,7 +205,6 @@ else()
             no-zlib
             no-ssl2
             no-idea
-            no-bf
             no-cast
             no-seed
             no-md2

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version-string": "1.1.1k",
-  "port-version": 2,
+  "port-version": 3,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4566,7 +4566,7 @@
     },
     "openssl": {
       "baseline": "1.1.1k",
-      "port-version": 2
+      "port-version": 3
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9f4e7983d2a78b8e865d0444d90ef19ce3a9636c",
+      "version-string": "1.1.1k",
+      "port-version": 3
+    },
+    {
       "git-tree": "dcaa59e72471884bf333486e49be386dd4a3da4f",
       "version-string": "1.1.1k",
       "port-version": 2


### PR DESCRIPTION
OpenSSL port today excludes Blowfish cipher on *nix platforms. I couldn't find a particular reason for why that is in `git blame` and this is still a useful cipher to have for some older systems. This PR removes `no-bf` flag to restore Blowfish cipher on *nix and bring consistency across supported platforms.

- #### What does your PR fix?  
  Fixes #17183

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
- Only changes *nix port. As far as I can tell, Windows already has this cipher enabled

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
- I believe so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
- Yes
