### PR TITLE
[vcpkg baseline][rbdl-orb/rbdl/ptex] file conflicts, skip rbdl-orb in CI testing

### DIFF
--- a/ports/ptex/CONTROL
+++ b/ports/ptex/CONTROL
@@ -1,7 +1,0 @@
-Source: ptex
-Version: 2.3.2
-Port-Version: 2
-Homepage: https://github.com/wdas/ptex
-Description: Per-Face Texture Mapping for Production Rendering.
-Build-Depends: zlib
-Supports: !uwp

--- a/ports/ptex/portfile.cmake
+++ b/ports/ptex/portfile.cmake
@@ -21,29 +21,29 @@ else()
     set(BUILD_STATIC_LIB ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DPTEX_VER=v${PTEX_VER}
         -DPTEX_BUILD_SHARED_LIBS=${BUILD_SHARED_LIB}
         -DPTEX_BUILD_STATIC_LIBS=${BUILD_STATIC_LIB}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/Ptex)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/Ptex)
 vcpkg_copy_pdbs()
 
 foreach(HEADER PtexHalf.h Ptexture.h)
-    file(READ ${CURRENT_PACKAGES_DIR}/include/${HEADER} PTEX_HEADER)
+    file(READ "${CURRENT_PACKAGES_DIR}/include/${HEADER}" PTEX_HEADER)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         string(REPLACE "ifndef PTEX_STATIC" "if 1" PTEX_HEADER "${PTEX_HEADER}")
     else()
         string(REPLACE "ifndef PTEX_STATIC" "if 0" PTEX_HEADER "${PTEX_HEADER}")
     endif()
-    file(WRITE ${CURRENT_PACKAGES_DIR}/include/${HEADER} "${PTEX_HEADER}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/include/${HEADER}" "${PTEX_HEADER}")
 endforeach()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/src/doc/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/src/doc/License.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ptex/vcpkg.json
+++ b/ports/ptex/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "ptex",
+  "version": "2.3.2",
+  "port-version": 3,
+  "description": "Per-Face Texture Mapping for Production Rendering.",
+  "homepage": "https://github.com/wdas/ptex",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ]
+}

--- a/ports/rbdl-orb/portfile.cmake
+++ b/ports/rbdl-orb/portfile.cmake
@@ -1,12 +1,16 @@
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RBDL_STATIC)	
-	
+if (EXISTS ${CURRENT_INSTALLED_DIR}/share/rbdl/copyright)
+    message(FATAL_ERROR "${PORT} conflict with rbdl, please remove rbdl before install ${PORT}.")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RBDL_STATIC)
+
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO ORB-HD/rbdl-orb
   REF b22abab856a90dbc62e6b2e79f148bd383b5ce43
   SHA512 744a60145243454a9d148971d998ae7a3cc5b9d66131b5d6f3c7be80d6c9ef8b8bf4390b9d1b90b14be6c619c2e1d14c7c6104b3ca6e606e22e3581b548e4f9d	
   HEAD_REF master
-)	
+)
 
 vcpkg_from_github(
   OUT_SOURCE_PATH PARSER_SOURCE_PATH
@@ -17,10 +21,10 @@ vcpkg_from_github(
 if(NOT EXISTS "${SOURCE_PATH}/addons/urdfreader/thirdparty/urdfparser/CMakeLists.txt")
     file(REMOVE_RECURSE "${SOURCE_PATH}/addons/urdfreader/thirdparty/urdfparser")
     file(RENAME "${PARSER_SOURCE_PATH}" "${SOURCE_PATH}/addons/urdfreader/thirdparty/urdfparser")
-endif()		
+endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DRBDL_BUILD_STATIC=${RBDL_STATIC}
         -DRBDL_BUILD_ADDON_LUAMODEL=ON
@@ -31,10 +35,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-# # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-# # Remove duplicated include directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rbdl-orb/portfile.cmake
+++ b/ports/rbdl-orb/portfile.cmake
@@ -1,4 +1,4 @@
-if (EXISTS ${CURRENT_INSTALLED_DIR}/share/rbdl/copyright)
+if (EXISTS "${CURRENT_INSTALLED_DIR}/share/rbdl/copyright")
     message(FATAL_ERROR "${PORT} conflict with rbdl, please remove rbdl before install ${PORT}.")
 endif()
 

--- a/ports/rbdl-orb/vcpkg.json
+++ b/ports/rbdl-orb/vcpkg.json
@@ -11,10 +11,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/rbdl-orb/vcpkg.json
+++ b/ports/rbdl-orb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rbdl-orb",
   "version": "3.0.0",
+  "port-version": 1,
   "description": "Rigid Body Dynamics Library - ORB",
   "homepage": "https://github.com/orb-hd/rbdl-orb",
   "dependencies": [

--- a/ports/rbdl/CONTROL
+++ b/ports/rbdl/CONTROL
@@ -1,6 +1,0 @@
-Source: rbdl
-Version: 2.6.0
-Port-Version: 0
-Homepage: https://github.com/rbdl/rbdl
-Description: Rigid Body Dynamics Library
-Build-Depends: eigen3

--- a/ports/rbdl/portfile.cmake
+++ b/ports/rbdl/portfile.cmake
@@ -1,8 +1,8 @@
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(RBDL_STATIC ON)
-else()
-    set(RBDL_STATIC OFF)
+if (EXISTS ${CURRENT_INSTALLED_DIR}/share/rbdl-orb/copyright)
+    message(FATAL_ERROR "${PORT} conflict with rbdl-orb, please remove rbdl-orb before install ${PORT}.")
 endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RBDL_STATIC)
 
 vcpkg_from_github(ARCHIVE
     OUT_SOURCE_PATH SOURCE_PATH
@@ -14,19 +14,16 @@ vcpkg_from_github(ARCHIVE
 )
 
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DRBDL_BUILD_STATIC=${RBDL_STATIC}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-# # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-# # Remove duplicated include directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rbdl/portfile.cmake
+++ b/ports/rbdl/portfile.cmake
@@ -1,4 +1,4 @@
-if (EXISTS ${CURRENT_INSTALLED_DIR}/share/rbdl-orb/copyright)
+if (EXISTS "${CURRENT_INSTALLED_DIR}/share/rbdl-orb/copyright")
     message(FATAL_ERROR "${PORT} conflict with rbdl-orb, please remove rbdl-orb before install ${PORT}.")
 endif()
 

--- a/ports/rbdl/vcpkg.json
+++ b/ports/rbdl/vcpkg.json
@@ -9,10 +9,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/rbdl/vcpkg.json
+++ b/ports/rbdl/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "rbdl",
+  "version": "2.6.0",
+  "port-version": 1,
+  "description": "Rigid Body Dynamics Library",
+  "homepage": "https://github.com/rbdl/rbdl",
+  "dependencies": [
+    "eigen3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1325,6 +1325,16 @@ rapidstring:x86-windows=fail
 raylib:arm64-windows=fail
 raylib:arm-uwp=fail
 raylib:x64-uwp=fail
+# file conflicts with rbdl
+rbdl-orb:x86-windows=skip
+rbdl-orb:x64-windows=skip
+rbdl-orb:x64-windows-static=skip
+rbdl-orb:x64-windows-static-md=skip
+rbdl-orb:x64-uwp=skip
+rbdl-orb:arm-uwp=skip
+rbdl-orb:arm64-windows=skip
+rbdl-orb:x64-linux=skip
+rbdl-orb:x64-osx=skip
 readline:arm-uwp=fail
 readline:x64-uwp=fail
 readline-win32:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5098,7 +5098,7 @@
     },
     "ptex": {
       "baseline": "2.3.2",
-      "port-version": 2
+      "port-version": 3
     },
     "pthread": {
       "baseline": "3.0.0",
@@ -5526,11 +5526,11 @@
     },
     "rbdl": {
       "baseline": "2.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rbdl-orb": {
       "baseline": "3.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "re2": {
       "baseline": "2020-10-01",

--- a/versions/p-/ptex.json
+++ b/versions/p-/ptex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c524a2ab1940315d3481e9fbf745425caf5b7c15",
+      "version": "2.3.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "e4ee03f1ba1d9c807b8baee1bd3b1089e71476ca",
       "version-string": "2.3.2",
       "port-version": 2

--- a/versions/r-/rbdl-orb.json
+++ b/versions/r-/rbdl-orb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28e61b5024e10a70c5f7aab4349958cf82adb05e",
+      "git-tree": "5850c6901f4123803184bfe9b6e587af9350331a",
       "version": "3.0.0",
       "port-version": 1
     },

--- a/versions/r-/rbdl-orb.json
+++ b/versions/r-/rbdl-orb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28e61b5024e10a70c5f7aab4349958cf82adb05e",
+      "version": "3.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d475aade9be86281a6db741ee68e30a23d0f16d3",
       "version": "3.0.0",
       "port-version": 0

--- a/versions/r-/rbdl.json
+++ b/versions/r-/rbdl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "15d77c914d87de185a94ed5e345be7416d00533a",
+      "git-tree": "44606d1a4e33112ca45274e823041ad877e62623",
       "version": "2.6.0",
       "port-version": 1
     },

--- a/versions/r-/rbdl.json
+++ b/versions/r-/rbdl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15d77c914d87de185a94ed5e345be7416d00533a",
+      "version": "2.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c2823f8341acd1e564485661989fb3780a6b4a2a",
       "version-string": "2.6.0",
       "port-version": 0


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/19369

Changes:
1. rbdl-orb and rbdl are conflicts, from https://github.com/ORB-HD/rbdl-orb, the two main differences to the original [rbdl](https://github.com/rbdl/rbdl) is that this version has error handling and uses polymorphism for constraints. It tends to be conflict, instead of depending on each other. 

2. ptex: Add DISABLE_PARALLEL_CONFIGURE to ptex to disable parallel.

Failures:
rbdl-orb:
```
The following files are already installed in D:/installed/x86-windows and are in conflict with rbdl-orb:x86-windows

Installed by rbdl:x86-windows
    debug/lib/pkgconfig/rbdl.pc
    debug/lib/rbdl.lib
    include/rbdl/Body.h
    include/rbdl/Constraints.h
    include/rbdl/Dynamics.h
    include/rbdl/Joint.h
    include/rbdl/Kinematics.h
    include/rbdl/Logging.h
    include/rbdl/Model.h
    include/rbdl/Quaternion.h
    include/rbdl/SpatialAlgebraOperators.h
    include/rbdl/compileassert.h
    include/rbdl/rbdl.h
    include/rbdl/rbdl_config.h
    include/rbdl/rbdl_eigenmath.h
    include/rbdl/rbdl_math.h
    include/rbdl/rbdl_mathutils.h
    include/rbdl/rbdl_utils.h
    lib/pkgconfig/rbdl.pc
    lib/rbdl.lib
```

ptex:
```
CMake Error at src/ptex/CMakeLists.txt:7 (configure_file):
  File exists
```
cc @ju6ge