### PR TITLE
[tensorflow] Update the max version of the supported bazel

### DIFF
--- a/ports/tensorflow-common/Update-bazel-max-version.patch
+++ b/ports/tensorflow-common/Update-bazel-max-version.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.py b/configure.py
+index e5428a6..9324d7b 100644
+--- a/configure.py
++++ b/configure.py
+@@ -47,7 +47,7 @@ _TF_WORKSPACE_ROOT = ''
+ _TF_BAZELRC = ''
+ _TF_CURRENT_BAZEL_VERSION = None
+ _TF_MIN_BAZEL_VERSION = '3.1.0'
+-_TF_MAX_BAZEL_VERSION = '3.99.0'
++_TF_MAX_BAZEL_VERSION = '4.1.0'
+ 
+ NCCL_LIB_PATHS = [
+     'lib64/', 'lib/powerpc64le-linux-gnu/', 'lib/x86_64-linux-gnu/', ''

--- a/ports/tensorflow-common/portfile.cmake
+++ b/ports/tensorflow-common/portfile.cmake
@@ -18,6 +18,7 @@ set(TENSORFLOW_FILES
     "${CMAKE_CURRENT_LIST_DIR}/tensorflow-config-static.cmake.in"
     "${CMAKE_CURRENT_LIST_DIR}/tensorflow-config-windows-dll.cmake.in"
     "${CMAKE_CURRENT_LIST_DIR}/tensorflow-config-windows-lib.cmake.in"
+    "${CMAKE_CURRENT_LIST_DIR}/Update-bazel-max-version.patch"
     )
 
 file(COPY ${TENSORFLOW_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/tensorflow-common/tensorflow-common.cmake
+++ b/ports/tensorflow-common/tensorflow-common.cmake
@@ -138,6 +138,7 @@ foreach(BUILD_TYPE dbg rel)
 		HEAD_REF master
 		PATCHES
 			"${CMAKE_CURRENT_LIST_DIR}/fix-build-error.patch" # Fix namespace error
+			"${CMAKE_CURRENT_LIST_DIR}/Update-bazel-max-version.patch"
 			${STATIC_ONLY_PATCHES}
 			${WINDOWS_ONLY_PATCHES}
 			${LINUX_ONLY_PATCHES}

--- a/ports/tensorflow-common/vcpkg.json
+++ b/ports/tensorflow-common/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tensorflow-common",
   "version-semver": "2.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This meta package holds common files for the C [tensorflow] and the C++ [tensorflow-cc] API version of TensorFlow but is not installable on its own.",
   "homepage": "https://github.com/tensorflow/tensorflow"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6186,7 +6186,7 @@
     },
     "tensorflow-common": {
       "baseline": "2.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "tensorpipe": {
       "baseline": "2021-04-26",

--- a/versions/t-/tensorflow-common.json
+++ b/versions/t-/tensorflow-common.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd652b405ef53658c13af438e8414110f2977520",
+      "version-semver": "2.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "84ba326c66ab77faaf3e59d8eb3f04ffa155a4bb",
       "version-semver": "2.4.1",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Since the PR https://github.com/microsoft/vcpkg/pull/18817, the version of bazel used by vcpkg has been upgraded from 3.7.0 to 4.1.0, this causes tensorflow installation failed with following error:
```
You have bazel 4.1.0 installed.
Please downgrade your bazel installation to version 3.99.0 or lower to build TensorFlow! To downgrade: download the installer for the old version (from https://github.com/bazelbuild/bazel/releases) then run the installer.
```
For fixing this issue, I add a patch to modify the highest version of bazel supported by tensorflow to 4.1.0.

No feature need to be tested.