### PR TITLE
[boost-modular-build-helper] Fix boost build toolchain options not being used

### DIFF
--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -46,13 +46,17 @@ else()
 endif()
 
 if(APPLE)
-    list(APPEND B2_OPTIONS target-os=darwin toolset=clang)
+    set(B2_TOOLSET clang)
+    list(APPEND B2_OPTIONS target-os=darwin)
 elseif(WIN32)
-    list(APPEND B2_OPTIONS target-os=windows toolset=gcc)
+    set(B2_TOOLSET gcc)
+    list(APPEND B2_OPTIONS target-os=windows)
 elseif(ANDROID)
-    list(APPEND B2_OPTIONS target-os=android toolset=gcc)
+    set(B2_TOOLSET gcc)
+    list(APPEND B2_OPTIONS target-os=android)
 else()
-    list(APPEND B2_OPTIONS target-os=linux toolset=gcc)
+    set(B2_TOOLSET gcc)
+    list(APPEND B2_OPTIONS target-os=linux)
 endif()
 
 if(WIN32)
@@ -78,6 +82,28 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
     else()
         set(LDFLAGS "${CMAKE_STATIC_LINKER_FLAGS} ${CMAKE_STATIC_LINKER_FLAGS_DEBUG}")
     endif()
+endif()
+
+if(APPLE)
+    if(CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(CXXFLAGS "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} ${CXXFLAGS}")
+        set(CFLAGS "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} ${CFLAGS}")
+        set(LDFLAGS "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET} ${LDFLAGS}")
+    endif()
+
+    if(CMAKE_OSX_SYSROOT)
+        set(CXXFLAGS "-isysroot ${CMAKE_OSX_SYSROOT} ${CXXFLAGS}")
+        set(CFLAGS "-isysroot ${CMAKE_OSX_SYSROOT} ${CFLAGS}")
+        set(LDFLAGS "-isysroot ${CMAKE_OSX_SYSROOT} ${LDFLAGS}")
+    endif()
+
+    # if specific architectures are set, configure them,
+    # if not set, this will still default to current arch
+    foreach(ARCH ${CMAKE_OSX_ARCHITECTURES})
+        set(CXXFLAGS "-arch ${ARCH} ${CXXFLAGS}")
+        set(CFLAGS "-arch ${ARCH} ${CFLAGS}")
+        set(LDFLAGS "-arch ${ARCH} ${LDFLAGS}")
+    endforeach()
 endif()
 
 string(STRIP "${CXXFLAGS}" CXXFLAGS)
@@ -122,7 +148,7 @@ foreach(INCDIR ${CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES})
 endforeach()
 
 if(APPLE)
-  set(CXXFLAGS "${CXXFLAGS} <compileflags>-D_DARWIN_C_SOURCE <compileflags>-std=c++11 <compileflags>-stdlib=libc++")
+  set(CXXFLAGS "${CXXFLAGS} <compileflags>-D_DARWIN_C_SOURCE <cxxflags>-std=c++11 <cxxflags>-stdlib=libc++")
   set(LDFLAGS "${LDFLAGS} <linkflags>-stdlib=libc++")
 endif()
 
@@ -157,6 +183,7 @@ endif()
 
 add_custom_target(boost ALL
     COMMAND "${B2_EXE}"
+        toolset=${B2_TOOLSET}
         --user-config=${CMAKE_CURRENT_BINARY_DIR}/user-config.jam
         --stagedir=${CMAKE_CURRENT_BINARY_DIR}/stage
         --build-dir=${CMAKE_CURRENT_BINARY_DIR}

--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -99,7 +99,7 @@ if(APPLE)
 
     # if specific architectures are set, configure them,
     # if not set, this will still default to current arch
-    foreach(ARCH ${CMAKE_OSX_ARCHITECTURES})
+    foreach(ARCH IN LISTS CMAKE_OSX_ARCHITECTURES)
         set(CXXFLAGS "-arch ${ARCH} ${CXXFLAGS}")
         set(CFLAGS "-arch ${ARCH} ${CFLAGS}")
         set(LDFLAGS "-arch ${ARCH} ${LDFLAGS}")

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -84,18 +84,6 @@ function(boost_modular_build)
         if(DEFINED _bm_BOOST_CMAKE_FRAGMENT)
             list(APPEND configure_option "-DBOOST_CMAKE_FRAGMENT=${_bm_BOOST_CMAKE_FRAGMENT}")
         endif()
-        if(VCPKG_TARGET_IS_OSX)
-            if(VCPKG_OSX_DEPLOYMENT_TARGET)
-                list(APPEND configure_options "-DCMAKE_OSX_DEPLOYMENT_TARGET=${VCPKG_OSX_DEPLOYMENT_TARGET}")
-            endif()
-            if(VCPKG_OSX_SYSROOT)
-                list(APPEND configure_options "-DCMAKE_OSX_SYSROOT=${VCPKG_OSX_SYSROOT}")
-            endif()
-            if(VCPKG_OSX_ARCHITECTURES)
-                # note: VCPKG_OSX_ARCHITECTURES is a list and must be enclosed in quotes
-                list(APPEND configure_options "-DCMAKE_OSX_ARCHITECTURES=\"${VCPKG_OSX_ARCHITECTURES}\"")
-            endif()
-        endif()
 
         vcpkg_configure_cmake(
             SOURCE_PATH ${BOOST_BUILD_INSTALLED_DIR}/share/boost-build

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -84,6 +84,19 @@ function(boost_modular_build)
         if(DEFINED _bm_BOOST_CMAKE_FRAGMENT)
             list(APPEND configure_option "-DBOOST_CMAKE_FRAGMENT=${_bm_BOOST_CMAKE_FRAGMENT}")
         endif()
+        if(VCPKG_TARGET_IS_OSX)
+            if(VCPKG_OSX_DEPLOYMENT_TARGET)
+                list(APPEND configure_options "-DCMAKE_OSX_DEPLOYMENT_TARGET=${VCPKG_OSX_DEPLOYMENT_TARGET}")
+            endif()
+            if(VCPKG_OSX_SYSROOT)
+                list(APPEND configure_options "-DCMAKE_OSX_SYSROOT=${VCPKG_OSX_SYSROOT}")
+            endif()
+            if(VCPKG_OSX_ARCHITECTURES)
+                # note: VCPKG_OSX_ARCHITECTURES is a list and must be enclosed in quotes
+                list(APPEND configure_options "-DCMAKE_OSX_ARCHITECTURES=\"${VCPKG_OSX_ARCHITECTURES}\"")
+            endif()
+        endif()
+
         vcpkg_configure_cmake(
             SOURCE_PATH ${BOOST_BUILD_INSTALLED_DIR}/share/boost-build
             PREFER_NINJA

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -10,7 +10,7 @@ if "@VCPKG_PLATFORM_TOOLSET@" != "external"
 }
 else
 {
-    using gcc : 5.4.1 : @CMAKE_CXX_COMPILER@
+    using @B2_TOOLSET@ : : @CMAKE_CXX_COMPILER@
         :
         <ranlib>@CMAKE_RANLIB@
         <archiver>@CMAKE_AR@

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.75.0",
-  "port-version": 9,
+  "port-version": 10,
   "dependencies": [
     "boost-build",
     "boost-uninstall"

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09b58787785be0fcc5fb86560ef421eb341aa537",
+      "git-tree": "95cad6d5f2d9a858aacbb3b2bc0e3a0db4b06b4b",
       "version-string": "1.75.0",
       "port-version": 10
     },

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09b58787785be0fcc5fb86560ef421eb341aa537",
+      "version-string": "1.75.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "c475b268ac42e886acfdc783944e1e3a988b0ac8",
       "version-string": "1.75.0",
       "port-version": 9

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -738,7 +738,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.75.0",
-      "port-version": 9
+      "port-version": 10
     },
     "boost-move": {
       "baseline": "1.75.0",


### PR DESCRIPTION
The issue was due to the options only being set for the gcc toolchain,
and then only for a specific version. On platforms defaulting to a
different toolchain (e.g. macOS) this didn't work at all.

Additionally, some missing flags were not propagated, in particular the
CMAKE_OSX_DEPLOYMENT_TARGET, CMAKE_OSX_SYSROOT and CMAKE_OSX_ARCHITECTURES

Some branching was also removed from the user-config.jam, as this was
unnecessary. The options are only relevant to the selected toolset and
ignored otherwise, so there is no need to artificially restrict scope.

- #### What does your PR fix?  
Building ports using Boost.build on platforms not using gcc 5.4.1. These were using their default compiler options, completely ignoring whatever was set from vcpkg.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
This PR improves triplet support on linux and macOS by correctly propagating triplet options to Boost.build.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes. Port-version for boost-modular-build-helper is updated.
