### PR TITLE
[liblzma] Fix for wasm32-emscripten

### DIFF
--- a/ports/liblzma/emscripten_little_endian.patch
+++ b/ports/liblzma/emscripten_little_endian.patch
@@ -1,0 +1,32 @@
+diff --git a/cmake/tuklib_integer.cmake b/cmake/tuklib_integer.cmake
+index d7e2e28..a674877 100644
+--- a/cmake/tuklib_integer.cmake
++++ b/cmake/tuklib_integer.cmake
+@@ -8,7 +8,9 @@
+ #
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/tuklib_common.cmake")
+-include(TestBigEndian)
++if(NOT EMSCRIPTEN)
++    include(TestBigEndian)
++endif()
+ include(CheckCSourceCompiles)
+ include(CheckIncludeFile)
+ include(CheckSymbolExists)
+@@ -18,9 +20,13 @@ function(tuklib_integer TARGET_OR_ALL)
+     # support Apple universal binaries. The CMake module will leave the
+     # variable unset so we can catch that situation here instead of continuing
+     # as if we were little endian.
+-    test_big_endian(WORDS_BIGENDIAN)
+-    if(NOT DEFINED WORDS_BIGENDIAN)
+-        message(FATAL_ERROR "Cannot determine endianness")
++    if(NOT EMSCRIPTEN)
++        test_big_endian(WORDS_BIGENDIAN)
++        if(NOT DEFINED WORDS_BIGENDIAN)
++            message(FATAL_ERROR "Cannot determine endianness")
++        endif()
++    else()
++        set(WORDS_BIGENDIAN 0)
+     endif()
+     tuklib_add_definition_if("${TARGET_OR_ALL}" WORDS_BIGENDIAN)
+ 

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         fix_config_include.patch
         win_output_name.patch # Fix output name on Windows. Autotool build does not generate lib prefixed libraries on windows. 
         add_support_ios.patch # add install bundle info for support ios 
+        emscripten_little_endian.patch # Allows building for wasm32-emscripten by disabling endianness test (WASM is little-endian)
 )
 
 vcpkg_cmake_configure(

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liblzma",
   "version-semver": "5.2.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "hhttps://github.com/xz-mirror/xz",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3334,7 +3334,7 @@
     },
     "liblzma": {
       "baseline": "5.2.5",
-      "port-version": 3
+      "port-version": 4
     },
     "libmad": {
       "baseline": "0.15.1-8",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1880016bbbf363f1523564821b2801df1155773",
+      "version-semver": "5.2.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "2c5f893c8d78d30c4641e9f4d0c7818386f8c8c9",
       "version-semver": "5.2.5",
       "port-version": 3


### PR DESCRIPTION
This PR allows building liblzma with Emscripten by disabling a buggy endianness test.

**Note:** This patch uses a workaround by manually setting the endianness to little-endian; it has been proposed that vcpkg should use an endianness test designed specifically designed for WebAssembly.

- #### What does your PR fix?
  Fixes #17750

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  wasm32-emscripten, I couldn't find liblzma in the baseline and I'm not sure if I should add it or not.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
