### PR TITLE
Adapting for HPX V1.7.0

### DIFF
--- a/ports/hpx/CONTROL
+++ b/ports/hpx/CONTROL
@@ -1,7 +1,0 @@
-Source: hpx
-Version: 1.6.0
-Port-Version: 0
-Build-Depends: hwloc, boost-accumulators, boost-asio, boost-bimap, boost-config, boost-context, boost-dynamic-bitset, boost-exception, boost-filesystem, boost-iostreams, boost-lockfree, boost-program-options, boost-range, boost-spirit, boost-system, boost-throw-exception, boost-variant, boost-winapi
-Homepage: https://github.com/STEllAR-GROUP/hpx
-Description: The C++ Standards Library for Concurrency and Parallelism
-  HPX is a C++ Standards Library for Concurrency and Parallelism. It implements all of the corresponding facilities as defined by the C++ Standard. Additionally, in HPX we implement functionalities proposed as part of the ongoing C++ standardization process. We also extend the C++ Standard APIs to the distributed case.

--- a/ports/hpx/hpx-1.7.0-format-from-string.patch
+++ b/ports/hpx/hpx-1.7.0-format-from-string.patch
@@ -1,0 +1,12 @@
+diff --git a/libs/core/format/include/hpx/util/from_string.hpp b/libs/core/format/include/hpx/util/from_string.hpp
+index 07eb9b68dfb..c3d0d857143 100644
+--- a/libs/core/format/include/hpx/util/from_string.hpp
++++ b/libs/core/format/include/hpx/util/from_string.hpp
+@@ -10,6 +10,7 @@
+ #include <hpx/util/bad_lexical_cast.hpp>
+ 
+ #include <algorithm>
++#include <cctype>
+ #include <cstddef>
+ #include <limits>
+ #include <sstream>

--- a/ports/hpx/portfile.cmake
+++ b/ports/hpx/portfile.cmake
@@ -4,17 +4,17 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO STEllAR-GROUP/hpx
-    REF 1.6.0
-    SHA512 cd717db3812fc26117d72c8afa654972b16f7059d8e6965484edd938788f3369fcd5ca791eee80e803703d6f3c39b3a3cd0525ab9f58ff1312e1b49f06ce67bc
+    REF 1.7.0
+    SHA512 052b3278710d8047c8e0e0979a668aa5161c495fcd12b089dd5039c64bd414b4ec0b96dfcd414d68e0db5b31c360dffb84374413c53794f37ce77d9cabc89518
     HEAD_REF stable
+    PATCHES
+        hpx-1.7.0-format-from-string.patch
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS
-        "-DBOOST_ROOT=${CURRENT_INSTALLED_DIR}/share/boost"
-        "-DHWLOC_ROOT=${CURRENT_INSTALLED_DIR}/share/hwloc"
         -DHPX_WITH_VCPKG=ON
         -DHPX_WITH_TESTS=OFF
         -DHPX_WITH_EXAMPLES=OFF
@@ -79,13 +79,11 @@ if(DLLS)
     file(REMOVE ${DLLS})
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/bazel)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/bazel)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
 

--- a/ports/hpx/vcpkg.json
+++ b/ports/hpx/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "hpx",
+  "version-string": "1.7.0",
+  "description": [
+    "The C++ Standards Library for Concurrency and Parallelism",
+    "HPX is a C++ Standards Library for Concurrency and Parallelism. It implements all of the corresponding facilities as defined by the C++ Standard. Additionally, in HPX we implement functionalities proposed as part of the ongoing C++ standardization process. We also extend the C++ Standard APIs to the distributed case."
+  ],
+  "homepage": "https://github.com/STEllAR-GROUP/hpx",
+  "dependencies": [
+    "asio",
+    "boost-accumulators",
+    "boost-config",
+    "boost-context",
+    "boost-dynamic-bitset",
+    "boost-exception",
+    "boost-filesystem",
+    "boost-iostreams",
+    "boost-lockfree",
+    "boost-range",
+    "boost-spirit",
+    "boost-system",
+    "boost-throw-exception",
+    "boost-variant",
+    "boost-winapi",
+    "hwloc"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2521,7 +2521,7 @@
       "port-version": 1
     },
     "hpx": {
-      "baseline": "1.6.0",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "http-parser": {

--- a/versions/h-/hpx.json
+++ b/versions/h-/hpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6abaf9002afc0d46fd8700438776403d63959ebf",
+      "version-string": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3e07ee0cdfdf093d41ddb40267f5910f71bfd944",
       "version-string": "1.6.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates HPX to V1.7.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Known functioning platforms: Windows 64Bit

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

