### PR TITLE
[google-cloud-cpp] update to latest version (v1.30.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.29.0
-    SHA512 1dda15eaece6d574ba49eb3756e8a72eac6c9b508acf30ed1de0a0234e1e36a352f11494411a84533f8412779040da3e3ffc98d33d43a99b3626c15627513f20
+    REF v1.30.0
+    SHA512 4609bd1240ed88d7f4d7b1685f96fdbfffa0f8a296f24fa69984d14351671bfa7c283975978b1c41b816ed5cb181da0166bc5f9377d362331e2de42b66f1d1ae
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2365,7 +2365,7 @@
       "port-version": 6
     },
     "google-cloud-cpp": {
-      "baseline": "1.29.0",
+      "baseline": "1.30.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4cc90bac3e6db351ea0daa3de00a32947c3b2050",
+      "version": "1.30.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "47a4d6d3258efe94ffe95b10abd1f0a19c48aab2",
       "version": "1.29.0",
       "port-version": 0


### PR DESCRIPTION
Updates the `google-cloud-cpp` port to the latest release (v1.30.0)

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes, I think so.

