### PR TITLE
[spdlog] Do not build examples

### DIFF
--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_cmake_configure(
         -DSPDLOG_FMT_EXTERNAL=ON
         -DSPDLOG_INSTALL=ON
         -DSPDLOG_BUILD_SHARED=${SPDLOG_BUILD_SHARED}
+        -DSPDLOG_BUILD_EXAMPLE=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.8.5",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5922,7 +5922,7 @@
     },
     "spdlog": {
       "baseline": "1.8.5",
-      "port-version": 2
+      "port-version": 3
     },
     "spectra": {
       "baseline": "0.9.0",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f74643a7b8056237da08c41a653f5b0592870906",
+      "version-semver": "1.8.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "9aa80a12ad92e29cfc19df70b9fd615b4aa5997b",
       "version-semver": "1.8.5",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Skip building `spdlog` examples which are built by default when `spdlog` is built as a master project

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all
- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
