### PR TITLE
[lua] Add error message to feature `cpp` when building uwp

### DIFF
--- a/ports/lua/portfile.cmake
+++ b/ports/lua/portfile.cmake
@@ -16,6 +16,9 @@ file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 # Used in cmake wrapper
 set(ENABLE_LUA_CPP 0)
 if ("cpp" IN_LIST FEATURES)
+    if (VCPKG_TARGET_IS_UWP)
+        message(FATAL_ERROR "Feature cpp does not support uwp.")
+    endif()
     set(ENABLE_LUA_CPP 1)
 endif()
 

--- a/ports/lua/vcpkg.json
+++ b/ports/lua/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lua",
   "version-semver": "5.4.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A powerful, fast, lightweight, embeddable scripting language",
   "homepage": "https://www.lua.org",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3890,7 +3890,7 @@
     },
     "lua": {
       "baseline": "5.4.3",
-      "port-version": 2
+      "port-version": 3
     },
     "luabridge": {
       "baseline": "2.6",

--- a/versions/l-/lua.json
+++ b/versions/l-/lua.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a9a787a9369019f1dd867cc1c1d6c10296441d9",
+      "version-semver": "5.4.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "3be47dc8a0f0e6497caac10e26e2eaf8866b2990",
       "version-semver": "5.4.3",
       "port-version": 2


### PR DESCRIPTION
When building `lua[cpp]:x64-uwp`:
```
     4>C:\dev\vcpkg\buildtrees\lua\src\lua-5-60afff5bd1.clean\src\lgc.c(720,19): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) [C:\dev\vcpkg\buildtrees\lua\x64-uwp-dbg\lua.vcxproj]
     4>C:\dev\vcpkg\buildtrees\lua\src\lua-5-60afff5bd1.clean\src\lgc.c(739,23): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) [C:\dev\vcpkg\buildtrees\lua\x64-uwp-dbg\lua.vcxproj]
     4>C:\dev\vcpkg\buildtrees\lua\src\lua-5-60afff5bd1.clean\src\liolib.c(286,29): error C3861: '_pclose': identifier not found [C:\dev\vcpkg\buildtrees\lua\x64-uwp-dbg\lua.vcxproj]
         lstate.c
         lstring.c
     4>C:\dev\vcpkg\buildtrees\lua\src\lua-5-60afff5bd1.clean\src\liolib.c(295,10): error C3861: '_popen': identifier not found [C:\dev\vcpkg\buildtrees\lua\x64-uwp-dbg\lua.vcxproj]
```

According to [msdn docs](https://docs.microsoft.com/en-us/cpp/cppcx/crt-functions-not-supported-in-universal-windows-platform-apps?view=msvc-160):
_pclose _pipe _popen _wpopen | Pipe functionality is not available to UWP apps. | No workaround.
-- | -- | --

So it's by design. Add error message to feature `cpp` when building uwp.

Fixes #19449.