### PR TITLE
[lcms] Update to 2.12

### DIFF
--- a/ports/lcms/CMakeLists.txt
+++ b/ports/lcms/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 
 option(CMAKE_VERBOSE_MAKEFILE "Create verbose makefile" OFF)
-option(BUILD_SHARED_LIBS "Create lcms as a shared library" ON)
+option(BUILD_SHARED_LIBS "Create lcms2 as a shared library" ON)
 
 project(little-cms)
 
 set(CMAKE_DEBUG_POSTFIX d)
 
-add_library(lcms
+add_library(lcms2
     "${CMAKE_CURRENT_LIST_DIR}/src/cmstypes.c"
     "${CMAKE_CURRENT_LIST_DIR}/src/cmsvirt.c"
     "${CMAKE_CURRENT_LIST_DIR}/src/cmswtpnt.c"
@@ -39,15 +39,33 @@ add_library(lcms
 )
 
 if(BUILD_SHARED_LIBS)
-    target_compile_options(lcms PRIVATE -DCMS_DLL_BUILD)
-    target_compile_options(lcms PUBLIC -DCMS_DLL)
+    target_compile_options(lcms2 PRIVATE -DCMS_DLL_BUILD)
+    target_compile_options(lcms2 PUBLIC -DCMS_DLL)
 endif()
-target_compile_options(lcms PRIVATE -DUNICODE -D_UNICODE)
+target_compile_options(lcms2 PRIVATE -DUNICODE -D_UNICODE)
 
-target_include_directories(lcms PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include")
-set_target_properties(lcms PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_LIST_DIR}/include/lcms2.h;${CMAKE_CURRENT_LIST_DIR}/include/lcms2_plugin.h")
+target_include_directories(lcms2 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include")
+set_target_properties(lcms2 PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_LIST_DIR}/include/lcms2.h;${CMAKE_CURRENT_LIST_DIR}/include/lcms2_plugin.h")
 
-install(TARGETS lcms
+# Generate pkg-config file
+SET(PACKAGE "lcms2")
+# Read VERSION from file configure
+file(READ "${CMAKE_CURRENT_LIST_DIR}/configure" lcms2_configure)
+string(REGEX MATCH "PACKAGE_VERSION='(([0-9]+)\\.([0-9]+))'" _ ${lcms2_configure})
+set(VERSION "${CMAKE_MATCH_1}")
+SET(prefix "${CMAKE_INSTALL_PREFIX}")
+SET(exec_prefix "\${prefix}")
+SET(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+SET(includedir "\${prefix}/include")
+CONFIGURE_FILE(lcms2.pc.in "${PROJECT_BINARY_DIR}/lcms2.pc" @ONLY)
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    # Add CMAKE_DEBUG_POSTFIX
+    file(READ "${PROJECT_BINARY_DIR}/lcms2.pc" LCMS2_PC)
+    string(REPLACE "-llcms2" "-llcms2${CMAKE_DEBUG_POSTFIX}" LCMS2_PC "${LCMS2_PC}")
+    file(WRITE "${PROJECT_BINARY_DIR}/lcms2.pc" "${LCMS2_PC}") 
+ENDIF()
+
+install(TARGETS lcms2
     EXPORT lcmsConfig
     RUNTIME DESTINATION "bin"
     LIBRARY DESTINATION "lib"
@@ -56,12 +74,14 @@ install(TARGETS lcms
     COMPONENT dev
 )
 
-export(TARGETS lcms
-    NAMESPACE lcms::
+INSTALL(FILES ${PROJECT_BINARY_DIR}/lcms2.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+export(TARGETS lcms2
+    NAMESPACE lcms2::
     FILE "share/lcms/lcmsConfig.cmake"
 )
 
 install(EXPORT lcmsConfig
     DESTINATION "share/lcms"
-    NAMESPACE lcms::
+    NAMESPACE lcms2::
 )

--- a/ports/lcms/CONTROL
+++ b/ports/lcms/CONTROL
@@ -1,4 +1,4 @@
 Source: lcms
-Version: 2.11
+Version: 2.12
 Homepage: https://github.com/mm2/Little-CMS
 Description: Little CMS.

--- a/ports/lcms/portfile.cmake
+++ b/ports/lcms/portfile.cmake
@@ -5,15 +5,15 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mm2/Little-CMS
-    REF 17eb080324a9f16e0e7ab37bbcda7ae42b946294 # 2.11
-    SHA512 e8112bc4868448770d3ca33fc5aef5ef83cae59e907675b861931719a6a043df76a1ce72ac945111ce966698be96117388eb4770697797d93d75726b23a490ad
+    REF 924a020d09bfe468c665467caf24aadeb41ff77c # 2.12
+    SHA512 0c2dc069878ca38a92af4800aa3fb2660203fbcdf6dccd9db60cfacb6896185e3e9222893f39ec3e132b0f4900a2932d490dd8db5b1b431519966a64d28404d2
     HEAD_REF master
     PATCHES
         remove_library_directive.patch
         ${ADDITIONAL_PATCH}
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -23,6 +23,7 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/lcms RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3061,7 +3061,7 @@
       "port-version": 2
     },
     "lcms": {
-      "baseline": "2.11",
+      "baseline": "2.12",
       "port-version": 0
     },
     "leaf": {

--- a/versions/l-/lcms.json
+++ b/versions/l-/lcms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0020f124dcd6fa36e8ab5edad1efc85c59c51a56",
+      "version-string": "2.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "87ed3cf04e19a238f357a256419016aa49f88eb4",
       "version-string": "2.11",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
In addition to updating the version to 2.12, the following
modifications were applied to the port:
  - Use the name `lcms2` for the library, as it is called upstream since
  version 2 of Little-CMS.
  Remark: In the past, the library has already been called `lcms2` for
  a while in vcpkg (1e53c60 until 726c111).
  The ports in vcpkg, which currently require the port lcms
  (devil, libraw and opencolorio), use and support lcms2 include/lib.
  - Add generating a `pkg-config` file
  - Add quotes to file commands in portfile.cmake

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
