### PR TITLE
[ffmpeg] multi arch support

### DIFF
--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -15,6 +15,61 @@ cygpath() {
     fi
 }
 
+move_binary() {
+    SOURCE=$1
+    TARGET=$2
+    BINARY=$3
+
+    # run lipo over the command to check whether it really
+    # is a binary that we need to merge architectures
+    /usr/bin/lipo $SOURCE/$BINARY -info &> /dev/null || return 0
+
+    # get the directory name the file is in
+    DIRNAME=$(/usr/bin/dirname $BINARY)
+
+    # ensure the directory to move the binary to exists
+    /bin/mkdir -p $TARGET/$DIRNAME
+
+    # now finally move the binary
+    mv $SOURCE/$BINARY $TARGET/$BINARY
+}
+
+move_binaries() {
+    SOURCE=$1
+    TARGET=$2
+
+    [ ! -d $SOURCE ] && return 0
+    pushd $SOURCE
+
+    for BINARY in $(/usr/bin/find . -type f); do
+        move_binary $SOURCE $TARGET $BINARY
+    done
+
+    popd
+}
+
+merge_binaries() {
+    TARGET=$1
+    SOURCE=$2
+
+    shift
+    shift
+
+    pushd $SOURCE/$1
+    BINARIES=$(/usr/bin/find . -type f)
+    popd
+
+    for BINARY in $BINARIES; do
+        COMMAND="/usr/bin/lipo -create -output $TARGET/$BINARY"
+
+        for ARCH in $@; do
+            COMMAND="$COMMAND -arch $ARCH $SOURCE/$ARCH/$BINARY"
+        done
+
+        $($COMMAND)
+    done
+}
+
 export PKG_CONFIG_PATH="$(cygpath -p "${PKG_CONFIG_PATH}")"
 
 # Export HTTP(S)_PROXY as http(s)_proxy:
@@ -27,19 +82,45 @@ PATH_TO_PACKAGE_DIR=$(cygpath "@INST_PREFIX@")
 
 JOBS=@VCPKG_CONCURRENCY@
 
+ARCHS=(@ARCHITECTURES@)
+
 # Default to hardware concurrency if unset.
 : ${JOBS:=$(nproc)}
 
+build_ffmpeg() {
+    echo "=== CONFIGURING ==="
+
+    echo sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@ $@
+    sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@ $@
+
+    echo "=== BUILDING ==="
+
+    make -j${JOBS}
+
+    echo "=== INSTALLING ==="
+
+    make install
+}
+
 cd "$PATH_TO_BUILD_DIR"
 
-echo "=== CONFIGURING ==="
+if [ ${#ARCHS[@]} -gt 1 ]; then
+    for ARCH in ${ARCHS[*]}; do
+        echo "=== CLEANING FOR $ARCH ==="
 
-sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@
+        make clean && make distclean
 
-echo "=== BUILDING ==="
+        build_ffmpeg --enable-cross-compile --arch=$ARCH --extra-cflags=-arch --extra-cflags=$ARCH --extra-ldflags=-arch --extra-ldflags=$ARCH
 
-make -j${JOBS}
+        echo "=== COLLECTING BINARIES FOR $ARCH ==="
 
-echo "=== INSTALLING ==="
+        move_binaries $PATH_TO_PACKAGE_DIR/lib $PATH_TO_BUILD_DIR/stage/$ARCH/lib
+        move_binaries $PATH_TO_PACKAGE_DIR/bin $PATH_TO_BUILD_DIR/stage/$ARCH/bin
+    done
 
-make install
+    echo "=== MERGING ARCHITECTURES ==="
+
+    merge_binaries $PATH_TO_PACKAGE_DIR $PATH_TO_BUILD_DIR/stage ${ARCHS[*]}
+else
+    build_ffmpeg
+fi

--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -41,7 +41,7 @@ move_binaries() {
     [ ! -d $SOURCE ] && return 0
     pushd $SOURCE
 
-    for BINARY in $(/usr/bin/find . -type f); do
+    for BINARY in $(find . -type f); do
         move_binary $SOURCE $TARGET $BINARY
     done
 
@@ -82,7 +82,8 @@ PATH_TO_PACKAGE_DIR=$(cygpath "@INST_PREFIX@")
 
 JOBS=@VCPKG_CONCURRENCY@
 
-ARCHS=(@ARCHITECTURES@)
+OSX_ARCHS="@OSX_ARCHS@"
+OSX_ARCH_COUNT=0@OSX_ARCH_COUNT@
 
 # Default to hardware concurrency if unset.
 : ${JOBS:=$(nproc)}
@@ -103,8 +104,8 @@ build_ffmpeg() {
 
 cd "$PATH_TO_BUILD_DIR"
 
-if [ ${#ARCHS[@]} -gt 1 ]; then
-    for ARCH in ${ARCHS[*]}; do
+if [ $OSX_ARCH_COUNT -gt 1 ]; then
+    for ARCH in $OSX_ARCHS; do
         echo "=== CLEANING FOR $ARCH ==="
 
         make clean && make distclean
@@ -119,7 +120,7 @@ if [ ${#ARCHS[@]} -gt 1 ]; then
 
     echo "=== MERGING ARCHITECTURES ==="
 
-    merge_binaries $PATH_TO_PACKAGE_DIR $PATH_TO_BUILD_DIR/stage ${ARCHS[*]}
+    merge_binaries $PATH_TO_PACKAGE_DIR $PATH_TO_BUILD_DIR/stage $OSX_ARCHS
 else
     build_ffmpeg
 fi

--- a/ports/ffmpeg/build.sh.in
+++ b/ports/ffmpeg/build.sh.in
@@ -22,13 +22,13 @@ move_binary() {
 
     # run lipo over the command to check whether it really
     # is a binary that we need to merge architectures
-    /usr/bin/lipo $SOURCE/$BINARY -info &> /dev/null || return 0
+    lipo $SOURCE/$BINARY -info &> /dev/null || return 0
 
     # get the directory name the file is in
-    DIRNAME=$(/usr/bin/dirname $BINARY)
+    DIRNAME=$(dirname $BINARY)
 
     # ensure the directory to move the binary to exists
-    /bin/mkdir -p $TARGET/$DIRNAME
+    mkdir -p $TARGET/$DIRNAME
 
     # now finally move the binary
     mv $SOURCE/$BINARY $TARGET/$BINARY
@@ -56,11 +56,11 @@ merge_binaries() {
     shift
 
     pushd $SOURCE/$1
-    BINARIES=$(/usr/bin/find . -type f)
+    BINARIES=$(find . -type f)
     popd
 
     for BINARY in $BINARIES; do
-        COMMAND="/usr/bin/lipo -create -output $TARGET/$BINARY"
+        COMMAND="lipo -create -output $TARGET/$BINARY"
 
         for ARCH in $@; do
             COMMAND="$COMMAND -arch $ARCH $SOURCE/$ARCH/$BINARY"
@@ -90,7 +90,6 @@ ARCHS=(@ARCHITECTURES@)
 build_ffmpeg() {
     echo "=== CONFIGURING ==="
 
-    echo sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@ $@
     sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@ $@
 
     echo "=== BUILDING ==="

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -550,8 +550,19 @@ else()
     set(OPTIONS "${OPTIONS} --disable-zlib")
 endif()
 
+set(CMAKE_VARS_FILE "${CURRENT_BUILDTREES_DIR}/vars.cmake")
+vcpkg_internal_get_cmake_vars(OUTPUT_FILE CMAKE_VARS_FILE)
+include("${CMAKE_VARS_FILE}")
+
 if (VCPKG_TARGET_IS_OSX)
+    # if the sysroot isn't set in the triplet we fall back to whatever CMake detected for us
+    if ("${VCPKG_OSX_SYSROOT}" STREQUAL "")
+        set(VCPKG_OSX_SYSROOT ${VCPKG_DETECTED_CMAKE_OSX_SYSROOT})
+    endif()
+
     set(OPTIONS "${OPTIONS} --disable-vdpau") # disable vdpau in OSX
+    set(OPTIONS "${OPTIONS} --extra-cflags=\"-isysroot ${VCPKG_OSX_SYSROOT}\"")
+    set(OPTIONS "${OPTIONS} --extra-ldflags=\"-isysroot ${VCPKG_OSX_SYSROOT}\"")
 endif()
 
 set(OPTIONS_CROSS "")
@@ -564,8 +575,17 @@ if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQU
             get_filename_component(GAS_ITEM_PATH ${GAS_PATH} DIRECTORY)
             set(ENV{PATH} "$ENV{PATH}${VCPKG_HOST_PATH_SEPARATOR}${GAS_ITEM_PATH}")
         endforeach(GAS_PATH)
-    elseif(VCPKG_TARGET_IS_OSX) # VCPKG_TARGET_ARCHITECTURE = arm64
-        set(OPTIONS_CROSS " --enable-cross-compile --target-os=darwin --arch=arm64 --extra-ldflags=-arch --extra-ldflags=arm64 --extra-cflags=-arch --extra-cflags=arm64 --extra-cxxflags=-arch --extra-cxxflags=arm64")
+    elseif(VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "${VCPKG_DETECTED_CMAKE_SYSTEM_PROCESSOR}") # VCPKG_TARGET_ARCHITECTURE = arm64
+        # get the number of architectures requested
+        list(LENGTH VCPKG_OSX_ARCHITECTURES ARCHITECTURE_COUNT)
+
+        # ideally we should check the CMAKE_HOST_SYSTEM_PROCESSOR, but that seems to be
+        # broken when inside a vcpkg port, so we only set it when doing a simple build
+        # for a single platform. multi-platform builds use a different script
+        if (ARCHITECTURE_COUNT LESS 2)
+            message(STATUS "Building on host: ${CMAKE_SYSTEM_PROCESSOR}")
+            set(OPTIONS_CROSS " --enable-cross-compile --target-os=darwin --arch=arm64 --extra-ldflags=-arch --extra-ldflags=arm64 --extra-cflags=-arch --extra-cflags=arm64 --extra-cxxflags=-arch --extra-cxxflags=arm64")
+        endif()
     endif()
 elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
 elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -563,6 +563,9 @@ if (VCPKG_TARGET_IS_OSX)
     set(OPTIONS "${OPTIONS} --disable-vdpau") # disable vdpau in OSX
     set(OPTIONS "${OPTIONS} --extra-cflags=\"-isysroot ${VCPKG_OSX_SYSROOT}\"")
     set(OPTIONS "${OPTIONS} --extra-ldflags=\"-isysroot ${VCPKG_OSX_SYSROOT}\"")
+
+    list(JOIN VCPKG_OSX_ARCHITECTURES " " OSX_ARCHS)
+    LIST(LENGTH VCPKG_OSX_ARCHITECTURES OSX_ARCH_COUNT)
 endif()
 
 set(OPTIONS_CROSS "")

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 5,
+  "port-version": 6,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,5 +1,5 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2021-02-28",
-  "port-version": 3
+  "version-date": "2021-06-25",
+  "port-version": 4
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -251,6 +251,7 @@ function(vcpkg_cmake_configure)
     endif()
 
 
+    list(JOIN VCPKG_TARGET_ARCHITECTURE "\;" target_architecture_string)
     list(APPEND arg_OPTIONS
         "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}"
         "-DVCPKG_TARGET_TRIPLET=${TARGET_TRIPLET}"
@@ -274,7 +275,7 @@ function(vcpkg_cmake_configure)
         "-DVCPKG_LINKER_FLAGS=${VCPKG_LINKER_FLAGS}"
         "-DVCPKG_LINKER_FLAGS_RELEASE=${VCPKG_LINKER_FLAGS_RELEASE}"
         "-DVCPKG_LINKER_FLAGS_DEBUG=${VCPKG_LINKER_FLAGS_DEBUG}"
-        "-DVCPKG_TARGET_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}"
+        "-DVCPKG_TARGET_ARCHITECTURE=${target_architecture_string}"
         "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
         "-DCMAKE_INSTALL_BINDIR:STRING=bin"
         "-D_VCPKG_ROOT_DIR=${VCPKG_ROOT_DIR}"
@@ -289,7 +290,8 @@ function(vcpkg_cmake_configure)
     # Sets configuration variables for macOS builds
     foreach(config_var IN ITEMS INSTALL_NAME_DIR OSX_DEPLOYMENT_TARGET OSX_SYSROOT OSX_ARCHITECTURES)
         if(DEFINED VCPKG_${config_var})
-            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${VCPKG_${config_var}}")
+            list(JOIN VCPKG_${config_var} "\;" config_var_value)
+            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${config_var_value}")
         endif()
     endforeach()
 

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -231,7 +231,7 @@ function(vcpkg_configure_cmake)
         endif()
     endif()
 
-
+    list(JOIN VCPKG_TARGET_ARCHITECTURE "\;" target_architecure_string)
     list(APPEND arg_OPTIONS
         "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}"
         "-DVCPKG_TARGET_TRIPLET=${TARGET_TRIPLET}"
@@ -255,7 +255,7 @@ function(vcpkg_configure_cmake)
         "-DVCPKG_LINKER_FLAGS=${VCPKG_LINKER_FLAGS}"
         "-DVCPKG_LINKER_FLAGS_RELEASE=${VCPKG_LINKER_FLAGS_RELEASE}"
         "-DVCPKG_LINKER_FLAGS_DEBUG=${VCPKG_LINKER_FLAGS_DEBUG}"
-        "-DVCPKG_TARGET_ARCHITECTURE=${VCPKG_TARGET_ARCHITECTURE}"
+        "-DVCPKG_TARGET_ARCHITECTURE=${target_architecure_string}"
         "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
         "-DCMAKE_INSTALL_BINDIR:STRING=bin"
         "-D_VCPKG_ROOT_DIR=${VCPKG_ROOT_DIR}"
@@ -272,7 +272,8 @@ function(vcpkg_configure_cmake)
     # Sets configuration variables for macOS builds
     foreach(config_var  INSTALL_NAME_DIR OSX_DEPLOYMENT_TARGET OSX_SYSROOT OSX_ARCHITECTURES)
         if(DEFINED VCPKG_${config_var})
-            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${VCPKG_${config_var}}")
+            list(JOIN VCPKG_${config_var} "\;" config_var_value)
+            list(APPEND arg_OPTIONS "-DCMAKE_${config_var}=${config_var_value}")
         endif()
     endforeach()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1982,7 +1982,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 5
+      "port-version": 6
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6501,8 +6501,8 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2021-02-28",
-      "port-version": 3
+      "baseline": "2021-06-25",
+      "port-version": 4
     },
     "vcpkg-cmake-config": {
       "baseline": "2021-05-22",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3887b837d6c4c8b0f4ab2c38d5e24698e1e3c19",
+      "version": "4.4",
+      "port-version": 6
+    },
+    {
       "git-tree": "234eb0e352d2a7be0a3b34fb9eb8a9f0417ffe94",
       "version": "4.4",
       "port-version": 5

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d3887b837d6c4c8b0f4ab2c38d5e24698e1e3c19",
+      "git-tree": "8405d9f6850d7ceb6cede89a791b42c41253ef29",
       "version": "4.4",
       "port-version": 6
     },

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acc25ec22f8fd8887a865705580b1d6de041616d",
+      "version-date": "2021-06-25",
+      "port-version": 4
+    },
+    {
       "git-tree": "0e8bb94599a00fd9c61fd0ae524c22a067c21420",
       "version-date": "2021-02-28",
       "port-version": 3


### PR DESCRIPTION
This PR enables multi-arch (or "universal") builds for ffmpeg on macOS

- #### What does your PR fix?  
It works around lack of support for multi-arch builds in Autotools by doing two separate builds and then joining them using lipo to create a universal binary.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
New triplet is supported, with both `arm64` and `x86_64` defined for `VCPKG_OSX_ARCHITECTURES`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Port version is updated

NOTE: This PR depends on https://github.com/microsoft/vcpkg/pull/18156 which has been rebased (for the latest ffmpeg changes) and then used as a base in this PR. When that PR is merged I'll rebase it on current master. I just think we should get the review-cycle for this going.