### PR TITLE
[icu] Fix removing tests with alternative lib dir name

### DIFF
--- a/ports/icu/portfile.cmake
+++ b/ports/icu/portfile.cmake
@@ -150,11 +150,13 @@ file(REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/share
     ${CURRENT_PACKAGES_DIR}/debug/share
     ${CURRENT_PACKAGES_DIR}/lib/icu
+    ${CURRENT_PACKAGES_DIR}/lib64/icu
     ${CURRENT_PACKAGES_DIR}/debug/lib/icu
     ${CURRENT_PACKAGES_DIR}/debug/lib/icud)
 
 file(GLOB TEST_LIBS
     ${CURRENT_PACKAGES_DIR}/lib/*test*
+    ${CURRENT_PACKAGES_DIR}/lib64/*test*
     ${CURRENT_PACKAGES_DIR}/debug/lib/*test*)
 file(REMOVE ${TEST_LIBS})
 


### PR DESCRIPTION
On some Linux distros (e.g. OpenSUSE) lib64 is used instead of lib for
libraries.

Take that into account when removing the tests, otherwise the tests are
not removed and the file(REMOVE) call fails because the variable is
empty