### PR TITLE
[morton-nd] Update to v4.0.0.

### DIFF
--- a/ports/morton-nd/CONTROL
+++ b/ports/morton-nd/CONTROL
@@ -1,4 +1,4 @@
 Source: morton-nd
-Version: 3.0.0
+Version: 4.0.0
 Homepage: https://github.com/kevinhartman/morton-nd
 Description: header-only constexpr library for fast Morton encoding/decoding in N dimensions.

--- a/ports/morton-nd/portfile.cmake
+++ b/ports/morton-nd/portfile.cmake
@@ -3,9 +3,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kevinhartman/morton-nd
-    REF v3.0.0
-    SHA512 659c903c0c4a4ee4179d01950a952fe0c40d2c426063c10515ae5d2ad13ec8ca6b83d8de50c9eb86dd3c2c3747e1594d832f0c28cd6d414703baf9a7ab2f1f36
-    HEAD_REF master
+    REF v4.0.0
+    SHA512 19dc51ae5d7fc868625a9c9f0dddec95a77fdeac714300033008f096bc3a83f146738e525e8a0ec541903263355a7fec84b1873d8eacfca4b93d3cd8945653da
+    HEAD_REF main
 )
 
 vcpkg_configure_cmake(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },
@@ -4105,7 +4105,7 @@
       "port-version": 0
     },
     "morton-nd": {
-      "baseline": "3.0.0",
+      "baseline": "4.0.0",
       "port-version": 0
     },
     "mosquitto": {

--- a/versions/m-/morton-nd.json
+++ b/versions/m-/morton-nd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "949f90299960d91f4cfd457a093dd70c5e285782",
+      "version-string": "4.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "acdac4e47f9b91d7a7dd27aa9689f029fdd43895",
       "version-string": "3.0.0",
       "port-version": 0


### PR DESCRIPTION
Updates `morton-nd` to current version 4.0.0.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  `all`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
