### PR TITLE
[argtable3] Update to v3.2.1

### DIFF
--- a/ports/argtable3/portfile.cmake
+++ b/ports/argtable3/portfile.cmake
@@ -1,9 +1,12 @@
-vcpkg_from_github(
+vcpkg_download_distfile(ARCHIVE
+   URLS "https://github.com/argtable/argtable3/releases/download/v3.2.1.52f24e5/argtable-v3.2.1.52f24e5.tar.gz"
+   FILENAME "argtable-v3.2.1.52f24e5.tar.gz"
+   SHA512 cec77d56048b38bb7af8553cb660e745972bbd90378eeea4e928579af78190c8a41fdb29c972263e18955e3a497e09c42f705f7c4d548c3c523c5cb104c97a10
+)
+
+vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO argtable/argtable3
-    REF 1c1bb23b305c8cf349328fc0cacd7beb7a575ff4 # v3.1.5
-    SHA512 13150c8adc1eda107b6df65a2e276510a66bd912f6067d7cc72951735a4c20307144b04cda959cdd24f160da3810ba8bb35e48992ff4281e44ed2331d030fb1d
-    HEAD_REF master
+    ARCHIVE ${ARCHIVE}
 )
 
 vcpkg_configure_cmake(
@@ -12,7 +15,6 @@ vcpkg_configure_cmake(
     OPTIONS
         -DARGTABLE3_ENABLE_CONAN=OFF
         -DARGTABLE3_ENABLE_TESTS=OFF
-        -DARGTABLE3_BUILD_STATIC_EXAMPLES=OFF
 )
 
 vcpkg_install_cmake()
@@ -25,20 +27,6 @@ elseif(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT})
     vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
 endif()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    vcpkg_replace_string(
-        "${CURRENT_PACKAGES_DIR}/include/argtable3.h"
-        "defined(argtable3_IMPORTS)"
-        "1 // defined(argtable3_IMPORTS)"
-    )
-endif()
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
 
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/ports/argtable3/vcpkg-cmake-wrapper.cmake
+++ b/ports/argtable3/vcpkg-cmake-wrapper.cmake
@@ -1,9 +1,0 @@
-_find_package(${ARGS})
-
-if(TARGET argtable3 AND NOT TARGET argtable3_static)
-    add_library(argtable3_static INTERFACE IMPORTED)
-    set_target_properties(argtable3_static PROPERTIES INTERFACE_LINK_LIBRARIES argtable3)
-elseif(TARGET argtable3_static AND NOT TARGET argtable3)
-    add_library(argtable3 INTERFACE IMPORTED)
-    set_target_properties(argtable3 PROPERTIES INTERFACE_LINK_LIBRARIES argtable3_static)
-endif()

--- a/ports/argtable3/vcpkg.json
+++ b/ports/argtable3/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "argtable3",
-  "version-string": "3.1.5",
+  "version-string": "3.2.1",
   "description": "A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options",
   "homepage": "www.argtable.org"
 }

--- a/versions/a-/argtable3.json
+++ b/versions/a-/argtable3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0dc3ede1be6316bee6853f84c5f147340be70ee8",
+      "version-string": "3.2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7a1d8f216b96823aed9e08cd73efc09ca7baec14",
       "version-string": "3.1.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -129,7 +129,7 @@
       "port-version": 8
     },
     "argtable3": {
-      "baseline": "3.1.5",
+      "baseline": "3.2.1",
       "port-version": 0
     },
     "argumentum": {


### PR DESCRIPTION
We have modified Argtable3 CMake scripts, which now respect `BUILD_SHARED_LIBS` and build either the static library or the dynamic library at a time, so the latest Argtable3 can support vcpkg manifest without any issue. In the patch, we not only update the port to the latest stable release, but also remove unnecessary code snippets and deprecated targets/variables.

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #12297. However, this patch is not only used to resolve old issues, but also used to point to the latest stable release.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All triplets should be supported. No, we didn't modify `ci.baseline.txt`.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, we have followed the maintainer guide.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes, we have run the command to update the version information. You can see `baseline.json` and `argtable3.json` in the patch.

