### PR TITLE
 [libdatachannel] Fix usage

### DIFF
--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -34,4 +34,12 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/libdatachannel)
 vcpkg_fixup_pkgconfig()
 
+file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake DATACHANNEL_CONFIG)
+file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake "
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+find_dependency(OpenSSL)
+find_dependency(libjuice)
+${DATACHANNEL_CONFIG}")
+
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.12.2",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3074,7 +3074,7 @@
     },
     "libdatachannel": {
       "baseline": "0.12.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.10-3",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a13526e9cfc5bfca3aa00e95afa184b498890f69",
+      "version-semver": "0.12.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "dd3107dd99419236f97e299ce4b61c2379a08f55",
       "version-semver": "0.12.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18616

Add `find_dependency() ` in libdatachannel-config.cmake to enable `libdatachannel` found successfully via `find_package(libdatachannel CONFIG REQUIRED)`.

Note: No need to test features.