### PR TITLE
[vcpkg.cmake] Fix variable case

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -692,7 +692,7 @@ if(X_VCPKG_APPLOCAL_DEPS_INSTALL)
                     list(APPEND parsed_targets "${arg}")
                 endif()
 
-                if(last_command STREQUAL "DESTINATION" AND (MODIFIER STREQUAL "" OR MODIFIER STREQUAL "RUNTIME"))
+                if(last_command STREQUAL "DESTINATION" AND (modifier STREQUAL "" OR modifier STREQUAL "RUNTIME"))
                     set(destination "${arg}")
                 endif()
                 if(last_command STREQUAL "COMPONENT")


### PR DESCRIPTION
This fixes X_VCPKG_APPLOCAL_DEPS_INSTALL when the install() command has a DESTINATION argument.

- #### What does your PR fix?  
  Fixes #19123

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  No ports changed.
