### PR TITLE
[vcpkg] bootstrap.sh: fail if there is no entry for a tool os combination

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -165,8 +165,8 @@ fetchTool()
     xmlFileAsString=`cat "$vcpkgRootDir/scripts/vcpkgTools.xml"`
     toolRegexStart="<tool name=\"$tool\" os=\"$os\">"
     toolData="$(extractStringBetweenDelimiters "$xmlFileAsString" "$toolRegexStart" "</tool>")"
-    if [ "$toolData" = "" ]; then
-        echo "Unknown tool: $tool"
+    if [ "$toolData" = "" ] || [[ "$toolData" == "<?xml"* ]]; then
+        echo "No entry for $toolRegexStart in $vcpkgRootDir/scripts/vcpkgTools.xml"
         return 1
     fi
 


### PR DESCRIPTION
Currently is then simply try to use python for windows and you get errors like:
```
➜  vcpkg git:(update-fontconfig) ✗ ./bootstrap-vcpkg.sh 
Building vcpkg-tool...
/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/scripts/bootstrap.sh: line 309: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/downloads/tools/cmake-3.9.6-freebsd/python.exe: Permission denied
```
Now you get the following:
```
➜  vcpkg git:(update-fontconfig) ✗ ./bootstrap-vcpkg.sh 
No entry for <tool name="cmake" os="freebsd"> in /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/scripts/vcpkgTools.xml
``` 