### PR TITLE
[jasper] update to 2.0.33

### DIFF
--- a/ports/jasper/CONTROL
+++ b/ports/jasper/CONTROL
@@ -1,5 +1,0 @@
-Source: jasper
-Version: 2.0.20
-Homepage: https://github.com/mdadams/jasper
-Description: Open source implementation of the JPEG-2000 Part-1 standard
-Build-Depends: libjpeg-turbo, opengl, freeglut (!osx)

--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mdadams/jasper
-    REF d10a710f31da3d079a984d35ff6cc82a853d25d7 # version-2.0.20
-    SHA512 b581268d9a36ef4756aa0ec74ab4a96624e8cb6d03753e6f21148b6d2f62c081d434b319466f29c2cca34c547543ad5d41f68b838f3e131bbf01bab960d0f51c
+    REF fe00207dc10db1d7cc6f2757961c5c6bdfd10973 # version-2.0.33
+    SHA512 887bb8e6096b41d5b61970d70b0e7b9cc1c31dd63467386aa35003c146d200bbae9ad46825a3313aeed403ac6fb26d504f489386cbc7ca364d95deeb5a94af46
     HEAD_REF master
 )
 
@@ -12,9 +12,8 @@ else()
     set(JAS_ENABLE_SHARED OFF)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=OFF
         -DJAS_ENABLE_LIBJPEG=ON
@@ -25,13 +24,12 @@ vcpkg_configure_cmake(
         -DCMAKE_DEBUG_POSTFIX=d # Due to CMakes FindJasper
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/pkgconfig)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/jasper RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/jasper/portfile.cmake
+++ b/ports/jasper/portfile.cmake
@@ -6,11 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    set(JAS_ENABLE_SHARED ON)
-else()
-    set(JAS_ENABLE_SHARED OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JAS_ENABLE_SHARED)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jasper",
-  "version-string": "2.0.33",
+  "version": "2.0.33",
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/mdadams/jasper",
   "dependencies": [

--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "jasper",
+  "version-string": "2.0.33",
+  "description": "Open source implementation of the JPEG-2000 Part-1 standard",
+  "homepage": "https://github.com/mdadams/jasper",
+  "dependencies": [
+    {
+      "name": "freeglut",
+      "platform": "!osx"
+    },
+    "libjpeg-turbo",
+    "opengl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2785,7 +2785,7 @@
       "port-version": 0
     },
     "jasper": {
-      "baseline": "2.0.20",
+      "baseline": "2.0.33",
       "port-version": 0
     },
     "jbig2dec": {

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "efdfbf8b5ab437b50d03a3611223bb246fd28e8f",
+      "version-string": "2.0.33",
+      "port-version": 0
+    },
+    {
       "git-tree": "042e508623cae7cb25924aff2544acf360aa9862",
       "version-string": "2.0.20",
       "port-version": 0

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "efdfbf8b5ab437b50d03a3611223bb246fd28e8f",
-      "version-string": "2.0.33",
+      "git-tree": "c00bfcf7f17b8ba6db6ee5e62ac379902bbba96f",
+      "version": "2.0.33",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Fix #19783 

Update jasper to the latest version 2.0.33

Note: no feature need to test