### PR TITLE
[kf5windowsystem] fix cmake.in for static usage; extra fixes

### DIFF
--- a/ports/kf5windowsystem/27.patch
+++ b/ports/kf5windowsystem/27.patch
@@ -1,0 +1,31 @@
+From 2ee7179c17fd9bd6d8e883ea304cc050cb197834 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dawid=20Wro=CC=81bel?= <me@dawidwrobel.com>
+Date: Thu, 29 Jul 2021 13:47:28 +0200
+Subject: [PATCH] Support static builds
+
+---
+ KF5WindowSystemConfig.cmake.in | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/KF5WindowSystemConfig.cmake.in b/KF5WindowSystemConfig.cmake.in
+index 6c1b4c0..bcb7128 100644
+--- a/KF5WindowSystemConfig.cmake.in
++++ b/KF5WindowSystemConfig.cmake.in
+@@ -4,7 +4,13 @@ include(CMakeFindDependencyMacro)
+ find_dependency(Qt5Gui @REQUIRED_QT_VERSION@)
+ 
+ if(NOT @KWINDOWSYSTEM_NO_WIDGETS@)
+-find_dependency(Qt5Widgets @REQUIRED_QT_VERSION@)
++    find_dependency(Qt5Widgets @REQUIRED_QT_VERSION@)
++endif()
++
++if(NOT @BUILD_SHARED_LIBS@)
++    if(@WIN32@)
++        find_dependency(Qt5WinExtras @REQUIRED_QT_VERSION@)
++    endif()
+ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/KF5WindowSystemTargets.cmake")
+-- 
+GitLab
+

--- a/ports/kf5windowsystem/28.patch
+++ b/ports/kf5windowsystem/28.patch
@@ -1,0 +1,27 @@
+From b4bf29e297dd75eb2f4af6ed143839e223833b4b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dawid=20Wro=CC=81bel?= <me@dawidwrobel.com>
+Date: Mon, 9 Aug 2021 22:45:50 +0000
+Subject: [PATCH] Support static builds on Linux as well
+
+---
+ KF5WindowSystemConfig.cmake.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/KF5WindowSystemConfig.cmake.in b/KF5WindowSystemConfig.cmake.in
+index bcb7128..62580e9 100644
+--- a/KF5WindowSystemConfig.cmake.in
++++ b/KF5WindowSystemConfig.cmake.in
+@@ -11,6 +11,10 @@ if(NOT @BUILD_SHARED_LIBS@)
+     if(@WIN32@)
+         find_dependency(Qt5WinExtras @REQUIRED_QT_VERSION@)
+     endif()
++
++    if(@X11_FOUND@)
++        find_dependency(Qt5X11Extras @REQUIRED_QT_VERSION@)
++    endif()
+ endif()
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/KF5WindowSystemTargets.cmake")
+-- 
+GitLab
+

--- a/ports/kf5windowsystem/portfile.cmake
+++ b/ports/kf5windowsystem/portfile.cmake
@@ -3,35 +3,31 @@ vcpkg_from_github(
     REPO KDE/kwindowsystem
     REF v5.84.0
     SHA512 53491f8576db8ebb48627e098fd8c3d4029c024bb9048d97daa1a8f5c39e594ca05dcd80ecb18ac591af7455457a0f14459c24cf44487727a26e34f977c5b81a
+    PATCHES
+        27.patch # https://invent.kde.org/frameworks/kwindowsystem/-/merge_requests/27
 )
 
 if (VCPKG_TARGET_IS_LINUX)
     message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libxcb-res0-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxcb-res0-dev")
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KF5WindowSystem)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF5WindowSystem)
 vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/data)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/data)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/etc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/etc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-
-file(INSTALL ${SOURCE_PATH}/LICENSES/ DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSES/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")

--- a/ports/kf5windowsystem/portfile.cmake
+++ b/ports/kf5windowsystem/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 53491f8576db8ebb48627e098fd8c3d4029c024bb9048d97daa1a8f5c39e594ca05dcd80ecb18ac591af7455457a0f14459c24cf44487727a26e34f977c5b81a
     PATCHES
         27.patch # https://invent.kde.org/frameworks/kwindowsystem/-/merge_requests/27
+        28.patch # https://invent.kde.org/frameworks/kwindowsystem/-/merge_requests/28
 )
 
 if (VCPKG_TARGET_IS_LINUX)

--- a/ports/kf5windowsystem/vcpkg.json
+++ b/ports/kf5windowsystem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5windowsystem",
-  "version": "5.84.0",
-  "port-version": 1,
+  "version-semver": "5.84.0",
+  "port-version": 2,
   "description": "Access to the windowing system",
   "homepage": "https://api.kde.org/frameworks/kwindowsystem/html/",
   "dependencies": [
@@ -14,6 +14,14 @@
     {
       "name": "qt5-x11extras",
       "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2950,7 +2950,7 @@
     },
     "kf5windowsystem": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kfr": {
       "baseline": "2020-06-15",

--- a/versions/k-/kf5windowsystem.json
+++ b/versions/k-/kf5windowsystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c4e94887aa52cceadf2cffa98ef62feafa76aae8",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "719b81cebad63502bbb619781290844c586acef9",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5windowsystem.json
+++ b/versions/k-/kf5windowsystem.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c4e94887aa52cceadf2cffa98ef62feafa76aae8",
+      "git-tree": "e8ec0d393c0ccf286aab3bbe310dd5c09eaecf88",
       "version-semver": "5.84.0",
       "port-version": 2
     },


### PR DESCRIPTION
- #### What does your PR fix?  
    - Apply https://invent.kde.org/frameworks/kwindowsystem/-/merge_requests/27 patch
    - fix MAYBE_UNUSED_VARIABLES usage
    - use semVer
    - update deprecated functions
    - wrap paths in quotes
    - don't overzealously remove folders and actually remove those that need to be

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.