### PR TITLE
[libconfig] build on macos

### DIFF
--- a/ports/libconfig/CMakeLists.txt
+++ b/ports/libconfig/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(libconfig C CXX)
 
 if(MSVC)
-  add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
+  add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS -DYY_NO_UNISTD_H -DYY_USE_CONST)
 endif()
 
 set(C_SOURCES
@@ -20,11 +20,9 @@ set(CPP_SOURCES
   lib/libconfigcpp.cc
 )
 
-find_path(STDINT_H stdint.h)
+set(CMAKE_C_STANDARD 99)
 
 include_directories(lib ${STDINT_H})
-
-add_definitions(-DYY_NO_UNISTD_H -DYY_USE_CONST)
 
 add_library(libconfig  ${C_SOURCES})
 add_library(libconfig++ ${CPP_SOURCES})

--- a/ports/libconfig/CONTROL
+++ b/ports/libconfig/CONTROL
@@ -1,5 +1,5 @@
 Source: libconfig
-Version: 1.7.2
-Port-Version: 4
+Version: 1.7.3
+Port-Version: 0
 Homepage: https://github.com/hyperrealm/libconfig
 Description: C/C++ library for processing configuration files

--- a/ports/libconfig/portfile.cmake
+++ b/ports/libconfig/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hyperrealm/libconfig
-    REF v1.7.2
-    SHA512 9df57355c2d08381b4a0a6366f0db3633fbe8f73c2bb8c370c040b0bae96ce89ee4ac6c17a5a247fed855d890fa383e5b70cb5573fc9cfc62194d5b94e161cee
+    REF v1.7.3
+    SHA512 3749bf9eb29bab0f6b14f4fc759f0c419ed27a843842aaabed1ec1fbe0faa8c93322ff875ca1291d69cb28a39ece86d512aec42c2140d566c38c56dc616734f4
     HEAD_REF master
 )
 

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -540,7 +540,6 @@ libbson:x64-uwp=fail
 libcds:arm64-windows=fail
 libcds:arm-uwp=fail
 libcds:x64-uwp=fail
-libconfig:x64-osx=fail
 libcopp:arm64-windows=fail
 libcopp:arm-uwp=fail
 libcrafter:x86-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3105,8 +3105,8 @@
       "port-version": 0
     },
     "libconfig": {
-      "baseline": "1.7.2",
-      "port-version": 4
+      "baseline": "1.7.3",
+      "port-version": 0
     },
     "libconfuse": {
       "baseline": "2019-07-14",

--- a/versions/l-/libconfig.json
+++ b/versions/l-/libconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ef471f5497ea4d07f8282487141bcbe3ea9f319",
+      "version-string": "1.7.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "079c1b8cc62fe544a3277a949422bd68c57e0c45",
       "version-string": "1.7.2",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Fixes compilation errors on macOS by making the compilation flags better match what the upstream libconfig CMakeLists.txt is doing. In particular, the line `find_path(STDINT_H stdint.h)` was picking up the kernel header version of `stdint.h` on macOS, altering the header search paths and preventing libconfig from compiling against the C standard library.

Also updates the library to the latest patch release (1.7.2 -> 1.7.3).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

This PR addresses the build failure on macOS, so this PR also removes the "fail" line from `ci.baseline.txt`.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.