### PR TITLE
[flashlight-cuda] Fix installation

### DIFF
--- a/ports/flashlight-cuda/portfile.cmake
+++ b/ports/flashlight-cuda/portfile.cmake
@@ -19,19 +19,18 @@ set(FL_DEFAULT_VCPKG_CMAKE_FLAGS
   -DFL_BUILD_EXAMPLES=OFF
   -DFL_BACKEND=CUDA # this port is CUDA-backend only
   -DFL_BUILD_STANDALONE=OFF
-  -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/${PORT} # for CMake configs/targets
 )
 
 # Determine which components to build via specified feature
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-    lib FL_BUILD_LIBRARIES
-    fl FL_BUILD_CORE
-    asr FL_BUILD_APP_ASR
-    imgclass FL_BUILD_APP_IMGCLASS
-    lm FL_BUILD_APP_LM
-    objdet FL_BUILD_APP_OBJDET
+        lib FL_BUILD_LIBRARIES
+        fl FL_BUILD_CORE
+        asr FL_BUILD_APP_ASR
+        imgclass FL_BUILD_APP_IMGCLASS
+        lm FL_BUILD_APP_LM
+        objdet FL_BUILD_APP_OBJDET
 )
 
 # Build and install
@@ -41,10 +40,14 @@ vcpkg_configure_cmake(
     OPTIONS 
         ${FL_DEFAULT_VCPKG_CMAKE_FLAGS} 
         ${FEATURE_OPTIONS}
+    OPTIONS_DEBUG
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/debug/share/flashlight    
+    OPTIONS_RELEASE        
+        -DFL_INSTALL_CMAKE_DIR=${CURRENT_PACKAGES_DIR}/share/flashlight
 )
 vcpkg_install_cmake()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/flashlight-cuda TARGET_PATH share/flashlight)
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/flashlight TARGET_PATH share/flashlight)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/flashlight-cuda/vcpkg.json
+++ b/ports/flashlight-cuda/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "flashlight-cuda",
   "version": "0.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C++ standalone library for machine learning. CUDA backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
   "supports": "!(windows | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2018,7 +2018,7 @@
     },
     "flashlight-cuda": {
       "baseline": "0.3",
-      "port-version": 1
+      "port-version": 2
     },
     "flatbuffers": {
       "baseline": "1.12.0",

--- a/versions/f-/flashlight-cuda.json
+++ b/versions/f-/flashlight-cuda.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afbc9bcce8e115033ecd9d1c64c2b4375c556e67",
+      "version": "0.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "9147d15ccbb61b2de168a8cc78527341edf1540d",
       "version": "0.3",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18361

```
CMake Error at scripts/cmake/vcpkg_fixup_cmake_targets.cmake:95 (message):

   '/home/user/vcpkg/packages/flashlight-cuda_x64-linux/debug/share/flashlight-cuda'
  does not exist.
Call Stack (most recent call first):
  ports/flashlight-cuda/portfile.cmake:47 (vcpkg_fixup_cmake_targets)
  scripts/ports.cmake:139 (include)
```


