### PR TITLE
[docs] Instruct how to deploy several license files

### DIFF
--- a/docs/examples/packaging-github-repos.md
+++ b/docs/examples/packaging-github-repos.md
@@ -37,7 +37,13 @@ vcpkg_configure_cmake(
     PREFER_NINJA
 )
 vcpkg_install_cmake()
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libogg RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+```
+
+Should your project contain more than a single license file, e.g. SPDX licenses located in a `LICENSES` folder, you can instead copy them all with:
+
+```
+file(INSTALL "${SOURCE_PATH}/LICENSES/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
 ```
 
 Check the documentation for [`vcpkg_configure_cmake`](../maintainers/vcpkg_configure_cmake.md) and [`vcpkg_install_cmake`](../maintainers/vcpkg_install_cmake.md) if your package needs additional options. 


### PR DESCRIPTION
Many projects will have more than a single license. Such projects typically have a LICENSES folder with SPDX copies of them. This explains how to copy them all instead just a single one. 

Such projects with multiple licenses should be officially recognized, so that maintainers are aware of it. See e.g.: https://github.com/microsoft/vcpkg/pull/19199#pullrequestreview-717624939
https://github.com/microsoft/vcpkg/pull/19200#discussion_r678871016

EDIT: also promotes `${PORT}` usage and wrapping paths in quotes.