### PR TITLE
[pthreads] Fix debug dll look-up path

### DIFF
--- a/ports/pthreads/vcpkg-cmake-wrapper.cmake
+++ b/ports/pthreads/vcpkg-cmake-wrapper.cmake
@@ -77,13 +77,16 @@ mark_as_advanced(PThreads4W_INCLUDE_DIR PThreads4W_LIBRARY PThreads4W_CXXEXC_LIB
 set(PThreads4W_DLL_DIR ${PThreads4W_INCLUDE_DIR})
 list(TRANSFORM PThreads4W_DLL_DIR APPEND "/../bin")
 message(STATUS "PThreads4W_DLL_DIR: ${PThreads4W_DLL_DIR}")
+set(PThreads4W_DEBUG_DLL_DIR ${PThreads4W_INCLUDE_DIR})
+list(TRANSFORM PThreads4W_DEBUG_DLL_DIR APPEND "/../debug/bin")
+message(STATUS "PThreads4W_DEBUG_DLL_DIR: ${PThreads4W_DEBUG_DLL_DIR}")
 
 find_file(PThreads4W_LIBRARY_RELEASE_DLL NAMES pthreadVC${PThreads4W_MAJOR_VERSION}.dll PATHS ${PThreads4W_DLL_DIR})
-find_file(PThreads4W_LIBRARY_DEBUG_DLL NAMES pthreadVC${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DLL_DIR})
+find_file(PThreads4W_LIBRARY_DEBUG_DLL NAMES pthreadVC${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DEBUG_DLL_DIR})
 find_file(PThreads4W_CXXEXC_LIBRARY_RELEASE_DLL NAMES pthreadVCE${PThreads4W_MAJOR_VERSION}.dll PATHS ${PThreads4W_DLL_DIR})
-find_file(PThreads4W_CXXEXC_LIBRARY_DEBUG_DLL NAMES pthreadVCE${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DLL_DIR})
+find_file(PThreads4W_CXXEXC_LIBRARY_DEBUG_DLL NAMES pthreadVCE${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DEBUG_DLL_DIR})
 find_file(PThreads4W_STRUCTEXC_LIBRARY_RELEASE_DLL NAMES pthreadVSE${PThreads4W_MAJOR_VERSION}.dll PATHS ${PThreads4W_DLL_DIR})
-find_file(PThreads4W_STRUCTEXC_LIBRARY_DEBUG_DLL NAMES pthreadVSE${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DLL_DIR})
+find_file(PThreads4W_STRUCTEXC_LIBRARY_DEBUG_DLL NAMES pthreadVSE${PThreads4W_MAJOR_VERSION}d.dll PATHS ${PThreads4W_DEBUG_DLL_DIR})
 
 #Compatibility definitions, deprecated
 set(PTHREAD_INCLUDE_DIR ${PThreads4W_INCLUDE_DIR} CACHE PATH "")

--- a/ports/pthreads/vcpkg.json
+++ b/ports/pthreads/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pthreads",
   "version": "3.0.0",
-  "port-version": 9,
+  "port-version": 10,
   "description": "pthreads for windows",
   "homepage": "https://sourceware.org/pub/pthreads-win32/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5018,7 +5018,7 @@
     },
     "pthreads": {
       "baseline": "3.0.0",
-      "port-version": 9
+      "port-version": 10
     },
     "pugixml": {
       "baseline": "1.11.4",

--- a/versions/p-/pthreads.json
+++ b/versions/p-/pthreads.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab9d25f08115355ea2d4e4c6eae94626fa86fded",
+      "version": "3.0.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "f5b91f46526fb5abd97b07febd2563f3a3688769",
       "version": "3.0.0",
       "port-version": 9


### PR DESCRIPTION
Fix debug dll look-up path. 

- #### What does your PR fix?  
Without this patch it is looking for debug dlls in: 
installed/x64-windows/include/../bin and not
installed/x64-windows/include/../debug/bin

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
no change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

