### PR TITLE
[zlib-ng] create a new port

### DIFF
--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zlib-ng/zlib-ng
+    REF 2.0.3
+    SHA512 e1afe91e1a8b4c54a004b672f539ae68f7dc1f1b08ba93514c0de674230354c944d496753f00ad272f16ef322705f275b5b72dac6c2a757ec741ef3f1ea1d59a
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib-compat ZLIB_COMPAT # "-ng" suffix will be removed
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DZLIB_FULL_VERSION=2.0.3
+        -DZLIB_ENABLE_TESTS=OFF
+        -DWITH_NEW_STRATEGIES=ON
+    OPTIONS_RELEASE
+        -DWITH_OPTIM=ON
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
+                    ${CURRENT_PACKAGES_DIR}/debug/include
+)
+file(INSTALL ${SOURCE_PATH}/LICENSE.md
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
+)

--- a/ports/zlib-ng/portfile.cmake
+++ b/ports/zlib-ng/portfile.cmake
@@ -6,15 +6,9 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        zlib-compat ZLIB_COMPAT # "-ng" suffix will be removed
-)
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
-        ${FEATURE_OPTIONS}
         -DZLIB_FULL_VERSION=2.0.3
         -DZLIB_ENABLE_TESTS=OFF
         -DWITH_NEW_STRATEGIES=ON

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "zlib-ng",
+  "version": "2.0.3",
+  "description": "zlib replacement with optimizations for 'next generation' systems",
+  "homepage": "https://github.com/zlib-ng/zlib-ng",
+  "license": "Zlib",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "zlib-compat": {
+      "description": "Compile with zlib compatible API"
+    }
+  }
+}

--- a/ports/zlib-ng/vcpkg.json
+++ b/ports/zlib-ng/vcpkg.json
@@ -13,10 +13,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "zlib-compat": {
-      "description": "Compile with zlib compatible API"
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6688,6 +6688,10 @@
       "baseline": "1.2.11",
       "port-version": 10
     },
+    "zlib-ng": {
+      "baseline": "2.0.3",
+      "port-version": 0
+    },
     "zookeeper": {
       "baseline": "3.5.5-1",
       "port-version": 0

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "cb34f91221aab004d5e353a3eb4eb1cdb35bc382",
+      "version": "2.0.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cb34f91221aab004d5e353a3eb4eb1cdb35bc382",
+      "git-tree": "12c2481cdf061618cf62685445efc63edbed0eaa",
       "version": "2.0.3",
       "port-version": 0
     }

--- a/versions/z-/zlib-ng.json
+++ b/versions/z-/zlib-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "12c2481cdf061618cf62685445efc63edbed0eaa",
+      "git-tree": "7020274700cc1aaa817aa752f36a423fed7c095c",
       "version": "2.0.3",
       "port-version": 0
     }


### PR DESCRIPTION
### What does your PR fix?  

Resolve #18062

By default, the port will generate with `-ng` suffix(e.g. `libz-ng.a`, `zlib-ng.h`).
~~There is a feature(`zlib-compat`) which removes it and will install like `zlib`. (port output collides!!)~~

Its .pc files are similar to those of `zlib`, but version value is higher. (zlib is 1.2.11)
```
prefix=${pcfiledir}/../..

exec_prefix=${prefix}
libdir=${exec_prefix}/lib
sharedlibdir=${libdir}
includedir=${prefix}/include

Name: zlib-ng
Description: zlib-ng compression library
Version: 2.0.3

Requires:
Libs: -L"${libdir}" -L"${sharedlibdir}" -lz-ng
Cflags: -I"${includedir}"

```

#### Related Issues?

* #17101 (`minizip-ng`)

### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Need some checks. At a glance most of triplets should be available, but not sure.

Major Windows, Apple, Android platform triplets are available. Both `VCPKG_LIBRARY_LINKAGE` static/dynamic.

* x86-windows
* x64-windows
* x64-osx
* arm64-osx
* arm64-ios
* x64-ios
* arm64-android
* arm-android
* x64-android
* x86-android

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.
