### PR TITLE
[vcpkg] Pass AUTHORIZATION_TOKEN to the vcpkg_download_distfile() command which retrieves VCPKG_HEAD_VERSION

### DIFF
--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -153,6 +153,7 @@ function(vcpkg_from_github)
         vcpkg_download_distfile(archive_version
             URLS "${github_api_url}/repos/${org_name}/${repo_name}/git/refs/heads/${arg_HEAD_REF}"
             FILENAME "${downloaded_file_name}.version"
+            ${headers_param}
             SKIP_SHA512
             ALWAYS_REDOWNLOAD
         )


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #19078

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  N/A
