### PR TITLE
[wxwidgets] make wxUSE_STL an optional triplet feature disabled by default

### DIFF
--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -23,6 +23,13 @@ if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64 OR VCPKG_TARGET_ARCHITECTURE STREQUA
     )
 endif()
 
+# This may be set to ON by users in a custom triplet.
+# wxUSE_STL=ON and wxUSE_STL=OFF are not API compatible which is why this must be set
+# in a custom triplet rather than a port feature.
+if(NOT DEFINED WXWIDGETS_USE_STL)
+    set(WXWIDGETS_USE_STL OFF)
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -33,8 +40,8 @@ vcpkg_configure_cmake(
         -DwxUSE_LIBJPEG=sys
         -DwxUSE_LIBPNG=sys
         -DwxUSE_LIBTIFF=sys
-        -DwxUSE_STL=ON
         -DwxBUILD_DISABLE_PLATFORM_LIB_DIR=ON
+        -DwxUSE_STL=${WXWIDGETS_USE_STL}
         ${OPTIONS}
 )
 

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,8 +1,11 @@
 {
   "name": "wxwidgets",
   "version-semver": "3.1.5",
-  "port-version": 2,
-  "description": "a widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications.",
+  "port-version": 3,
+  "description": [
+    "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
+    "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option."
+  ],
   "homepage": "https://github.com/wxWidgets/wxWidgets",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6738,7 +6738,7 @@
     },
     "wxwidgets": {
       "baseline": "3.1.5",
-      "port-version": 2
+      "port-version": 3
     },
     "x-plane": {
       "baseline": "3.0.3",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dcd0a52fd041f8c7b658a01ec1141f36d77220c6",
+      "version-semver": "3.1.5",
+      "port-version": 3
+    },
+    {
       "git-tree": "6fa230bffdee1e7d700570c31e6f08367460c0c9",
       "version-semver": "3.1.5",
       "port-version": 2


### PR DESCRIPTION
wxUSE_STL defaults to OFF so that is how it is in Linux
distribution packages. Downstream projects developed with
wxUSE_STL=ON are not necessarily compatible with wxUSE_STL=OFF
without modification. So, by default, go with wxWidgets' default
for compatibility with downstream codebases. vcpkg users who need
wxUSE_STL=ON can still do so by simply opting into the new 'stl'
feature of this port.

https://forums.wxwidgets.org/viewtopic.php?p=165208

**Describe the pull request**

- #### What does your PR fix?  
  Fixes downstream applications not building with wxwidgets port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes