### PR TITLE
[protobuf] Protobuf no longer compiles with vs2019 Update 16.10 w/ c++latest

### DIFF
--- a/ports/protobuf/port_def.patch
+++ b/ports/protobuf/port_def.patch
@@ -1,0 +1,14 @@
+diff --git a/src/google/protobuf/port_def.inc b/src/google/protobuf/port_def.inc
+index f7b64a080..3493d9082 100644
+--- a/src/google/protobuf/port_def.inc
++++ b/src/google/protobuf/port_def.inc
+@@ -564,7 +564,8 @@
+ 
+ // Our use of constinit does not yet work with GCC:
+ // https://github.com/protocolbuffers/protobuf/issues/8310
+-#if defined(__cpp_constinit) && !defined(__GNUC__)
++// Does not work yet with Visual Studio 2019 Update 16.10
++#if defined(__cpp_constinit) && !defined(__GNUC__) && !defined(_MSC_VER)
+ #define PROTOBUF_CONSTINIT constinit
+ #elif defined(__has_cpp_attribute)
+ #if __has_cpp_attribute(clang::require_constant_initialization)

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-static-build.patch
         fix-default-proto-file-path.patch
+        port_def.patch
 )
 
 string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf",
   "version-semver": "3.15.8",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4954,7 +4954,7 @@
     },
     "protobuf": {
       "baseline": "3.15.8",
-      "port-version": 1
+      "port-version": 2
     },
     "protobuf-c": {
       "baseline": "1.3.2-2",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c52c3eb43c2dfd9603673eb5c173ec69c21ea73",
+      "version-semver": "3.15.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "04dc7ffb4ebb123e734652cdb359ff18dca83ffc",
       "version-semver": "3.15.8",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  

Temporary Workaround for https://github.com/protocolbuffers/protobuf/issues/8688

The fix is needed to unblock compiling OpenTelemetry C++ SDK with vs2019-update16.10 . Note that the previous compiler was fine because 16.9 did not have support for `constinit`. I am not sure if it's a bug in Visual Studio 2019 support of `constinit`. Thus, the safest is to avoid using the feature in protobuf.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

All previous triplets supported. No changes intended. Verified that local build on Windows msvc2019-16.10 with C++20 passes all tests.

- #### Does your PR follow the [maintainer guide]

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**

Opening it as a draft because it is my first PR in this repository.