### PR TITLE
[vcpkg][vcpkg_from_github] Fix version regex matching issue

### DIFF
--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -160,7 +160,7 @@ function(vcpkg_from_github)
         # Parse the github refs response with regex.
         # TODO: add json-pointer support to vcpkg
         file(READ "${archive_version}" version_contents)
-        if(NOT version_contents MATCHES [["sha": "([a-f0-9]+)"]])
+        if(NOT version_contents MATCHES [["sha":"([a-f0-9]+)"]])
             message(FATAL_ERROR "Failed to parse API response from '${version_url}':
 
 ${version_contents}


### PR DESCRIPTION
When build port with --head, it will fail with following failure, it's due to the regex match failed in https://github.com/microsoft/vcpkg/blob/master/scripts/cmake/vcpkg_from_github.cmake#L163. The issue from PR https://github.com/microsoft/vcpkg/pull/18838.

This blocks RWC testing in internal team.

```
CMake Error at scripts/cmake/vcpkg_from_github.cmake:164 (message):
  Failed to parse API response from '':
 {"ref":"refs/heads/master","node_id":"MDM6UmVmNDUyNDE4MTpyZWZzL2hlYWRzL21hc3Rlcg==","url":"https://api.github.com/repos/facebook/folly/git/refs/heads/master","object":{"sha":"b765365df4d2b6a17f29ffbcf797141142ee4e22","type":"commit","url":"https://api.github.com/repos/facebook/folly/git/commits/b765365df4d2b6a17f29ffbcf797141142ee4e22"}}

Call Stack (most recent call first):
  ports/folly/portfile.cmake:12 (vcpkg_from_github)
  scripts/ports.cmake:140 (include)
```