### PR TITLE
[vcpkg-cmake-config] documentation fix

### DIFF
--- a/docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md
+++ b/docs/maintainers/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.md
@@ -10,7 +10,7 @@ Additionally corrects common issues with targets, such as absolute paths and inc
 vcpkg_cmake_config_fixup(
     [PACKAGE_NAME <name>]
     [CONFIG_PATH <config-directory>]
-    [DO_NOT_DELETE_CONFIG_PATH_PARENT]
+    [DO_NOT_DELETE_PARENT_CONFIG_PATH]
     [NO_PREFIX_CORRECTION]
 )
 ```

--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-05-22"
+  "version-date": "2021-06-12"
 }

--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,4 +1,5 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-06-12"
+  "version-date": "2021-05-22",
+  "port-version": 1
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -9,7 +9,7 @@ Additionally corrects common issues with targets, such as absolute paths and inc
 vcpkg_cmake_config_fixup(
     [PACKAGE_NAME <name>]
     [CONFIG_PATH <config-directory>]
-    [DO_NOT_DELETE_CONFIG_PATH_PARENT]
+    [DO_NOT_DELETE_PARENT_CONFIG_PATH]
     [NO_PREFIX_CORRECTION]
 )
 ```

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6497,7 +6497,7 @@
       "port-version": 3
     },
     "vcpkg-cmake-config": {
-      "baseline": "2021-05-22",
+      "baseline": "2021-06-12",
       "port-version": 0
     },
     "vcpkg-gfortran": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6497,8 +6497,8 @@
       "port-version": 3
     },
     "vcpkg-cmake-config": {
-      "baseline": "2021-06-12",
-      "port-version": 0
+      "baseline": "2021-05-22",
+      "port-version": 1
     },
     "vcpkg-gfortran": {
       "baseline": "3",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "17057962d2240609d9be39740e4dadac27d1d82d",
-      "version-date": "2021-06-12",
-      "port-version": 0
+      "git-tree": "55c2da88ae939c97d8d1a9068aeeebad352f324b",
+      "version-date": "2021-05-22",
+      "port-version": 1
     },
     {
       "git-tree": "2d4f997a32b8e8bfe98d12beb2bfe6be713c7086",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "17057962d2240609d9be39740e4dadac27d1d82d",
+      "version-date": "2021-06-12",
+      "port-version": 0
+    },
+    {
       "git-tree": "2d4f997a32b8e8bfe98d12beb2bfe6be713c7086",
       "version-date": "2021-05-22",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes mistake in vcpkg_cmake_config_fixup example: It said `DO_NOT_DELETE_CONFIG_PATH_PARENT` when it should have said *`DO_NOT_DELETE_PARENT_CONFIG_PATH`*.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All. No need.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
