### PR TITLE
[scripts-audit] vcpkg_from_*

### DIFF
--- a/docs/maintainers/vcpkg_download_distfile.md
+++ b/docs/maintainers/vcpkg_download_distfile.md
@@ -13,6 +13,7 @@ vcpkg_download_distfile(
     URLS <http://mainUrl> <http://mirror1>...
     FILENAME <output.zip>
     SHA512 <5981de...>
+    [ALWAYS_REDOWNLOAD]
 )
 ```
 ## Parameters
@@ -37,6 +38,10 @@ Suppress output on cache hit
 Skip SHA512 hash check for file.
 
 This switch is only valid when building with the `--head` command line flag.
+
+### ALWAYS_REDOWNLOAD
+This should be used when in `--head` mode, in order to tell this command to redownload when possible;
+in other words, avoid caching. This has no effect in `--no-downloads` mode.
 
 ### HEADERS
 A list of headers to append to the download request. This can be used for authentication during a download.

--- a/docs/maintainers/vcpkg_download_distfile.md
+++ b/docs/maintainers/vcpkg_download_distfile.md
@@ -40,8 +40,9 @@ Skip SHA512 hash check for file.
 This switch is only valid when building with the `--head` command line flag.
 
 ### ALWAYS_REDOWNLOAD
-This should be used when in `--head` mode, in order to tell this command to redownload when possible;
-in other words, avoid caching. This has no effect in `--no-downloads` mode.
+Avoid caching; this is a REST call or otherwise unstable.
+
+Requires `SKIP_SHA512`.
 
 ### HEADERS
 A list of headers to append to the download request. This can be used for authentication during a download.

--- a/docs/maintainers/vcpkg_from_bitbucket.md
+++ b/docs/maintainers/vcpkg_from_bitbucket.md
@@ -3,7 +3,6 @@
 The latest version of this document lives in the [vcpkg repo](https://github.com/Microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_from_bitbucket.md).
 
 Download and extract a project from Bitbucket.
-Enables support for installing HEAD `vcpkg.exe install --head <port>`.
 
 ## Usage:
 ```cmake

--- a/docs/maintainers/vcpkg_from_git.md
+++ b/docs/maintainers/vcpkg_from_git.md
@@ -10,7 +10,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH <SOURCE_PATH>
     URL <https://android.googlesource.com/platform/external/fdlibm>
     REF <59f7335e4d...>
-    [TAG <v1.0.2>]
+    [HEAD_REF <ref>]
     [PATCHES <patch1.patch> <patch2.patch>...]
 )
 ```
@@ -27,16 +27,10 @@ The url of the git repository.
 ### REF
 The git sha of the commit to download.
 
-### TAG
-An optional git tag to be verified against the `REF`. If the remote repository's tag does not match the specified `REF`, the build will fail.
-
 ### PATCHES
 A list of patches to be applied to the extracted sources.
 
 Relative paths are based on the port directory.
-
-### X_OUT_REF (internal only)
-This parameter is used for automatic REF updates for certain ports in the central vcpkg catalog. It should not be used by any ports outside the central catalog and within the central catalog it should not be used on any user path. This parameter may change behavior incompatibly or be removed at any time.
 
 ## Notes:
 `OUT_SOURCE_PATH`, `REF`, and `URL` must be specified.

--- a/docs/maintainers/vcpkg_from_sourceforge.md
+++ b/docs/maintainers/vcpkg_from_sourceforge.md
@@ -4,6 +4,10 @@ The latest version of this document lives in the [vcpkg repo](https://github.com
 
 Download and extract a project from sourceforge.
 
+This function automatically checks a set of sourceforge mirrors;
+additionally, mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
+variable, which should be a semicolon-separated list.
+
 ## Usage:
 ```cmake
 vcpkg_from_sourceforge(

--- a/docs/maintainers/vcpkg_from_sourceforge.md
+++ b/docs/maintainers/vcpkg_from_sourceforge.md
@@ -4,9 +4,9 @@ The latest version of this document lives in the [vcpkg repo](https://github.com
 
 Download and extract a project from sourceforge.
 
-This function automatically checks a set of sourceforge mirrors;
-additionally, mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
-variable, which should be a semicolon-separated list.
+This function automatically checks a set of sourceforge mirrors.
+Additional mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
+list variable in the triplet.
 
 ## Usage:
 ```cmake
@@ -57,9 +57,6 @@ Note that the archive will still be extracted into a subfolder underneath that d
 A list of patches to be applied to the extracted sources.
 
 Relative paths are based on the port directory.
-
-### DISABLE_SSL
-Disable ssl when downloading source.
 
 ### NO_REMOVE_ONE_LEVEL
 Specifies that the default removal of the top level folder should not occur.

--- a/docs/regenerate.ps1
+++ b/docs/regenerate.ps1
@@ -212,7 +212,7 @@ function ParseCmakeDocComment
         $Docs.HasError = $True
     }
 
-    if ($contents.Length -ne 0)
+    if ($null -eq $contents -or $contents.Length -ne 0)
     {
         $Docs.ActualDocumentation = $contents
     }
@@ -311,6 +311,7 @@ function GetDeprecationMessage
     Param(
         [CMakeDocumentation]$Doc
     )
+    $message = ''
     if ($Doc.IsDeprecated)
     {
         $message = " (deprecated"

--- a/docs/regenerate.ps1
+++ b/docs/regenerate.ps1
@@ -212,7 +212,7 @@ function ParseCmakeDocComment
         $Docs.HasError = $True
     }
 
-    if ($null -eq $contents -or $contents.Length -ne 0)
+    if ([String]::IsNullOrEmpty($contents))
     {
         $Docs.ActualDocumentation = $contents
     }

--- a/ports/qt5-mqtt/CONTROL
+++ b/ports/qt5-mqtt/CONTROL
@@ -1,4 +1,0 @@
-Source: qt5-mqtt
-Version: 5.15.2
-Description: Qt5 MQTT module.
-Build-Depends:  qt5-base[core]

--- a/ports/qt5-mqtt/portfile.cmake
+++ b/ports/qt5-mqtt/portfile.cmake
@@ -1,20 +1,19 @@
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
 #qt_submodule_installation() No binary package for this port. 
 if(QT_UPDATE_VERSION)
-    set(UPDATE_PORT_GIT_OPTIONS X_OUT_REF NEW_REF) # TO get an SHA512 error if the variable is set. 
+    set(VCPKG_USE_HEAD_VERSION ON)
 endif()
 
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://code.qt.io/qt/qtmqtt.git
-    TAG v${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER}
     REF ${QT_HASH_${PORT}}
-    ${UPDATE_PORT_GIT_OPTIONS}
+    HEAD_REF "v${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER}"
     PATCHES ${_qis_PATCHES}
 )
 
-if(NEW_REF)
-    message(STATUS "New qtmqtt ref: ${NEW_REF}")
+if(QT_UPDATE_VERSION)
+    message(STATUS "New qtmqtt ref: ${VCPKG_HEAD_VERSION}")
 endif()
 
 # qt module builds from a git repository require a .git entry to invoke syncqt

--- a/ports/qt5-mqtt/vcpkg.json
+++ b/ports/qt5-mqtt/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "qt5-mqtt",
+  "version": "5.15.2",
+  "port-version": 1,
+  "description": "Qt5 MQTT module.",
+  "dependencies": [
+    {
+      "name": "qt5-base",
+      "default-features": false
+    }
+  ]
+}

--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -12,6 +12,7 @@ vcpkg_download_distfile(
     URLS <http://mainUrl> <http://mirror1>...
     FILENAME <output.zip>
     SHA512 <5981de...>
+    [ALWAYS_REDOWNLOAD]
 )
 ```
 ## Parameters
@@ -37,6 +38,10 @@ Skip SHA512 hash check for file.
 
 This switch is only valid when building with the `--head` command line flag.
 
+### ALWAYS_REDOWNLOAD
+This should be used when in `--head` mode, in order to tell this command to redownload when possible;
+in other words, avoid caching. This has no effect in `--no-downloads` mode.
+
 ### HEADERS
 A list of headers to append to the download request. This can be used for authentication during a download.
 
@@ -55,7 +60,7 @@ The helper [`vcpkg_from_github`](vcpkg_from_github.md) should be used for downlo
 include(vcpkg_execute_in_download_mode)
 
 function(vcpkg_download_distfile VAR)
-    set(options SKIP_SHA512 SILENT_EXIT QUIET)
+    set(options SKIP_SHA512 SILENT_EXIT QUIET ALWAYS_REDOWNLOAD)
     set(oneValueArgs FILENAME SHA512)
     set(multipleValuesArgs URLS HEADERS)
     # parse parameters such that semicolons in options arguments to COMMAND don't get erased
@@ -125,7 +130,9 @@ function(vcpkg_download_distfile VAR)
         endif()
     endfunction()
 
-    if(EXISTS "${downloaded_file_path}")
+    # vcpkg_download_distfile_ALWAYS_REDOWNLOAD only triggers when NOT _VCPKG_NO_DOWNLOADS
+    # this could be de-morgan'd out but it's more clear this way
+    if(EXISTS "${downloaded_file_path}" AND NOT (vcpkg_download_distfile_ALWAYS_REDOWNLOAD AND NOT _VCPKG_NO_DOWNLOADS))
         if(NOT vcpkg_download_distfile_QUIET)
             message(STATUS "Using ${downloaded_file_path}")
         endif()

--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -39,8 +39,9 @@ Skip SHA512 hash check for file.
 This switch is only valid when building with the `--head` command line flag.
 
 ### ALWAYS_REDOWNLOAD
-This should be used when in `--head` mode, in order to tell this command to redownload when possible;
-in other words, avoid caching. This has no effect in `--no-downloads` mode.
+Avoid caching; this is a REST call or otherwise unstable.
+
+Requires `SKIP_SHA512`.
 
 ### HEADERS
 A list of headers to append to the download request. This can be used for authentication during a download.
@@ -74,6 +75,9 @@ function(vcpkg_download_distfile VAR)
     endif()
     if(vcpkg_download_distfile_SILENT_EXIT)
         message(WARNING "SILENT_EXIT has been deprecated as an argument to vcpkg_download_distfile -- remove the argument to resolve this warning")
+    endif()
+    if(vcpkg_download_distfile_ALWAYS_REDOWNLOAD AND NOT vcpkg_download_distfile_SKIP_SHA512)
+        message(FATAL_ERROR "ALWAYS_REDOWNLOAD option requires SKIP_SHA512 as well")
     endif()
     if(_VCPKG_INTERNAL_NO_HASH_CHECK)
         set(vcpkg_download_distfile_SKIP_SHA512 1)

--- a/scripts/cmake/vcpkg_from_bitbucket.cmake
+++ b/scripts/cmake/vcpkg_from_bitbucket.cmake
@@ -91,14 +91,15 @@ function(vcpkg_from_bitbucket)
     set(org_name "${CMAKE_MATCH_1}")
     set(repo_name "${CMAKE_MATCH_2}")
 
-    set(redownload)
-    set(sha512 "SHA512" "${arg_SHA512}")
+    set(redownload_param "")
+    set(working_directory_param "")
+    set(sha512_param "SHA512" "${arg_SHA512}")
     set(ref_to_use "${arg_REF}")
     if(VCPKG_USE_HEAD_VERSION)
         if(DEFINED arg_HEAD_REF)
-            set(redownload "ALWAYS_REDOWNLOAD")
-            set(sha512 "SKIP_SHA512")
-            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(redownload_param "ALWAYS_REDOWNLOAD")
+            set(sha512_param "SKIP_SHA512")
+            set(working_directory_param "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
             set(ref_to_use "${arg_HEAD_REF}")
         else()
             message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
@@ -136,15 +137,15 @@ ${version_contents}
     vcpkg_download_distfile(archive
         URLS "https://bitbucket.com/${org_name}/${repo_name}/get/${ref_to_use}.tar.gz"
         FILENAME "${downloaded_file_name}"
-        ${sha512}
-        ${redownload}
+        ${sha512_param}
+        ${redownload_param}
     )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${archive}"
         REF "${sanitized_ref}"
         PATCHES ${arg_PATCHES}
-        ${working_directory}
+        ${working_directory_param}
     )
     set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_bitbucket.cmake
+++ b/scripts/cmake/vcpkg_from_bitbucket.cmake
@@ -2,7 +2,6 @@
 # vcpkg_from_bitbucket
 
 Download and extract a project from Bitbucket.
-Enables support for installing HEAD `vcpkg.exe install --head <port>`.
 
 ## Usage:
 ```cmake
@@ -58,144 +57,94 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 #]===]
 
 function(vcpkg_from_bitbucket)
-    set(oneValueArgs OUT_SOURCE_PATH REPO REF SHA512 HEAD_REF)
-    set(multipleValuesArgs PATCHES)
-    # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _vdud "" "${oneValueArgs}" "${multipleValuesArgs}")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        "OUT_SOURCE_PATH;REPO;REF;SHA512;HEAD_REF"
+        "PATCHES")
 
-    if(NOT _vdud_OUT_SOURCE_PATH)
-        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(WARNING "vcpkg_from_bitbucket was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
     endif()
 
-    if((_vdud_REF AND NOT _vdud_SHA512) OR (NOT _vdud_REF AND _vdud_SHA512))
+    if(DEFINED arg_REF AND NOT DEFINED arg_SHA512)
         message(FATAL_ERROR "SHA512 must be specified if REF is specified.")
     endif()
+    if(NOT DEFINED arg_REF AND DEFINED arg_SHA512)
+        message(FATAL_ERROR "REF must be specified if SHA512 is specified.")
+    endif()
 
-    if(NOT _vdud_REPO)
+    if(NOT DEFINED arg_OUT_SOURCE_PATH)
+        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    endif()
+    if(NOT DEFINED arg_REPO)
         message(FATAL_ERROR "The Bitbucket repository must be specified.")
     endif()
 
-    if(NOT _vdud_REF AND NOT _vdud_HEAD_REF)
-        message(FATAL_ERROR "At least one of REF and HEAD_REF must be specified.")
+    if(NOT DEFINED arg_REF AND NOT DEFINED arg_HEAD_REF)
+        message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
     endif()
 
-    string(REGEX REPLACE ".*/" "" REPO_NAME ${_vdud_REPO})
-    string(REGEX REPLACE "/.*" "" ORG_NAME ${_vdud_REPO})
+    if(NOT arg_REPO MATCHES "^([^/]*)/([^/]*)$")
+        message(FATAL_ERROR "REPO (${arg_REPO}) is not a valid repo name:
+    must be an organization name followed by a repository name separated by a single slash.")
+    endif()
+    set(org_name "${CMAKE_MATCH_1}")
+    set(repo_name "${CMAKE_MATCH_2}")
 
-    macro(set_SOURCE_PATH BASE BASEREF)
-        set(SOURCE_PATH "${BASE}/${ORG_NAME}-${REPO_NAME}-${BASEREF}")
-        if(EXISTS ${SOURCE_PATH})
-            set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    set(redownload)
+    set(sha512 "SHA512" "${arg_SHA512}")
+    set(ref_to_use "${arg_REF}")
+    if(VCPKG_USE_HEAD_VERSION)
+        if(DEFINED arg_HEAD_REF)
+            set(redownload "ALWAYS_REDOWNLOAD")
+            set(sha512 "SKIP_SHA512")
+            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(ref_to_use "${arg_HEAD_REF}")
         else()
-            # Sometimes GitHub strips a leading 'v' off the REF.
-            string(REGEX REPLACE "^v" "" REF ${BASEREF})
-            set(SOURCE_PATH "${BASE}/${ORG_NAME}-${REPO_NAME}-${REF}")
-            if(EXISTS ${SOURCE_PATH})
-                set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-            else()
-                message(FATAL_ERROR "Could not determine source path: '${BASE}/${ORG_NAME}-${REPO_NAME}-${BASEREF}' does not exist")
-            endif()
+            message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
         endif()
-    endmacro()
-
-    if(VCPKG_USE_HEAD_VERSION AND NOT _vdud_HEAD_REF)
-        message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
-        set(VCPKG_USE_HEAD_VERSION OFF)
+    elseif(NOT DEFINED arg_REF)
+        message(FATAL_ERROR "Package does not specify REF. It must be built using --head.")
     endif()
 
-    # Handle --no-head scenarios
-    if(NOT VCPKG_USE_HEAD_VERSION)
-        if(NOT _vdud_REF)
-            message(FATAL_ERROR "Package does not specify REF. It must built using --head.")
-        endif()
-
-        set(URL "https://bitbucket.com/${ORG_NAME}/${REPO_NAME}/get/${_vdud_REF}.tar.gz")
-        set(downloaded_file_path "${DOWNLOADS}/${ORG_NAME}-${REPO_NAME}-${_vdud_REF}.tar.gz")
-
-        file(DOWNLOAD "https://api.bitbucket.com/2.0/repositories/${ORG_NAME}/${REPO_NAME}/refs/tags/${_vdud_REF}"
-            ${downloaded_file_path}.version
-            STATUS download_status
-        )
-        list(GET download_status 0 status_code)
-        if ("${status_code}" STREQUAL "0")
-            # Parse the github refs response with regex.
-            # TODO: use some JSON swiss-army-knife utility instead.
-            file(READ "${downloaded_file_path}.version" _contents)
-            string(REGEX MATCH "\"hash\": \"[a-f0-9]+\"" x "${_contents}")
-            string(REGEX REPLACE "\"hash\": \"([a-f0-9]+)\"" "\\1" _version ${x})
-            string(SUBSTRING ${_version} 0 12 _version) # Get the 12 first numbers from commit hash
-        else()
-            string(SUBSTRING ${_vdud_REF} 0 12 _version) # Get the 12 first numbers from commit hash
-        endif()
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS "https://bitbucket.com/${ORG_NAME}/${REPO_NAME}/get/${_vdud_REF}.tar.gz"
-            SHA512 "${_vdud_SHA512}"
-            FILENAME "${ORG_NAME}-${REPO_NAME}-${_vdud_REF}.tar.gz"
-        )
-
-        vcpkg_extract_source_archive_ex(
-            OUT_SOURCE_PATH SOURCE_PATH
-            ARCHIVE "${ARCHIVE}"
-            REF "${_vdud_REF}"
-            PATCHES ${_vdud_PATCHES}
-        )
-        set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-        return()
-    endif()
-
-    # The following is for --head scenarios
-    set(URL "https://bitbucket.com/${ORG_NAME}/${REPO_NAME}/get/${_vdud_HEAD_REF}.tar.gz")
-    set(downloaded_file_name "${ORG_NAME}-${REPO_NAME}-${_vdud_HEAD_REF}.tar.gz")
-    set(downloaded_file_path "${DOWNLOADS}/${downloaded_file_name}")
-
-    if(_VCPKG_NO_DOWNLOADS)
-        if(NOT EXISTS ${downloaded_file_path} OR NOT EXISTS ${downloaded_file_path}.version)
-            message(FATAL_ERROR "Downloads are disabled, but '${downloaded_file_path}' does not exist.")
-        endif()
-        message(STATUS "Using cached ${downloaded_file_path}")
-    else()
-        if(EXISTS ${downloaded_file_path})
-            message(STATUS "Purging cached ${downloaded_file_path} to fetch latest (use --no-downloads to suppress)")
-            file(REMOVE ${downloaded_file_path})
-        endif()
-        if(EXISTS ${downloaded_file_path}.version)
-            file(REMOVE ${downloaded_file_path}.version)
-        endif()
-        if(EXISTS ${CURRENT_BUILDTREES_DIR}/src/head)
-            file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src/head)
-        endif()
-
-        # Try to download the file and version information from bitbucket.
-        vcpkg_download_distfile(ARCHIVE_VERSION
-            URLS "https://api.bitbucket.com/2.0/repositories/${ORG_NAME}/${REPO_NAME}/refs/branches/${_vdud_HEAD_REF}"
-            FILENAME "${downloaded_file_name}.version"
-            SKIP_SHA512
-        )
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS "${URL}"
-            FILENAME "${downloaded_file_name}"
-            SKIP_SHA512
-        )
-    endif()
-
-    # Parse the github refs response with regex.
-    # TODO: use some JSON swiss-army-knife utility instead.
-    file(READ "${ARCHIVE_VERSION}" _contents)
-    string(REGEX MATCH "\"hash\": \"[a-f0-9]+\"" x "${_contents}")
-    string(REGEX REPLACE "\"hash\": \"([a-f0-9]+)\"" "\\1" _version ${x})
-    string(SUBSTRING ${_version} 0 12 _vdud_HEAD_REF) # Get the 12 first numbers from commit hash
+    # avoid using either - or _, to allow both `foo/bar` and `foo-bar` to coexist
+    # we assume that no one will name a ref "foo_-bar"
+    string(REPLACE "/" "_-" sanitized_ref "${ref_to_use}")
+    set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}.tar.gz")
 
     # exports VCPKG_HEAD_VERSION to the caller. This will get picked up by ports.cmake after the build.
-    set(VCPKG_HEAD_VERSION ${_version} PARENT_SCOPE)
+    if(VCPKG_USE_HEAD_VERSION)
+        vcpkg_download_distfile(archive_version
+            URLS "https://api.bitbucket.com/2.0/repositories/${org_name}/${repo_name}/refs/branches/${arg_HEAD_REF}"
+            FILENAME "${downloaded_file_name}.version"
+            SKIP_SHA512
+            ALWAYS_REDOWNLOAD
+        )
+        # Parse the github refs response with regex.
+        # TODO: add json-pointer support to vcpkg
+        file(READ "${archive_version}" version_contents)
+        if(NOT version_contents MATCHES [["hash": "([a-f0-9]+)"]])
+            message(FATAL_ERROR "Failed to parse API response from '${version_url}':
 
+${version_contents}
+")
+        endif()
+        set(VCPKG_HEAD_VERSION "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    endif()
+
+    # download the file information from bitbucket.
+    vcpkg_download_distfile(archive
+        URLS "https://bitbucket.com/${org_name}/${repo_name}/get/${ref_to_use}.tar.gz"
+        FILENAME "${downloaded_file_name}"
+        ${sha512}
+        ${redownload}
+    )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE "${downloaded_file_path}"
-        REF "${_vdud_HEAD_REF}"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
-        PATCHES ${_vdud_PATCHES}
+        ARCHIVE "${archive}"
+        REF "${sanitized_ref}"
+        PATCHES ${arg_PATCHES}
+        ${working_directory}
     )
-    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -26,6 +26,11 @@ The url of the git repository.
 ### REF
 The git sha of the commit to download.
 
+### HEAD_REF
+The git branch to use when the package is requested to be built from the latest sources.
+
+Example: `main`, `develop`, `HEAD`
+
 ### PATCHES
 A list of patches to be applied to the extracted sources.
 

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -66,11 +66,11 @@ function(vcpkg_from_git)
         message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
     endif()
 
-    set(working_directory)
+    set(working_directory_param "")
     set(ref_to_use "${arg_REF}")
     if(VCPKG_USE_HEAD_VERSION)
         if(DEFINED arg_HEAD_REF)
-            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(working_directory_param "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
             set(ref_to_use "${arg_HEAD_REF}")
         else()
             message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
@@ -107,7 +107,7 @@ function(vcpkg_from_git)
             OUTPUT_VARIABLE rev_parse_head
             ERROR_VARIABLE rev_parse_head
             RESULT_VARIABLE error_code
-            WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
+            WORKING_DIRECTORY "${DOWNLOADS}/git-tmp"
         )
         if(error_code)
             message(FATAL_ERROR "unable to determine FETCH_HEAD after fetching git repository")
@@ -138,7 +138,7 @@ function(vcpkg_from_git)
         REF "${sanitized_ref}"
         PATCHES ${arg_PATCHES}
         NO_REMOVE_ONE_LEVEL
-        ${working_directory}
+        ${working_directory_param}
     )
 
     set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -117,7 +117,9 @@ function(vcpkg_from_git)
             set(VCPKG_HEAD_VERSION "${rev_parse_head}" PARENT_SCOPE)
         elseif(NOT rev_parse_head STREQUAL arg_REF)
             message(FATAL_ERROR "REF (${arg_REF}) does not match FETCH_HEAD (${rev_parse_head})
-    This means that the argument passed to REF is not a full commit ID.")
+    [Expected : ( ${arg_REF} )])
+    [  Actual : ( ${rev_parse_head} )]"
+            )
         endif()
 
         file(MAKE_DIRECTORY "${DOWNLOADS}/temp")

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -9,7 +9,7 @@ vcpkg_from_git(
     OUT_SOURCE_PATH <SOURCE_PATH>
     URL <https://android.googlesource.com/platform/external/fdlibm>
     REF <59f7335e4d...>
-    [TAG <v1.0.2>]
+    [HEAD_REF <ref>]
     [PATCHES <patch1.patch> <patch2.patch>...]
 )
 ```
@@ -26,16 +26,10 @@ The url of the git repository.
 ### REF
 The git sha of the commit to download.
 
-### TAG
-An optional git tag to be verified against the `REF`. If the remote repository's tag does not match the specified `REF`, the build will fail.
-
 ### PATCHES
 A list of patches to be applied to the extracted sources.
 
 Relative paths are based on the port directory.
-
-### X_OUT_REF (internal only)
-This parameter is used for automatic REF updates for certain ports in the central vcpkg catalog. It should not be used by any ports outside the central catalog and within the central catalog it should not be used on any user path. This parameter may change behavior incompatibly or be removed at any time.
 
 ## Notes:
 `OUT_SOURCE_PATH`, `REF`, and `URL` must be specified.
@@ -48,94 +42,104 @@ This parameter is used for automatic REF updates for certain ports in the centra
 include(vcpkg_execute_in_download_mode)
 
 function(vcpkg_from_git)
-  set(oneValueArgs OUT_SOURCE_PATH URL REF TAG X_OUT_REF)
-  set(multipleValuesArgs PATCHES)
-  # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-  cmake_parse_arguments(PARSE_ARGV 0 _vdud "" "${oneValueArgs}" "${multipleValuesArgs}")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        "OUT_SOURCE_PATH;URL;REF;HEAD_REF;TAG"
+        "PATCHES"
+    )
 
-  if(NOT DEFINED _vdud_OUT_SOURCE_PATH)
-    message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
-  endif()
-
-  if(NOT DEFINED _vdud_URL)
-    message(FATAL_ERROR "The git url must be specified")
-  endif()
-
-  if(NOT DEFINED _vdud_REF)
-    message(FATAL_ERROR "The git ref must be specified.")
-  endif()
-
-  if(NOT DEFINED _vdud_TAG)
-    set(_vdud_TAG ${_vdud_REF})
-  endif()
-  
-  # using .tar.gz instead of .zip because the hash of the latter is affected by timezone.
-  string(REPLACE "/" "-" SANITIZED_REF "${_vdud_TAG}")
-  set(TEMP_ARCHIVE "${DOWNLOADS}/temp/${PORT}-${SANITIZED_REF}.tar.gz")
-  set(ARCHIVE "${DOWNLOADS}/${PORT}-${SANITIZED_REF}.tar.gz")
-  set(TEMP_SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/${SANITIZED_REF}")
-
-  if(NOT EXISTS "${ARCHIVE}")
-    if(_VCPKG_NO_DOWNLOADS)
-        message(FATAL_ERROR "Downloads are disabled, but '${ARCHIVE}' does not exist.")
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(WARNING "vcpkg_from_git was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
     endif()
-    message(STATUS "Fetching ${_vdud_URL}...")
-    find_program(GIT NAMES git git.cmd)
-    # Note: git init is safe to run multiple times
-    vcpkg_execute_required_process(
-      ALLOW_IN_DOWNLOAD_MODE
-      COMMAND ${GIT} init git-tmp
-      WORKING_DIRECTORY ${DOWNLOADS}
-      LOGNAME git-init-${TARGET_TRIPLET}
-    )
-    vcpkg_execute_required_process(
-      ALLOW_IN_DOWNLOAD_MODE
-      COMMAND ${GIT} fetch ${_vdud_URL} ${_vdud_TAG} --depth 1 -n
-      WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
-      LOGNAME git-fetch-${TARGET_TRIPLET}
-    )
-    vcpkg_execute_in_download_mode(
-      COMMAND ${GIT} rev-parse FETCH_HEAD
-      OUTPUT_VARIABLE REV_PARSE_HEAD
-      ERROR_VARIABLE REV_PARSE_HEAD
-      RESULT_VARIABLE error_code
-      WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
-    )
-    if(error_code)
-        message(FATAL_ERROR "unable to determine FETCH_HEAD after fetching git repository")
+    if(DEFINED arg_TAG)
+        message(WARNING "The TAG argument to vcpkg_from_git has been deprecated and has no effect.")
     endif()
-    string(REGEX REPLACE "\n$" "" REV_PARSE_HEAD "${REV_PARSE_HEAD}")
-    if(NOT REV_PARSE_HEAD STREQUAL _vdud_REF AND NOT DEFINED _vdud_X_OUT_REF)
-        message(STATUS "[Expected : ( ${_vdud_REF} )]")
-        message(STATUS "[  Actual : ( ${REV_PARSE_HEAD} )]")
-        message(FATAL_ERROR "REF (${_vdud_REF}) does not match FETCH_HEAD (${REV_PARSE_HEAD})")
-    elseif(DEFINED _vdud_X_OUT_REF)
-        set(${_vdud_X_OUT_REF} ${REV_PARSE_HEAD} PARENT_SCOPE)
-        return()
+    
+
+    if(NOT DEFINED arg_OUT_SOURCE_PATH)
+        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    endif()
+    if(NOT DEFINED arg_URL)
+        message(FATAL_ERROR "The git url must be specified")
+    endif()
+    if(NOT DEFINED arg_REF AND NOT DEFINED arg_HEAD_REF)
+        message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
     endif()
 
-    file(MAKE_DIRECTORY "${DOWNLOADS}/temp")
-    vcpkg_execute_required_process(
-      ALLOW_IN_DOWNLOAD_MODE
-      COMMAND ${GIT} archive FETCH_HEAD -o "${TEMP_ARCHIVE}"
-      WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
-      LOGNAME git-archive
+    set(working_directory)
+    set(ref_to_use "${arg_REF}")
+    if(VCPKG_USE_HEAD_VERSION)
+        if(DEFINED arg_HEAD_REF)
+            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(ref_to_use "${arg_HEAD_REF}")
+        else()
+            message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
+        endif()
+    elseif(NOT DEFINED arg_REF)
+        message(FATAL_ERROR "Package does not specify REF. It must be built using --head.")
+    endif()
+
+    string(REPLACE "/" "_-" sanitized_ref "${ref_to_use}")
+    set(temp_archive "${DOWNLOADS}/temp/${PORT}-${sanitized_ref}.tar.gz")
+    set(archive "${DOWNLOADS}/${PORT}-${sanitized_ref}.tar.gz")
+
+    if(NOT EXISTS "${archive}")
+        if(_VCPKG_NO_DOWNLOADS)
+            message(FATAL_ERROR "Downloads are disabled, but '${archive}' does not exist.")
+        endif()
+        message(STATUS "Fetching ${arg_URL} ${ref_to_use}...")
+        find_program(GIT NAMES git git.cmd)
+        # Note: git init is safe to run multiple times
+        vcpkg_execute_required_process(
+            ALLOW_IN_DOWNLOAD_MODE
+            COMMAND "${GIT}" init git-tmp
+            WORKING_DIRECTORY "${DOWNLOADS}"
+            LOGNAME "git-init-${TARGET_TRIPLET}"
+        )
+        vcpkg_execute_required_process(
+            ALLOW_IN_DOWNLOAD_MODE
+            COMMAND "${GIT}" fetch "${arg_URL}" "${ref_to_use}" --depth 1 -n
+            WORKING_DIRECTORY "${DOWNLOADS}/git-tmp"
+            LOGNAME "git-fetch-${TARGET_TRIPLET}"
+        )
+        vcpkg_execute_in_download_mode(
+            COMMAND "${GIT}" rev-parse FETCH_HEAD
+            OUTPUT_VARIABLE rev_parse_head
+            ERROR_VARIABLE rev_parse_head
+            RESULT_VARIABLE error_code
+            WORKING_DIRECTORY ${DOWNLOADS}/git-tmp
+        )
+        if(error_code)
+            message(FATAL_ERROR "unable to determine FETCH_HEAD after fetching git repository")
+        endif()
+        string(STRIP "${rev_parse_head}" rev_parse_head)
+        if(VCPKG_USE_HEAD_VERSION)
+            set(VCPKG_HEAD_VERSION "${rev_parse_head}" PARENT_SCOPE)
+        elseif(NOT rev_parse_head STREQUAL arg_REF)
+            message(FATAL_ERROR "REF (${arg_REF}) does not match FETCH_HEAD (${rev_parse_head})
+    This means that the argument passed to REF is not a full commit ID.")
+        endif()
+
+        file(MAKE_DIRECTORY "${DOWNLOADS}/temp")
+        vcpkg_execute_required_process(
+            ALLOW_IN_DOWNLOAD_MODE
+            COMMAND "${GIT}" archive "${rev_parse_head}" -o "${temp_archive}"
+            WORKING_DIRECTORY "${DOWNLOADS}/git-tmp"
+            LOGNAME git-archive
+        )
+        file(RENAME "${temp_archive}" "${archive}")
+    else()
+        message(STATUS "Using cached ${archive}")
+    endif()
+
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE "${archive}"
+        REF "${sanitized_ref}"
+        PATCHES ${arg_PATCHES}
+        NO_REMOVE_ONE_LEVEL
+        ${working_directory}
     )
 
-    get_filename_component(downloaded_file_dir "${ARCHIVE}" DIRECTORY)
-    file(MAKE_DIRECTORY "${downloaded_file_dir}")
-    file(RENAME "${TEMP_ARCHIVE}" "${ARCHIVE}")
-  else()
-    message(STATUS "Using cached ${ARCHIVE}")
-  endif()
-
-  vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE "${ARCHIVE}"
-    REF "${SANITIZED_REF}"
-    PATCHES ${_vdud_PATCHES}
-    NO_REMOVE_ONE_LEVEL
-  )
-
-  set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -73,159 +73,116 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 #]===]
 
 function(vcpkg_from_github)
-    set(oneValueArgs OUT_SOURCE_PATH REPO REF SHA512 HEAD_REF GITHUB_HOST AUTHORIZATION_TOKEN FILE_DISAMBIGUATOR)
-    set(multipleValuesArgs PATCHES)
-    # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _vdud "" "${oneValueArgs}" "${multipleValuesArgs}")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        "OUT_SOURCE_PATH;REPO;REF;SHA512;HEAD_REF;GITHUB_HOST;AUTHORIZATION_TOKEN;FILE_DISAMBIGUATOR"
+        "PATCHES")
 
-    if(NOT DEFINED _vdud_OUT_SOURCE_PATH)
-        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(WARNING "vcpkg_from_github was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
     endif()
 
-    if((DEFINED _vdud_REF AND NOT DEFINED _vdud_SHA512) OR (NOT DEFINED _vdud_REF AND DEFINED _vdud_SHA512))
+    if(DEFINED arg_REF AND NOT DEFINED arg_SHA512)
         message(FATAL_ERROR "SHA512 must be specified if REF is specified.")
     endif()
+    if(NOT DEFINED arg_REF AND DEFINED arg_SHA512)
+        message(FATAL_ERROR "REF must be specified if SHA512 is specified.")
+    endif()
 
-    if(NOT DEFINED _vdud_REPO)
+    if(NOT DEFINED arg_OUT_SOURCE_PATH)
+        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    endif()
+    if(NOT DEFINED arg_REPO)
         message(FATAL_ERROR "The GitHub repository must be specified.")
     endif()
 
-    if(NOT DEFINED _vdud_REF AND NOT DEFINED _vdud_HEAD_REF)
-        message(FATAL_ERROR "At least one of REF and HEAD_REF must be specified.")
-    endif()
-
-    if(NOT DEFINED _vdud_GITHUB_HOST)
-        set(GITHUB_HOST https://github.com)
-        set(GITHUB_API_URL https://api.github.com)
+    if(NOT DEFINED arg_GITHUB_HOST)
+        set(github_host "https://github.com")
+        set(github_api_url "https://api.github.com")
     else()
-        set(GITHUB_HOST "${_vdud_GITHUB_HOST}")
-        set(GITHUB_API_URL "${_vdud_GITHUB_HOST}/api/v3")
+        set(github_host "${arg_GITHUB_HOST}")
+        set(github_api_url "${arg_GITHUB_HOST}/api/v3")
     endif()
 
-    if(DEFINED _vdud_AUTHORIZATION_TOKEN)
-        set(HEADERS "HEADERS" "Authorization: token ${_vdud_AUTHORIZATION_TOKEN}")
+    if(DEFINED arg_AUTHORIZATION_TOKEN)
+        set(headers "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
     else()
-        set(HEADERS)
+        set(headers)
     endif()
 
-    string(REGEX REPLACE ".*/" "" REPO_NAME "${_vdud_REPO}")
-    string(REGEX REPLACE "/.*" "" ORG_NAME "${_vdud_REPO}")
 
-    macro(set_TEMP_SOURCE_PATH BASE BASEREF)
-        set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${BASEREF}")
-        if(NOT EXISTS "${TEMP_SOURCE_PATH}")
-            # Sometimes GitHub strips a leading 'v' off the REF.
-            string(REGEX REPLACE "^v" "" REF "${BASEREF}")
-            string(REPLACE "/" "-" REF "${REF}")
-            set(TEMP_SOURCE_PATH "${BASE}/${REPO_NAME}-${REF}")
-            if(NOT EXISTS "${TEMP_SOURCE_PATH}")
-                message(FATAL_ERROR "Could not determine source path: '${BASE}/${REPO_NAME}-${BASEREF}' does not exist")
-            endif()
-        endif()
-    endmacro()
-
-    if(VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_HEAD_REF)
-        message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
-        set(VCPKG_USE_HEAD_VERSION OFF)
+    if(NOT DEFINED arg_REF AND NOT DEFINED arg_HEAD_REF)
+        message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
     endif()
 
-    # Handle --no-head scenarios
-    if(NOT VCPKG_USE_HEAD_VERSION)
-        if(NOT _vdud_REF)
-            message(FATAL_ERROR "Package does not specify REF. It must built using --head.")
+    if(NOT arg_REPO MATCHES "^([^/]*)/([^/]*)$")
+        message(FATAL_ERROR "REPO (${arg_REPO}) is not a valid repo name:
+    must be an organization name followed by a repository name separated by a single slash.")
+    endif()
+    set(org_name "${CMAKE_MATCH_1}")
+    set(repo_name "${CMAKE_MATCH_2}")
+
+    set(redownload)
+    set(working_directory)
+    set(sha512 "SHA512" "${arg_SHA512}")
+    set(ref_to_use "${arg_REF}")
+    if(VCPKG_USE_HEAD_VERSION)
+        if(DEFINED arg_HEAD_REF)
+            set(redownload "ALWAYS_REDOWNLOAD")
+            set(sha512 "SKIP_SHA512")
+            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(ref_to_use "${arg_HEAD_REF}")
+        else()
+            message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
         endif()
-
-        string(REPLACE "/" "-" SANITIZED_REF "${_vdud_REF}")
-
-        set(downloaded_file_name "${ORG_NAME}-${REPO_NAME}-${SANITIZED_REF}")
-        if (_vdud_FILE_DISAMBIGUATOR)
-            set(downloaded_file_name "${downloaded_file_name}-${_vdud_FILE_DISAMBIGUATOR}")
-        endif()
-
-        set(downloaded_file_name "${downloaded_file_name}.tar.gz")
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS "${GITHUB_HOST}/${ORG_NAME}/${REPO_NAME}/archive/${_vdud_REF}.tar.gz"
-            SHA512 "${_vdud_SHA512}"
-            FILENAME "${downloaded_file_name}"
-            ${HEADERS}
-        )
-
-        vcpkg_extract_source_archive_ex(
-            OUT_SOURCE_PATH SOURCE_PATH
-            ARCHIVE "${ARCHIVE}"
-            REF "${SANITIZED_REF}"
-            PATCHES ${_vdud_PATCHES}
-        )
-
-        set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-        return()
+    elseif(NOT DEFINED arg_REF)
+        message(FATAL_ERROR "Package does not specify REF. It must be built using --head.")
     endif()
 
-    # The following is for --head scenarios
-    set(URL "${GITHUB_HOST}/${ORG_NAME}/${REPO_NAME}/archive/${_vdud_HEAD_REF}.tar.gz")
-    string(REPLACE "/" "-" SANITIZED_HEAD_REF "${_vdud_HEAD_REF}")
-    set(downloaded_file_name "${ORG_NAME}-${REPO_NAME}-${SANITIZED_HEAD_REF}")
-    if (_vdud_FILE_DISAMBIGUATOR)
-        set(downloaded_file_name "${downloaded_file_name}-${_vdud_FILE_DISAMBIGUATOR}")
-    endif()
-
-    set(downloaded_file_name "${downloaded_file_name}.tar.gz")
-
-    set(downloaded_file_path "${DOWNLOADS}/${downloaded_file_name}")
-
-    if(_VCPKG_NO_DOWNLOADS)
-        if(NOT EXISTS "${downloaded_file_path}" OR NOT EXISTS "${downloaded_file_path}.version")
-            message(FATAL_ERROR "Downloads are disabled, but '${downloaded_file_path}' does not exist.")
-        endif()
-        message(STATUS "Using cached ${downloaded_file_path}")
+    # avoid using either - or _, to allow both `foo/bar` and `foo-bar` to coexist
+    # we assume that no one will name a ref "foo_-bar"
+    string(REPLACE "/" "_-" sanitized_ref "${ref_to_use}")
+    if(DEFINED arg_FILE_DISAMBIGUATOR AND NOT VCPKG_USE_HEAD_VERSION)
+        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}-${arg_FILE_DISAMBIGUATOR}.tar.gz")
     else()
-        if(EXISTS "${downloaded_file_path}")
-            message(STATUS "Purging cached ${downloaded_file_path} to fetch latest (use --no-downloads to suppress)")
-            file(REMOVE "${downloaded_file_path}")
-        endif()
-        if(EXISTS "${downloaded_file_path}.version")
-            file(REMOVE "${downloaded_file_path}.version")
-        endif()
-        if(EXISTS "${CURRENT_BUILDTREES_DIR}/src/head")
-            file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/src/head")
-        endif()
-
-        # Try to download the file and version information from github.
-        vcpkg_download_distfile(ARCHIVE_VERSION
-            URLS "${GITHUB_API_URL}/repos/${ORG_NAME}/${REPO_NAME}/git/refs/heads/${_vdud_HEAD_REF}"
-            FILENAME "${downloaded_file_name}.version"
-            SKIP_SHA512
-            ${HEADERS}
-        )
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS ${URL}
-            FILENAME "${downloaded_file_name}"
-            SKIP_SHA512
-            ${HEADERS}
-        )
+        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}.tar.gz")
     endif()
 
-    # Parse the github refs response with regex.
-    # TODO: use some JSON swiss-army-knife utility instead.
-    file(READ "${downloaded_file_path}.version" _contents)
-    string(REGEX MATCH "\"sha\": \"[a-f0-9]+\"" x "${_contents}")
-    string(REGEX REPLACE "\"sha\": \"([a-f0-9]+)\"" "\\1" _version ${x})
 
     # exports VCPKG_HEAD_VERSION to the caller. This will get picked up by ports.cmake after the build.
-    # When multiple vcpkg_from_github's are used after each other, only use the version from the first (hopefully the primary one).
-    if(NOT DEFINED VCPKG_HEAD_VERSION)
-        set(VCPKG_HEAD_VERSION "${_version}" PARENT_SCOPE)
+    if(VCPKG_USE_HEAD_VERSION)
+        vcpkg_download_distfile(archive_version
+            URLS "${github_api_url}/repos/${org_name}/${repo_name}/git/refs/heads/${arg_HEAD_REF}"
+            FILENAME "${downloaded_file_name}.version"
+            SKIP_SHA512
+            ALWAYS_REDOWNLOAD
+        )
+        # Parse the github refs response with regex.
+        # TODO: add json-pointer support to vcpkg
+        file(READ "${archive_version}" version_contents)
+        if(NOT version_contents MATCHES [["sha": "([a-f0-9]+)"]])
+            message(FATAL_ERROR "Failed to parse API response from '${version_url}':
+
+${version_contents}
+")
+        endif()
+        set(VCPKG_HEAD_VERSION "${CMAKE_MATCH_1}" PARENT_SCOPE)
     endif()
 
-    vcpkg_extract_source_archive_ex(
-        SKIP_PATCH_CHECK
-        OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE "${downloaded_file_path}"
-        REF "${SANITIZED_HEAD_REF}"
-        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src/head"
-        PATCHES ${_vdud_PATCHES}
+    # Try to download the file information from github
+    vcpkg_download_distfile(archive
+        URLS "${github_host}/${org_name}/${repo_name}/archive/${ref_to_use}.tar.gz"
+        FILENAME "${downloaded_file_name}"
+        ${headers}
+        ${sha512}
+        ${redownload}
     )
-    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    vcpkg_extract_source_archive_ex(
+        OUT_SOURCE_PATH SOURCE_PATH
+        ARCHIVE "${archive}"
+        REF "${sanitized_ref}"
+        PATCHES ${arg_PATCHES}
+        ${working_directory}
+    )
+    set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -104,10 +104,9 @@ function(vcpkg_from_github)
         set(github_api_url "${arg_GITHUB_HOST}/api/v3")
     endif()
 
+    set(headers_param "")
     if(DEFINED arg_AUTHORIZATION_TOKEN)
-        set(headers "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
-    else()
-        set(headers)
+        set(headers_param "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
     endif()
 
 
@@ -122,15 +121,15 @@ function(vcpkg_from_github)
     set(org_name "${CMAKE_MATCH_1}")
     set(repo_name "${CMAKE_MATCH_2}")
 
-    set(redownload)
-    set(working_directory)
-    set(sha512 "SHA512" "${arg_SHA512}")
+    set(redownload_param "")
+    set(working_directory_param "")
+    set(sha512_param "SHA512" "${arg_SHA512}")
     set(ref_to_use "${arg_REF}")
     if(VCPKG_USE_HEAD_VERSION)
         if(DEFINED arg_HEAD_REF)
-            set(redownload "ALWAYS_REDOWNLOAD")
-            set(sha512 "SKIP_SHA512")
-            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(redownload_param "ALWAYS_REDOWNLOAD")
+            set(sha512_param "SKIP_SHA512")
+            set(working_directory_param "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
             set(ref_to_use "${arg_HEAD_REF}")
         else()
             message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
@@ -173,16 +172,16 @@ ${version_contents}
     vcpkg_download_distfile(archive
         URLS "${github_host}/${org_name}/${repo_name}/archive/${ref_to_use}.tar.gz"
         FILENAME "${downloaded_file_name}"
-        ${headers}
-        ${sha512}
-        ${redownload}
+        ${headers_param}
+        ${sha512_param}
+        ${redownload_param}
     )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${archive}"
         REF "${sanitized_ref}"
         PATCHES ${arg_PATCHES}
-        ${working_directory}
+        ${working_directory_param}
     )
     set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -110,7 +110,7 @@ function(vcpkg_from_gitlab)
         set(org_name "${CMAKE_MATCH_1}")
         set(repo_name "${CMAKE_MATCH_2}")
         set(gitlab_link "${arg_GITLAB_URL}/${org_name}/${repo_name}")
-    elseif(arg_REPO MATCHES [[^([^/]*)/([^/]*)/([^/]*)]]) # 3 elements
+    elseif(arg_REPO MATCHES [[^([^/]*)/([^/]*)/([^/]*)$]]) # 3 elements
         set(org_name "${CMAKE_MATCH_1}")
         set(group_name "${CMAKE_MATCH_2}")
         set(repo_name "${CMAKE_MATCH_3}")

--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -70,132 +70,120 @@ This exports the `VCPKG_HEAD_VERSION` variable during head builds.
 include(vcpkg_execute_in_download_mode)
 
 function(vcpkg_from_gitlab)
-    set(oneValueArgs OUT_SOURCE_PATH GITLAB_URL USER REPO REF SHA512 HEAD_REF FILE_DISAMBIGUATOR)
-    set(multipleValuesArgs PATCHES)
-    # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _vdud "" "${oneValueArgs}" "${multipleValuesArgs}")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        "OUT_SOURCE_PATH;GITLAB_URL;REPO;REF;SHA512;HEAD_REF;FILE_DISAMBIGUATOR"
+        "PATCHES")
 
-    if(NOT DEFINED _vdud_GITLAB_URL)
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(WARNING "vcpkg_from_gitlab was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+
+    if(NOT DEFINED arg_GITLAB_URL)
         message(FATAL_ERROR "GITLAB_URL must be specified.")
     endif()
 
-    if(NOT DEFINED _vdud_OUT_SOURCE_PATH)
-        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
-    endif()
-
-    if((DEFINED _vdud_REF AND NOT DEFINED _vdud_SHA512) OR (NOT DEFINED _vdud_REF AND DEFINED _vdud_SHA512))
+    if(DEFINED arg_REF AND NOT DEFINED arg_SHA512)
         message(FATAL_ERROR "SHA512 must be specified if REF is specified.")
     endif()
-
-    if(NOT DEFINED _vdud_REPO)
-        message(FATAL_ERROR "REPO must be specified.")
+    if(NOT DEFINED arg_REF AND DEFINED arg_SHA512)
+        message(FATAL_ERROR "REF must be specified if SHA512 is specified.")
     endif()
 
-    if(NOT DEFINED _vdud_REF AND NOT DEFINED _vdud_HEAD_REF)
-        message(FATAL_ERROR "At least one of REF and HEAD_REF must be specified.")
+    if(NOT DEFINED arg_OUT_SOURCE_PATH)
+        message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
+    endif()
+    if(NOT DEFINED arg_REPO)
+        message(FATAL_ERROR "The GitHub repository must be specified.")
     endif()
 
-    if(VCPKG_USE_HEAD_VERSION AND NOT DEFINED _vdud_HEAD_REF)
-        message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
-        set(VCPKG_USE_HEAD_VERSION OFF)
-    endif()
-
-    string(REPLACE "/" ";" GITLAB_REPO_LINK ${_vdud_REPO})
-    
-    list(LENGTH GITLAB_REPO_LINK len)
-    if(${len} EQUAL "2")
-		list(GET GITLAB_REPO_LINK 0 ORG_NAME)
-		list(GET GITLAB_REPO_LINK 1 REPO_NAME)
-		set(GITLAB_LINK ${_vdud_GITLAB_URL}/${ORG_NAME}/${REPO_NAME})
-	endif()
-	
-	if(${len} EQUAL "3")
-		list(GET GITLAB_REPO_LINK 0 ORG_NAME)
-		list(GET GITLAB_REPO_LINK 1 GROUP_NAME)
-		list(GET GITLAB_REPO_LINK 2 REPO_NAME)
-		set(GITLAB_LINK ${_vdud_GITLAB_URL}/${ORG_NAME}/${GROUP_NAME}/${REPO_NAME})
-	endif()
-    
-    # Handle --no-head scenarios
-    if(NOT VCPKG_USE_HEAD_VERSION)
-        if(NOT _vdud_REF)
-            message(FATAL_ERROR "Package does not specify REF. It must built using --head.")
-        endif()
-
-        string(REPLACE "/" "-" SANITIZED_REF "${_vdud_REF}")
-        set(downloaded_file_name "${ORG_NAME}-${REPO_NAME}-${SANITIZED_REF}")
-        if (_vdud_FILE_DISAMBIGUATOR)
-            set(downloaded_file_name "${downloaded_file_name}-${_vdud_FILE_DISAMBIGUATOR}")
-        endif()
-
-        set(downloaded_file_name "${downloaded_file_name}.tar.gz")
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS "${GITLAB_LINK}/-/archive/${_vdud_REF}/${REPO_NAME}-${_vdud_REF}.tar.gz"
-            SHA512 "${_vdud_SHA512}"
-            FILENAME "${downloaded_file_name}"
-        )
-
-        vcpkg_extract_source_archive_ex(
-            OUT_SOURCE_PATH SOURCE_PATH
-            ARCHIVE "${ARCHIVE}"
-            REF "${SANITIZED_REF}"
-            PATCHES ${_vdud_PATCHES}
-        )
-
-        set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
-        return()
-    endif()
-
-    # The following is for --head scenarios
-    set(URL "${GITLAB_LINK}/-/archive/${_vdud_HEAD_REF}/${_vdud_HEAD_REF}.tar.gz")
-    string(REPLACE "/" "-" SANITIZED_HEAD_REF "${_vdud_HEAD_REF}")
-    set(downloaded_file_name "${ORG_NAME}-${REPO_NAME}-${SANITIZED_HEAD_REF}.tar.gz")
-    set(downloaded_file_path "${DOWNLOADS}/${downloaded_file_name}")
-
-    if(_VCPKG_NO_DOWNLOADS)
-        if(NOT EXISTS ${downloaded_file_path} OR NOT EXISTS ${downloaded_file_path}.version)
-            message(FATAL_ERROR "Downloads are disabled, but '${downloaded_file_path}' does not exist.")
-        endif()
-        message(STATUS "Using cached ${downloaded_file_path}")
+    if(DEFINED arg_AUTHORIZATION_TOKEN)
+        set(headers "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
     else()
-        if(EXISTS ${downloaded_file_path})
-            message(STATUS "Purging cached ${downloaded_file_path} to fetch latest (use --no-downloads to suppress)")
-            file(REMOVE ${downloaded_file_path})
-        endif()
-        if(EXISTS ${downloaded_file_path}.version)
-            file(REMOVE ${downloaded_file_path}.version)
-        endif()
-        if(EXISTS ${CURRENT_BUILDTREES_DIR}/src/head)
-            file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/src/head)
-        endif()
-
-        vcpkg_download_distfile(ARCHIVE
-            URLS ${URL}
-            FILENAME ${downloaded_file_name}
-            SKIP_SHA512
-        )
+        set(headers)
     endif()
 
-    # There are issues with the Gitlab API project paths being URL-escaped, so we use git here to get the head revision
-    vcpkg_execute_in_download_mode(COMMAND ${GIT} ls-remote
-        "${GITLAB_LINK}.git" "${_vdud_HEAD_REF}"
-        RESULT_VARIABLE _git_result
-        OUTPUT_VARIABLE _git_output
-    )
-    string(REGEX MATCH "[a-f0-9]+" _version "${_git_output}")
+    if(NOT DEFINED arg_REF AND NOT DEFINED arg_HEAD_REF)
+        message(FATAL_ERROR "At least one of REF or HEAD_REF must be specified.")
+    endif()
+
+    if(arg_REPO MATCHES [[^([^/]*)/([^/]*)$]]) # 2 elements
+        set(org_name "${CMAKE_MATCH_1}")
+        set(repo_name "${CMAKE_MATCH_2}")
+        set(gitlab_link "${arg_GITLAB_URL}/${org_name}/${repo_name}")
+    elseif(arg_REPO MATCHES [[^([^/]*)/([^/]*)/([^/]*)]]) # 3 elements
+        set(org_name "${CMAKE_MATCH_1}")
+        set(group_name "${CMAKE_MATCH_2}")
+        set(repo_name "${CMAKE_MATCH_3}")
+        set(gitlab_link "${arg_GITLAB_URL}/${org_name}/${group_name}/${repo_name}")
+    else()
+        message(FATAL_ERROR "REPO (${arg_REPO}) is not a valid repo name. It must be:
+    - an organization name followed by a repository name separated by a single slash, or
+    - an organization name, group name, and repository name separated by slashes.")
+    endif()
+
+    set(redownload)
+    set(working_directory)
+    set(sha512 "SHA512" "${arg_SHA512}")
+    set(ref_to_use "${arg_REF}")
+    if(VCPKG_USE_HEAD_VERSION)
+        if(DEFINED arg_HEAD_REF)
+            set(redownload "ALWAYS_REDOWNLOAD")
+            set(sha512 "SKIP_SHA512")
+            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(ref_to_use "${arg_HEAD_REF}")
+        else()
+            message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
+        endif()
+    elseif(NOT DEFINED arg_REF)
+        message(FATAL_ERROR "Package does not specify REF. It must be built using --head.")
+    endif()
+
+    # avoid using either - or _, to allow both `foo/bar` and `foo-bar` to coexist
+    # we assume that no one will name a ref "foo_-bar"
+    string(REPLACE "/" "_-" sanitized_ref "${ref_to_use}")
+    if(DEFINED arg_FILE_DISAMBIGUATOR AND NOT VCPKG_USE_HEAD_VERSION)
+        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}-${arg_FILE_DISAMBIGUATOR}.tar.gz")
+    else()
+        set(downloaded_file_name "${org_name}-${repo_name}-${sanitized_ref}.tar.gz")
+    endif()
+
+
     # exports VCPKG_HEAD_VERSION to the caller. This will get picked up by ports.cmake after the build.
-    # When multiple vcpkg_from_gitlab's are used after each other, only use the version from the first (hopefully the primary one).
-    if(NOT DEFINED VCPKG_HEAD_VERSION)
-        set(VCPKG_HEAD_VERSION ${_version} PARENT_SCOPE)
+    if(VCPKG_USE_HEAD_VERSION)
+        # There are issues with the Gitlab API project paths being URL-escaped, so we use git here to get the head revision
+        vcpkg_execute_in_download_mode(COMMAND ${GIT} ls-remote
+            "${gitlab_link}.git" "${arg_HEAD_REF}"
+            RESULT_VARIABLE git_result
+            OUTPUT_VARIABLE git_output
+        )
+        if(NOT git_result EQUAL 0)
+            message(FATAL_ERROR "git ls-remote failed to read ref data of repository: '${gitlab_link}'")
+        endif()
+        if(NOT git_output MATCHES "^([a-f0-9]*)\t")
+            message(FATAL_ERROR "git ls-remote returned unexpected result:
+${git_output}
+")
+        endif()
+        # When multiple vcpkg_from_gitlab's are used after each other, only use the version from the first (hopefully the primary one).
+        if(NOT DEFINED VCPKG_HEAD_VERSION)
+            set(VCPKG_HEAD_VERSION "${CMAKE_MATCH_1}" PARENT_SCOPE)
+        endif()
     endif()
 
+    # download the file information from gitlab
+    vcpkg_download_distfile(archive
+        URLS "${gitlab_link}/-/archive/${ref_to_use}/${repo_name}-${ref_to_use}.tar.gz"
+        FILENAME "${downloaded_file_name}"
+        ${sha512}
+        ${redownload}
+    )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE "${downloaded_file_path}"
-        REF "${SANITIZED_HEAD_REF}"
-        WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR}/src/head
-        PATCHES ${_vdud_PATCHES}
+        ARCHIVE "${archive}"
+        REF "${sanitized_ref}"
+        PATCHES ${arg_PATCHES}
+        ${working_directory}
     )
-    set(${_vdud_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -97,10 +97,9 @@ function(vcpkg_from_gitlab)
         message(FATAL_ERROR "The GitHub repository must be specified.")
     endif()
 
+    set(headers_param "")
     if(DEFINED arg_AUTHORIZATION_TOKEN)
-        set(headers "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
-    else()
-        set(headers)
+        set(headers_param "HEADERS" "Authorization: token ${arg_AUTHORIZATION_TOKEN}")
     endif()
 
     if(NOT DEFINED arg_REF AND NOT DEFINED arg_HEAD_REF)
@@ -122,15 +121,15 @@ function(vcpkg_from_gitlab)
     - an organization name, group name, and repository name separated by slashes.")
     endif()
 
-    set(redownload)
-    set(working_directory)
-    set(sha512 "SHA512" "${arg_SHA512}")
+    set(redownload_param "")
+    set(working_directory_param "")
+    set(sha512_param "SHA512" "${arg_SHA512}")
     set(ref_to_use "${arg_REF}")
     if(VCPKG_USE_HEAD_VERSION)
         if(DEFINED arg_HEAD_REF)
-            set(redownload "ALWAYS_REDOWNLOAD")
-            set(sha512 "SKIP_SHA512")
-            set(working_directory "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
+            set(redownload_param "ALWAYS_REDOWNLOAD")
+            set(sha512_param "SKIP_SHA512")
+            set(working_directory_param "WORKING_DIRECTORY" "${CURRENT_BUILDTREES_DIR}/src/head")
             set(ref_to_use "${arg_HEAD_REF}")
         else()
             message(STATUS "Package does not specify HEAD_REF. Falling back to non-HEAD version.")
@@ -175,15 +174,16 @@ ${git_output}
     vcpkg_download_distfile(archive
         URLS "${gitlab_link}/-/archive/${ref_to_use}/${repo_name}-${ref_to_use}.tar.gz"
         FILENAME "${downloaded_file_name}"
-        ${sha512}
-        ${redownload}
+        ${headers_param}
+        ${sha512_param}
+        ${redownload_param}
     )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${archive}"
         REF "${sanitized_ref}"
         PATCHES ${arg_PATCHES}
-        ${working_directory}
+        ${working_directory_param}
     )
     set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_sourceforge.cmake
+++ b/scripts/cmake/vcpkg_from_sourceforge.cmake
@@ -3,6 +3,10 @@
 
 Download and extract a project from sourceforge.
 
+This function automatically checks a set of sourceforge mirrors;
+additionally, mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
+variable, which should be a semicolon-separated list.
+
 ## Usage:
 ```cmake
 vcpkg_from_sourceforge(
@@ -67,67 +71,53 @@ Specifies that the default removal of the top level folder should not occur.
 #]===]
 
 function(vcpkg_from_sourceforge)
-    set(booleanValueArgs DISABLE_SSL NO_REMOVE_ONE_LEVEL)
-    set(oneValueArgs OUT_SOURCE_PATH REPO REF SHA512 FILENAME WORKING_DIRECTORY)
-    set(multipleValuesArgs PATCHES)
-    # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _vdus "${booleanValueArgs}" "${oneValueArgs}" "${multipleValuesArgs}")
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        "DISABLE_SSL;NO_REMOVE_ONE_LEVEL"
+        "OUT_SOURCE_PATH;REPO;REF;SHA512;FILENAME;WORKING_DIRECTORY"
+        "PATCHES")
 
-    if(NOT DEFINED _vdus_OUT_SOURCE_PATH)
+    if(NOT DEFINED arg_OUT_SOURCE_PATH)
         message(FATAL_ERROR "OUT_SOURCE_PATH must be specified.")
     endif()
-
-    if(NOT DEFINED _vdus_SHA512)
+    if(NOT DEFINED arg_SHA512)
         message(FATAL_ERROR "SHA512 must be specified.")
     endif()
-
-    if(NOT DEFINED _vdus_REPO)
+    if(NOT DEFINED arg_REPO)
         message(FATAL_ERROR "The sourceforge repository must be specified.")
     endif()
 
-    if(DEFINED _vdus_WORKING_DIRECTORY)
-        set(WORKING_DIRECTORY WORKING_DIRECTORY "${_vdus_WORKING_DIRECTORY}")
-    else()
-        set(WORKING_DIRECTORY)
-    endif()
 
-    if (_vdus_DISABLE_SSL)
-        set(URL_PROTOCOL http:)
+    if(arg_DISABLE_SSL)
+        set(url_protocol "http:")
     else()
-        set(URL_PROTOCOL https:)
+        set(url_protocol "https:")
     endif()
     
-    set(SOURCEFORGE_HOST ${URL_PROTOCOL}//sourceforge.net/projects)
+    set(sourceforge_host "${url_protocol}//sourceforge.net/projects")
 
-    string(FIND ${_vdus_REPO} "/" FOUND_ORG)
-    if (NOT FOUND_ORG EQUAL -1)
-        string(SUBSTRING "${_vdus_REPO}" 0 ${FOUND_ORG} ORG_NAME)
-        math(EXPR FOUND_ORG "${FOUND_ORG} + 1") # skip the slash
-        string(SUBSTRING "${_vdus_REPO}" ${FOUND_ORG} -1 REPO_NAME)
-        if (REPO_NAME MATCHES "/")
-            message(FATAL_ERROR "REPO should contain at most one slash (found ${_vdus_REPO}).")
-        endif()
-        set(ORG_NAME ${ORG_NAME}/)
+    if(arg_REPO MATCHES "^([^/]*)$") # just one element
+        set(org_name "${CMAKE_MATCH_1}")
+        set(repo_name)
+    elseif(arg_REPO MATCHES "^([^/]*)/([^/]*)$") # two elements
+        set(org_name "${CMAKE_MATCH_1}")
+        set(repo_name "${CMAKE_MATCH_2}")
     else()
-        set(ORG_NAME ${_vdus_REPO}/)
-        set(REPO_NAME )
+        message(FATAL_ERROR "REPO (${arg_REPO}) is not a valid repo name. It must be:
+    - an organization name without any slashes, or
+    - an organization name followed by a repository name separated by a single slash")
     endif()
     
-    if (DEFINED _vdus_REF)
-        set(URL "${SOURCEFORGE_HOST}/${ORG_NAME}files/${REPO_NAME}/${_vdus_REF}/${_vdus_FILENAME}")
+    if(DEFINED arg_REF)
+        set(url "${sourceforge_host}/${org_name}/files/${repo_name}/${arg_REF}/${arg_FILENAME}")
+    elseif(DEFINED repo_name)
+        set(url "${sourceforge_host}/${org_name}/${repo_name}/files/${arg_FILENAME}")
     else()
-        set(URL "${SOURCEFORGE_HOST}/${ORG_NAME}${REPO_NAME}/files/${_vdus_FILENAME}")
+        set(url "${sourceforge_host}/${org_name}/files/${arg_FILENAME}")
     endif()
         
-    set(NO_REMOVE_ONE_LEVEL )
-    if (_vdus_NO_REMOVE_ONE_LEVEL)
-        set(NO_REMOVE_ONE_LEVEL "NO_REMOVE_ONE_LEVEL")
-    endif()
+    string(SUBSTRING "${arg_SHA512}" 0 10 sanitized_ref)
 
-    string(SUBSTRING "${_vdus_SHA512}" 0 10 SANITIZED_REF)
-
-    set(Z_VCPKG_SOURCEFORGE_MIRRORS ${SOURCEFORGE_MIRRORS})
-    list(APPEND Z_VCPKG_SOURCEFORGE_MIRRORS
+    set(sourceforge_mirrors
         cfhcable        # United States
         pilotfiber      # New York, NY
         gigenet         # Chicago, IL
@@ -149,26 +139,43 @@ function(vcpkg_from_sourceforge)
         ufpr            # Curitiba, Brazil
         tenet           # Wynberg, South Africa
     )
+    if(DEFINED SOURCEFORGE_MIRRORS AND NOT DEFINED VCPKG_SOURCEFORGE_EXTRA_MIRRORS)
+        message(WARNING "Extension point SOURCEFORGE_MIRRORS has been deprecated.
+    Please use the replacement VCPKG_SOURCEFORGE_EXTRA_MIRRORS variable instead.")
+        list(APPEND sourceforge_mirrors "${SOURCEFORGE_MIRRORS}")
+        list(REMOVE_DUPLICATES sourceforge_mirrors)
+    elseif(DEFINED VCPKG_SOURCEFORGE_EXTRA_MIRRORS)
+        list(APPEND sourceforge_mirrors "${VCPKG_SOURCEFORGE_EXTRA_MIRRORS}")
+        list(REMOVE_DUPLICATES sourceforge_mirrors)
+    endif()
 
-    set(URLS "${URL}/download")
-    foreach(SOURCEFORGE_MIRROR IN LISTS Z_VCPKG_SOURCEFORGE_MIRRORS)
-        list(APPEND URLS "${URL}/download?use_mirror=${SOURCEFORGE_MIRROR}")
+    set(all_urls "${url}/download")
+    foreach(mirror IN LISTS sourceforge_mirrors)
+        list(APPEND all_urls "${url}/download?use_mirror=${mirror}")
     endforeach()
-
+    
     vcpkg_download_distfile(ARCHIVE
-        URLS ${URLS}
-        SHA512 "${_vdus_SHA512}"
-        FILENAME "${_vdus_FILENAME}"
+        URLS ${all_urls}
+        SHA512 "${arg_SHA512}"
+        FILENAME "${arg_FILENAME}"
     )
 
+    set(no_remove_one_level)
+    set(working_directory)
+    if(arg_NO_REMOVE_ONE_LEVEL)
+        set(no_remove_one_level "NO_REMOVE_ONE_LEVEL")
+    endif()
+    if(DEFINED arg_WORKING_DIRECTORY)
+        set(working_directory "WORKING_DIRECTORY" "${arg_WORKING_DIRECTORY}")
+    endif()
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${ARCHIVE}"
-        REF "${SANITIZED_REF}"
-        ${NO_REMOVE_ONE_LEVEL}
-        ${WORKING_DIRECTORY}
-        PATCHES ${_vdus_PATCHES}
+        REF "${sanitized_ref}"
+        ${no_remove_one_level}
+        ${working_directory}
+        PATCHES ${arg_PATCHES}
     )
 
-    set(${_vdus_OUT_SOURCE_PATH} "${SOURCE_PATH}" PARENT_SCOPE)
+    set("${arg_OUT_SOURCE_PATH}" "${SOURCE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/vcpkg_from_sourceforge.cmake
+++ b/scripts/cmake/vcpkg_from_sourceforge.cmake
@@ -3,9 +3,9 @@
 
 Download and extract a project from sourceforge.
 
-This function automatically checks a set of sourceforge mirrors;
-additionally, mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
-variable, which should be a semicolon-separated list.
+This function automatically checks a set of sourceforge mirrors.
+Additional mirrors can be injected through the `VCPKG_SOURCEFORGE_EXTRA_MIRRORS`
+list variable in the triplet.
 
 ## Usage:
 ```cmake
@@ -57,9 +57,6 @@ A list of patches to be applied to the extracted sources.
 
 Relative paths are based on the port directory.
 
-### DISABLE_SSL
-Disable ssl when downloading source.
-
 ### NO_REMOVE_ONE_LEVEL
 Specifies that the default removal of the top level folder should not occur.
 
@@ -88,12 +85,10 @@ function(vcpkg_from_sourceforge)
 
 
     if(arg_DISABLE_SSL)
-        set(url_protocol "http:")
-    else()
-        set(url_protocol "https:")
+        message(WARNING "DISABLE_SSL has been deprecated and has no effect")
     endif()
     
-    set(sourceforge_host "${url_protocol}//sourceforge.net/projects")
+    set(sourceforge_host "https://sourceforge.net/projects")
 
     if(arg_REPO MATCHES "^([^/]*)$") # just one element
         set(org_name "${CMAKE_MATCH_1}")

--- a/scripts/cmake/vcpkg_from_sourceforge.cmake
+++ b/scripts/cmake/vcpkg_from_sourceforge.cmake
@@ -92,7 +92,7 @@ function(vcpkg_from_sourceforge)
 
     if(arg_REPO MATCHES "^([^/]*)$") # just one element
         set(org_name "${CMAKE_MATCH_1}")
-        set(repo_name)
+        set(repo_name "")
     elseif(arg_REPO MATCHES "^([^/]*)/([^/]*)$") # two elements
         set(org_name "${CMAKE_MATCH_1}")
         set(repo_name "${CMAKE_MATCH_2}")
@@ -155,20 +155,20 @@ function(vcpkg_from_sourceforge)
         FILENAME "${arg_FILENAME}"
     )
 
-    set(no_remove_one_level)
-    set(working_directory)
+    set(no_remove_one_level_param "")
+    set(working_directory_param "")
     if(arg_NO_REMOVE_ONE_LEVEL)
-        set(no_remove_one_level "NO_REMOVE_ONE_LEVEL")
+        set(no_remove_one_level_param "NO_REMOVE_ONE_LEVEL")
     endif()
     if(DEFINED arg_WORKING_DIRECTORY)
-        set(working_directory "WORKING_DIRECTORY" "${arg_WORKING_DIRECTORY}")
+        set(working_directory_param "WORKING_DIRECTORY" "${arg_WORKING_DIRECTORY}")
     endif()
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH SOURCE_PATH
         ARCHIVE "${ARCHIVE}"
         REF "${sanitized_ref}"
-        ${no_remove_one_level}
-        ${working_directory}
+        ${no_remove_one_level_param}
+        ${working_directory_param}
         PATCHES ${arg_PATCHES}
     )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5142,7 +5142,7 @@
     },
     "qt5-mqtt": {
       "baseline": "5.15.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-multimedia": {
       "baseline": "5.15.2",

--- a/versions/q-/qt5-mqtt.json
+++ b/versions/q-/qt5-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9a02099176012e710ae215855f4e72fe6f5b704a",
+      "version": "5.15.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "af160578b6f6fe501b01817d6d171d123a4841d1",
       "version-string": "5.15.2",
       "port-version": 0


### PR DESCRIPTION
This PR goes through the `vcpkg_from_*` functions and brings them in line with the script audit (while also making them _far_ easier to read and much DRY-er, imo)

See issue #17691

This PR should likely be reviewed a commit at a time; or at least the first commit alone, the next three commits together, and then the latter two separately.

Still to do:
- [x] `vcpkg_from_sourceforge`
- [x] `vcpkg_from_git`