### PR TITLE
[fmt] Fix an easily avoidable compilation warning

### DIFF
--- a/ports/fmt/fix-warning4189.patch
+++ b/ports/fmt/fix-warning4189.patch
@@ -2,11 +2,13 @@ diff --git a/include/fmt/format.h b/include/fmt/format.h
 index 4e96539..0f1d179 100644
 --- a/include/fmt/format.h
 +++ b/include/fmt/format.h
-@@ -33,6 +33,7 @@
+@@ -33,6 +33,9 @@
  #ifndef FMT_FORMAT_H_
  #define FMT_FORMAT_H_
- 
+
++#ifdef _MSC_VER
 +#pragma warning(disable:4189)
++#endif
  #include <algorithm>
  #include <cerrno>
  #include <cmath>

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fmt",
   "version": "7.1.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2054,7 +2054,7 @@
     },
     "fmt": {
       "baseline": "7.1.3",
-      "port-version": 4
+      "port-version": 5
     },
     "folly": {
       "baseline": "2020.10.19.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e045961b4542ae6a821e7f50acd04d1f1b3bc551",
+      "version": "7.1.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "230e140a15afbb9089537e153d8b83f5b994adbe",
       "version": "7.1.3",
       "port-version": 4

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e045961b4542ae6a821e7f50acd04d1f1b3bc551",
+      "git-tree": "52a5c56d85771a278330e955b703f4db86cfe86d",
       "version": "7.1.3",
       "port-version": 5
     },


### PR DESCRIPTION
In the fmt package, there is a patch that adds `#pragma warning(disable:4189)` near the top of the main include file. This does not account for non-MSVC compilers, so I added a check for that.

- #### What does your PR fix?  
  Fixes fmt not being able to compile on non-MSVC compilers that treat unknown pragmas as errors (whether due to warnings-as-errors, or otherwise).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Only a compile issue fix.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, only a compile issue fix.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
