### PR TITLE
[matplotplusplus] Re-fix 3rd libraries installation

### DIFF
--- a/ports/matplotplusplus/install-3rd-libraries.patch
+++ b/ports/matplotplusplus/install-3rd-libraries.patch
@@ -1,13 +1,15 @@
 diff --git a/source/3rd_party/CMakeLists.txt b/source/3rd_party/CMakeLists.txt
-index 52f20eb..ab58bbd 100644
+index bef0c08..e7521a7 100644
 --- a/source/3rd_party/CMakeLists.txt
 +++ b/source/3rd_party/CMakeLists.txt
-@@ -41,6 +41,8 @@ endif()
+@@ -41,7 +41,9 @@ endif()
  if(MASTER_PROJECT AND NOT BUILD_SHARED_LIBS)
    install(TARGETS nodesoup
        EXPORT Matplot++Targets
+-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
 +      RUNTIME DESTINATION bin
 +      LIBRARY DESTINATION lib
-       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/Matplot++)
++      ARCHIVE DESTINATION lib)
  endif()
+ 
  

--- a/ports/matplotplusplus/portfile.cmake
+++ b/ports/matplotplusplus/portfile.cmake
@@ -49,12 +49,12 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 file(RENAME
-    ${CURRENT_PACKAGES_DIR}/lib/cmake/Matplot++/matplot++-config.cmake
-    ${CURRENT_PACKAGES_DIR}/lib/cmake/Matplot++/Matplot++-config.cmake
+    "${CURRENT_PACKAGES_DIR}/lib/cmake/Matplot++/matplot++-config.cmake"
+    "${CURRENT_PACKAGES_DIR}/lib/cmake/Matplot++/Matplot++-config.cmake"
 )
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME Matplot++ CONFIG_PATH lib/cmake/Matplot++)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/matplotplusplus/vcpkg.json
+++ b/ports/matplotplusplus/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "matplotplusplus",
   "version-date": "2021-04-11",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A C++ graphics library for data visualization",
   "homepage": "https://alandefreitas.github.io/matplotplusplus/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3910,7 +3910,7 @@
     },
     "matplotplusplus": {
       "baseline": "2021-04-11",
-      "port-version": 2
+      "port-version": 3
     },
     "matroska": {
       "baseline": "1.6.2",

--- a/versions/m-/matplotplusplus.json
+++ b/versions/m-/matplotplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e60b72bfb17b3263a7ee1e056af221991f5c7d69",
+      "version-date": "2021-04-11",
+      "port-version": 3
+    },
+    {
       "git-tree": "6b6b0deac894d376c04b11f3f01a26952b97b0b1",
       "version-date": "2021-04-11",
       "port-version": 2


### PR DESCRIPTION
Install the 3rd libraries to _lib_ / _debug/lib_ to fix the link error when using msvc project.

Fixes #18287.