### PR TITLE
[c-ares] Update to 1.17.2.

### DIFF
--- a/ports/c-ares/portfile.cmake
+++ b/ports/c-ares/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO c-ares/c-ares
-    REF cares-1_17_1
-    SHA512 e2a2a40118b128755571274d0cfe7cc822bc18392616378c6dd5f73f210571d7e5005a40ba0763658bdae7f2c7aadb324b2888ad8b4dcb54ad47dfaf97c2ebfc
+    REF cares-1_17_2
+    SHA512 1111f1e7eeb0e5d9e70d1a7c8566145d0a5e6e71b020f3fcaa02ecdf1931553ddeff83fdc152a1f9c5a780078e8afe3670164b631df56eecd2b638210cc59bb3
     HEAD_REF master
 )
 

--- a/ports/c-ares/vcpkg.json
+++ b/ports/c-ares/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "c-ares",
-  "version": "1.17.1",
-  "port-version": 2,
+  "version": "1.17.2",
   "description": "A C library for asynchronous DNS requests",
   "homepage": "https://github.com/c-ares/c-ares",
   "supports": "!uwp"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1101,8 +1101,8 @@
       "port-version": 2
     },
     "c-ares": {
-      "baseline": "1.17.1",
-      "port-version": 2
+      "baseline": "1.17.2",
+      "port-version": 0
     },
     "c4core": {
       "baseline": "2021-07-18",

--- a/versions/c-/c-ares.json
+++ b/versions/c-/c-ares.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a8a471e681a33c8dde0a209900ac24a2e8e7f72",
+      "version": "1.17.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "5d48aae0b9e4a0e201eab417117bab9491665193",
       "version": "1.17.1",
       "port-version": 2


### PR DESCRIPTION
Version 1.17.2 fixes CVE-2021-3672. Details can be found in the security
advisory at https://c-ares.haxx.se/adv_20210810.html

**Describe the pull request**

- #### What does your PR fix?  
  Fixes CVE-2021-3672

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  !uwp, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
