### PR TITLE
[openblas] Fix the macro collision with Windows 10 SDK

### DIFF
--- a/ports/openblas/fix-marco-conflict.patch
+++ b/ports/openblas/fix-marco-conflict.patch
@@ -1,0 +1,244 @@
+diff --git a/cmake/utils.cmake b/cmake/utils.cmake
+index 1c21e77..3894011 100644
+--- a/cmake/utils.cmake
++++ b/cmake/utils.cmake
+@@ -251,6 +251,19 @@ function(GenerateNamedObjects sources_in)
+       # now add the object and set the defines
+       set(obj_defines ${defines_in})
+ 
++      list(FIND obj_defines "RC" def_idx)
++      if (${def_idx} GREATER -1) 
++	      #	      list(REMOVE_AT ${obj_defines} ${def_idx})
++	      list (REMOVE_ITEM obj_defines "RC")
++	      list(APPEND obj_defines  "RC=RC")
++      endif ()
++      list(FIND obj_defines "CR" def_idx)
++      if (${def_idx} GREATER -1) 
++	      #	      list(REMOVE_AT ${obj_defines} ${def_idx})
++	      list (REMOVE_ITEM obj_defines "CR")
++	      list(APPEND obj_defines  "CR=CR")
++      endif ()
++
+       if (use_cblas)
+         set(obj_name "cblas_${obj_name}")
+         list(APPEND obj_defines "CBLAS")
+diff --git a/driver/level3/Makefile b/driver/level3/Makefile
+index 09a62d9..970bc58 100644
+--- a/driver/level3/Makefile
++++ b/driver/level3/Makefile
+@@ -371,7 +371,7 @@ cgemm_rr.$(SUFFIX) : gemm.c level3.c  ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm_rc.$(SUFFIX) : gemm.c level3.c  ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm_cn.$(SUFFIX) : gemm.c level3.c  ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -419,7 +419,7 @@ zgemm_rr.$(SUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm_rc.$(SUFFIX) : gemm.c level3.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm_cn.$(SUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -467,7 +467,7 @@ xgemm_rr.$(SUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm_rc.$(SUFFIX) : gemm.c level3.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm_cn.$(SUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -578,7 +578,7 @@ cgemm_thread_rr.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm_thread_rc.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm_thread_cn.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -626,7 +626,7 @@ zgemm_thread_rr.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm_thread_rc.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm_thread_cn.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -674,7 +674,7 @@ xgemm_thread_rr.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm_thread_rc.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm_thread_cn.$(SUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -1841,7 +1841,7 @@ cgemm3m_rr.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm3m_rc.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm3m_cn.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -1889,7 +1889,7 @@ zgemm3m_rr.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm3m_rc.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm3m_cn.$(SUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -1937,7 +1937,7 @@ xgemm3m_rr.$(SUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm3m_rc.$(SUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm3m_cn.$(SUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -1994,7 +1994,7 @@ cgemm3m_thread_rr.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm3m_thread_rc.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm3m_thread_cn.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2042,7 +2042,7 @@ zgemm3m_thread_rr.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm3m_thread_rc.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm3m_thread_cn.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2090,7 +2090,7 @@ xgemm3m_thread_rr.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm3m_thread_rc.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm3m_thread_cn.$(SUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(CFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2763,7 +2763,7 @@ cgemm_rr.$(PSUFFIX) : gemm.c level3.c  ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm_rc.$(PSUFFIX) : gemm.c level3.c  ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm_cn.$(PSUFFIX) : gemm.c level3.c  ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2811,7 +2811,7 @@ zgemm_rr.$(PSUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm_rc.$(PSUFFIX) : gemm.c level3.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm_cn.$(PSUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2859,7 +2859,7 @@ xgemm_rr.$(PSUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm_rc.$(PSUFFIX) : gemm.c level3.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm_cn.$(PSUFFIX) : gemm.c level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -2971,7 +2971,7 @@ cgemm_thread_rr.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm_thread_rc.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm_thread_cn.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -3019,7 +3019,7 @@ zgemm_thread_rr.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm_thread_rc.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm_thread_cn.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -3067,7 +3067,7 @@ xgemm_thread_rr.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm_thread_rc.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm_thread_cn.$(PSUFFIX) : gemm.c level3_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4234,7 +4234,7 @@ cgemm3m_rr.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm3m_rc.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm3m_cn.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4282,7 +4282,7 @@ zgemm3m_rr.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm3m_rc.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm3m_cn.$(PSUFFIX) : gemm3m.c gemm3m_level3.c
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4330,7 +4330,7 @@ xgemm3m_rr.$(PSUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm3m_rc.$(PSUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm3m_cn.$(PSUFFIX) : gemm3m.c gemm3m_level3.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4387,7 +4387,7 @@ cgemm3m_thread_rr.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ cgemm3m_thread_rc.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ cgemm3m_thread_cn.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -UDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4435,7 +4435,7 @@ zgemm3m_thread_rr.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ zgemm3m_thread_rc.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ zgemm3m_thread_cn.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DDOUBLE -DCOMPLEX -DCN $< -o $(@F)
+@@ -4483,7 +4483,7 @@ xgemm3m_thread_rr.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRR $< -o $(@F)
+ 
+ xgemm3m_thread_rc.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+-	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC $< -o $(@F)
++	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DRC=RC $< -o $(@F)
+ 
+ xgemm3m_thread_cn.$(PSUFFIX) : gemm3m.c level3_gemm3m_thread.c ../../param.h
+ 	$(CC) $(PFLAGS) $(BLOCKS) -c -DTHREADED_LEVEL3 -DXDOUBLE -DCOMPLEX -DCN $< -o $(@F)

--- a/ports/openblas/portfile.cmake
+++ b/ports/openblas/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
         fix-redefinition-function.patch
         fix-pkg-config.patch
         fix-uwp-build.patch
+        fix-marco-conflict.patch
 )
 
 find_program(GIT NAMES git git.cmd)

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openblas",
   "version": "0.3.10",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.",
   "homepage": "https://github.com/xianyi/OpenBLAS",
   "default-features": [

--- a/ports/openblas/vcpkg.json
+++ b/ports/openblas/vcpkg.json
@@ -14,7 +14,7 @@
         {
           "name": "openblas",
           "features": [
-            "thread"
+            "threads"
           ]
         }
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4490,7 +4490,7 @@
     },
     "openblas": {
       "baseline": "0.3.10",
-      "port-version": 1
+      "port-version": 2
     },
     "opencascade": {
       "baseline": "7.5.0",

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3ff189cb7a17eeeb2d60997868cc36480c6129c2",
+      "version": "0.3.10",
+      "port-version": 2
+    },
+    {
       "git-tree": "b2beefd63c302b41dc5699ea88b825659c86ac2d",
       "version": "0.3.10",
       "port-version": 1

--- a/versions/o-/openblas.json
+++ b/versions/o-/openblas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3ff189cb7a17eeeb2d60997868cc36480c6129c2",
+      "git-tree": "510adc011214327468768aa22c1f08a2d2d632ab",
       "version": "0.3.10",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17393 

`openblas `build failed with the following errors on the latest Windows SDK 10.0.20348.0:

```
C:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\um\winnt.h(6875): error C2059: syntax error: '='
C:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\um\winnt.h(6939): error C2059: syntax error: '&'
```

The fix patch from upstream https://github.com/xianyi/OpenBLAS/pull/3276

All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 