### PR TITLE
[rapidjson] Remove usage

### DIFF
--- a/ports/rapidjson/CONTROL
+++ b/ports/rapidjson/CONTROL
@@ -1,4 +1,0 @@
-Source: rapidjson
-Version: 2020-09-14
-Description: A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>
-Homepage: http://rapidjson.org/

--- a/ports/rapidjson/portfile.cmake
+++ b/ports/rapidjson/portfile.cmake
@@ -21,12 +21,10 @@ vcpkg_install_cmake()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/share/doc)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/share/doc")
 
 file(READ "${CURRENT_PACKAGES_DIR}/share/rapidjson/RapidJSONConfig.cmake" _contents)
 string(REPLACE "\${RapidJSON_SOURCE_DIR}" "\${RapidJSON_CMAKE_DIR}/../.." _contents "${_contents}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/rapidjson/RapidJSONConfig.cmake" "${_contents}\nset(RAPIDJSON_INCLUDE_DIRS \"\${RapidJSON_INCLUDE_DIRS}\")\n")
 
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
+file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rapidjson/usage
+++ b/ports/rapidjson/usage
@@ -1,9 +1,0 @@
-The package rapidjson provides CMake integration:
-
-    find_package(RapidJSON CONFIG REQUIRED)
-
-    target_link_libraries(main PRIVATE rapidjson)
-    # Or
-    target_include_directories(main PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
-    # Or
-    target_include_directories(main PRIVATE ${RapidJSON_INCLUDE_DIRS})

--- a/ports/rapidjson/usage
+++ b/ports/rapidjson/usage
@@ -1,4 +1,9 @@
 The package rapidjson provides CMake integration:
 
     find_package(RapidJSON CONFIG REQUIRED)
+
+    target_link_libraries(main PRIVATE rapidjson)
+    # Or
     target_include_directories(main PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+    # Or
+    target_include_directories(main PRIVATE ${RapidJSON_INCLUDE_DIRS})

--- a/ports/rapidjson/vcpkg.json
+++ b/ports/rapidjson/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "rapidjson",
+  "version-date": "2020-09-14",
+  "port-version": 1,
+  "description": "A fast JSON parser/generator for C++ with both SAX/DOM style API <http://rapidjson.org/>",
+  "homepage": "http://rapidjson.org/"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5402,7 +5402,7 @@
     },
     "rapidjson": {
       "baseline": "2020-09-14",
-      "port-version": 0
+      "port-version": 1
     },
     "rapidxml": {
       "baseline": "1.13-4",

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a981b789e81a0002e88f068874a6c561da90f45f",
+      "git-tree": "6d70aec68e6db30b2fb6b659bc6f1453fe8c80a3",
       "version-date": "2020-09-14",
       "port-version": 1
     },

--- a/versions/r-/rapidjson.json
+++ b/versions/r-/rapidjson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a981b789e81a0002e88f068874a6c561da90f45f",
+      "version-date": "2020-09-14",
+      "port-version": 1
+    },
+    {
       "git-tree": "85e20cbcb5a3a60d6f64064055d149e2c2f01534",
       "version-string": "2020-09-14",
       "port-version": 0


### PR DESCRIPTION
Remove the usage since the upstream export the target `rapidjson`.

Fixes #18292.