### PR TITLE
[vcpkg-ci] Add AZP logging markup for versioning errors

### DIFF
--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -47,7 +47,35 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        ./vcpkg.exe --feature-flags=versions x-ci-verify-versions --verbose
+        ./vcpkg.exe --feature-flags=versions x-ci-verify-versions --verbose |
+        ForEach-Object -Begin {
+          $long_error = ''
+        } -Process {
+          if ($long_error -ne '' -and $_ -match '^$|^       ') {
+             # Extend multi-line message
+             $long_error = -join($long_error, "%0D%0A", $_ -replace '^       ','' `
+               -replace '(git add) [^ ]*\\ports\\([^ ]*)', '$1 ports/$2' )
+          } else {
+            if ($long_error -ne '') {
+              # Flush multi-line message
+              $long_error
+              $long_error = ''
+            }
+            if ($_ -match '^Error: ') {
+              # Start multi-line message
+              $long_error = $_ -replace '^Error: ', '##vso[task.logissue type=error]' `
+                -replace '(^##vso[^\]]*)](.*) [^ ]*\\versions\\(.-)\\(.*.json)(.*)', '$1;sourcepath=versions/$3/$4;linenumber=2]$2 version/$3/$4$5'
+            } else {
+              # Normal line
+              $_
+            }
+          }
+        } -End {
+          if ($long_error -ne '') {
+            # Flush multi-line message
+            $long_error
+          }
+        }
       pwsh: true
   - task: PowerShell@2
     displayName: 'Report on Disk Space After Build'


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixes the poor visibility of version files errors in Github.
  In its initial form, it contains an experimental commit to test the expected behaviour. This commit will be reverted or removed when the main change is accepted.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unrelated

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  unrelated

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed


