### PR TITLE
[docs] Use valid commit SHA for baseline in the versioning Getting Started guide

### DIFF
--- a/docs/examples/versioning.getting-started.md
+++ b/docs/examples/versioning.getting-started.md
@@ -24,7 +24,7 @@ Create a folder with the following files:
         }, 
         "zlib"
     ],
-    "builtin-baseline": "b60f003ccf5fe8613d029f49f835c8929a66eb61"
+    "builtin-baseline": "68a74950d0400f5a803026d0860f49853984bf11"
 }
 ```
 
@@ -141,12 +141,12 @@ If you want to upgrade your dependencies, you can bump the minimum version const
 #### **`builtin-baseline`**
 
 ```json
-{ "builtin-baseline": "b60f003ccf5fe8613d029f49f835c8929a66eb61" }
+{ "builtin-baseline": "68a74950d0400f5a803026d0860f49853984bf11" }
 ```
 
 This field declares the versioning baseline for all ports. Setting a baseline is required to enable versioning, otherwise you will get the current versions on the ports directory. You can run 'git rev-parse HEAD' to get the current commit of vcpkg and set it as the builtin-baseline. See the [`builtin-baseline` documentation](../users/versioning.md#builtin-baseline) for more information.
 
-In our example, you can notice that we do not declare a version constraint for `zlib`; instead, the version is taken from the baseline. Internally, vcpkg will look in commit `b60f003ccf5fe8613d029f49f835c8929a66eb61` to find out what version of `zlib` was the latest at that point in time (in our case it was `1.2.11#9`).
+In our example, you can notice that we do not declare a version constraint for `zlib`; instead, the version is taken from the baseline. Internally, vcpkg will look in commit `68a74950d0400f5a803026d0860f49853984bf11` to find out what version of `zlib` was the latest at that point in time (in our case it was `1.2.11#9`).
 
 During version resolution, baseline versions are treated as minimum version constraints. If you declare an explicit constraint that is lower than a baseline version, the explicit constraint will be upgraded to the baseline version. 
 
@@ -194,7 +194,7 @@ Let's modify our example once more, this time to force vcpkg to use version `6.0
             "version>=": "1.2.11#7"
         }
     ],
-    "builtin-baseline": "b60f003ccf5fe8613d029f49f835c8929a66eb61",
+    "builtin-baseline": "68a74950d0400f5a803026d0860f49853984bf11",
     "overrides": [
         {
             "name": "fmt",


### PR DESCRIPTION
This PR fixes an issue with the getting started guide for versioning by using a valid commit ID as the baseline for the tutorial.

The root cause of the issue was using a commit older than the existence of the `versions/` folder.

Fixes #18533