### PR TITLE
[seal] Fixed cannot find SEAL.

### DIFF
--- a/ports/seal/portfile.cmake
+++ b/ports/seal/portfile.cmake
@@ -31,7 +31,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "SEAL" CONFIG_PATH "lib/cmake/")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "SEAL" CONFIG_PATH "lib/cmake/SEAL-3.6")
 
 if("hexl" IN_LIST FEATURES)
     vcpkg_fixup_pkgconfig(SKIP_CHECK)

--- a/ports/seal/vcpkg.json
+++ b/ports/seal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "seal",
   "version-semver": "3.6.6",
+  "port-version": 1,
   "description": "Microsoft SEAL is an easy-to-use and powerful homomorphic encryption library.",
   "homepage": "https://github.com/microsoft/SEAL",
   "supports": "!windows | (windows & static)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5682,7 +5682,7 @@
     },
     "seal": {
       "baseline": "3.6.6",
-      "port-version": 0
+      "port-version": 1
     },
     "secp256k1": {
       "baseline": "2017-19-10",

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89d120a6c3ac5306d90e29913048b518dc5a2c9b",
+      "version-semver": "3.6.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "e487b9120a78480800a1fd914477acf03f677919",
       "version-semver": "3.6.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes an issue that seal cannot be found. The fix is changing seal's cmake configuration files' path.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  x64-windows/x86-windows are not supported as the library only supports static linkage in Windows.
No change to the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
