### PR TITLE
[laszip] Migrate LASzip to the new manifest format.

### DIFF
--- a/ports/laszip/CONTROL
+++ b/ports/laszip/CONTROL
@@ -1,3 +1,0 @@
-Source: laszip
-Version: 3.4.3
-Description: LASzip - free and lossless LiDAR compression

--- a/ports/laszip/portfile.cmake
+++ b/ports/laszip/portfile.cmake
@@ -8,19 +8,18 @@ vcpkg_from_github(
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LASZIP_BUILD_STATIC)
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DLASZIP_BUILD_STATIC=${LASZIP_BUILD_STATIC}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/laszip RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/laszip" RENAME copyright)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 # Remove laszip_api3 dll since it doesn't export functions properly during build.
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/laszip_api3.dll)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/laszip_api3.dll)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/laszip_api3.dll")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/laszip_api3.dll")

--- a/ports/laszip/vcpkg.json
+++ b/ports/laszip/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "laszip",
+  "version": "3.4.3",
+  "port-version": 1,
+  "description": "LASzip - free and lossless LiDAR compression",
+  "homepage": "https://laszip.org/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2954,7 +2954,7 @@
     },
     "laszip": {
       "baseline": "3.4.3",
-      "port-version": 0
+      "port-version": 1
     },
     "lazy-importer": {
       "baseline": "2019-08-10",

--- a/versions/l-/laszip.json
+++ b/versions/l-/laszip.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6c062942b2d4116c89339a9244da9d2abe1e97c1",
+      "version": "3.4.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "6b7b406aadbae2a288bde7f2b268a7c302bfdf67",
       "version-string": "3.4.3",
       "port-version": 0

--- a/versions/l-/laszip.json
+++ b/versions/l-/laszip.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6c062942b2d4116c89339a9244da9d2abe1e97c1",
+      "git-tree": "81b6a105440d08f2c29b044da3f0661e46ddb0a8",
       "version": "3.4.3",
       "port-version": 1
     },


### PR DESCRIPTION
**Description**

- #### What does your PR fix?  
  Migrate [LASzip](https://github.com/LASzip/LASzip) to the preferred manifest format.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`
  
- #### Note
  It also fixed an issue on Windows with MSVC where `LASZIP_ROOT` needed to be defined. With the new cmake configure and install functions this is no longer needed.