### PR TITLE
[avif] Add AVIF

### DIFF
--- a/ports/avif/disable-source-utf8.patch
+++ b/ports/avif/disable-source-utf8.patch
@@ -1,0 +1,12 @@
+diff -pruN v0.9.0-92388ab3ad.clean.o/CMakeLists.txt v0.9.0-92388ab3ad.clean/CMakeLists.txt
+--- a/CMakeLists.txt	2021-02-23 04:51:41.000000000 +0300
++++ b/CMakeLists.txt	2021-04-14 23:35:50.866487600 +0300
+@@ -165,7 +165,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC
+         # A C4556 warning will be generated on violation.
+         # Commonly used /utf-8 flag assumes UTF-8 for both source and console, which is usually not the case.
+         # Warnings can be suppressed but there will still be random characters printed to the console.
+-        /source-charset:utf-8 /execution-charset:us-ascii
++        #/source-charset:utf-8 /execution-charset:us-ascii
+     )
+ else()
+     MESSAGE(FATAL_ERROR "libavif: Unknown compiler, bailing out")

--- a/ports/avif/portfile.cmake
+++ b/ports/avif/portfile.cmake
@@ -1,0 +1,36 @@
+# AVIF depends on AOM, but AOM doesn't support ARM and UWP
+vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "UWP")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AOMediaCodec/libavif
+    REF v0.9.1
+    SHA512 15fa857ee40aeae2ee077d244c6e11a34193f2348e922b5dfa8579a91fa6ceff05c7146e85f9222ebaa6ef2d76e876ea050e8056990cad80850fb4d9581de9a5
+    HEAD_REF master
+    PATCHES
+        disable-source-utf8.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DAVIF_CODEC_AOM=ON
+        -DAVIF_BUILD_APPS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+
+# Move cmake configs
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libavif)
+
+# Fix pkg-config files
+vcpkg_fixup_pkgconfig()
+
+# Remove duplicate files
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
+                    ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/avif/vcpkg.json
+++ b/ports/avif/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "avif",
+  "version-semver": "0.9.1",
+  "description": "Library for encoding and decoding AVIF files",
+  "homepage": "https://github.com/AOMediaCodec/libavif",
+  "supports": "!uwp & !arm",
+  "dependencies": [
+    "aom",
+    "libyuv",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/a-/avif.json
+++ b/versions/a-/avif.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "734d939f00cc4bb721eb9157b835ece6a17ab45a",
+      "version-semver": "0.9.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -216,6 +216,10 @@
       "baseline": "2021-05-06",
       "port-version": 0
     },
+    "avif": {
+      "baseline": "0.9.1",
+      "port-version": 0
+    },
     "avisynthplus": {
       "baseline": "3.7.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

Add AVIF decoding/encoding library v0.9.1

https://github.com/AOMediaCodec/libavif
https://en.wikipedia.org/wiki/AV1#AV1_Image_File_Format_(AVIF)

- #### What does your PR fix?  
\-

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Everything except ARM and UWP. CI baseline is not updated.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

Tested with AVIF tools compiled separately.