### PR TITLE
[libgit2] fixup regex backend dependency

### DIFF
--- a/ports/libgit2/CONTROL
+++ b/ports/libgit2/CONTROL
@@ -3,7 +3,7 @@ Version: 1.1.0
 Homepage: https://github.com/libgit2/libgit2
 Build-Depends: zlib, http-parser
 Description: Git linkable library
-Default-Features: pcre, ssl
+Default-Features: ssl
 Supports: !uwp
 
 Feature: pcre

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -11,11 +11,11 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)
 
-set(REGEX_BACKEND OFF)
+set(REGEX_BACKEND builtin)
 set(USE_HTTPS OFF)
 
 function(set_regex_backend VALUE)
-    if(REGEX_BACKEND)
+    if(NOT REGEX_BACKEND STREQUAL "builtin")
         message(FATAL_ERROR "Only one regex backend (pcre,pcre2) is allowed")
     endif()
     set(REGEX_BACKEND ${VALUE} PARENT_SCOPE)
@@ -52,10 +52,6 @@ foreach(GIT2_FEATURE ${FEATURES})
         set_tls_backend("mbedTLS")
     endif()
 endforeach()
-
-if(NOT REGEX_BACKEND)
-    message(FATAL_ERROR "Must choose pcre or pcre2 regex backend")
-endif()
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS GIT2_FEATURES

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3b816585ddf5056a577f1a9ee0ac0fc68b9c406",
+      "version-string": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "23d98ed81409eaac3ae1abc9ddbc175564533d65",
       "version-string": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

libgit2 allows for at least three regex regex backends: builtin, pcre,
and pcre2. While builtin uses a statically linked pcre, if "pcre" is
specified as the regex backend, and pcre is never linked to or used in
the production code, vcpkg won't copy the required pcre DLL into the
build output directory (at least in msbuild). Therefore, unless a
dynamically linked pcre or pcre2 is preferred, the vcpkg libgit2 port
ought to use the builtin regex backend.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
