### PR TITLE
[pystring] rename `libpystring` to `pystring`

### DIFF
--- a/ports/pystring/CMakeLists.txt
+++ b/ports/pystring/CMakeLists.txt
@@ -1,31 +1,23 @@
-cmake_minimum_required(VERSION 3.5.1)
-project(pystring C CXX)
+cmake_minimum_required(VERSION 3.12)
+project(pystring CXX)
 
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-add_library(${PROJECT_NAME} "")
-add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+add_library(pystring pystring.cpp)
 target_include_directories(
-	${PROJECT_NAME}
-	PUBLIC
-		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-		$<INSTALL_INTERFACE:include>
+  pystring
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
 )
 
-target_sources(
-	${PROJECT_NAME}
-	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/pystring.cpp
-)
+include(GNUInstallDirs)
 
 install(
-  TARGETS ${PROJECT_NAME}
-	EXPORT ${PROJECT_NAME}_target
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  TARGETS pystring
+  EXPORT unofficial-pystring-config
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
@@ -33,8 +25,7 @@ if(NOT DISABLE_INSTALL_HEADERS)
 endif()
 
 install(
-	EXPORT ${PROJECT_NAME}_target
-	NAMESPACE ${PROJECT_NAME}::
-	FILE ${PROJECT_NAME}-config.cmake
-	DESTINATION share/${PROJECT_NAME}
+  EXPORT unofficial-pystring-config
+  NAMESPACE unofficial::pystring::
+  DESTINATION share/unofficial-pystring
 )

--- a/ports/pystring/CMakeLists.txt
+++ b/ports/pystring/CMakeLists.txt
@@ -1,14 +1,28 @@
 cmake_minimum_required(VERSION 3.5.1)
-project(libpystring C CXX)
+project(pystring C CXX)
 
 if(MSVC)
   add_compile_options(/W3 /wd4005 /wd4996 /wd4018 -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-add_library(libpystring pystring.cpp)
+add_library(${PROJECT_NAME} "")
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include>
+)
+
+target_sources(
+	${PROJECT_NAME}
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/pystring.cpp
+)
 
 install(
-  TARGETS libpystring
+  TARGETS ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}_target
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -17,3 +31,10 @@ install(
 if(NOT DISABLE_INSTALL_HEADERS)
   install(FILES pystring.h DESTINATION include/pystring)
 endif()
+
+install(
+	EXPORT ${PROJECT_NAME}_target
+	NAMESPACE ${PROJECT_NAME}::
+	FILE ${PROJECT_NAME}-config.cmake
+	DESTINATION share/${PROJECT_NAME}
+)

--- a/ports/pystring/CMakeLists.txt
+++ b/ports/pystring/CMakeLists.txt
@@ -17,7 +17,7 @@ include(GNUInstallDirs)
 
 install(
   TARGETS pystring
-  EXPORT unofficial-pystring-config
+  EXPORT pystring-config
 )
 
 if(NOT DISABLE_INSTALL_HEADERS)
@@ -25,7 +25,7 @@ if(NOT DISABLE_INSTALL_HEADERS)
 endif()
 
 install(
-  EXPORT unofficial-pystring-config
-  NAMESPACE unofficial::pystring::
-  DESTINATION share/unofficial-pystring
+  EXPORT pystring-config
+  NAMESPACE pystring::
+  DESTINATION share/pystring
 )

--- a/ports/pystring/portfile.cmake
+++ b/ports/pystring/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets()
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/pystring RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pystring/portfile.cmake
+++ b/ports/pystring/portfile.cmake
@@ -10,14 +10,14 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}
   PREFER_NINJA
   OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-pystring)
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pystring/portfile.cmake
+++ b/ports/pystring/portfile.cmake
@@ -17,7 +17,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-pystring)
+vcpkg_cmake_config_fixup()
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pystring/vcpkg.json
+++ b/ports/pystring/vcpkg.json
@@ -3,5 +3,15 @@
   "version-semver": "1.1.3",
   "port-version": 4,
   "description": "Pystring is a collection of C++ functions which match the interface and behavior of python's string class methods using std::string",
-  "homepage": "https://github.com/imageworks/pystring"
+  "homepage": "https://github.com/imageworks/pystring",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/pystring/vcpkg.json
+++ b/ports/pystring/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pystring",
   "version-semver": "1.1.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Pystring is a collection of C++ functions which match the interface and behavior of python's string class methods using std::string",
   "homepage": "https://github.com/imageworks/pystring"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5134,7 +5134,7 @@
     },
     "pystring": {
       "baseline": "1.1.3",
-      "port-version": 3
+      "port-version": 4
     },
     "python2": {
       "baseline": "2.7.18",

--- a/versions/p-/pystring.json
+++ b/versions/p-/pystring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32266c82192b0e74468398f9c441d7dc009acb43",
+      "version-semver": "1.1.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "f79bc19acdfb0e0d9445191d54f89234c27db843",
       "version-semver": "1.1.3",
       "port-version": 3

--- a/versions/p-/pystring.json
+++ b/versions/p-/pystring.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "32266c82192b0e74468398f9c441d7dc009acb43",
+      "git-tree": "7d4b117aef6dd65ee9477c365e53ece58f465ee1",
       "version-semver": "1.1.3",
       "port-version": 4
     },

--- a/versions/p-/pystring.json
+++ b/versions/p-/pystring.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7d4b117aef6dd65ee9477c365e53ece58f465ee1",
+      "git-tree": "ed5bf60bd6e1720457de5eaa39f01f5b3a414f01",
       "version-semver": "1.1.3",
       "port-version": 4
     },


### PR DESCRIPTION
**Describe the pull request**

I installed the `pystring`, but the CMake project can't find the `pystringConfig.cmake`.
Rename the `libpystring` to `pystring` like its port name and avoid linking incorrectly.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  windows, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
