### PR TITLE
[vcpkg] Optionally limit the number of cores during vcpkg bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,7 @@ done
 vcpkgDisableMetrics="OFF"
 vcpkgUseSystem=false
 vcpkgAllowAppleClang=false
+vcpkgLimitBuildMemory=false
 vcpkgBuildTests="OFF"
 for var in "$@"
 do
@@ -17,6 +18,8 @@ do
         vcpkgDisableMetrics="ON"
     elif [ "$var" = "-useSystemBinaries" -o "$var" = "--useSystemBinaries" ]; then
         vcpkgUseSystem=true
+    elif [ "$var" = "-limitBuildMemory" -o "$var" = "--limitBuildMemory" ]; then
+        vcpkgLimitBuildMemory=true
     elif [ "$var" = "-allowAppleClang" -o "$var" = "--allowAppleClang" ]; then
         vcpkgAllowAppleClang=true
     elif [ "$var" = "-buildTests" ]; then
@@ -29,6 +32,7 @@ do
         echo "    -disableMetrics      Do not build metrics reporting into the executable"
         echo "    -useSystemBinaries   Force use of the system utilities for building vcpkg"
         echo "    -allowAppleClang     Set VCPKG_ALLOW_APPLE_CLANG to build vcpkg in apple with clang anyway"
+        echo "    -limitBuildMemory    Force builds to use only a single core for compile and link operations while building vcpkg"
         exit 1
     else
         echo "Unknown argument $var. Use '-help' for help."
@@ -299,8 +303,13 @@ echo "Building vcpkg-tool..."
 rm -rf "$baseBuildDir"
 mkdir -p "$buildDir"
 vcpkgExtractArchive "$tarballPath" "$srcBaseDir"
+cmakeConfigOptions="-DCMAKE_BUILD_TYPE=Release -G 'Ninja' -DCMAKE_MAKE_PROGRAM='$ninjaExe'"
 
-(cd "$buildDir" && CXX="$CXX" "$cmakeExe" "$srcDir" -DCMAKE_BUILD_TYPE=Release -G "Ninja" "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DBUILD_TESTING=$vcpkgBuildTests" "-DVCPKG_DEVELOPMENT_WARNINGS=OFF" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
+if [ "$vcpkgLimitBuildMemory" = "true" ] ; then
+    cmakeConfigOptions=" $cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=1;link=1' "
+fi
+
+(cd "$buildDir" && eval CXX="$CXX" "$cmakeExe" "$srcDir" $cmakeConfigOptions "-DBUILD_TESTING=$vcpkgBuildTests" "-DVCPKG_DEVELOPMENT_WARNINGS=OFF" "-DVCPKG_ALLOW_APPLE_CLANG=$vcpkgAllowAppleClang") || exit 1
 (cd "$buildDir" && "$cmakeExe" --build .) || exit 1
 
 rm -rf "$vcpkgRootDir/vcpkg"


### PR DESCRIPTION
Add an option to the bash bootstrap script that allows a user to force the use of only a single CPU during both compilation and linking of the vcpkg executable.  

Building on low-memory / high-core count systems like 1-2 GB variants of Raspberry PIs will often fail because of memory exhaustion.  Each compile will typically take a few hundred MB and running 4 of them concurrently will easily exhaust even a 2GB setup.  Further, such systems often have no swap space configured.  This command line option ensures that `vcpkg` will bootstrap successfully, albeit slowly, even when only 1GB of ram is available.

This PR _does not_ attempt to address any similar issues that might arise from building packages using `vcpkg`

- #### What does your PR fix?  

Fixes #14534 


- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

This is a modification to the bootstrap script and should have no impact on the triplets, only a potential impact on the speed of bootstrapping.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.  The vast majority of the guide doesn't apply since this is a change to the boostrapping mechanism, not to any port or vcpkg functionality.  

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

N/A
