### PR TITLE
[gdal] Fix GDAL_LIBRARY passing by cache variable

### DIFF
--- a/ports/gdal/vcpkg-cmake-wrapper.cmake
+++ b/ports/gdal/vcpkg-cmake-wrapper.cmake
@@ -23,6 +23,8 @@ if(NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY)
     message(FATAL_ERROR "Installation of vcpkg port gdal is broken.")
 endif()
 
+set(GDAL_LIBRARY "${GDAL_LIBRARY}" CACHE STRING "")
+
 set(FindGDAL_SKIP_GDAL_CONFIG TRUE)
 
 _find_package(${ARGS})

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.2.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "supports": "!arm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2218,7 +2218,7 @@
     },
     "gdal": {
       "baseline": "3.2.2",
-      "port-version": 2
+      "port-version": 3
     },
     "gdcm": {
       "baseline": "3.0.7",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5bb72450f69322e39e09bea191e5c947833e698d",
+      "version-semver": "3.2.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "cee8a26ec45230cb4b11e18582b41291b264d82e",
       "version-semver": "3.2.2",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes #19116. `FindGDAL.cmake` calls `find_library(GDAL_LIBRARY ...)` which needs a *cache* variable to shortcut the lookup.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
