### PR TITLE
[cppitertools] update to version 2.1

### DIFF
--- a/ports/cppitertools/CONTROL
+++ b/ports/cppitertools/CONTROL
@@ -1,5 +1,5 @@
 Source: cppitertools
-Version: 2.0
+Version: 2.1
 Homepage: https://github.com/ryanhaining/cppitertools
 Description: Range-based for loop add-ons inspired by the Python builtins and itertools library
 Build-Depends: boost-optional

--- a/ports/cppitertools/portfile.cmake
+++ b/ports/cppitertools/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ryanhaining/cppitertools
-    REF d716cf6c8281ab6383d1fbecb456e0b9d808694c
-    SHA512 47bc490d798b445e965169a754dc977d5add217f133130671301dee6294744fa4b3f7a3b146cbd002c31325e5bc7c2206d57560a6db58693ca13ca972ca09d39
+    REF 539a5be8359c4330b3f88ed1821f32bb5c89f5f6
+    SHA512 cab0cb8a6b711824c13ca013b3349b9decb84f2dab6305bfb1bdd013f7426d5b199c127dadabeaaafc2e7ff6ad442222dd0fffee9aaacfa27d3aeb82c344ae4f
     HEAD_REF master
 )
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1449,7 +1449,7 @@
       "port-version": 0
     },
     "cppitertools": {
-      "baseline": "2.1",
+      "baseline": "2.0",
       "port-version": 0
     },
     "cppkafka": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1449,7 +1449,7 @@
       "port-version": 0
     },
     "cppitertools": {
-      "baseline": "2.0",
+      "baseline": "2.1",
       "port-version": 0
     },
     "cppkafka": {

--- a/versions/c-/cppitertools.json
+++ b/versions/c-/cppitertools.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b4908a6183e914b33014a6b2f640df56e99d9f0",
+      "version-string": "2.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f5ac65e92858f04e97468de01d59b60c0eac058",
       "version-string": "2.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Updates CppIterTools port to version 2.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
Should work for all triplets. But tested only on windows. Don't have other environments to test on.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I think i did this correctly. 

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
