### PR TITLE
[hazelcast-cpp-client] update to v4.2.0

### DIFF
--- a/ports/hazelcast-cpp-client/portfile.cmake
+++ b/ports/hazelcast-cpp-client/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hazelcast/hazelcast-cpp-client
-    REF v4.1.1
-    SHA512 2f6d578c43dfc8c03f83a5b7c98fe67b7dc450cbc542031e625ec3bc91b9ec2e430e3ced670608a651fcf77775d2d4a333ca82689cae793e8b13a8e0438bbfb9
+    REF v4.2.0
+    SHA512 7dc91968c95930d966c9bf005c0756c3702b9f27d96543bd6beffd20be36f9d9840676be2e9473b68f5cfa420c39c6feef0d7538270c798633aad5d0714df56c
     HEAD_REF master
 )
 

--- a/ports/hazelcast-cpp-client/vcpkg.json
+++ b/ports/hazelcast-cpp-client/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "hazelcast-cpp-client",
-  "version-semver": "4.1.1",
+  "version-semver": "4.2.0",
   "description": "C++ client library for Hazelcast in-memory database.",
   "homepage": "https://github.com/hazelcast/hazelcast-cpp-client",
   "documentation": "http://hazelcast.github.io/hazelcast-cpp-client/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2513,7 +2513,7 @@
       "port-version": 0
     },
     "hazelcast-cpp-client": {
-      "baseline": "4.1.1",
+      "baseline": "4.2.0",
       "port-version": 0
     },
     "hdf5": {

--- a/versions/h-/hazelcast-cpp-client.json
+++ b/versions/h-/hazelcast-cpp-client.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3b0181d25656c1a524f51a5aca0279faba58318",
+      "version-semver": "4.2.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "17cace53a35339535e20e587090ae1c6c16f5a3d",
       "version-semver": "4.1.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates port `hazelcast-cpp-client` to the latest version.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Same as before, all except `uwp` ones. No need to update the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.


