### PR TITLE
[cspice] Support building in UWP

### DIFF
--- a/ports/cspice/CMakeLists.txt
+++ b/ports/cspice/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 target_include_directories(cspice PUBLIC "${INCLUDE_PATH}")
 
 if (WIN32)
-    target_compile_definitions(cspice PUBLIC "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO")
+    target_compile_definitions(cspice PUBLIC "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO;_CRT_SECURE_NO_WARNINGS")
     set_target_properties(cspice PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 elseif (UNIX)
     target_compile_definitions(cspice PUBLIC "NON_UNIX_STDIO")
@@ -29,7 +29,7 @@ endif ()
 
 if (NOT _SKIP_HEADERS)
     file(GLOB SPICE_HEADERS ${INCLUDE_PATH}/*.h)
-    install(FILES ${SPICE_HEADERS} DESTINATION include/cspice)
+    install(FILES ${SPICE_HEADERS} DESTINATION include)
 endif()
 
 set_target_properties(

--- a/ports/cspice/CONTROL
+++ b/ports/cspice/CONTROL
@@ -1,6 +1,5 @@
 Source: cspice
 Version: 66
-Port-Version: 3
+Port-Version: 4
 Homepage: https://naif.jpl.nasa.gov/naif/toolkit_C.html
 Description: NASA C SPICE toolkit
-Supports: !uwp

--- a/ports/cspice/portfile.cmake
+++ b/ports/cspice/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     if (VCPKG_TARGET_IS_WINDOWS)
         vcpkg_download_distfile(ARCHIVE
@@ -58,6 +56,11 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     set(_STATIC_BUILD ON)
+endif()
+
+if (VCPKG_TARGET_IS_UWP)
+    set(VCPKG_C_FLAGS "/sdl- ${VCPKG_C_FLAGS}")
+    set(VCPKG_CXX_FLAGS "/sdl- ${VCPKG_CXX_FLAGS}")
 endif()
 
 vcpkg_configure_cmake(

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1538,7 +1538,7 @@
     },
     "cspice": {
       "baseline": "66",
-      "port-version": 3
+      "port-version": 4
     },
     "ctbignum": {
       "baseline": "2019-08-02",

--- a/versions/c-/cspice.json
+++ b/versions/c-/cspice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de8a1c53f62f307ac805ace26e3b9c9ece91829a",
+      "version-string": "66",
+      "port-version": 4
+    },
+    {
       "git-tree": "743b26ef365d681a5252d2d72a58aa8c2e76d80b",
       "version-string": "66",
       "port-version": 3


### PR DESCRIPTION
- #### What does your PR fix?  
1. Support building cspice with UWP
2. Install cspice headers to include rather than include/cspice (same as homebrew)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, NO

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes