### PR TITLE
Download khrplatform.h with vcpkg instead of gl3w_gen.py so that our downloader settings are used

### DIFF
--- a/ports/gl3w/CONTROL
+++ b/ports/gl3w/CONTROL
@@ -1,5 +1,0 @@
-Source: gl3w
-Version: 2018-05-31-2
-Homepage: https://github.com/skaslev/gl3w
-Description: Simple OpenGL core profile loading
-Build-Depends: opengl-registry

--- a/ports/gl3w/vcpkg.json
+++ b/ports/gl3w/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "gl3w",
+  "version-date": "2018-05-31",
+  "port-version": 3,
+  "description": "Simple OpenGL core profile loading",
+  "homepage": "https://github.com/skaslev/gl3w",
+  "dependencies": [
+    "opengl-registry"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2285,8 +2285,8 @@
       "port-version": 0
     },
     "gl3w": {
-      "baseline": "2018-05-31-2",
-      "port-version": 0
+      "baseline": "2018-05-31",
+      "port-version": 3
     },
     "glad": {
       "baseline": "0.1.34",

--- a/versions/g-/gl3w.json
+++ b/versions/g-/gl3w.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbd82479631534cfe954646d63d29734c3b7728f",
+      "version-date": "2018-05-31",
+      "port-version": 3
+    },
+    {
       "git-tree": "7786d613957355b4d238d8fd2278f78fbab5a886",
       "version-string": "2018-05-31-2",
       "port-version": 0


### PR DESCRIPTION
Alternative resolution of https://github.com/microsoft/vcpkg/pull/18846/

The port's python script skips the download attempt if it's already in the right place, and I validated that this gets picked up:

```
Reusing glcorearb.h from include/GL...
Reusing khrplatform.h from include/KHR...                  # <-- note!
Parsing glcorearb.h header...
Generating gl3w.h in include/GL...
Generating gl3w.c in src...
```
