### PR TITLE
[vcpkg-ci] Add AZP logging markup for skipped ports

### DIFF
--- a/ports/freexl/portfile.cmake
+++ b/ports/freexl/portfile.cmake
@@ -1,3 +1,5 @@
+message(FATAL_ERROR "Simulate failure")
+
 set(FREEXL_VERSION_STR "1.0.4")
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/spatialite-tools/portfile.cmake
+++ b/ports/spatialite-tools/portfile.cmake
@@ -1,3 +1,5 @@
+message(FATAL_ERROR "Should not build, CASCADED_DUE_TO_MISSING_DEPENDENCIES (freexl)")
+
 set(SPATIALITE_TOOLS_VERSION_STR "5.0.0")
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.gaia-gis.it/gaia-sins/spatialite-tools-sources/spatialite-tools-${SPATIALITE_TOOLS_VERSION_STR}.tar.gz"

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -142,16 +142,16 @@ $skipList = . "$PSScriptRoot/generate-skip-list.ps1" `
     -BaselineFile "$PSScriptRoot/../ci.baseline.txt" `
     -SkipFailures:$skipFailures
 
+$hostArgs = @()
 if ($Triplet -in @('x64-windows', 'x64-osx', 'x64-linux'))
 {
     # WORKAROUND: These triplets are native-targetting which triggers an issue in how vcpkg handles the skip list.
     # The workaround is to pass the skip list as host-excludes as well.
-    & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --host-exclude=$skipList --failure-logs=$failureLogs @commonArgs
+    $hostArgs = @("--host-exclude=$skipList")
 }
-else
-{
-    & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @commonArgs
-}
+
+& "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @hostArgs @commonArgs
+
 & "$PSScriptRoot/analyze-test-results.ps1" -logDir $xmlResults `
     -triplet $Triplet `
     -baselineFile .\scripts\ci.baseline.txt `

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -147,7 +147,7 @@ $changedPorts = @()
 $skippedPorts = @()
 if ($LogSkippedPorts) {
     $diffFile = Join-Path $WorkingRoot 'changed-ports.diff'
-    Start-Process -FilePath 'git' -ArgumentList 'diff --name-only HEAD~1 -- versions ports' `
+    Start-Process -FilePath 'git' -ArgumentList 'diff --name-only HEAD~10 -- versions ports' `
         -NoNewWindow -Wait `
         -RedirectStandardOutput $diffFile
     $changedPorts = (Get-Content -Path $diffFile) `

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -158,7 +158,7 @@ if ($LogSkippedPorts) {
     $changedPorts | ForEach-Object {
         if ($skippedPorts -contains $_) {
             $port = $_
-            Write-Host "##vso[task.logissue type=error]Not building changed port '$port`:$Triplet', reason: CI baseline file."
+            Write-Host "##vso[task.logissue type=error]$port`: build skipped, reason: CI baseline file."
         }
     }
 }
@@ -178,7 +178,7 @@ $current_port_and_features = ':'
         if ($LogSkippedPorts) {
             if ($_ -match '^ *([^ :]+):[^:]*: *cascade:' -and $changedPorts -contains $Matches[1]) {
                 $port = $Matches[1]
-                Write-Host "##vso[task.logissue type=error]Not building changed port '$port`:$Triplet', reason: cascade from CI baseline file."
+                Write-Host "##vso[task.logissue type=error]$port`: build skipped, reason: cascade from CI baseline file."
             }
             elseif ($_ -match '^Building package ([^ ]+)[.][.][.]') {
                 $current_port_and_features = $Matches[1]
@@ -186,7 +186,10 @@ $current_port_and_features = ':'
             elseif ($_ -match 'failed with: CASCADED_DUE_TO_MISSING_DEPENDENCIES') {
                 & "./vcpkg$executableExtension" depend-info $current_port_and_features | ForEach-Object {
                     if ($_ -match '^([^:[]+)[:[]' -and $changedPorts -contains $Matches[1]) {
-                        Write-Host "##vso[task.logissue type=error]Not building depending port '$current_port_and_features', reason: cascade due to missing dependencies."
+                        $port = $Matches[1]
+                        if ($current_port_and_features -notmatch "^$port[:[]") {
+                            Write-Host "##vso[task.logissue type=error]$port`: build of depending port '$current_port_and_features' skipped due to missing dependencies."
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- #### What does your PR fix?  
  Occassionally, skipped builds (in particular "cascade") for changed ports went unnoticed.
  Based on changed `ports` and `versions` files in git, this change adds AZP error messages (but not job failures) for skipped ports, making them more visible in Github. 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, not needed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed
