### PR TITLE
[libics] Add DISABLE_PARALLEL_CONFIGURE and update to 1.6.5

### DIFF
--- a/ports/libics/CONTROL
+++ b/ports/libics/CONTROL
@@ -1,3 +1,0 @@
-Source: libics
-Version: 1.6.4
-Description: Reference library for ICS (Image Cytometry Standard), an open standard for writing images of any dimensionality and data type to file, together with associated information regarding the recording equipment or recorded subject.

--- a/ports/libics/portfile.cmake
+++ b/ports/libics/portfile.cmake
@@ -1,20 +1,20 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO svi-opensource/libics
-    REF 807193979650ab3d474e9a4bf907cf046eb0f3f0 # 1.6.4
-    SHA512 9fcbc14d4b62a8f5c6c114123a5cd3102c3398dd25f44caf07d033dbfc8304fc22dcde35e545ed984047a6009a0e7d7e30cbb6075fb10b9ceda0311cabc56ecb
+    REF ae55128e0532d78aaea4adce21a3fa553d208b83 # 1.6.5
+    SHA512 37a1e9034d7e32954840e18f3e3c19f6ed2f8c651ce0da53f678e2f04653be0fc4d9ab3dca8b6f0bfcaec2a9cc560ccfbc7d9034977faa14036281d6a3ca662a
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(COPY ${SOURCE_PATH}/GNU_LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libics)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libics/GNU_LICENSE ${CURRENT_PACKAGES_DIR}/share/libics/copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${SOURCE_PATH}/GNU_LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libics/vcpkg.json
+++ b/ports/libics/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libics",
+  "version": "1.6.5",
+  "description": "Reference library for ICS (Image Cytometry Standard), an open standard for writing images of any dimensionality and data type to file, together with associated information regarding the recording equipment or recorded subject.",
+  "homepage": "https://github.com/svi-opensource/libics",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3293,7 +3293,7 @@
       "port-version": 10
     },
     "libics": {
-      "baseline": "1.6.4",
+      "baseline": "1.6.5",
       "port-version": 0
     },
     "libideviceactivation": {

--- a/versions/l-/libics.json
+++ b/versions/l-/libics.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aea77d2369ae831edee51b05bc8dcad585795990",
+      "version": "1.6.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "f652729b1d084f65627ccd3c5d302bf73187bb57",
       "version-string": "1.6.4",
       "port-version": 0


### PR DESCRIPTION
libics:x64-windows failed temporarily with following failures in https://github.com/microsoft/vcpkg/pull/19633.
Add DISABLE_PARALLEL_CONFIGURE for fixing the issue. And update libics to latest release.

Failures:
```
CMake Error at CMakeLists.txt:48 (configure_file):
  No such file or directory
```