### PR TITLE
[vcpkg baseline][ncurses] Fix gnu download link

### DIFF
--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_download_distfile(
     URLS
         "https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz"
         "ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz"
-        "ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz"
+        "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz"
     FILENAME "ncurses-6.2.tgz"
     SHA512 4c1333dcc30e858e8a9525d4b9aefb60000cfc727bc4a1062bace06ffc4639ad9f6e54f6bdda0e3a0e5ea14de995f96b52b3327d9ec633608792c99a1e8d840d
 )

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ncurses",
   "version-string": "6.2",
+  "port-version": 1,
   "description": "free software emulation of curses in System V Release 4.0",
   "supports": "!(windows | uwp)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4270,7 +4270,7 @@
     },
     "ncurses": {
       "baseline": "6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "neargye-semver": {
       "baseline": "0.2.2",

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f196044f9f7779e0bdb54015dbd3be84aaa00820",
+      "version-string": "6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "ab8de39c1659867da459ac0bec7e09bee5762819",
       "version-string": "6.2",
       "port-version": 0


### PR DESCRIPTION
Change ftp to https since ftp doesn't work:
```
root@usr:/home/usr/work/vcpkg# wget ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz
--2021-06-22 01:43:36--  ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz
           => ‘ncurses-6.2.tar.gz’
Resolving ftp.gnu.org (ftp.gnu.org)... 209.51.188.20, 2001:470:142:3::b
Connecting to ftp.gnu.org (ftp.gnu.org)|209.51.188.20|:21...

^C
root@usr:/home/usr/work/vcpkg# wget https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz
--2021-06-22 01:43:46--  https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz
Resolving ftp.gnu.org (ftp.gnu.org)... 209.51.188.20, 2001:470:142:3::b
Connecting to ftp.gnu.org (ftp.gnu.org)|209.51.188.20|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 3425862 (3.3M) [application/x-gzip]
Saving to: ‘ncurses-6.2.tar.gz’

ncurses-6.2.tar.gz                                          100%[========================================================================================================================================>]   3.27M  5.39MB/s    in 0.6s

2021-06-22 01:43:47 (5.39 MB/s) - ‘ncurses-6.2.tar.gz’ saved [3425862/3425862]
```

Related: https://github.com/microsoft/vcpkg/pull/18554