### PR TITLE
[libarchive] Restore pkgconfig file

### DIFF
--- a/ports/libarchive/fix-buildsystem.patch
+++ b/ports/libarchive/fix-buildsystem.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b2634da..6a1dc1f 100644
+index b2634da6..0d846877 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -148,10 +148,6 @@ IF (CMAKE_C_COMPILER_ID MATCHES "^XL$")
@@ -34,7 +34,7 @@ index b2634da..6a1dc1f 100644
 -      RUNS
 -      "#include <zlib.h>\nint main() {uLong f = zlibCompileFlags(); return (f&(1U<<10))?0:-1; }"
 -      ZLIB_WINAPI)
-+	SET(ZLIB_WINAPI OFF) # skip following test, it crashes with weird message box  
++    SET(ZLIB_WINAPI OFF) # skip following test, it crashes with weird message box
      IF(ZLIB_WINAPI)
        ADD_DEFINITIONS(-DZLIB_WINAPI)
      ELSE(ZLIB_WINAPI)
@@ -106,13 +106,7 @@ index b2634da..6a1dc1f 100644
  
  IF(HAVE_STRERROR_R)
    SET(HAVE_DECL_STRERROR_R 1)
-@@ -2012,13 +2001,10 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/build/cmake/config.h.in
- INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
- ADD_DEFINITIONS(-DHAVE_CONFIG_H)
- 
--# Handle generation of the libarchive.pc file for pkg-config
--INCLUDE(CreatePkgConfigFile)
--
+@@ -2018,7 +2007,7 @@ INCLUDE(CreatePkgConfigFile)
  #
  # Register installation of PDF documents.
  #
@@ -122,7 +116,7 @@ index b2634da..6a1dc1f 100644
    # On Windows platform, It's better that we install PDF documents
    # on one's computer.
 diff --git a/libarchive/CMakeLists.txt b/libarchive/CMakeLists.txt
-index 9389bbc..0793d96 100644
+index 9389bbc9..c34a42b2 100644
 --- a/libarchive/CMakeLists.txt
 +++ b/libarchive/CMakeLists.txt
 @@ -236,28 +236,22 @@ ELSEIF(ARCHIVE_ACL_SUNOS)
@@ -153,7 +147,7 @@ index 9389bbc..0793d96 100644
  IF(ENABLE_INSTALL)
    # How to install the libraries
 -  INSTALL(TARGETS archive archive_static
-+  INSTALL(TARGETS archive 
++  INSTALL(TARGETS archive
            RUNTIME DESTINATION bin
            LIBRARY DESTINATION lib
            ARCHIVE DESTINATION lib)

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -14,26 +14,27 @@ vcpkg_from_github(
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    bzip2   ENABLE_BZip2
-    libxml2 ENABLE_LIBXML2
-    lz4     ENABLE_LZ4
-    lzma    ENABLE_LZMA
-    lzo     ENABLE_LZO
-    openssl ENABLE_OPENSSL
-    zstd    ENABLE_ZSTD
-    # The below features should be added to CONTROL
-    #pcre    ENABLE_PCREPOSIX
-    #nettle  ENABLE_NETTLE
-    #expat   ENABLE_EXPAT
-    #libgcc  ENABLE_LibGCC
-    #cng     ENABLE_CNG
-    #tar     ENABLE_TAR # Tool build option?
-    #cpio    ENABLE_CPIO # Tool build option?
-    #cat     ENABLE_CAT # Tool build option?
-    #xattr   ENABLE_XATTR # Tool support option?
-    #acl     ENABLE_ACL # Tool support option?
-    #iconv   ENABLE_ICONV # iconv support option?
-    #libb2   ENABLE_LIBB2
+    FEATURES
+        bzip2   ENABLE_BZip2
+        libxml2 ENABLE_LIBXML2
+        lz4     ENABLE_LZ4
+        lzma    ENABLE_LZMA
+        lzo     ENABLE_LZO
+        openssl ENABLE_OPENSSL
+        zstd    ENABLE_ZSTD
+        # The below features should be added to CONTROL
+        #pcre    ENABLE_PCREPOSIX
+        #nettle  ENABLE_NETTLE
+        #expat   ENABLE_EXPAT
+        #libgcc  ENABLE_LibGCC
+        #cng     ENABLE_CNG
+        #tar     ENABLE_TAR # Tool build option?
+        #cpio    ENABLE_CPIO # Tool build option?
+        #cat     ENABLE_CAT # Tool build option?
+        #xattr   ENABLE_XATTR # Tool support option?
+        #acl     ENABLE_ACL # Tool support option?
+        #iconv   ENABLE_ICONV # iconv support option?
+        #libb2   ENABLE_LIBB2
 )
 
 if(FEATURES MATCHES "pcre")
@@ -67,6 +68,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
 

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libarchive",
   "version-semver": "3.4.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://github.com/libarchive/libarchive",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3062,7 +3062,7 @@
     },
     "libarchive": {
       "baseline": "3.4.3",
-      "port-version": 6
+      "port-version": 7
     },
     "libass": {
       "baseline": "0.15.1",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c9f2bae07e5615f25bfc8326b1b85686953e918",
+      "version-semver": "3.4.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "8990b8db984f4a3652bb644608efd7dcd1573bf3",
       "version-semver": "3.4.3",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  So far, generating `libarchive.pc` has been disabled by the
  fix-buildsystem.patch, whereas `INCLUDE(CreatePkgConfigFile)` was removed
  from `CMakeLists.txt`
  - Update fix-buildsystem.patch and allow creating the pkgconfig file
  - Add `vcpkg_fixup_pkgconfig()` to portfile
  - Add `FEATURES` keyword to `vcpkg_check_features()` to avoid deprecation
    warning

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
