### PR TITLE
[intel-mkl] Lookup oneapi installation for mkl headers

### DIFF
--- a/ports/intel-mkl/CONTROL
+++ b/ports/intel-mkl/CONTROL
@@ -1,3 +1,4 @@
 Source: intel-mkl
 Version: 2020.0.0
+Port-Version: 1
 Description: Intel® Math Kernel Library (Intel® MKL) accelerates math processing routines, increases application performance, and reduces development time on Intel® processors. 

--- a/ports/intel-mkl/portfile.cmake
+++ b/ports/intel-mkl/portfile.cmake
@@ -8,8 +8,16 @@ set(MKL_REQUIRED_VERSION "20200000")
 
 set(ProgramFilesx86 "ProgramFiles(x86)")
 set(INTEL_ROOT $ENV{${ProgramFilesx86}}/IntelSWTools/compilers_and_libraries/windows)
+set(ONEMKL_ROOT $ENV{${ProgramFilesx86}}/Intel/oneAPI/mkl/latest)
 
-find_path(MKL_ROOT include/mkl.h PATHS $ENV{MKLROOT} ${INTEL_ROOT}/mkl DOC "Folder contains MKL")
+find_path(MKL_ROOT include/mkl.h
+    PATHS
+    $ENV{MKLROOT}
+    ${INTEL_ROOT}/mkl
+    $ENV{ONEAPI_ROOT}/mkl/latest
+    ${ONEMKL_ROOT}
+    DOC
+    "Folder contains MKL")
 
 if (MKL_ROOT STREQUAL "MKL_ROOT-NOTFOUND")
     message(FATAL_ERROR "Could not find MKL. Before continuing, please download and install MKL  (${MKL_REQUIRED_VERSION} or higher) from:"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2714,7 +2714,7 @@
     },
     "intel-mkl": {
       "baseline": "2020.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "intelrdfpmathlib": {
       "baseline": "20U2-1",

--- a/versions/i-/intel-mkl.json
+++ b/versions/i-/intel-mkl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f91c30839fe3222faa4c81d978ae4f52f61a1df",
+      "version-string": "2020.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "27543f95c3c01ee6993990c80b06217a1e2dd9fe",
       "version-string": "2020.0.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Scenarios where oneMKL is installed but vcpkg's `intel-mkl` port cannot locate MKL.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  NA

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  YES

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I don't think port changed per say, but I am not sure how empty packages are handled when lookup logic changes. Please advice.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**