### PR TITLE
[bzip2] Update repository

### DIFF
--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -1,10 +1,14 @@
-vcpkg_from_git(
+set(BZIP2_VERSION 1.0.8)
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz"
+    FILENAME "bzip2-${BZIP2_VERSION}.tar.gz"
+    SHA512 083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3
+)
+
+vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://sourceware.org/git/bzip2.git
-    REF 75a94bea3918e612b879d6a11ca64b8689526147 # REFERENCE BZIP2 VERSION 1.0.8
-    SHA512 4611105f9090477b5f6f6dbd303a282099df71644e04d8a998ef81de487f6c8cac4c0ec1283ad737f6767c51f1e3b4e24e2ee021c6dd085925617d9ed145b2ba
-    PATCHES
-        fix-import-export-macros.patch
+    ARCHIVE ${ARCHIVE}
+    PATCHES fix-import-export-macros.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/bzip2/vcpkg.json
+++ b/ports/bzip2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bzip2",
-  "version-string": "1.0.8",
-  "port-version": 1,
+  "version-semver": "1.0.8",
+  "port-version": 2,
   "description": "bzip2 is a freely available, patent free, high-quality data compressor. It typically compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical compressors), whilst being around twice as fast at compression and six times faster at decompression.",
   "homepage": "https://sourceware.org/bzip2/",
   "documentation": "https://sourceware.org/bzip2/docs.html"

--- a/versions/b-/bzip2.json
+++ b/versions/b-/bzip2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1ea352502e69888a565563d9151d3f7ab609fb1",
+      "version-semver": "1.0.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "5a1b1b8d666b9ef64e8596e4716c2e2f654f4532",
       "version-string": "1.0.8",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1090,7 +1090,7 @@
     },
     "bzip2": {
       "baseline": "1.0.8",
-      "port-version": 1
+      "port-version": 2
     },
     "c-ares": {
       "baseline": "1.17.1",
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18678

Currently, `bzip2 `downloads the source from git https://sourceware.org/git/bzip2.git via `vcpkg_from_git `, which causes some problems while downloading.

So I updated to use `vcpkg_download_disfile `from https://sourceware.org/pub/bzip2/ to download the source.

Related issue #18291, #16282, #14424, #18071, #17704, #17517, #16846, #16015, #15911, #15649, #15648, #14974, #13851
