### PR TITLE
[vamp-sdk] update to 2.10; switch download URL to GitHub; fix path of installed headers

### DIFF
--- a/ports/vamp-sdk/CMakeLists.txt
+++ b/ports/vamp-sdk/CMakeLists.txt
@@ -85,21 +85,21 @@ install(
 if(NOT DISABLE_INSTALL_HEADERS)
   install(
     DIRECTORY vamp-hostsdk/
-    DESTINATION include/vamp-sdk/vamp-hostsdk
+    DESTINATION include/vamp-hostsdk
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*_priv.h" EXCLUDE
     PATTERN "config.h" EXCLUDE)
   install(
     DIRECTORY vamp-sdk/
-    DESTINATION include/vamp-sdk/vamp-sdk
+    DESTINATION include/vamp-sdk
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*_priv.h" EXCLUDE
     PATTERN "config.h" EXCLUDE)
   install(
     DIRECTORY vamp/
-    DESTINATION include/vamp-sdk/vamp
+    DESTINATION include/vamp
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "*_priv.h" EXCLUDE

--- a/ports/vamp-sdk/portfile.cmake
+++ b/ports/vamp-sdk/portfile.cmake
@@ -1,12 +1,8 @@
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://code.soundsoftware.ac.uk/attachments/download/2589/vamp-plugin-sdk-2.9.0.zip"
-    FILENAME "vamp-plugin-sdk-2.9.0.zip"
-    SHA512 38222f074c17ba420fcc1ad6639048c8f282b892a4baf4257481d7f65f2b5a62685d8bc8e9cbbb5b77063a92f33dc3d2f138ea9b21c475ae1c456146056720ed
-)
-
-vcpkg_extract_source_archive_ex(
+vcpkg_from_github(
+    REPO c4dm/vamp-plugin-sdk
+    REF vamp-plugin-sdk-v2.10
+    SHA512 67a71e5396eab5ce9503e9111b4cfc16fc9755cf6ae2d8dfc99ed29fd91e75eaf0de9a9c55ce8f7751f04c235eb86430856eff18f02adde54f1850a87c917ef0
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "vamp-sdk",
-  "version": "2.9",
+  "version": "2.10",
   "description": "Library for VAMP plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6597,7 +6597,7 @@
       "port-version": 1
     },
     "vamp-sdk": {
-      "baseline": "2.9",
+      "baseline": "2.10",
       "port-version": 0
     },
     "variant-lite": {

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4046790dc82dda4733e99e83eb9df06275073588",
+      "git-tree": "da7ad3424d8266657eec1b28b16a8d389e50b67c",
       "version": "2.10",
       "port-version": 0
     },

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4046790dc82dda4733e99e83eb9df06275073588",
+      "version": "2.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "f98530b4731d88b3ddda90a25ad998076da19425",
       "version": "2.9",
       "port-version": 0


### PR DESCRIPTION
This works around a bad SSL certificate on
https://code.soundsoftware.ac.uk :

Error: Failed to download from mirror set:
https://code.soundsoftware.ac.uk/attachments/download/2589/vamp-plugin-sdk-2.9.0.zip: % Total    % Received % Xferd  Average Speed   Time    Time Time  Current
                                 Dload  Upload   Total   Spent Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

**Describe the pull request**

- #### What does your PR fix?  
  Fixed outdated port and works around bad SSL certificate

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes