### PR TITLE
[boost-multiprecision] Add missing dependency

### DIFF
--- a/ports/boost-multiprecision/vcpkg.json
+++ b/ports/boost-multiprecision/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-multiprecision",
   "version": "1.76.0",
+  "port-version": 1,
   "description": "Boost multiprecision module",
   "homepage": "https://github.com/boostorg/multiprecision",
   "dependencies": [
@@ -12,6 +13,7 @@
     "boost-functional",
     "boost-integer",
     "boost-lexical-cast",
+    "boost-math",
     "boost-predef",
     "boost-rational",
     "boost-throw-exception",

--- a/versions/b-/boost-multiprecision.json
+++ b/versions/b-/boost-multiprecision.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2190d2603af80c39dad9649c462876e984e889bf",
+      "version": "1.76.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "55ee6b85fe02f7875374cb3f78a427365ba7beb5",
       "version": "1.76.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -778,7 +778,7 @@
     },
     "boost-multiprecision": {
       "baseline": "1.76.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-nowide": {
       "baseline": "1.76.0",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/19506

boost-multiprecision depends on boost-math. 
See https://github.com/boostorg/multiprecision/blob/develop/CMakeLists.txt