### PR TITLE
[scripts-audit] vcpkg_extract_source_archive

### DIFF
--- a/docs/maintainers/vcpkg_extract_source_archive.md
+++ b/docs/maintainers/vcpkg_extract_source_archive.md
@@ -2,27 +2,72 @@
 
 The latest version of this document lives in the [vcpkg repo](https://github.com/Microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_extract_source_archive.md).
 
-Extract an archive into the source directory. Deprecated in favor of [`vcpkg_extract_source_archive_ex`](vcpkg_extract_source_archive_ex.md).
+Extract an archive into the source directory.
 
 ## Usage
+There are two "overloads" of this function. The first is deprecated:
+
 ```cmake
-vcpkg_extract_source_archive(
-    <${ARCHIVE}> [<${TARGET_DIRECTORY}>]
+vcpkg_extract_source_archive(<${ARCHIVE}> [<${TARGET_DIRECTORY}>])
+```
+
+This overload should not be used.
+
+The latter is suggested to use for all future `vcpkg_extract_source_archive`s.
+
+```cmake
+vcpkg_extract_source_archive(<out-var>
+    ARCHIVE <path>
+    [NO_REMOVE_ONE_LEVEL]
+    [PATCHES <patch>...]
+    [SOURCE_BASE <base>]
+    [BASE_DIRECTORY <relative-path>]
 )
 ```
-## Parameters
-### ARCHIVE
-The full path to the archive to be extracted.
 
-This is usually obtained from calling [`vcpkg_download_distfile`](vcpkg_download_distfile.md).
+`vcpkg_extract_source_archive` takes an archive and extracts it.
+It replaces existing uses of `vcpkg_extract_source_archive_ex`.
+The simplest use of it is:
 
-### TARGET_DIRECTORY
-If specified, the archive will be extracted into the target directory instead of `${CURRENT_BUILDTREES_DIR}/src/`.
+```cmake
+vcpkg_download_distfile(archive ...)
+vcpkg_extract_source_archive(source_path ARCHIVE "${archive}")
+```
 
-This can be used to mimic git submodules, by extracting into a subdirectory of another archive.
+The general expectation is that an archives are laid out with a base directory,
+and all the actual files underneath that directory; in other words, if you
+extract the archive, you'll get something that looks like:
 
-## Notes
-This command will also create a tracking file named <FILENAME>.extracted in the TARGET_DIRECTORY. This file, when present, will suppress the extraction of the archive.
+```
+zlib-1.2.11/
+    doc/
+        ...
+    examples/
+        ...
+    ChangeLog
+    CMakeLists.txt
+    README
+    zlib.h
+    ...
+```
+
+`vcpkg_extract_source_archive` automatically removes this directory,
+and gives you the items under it directly. However, this only works
+when there is exactly one item in the top level of an archive.
+Otherwise, you'll have to pass the `NO_REMOVE_ONE_LEVEL` argument to
+prevent `vcpkg_extract_source_archive` from performing this transformation.
+
+If the source needs to be patched in some way, the `PATCHES` argument
+allows one to do this, just like other `vcpkg_from_*` functions.
+
+`vcpkg_extract_source_archive` extracts the files to
+`${CURRENT_BUILDTREES_DIR}/<base-directory>/<source-base>-<hash>.clean`.
+When in editable mode, no `.clean` is appended,
+to allow for a user to modify the sources.
+`base-directory` defaults to `src`,
+and `source-base` defaults to the stem of `<archive>`.
+You can change these via the `BASE_DIRECTORY` and `SOURCE_BASE` arguments
+respectively.
 
 ## Examples
 

--- a/docs/maintainers/vcpkg_extract_source_archive_ex.md
+++ b/docs/maintainers/vcpkg_extract_source_archive_ex.md
@@ -2,7 +2,10 @@
 
 The latest version of this document lives in the [vcpkg repo](https://github.com/Microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_extract_source_archive_ex.md).
 
-Extract an archive into the source directory. Replaces [`vcpkg_extract_source_archive`](vcpkg_extract_source_archive.md).
+Extract an archive into the source directory.
+Originally replaced `vcpkg_extract_source_archive`,
+but new ports should instead use the second overload of
+`vcpkg_extract_source_archive`.
 
 ## Usage
 ```cmake

--- a/ports/avisynthplus/portfile.cmake
+++ b/ports/avisynthplus/portfile.cmake
@@ -15,8 +15,8 @@ vcpkg_download_distfile(GHC_ARCHIVE
 )
 
 file(REMOVE_RECURSE ${SOURCE_PATH}/filesystem)
-vcpkg_extract_source_archive(${GHC_ARCHIVE} ${SOURCE_PATH})
-file(RENAME ${SOURCE_PATH}/filesystem-3f1c185ab414e764c694b8171d1c4d8c5c437517 ${SOURCE_PATH}/filesystem)
+vcpkg_extract_source_archive(extracted_archive ARCHIVE "${GHC_ARCHIVE}")
+file(RENAME "${extracted_archive}" "${SOURCE_PATH}/filesystem")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/avisynthplus/vcpkg.json
+++ b/ports/avisynthplus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "avisynthplus",
   "version-semver": "3.7.0",
+  "port-version": 1,
   "description": "An improved version of the AviSynth frameserver, with improved features and developer friendliness",
   "homepage": "http://avs-plus.net/",
   "supports": "!arm & !uwp"

--- a/ports/bond/CONTROL
+++ b/ports/bond/CONTROL
@@ -1,9 +1,0 @@
-Source: bond
-Version: 9.0.3
-Description: Bond is a cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data. Bond is broadly used at Microsoft in high scale services.
-Homepage: https://github.com/Microsoft/bond
-Build-Depends: rapidjson, boost-config, boost-utility, boost-assign, boost-locale
-
-Feature: bond-over-grpc
-Description: Bond-over-gRPC provides code generation from Bond IDL service definitions to send Bond objects via gRPC.
-Build-Depends: grpc

--- a/ports/bond/portfile.cmake
+++ b/ports/bond/portfile.cmake
@@ -21,13 +21,10 @@ if (VCPKG_TARGET_IS_WINDOWS)
     # Clear the generator to prevent it from updating
     file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/tools/)
     # Extract the precompiled gbc
-    vcpkg_extract_source_archive(${GBC_ARCHIVE} ${CURRENT_BUILDTREES_DIR}/tools/)
-    set(FETCHED_GBC_PATH ${CURRENT_BUILDTREES_DIR}/tools/gbc-${BOND_VER}-amd64.exe)
-
-    if (NOT EXISTS "${FETCHED_GBC_PATH}")
-        message(FATAL_ERROR "Fetching GBC failed. Expected '${FETCHED_GBC_PATH}' to exists, but it doesn't.")
-    endif()
-
+    vcpkg_extract_source_archive(extracted_tool_dir ARCHIVE "${GBC_ARCHIVE}" NO_REMOVE_ONE_LEVEL)
+    set(TOOL_NAME "gbc-${BOND_VER}-amd64.exe")
+    set(FETCHED_GBC_PATH "${CURRENT_BUILDTREES_DIR}/tools/${TOOL_NAME}")
+    file(RENAME "${extracted_tool_dir}/${TOOL_NAME}" "${FETCHED_GBC_PATH}")
 else()
     # According to the readme on https://github.com/microsoft/bond/
     # The build needs a version of the Haskel Tool stack that is newer than some distros ship with.

--- a/ports/bond/vcpkg.json
+++ b/ports/bond/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "bond",
+  "version-string": "9.0.3",
+  "port-version": 1,
+  "description": "Bond is a cross-platform framework for working with schematized data. It supports cross-language de/serialization and powerful generic mechanisms for efficiently manipulating data. Bond is broadly used at Microsoft in high scale services.",
+  "homepage": "https://github.com/Microsoft/bond",
+  "dependencies": [
+    "boost-assign",
+    "boost-config",
+    "boost-locale",
+    "boost-utility",
+    "rapidjson"
+  ],
+  "features": {
+    "bond-over-grpc": {
+      "description": "Bond-over-gRPC provides code generation from Bond IDL service definitions to send Bond objects via gRPC.",
+      "dependencies": [
+        "grpc"
+      ]
+    }
+  }
+}

--- a/ports/nmap/CONTROL
+++ b/ports/nmap/CONTROL
@@ -1,4 +1,0 @@
-Source: nmap
-Version: 7.70-4
-Build-Depends: winpcap (windows), libpcap (!windows), lua, openssl, python2 (windows), libssh2, zlib, pcre
-Description: A library for scanning network ports.

--- a/ports/nmap/portfile.cmake
+++ b/ports/nmap/portfile.cmake
@@ -62,8 +62,8 @@ else()
         file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${BUILD_TYPE})
         file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${BUILD_TYPE})
         # Since nmap makefile has strong relationshop with codes, copy codes to obj path
-        vcpkg_extract_source_archive(${ARCHIVE} ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${BUILD_TYPE})
-
+        vcpkg_extract_source_archive(extracted_directory ARCHIVE "${ARCHIVE}")
+        file(RENAME extracted_directory "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${BUILD_TYPE}")
     endforeach()
     set(OPTIONS --without-nmap-update --with-openssl=${CURRENT_INSTALLED_DIR} --with-libssh2=${CURRENT_INSTALLED_DIR} --with-libz=${CURRENT_INSTALLED_DIR} --with-libpcre=${CURRENT_INSTALLED_DIR})
     message(STATUS "Building Options: ${OPTIONS}")

--- a/ports/nmap/vcpkg.json
+++ b/ports/nmap/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "nmap",
+  "version": "7.70",
+  "port-version": 5,
+  "description": "A library for scanning network ports.",
+  "dependencies": [
+    {
+      "name": "libpcap",
+      "platform": "!windows"
+    },
+    "libssh2",
+    "lua",
+    "openssl",
+    "pcre",
+    {
+      "name": "python2",
+      "platform": "windows"
+    },
+    {
+      "name": "winpcap",
+      "platform": "windows"
+    },
+    "zlib"
+  ]
+}

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -135,9 +135,9 @@ if("contrib" IN_LIST FEATURES)
           FILENAME "opencv_3rdparty-${COMMIT}.zip"
           SHA512 ${HASH}
       )
-      vcpkg_extract_source_archive(${OCV_DOWNLOAD})
+      vcpkg_extract_source_archive(extracted_ocv ARCHIVE "${OCV_DOWNLOAD}")
       file(MAKE_DIRECTORY "${DOWNLOADS}/opencv-cache/${ID}")
-      file(GLOB XFEATURES2D_I ${CURRENT_BUILDTREES_DIR}/src/opencv_3rdparty-${COMMIT}/*)
+      file(GLOB XFEATURES2D_I "${extracted_ocv}/*")
       foreach(FILE ${XFEATURES2D_I})
         file(COPY ${FILE} DESTINATION "${DOWNLOADS}/opencv-cache/${ID}")
         get_filename_component(XFEATURES2D_I_NAME "${FILE}" NAME)

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.14",
+  "port-version": 1,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "dependencies": [

--- a/ports/qcustomplot/CONTROL
+++ b/ports/qcustomplot/CONTROL
@@ -1,4 +1,0 @@
-Source: qcustomplot
-Version: 2.0.1-4
-Description: QCustomPlot is a Qt C++ widget for plotting and data visualization.
-Build-Depends: qt5-base[core]

--- a/ports/qcustomplot/portfile.cmake
+++ b/ports/qcustomplot/portfile.cmake
@@ -16,7 +16,9 @@ vcpkg_download_distfile(ARCHIVE
     FILENAME "QCustomPlot-sharedlib-${QCP_VERSION}.tar.gz"
     SHA512 ce90540fca7226eac37746327e1939a9c7af38fc2595f385ed04d6d1f49560da08fb5fae15d1b9d22b6ba578583f70de8f89ef26796770d41bf599c1b15c535d
 )
-vcpkg_extract_source_archive(${ARCHIVE} ${SOURCE_PATH})
+vcpkg_extract_source_archive(SharedLib_SOURCE_PATH ARCHIVE "${ARCHIVE}")
+file(RENAME "${SharedLib_SOURCE_PATH}" "${SOURCE_PATH}/qcustomplot-sharedlib")
+
 
 vcpkg_configure_qmake(SOURCE_PATH
     ${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro

--- a/ports/qcustomplot/vcpkg.json
+++ b/ports/qcustomplot/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "qcustomplot",
+  "version": "2.0.1",
+  "port-version": 5,
+  "description": "QCustomPlot is a Qt C++ widget for plotting and data visualization.",
+  "dependencies": [
+    {
+      "name": "qt5-base",
+      "default-features": false
+    }
+  ]
+}

--- a/scripts/cmake/vcpkg_extract_source_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive.cmake
@@ -147,6 +147,9 @@ function(vcpkg_extract_source_archive)
             BASE_DIRECTORY "${CURRENT_PORT_DIR}"
             OUTPUT_VARIABLE absolute_patch
         )
+        if(NOT EXISTS "${absolute_patch}")
+            message(FATAL_ERROR "Could not find patch: '${patch}'")
+        endif()
         file(SHA512 "${absolute_patch}" current_hash)
         string(APPEND patchset_hash "${current_hash}")
     endforeach()

--- a/scripts/cmake/vcpkg_extract_source_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive.cmake
@@ -92,7 +92,8 @@ endfunction()
 
 function(vcpkg_extract_source_archive)
     if(ARGC LESS_EQUAL "2")
-        message(WARNING "Deprecated form of vcpkg_extract_source_archive used. Please use the newer form.")
+        z_vcpkg_deprecation_message( "Deprecated form of vcpkg_extract_source_archive used:
+    Please use the `vcpkg_extract_source_archive(<out-var> ARCHIVE <archive>)` form.")
         if(ARGC EQUAL "0")
             message(FATAL_ERROR "vcpkg_extract_source_archive requires at least one argument.")
         endif()

--- a/scripts/cmake/vcpkg_extract_source_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive.cmake
@@ -1,27 +1,72 @@
 #[===[.md:
 # vcpkg_extract_source_archive
 
-Extract an archive into the source directory. Deprecated in favor of [`vcpkg_extract_source_archive_ex`](vcpkg_extract_source_archive_ex.md).
+Extract an archive into the source directory.
 
 ## Usage
+There are two "overloads" of this function. The first is deprecated:
+
 ```cmake
-vcpkg_extract_source_archive(
-    <${ARCHIVE}> [<${TARGET_DIRECTORY}>]
+vcpkg_extract_source_archive(<${ARCHIVE}> [<${TARGET_DIRECTORY}>])
+```
+
+This overload should not be used.
+
+The latter is suggested to use for all future `vcpkg_extract_source_archive`s.
+
+```cmake
+vcpkg_extract_source_archive(<out-var>
+    ARCHIVE <path>
+    [NO_REMOVE_ONE_LEVEL]
+    [PATCHES <patch>...]
+    [SOURCE_BASE <base>]
+    [BASE_DIRECTORY <relative-path>]
 )
 ```
-## Parameters
-### ARCHIVE
-The full path to the archive to be extracted.
 
-This is usually obtained from calling [`vcpkg_download_distfile`](vcpkg_download_distfile.md).
+`vcpkg_extract_source_archive` takes an archive and extracts it.
+It replaces existing uses of `vcpkg_extract_source_archive_ex`.
+The simplest use of it is:
 
-### TARGET_DIRECTORY
-If specified, the archive will be extracted into the target directory instead of `${CURRENT_BUILDTREES_DIR}/src/`.
+```cmake
+vcpkg_download_distfile(archive ...)
+vcpkg_extract_source_archive(source_path ARCHIVE "${archive}")
+```
 
-This can be used to mimic git submodules, by extracting into a subdirectory of another archive.
+The general expectation is that an archives are laid out with a base directory,
+and all the actual files underneath that directory; in other words, if you
+extract the archive, you'll get something that looks like:
 
-## Notes
-This command will also create a tracking file named <FILENAME>.extracted in the TARGET_DIRECTORY. This file, when present, will suppress the extraction of the archive.
+```
+zlib-1.2.11/
+    doc/
+        ...
+    examples/
+        ...
+    ChangeLog
+    CMakeLists.txt
+    README
+    zlib.h
+    ...
+```
+
+`vcpkg_extract_source_archive` automatically removes this directory,
+and gives you the items under it directly. However, this only works
+when there is exactly one item in the top level of an archive.
+Otherwise, you'll have to pass the `NO_REMOVE_ONE_LEVEL` argument to
+prevent `vcpkg_extract_source_archive` from performing this transformation.
+
+If the source needs to be patched in some way, the `PATCHES` argument
+allows one to do this, just like other `vcpkg_from_*` functions.
+
+`vcpkg_extract_source_archive` extracts the files to
+`${CURRENT_BUILDTREES_DIR}/<base-directory>/<source-base>-<hash>.clean`.
+When in editable mode, no `.clean` is appended,
+to allow for a user to modify the sources.
+`base-directory` defaults to `src`,
+and `source-base` defaults to the stem of `<archive>`.
+You can change these via the `BASE_DIRECTORY` and `SOURCE_BASE` arguments
+respectively.
 
 ## Examples
 
@@ -30,25 +75,140 @@ This command will also create a tracking file named <FILENAME>.extracted in the 
 * [msgpack](https://github.com/Microsoft/vcpkg/blob/master/ports/msgpack/portfile.cmake)
 #]===]
 
-include(vcpkg_execute_required_process)
-
-function(vcpkg_extract_source_archive ARCHIVE)
-    if(NOT ARGC EQUAL 2)
-        set(WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/src")
-    else()
-        set(WORKING_DIRECTORY ${ARGV1})
-    endif()
-
-    get_filename_component(ARCHIVE_FILENAME "${ARCHIVE}" NAME)
-    if(NOT EXISTS ${WORKING_DIRECTORY}/${ARCHIVE_FILENAME}.extracted)
-        message(STATUS "Extracting source ${ARCHIVE}")
-        file(MAKE_DIRECTORY ${WORKING_DIRECTORY})
+function(z_vcpkg_extract_source_archive_deprecated_mode archive working_directory)
+    cmake_path(GET archive FILENAME archive_filename)
+    if(NOT EXISTS "${working_directory}/${archive_filename}.extracted")
+        message(STATUS "Extracting source ${archive}")
+        file(MAKE_DIRECTORY "${working_directory}")
         vcpkg_execute_required_process(
             ALLOW_IN_DOWNLOAD_MODE
-            COMMAND ${CMAKE_COMMAND} -E tar xjf ${ARCHIVE}
-            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            COMMAND "${CMAKE_COMMAND}" -E tar xjf "${archive}"
+            WORKING_DIRECTORY "${working_directory}"
             LOGNAME extract
         )
-        file(WRITE ${WORKING_DIRECTORY}/${ARCHIVE_FILENAME}.extracted)
+        file(TOUCH "${working_directory}/${archive_filename}.extracted")
     endif()
 endfunction()
+
+function(vcpkg_extract_source_archive)
+    if(ARGC LESS_EQUAL "2")
+        message(WARNING "Deprecated form of vcpkg_extract_source_archive used. Please use the newer form.")
+        if(ARGC EQUAL "0")
+            message(FATAL_ERROR "vcpkg_extract_source_archive requires at least one argument.")
+        endif()
+
+        set(archive "${ARGV0}")
+        if(ARGC EQUAL "1")
+            set(working_directory "${CURRENT_BUILDTREES_DIR}/src")
+        else()
+            set(working_directory "${ARGV1}")
+        endif()
+
+        z_vcpkg_extract_source_archive_deprecated_mode("${archive}" "${working_directory}")
+        return()
+    endif()
+
+    set(out_source_path "${ARGV0}")
+    cmake_parse_arguments(PARSE_ARGV 1 "arg"
+        "NO_REMOVE_ONE_LEVEL;Z_SKIP_PATCH_CHECK"
+        "ARCHIVE;SOURCE_BASE;BASE_DIRECTORY"
+        "PATCHES"
+    )
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+    if(NOT DEFINED arg_ARCHIVE)
+        message(FATAL_ERROR "ARCHIVE must be specified")
+    endif()
+
+    if(NOT DEFINED arg_BASE_DIRECTORY)
+        set(arg_BASE_DIRECTORY "src")
+    elseif(IS_ABSOLUTE arg_BASE_DIRECTORY)
+        message(FATAL_ERROR "BASE_DIRECTORY (${arg_BASE_DIRECTORY}) must be a relative path.")
+    endif()
+    if(NOT DEFINED arg_SOURCE_BASE)
+        cmake_path(GET arg_ARCHIVE STEM arg_SOURCE_BASE)
+    elseif(arg_SOURCE_BASE MATCHES [[\\|/]])
+        message(FATAL_ERROR "SOURCE_BASE (${arg_SOURCE_BASE}) must not contain slashes.")
+    endif()
+
+    # Take the last 10 chars of the base
+    set(base_max_length 10)
+    string(LENGTH "${arg_SOURCE_BASE}" source_base_length)
+    if(source_base_length GREATER base_max_length)
+        math(EXPR start "${source_base_length} - ${base_max_length}")
+        string(SUBSTRING "${arg_SOURCE_BASE}" "${start}" -1 arg_SOURCE_BASE)
+    endif()
+
+    # Hash the archive hash along with the patches. Take the first 10 chars of the hash
+    file(SHA512 "${arg_ARCHIVE}" patchset_hash)
+    foreach(patch IN LISTS arg_PATCHES)
+        cmake_path(ABSOLUTE_PATH patch
+            BASE_DIRECTORY "${CURRENT_PORT_DIR}"
+            OUTPUT_VARIABLE absolute_patch
+        )
+        file(SHA512 "${absolute_patch}" current_hash)
+        string(APPEND patchset_hash "${current_hash}")
+    endforeach()
+
+    string(SHA512 patchset_hash "${patchset_hash}")
+    string(SUBSTRING "${patchset_hash}" 0 10 patchset_hash)
+    cmake_path(APPEND CURRENT_BUILDTREES_DIR 
+        "${arg_BASE_DIRECTORY}" "${arg_SOURCE_BASE}-${patchset_hash}"
+        OUTPUT_VARIABLE source_path
+    )
+
+    if(_VCPKG_EDITABLE AND EXISTS "${source_path}")
+        set("${out_source_path}" "${source_path}" PARENT_SCOPE)
+        message(STATUS "Using source at ${source_path}")
+        return()
+    elseif(NOT _VCPKG_EDITABLE)
+        cmake_path(APPEND_STRING source_path ".clean")
+        if(EXISTS "${source_path}")
+            message(STATUS "Cleaning sources at ${source_path}. Use --editable to skip cleaning for the packages you specify.")
+            file(REMOVE_RECURSE "${source_path}")
+        endif()
+    endif()
+
+    message(STATUS "Extracting source ${arg_ARCHIVE}")
+    cmake_path(APPEND_STRING source_path ".tmp" OUTPUT_VARIABLE temp_dir)
+    file(REMOVE_RECURSE "${temp_dir}")
+    file(MAKE_DIRECTORY "${temp_dir}")
+    vcpkg_execute_required_process(
+        ALLOW_IN_DOWNLOAD_MODE
+        COMMAND "${CMAKE_COMMAND}" -E tar xjf "${arg_ARCHIVE}"
+        WORKING_DIRECTORY "${temp_dir}"
+        LOGNAME extract
+    )
+
+    if(arg_NO_REMOVE_ONE_LEVEL)
+        cmake_path(SET temp_source_path "${temp_dir}")
+    else()
+        file(GLOB archive_directory "${temp_dir}/*")
+        # make sure `archive_directory` is only a single file
+        if(NOT archive_directory MATCHES ";" AND IS_DIRECTORY "${archive_directory}")
+            cmake_path(SET temp_source_path "${archive_directory}")
+        else()
+            message(FATAL_ERROR "Could not unwrap top level directory from archive. Pass NO_REMOVE_ONE_LEVEL to disable this.")
+        endif()
+    endif()
+
+    if (arg_Z_SKIP_PATCH_CHECK)
+        set(quiet_param QUIET)
+    else()
+        set(quiet_param "")
+    endif()
+
+    z_vcpkg_apply_patches(
+        SOURCE_PATH "${temp_source_path}"
+        PATCHES ${arg_PATCHES}
+        ${quiet_param}
+    )
+
+    file(RENAME "${temp_source_path}" "${source_path}")
+    file(REMOVE_RECURSE "${temp_dir}")
+
+    set("${out_source_path}" "${source_path}" PARENT_SCOPE)
+    message(STATUS "Using source at ${source_path}")
+endfunction()
+

--- a/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
@@ -100,7 +100,7 @@ function(vcpkg_extract_source_archive_ex)
 
     vcpkg_extract_source_archive(source_path
         ARCHIVE "${arg_ARCHIVE}"
-        PATCHES ${PATCHES}
+        PATCHES ${arg_PATCHES}
         ${base_directory_param}
         ${source_base_param}
         ${no_remove_one_level_param}

--- a/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
@@ -90,11 +90,11 @@ function(vcpkg_extract_source_archive_ex)
     endif()
 
     set(no_remove_one_level_param "")
-    if(NO_REMOVE_ONE_LEVEL)
+    if(arg_NO_REMOVE_ONE_LEVEL)
         set(no_remove_one_level_param NO_REMOVE_ONE_LEVEL)
     endif()
     set(skip_patch_check_param "")
-    if(SKIP_PATCH_CHECK)
+    if(arg_SKIP_PATCH_CHECK)
         set(skip_patch_check_param Z_SKIP_PATCH_CHECK)
     endif()
 

--- a/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive_ex.cmake
@@ -2,110 +2,34 @@
 # vcpkg_extract_source_archive_ex
 
 Extract an archive into the source directory.
-Originally replaced `vcpkg_extract_source_archive`,
+Originally replaced [`vcpkg_extract_source_archive()`],
 but new ports should instead use the second overload of
-`vcpkg_extract_source_archive`.
+[`vcpkg_extract_source_archive()`].
 
 ## Usage
 ```cmake
 vcpkg_extract_source_archive_ex(
-    SKIP_PATCH_CHECK
-    OUT_SOURCE_PATH <SOURCE_PATH>
-    ARCHIVE <${ARCHIVE}>
-    [REF <1.0.0>]
-    [NO_REMOVE_ONE_LEVEL]
-    [WORKING_DIRECTORY <${CURRENT_BUILDTREES_DIR}/src>]
-    [PATCHES <a.patch>...]
+    [OUT_SOURCE_PATH <source_path>]
+    ...
 )
 ```
-## Parameters
-### SKIP_PATCH_CHECK
-If this option is set the failure to apply a patch is ignored.
 
-### OUT_SOURCE_PATH
-Specifies the out-variable that will contain the extracted location.
+See the documentation for [`vcpkg_extract_source_archive()`] for other parameters.
+Additionally, `vcpkg_extract_source_archive_ex()` adds the `REF` and `WORKING_DIRECTORY`
+parameters, which are wrappers around `SOURCE_BASE` and `BASE_DIRECTORY`
+respectively.
 
-This should be set to `SOURCE_PATH` by convention.
-
-### ARCHIVE
-The full path to the archive to be extracted.
-
-This is usually obtained from calling [`vcpkg_download_distfile`](vcpkg_download_distfile.md).
-
-### REF
-A friendly name that will be used instead of the filename of the archive.  If more than 10 characters it will be truncated.
-
-By convention, this is set to the version number or tag fetched
-
-### WORKING_DIRECTORY
-If specified, the archive will be extracted into the working directory instead of `${CURRENT_BUILDTREES_DIR}/src/`.
-
-Note that the archive will still be extracted into a subfolder underneath that directory (`${WORKING_DIRECTORY}/${REF}-${HASH}/`).
-
-### PATCHES
-A list of patches to be applied to the extracted sources.
-
-Relative paths are based on the port directory.
-
-### NO_REMOVE_ONE_LEVEL
-Specifies that the default removal of the top level folder should not occur.
-
-## Examples
-
-* [bzip2](https://github.com/Microsoft/vcpkg/blob/master/ports/bzip2/portfile.cmake)
-* [sqlite3](https://github.com/Microsoft/vcpkg/blob/master/ports/sqlite3/portfile.cmake)
-* [cairo](https://github.com/Microsoft/vcpkg/blob/master/ports/cairo/portfile.cmake)
+[`vcpkg_extract_source_archive()`]: vcpkg_extract_source_archive.md
 #]===]
 
 function(vcpkg_extract_source_archive_ex)
-    cmake_parse_arguments(PARSE_ARGV 0 "arg"
-        "NO_REMOVE_ONE_LEVEL;SKIP_PATCH_CHECK"
-        "OUT_SOURCE_PATH;ARCHIVE;REF;WORKING_DIRECTORY"
-        "PATCHES"
-    )
-
-    if(NOT DEFINED arg_ARCHIVE)
-        message(FATAL_ERROR "ARCHIVE must be specified")
-    endif()
+    # OUT_SOURCE_PATH is an out-parameter so we need to parse it
+    cmake_parse_arguments(PARSE_ARGV 0 "arg" "" "OUT_SOURCE_PATH" "")
     if(NOT DEFINED arg_OUT_SOURCE_PATH)
         message(FATAL_ERROR "OUT_SOURCE_PATH must be specified")
     endif()
 
-    set(base_directory_param "")
-    if(DEFINED arg_WORKING_DIRECTORY)
-        cmake_path(IS_PREFIX CURRENT_BUILDTREES_DIR "${arg_WORKING_DIRECTORY}" NORMALIZE is_prefix)
-        if(NOT is_prefix)
-            message(FATAL_ERROR "WORKING_DIRECTORY must be located under CURRENT_BUILDTREES_DIR:
-    WORKING_DIRECTORY     : ${arg_WORKING_DIRECTORY}
-    CURRENT_BUILDTREES_DIR: ${CURRENT_BUILDTRESS_DIR}")
-        endif()
-        cmake_path(RELATIVE_PATH arg_WORKING_DIRECTORY BASE_DIRECTORY "${CURRENT_BUILDTREES_DIR}")
-        set(base_directory_param BASE_DIRECTORY "${arg_WORKING_DIRECTORY}")
-    endif()
+    vcpkg_extract_source_archive(source_path ${arg_UNPARSED_ARGUMENTS} Z_ALLOW_OLD_PARAMETER_NAMES)
 
-    set(source_base_param "")
-    if(DEFINED arg_REF)
-        string(REPLACE "/" "-" sanitized_ref "${arg_REF}")
-        set(source_base_param SOURCE_BASE "${sanitized_ref}")
-    endif()
-
-    set(no_remove_one_level_param "")
-    if(arg_NO_REMOVE_ONE_LEVEL)
-        set(no_remove_one_level_param NO_REMOVE_ONE_LEVEL)
-    endif()
-    set(skip_patch_check_param "")
-    if(arg_SKIP_PATCH_CHECK)
-        set(skip_patch_check_param Z_SKIP_PATCH_CHECK)
-    endif()
-
-    vcpkg_extract_source_archive(source_path
-        ARCHIVE "${arg_ARCHIVE}"
-        PATCHES ${arg_PATCHES}
-        ${base_directory_param}
-        ${source_base_param}
-        ${no_remove_one_level_param}
-        ${skip_patch_check_param}
-    )
-
-    set(${arg_OUT_SOURCE_PATH} "${source_path}" PARENT_SCOPE)
+    set("${arg_OUT_SOURCE_PATH}" "${source_path}" PARENT_SCOPE)
 endfunction()

--- a/versions/a-/avisynthplus.json
+++ b/versions/a-/avisynthplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "747e0dd9f81ace8b2f473dc455871938d930df28",
+      "version-semver": "3.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3d573152a7d82faefcb525b1d6cf688a1465a71b",
       "version-semver": "3.7.0",
       "port-version": 0

--- a/versions/b-/bond.json
+++ b/versions/b-/bond.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd9f5b1815bb95cc049532d8507f85e1af4b388e",
+      "version-string": "9.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "bde4f6ac4c95a05f823e8de810f57df015738ac4",
       "version-string": "9.0.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -226,7 +226,7 @@
     },
     "avisynthplus": {
       "baseline": "3.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "avro-c": {
       "baseline": "1.9.2-1",
@@ -434,7 +434,7 @@
     },
     "bond": {
       "baseline": "9.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "boolinq": {
       "baseline": "3.0.1",
@@ -4325,8 +4325,8 @@
       "port-version": 0
     },
     "nmap": {
-      "baseline": "7.70-4",
-      "port-version": 0
+      "baseline": "7.70",
+      "port-version": 5
     },
     "nmslib": {
       "baseline": "2.0.6",
@@ -4530,7 +4530,7 @@
     },
     "opencv3": {
       "baseline": "3.4.14",
-      "port-version": 0
+      "port-version": 1
     },
     "opencv4": {
       "baseline": "4.5.2",
@@ -5045,8 +5045,8 @@
       "port-version": 2
     },
     "qcustomplot": {
-      "baseline": "2.0.1-4",
-      "port-version": 0
+      "baseline": "2.0.1",
+      "port-version": 5
     },
     "qhull": {
       "baseline": "8.0.2",

--- a/versions/n-/nmap.json
+++ b/versions/n-/nmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b97062b9e404d29fe1ce3d0747e6a191fa04a181",
+      "version": "7.70",
+      "port-version": 5
+    },
+    {
       "git-tree": "83ebdc9303a1f8917df4275921160636cdb05eef",
       "version-string": "7.70-4",
       "port-version": 0

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "850be938a178de206c52be71229048d501bd61e8",
+      "version": "3.4.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "766b570f861ad21af950db7c02e5dc48d4fd1a1e",
       "version": "3.4.14",
       "port-version": 0

--- a/versions/q-/qcustomplot.json
+++ b/versions/q-/qcustomplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fcc18d2987ed5b3af803d5e0ac5c9afd026fc37",
+      "version": "2.0.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "c995c8e160e05060606844f9a0ea84b1fd5d61d3",
       "version-string": "2.0.1-4",
       "port-version": 0


### PR DESCRIPTION
This PR audits `vcpkg_extract_source_archive` and `vcpkg_extract_source_archive_ex` to follow in line with issue #17691.

Additionally, it changes the "default function" back to `vcpkg_extract_source_archive`.

This is quite a sizeable change, so it needs serious CR from the team.