### PR TITLE
[immer] update port

### DIFF
--- a/ports/immer/CONTROL
+++ b/ports/immer/CONTROL
@@ -1,3 +1,0 @@
-Source: immer
-Version: 2019-06-07
-Description: Postmodern immutable and persistent data structures for C++

--- a/ports/immer/portfile.cmake
+++ b/ports/immer/portfile.cmake
@@ -13,9 +13,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "docs"  immer_BUILD_DOCS
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DENABLE_PYTHON=OFF
         -DENABLE_GUILE=OFF

--- a/ports/immer/portfile.cmake
+++ b/ports/immer/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Immer)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")

--- a/ports/immer/portfile.cmake
+++ b/ports/immer/portfile.cmake
@@ -31,4 +31,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Immer)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/immer/portfile.cmake
+++ b/ports/immer/portfile.cmake
@@ -3,9 +3,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO arximboldi/immer
-    REF fe1d5151f8e62a97a953664f8de39b05ac0d2031
-    SHA512 2f78c2d85a24b2bcb69bbbf8b038c8bacb5a841e0f0ce7e4e521d369423c7d44f803a1c766a77d0955246a1b22476de15fa708a3786f05c41a3b705a574bbb71
+    REF a11df7243cb516a1aeffc83c31366d7259c79e82
+    SHA512 7aefa894d57167e8606ffd20c78490731885da610da084ffdc4ee677e40c7a3b4edcd0fbf74e354fc68866d09ec7a35a7c549f78ce91f2f1a84bb6ccc605e135
     HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "docs"  immer_BUILD_DOCS
 )
 
 vcpkg_configure_cmake(
@@ -15,13 +20,16 @@ vcpkg_configure_cmake(
         -DENABLE_PYTHON=OFF
         -DENABLE_GUILE=OFF
         -DENABLE_BOOST_COROUTINE=OFF
+        -Dimmer_BUILD_TESTS=OFF
+        -Dimmer_BUILD_EXAMPLES=OFF
+        -Dimmer_BUILD_EXTRAS=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Immer)
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Immer)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/immer/vcpkg.json
+++ b/ports/immer/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "immer",
   "version-string": "2021-05-03",
-  "port-version": 2,
   "description": "Postmodern immutable and persistent data structures for C++",
   "homepage": "https://sinusoid.es/immer/",
   "dependencies": [

--- a/ports/immer/vcpkg.json
+++ b/ports/immer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "immer",
-  "version-string": "2021-05-03",
+  "version-date": "2021-05-03",
   "description": "Postmodern immutable and persistent data structures for C++",
   "homepage": "https://sinusoid.es/immer/",
   "dependencies": [

--- a/ports/immer/vcpkg.json
+++ b/ports/immer/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "immer",
+  "version-string": "2021-05-03",
+  "port-version": 2,
+  "description": "Postmodern immutable and persistent data structures for C++",
+  "homepage": "https://sinusoid.es/immer/",
+  "dependencies": [
+    "vcpkg-cmake-config"
+  ],
+  "features": {
+    "docs": {
+      "description": "Build documentation"
+    }
+  }
+}

--- a/ports/immer/vcpkg.json
+++ b/ports/immer/vcpkg.json
@@ -5,7 +5,14 @@
   "description": "Postmodern immutable and persistent data structures for C++",
   "homepage": "https://sinusoid.es/immer/",
   "dependencies": [
-    "vcpkg-cmake-config"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "docs": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2694,7 +2694,7 @@
     },
     "immer": {
       "baseline": "2021-05-03",
-      "port-version": 2
+      "port-version": 0
     },
     "implot": {
       "baseline": "0.11",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2693,8 +2693,8 @@
       "port-version": 0
     },
     "immer": {
-      "baseline": "2019-06-07",
-      "port-version": 0
+      "baseline": "2021-05-03",
+      "port-version": 2
     },
     "implot": {
       "baseline": "0.11",

--- a/versions/i-/immer.json
+++ b/versions/i-/immer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "109831691a62c81c985e8652aa7e1f073d776660",
+      "version-string": "2021-05-03",
+      "port-version": 2
+    },
+    {
       "git-tree": "515103042c70e0f9cf8d1518816d09fc6110a669",
       "version-string": "2019-06-07",
       "port-version": 0

--- a/versions/i-/immer.json
+++ b/versions/i-/immer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ee78459721140ead0ace0a031bbb9d28039b19e",
+      "version-date": "2021-05-03",
+      "port-version": 0
+    },
+    {
       "git-tree": "109831691a62c81c985e8652aa7e1f073d776660",
       "version-string": "2021-05-03",
       "port-version": 2

--- a/versions/i-/immer.json
+++ b/versions/i-/immer.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "109831691a62c81c985e8652aa7e1f073d776660",
-      "version-string": "2021-05-03",
-      "port-version": 2
-    },
-    {
       "git-tree": "515103042c70e0f9cf8d1518816d09fc6110a669",
       "version-string": "2019-06-07",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Immer port was previously out of date.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  I have tested `x86-linux`, and there appears to be no incompatible triplets.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
