### PR TITLE
[notcurses] new port

### DIFF
--- a/ports/notcurses/portfile.cmake
+++ b/ports/notcurses/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO dankamongmen/notcurses
+  REF v2.3.7
+  SHA512 a5563c2bf13ccefb6e08140bf63b03ba1a9e0cfa628e31e5b2a1d0d069ea9f88038a903f3fbebf2e037de969a47443b97912669656ade3024bac300799ce7e79
+  HEAD_REF master
+)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" NOTCURSES_BUILD_STATIC)
+vcpkg_cmake_configure(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+    -DUSE_STATIC=${NOTCURSES_BUILD_STATIC}
+)
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PROCESS_DIR}/share/notcurses RENAME copyright)

--- a/ports/notcurses/vcpkg.json
+++ b/ports/notcurses/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "notcurses",
+  "version": "2.3.7",
+  "port-version": 1,
+  "description": "Blingful character graphics and TUI library",
+  "homepage": "https://notcurses.com",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
**Add new port, Notcurses (only Linux for the short-term future)**

- #### What does your PR fix?  
Adds a vcpkg port for [Notcurses](https://notcurses.com/), the most powerful TUI library in the known universe.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>
not yet!

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
I am still working on this PR