### PR TITLE
[vcpkg_from_git] Fix error if downloads folder does not exist

### DIFF
--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -82,6 +82,7 @@ function(vcpkg_from_git)
     message(STATUS "Fetching ${_vdud_URL}...")
     find_program(GIT NAMES git git.cmd)
     # Note: git init is safe to run multiple times
+    file(MAKE_DIRECTORY ${DOWNLOADS})
     vcpkg_execute_required_process(
       ALLOW_IN_DOWNLOAD_MODE
       COMMAND ${GIT} init git-tmp

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -82,7 +82,7 @@ function(vcpkg_from_git)
     message(STATUS "Fetching ${_vdud_URL}...")
     find_program(GIT NAMES git git.cmd)
     # Note: git init is safe to run multiple times
-    file(MAKE_DIRECTORY ${DOWNLOADS})
+    file(MAKE_DIRECTORY "${DOWNLOADS}")
     vcpkg_execute_required_process(
       ALLOW_IN_DOWNLOAD_MODE
       COMMAND ${GIT} init git-tmp


### PR DESCRIPTION
From https://github.com/microsoft/vcpkg/pull/18705:

> Related issue #18291, #16282, #14424, #18071, #17704, #17517, #16846, #16015, #15911, #15649, #15648, #14974, #13851

This PR actually fixes the root cause.