### PR TITLE
[libgpg-error] Remove COPYING.LIB from lib folder

### DIFF
--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -67,6 +67,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     configure_file("${SOURCE_PATH}/src/gpg-error.pc.in" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gpg-error.pc" @ONLY)
     vcpkg_fixup_pkgconfig()
     vcpkg_copy_pdbs()
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/COPYING.LIB" "${CURRENT_PACKAGES_DIR}/debug/lib/COPYING.LIB")
 else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
@@ -74,8 +75,8 @@ else()
         REF libgpg-error-${PACKAGE_VERSION}
         SHA512 f5a1c1874ac1dee36ee01504f1ab0146506aa7af810879e192eac17a31ec81945fe850953ea1c57188590c023ce3ff195c7cab62af486b731fa1534546d66ba3
         HEAD_REF master
-    PATCHES
-        add_cflags_to_tools.patch
+        PATCHES
+            add_cflags_to_tools.patch
     )
 
     vcpkg_configure_make(
@@ -91,6 +92,6 @@ else()
     vcpkg_fixup_pkgconfig() 
     vcpkg_copy_pdbs()
 
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/locale ${CURRENT_PACKAGES_DIR}/debug/share)
-    file(INSTALL ${SOURCE_PATH}/COPYING.LIB DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/locale" "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 endif()

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libgpg-error",
   "version": "1.42",
+  "port-version": 1,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
   "supports": "!(windows & (arm | arm64))"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3178,7 +3178,7 @@
     },
     "libgpg-error": {
       "baseline": "1.42",
-      "port-version": 0
+      "port-version": 1
     },
     "libgpod": {
       "baseline": "2019-08-29",

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5abbf9cf832337e202ff5d8d4296025b47be1a0",
+      "version": "1.42",
+      "port-version": 1
+    },
+    {
       "git-tree": "80b315c6991fd5092637d010433ebfcbcbfda92d",
       "version": "1.42",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  

Currently, `libgpg-error` installs `COPYING.LIB` to _lib_ and _debug/lib_ folders, which will cause the following errors when building some ports in [latest CI stable test](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4874087&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=491b9f02-7edc-5990-cda1-511e95a3768e).

```
D:\installed\x64-windows\lib\COPYING.LIB : fatal error LNK1107: invalid or corrupt file: cannot read at 0x679F [D:\buildtrees\libirecovery\x64-windows-rel\1.0.25-bfb41f9807.clean\libirecovery.vcxproj]

D:\installed\x64-windows\lib\COPYING.LIB : fatal error LNK1107: invalid or corrupt file: cannot read at 0x679F [D:\buildtrees\usbmuxd\x64-windows-rel\0ef8b6f751-8a2849754f.clean\usbmuxd.vcxproj]

D:\installed\x64-windows\lib\COPYING.LIB : fatal error LNK1107: invalid or corrupt file: cannot read at 0x679F [D:\buildtrees\ocilib\x64-windows-rel\4fc7a69e6d-337dbe59ca.clean\proj\dll\ocilib_dll_vs2019.vcxproj]

D:\installed\x64-windows\lib\COPYING.LIB : fatal error LNK1107: invalid or corrupt file: cannot read at 0x679F [D:\buildtrees\libfabric\x64-windows-rel\v1.8.1-308a2d3549.clean\libfabric.vcxproj]

D:\installed\x64-windows\lib\COPYING.LIB : fatal error LNK1107: invalid or corrupt file: cannot read at 0x679F [D:\buildtrees\ideviceinstaller\x64-windows-rel\1.1.2.23-51eb34ebea.clean\ideviceinstaller.vcxproj]
```
Since `COPYING.LIB` is a license file instead of a general binary, removing `COPYING.LIB` from _lib_ and _debug/lib_ to fix this problem.

Note: No feature needs to test.
  

