### PR TITLE
[v8] Update to stable version 9.1.269.39

### DIFF
--- a/ports/v8/build.patch
+++ b/ports/v8/build.patch
@@ -1,16 +1,16 @@
 diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index 0c8743726..e6a5ae0b4 100644
+index 1904a2559..e66586c88 100644
 --- a/config/compiler/BUILD.gn
 +++ b/config/compiler/BUILD.gn
-@@ -1545,6 +1545,7 @@ config("default_warnings") {
+@@ -1571,6 +1571,7 @@ config("default_warnings") {
        # Disables.
        "-Wno-missing-field-initializers",  # "struct foo f = {0};"
        "-Wno-unused-parameter",  # Unused function parameters.
 +      "-Wno-invalid-offsetof", # Use of "conditionally-supported" offsetof in c++17
      ]
    }
-
-@@ -1969,8 +1970,17 @@ config("no_incompatible_pointer_warnings") {
+ 
+@@ -1987,8 +1988,17 @@ config("no_incompatible_pointer_warnings") {
  # Shared settings for both "optimize" and "optimize_max" configs.
  # IMPORTANT: On Windows "/O1" and "/O2" must go before the common flags.
  if (is_win) {
@@ -31,7 +31,7 @@ index 0c8743726..e6a5ae0b4 100644
      "/Zc:inline",  # Remove unreferenced COMDAT (faster links).
    ]
 diff --git a/config/linux/pkg-config.py b/config/linux/pkg-config.py
-index 5adf70cc3..dab159f98 100644
+index 5adf70cc3..dab159f98 100755
 --- a/config/linux/pkg-config.py
 +++ b/config/linux/pkg-config.py
 @@ -41,6 +41,11 @@ from optparse import OptionParser
@@ -43,13 +43,13 @@ index 5adf70cc3..dab159f98 100644
 +# of the PKG_CONFIG_LIBDIR environment library.
 +#
 +# --full-path-libs causes lib names to include their full path.
-
-
+ 
+ 
  def SetConfigPath(options):
 @@ -105,11 +110,32 @@ def RewritePath(path, strip_prefix, sysroot):
      return path
-
-
+ 
+ 
 +flag_regex = re.compile("(-.)(.+)")
 +
 +
@@ -79,7 +79,7 @@ index 5adf70cc3..dab159f98 100644
 +  if "linux" not in sys.platform and 'win32' not in sys.platform:
      print("[[],[],[],[],[]]")
      return 0
-
+ 
 @@ -128,6 +154,9 @@ def main():
    parser.add_option('--dridriverdir', action='store_true', dest='dridriverdir')
    parser.add_option('--version-as-components', action='store_true',
@@ -88,12 +88,12 @@ index 5adf70cc3..dab159f98 100644
 +                    type='string')
 +  parser.add_option('--full-path-libs', action='store_true', dest='full_path_libs')
    (options, args) = parser.parse_args()
-
+ 
    # Make a list of regular expressions to strip out.
 @@ -144,6 +173,10 @@ def main():
    else:
      prefix = ''
-
+ 
 +  # Override PKG_CONFIG_LIBDIR
 +  if options.pkg_config_libdir:
 +    os.environ['PKG_CONFIG_LIBDIR'] = options.pkg_config_libdir
@@ -107,12 +107,12 @@ index 5adf70cc3..dab159f98 100644
    # to happen in practice.
 -  all_flags = flag_string.strip().split(' ')
 +  all_flags = ConvertGCCToMSVC(flag_string.strip().split(' '))
-
-
+ 
+ 
    sysroot = options.sysroot
 @@ -220,7 +253,10 @@ def main():
        continue;
-
+ 
      if flag[:2] == '-l':
 -      libs.append(RewritePath(flag[2:], prefix, sysroot))
 +      library = RewritePath(flag[2:], prefix, sysroot)
@@ -125,7 +125,7 @@ index 5adf70cc3..dab159f98 100644
 @@ -237,6 +273,14 @@ def main():
      else:
        cflags.append(flag)
-
+ 
 +  if options.full_path_libs:
 +    full_path_libs = []
 +    for lib_dir in lib_dirs:
@@ -149,12 +149,12 @@ index 428e44ac0..a0d2175ee 100644
 +  # Allow directly overriding the PKG_CONFIG_LIBDIR enviroment variable
 +  pkg_config_libdir = ""
  }
-
+ 
  pkg_config_script = "//build/config/linux/pkg-config.py"
 @@ -87,6 +90,17 @@ if (host_pkg_config != "") {
    host_pkg_config_args = pkg_config_args
  }
-
+ 
 +if (pkg_config_libdir != "") {
 +  pkg_config_args += [
 +    "--pkg_config_libdir",
@@ -170,10 +170,10 @@ index 428e44ac0..a0d2175ee 100644
    assert(defined(invoker.packages),
           "Variable |packages| must be defined to be a list in pkg_config.")
 diff --git a/util/lastchange.py b/util/lastchange.py
-index 874870ad5..a4fc0be8d 100644
+index 02a36642b..78934f1b0 100755
 --- a/util/lastchange.py
 +++ b/util/lastchange.py
-@@ -191,7 +191,10 @@ def GetGitTopDirectory(source_dir):
+@@ -192,7 +192,10 @@ def GetGitTopDirectory(source_dir):
    Returns:
      The output of "git rev-parse --show-toplevel" as a string
    """
@@ -182,6 +182,6 @@ index 874870ad5..a4fc0be8d 100644
 +  if "GCC" in sys.version and sys.platform=='win32':
 +    return subprocess.check_output(["cygpath", "-w", directory]).strip(b"\n").decode()
 +  return directory
-
-
+ 
+ 
  def WriteIfChanged(file_name, contents):

--- a/ports/v8/portfile.cmake
+++ b/ports/v8/portfile.cmake
@@ -1,5 +1,5 @@
 
-set(pkgver "9.0.257.17")
+set(pkgver "9.1.269.39")
 
 set(ENV{DEPOT_TOOLS_WIN_TOOLCHAIN} 0)
 
@@ -71,7 +71,7 @@ endfunction()
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL https://chromium.googlesource.com/v8/v8.git
-    REF 462fc27a2892702a4d42ffd647789c58ffcee747
+    REF 7d3d62c91f69a702e5aa54c6b4dbbaa883683717
     PATCHES ${CURRENT_PORT_DIR}/v8.patch
 )
 
@@ -79,7 +79,7 @@ message(STATUS "Fetching submodules")
 v8_fetch(
         DESTINATION build
         URL https://chromium.googlesource.com/chromium/src/build.git
-        REF acacc4cc0668cb4dc7f44a3f4430635f438d7478 
+        REF fd86d60f33cbc794537c4da2ef7e298d7f81138e 
         SOURCE ${SOURCE_PATH}
         PATCHES ${CURRENT_PORT_DIR}/build.patch)
 v8_fetch(

--- a/ports/v8/v8.patch
+++ b/ports/v8/v8.patch
@@ -1,20 +1,20 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index a9ab6783fa..bc8455ce64 100644
+index d2bfb6129d..c5ab18ee44 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -5202,6 +5202,7 @@ if (is_component_build) {
-
+@@ -5366,6 +5366,7 @@ if (is_component_build) {
+ 
      public_deps = [
        ":v8_base",
 +      ":v8_initializers",
        ":v8_snapshot",
      ]
-
+ 
 diff --git a/src/codegen/code-stub-assembler.h b/src/codegen/code-stub-assembler.h
-index 03af2cc5e2..bb19092c54 100644
+index 72b8fbc8a8..3ebfc23f1f 100644
 --- a/src/codegen/code-stub-assembler.h
 +++ b/src/codegen/code-stub-assembler.h
-@@ -301,7 +301,7 @@ enum class PrimitiveType { kBoolean, kNumber, kString, kSymbol };
+@@ -303,7 +303,7 @@ enum class PrimitiveType { kBoolean, kNumber, kString, kSymbol };
  // it's possible to add JavaScript-specific useful CodeAssembler "macros"
  // without modifying files in the compiler directory (and requiring a review
  // from a compiler directory OWNER).
@@ -24,10 +24,10 @@ index 03af2cc5e2..bb19092c54 100644
        public TorqueGeneratedExportedMacrosAssembler {
   public:
 diff --git a/src/common/globals.h b/src/common/globals.h
-index d9d502aa51..7495c898fc 100644
+index f51c3210f8..5291285337 100644
 --- a/src/common/globals.h
 +++ b/src/common/globals.h
-@@ -1348,7 +1348,7 @@ class BinaryOperationFeedback {
+@@ -1364,7 +1364,7 @@ class BinaryOperationFeedback {
  // This is distinct from BinaryOperationFeedback on purpose, because the
  // feedback that matters differs greatly as well as the way it is consumed.
  class CompareOperationFeedback {
@@ -36,14 +36,14 @@ index d9d502aa51..7495c898fc 100644
      kSignedSmallFlag = 1 << 0,
      kOtherNumberFlag = 1 << 1,
      kBooleanFlag = 1 << 2,
-@@ -1362,7 +1362,7 @@ class CompareOperationFeedback {
+@@ -1378,7 +1378,7 @@ class CompareOperationFeedback {
    };
-
+ 
   public:
 -  enum Type {
 +  enum Type : uint32_t {
      kNone = 0,
-
+ 
      kBoolean = kBooleanFlag,
 diff --git a/src/compiler/node-cache.h b/src/compiler/node-cache.h
 index 8e1d3d4eae..c55d8329de 100644
@@ -65,14 +65,14 @@ index e135e30efc..0c055247bc 100644
 @@ -19,7 +19,7 @@ namespace internal {
  // -----------------------------------------------------------------------------
  // PagedSpaceObjectIterator
-
+ 
 -HeapObject PagedSpaceObjectIterator::Next() {
 +inline HeapObject PagedSpaceObjectIterator::Next() {
    do {
      HeapObject next_obj = FromCurrentPage();
      if (!next_obj.is_null()) return next_obj;
 diff --git a/src/heap/paged-spaces.h b/src/heap/paged-spaces.h
-index 5168f0f053..ae5c22d1f3 100644
+index 621d92aa89..a8592a5b4d 100644
 --- a/src/heap/paged-spaces.h
 +++ b/src/heap/paged-spaces.h
 @@ -45,7 +45,7 @@ class V8_EXPORT_PRIVATE PagedSpaceObjectIterator : public ObjectIterator {
@@ -81,7 +81,7 @@ index 5168f0f053..ae5c22d1f3 100644
    // Returns nullptr when the iteration has ended.
 -  inline HeapObject Next() override;
 +  HeapObject Next() override;
-
+ 
   private:
    // Fast (inlined) path of next().
 diff --git a/src/objects/feedback-vector.cc b/src/objects/feedback-vector.cc
@@ -91,74 +91,61 @@ index a77ea5d265..0cddb92a02 100644
 @@ -114,9 +114,9 @@ Handle<FeedbackMetadata> FeedbackMetadata::New(LocalIsolate* isolate,
    return metadata;
  }
-
+ 
 -template Handle<FeedbackMetadata> FeedbackMetadata::New(
 +template V8_EXPORT Handle<FeedbackMetadata> FeedbackMetadata::New(
      Isolate* isolate, const FeedbackVectorSpec* spec);
 -template Handle<FeedbackMetadata> FeedbackMetadata::New(
 +template V8_EXPORT Handle<FeedbackMetadata> FeedbackMetadata::New(
      LocalIsolate* isolate, const FeedbackVectorSpec* spec);
-
+ 
  bool FeedbackMetadata::SpecDiffersFrom(
 diff --git a/src/objects/fixed-array-inl.h b/src/objects/fixed-array-inl.h
-index a91f89784f..5ecf7e3372 100644
+index cca6d40070..d6d36ff59f 100644
 --- a/src/objects/fixed-array-inl.h
 +++ b/src/objects/fixed-array-inl.h
 @@ -88,7 +88,7 @@ bool FixedArray::is_the_hole(Isolate* isolate, int index) {
    return get(isolate, index).IsTheHole(isolate);
  }
-
+ 
 -void FixedArray::set(int index, Smi value) {
 +inline V8_EXPORT_PRIVATE void FixedArray::set(int index, Smi value) {
    DCHECK_NE(map(), GetReadOnlyRoots().fixed_cow_array_map());
    DCHECK_LT(static_cast<unsigned>(index), static_cast<unsigned>(length()));
    DCHECK(Object(value).IsSmi());
 diff --git a/src/objects/fixed-array.h b/src/objects/fixed-array.h
-index 53b4cbb22b..8dd24df399 100644
+index 98c5d8d5b5..bd5303e44c 100644
 --- a/src/objects/fixed-array.h
 +++ b/src/objects/fixed-array.h
-@@ -130,7 +130,7 @@ class FixedArray
+@@ -132,7 +132,7 @@ class FixedArray
    inline bool is_the_hole(Isolate* isolate, int index);
-
+ 
    // Setter that doesn't need write barrier.
 -  inline void set(int index, Smi value);
 +  inline V8_EXPORT_PRIVATE void set(int index, Smi value);
    // Setter with explicit barrier mode.
    inline void set(int index, Object value, WriteBarrierMode mode);
-
-diff --git a/src/runtime/runtime-wasm.cc b/src/runtime/runtime-wasm.cc
-index 9ba26c23ad..5857bf4c39 100644
---- a/src/runtime/runtime-wasm.cc
-+++ b/src/runtime/runtime-wasm.cc
-@@ -570,7 +570,7 @@ RUNTIME_FUNCTION(Runtime_WasmDebugBreak) {
-   DebugScope debug_scope(isolate->debug());
-
-   // Check for instrumentation breakpoint.
--  DCHECK_EQ(script->break_on_entry(), instance->break_on_entry());
-+  DCHECK_EQ(script->break_on_entry(), static_cast<bool>(instance->break_on_entry()));
-   if (script->break_on_entry()) {
-     MaybeHandle<FixedArray> maybe_on_entry_breakpoints =
-         WasmScript::CheckBreakPoints(
+ 
 diff --git a/src/snapshot/snapshot-utils.cc b/src/snapshot/snapshot-utils.cc
 index eb2372372c..7defadb4b1 100644
 --- a/src/snapshot/snapshot-utils.cc
 +++ b/src/snapshot/snapshot-utils.cc
 @@ -5,7 +5,7 @@
  #include "src/snapshot/snapshot-utils.h"
-
+ 
  #include "src/sanitizer/msan.h"
 -#include "third_party/zlib/zlib.h"
 +#include "zlib.h"
-
+ 
  namespace v8 {
  namespace internal {
 diff --git a/src/wasm/function-body-decoder-impl.h b/src/wasm/function-body-decoder-impl.h
-index 6c9700b100..e3be3c31f5 100644
+index d37f718681..3a409e1d76 100644
 --- a/src/wasm/function-body-decoder-impl.h
 +++ b/src/wasm/function-body-decoder-impl.h
-@@ -2006,7 +2006,7 @@ class WasmDecoder : public Decoder {
+@@ -2013,7 +2013,7 @@ class WasmDecoder : public Decoder {
    }
-
+ 
    // TODO(clemensb): This is only used by the interpreter; move there.
 -  V8_EXPORT_PRIVATE std::pair<uint32_t, uint32_t> StackEffect(const byte* pc) {
 +  std::pair<uint32_t, uint32_t> StackEffect(const byte* pc) {
@@ -166,48 +153,48 @@ index 6c9700b100..e3be3c31f5 100644
      // Handle "simple" opcodes with a fixed signature first.
      const FunctionSig* sig = WasmOpcodes::Signature(opcode);
 diff --git a/test/cctest/BUILD.gn b/test/cctest/BUILD.gn
-index e63fe5ed35..ec48403c42 100644
+index ffa4e3a136..a279faee9b 100644
 --- a/test/cctest/BUILD.gn
 +++ b/test/cctest/BUILD.gn
-@@ -480,6 +480,10 @@ v8_source_set("cctest_sources") {
+@@ -493,6 +493,10 @@ v8_source_set("cctest_sources") {
      # C4309: 'static_cast': truncation of constant value
      cflags += [ "/wd4309" ]
-
+ 
 +    if(!is_clang) {
 +      cflags += [ "/wd4789" ]
 +    }
 +
      # MSVS wants this for gay-{precision,shortest}.cc.
      cflags += [ "/bigobj" ]
-
+ 
 diff --git a/tools/debug_helper/BUILD.gn b/tools/debug_helper/BUILD.gn
-index 54cd3b7a4c..9c6666871d 100644
+index 2256df1f55..29e27c6af9 100644
 --- a/tools/debug_helper/BUILD.gn
 +++ b/tools/debug_helper/BUILD.gn
-@@ -99,10 +99,12 @@ v8_component("v8_debug_helper") {
+@@ -100,10 +100,12 @@ v8_component("v8_debug_helper") {
      "../..:v8_libbase",
      "../..:v8_shared_internal_headers",
      "../..:v8_tracing",
 +    "../..:v8",
    ]
-
+ 
    configs = [ ":internal_config" ]
    if (v8_enable_i18n_support) {
 +    public_deps = [ "//third_party/icu" ]
      configs += [ "//third_party/icu:icu_config" ]
    }
-
+ 
 diff --git a/tools/v8windbg/BUILD.gn b/tools/v8windbg/BUILD.gn
-index 10d06a127f..d0deb7adca 100644
+index 5618d2d945..71568f1670 100644
 --- a/tools/v8windbg/BUILD.gn
 +++ b/tools/v8windbg/BUILD.gn
 @@ -6,7 +6,7 @@ import("../../gni/v8.gni")
-
+ 
  config("v8windbg_config") {
    # Required for successful compilation of SDK header file DbgModel.h.
 -  cflags_cc = [ "/Zc:twoPhase-" ]
 +  cflags_cc = [ "/Zc:twoPhase-", "/std:c++latest" ]
-
+ 
    include_dirs = [ "../.." ]
  }
 diff --git a/tools/v8windbg/base/dbgext.h b/tools/v8windbg/base/dbgext.h
@@ -217,7 +204,7 @@ index 8b36a8f361..f8d9f0d64e 100644
 @@ -9,6 +9,7 @@
  #error Unicode not defined
  #endif
-
+ 
 +#include <new>
  #include <DbgEng.h>
  #include <DbgModel.h>
@@ -229,13 +216,13 @@ index f7d78c5dd3..1c70e54e7a 100644
 @@ -5,10 +5,11 @@
  #ifndef V8_TOOLS_V8WINDBG_SRC_V8_DEBUG_HELPER_INTEROP_H_
  #define V8_TOOLS_V8WINDBG_SRC_V8_DEBUG_HELPER_INTEROP_H_
-
+ 
 -#include <wrl/client.h>
 -
 +#include <new>
 +#include <DbgEng.h>
  #include <DbgModel.h>
-
+ 
 +#include <wrl/client.h>
  #include <cstdint>
  #include <map>
@@ -247,7 +234,7 @@ index 8855d6ffbc..ed2b0f62e9 100644
 @@ -9,6 +9,7 @@
  #error Unicode not defined
  #endif
-
+ 
 +#include <new>
  #include <DbgEng.h>
  #include <DbgModel.h>

--- a/ports/v8/vcpkg.json
+++ b/ports/v8/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "v8",
-  "version-string": "9.0.257.17",
-  "port-version": 1,
+  "version-string": "9.1.269.39",
   "description": "Google Chrome's JavaScript engine",
   "homepage": "https://v8.dev",
   "supports": "!(arm | arm64 | uwp | osx)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3120,12 +3120,12 @@
       "baseline": "0.6.0-1",
       "port-version": 0
     },
-    "libebur128": {
-      "baseline": "1.2.6",
-      "port-version": 0
-    },
     "libe57": {
       "baseline": "1.1.312",
+      "port-version": 0
+    },
+    "libebur128": {
+      "baseline": "1.2.6",
       "port-version": 0
     },
     "libepoxy": {
@@ -6509,8 +6509,8 @@
       "port-version": 1
     },
     "v8": {
-      "baseline": "9.0.257.17",
-      "port-version": 1
+      "baseline": "9.1.269.39",
+      "port-version": 0
     },
     "valijson": {
       "baseline": "2018-11-17-1",

--- a/versions/v-/v8.json
+++ b/versions/v-/v8.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1cd6a72ff77695151205fb2d2e55ed93d2f4193d",
+      "version-string": "9.1.269.39",
+      "port-version": 0
+    },
+    {
       "git-tree": "4c95acd67f1f8b99aada4af754b4608c9ee80661",
       "version-string": "9.0.257.17",
       "port-version": 1


### PR DESCRIPTION
Allows for clang builds when environment variables are set accordingly:

CC=clang
CXX=clang
AR=llvm-ar
NM=llvm-nm

**Describe the pull request**

Update to stable version 9.1.269.39

- #### What does your PR fix?  
  Fixes #17536

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
windows, windows-static, linux. Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
