### PR TITLE
[libsbsms] add new port with version 2.3.0

### DIFF
--- a/ports/libsbsms/portfile.cmake
+++ b/ports/libsbsms/portfile.cmake
@@ -1,0 +1,17 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO claytonotey/libsbsms
+    REF 2.3.0
+    SHA512 e5b544c2bdbaa2169236987c7a043838c8d1761b25280c476d7a32656d482c6485cb33f579ea9d1ce586ec7b2913ed8fdcf1abe5c7cc8b9e4eef9ce87de54627
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sbsms" PACKAGE_NAME sbsms)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libsbsms/vcpkg.json
+++ b/ports/libsbsms/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libsbsms",
+  "version-semver": "2.3.0",
+  "description": "libsbsms is a library for high quality time and pitch scale modification of digital audio. It uses octave subband sinusoidal modeling.",
+  "homepage": "https://github.com/claytonotey/libsbsms",
+  "license": "GPL-2.0-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3568,6 +3568,10 @@
       "baseline": "5.18.0",
       "port-version": 0
     },
+    "libsbsms": {
+      "baseline": "2.3.0",
+      "port-version": 0
+    },
     "libsigcpp": {
       "baseline": "3.0.3",
       "port-version": 1

--- a/versions/l-/libsbsms.json
+++ b/versions/l-/libsbsms.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e6367a94b6e35f2acf16b6a931749fcfab8ffefe",
+      "version-semver": "2.3.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

I am not sure whether to call this new port `sbsms` or `libsbsms`. I initially tried `libsbms`, but then `find_package(sbsms)` and `find_package(libsbsms)` both failed to find the CMake config module installed by the library's build system.

- #### What does your PR fix?  
  Adds libsbsms port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes