### PR TITLE
[vcpkg baseline][tensorflow] Skip osx check in baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1541,6 +1541,8 @@ teemo:arm64-windows=fail
 teemo:x64-osx=fail
 telnetpp:arm-uwp=fail
 telnetpp:x64-uwp=fail
+# https://github.com/microsoft/vcpkg/issues/18809
+tensorflow:x64-osx=skip
 tfhe:x86-windows=fail
 tfhe:x64-windows=fail
 tfhe:x64-windows-static=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1541,8 +1541,6 @@ teemo:arm64-windows=fail
 teemo:x64-osx=fail
 telnetpp:arm-uwp=fail
 telnetpp:x64-uwp=fail
-# https://github.com/microsoft/vcpkg/issues/18809
-tensorflow:x64-osx=skip
 tfhe:x86-windows=fail
 tfhe:x64-windows=fail
 tfhe:x64-windows-static=fail
@@ -1796,4 +1794,5 @@ dimcli:x64-windows-static=fail
 cppgraphqlgen:x64-osx=fail
 
 # Changes in Python have broken tensorflow on our osx hardware
+tensorflow:x64-osx=fail
 tensorflow-cc:x64-osx=fail


### PR DESCRIPTION
`tensorflow:x64-osx` has blocked some PR testing and cannot fix it in the short term (same reason with https://github.com/microsoft/vcpkg/issues/18597). Disable it in the pipeline test.

Related: https://github.com/microsoft/vcpkg/issues/18809  https://github.com/microsoft/vcpkg/pull/18695