### PR TITLE
[docs] Add comment about VCPKG_TARGET_TRIPLET to README and installing package

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ This will still allow people to not use vcpkg,
 by passing the `CMAKE_TOOLCHAIN_FILE` directly,
 but it will make the configure-build step slightly easier.
 
+### Specifying Target Triplet
+
+When using a triplet that isn't the default, like `x64-windows-static`, cmake needs to be made aware of the target triplet. This can be done with `VCPKG_TARGET_TRIPLET`.
+
+```
+-DVCPKG_TARGET_TRIPLET=[triplet]
+```
+
 [getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
 [getting-started:integration]: docs/users/integration.md
 [getting-started:git]: https://git-scm.com/downloads

--- a/README.md
+++ b/README.md
@@ -288,13 +288,23 @@ This will still allow people to not use vcpkg,
 by passing the `CMAKE_TOOLCHAIN_FILE` directly,
 but it will make the configure-build step slightly easier.
 
-### Specifying Target Triplet
+### Specifying Triplets
 
-When using a triplet that isn't the default, like `x64-windows-static`, cmake needs to be made aware of the target triplet. This can be done with `VCPKG_TARGET_TRIPLET`.
+Vcpkg uses triplets to capture the desired target platform, and link type, as well as the host platform and link type.
+If the default triplets are not used, then they must be specified both when building packages and when using them.
+See the documenation on [integrating](docs/users/integration.md) and [host dependencies](docs/users/host-dependencies.md) for more information.
 
+When installing packages, the triplets can be specified with command line flags.
+`--triplet [triplet]` for target packages and `--host-triplet [triplet]` for host dependencies.
+
+For projects cmake projects using the vcpkg toolchain, the triplets can be specified using the `VCPKG_TARGET_TRIPLET` and `VCPKG_HOST_TRIPLET` respectivley.
+For example
 ```
--DVCPKG_TARGET_TRIPLET=[triplet]
+-DVCPKG_TARGET_TRIPLET=[target-triplet]
+-DVCPKG_HOST_TRIPLET=[host-triplet]
 ```
+
+For both installation and use, `VCPKG_TARGET_TRIPLET` and `VCPKG_HOST_TRIPLET` environment variables can also be used.
 
 [getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
 [getting-started:integration]: docs/users/integration.md

--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -92,6 +92,12 @@ To remove the integration for your user, you can use `.\vcpkg integrate remove`.
 The best way to use installed libraries with cmake is via the toolchain file `scripts\buildsystems\vcpkg.cmake`. To use this file, you simply need to add it onto your CMake command line as:  
 `-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.
 
+When using a triplet that isn't the default, like `x64-windows-static`, cmake needs to be made aware of the target triplet. This can be done with `VCPKG_TARGET_TRIPLET`.
+
+```
+-DVCPKG_TARGET_TRIPLET=[triplet]
+```
+
 If you are using CMake through Open Folder with Visual Studio you can define `CMAKE_TOOLCHAIN_FILE` by adding a "variables" section to each of your `CMakeSettings.json` configurations:
 
 ```json

--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -92,11 +92,15 @@ To remove the integration for your user, you can use `.\vcpkg integrate remove`.
 The best way to use installed libraries with cmake is via the toolchain file `scripts\buildsystems\vcpkg.cmake`. To use this file, you simply need to add it onto your CMake command line as:  
 `-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.
 
-When using a triplet that isn't the default, like `x64-windows-static`, cmake needs to be made aware of the target triplet. This can be done with `VCPKG_TARGET_TRIPLET`.
+When using non-default triplets, they need to specified for cmake.
+They can be specified using the `VCPKG_TARGET_TRIPLET` and `VCPKG_HOST_TRIPLET` respectivley.
+For example
+```
+-DVCPKG_TARGET_TRIPLET=[target-triplet]
+-DVCPKG_HOST_TRIPLET=[host-triplet]
+```
 
-```
--DVCPKG_TARGET_TRIPLET=[triplet]
-```
+Alternativley, `VCPKG_TARGET_TRIPLET` and `VCPKG_HOST_TRIPLET` environment variables can also be used.
 
 If you are using CMake through Open Folder with Visual Studio you can define `CMAKE_TOOLCHAIN_FILE` by adding a "variables" section to each of your `CMakeSettings.json` configurations:
 


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
 I recently had an [issue](https://github.com/microsoft/vcpkg/issues/19528) where I needed to specify `VCPKG_TARGET_TRIPLET`. I now see that I missed the critical piece of information at the bottom of [integration.md](https://github.com/microsoft/vcpkg/blob/master/docs/users/integration.md). However, I'm of the opinion. VCPKG_TARGET_TRIPLET deserved some mention in a couple other areas.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
Its a documentation update.

- #### Does your PR follow the [maintainer guide]
To the best of my knowledge

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
N/A
