### PR TITLE
[vcpkg-cmake] Fix docs and usage of option MAYBE_UNUSED_VARIABLES

### DIFF
--- a/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_configure.md
+++ b/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_configure.md
@@ -19,7 +19,7 @@ vcpkg_cmake_configure(
     [OPTIONS_DEBUG
         <configure-setting>...]
     [MAYBE_UNUSED_VARIABLES
-        <variable-name>...]
+        <option-name>...]
 )
 ```
 
@@ -61,7 +61,17 @@ If the library sets its own code page, pass the `NO_CHARSET_FLAG` option.
 This function makes certain that all options passed in are used by the
 underlying CMake build system. If there are options that might be unused,
 perhaps on certain platforms, pass those variable names to
-`MAYBE_UNUSED_VARIABLES`.
+`MAYBE_UNUSED_VARIABLES`. For example:
+```cmake
+vcpkg_cmake_configure(
+    ...
+    OPTIONS
+        -DBUILD_EXAMPLE=OFF
+    ...
+    MAYBE_UNUSED_VARIABLES
+        BUILD_EXAMPLE
+)
+```
 
 `LOGFILE_BASE` is used to set the base of the logfile names;
 by default, this is `config`, and thus the logfiles end up being something like

--- a/docs/maintainers/vcpkg_configure_cmake.md
+++ b/docs/maintainers/vcpkg_configure_cmake.md
@@ -17,7 +17,7 @@ vcpkg_configure_cmake(
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
-    [MAYBE_UNUSED_VARIABLES <option-name>...]
+    [MAYBE_UNUSED_VARIABLES <OPTION_NAME>...]
 )
 ```
 
@@ -58,6 +58,17 @@ Additional options passed to CMake during the Debug configuration. These are in 
 
 ### MAYBE_UNUSED_VARIABLES
 Any CMake variables which are explicitly passed in, but which may not be used on all platforms.
+For example:
+```cmake
+vcpkg_cmake_configure(
+    ...
+    OPTIONS
+        -DBUILD_EXAMPLE=OFF
+    ...
+    MAYBE_UNUSED_VARIABLES
+        BUILD_EXAMPLE
+)
+```
 
 ### LOGNAME
 Name of the log to write the output of the configure call to.

--- a/ports/kf5auth/portfile.cmake
+++ b/ports/kf5auth/portfile.cmake
@@ -13,10 +13,6 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins
         -DKDE_INSTALL_DATAROOTDIR=data
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 
 )
 

--- a/ports/kf5auth/vcpkg.json
+++ b/ports/kf5auth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5auth",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Execute actions as privileged user",
   "homepage": "https://api.kde.org/frameworks/kauth/html/index.html",
   "dependencies": [

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -15,10 +15,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5codecs/vcpkg.json
+++ b/ports/kf5codecs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5codecs",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "String encoding library",
   "homepage": "https://api.kde.org/frameworks/kcodecs/html/index.html",
   "dependencies": [

--- a/ports/kf5completion/portfile.cmake
+++ b/ports/kf5completion/portfile.cmake
@@ -13,10 +13,6 @@ vcpkg_configure_cmake(
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DBUILD_DESIGNERPLUGIN=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5completion/vcpkg.json
+++ b/ports/kf5completion/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5completion",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Text completion helpers and widgets",
   "homepage": "https://api.kde.org/frameworks/kcompletion/html/index.html",
   "dependencies": [

--- a/ports/kf5config/portfile.cmake
+++ b/ports/kf5config/portfile.cmake
@@ -12,10 +12,6 @@ vcpkg_configure_cmake(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF    
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5config/vcpkg.json
+++ b/ports/kf5config/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5config",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Configuration system",
   "homepage": "https://api.kde.org/frameworks/kconfig/html/index.html",
   "dependencies": [

--- a/ports/kf5dbusaddons/portfile.cmake
+++ b/ports/kf5dbusaddons/portfile.cmake
@@ -11,10 +11,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5dbusaddons/vcpkg.json
+++ b/ports/kf5dbusaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5dbusaddons",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Convenience classes for D-Bus",
   "homepage": "https://api.kde.org/frameworks/kdbusaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5guiaddons/portfile.cmake
+++ b/ports/kf5guiaddons/portfile.cmake
@@ -23,10 +23,6 @@ vcpkg_configure_cmake(
         -DBUILD_TESTING=OFF
         -DQtWaylandScanner_EXECUTABLE=${CURRENT_INSTALLED_DIR}/tools/qt5-wayland/bin/qtwaylandscanner
         ${FEATURE_OPTIONS}
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5guiaddons/vcpkg.json
+++ b/ports/kf5guiaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5guiaddons",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Addons to QtGui",
   "homepage": "https://api.kde.org/frameworks/kguiaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5holidays/portfile.cmake
+++ b/ports/kf5holidays/portfile.cmake
@@ -12,10 +12,6 @@ vcpkg_configure_cmake(
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5holidays/vcpkg.json
+++ b/ports/kf5holidays/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5holidays",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Holiday calculation library",
   "dependencies": [
     "ecm",

--- a/ports/kf5i18n/portfile.cmake
+++ b/ports/kf5i18n/portfile.cmake
@@ -15,10 +15,6 @@ vcpkg_configure_cmake(
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins
         -DPYTHON_EXECUTABLE=${PYTHON3}
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5i18n",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [

--- a/ports/kf5itemmodels/portfile.cmake
+++ b/ports/kf5itemmodels/portfile.cmake
@@ -12,10 +12,6 @@ vcpkg_configure_cmake(
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_QMLDIR=qml
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5itemmodels/vcpkg.json
+++ b/ports/kf5itemmodels/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5itemmodels",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Models for Qt Model/View system",
   "homepage": "https://api.kde.org/frameworks/kitemmodels/html/index.html",
   "dependencies": [

--- a/ports/kf5itemviews/portfile.cmake
+++ b/ports/kf5itemviews/portfile.cmake
@@ -12,10 +12,6 @@ vcpkg_configure_cmake(
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DBUILD_DESIGNERPLUGIN=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5itemviews/vcpkg.json
+++ b/ports/kf5itemviews/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5itemviews",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Widget addons for Qt Model/View",
   "homepage": "https://api.kde.org/frameworks/kitemviews/html/index.html",
   "dependencies": [

--- a/ports/kf5plotting/portfile.cmake
+++ b/ports/kf5plotting/portfile.cmake
@@ -12,10 +12,6 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5plotting/vcpkg.json
+++ b/ports/kf5plotting/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5plotting",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Lightweight plotting framework",
   "homepage": "https://api.kde.org/frameworks/kplotting/html/index.html",
   "dependencies": [

--- a/ports/kf5sonnet/portfile.cmake
+++ b/ports/kf5sonnet/portfile.cmake
@@ -14,13 +14,6 @@ vcpkg_cmake_configure(
         -DKDE_INSTALL_PLUGINDIR=plugins
         -DKDE_INSTALL_DATAROOTDIR=data
         -DKDE_INSTALL_QTPLUGINDIR=plugins
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
-    MAYBE_UNUSED_VARIABLES
-        BUILD_HTML_DOCS
-        BUILD_MAN_DOCS
-        BUILD_QTHELP_DOCS
 )
 
 vcpkg_add_to_path(PREPEND "${CURRENT_INSTALLED_DIR}/bin")

--- a/ports/kf5sonnet/vcpkg.json
+++ b/ports/kf5sonnet/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5sonnet",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "Multi-language spell checker",
   "homepage": "https://api.kde.org/frameworks/sonnet/html/index.html",
   "dependencies": [

--- a/ports/kf5syntaxhighlighting/portfile.cmake
+++ b/ports/kf5syntaxhighlighting/portfile.cmake
@@ -16,10 +16,6 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)

--- a/ports/kf5syntaxhighlighting/vcpkg.json
+++ b/ports/kf5syntaxhighlighting/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5syntaxhighlighting",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Syntax highlighting engine for Kate syntax definitions",
   "homepage": "https://github.com/KDE/syntax-highlighting",
   "dependencies": [

--- a/ports/kf5widgetsaddons/portfile.cmake
+++ b/ports/kf5widgetsaddons/portfile.cmake
@@ -13,10 +13,6 @@ vcpkg_configure_cmake(
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DBUILD_DESIGNERPLUGIN=OFF
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5widgetsaddons/vcpkg.json
+++ b/ports/kf5widgetsaddons/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5widgetsaddons",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Addons to QtWidgets",
   "homepage": "https://api.kde.org/frameworks/kwidgetsaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5windowsystem/portfile.cmake
+++ b/ports/kf5windowsystem/portfile.cmake
@@ -16,10 +16,6 @@ vcpkg_configure_cmake(
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins
-    MAYBE_UNUSED_VARIABLES
-        -DBUILD_HTML_DOCS=OFF
-        -DBUILD_MAN_DOCS=OFF
-        -DBUILD_QTHELP_DOCS=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/kf5windowsystem/vcpkg.json
+++ b/ports/kf5windowsystem/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5windowsystem",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Access to the windowing system",
   "homepage": "https://api.kde.org/frameworks/kwindowsystem/html/",
   "dependencies": [

--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2021-07-26"
+  "version-date": "2021-07-30"
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -18,7 +18,7 @@ vcpkg_cmake_configure(
     [OPTIONS_DEBUG
         <configure-setting>...]
     [MAYBE_UNUSED_VARIABLES
-        <variable-name>...]
+        <option-name>...]
 )
 ```
 
@@ -60,7 +60,17 @@ If the library sets its own code page, pass the `NO_CHARSET_FLAG` option.
 This function makes certain that all options passed in are used by the
 underlying CMake build system. If there are options that might be unused,
 perhaps on certain platforms, pass those variable names to
-`MAYBE_UNUSED_VARIABLES`.
+`MAYBE_UNUSED_VARIABLES`. For example:
+```cmake
+vcpkg_cmake_configure(
+    ...
+    OPTIONS
+        -DBUILD_EXAMPLE=OFF
+    ...
+    MAYBE_UNUSED_VARIABLES
+        BUILD_EXAMPLE
+)
+```
 
 `LOGFILE_BASE` is used to set the base of the logfile names;
 by default, this is `config`, and thus the logfiles end up being something like

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -15,7 +15,7 @@ vcpkg_configure_cmake(
     [OPTIONS <-DUSE_THIS_IN_ALL_BUILDS=1>...]
     [OPTIONS_RELEASE <-DOPTIMIZE=1>...]
     [OPTIONS_DEBUG <-DDEBUGGABLE=1>...]
-    [MAYBE_UNUSED_VARIABLES <option-name>...]
+    [MAYBE_UNUSED_VARIABLES <OPTION_NAME>...]
 )
 ```
 
@@ -56,6 +56,17 @@ Additional options passed to CMake during the Debug configuration. These are in 
 
 ### MAYBE_UNUSED_VARIABLES
 Any CMake variables which are explicitly passed in, but which may not be used on all platforms.
+For example:
+```cmake
+vcpkg_cmake_configure(
+    ...
+    OPTIONS
+        -DBUILD_EXAMPLE=OFF
+    ...
+    MAYBE_UNUSED_VARIABLES
+        BUILD_EXAMPLE
+)
+```
 
 ### LOGNAME
 Name of the log to write the output of the configure call to.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2866,19 +2866,19 @@
     },
     "kf5auth": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5codecs": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5completion": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5config": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5coreaddons": {
       "baseline": "5.84.0",
@@ -2890,47 +2890,47 @@
     },
     "kf5dbusaddons": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5guiaddons": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5holidays": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5i18n": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5itemmodels": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5itemviews": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5plotting": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5sonnet": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5syntaxhighlighting": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5widgetsaddons": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5windowsystem": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kfr": {
       "baseline": "2020-06-15",
@@ -6573,7 +6573,7 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2021-07-26",
+      "baseline": "2021-07-30",
       "port-version": 0
     },
     "vcpkg-cmake-config": {

--- a/versions/k-/kf5auth.json
+++ b/versions/k-/kf5auth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f1399e14100a7c100bc55f8d436224c680a7f52",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "09194a3548898b6548ab3e61e45a9f6a4388aa6e",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5codecs.json
+++ b/versions/k-/kf5codecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cc839f57cba8b67ed071d5dc3a472b605033cd7a",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b0b56e3e645427bfc9efe47c4050ba295e5e261e",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5completion.json
+++ b/versions/k-/kf5completion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b32643e981f1d9bab04fd3526e9c6c4499d35d1f",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0ffa13221ac2980b44af52cae6392718f80f5d3f",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5config.json
+++ b/versions/k-/kf5config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67fa669df81328489ba66231cef84fc17ae4f434",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "57c0ad579f0582463fe73a7ca64f1af6eadcea16",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5dbusaddons.json
+++ b/versions/k-/kf5dbusaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "417fdf58b130c7e24794cf4d1d29336cb946f9fa",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d7d33a4c88aa692230617ecc58693dbaa3290ba7",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5guiaddons.json
+++ b/versions/k-/kf5guiaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7413c9e8bfa4e7db669271b3c13fe5cf7c52567a",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "13acc7a53a47646048061054946bcce0f8acbf7b",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5holidays.json
+++ b/versions/k-/kf5holidays.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b969d43d406c095970b4e98cc3b19c27567b557c",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a43e4fcc0dedd0d8f6722386a97a688c001fa508",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5i18n.json
+++ b/versions/k-/kf5i18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0d01fec0fb56e9c2d95b743b0b13e544d5428a7",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "08dd3d175400c8e6f91fc3d7f6cbc7eff8a3e976",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5itemmodels.json
+++ b/versions/k-/kf5itemmodels.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b222a404755239053edfac06ee63bf3710719fe9",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2efa93694b3389e09de76095a6fa35ce41b30f2d",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5itemviews.json
+++ b/versions/k-/kf5itemviews.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "164cc5f1d9ccfdf89ef60c4b718b8f6777162ea5",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "257c4740f00dab4e0c650543f7cec08b395bcceb",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5plotting.json
+++ b/versions/k-/kf5plotting.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39f28709c5b4d6e1c706c7e15617b7c052830122",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b105a7f2a86040a1a7b5622371d7c0d5cd65fd16",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5sonnet.json
+++ b/versions/k-/kf5sonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de4fdcac67da4df0962414b4b1f71d98753d4c4e",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7f6d9ebeec45c6354fd96f1ee04b9e34063e33b0",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5syntaxhighlighting.json
+++ b/versions/k-/kf5syntaxhighlighting.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0bec703b0c5345b456bdbddf6e043d1c31dd2906",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6033609633223323ffc8762d0e2a6ab24c323de7",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5widgetsaddons.json
+++ b/versions/k-/kf5widgetsaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de99d19b892fe1551e87c6dd3a1c2d353bfc3f76",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f27e6f9ba66090bf93b9db1bbf3973d472bd9627",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5windowsystem.json
+++ b/versions/k-/kf5windowsystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "719b81cebad63502bbb619781290844c586acef9",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "178fa49af1a113118be6d61a68c31930aa276e17",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d70d64792b10b091a27d19372db25cfb74d9e9c",
+      "version-date": "2021-07-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae2178d81ee39baf4c7e9fd6ed3f011b01a93635",
       "version-date": "2021-07-26",
       "port-version": 0

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d70d64792b10b091a27d19372db25cfb74d9e9c",
+      "git-tree": "c6df7e0faeda9e783175746c7c440c9bc2bdb111",
       "version-date": "2021-07-30",
       "port-version": 0
     },


### PR DESCRIPTION
In the current document, our description of `MAYBE_UNUSED_VARIABLES` caused the user to misunderstand the parameter and incorporate the wrong changes.

Fix the option description and add sample code to the docs.

Related: https://github.com/microsoft/vcpkg/pull/13467