### PR TITLE
[vcpkg baseline][easyhook] Remove mismatch prebuild library after build

### DIFF
--- a/ports/easyhook/CONTROL
+++ b/ports/easyhook/CONTROL
@@ -1,5 +1,0 @@
-Source: easyhook
-Version: 2.7.6789.0
-Homepage: https://github.com/EasyHook/EasyHook
-Description: This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.
-Supports: windows

--- a/ports/easyhook/portfile.cmake
+++ b/ports/easyhook/portfile.cmake
@@ -1,12 +1,6 @@
-if (NOT VCPKG_TARGET_IS_WINDOWS)
-	message(FATAL_ERROR "easyhook only support windows.")
-endif()
+vcpkg_fail_port_install(ON_TARGET "Linux" "OSX" "UWP" ON_ARCH "arm" ON_LIBRARY_LINKAGE "static")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    message(FATAL_ERROR "easyhook can only be built as dynamic library.")
-endif()
-
-message(".Net framework 4.0 is required, please install it before install easyhook.")
+message(WARNING ".Net framework 4.0 is required, please install it before install easyhook.")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -17,20 +11,50 @@ vcpkg_from_github(
     PATCHES fix-build.patch
 )
 
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(BUILD_ARCH "Win32")
+elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(BUILD_ARCH "x64")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
 vcpkg_install_msbuild(
     SOURCE_PATH ${SOURCE_PATH}
     PROJECT_SUBPATH EasyHook.sln
 	TARGET EasyHookDll
     RELEASE_CONFIGURATION "netfx4-Release"
     DEBUG_CONFIGURATION "netfx4-Debug"
+    PLATFORM ${BUILD_ARCH}
 )
 
+# Remove the mismatch rebuild library
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/AUX_ULIB_x64.LIB")
+    endif()
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/AUX_ULIB_x64.LIB")
+    endif()
+elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/AUX_ULIB_x86.LIB")
+    endif()
+    if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/AUX_ULIB_x86.LIB")
+    endif()
+endif()
+
 # These libraries are useless, so remove.
-file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/EasyHook.dll ${CURRENT_PACKAGES_DIR}/bin/EasyHook.pdb)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/bin/EasyHook.dll ${CURRENT_PACKAGES_DIR}/debug/bin/EasyHook.pdb)
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/EasyHook.dll" "${CURRENT_PACKAGES_DIR}/bin/EasyHook.pdb")
+endif()
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/EasyHook.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/EasyHook.pdb")
+endif()
 
 # Install includes
-file(INSTALL ${SOURCE_PATH}/Public/easyhook.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/easyhook)
+file(INSTALL "${SOURCE_PATH}/Public/easyhook.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/easyhook")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/easyhook RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/easyhook" RENAME copyright)

--- a/ports/easyhook/portfile.cmake
+++ b/ports/easyhook/portfile.cmake
@@ -57,4 +57,4 @@ endif()
 file(INSTALL "${SOURCE_PATH}/Public/easyhook.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/easyhook")
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/easyhook" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "easyhook",
-  "version-string": "2.7.6789.0",
+  "version": "2.7.6789.0",
   "port-version": 1,
   "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
   "homepage": "https://github.com/EasyHook/EasyHook",

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "easyhook",
+  "version-string": "2.7.6789.0",
+  "port-version": 1,
+  "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
+  "homepage": "https://github.com/EasyHook/EasyHook",
+  "supports": "windows & !(static | arm | uwp)"
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -247,13 +247,6 @@ duilib:x64-uwp=fail
 duktape:x64-osx=skip
 
 eastl:arm-uwp=fail
-easyhook:arm64-windows=fail
-easyhook:arm-uwp=fail
-easyhook:x64-linux=fail
-easyhook:x64-osx=fail
-easyhook:x64-uwp=fail
-easyhook:x64-windows-static=fail
-easyhook:x64-windows-static-md=fail
 easyloggingpp:arm-uwp=fail
 easyloggingpp:x64-uwp=fail
 eathread:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1810,7 +1810,7 @@
     },
     "easyhook": {
       "baseline": "2.7.6789.0",
-      "port-version": 0
+      "port-version": 1
     },
     "easyloggingpp": {
       "baseline": "9.96.7-1",

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "178522271d2755aedb74382d5177d7856ec66435",
-      "version-string": "2.7.6789.0",
+      "version": "2.7.6789.0",
       "port-version": 1
     },
     {

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "178522271d2755aedb74382d5177d7856ec66435",
+      "git-tree": "e427f42cec56130de81333fda405afabc88c9e82",
       "version": "2.7.6789.0",
       "port-version": 1
     },

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "178522271d2755aedb74382d5177d7856ec66435",
+      "version-string": "2.7.6789.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cf87554bbdd4736b3b64210e7662d6bbe3d72b2a",
       "version-string": "2.7.6789.0",
       "port-version": 0


### PR DESCRIPTION
The prebuild library `AUX_ULIB_${ARCH}.lib` should match the triplet.
Remove the mismatch one.