### PR TITLE
[kf5config] Add DISABLE_PARALLEL_CONFIGURE

### DIFF
--- a/ports/kf5config/portfile.cmake
+++ b/ports/kf5config/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF
         -DBUILD_MAN_DOCS=OFF

--- a/ports/kf5config/vcpkg.json
+++ b/ports/kf5config/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5config",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Configuration system",
   "homepage": "https://api.kde.org/frameworks/kconfig/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2842,7 +2842,7 @@
     },
     "kf5config": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5coreaddons": {
       "baseline": "5.81.0",

--- a/versions/k-/kf5config.json
+++ b/versions/k-/kf5config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1bd7078c91196234f1c9686533b7d7a32236cbd7",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "79afbe3512b5e5d144212f69294ed2859f2df3e9",
       "version": "5.81.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
 `kf5config `failed with parallel problem like this:
```
Installing in D:/packages/kf5config_x64-windows-static/debug. Run D:/buildtrees/kf5config/x64-windows-static-dbg/prefix.sh to set the environment for KConfig.
-- Looking for __GLIBC__
-- Looking for __GLIBC__ - not found
CMake Error at D:/installed/x64-windows-static/share/ECM/kde-modules/KDEClangFormat.cmake:67 (configure_file):
  Permission denied
Call Stack (most recent call first):
  D:/installed/x64-windows-static/share/ECM/kde-modules/KDEFrameworkCompilerSettings.cmake:79 (include)
  CMakeLists.txt:32 (include)
```
Related PR:  #18295

Note: No feature needs to test.


