### PR TITLE
[kf5solid] Fix CMake config; some extra fixes

### DIFF
--- a/ports/kf5solid/fix_config_cmake.patch
+++ b/ports/kf5solid/fix_config_cmake.patch
@@ -1,0 +1,36 @@
+From c1e261d57383533a008f0c02689dd0292d4dc75a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dawid=20Wro=CC=81bel?= <me@dawidwrobel.com>
+Date: Tue, 31 Aug 2021 02:18:42 +0200
+Subject: [PATCH] Add support for static builds
+
+---
+ KF5SolidConfig.cmake.in | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/KF5SolidConfig.cmake.in b/KF5SolidConfig.cmake.in
+index b597b3a..0a23f44 100644
+--- a/KF5SolidConfig.cmake.in
++++ b/KF5SolidConfig.cmake.in
+@@ -19,6 +19,19 @@ set(SOLID_DBUS_INTERFACES_DIR "@PACKAGE_KDE_INSTALL_DBUSINTERFACEDIR@")
+ include(CMakeFindDependencyMacro)
+ find_dependency(Qt5Core @REQUIRED_QT_VERSION@)
+ 
++if (NOT @BUILD_SHARED_LIBS@)
++    find_dependency(Qt5Xml @REQUIRED_QT_VERSION@)
++    find_dependency(Qt5Gui @REQUIRED_QT_VERSION@)
++
++    if (@Qt5DBus_FOUND@)
++        find_dependency(Qt5DBus @REQUIRED_QT_VERSION@)
++    endif()
++
++    if (@UDev_FOUND@)
++        find_dependency(UDev)
++    endif()
++endif()
++
+ include("${CMAKE_CURRENT_LIST_DIR}/KF5SolidTargets.cmake")
+ @PACKAGE_INCLUDE_QCHTARGETS@
+ 
+-- 
+GitLab
+

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -7,20 +7,19 @@ vcpkg_from_github(
 )
 
 if(VCPKG_TARGET_IS_OSX)
-     # In Darwin platform, there can be an old version of `bison`, 
-     # Which can't be used for `gst-build`. It requires 2.4+
-     vcpkg_find_acquire_program(BISON)
-     execute_process(
-         COMMAND ${BISON} --version
-         OUTPUT_VARIABLE BISON_OUTPUT
-     )
-     string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" BISON_VERSION "${BISON_OUTPUT}")
-     set(BISON_MAJOR ${CMAKE_MATCH_1})
-     set(BISON_MINOR ${CMAKE_MATCH_2})
-     message(STATUS "Using bison: ${BISON_MAJOR}.${BISON_MINOR}.${CMAKE_MATCH_3}")
-     if(NOT (BISON_MAJOR GREATER_EQUAL 2 AND BISON_MINOR GREATER_EQUAL 4))
-         message(WARNING "${PORT} requires bison version greater than one provided by macOS, please use \`brew install bison\` to install a newer bison.")
-     endif()
+    # On Darwin platform, the bundled version of 'bison' may be too old (< 3.0).
+    vcpkg_find_acquire_program(BISON)
+    execute_process(
+        COMMAND ${BISON} --version
+        OUTPUT_VARIABLE BISON_OUTPUT
+    )
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" BISON_VERSION "${BISON_OUTPUT}")
+    set(BISON_MAJOR ${CMAKE_MATCH_1})
+    set(BISON_MINOR ${CMAKE_MATCH_2})
+    message(STATUS "Using bison: ${BISON_MAJOR}.${BISON_MINOR}.${CMAKE_MATCH_3}")
+    if(NOT (BISON_MAJOR GREATER_EQUAL 3 AND BISON_MINOR GREATER_EQUAL 0))
+        message(WARNING "${PORT} requires bison version greater than one provided by macOS, please use \`brew install bison\` to install a newer bison.")
+    endif()
 endif()
 
 vcpkg_find_acquire_program(BISON)

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -54,8 +54,8 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/etc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/qml" "${CURRENT_PACKAGES_DIR}/debug/qml")
 file(RENAME "${CURRENT_PACKAGES_DIR}/lib/qml" "${CURRENT_PACKAGES_DIR}/qml")
 

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -41,7 +41,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF5Solid)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KF5Solid CONFIG_PATH lib/cmake/KF5Solid)
 vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v5.84.0
     SHA512 b6452e56c6029289450850c1fcfff96da0005f8dfa03f1817754910945e3ccadd8502e330a4484a5c5e9a8d5525838c8090268bb083639062dfca7176852c159
     HEAD_REF master
+    PATCHES
+        fix_config_cmake.patch # https://invent.kde.org/frameworks/solid/-/merge_requests/53
 )
 
 if(VCPKG_TARGET_IS_OSX)

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -44,6 +44,11 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/KF5Solid)
 vcpkg_copy_pdbs()
 
+vcpkg_copy_tools(
+      TOOL_NAMES solid-hardware5
+      AUTO_CLEAN
+ )
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
@@ -51,9 +56,6 @@ endif()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/etc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-# solid-hardware and solid-power are a non-dev tools allowing to list hardware and power managament status of one's system. No need to keep them.
-file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/solid-hardware5${VCPKG_HOST_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/debug/bin/solid-hardware5${VCPKG_HOST_EXECUTABLE_SUFFIX}")
-file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/solid-power${VCPKG_HOST_EXECUTABLE_SUFFIX}" "${CURRENT_PACKAGES_DIR}/debug/bin/solid-power${VCPKG_HOST_EXECUTABLE_SUFFIX}")
 file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/qml" "${CURRENT_PACKAGES_DIR}/debug/qml")
 file(RENAME "${CURRENT_PACKAGES_DIR}/lib/qml" "${CURRENT_PACKAGES_DIR}/qml")
 

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5solid",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2946,7 +2946,7 @@
     },
     "kf5solid": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5sonnet": {
       "baseline": "5.84.0",

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1f726a86d2961fd90661f27469d1e77b2b75c612",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ddc168b71ca68e8c765edca7a018753871b84e6",
       "version-semver": "5.84.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
  Fixes CMake Config file for static usage (https://invent.kde.org/frameworks/solid/-/merge_requests/53)
  Tested in #19779 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes