### PR TITLE
[ryml] Add windows arm/arm64 support

### DIFF
--- a/ports/ryml/CONTROL
+++ b/ports/ryml/CONTROL
@@ -1,6 +1,6 @@
 Source: ryml
-Version: 2020-04-12
+Version: 2021-02-15
 Homepage: https://github.com/biojppm/rapidyaml 
 Description: Rapid YAML library
 Build-Depends: c4core[core]
-Supports: !(arm|arm64|osx)
+Supports: !(osx)

--- a/ports/ryml/cmake-fix.patch
+++ b/ports/ryml/cmake-fix.patch
@@ -1,14 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3e4eb23..115b8aa 100644
+index 34b89f2..ec53588 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,4 +1,5 @@
- cmake_minimum_required(VERSION 3.9)
-+
- project(ryml)
- 
- include(./ext/c4core/cmake/c4Project.cmake)
-@@ -19,8 +20,7 @@ option(RYML_BUILD_API "Enable API generation (python, etc)" OFF)
+@@ -17,8 +17,7 @@ option(RYML_DBG "Enable (very verbose) ryml debug prints." OFF)
  
  #-------------------------------------------------------
  
@@ -18,11 +12,11 @@ index 3e4eb23..115b8aa 100644
  
  c4_add_library(ryml
      SOURCES
-@@ -46,10 +46,10 @@ c4_add_library(ryml
+@@ -48,10 +47,10 @@ c4_add_library(ryml
          ryml.natvis
      SOURCE_ROOT ${RYML_SRC_DIR}
      INC_DIRS
-+	 $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
++        $<BUILD_INTERFACE:${C4CORE_INCLUDE_DIR}>
          $<BUILD_INTERFACE:${RYML_SRC_DIR}>
          $<INSTALL_INTERFACE:include>
 -    LIBS c4core
@@ -31,4 +25,3 @@ index 3e4eb23..115b8aa 100644
      )
  
  if(NOT RYML_DEFAULT_CALLBACKS)
-

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -1,7 +1,6 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_fail_port_install(
-    ON_ARCH "arm" "arm64"
     ON_TARGET "OSX"
 )
 
@@ -9,19 +8,18 @@ vcpkg_fail_port_install(
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO biojppm/rapidyaml
-    REF ec23e87007ccc39c6132345c154b267de9381706
-    SHA512 7d349c0dd58da814dad02de88a5c54394ef8d77e7db3014fb5fb684d519e35604d45f5d16db5ed6ed8ccb52b1ed4a4dbc91e717a091b54b04dc18901800e12c1
+    REF db387345abf9cd6710e0c4a487a476bfd176fea3
+    SHA512 4dda145b561e3b8420f89ad01e42eb5056b51a8a28a47f3b8c91bb0a2a6420d1842016a23cbb17d9f119ebce0e2e404b4f4fb67d71bf0d3c87aa81f346c6cfe2
     HEAD_REF master
     PATCHES cmake-fix.patch
 )
 
-set(COMMIT_HASH a0f0c17bfc9a9a91cc72891539b513c129c6d122)
-
 # Get cmake scripts for rapidyaml
+set(COMMIT_HASH 71c211187b8c52a13d5c59a7979f2ccf8429e350)
 vcpkg_download_distfile(CMAKE_ARCHIVE
     URLS "https://github.com/biojppm/cmake/archive/${COMMIT_HASH}.zip"
     FILENAME "cmake-${COMMIT_HASH}.zip"
-    SHA512 4fbc711f3120501fa40733c3b66e34cd6a7e1b598b1378fbb59d1a87c88290a03d021f5176634089da41682fd918d7e27c6c146052dec54d7e956be15f12744f
+    SHA512 d15884d985a477df47ead9c5c486cfdeb1df8b6de4f308c36bd7a8c0e901fb876980a2a4f239abd8ecb1fb0baf75ad559ca0780b50c84070762f8cbfe55cb9d2
 )
 
 vcpkg_extract_source_archive_ex(

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1406,7 +1406,6 @@ rttr:x64-uwp=fail
 rxspencer:x64-uwp=fail
 rxspencer:arm-uwp=fail
 ryml:arm-uwp=fail
-ryml:arm64-windows=fail
 ryml:x64-osx=fail
 ryu:arm-uwp=fail
 ryu:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5573,7 +5573,7 @@
       "port-version": 0
     },
     "ryml": {
-      "baseline": "2020-04-12",
+      "baseline": "2021-02-15",
       "port-version": 0
     },
     "ryu": {

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1289d79114def32da624bad2bd4a0d9025566af",
+      "version-string": "2021-02-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff07e4add8c6becd2fc4d57c2707cc141af1e341",
       "version-string": "2020-04-12",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Add arm/arm64 support for rapidyaml. This pr requires #18316.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  windows x86, x64, arm, arm64. Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I think yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
