### PR TITLE
[box2d] Update CMake arguments

### DIFF
--- a/ports/box2d/portfile.cmake
+++ b/ports/box2d/portfile.cmake
@@ -14,8 +14,8 @@ vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        -DBUILD_TESTS=OFF
-        -DBUILD_SAMPLES=OFF
+        -DBOX2D_BUILD_UNIT_TESTS=OFF
+        -DBOX2D_BUILD_TESTBED=OFF
 )
 vcpkg_install_cmake()
 

--- a/ports/box2d/vcpkg.json
+++ b/ports/box2d/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "box2d",
   "version-semver": "2.4.1",
+  "port-version": 1,
   "description": "An open source C++ engine for simulating rigid bodies in 2D",
   "homepage": "https://box2d.org",
   "supports": "!uwp"

--- a/versions/b-/box2d.json
+++ b/versions/b-/box2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f40a0f5f20b3e546e55850df8babf2d9cd526ee8",
+      "version-semver": "2.4.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "fc279cfa6011af543c0b1ebb043767acd13a7930",
       "version-semver": "2.4.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1026,7 +1026,7 @@
     },
     "box2d": {
       "baseline": "2.4.1",
-      "port-version": 0
+      "port-version": 1
     },
     "breakpad": {
       "baseline": "2020-09-14",


### PR DESCRIPTION
The CMake arguments were outdated and were causing errors for arm64-osx/-dynamic. 

- #### What does your PR fix?  
  N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  arm64-osx, arm64-osx-dynamic, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
