### PR TITLE
[hdf5] Fix linking order in pc file

### DIFF
--- a/ports/hdf5/pkgconfig-link-order.patch
+++ b/ports/hdf5/pkgconfig-link-order.patch
@@ -1,0 +1,11 @@
+diff --git a/config/cmake/libhdf5.pc.in b/config/cmake/libhdf5.pc.in
+index 4a2ebaa..3cb42d2 100644
+--- a/config/cmake/libhdf5.pc.in
++++ b/config/cmake/libhdf5.pc.in
+@@ -10,5 +10,5 @@ Version: @_PKG_CONFIG_VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} @_PKG_CONFIG_SH_LIBS@
+ Requires: @_PKG_CONFIG_REQUIRES@
+-Libs.private: @_PKG_CONFIG_LIBS_PRIVATE@ @_PKG_CONFIG_LIBS@
++Libs.private: @_PKG_CONFIG_LIBS@ @_PKG_CONFIG_LIBS_PRIVATE@
+ Requires.private: @_PKG_CONFIG_REQUIRES_PRIVATE@

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -13,6 +13,7 @@ vcpkg_from_github(
         szip.patch
         mingw-import-libs.patch
         pkgconfig-requires.patch
+        pkgconfig-link-order.patch
 )
 
 if ("parallel" IN_LIST FEATURES AND "cpp" IN_LIST FEATURES)

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.12.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2478,7 +2478,7 @@
     },
     "hdf5": {
       "baseline": "1.12.0",
-      "port-version": 3
+      "port-version": 4
     },
     "healpix": {
       "baseline": "1.12.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "77eb81be380363280c67a3b15043696f6cee2001",
+      "version": "1.12.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "0a7e8bbf885fa0b111c3041102cb2c9adb45f5c3",
       "version": "1.12.0",
       "port-version": 3


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixing the linking order in the hdf5 pc files where the hdf5 library of interest must be placed before the libraries it depends on. For example, `-ldl` must come after `-lhdf5`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all (observable change on linux with #17698), no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
