### PR TITLE
[vcpkg] Update the minimum version of vcpkg

### DIFF
--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -26,7 +26,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${SCRIPTS}/cmake")
 include("${SCRIPTS}/cmake/vcpkg_minimum_required.cmake")
-vcpkg_minimum_required(VERSION 2021-01-13)
+vcpkg_minimum_required(VERSION 2021-05-05)
 
 file(TO_CMAKE_PATH "${BUILDTREES_DIR}" BUILDTREES_DIR)
 file(TO_CMAKE_PATH "${PACKAGES_DIR}" PACKAGES_DIR)


### PR DESCRIPTION
Since microsoft/vcpkg and microsoft/vcpkg-tool are synchronized to update `x-download` related content, update to `2021-05-05` (contains `x-download`) version to avoid being unable to find this command:
```
E:\Lib\vcpkg>vcpkg install sundials --triplet x64-windows
Computing installation plan...
The following packages will be built and installed:
    sundials[core]:x64-windows -> 5.7.0#1
Detecting compiler hash for triplet x64-windows...
Could not locate cached archive: C:\Users\ch6535\AppData\Local\vcpkg\archives\df\df61b63fc4d86a443bbedaa77be748372df4bfe
c.zip
Starting package 1/1: sundials:x64-windows
Building package sundials[core]:x64-windows...
-- Downloading https://github.com/LLNL/sundials/archive/73c280cd55ca2b42019c8a9aa54af10e41e27b9d.tar.gz -> LLNL-sundials
-73c280cd55ca2b42019c8a9aa54af10e41e27b9d.tar.gz...
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'manifests' = off
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] BuiltinRegistry initialized with: ""
[DEBUG] Using vcpkg-root: E:\Lib\vcpkg
[DEBUG] Using installed-root: E:\Lib\vcpkg\installed
[DEBUG] BuiltinRegistry initialized with: ""
[DEBUG] Using buildtrees-root: E:\Lib\vcpkg\buildtrees
[DEBUG] Using downloads-root: E:\Lib\vcpkg\downloads
[DEBUG] Using packages-root: E:\Lib\vcpkg\packages
[DEBUG] Using scripts-root: E:\Lib\vcpkg\scripts
[DEBUG] Using ports-root: E:\Lib\vcpkg\ports
[DEBUG] Using versions-root: E:\Lib\vcpkg\versions
invalid command: x-download
```

Related: https://github.com/microsoft/vcpkg/pull/13639#discussion_r659941583 https://github.com/microsoft/vcpkg/issues/18353 etc.