### PR TITLE
[Pkgconf] pkg-config compatibility feature

### DIFF
--- a/ports/pkgconf/portfile.cmake
+++ b/ports/pkgconf/portfile.cmake
@@ -18,6 +18,11 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 vcpkg_copy_tools(TOOL_NAMES pkgconf AUTO_CLEAN)
+if("pkg-config-compat" IN_LIST FEATURES)
+    configure_file("${CURRENT_PACKAGES_DIR}/tools/${PORT}/pkgconf${VCPKG_TARGET_EXECUTABLE_SUFFIX}" 
+                   "${CURRENT_PACKAGES_DIR}/tools/${PORT}/pkg-config${VCPKG_TARGET_EXECUTABLE_SUFFIX}" COPYONLY)
+endif()
+
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pkgconf/vcpkg.json
+++ b/ports/pkgconf/vcpkg.json
@@ -1,7 +1,13 @@
 {
   "name": "pkgconf",
   "version": "1.7.4",
+  "port-version": 1,
   "description": "pkgconf is a program which helps to configure compiler and linker flags for development libraries. It is similar to pkg-config from freedesktop.org.",
   "homepage": "https://github.com/pkgconf/pkgconf",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "features": {
+    "pkg-config-compat": {
+      "description": "Install a copy of pkgconf with the name pkg-config. Useful for programs (like cmake) that only search for pkg-config and not pkgconf"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4838,7 +4838,7 @@
     },
     "pkgconf": {
       "baseline": "1.7.4",
-      "port-version": 0
+      "port-version": 1
     },
     "platform-folders": {
       "baseline": "4.0.0",

--- a/versions/p-/pkgconf.json
+++ b/versions/p-/pkgconf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84ca32b8c04d4bb972fe5bc5800573b69bc74baf",
+      "version": "1.7.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "75fe71378e6521fe0e14a82218a9430c831b9809",
       "version": "1.7.4",
       "port-version": 0


### PR DESCRIPTION
Cmake uses the "findPkgConfig module to find pkg-config and define functions to use it to find libraries and create imported targets. pkgconf is a drop in replacement for pkg-config that's easier to build on windows (pkg-config itself _can_ actually build on windows, with msvc just fine, however there are problems with static linking (that are being worked on), and most annoyingly, pkg-config depends on glib which depends on pkg-config, meaning you need to do a bootstrap process to get pkg-config to use the "system" glib.

Anyway, while cmake's FindPkgConfig module will work fine if you have pkgconf on the path and set PKG_CONFIG_EXECUTABLE to "pkgconf" or if you set the full path in PKG_CONFIG_EXECUTABLE, it won't look for pkgconf(.exe) using find_library, only pkg-config(.exe). pkgconf recommends creating a symlink named pkg-config to pkgconf if you're using pkgconf to replace pkg-config. Because symlinks are somewhat fought on windows I just created a copy, pkgconf isn't that big.

I came across this problem when using ffmpeg, I don't want to use the vcpkg specific cmake config file provided by vcpkg, and I'd rather not vendor a find module, so the best way to find it is to use pkg-config, as upstream supports. With this patch my program can just depend on pkgconf[pkg-config-compat] and everything works with no vcpkg specific code at all in my cmake.

