### PR TITLE
[vcpkg docs] Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ including [installing and using a package](docs/examples/installing-and-using-pa
 [adding a new package from a zipfile](docs/examples/packaging-zipfiles.md),
 and [adding a new package from a GitHub repo](docs/examples/packaging-github-repos.md).
 
-Our docs are now also available online at our website https://vcpkg.io/en/index.html. We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
+Our docs are now also available online at our website https://vcpkg.io/. We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
 
 See a 4 minute [video demo](https://www.youtube.com/watch?v=y41WFKbQFTw).
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ including [installing and using a package](docs/examples/installing-and-using-pa
 [adding a new package from a zipfile](docs/examples/packaging-zipfiles.md),
 and [adding a new package from a GitHub repo](docs/examples/packaging-github-repos.md).
 
-Our docs are now also available online at new website https://vcpkg.io/en/index.html which is available to view as a draft! We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
+Our docs are now also available online at our website https://vcpkg.io/en/index.html. We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
 
 See a 4 minute [video demo](https://www.youtube.com/watch?v=y41WFKbQFTw).
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To install the libraries for your project, run:
 Note: This will install x86 libraries by default. To install x64, run:
 
 ```cmd
-> .\vcpkg\vcpkg install package:x64-windows
+> .\vcpkg\vcpkg install [package name]:x64-windows
 ```
 
 Or
@@ -324,7 +324,7 @@ including [installing and using a package](docs/examples/installing-and-using-pa
 [adding a new package from a zipfile](docs/examples/packaging-zipfiles.md),
 and [adding a new package from a GitHub repo](docs/examples/packaging-github-repos.md).
 
-Our docs are now also available online at ReadTheDocs: <https://vcpkg.readthedocs.io/>!
+Our docs are now also available online at new website https://vcpkg.io/en/index.html which is available to view as a draft! We really appreciate any and all feedback! You can submit an issue in https://github.com/vcpkg/vcpkg.github.io/issues.
 
 See a 4 minute [video demo](https://www.youtube.com/watch?v=y41WFKbQFTw).
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/18191
Fixes https://github.com/microsoft/vcpkg/issues/18231

1. The ' .\vcpkg\vcpkg install package:x64-windows' in readme confuse the users, update it to make things clearer to reader.
2. The readthedocs.io is broken, since issue https://github.com/vcpkg/vcpkg.github.io/issues/12#issuecomment-846094957 closed, so I think it's ready to update it in readme.
