### PR TITLE
[directxtk, directxtk12, directxtex] ports updated for August 2021 release

### DIFF
--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF jun2021
-    SHA512 aa67e814248b3e6163eb8670a8740831bc449b0cc1d83ba0e83d022cc3a8b78c92bc79dee15a089ef1d20566e22c4236ae871906b467bab688c223b32900ec60
+    REF aug2021
+    SHA512 72b688848ad7645e018bb7dc3a3179ea3857e8349185ad53ad583b17aca555554ce44773a4b900ad163b2fd8551c28c3503b88333d8cff8f8d3ee03017bad35d
     HEAD_REF master
 )
 
@@ -65,23 +65,23 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jun2021/texassemble.exe"
-    FILENAME "texassemble-jun2021.exe"
-    SHA512 98fbd891b36c1f0c400670e4ad7943929a278995d1c1d99fe6c4d490abfabe001885eeafad3f913962c560a0ddd960126c979c60d89edcdf0dd002be919048d8
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texassemble.exe"
+    FILENAME "texassemble-aug2021.exe"
+    SHA512 11b07da257d7ea394fa789210b2985656bf28a0b6117d5380d9639ffc0a460a0e6c4bdbb24256dcf3b4d75088b4b5386951a7de856fecb99e73dfe326b4bfe45
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jun2021/texconv.exe"
-    FILENAME "texconv-jun2021.exe"
-    SHA512 47719cca9a2eaf7b28da6b68f87c54ed89507e864d93a35ce7dc417dd0f40cbef23e54039c27c4addfbda79f2f94b1224172e6c8cf2b9ed1e784e60661900102
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texconv.exe"
+    FILENAME "texconv-aug2021.exe"
+    SHA512 c11bc77a36d5989189519793f3a44c15f1e01b3e0a6254bffca4ee6f96c933a6add34ffc7e409f3c3f97d862816006d3ca440876a4af200f035353d096902c5b
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/jun2021/texdiag.exe"
-    FILENAME "texdiag-jun2021.exe"
-    SHA512 484f582c01a001ad97dedecf9ac4be6602a82f52a4e22750dd8ee2c4fa09a776d74aa77b3e50339248dd547f832d293d6d789fabeafe9593271100085e838a86
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texdiag.exe"
+    FILENAME "texdiag-aug2021.exe"
+    SHA512 73ae5fbc20ff7d970891d8e4029f1400f5d16675912cc4af97f9ef0e563dc77fa89690989e80eec5fd033975cf67d350be5a547d08fc5fecbabd4577603eef80
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -92,9 +92,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtex/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-string": "jun2021",
+  "version-string": "aug2021",
   "description": "DirectXTex texture processing library",
   "homepage": "http://go.microsoft.com/fwlink/?LinkId=248926",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "directxtex",
   "version-string": "aug2021",
   "description": "DirectXTex texture processing library",
-  "homepage": "http://go.microsoft.com/fwlink/?LinkId=248926",
+  "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
   "license": "MIT",
   "supports": "windows | linux",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -65,12 +65,6 @@ elseif(NOT VCPKG_TARGET_IS_UWP)
         SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
     )
 
-  vcpkg_install_msbuild(
-      SOURCE_PATH ${SOURCE_PATH}
-      PROJECT_SUBPATH MakeSpriteFont/MakeSpriteFont.csproj
-      PLATFORM AnyCPU
-  )
-
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF jun2021
-    SHA512 df15d20c3ab586e4f08b92a30d82f277e966aaa2555fa6161a6fb2308e65d79fdb3c65518f150fb08c31902d929aa01369dc8a852d2be31d30ecdf9253898fe0
+    REF aug2021
+    SHA512 ed4ff5c8a1f12e2489a4ddb653a0d8097da4a901498852ada5595959f6e6275531e11ca20d8ce16da19f3ac37193b23edf7c9c1b6d6a78a8810e8f0d399ca4b8
     HEAD_REF master
 )
 
@@ -36,16 +36,16 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jun2021.exe"
-    SHA512 4618090f65332c64cb5601a7095c60c87a3a41e9c030d7422d36f14b04dcd80c7aa26438733b892f91daf19fadd44591a814b77c3ca04590ad6c61ecbe909a65
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/aug2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-aug2021.exe"
+    SHA512 a84786f57f7f26c4ab0cd446136d79c19a74296f5074396854c81ad67aedfccfe76e15025ba9bcfcabb993f0bb7247ca536d55b4574192efb3e7c2069abf70d7
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2021/XWBTool.exe"
-    FILENAME "xwbtool-jun2021.exe"
-    SHA512 dc74081b9569a9ca736984d8da1a5b2dc852f85d07a629d6e0ef7f2b4313987ec82d2ff1e0cfa19a89c7387182644869ac2a8f842d30609d88ccae7c01ce3f80
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/aug2021/XWBTool.exe"
+    FILENAME "xwbtool-aug2021.exe"
+    SHA512 3dd1ebd04db21517f74453727512783141b997d33efc1a47236c9ff343310da17b4add4c4ba6e138ad35095fb77f4207e7458a9e51ee3f4872fc0e0cf62be5b5
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -55,8 +55,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "directxtk",
-  "version-string": "jun2021",
+  "version-string": "aug2021",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
-  "homepage": "http://go.microsoft.com/fwlink/?LinkId=248929",
+  "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
   "license": "MIT",
   "supports": "windows",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF jun2021
-    SHA512 8d33232a5422283a0a69850a7913b88ccbf9720e5172fe82171d38a0f42b487ba5cca4f356eeaee975bcbb931a5e7ddbce1c335c3c93f01e79f85d65613e5387
+    REF aug2021
+    SHA512 9d0234d7f8d631fa7cb434487bb1fbb4a52760550962f8ebd5a8c09b33cc2b328651b0c0355057e9b172b7445c86b083f33967ee7918a5eeaf19b3e4915dfe00
     HEAD_REF master
 )
 
@@ -22,16 +22,16 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-jun2021.exe"
-    SHA512 4618090f65332c64cb5601a7095c60c87a3a41e9c030d7422d36f14b04dcd80c7aa26438733b892f91daf19fadd44591a814b77c3ca04590ad6c61ecbe909a65
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/aug2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-aug2021.exe"
+    SHA512 a84786f57f7f26c4ab0cd446136d79c19a74296f5074396854c81ad67aedfccfe76e15025ba9bcfcabb993f0bb7247ca536d55b4574192efb3e7c2069abf70d7
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2021/XWBTool.exe"
-    FILENAME "xwbtool-jun2021.exe"
-    SHA512 dc74081b9569a9ca736984d8da1a5b2dc852f85d07a629d6e0ef7f2b4313987ec82d2ff1e0cfa19a89c7387182644869ac2a8f842d30609d88ccae7c01ce3f80
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/aug2021/XWBTool.exe"
+    FILENAME "xwbtool-aug2021.exe"
+    SHA512 3dd1ebd04db21517f74453727512783141b997d33efc1a47236c9ff343310da17b4add4c4ba6e138ad35095fb77f4207e7458a9e51ee3f4872fc0e0cf62be5b5
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -41,8 +41,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk12/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "directxtk12",
-  "version-string": "jun2021",
+  "version-string": "aug2021",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
-  "homepage": "http://go.microsoft.com/fwlink/?LinkID=615561",
+  "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
   "license": "MIT",
   "supports": "windows",

--- a/scripts/azure-pipelines/windows/deploy-visual-studio.ps1
+++ b/scripts/azure-pipelines/windows/deploy-visual-studio.ps1
@@ -18,6 +18,7 @@ $Workloads = @(
   'Microsoft.VisualStudio.Component.Windows10SDK.18362',
   'Microsoft.VisualStudio.Component.Windows10SDK.19041',
   'Microsoft.Net.Component.4.8.SDK',
+  'Microsoft.Net.Component.4.7.2.TargetingPack',
   'Microsoft.Component.NetFX.Native',
   'Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset',
   'Microsoft.VisualStudio.Component.VC.Llvm.Clang',

--- a/scripts/azure-pipelines/windows/deploy-visual-studio.ps1
+++ b/scripts/azure-pipelines/windows/deploy-visual-studio.ps1
@@ -18,7 +18,6 @@ $Workloads = @(
   'Microsoft.VisualStudio.Component.Windows10SDK.18362',
   'Microsoft.VisualStudio.Component.Windows10SDK.19041',
   'Microsoft.Net.Component.4.8.SDK',
-  'Microsoft.Net.Component.4.7.2.TargetingPack',
   'Microsoft.Component.NetFX.Native',
   'Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset',
   'Microsoft.VisualStudio.Component.VC.Llvm.Clang',

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1693,15 +1693,15 @@
       "port-version": 2
     },
     "directxtex": {
-      "baseline": "jun2021",
+      "baseline": "aug2021",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "jun2021",
+      "baseline": "aug2021",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "jun2021",
+      "baseline": "aug2021",
       "port-version": 0
     },
     "dirent": {

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa15773926896a6f0b1f9eb47a5aed34f65175e4",
+      "version-string": "aug2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "a98fe1cd0beed414488e36e18d5e2f5a54f2d6b6",
       "version-string": "jun2021",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd803efb0c7aec5d7b48107688b44353fcb66080",
+      "git-tree": "e7f8c6f80d18f82e3e5a6ab621f4e43d6a110b2b",
       "version-string": "aug2021",
       "port-version": 0
     },

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd803efb0c7aec5d7b48107688b44353fcb66080",
+      "version-string": "aug2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "d7cafe13a0edb883e2d15c917d5a042d4b599c1c",
       "version-string": "jun2021",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "49693bbdb6a484add7a33c52cb54059beca228b9",
+      "version-string": "aug2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "eba43932b7f93d4dedbd866542362f12933e3a74",
       "version-string": "jun2021",
       "port-version": 0


### PR DESCRIPTION
Updated the **directxtk**, **directxtk12**, and **directxtex** ports to the latest GitHub releases.

> Changed use of FWLINKs back to direct GitHub links per feedback from my last PR.