### PR TITLE
[pistache] Build fixes from 2021-07-18

### DIFF
--- a/ports/pistache/disable-warnings.patch
+++ b/ports/pistache/disable-warnings.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e051efa..9d65174 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,6 @@ project (pistache
+ 
+ include(GNUInstallDirs)
+ 
+-add_compile_options(-Wall -Wconversion -pedantic -Wextra -Wno-missing-field-initializers)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
+ 
+ include(CheckAtomic)

--- a/ports/pistache/portfile.cmake
+++ b/ports/pistache/portfile.cmake
@@ -10,11 +10,12 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-debug-empty.patch
+        disable-warnings.patch
 )
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA 
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
 )
 
 vcpkg_install_cmake()
@@ -22,8 +23,8 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/RapidJSON)
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pistache/vcpkg.json
+++ b/ports/pistache/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pistache",
   "version-date": "2021-03-31",
+  "port-version": 1,
   "description": "Pistache is a modern and elegant HTTP and REST framework for C++. It is entirely written in pure-C++11 and provides a clear and pleasant API",
   "homepage": "https://github.com/oktal/pistache",
   "supports": "linux"

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -208,8 +208,6 @@ devicenameresolver:x64-windows-static=fail
 dimcli:arm-uwp=fail
 dimcli:x64-osx=fail
 dimcli:x64-uwp=fail
-# directxtex requires GCC 9 or later for linux support
-directxtex:x64-linux=fail
 discord-game-sdk:x64-windows-static=fail
 discord-game-sdk:x64-windows-static-md=fail
 discord-rpc:arm-uwp=fail
@@ -353,9 +351,6 @@ fuzzylite:x64-uwp=fail
 gainput:arm-uwp=fail
 gainput:x64-linux=fail
 gainput:x64-uwp=fail
-
-# Requires a more recent gcc than we have in the test lab
-gamedev-framework:x64-linux=fail
 gasol:arm64-windows=fail
 gasol:arm-uwp=fail
 gasol:x64-uwp=fail
@@ -1611,8 +1606,6 @@ v8:arm64-windows=fail
 v8:arm-uwp=fail
 v8:x64-osx=fail
 v8:x64-uwp=fail
-# The domain hosting vamp-sdk uses a newer root cert than is available in our linux CI
-vamp-sdk:x64-linux=fail
 vectorclass:arm64-windows=fail
 vectorclass:arm-uwp=fail
 vlpp:x64-osx=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1750,7 +1750,6 @@ libmicrohttpd:x64-windows-static-md=fail
 libspatialite:x64-windows-static-md=fail
 linenoise-ng:x64-windows-static-md=fail
 mmloader:x64-windows-static-md=fail
-mpg123:x64-windows-static-md=fail
 netcdf-cxx4:x64-windows-static-md=fail
 open62541:x64-windows-static-md=fail
 openscap:x64-windows-static-md=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3120,12 +3120,12 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
-    "libebur128": {
-      "baseline": "1.2.6",
-      "port-version": 0
-    },
     "libe57": {
       "baseline": "1.1.312",
+      "port-version": 0
+    },
+    "libebur128": {
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "libepoxy": {
@@ -4862,7 +4862,7 @@
     },
     "pistache": {
       "baseline": "2021-03-31",
-      "port-version": 0
+      "port-version": 1
     },
     "pixel": {
       "baseline": "0.3-1",

--- a/versions/p-/pistache.json
+++ b/versions/p-/pistache.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6b15d3a79abbfb78408d1f49e8b976bcb9003f2",
+      "version-date": "2021-03-31",
+      "port-version": 1
+    },
+    {
       "git-tree": "f2c28dea6191ea1f399a862889d095f1d268a3f0",
       "version-date": "2021-03-31",
       "port-version": 0


### PR DESCRIPTION
From https://dev.azure.com/vcpkg/public/_build/results?buildId=56237

PASSING, REMOVE FROM FAIL LIST: mpg123:x64-windows-static-md

Probably fixed by https://github.com/microsoft/vcpkg/pull/18403

PASSING, REMOVE FROM FAIL LIST: directxtex:x64-linux (.\scripts\ci.baseline.txt)
PASSING, REMOVE FROM FAIL LIST: vamp-sdk:x64-linux (.\scripts\ci.baseline.txt)
PASSING, REMOVE FROM FAIL LIST: gamedev-framework:x64-linux (.\scripts\ci.baseline.txt)

Probably fixed by https://github.com/microsoft/vcpkg/pull/18892

REGRESSION: pistache:x64-linux. If expected, add pistache:x64-linux=fail to .\scripts\ci.baseline.txt.

Probably broken by merge conflict between https://github.com/microsoft/vcpkg/pull/18892 and https://github.com/microsoft/vcpkg/pull/17013