### PR TITLE
[portsmf] update to 238

### DIFF
--- a/ports/portsmf/portfile.cmake
+++ b/ports/portsmf/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "UWP")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tenacityteam/portsmf
-    REF 236
-    SHA512 ede5ca770cab37822eebda7876c4fce7e786a11e15b3e173704863de97ea621b284439ebe7a14fdeadd0dc315f963c8da467ebbb7c246ebf80f5b120c35aa027
+    REF 238
+    SHA512 af619d1b0a656361af8f8b8b65d7f98047613ac8e9ea51354031629c1732ad02755f84d63ac7c4ed24cdf0ad3db46381061bf32d9afe29b7be3226dc814ef552
     HEAD_REF main
 )
 

--- a/ports/portsmf/vcpkg.json
+++ b/ports/portsmf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "portsmf",
-  "version": "0.236",
+  "version": "0.238",
   "description": "Portsmf is 'Port Standard MIDI File', a cross-platform, C++ library for reading and writing Standard MIDI Files.",
   "homepage": "https://github.com/tenacityteam/portsmf",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5037,7 +5037,7 @@
       "port-version": 0
     },
     "portsmf": {
-      "baseline": "0.236",
+      "baseline": "0.238",
       "port-version": 0
     },
     "ppconsul": {

--- a/versions/p-/portsmf.json
+++ b/versions/p-/portsmf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6edc5e2a3d90cd44a65b5d0f28207b5eb3c2dec5",
+      "version": "0.238",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d9de0a9782866958a9aafdfa6cde176c0867dfc",
       "version": "0.236",
       "port-version": 0


### PR DESCRIPTION


**Describe the pull request**

- #### What does your PR fix?  
This fixes a missing `#include <cstring>` in one of the library's headers (allegro.h).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 yes
