### PR TITLE
[vcpkg] Expand Architecture list with escape chars

### DIFF
--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2021-02-28",
-  "port-version": 3
+  "version-date": "2021-06-25",
+  "port-version": 4
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -251,6 +251,7 @@ function(vcpkg_cmake_configure)
     endif()
 
 
+    list(JOIN VCPKG_TARGET_ARCHITECTURE "\;" target_architecture_string)
     list(APPEND arg_OPTIONS
         "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}"
         "-DVCPKG_TARGET_TRIPLET=${TARGET_TRIPLET}"
@@ -274,7 +275,7 @@ function(vcpkg_cmake_configure)
         "-DVCPKG_LINKER_FLAGS=${VCPKG_LINKER_FLAGS}"
         "-DVCPKG_LINKER_FLAGS_RELEASE=${VCPKG_LINKER_FLAGS_RELEASE}"
         "-DVCPKG_LINKER_FLAGS_DEBUG=${VCPKG_LINKER_FLAGS_DEBUG}"
-        "-DVCPKG_TARGET_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}"
+        "-DVCPKG_TARGET_ARCHITECTURE=${target_architecture_string}"
         "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
         "-DCMAKE_INSTALL_BINDIR:STRING=bin"
         "-D_VCPKG_ROOT_DIR=${VCPKG_ROOT_DIR}"
@@ -289,7 +290,8 @@ function(vcpkg_cmake_configure)
     # Sets configuration variables for macOS builds
     foreach(config_var IN ITEMS INSTALL_NAME_DIR OSX_DEPLOYMENT_TARGET OSX_SYSROOT OSX_ARCHITECTURES)
         if(DEFINED VCPKG_${config_var})
-            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${VCPKG_${config_var}}")
+            list(JOIN VCPKG_${config_var} "\;" config_var_value)
+            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${config_var_value}")
         endif()
     endforeach()
 

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -231,7 +231,7 @@ function(vcpkg_configure_cmake)
         endif()
     endif()
 
-
+    list(JOIN VCPKG_TARGET_ARCHITECTURE "\;" target_architecure_string)
     list(APPEND arg_OPTIONS
         "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}"
         "-DVCPKG_TARGET_TRIPLET=${TARGET_TRIPLET}"
@@ -255,7 +255,7 @@ function(vcpkg_configure_cmake)
         "-DVCPKG_LINKER_FLAGS=${VCPKG_LINKER_FLAGS}"
         "-DVCPKG_LINKER_FLAGS_RELEASE=${VCPKG_LINKER_FLAGS_RELEASE}"
         "-DVCPKG_LINKER_FLAGS_DEBUG=${VCPKG_LINKER_FLAGS_DEBUG}"
-        "-DVCPKG_TARGET_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}"
+        "-DVCPKG_TARGET_ARCHITECTURE=${target_architecure_string}"
         "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
         "-DCMAKE_INSTALL_BINDIR:STRING=bin"
         "-D_VCPKG_ROOT_DIR=${VCPKG_ROOT_DIR}"
@@ -272,7 +272,8 @@ function(vcpkg_configure_cmake)
     # Sets configuration variables for macOS builds
     foreach(config_var  INSTALL_NAME_DIR OSX_DEPLOYMENT_TARGET OSX_SYSROOT OSX_ARCHITECTURES)
         if(DEFINED VCPKG_${config_var})
-            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${VCPKG_${config_var}}")
+            list(JOIN VCPKG_${config_var} "\;" config_var_value)
+            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${config_var_value}")
         endif()
     endforeach()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6501,8 +6501,8 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2021-02-28",
-      "port-version": 3
+      "baseline": "2021-06-25",
+      "port-version": 4
     },
     "vcpkg-cmake-config": {
       "baseline": "2021-05-22",

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acc25ec22f8fd8887a865705580b1d6de041616d",
+      "version-date": "2021-06-25",
+      "port-version": 4
+    },
+    {
       "git-tree": "0e8bb94599a00fd9c61fd0ae524c22a067c21420",
       "version-date": "2021-02-28",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**
This expands the architecture lists with escape characters. When
building FAT binaries for macos using multiple architectures in the
values they need to be escaped otherwise they are passed on to CMake
incorrectly #14932

- #### What does your PR fix?  
  Fixes #14932

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `yes`
