### PR TITLE
[portmidi] update to 235.1; add macOS and Linux support

### DIFF
--- a/ports/portmidi/CONTROL
+++ b/ports/portmidi/CONTROL
@@ -1,5 +1,0 @@
-Source: portmidi
-Version: 0.234
-Homepage: https://sourceforge.net/projects/portmedia/
-Description: Free, cross-platform, open-source I/O library for MIDI
-Supports: windows&!uwp&!arm

--- a/ports/portmidi/portfile.cmake
+++ b/ports/portmidi/portfile.cmake
@@ -1,47 +1,22 @@
-vcpkg_fail_port_install(ON_TARGET "linux" "osx" "uwp" ON_ARCH "arm")
+vcpkg_fail_port_install(ON_TARGET "UWP")
 
-vcpkg_from_sourceforge(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO portmedia
-    FILENAME "portmedia-code-r234.zip"
-    SHA512 cbc332d89bc465450b38245a83cc300dfd2e1e6de7c62284edf754ff4d8a9aa3dc49a395dcee535ed9688befb019186fa87fd6d8a3698898c2acbf3e6b7a0794
+    REPO mixxxdj/portmidi
+    REF 235.1
+    SHA512 a2bbaa65d209060b156bba404daf8d3da7c42611b837e4fb854758c863024c64d63ea2f15227549ad73cd3916e7b3a259b61e8ec2b4a3a2e2355b874ee4a16ea
+    HEAD_REF main
 )
 
-# Alter path to main portmidi root
-set(SOURCE_PATH "${SOURCE_PATH}/portmidi/trunk")
-
-# Mark portmidi-static as static, disable pmjni library depending on the Java SDK
-
-file(READ "${SOURCE_PATH}/pm_common/CMakeLists.txt" PM_CMAKE)
-string(REPLACE "add_library(portmidi-static \${LIBSRC})" "add_library(portmidi-static STATIC \${LIBSRC})" PM_CMAKE "${PM_CMAKE}")
-string(REPLACE "add_library(pmjni SHARED \${JNISRC})" "# Removed pmjni" PM_CMAKE "${PM_CMAKE}")
-string(REPLACE "target_link_libraries(pmjni \${JNI_EXTRA_LIBS})" "# Removed pmjni" PM_CMAKE "${PM_CMAKE}")
-string(REPLACE "set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION \"jnilib\")" "# Removed pmjni" PM_CMAKE "${PM_CMAKE}")
-file(WRITE "${SOURCE_PATH}/pm_common/CMakeLists.txt" "${PM_CMAKE}")
-
-# Run cmake configure step
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-        -DJAVA_INCLUDE_PATH=
-        -DJAVA_INCLUDE_PATH2=
-        -DJAVA_JVM_LIBRARY=
+    PREFER_NINJA
 )
 
-# Run cmake build step, nothing is installed on Windows
-vcpkg_build_cmake()
+vcpkg_install_cmake()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/PortMidi TARGET_PATH share/PortMidi)
 
-file(INSTALL ${SOURCE_PATH}/pm_common/portmidi.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-file(INSTALL ${SOURCE_PATH}/porttime/porttime.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
-
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/Release/portmidi_s.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/Debug/portmidi_s.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-else()
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/Release/portmidi.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/Release/portmidi.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/Debug/portmidi.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(INSTALL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/Debug/portmidi.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-endif()
-
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/portmidi RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/portmidi/vcpkg.json
+++ b/ports/portmidi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "portmidi",
+  "version-string": "0.235.1",
+  "description": "PortMidi is a cross platform (Windows, macOS, Linux, and BSDs which support alsalib) library for interfacing with operating systems' MIDI I/O APIs. ",
+  "homepage": "https://github.com/mixxxdj/portmidi",
+  "license": "MIT",
+  "supports": "!uwp"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3120,12 +3120,12 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
-    "libebur128": {
-      "baseline": "1.2.6",
-      "port-version": 0
-    },
     "libe57": {
       "baseline": "1.1.312",
+      "port-version": 0
+    },
+    "libebur128": {
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "libepoxy": {
@@ -4977,7 +4977,7 @@
       "port-version": 1
     },
     "portmidi": {
-      "baseline": "0.234",
+      "baseline": "0.235.1",
       "port-version": 0
     },
     "ppconsul": {

--- a/versions/p-/portmidi.json
+++ b/versions/p-/portmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d14a0343edb78d06fb797b5f20397b3cac0a8d5",
+      "version-string": "0.235.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "16f079de23d02226d49bd22659392d85e568528e",
       "version-string": "0.234",
       "port-version": 0


### PR DESCRIPTION
PortMidi has been forked to https://github.com/mixxxdj/portmidi
and the build system rewritten with modern CMake so it works on
Windows, macOS, and Linux without requiring ugly hacks in the
portfile.cmake.

**Describe the pull request**

- #### What does your PR fix?  
  Fixes portmidi port not building on macOS and Linux

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all except UWP

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
