### PR TITLE
Fix the false warning on missing pdbs

### DIFF
--- a/scripts/cmake/vcpkg_copy_pdbs.cmake
+++ b/scripts/cmake/vcpkg_copy_pdbs.cmake
@@ -65,7 +65,7 @@ function(vcpkg_copy_pdbs)
 
         set(ENV{VSLANG} "${vslang_backup}")
 
-        if(NOT unmatched_dlls_length STREQUAL "")
+        if(NOT dlls_without_matching_pdbs STREQUAL "")
             list(JOIN dlls_without_matching_pdbs "\n    " message)
             message(WARNING "Could not find a matching pdb file for:
     ${message}\n")


### PR DESCRIPTION
Couldn't find from where `unmatched_dlls_length` was adjusted and it seemingly throwing wrong warnings for missing pdbs. Might be a hack from my side though.