### PR TITLE
[pe-parse] update to 1.3.0 and fix  uthenticode dependency path loss problem

### DIFF
--- a/ports/pe-parse/CONTROL
+++ b/ports/pe-parse/CONTROL
@@ -1,5 +1,0 @@
-Source: pe-parse
-Version: 1.2.0
-Description: pe-parse is a principled, lightweight C/C++ PE parser
-Homepage: https://github.com/trailofbits/pe-parse
-Supports: !uwp

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/pe-parse
-    REF v1.2.0
-    SHA512 916ec515585ba1e83e2c6ae29667fd25bd4cac90c39e587ae6847dc9d503186e8853bd80f4e2a99177a3214f5c51eceff85fa610cadbc2bc1d3a79251e8ce942
+    REF ff4f8449bf9a04710507b75e6dcef6f156f2ec4c   #v1.3.0
+    SHA512 4687e0ffdb84537fa9a2a78a4584d0f8e7cd39ea797d7bbdff2aa40e80e1f87f4230fba0e30c662062a98db6d70f08c524f0203aa86d00bc02088d432b7eacc5
     HEAD_REF master
 )
 

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -1,27 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/pe-parse
-    REF ff4f8449bf9a04710507b75e6dcef6f156f2ec4c   #v1.3.0
-    SHA512 4687e0ffdb84537fa9a2a78a4584d0f8e7cd39ea797d7bbdff2aa40e80e1f87f4230fba0e30c662062a98db6d70f08c524f0203aa86d00bc02088d432b7eacc5
+    REF v1.3.0
+    SHA512 b723e90821e0ac67b4d6b15e5a46cf13544f21380a4d2add013eedcaa309e1be2cff6789247397c6fb4a938e4a240a835cbe21c8221bd558a4fccf8e93ce1548
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DBUILD_COMMAND_LINE_TOOLS=OFF
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS 
+        -DBUILD_COMMAND_LINE_TOOLS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/pe-parse TARGET_PATH share/pe-parse)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/pe-parse)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(
-    INSTALL
-    "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/pe-parse"
-    RENAME copyright
-)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "pe-parse",
+  "version": "1.3.0",
+  "description": "pe-parse is a principled, lightweight C/C++ PE parser",
+  "homepage": "https://github.com/trailofbits/pe-parse",
+  "supports": "!uwp"
+}

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -3,5 +3,15 @@
   "version": "1.3.0",
   "description": "pe-parse is a principled, lightweight C/C++ PE parser",
   "homepage": "https://github.com/trailofbits/pe-parse",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/uthenticode/CONTROL
+++ b/ports/uthenticode/CONTROL
@@ -1,6 +1,0 @@
-Source: uthenticode
-Version: 1.0.4
-Description: A cross-platform library for verifying Authenticode signatures
-Homepage: https://github.com/trailofbits/uthenticode
-Supports: !uwp
-Build-Depends: pe-parse, openssl

--- a/ports/uthenticode/fix-include-path-notfind.patch
+++ b/ports/uthenticode/fix-include-path-notfind.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/uthenticode.h b/src/include/uthenticode.h
+index 8422cc3..b104ddb 100644
+--- a/src/include/uthenticode.h
++++ b/src/include/uthenticode.h
+@@ -4,7 +4,7 @@
+ #include <openssl/asn1t.h>
+ #include <openssl/crypto.h>
+ #include <openssl/x509.h>
+-#include <parser-library/parse.h>
++#include <pe-parse/parse.h>
+ 
+ #include <cstdint>
+ #include <exception>

--- a/ports/uthenticode/portfile.cmake
+++ b/ports/uthenticode/portfile.cmake
@@ -3,26 +3,23 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/uthenticode
-    REF v1.0.4
-    SHA512 82d5ff61071adefec886a140d253b733cb2318ccf34e831087973b05f7e274b207031e606303f65269a5ed1b45c3c599d79e217cf6229d60c8cc2396e842f32e
+    REF fb9b05b5273af748f5075b7e82ac8be446570574 #v1.0.4
+    SHA512 2e8ff1c0c40359102a999952f820d6c7fbd653bc084901b6d42ba95f3d50498219f6afddd837faa11fb23e11cfa6ac39b18bf1fa0491de6a2fdc37759bb78a30
     HEAD_REF master
+    PATCHES
+        fix-include-path-notfind.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/uthenticode TARGET_PATH share/uthenticode)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uthenticode)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(
-    INSTALL
-    ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-    RENAME copyright
-)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/uthenticode/vcpkg.json
+++ b/ports/uthenticode/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "uthenticode",
+  "version": "1.0.6",
+  "description": "A cross-platform library for verifying Authenticode signatures",
+  "homepage": "https://github.com/trailofbits/uthenticode",
+  "supports": "!uwp",
+  "dependencies": [
+    "openssl",
+    "pe-parse",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6461,7 +6461,7 @@
       "port-version": 0
     },
     "uthenticode": {
-      "baseline": "1.0.4",
+      "baseline": "1.0.6",
       "port-version": 0
     },
     "uvatlas": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4789,7 +4789,7 @@
       "port-version": 0
     },
     "pe-parse": {
-      "baseline": "1.2.0",
+      "baseline": "1.3.0",
       "port-version": 0
     },
     "pegtl": {

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e76c8939d6619f451e4ddb68a801c8bb54b27dc",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b26d3371c165c5888f2aca0c7c63107fa2ea1fdc",
       "version-string": "1.2.0",
       "port-version": 0

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e76c8939d6619f451e4ddb68a801c8bb54b27dc",
+      "git-tree": "1f09076d11d60965390e9aa470a3d711bfc0d95d",
       "version": "1.3.0",
       "port-version": 0
     },

--- a/versions/u-/uthenticode.json
+++ b/versions/u-/uthenticode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d5d0734b7c095b71ff86cfbc26f7651730b6028",
+      "version": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "be0c3da6f7d93aa3a5252b03adc09ffa8105eaf8",
       "version-string": "1.0.4",
       "port-version": 0


### PR DESCRIPTION
Fix #18756 

Update pe-parse to the latest version 1.3.0
Update uthenticode  to 1.0.4 and fix  uthenticode dependency path loss problem
Note: no feature need to test 