### PR TITLE
[spix] Bump version to 0.3

### DIFF
--- a/ports/spix/portfile.cmake
+++ b/ports/spix/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO faaxm/spix
+    REF v0.3
+    SHA512 14eb742b7861d510466341f90f8d5b9d519aeaf27a032a8be8ab15743c7dd20d0584aa1f815a82dd54e73cb747612975f4a52db23c57390e9b5cd4a102a789c6
+    HEAD_REF master
+    PATCHES
+        export-header.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ANYRPC_LIB_BUILD_SHARED)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+    -DSPIX_BUILD_EXAMPLES=OFF
+    -DBUILD_TESTS=OFF
+)
+
+vcpkg_install_cmake()
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/spix RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/spix/vcpkg.json
+++ b/ports/spix/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "spix",
+  "version-string": "0.3",
+  "port-version": 1,
+  "description": "A minimally invasive UI testing library that enables your Qt/QML app's UI to be controlled either via c++ code, or through an http RPC interface.",
+  "homepage": "https://github.com/faaxm/spix",
+  "dependencies": [
+    "anyrpc"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5588,6 +5588,10 @@
       "baseline": "2020.1",
       "port-version": 2
     },
+    "spix": {
+      "baseline": "0.3",
+      "port-version": 1
+    },
     "sprout": {
       "baseline": "2019-06-20",
       "port-version": 0

--- a/versions/s-/spix.json
+++ b/versions/s-/spix.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3d4f6a154fac42af3849cd83eeb1c05d3db7bc10",
+      "version-string": "0.3",
+      "port-version": 1
+    }
+  ]
+}


### PR DESCRIPTION
Bumps the spix version to 0.3

- #### What does your PR fix?  
Removes custom patch which has been integrated upstream

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, n/a

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
