### PR TITLE
[libssh] disable gssapi

### DIFF
--- a/ports/libssh/CONTROL
+++ b/ports/libssh/CONTROL
@@ -1,6 +1,6 @@
 Source: libssh
 Version: 0.9.5
-Port-Version: 3
+Port-Version: 4
 Homepage: https://www.libssh.org/
 Build-Depends: libssh[core,mbedtls] (android)
 Description: libssh is a multiplatform C library implementing the SSHv2 protocol on client and server side

--- a/ports/libssh/portfile.cmake
+++ b/ports/libssh/portfile.cmake
@@ -32,7 +32,8 @@ vcpkg_configure_cmake(
         -DUNIT_TESTING=OFF
         -DCLIENT_TESTING=OFF
         -DSERVER_TESTING=OFF
-        -DWITH_NACL=OFF)
+        -DWITH_NACL=OFF
+        -DWITH_GSSAPI=OFF)
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3546,7 +3546,7 @@
     },
     "libssh": {
       "baseline": "0.9.5",
-      "port-version": 3
+      "port-version": 4
     },
     "libssh2": {
       "baseline": "1.9.0",

--- a/versions/l-/libssh.json
+++ b/versions/l-/libssh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c5ced4b1fab4db90e2b032a3339a404cdc2f3ab",
+      "version-string": "0.9.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "7436981a351a747649d03c4a27a06dc0bc3a0d16",
       "version-string": "0.9.5",
       "port-version": 3


### PR DESCRIPTION
- #### What does your PR fix?  
  The .pc file of libssh does not add the appropriate linking flags for gssapi when it is found as a system library on linux or osx. This patch disables the feature so libssh can still be linked against on those platforms. ~~Potential fix for~~ Fixes #18166.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, to the best of my knowledge.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
