### PR TITLE
[vcpkg baseline][gl3w] Fix download issue: certification failed

### DIFF
--- a/ports/gl3w/CONTROL
+++ b/ports/gl3w/CONTROL
@@ -1,6 +1,0 @@
-Source: gl3w
-Version: 2018-05-31
-Port-Version: 3
-Homepage: https://github.com/skaslev/gl3w
-Description: Simple OpenGL core profile loading
-Build-Depends: opengl-registry

--- a/ports/gl3w/CONTROL
+++ b/ports/gl3w/CONTROL
@@ -1,5 +1,6 @@
 Source: gl3w
-Version: 2018-05-31-2
+Version: 2018-05-31
+Port-Version: 3
 Homepage: https://github.com/skaslev/gl3w
 Description: Simple OpenGL core profile loading
 Build-Depends: opengl-registry

--- a/ports/gl3w/fix-download-failure.patch
+++ b/ports/gl3w/fix-download-failure.patch
@@ -1,0 +1,35 @@
+diff --git a/gl3w_gen.py b/gl3w_gen.py
+index 6ef8f38..113b59f 100644
+--- a/gl3w_gen.py
++++ b/gl3w_gen.py
+@@ -38,6 +38,12 @@ try:
+     import urllib.request as urllib2
+ except ImportError:
+     import urllib2
++    
++import ssl
++
++ctx = ssl.create_default_context()
++ctx.check_hostname = False
++ctx.verify_mode = ssl.CERT_NONE
+ 
+ # UNLICENSE copyright header
+ UNLICENSE = r'''/*
+@@ -103,7 +109,7 @@ if not os.path.exists(os.path.join(args.root, 'src')):
+ # Download glcorearb.h
+ if not os.path.exists(os.path.join(args.root, 'include/GL/glcorearb.h')):
+     print('Downloading glcorearb.h to {0}...'.format(os.path.join(args.root, 'include/GL/glcorearb.h')))
+-    web = urllib2.urlopen('https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h')
++    web = urllib2.urlopen('https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h', context=ctx)
+     with open(os.path.join(args.root, 'include/GL/glcorearb.h'), 'wb') as f:
+         f.writelines(web.readlines())
+ else:
+@@ -112,7 +118,7 @@ else:
+ # Download khrplatform.h
+ if not os.path.exists(os.path.join(args.root, 'include/KHR/khrplatform.h')):
+     print('Downloading khrplatform.h to {0}...'.format(os.path.join(args.root, 'include/KHR/khrplatform.h')))
+-    web = urllib2.urlopen('https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h')
++    web = urllib2.urlopen('https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h', context=ctx)
+     with open(os.path.join(args.root, 'include/KHR/khrplatform.h'), 'wb') as f:
+         f.writelines(web.readlines())
+ else:

--- a/ports/gl3w/portfile.cmake
+++ b/ports/gl3w/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
   HEAD_REF master
   PATCHES
       0001-enable-shared-build.patch
+      fix-download-failure.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/gl3w/vcpkg.json
+++ b/ports/gl3w/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "gl3w",
+  "version-date": "2018-05-31",
+  "port-version": 3,
+  "description": "Simple OpenGL core profile loading",
+  "homepage": "https://github.com/skaslev/gl3w",
+  "dependencies": [
+    "opengl-registry"
+  ]
+}

--- a/scripts/cmake/vcpkg_install_msbuild.cmake
+++ b/scripts/cmake/vcpkg_install_msbuild.cmake
@@ -185,7 +185,7 @@ function(vcpkg_install_msbuild)
         endif()
         if(NOT exes STREQUAL "")
             file(COPY ${exes} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-            vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+            vcpkg_copy_tool_dependencies(TOOL_DIR "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
         endif()
     endif()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2281,8 +2281,8 @@
       "port-version": 0
     },
     "gl3w": {
-      "baseline": "2018-05-31-2",
-      "port-version": 0
+      "baseline": "2018-05-31",
+      "port-version": 3
     },
     "glad": {
       "baseline": "0.1.34",

--- a/versions/g-/gl3w.json
+++ b/versions/g-/gl3w.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c07b0603f4de7b67c2a411da195780b658b5c0a",
+      "version-date": "2018-05-31",
+      "port-version": 3
+    },
+    {
       "git-tree": "7786d613957355b4d238d8fd2278f78fbab5a886",
       "version-string": "2018-05-31-2",
       "port-version": 0


### PR DESCRIPTION
Now, we have 2 ports depend on gl3w:
- `imgui` feature `opengl3-gl3w-binding`, but it's not a default feature.
- `azure-kinect-sensor-sdk[core]` requires it.

If we skip it on the baseline, only one port is affected.