### PR TITLE
[vcpkg baseline][tinyfiledialogs] Change repo to sourceforge

### DIFF
--- a/ports/tinyfiledialogs/CMakeLists.txt
+++ b/ports/tinyfiledialogs/CMakeLists.txt
@@ -3,6 +3,8 @@ project(tinyfiledialogs C)
 
 add_library(tinyfiledialogs tinyfiledialogs.c)
 
+target_include_directories(tinyfiledialogs INTERFACE $<INSTALL_INTERFACE:include/tinyfiledialogs>)
+
 install(
     TARGETS tinyfiledialogs
     EXPORT tinyfiledialogsConfig

--- a/ports/tinyfiledialogs/CONTROL
+++ b/ports/tinyfiledialogs/CONTROL
@@ -1,5 +1,0 @@
-Source: tinyfiledialogs
-Version: 3.8.8
-Description: Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more
-Homepage: https://sourceforge.net/projects/tinyfiledialogs/
-Supports: !uwp

--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -2,26 +2,30 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_git(
+vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL "https://git.code.sf.net/p/tinyfiledialogs/code"
-    REF "8e966d92d0e772b5e34ffc3d8ec1559731a07ccb"
+    REPO tinyfiledialogs
+    SHA512 d63d6dd847d6bbd1f252c8fbd228086381af7189ac71afc97bd57e06badd1d3f4d90c6aab6207191ae7253d5a71fc44636cf8e33714089d5b478dd2714f59376
+    FILENAME "tinyfiledialogs-current.zip"
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 file(READ "${CURRENT_PACKAGES_DIR}/include/tinyfiledialogs/tinyfiledialogs.h" _contents)
 # reads between the line "- License -" and a closing "*/"
 if (NOT _contents MATCHES [[- License -(([^*]|\*[^/])*)\*/]])
 	message(FATAL_ERROR "Failed to parse license from tinyfiledialogs.h")
 endif()
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "${CMAKE_MATCH_1}")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tinyfiledialogs/vcpkg.json
+++ b/ports/tinyfiledialogs/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "tinyfiledialogs",
+  "version-semver": "3.8.8",
+  "port-version": 1,
+  "description": "Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more",
+  "homepage": "https://sourceforge.net/projects/tinyfiledialogs/",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "tinyfiledialogs": {
       "baseline": "3.8.8",
-      "port-version": 0
+      "port-version": 1
     },
     "tinygltf": {
       "baseline": "2020-07-28",

--- a/versions/t-/tinyfiledialogs.json
+++ b/versions/t-/tinyfiledialogs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "02f1f2a70350a2bf3701cf6279af2ab577d0e6da",
+      "git-tree": "3959a47c7d93ca7db6e2022553b1d3427970cecf",
       "version-semver": "3.8.8",
       "port-version": 1
     },

--- a/versions/t-/tinyfiledialogs.json
+++ b/versions/t-/tinyfiledialogs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02f1f2a70350a2bf3701cf6279af2ab577d0e6da",
+      "version-semver": "3.8.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "1a5b599e8303e1b62bca446461bd7114ec97caba",
       "version-string": "3.8.8",
       "port-version": 0


### PR DESCRIPTION
Since the repo `https://git.code.sf.net` is unavaliable (404), change it to sourceforge.

Note the `current` version is `3.8.8`.