### PR TITLE
fix bootstrap.sh on arm macs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -268,7 +268,7 @@ else
     fetchTool "ninja" "$UNAME" ninjaExe || exit 1
 fi
 if [ "$os" = "osx" ]; then
-    if [ "$vcpkgAllowAppleClang" = "true" ] ; then
+    if [ "$vcpkgAllowAppleClang" = "true" ] || [[ $(sw_vers -productVersion | awk -F '.' '{print $1}') -ge 11 ]]; then
         CXX=clang++
     else
         selectCXX


### PR DESCRIPTION
Fixes #19332

Automatically selects clang instead of gcc on macOS version >= 11 (all arm macs have macOS >= 11.0.0)
