### PR TITLE
[eastl] fix dependency eabase

### DIFF
--- a/ports/eabase/CONTROL
+++ b/ports/eabase/CONTROL
@@ -1,4 +1,0 @@
-Source: eabase
-Version: 2.09.12-1
-Homepage: https://github.com/electronicarts/EABase
-Description: Electronic Arts Base. EABase is a small set of header files that define platform-independent data types and macros.

--- a/ports/eabase/fix_cmake_install.patch
+++ b/ports/eabase/fix_cmake_install.patch
@@ -36,7 +36,7 @@ index 89c6703..ab8e553 100644
 +    #-------------------------------------------------------------------------------------------
 +    target_include_directories(EABase INTERFACE
 +        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/Common>
-+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Common>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 +    )
 +
 +    # create and install an export set for eabase target as EABase::EABase
@@ -64,7 +64,7 @@ index 89c6703..ab8e553 100644
 +    )
 +
 +    install(TARGETS EABase LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-+    install(DIRECTORY "include/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++    install(DIRECTORY "include/Common/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 +
 +    install(
 +        FILES

--- a/ports/eabase/vcpkg.json
+++ b/ports/eabase/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "eabase",
+  "version-string": "2.09.12",
+  "port-version": 2,
+  "description": "Electronic Arts Base. EABase is a small set of header files that define platform-independent data types and macros.",
+  "homepage": "https://github.com/electronicarts/EABase"
+}

--- a/ports/eastl/CONTROL
+++ b/ports/eastl/CONTROL
@@ -1,5 +1,0 @@
-Source: eastl
-Version: 3.17.03
-Homepage: https://github.com/electronicarts/EASTL
-Description: Electronic Arts Standard Template Library. It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.
-Build-Depends: eabase

--- a/ports/eastl/EASTLConfig.cmake.in
+++ b/ports/eastl/EASTLConfig.cmake.in
@@ -1,5 +1,8 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(EABase CONFIG REQUIRED)
+
 # Provide path for scripts
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 

--- a/ports/eastl/vcpkg.json
+++ b/ports/eastl/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "eastl",
+  "version-string": "3.17.03",
+  "port-version": 1,
+  "description": "Electronic Arts Standard Template Library. It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.",
+  "homepage": "https://github.com/electronicarts/EASTL",
+  "dependencies": [
+    "eabase"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1813,12 +1813,12 @@
       "port-version": 0
     },
     "eabase": {
-      "baseline": "2.09.12-1",
-      "port-version": 0
+      "baseline": "2.09.12",
+      "port-version": 2
     },
     "eastl": {
       "baseline": "3.17.03",
-      "port-version": 0
+      "port-version": 1
     },
     "easycl": {
       "baseline": "0.3",

--- a/versions/e-/eabase.json
+++ b/versions/e-/eabase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "40dfd9d387e788a7987db75e0d9fc22786b8e43b",
+      "version-string": "2.09.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "171ca1fc19c06e74b273601aa815049126f84212",
       "version-string": "2.09.12-1",
       "port-version": 0

--- a/versions/e-/eastl.json
+++ b/versions/e-/eastl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63d695972dd9861a2726ca90361aaafac0f710f6",
+      "version-string": "3.17.03",
+      "port-version": 1
+    },
+    {
       "git-tree": "69fe302d6e81880f94a6a9b3ddb88437e42a9731",
       "version-string": "3.17.03",
       "port-version": 0


### PR DESCRIPTION
Trying to use EASTL fails hard due to some include problem with EABase (see #12734). It is still not usable to this day and it seems highly unlikely solution will come from upstream.

All EASTL files rely on having the problematic `include/Common/` folder on the include path so it is never mentioned in the source files. Currently, the folder somehow exists on the path for the user (not in the eyes of EASTL though, don't know why, the cmake files seem correct), so the user could already use simply `#include<EABase/xxxx>`. This PR is a small change to existing patch to install EABase at the root of vcpkg include folder, which solved the problem. 

- #### What does your PR fix?  
  Fixes #12734

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Same as in previous version of the port

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
