### PR TITLE
[google-cloud-cpp] update to latest release (v1.31.1)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.31.0
-    SHA512 aa650297e60d36f79392a9e206f42bd58f63036e32466ee7a5cd2862cb4b38edf8178e2b04ef3a2dda47ab4f4a544ad3fa4de560f8fd8b9dcf02e60b76a07108
+    REF v1.31.1
+    SHA512 c172280cc934978505524d53bc804dc9079af21a1357f347b0bd3554d25cc2d57dec3869f1ba01f9eacaa1367feede84ae158fa3e9039b0e6bb87f7c27717bb1
     HEAD_REF master
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2389,7 +2389,7 @@
       "port-version": 6
     },
     "google-cloud-cpp": {
-      "baseline": "1.31.0",
+      "baseline": "1.31.1",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64af5624931918b1df7ff30a2f44ef86104739cd",
+      "version": "1.31.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "81d0a42380da299b4942b6d7f8c00ecba4ca7745",
       "version": "1.31.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.31.1).

We found a regression one day after the release :cry: 

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No Change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.

