### PR TITLE
[uvatlas, spectra] ports updated

### DIFF
--- a/ports/spectra/CONTROL
+++ b/ports/spectra/CONTROL
@@ -1,5 +1,0 @@
-Source: spectra
-Version: 0.9.0
-Description: A header-only C++ library for large scale eigenvalue problems
-Homepage: https://spectralib.org
-Build-Depends: eigen3

--- a/ports/spectra/portfile.cmake
+++ b/ports/spectra/portfile.cmake
@@ -15,6 +15,5 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/spectra/portfile.cmake
+++ b/ports/spectra/portfile.cmake
@@ -6,5 +6,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/spectra RENAME copyright)
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/spectra/vcpkg.json
+++ b/ports/spectra/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "spectra",
+  "version": "0.9.0",
+  "port-version": 1,
+  "description": "A header-only C++ library for large scale eigenvalue problems",
+  "homepage": "https://spectralib.org",
+  "documentation": "https://spectralib.org/quick-start.html",
+  "license": "MPL-2.0",
+  "dependencies": [
+    "eigen3"
+  ]
+}

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -5,14 +5,20 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF jun2021
-    SHA512 f0ecba24c63214876f69eec2de7e5dd15e63aee20641e0989211f7dcab7182c7f6cb73960dbbc1504cd0fab18af8b024c8ee3bde087694d4acd3d1254b90f608
+    REF jun2021b
+    SHA512 d08bacacba324ddf60b003c5cbd5ad715bdbc1cf352a0dc9de58c40fd8f4bcbb562b8285ff1a443453399167a96e5b1af51d32ffc5e1e8f65391ef124c0706d4
     HEAD_REF master
 )
 
 if (VCPKG_HOST_IS_LINUX)
     message(WARNING "Build ${PORT} requires GCC version 9 or later")
 endif()
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        eigen ENABLE_USE_EIGEN
+)
 
 if(VCPKG_TARGET_IS_UWP)
   set(EXTRA_OPTIONS -DBUILD_TOOLS=OFF)
@@ -29,7 +35,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 
-if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
+if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
     URLS "https://github.com/Microsoft/UVAtlas/releases/download/jun2021/uvatlastool.exe"

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "uvatlas",
   "version-string": "jun2021b",
   "description": "UVAtlas isochart texture atlas",
-  "homepage": "http://go.microsoft.com/fwlink/?LinkID=512686",
+  "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",
   "license": "MIT",
   "supports": "windows | linux",

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-string": "jun2021",
+  "version-string": "jun2021b",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "http://go.microsoft.com/fwlink/?LinkID=512686",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",
@@ -17,5 +17,14 @@
       "name": "directxtex",
       "platform": "!(uwp | linux)"
     }
-  ]
+  ],
+  "features": {
+    "eigen": {
+      "description": "Use Eigen & Spectra for eigen-value computations",
+      "dependencies": [
+        "eigen3",
+        "spectra"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5918,7 +5918,7 @@
     },
     "spectra": {
       "baseline": "0.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "speex": {
       "baseline": "1.2.0",
@@ -6449,7 +6449,7 @@
       "port-version": 0
     },
     "uvatlas": {
-      "baseline": "jun2021",
+      "baseline": "jun2021b",
       "port-version": 0
     },
     "uvw": {

--- a/versions/s-/spectra.json
+++ b/versions/s-/spectra.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "937ae0076878470a646993b9de1e353411839da4",
+      "git-tree": "79e61cb55ecfe0e16944d963259bf758b5405a74",
       "version": "0.9.0",
       "port-version": 1
     },

--- a/versions/s-/spectra.json
+++ b/versions/s-/spectra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "937ae0076878470a646993b9de1e353411839da4",
+      "version": "0.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b33cdb035b8b412b662a052b66437743330fccde",
       "version-string": "0.9.0",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7593b43258fda8a9488ba03e8e00c88c64138e23",
+      "version-string": "jun2021b",
+      "port-version": 0
+    },
+    {
       "git-tree": "24f38b36247b90b011cb96c5b06728fa6b2f1011",
       "version-string": "jun2021",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7593b43258fda8a9488ba03e8e00c88c64138e23",
+      "git-tree": "60f3026412b95786a91eadb5e97483cb9539b8c1",
       "version-string": "jun2021b",
       "port-version": 0
     },


### PR DESCRIPTION
The **uvatlas** port was updated to add the [eigen] feature. This uses Eigen3 & Spectra instead of the 'home-rolled' eigenvalue solver.

> The original jun2021 release of uvtlas has a build option for Eigen3 & BLAS, but it turns out (a) it doesn't build correctly in vcpkg, (b) BLAS has some compatibility issues with Windows 10 SDK (20348), and (c) BLAS/OPENBLAS takes a really long time to build. I didn't add the [eigen] feature in the previous PR for this reason. The Spectra library is easier to integrate and is C++ header based like Eigen, so there was a minor upstream jun2021b release made for this.

When using **spectra**, I realized that the vcpkg port had been updated to version 0.9.0 without being updated to take advantage of the fact that upstream now has proper CMake install support. This port revision uses this new support. Also converted the ``CONTROL`` to ``vcpkg.json``.
