### PR TITLE
[vcpkg] Decouple the storage account used for binary caching from the images.

### DIFF
--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     value: "x-azurl,$(root-url),$(sas),readwrite"
   - group: vcpkg-binary-caching-credentials
   - name: X_VCPKG_BINARY_SOURCE_STUB
-    value: "x-azblob,$(root-url),$(sas)"
+    value: "x-azblob,$(root-bin-url),$(sas-bin)"
 
   steps:
   - bash: df -h

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     value: "x-azurl,$(root-url),$(sas),readwrite"
   - group: vcpkg-binary-caching-credentials
   - name: X_VCPKG_BINARY_SOURCE_STUB
-    value: "x-azurl,$(root-url),$(sas)"
+    value: "x-azblob,$(root-url),$(sas)"
 
   steps:
   - bash: df -h

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -17,6 +17,9 @@ jobs:
   - group: vcpkg-asset-caching-credentials
   - name: X_VCPKG_ASSET_SOURCES
     value: "x-azurl,$(root-url),$(sas),readwrite"
+  - group: vcpkg-binary-caching-credentials
+  - name: X_VCPKG_BINARY_SOURCE_STUB
+    value: "x-azurl,$(root-url),$(sas)"
 
   steps:
   - bash: df -h
@@ -42,7 +45,7 @@ jobs:
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'
-      arguments: '-Triplet x64-linux -BuildReason $(Build.Reason) -UseEnvironmentSasToken -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+      arguments: '-Triplet x64-linux -BuildReason $(Build.Reason) -BinarySourceStub $(X_VCPKG_BINARY_SOURCE_STUB) -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
       pwsh: true
   - bash: |
       df -h

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'
-      arguments: '-Triplet x64-linux -BuildReason $(Build.Reason) -BinarySourceStub $(X_VCPKG_BINARY_SOURCE_STUB) -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+      arguments: '-Triplet x64-linux -BuildReason $(Build.Reason) -BinarySourceStub "$(X_VCPKG_BINARY_SOURCE_STUB)" -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
       pwsh: true
   - bash: |
       df -h

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -18,9 +18,6 @@ The Azure Pipelines artifacts directory. If not supplied, defaults to the curren
 .PARAMETER ArchivesRoot
 Equivalent to '-BinarySourceStub "files,$ArchivesRoot"'
 
-.PARAMETER UseEnvironmentSasToken
-Equivalent to '-BinarySourceStub "x-azblob,https://$($env:PROVISIONED_AZURE_STORAGE_NAME).blob.core.windows.net/archives,$($env:PROVISIONED_AZURE_STORAGE_SAS_TOKEN)"'
-
 .PARAMETER BinarySourceStub
 The type and parameters of the binary source. Shared across runs of this script. If
 this parameter is not set, binary caching will not be used. Example: "files,W:\"
@@ -47,8 +44,6 @@ Param(
     $ArtifactStagingDirectory = '.',
     [Parameter(ParameterSetName='ArchivesRoot')]
     $ArchivesRoot = $null,
-    [switch]
-    $UseEnvironmentSasToken = $false,
     [Parameter(ParameterSetName='BinarySourceStub')]
     $BinarySourceStub = $null,
     $BuildReason = $null,
@@ -61,25 +56,13 @@ if (-Not ((Test-Path "triplets/$Triplet.cmake") -or (Test-Path "triplets/communi
     throw
 }
 
-$usingBinaryCaching = $true
-if ([string]::IsNullOrWhiteSpace($BinarySourceStub)) {
-    if ([string]::IsNullOrWhiteSpace($ArchivesRoot)) {
-        if ($UseEnvironmentSasToken) {
-            $BinarySourceStub = "x-azblob,https://$($env:PROVISIONED_AZURE_STORAGE_NAME).blob.core.windows.net/archives,$($env:PROVISIONED_AZURE_STORAGE_SAS_TOKEN)"
-        } else {
-            $usingBinaryCaching = $false
-        }
-    } else {
-        if ($UseEnvironmentSasToken) {
-            Write-Error "Only one binary caching setting may be used."
-            throw
-        } else {
-            $BinarySourceStub = "files,$ArchivesRoot"
-        }
+if ((-Not [string]::IsNullOrWhiteSpace($ArchivesRoot))) {
+    if ((-Not [string]::IsNullOrWhiteSpace($BinarySourceStub))) {
+        Write-Error "Only one binary caching setting may be used."
+        throw
     }
-} elseif ((-Not [string]::IsNullOrWhiteSpace($ArchivesRoot)) -Or $UseEnvironmentSasToken) {
-    Write-Error "Only one binary caching setting may be used."
-    throw
+
+    $BinarySourceStub = "files,$ArchivesRoot"
 }
 
 $env:VCPKG_DOWNLOADS = Join-Path $WorkingRoot 'downloads'
@@ -87,14 +70,7 @@ $buildtreesRoot = Join-Path $WorkingRoot 'buildtrees'
 $installRoot = Join-Path $WorkingRoot 'installed'
 $packagesRoot = Join-Path $WorkingRoot 'packages'
 
-$commonArgs = @()
-if ($usingBinaryCaching) {
-    $commonArgs += @('--binarycaching')
-} else {
-    $commonArgs += @('--no-binarycaching')
-}
-
-$commonArgs += @(
+$commonArgs = @(
     "--x-buildtrees-root=$buildtreesRoot",
     "--x-install-root=$installRoot",
     "--x-packages-root=$packagesRoot",
@@ -102,7 +78,10 @@ $commonArgs += @(
 )
 
 $skipFailures = $false
-if ($usingBinaryCaching) {
+if ([string]::IsNullOrWhiteSpace($BinarySourceStub)) {
+    $commonArgs += @('--no-binarycaching')
+} else {
+    $commonArgs += @('--binarycaching')
     $binaryCachingMode = 'readwrite'
     if ([string]::IsNullOrWhiteSpace($BuildReason)) {
         Write-Host 'Build reason not specified, defaulting to using binary caching in read write mode.'

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -17,6 +17,9 @@ jobs:
   - group: vcpkg-asset-caching-credentials
   - name: X_VCPKG_ASSET_SOURCES
     value: "x-azurl,$(root-url),$(sas),readwrite"
+  - group: vcpkg-binary-caching-credentials
+  - name: X_VCPKG_BINARY_SOURCE_STUB
+    value: "x-azurl,$(root-url),$(sas)"
 
   steps:
   - task: PowerShell@2
@@ -36,7 +39,7 @@ jobs:
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'
-      arguments: '-Triplet ${{ parameters.triplet }} -BuildReason $(Build.Reason) -UseEnvironmentSasToken -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+      arguments: '-Triplet ${{ parameters.triplet }} -BuildReason $(Build.Reason) -BinarySourceStub $(X_VCPKG_BINARY_SOURCE_STUB) -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
       pwsh: true
   - task: PowerShell@2
     displayName: 'Validate version files'

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     value: "x-azurl,$(root-url),$(sas),readwrite"
   - group: vcpkg-binary-caching-credentials
   - name: X_VCPKG_BINARY_SOURCE_STUB
-    value: "x-azblob,$(root-url),$(sas)"
+    value: "x-azblob,$(root-bin-url),$(sas-bin)"
 
   steps:
   - task: PowerShell@2

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
     value: "x-azurl,$(root-url),$(sas),readwrite"
   - group: vcpkg-binary-caching-credentials
   - name: X_VCPKG_BINARY_SOURCE_STUB
-    value: "x-azurl,$(root-url),$(sas)"
+    value: "x-azblob,$(root-url),$(sas)"
 
   steps:
   - task: PowerShell@2

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'
-      arguments: '-Triplet ${{ parameters.triplet }} -BuildReason $(Build.Reason) -BinarySourceStub $(X_VCPKG_BINARY_SOURCE_STUB) -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
+      arguments: '-Triplet ${{ parameters.triplet }} -BuildReason $(Build.Reason) -BinarySourceStub "$(X_VCPKG_BINARY_SOURCE_STUB)" -WorkingRoot ${{ variables.WORKING_ROOT }} -ArtifactStagingDirectory $(Build.ArtifactStagingDirectory)'
       pwsh: true
   - task: PowerShell@2
     displayName: 'Validate version files'


### PR DESCRIPTION
We are being forced to change infrastructure somewhat more frequently than we would like, so change the binary caches to use a shared storage account like we already use for asset caching.
