### PR TITLE
[imguizmo] new port

### DIFF
--- a/ports/imguizmo/CMakeLists.txt
+++ b/ports/imguizmo/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_DEBUG_POSTFIX d)
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+target_compile_options(${PROJECT_NAME} PRIVATE "-std=c++11")
+
 target_include_directories(
 	${PROJECT_NAME}
 	PUBLIC

--- a/ports/imguizmo/CMakeLists.txt
+++ b/ports/imguizmo/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.8)
+project(imguizmo)
+
+find_package(imgui CONFIG REQUIRED)
+get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+
+set(CMAKE_DEBUG_POSTFIX d)
+
+add_library(${PROJECT_NAME} "")
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC
+	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include>
+	PRIVATE
+		${IMGUI_INCLUDE_DIRS}
+)
+
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/GraphEditor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ImCurveEdit.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ImGradient.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ImGuizmo.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ImSequencer.cpp
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}_target
+    ARCHIVE DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+if (NOT IMGUIZMO_SKIP_HEADERS)
+    install(
+        FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/GraphEditor.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/ImCurveEdit.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/ImGradient.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/ImGuizmo.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/ImSequencer.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/ImZoomSlider.h
+        DESTINATION include
+    )
+endif()
+
+install(
+    EXPORT ${PROJECT_NAME}_target
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION share/${PROJECT_NAME}
+)

--- a/ports/imguizmo/CMakeLists.txt
+++ b/ports/imguizmo/CMakeLists.txt
@@ -6,8 +6,6 @@ get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
     INTERFACE_INCLUDE_DIRECTORIES
 )
 
-set(CMAKE_DEBUG_POSTFIX d)
-
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -8,18 +8,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CURRENT_PORT_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-vcpkg_configure_cmake(
+
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS_DEBUG
         -DIMGUIZMO_SKIP_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+
 
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -8,17 +8,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
 
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
+
     OPTIONS_DEBUG
         -DIMGUIZMO_SKIP_HEADERS=ON
 )
 
 vcpkg_cmake_install()
-
 
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO CedricGuillemet/ImGuizmo
+    REF 7daa4b24ffe08b906040079bf297e8b920f86f47
+    SHA512 dd4d5ee47753f7f70519f94dd63ab19badc962d02f05e847bc1b9fc9798a5fa617daf9d801dcc9856ffbb989c3070defe71f6d3706eefa72c165327a0d577d22
+    HEAD_REF master
+)
+
+file(COPY ${CURRENT_PORT_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS_DEBUG
+        -DIMGUIZMO_SKIP_HEADERS=ON
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_cmake_targets()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CedricGuillemet/ImGuizmo
-    REF v1.83
-    SHA512 dd4d5ee47753f7f70519f94dd63ab19badc962d02f05e847bc1b9fc9798a5fa617daf9d801dcc9856ffbb989c3070defe71f6d3706eefa72c165327a0d577d22
+    REF 1.83
+    SHA512 23285398688b4cdf3128ecb918b70c9a52f06c8e911da57430442b838cecf653e233d8cdfefc6acd3e4da381869ffc6fb74bcaaafc8e33657d6060a645517363
     HEAD_REF master
 )
 

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -10,11 +10,8 @@ vcpkg_from_github(
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-
     OPTIONS_DEBUG
         -DIMGUIZMO_SKIP_HEADERS=ON
 )
@@ -24,4 +21,4 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/imguizmo/portfile.cmake
+++ b/ports/imguizmo/portfile.cmake
@@ -3,7 +3,7 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CedricGuillemet/ImGuizmo
-    REF 7daa4b24ffe08b906040079bf297e8b920f86f47
+    REF v1.83
     SHA512 dd4d5ee47753f7f70519f94dd63ab19badc962d02f05e847bc1b9fc9798a5fa617daf9d801dcc9856ffbb989c3070defe71f6d3706eefa72c165327a0d577d22
     HEAD_REF master
 )

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "imguizmo",
+  "version-string": "2021-07-15",
+  "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
+  "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
+  "dependencies": [
+    "imgui"
+  ]
+}

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imguizmo",
-  "version-date": "2021-07-15",
+  "version": "1.83",
   "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
   "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
   "dependencies": [

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -6,12 +6,12 @@
   "dependencies": [
     "imgui",
     {
-    "name": "vcpkg-cmake",
-    "host": true
-  },
-  {
-    "name": "vcpkg-cmake-config",
-    "host": true
-  }
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/imguizmo/vcpkg.json
+++ b/ports/imguizmo/vcpkg.json
@@ -1,9 +1,17 @@
 {
   "name": "imguizmo",
-  "version-string": "2021-07-15",
+  "version-date": "2021-07-15",
   "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
   "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
   "dependencies": [
-    "imgui"
+    "imgui",
+    {
+    "name": "vcpkg-cmake",
+    "host": true
+  },
+  {
+    "name": "vcpkg-cmake-config",
+    "host": true
+  }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2664,6 +2664,10 @@
       "baseline": "2.1-2",
       "port-version": 0
     },
+    "imguizmo": {
+      "baseline": "2021-07-15",
+      "port-version": 0
+    },
     "immer": {
       "baseline": "2019-06-07",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2665,7 +2665,7 @@
       "port-version": 0
     },
     "imguizmo": {
-      "baseline": "2021-07-15",
+      "baseline": "1.83",
       "port-version": 0
     },
     "immer": {

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e9e99f67175df01ac1e928ac2b063ebb6e29c921",
+      "git-tree": "27cb106055dc73b6330d8494c8c981d1b235ba4c",
       "version-string": "2021-07-15",
       "port-version": 0
     }

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "4e4dbabfc0ed8f82419c799bc5f240d50c973595",
-      "version-date": "2021-07-15",
+      "git-tree": "e72b6c21eae80a46d34a6cb2111c814cbe3085ff",
+      "version": "1.83",
       "port-version": 0
     }
   ]

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "ffb654799b70ca535a4b6aa2de3c67b3d1f4644b",
-      "version-string": "2021-07-15",
+      "version-date": "2021-07-15",
       "port-version": 0
     }
   ]

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e72b6c21eae80a46d34a6cb2111c814cbe3085ff",
+      "git-tree": "9611b5ef89fd20182ee8d6c84c505e986f3ea880",
       "version": "1.83",
       "port-version": 0
     }

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffb654799b70ca535a4b6aa2de3c67b3d1f4644b",
+      "git-tree": "33030adc4f25d42d2c12ef81dbd6cd8367b0d93b",
       "version-date": "2021-07-15",
       "port-version": 0
     }

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "33030adc4f25d42d2c12ef81dbd6cd8367b0d93b",
+      "git-tree": "4e4dbabfc0ed8f82419c799bc5f240d50c973595",
       "version-date": "2021-07-15",
       "port-version": 0
     }

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e9e99f67175df01ac1e928ac2b063ebb6e29c921",
+      "version-string": "2021-07-15",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/i-/imguizmo.json
+++ b/versions/i-/imguizmo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "27cb106055dc73b6330d8494c8c981d1b235ba4c",
+      "git-tree": "ffb654799b70ca535a4b6aa2de3c67b3d1f4644b",
       "version-string": "2021-07-15",
       "port-version": 0
     }


### PR DESCRIPTION
Adding a port for the ImGuizmo library to go along with ImGui and ImPlot

Source library uses a make build so this port uses the same method of ImPlot to define a `CMakeLists.txt` in the port and copy it over during install to correctly build the project

Source library is not versioned, I have an open issue about whether there they will use releases. Currently I am using a yyyy-mm-dd as the version string

- #### What does your PR fix?  
  Adds a port for [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo) 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  Tested x86-windows, x64-windows, x64-linux  sucessfully, unable to test others

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  As far as I know. Port is very similar to pre-existing ImPlot port, and the example code in source repo is excluded by the custom `CMakeLists.txt` included in the port directory

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
