### PR TITLE
Clean the downloads directory every CI run.

### DIFF
--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -28,10 +28,11 @@ jobs:
     displayName: 'Create /home/agent'
     # Note: /mnt is the Azure machines' temporary disk.
   - bash: |
+      sudo rm -rf ${{ variables.VCPKG_DOWNLOADS }}
       sudo mkdir ${{ variables.WORKING_ROOT }} -m=777
       sudo mkdir ${{ variables.VCPKG_DOWNLOADS }} -m=777
       exit 0
-    displayName: 'Create ${{ variables.VCPKG_DOWNLOADS }}'
+    displayName: 'Create ${{ variables.WORKING_ROOT }} and ${{ variables.VCPKG_DOWNLOADS }}'
   - task: Bash@3
     displayName: 'Bootstrap vcpkg'
     inputs:

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
   - bash: df -h
     displayName: 'Report on Disk Space'
   - bash: |
+      sudo rm -rf ${{ variables.VCPKG_DOWNLOADS }} || 0
       sudo mkdir ${{ variables.VCPKG_DOWNLOADS }} || 0
       sudo chmod 777 ${{ variables.VCPKG_DOWNLOADS }} || 0
       exit 0

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -29,11 +29,8 @@ jobs:
   - script: .\bootstrap-vcpkg.bat
     displayName: 'Bootstrap vcpkg'
   - script: |
-      dir ${{ variables.VCPKG_DOWNLOADS }} 2>&1 || (call )
-      dir ${{ variables.VCPKG_DOWNLOADS }}\tools 2>&1 || (call )
-      dir ${{ variables.VCPKG_DOWNLOADS }}\tools\msys2 2>&1 || (call )
-      rmdir /S /Q ${{ variables.VCPKG_DOWNLOADS }}\tools\msys2 2>&1 || (call )
-    displayName: 'Clean msys2 downloads'
+      rmdir /S /Q ${{ variables.VCPKG_DOWNLOADS }} 2>&1
+    displayName: 'Clean downloads'
   - task: PowerShell@2
     displayName: '*** Test Modified Ports and Prepare Test Logs ***'
     inputs:


### PR DESCRIPTION
Now that vcpkg has artifact caching, meaning downloading artifacts usually doesn't have to leave the datacenter, there's no need to potentially dirty different runs with leftover downloads from each other.

This resulted in some "impossible" results in https://github.com/microsoft/vcpkg/pull/18687 where a previous PR run accidentally downloaded the Windows version of nodejs to /mnt/vcpkg-ci/downloads/node-v14.17.4-linux-x64.tar.xz
