### PR TITLE
[hazelcast-cpp-client] update to v4.1.1

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,14 +1,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF v4.1.0
-    SHA512 e93a0d0d9e6298dc974e8dcbd8487514d4f7be1a5341ac4de2b65ebdb30e5d2428c7605579121ce0469466b26ef9fafd41c5101a9607f2c63b10beaf63e3c762
+    REF v4.1.1
+    SHA512 2f6d578c43dfc8c03f83a5b7c98fe67b7dc450cbc542031e625ec3bc91b9ec2e430e3ced670608a651fcf77775d2d4a333ca82689cae793e8b13a8e0438bbfb9
     HEAD_REF master
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    openssl WITH_OPENSSL
-    example BUILD_EXAMPLES
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openssl WITH_OPENSSL
+        example BUILD_EXAMPLES
 )
 
 vcpkg_configure_cmake(

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version-semver": "4.1.0",
+  "version-semver": "4.1.1",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2465,7 +2465,7 @@
       "port-version": 0
     },
     "hazelcast-cpp-client": {
-      "baseline": "4.1.0",
+      "baseline": "4.1.1",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17cace53a35339535e20e587090ae1c6c16f5a3d",
+      "version-semver": "4.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "cdb9d51f25164c0c4e6555fcbe709a92c5b9adcf",
       "version-semver": "4.1.0",
       "port-version": 0


### PR DESCRIPTION

- #### What does your PR fix?  
  Updates port `hazelcast-cpp-client` to the latest version, fixes deprecated use of `vcpkg_check_features` in the port file. 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Same as before, all except `uwp` triplets. No need to update the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
