### PR TITLE
[tgui] Fix feature tool dependency

### DIFF
--- a/ports/tgui/vcpkg.json
+++ b/ports/tgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tgui",
   "version-date": "2021-04-19",
-  "port-version": 1,
+  "port-version": 2,
   "description": "TGUI is an easy to use, cross-platform, C++ GUI for SFML.",
   "homepage": "https://tgui.eu",
   "default-features": [
@@ -35,7 +35,16 @@
       ]
     },
     "tool": {
-      "description": "Build GUI builder"
+      "description": "Build GUI builder",
+      "dependencies": [
+        {
+          "name": "tgui",
+          "features": [
+            "sdl2",
+            "sfml"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },
@@ -6150,7 +6150,7 @@
     },
     "tgui": {
       "baseline": "2021-04-19",
-      "port-version": 1
+      "port-version": 2
     },
     "theia": {
       "baseline": "0.8",

--- a/versions/t-/tgui.json
+++ b/versions/t-/tgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0fd517c4e738da62e959b791a6cdd952e7bd8345",
+      "version-date": "2021-04-19",
+      "port-version": 2
+    },
+    {
       "git-tree": "354b5135bda4bcef9c5e7cbfeaff3d457b336e8c",
       "version-date": "2021-04-19",
       "port-version": 1


### PR DESCRIPTION
Add features `sdl2` and `sfml` as dependencies of feature `tool` since the upstream reuqires that:
https://github.com/texus/TGUI/commit/6e53b466b3ce2d3d5bc993259b855b688fd8884d

Fixes #18691.

All feature are succesful testead on `x86-windows`, `x64-windows` and `x64-windows-static`.