### PR TITLE
[imgui] Update to 1.84.1

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -65,27 +65,7 @@ if(IMGUI_BUILD_OPENGL2_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.cpp)
 endif()
 
-if(IMGUI_BUILD_OPENGL3_GLEW_BINDING)
-    find_package(GLEW REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC GLEW::GLEW)
-    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
-endif()
-
-if(IMGUI_BUILD_OPENGL3_GLAD_BINDING)
-    find_package(glad CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC glad::glad)
-    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
-endif()
-
-if(IMGUI_BUILD_OPENGL3_GL3W_BINDING)
-    find_package(gl3w CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC unofficial::gl3w::gl3w)
-    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
-endif()
-
-if(IMGUI_BUILD_OPENGL3_GLBINDING_BINDING)
-    find_package(glbinding CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC glbinding::glbinding)
+if(IMGUI_BUILD_OPENGL3_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
 endif()
 
@@ -193,8 +173,14 @@ if(NOT IMGUI_SKIP_HEADERS)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.h DESTINATION include)
     endif()
 
-    if(IMGUI_BUILD_OPENGL3_GLEW_BINDING OR IMGUI_BUILD_OPENGL3_GLAD_BINDING OR IMGUI_BUILD_OPENGL3_GL3W_BINDING OR IMGUI_BUILD_OPENGL3_GLBINDING_BINDING)
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.h DESTINATION include)
+    if(IMGUI_BUILD_OPENGL3_BINDING)
+        install(
+            FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3_loader.h
+            DESTINATION
+                include
+        )
     endif()
 
     if(IMGUI_BUILD_OSX_BINDING)

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -8,24 +8,8 @@ if (@IMGUI_BUILD_GLFW_BINDING@)
     find_dependency(glfw3 CONFIG)
 endif()
 
-if (@IMGUI_BUILD_OPENGL3_GLEW_BINDING@)
-    find_dependency(GLEW)
-endif()
-
-if (@IMGUI_BUILD_OPENGL3_GLAD_BINDING@)
-    find_dependency(glad CONFIG)
-endif()
-
-if (@IMGUI_BUILD_OPENGL3_GL3W_BINDING@)
-    find_dependency(gl3w CONFIG)
-endif()
-
 if (@IMGUI_BUILD_GLUT_BINDING@)
     find_dependency(GLUT)
-endif()
-
-if (@IMGUI_BUILD_OPENGL3_GLBINDING_BINDING@)
-    find_dependency(glbinding CONFIG)
 endif()
 
 if (@IMGUI_BUILD_SDL2_BINDING@)

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,16 +4,16 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF 1b435ae3e07ca813eb3ef40aaabe7053f5570fae
-       SHA512 bbdbcb4e8544810a51f1d8824a248ddbe19eed4978db7a059bd9c85bb997b1f98ad3997626fd2e9ea67d0e50f1ba1e11338858ebb2cc41c116bd6fd208aac684
+       REF 47fb332fb20921658732107e115aa397e9b08cbe
+       SHA512 92bfb20c9734dc37381d24325156c149f110b53dfabaf294e4bb2b0bccd618ab421aa347fa3c7fcaa1929b5bec8885246e7f49dc5fb6e81f1a8e80ff2d980f28
        HEAD_REF docking
        )
 else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v1.83
-    SHA512 2150e7101f384b1c749b2e89876b2085a7ff43435f04e88602d0e5e00db7a41c1ace5176bdb0963326845d1c8303b5092a7ca1c9c8e70c522ba96f899ed5bb9c
+    REF v1.84.1
+    SHA512 054beebda9a17758a9a6b9edf075279800a314b0e255e528bb9ac248b4911fd8fd2b5160079896d116b58fe6d993281ba9082780a31197faefd9f7adf32aec51
     HEAD_REF master
     )
 endif()
@@ -37,10 +37,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     marmalade-binding           IMGUI_COPY_MARMALADE_BINDING
     metal-binding               IMGUI_BUILD_METAL_BINDING
     opengl2-binding             IMGUI_BUILD_OPENGL2_BINDING
-    opengl3-glew-binding        IMGUI_BUILD_OPENGL3_GLEW_BINDING
-    opengl3-glad-binding        IMGUI_BUILD_OPENGL3_GLAD_BINDING
-    opengl3-gl3w-binding        IMGUI_BUILD_OPENGL3_GL3W_BINDING
-    opengl3-glbinding-binding   IMGUI_BUILD_OPENGL3_GLBINDING_BINDING
+    opengl3-binding             IMGUI_BUILD_OPENGL3_BINDING
     osx-binding                 IMGUI_BUILD_OSX_BINDING
     sdl2-binding                IMGUI_BUILD_SDL2_BINDING
     vulkan-binding              IMGUI_BUILD_VULKAN_BINDING
@@ -69,6 +66,8 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
+    MAYBE_UNUSED_VARIABLES
+        IMGUI_COPY_MARMALADE_BINDING
 )
 
 vcpkg_install_cmake()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.83",
+  "version": "1.84.1",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {
@@ -55,29 +55,8 @@
     "opengl2-binding": {
       "description": "Make available OpenGL (legacy) binding"
     },
-    "opengl3-gl3w-binding": {
-      "description": "Make available OpenGL3/ES/ES2 (modern) binding with gl3w",
-      "dependencies": [
-        "gl3w"
-      ]
-    },
-    "opengl3-glad-binding": {
-      "description": "Make available OpenGL3/ES/ES2 (modern) binding with glad",
-      "dependencies": [
-        "glad"
-      ]
-    },
-    "opengl3-glbinding-binding": {
-      "description": "Make available OpenGL3/ES/ES2 (modern) binding glbinding",
-      "dependencies": [
-        "glbinding"
-      ]
-    },
-    "opengl3-glew-binding": {
-      "description": "Make available OpenGL3/ES/ES2 (modern) binding with GLEW",
-      "dependencies": [
-        "glew"
-      ]
+    "opengl3-binding": {
+      "description": "Make available OpenGL3/ES/ES2 (modern) binding"
     },
     "osx-binding": {
       "description": "Make available OSX binding"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2681,7 +2681,7 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.83",
+      "baseline": "1.84.1",
       "port-version": 0
     },
     "imgui-sfml": {

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1be902aeef127530aa2817829ff44f29b1eb6e52",
+      "version": "1.84.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "07ff738266906a6d9faf3957e828acb87d48b782",
       "version": "1.83",
       "port-version": 0


### PR DESCRIPTION
Update imgui from 1.83 to 1.84.1. I also merged all the different opengl3 bindings into one because imgui now provides its own lightweight loader to make the opengl3 backend usage easier : https://github.com/ocornut/imgui/issues/4445

Changelogs:
https://github.com/ocornut/imgui/releases/tag/v1.84
https://github.com/ocornut/imgui/releases/tag/v1.84.1