### PR TITLE
[ffmpeg] enable windres

### DIFF
--- a/ports/ffmpeg/0018-configure-enable-windres-on-win32-win64-if-available.patch
+++ b/ports/ffmpeg/0018-configure-enable-windres-on-win32-win64-if-available.patch
@@ -1,0 +1,24 @@
+From 972f4367910206d82668dec1e47602328d050b69 Mon Sep 17 00:00:00 2001
+From: "Matthias C. M. Troffaes" <matthias.troffaes@gmail.com>
+Date: Fri, 9 Jul 2021 19:49:47 +0100
+Subject: [PATCH] configure: enable windres on win32/win64 if available
+
+---
+ configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure b/configure
+index b124411609..0fea0bf595 100755
+--- a/configure
++++ b/configure
+@@ -5544,6 +5544,7 @@ case $target_os in
+         enabled x86_64 && objformat="win64" || objformat="win32"
+         ranlib=:
+         enable dos_paths
++        enabled shared && ! enabled small && test_cmd $windres --version && enable gnu_windres
+         ;;
+     cygwin*)
+         target_os=cygwin
+-- 
+2.25.1
+

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -837,8 +837,8 @@ list(REMOVE_DUPLICATES FFMPEG_DEPENDENCIES_DEBUG)
 list(REVERSE FFMPEG_DEPENDENCIES_RELEASE)
 list(REVERSE FFMPEG_DEPENDENCIES_DEBUG)
 
-message("Dependencies (release): ${FFMPEG_DEPENDENCIES_RELEASE}")
-message("Dependencies (debug):   ${FFMPEG_DEPENDENCIES_DEBUG}")
+message(STATUS "Dependencies (release): ${FFMPEG_DEPENDENCIES_RELEASE}")
+message(STATUS "Dependencies (debug):   ${FFMPEG_DEPENDENCIES_DEBUG}")
 
 # Handle version strings
 

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -150,6 +150,7 @@ vcpkg_from_github(
         0014-avfilter-dependency-fix.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-February/275819.html
         0015-Fix-xml2-detection.patch
         0016-configure-dnn-needs-avformat.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/279926.html
+        0018-configure-enable-windres-on-win32-win64-if-available.patch
         ${PATCHES}
 )
 
@@ -209,7 +210,8 @@ if(VCPKG_TARGET_IS_WINDOWS)
                 1389a443e775bb255d905665dd577bef7ed71d51a8c24d118097f8119c08c4dfe67505e88ddd1e9a3764dd1d50ed8b84fa34abefa797d257e90586f0cbf54de8
         )
     else()
-        vcpkg_acquire_msys(MSYS_ROOT)
+        vcpkg_acquire_msys(MSYS_ROOT
+            PACKAGES binutils)
     endif()
 
     set(SHELL ${MSYS_ROOT}/usr/bin/bash.exe)

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -150,7 +150,7 @@ vcpkg_from_github(
         0014-avfilter-dependency-fix.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-February/275819.html
         0015-Fix-xml2-detection.patch
         0016-configure-dnn-needs-avformat.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/279926.html
-        0018-configure-enable-windres-on-win32-win64-if-available.patch
+        0018-configure-enable-windres-on-win32-win64-if-available.patch  # http://ffmpeg.org/pipermail/ffmpeg-devel/2021-July/282131.html
         ${PATCHES}
 )
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1986,7 +1986,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 7
+      "port-version": 8
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fc65e70fca5f14a2b67736b59941de3325108cb",
+      "version": "4.4",
+      "port-version": 8
+    },
+    {
       "git-tree": "efdbc20f5003313df2fde681a28ab8718455495f",
       "version": "4.4",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #18775. The ffmpeg configure patch was also posted upstream here: http://ffmpeg.org/pipermail/ffmpeg-devel/2021-July/282131.html I also fixed some status messages (not related to the problem but I noticed it, so I snuck it in... hope that's ok).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
