### PR TITLE
[ffmpeg] fix LGPL build, disable avisynthplus on static builds

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -20,8 +20,8 @@ if("ass" IN_LIST FEATURES)
 endif()
 
 if("avisynthplus" IN_LIST FEATURES)
-    if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" OR (NOT VCPKG_TARGET_IS_WINDOWS))
-        message(FATAL_ERROR "Feature 'avisynthplus' does not support '!windows | arm | uwp'")
+    if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" OR (NOT VCPKG_TARGET_IS_WINDOWS) OR (VCPKG_LIBRARY_LINKAGE STREQUAL "static"))
+        message(FATAL_ERROR "Feature 'avisynthplus' does not support '!windows | arm | uwp | static'")
     endif()
 endif()
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -28,7 +28,12 @@
       "dependencies": [
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
+            "avcodec",
+            "avdevice",
+            "avfilter",
+            "avformat",
             "avresample",
             "bzip2",
             "freetype",
@@ -40,6 +45,8 @@
             "snappy",
             "soxr",
             "speex",
+            "swresample",
+            "swscale",
             "theora",
             "vorbis",
             "vpx",
@@ -49,6 +56,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "sdl2"
           ],
@@ -56,6 +64,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "opencl"
           ],
@@ -63,6 +72,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "openh264"
           ],
@@ -70,6 +80,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "xml2"
           ],
@@ -77,6 +88,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "ilbc"
           ],
@@ -84,6 +96,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "ass"
           ],
@@ -91,6 +104,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "fribidi"
           ],
@@ -98,6 +112,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "ssh"
           ],
@@ -105,6 +120,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "dav1d"
           ],
@@ -112,6 +128,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "modplug"
           ],
@@ -119,6 +136,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "tensorflow"
           ],
@@ -126,6 +144,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "opengl"
           ],
@@ -133,6 +152,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "nvcodec"
           ],
@@ -140,6 +160,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "tesseract"
           ],
@@ -147,6 +168,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "fontconfig"
           ],
@@ -159,13 +181,16 @@
       "dependencies": [
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "all",
-            "gpl"
+            "gpl",
+            "postproc"
           ]
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "x264"
           ],
@@ -173,6 +198,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "x265"
           ],
@@ -180,6 +206,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "avisynthplus"
           ],
@@ -192,6 +219,7 @@
       "dependencies": [
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "all-gpl",
             "nonfree",
@@ -200,6 +228,7 @@
         },
         {
           "name": "ffmpeg",
+          "default-features": false,
           "features": [
             "fdk-aac"
           ],

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 6,
+  "port-version": 7,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -210,7 +210,7 @@
           "features": [
             "avisynthplus"
           ],
-          "platform": "windows & !arm & !uwp"
+          "platform": "windows & !arm & !uwp & !static"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1982,7 +1982,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 6
+      "port-version": 7
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efdbc20f5003313df2fde681a28ab8718455495f",
+      "version": "4.4",
+      "port-version": 7
+    },
+    {
       "git-tree": "8405d9f6850d7ceb6cede89a791b42c41253ef29",
       "version": "4.4",
       "port-version": 6


### PR DESCRIPTION
- #### What does your PR fix?  
  Building ``ffmpeg[core,all]`` currently results in a GPL build of ffmpeg because it pulls in postproc as a default feature, which is GPL licensed, and should not be included in this build. This patch ensures that the ``all`` feature no longer pulls in the default features, thereby again allowing a pure LGPL build as intended. I've also explicitly listed ``postproc`` under ``all-gpl`` rather than relying on the default feature list.

  Whilst at it, I also noticed that the avisynthplus feature is not functional on static builds. The library itself can be built statically since 3.7.0, however there are still some bugs with this build (which I've reported upstream), but even more importantly ffmpeg is not set up to link statically against it, and can only dynamically load the avisynthplus dll. So I think it's best to disable it for now until the bugs are ironed out and ffmpeg wants to support it statically if that ever happens.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  To the best of my ability, yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
