### PR TITLE
[embree2] Fix static linking

### DIFF
--- a/ports/embree2/portfile.cmake
+++ b/ports/embree2/portfile.cmake
@@ -10,11 +10,7 @@ vcpkg_from_github(
 
 file(REMOVE "${SOURCE_PATH}/common/cmake/FindTBB.cmake")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(EMBREE_STATIC_LIB ON)
-else()
-    set(EMBREE_STATIC_LIB OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" EMBREE_STATIC_LIB)
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)
     set(EMBREE_STATIC_RUNTIME ON)

--- a/ports/embree2/portfile.cmake
+++ b/ports/embree2/portfile.cmake
@@ -11,12 +11,7 @@ vcpkg_from_github(
 file(REMOVE "${SOURCE_PATH}/common/cmake/FindTBB.cmake")
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" EMBREE_STATIC_LIB)
-
-if(VCPKG_CRT_LINKAGE STREQUAL static)
-    set(EMBREE_STATIC_RUNTIME ON)
-else()
-    set(EMBREE_STATIC_RUNTIME OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" EMBREE_STATIC_RUNTIME)
 
 vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -54,5 +49,4 @@ endif()
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/embree2")
 file(RENAME "${CURRENT_PACKAGES_DIR}/share/doc" "${CURRENT_PACKAGES_DIR}/share/embree2/doc")
 
-# Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/embree2/portfile.cmake
+++ b/ports/embree2/portfile.cmake
@@ -8,7 +8,13 @@ vcpkg_from_github(
         cmake_policy.patch
 )
 
-file(REMOVE ${SOURCE_PATH}/common/cmake/FindTBB.cmake)
+file(REMOVE "${SOURCE_PATH}/common/cmake/FindTBB.cmake")
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(EMBREE_STATIC_LIB ON)
+else()
+    set(EMBREE_STATIC_LIB OFF)
+endif()
 
 if(VCPKG_CRT_LINKAGE STREQUAL static)
     set(EMBREE_STATIC_RUNTIME ON)
@@ -17,12 +23,13 @@ else()
 endif()
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+    PREFER_NINJA
     OPTIONS
         -DEMBREE_ISPC_SUPPORT=OFF
         -DEMBREE_TUTORIALS=OFF
+        -DEMBREE_STATIC_LIB=${EMBREE_STATIC_LIB}
         -DEMBREE_STATIC_RUNTIME=${EMBREE_STATIC_RUNTIME}
         "-DTBB_LIBRARIES=TBB::tbb"
         "-DTBB_INCLUDE_DIRS=${CURRENT_INSTALLED_DIR}/include"
@@ -34,19 +41,22 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 # these cmake files do not seem to contain helpful configuration for find libs, just remove them
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/embree-config.cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/embree-config-version.cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/embree-config.cmake)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/embree-config-version.cmake)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/embree-config.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/embree-config-version.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/embree-config.cmake")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/embree-config-version.cmake")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/models)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/models)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/models")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin/models")
 
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/embree2)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/doc ${CURRENT_PACKAGES_DIR}/share/embree2/doc)
+if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/embree2")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/doc" "${CURRENT_PACKAGES_DIR}/share/embree2/doc")
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/embree2)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/embree2/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/embree2/copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/embree2/vcpkg.json
+++ b/ports/embree2/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "High Performance Ray Tracing Kernels.",
   "homepage": "https://github.com/embree/embree",
+  "supports": "windows",
   "dependencies": [
     "tbb"
   ]

--- a/ports/embree2/vcpkg.json
+++ b/ports/embree2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "embree2",
   "version-semver": "2.17.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High Performance Ray Tracing Kernels.",
   "homepage": "https://github.com/embree/embree",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -270,10 +270,6 @@ ecsutil:x64-osx=fail
 ecsutil:x64-uwp=fail
 # Checks for gnu extension so only works with gcc.
 elfutils:x64-osx=fail
-embree2:x64-linux=fail
-embree2:x64-osx=fail
-embree2:x64-windows-static=fail
-embree2:x64-windows-static-md=fail
 enet:arm-uwp=fail
 enet:x64-uwp=fail
 epsilon:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1862,7 +1862,7 @@
     },
     "embree2": {
       "baseline": "2.17.7",
-      "port-version": 1
+      "port-version": 2
     },
     "embree3": {
       "baseline": "3.12.2",
@@ -3120,12 +3120,12 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
-    "libebur128": {
-      "baseline": "1.2.6",
-      "port-version": 0
-    },
     "libe57": {
       "baseline": "1.1.312",
+      "port-version": 0
+    },
+    "libebur128": {
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "libepoxy": {

--- a/versions/e-/embree2.json
+++ b/versions/e-/embree2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "163e5e4f14e9b6b926cbf5b36987a2b2745c6e84",
+      "git-tree": "b9643e99cae126f869c4d2d67252d45477673b1d",
       "version-semver": "2.17.7",
       "port-version": 2
     },

--- a/versions/e-/embree2.json
+++ b/versions/e-/embree2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9643e99cae126f869c4d2d67252d45477673b1d",
+      "git-tree": "2eba5a73be8ff3ea2ec2324af483dcb9b0e9e47d",
       "version-semver": "2.17.7",
       "port-version": 2
     },

--- a/versions/e-/embree2.json
+++ b/versions/e-/embree2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2eba5a73be8ff3ea2ec2324af483dcb9b0e9e47d",
+      "git-tree": "cc259bcc8185631761c55b23d95afba48e8bae70",
       "version-semver": "2.17.7",
       "port-version": 2
     },

--- a/versions/e-/embree2.json
+++ b/versions/e-/embree2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "163e5e4f14e9b6b926cbf5b36987a2b2745c6e84",
+      "version-semver": "2.17.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "234d3da49438399d5df9e1a105401bc930ae22fe",
       "version-semver": "2.17.7",
       "port-version": 1


### PR DESCRIPTION
Recently attempting to build embree2 is causing our osx workers to die. Example recent CIs:

https://dev.azure.com/vcpkg/public/_build/results?buildId=56146
https://dev.azure.com/vcpkg/public/_build/results?buildId=55886
https://dev.azure.com/vcpkg/public/_build/results?buildId=55802

Notably, we don't see this problem in PRs because it is marked "fail" in ci.baseline.txt. Initially, I was going to change it to skip, but observed that the project uses an ordinary cmake build and all the failing triplets were static ones.

Unfortunately, PR testing replicated the broke MacOS and Linux behavior, so this PR adds "supports: windows". If someone wants embree2 on non-Windows we would love to see a contribution that makes it work.