### PR TITLE
[harfbuzz] update to 2.9.0

### DIFF
--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -49,7 +49,6 @@ vcpkg_configure_meson(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS ${FEATURE_OPTIONS}
         -Dcairo=disabled # Use Cairo graphics library
-        -Dfontconfig=disabled    # Use fontconfig
         -Dintrospection=disabled # Generate gobject-introspection bindings (.gir/.typelib files)
         -Ddocs=disabled          # Generate documentation with gtk-doc
         -Dtests=disabled

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO harfbuzz/harfbuzz
-    REF 63e15eac4f443fa53565d1e4fb9611cdd7814f28 # 2.8.2
-    SHA512 8a743ce465f01d6cb49ac74efb1159d965e41c89267eeb4078ec4c342c24599e14419a0416f8d35a0b9dd00e76cc79b4dbd6f50ddd1b8da761d61158d1018ebc
+    REF 9aa6f8a93f035dd0a1e3978da495d830049480c8 # 2.9.0
+    SHA512 7ef82298e6f5e0d8a78bb6a408e2ec0a4016c7931ef69d52e75ed8e9e0b31628f2ae5ea913dcbfa7d5159412ae487400ea1391254477064ba8fb1aa0cdbe5ed9
     HEAD_REF master
     PATCHES
         # This patch is a workaround that is needed until the following issues are resolved upstream:

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "dependencies": [

--- a/ports/harfbuzz/vcpkg.json
+++ b/ports/harfbuzz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "harfbuzz",
-  "version": "2.9.0",
+  "version-semver": "2.9.0",
   "description": "HarfBuzz OpenType text shaping engine",
   "homepage": "https://github.com/harfbuzz/harfbuzz",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2505,7 +2505,7 @@
       "port-version": 0
     },
     "harfbuzz": {
-      "baseline": "2.8.2",
+      "baseline": "2.9.0",
       "port-version": 0
     },
     "hayai": {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a4608f8d4ae8fa5bac1369504cc07b20cbcad23b",
+      "git-tree": "7bc55c4f88d240855ec6c7da3907811600e61b28",
       "version-semver": "2.9.0",
       "port-version": 0
     },

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "e64e8ece855f8faae4e14288ae72913f4238e451",
-      "version": "2.9.0",
+      "git-tree": "a4608f8d4ae8fa5bac1369504cc07b20cbcad23b",
+      "version-semver": "2.9.0",
       "port-version": 0
     },
     {

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e64e8ece855f8faae4e14288ae72913f4238e451",
+      "version": "2.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "823024398648ee98849f8a4f73f778a8f97ccd1f",
       "version": "2.8.2",
       "port-version": 0


### PR DESCRIPTION
Fix #19808 
Update harfbuzz to the latest version 2.9.0

All featurse are tested successfully in the following triplet:

x64-windows

Feature 'glib' only supports dynamic library linkage.

Feature 'coretext' os only available on OSX