### PR TITLE
[orocos-kdl] Export include path to targets

### DIFF
--- a/ports/orocos-kdl/CONTROL
+++ b/ports/orocos-kdl/CONTROL
@@ -1,6 +1,0 @@
-Source: orocos-kdl
-Version: 1.4
-Port-Version: 3
-Homepage: https://github.com/orocos/orocos_kinematics_dynamics
-Description: Kinematics and Dynamics Library
-Build-Depends: eigen3

--- a/ports/orocos-kdl/export-include-dir.patch
+++ b/ports/orocos-kdl/export-include-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/orocos_kdl/src/CMakeLists.txt b/orocos_kdl/src/CMakeLists.txt
+index 079ca8a..07eff4f 100644
+--- a/orocos_kdl/src/CMakeLists.txt
++++ b/orocos_kdl/src/CMakeLists.txt
+@@ -126,7 +126,7 @@ ENDIF()
+ #####end RPATH
+ 
+ # Needed so that the generated config.h can be used
+-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
++TARGET_INCLUDE_DIRECTORIES(orocos-kdl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
+ TARGET_LINK_LIBRARIES(orocos-kdl ${Boost_LIBRARIES})
+ 
+ INSTALL(TARGETS orocos-kdl

--- a/ports/orocos-kdl/portfile.cmake
+++ b/ports/orocos-kdl/portfile.cmake
@@ -4,14 +4,12 @@ vcpkg_from_github(
     REF v1.4.0
     SHA512 7156465e2aff02f472933617512069355836a03a02d4587cfe03c1b1d667a9762a4e3ed6e055b2a44f1fce1b6746179203c7204389626a7b458dcab1b28930d8
     HEAD_REF master
+    PATCHES export-include-dir.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}/orocos_kdl
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
-    # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
-    # OPTIONS_RELEASE -DOPTIMIZE=1
-    # OPTIONS_DEBUG -DDEBUGGABLE=1
+    PREFER_NINJA
 )
 
 vcpkg_install_cmake()

--- a/ports/orocos-kdl/vcpkg.json
+++ b/ports/orocos-kdl/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "orocos-kdl",
+  "version": "1.4",
+  "port-version": 4,
+  "description": "Kinematics and Dynamics Library.",
+  "homepage": "https://github.com/orocos/orocos_kinematics_dynamics",
+  "dependencies": [
+    "eigen3"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4630,7 +4630,7 @@
     },
     "orocos-kdl": {
       "baseline": "1.4",
-      "port-version": 3
+      "port-version": 4
     },
     "osg": {
       "baseline": "3.6.5",

--- a/versions/o-/orocos-kdl.json
+++ b/versions/o-/orocos-kdl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c882240643c0748d609a52adec04abd93ffc120e",
+      "version": "1.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "dc60323664cfc26eb992383022f99d5ec1b6c25c",
       "version-string": "1.4",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18173

 Export include path to targets to enable headers can be found when using this port via the usage:
```
    find_package(orocos_kdl CONFIG REQUIRED)
    target_link_libraries(main PRIVATE orocos-kdl)
```
Note: The package can be found successfully with above usage.