### PR TITLE
[kf5kirigami2] Add new port

### DIFF
--- a/ports/kf5kirigami2/portfile.cmake
+++ b/ports/kf5kirigami2/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO KDE/kirigami
+    REF v5.84.0
+    SHA512 e941395a31b3cf6fd321f7bcfecad07be6f546d09ae31e0f6210f90e2fe425444ab0c96af859859a04ba07af086edc24af8feed6a580bd8ad9968494d874dd4c
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    DISABLE_PARALLEL_CONFIGURE
+    PREFER_NINJA
+    OPTIONS 
+        -DBUILD_TESTING=OFF
+        -DKDE_INSTALL_DATAROOTDIR=data
+        -DKDE_INSTALL_QMLDIR=qml
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KF5Kirigami2)
+vcpkg_copy_pdbs()
+
+file(APPEND ${CURRENT_PACKAGES_DIR}/tools/${PORT}/qt.conf "Data = ../../data")
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/data)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/data)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(INSTALL ${SOURCE_PATH}/LICENSES/ DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)

--- a/ports/kf5kirigami2/vcpkg.json
+++ b/ports/kf5kirigami2/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "kf5kirigami2",
+  "version": "5.84.0",
+  "description": "A QtQuick based components set",
+  "homepage": "https://api.kde.org/frameworks/kirigami/html/index.html",
+  "dependencies": [
+    "ecm",
+    "qt5-base",
+    "qt5-quickcontrols2"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2936,6 +2936,10 @@
       "baseline": "5.84.0",
       "port-version": 0
     },
+    "kf5kirigami2": {
+      "baseline": "5.84.0",
+      "port-version": 0
+    },
     "kf5plotting": {
       "baseline": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5kirigami2.json
+++ b/versions/k-/kf5kirigami2.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0ff1a5b10615412d3cf58e3b0865ecf16c787aa9",
+      "version": "5.84.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add port for KDE's Kirigami library

Only tested on Linux, but it should work fine on Windows and macOS too