### PR TITLE
[qtbase] Download submodules over https instead of plain git protocol

### DIFF
--- a/ports/qtbase/cmake/qt_install_submodule.cmake
+++ b/ports/qtbase/cmake/qt_install_submodule.cmake
@@ -37,7 +37,7 @@ function(qt_install_submodule)
 
     vcpkg_from_git(
         OUT_SOURCE_PATH SOURCE_PATH
-        URL git://code.qt.io/qt/${PORT}.git
+        URL https://code.qt.io/qt/${PORT}.git
         TAG ${${PORT}_TAG}
         REF ${${PORT}_REF}
         ${UPDATE_PORT_GIT_OPTIONS}

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version-semver": "6.1.2",
+  "port-version": 1,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5386,7 +5386,7 @@
     },
     "qtbase": {
       "baseline": "6.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.1.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed0018dce35e4246be83589358400a7617a8933f",
+      "version-semver": "6.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "953b2fbc4ecc9e3ec83df47f2470d078f21758bd",
       "version-semver": "6.1.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Download submodules over https instead of plain git protocol

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not changed, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
