### PR TITLE
[google-cloud-cpp] update to latest release (v1.30.1)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.30.0
-    SHA512 4609bd1240ed88d7f4d7b1685f96fdbfffa0f8a296f24fa69984d14351671bfa7c283975978b1c41b816ed5cb181da0166bc5f9377d362331e2de42b66f1d1ae
+    REF v1.30.1
+    SHA512 2a49c92eae39e2389bb8c765c2aa9374ae38a64f8f19a7744887d2176dc846017d8bc78c0391c55654765aaeff11bb1f3ea7e904d1e7b16580941ab74585e8bc
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2377,7 +2377,7 @@
       "port-version": 6
     },
     "google-cloud-cpp": {
-      "baseline": "1.30.0",
+      "baseline": "1.30.1",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "254b48f7254b7ab5b4ac6676ccd3149274f154f0",
+      "version": "1.30.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "4cc90bac3e6db351ea0daa3de00a32947c3b2050",
       "version": "1.30.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` port to the latest release (v1.30.1)

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
