### PR TITLE
[shaderc] Add fix for installing shaderc_util

### DIFF
--- a/ports/shaderc/fix-install-shaderc_util.patch
+++ b/ports/shaderc/fix-install-shaderc_util.patch
@@ -1,0 +1,18 @@
+diff --git a/libshaderc_util/CMakeLists.txt b/libshaderc_util/CMakeLists.txt
+index ec0e8fb..53e6fe7 100644
+--- a/libshaderc_util/CMakeLists.txt
++++ b/libshaderc_util/CMakeLists.txt
+@@ -31,6 +31,13 @@ target_link_libraries(shaderc_util PRIVATE
+   glslang OSDependent OGLCompiler HLSL glslang SPIRV
+   SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
+ 
++if(SHADERC_ENABLE_INSTALL)
++  install(TARGETS shaderc_util
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++endif(SHADERC_ENABLE_INSTALL)
++
+ shaderc_add_tests(
+   TEST_PREFIX shaderc_util
+   LINK_LIBS shaderc_util

--- a/ports/shaderc/fix-install-shaderc_util.patch
+++ b/ports/shaderc/fix-install-shaderc_util.patch
@@ -1,12 +1,12 @@
 diff --git a/libshaderc_util/CMakeLists.txt b/libshaderc_util/CMakeLists.txt
-index ec0e8fb..53e6fe7 100644
+index 99ce3c4..4926203 100644
 --- a/libshaderc_util/CMakeLists.txt
 +++ b/libshaderc_util/CMakeLists.txt
-@@ -31,6 +31,13 @@ target_link_libraries(shaderc_util PRIVATE
+@@ -49,6 +49,13 @@ target_link_libraries(shaderc_util PRIVATE
    glslang OSDependent OGLCompiler HLSL glslang SPIRV
    SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
  
-+if(SHADERC_ENABLE_INSTALL)
++if(SHADERC_ENABLE_INSTALL AND NOT BUILD_SHARED_LIBS)
 +  install(TARGETS shaderc_util
 +    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 +    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/ports/shaderc/portfile.cmake
+++ b/ports/shaderc/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     PATCHES 
         disable-update-version.patch
         fix-build-type.patch
+        fix-install-shaderc_util.patch
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/build-version.inc DESTINATION ${SOURCE_PATH}/glslc/src)

--- a/ports/shaderc/vcpkg.json
+++ b/ports/shaderc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "shaderc",
   "version": "2021.1",
+  "port-version": 1,
   "description": "A collection of tools, libraries and tests for shader compilation.",
   "homepage": "https://github.com/google/shaderc",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5762,7 +5762,7 @@
     },
     "shaderc": {
       "baseline": "2021.1",
-      "port-version": 0
+      "port-version": 1
     },
     "shaderwriter": {
       "baseline": "1.1.0",

--- a/versions/s-/shaderc.json
+++ b/versions/s-/shaderc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a3f80b3aa461d57ffd7efe73a901aad8a46f99d5",
+      "version": "2021.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2bf34bbfc26bddfe440bb115157a3b5cd07e7e79",
       "version": "2021.1",
       "port-version": 0

--- a/versions/s-/shaderc.json
+++ b/versions/s-/shaderc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3f80b3aa461d57ffd7efe73a901aad8a46f99d5",
+      "git-tree": "e8590ab232dd5ccd2331bb321127f00788b573a3",
       "version": "2021.1",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  The current version of the port shaderc neither installs shaderc_combined nor shaderc_shared, which both combine the targets shaderc and shaderc_util. Currently, only shaderc is installed by the port. However, if a program uses functionality from shaderc_util, there is currently no way to link to it. Thus, this PR adds shaderc_util as an installation target.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
