### PR TITLE
[asio] update to 1.19.2

### DIFF
--- a/ports/asio/portfile.cmake
+++ b/ports/asio/portfile.cmake
@@ -3,8 +3,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO chriskohlhoff/asio
-    REF asio-1-18-2
-    SHA512 5a2312f1a14106e3109a9f02e8ac65a1d639b411834f0aa301767a4dd30d8384f6f1a94034b6016ef989c7d7880fd4c8de11c7be0cb58b4dc64a49ec335a7113
+    REF asio-1-19-2
+    SHA512 a6d1c5534fef0fe5ac549e1bd20919d180fbfe4c146be40ec6ebfa862534b8551778b0e79a5ba822ed645535e010646909f02f9e1d1f385ed758f07f57351ea8
     HEAD_REF master
 )
 
@@ -12,19 +12,18 @@ vcpkg_from_github(
 vcpkg_replace_string("${SOURCE_PATH}/asio/include/asio/detail/config.hpp" "defined(ASIO_STANDALONE)" "!defined(VCPKG_DISABLE_ASIO_STANDALONE)")
 
 # CMake install
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "share/asio")
+vcpkg_cmake_config_fixup()
 file(INSTALL
-    ${CMAKE_CURRENT_LIST_DIR}/asio-config.cmake
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+    "${CMAKE_CURRENT_LIST_DIR}/asio-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/asio/LICENSE_1_0.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/asio/LICENSE_1_0.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/asio/vcpkg.json
+++ b/ports/asio/vcpkg.json
@@ -1,9 +1,19 @@
 {
   "name": "asio",
-  "version": "1.18.2",
+  "version": "1.19.2",
   "description": "Asio is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach.",
   "homepage": "https://github.com/chriskohlhoff/asio",
   "documentation": "https://think-async.com/Asio/asio-1.18.0/doc/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "coroutine": {
       "description": "Boost.Coroutine (optional) if you use spawn() to launch coroutines",

--- a/versions/a-/asio.json
+++ b/versions/a-/asio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c6bba20de9d8e7d6278ab8d7b333bb14bd35f21f",
+      "version": "1.19.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae594f45685a04883ec38208caf740ee9c9635e8",
       "version": "1.18.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -173,7 +173,7 @@
       "port-version": 0
     },
     "asio": {
-      "baseline": "1.18.2",
+      "baseline": "1.19.2",
       "port-version": 0
     },
     "asiosdk": {


### PR DESCRIPTION
Fix #19835 

Update asio to the latest version 1.19.2

All feature are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static