### PR TITLE
[vcpkg_configure_make] MacOS assume target arch is host arch

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -148,7 +148,9 @@ endmacro()
 
 macro(_vcpkg_determine_autotools_target_arch_mac out_var)
     list(LENGTH VCPKG_OSX_ARCHITECTURES _num_osx_archs)
-    if(_num_osx_archs GREATER_EQUAL 2)
+    if(_num_osx_archs EQUAL 0)
+        set(${out_var} "${VCPKG_DETECTED_CMAKE_HOST_SYSTEM_PROCESSOR}")
+    elseif(_num_osx_archs GREATER_EQUAL 2)
         set(${out_var} "universal")
     else()
         # Better match the arch behavior of config.guess


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  After forgetting to `set(VCPKG_OSX_ARCHITECTURES <arch>)` in a custom triplet file, I noticed that some configure scripts weren't working. This PR fixes this edge case by reasonably defaulting to the host architecture as the target architecture for macOS builds.

I did a quick search for `VCPKG_OSX_ARCHITECTURES` and only really found this spot where it is used, but I can see how it would be easy to miss something like this for other build systems in the future, and maybe I'm missing another spot even now.

On the other hand, if `VCPKG_OSX_ARCHITECTURES` is a _required_ variable with value, then vcpkg should either default to something reasonable earlier in the process as opposed to within each build system script (this PR), or the user should receive an error indicating a value is required for this variable. If you point me to the correct file(s), I can make these changes, but I'm unsure where that is right now. Thank you!

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Affects `osx` triplets

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  N/A
