### PR TITLE
[kenlm] Update port

### DIFF
--- a/ports/kenlm/portfile.cmake
+++ b/ports/kenlm/portfile.cmake
@@ -3,17 +3,17 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kpu/kenlm
-    REF 1f054617eca14eae921e987b4b4eeb2b1d91de6b
-    SHA512 c18f9c22fbbb1f54ebe9c3b771fb2d7c09d502141d1b3645cff9db44cc51b3c976311ff0db79b60f410622579d043f185c56a4c7386e1b0ba8708e433238968b
+    REF bdf3c71a34a874de11ab02f23ebe0a0b877c27ef
+    SHA512 3782cf4b08b5686ea320fa248012c780faa0417fa5b23f2645bc8c92f7741ec8b8c7f81cd3f58676b1d1ea5817d1b56eaffa608ea993e3d213b63fcba44e2afb
     HEAD_REF master
     PATCHES 
         fix-boost.patch
-        fix-const-overloaded.patch
 )
 
 file(REMOVE ${SOURCE_PATH}/cmake/modules/FindEigen3.cmake)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
     interpolate ENABLE_INTERPOLATE
 )
 
@@ -44,6 +44,7 @@ vcpkg_copy_tools(TOOL_NAMES ${KENLM_TOOLS} AUTO_CLEAN)
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Copyright and License
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/kenlm/vcpkg.json
+++ b/ports/kenlm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "kenlm",
-  "version-string": "20200924",
-  "port-version": 1,
+  "version-string": "20210517",
   "description": "KenLM: Faster and Smaller Language Model Queries",
   "supports": "!(arm64 & windows)",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2817,8 +2817,8 @@
       "port-version": 0
     },
     "kenlm": {
-      "baseline": "20200924",
-      "port-version": 1
+      "baseline": "20210517",
+      "port-version": 0
     },
     "keystone": {
       "baseline": "0.9.2",

--- a/versions/k-/kenlm.json
+++ b/versions/k-/kenlm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8b78b078811781dff7e748851ce2ba2ce0605694",
+      "version-string": "20210517",
+      "port-version": 0
+    },
+    {
       "git-tree": "5fd24bb27699940f72b94a9c3cf3e77a7d645a76",
       "version-string": "20200924",
       "port-version": 1


### PR DESCRIPTION
Updates the KenLM port. I've added a `kenlmConfig.cmake` in https://github.com/kpu/kenlm/pull/334 and https://github.com/kpu/kenlm/pull/339. Updating the port to contain those so we can use modern CMake targets with the port. This generally fixes a bunch of problems with downstream projects that depend on kenlm and removes the need to specify a bunch of env vars just to find relevant bits.

Still depends on https://github.com/kpu/kenlm/pull/342.

A fix to some const things for msvc has also been merged upstream, so remove that patch.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Same triplets as before. No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes

cc @kpu, @tlikhomanenko, @xuqiantong, @vineelpratap, @padentomasello, @andresy, @syhw