### PR TITLE
[quill] Update to 1.6.3

### DIFF
--- a/ports/quill/CONTROL
+++ b/ports/quill/CONTROL
@@ -1,7 +1,0 @@
-Source: quill
-Version: 1.6.2
-Port-Version: 0
-Homepage: https://github.com/odygrd/quill/
-Description: C++14 Asynchronous Low Latency Logging Library
-Supports: !(uwp|android)
-Build-Depends: fmt

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v1.6.2
-    SHA512 c1db04c96c70b6bced38ecc83b4bba9e60b02cf13ff48ab92132ceb828414fcf046cb2c41337a4ae321b0bad8598eb280a7edcc30e0720d7609898e15d514380
+    REF v1.6.3
+    SHA512 e75aca827fe0833422da0d38df482cbc39db0e43dcc3cb791f3e2649f7022dcc448831a5ede85daf6feada60a2d5eaf312a3411abbba92fb9d76466336a7244d
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "quill",
+  "version-semver": "1.6.3",
+  "description": "C++14 Asynchronous Low Latency Logging Library",
+  "homepage": "https://github.com/odygrd/quill/",
+  "supports": "!(uwp | android)",
+  "dependencies": [
+    "fmt"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5493,7 +5493,7 @@
       "port-version": 0
     },
     "quill": {
-      "baseline": "1.6.2",
+      "baseline": "1.6.3",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6ee8372d06d69dda719c955d24baa1f61924f86",
+      "version-semver": "1.6.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "0e3b811db3b65c4239a657bfd1a2fae470a8096a",
       "version-string": "1.6.2",
       "port-version": 0


### PR DESCRIPTION
Update quill from 1.6.2 to 1.6.3.

Changelog : https://github.com/odygrd/quill/releases/tag/v1.6.3
