### PR TITLE
[assimp] Use contrib polyclipping

### DIFF
--- a/ports/assimp/CONTROL
+++ b/ports/assimp/CONTROL
@@ -1,6 +1,6 @@
 Source: assimp
 Version: 5.0.1
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/assimp/assimp
 Description: The Open Asset import library
-Build-Depends: zlib, rapidjson, minizip, stb, kubazip, irrlicht, polyclipping, utfcpp, poly2tri
+Build-Depends: zlib, rapidjson, minizip, stb, kubazip, irrlicht, utfcpp, poly2tri

--- a/ports/assimp/build_fixes.patch
+++ b/ports/assimp/build_fixes.patch
@@ -257,7 +257,7 @@ diff --git a/code/CMakeLists.txt b/code/CMakeLists.txt
 index 55538d9..f5553e5 100644
 --- a/code/CMakeLists.txt
 +++ b/code/CMakeLists.txt
-@@ -862,89 +862,24 @@ SET( Extra_SRCS
+@@ -862,89 +862,23 @@ SET( Extra_SRCS
  SOURCE_GROUP( Extra FILES ${Extra_SRCS})
  
  # irrXML
@@ -279,7 +279,7 @@ index 55538d9..f5553e5 100644
  # polyclipping
 -IF(HUNTER_ENABLED)
 -  hunter_add_package(polyclipping)
-   find_package(polyclipping CONFIG REQUIRED)
+-  find_package(polyclipping CONFIG REQUIRED)
 -ELSE(HUNTER_ENABLED)
    SET( Clipper_SRCS
      ../contrib/clipper/clipper.hpp
@@ -348,7 +348,7 @@ index 55538d9..f5553e5 100644
  
  # openddlparser
  IF(HUNTER_ENABLED)
-@@ -1021,13 +956,7 @@ ELSE ()
+@@ -1021,13 +955,7 @@ ELSE ()
  ENDIF ()
  
  # RapidJSON
@@ -362,7 +362,7 @@ index 55538d9..f5553e5 100644
  
  # VC2010 fixes
  if(MSVC10)
-@@ -1044,15 +973,6 @@ if ( MSVC )
+@@ -1044,15 +972,6 @@ if ( MSVC )
    ADD_DEFINITIONS( -D_CRT_SECURE_NO_WARNINGS )
  endif ( MSVC )
  
@@ -378,14 +378,14 @@ index 55538d9..f5553e5 100644
  MESSAGE(STATUS "Enabled importer formats:${ASSIMP_IMPORTERS_ENABLED}")
  MESSAGE(STATUS "Disabled importer formats:${ASSIMP_IMPORTERS_DISABLED}")
  
-@@ -1111,22 +1031,14 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
+@@ -1111,22 +1030,13 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
    $<INSTALL_INTERFACE:include>
  )
  
 -IF(HUNTER_ENABLED)
    TARGET_LINK_LIBRARIES(assimp
 -      PUBLIC
-       polyclipping::polyclipping
+-      polyclipping::polyclipping
        irrXML::irrXML
 -      openddlparser::openddl_parser
 -      poly2tri::poly2tri
@@ -404,7 +404,7 @@ index 55538d9..f5553e5 100644
  
  if(ASSIMP_ANDROID_JNIIOSYSTEM)
    set(ASSIMP_ANDROID_JNIIOSYSTEM_PATH port/AndroidJNI)
-@@ -1208,21 +1120,12 @@ ENDIF(APPLE)
+@@ -1208,21 +1118,12 @@ ENDIF(APPLE)
  
  # Build against external unzip, or add ../contrib/unzip so
  # assimp can #include "unzip.h"
@@ -426,7 +426,7 @@ index 55538d9..f5553e5 100644
    INSTALL( TARGETS assimp
      EXPORT "${TARGETS_EXPORT_NAME}"
      LIBRARY DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
-@@ -1231,14 +1134,6 @@ IF(HUNTER_ENABLED)
+@@ -1231,14 +1132,6 @@ IF(HUNTER_ENABLED)
      FRAMEWORK DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
      COMPONENT ${LIBASSIMP_COMPONENT}
      INCLUDES DESTINATION "include")

--- a/ports/assimp/irrlicht.patch
+++ b/ports/assimp/irrlicht.patch
@@ -10,11 +10,10 @@ index f5553e5..5cffa0c 100644
 +  find_package(irrlicht CONFIG REQUIRED)
  
  # polyclipping
-   find_package(polyclipping CONFIG REQUIRED)
-@@ -1033,7 +1033,7 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
+   SET( Clipper_SRCS
+@@ -1032,6 +1032,6 @@ TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
  
    TARGET_LINK_LIBRARIES(assimp
-       polyclipping::polyclipping
 -      irrXML::irrXML
 +      Irrlicht
        minizip::minizip


### PR DESCRIPTION
It appears that the assimp port is linking polyclipping twice: once as a
dependency port via `find_package()`, and again by linking in a local copy
in `contrib/`.  This results in colliding symbols at link.

Given that assimp upstream doesn't seem to be directly compatible with
the polyclipping port version, use the one that works in `contrib/`.

Discovered while trying to fix building russimp tests on Windows here: https://github.com/jkvargas/russimp/pull/16

- #### What does your PR fix?  
  Fixes the many link errors that come about from two copies of polyclipper being linked (many, similar to):
```
  = note: rust-lld: error: duplicate symbol: bool __cdecl ClipperLib::Orientation(class std::vector<struct ClipperLib::IntPoint, class std::allocator<str       uct ClipperLib::IntPoint>> const &)
          >>> defined at C:\Users\mike\Windows-Code\sprinkle\target\vcpkg\buildtrees\polyclipping\src\ffc88818c4-06b887c850.clean\cpp\clipper.cpp:386
          >>>            polyclipping.lib(clipper.cpp.obj)
          >>> defined at assimp-vc142-mt.lib(clipper.cpp.obj)
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change in triplets supported.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  This breaks the **Do not use vendored dependencies** rule.

  Justification is that the upstream `assimp` has been stuck on a really old version of `polyclipping` for a number of years and has yet to be updated.  The version in ports doesn't work if used directly and it seems non-trivial to update upstream `assimp` to the new version.  See also: 
       - https://github.com/assimp/assimp/issues/2401 and
       - https://github.com/assimp/assimp/issues/788

  Further justification: without this change, the contrib version is already being used.  The change performed here is to drop in dependency of the `polyclipping` port, which is superfluous. This superfluous dependency likely went unnoticed as it silently works on Linux, with the library being ignored, while failing on Windows due to causing collisions.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes