### PR TITLE
[aubio] fix features

### DIFF
--- a/ports/aubio/CMakeLists.txt
+++ b/ports/aubio/CMakeLists.txt
@@ -12,7 +12,6 @@ add_definitions(
     -DHAVE_STDARG_H=1
     -DHAVE_ERRNO_H=1
     -DHAVE_C99_VARARGS_MACROS=1
-
     -D_CRT_SECURE_NO_WARNINGS=1
 )
 
@@ -46,6 +45,13 @@ if(WITH_DEPENDENCIES)
         ${FFMPEG_LIBRARIES}
         BZip2::BZip2
         ${LIBLZMA_LIBRARIES}
+    )
+    add_definitions(
+        -DHAVE_SNDFILE=1
+        -DHAVE_WAVWRITE=1
+        -DHAVE_WAVREAD=1
+        -DHAVE_LIBAV=1
+        -DHAVE_SWRESAMPLE=1
     )
 endif()
 

--- a/ports/aubio/CMakeLists.txt
+++ b/ports/aubio/CMakeLists.txt
@@ -22,7 +22,7 @@ option(BUILD_TOOLS "Build and install tools" ON)
 set(TOOLS_INSTALLDIR "bin" CACHE STRING "Target directory for installed tools")
 
 if(WITH_DEPENDENCIES)
-    find_package(FFMPEG COMPONENTS avcodec avutil avdevice avfilter avformat swresample REQUIRED)
+    find_package(FFMPEG COMPONENTS avcodec avformat swresample REQUIRED)
     find_package(BZip2 REQUIRED)
     find_package(LibLZMA REQUIRED)
     find_package(SndFile REQUIRED)

--- a/ports/aubio/portfile.cmake
+++ b/ports/aubio/portfile.cmake
@@ -13,11 +13,6 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
     tools WITH_DEPENDENCIES
-    tools HAVE_SNDFILE
-    tools HAVE_WAVWRITE
-    tools HAVE_WAVREAD
-    tools HAVE_LIBAV
-    tools HAVE_SWRESAMPLE
 )
 
 vcpkg_configure_cmake(

--- a/ports/aubio/vcpkg.json
+++ b/ports/aubio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "aubio",
   "version-string": "0.4.9",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Aubio is a tool designed for the extraction of annotations from audio signals. Its features include segmenting a sound file before each of its attacks, performing pitch detection, tapping the beat and producing midi streams from live audio.",
   "homepage": "https://github.com/aubio/aubio",
   "default-features": [
@@ -12,7 +12,15 @@
       "description": "Build tools and add extra dependencies",
       "dependencies": [
         "bzip2",
-        "ffmpeg",
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec",
+            "avformat",
+            "swresample"
+          ]
+        },
         "libflac",
         "liblzma",
         "libogg",

--- a/versions/a-/aubio.json
+++ b/versions/a-/aubio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77462ad5a7a4176a28f4f7b40e25fe7e9c37bd95",
+      "version-string": "0.4.9",
+      "port-version": 5
+    },
+    {
       "git-tree": "a5fd622dc9d70a1f4cca1e6bc09829e1844b7e0f",
       "version-string": "0.4.9",
       "port-version": 4

--- a/versions/a-/aubio.json
+++ b/versions/a-/aubio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "77462ad5a7a4176a28f4f7b40e25fe7e9c37bd95",
+      "git-tree": "ec32f71f32fc801a12e4059766a7c6e0e819aab3",
       "version-string": "0.4.9",
       "port-version": 5
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -194,7 +194,7 @@
     },
     "aubio": {
       "baseline": "0.4.9",
-      "port-version": 4
+      "port-version": 5
     },
     "audiofile": {
       "baseline": "1.0.7",


### PR DESCRIPTION
- #### What does your PR fix?  
  Whilst checking ffmpeg's dependents in vcpkg, I noticed that aubio was not functional, and could not read any audio files, and moreover that it dependent on far more features of ffmpeg than required. This PR addresses both problems. Before patch:
  ```
  $ ./installed/x64-linux/tools/aubio/aubiopitch ...
  AUBIO ERROR: source: failed creating with ... at 0Hz with hop size 256 (no source built-in)
  Error: could not open input file ...
  ```
  After patch:
  ```
  $ ./installed/x64-linux/tools/aubio/aubiopitch ...
  [output as expected]
  ```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, to the best of my knowledge.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
