### PR TITLE
[vcpkg docs] Updated list of off-by-default features

### DIFF
--- a/docs/users/config-environment.md
+++ b/docs/users/config-environment.md
@@ -17,8 +17,6 @@ subject to change without notice and should be considered highly unstable.
 Non-exhaustive list of off-by-default features:
 
 - `manifest`
-- `versions`
-- `registries`
 
 #### EDITOR
 


### PR DESCRIPTION
According to [Microsoft's blog post](https://devblogs.microsoft.com/cppblog/all-vcpkg-enterprise-features-now-generally-available-versioning-binary-caching-manifests-and-registries) :

> We also turned registries and versioning on by default, so you no longer need to specify a feature flag to use them.

So the documentation should be updated accordingly :)