### PR TITLE
[libunistring] New port

### DIFF
--- a/ports/libunistring/copyright
+++ b/ports/libunistring/copyright
@@ -1,0 +1,18 @@
+The libunistring library and its header files are dual-licensed under
+"the GNU LGPLv3+ or the GNU GPLv2". This means, you can use it under either
+  - the terms of the GNU Lesser General Public License (LGPL) version 3 or
+    (at your option) any later version, or
+  - the terms of the GNU General Public License (GPL) version 2, or
+  - the same dual license "the GNU LGPLv3+ or the GNU GPLv2".
+
+You find the GNU LGPL version 3 in the file COPYING.LIB.  This license is
+based on the GNU GPL version 3, see file COPYING.
+
+You can find the GNU GPL version 2 at
+<https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+
+Note: This dual license makes it possible for the libunistring library
+to be used by packages under GPLv2 or GPLv2+ licenses, in particular. See
+the table in <https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility>.
+
+The documentation is under another license; see in the documentation.

--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -1,6 +1,10 @@
 set(LIBUNISTRING_VERSION 0.9.10)
 set(LIBUNISTRING_FILENAME libunistring-${LIBUNISTRING_VERSION}.tar.gz)
 
+if(NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_fail_port_install(ON_TARGET "Windows" "UWP")
+endif()
+
 vcpkg_download_distfile(ARCHIVE
     URLS
         "https://ftp.gnu.org/gnu/libunistring/${LIBUNISTRING_FILENAME}"

--- a/ports/libunistring/portfile.cmake
+++ b/ports/libunistring/portfile.cmake
@@ -1,0 +1,32 @@
+set(LIBUNISTRING_VERSION 0.9.10)
+set(LIBUNISTRING_FILENAME libunistring-${LIBUNISTRING_VERSION}.tar.gz)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://ftp.gnu.org/gnu/libunistring/${LIBUNISTRING_FILENAME}"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libunistring/${LIBUNISTRING_FILENAME}"
+    FILENAME "${LIBUNISTRING_FILENAME}"
+    SHA512 690082732fbbd47ab4ffbd6f21d85afece0f8e2ded24982f949f4ae52bf0a981b75ea9bc14ab289e0954cde07f31a7a4c2bb65615a8eb5b2bfa65720310b6fc9
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    REF ${LIBUNISTRING_VERSION}
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    COPY_SOURCE
+    OPTIONS
+        "--with-libiconv-prefix=${CURRENT_INSTALLED_DIR}"
+)
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# copyright excerpt from README, to cover dual license under "LGPLv3+ or GPLv2".
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "0.9.10",
   "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
   "homepage": "https://www.gnu.org/software/libunistring/",
+  "supports": "!windows",
   "dependencies": [
     "libiconv"
   ]

--- a/ports/libunistring/vcpkg.json
+++ b/ports/libunistring/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "libunistring",
+  "version": "0.9.10",
+  "description": "GNU libunistring provides functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.",
+  "homepage": "https://www.gnu.org/software/libunistring/",
+  "dependencies": [
+    "libiconv"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3668,6 +3668,10 @@
       "baseline": "4.3-0",
       "port-version": 0
     },
+    "libunistring": {
+      "baseline": "0.9.10",
+      "port-version": 0
+    },
     "liburing": {
       "baseline": "2.0",
       "port-version": 0

--- a/versions/l-/libunistring.json
+++ b/versions/l-/libunistring.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "586bf47f6b9ee55aa3eb9ec7c7ff36363e39980b",
+      "version": "0.9.10",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR adds GNU libunistring, a library strongly recommended for GNU libidn2, which is used by curl.
  libidn2 can be built without libunistring, but it is not easy to stop it from picking up the system library if installed.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
