### PR TITLE
[rtmidi] Fix fatal error C1083: Cannot open include file: jack/jack.h

### DIFF
--- a/ports/rtmidi/CONTROL
+++ b/ports/rtmidi/CONTROL
@@ -1,6 +1,0 @@
-Source: rtmidi
-Version: 4.0.0
-Port-Version: 2
-Homepage: https://github.com/thestk/rtmidi
-Description: A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)
-Supports: !uwp

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -17,8 +17,8 @@ vcpkg_from_github(
 vcpkg_configure_cmake(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
-  OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
   OPTIONS -DRTMIDI_API_ALSA=OFF
+  OPTIONS -DRTMIDI_API_JACK=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -15,15 +15,16 @@ vcpkg_from_github(
 )
 
 vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
-  OPTIONS -DRTMIDI_API_ALSA=OFF
-  OPTIONS -DRTMIDI_API_JACK=OFF
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DRTMIDI_API_ALSA=OFF
+        -DRTMIDI_API_JACK=OFF
 )
 
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/README.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "rtmidi",
+  "version": "4.0.0",
+  "port-version": 3,
+  "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
+  "homepage": "https://github.com/thestk/rtmidi",
+  "supports": "!uwp"
+}

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rtmidi",
-  "version": "4.0.0",
+  "version-semver": "4.0.0",
   "port-version": 3,
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5666,7 +5666,7 @@
     },
     "rtmidi": {
       "baseline": "4.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "rttr": {
       "baseline": "0.9.6-2",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "12c60dcfde7e2b6817daaead3016f4ddb4a08334",
-      "version": "4.0.0",
+      "git-tree": "4c13583da321fa3efa7a075032d0ed880dd15e48",
+      "version-semver": "4.0.0",
       "port-version": 3
     },
     {

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12c60dcfde7e2b6817daaead3016f4ddb4a08334",
+      "version": "4.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "65614f322a89cff92478b3f6736d287653085a34",
       "version-string": "4.0.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  In the latest CI testing, rtmidi installation failed with fatal error C1083: Cannot open include file: jack/jack.h, this issue only occurs when the port: jack2 installed before rtmidi.
Since jack2 is not a dependency of rtmidi, I currently add OPTIONS -DRTMIDI_API_JACK=OFF to the portfile.cmake file to solve this error. 

  Delete unused option: DISABLE_INSTALL_HEADERS.


No feature need to be tested.