### PR TITLE
Fix nativefiledialog port using build time include dir

### DIFF
--- a/ports/nativefiledialog/CMakeLists.txt
+++ b/ports/nativefiledialog/CMakeLists.txt
@@ -45,15 +45,14 @@ target_compile_definitions(
         $<$<C_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
 )
 
-target_include_directories(
-    nfd
-    PUBLIC
+target_include_directories(nfd PRIVATE
         $<BUILD_INTERFACE:
-            ${CMAKE_CURRENT_LIST_DIR}/src
-            ${CMAKE_CURRENT_LIST_DIR}/src/include
-        >
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
+			${CMAKE_CURRENT_LIST_DIR}/src 
+			${CMAKE_CURRENT_LIST_DIR}/src/include
+		>)
+		
+target_include_directories(nfd INTERFACE 
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if (GTK3_FOUND)
     target_include_directories(nfd PUBLIC ${GTK3_INCLUDE_DIRS})

--- a/ports/nativefiledialog/CONTROL
+++ b/ports/nativefiledialog/CONTROL
@@ -1,8 +1,0 @@
-Source: nativefiledialog
-Version: 2019-08-28
-Description: A tiny, neat C library that portably invokes native file open and save dialogs
-Homepage: https://github.com/mlabbe/nativefiledialog
-Supports: !uwp
-
-Feature: zenity
-Description: Using Zenity backend on Linux

--- a/ports/nativefiledialog/portfile.cmake
+++ b/ports/nativefiledialog/portfile.cmake
@@ -19,18 +19,20 @@ vcpkg_check_features(
     INVERTED_FEATURES "zenity" NFD_GTK_BACKEND
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
 # Handle copyright
 configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/ports/nativefiledialog/vcpkg.json
+++ b/ports/nativefiledialog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nativefiledialog",
-  "version-string": "2019-08-28",
+  "version-date": "2019-08-28",
   "port-version": 2,
   "description": "A tiny, neat C library that portably invokes native file open and save dialogs",
   "homepage": "https://github.com/mlabbe/nativefiledialog",

--- a/ports/nativefiledialog/vcpkg.json
+++ b/ports/nativefiledialog/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nativefiledialog",
   "version-date": "2019-08-28",
-  "port-version": 2,
+  "port-version": 1,
   "description": "A tiny, neat C library that portably invokes native file open and save dialogs",
   "homepage": "https://github.com/mlabbe/nativefiledialog",
   "supports": "!uwp",

--- a/ports/nativefiledialog/vcpkg.json
+++ b/ports/nativefiledialog/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "nativefiledialog",
+  "version-string": "2019-08-28",
+  "port-version": 2,
+  "description": "A tiny, neat C library that portably invokes native file open and save dialogs",
+  "homepage": "https://github.com/mlabbe/nativefiledialog",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "zenity": {
+      "description": "Using Zenity backend on Linux"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4286,7 +4286,7 @@
     },
     "nativefiledialog": {
       "baseline": "2019-08-28",
-      "port-version": 0
+      "port-version": 2
     },
     "nccl": {
       "baseline": "2.4.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4286,7 +4286,7 @@
     },
     "nativefiledialog": {
       "baseline": "2019-08-28",
-      "port-version": 2
+      "port-version": 1
     },
     "nccl": {
       "baseline": "2.4.6",

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "03f4dfbad900edcd63e45f26139483495f0c4efb",
+      "git-tree": "d765a8f84ba49c18701f68b7471f1b93b7313ddc",
       "version-string": "2019-08-28",
       "port-version": 1
     },

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "bcb4c6b297cce40942c05838842ddf0b40b78811",
+      "version-string": "2019-08-28",
+      "port-version": 2
+    },
+    {
+      "git-tree": "03f4dfbad900edcd63e45f26139483495f0c4efb",
+      "version-string": "2019-08-28",
+      "port-version": 1
+    },
+    {
       "git-tree": "b2e484cc447978109bcd69b2fa61920b2059d0f9",
       "version-string": "2019-08-28",
       "port-version": 0

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "d765a8f84ba49c18701f68b7471f1b93b7313ddc",
-      "version-string": "2019-08-28",
+      "version-date": "2019-08-28",
       "port-version": 1
     },
     {

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "bcb4c6b297cce40942c05838842ddf0b40b78811",
-      "version-string": "2019-08-28",
-      "port-version": 2
-    },
-    {
       "git-tree": "03f4dfbad900edcd63e45f26139483495f0c4efb",
       "version-string": "2019-08-28",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Fixes installed lib include path pointing to build-time location. Problem is in this bit:
```
target_include_directories(
    nfd
    PUBLIC
        $<BUILD_INTERFACE:
            ${CMAKE_CURRENT_LIST_DIR}/src
            ${CMAKE_CURRENT_LIST_DIR}/src/include
        >
        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
)
```
For install target, BUILD_INTERFACE evaluates to empty string, which is expanded to current build folder and so `unofficial-nativefiledialog-config.cmake` has lines like these that include absolute build folder path:
```
set_target_properties(unofficial::nativefiledialog::nfd PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "C:/src/vcpkg/buildtrees/nativefiledialog/src/44c798f8b9-0d908eb5b1.clean/;${_IMPORT_PREFIX}/include"
)
```

Separating into two different target_include_directories fixes it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All (except UWP), No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
