### PR TITLE
[redis-plus-plus] update to 1.2.3 

### DIFF
--- a/ports/redis-plus-plus/CONTROL
+++ b/ports/redis-plus-plus/CONTROL
@@ -1,9 +1,0 @@
-Source: redis-plus-plus
-Version: 1.2.1
-Port-Version: 1
-Homepage: https://github.com/sewenew/redis-plus-plus
-Description: This is a C++ client for Redis. It's based on hiredis, and written in C++ 11.
-Build-Depends: hiredis
-
-Feature: cxx17
-Description: Build redis-plus-plus with cxx 17 standard

--- a/ports/redis-plus-plus/fix-conversion.patch
+++ b/ports/redis-plus-plus/fix-conversion.patch
@@ -1,8 +1,8 @@
 diff --git a/src/sw/redis++/shards.cpp b/src/sw/redis++/shards.cpp
-index e06d2a7..273d039 100644
+index c5baf5a..08e96cd 100644
 --- a/src/sw/redis++/shards.cpp
 +++ b/src/sw/redis++/shards.cpp
-@@ -39,7 +39,7 @@ std::pair<Slot, Node> RedirectionError::_parse_error(const std::string &msg) con
+@@ -41,7 +41,7 @@ std::pair<Slot, Node> RedirectionError::_parse_error(const std::string &msg) con
          auto host = msg.substr(space_pos + 1, colon_pos - space_pos - 1);
          auto port = std::stoi(msg.substr(colon_pos + 1));
  

--- a/ports/redis-plus-plus/fix-ws2-linking-windows.patch
+++ b/ports/redis-plus-plus/fix-ws2-linking-windows.patch
@@ -1,12 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index eb3ff66..1309213 100644
+index 452cc0f..90932ce 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -77,6 +77,7 @@ if (REDIS_PLUS_PLUS_BUILD_SHARED)
+@@ -148,6 +148,7 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
          target_compile_definitions(${SHARED_LIB} PRIVATE NOMINMAX)
-         set_target_properties(${SHARED_LIB} PROPERTIES CXX_STANDARD ${REDIS_PLUS_PLUS_CXX_STANDARD} CXX_EXTENSIONS OFF)
+         set_target_properties(${SHARED_LIB} PROPERTIES CXX_STANDARD ${REDIS_PLUS_PLUS_CXX_STANDARD})
          set_target_properties(${SHARED_LIB} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-+        target_link_libraries(${SHARED_LIB} Ws2_32.lib)
++        target_link_libraries(${SHARED_LIB} PUBLIC Ws2_32.lib)
+     else()
+         target_compile_options(${SHARED_LIB} PRIVATE "-Wall" "-W" "-Werror")
      endif()
- 
-     target_link_libraries(${SHARED_LIB} ${HIREDIS_LIB})

--- a/ports/redis-plus-plus/portfile.cmake
+++ b/ports/redis-plus-plus/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sewenew/redis-plus-plus
-    REF a9f9c301f8de1c181e6d45c573b5d1fe7b8200b1 # 1.2.1
-    SHA512 038641a91a2d62f8b07b548fb16f03e87a014fc3a53e59d95e9d31d707e800de4922838bc1bc181d642bb6ac23eae877e0a8724548d9d8f113ebc8d744384abf
+    REF df522812ba4114f1dd3386b81afc2369c82b717d # 1.2.3
+    SHA512 2ac59c5416ba85a60061d941787cb3bc2e43042ca0a53829f866448015ed6800c38ecbde3319d9756a70bfba2860732136d89d296382a6b9a675bbe32173f22b
     HEAD_REF master
     PATCHES
         fix-ws2-linking-windows.patch
@@ -39,6 +39,7 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright )

--- a/ports/redis-plus-plus/vcpkg.json
+++ b/ports/redis-plus-plus/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "redis-plus-plus",
+  "version-semver": "1.2.3",
+  "description": "This is a C++ client for Redis. It's based on hiredis, and written in C++ 11",
+  "homepage": "https://github.com/sewenew/redis-plus-plus",
+  "dependencies": [
+    "hiredis"
+  ],
+  "features": {
+    "cxx17": {
+      "description": "Build redis-plus-plus with cxx 17 standard"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5453,8 +5453,8 @@
       "port-version": 0
     },
     "redis-plus-plus": {
-      "baseline": "1.2.1",
-      "port-version": 1
+      "baseline": "1.2.3",
+      "port-version": 0
     },
     "refl-cpp": {
       "baseline": "0.12.0",

--- a/versions/r-/redis-plus-plus.json
+++ b/versions/r-/redis-plus-plus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a76da721b6b5c1820ccf60184f1c0aa44af788d",
+      "version-semver": "1.2.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4a1bafd6e609b8e012268c755d69566b8c29154",
       "version-string": "1.2.1",
       "port-version": 1


### PR DESCRIPTION
Fix #18331 

Update redis-plus-plus to the latest version 1.2.3

All features are tested successfully in the following triplets:
- x86-windows
- x64-windows-
- x64-windows-static