### PR TITLE
[vcpkg_configure_make] Force libdir to lib

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -491,7 +491,7 @@ function(vcpkg_configure_make)
                             # Important: These should all be relative to prefix!
                             "--bindir=${prefix_var}/tools/${PORT}/bin"
                             "--sbindir=${prefix_var}/tools/${PORT}/sbin"
-                            #"--libdir='\${prefix}'/lib" # already the default!
+                            "--libdir=${prefix_var}/lib" # On some Linux distributions lib64 is the default
                             #"--includedir='\${prefix}'/include" # already the default!
                             "--mandir=${prefix_var}/share/${PORT}"
                             "--docdir=${prefix_var}/share/${PORT}"
@@ -500,7 +500,7 @@ function(vcpkg_configure_make)
                             # Important: These should all be relative to prefix!
                             "--bindir=${prefix_var}/../tools/${PORT}/debug/bin"
                             "--sbindir=${prefix_var}/../tools/${PORT}/debug/sbin"
-                            #"--libdir='\${prefix}'/lib" # already the default!
+                            "--libdir=${prefix_var}/lib" # On some Linux distributions lib64 is the default
                             "--includedir=${prefix_var}/../include"
                             "--datarootdir=${prefix_var}/share/${PORT}")
     endif()


### PR DESCRIPTION
Some Linux distributions (e.g. the OpenSUSE family) defaults to lib64
instead of lib, which breaks vcpkg's assumtion that libraries are in
lib.

Use the --libdir option of autotools to force the directory to be lib
