### PR TITLE
[libffi] Use -llibffi on Windows

### DIFF
--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -44,7 +44,7 @@ endif()
 
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets()
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc
         "-lffi" "-llibffi")
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -8,11 +8,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake.in DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
     OPTIONS
         -DFFI_CONFIG_FILE=${CMAKE_CURRENT_LIST_DIR}/fficonfig.h
@@ -45,15 +45,15 @@ endif()
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets()
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_MINGW)
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc"
         "-lffi" "-llibffi")
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc"
         "-lffi" "-llibffi")
 endif()
 vcpkg_fixup_pkgconfig()
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/ffi.h
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h"
         "   *know* they are going to link with the static library.  */"
         "   *know* they are going to link with the static library.  */
 
@@ -62,4 +62,4 @@ if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     )
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -44,7 +44,7 @@ endif()
 
 vcpkg_copy_pdbs()
 vcpkg_fixup_cmake_targets()
-if(VCPKG_TARGET_IS_MINGW)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libffi.pc
         "-lffi" "-llibffi")
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libffi.pc

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.2",
+  "port-version": 1,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3194,7 +3194,7 @@
     },
     "libffi": {
       "baseline": "3.4.2",
-      "port-version": 0
+      "port-version": 2
     },
     "libfido2": {
       "baseline": "1.7.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3194,7 +3194,7 @@
     },
     "libffi": {
       "baseline": "3.4.2",
-      "port-version": 2
+      "port-version": 1
     },
     "libfido2": {
       "baseline": "1.7.0",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "eb894a9c18e0d770850a66b046cd4beaa4829872",
+      "git-tree": "f9f43cad9f7bd65719c32b242d330492ad326456",
       "version": "3.4.2",
-      "port-version": 2
+      "port-version": 1
     },
     {
       "git-tree": "683012a89ed0185eecbc3035b2490af7d2cd2379",

--- a/versions/l-/libffi.json
+++ b/versions/l-/libffi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eb894a9c18e0d770850a66b046cd4beaa4829872",
+      "version": "3.4.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "683012a89ed0185eecbc3035b2490af7d2cd2379",
       "version": "3.4.2",
       "port-version": 0


### PR DESCRIPTION
Replace -lffi with -llibffi for Windows development, not just mingw

**Describe the pull request**

- #### What does your PR fix?  
  Gtkmm could not link in Visual Studio 19 on WIndows 10.  See #18328 for details

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  It should support all triplets, but only affect Windows.  I did not change the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I think so.  This change allows the library to properly link in Windows when not using mingw.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  No, I don't think this qualifies as updating the entire port?

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**

This is my first update to a project on Github.  If I've done something wrong, please let me know!
