### PR TITLE
[ogre] Fix include path in usage

### DIFF
--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -21,31 +21,27 @@ vcpkg_from_github(
 
 file(REMOVE "${SOURCE_PATH}/CMake/Packages/FindOpenEXR.cmake")
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    set(OGRE_STATIC ON)
-else()
-    set(OGRE_STATIC OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" OGRE_STATIC)
 
 # Configure features
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    d3d9     OGRE_BUILD_RENDERSYSTEM_D3D9
-    java     OGRE_BUILD_COMPONENT_JAVA
-    python   OGRE_BUILD_COMPONENT_PYTHON
-    csharp   OGRE_BUILD_COMPONENT_CSHARP        
-    overlay  OGRE_BUILD_COMPONENT_OVERLAY
-    zziplib  OGRE_CONFIG_ENABLE_ZIP
-    strict   OGRE_RESOURCEMANAGER_STRICT
+    FEATURES
+        d3d9     OGRE_BUILD_RENDERSYSTEM_D3D9
+        java     OGRE_BUILD_COMPONENT_JAVA
+        python   OGRE_BUILD_COMPONENT_PYTHON
+        csharp   OGRE_BUILD_COMPONENT_CSHARP        
+        overlay  OGRE_BUILD_COMPONENT_OVERLAY
+        zziplib  OGRE_CONFIG_ENABLE_ZIP
+        strict   OGRE_RESOURCEMANAGER_STRICT
 )
 
 # OGRE_RESOURCEMANAGER_STRICT need to be 0 for OFF and 1 for ON, because it is used 'as is' in sources
 string(REPLACE "OGRE_RESOURCEMANAGER_STRICT=ON" "OGRE_RESOURCEMANAGER_STRICT=1" FEATURE_OPTIONS "${FEATURE_OPTIONS}")
 string(REPLACE "OGRE_RESOURCEMANAGER_STRICT=OFF" "OGRE_RESOURCEMANAGER_STRICT=0" FEATURE_OPTIONS "${FEATURE_OPTIONS}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DOGRE_BUILD_DEPENDENCIES=OFF
         -DOGRE_BUILD_SAMPLES=OFF
@@ -65,7 +61,6 @@ vcpkg_configure_cmake(
         -DOGRE_BUILD_RENDERSYSTEM_D3D11=ON
         -DOGRE_BUILD_RENDERSYSTEM_GL=ON
         -DOGRE_BUILD_RENDERSYSTEM_GL3PLUS=ON
-        -DOGRE_BUILD_RENDERSYSTEM_GLES=OFF
         -DOGRE_BUILD_RENDERSYSTEM_GLES2=OFF
         -DFREETYPE_FOUND=ON
 # Optional stuff
@@ -74,49 +69,49 @@ vcpkg_configure_cmake(
         -DOGRE_CMAKE_DIR=share/ogre
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(GLOB REL_CFGS ${CURRENT_PACKAGES_DIR}/bin/*.cfg)
+file(GLOB REL_CFGS "${CURRENT_PACKAGES_DIR}/bin/*.cfg")
 if(REL_CFGS)
-  file(COPY ${REL_CFGS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+  file(COPY ${REL_CFGS} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
   file(REMOVE ${REL_CFGS})
 endif()
 
-file(GLOB DBG_CFGS ${CURRENT_PACKAGES_DIR}/debug/bin/*.cfg)
+file(GLOB DBG_CFGS "${CURRENT_PACKAGES_DIR}/debug/bin/*.cfg")
 if(DBG_CFGS)
-  file(COPY ${DBG_CFGS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+  file(COPY ${DBG_CFGS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
   file(REMOVE ${DBG_CFGS})
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 #Remove OgreMain*.lib from lib/ folder, because autolink would complain, since it defines a main symbol
 #manual-link subfolder is here to the rescue!
 if(VCPKG_TARGET_IS_WINDOWS)
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Release")
-        file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/lib/manual-link)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/manual-link")
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-            file(RENAME ${CURRENT_PACKAGES_DIR}/lib/OgreMain.lib ${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMain.lib)
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/OgreMain.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMain.lib")
         else()
-            file(RENAME ${CURRENT_PACKAGES_DIR}/lib/OgreMainStatic.lib ${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMainStatic.lib)
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/OgreMainStatic.lib" "${CURRENT_PACKAGES_DIR}/lib/manual-link/OgreMainStatic.lib")
         endif()
     endif()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "Debug")
-        file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link")
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-            file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/OgreMain_d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMain_d.lib)
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/OgreMain_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMain_d.lib")
         else()
-            file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/OgreMainStatic_d.lib ${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib)
+            file("RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/OgreMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib")
         endif()
     endif()
 
-    file(GLOB SHARE_FILES ${CURRENT_PACKAGES_DIR}/share/ogre/*.cmake)
+    file(GLOB SHARE_FILES "${CURRENT_PACKAGES_DIR}/share/ogre/*.cmake")
     foreach(SHARE_FILE ${SHARE_FILES})
         file(READ "${SHARE_FILE}" _contents)
         string(REPLACE "lib/OgreMain" "lib/manual-link/OgreMain" _contents "${_contents}")
@@ -124,7 +119,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endforeach()
 endif()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/OGRE/Bites/OgreSGTechniqueResolverListener.h" "OgreRTShaderSystem.h" "../RTShaderSystem/OgreRTShaderSystem.h")
+
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/ogre/portfile.cmake
+++ b/ports/ogre/portfile.cmake
@@ -107,7 +107,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
             file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/OgreMain_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMain_d.lib")
         else()
-            file("RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/OgreMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/OgreMainStatic_d.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/manual-link/OgreMainStatic_d.lib")
         endif()
     endif()
 

--- a/ports/ogre/vcpkg.json
+++ b/ports/ogre/vcpkg.json
@@ -1,12 +1,20 @@
 {
   "name": "ogre",
-  "version-string": "1.12.9",
-  "port-version": 5,
+  "version-semver": "1.12.9",
+  "port-version": 6,
   "description": "3D Object-Oriented Graphics Rendering Engine",
   "homepage": "https://github.com/OGRECave/ogre",
   "dependencies": [
     "pugixml",
     "sdl2",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4546,7 +4546,7 @@
     },
     "ogre": {
       "baseline": "1.12.9",
-      "port-version": 5
+      "port-version": 6
     },
     "ogre-next": {
       "baseline": "2019-10-20-1",

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "19babe49543ff790585bbc026326fe05446f9ea7",
+      "version-semver": "1.12.9",
+      "port-version": 6
+    },
+    {
       "git-tree": "322b9a5290ce1656aa66b684b07d1e327b18eeeb",
       "version-string": "1.12.9",
       "port-version": 5

--- a/versions/o-/ogre.json
+++ b/versions/o-/ogre.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "19babe49543ff790585bbc026326fe05446f9ea7",
+      "git-tree": "9c35ef4f5b30d305e6a128f9531692a64eae1b4a",
       "version-semver": "1.12.9",
       "port-version": 6
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #15333

   Replace #include "OgreRTShaderSystem.h" as #include "../RTShaderSystem/OgreRTShaderSystem.h" in ../Bites/OgreSGTechniqueResolverListener.h file.

Note: No need to test features.