### PR TITLE
[meson] Fix operator precedence in if statement

### DIFF
--- a/scripts/cmake/vcpkg_configure_meson.cmake
+++ b/scripts/cmake/vcpkg_configure_meson.cmake
@@ -316,7 +316,7 @@ function(vcpkg_internal_meson_generate_cross_file _additional_binaries) #https:/
         string(APPEND CROSS "cpu = '${BUILD_CPU}'\n")
     endif()
 
-    if(NOT BUILD_CPU_FAM MATCHES "${HOST_CPU_FAM}" OR VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_UWP)
+    if((NOT BUILD_CPU_FAM MATCHES "${HOST_CPU_FAM}") OR VCPKG_TARGET_IS_ANDROID OR VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_UWP)
         set(_file "${CURRENT_BUILDTREES_DIR}/meson-cross-${TARGET_TRIPLET}.log")
         set(VCPKG_MESON_CROSS_FILE "${_file}" PARENT_SCOPE)
         file(WRITE "${_file}" "${CROSS}")


### PR DESCRIPTION
This pull request fixes a precedence issue with the NOT that was actually applied to the whole expression.