### PR TITLE
[sentry-native] Enable arm64 on macOS

### DIFF
--- a/ports/sentry-native/fix-libcurl.patch
+++ b/ports/sentry-native/fix-libcurl.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a74a93..30c131c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -249,13 +249,7 @@ target_compile_definitions(sentry PRIVATE SIZEOF_LONG=${CMAKE_SIZEOF_LONG})
+ 
+ if(SENTRY_TRANSPORT_CURL)
+ 	find_package(CURL REQUIRED)
+-	target_include_directories(sentry PRIVATE ${CURL_INCLUDE_DIR})
+-	# The exported sentry target must not contain any path of the build machine, therefore use generator expressions
+-	# FIXME: cmake 3.12 introduced the target CURL::libcurl
+-	string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_LIBRARIES "${CURL_LIBRARIES}")
+-	string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_COMPILE_DEFINITIONS "${CURL_COMPILE_DEFINITIONS}")
+-	target_link_libraries(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_LIBRARIES}>)
+-	target_compile_definitions(sentry PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_COMPILE_DEFINITIONS}>)
++	target_link_libraries(sentry PRIVATE CURL::libcurl)
+ endif()
+ 
+ set_property(TARGET sentry PROPERTY C_VISIBILITY_PRESET hidden)

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         fix-warningC5105.patch
         fix-config-cmake.patch
+        fix-libcurl.patch
 )
 
 if (NOT DEFINED SENTRY_BACKEND)
@@ -46,7 +47,7 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sentry TARGET_PATH share/sentry)
 
-if (WIN32 AND SENTRY_BACKEND STREQUAL "crashpad")
+if (SENTRY_BACKEND STREQUAL "crashpad")
     vcpkg_copy_tools(
         TOOL_NAMES crashpad_handler
         AUTO_CLEAN

--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+if(NOT VCPKG_TARGET_IS_OSX)
+    vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+endif()
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "sentry-native",
   "version-semver": "0.4.9",
+  "port-version": 1,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
-  "supports": "!(arm | arm64 | uwp)",
+  "supports": "!(arm | (arm64 & !osx) | uwp)",
   "dependencies": [
     {
       "name": "curl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5570,7 +5570,7 @@
     },
     "sentry-native": {
       "baseline": "0.4.9",
-      "port-version": 0
+      "port-version": 1
     },
     "septag-sx": {
       "baseline": "2019-05-07-2",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "149620161d000de9ae62c4293c1b3142d7bb28e7",
+      "git-tree": "8200b5e337c4e6074c67a6a2398fa7bbbb3c2e4b",
       "version-semver": "0.4.9",
       "port-version": 1
     },

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "149620161d000de9ae62c4293c1b3142d7bb28e7",
+      "version-semver": "0.4.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "17febc7e743aa5a91308dd2afd46cec3ef4a6c36",
       "version-semver": "0.4.9",
       "port-version": 0


### PR DESCRIPTION
Sentry added support for Apple Silicon in the latest version.

- #### What does your PR fix?  
  N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  arm64-osx, arm64-osx-dynamic, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
