### PR TITLE
[Help needed][brotli] Remove PowerShell dependency when compile in mingw ports

### DIFF
--- a/ports/brotli/CONTROL
+++ b/ports/brotli/CONTROL
@@ -1,5 +1,5 @@
 Source: brotli
 Version: 1.0.9
-Port-Version: 1
+Port-Version: 2
 Homepage: https://github.com/google/brotli
 Description: a generic-purpose lossless compression algorithm that compresses data using a combination of a modern variant of the LZ77 algorithm, Huffman coding and 2nd order context modeling.

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/brotli)
+vcpkg_copy_tools(${CURRENT_PACKAGES_DIR}/tools/brotli)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-brotli TARGET_PATH share/unofficial-brotli)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -22,6 +22,10 @@ vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES ../tools/brotli/brotli)
+vcpkg_copy_tools(
+    TOOL_NAMES brotli
+    SEARCH_DIR "${CURRENT_PACKAGES_DIR}/tools/brotli/"
+)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-brotli TARGET_PATH share/unofficial-brotli)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(TOOL_NAMES ${CURRENT_PACKAGES_DIR}/tools/brotli/brotli)
+vcpkg_copy_tools(TOOL_NAMES ../tools/brotli/brotli)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-brotli TARGET_PATH share/unofficial-brotli)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(TOOL_NAMES ${CURRENT_PACKAGES_DIR}/tools/brotli)
+vcpkg_copy_tools(TOOL_NAMES ${CURRENT_PACKAGES_DIR}/tools/brotli/brotli)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-brotli TARGET_PATH share/unofficial-brotli)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -21,7 +21,7 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(${CURRENT_PACKAGES_DIR}/tools/brotli)
+vcpkg_copy_tools(TOOL_NAMES ${CURRENT_PACKAGES_DIR}/tools/brotli)
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-brotli TARGET_PATH share/unofficial-brotli)
 vcpkg_fixup_pkgconfig()
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -21,7 +21,6 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(TOOL_NAMES ../tools/brotli/brotli)
 vcpkg_copy_tools(
     TOOL_NAMES brotli
     SEARCH_DIR "${CURRENT_PACKAGES_DIR}/tools/brotli/"

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a6b6234ebdf767e958b8dca2e78023f12b06ee0",
+      "version-string": "1.0.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "8f55fe158d8bd753a6e6908164e03ae4f0b73cea",
       "version-string": "1.0.9",
       "port-version": 1

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9c9058cd3243a9078bbed114a799ca809ca8055",
+      "git-tree": "0135e095e4206985817019f32389e81730f30723",
       "version-string": "1.0.9",
       "port-version": 2
     },

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "393c98585f733610f934f19965a6784f258d6189",
+      "git-tree": "f20fdd5ce3afa8b201631e117d4a52ec7bb1b536",
       "version-string": "1.0.9",
       "port-version": 2
     },

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2a6b6234ebdf767e958b8dca2e78023f12b06ee0",
+      "git-tree": "393c98585f733610f934f19965a6784f258d6189",
       "version-string": "1.0.9",
       "port-version": 2
     },

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f20fdd5ce3afa8b201631e117d4a52ec7bb1b536",
+      "git-tree": "b9c9058cd3243a9078bbed114a799ca809ca8055",
       "version-string": "1.0.9",
       "port-version": 2
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1062,7 +1062,7 @@
     },
     "brotli": {
       "baseline": "1.0.9",
-      "port-version": 1
+      "port-version": 2
     },
     "brpc": {
       "baseline": "0.9.7",


### PR DESCRIPTION
~~Update deprecated function~~
https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md#avoid-deprecated-helper-functions

> 4. vcpkg_copy_tool_dependencies() should be replaced by vcpkg_copy_tools()

I want to remove PowerShell dependency when compile in mingw.
It using PowerShell to copy a file. I think It overkill. 
I will happy if someone can help me to solve this. 
