### PR TITLE
[utf8proc] Export cmake targets

### DIFF
--- a/ports/utf8proc/CONTROL
+++ b/ports/utf8proc/CONTROL
@@ -1,4 +1,0 @@
-Source: utf8proc
-Version: 2.5.0
-Homepage: https://github.com/JuliaLang/utf8proc
-Description: Clean C library for processing UTF-8 Unicode data.

--- a/ports/utf8proc/export-cmake-targets.patch
+++ b/ports/utf8proc/export-cmake-targets.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea6b80e..5e5e829 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,7 @@ add_library (utf8proc
+ )
+ 
+ # expose header path, for when this is part of a larger cmake project
+-target_include_directories(utf8proc PUBLIC .)
++target_include_directories(utf8proc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+ 
+ if (BUILD_SHARED_LIBS)
+   # Building shared library
+@@ -51,10 +51,13 @@ set_target_properties (utf8proc PROPERTIES
+ 
+ if (UTF8PROC_INSTALL)
+   install(TARGETS utf8proc
++    EXPORT unofficial-utf8proc-config
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+ 
++  install(EXPORT unofficial-utf8proc-config DESTINATION share/unofficial-utf8proc)
++
+   install(
+     FILES
+       "${PROJECT_SOURCE_DIR}/utf8proc.h"

--- a/ports/utf8proc/portfile.cmake
+++ b/ports/utf8proc/portfile.cmake
@@ -1,25 +1,33 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO JuliaLang/utf8proc
-    REF 0890a538bf8238cded9be0c81171f57e43f2c755 # v2.5.0
-    SHA512 5daca349dc9ba6575efbd93d7a4e072202a2e1c2e55233d2e52be20586bb5fb26455654a77ec53336e9cdf59806457d1c31d1a926f7ef5bdd56b0232d96190dc
+    REF 3203baa7374d67132384e2830b2183c92351bffc # v2.6.1
+    SHA512 582831c4c2d118f1c6f9e6de812878b96428d8fa1b9a2bbca32633a3853cb1981c917c724d2a8db51282ed13fd1654ca45f5d227731f5b90b17e7fc3acc93b07
+    PATCHES
+        export-cmake-targets.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA)
+    OPTIONS
+        -DUTF8PROC_ENABLE_TESTING=OFF
+        -DUTF8PROC_INSTALL=ON
+)
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-utf8proc CONFIG_PATH share/unofficial-utf8proc)
+
 vcpkg_copy_pdbs()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(READ ${CURRENT_PACKAGES_DIR}/include/utf8proc.h UTF8PROC_H)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(READ "${CURRENT_PACKAGES_DIR}/include/utf8proc.h" UTF8PROC_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     string(REPLACE "defined UTF8PROC_SHARED" "0" UTF8PROC_H "${UTF8PROC_H}")
 else()
     string(REPLACE "defined UTF8PROC_SHARED" "1" UTF8PROC_H "${UTF8PROC_H}")
 endif()
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/utf8proc.h "${UTF8PROC_H}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/utf8proc.h" "${UTF8PROC_H}")
 
-file(COPY ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/utf8proc)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/utf8proc/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/utf8proc/copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/utf8proc/vcpkg.json
+++ b/ports/utf8proc/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "utf8proc",
+  "version": "2.6.1",
+  "description": "Clean C library for processing UTF-8 Unicode data.",
+  "homepage": "https://github.com/JuliaLang/utf8proc",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6465,7 +6465,7 @@
       "port-version": 0
     },
     "utf8proc": {
-      "baseline": "2.5.0",
+      "baseline": "2.6.1",
       "port-version": 0
     },
     "utfcpp": {

--- a/versions/u-/utf8proc.json
+++ b/versions/u-/utf8proc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "659423c8c76de9194980ba25a2755bde258ed173",
+      "version": "2.6.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2b0e7ac6367f7dbe8fc0e6fea7d0ad81cbbedba6",
       "version-string": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/18801

Update utf8proc to latest release 2.6.1
Export cmake targest for utf8proc:

```
The package utf8proc:x64-windows provides CMake targets:

    find_package(unofficial-utf8proc CONFIG REQUIRED)
    target_link_libraries(main PRIVATE utf8proc)
```