### PR TITLE
[vcpkg baseline][cnl] Disable tests

### DIFF
--- a/ports/cnl/CONTROL
+++ b/ports/cnl/CONTROL
@@ -1,4 +1,0 @@
-Source: cnl
-Version: 1.1.7
-Description: A Compositional Numeric Library for C++
-Homepage: https://github.com/johnmcfarlane/cnl

--- a/ports/cnl/disable-test.patch
+++ b/ports/cnl/disable-test.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73111fc..a0cb3db 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,8 +9,8 @@ project(cnl)
+ 
+ cmake_minimum_required(VERSION 3.5.1)
+ 
+-include(CTest)
+-add_subdirectory("test")
++# include(CTest)
++# add_subdirectory("test")
+ 
+ # the CNL library
+ add_library(Cnl INTERFACE)

--- a/ports/cnl/portfile.cmake
+++ b/ports/cnl/portfile.cmake
@@ -5,6 +5,8 @@ vcpkg_from_github(
     REF 2dde6e62e608a4adc3c5504f067575efa4910568 #v1.1.7
     SHA512 33a81ea726802c71a684bcd002b5119cde4db471ebc9ba02cd15c7487ab468eeca09fb8dcaed953e3f3cded2cd813a903f808d97527b0ec7f393647b64a22572
     HEAD_REF main
+    PATCHES
+        disable-test.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/cnl/vcpkg.json
+++ b/ports/cnl/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "cnl",
+  "version-string": "1.1.7",
+  "port-version": 1,
+  "description": "A Compositional Numeric Library for C++",
+  "homepage": "https://github.com/johnmcfarlane/cnl"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1326,7 +1326,7 @@
     },
     "cnl": {
       "baseline": "1.1.7",
-      "port-version": 0
+      "port-version": 1
     },
     "coin": {
       "baseline": "4.0.0",

--- a/versions/c-/cnl.json
+++ b/versions/c-/cnl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fe1aa7188d2e673265a0c1f20616bdf647c7390",
+      "version-string": "1.1.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "645e64c52fc7d6d9570376aba9c684ca45038f54",
       "version-string": "1.1.7",
       "port-version": 0


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/18758

Disable the cnl tests:
1. cnl is a header only library.
2. Building the tests requires to download, configure and build the external project, which cause failure in our CI testing machines.

```
   4>CustomBuild:
         CMake Error at D:/downloads/tools/cmake-3.20.2-windows/cmake-3.20.2-windows-i386/share/cmake-3.20/Modules/ExternalProject.cmake:2633 (message):
     4>CUSTOMBUILD : error : could not find git for clone of NS_CMAKE [D:\buildtrees\cnl\arm-uwp-dbg\test\unit\BoostSimd.vcxproj]
         Call Stack (most recent call first):
           D:/downloads/tools/cmake-3.20.2-windows/cmake-3.20.2-windows-i386/share/cmake-3.20/Modules/ExternalProject.cmake:3681 (_ep_add_download_command)
           cmake/ns.cmake.install.cmake:29 (ExternalProject_Add)
           CMakeLists.txt:19 (include)
```
