### PR TITLE
[protobuf] Set visibility to "hidden" to avoid a linker warning

### DIFF
--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -30,6 +30,17 @@ if (VCPKG_DOWNLOAD_MODE)
     vcpkg_find_acquire_program(PKGCONFIG)
 endif()
 
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static") 
+    set(protobuf_VISIBILITY_FLAGS 
+        -DCMAKE_POLICY_DEFAULT_CMP0063=NEW
+        -DCMAKE_C_VISIBILITY_PRESET=hidden
+        -DCMAKE_CXX_VISIBILITY_PRESET=hidden
+        -DCMAKE_VISIBILITY_INLINES_HIDDEN=TRUE
+    )
+else()
+    set(protobuf_VISIBILITY_FLAGS "")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/cmake
     OPTIONS
@@ -39,6 +50,7 @@ vcpkg_cmake_configure(
         -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
         -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
         -Dprotobuf_BUILD_LIBPROTOC=${protobuf_BUILD_LIBPROTOC}
+        ${protobuf_VISIBILITY_FLAGS}
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf",
   "version-semver": "3.19.4",
+  "port-version": 1,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5526,7 +5526,7 @@
     },
     "protobuf": {
       "baseline": "3.19.4",
-      "port-version": 0
+      "port-version": 1
     },
     "protobuf-c": {
       "baseline": "1.4.0",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d7872a24a876ec6ccf7e9fd8a32e87c0d6f92f14",
+      "version-semver": "3.19.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "984039810172eb397ca0ec6d426d60764d6dfe46",
       "version-semver": "3.19.4",
       "port-version": 0


### PR DESCRIPTION
Apple's ld warns when linked as a static library:
"direct access in function ... to global weak symbol. The weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.

**Describe the pull request**

- #### What does your PR fix?  
  Fixes a linker warning on OSX

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
 all 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
