### PR TITLE
[azure-storage-cpp] Deprecate azure-storage-cpp package

### DIFF
--- a/ports/azure-storage-cpp/CONTROL
+++ b/ports/azure-storage-cpp/CONTROL
@@ -1,5 +1,6 @@
 Source: azure-storage-cpp
 Version: 7.5.0
+Port-version: 1
 Build-Depends: cpprestsdk[core], atlmfc (windows), boost-log (!windows&!uwp), boost-locale (!windows&!uwp), libxml2 (!windows&!uwp), libuuid (!windows&!uwp&!osx), gettext (osx)
 Description: [legacy] Microsoft Azure Storage Client SDK for C++
   A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues. This client library enables working with the Microsoft Azure storage services which include the blob service for storing binary and text data, the file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.

--- a/ports/azure-storage-cpp/CONTROL
+++ b/ports/azure-storage-cpp/CONTROL
@@ -1,7 +1,7 @@
 Source: azure-storage-cpp
 Version: 7.5.0
 Build-Depends: cpprestsdk[core], atlmfc (windows), boost-log (!windows&!uwp), boost-locale (!windows&!uwp), libxml2 (!windows&!uwp), libuuid (!windows&!uwp&!osx), gettext (osx)
-Description: Microsoft Azure Storage Client SDK for C++
+Description: [legacy] Microsoft Azure Storage Client SDK for C++
   A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues. This client library enables working with the Microsoft Azure storage services which include the blob service for storing binary and text data, the file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
 Homepage: https://blogs.msdn.com/b/windowsazurestorage/
 Supports: !uwp

--- a/ports/azure-storage-cpp/CONTROL
+++ b/ports/azure-storage-cpp/CONTROL
@@ -1,6 +1,6 @@
 Source: azure-storage-cpp
 Version: 7.5.0
-Port-version: 1
+Port-Version: 1
 Build-Depends: cpprestsdk[core], atlmfc (windows), boost-log (!windows&!uwp), boost-locale (!windows&!uwp), libxml2 (!windows&!uwp), libuuid (!windows&!uwp&!osx), gettext (osx)
 Description: [legacy] Microsoft Azure Storage Client SDK for C++
   A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues. This client library enables working with the Microsoft Azure storage services which include the blob service for storing binary and text data, the file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.

--- a/ports/azure-storage-cpp/portfile.cmake
+++ b/ports/azure-storage-cpp/portfile.cmake
@@ -1,3 +1,4 @@
+message(WARNING "azure-storage-cpp is no longer actively developed. Instead, users should migrate to the new sdk: https://github.com/Azure/azure-sdk-for-cpp/releases")
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_from_github(

--- a/ports/azure-storage-cpp/portfile.cmake
+++ b/ports/azure-storage-cpp/portfile.cmake
@@ -1,4 +1,4 @@
-message(WARNING "azure-storage-cpp is no longer actively developed. Instead, users should migrate to the new sdk: https://github.com/Azure/azure-sdk-for-cpp/releases")
+message(WARNING "azure-storage-cpp is no longer actively developed. Instead, users should migrate to the new sdk:azure-core-cpp")
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
 vcpkg_from_github(

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "33726a9bd468c992280ab03b35462b2a66e2317c",
+      "git-tree": "5f0d333f1213ba764b57eb4c4698f7c4bd6f51ce",
       "version-string": "7.5.0",
       "port-version": 0
     },

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5f0d333f1213ba764b57eb4c4698f7c4bd6f51ce",
+      "git-tree": "2f95f8b92596e23af8db61cd1b4e11a06078015f",
       "version-string": "7.5.0",
       "port-version": 0
     },

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7edf61cbc7c2221cfc610c2a5857ae2a922521c",
+      "version-string": "7.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2f95f8b92596e23af8db61cd1b4e11a06078015f",
       "version-string": "7.5.0",
       "port-version": 0

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7edf61cbc7c2221cfc610c2a5857ae2a922521c",
+      "git-tree": "2b3b868fab128f5e37adeffcde308124512d25e0",
       "version-string": "7.5.0",
       "port-version": 1
     },

--- a/versions/a-/azure-storage-cpp.json
+++ b/versions/a-/azure-storage-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f95f8b92596e23af8db61cd1b4e11a06078015f",
+      "git-tree": "33726a9bd468c992280ab03b35462b2a66e2317c",
       "version-string": "7.5.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -302,7 +302,7 @@
     },
     "azure-storage-cpp": {
       "baseline": "7.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-files-datalake-cpp": {
       "baseline": "12.0.0",


### PR DESCRIPTION
Hi, I'm developer of Azure Storage Client team. Since we've announced GA of our Track2 version of azure storage C++ sdk and it's now available on vcpkg, we'd like to deprecate the old azure-storage-cpp package.

**Describe the pull request**

- #### What does your PR fix?  
Deprecate a package.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
I didn't update any port.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
