### PR TITLE
[spdlog] Update to 1.9.0

### DIFF
--- a/ports/spdlog/fix-mingw-build.patch
+++ b/ports/spdlog/fix-mingw-build.patch
@@ -2,12 +2,12 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b969465..31e23cd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -136,7 +136,7 @@ if(SPDLOG_BUILD_SHARED OR BUILD_SHARED_LIBS)
+@@ -142,7 +142,7 @@ if(SPDLOG_BUILD_SHARED OR BUILD_SHARED_LIBS)
      endif()
      add_library(spdlog SHARED ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
      target_compile_definitions(spdlog PUBLIC SPDLOG_SHARED_LIB)
 -    if(MSVC)
 +    if(MSVC AND NOT MINGW)
-         target_compile_options(spdlog PUBLIC 
-             $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/wd4251 /wd4275>)
+         target_compile_options(spdlog PUBLIC $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/wd4251
+                                             /wd4275>)
      endif()

--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gabime/spdlog
-    REF v1.8.5
-    SHA512 77cc9df0c40bbdbfe1f3e5818dccf121918bfceac28f2608f39e5bf944968b7e8e24a6fc29f01bc58a9bae41b8892d49cfb59c196935ec9868884320b50f130c
+    REF v1.9.0
+    SHA512 df023847e49b2ad8e5dc4cb681d31515bb7f87644a4baa946836cf3cb4114bb95ad603b746969e0e7f8220d3bfa453220c00dfde812f1e610801a5cc62e1f0f2
     HEAD_REF v1.x
     PATCHES fix-mingw-build.patch
 )

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spdlog",
-  "version-semver": "1.8.5",
-  "port-version": 4,
+  "version-semver": "1.9.0",
+  "port-version": 1,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5957,8 +5957,8 @@
       "port-version": 0
     },
     "spdlog": {
-      "baseline": "1.8.5",
-      "port-version": 4
+      "baseline": "1.9.0",
+      "port-version": 1
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "580c9da088d8545f17b4b5753b4216ddb2ea977f",
+      "version-semver": "1.9.0",
+      "port-version": 1
+    },    
+    {
       "git-tree": "ac601a8d86ea3edc831933ad7e12eee11ac6e6db",
       "version-semver": "1.8.5",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates spdlog to 1.9.0 to fix [build issue](https://github.com/gabime/spdlog/commit/6442963f49526423a13c160883cec881e9667fe7) on latest VS with /W4

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

