### PR TITLE
[docs] CMake command docs say to use 0 for missing SHA512

### DIFF
--- a/docs/maintainers/vcpkg_from_bitbucket.md
+++ b/docs/maintainers/vcpkg_from_bitbucket.md
@@ -36,7 +36,7 @@ If `REF` is specified, `SHA512` must also be specified.
 ### SHA512
 The SHA512 hash that should match the archive (https://bitbucket.com/${REPO}/get/${REF}.tar.gz).
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/docs/maintainers/vcpkg_from_github.md
+++ b/docs/maintainers/vcpkg_from_github.md
@@ -38,7 +38,7 @@ If `REF` is specified, `SHA512` must also be specified.
 ### SHA512
 The SHA512 hash that should match the archive (https://github.com/${REPO}/archive/${REF}.tar.gz).
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/docs/maintainers/vcpkg_from_gitlab.md
+++ b/docs/maintainers/vcpkg_from_gitlab.md
@@ -42,7 +42,7 @@ If `REF` is specified, `SHA512` must also be specified.
 The SHA512 hash that should match the archive (${GITLAB_URL}/${REPO}/-/archive/${REF}/${REPO_NAME}-${REF}.tar.gz).
 The REPO_NAME variable is parsed from the value of REPO.
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/docs/maintainers/vcpkg_from_sourceforge.md
+++ b/docs/maintainers/vcpkg_from_sourceforge.md
@@ -44,6 +44,8 @@ The REPO is `soxr`, REF is not exist, and the FILENAME is `soxr-0.1.3-Source.tar
 ### SHA512
 The SHA512 hash that should match the archive.
 
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+
 ### WORKING_DIRECTORY
 If specified, the archive will be extracted into the working directory instead of `${CURRENT_BUILDTREES_DIR}/src/`.
 

--- a/scripts/cmake/vcpkg_from_bitbucket.cmake
+++ b/scripts/cmake/vcpkg_from_bitbucket.cmake
@@ -35,7 +35,7 @@ If `REF` is specified, `SHA512` must also be specified.
 ### SHA512
 The SHA512 hash that should match the archive (https://bitbucket.com/${REPO}/get/${REF}.tar.gz).
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -37,7 +37,7 @@ If `REF` is specified, `SHA512` must also be specified.
 ### SHA512
 The SHA512 hash that should match the archive (https://github.com/${REPO}/archive/${REF}.tar.gz).
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/scripts/cmake/vcpkg_from_gitlab.cmake
+++ b/scripts/cmake/vcpkg_from_gitlab.cmake
@@ -41,7 +41,7 @@ If `REF` is specified, `SHA512` must also be specified.
 The SHA512 hash that should match the archive (${GITLAB_URL}/${REPO}/-/archive/${REF}/${REPO_NAME}-${REF}.tar.gz).
 The REPO_NAME variable is parsed from the value of REPO.
 
-This is most easily determined by first setting it to `1`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
 
 ### HEAD_REF
 The unstable git commit-ish (ideally a branch) to pull for `--head` builds.

--- a/scripts/cmake/vcpkg_from_sourceforge.cmake
+++ b/scripts/cmake/vcpkg_from_sourceforge.cmake
@@ -43,6 +43,8 @@ The REPO is `soxr`, REF is not exist, and the FILENAME is `soxr-0.1.3-Source.tar
 ### SHA512
 The SHA512 hash that should match the archive.
 
+This is most easily determined by first setting it to `0`, then trying to build the port. The error message will contain the full hash, which can be copied back into the portfile.
+
 ### WORKING_DIRECTORY
 If specified, the archive will be extracted into the working directory instead of `${CURRENT_BUILDTREES_DIR}/src/`.
 


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This is a follow-up to the PR closing #18459 which made 0 the only value to use for `SHA512` arguments which would result in showing the hash that vcpkg calculated when it didn't match.
  
  Some of the remaining documentation for vcpkg's CMake commands still directs users to put the value 1 when they do not yet know the correct hash. This PR fixes the documentation in those places that I was able to identify.
  
  It also adds the instructions about using the value 0 to the documentation for `vcpkg_from_sourceforge` because it did not have that line before. I believe this is correct because the code for that command uses the same `vcpkg_download_distfile` function that was changed, but I have not tested it myself.
