### PR TITLE
[ffmpeg] Honor macosx deployment target for ffmpeg

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -220,9 +220,12 @@ else()
     set(SHELL /bin/sh)
 endif()
 
-if(VCPKG_TARGET_IS_OSX AND VCPKG_OSX_DEPLOYMENT_TARGET)
-    set(OPTIONS "--extra-cflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
-    set(OPTIONS "--extra-ldflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if(VCPKG_TARGET_IS_OSX AND VCPKG_DETECTED_CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(OPTIONS "--extra-cflags=-mmacosx-version-min=${VCPKG_DETECTED_CMAKE_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
+    set(OPTIONS "--extra-ldflags=-mmacosx-version-min=${VCPKG_DETECTED_CMAKE_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
 endif()
 
 set(ENV{${INCLUDE_VAR}} "${CURRENT_INSTALLED_DIR}/include${VCPKG_HOST_PATH_SEPARATOR}$ENV{${INCLUDE_VAR}}")
@@ -548,9 +551,6 @@ if("zlib" IN_LIST FEATURES)
 else()
     set(OPTIONS "${OPTIONS} --disable-zlib")
 endif()
-
-vcpkg_cmake_get_vars(cmake_vars_file)
-include("${cmake_vars_file}")
 
 if (VCPKG_TARGET_IS_OSX)
     # if the sysroot isn't set in the triplet we fall back to whatever CMake detected for us

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -220,6 +220,11 @@ else()
     set(SHELL /bin/sh)
 endif()
 
+if(VCPKG_TARGET_IS_OSX AND VCPKG_OSX_DEPLOYMENT_TARGET)
+    set(OPTIONS "--extra-cflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
+    set(OPTIONS "--extra-ldflags=-mmacosx-version-min=${VCPKG_OSX_DEPLOYMENT_TARGET} ${OPTIONS}")
+endif()
+
 set(ENV{${INCLUDE_VAR}} "${CURRENT_INSTALLED_DIR}/include${VCPKG_HOST_PATH_SEPARATOR}$ENV{${INCLUDE_VAR}}")
 
 set(_csc_PROJECT_PATH ffmpeg)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 14,
+  "port-version": 15,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2022,7 +2022,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 14
+      "port-version": 15
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "adbff70b914d111ca076f7d41421bc8c78436fde",
+      "git-tree": "24cb6ddcd146248cb3758ec1aa4c038b28d4c0c5",
       "version": "4.4",
       "port-version": 15
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "adbff70b914d111ca076f7d41421bc8c78436fde",
+      "version": "4.4",
+      "port-version": 15
+    },
+    {
       "git-tree": "5d893a1c421f553fbdd9c1f79530a6a84bd0eb76",
       "version": "4.4",
       "port-version": 14


### PR DESCRIPTION
Ports that are not CMake-based, which includes most nominally ports using Autotools, ignore options like VCPKG_OSX_DEPLOYMENT_TARGET. This is not an issue for our normal triplets, since they don't set this flag anyway, but when used in manifest mode it's common to set this to the same deployment target as the software it's used in.

This PR makes ffmpeg honor this flag by setting the correct c- and linker flags.

- #### What does your PR fix?  
Fixes ffmpeg ignoring VCPKG_MACOSX_DEPLOYMENT_TARGET

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No changes to triplets, ci baseline is not updated

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Versions have been updated. 

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
