### PR TITLE
[recast] Export unofficial target

### DIFF
--- a/ports/recast/CMakeLists.txt
+++ b/ports/recast/CMakeLists.txt
@@ -44,9 +44,12 @@ add_library(recast ${SRC})
 
 install(
   TARGETS recast
+  EXPORT unofficial-recast-config
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
+
+install(EXPORT unofficial-recast-config DESTINATION share/unofficial-recast)
 
 if(NOT DISABLE_INSTALL_HEADERS)
   install(DIRECTORY DebugUtils/Include/ DESTINATION include/recast/DebugUtils)

--- a/ports/recast/CMakeLists.txt
+++ b/ports/recast/CMakeLists.txt
@@ -42,6 +42,11 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DetourTileCache/Include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Recast/Include>
   $<INSTALL_INTERFACE:include>
+  $<INSTALL_INTERFACE:include/Detour/Include>
+  $<INSTALL_INTERFACE:include/DetourCrowd/Include>
+  $<INSTALL_INTERFACE:include/DetourTileCache/Include>
+  $<INSTALL_INTERFACE:include/Recast/Include>
+  $<INSTALL_INTERFACE:include/DebugUtils/Include>
 )
 
 install(

--- a/ports/recast/CMakeLists.txt
+++ b/ports/recast/CMakeLists.txt
@@ -1,14 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(recast)
 
-include_directories(
-  DebugUtils/Include
-  Detour/Include
-  DetourCrowd/Include
-  DetourTileCache/Include
-  Recast/Include
-)
-
 set(SRC
   DebugUtils/Source/DebugDraw.cpp
   DebugUtils/Source/DetourDebugDraw.cpp
@@ -41,6 +33,16 @@ set(SRC
 )
 
 add_library(recast ${SRC})
+
+target_include_directories(
+  recast PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DebugUtils/Include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Detour/Include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DetourCrowd/Include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/DetourTileCache/Include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Recast/Include>
+  $<INSTALL_INTERFACE:include>
+)
 
 install(
   TARGETS recast

--- a/ports/recast/CONTROL
+++ b/ports/recast/CONTROL
@@ -1,4 +1,0 @@
-Source: recast
-Version: 1.5.1-3
-Homepage: https://github.com/recastnavigation/recastnavigation
-Description: Navigation-mesh Toolset for Games

--- a/ports/recast/portfile.cmake
+++ b/ports/recast/portfile.cmake
@@ -8,16 +8,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/recast RENAME copyright)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-recast CONFIG_PATH share/unofficial-recast)
 
 vcpkg_copy_pdbs()
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+file(INSTALL "${SOURCE_PATH}/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/recast/vcpkg.json
+++ b/ports/recast/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "recast",
+  "version": "1.5.1",
+  "port-version": 4,
+  "description": "Navigation-mesh Toolset for Games",
+  "homepage": "https://github.com/recastnavigation/recastnavigation",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },
@@ -5469,8 +5469,8 @@
       "port-version": 1
     },
     "recast": {
-      "baseline": "1.5.1-3",
-      "port-version": 0
+      "baseline": "1.5.1",
+      "port-version": 4
     },
     "redis-plus-plus": {
       "baseline": "1.2.3",

--- a/versions/r-/recast.json
+++ b/versions/r-/recast.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "949b280dbfefbc4ad6c1af2141e2632786baa30d",
+      "git-tree": "2f34af0b398b4c37f0cdf3fcd8dc9db965e4dd5e",
       "version": "1.5.1",
       "port-version": 4
     },

--- a/versions/r-/recast.json
+++ b/versions/r-/recast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "949b280dbfefbc4ad6c1af2141e2632786baa30d",
+      "version": "1.5.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "41f8cc06fc981d330671b88e08d02de55934155c",
       "version-string": "1.5.1-3",
       "port-version": 0


### PR DESCRIPTION
Export the target that the user can use recast simply:
```
The package recast:x86-windows provides CMake targets:

    find_package(unofficial-recast CONFIG REQUIRED)
    target_link_libraries(main PRIVATE recast)
```

Fixes #18649.