### PR TITLE
[Azure-*] Remove version constraint

### DIFF
--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -7,8 +7,7 @@
     "This library provides Azure Key Vault Keys SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-keys",
-  "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
+  "license": "MIT"
   "dependencies": [
     {
       "name": "azure-core-cpp",

--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-security-keyvault-keys-cpp",
   "version-semver": "4.0.0-beta.4",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Key Vault Keys SDK for C++",
     "This library provides Azure Key Vault Keys SDK."
@@ -11,8 +12,7 @@
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.1.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/azure-security-keyvault-keys-cpp/vcpkg.json
+++ b/ports/azure-security-keyvault-keys-cpp/vcpkg.json
@@ -7,7 +7,7 @@
     "This library provides Azure Key Vault Keys SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/keyvault/azure-security-keyvault-keys",
-  "license": "MIT"
+  "license": "MIT",
   "dependencies": [
     {
       "name": "azure-core-cpp",

--- a/ports/azure-storage-blobs-cpp/vcpkg.json
+++ b/ports/azure-storage-blobs-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-storage-blobs-cpp",
   "version-semver": "12.0.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Blobs SDK for C++",
     "This library provides Azure Storage Blobs SDK."
@@ -11,8 +12,7 @@
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/azure-storage-blobs-cpp/vcpkg.json
+++ b/ports/azure-storage-blobs-cpp/vcpkg.json
@@ -7,8 +7,7 @@
     "This library provides Azure Storage Blobs SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs",
-  "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
+  "license": "MIT"
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",

--- a/ports/azure-storage-blobs-cpp/vcpkg.json
+++ b/ports/azure-storage-blobs-cpp/vcpkg.json
@@ -7,7 +7,7 @@
     "This library provides Azure Storage Blobs SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs",
-  "license": "MIT"
+  "license": "MIT",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -7,7 +7,7 @@
     "This library provides common Azure Storage-related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-common",
-  "license": "MIT"
+  "license": "MIT",
   "dependencies": [
     {
       "name": "azure-core-cpp",

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -7,8 +7,7 @@
     "This library provides common Azure Storage-related abstractions for Azure SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-common",
-  "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
+  "license": "MIT"
   "dependencies": [
     {
       "name": "azure-core-cpp",

--- a/ports/azure-storage-common-cpp/vcpkg.json
+++ b/ports/azure-storage-common-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-storage-common-cpp",
   "version-semver": "12.0.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Common Storage SDK for C++",
     "This library provides common Azure Storage-related abstractions for Azure SDK."
@@ -11,8 +12,7 @@
   "dependencies": [
     {
       "name": "azure-core-cpp",
-      "default-features": false,
-      "version>=": "1.0.0"
+      "default-features": false
     },
     "libxml2",
     {

--- a/ports/azure-storage-files-datalake-cpp/vcpkg.json
+++ b/ports/azure-storage-files-datalake-cpp/vcpkg.json
@@ -7,8 +7,7 @@
     "This library provides Azure Storage Files Data Lake SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
-  "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
+  "license": "MIT"
   "dependencies": [
     {
       "name": "azure-storage-blobs-cpp",

--- a/ports/azure-storage-files-datalake-cpp/vcpkg.json
+++ b/ports/azure-storage-files-datalake-cpp/vcpkg.json
@@ -7,7 +7,7 @@
     "This library provides Azure Storage Files Data Lake SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
-  "license": "MIT"
+  "license": "MIT",
   "dependencies": [
     {
       "name": "azure-storage-blobs-cpp",

--- a/ports/azure-storage-files-datalake-cpp/vcpkg.json
+++ b/ports/azure-storage-files-datalake-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-storage-files-datalake-cpp",
   "version-semver": "12.0.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Files Data Lake SDK for C++",
     "This library provides Azure Storage Files Data Lake SDK."
@@ -11,8 +12,7 @@
   "dependencies": [
     {
       "name": "azure-storage-blobs-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/azure-storage-files-shares-cpp/vcpkg.json
+++ b/ports/azure-storage-files-shares-cpp/vcpkg.json
@@ -7,8 +7,7 @@
     "This library provides Azure Storage Files Shares SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares",
-  "license": "MIT",
-  "builtin-baseline": "14c54c49b56a964ac7f2f701a6857adb02ae1bec",
+  "license": "MIT"
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",

--- a/ports/azure-storage-files-shares-cpp/vcpkg.json
+++ b/ports/azure-storage-files-shares-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-storage-files-shares-cpp",
   "version-semver": "12.0.1",
+  "port-version": 1,
   "description": [
     "Microsoft Azure Storage Files Shares SDK for C++",
     "This library provides Azure Storage Files Shares SDK."
@@ -11,8 +12,7 @@
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",
-      "default-features": false,
-      "version>=": "12.0.0"
+      "default-features": false
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/azure-storage-files-shares-cpp/vcpkg.json
+++ b/ports/azure-storage-files-shares-cpp/vcpkg.json
@@ -7,7 +7,7 @@
     "This library provides Azure Storage Files Shares SDK."
   ],
   "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-shares",
-  "license": "MIT"
+  "license": "MIT",
   "dependencies": [
     {
       "name": "azure-storage-common-cpp",

--- a/versions/a-/azure-security-keyvault-keys-cpp.json
+++ b/versions/a-/azure-security-keyvault-keys-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09755978bf38dd01753da7d6e756cbc3e3577755",
+      "git-tree": "6a62e90cc13ab362ba09462fa444512aee671482",
       "version-semver": "4.0.0-beta.4",
       "port-version": 1
     },

--- a/versions/a-/azure-security-keyvault-keys-cpp.json
+++ b/versions/a-/azure-security-keyvault-keys-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09755978bf38dd01753da7d6e756cbc3e3577755",
+      "version-semver": "4.0.0-beta.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "beff44522cd72f08bddabfc35a520533b97d1819",
       "version-semver": "4.0.0-beta.4",
       "port-version": 0

--- a/versions/a-/azure-storage-blobs-cpp.json
+++ b/versions/a-/azure-storage-blobs-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea3400f37a02366e4bdc66333336dd153621454c",
+      "version-semver": "12.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "07131431279c91d81edd9ec56005ee8628c3efdb",
       "version-semver": "12.0.1",
       "port-version": 0

--- a/versions/a-/azure-storage-blobs-cpp.json
+++ b/versions/a-/azure-storage-blobs-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ea3400f37a02366e4bdc66333336dd153621454c",
+      "git-tree": "4927a9eacb27a8088d82005fbae2851755d09ce1",
       "version-semver": "12.0.1",
       "port-version": 1
     },

--- a/versions/a-/azure-storage-common-cpp.json
+++ b/versions/a-/azure-storage-common-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cdbab78ba2af306c938299985c992638b26a9e54",
+      "git-tree": "f18fbd3b20bfc22766b8767ab8b668be4ea18f58",
       "version-semver": "12.0.1",
       "port-version": 1
     },

--- a/versions/a-/azure-storage-common-cpp.json
+++ b/versions/a-/azure-storage-common-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdbab78ba2af306c938299985c992638b26a9e54",
+      "version-semver": "12.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "d4ce9c53796add134d3ce8f29a9be4e33eba6c2a",
       "version-semver": "12.0.1",
       "port-version": 0

--- a/versions/a-/azure-storage-files-datalake-cpp.json
+++ b/versions/a-/azure-storage-files-datalake-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b31652a1ee436918f516f494fc35dd3ed2f76a6d",
+      "version-semver": "12.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "305658dfe1b6b28abc8be014794e6b21e8ba5722",
       "version-semver": "12.0.1",
       "port-version": 0

--- a/versions/a-/azure-storage-files-datalake-cpp.json
+++ b/versions/a-/azure-storage-files-datalake-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b31652a1ee436918f516f494fc35dd3ed2f76a6d",
+      "git-tree": "649b055538511bad19442d11dd356688cac46370",
       "version-semver": "12.0.1",
       "port-version": 1
     },

--- a/versions/a-/azure-storage-files-shares-cpp.json
+++ b/versions/a-/azure-storage-files-shares-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ee20eb0f87311840798b79ec437ad81ab8b0fc8",
+      "version-semver": "12.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "70c68c7920b221b2b571ba85d48ba215c0e9cb58",
       "version-semver": "12.0.1",
       "port-version": 0

--- a/versions/a-/azure-storage-files-shares-cpp.json
+++ b/versions/a-/azure-storage-files-shares-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6ee20eb0f87311840798b79ec437ad81ab8b0fc8",
+      "git-tree": "eccf58c6719e0f859f90420dffb5deb2cccac731",
       "version-semver": "12.0.1",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -298,15 +298,15 @@
     },
     "azure-security-keyvault-keys-cpp": {
       "baseline": "4.0.0-beta.4",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-blobs-cpp": {
       "baseline": "12.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-common-cpp": {
       "baseline": "12.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-cpp": {
       "baseline": "7.5.0",
@@ -314,11 +314,11 @@
     },
     "azure-storage-files-datalake-cpp": {
       "baseline": "12.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-storage-files-shares-cpp": {
       "baseline": "12.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-uamqp-c": {
       "baseline": "2020-12-09",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/19267

This version constraint used in related ports cause the failures in manifest mode. See https://github.com/microsoft/vcpkg/pull/18779#discussion_r664850641

Failures:
```
Error: no version entry for azure-storage-common-cpp at version 12.0.0.
We are currently using the version in the ports tree (12.0.1).
Error: no version entry for azure-core-cpp at version 1.0.0.
We are currently using the version in the ports tree (1.1.0).
Error: no version entry for azure-storage-blobs-cpp at version 12.0.0.
We are currently using the version in the ports tree (12.0.1).
Error: no version entry for azure-storage-common-cpp at version 12.0.0.
We are currently using the version in the ports tree (12.0.1).
```

cc @ahsonkhan cc @RickWinter, @vhvb1989