### PR TITLE
[vcpkg_copy_tool_dependencies] Only run on Windows hosts

### DIFF
--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -38,7 +38,7 @@ function(vcpkg_copy_tool_dependencies tool_dir)
         message(WARNING "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${ARGN}")
     endif()
 
-    if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_TARGET_IS_WINDOWS AND CMAKE_HOST_WIN32)
         find_program(Z_VCPKG_POWERSHELL_CORE pwsh)
         if (NOT Z_VCPKG_POWERSHELL_CORE)
             message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Only copy dependencies on Windows hosts, since PowerShell isn't present on other platforms by default.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  mingw triplets, not needed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
