### PR TITLE
msbuild: Fix msbuild integration with custom installation dir and broken change detection

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -76,16 +76,12 @@
   <PropertyGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <_ZVcpkgManifestFileLocation>$(VcpkgManifestRoot)vcpkg.json </_ZVcpkgManifestFileLocation>
     <_ZVcpkgConfigurationFileLocation>$(VcpkgManifestRoot)vcpkg-configuration.json</_ZVcpkgConfigurationFileLocation>
-
-    <_ZVcpkgTLogFileLocation>$(TLogLocation)VcpkgInstallManifest$(VcpkgTriplet).$(VcpkgHostTriplet).read.1u.tlog</_ZVcpkgTLogFileLocation>
-    <_ZVcpkgMSBuildStampFile>$(VcpkgInstalledDir).msbuildstamp-$(VcpkgTriplet).$(VcpkgHostTriplet).stamp</_ZVcpkgMSBuildStampFile>
   </PropertyGroup>
   <ItemGroup Condition="'$(VcpkgEnabled)' == 'true'">
     <_ZVcpkgInstallManifestDependenciesInputs Include="$(_ZVcpkgManifestFileLocation)"/>
     <_ZVcpkgInstallManifestDependenciesInputs Include="$(_ZVcpkgConfigurationFileLocation)" Condition="Exists('$(_ZVcpkgConfigurationFileLocation)')"/>
 
-    <_ZVcpkgInstallManifestDependenciesOutputs Include="$(_ZVcpkgTLogFileLocation)"/>
-    <_ZVcpkgInstallManifestDependenciesOutputs Include="$(_ZVcpkgMSBuildStampFile)"/>
+    <_ZVcpkgInstallManifestDependenciesOutputs Include="$(VcpkgInstalledDir).msbuild-target-VcpkgInstallManifest.$(VcpkgTriplet).$(VcpkgHostTriplet).read.1u.tlog"/>
   </ItemGroup>
 
   <Target Name="VcpkgInstallManifestDependencies" BeforeTargets="ClCompile"
@@ -94,21 +90,15 @@
           Outputs="@(_ZVcpkgInstallManifestDependenciesOutputs)">
     <Message Text="Installing vcpkg dependencies to $(VcpkgInstalledDir)" Importance="High" />
     <MakeDir Directories="$(TLogLocation)" />
-    <ItemGroup>
-      <_ZVcpkgItemToDelete Include="$(TLogLocation)VcpkgInstallManifest*.read.1u.tlog" />
-      <_ZVcpkgItemToDelete Include="$(VcpkgInstalledDir).msbuildstamp-*" />
-    </ItemGroup>
-    <Delete Files="@(_ZVcpkgItemToDelete)" />
+    <Delete Files="$(VcpkgInstalledDir).msbuild-target-VcpkgInstallManifest.$(VcpkgTriplet).$(VcpkgHostTriplet).read.1u.tlog" />
     <Message Text="%22$(_ZVcpkgExecutable)%22 install $(_ZVcpkgHostTripletParameter) --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
           Importance="High" />
     <Exec Command="%22$(_ZVcpkgExecutable)%22 install $(_ZVcpkgHostTripletParameter) --x-wait-for-lock --triplet %22$(VcpkgTriplet)%22 --vcpkg-root %22$(VcpkgRoot)\%22 %22--x-manifest-root=$(VcpkgManifestRoot)\%22 %22--x-install-root=$(VcpkgInstalledDir)\%22 $(VcpkgAdditionalInstallOptions)"
           StandardOutputImportance="High" />
-    <WriteLinesToFile File="$(_ZVcpkgTLogFileLocation)"
-                      Lines="@(_VcpkgInstallManifestDependenciesInputs -> '^%(Identity)')"
+    <WriteLinesToFile File="$(VcpkgInstalledDir).msbuild-target-VcpkgInstallManifest.$(VcpkgTriplet).$(VcpkgHostTriplet).read.1u.tlog"
+                      Lines="@(_ZVcpkgInstallManifestDependenciesInputs -> '^%(Identity)')"
                       Encoding="Unicode"
                       Overwrite="true"/>
-    <Touch Files="$(_ZVcpkgMSBuildStampFile)" AlwaysCreate="true" />
-
     <CreateProperty Value="false">
       <Output TaskParameter="ValueSetByTask" PropertyName="Link_MinimalRebuildFromTracking" />
     </CreateProperty>


### PR DESCRIPTION
Variables in a PropertyGroup are set when the file is loaded, but the variables that are used there
are set later in the project settings and the variables defined in the PropertyGroup are broken. So don't
use variable declarations within PropertyGroups.
Save the file that is used to determine if the target must be executed in $(VcpkgInstalledDir) instead of
$(TLogLocation), because we don't have to rerun vcpkg.exe within all projects that use the same
$(VcpkgInstalledDir). Otherwise the target is executed for every project even is they use the same
vcpkg.json and $(VcpkgInstalledDir) and nothing changed.

Fixes #18805

@ras0219 @ras0219-msft Can you review this change?