### PR TITLE
[libmt32emu] update from 2.5.0 to 2.5.3

### DIFF
--- a/ports/libmt32emu/portfile.cmake
+++ b/ports/libmt32emu/portfile.cmake
@@ -1,21 +1,20 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO munt/munt
-    REF libmt32emu_2_5_0
-    SHA512 e86733bb26714a2a5f54a1b443db1e6f320bc3373dde6bbbe6662ecfb5b36c8ba0811919f2ddd54a11f264551add76e7032cd51f5803c502bfd4b1020fafb86b
+    REF libmt32emu_2_5_3
+    SHA512 c801e22e861898281316109533ca6264f5a9cf778d4f0bb14b49bb6d04d53b7e60cd8320d5b29a63534f6c470b4feb67c881e86c49b7860a98639ce01b99debf
     HEAD_REF master
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}/mt32emu
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}/mt32emu"
     OPTIONS
         -Dlibmt32emu_SHARED:BOOL=${BUILD_SHARED}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
@@ -23,4 +22,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
 
-file(INSTALL ${SOURCE_PATH}/mt32emu/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/mt32emu/COPYING.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -1,6 +1,16 @@
 {
   "name": "libmt32emu",
-  "version": "2.5.0",
+  "version": "2.5.3",
   "description": "A MT-32 emulator",
-  "homepage": "https://github.com/munt/munt/tree/master/mt32emu"
+  "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3429,7 +3429,7 @@
       "port-version": 0
     },
     "libmt32emu": {
-      "baseline": "2.5.0",
+      "baseline": "2.5.3",
       "port-version": 0
     },
     "libmupdf": {

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a1893148ecacd02e10cb14c90539f23687b597b6",
+      "version": "2.5.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a57fc5791efae931cf33dc307104c0463a2207be",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
Fix #19684 

Update libmt32emu to the latest version 2.5.3

Note : no feature need to test