### PR TITLE
[grpc] fix generated pkg-config file

### DIFF
--- a/ports/grpc/00014-pkgconfig-upbdefs.patch
+++ b/ports/grpc/00014-pkgconfig-upbdefs.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3808016..059a16b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15516,7 +15516,7 @@ generate_pkgconfig(
+   "high performance general RPC framework"
+   "${gRPC_CORE_VERSION}"
+   "gpr openssl"
+-  "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
++  "-lgrpc -laddress_sorting -lre2 -lupb_fastdecode -lupb_json -lupb_pb -lupb_handlers -lupb_textformat -lupb_reflection -lupb -lcares -lz -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
+   ""
+   "grpc.pc")
+ 

--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -20,6 +20,7 @@ vcpkg_from_github(
         snprintf.patch
         00012-fix-use-cxx17.patch
         00013-build-upbdefs.patch
+        00014-pkgconfig-upbdefs.patch
 )
 
 if(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "grpc",
   "version-semver": "1.37.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An RPC library and framework",
   "homepage": "https://github.com/grpc/grpc",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2418,7 +2418,7 @@
     },
     "grpc": {
       "baseline": "1.37.0",
-      "port-version": 2
+      "port-version": 3
     },
     "grppi": {
       "baseline": "0.4.0",

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "38a2b1bc9dd5fca170489b616d33efae6dd43158",
+      "version-semver": "1.37.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "9bcee29de46cc5f1edbe016d192f243f65e64a5f",
       "version-semver": "1.37.0",
       "port-version": 2


### PR DESCRIPTION
gRPC uses `upb`, but normally it vendors-in the dependency. The
vendored-in version uses a single library artifact, and the generated
pkg-config file simply adds `-lupb`.  In `vcpkg` we use the `upb`
package. This has more libraries, and thus more `-lupb_*` options are
needed.  Ideally we would use a `upb.pc` file, but that does not exist.

- #### What does your PR fix?  

Using gRPC compiled with vcpkg via pkg-config does not work.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
