### PR TITLE
[vcpkg_download_distfile] fix download while in manifest root

### DIFF
--- a/scripts/cmake/vcpkg_download_distfile.cmake
+++ b/scripts/cmake/vcpkg_download_distfile.cmake
@@ -202,7 +202,13 @@ function(vcpkg_download_distfile VAR)
                 endforeach()
             endif()
             vcpkg_execute_in_download_mode(
-                COMMAND "$ENV{VCPKG_COMMAND}" x-download "${downloaded_file_path}" "${vcpkg_download_distfile_SHA512}" ${urls} ${request_headers} --debug
+                COMMAND "$ENV{VCPKG_COMMAND}" x-download
+                    "${downloaded_file_path}"
+                    "${vcpkg_download_distfile_SHA512}"
+                    ${urls}
+                    ${request_headers}
+                    --debug
+                    --feature-flags=-manifests # there's a bug in vcpkg x-download when it finds a manifest-root
                 OUTPUT_VARIABLE output
                 ERROR_VARIABLE output
                 RESULT_VARIABLE failure


### PR DESCRIPTION
When vcpkg detects a manifest root, it attempts to take a filesystem lock;
this is a bug in `x-download`.
We fix this bug by disabling manifests.

Fixes a bug in #13639 
