### PR TITLE
[halide] Fix several issues with the Halide port after v12

### DIFF
--- a/ports/halide/usage
+++ b/ports/halide/usage
@@ -11,4 +11,4 @@ The package halide provides CMake targets:
     target_link_libraries(main PRIVATE filter)
 
 For more information see:
-    https://github.com/halide/Halide/blob/v11.0.1/README_cmake.md
+    https://github.com/halide/Halide/blob/v12.0.1/README_cmake.md

--- a/ports/halide/vcpkg.json
+++ b/ports/halide/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "halide",
   "version": "12.0.1",
+  "port-version": 1,
   "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
   "homepage": "https://github.com/halide/Halide",
   "supports": "!uwp",
@@ -12,6 +13,14 @@
         "enable-rtti",
         "tools"
       ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "default-features": [
@@ -82,7 +91,6 @@
             "target-mips",
             "target-nvptx",
             "target-opencl",
-            "target-opengl",
             "target-powerpc",
             "target-riscv",
             "target-x86"
@@ -158,9 +166,6 @@
     },
     "target-opencl": {
       "description": "Include OpenCL-C target"
-    },
-    "target-opengl": {
-      "description": "Include OpenGL/GLSL target"
     },
     "target-powerpc": {
       "description": "Include PowerPC target",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2458,7 +2458,7 @@
     },
     "halide": {
       "baseline": "12.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "happly": {
       "baseline": "2021-03-19",
@@ -3539,8 +3539,8 @@
     "libsigcpp-3": {
       "baseline": "3.0.3",
       "port-version": 1
-    }, 
-	"libsmb2": {
+    },
+    "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0
     },

--- a/versions/h-/halide.json
+++ b/versions/h-/halide.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "512cb4dd40ca40afbf0c6a35f7bdc595589a0b10",
+      "version": "12.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "50e2c4835a57bb4a172c4b82b2a0e0a3077088ab",
       "version": "12.0.1",
       "port-version": 0


### PR DESCRIPTION
1. Use `vcpkg-cmake` and `vcpkg-cmake-config` ports
2. Fix usage file to point to relevant documentation
3. Remove OpenGL feature (Halide 12 dropped support)
4. Drop `VCPKG_POLICY_EMPTY_PACKAGE` workaround
5. Set new Halide packaging variables for better vcpkg compliance.

No updates to CI baseline. I should be even more compliant with the maintainer guide than I was before. I have updated the version.