### PR TITLE
[librsvg] Remove debug postfix

### DIFF
--- a/ports/librsvg/CMakeLists.txt
+++ b/ports/librsvg/CMakeLists.txt
@@ -86,8 +86,6 @@ else()
     list(APPEND LIBRSVG_SOURCES rsvg.symbols)
 endif()
 
-set(CMAKE_DEBUG_POSTFIX "d")
-
 add_library(rsvg-2.40 ${LIBRSVG_SOURCES})
 add_library(pixbufloader-svg ${PIXBUFLOADERSVG_SOURCES})
 
@@ -130,8 +128,8 @@ install(
 )
 
 install(FILES
-	rsvg.h
-	rsvg-cairo.h
+    rsvg.h
+    rsvg-cairo.h
     librsvg-features.h
     librsvg-enum-types.h
     DESTINATION include/librsvg

--- a/ports/librsvg/portfile.cmake
+++ b/ports/librsvg/portfile.cmake
@@ -11,25 +11,23 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.linux ${SOURCE_PATH}/config.h.linux COPYONLY)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+configure_file("${CMAKE_CURRENT_LIST_DIR}/config.h.linux" "${SOURCE_PATH}/config.h.linux" COPYONLY)
 
 vcpkg_find_acquire_program(PKGCONFIG)
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE 
-    PREFER_NINJA
     OPTIONS
         -DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-librsvg TARGET_PATH share/unofficial-librsvg)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-librsvg CONFIG_PATH share/unofficial-librsvg)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/librsvg/vcpkg.json
+++ b/ports/librsvg/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "librsvg",
   "version": "2.40.20",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "dependencies": [
     "cairo",
     "gdk-pixbuf",
     "libcroco",
-    "pango"
+    "pango",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3562,7 +3562,7 @@
     },
     "librsvg": {
       "baseline": "2.40.20",
-      "port-version": 4
+      "port-version": 5
     },
     "librsync": {
       "baseline": "2020-09-16",

--- a/versions/l-/librsvg.json
+++ b/versions/l-/librsvg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1c471322f23a090a973337e83f0d9743adc549d",
+      "version": "2.40.20",
+      "port-version": 5
+    },
+    {
       "git-tree": "0a02c4941810ea725b6686e203ae81deb257e24c",
       "version": "2.40.20",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/19416

Remove the debug postfix 'd' since it breaks the [policy](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md#do-not-rename-binaries-outside-the-names-given-by-upstream). The [Upstream](https://gitlab.gnome.org/GNOME/librsvg/-/blob/librsvg-2.40/build/win32/vs10/rsvg-install.propsin#L22) looks not has the postfix 'd' in debug configuration.