### PR TITLE
[glew] Fix the dependency

### DIFF
--- a/ports/glew/CONTROL
+++ b/ports/glew/CONTROL
@@ -1,6 +1,0 @@
-Source: glew
-Version: 2.1.0
-Port-Version: 10
-Description: The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.
-Homepage: https://github.com/nigels-com/glew
-Build-Depends: opengl

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -1,5 +1,5 @@
 if(VCPKG_TARGET_IS_LINUX)
-    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libxmu-dev\n    libxi-dev\n    libgl-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxmu-dev libxi-dev libgl-dev.")
+    message(WARNING "${PORT} requires the following libraries from the system package manager:\n    libxmu-dev\n    libxi-dev\n    libgl-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxmu-dev libxi-dev libgl-dev.")
 endif()
 
 # Don't change to vcpkg_from_github! The sources in the git repository (archives) are missing some files that are distributed inside releases.

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -1,3 +1,7 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libxmu-dev\n    libxi-dev\n    libgl-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxmu-dev libxi-dev libgl-dev.")
+endif()
+
 # Don't change to vcpkg_from_github! The sources in the git repository (archives) are missing some files that are distributed inside releases.
 # More info: https://github.com/nigels-com/glew/issues/31 and https://github.com/nigels-com/glew/issues/13
 vcpkg_download_distfile(ARCHIVE

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "glew",
+  "version-string": "2.1.0",
+  "port-version": 11,
+  "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
+  "homepage": "https://github.com/nigels-com/glew",
+  "dependencies": [
+    {
+      "name": "opengl",
+      "platform": "windows"
+    }
+  ]
+}

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -5,9 +5,6 @@
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
   "dependencies": [
-    {
-      "name": "opengl",
-      "platform": "windows"
-    }
+    "opengl"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2290,7 +2290,7 @@
     },
     "glew": {
       "baseline": "2.1.0",
-      "port-version": 10
+      "port-version": 11
     },
     "glfw3": {
       "baseline": "3.3.4",
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f0d1692409b7a934c21fc44652ffac9ec508c0a9",
+      "git-tree": "622e27b2a746c088f0acd2f98445c0968f485a69",
       "version-string": "2.1.0",
       "port-version": 11
     },

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0d1692409b7a934c21fc44652ffac9ec508c0a9",
+      "version-string": "2.1.0",
+      "port-version": 11
+    },
+    {
       "git-tree": "c87d7f619c69630fa4d1bd0bf3767f0d31ef22d6",
       "version-string": "2.1.0",
       "port-version": 10


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/18662

glew depends on port opengl, which only built for windows, so limit to platform for dependencies. 
It requires libraries libxmu-dev libxi-dev libgl-dev which should be installed via system package manager on linux, providing the message with user.