### PR TITLE
[vcpkg baseline][kf5* librsvg] Add DISABLE_PARALLEL_CONFIGURE

### DIFF
--- a/ports/kf5completion/portfile.cmake
+++ b/ports/kf5completion/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5completion/vcpkg.json
+++ b/ports/kf5completion/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5completion",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Text completion helpers and widgets",
   "homepage": "https://api.kde.org/frameworks/kcompletion/html/index.html",
   "dependencies": [

--- a/ports/kf5coreaddons/portfile.cmake
+++ b/ports/kf5coreaddons/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5coreaddons/vcpkg.json
+++ b/ports/kf5coreaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5coreaddons",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Addons to QtCore",
   "homepage": "https://api.kde.org/frameworks/kcoreaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5crash/portfile.cmake
+++ b/ports/kf5crash/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5crash/vcpkg.json
+++ b/ports/kf5crash/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5crash",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "KCrash provides support for intercepting and handling application crashes.",
   "homepage": "https://api.kde.org/frameworks/kcrash/html/index.html",
   "supports": "linux",

--- a/ports/kf5i18n/portfile.cmake
+++ b/ports/kf5i18n/portfile.cmake
@@ -35,6 +35,7 @@ vcpkg_find_acquire_program(PYTHON3)
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5i18n",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [

--- a/ports/kf5itemmodels/portfile.cmake
+++ b/ports/kf5itemmodels/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5itemmodels/vcpkg.json
+++ b/ports/kf5itemmodels/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5itemmodels",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Models for Qt Model/View system",
   "homepage": "https://api.kde.org/frameworks/kitemmodels/html/index.html",
   "dependencies": [

--- a/ports/kf5itemviews/portfile.cmake
+++ b/ports/kf5itemviews/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5itemviews/vcpkg.json
+++ b/ports/kf5itemviews/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5itemviews",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Widget addons for Qt Model/View",
   "homepage": "https://api.kde.org/frameworks/kitemviews/html/index.html",
   "dependencies": [

--- a/ports/kf5plotting/portfile.cmake
+++ b/ports/kf5plotting/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS -DBUILD_HTML_DOCS=OFF
             -DBUILD_MAN_DOCS=OFF

--- a/ports/kf5plotting/vcpkg.json
+++ b/ports/kf5plotting/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5plotting",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Lightweight plotting framework",
   "homepage": "https://api.kde.org/frameworks/kplotting/html/index.html",
   "dependencies": [

--- a/ports/kf5widgetsaddons/portfile.cmake
+++ b/ports/kf5widgetsaddons/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_HTML_DOCS=OFF

--- a/ports/kf5widgetsaddons/vcpkg.json
+++ b/ports/kf5widgetsaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5widgetsaddons",
   "version": "5.81.0",
+  "port-version": 1,
   "description": "Addons to QtWidgets",
   "homepage": "https://api.kde.org/frameworks/kwidgetsaddons/html/index.html",
   "dependencies": [

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -17,6 +17,7 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.linux ${SOURCE_PATH}/config.h.
 vcpkg_find_acquire_program(PKGCONFIG)
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE 
     PREFER_NINJA
     OPTIONS
         -DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3502,7 +3502,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 3
+      "port-version": 4
     },
     "librsync": {
       "baseline": "2020-09-16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2846,7 +2846,7 @@
     },
     "kf5completion": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5config": {
       "baseline": "5.81.0",
@@ -2854,11 +2854,11 @@
     },
     "kf5coreaddons": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5crash": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5dbusaddons": {
       "baseline": "5.81.0",
@@ -2874,19 +2874,19 @@
     },
     "kf5i18n": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5itemmodels": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5itemviews": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5plotting": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5syntaxhighlighting": {
       "baseline": "5.81.0",
@@ -2894,7 +2894,7 @@
     },
     "kf5widgetsaddons": {
       "baseline": "5.81.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5windowsystem": {
       "baseline": "5.81.0",

--- a/versions/k-/kf5completion.json
+++ b/versions/k-/kf5completion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82b63d20234241b66dc8f7242619d713d43340de",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8e4e693e3597dcada6e28243e1d536a44063fc18",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5coreaddons.json
+++ b/versions/k-/kf5coreaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8467a9d9763b072c6fd898b1d5be2227205216bd",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "47f0a0b5ec4ebb494396fbc3118ef864e1c66689",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5crash.json
+++ b/versions/k-/kf5crash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18cf44844a7becb7d932cd96709fb40f800236ad",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cc944375b9c277d67a8c7174c24e5ed4221e413a",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5i18n.json
+++ b/versions/k-/kf5i18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a749b5eb069f5e7a8c84a65746ca7579d2e85af5",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "85675e319c19cb4303a56719af9ad49feb733983",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5itemmodels.json
+++ b/versions/k-/kf5itemmodels.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc5ec5bc67cce9eed6f93724083656ffd691365b",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8253bf274c45235c1fa763255fbc9c765de8d245",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5itemviews.json
+++ b/versions/k-/kf5itemviews.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2b8ea2e118cf093ca85c444bd16dee60a1a1777",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c299c11853b1ca953bbc5801a596f4db51bc5782",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5plotting.json
+++ b/versions/k-/kf5plotting.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e45f62745247b51d6583a1bc9a45e4a4bc26701b",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d0991bf27a381493f05e2c2c724a4e523cf893be",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/k-/kf5widgetsaddons.json
+++ b/versions/k-/kf5widgetsaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eaf1fa333a58906c39eaafc1f5e9aa0ca52aca92",
+      "version": "5.81.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3f982e6ab4ef615b0978a477c0943d3b490e6823",
       "version": "5.81.0",
       "port-version": 0

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0a02c4941810ea725b6686e203ae81deb257e24c",
+      "version": "2.40.20",
+      "port-version": 4
+    },
+    {
       "git-tree": "0de6b9c0d9dc0ada7b9223669bb08e9ef146aa7a",
       "version": "2.40.20",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
 `kf5completion `failed with parallel problem like this:

```
Installing in D:/packages/kf5completion_x86-windows/debug. Run D:/buildtrees/kf5completion/x86-windows-dbg/prefix.sh to set the environment for KCompletion.
-- Looking for __GLIBC__
-- Looking for __GLIBC__ - not found
CMake Error at D:/installed/x86-windows/share/ECM/kde-modules/KDEClangFormat.cmake:67 (configure_file):
  No such file or directory
Call Stack (most recent call first):
  D:/installed/x86-windows/share/ECM/kde-modules/KDEFrameworkCompilerSettings.cmake:79 (include)
  CMakeLists.txt:18 (include)
```
Since there are many kf5* ports that have the dependency of `ecm`, so adding `DISABLE_PARALLEL_CONFIGURE` for other ports.

`librsvg `also failed with the similar problem:

```
CMake Error at CMakeLists.txt:79 (configure_file):
  No error
```

Related PR https://github.com/microsoft/vcpkg/pull/18570

Note: No feature needs to test.