### PR TITLE
[libxml2] Fix build error on uwp

### DIFF
--- a/ports/libxml2/fix-uwp.patch
+++ b/ports/libxml2/fix-uwp.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9b45d62..ba8bfec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -129,6 +129,7 @@ endif()
+ 
+ if(MSVC)
+ 	configure_file(include/win32config.h config.h COPYONLY)
++    add_compile_options(/wd4996)
+ else()
+ 	check_c_source_compiles("
+ 		void __attribute__((destructor))

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
     PATCHES 
         fix_cmakelist.patch
+        fix-uwp.patch
 )
 
 if (VCPKG_TARGET_IS_UWP)
@@ -18,11 +19,10 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-    "tools"         LIBXML2_WITH_PROGRAMS
+        "tools"         LIBXML2_WITH_PROGRAMS
 )
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
         -DLIBXML2_WITH_TESTS=OFF
@@ -61,9 +61,9 @@ vcpkg_configure_cmake(
         -DLIBXML2_WITH_XPTR=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libxml2)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libxml2)
 vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()

--- a/ports/libxml2/vcpkg.json
+++ b/ports/libxml2/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "name": "libxml2",
   "version-semver": "2.9.12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libxml2 is the XML C parser and toolkit developed for the Gnome project (but usable outside of the Gnome platform).",
   "homepage": "https://xmlsoft.org/",
-  "supports": "!uwp",
   "dependencies": [
     "libiconv",
     "liblzma",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3750,7 +3750,7 @@
     },
     "libxml2": {
       "baseline": "2.9.12",
-      "port-version": 1
+      "port-version": 2
     },
     "libxmlmm": {
       "baseline": "0.6.0",

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f86cd2ab2c75dcd8e97ee18191b343f0b31bfb7c",
+      "version-semver": "2.9.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "a68bece41619060ca2e212b916dcc60c65ca3603",
       "version-semver": "2.9.12",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #17945

Related https://github.com/microsoft/vcpkg/pull/17945/files#r678821283
https://github.com/microsoft/vcpkg/pull/18827#issuecomment-888798452

Currently, `libxml2` build failed on uwp, which caused those ports that depends on `libxml2` also cannot build on uwp.

So add a patch to fix the problem.

Note: Feature `tools `has passed on arm-uwp.

