### PR TITLE
[vcpkg_install_gn] Fix variable name typo

### DIFF
--- a/scripts/cmake/vcpkg_install_gn.cmake
+++ b/scripts/cmake/vcpkg_install_gn.cmake
@@ -81,7 +81,7 @@ function(z_vcpkg_install_gn_install)
             TARGET "//${target}"
         )
 
-        foreach(output IN LISTS OUTPUTS)
+        foreach(output IN LISTS outputs)
             if(output MATCHES "^//")
                 # relative path (e.g. //out/Release/target.lib)
                 string(REGEX REPLACE "^//" "${arg_SOURCE_PATH}/" output "${output}")


### PR DESCRIPTION
Fixes a typo in `vcpkg_install_gn` preventing binaries from installing.

- #### What does your PR fix?  
  Fixes #18164

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  N/A, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
