### PR TITLE
[vcpkg] The FreeBSD spelling of x86-64 is amd64.

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -311,7 +311,9 @@ else()
                 cmake_policy(POP)
                 return()
             endif()
-        elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64")
+        elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
+               CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64" OR
+               CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
             set(Z_VCPKG_TARGET_TRIPLET_ARCH x64)
         elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "s390x")
             set(Z_VCPKG_TARGET_TRIPLET_ARCH s390x)


### PR DESCRIPTION
**Describe the pull request**

`CMAKE_HOST_SYSTEM_PROCESSOR` is set to amd64 on x86-64 FreeBSD systems. CMake's `STREQUAL` gives a case-sensitive comparison so this case was missed during bootstrapping when using vcpkg as a submodule.

- #### What does your PR fix?  

Bootstrapping via including the toolchain file on FreeBSD.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

x64-freebsd.  It may affect other community triplets where the system provides the same `uname -m` output as FreeBSD.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 
Yes, as far as I can tell.

