### PR TITLE
[libigl] fix imgui feature

### DIFF
--- a/ports/libigl/CONTROL
+++ b/ports/libigl/CONTROL
@@ -1,6 +1,6 @@
 Source: libigl
 Version: 2.2.0
-Port-Version: 4
+Port-Version: 5
 Homepage: https://github.com/libigl/libigl
 Description: libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.
 Build-Depends: eigen3
@@ -20,7 +20,7 @@ Build-Depends: libigl[core, opengl], glfw3
 
 Feature: imgui
 Description: Build with imgui
-Build-Depends: libigl[core, glfw], imgui[core, glfw-binding, opengl3-glew-binding, libigl-imgui]
+Build-Depends: libigl[core, glfw], imgui[core, glfw-binding, opengl3-binding, libigl-imgui]
 
 Feature: xml
 Description: Build with libxml

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3310,7 +3310,7 @@
     },
     "libigl": {
       "baseline": "2.2.0",
-      "port-version": 4
+      "port-version": 5
     },
     "libilbc": {
       "baseline": "3.0.3",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09f126e97a2f0d9e76a1109d6855bbdd4cab9c9d",
+      "version-string": "2.2.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "d150e0cc468dec8769382b413a5c477a0682f1fd",
       "version-string": "2.2.0",
       "port-version": 4


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes imgui feature for libigl port. https://github.com/microsoft/vcpkg/pull/19677 changed the feature name opengl3-glew-binding to opengl3-binding which is used on https://github.com/microsoft/vcpkg/blob/master/ports/libigl/CONTROL for imgui feature. 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Same as before

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
