### PR TITLE
[gtest] Update to 1.11.0

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -5,8 +5,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/googletest
-    REF f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4 #commite on 2021-04-29
-    SHA512 8168cc2b2c2f18ae7411db8a74369c98bb2d19b5be94a5a5f96a1d4e8e22b70c219c1cdfaef934b674d9c078dd97d0481c62e382aab432e3b89aa79ea5051673
+    REF release-1.11.0
+    SHA512 6fcc7827e4c4d95e3ae643dd65e6c4fc0e3d04e1778b84f6e06e390410fe3d18026c131d828d949d2f20dde6327d30ecee24dcd3ef919e21c91e010d149f3a28
     HEAD_REF master
     PATCHES
         fix-main-lib-path.patch

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtest",
-  "version": "1.11.0",
+  "version-semver": "1.11.0",
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest"
 }

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtest",
-  "version-date": "2021-05-07",
+  "version": "1.11.0",
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2417,7 +2417,7 @@
       "port-version": 0
     },
     "gtest": {
-      "baseline": "2021-05-07",
+      "baseline": "1.11.0",
       "port-version": 0
     },
     "gtk": {

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "cc0d3193b6c3bcf748f51d13d1c9910dfebc1c5d",
-      "version": "1.11.0",
+      "git-tree": "8dd6b8fb34e78fd1646f5d98720dd563d4a38a33",
+      "version-semver": "1.11.0",
       "port-version": 0
     },
     {

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc0d3193b6c3bcf748f51d13d1c9910dfebc1c5d",
+      "version": "1.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "c37414d7a3b02afc05799bf525acb49c5ee060d1",
       "version-date": "2021-05-07",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updating to new 1.11.0 release. There are some compiler errors fixed compared to the current vcpkg version.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
