### PR TITLE
[tgui] Fixed sfml feature

### DIFF
--- a/ports/tgui/portfile.cmake
+++ b/ports/tgui/portfile.cmake
@@ -30,7 +30,7 @@ vcpkg_configure_cmake(
     OPTIONS ${FEATURE_OPTIONS}
         -DTGUI_MISC_INSTALL_PREFIX=${TGUI_SHARE_PATH}
         -DTGUI_SHARED_LIBS=${TGUI_SHARED_LIBS}
-        -DTGUI_BACKEND="Custom"
+        -DTGUI_BACKEND=Custom
         -DTGUI_BUILD_EXAMPLES=OFF
 )
 

--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tgui",
   "version-date": "2021-04-19",
+  "port-version": 1,
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6126,7 +6126,7 @@
     },
     "tgui": {
       "baseline": "2021-04-19",
-      "port-version": 0
+      "port-version": 1
     },
     "theia": {
       "baseline": "0.8",

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "354b5135bda4bcef9c5e7cbfeaff3d457b336e8c",
+      "version-date": "2021-04-19",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf02ffb145ee6449fd7479d72920c1e1ca9843c8",
       "version-date": "2021-04-19",
       "port-version": 0


### PR DESCRIPTION
No matter whether the `sfml` or `sdl2` feature was selected, only the SDL backend would be build. The backend name contained quotes around it which caused it to not match with any backend and silently fall back to the SDL one.

- #### What does your PR fix?  
  The SFML backend can be used again.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
