### PR TITLE
[harfbuzz] Don't make use of IN_LIST

### DIFF
--- a/ports/harfbuzz/harfbuzzConfig.cmake.in
+++ b/ports/harfbuzz/harfbuzzConfig.cmake.in
@@ -1,3 +1,6 @@
+# For old projects where the minimum CMake version is lower than 3.3.
+cmake_policy(SET CMP0057 NEW)
+
 if(TARGET harfbuzz)
   return()
 endif()

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "harfbuzz",
   "version": "2.8.1",
+  "port-version": 1,
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2498,7 +2498,7 @@
     },
     "harfbuzz": {
       "baseline": "2.8.1",
-      "port-version": 0
+      "port-version": 1
     },
     "hayai": {
       "baseline": "2019-08-10",

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0af28da9fe1d9f70c2f0b572c8e9eee085eb7c3b",
+      "version": "2.8.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "32e5438e1f8c76646b657f14fbe0dac7646d80f6",
       "version": "2.8.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
 This fixes compatibility issues with Policy CMP0057 
 In projects where CMP0057 is not set you receive:

```
CMake Warning (dev) at /Users/runner/mixxx-vcpkg/installed/x64-osx-mixxx/share/harfbuzz/harfbuzzConfig.cmake:28 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /Users/runner/mixxx-vcpkg/scripts/buildsystems/vcpkg.cmake:782 (_find_package)
  /Users/runner/mixxx-vcpkg/installed/x64-osx-mixxx/share/qt5core/vcpkg-cmake-wrapper.cmake:22 (find_package)
  /Users/runner/mixxx-vcpkg/scripts/buildsystems/vcpkg.cmake:736 (include)
  cmake/Modules/ECMQueryQmake.cmake:1 (find_package)
  cmake/Modules/ECMGeneratePriFile.cmake:83 (include)
  CMakeLists.txt:18 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /Users/runner/mixxx-vcpkg/installed/x64-osx-mixxx/share/harfbuzz/harfbuzzConfig.cmake:28 (if):
  if given arguments:

    "graphite2" "IN_LIST" "HARFBUZZ_FEATURES"
```
 


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
