### PR TITLE
[protozero] update to 1.7.0

### DIFF
--- a/ports/protozero/CONTROL
+++ b/ports/protozero/CONTROL
@@ -1,5 +1,0 @@
-Source: protozero
-Version: 1.6.8
-Homepage: https://github.com/am2222/mapnik-windows/
-Description: Minimalist protocol buffer decoder and encoder in C++
-Build-Depends: protobuf

--- a/ports/protozero/portfile.cmake
+++ b/ports/protozero/portfile.cmake
@@ -2,18 +2,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mapbox/protozero
-    SHA512 24bab4bf4ff7c67b4f2d8e97919ccde115db4fa476462926102da2f48b4689d6b454df56dbc30754d0e81c37f669535e4b2101033b079ace0f4ea2706447abe1
-    REF v1.6.8
+    SHA512 d09a34865c535264c52f9c605ccb6f453c357f5e3a7b0dc72b097de288eabc6985a5b81ddbe79c47d0af2d8f74e33bd380fefce47acb15d8d51d5c151d71786b
+    REF v1.7.0
     HEAD_REF master
 )
 
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    PREFER_NINJA
+    OPTIONS
+        -DBUILD_TESTING=OFF
 )
 
 vcpkg_install_cmake()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug")
-file(COPY ${SOURCE_PATH}/include/protozero DESTINATION ${CURRENT_PACKAGES_DIR}/include FILES_MATCHING PATTERN *.h)
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/protozero/portfile.cmake
+++ b/ports/protozero/portfile.cmake
@@ -14,7 +14,8 @@ vcpkg_configure_cmake(
     OPTIONS
         -DBUILD_TESTING=OFF
 )
-
 vcpkg_install_cmake()
+vcpkg_fixup_pkgconfig()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug")
 file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/protozero/vcpkg.json
+++ b/ports/protozero/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "protozero",
+  "version-string": "1.7.0",
+  "description": "Minimalist protocol buffer decoder and encoder in C++",
+  "homepage": "https://github.com/mapbox/protozero",
+  "dependencies": [
+    "protobuf"
+  ]
+}

--- a/ports/protozero/vcpkg.json
+++ b/ports/protozero/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protozero",
-  "version-string": "1.7.0",
+  "version-semver": "1.7.0",
   "description": "Minimalist protocol buffer decoder and encoder in C++",
   "homepage": "https://github.com/mapbox/protozero",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4997,7 +4997,7 @@
       "port-version": 0
     },
     "protozero": {
-      "baseline": "1.6.8",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "proxygen": {

--- a/versions/p-/protozero.json
+++ b/versions/p-/protozero.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "5438e33b24ac1d440595cf937053457dd7b45d26",
-      "version-string": "1.7.0",
+      "git-tree": "23f6ec11be6bbf623dc7590b128027ccb7f69727",
+      "version-semver": "1.7.0",
       "port-version": 0
     },
     {

--- a/versions/p-/protozero.json
+++ b/versions/p-/protozero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5438e33b24ac1d440595cf937053457dd7b45d26",
+      "version-string": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b064bd3211a8ba5ddfe33a49c84bcfa714d1bf8c",
       "version-string": "1.6.8",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

#### What does your PR fix?  

* Updates protozero to 1.7.0
* Changes the homepage. The previous was wrong.

#### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
yes

 #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

#### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes
