### PR TITLE
Skip embree2 in CI for static triplets due to conflicts. 

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -262,6 +262,10 @@ ecsutil:x64-osx=fail
 ecsutil:x64-uwp=fail
 # Checks for gnu extension so only works with gcc.
 elfutils:x64-osx=fail
+# embree creates common conflicting static library names when built in static mode, reported upstream:
+# https://github.com/embree/embree/issues/331
+embree2:x64-windows-static=skip
+embree2:x64-windows-static-md=skip
 enet:arm-uwp=fail
 enet:x64-uwp=fail
 epsilon:arm-uwp=fail


### PR DESCRIPTION
Common name problem reported upstream as https://github.com/embree/embree/issues/331

```
Starting package 3/3: embree3:x64-windows-static
Building package embree3[avx,avx2,core,sse2,sse42]:x64-windows-static...
-- Using C:/Dev/vcpkg/downloads/embree-embree-v3.12.2.tar.gz
-- Extracting source C:/Dev/vcpkg/downloads/embree-embree-v3.12.2.tar.gz
-- Applying patch fix-path.patch
-- Applying patch fix-static-usage.patch
-- Applying patch cmake_policy.patch
-- Applying patch fix-targets-file-not-found.patch
-- Using source at C:/Dev/vcpkg/buildtrees/embree3/src/v3.12.2-cbae4ce8b1.clean
-- Found external ninja('1.10.2').
-- Configuring x64-windows-static-dbg
-- Configuring x64-windows-static-rel
-- Building x64-windows-static-dbg
-- Building x64-windows-static-rel
-- Installing: C:/Dev/vcpkg/packages/embree3_x64-windows-static/share/embree3/copyright
-- Performing post-build validation
-- Performing post-build validation done
Building package embree3[avx,avx2,core,sse2,sse42]:x64-windows-static... done
Installing package embree3[avx,avx2,core,sse2,sse42]:x64-windows-static...
The following files are already installed in C:/Dev/vcpkg/installed/x64-windows-static and are in conflict with embree3:x64-windows-static

Installed by embree2:x64-windows-static
    debug/lib/embree_avx.lib
    debug/lib/embree_avx2.lib
    debug/lib/embree_sse42.lib
    debug/lib/lexers.lib
    debug/lib/math.lib
    debug/lib/simd.lib
    debug/lib/sys.lib
    debug/lib/tasking.lib
    lib/embree_avx.lib
    lib/embree_avx2.lib
    lib/embree_sse42.lib
    lib/lexers.lib
    lib/math.lib
    lib/simd.lib
    lib/sys.lib
    lib/tasking.lib

Please ensure you're using the latest portfiles with `.\vcpkg update`, then
submit an issue at https://github.com/Microsoft/vcpkg/issues including:
  Package: embree3:x64-windows-static
  Vcpkg version: 2021-08-12-85ab112d5ee102bc6eac8cdbbfdd173a71374e04

Additionally, attach any relevant sections from the log files above.
```
