### PR TITLE
[qhull] fix missing symbols

### DIFF
--- a/ports/qhull/CONTROL
+++ b/ports/qhull/CONTROL
@@ -1,4 +1,5 @@
 Source: qhull
 Version: 8.0.2
+Port-Version: 1
 Homepage: https://github.com/qhull/qhull
 Description: computes the convex hull, Delaunay triangulation, Voronoi diagram

--- a/ports/qhull/fix-missing-symbols.patch
+++ b/ports/qhull/fix-missing-symbols.patch
@@ -1,0 +1,29 @@
+From 02ba907908ccf5ed0d40a2251272b67cb05c23ea Mon Sep 17 00:00:00 2001
+From: Francisco Facioni <fran6co@gmail.com>
+Date: Sat, 31 Jul 2021 22:30:45 +0100
+Subject: [PATCH] Missing symbols in the export
+
+---
+ src/libqhull_r/qhull_r-exports.def | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/libqhull_r/qhull_r-exports.def b/src/libqhull_r/qhull_r-exports.def
+index 4c5e17c..b789673 100644
+--- a/src/libqhull_r/qhull_r-exports.def
++++ b/src/libqhull_r/qhull_r-exports.def
+@@ -183,6 +183,7 @@ qh_maxouter
+ qh_maxsimplex
+ qh_maydropneighbor
+ qh_memalloc
++qh_memcheck
+ qh_memfree
+ qh_memfreeshort
+ qh_meminit
+@@ -351,6 +352,7 @@ qh_setdelnth
+ qh_setdelnthsorted
+ qh_setdelsorted
+ qh_setduplicate
++qh_setendpointer
+ qh_setequal
+ qh_setequal_except
+ qh_setequal_skip

--- a/ports/qhull/portfile.cmake
+++ b/ports/qhull/portfile.cmake
@@ -4,7 +4,9 @@ vcpkg_from_github(
     REF 613debeaea72ee66626dace9ba1a2eff11b5d37d
     SHA512 5b8ff9665ba73621a9859a6e86717b980b67f8d79d6c78cbf5672bce66aed671f7d64fcbec457bca79eef2e17e105f136017afdf442bb430b9f4a059d7cb93c3
     HEAD_REF master
-    PATCHES include-qhullcpp-shared.patch
+    PATCHES 
+        include-qhullcpp-shared.patch
+        fix-missing-symbols.patch # upstream https://github.com/qhull/qhull/pull/93
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5114,7 +5114,7 @@
     },
     "qhull": {
       "baseline": "8.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qnnpack": {
       "baseline": "2021-02-26",

--- a/versions/q-/qhull.json
+++ b/versions/q-/qhull.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "248e6da5d026e3d25975912d727d35612b32f5c1",
+      "version-string": "8.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "a126a4ddc8a30d5e50f27579acf06af3436ef6ed",
       "version-string": "8.0.2",
       "port-version": 0


### PR DESCRIPTION
I need this fix for https://github.com/microsoft/vcpkg/pull/17423

It contains upstream fix https://github.com/qhull/qhull/pull/93

- #### What does your PR fix?  
  Fixes #18854

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
