### PR TITLE
[vcpkg doc] Update examples

### DIFF
--- a/docs/maintainers/vcpkg_clean_msbuild.md
+++ b/docs/maintainers/vcpkg_clean_msbuild.md
@@ -11,7 +11,7 @@ vcpkg_clean_msbuild()
 
 ## Examples
 
-* [xalan-c](https://github.com/Microsoft/vcpkg/blob/master/ports/xalan-c/portfile.cmake)
+* [python3](https://github.com/Microsoft/vcpkg/blob/master/ports/python3/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_clean\_msbuild.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_clean_msbuild.cmake)

--- a/docs/maintainers/vcpkg_install_msbuild.md
+++ b/docs/maintainers/vcpkg_install_msbuild.md
@@ -88,8 +88,8 @@ Additional options passed to msbuild for Debug builds. These are in addition to 
 
 ## Examples
 
-* [xalan-c](https://github.com/Microsoft/vcpkg/blob/master/ports/xalan-c/portfile.cmake)
-* [libimobiledevice](https://github.com/Microsoft/vcpkg/blob/master/ports/libimobiledevice/portfile.cmake)
+* [libirecovery](https://github.com/microsoft/vcpkg/blob/master/ports/libirecovery/portfile.cmake)
+* [libfabric](https://github.com/microsoft/vcpkg/blob/master/ports/libfabric/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_install\_msbuild.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_install_msbuild.cmake)

--- a/docs/maintainers/vcpkg_install_msbuild.md
+++ b/docs/maintainers/vcpkg_install_msbuild.md
@@ -88,8 +88,8 @@ Additional options passed to msbuild for Debug builds. These are in addition to 
 
 ## Examples
 
-* [libirecovery](https://github.com/microsoft/vcpkg/blob/master/ports/libirecovery/portfile.cmake)
-* [libfabric](https://github.com/microsoft/vcpkg/blob/master/ports/libfabric/portfile.cmake)
+* [libirecovery](https://github.com/Microsoft/vcpkg/blob/master/ports/libirecovery/portfile.cmake)
+* [libfabric](https://github.com/Microsoft/vcpkg/blob/master/ports/libfabric/portfile.cmake)
 
 ## Source
 [scripts/cmake/vcpkg\_install\_msbuild.cmake](https://github.com/Microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_install_msbuild.cmake)

--- a/scripts/cmake/vcpkg_clean_msbuild.cmake
+++ b/scripts/cmake/vcpkg_clean_msbuild.cmake
@@ -10,7 +10,7 @@ vcpkg_clean_msbuild()
 
 ## Examples
 
-* [xalan-c](https://github.com/Microsoft/vcpkg/blob/master/ports/xalan-c/portfile.cmake)
+* [python3](https://github.com/Microsoft/vcpkg/blob/master/ports/python3/portfile.cmake)
 #]===]
 
 function(vcpkg_clean_msbuild)

--- a/scripts/cmake/vcpkg_install_msbuild.cmake
+++ b/scripts/cmake/vcpkg_install_msbuild.cmake
@@ -87,8 +87,8 @@ Additional options passed to msbuild for Debug builds. These are in addition to 
 
 ## Examples
 
-* [xalan-c](https://github.com/Microsoft/vcpkg/blob/master/ports/xalan-c/portfile.cmake)
-* [libimobiledevice](https://github.com/Microsoft/vcpkg/blob/master/ports/libimobiledevice/portfile.cmake)
+* [libirecovery](https://github.com/Microsoft/vcpkg/blob/master/ports/libirecovery/portfile.cmake)
+* [libfabric](https://github.com/Microsoft/vcpkg/blob/master/ports/libfabric/portfile.cmake)
 #]===]
 
 function(vcpkg_install_msbuild)


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #16680

The original examples in `vcpkg_install_msbuild `and `vcpkg_clean_msbuild ` are outdated. Since these ports don't use `msbuild `now.

So add other ports that use `msbuild` as the examples in these docs.
 
