### PR TITLE
[fbthrift] Fix dependency and path in FBThriftConfig.cmake

### DIFF
--- a/ports/fbthrift/CONTROL
+++ b/ports/fbthrift/CONTROL
@@ -1,6 +1,0 @@
-Source: fbthrift
-Version: 2020.10.19.00
-Homepage: https://github.com/facebook/fbthrift
-Description: Facebook's branch of Apache Thrift, including a new C++ server.
-Build-Depends: openssl, zlib, fmt, gflags, glog, rsocket, fizz, folly, wangle, zstd, boost-context, boost-filesystem, boost-program-options, boost-regex, boost-system, boost-thread
-Supports: x64

--- a/ports/fbthrift/fix-config.cmake.patch
+++ b/ports/fbthrift/fix-config.cmake.patch
@@ -1,0 +1,28 @@
+diff --git a/thrift/cmake/FBThriftConfig.cmake.in b/thrift/cmake/FBThriftConfig.cmake.in
+index 69b29b9..145df48 100644
+--- a/thrift/cmake/FBThriftConfig.cmake.in
++++ b/thrift/cmake/FBThriftConfig.cmake.in
+@@ -15,17 +15,20 @@
+ 
+ include(CMakeFindDependencyMacro)
+ 
++find_dependency(folly)
++find_dependency(fmt)
++
+ # Save the PACKAGE_PREFIX_DIR in a separate variable.  find_dependency() calls
+ # below can replace PACKAGE_PREFIX_DIR with the prefix of the dependency that
+ # was searched for.
+ set(FBTHRIFT_PREFIX_DIR "${PACKAGE_PREFIX_DIR}")
+ 
+-set_and_check(FBTHRIFT_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_DIR@")
++set_and_check(FBTHRIFT_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/share/fbthrift")
+ set_and_check(FBTHRIFT_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+ if (WIN32)
+-  set_and_check(FBTHRIFT_COMPILER "@PACKAGE_BIN_INSTALL_DIR@/thrift1.exe")
++  set_and_check(FBTHRIFT_COMPILER "${PACKAGE_PREFIX_DIR}/tools/fbthrift/thrift1.exe")
+ else()
+-  set_and_check(FBTHRIFT_COMPILER "@PACKAGE_BIN_INSTALL_DIR@/thrift1")
++  set_and_check(FBTHRIFT_COMPILER "${PACKAGE_PREFIX_DIR}/tools/fbthrift/thrift1")
+ endif()
+ 
+ if (NOT TARGET FBThrift::thriftcpp2)

--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     REF e184b41448dab2f462094fa005ed05269cfba3e3 # v2020.10.19.00
     SHA512 df03e1779fd3f1868ed7be21292bcd91ae65bcca591b0265a40391dde7e3b3b81d83fe7eb4ec8dd5c440be471375b8e2c8c24befefaca3ae0cab9ce10bfd362c
     HEAD_REF master
+    PATCHES fix-config.cmake.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "fbthrift",
+  "version-string": "2020.10.19.00",
+  "port-version": 1,
+  "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
+  "homepage": "https://github.com/facebook/fbthrift",
+  "supports": "x64",
+  "dependencies": [
+    "boost-context",
+    "boost-filesystem",
+    "boost-program-options",
+    "boost-regex",
+    "boost-system",
+    "boost-thread",
+    "fizz",
+    "fmt",
+    "folly",
+    "gflags",
+    "glog",
+    "openssl",
+    "rsocket",
+    "wangle",
+    "zlib",
+    "zstd"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1962,7 +1962,7 @@
     },
     "fbthrift": {
       "baseline": "2020.10.19.00",
-      "port-version": 0
+      "port-version": 1
     },
     "fcl": {
       "baseline": "0.6.1",

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0936f5295ad9d3cd2473c93486f3b3578832422",
+      "version-string": "2020.10.19.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "4f77ee90c3b33600d679483776c5b5f7cb59def7",
       "version-string": "2020.10.19.00",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18249

 Adding dependent packages and fixing the path in `FBThriftConfig.cmake` to enable `fbthrift ` work fine.

Note: No feature needs to test.
