### PR TITLE
Linux support for x_vcpkg_install_local_dependencies

### DIFF
--- a/scripts/buildsystems/linux/applocal.sh
+++ b/scripts/buildsystems/linux/applocal.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+DESTDIR=$1
+PREFIX=$2
+EXECUTABLE=$3
+VCPKG_INSTALLED=$(dirname $4) # vcpkg has some weird "bin" suffix that may not even exist!
+
+# if the executable is not an absolute path
+# we need to prefix the prefix directory
+case "${EXECUTABLE}" in
+    /*)
+        # nothing to be done, but we need to catch
+        # this so it doesn't go to the default case
+        ;;
+    *)
+        # not an absolute path, so it should
+        # fall under prefix
+        EXECUTABLE="${PREFIX}/${EXECUTABLE}"
+        ;;
+esac
+
+# iterate over all dependencies of the binary
+for DEPENDENCY in $(readelf -d "${DESTDIR}/${EXECUTABLE}" | grep "Shared library" | awk -F'[\[|\]]' '{print $2}'); do
+    DEPENDENCY_PATH="${VCPKG_INSTALLED}/lib/${DEPENDENCY}"
+
+    # check if vcpkg has the requested dependency
+    if [ ! -e "${DEPENDENCY_PATH}" ]; then
+        continue
+    fi
+
+    # check if the dependency is already installed
+    if [ -e "${DESTDIR}/${PREFIX}/lib/${DEPENDENCY}" ]; then
+        continue
+    fi
+
+    echo "Installing vcpkg-provided dependency: ${DEPENDENCY_PATH}" >> /tmp/vcpkg.fixup
+    mkdir -p ${DESTDIR}/${PREFIX}/lib
+
+    if [ -L "${DEPENDENCY_PATH}" ]; then
+        # recreate the link in the install dir
+        cp $(realpath ${DEPENDENCY_PATH}) ${DESTDIR}/${PREFIX}/lib/
+    fi
+
+    cp --no-dereference ${DEPENDENCY_PATH} ${DESTDIR}/${PREFIX}/lib/
+done

--- a/scripts/buildsystems/linux/applocal.sh
+++ b/scripts/buildsystems/linux/applocal.sh
@@ -3,7 +3,7 @@
 DESTDIR=$1
 PREFIX=$2
 EXECUTABLE=$3
-VCPKG_INSTALLED=$(dirname $4) # vcpkg has some weird "bin" suffix that may not even exist!
+VCPKG_INSTALLED=$4
 
 # if the executable is not an absolute path
 # we need to prefix the prefix directory
@@ -33,7 +33,6 @@ for DEPENDENCY in $(readelf -d "${DESTDIR}/${EXECUTABLE}" | grep "Shared library
         continue
     fi
 
-    echo "Installing vcpkg-provided dependency: ${DEPENDENCY_PATH}" >> /tmp/vcpkg.fixup
     mkdir -p ${DESTDIR}/${PREFIX}/lib
 
     if [ -L "${DEPENDENCY_PATH}" ]; then

--- a/scripts/buildsystems/linux/applocal.sh
+++ b/scripts/buildsystems/linux/applocal.sh
@@ -19,26 +19,39 @@ case "${EXECUTABLE}" in
         ;;
 esac
 
-# iterate over all dependencies of the binary
-for DEPENDENCY in $(readelf -d "${DESTDIR}/${EXECUTABLE}" | grep "Shared library" | awk -F'[\[|\]]' '{print $2}'); do
-    DEPENDENCY_PATH="${VCPKG_INSTALLED}/lib/${DEPENDENCY}"
+# copy dependencies from the given executable or shared library
+# to the matching library path, recursive
+function copy_dependencies() {
+    DESTDIR=$1
+    PREFIX=$2
+    BINARY=$3
+    VCPKG_INSTALLED=$4
 
-    # check if vcpkg has the requested dependency
-    if [ ! -e "${DEPENDENCY_PATH}" ]; then
-        continue
-    fi
+    # iterate over all dependencies of the binary
+    for DEPENDENCY in $(readelf -d "${BINARY}" | grep "Shared library" | awk -F'[\[|\]]' '{print $2}'); do
+        DEPENDENCY_PATH="${VCPKG_INSTALLED}/lib/${DEPENDENCY}"
 
-    # check if the dependency is already installed
-    if [ -e "${DESTDIR}/${PREFIX}/lib/${DEPENDENCY}" ]; then
-        continue
-    fi
+        # check if vcpkg has the requested dependency
+        if [ ! -e "${DEPENDENCY_PATH}" ]; then
+            continue
+        fi
 
-    mkdir -p ${DESTDIR}/${PREFIX}/lib
+        # check if the dependency is already installed
+        if [ ! -e "${DESTDIR}/${PREFIX}/lib/${DEPENDENCY}" ]; then
+            mkdir -p ${DESTDIR}/${PREFIX}/lib
 
-    if [ -L "${DEPENDENCY_PATH}" ]; then
-        # recreate the link in the install dir
-        cp $(realpath ${DEPENDENCY_PATH}) ${DESTDIR}/${PREFIX}/lib/
-    fi
+            if [ -L "${DEPENDENCY_PATH}" ]; then
+                # recreate the link in the install dir
+                cp $(realpath ${DEPENDENCY_PATH}) ${DESTDIR}/${PREFIX}/lib/
+            fi
 
-    cp --no-dereference ${DEPENDENCY_PATH} ${DESTDIR}/${PREFIX}/lib/
-done
+            cp --no-dereference ${DEPENDENCY_PATH} ${DESTDIR}/${PREFIX}/lib/
+        fi
+
+        # copy dependencies for the library itself
+        copy_dependencies "${DESTDIR}" "${PREFIX}" "${DESTDIR}/${PREFIX}/lib/${DEPENDENCY}" "${VCPKG_INSTALLED}"
+    done
+}
+
+# copy dependencies for the executable
+copy_dependencies "${DESTDIR}" "${PREFIX}" "${DESTDIR}/${EXECUTABLE}" "${VCPKG_INSTALLED}"

--- a/scripts/buildsystems/linux/applocal.sh
+++ b/scripts/buildsystems/linux/applocal.sh
@@ -2,8 +2,9 @@
 
 DESTDIR=$1
 PREFIX=$2
-EXECUTABLE=$3
-VCPKG_INSTALLED=$4
+RPATH=$3
+EXECUTABLE=$4
+VCPKG_INSTALLED=$5
 
 # if the executable is not an absolute path
 # we need to prefix the prefix directory
@@ -46,6 +47,12 @@ function copy_dependencies() {
             fi
 
             cp --no-dereference ${DEPENDENCY_PATH} ${DESTDIR}/${PREFIX}/lib/
+
+            # if the original target had an RPATH, the installed library
+            # should have the same RPATH as well
+            if [ ! -z "${RPATH}" ]; then
+                patchelf --set-rpath "${RPATH}" ${DESTDIR}/${PREFIX}/lib/${DEPENDENCY}
+            fi
         fi
 
         # copy dependencies for the library itself

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -639,7 +639,7 @@ function(x_vcpkg_install_local_dependencies)
                 install(CODE "message(\"-- Installing app dependencies for ${target}...\")
                     execute_process(COMMAND \"${Z_VCPKG_POWERSHELL_PATH}\" -noprofile -executionpolicy Bypass -file \"${Z_VCPKG_TOOLCHAIN_DIR}/msbuild/applocal.ps1\"
                         -targetBinary \"${arg_DESTINATION}/$<TARGET_FILE_NAME:${target}>\"
-                        -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
+                        -installedDir \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>\"
                         -OutVariable out)"
                     ${component_param}
                 )

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -648,11 +648,13 @@ function(x_vcpkg_install_local_dependencies)
     elseif(Z_VCPKG_TARGET_TRIPLET_PLAT STREQUAL "linux")
         foreach(TARGET IN LISTS arg_TARGETS)
             get_target_property(TARGETTYPE "${TARGET}" TYPE)
+            get_target_property(TARGET_RPATH "${TARGET}" INSTALL_RPATH)
             if(NOT TARGETTYPE STREQUAL "INTERFACE_LIBRARY")
-                install(CODE "message(\" -- Installing app dependencies for ${TARGET}...\")
+                install(CODE "message(\" -- Installing app dependencies for ${TARGET} with RPATH ${TARGET_RPATH}...\")
                     execute_process(COMMAND /bin/sh \"${Z_VCPKG_TOOLCHAIN_DIR}/linux/applocal.sh\"
                         \"\$ENV{DESTDIR}\"
                         \"\${CMAKE_INSTALL_PREFIX}\"
+                        \"${TARGET_RPATH}\"
                         \"${arg_DESTINATION}/$<TARGET_FILE_NAME:${TARGET}>\"
                         \"${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/bin\"
                         )"


### PR DESCRIPTION
If a cmake install() target is executed, the installed targets are
checked for dependencies in vcpkg library folder. If a matching
dependency is found it is copied to the `lib` folder

**Describe the pull request**

- #### What does your PR fix?  
Fixes missing dependencies when installing or creating a package with cpack using vcpkg shared library dependencies on linux.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
n/a
