### PR TITLE
[vcpkg-ci] Add GitHub Actions precheck and reporting

### DIFF
--- a/.github/workflows/trustedPR.yml
+++ b/.github/workflows/trustedPR.yml
@@ -1,0 +1,58 @@
+# Modelled after https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+name: Post PR Suggestions
+
+on:
+  workflow_run:
+    workflows: ["PR Suggestions"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const { promises: fs } = require('fs')
+            const event = (await fs.readFile('event', 'utf8')).trim()
+            const body = (await fs.readFile('body', 'utf8')).trim()
+            const issue_number = Number(await fs.readFile('./NR'));
+
+            var req = {
+              owner: context.repo.owner,
+              pull_number: issue_number,
+              repo: context.repo.repo,
+              event: event
+            };
+            if (body !== "") {
+              req.body = body;
+            }
+            await github.pulls.createReview(req);

--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -1,0 +1,98 @@
+# Modelled after https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+
+# These "checks" are also performed as part of our critical-path azure-pipelines review,
+# however here they are better able to post back to the original PR
+name: PR Suggestions
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch-depth 2 ensures we capture both parents of the merge commit
+          fetch-depth: 2
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            ./vcpkg
+          key: ${{ runner.os }}-${{ hashFiles('scripts/bootstrap*') }}
+
+      - name: bootstrap
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./bootstrap-vcpkg.sh
+
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Formatting
+        run: |
+          git config user.email github-actions
+          git config user.name github-actions@github.com
+
+          ./vcpkg format-manifest ports/*/vcpkg.json
+          git diff > .github-pr.format-manifest
+          git add -u
+          git commit -m "tmp" --allow-empty
+          # HEAD^^ refers to the "main" commit that was merged into
+          git checkout HEAD^^ -- versions
+          git restore --staged versions
+          ./vcpkg x-add-version --all --skip-formatting-check > .github-pr.x-add-version.out
+          git diff > .github-pr.x-add-version.diff
+          git reset HEAD~ --mixed
+
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            const { promises: fs } = require('fs')
+            const add_version = (await fs.readFile('.github-pr.x-add-version.diff', 'utf8')).trim()
+            const add_version_out = (await fs.readFile('.github-pr.x-add-version.out', 'utf8')).trim()
+            const format = (await fs.readFile('.github-pr.format-manifest', 'utf8')).trim()
+
+            var output = ''
+            if (format !== "") {
+              output += "<details><summary><b>All manifest files must be formatted</b></summary>\n\n"
+              output += "`./vcpkg format-manifest ports/*/vcpkg.json`\n"
+              output += "<details><summary><b>Diff</b></summary>\n\n"
+              output += "```diff\n" + format + "\n```\n"
+              output += "</details></details>\n\n"
+            }
+            if (add_version_out !== "") {
+              output += "<details><summary><b>PRs must add only one version and must not modify any published versions</b></summary>\n\n"
+              output += "When making any changes to a library, the version or port-version in `vcpkg.json` or `CONTROL` must be modified.\n"
+              output += "```\n" + add_version_out + "\n```\n</details>\n"
+            }
+            if (add_version !== "") {
+              output += "<details><summary><b>After committing all other changes, the version database must be updated</b></summary>\n\n"
+              output += "```sh\n"
+              output += "git add -u && git commit\n"
+              output += "git checkout ${{ github.event.pull_request.base.sha }} -- versions\n"
+              output += "./vcpkg x-add-version --all\n"
+              output += "```\n"
+              output += "<details><summary><b>Diff</b></summary>\n\n"
+              output += "```diff\n" + add_version + "\n```\n"
+              output += "</details></details>\n\n"
+            }
+
+            if (output === "") {
+              await fs.writeFile("pr/event", "APPROVE")
+            } else {
+              output = "_This is a new experimental fast check for PR issues. Please let us know if this bot is helpful!_\n\n" + output
+              await fs.writeFile("pr/event", "REQUEST_CHANGES")
+            }
+            await fs.writeFile("pr/body", output)
+
+            console.log(output);
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/


### PR DESCRIPTION
This PR adds two pipelines which quickly post automated user-actionable PR feedback into a GitHub review.

Currently, this pipeline has three aspects it can report upon, which you can see in the example review (https://github.com/ras0219-msft/vcpkg/pull/7#pullrequestreview-714258302).

Whenever all automated issues are handled, it will push an approval (https://github.com/ras0219-msft/vcpkg/pull/7#pullrequestreview-714258386).