### PR TITLE
[approval-tests-cpp] Update to 10.10.0

### DIFF
--- a/ports/approval-tests-cpp/portfile.cmake
+++ b/ports/approval-tests-cpp/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_download_distfile(single_header
-    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.9.1/ApprovalTests.v.10.9.1.hpp
-    FILENAME ApprovalTests.v.10.9.1.hpp
-    SHA512 520901982b8d217ce18f8729ca13e3d4c52ac87aa6a2f40089a49e7b85a4c3910ae3ca3a9fff1520c516dc726fad2ce70f122b8f061e606459af4e57de5fa2d6
+    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.10.0/ApprovalTests.v.10.10.0.hpp
+    FILENAME ApprovalTests.v.10.10.0.hpp
+    SHA512 909302175fcaa23aea9839a8276a1c20b654e8544600bfb05d6bb76bc6a635f51ef6efe437ac07e01391724b2dc0e31cbf16bcb688fbec1ef3e378b027a6eb64
 )
 
 vcpkg_download_distfile(license_file
-    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.9.1/LICENSE
-    FILENAME ApprovalTestsLicense.v.10.9.1
+    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.10.0/LICENSE
+    FILENAME ApprovalTestsLicense.v.10.10.0
     SHA512 dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557
 )
 

--- a/ports/approval-tests-cpp/vcpkg.json
+++ b/ports/approval-tests-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "approval-tests-cpp",
-  "version": "10.9.1",
+  "version": "10.10.0",
   "description": "Approval Tests allow you to verify a chunk of output (such as a file) in one operation as opposed to writing test assertions for each element.",
   "homepage": "https://github.com/approvals/ApprovalTests.cpp"
 }

--- a/versions/a-/approval-tests-cpp.json
+++ b/versions/a-/approval-tests-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1134cf4c5199fef643ff13362b568948df8cc55",
+      "version": "10.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "757640a4ad0e49a5fd4d77e9ce8adb9b1464cf25",
       "version": "10.9.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "approval-tests-cpp": {
-      "baseline": "10.9.1",
+      "baseline": "10.10.0",
       "port-version": 0
     },
     "apr": {


### PR DESCRIPTION
Update approvaltests to v10.10.0


- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  No, only ran `./vcpkg x-add-version approval-tests-cpp` 
didn't see the `--all` in the docs. 
Please let us know if this is needed, thanks
