### PR TITLE
[yaml-cpp] fix yaml-cpp can't compile with `x64-windows-static` for debugging

### DIFF
--- a/ports/yaml-cpp/portfile.cmake
+++ b/ports/yaml-cpp/portfile.cmake
@@ -22,12 +22,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
-    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
-endif()
-if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/yaml-cpp")
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/yaml-cpp)
-endif()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/yaml-cpp)
 
 # Remove debug include files
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/yaml-cpp/vcpkg.json
+++ b/ports/yaml-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "yaml-cpp",
   "version-semver": "0.7.0",
+  "port-version": 1,
   "description": "yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.",
   "homepage": "https://github.com/jbeder/yaml-cpp",
   "documentation": "https://codedocs.xyz/jbeder/yaml-cpp/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6882,7 +6882,7 @@
     },
     "yaml-cpp": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "yara": {
       "baseline": "4.1.1",

--- a/versions/y-/yaml-cpp.json
+++ b/versions/y-/yaml-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "db67a32e2c013be3ebf697290953a993acecfd13",
+      "version-semver": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a71932a4f18c3cc6e0bd2bdce57fbf744e0efe2b",
       "version-semver": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #19736

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  windows, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes