### PR TITLE
[libogg] Upgrade to 1.3.5

### DIFF
--- a/ports/libogg/CONTROL
+++ b/ports/libogg/CONTROL
@@ -1,5 +1,0 @@
-Source: libogg
-Version: 1.3.4
-Port-Version: 3
-Description: Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.
-Homepage: https://github.com/xiph/ogg

--- a/ports/libogg/portfile.cmake
+++ b/ports/libogg/portfile.cmake
@@ -1,8 +1,9 @@
-vcpkg_from_github(
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.xiph.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO xiph/ogg
-    REF c8fca6b4a02d695b1ceea39b330d4406001c03ed
-    SHA512 52980fcca3c1dbb5fbfa4032f179679a5c4000f1fea88e7ed8b2522d80d27513be96d94933daeb9e36f4ac8556e7e4e8ec7e91101e2ba456e0fce51c484eee9e
+    REF v1.3.5
+    SHA512 72bfad534a459bfca534eae9b209fa630ac20364a82e82f2707b210a40deaf9a7dc9031532a8b27120a9dd66f804655ddce79875758ef14b109bf869e57fb747
     HEAD_REF master
 )
 

--- a/ports/libogg/vcpkg.json
+++ b/ports/libogg/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libogg",
-  "version-string": "1.3.5",
+  "version": "1.3.5",
   "description": "Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.",
   "homepage": "https://www.xiph.org/ogg"
 }

--- a/ports/libogg/vcpkg.json
+++ b/ports/libogg/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "libogg",
+  "version-string": "1.3.5",
+  "description": "Ogg is a multimedia container format, and the native file and stream format for the Xiph.org multimedia codecs.",
+  "homepage": "https://www.xiph.org/ogg"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3397,8 +3397,8 @@
       "port-version": 7
     },
     "libogg": {
-      "baseline": "1.3.4",
-      "port-version": 3
+      "baseline": "1.3.5",
+      "port-version": 0
     },
     "libopenmpt": {
       "baseline": "2017-01-28-cf2390140",

--- a/versions/l-/libogg.json
+++ b/versions/l-/libogg.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "100344f3d0e17ffe5eebc2f5154b92201a93e4b4",
-      "version-string": "1.3.5",
+      "git-tree": "70cb700f89c98b87d678a3aa7a14461eff4b99e4",
+      "version": "1.3.5",
       "port-version": 0
     },
     {

--- a/versions/l-/libogg.json
+++ b/versions/l-/libogg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "100344f3d0e17ffe5eebc2f5154b92201a93e4b4",
+      "version-string": "1.3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "156d376fca62197dd916c454d1299dcee84c72dc",
       "version-string": "1.3.4",
       "port-version": 3


### PR DESCRIPTION
* Upgrade to 1.3.5.
* Convert CONTROL to vcpkg.json
* Change homepage to https://www.xiph.org/ogg (as in README.md)
* Download from the main repo https://gitlab.xiph.org/xiph/ogg