### PR TITLE
[google-cloud-cpp] update to latest release (v1.31.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.30.1
-    SHA512 2a49c92eae39e2389bb8c765c2aa9374ae38a64f8f19a7744887d2176dc846017d8bc78c0391c55654765aaeff11bb1f3ea7e904d1e7b16580941ab74585e8bc
+    REF v1.31.0
+    SHA512 aa650297e60d36f79392a9e206f42bd58f63036e32466ee7a5cd2862cb4b38edf8178e2b04ef3a2dda47ab4f4a544ad3fa4de560f8fd8b9dcf02e60b76a07108
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.30.1",
-  "port-version": 1,
+  "version": "1.31.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -36,6 +35,28 @@
     "bigtable": {
       "description": "The Google Cloud Bigtable C++ client library",
       "dependencies": [
+        "grpc",
+        {
+          "name": "grpc",
+          "host": true
+        },
+        "protobuf",
+        {
+          "name": "protobuf",
+          "host": true
+        }
+      ]
+    },
+    "experimental-storage-grpc": {
+      "description": "The GCS+gRPC plugin",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "storage"
+          ]
+        },
         "grpc",
         {
           "name": "grpc",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2385,8 +2385,8 @@
       "port-version": 6
     },
     "google-cloud-cpp": {
-      "baseline": "1.30.1",
-      "port-version": 1
+      "baseline": "1.31.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81d0a42380da299b4942b6d7f8c00ecba4ca7745",
+      "version": "1.31.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7e4c28a8a9e84631228981bd73a3932596fe8e1f",
       "version": "1.30.1",
       "port-version": 1


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.31.0). It also adds the new features in that release.


- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

No change.

- #### Does your PR follow the [maintainer guide]

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
