### PR TITLE
[openblas] Typo on dependency of simplethread feature in openblas

### DIFF
--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "default-features": [

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -14,7 +14,7 @@
         {
           "name": "openblas",
           "features": [
-            "thread"
+            "threads"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4490,7 +4490,7 @@
     },
     "openblas": {
       "baseline": "0.3.10",
-      "port-version": 1
+      "port-version": 2
     },
     "opencascade": {
       "baseline": "7.5.0",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bce61f19c6ebfe98fe4408cfa6d94ee817f6ca96",
+      "version": "0.3.10",
+      "port-version": 2
+    },
+    {
       "git-tree": "b2beefd63c302b41dc5699ea88b825659c86ac2d",
       "version": "0.3.10",
       "port-version": 1

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bce61f19c6ebfe98fe4408cfa6d94ee817f6ca96",
+      "git-tree": "12affc47c11b93c81fb871d39424101759a7f512",
       "version": "0.3.10",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes a typo on the port of `openblas` during the PR https://github.com/microsoft/vcpkg/pull/18265

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  not relevant

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes


Tested with different features.

```bash
tonyxiang@L-AW88SO:~/vcpkg$ ./vcpkg install openblas[core] --dry-run
Computing installation plan...
The following packages will be built and installed:
    openblas[core]:x64-linux -> 0.3.10#2
tonyxiang@L-AW88SO:~/vcpkg$ ./vcpkg install openblas --dry-run
Computing installation plan...
The following packages will be built and installed:
    openblas[core,threads]:x64-linux -> 0.3.10#2
tonyxiang@L-AW88SO:~/vcpkg$ ./vcpkg install openblas[threads] --dry-run
Computing installation plan...
The following packages will be built and installed:
    openblas[core,threads]:x64-linux -> 0.3.10#2
tonyxiang@L-AW88SO:~/vcpkg$ ./vcpkg install openblas[simplethread] --dry-run
Computing installation plan...
The following packages will be built and installed:
    openblas[core,simplethread,threads]:x64-linux -> 0.3.10#2
```