### PR TITLE
[qt5-base] Download submodules over https instead of http

### DIFF
--- a/ports/qt5-base/cmake/qt_download_submodule.cmake
+++ b/ports/qt5-base/cmake/qt_download_submodule.cmake
@@ -15,8 +15,8 @@ function(qt_download_submodule)
 
     set(FULL_VERSION "${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER}")
     set(ARCHIVE_NAME "${NAME}-everywhere-src-${FULL_VERSION}.tar.xz")
-    set(URLS "http://download.qt.io/official_releases/qt/${QT_MAJOR_MINOR_VER}/${FULL_VERSION}/submodules/${ARCHIVE_NAME}"
-    "http://mirrors.ocf.berkeley.edu/qt/official_releases/qt/${QT_MAJOR_MINOR_VER}/${FULL_VERSION}/submodules/${ARCHIVE_NAME}"
+    set(URLS "https://download.qt.io/official_releases/qt/${QT_MAJOR_MINOR_VER}/${FULL_VERSION}/submodules/${ARCHIVE_NAME}"
+    "https://mirrors.ocf.berkeley.edu/qt/official_releases/qt/${QT_MAJOR_MINOR_VER}/${FULL_VERSION}/submodules/${ARCHIVE_NAME}"
     )
     vcpkg_download_distfile(ARCHIVE_FILE
         URLS ${URLS}

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.15.2",
-  "port-version": 9,
+  "port-version": 10,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5218,7 +5218,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.2",
-      "port-version": 9
+      "port-version": 10
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13593d8640bdca2663ba5bd497243274e51c4dc3",
+      "version-semver": "5.15.2",
+      "port-version": 10
+    },
+    {
       "git-tree": "2362119eaacd46f6d1b0d27bac82b8851d84448f",
       "version-semver": "5.15.2",
       "port-version": 9


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Download submodules over https instead of http.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not changed, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
