### PR TITLE
[function2] Update to version 4.2.0

### DIFF
--- a/ports/function2/CONTROL
+++ b/ports/function2/CONTROL
@@ -1,4 +1,4 @@
 Source: function2
-Version: 4.1.0
+Version: 4.2.0
 Homepage: https://github.com/Naios/function2
 Description: Improved drop-in replacement to std::function

--- a/ports/function2/portfile.cmake
+++ b/ports/function2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Naios/function2
-    REF 3a0746bf5f601dfed05330aefcb6854354fce07d # 4.1.0
-    SHA512 48dd8fb1ce47df0835c03edf78ae427beebfeeaaabf6b993eb02843f72cce796ba5d1042f505990f29debd42bc834e531335484d45ca33e841657e9ff9e5034f
+    REF 02ca99831de59c7c3a4b834789260253cace0ced # 4.2.0
+    SHA512 5b14d95584586c7365119f5171c86c7556ce402ae3c5db09e4e54e1225fc71e40f88ab77188986ecf9dac5eecbfd6330c5a7ecfe0375cb37773d007ebef1ba93
     HEAD_REF master
     PATCHES
         disable-testing.patch

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2121,7 +2121,7 @@
       "port-version": 0
     },
     "function2": {
-      "baseline": "4.1.0",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "functions-framework-cpp": {

--- a/versions/f-/function2.json
+++ b/versions/f-/function2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "844aa89a1d4dabf3d084f060c7b8036b1ba69f06",
+      "version-string": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e02d8c31f298e37fe21781f8114c31ae29a1e73",
       "version-string": "4.1.0",
       "port-version": 0


### PR DESCRIPTION
Update function2 to version 4.2.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
all / Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

