### PR TITLE
[ffmpeg] add CMake targets to FindFFMPEG.cmake module

### DIFF
--- a/ports/ffmpeg/FindFFMPEG.cmake.in
+++ b/ports/ffmpeg/FindFFMPEG.cmake.in
@@ -89,6 +89,17 @@ macro(FFMPEG_FIND varname shortname headername)
     list(APPEND FFMPEG_INCLUDE_DIRS ${FFMPEG_${varname}_INCLUDE_DIRS})
     list(APPEND FFMPEG_LIBRARIES ${FFMPEG_${varname}_LIBRARY})
     list(APPEND FFMPEG_LIBRARY_DIRS ${FFMPEG_${varname}_LIBRARY_RELEASE_DIR} ${FFMPEG_${varname}_LIBRARY_DEBUG_DIR})
+    if(NOT TARGET FFMPEG::${varname})
+      add_library(FFMPEG::${varname} INTERFACE IMPORTED)
+      set_target_properties(FFMPEG::${varname} PROPERTIES
+          INTERFACE_LINK_LIBRARIES FFMPEG_${varname}_LIBRARY
+          INTERFACE_INCLUDE_DIRECTORIES FFMPEG_${varname}_INCLUDE_DIRS
+      )
+    endif()
+    if(NOT TARGET FFMPEG::FFMPEG)
+      add_library(FFMPEG::FFMPEG INTERFACE IMPORTED)
+    endif()
+    target_link_libraries(FFMPEG::FFMPEG PUBLIC FFMPEG::${varname})
   endif()
 endmacro(FFMPEG_FIND)
 

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4",
-  "port-version": 12,
+  "port-version": 13,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1998,7 +1998,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4",
-      "port-version": 12
+      "port-version": 13
     },
     "ffnvcodec": {
       "baseline": "10.0.26.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28d446a8deaacd19a758b088e05078640914b075",
+      "version": "4.4",
+      "port-version": 13
+    },
+    {
       "git-tree": "4d910207840ec65730eb972e472dab548fb8b5d2",
       "version": "4.4",
       "port-version": 12


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
 missing CMake targets for ffmpeg. I ran into issues using `${FFMPEG_LIBRARIES}` in a generator expression like `$<$<BOOL:${USE_FFMPEG}>:${FFMPEG_LIBRARIES}>` because `${FFMPEG_LIBRARIES}` is a list. Using a target resolves that and also makes it easier to add the include directories.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I am still working on this PR and asking for help.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**

At the end of the build, this is printed:
```
The package ffmpeg:x64-linux provides CMake targets:

    find_package(ffmpeg CONFIG REQUIRED)
    target_link_libraries(main PRIVATE FFMPEG::FFMPEG)
```

I am getting an error I don't understand when doing `find_package(FFMPEG CONFIG REQUIRED)` in the application's CMakeLists.txt:
```
CMake Error at /home/be/sw/vcpkg/installed/x64-linux/share/ffmpeg/vcpkg-cmake-wrapper.cmake:6 (_find_package):
  Could not find a package configuration file provided by "FFMPEG" with any
  of the following names:

    FFMPEGConfig.cmake
    ffmpeg-config.cmake

  Add the installation prefix of "FFMPEG" to CMAKE_PREFIX_PATH or set
  "FFMPEG_DIR" to a directory containing one of the above files.  If "FFMPEG"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  /home/be/sw/vcpkg/scripts/buildsystems/vcpkg.cmake:736 (include)
  CMakeLists.txt:559 (find_package)


-- Configuring incomplete, errors occurred!
```

If I change it to `find_package(ffmpeg CONFIG REQURIED)` that does not work either:
```
CMake Error at /home/be/sw/vcpkg/installed/x64-linux/share/ffmpeg/vcpkg-cmake-wrapper.cmake:6 (_find_package):
  Could not find a package configuration file provided by "ffmpeg" with any
  of the following names:

    ffmpegConfig.cmake
    ffmpeg-config.cmake

  Add the installation prefix of "ffmpeg" to CMAKE_PREFIX_PATH or set
  "ffmpeg_DIR" to a directory containing one of the above files.  If "ffmpeg"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  /home/be/sw/vcpkg/scripts/buildsystems/vcpkg.cmake:736 (include)
  CMakeLists.txt:559 (find_package)


-- Configuring incomplete, errors occurred!
```