### PR TITLE
Remove ability to disable exception support in TBB runtime

### DIFF
--- a/ports/tbb/CMakeLists.txt
+++ b/ports/tbb/CMakeLists.txt
@@ -1,13 +1,9 @@
 project(tbb CXX)
 
-option(DISABLE_EXCEPTIONS "Set exceptions=0 for make to turn off exception support in TBB" OFF)
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*)
 file(COPY ${SOURCES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src)
 
 include(${CMAKE_CURRENT_BINARY_DIR}/src/cmake/TBBBuild.cmake REQUIRED)
-if(DISABLE_EXCEPTIONS)
-    set(DISABLE_EXCEPTIONS_ARG exceptions=0)
-endif()
 if(NOT BUILD_SHARED_LIBS)
     set(TBB_STATIC_INCLUDE extra_inc=big_iron.inc)
 endif()
@@ -30,7 +26,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   endif()
 endif()
 
-tbb_build(TBB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/src MAKE_ARGS ${arch} ${CPLUS} ${CONLY} ${DISABLE_EXCEPTIONS_ARG} ${TBB_STATIC_INCLUDE} ${FORWARD_SDK_ROOT})
+tbb_build(TBB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/src MAKE_ARGS ${arch} ${CPLUS} ${CONLY} ${TBB_STATIC_INCLUDE} ${FORWARD_SDK_ROOT})
 
 set(SUBDIR ${CMAKE_CURRENT_BINARY_DIR}/tbb_cmake_build/tbb_cmake_build_subdir)
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/ports/tbb/CONTROL
+++ b/ports/tbb/CONTROL
@@ -1,6 +1,6 @@
 Source: tbb
 Version: 2020_U3
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/01org/tbb
 Description: Intel's Threading Building Blocks.
 Supports: !(uwp|arm|arm64) | linux | osx

--- a/ports/tbb/portfile.cmake
+++ b/ports/tbb/portfile.cmake
@@ -14,22 +14,11 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-if (TBB_DISABLE_EXCEPTIONS)
-    message(STATUS "Building TBB with exception-handling constructs disabled because TBB_DISABLE_EXCEPTIONS is set to ON.")
-else()
-    message(STATUS "TBB uses exception-handling constructs by default (if supported by the compiler). This use can be disabled with 'SET(TBB_DISABLE_EXCEPTIONS ON)' in your custom triplet.")
-endif()
 
 if (NOT VCPKG_TARGET_IS_WINDOWS)
-    if (TBB_DISABLE_EXCEPTIONS)
-        set(DISABLE_EXCEPTIONS ON)
-    else()
-        set(DISABLE_EXCEPTIONS OFF)
-    endif()
     vcpkg_configure_cmake(
         SOURCE_PATH ${SOURCE_PATH}
         PREFER_NINJA
-        OPTIONS -DDISABLE_EXCEPTIONS=${DISABLE_EXCEPTIONS}
     )
 
     vcpkg_install_cmake()
@@ -72,10 +61,6 @@ else()
         else()
             string(REPLACE "\/D_CRT_SECURE_NO_DEPRECATE"
                         "\/D_CRT_SECURE_NO_DEPRECATE \/DIN_CILK_RUNTIME" SLN_CONFIGURE "${SLN_CONFIGURE}")
-        endif()
-        if (TBB_DISABLE_EXCEPTIONS)
-            string(REPLACE "<PreprocessorDefinitions>%(PreprocessorDefinitions)<\/PreprocessorDefinitions>"
-                        "<PreprocessorDefinitions>TBB_USE_EXCEPTIONS=0;%(PreprocessorDefinitions)<\/PreprocessorDefinitions>" SLN_CONFIGURE "${SLN_CONFIGURE}")
         endif()
         file(WRITE ${CONFIGURE_FILE_NAME} "${SLN_CONFIGURE}")
     endmacro()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },
@@ -6094,7 +6094,7 @@
     },
     "tbb": {
       "baseline": "2020_U3",
-      "port-version": 4
+      "port-version": 5
     },
     "tcl": {
       "baseline": "core-9-0-a1",

--- a/versions/t-/tbb.json
+++ b/versions/t-/tbb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "475f44cf5033c6f3bfb5c69c5a301cddf18e7aa0",
+      "version-string": "2020_U3",
+      "port-version": 5
+    },
+    {
       "git-tree": "4e6228578b0ca40358f584aa1ea8b4a9ac2d4ed9",
       "version-string": "2020_U3",
       "port-version": 4


### PR DESCRIPTION
After filing an issue with TBB (oneapi-src/oneTBB#414), I found out that building the library with exceptions explicitly disabled, as I had added support for in port-version 4 and the PR at https://github.com/microsoft/vcpkg/pull/16068, had gone from not officially supported to more explicitly disallowed

- #### What does your PR fix?  
Undoes the functionality I added in port-version 4 and moves the port-version to 5

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
- No changes

- #### Does your PR follow the [maintainer guide]
- Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

