### PR TITLE
[value-ptr-lite] Fix usage

### DIFF
--- a/ports/value-ptr-lite/CONTROL
+++ b/ports/value-ptr-lite/CONTROL
@@ -1,7 +1,0 @@
-Source: value-ptr-lite
-Version: 0.2.1
-Homepage: https://github.com/martinmoene/value-ptr-lite
-Description: A C++ smart-pointer with value semantics for C++98, C++11 and later in a single-file header-only library. 
-
-Feature: test
-Description: Build with test

--- a/ports/value-ptr-lite/portfile.cmake
+++ b/ports/value-ptr-lite/portfile.cmake
@@ -7,24 +7,22 @@ vcpkg_from_github(
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    test BUILD_TESTS
+    FEATURES
+        test VALUE_PTR_LITE_OPT_BUILD_TESTS
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA 
-    OPTIONS
-        -DVALUE_PTR_LITE_OPT_BUILD_TESTS=${BUILD_TESTS}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
         -DVALUE_PTR_LITE_OPT_BUILD_EXAMPLES=OFF   
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/value_ptr-lite)
+vcpkg_cmake_config_fixup(PACKAGE_NAME value_ptr-lite CONFIG_PATH lib/cmake/value_ptr-lite)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/value-ptr-lite/vcpkg.json
+++ b/ports/value-ptr-lite/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "value-ptr-lite",
+  "version-semver": "0.2.1",
+  "description": "A C++ smart-pointer with value semantics for C++98, C++11 and later in a single-file header-only library.",
+  "homepage": "https://github.com/martinmoene/value-ptr-lite",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "test": {
+      "description": "Build and perform value_ptr-lite tests."
+    }
+  }
+}

--- a/ports/value-ptr-lite/vcpkg.json
+++ b/ports/value-ptr-lite/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "value-ptr-lite",
   "version-semver": "0.2.1",
+  "port-version": 1,
   "description": "A C++ smart-pointer with value semantics for C++98, C++11 and later in a single-file header-only library.",
   "homepage": "https://github.com/martinmoene/value-ptr-lite",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6586,7 +6586,7 @@
     },
     "value-ptr-lite": {
       "baseline": "0.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "vamp-sdk": {
       "baseline": "2.9",

--- a/versions/v-/value-ptr-lite.json
+++ b/versions/v-/value-ptr-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69db499989a256cd9ce0397cb16814c6444b4877",
+      "version-semver": "0.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "c678a31c0e75e1cf5b53dc2f6ed0eecc156d9133",
       "version-string": "0.2.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #19448

Fix package name in usage.

Now the usage is like this:

```
    find_package(value_ptr-lite CONFIG REQUIRED)
    target_link_libraries(main PRIVATE nonstd::value_ptr-lite)
```

Note: Feature `test `has passed with the following triplets:

- x86-windows
- x64-windows
- x64-windows-static