### PR TITLE
[boost-python] Allow feature python2 on Unix

### DIFF
--- a/ports/boost-python/vcpkg.json
+++ b/ports/boost-python/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-python",
   "version": "1.76.0",
+  "port-version": 1,
   "description": "Boost python module",
   "homepage": "https://github.com/boostorg/python",
   "supports": "!uwp & !(arm & windows) & !emscripten",
@@ -41,10 +42,7 @@
     "python2": {
       "description": "Build with Python2 support",
       "dependencies": [
-        {
-          "name": "python2",
-          "platform": "windows"
-        }
+        "python2"
       ]
     }
   }

--- a/scripts/boost/generate-ports.ps1
+++ b/scripts/boost/generate-ports.ps1
@@ -27,6 +27,7 @@ else
 # Clear this array when moving to a new boost version
 $port_versions = @{
     #e.g.  "asio" = 1;
+    "python" = 1;
 }
 
 $per_port_data = @{
@@ -57,7 +58,7 @@ $per_port_data = @{
         "supports" = "!uwp&!(arm&windows)&!emscripten";
         "features" = @{
             python2=@{
-                dependencies=@(@{name="python2"; platform="windows"})
+                dependencies=@("python2")
                 description="Build with Python2 support"
             }
         }

--- a/versions/b-/boost-python.json
+++ b/versions/b-/boost-python.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "789047e74a9db18c96ada8dc7addda4fc867360e",
+      "version": "1.76.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "22a76d7b62c1e7eab693c827b1ca942acdb46a1b",
       "version": "1.76.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -854,7 +854,7 @@
     },
     "boost-python": {
       "baseline": "1.76.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-qvm": {
       "baseline": "1.76.0",


### PR DESCRIPTION
Since #18219 it is possible to build python2 for Unix. This PR also removes OS restrictions from python2 feature of boost-python.
