### PR TITLE
[libpmemobj-cpp] update to 1.13.0

### DIFF
--- a/ports/libpmemobj-cpp/CONTROL
+++ b/ports/libpmemobj-cpp/CONTROL
@@ -1,8 +1,0 @@
-Source: libpmemobj-cpp
-Version: 1.12
-Homepage: https://github.com/pmem/libpmemobj-cpp
-Description: C++ bindings for libpmemobj (https://github.com/pmem/pmdk).
-
-Feature: benchmark
-Build-Depends: pmdk
-Description: build benchmarks

--- a/ports/libpmemobj-cpp/portfile.cmake
+++ b/ports/libpmemobj-cpp/portfile.cmake
@@ -1,34 +1,35 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pmem/libpmemobj-cpp
-    REF b570268bec37735df1d4591605c0c7b2077c7bed #v1.12
-    SHA512 0914c35c708b5fec81ac2632cfbae52412c2ff2255940b54e72acc03875fdebf03f83194a6f91f1ac1d9c3531c7d1537fa0b9bc1a9da53acc50339a3b7df7b62
+    REF 9599f724d4edc3a3d973bac14eeebdc1bc31d327 #v1.13.0
+    SHA512 ae1f8ed8aecdc35e9e78c957fcd154e43c7bcb5bf5cf3e5b23be3e95d21de754dbbd9b6549bd6c7991fad24492b08421df338c3706ab0157c31ebc88b65fa4fe
     HEAD_REF master
     PATCHES
         fixlibpmemobj-cpp.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-	benchmark BUILD_BENCHMARKS
+    FEATURES
+	    benchmark BUILD_BENCHMARKS
 )
 
 vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path(${PERL_EXE_PATH})
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS ${FEATURE_OPTIONS}
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
         -DBUILD_DOC=OFF
+        -DTESTS_USE_VALGRIND=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/libpmemobj++/cmake TARGET_PATH share/libpmemobj++)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/libpmemobj++/cmake)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib/libpmemobj++)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib/libpmemobj++")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libpmemobj-cpp/vcpkg.json
+++ b/ports/libpmemobj-cpp/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "libpmemobj-cpp",
+  "version-semver": "1.13.0",
+  "description": "C++ bindings for libpmemobj (https://github.com/pmem/pmdk)",
+  "homepage": "https://github.com/pmem/libpmemobj-cpp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "benchmark": {
+      "description": "build benchmarks",
+      "dependencies": [
+        "pmdk"
+      ]
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3509,7 +3509,7 @@
       "port-version": 1
     },
     "libpmemobj-cpp": {
-      "baseline": "1.12",
+      "baseline": "1.13.0",
       "port-version": 0
     },
     "libpng": {

--- a/versions/l-/libpmemobj-cpp.json
+++ b/versions/l-/libpmemobj-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75d4c464f3bc9823857cab2f378bf7dc53cd7e2b",
+      "version-semver": "1.13.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "debedff0ebcfc704948550b14af45cfa1b7cf3bb",
       "version-string": "1.12",
       "port-version": 0


### PR DESCRIPTION
Fix #19483

Update libpmemobj-cpp to the latest version 1.13.0

Feature benchmark tested successfully in the following triplet:
- x64-windows