### PR TITLE
[tinyfiledialogs] Fix for good

### DIFF
--- a/docs/maintainers/vcpkg_from_git.md
+++ b/docs/maintainers/vcpkg_from_git.md
@@ -27,6 +27,11 @@ The url of the git repository.
 ### REF
 The git sha of the commit to download.
 
+### FETCH_REF
+The git branch to fetch in non-HEAD mode. After this is fetched,
+then `REF` is checked out. This is useful in cases where the git server
+does not allow checking out non-advertised objects.
+
 ### HEAD_REF
 The git branch to use when the package is requested to be built from the latest sources.
 

--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -2,11 +2,12 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_sourceforge(
+vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO tinyfiledialogs
-    SHA512 d63d6dd847d6bbd1f252c8fbd228086381af7189ac71afc97bd57e06badd1d3f4d90c6aab6207191ae7253d5a71fc44636cf8e33714089d5b478dd2714f59376
-    FILENAME "tinyfiledialogs-current.zip"
+    FETCH_REF master
+    HEAD_REF master
+    URL https://git.code.sf.net/p/tinyfiledialogs/code
+    REF e11f94cd7887b101d64f74892d769f0139b5e166
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
@@ -26,6 +27,6 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(READ "${CURRENT_PACKAGES_DIR}/include/tinyfiledialogs/tinyfiledialogs.h" _contents)
 # reads between the line "- License -" and a closing "*/"
 if (NOT _contents MATCHES [[- License -(([^*]|\*[^/])*)\*/]])
-	message(FATAL_ERROR "Failed to parse license from tinyfiledialogs.h")
+    message(FATAL_ERROR "Failed to parse license from tinyfiledialogs.h")
 endif()
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "${CMAKE_MATCH_1}")

--- a/ports/tinyfiledialogs/vcpkg.json
+++ b/ports/tinyfiledialogs/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyfiledialogs",
-  "version-semver": "3.8.8",
-  "port-version": 1,
+  "version": "3.8.8",
+  "port-version": 2,
   "description": "Highly portable and cross-platform dialogs for native inputbox, passwordbox, colorpicker and more",
   "homepage": "https://sourceforge.net/projects/tinyfiledialogs/",
   "supports": "!uwp",

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -117,6 +117,7 @@ function(vcpkg_from_git)
         vcpkg_execute_required_process(
             ALLOW_IN_DOWNLOAD_MODE
             COMMAND "${GIT}" init "${git_working_directory}"
+            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}"
             LOGNAME "git-init-${TARGET_TRIPLET}"
         )
         vcpkg_execute_required_process(
@@ -145,7 +146,7 @@ function(vcpkg_from_git)
                 OUTPUT_VARIABLE rev_parse_ref
                 ERROR_VARIABLE rev_parse_ref
                 RESULT_VARIABLE error_code
-                WORKING_DIRECTORY "${git_working_directory}/git-tmp"
+                WORKING_DIRECTORY "${git_working_directory}"
             )
             if(error_code)
                 message(FATAL_ERROR "unable to rev-parse ${arg_REF} after fetching git repository")

--- a/scripts/cmake/vcpkg_from_git.cmake
+++ b/scripts/cmake/vcpkg_from_git.cmake
@@ -26,6 +26,11 @@ The url of the git repository.
 ### REF
 The git sha of the commit to download.
 
+### FETCH_REF
+The git branch to fetch in non-HEAD mode. After this is fetched,
+then `REF` is checked out. This is useful in cases where the git server
+does not allow checking out non-advertised objects.
+
 ### HEAD_REF
 The git branch to use when the package is requested to be built from the latest sources.
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6302,7 +6302,7 @@
     },
     "tinyfiledialogs": {
       "baseline": "3.8.8",
-      "port-version": 1
+      "port-version": 2
     },
     "tinygltf": {
       "baseline": "2020-07-28",

--- a/versions/t-/tinyfiledialogs.json
+++ b/versions/t-/tinyfiledialogs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "abb5795ae7f012d210a4d98e4f072dea1b94c97a",
+      "version": "3.8.8",
+      "port-version": 2
+    },
+    {
       "git-tree": "3959a47c7d93ca7db6e2022553b1d3427970cecf",
       "version-semver": "3.8.8",
       "port-version": 1


### PR DESCRIPTION
This stabilizes the source access for tinyfiledialogs, so we no longer have to worry about it being inaccessible or changed.

It adds a new parameter to `vcpkg_from_git`, `FETCH_REF`, which tells vcpkg to instead fetch that branch in a non-shallow way. In almost all cases, unless the upstream rebases their entire history, this will allow us to avoid the issue of downloading non-advertised objects, which many git servers do not support.

This was originally part of #19207, but I didn't want to have to rebuild the world on that PR.