### PR TITLE
[vcpkg] Add vcpkg installed libraries to msvc external include path

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -35,6 +35,8 @@
     <_ZVcpkgExecutable>$([System.IO.Path]::Combine($(VcpkgRoot), 'vcpkg.exe'))</_ZVcpkgExecutable>
 
     <ProjectStateLine>VcpkgTriplet=$(VcpkgTriplet):$(ProjectStateLine)</ProjectStateLine>
+
+    <ExternalIncludePath>%(ExternalIncludePath);$(_ZVcpkgCurrentInstalledDir)include</ExternalIncludePath>
   </PropertyGroup>
 
   <!-- Import property page 'Vcpkg' -->


### PR DESCRIPTION
Now that we have a way to specify [external headers in Visual Studio](https://devblogs.microsoft.com/cppblog/customized-warning-levels-and-code-analysis-for-external-headers/), I thought it would be convenient to add the vcpkg include directory to it  with the integrate install command.

I made a draft pull request because, even if this is a very small change, my knowledge of the vcpkg internals is superficial and I'm not entirely sure the way I did it is clean or complete.