### PR TITLE
[cef-build] Create a new port

### DIFF
--- a/ports/cef-build/patch-cmake.patch
+++ b/ports/cef-build/patch-cmake.patch
@@ -1,0 +1,101 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 120db2b..649640d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -199,15 +199,87 @@ add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)
+ # Include application targets.
+ # Comes from the <target>/CMakeLists.txt file in the current directory.
+ # TODO: Change these lines to match your project target when you copy this file.
+-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
+-  add_subdirectory(tests/cefsimple)
+-  add_subdirectory(tests/gtest)
+-  add_subdirectory(tests/ceftests)
+-endif()
+-
+-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/cefclient")
+-  add_subdirectory(tests/cefclient)
+-endif()
++
++# PATCH: COMMENTED OUT
++
++# if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
++#   add_subdirectory(tests/cefsimple)
++#   add_subdirectory(tests/gtest)
++#   add_subdirectory(tests/ceftests)
++# endif()
++#
++# if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/cefclient")
++#   add_subdirectory(tests/cefclient)
++# endif()
++
++# INSTALL
++INSTALL(
++  TARGETS libcef_dll_wrapper
++  # CONFIGURATIONS Debug
++  # DESTINATION debug/lib
++)
++
++# TODO: Try without fileglob (just use install pattern)?
++file(GLOB libs_deb Debug/*.lib)
++file(GLOB libs_rel Release/*.lib)
++list(FILTER libs_deb EXCLUDE REGEX .*cef_sandbox.lib)  # Doesn't work on Windows
++list(FILTER libs_rel EXCLUDE REGEX .*cef_sandbox.lib)  # Doesn't work on Windows
++INSTALL(
++  FILES ${libs_deb}
++  CONFIGURATIONS Debug
++  TYPE LIB
++)
++INSTALL(
++  FILES ${libs_rel}
++  CONFIGURATIONS Release
++  TYPE LIB
++)
++
++# pdb
++# TODO: For release
++INSTALL(
++  FILES
++    ${CMAKE_CURRENT_BINARY_DIR}/libcef_dll_wrapper/Debug/libcef_dll_wrapper.pdb
++  CONFIGURATIONS Debug
++  TYPE LIB
++)
++
++file(GLOB bins_deb Debug/*.dll Debug/*.bin)
++file(GLOB bins_rel Release/*.dll Release/*.bin)
++INSTALL(
++  FILES ${bins_deb}
++  CONFIGURATIONS Debug
++  TYPE BIN
++)
++INSTALL(
++  FILES ${bins_rel}
++  CONFIGURATIONS Release
++  TYPE BIN
++)
++
++file(GLOB bins_deb Debug/swiftshader/*.dll)
++file(GLOB bins_rel Debug/swiftshader/*.dll)
++INSTALL(
++  FILES ${bins_deb}
++  CONFIGURATIONS Debug
++  DESTINATION bin/swiftshader
++)
++INSTALL(
++  FILES ${bins_rel}
++  CONFIGURATIONS Release
++  DESTINATION bin/swiftshader
++)
++
++INSTALL(
++  DIRECTORY include
++  DESTINATION .
++)
++
++# Fix for CEF imports
++INSTALL(
++  DIRECTORY include
++  DESTINATION include
++)
+ 
+ # Display configuration settings.
+ PRINT_CEF_CONFIG()

--- a/ports/cef-build/portfile.cmake
+++ b/ports/cef-build/portfile.cmake
@@ -9,7 +9,6 @@ set(ARCHIVE_HASH "7626bcf8bb7ec98575dd91ea6a726eb35567c6939b6387bd5c8c400bc4918d
 set(FOLDER_NAME "cef_binary_${CEF_VERSION}+${COMMIT_SHORTHASH}+chromium-${CHROMIUM_VERSION}_${PLATFORM_NAME}")
 set(ARCHIVE_NAME "${FOLDER_NAME}.tar.bz2")
 
-# Download
 vcpkg_download_distfile(
 	ARCHIVE
 	URLS "https://cef-builds.spotifycdn.com/${ARCHIVE_NAME}"
@@ -17,21 +16,16 @@ vcpkg_download_distfile(
 	SHA512 ${ARCHIVE_HASH}
 )
 
-# Extract
 vcpkg_extract_source_archive_ex(
 	OUT_SOURCE_PATH SOURCE_PATH
 	ARCHIVE "${ARCHIVE}"
 	REF "${CEF_VERSION}"
-	# NO_REMOVE_ONE_LEVEL
 )
-
-message("Extract archive: ${ARCHIVE}")
-message("To path: ${SOURCE_PATH}")
 
 # Required, or else libcef.lib gives the error "Could not find proper second linker member." Chromium does the same: https://github.com/microsoft/vcpkg/blob/030cfaa24de9ea1bbf0a4d9c615ce7312ba77af1/ports/chromium-base/portfile.cmake
 set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)
 
-# Temporarily override linker config to build properly
+# Required, or else you get linker errors
 set(VCPKG_LIBRARY_LINKAGE static)
 
 # Disable PREFER_NINJA because it changes the output directories slightly
@@ -41,14 +35,11 @@ vcpkg_configure_cmake(
 		-DCEF_RUNTIME_LIBRARY_FLAG=/MD
 )
 
-# Restore linker config
 set(VCPKG_LIBRARY_LINKAGE ${orig_VCPKG_LIBRARY_LINKAGE})
 
 vcpkg_build_cmake(
 	TARGET libcef_dll_wrapper
 )
-
-message("CURRENT_PACKAGES_DIR: ${CURRENT_PACKAGES_DIR}")
 
 set(RELEASE_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-rel")
 set(DEBUG_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-dbg")

--- a/ports/cef-build/portfile.cmake
+++ b/ports/cef-build/portfile.cmake
@@ -1,0 +1,104 @@
+set(orig_VCPKG_LIBRARY_LINKAGE ${VCPKG_LIBRARY_LINKAGE})
+
+set(CEF_VERSION "81.3.8")
+set(CHROMIUM_VERSION "81.0.4044.138")
+set(PLATFORM_NAME "windows64")
+set(COMMIT_SHORTHASH "g1a0137c")
+set(ARCHIVE_HASH "7626bcf8bb7ec98575dd91ea6a726eb35567c6939b6387bd5c8c400bc4918dc4a4575d9879ad40cc51c1627c0fcfaf2448d2d4259e2a3748ba7aa183cb1400cc")
+
+set(FOLDER_NAME "cef_binary_${CEF_VERSION}+${COMMIT_SHORTHASH}+chromium-${CHROMIUM_VERSION}_${PLATFORM_NAME}")
+set(ARCHIVE_NAME "${FOLDER_NAME}.tar.bz2")
+
+# Download
+vcpkg_download_distfile(
+	ARCHIVE
+	URLS "https://cef-builds.spotifycdn.com/${ARCHIVE_NAME}"
+	FILENAME "${ARCHIVE_NAME}"
+	SHA512 ${ARCHIVE_HASH}
+)
+
+# Extract
+vcpkg_extract_source_archive_ex(
+	OUT_SOURCE_PATH SOURCE_PATH
+	ARCHIVE "${ARCHIVE}"
+	REF "${CEF_VERSION}"
+	# NO_REMOVE_ONE_LEVEL
+)
+
+message("Extract archive: ${ARCHIVE}")
+message("To path: ${SOURCE_PATH}")
+
+# Required, or else libcef.lib gives the error "Could not find proper second linker member." Chromium does the same: https://github.com/microsoft/vcpkg/blob/030cfaa24de9ea1bbf0a4d9c615ce7312ba77af1/ports/chromium-base/portfile.cmake
+set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)
+
+# Temporarily override linker config to build properly
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# Disable PREFER_NINJA because it changes the output directories slightly
+vcpkg_configure_cmake(
+	SOURCE_PATH "${SOURCE_PATH}"
+	OPTIONS
+		-DCEF_RUNTIME_LIBRARY_FLAG=/MD
+)
+
+# Restore linker config
+set(VCPKG_LIBRARY_LINKAGE ${orig_VCPKG_LIBRARY_LINKAGE})
+
+vcpkg_build_cmake(
+	TARGET libcef_dll_wrapper
+)
+
+message("CURRENT_PACKAGES_DIR: ${CURRENT_PACKAGES_DIR}")
+
+set(RELEASE_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-rel")
+set(DEBUG_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-dbg")
+
+#########################################
+
+# /lib release
+file(
+	COPY
+		"${RELEASE_BUILD_DIR}/libcef_dll_wrapper/Release/libcef_dll_wrapper.lib"
+		"${RELEASE_BUILD_DIR}/libcef_dll_wrapper/Release/libcef_dll_wrapper.pdb"
+		"${SOURCE_PATH}/Release/libcef.lib"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+# /bin release
+file(
+	COPY "${SOURCE_PATH}/Release/libcef.dll"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
+)
+
+# /lib debug
+file(
+	COPY
+		"${DEBUG_BUILD_DIR}/libcef_dll_wrapper/Debug/libcef_dll_wrapper.lib"
+		"${DEBUG_BUILD_DIR}/libcef_dll_wrapper/Debug/libcef_dll_wrapper.pdb"
+		"${SOURCE_PATH}/Debug/libcef.lib"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
+)
+
+# /bin debug
+file(
+	COPY "${SOURCE_PATH}/Debug/libcef.dll"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
+)
+
+# /include
+file(
+	COPY "${SOURCE_PATH}/include"
+	DESTINATION "${CURRENT_PACKAGES_DIR}"
+)
+
+# Another /include for cef's own imports
+file(
+	COPY "${SOURCE_PATH}/include"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/include"
+)
+
+# /copyright
+file(
+	INSTALL "${SOURCE_PATH}/LICENSE.txt"
+	DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+	RENAME copyright)

--- a/ports/cef-build/portfile.cmake
+++ b/ports/cef-build/portfile.cmake
@@ -3,10 +3,10 @@ set(orig_VCPKG_LIBRARY_LINKAGE ${VCPKG_LIBRARY_LINKAGE})
 set(CEF_VERSION "81.3.8")
 set(CHROMIUM_VERSION "81.0.4044.138")
 set(PLATFORM_NAME "windows64")
-set(COMMIT_SHORTHASH "g1a0137c")
+set(COMMIT_SHORTHASH "1a0137c")
 set(ARCHIVE_HASH "7626bcf8bb7ec98575dd91ea6a726eb35567c6939b6387bd5c8c400bc4918dc4a4575d9879ad40cc51c1627c0fcfaf2448d2d4259e2a3748ba7aa183cb1400cc")
 
-set(FOLDER_NAME "cef_binary_${CEF_VERSION}+${COMMIT_SHORTHASH}+chromium-${CHROMIUM_VERSION}_${PLATFORM_NAME}")
+set(FOLDER_NAME "cef_binary_${CEF_VERSION}+g${COMMIT_SHORTHASH}+chromium-${CHROMIUM_VERSION}_${PLATFORM_NAME}")
 set(ARCHIVE_NAME "${FOLDER_NAME}.tar.bz2")
 
 vcpkg_download_distfile(
@@ -20,76 +20,47 @@ vcpkg_extract_source_archive_ex(
 	OUT_SOURCE_PATH SOURCE_PATH
 	ARCHIVE "${ARCHIVE}"
 	REF "${CEF_VERSION}"
+	PATCHES
+		"patch-cmake.patch"
 )
 
 # Required, or else libcef.lib gives the error "Could not find proper second linker member." Chromium does the same: https://github.com/microsoft/vcpkg/blob/030cfaa24de9ea1bbf0a4d9c615ce7312ba77af1/ports/chromium-base/portfile.cmake
 set(VCPKG_POLICY_SKIP_ARCHITECTURE_CHECK enabled)
 
+# Required, or else we get "outdated crt" errors when copying some pre-built DLLs.
+set(VCPKG_POLICY_SKIP_DUMPBIN_CHECKS enabled)
+
 # Required, or else you get linker errors
 set(VCPKG_LIBRARY_LINKAGE static)
 
 # Disable PREFER_NINJA because it changes the output directories slightly
+# TODO: Try adding it back
+
+set(CEF_CONFIG_OPTS -DUSE_SANDBOX=NO)
+if("${VCPKG_CRT_LINKAGE}" STREQUAL "dynamic")
+	list(APPEND CEF_CONFIG_OPTS -DCEF_RUNTIME_LIBRARY_FLAG=/MD)
+endif()
+
 vcpkg_configure_cmake(
 	SOURCE_PATH "${SOURCE_PATH}"
-	OPTIONS
-		-DCEF_RUNTIME_LIBRARY_FLAG=/MD
+	OPTIONS ${CEF_CONFIG_OPTS}
 )
 
 set(VCPKG_LIBRARY_LINKAGE ${orig_VCPKG_LIBRARY_LINKAGE})
 
-vcpkg_build_cmake(
-	TARGET libcef_dll_wrapper
-)
+# TODO: Try vcpkg_copy_pdbs
+vcpkg_install_cmake()
 
 set(RELEASE_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-rel")
 set(DEBUG_BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${HOST_TRIPLET}-dbg")
 
 #########################################
 
-# /lib release
-file(
-	COPY
-		"${RELEASE_BUILD_DIR}/libcef_dll_wrapper/Release/libcef_dll_wrapper.lib"
-		"${RELEASE_BUILD_DIR}/libcef_dll_wrapper/Release/libcef_dll_wrapper.pdb"
-		"${SOURCE_PATH}/Release/libcef.lib"
-	DESTINATION "${CURRENT_PACKAGES_DIR}/lib"
-)
-
-# /bin release
-file(
-	COPY "${SOURCE_PATH}/Release/libcef.dll"
-	DESTINATION "${CURRENT_PACKAGES_DIR}/bin"
-)
-
-# /lib debug
-file(
-	COPY
-		"${DEBUG_BUILD_DIR}/libcef_dll_wrapper/Debug/libcef_dll_wrapper.lib"
-		"${DEBUG_BUILD_DIR}/libcef_dll_wrapper/Debug/libcef_dll_wrapper.pdb"
-		"${SOURCE_PATH}/Debug/libcef.lib"
-	DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib"
-)
-
-# /bin debug
-file(
-	COPY "${SOURCE_PATH}/Debug/libcef.dll"
-	DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin"
-)
-
-# /include
-file(
-	COPY "${SOURCE_PATH}/include"
-	DESTINATION "${CURRENT_PACKAGES_DIR}"
-)
-
-# Another /include for cef's own imports
-file(
-	COPY "${SOURCE_PATH}/include"
-	DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-)
-
 # /copyright
 file(
 	INSTALL "${SOURCE_PATH}/LICENSE.txt"
 	DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 	RENAME copyright)
+
+# duplicate include
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/cef-build/vcpkg.json
+++ b/ports/cef-build/vcpkg.json
@@ -1,0 +1,7 @@
+{
+	"name": "cef-build",
+	"version": "81.3.8",
+	"description": "Chromium Embedded Framework (CEF) Automated Builds",
+	"homepage": "https://cef-builds.spotifycdn.com/index.html",
+	"supports": "windows & x64 & !static"
+}

--- a/ports/cef-build/vcpkg.json
+++ b/ports/cef-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
-	"name": "cef-build",
-	"version": "81.3.8",
-	"description": "Chromium Embedded Framework (CEF) Automated Builds",
-	"homepage": "https://cef-builds.spotifycdn.com/index.html",
-	"supports": "windows & x64 & !static"
+  "name": "cef-build",
+  "version": "81.3.8",
+  "description": "Chromium Embedded Framework (CEF) Automated Builds",
+  "homepage": "https://cef-builds.spotifycdn.com/index.html",
+  "supports": "windows & x64 & !static"
 }

--- a/ports/cef-build/vcpkg.json
+++ b/ports/cef-build/vcpkg.json
@@ -3,5 +3,5 @@
   "version": "81.3.8",
   "description": "Chromium Embedded Framework (CEF) Automated Builds",
   "homepage": "https://cef-builds.spotifycdn.com/index.html",
-  "supports": "windows & x64 & !static"
+  "supports": "windows & x64"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -95,6 +95,15 @@ catch-classic:x64-windows-static-md=skip
 catch-classic:x86-windows        = skip
 ccd:arm-uwp=fail
 ccd:x64-uwp=fail
+# Not tested / not implemented yet.
+cef-build:arm64-windows=skip
+cef-build:arm-uwp=skip
+cef-build:x64-linux=skip
+cef-build:x64-osx=skip
+cef-build:x64-uwp=skip
+cef-build:x64-windows-static=skip
+cef-build:x64-windows-static-md=skip
+cef-build:x86-windows=skip
 cello:arm-uwp=fail
 cello:x64-uwp=fail
 cfitsio:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1164,6 +1164,10 @@
       "baseline": "2.3-2",
       "port-version": 0
     },
+    "cef-build": {
+      "baseline": "81.3.8",
+      "port-version": 0
+    },
     "celero": {
       "baseline": "2.8.2",
       "port-version": 0

--- a/versions/c-/cef-build.json
+++ b/versions/c-/cef-build.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e10900d0da6918956feeec108fb908048c5c5458",
+      "git-tree": "03e776174b9a522359a54b2d8f565fa4c1a3b9ee",
       "version": "81.3.8",
       "port-version": 0
     }

--- a/versions/c-/cef-build.json
+++ b/versions/c-/cef-build.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "03e776174b9a522359a54b2d8f565fa4c1a3b9ee",
+      "git-tree": "17f466b192daad88d3084d26f1f2f98daafb059d",
       "version": "81.3.8",
       "port-version": 0
     }

--- a/versions/c-/cef-build.json
+++ b/versions/c-/cef-build.json
@@ -1,8 +1,9 @@
 {
-	"versions": [
-		{
-			"version": "81.3.8",
-			"git-tree": "cd6e313a16ac5546e55e27d9ee541f57e4d515e1"
-		}
-	]
+  "versions": [
+    {
+      "git-tree": "e10900d0da6918956feeec108fb908048c5c5458",
+      "version": "81.3.8",
+      "port-version": 0
+    }
+  ]
 }

--- a/versions/c-/cef-build.json
+++ b/versions/c-/cef-build.json
@@ -1,0 +1,8 @@
+{
+	"versions": [
+		{
+			"version": "81.3.8",
+			"git-tree": "cd6e313a16ac5546e55e27d9ee541f57e4d515e1"
+		}
+	]
+}


### PR DESCRIPTION
**Describe the pull request**

[CEF](https://bitbucket.org/chromiumembedded/cef/src/master/) was requested 5 years ago but nobody has added it yet: #332 

This is the next best thing: [Pre-built CEF binaries](https://cef-builds.spotifycdn.com/index.html).

#### What does your PR fix?  

Fixes #332 (for win64 builds.)

#### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

x64-windows, Yes

(There are binaries for other triplets on their website, but I didn't implement that.)

#### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

#### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
