### PR TITLE
[portsmf] add new port with version 236

### DIFF
--- a/ports/portsmf/portfile.cmake
+++ b/ports/portsmf/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tenacityteam/portsmf
+    REF 236
+    SHA512 ede5ca770cab37822eebda7876c4fce7e786a11e15b3e173704863de97ea621b284439ebe7a14fdeadd0dc315f963c8da467ebbb7c246ebf80f5b120c35aa027
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/PortSMF)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/portsmf/vcpkg.json
+++ b/ports/portsmf/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "portsmf",
+  "version": "0.236",
+  "description": "Portsmf is 'Port Standard MIDI File', a cross-platform, C++ library for reading and writing Standard MIDI Files.",
+  "homepage": "https://github.com/tenacityteam/portsmf",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3120,12 +3120,12 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
-    "libebur128": {
-      "baseline": "1.2.6",
-      "port-version": 0
-    },
     "libe57": {
       "baseline": "1.1.312",
+      "port-version": 0
+    },
+    "libebur128": {
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "libepoxy": {
@@ -4978,6 +4978,10 @@
     },
     "portmidi": {
       "baseline": "0.234",
+      "port-version": 0
+    },
+    "portsmf": {
+      "baseline": "0.236",
       "port-version": 0
     },
     "ppconsul": {

--- a/versions/p-/portsmf.json
+++ b/versions/p-/portsmf.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "4d9de0a9782866958a9aafdfa6cde176c0867dfc",
+      "version": "0.236",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Adds new port for [PortSMF](https://github.com/tenacityteam/portsmf)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all except UWP

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

