### PR TITLE
Fix c-ares compilation under Linux with dynamic linkage

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -32,10 +32,11 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/ares.h
         "#ifdef CARES_STATICLIB" "#if 1"
     )
-
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin") # Empty folders
 endif()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin") # Empty folders
+endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "c-ares",
   "version": "1.17.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "supports": "!uwp"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1094,7 +1094,7 @@
     },
     "c-ares": {
       "baseline": "1.17.1",
-      "port-version": 1
+      "port-version": 2
     },
     "c4core": {
       "baseline": "2021-01-14",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3d5d5ddbcc82ab346612b814ca44332b7e90fdf4",
+      "git-tree": "5d48aae0b9e4a0e201eab417117bab9491665193",
       "version": "1.17.1",
       "port-version": 2
     },

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d5d5ddbcc82ab346612b814ca44332b7e90fdf4",
+      "version": "1.17.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "1e8d84e28abdb8437a2665651b4359da40a3333f",
       "version": "1.17.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

Without the changes in this PR, the Linux build fails under dynamic linkage with the following error:

```
Building package c-ares[core]:x64-linux...
-- Downloading https://github.com/c-ares/c-ares/archive/cares-1_17_1.tar.gz -> c-ares-c-ares-cares-1_17_1.tar.gz...
-- Extracting source .../downloads/c-ares-c-ares-cares-1_17_1.tar.gz
-- Using source at .../buildtrees/c-ares/src/res-1_17_1-7723edf4cb.clean
-- Configuring x64-linux-dbg
-- Configuring x64-linux-rel
-- Building x64-linux-dbg
-- Building x64-linux-rel
-- Installing: .../packages/c-ares_x64-linux/share/c-ares/copyright
-- Performing post-build validation
There should be no empty directories in .../packages/c-ares_x64-linux
The following empty directories were found:
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
