### PR TITLE
[sdl2-mixer] Add fluidsynth feature 

### DIFF
--- a/ports/sdl2-mixer/CMakeLists.txt
+++ b/ports/sdl2-mixer/CMakeLists.txt
@@ -74,6 +74,18 @@ if(SDL_MIXER_ENABLE_OPUS)
     endif()
 endif()
 
+# Fluidsynth support
+if(SDL_MIXER_ENABLE_FLUIDSYNTH)
+    find_path(FLUIDSYNTH_INCLUDE_DIR fluidsynth.h)
+    find_library(FLUIDSYNTH_LIBRARY fluidsynth)
+    list(APPEND SDL_MIXER_INCLUDES ${FLUIDSYNTH_INCLUDE_DIR})
+    list(APPEND SDL_MIXER_DEFINES MUSIC_MID_FLUIDSYNTH)
+    if (SDL_DYNAMIC_LOAD)
+        get_filename_component(FLUIDSYNTH_LIBRARY_NAME "${FLUIDSYNTH_LIBRARY}" NAME_WE)
+        list(APPEND SDL_MIXER_LOAD_DEFINES -DFLUIDSYNTH_DYNAMIC="${FLUIDSYNTH_LIBRARY_NAME}${LIBRARY_SUFFIX}")
+    endif()
+endif()
+
 add_library(SDL2_mixer
     effect_position.c
     effect_stereoreverse.c

--- a/ports/sdl2-mixer/portfile.cmake
+++ b/ports/sdl2-mixer/portfile.cmake
@@ -35,6 +35,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     libvorbis SDL_MIXER_ENABLE_OGGVORBIS
     opusfile SDL_MIXER_ENABLE_OPUS
     nativemidi SDL_MIXER_ENABLE_NATIVEMIDI
+    fluidsynth SDL_MIXER_ENABLE_FLUIDSYNTH
 )
 
 vcpkg_configure_cmake(

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -46,6 +46,12 @@
       "dependencies": [
         "opusfile"
       ]
+    },
+    "fluidsynth": {
+      "description": "Support for FluidSynth MIDI/SF2 audio format.",
+      "dependencies": [
+        "fluidsynth"
+      ]
     }
   }
 }

--- a/ports/sdl2-mixer/vcpkg.json
+++ b/ports/sdl2-mixer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sdl2-mixer",
   "version": "2.0.4",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Multi-channel audio mixer library for SDL.",
   "homepage": "https://www.libsdl.org/projects/SDL_mixer",
   "dependencies": [
@@ -13,6 +13,12 @@
   "features": {
     "dynamic-load": {
       "description": "Load plugins with dynamic call."
+    },
+    "fluidsynth": {
+      "description": "Support for FluidSynth MIDI/SF2 audio format.",
+      "dependencies": [
+        "fluidsynth"
+      ]
     },
     "libflac": {
       "description": "Support for FLAC audio format.",
@@ -45,12 +51,6 @@
       "description": "Support for Opus audio format.",
       "dependencies": [
         "opusfile"
-      ]
-    },
-    "fluidsynth": {
-      "description": "Support for FluidSynth MIDI/SF2 audio format.",
-      "dependencies": [
-        "fluidsynth"
       ]
     }
   }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5678,7 +5678,7 @@
     },
     "sdl2-mixer": {
       "baseline": "2.0.4",
-      "port-version": 11
+      "port-version": 12
     },
     "sdl2-net": {
       "baseline": "2.0.1-8",

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "65f426a546b3183cb81bce7c8c9c8a761ce763f7",
+      "version": "2.0.4",
+      "port-version": 12
+    },
+    {
       "git-tree": "1ccb56f06529841debee949a42b71f5ce4ad1f16",
       "version": "2.0.4",
       "port-version": 11

--- a/versions/s-/sdl2-mixer.json
+++ b/versions/s-/sdl2-mixer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "65f426a546b3183cb81bce7c8c9c8a761ce763f7",
+      "git-tree": "fe2777f2acc7962d9d08092e4778221468e212cd",
       "version": "2.0.4",
       "port-version": 12
     },


### PR DESCRIPTION
**Describe the pull request**

This PR adds a `fluidsynth` feature to the `sdl2-mixer` port that enables FluidSynth support for loading MIDI & SF2 soundfonts.

- #### What does your PR fix?  
  This does not fix any issues.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
