### PR TITLE
[hdf5] Link zlib using the ZLIB::ZLIB target

### DIFF
--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         mingw-import-libs.patch
         pkgconfig-requires.patch
         pkgconfig-link-order.patch
+        zlib.patch
 )
 
 if ("parallel" IN_LIST FEATURES AND "cpp" IN_LIST FEATURES)

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.12.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "supports": "!uwp",

--- a/ports/hdf5/zlib.patch
+++ b/ports/hdf5/zlib.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeFilters.cmake b/CMakeFilters.cmake
+index 1ae05eb..3e5824f 100644
+--- a/CMakeFilters.cmake
++++ b/CMakeFilters.cmake
+@@ -53,6 +53,7 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
+       if (NOT ZLIB_FOUND)
+         find_package (ZLIB) # Legacy find
+         if (ZLIB_FOUND)
++          set (ZLIB_LIBRARIES ZLIB::ZLIB)
+           set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
+           set (LINK_COMP_SHARED_LIBS ${LINK_COMP_SHARED_LIBS} ${ZLIB_LIBRARIES})
+           set (zlib_PC_LIBS_PRIVATE "${ZLIB_LIBRARIES}")
+diff --git a/config/cmake/hdf5-config.cmake.in b/config/cmake/hdf5-config.cmake.in
+index a8cbacb..9f1a5cf 100644
+--- a/config/cmake/hdf5-config.cmake.in
++++ b/config/cmake/hdf5-config.cmake.in
+@@ -56,6 +56,10 @@ set (${HDF5_PACKAGE_NAME}_PARALLEL_FILTERED_WRITES "@PARALLEL_FILTERED_WRITES@")
+ #-----------------------------------------------------------------------------
+ include(CMakeFindDependencyMacro)
+ 
++if (${HDF5_PACKAGE_NAME}_ENABLE_Z_LIB_SUPPORT)
++  find_dependency(ZLIB)
++endif()
++
+ if (${HDF5_PACKAGE_NAME}_ENABLE_PARALLEL)
+   find_dependency(MPI)
+   set (${HDF5_PACKAGE_NAME}_MPI_C_INCLUDE_PATH "@MPI_C_INCLUDE_DIRS@")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2486,7 +2486,7 @@
     },
     "hdf5": {
       "baseline": "1.12.0",
-      "port-version": 4
+      "port-version": 5
     },
     "healpix": {
       "baseline": "1.12.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "df1f0132517790601e87da38c4c7f836df7e008e",
+      "version": "1.12.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "77eb81be380363280c67a3b15043696f6cee2001",
       "version": "1.12.0",
       "port-version": 4


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixes linking of the debug version of hdf5. Before the changes, it was linking to the *release* version of libz, and this was passed on via the exported cmake config files. This PR resolves the issue by always using the imported target `ZLIB::ZLIB` so that config resolution can happen as needed. 
  This was found when validating the extended gdal cmake wrapper/the linker flags used for a consuming executable. Before the change, it contained both debug and release version of libz:
  ~~~
  ...
  vcpkg_installed/x64-linux/debug/lib/libhdf5_hl_debug.a
  vcpkg_installed/x64-linux/debug/lib/libhdf5_debug.a
  vcpkg_installed/x64-linux/lib/libz.a
  ...
  vcpkg_installed/x64-linux/debug/lib/libjpeg.a
  vcpkg_installed/x64-linux/debug/lib/libz.a
  ...
  ~~~

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes.
