### PR TITLE
[stb] Add support for stb_vorbis and update port.

### DIFF
--- a/ports/stb/CMakeLists.txt
+++ b/ports/stb/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(stb)
+# create a library for stb
+add_library(stb "stb_vorbis.h" "stb_vorbis.c")
+target_compile_definitions(stb PRIVATE "STB_VORBIS_EXPORTS")
+# install library
+install(TARGETS stb
+    EXPORT stb_targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
+)
+install(EXPORT stb_targets
+    FILE stb-config.cmake
+    NAMESPACE stb::
+    DESTINATION share/stb
+)
+export(TARGETS stb
+    NAMESPACE stb::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/stb-config.cmake"
+)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/stb-config.cmake"
+    DESTINATION share/stb
+)

--- a/ports/stb/CONTROL
+++ b/ports/stb/CONTROL
@@ -1,4 +1,0 @@
-Source: stb
-Version: 2020-09-14
-Homepage: https://github.com/nothings/stb
-Description: public domain header-only libraries

--- a/ports/stb/portfile.cmake
+++ b/ports/stb/portfile.cmake
@@ -1,10 +1,56 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO nothings/stb
-    REF b42009b3b9d4ca35bc703f5310eedc74f584be58 # accessed on 2020-09-14
-    SHA512 a9ba80d19dae4e527171bb02e1caa4d3eb0704cdf7f8fef1a7a09e6b05c65b829b0aa580f469f158a39bf13018289f40c1680ab5c22bfa5e932bff94eced475d
+    REF 80c8f6af0304588b9d780a41015472013b705194 # accessed on 2021-06-24
+    SHA512 0a1d8ad6b606a0904fce29855693a6fed6de1979272edf5bcb9837904dff79abaaf8f1ef9606cd5933396daa56c0851e6c1e3fc24547ab91accc7a1f17ace9f4
     HEAD_REF master
 )
+
+# create a header file for stb_vorbis
+file(READ "${SOURCE_PATH}/stb_vorbis.c" stb_vorbis)
+#   find beginning and length of header
+string(FIND "${stb_vorbis}" "//  HEADER BEGINS HERE" stb_vorbis_header_begin)
+string(FIND "${stb_vorbis}" "//  HEADER ENDS HERE" stb_vorbis_header_end)
+math(EXPR stb_vorbis_header_length "${stb_vorbis_header_end} - ${stb_vorbis_header_begin}")
+#   create a substring for the header
+string(SUBSTRING "${stb_vorbis}" "${stb_vorbis_header_begin}" "${stb_vorbis_header_length}" stb_vorbis_header)
+#   create a string for the source
+string(SUBSTRING "${stb_vorbis}" "0" "${stb_vorbis_header_begin}" stb_vorbis_source_before)
+string(SUBSTRING "${stb_vorbis}" "${stb_vorbis_header_end}" "-1" stb_vorbis_source_after)
+string(CONCAT stb_vorbis_source "${stb_vorbis_source_before}" "#include \"stb_vorbis.h\"\n" "${stb_vorbis_source_after}")
+#   write source to file, replacing the original source file
+file(WRITE "${SOURCE_PATH}/stb_vorbis.c" "${stb_vorbis_source}")
+#   prepend export macro
+string(PREPEND stb_vorbis_header [[
+#ifdef _WIN32
+    #ifdef STB_VORBIS_EXPORTS
+        #define STB_VORBIS __declspec(dllexport)
+    #else
+        #define STB_VORBIS __declspec(dllimport)
+    #endif
+#else
+    #define STB_VORBIS
+#endif
+]])
+#   replace all instances of 'extern' beyond 'extern "C"' with 'STB_VORBIS extern'
+#     split string into before 'extern "C"' and after 'extern "C"'
+string(FIND "${stb_vorbis_header}" "extern \"C\"" extern_c_pos)
+math(EXPR after_extern_c_pos "${extern_c_pos} + 10")
+string(SUBSTRING "${stb_vorbis_header}" "0" "${after_extern_c_pos}" before_extern_c)
+string(SUBSTRING "${stb_vorbis_header}" "${after_extern_c_pos}" "-1" after_extern_c)
+#     replace
+string(REPLACE "extern" "STB_VORBIS extern" after_extern_c_modified "${after_extern_c}")
+#     concatenate
+string(CONCAT stb_vorbis_header_modified "${before_extern_c}" "${after_extern_c_modified}")
+#   write header to file
+file(WRITE "${SOURCE_PATH}/stb_vorbis.h" "${stb_vorbis_header_modified}")
+# configure
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+# install
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+vcpkg_copy_pdbs()
 
 file(GLOB HEADER_FILES ${SOURCE_PATH}/*.h)
 file(COPY ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include)

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "stb",
+  "version-string": "2021-06-20",
+  "description": "public domain header-only libraries",
+  "homepage": "https://github.com/nothings/stb",
+  "dependencies": [
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "stb",
-  "version-string": "2021-06-20",
+  "version-date": "2021-06-26",
   "description": "public domain header-only libraries",
   "homepage": "https://github.com/nothings/stb",
   "dependencies": [

--- a/ports/stb/vcpkg.json
+++ b/ports/stb/vcpkg.json
@@ -4,7 +4,13 @@
   "description": "public domain header-only libraries",
   "homepage": "https://github.com/nothings/stb",
   "dependencies": [
-    "vcpkg-cmake",
-    "vcpkg-cmake-config"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6005,7 +6005,7 @@
       "port-version": 0
     },
     "stb": {
-      "baseline": "2020-09-14",
+      "baseline": "2021-06-20",
       "port-version": 0
     },
     "stlab": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6005,7 +6005,7 @@
       "port-version": 0
     },
     "stb": {
-      "baseline": "2021-06-20",
+      "baseline": "2021-06-26",
       "port-version": 0
     },
     "stlab": {

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "177d66234c94ae95be4a7e8725b2f4b1d86a9386",
-      "version-string": "2021-06-20",
-      "port-version": 0
-    },
-    {
       "git-tree": "079dbaa8fb1658d6508be38e224c79aeb99a0c46",
       "version-string": "2020-09-14",
       "port-version": 0

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "177d66234c94ae95be4a7e8725b2f4b1d86a9386",
+      "version-string": "2021-06-20",
+      "port-version": 0
+    },
+    {
       "git-tree": "079dbaa8fb1658d6508be38e224c79aeb99a0c46",
       "version-string": "2020-09-14",
       "port-version": 0

--- a/versions/s-/stb.json
+++ b/versions/s-/stb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac9f688b619776c2923b958c3e49d87e4601498f",
+      "version-date": "2021-06-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "177d66234c94ae95be4a7e8725b2f4b1d86a9386",
       "version-string": "2021-06-20",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  I wanted to use the stb_vorbis library from stb.
  The current stb port does not have support for the stb_vorbis library.

  I have added support for stb_vorbis.

  I have also added some updates to the port.
  I have replaced the CONTROL file with a `vcpkg.json` manifest file since I needed to add some dependencies on vcpkg features.
  In the replacement file, I have updated the version string to "2021-06-20". That is the data of the latest commit in the stb repository.
  I updated the portfile's `REF` to the latest commit as well.

  To add stb_vorbis I used the compilation guide at https://nothings.org/stb_vorbis/.

  I made the portfile first cut the header out from the source file and write it to a seperate file.
  Then, the portfile needs to compile the source file as a library.
  First, it adds an export macro to the source file along with an include to find the header.
  Then it copies a `CMakeLists.txt` to the source path. I wrote this file to configure and install a library for stb_vorbis.
  Next, vcpkg configures and installs the library.

  The portfile installs the rest of the stb libraries as normal.

  I have no clue what `vcpkg-cmake-wrapper.cmake` is, and I do not think `FindStb.cmake` is still needed. If I do not install them, I can still use the other libraries, but I have kept them to be safe. At least keeping the `FindStb.cmake` should ensure that projects that use stb don't break.

  This is my first pull request. I hope that there are no issues. I updated this port for my personal use and it works for me so feel free to deny the request if there are issues.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  x64-windows, No
  Other triplets should be support but I have not tested them.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes. (hopefully)

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes. It seemed to also update the formatting of `libsmb2` in `baseline.json`, I reverted that change since it is not relevant to this.
