### PR TITLE
[open6254] Enable uwp support

### DIFF
--- a/ports/open62541/vcpkg.json
+++ b/ports/open62541/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "open62541",
   "version": "1.1.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "open62541 is an open source C (C99) implementation of OPC UA licensed under the Mozilla Public License v2.0.",
   "homepage": "https://open62541.org",
-  "supports": "!uwp",
   "default-features": [
     "openssl"
   ],

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1106,8 +1106,6 @@ ois:x64-uwp=fail
 # /usr/bin/ld: cannot find -lode
 ompl:x64-osx=fail
 ompl:x64-linux=fail
-open62541:arm-uwp=fail
-open62541:x64-uwp=fail
 openal-soft:arm-uwp=fail
 openal-soft:x64-uwp=fail
 openblas:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4478,7 +4478,7 @@
     },
     "open62541": {
       "baseline": "1.1.2",
-      "port-version": 1
+      "port-version": 2
     },
     "openal-soft": {
       "baseline": "1.21.1",

--- a/versions/o-/open62541.json
+++ b/versions/o-/open62541.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "98a37e8146a1e56f67a180b3c239f903ed59c401",
+      "version": "1.1.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "43c958ba9799820838fdf2332020ef83cacc4595",
       "version": "1.1.2",
       "port-version": 1


### PR DESCRIPTION
This PR enables uwp support for open62541. According to my tests, open62541 compiles fine on UWP, so the only thing necessary is to enable it in the conf files.

- #### What does your PR fix?  

This PR changes the `vcpkg.json` of open62541 to specify that uwp is supported.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

The `ci.baseline.txt` has been updated to remove the lines:
~~~
open62541:arm-uwp=fail
open62541:x64-uwp=fail
~~~
I left ` open62541:x64-windows-static-md=fail` as indeed the compilation on that triplet fails.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
