### PR TITLE
[ms-gltf] Update to latest release r1.9.5.4

### DIFF
--- a/ports/ms-gltf/fix-install.patch
+++ b/ports/ms-gltf/fix-install.patch
@@ -18,7 +18,7 @@ index 3d940f5..322f029 100644
  
      if (MSVC)
 -        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_SOURCE_DIR}/Built/Out/${platform}/$<CONFIG>/${PROJECT_NAME})
-+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
++        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
      endif()
  
  endfunction(CreateGLTFInstallTargets)

--- a/ports/ms-gltf/fix-install.patch
+++ b/ports/ms-gltf/fix-install.patch
@@ -18,7 +18,7 @@ index 3d940f5..322f029 100644
  
      if (MSVC)
 -        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_SOURCE_DIR}/Built/Out/${platform}/$<CONFIG>/${PROJECT_NAME})
-+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
++        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
      endif()
  
  endfunction(CreateGLTFInstallTargets)

--- a/ports/ms-gltf/portfile.cmake
+++ b/ports/ms-gltf/portfile.cmake
@@ -6,8 +6,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/glTF-SDK
-    REF 9428f114b540fb93e6533d5ec460fc123efe0c86 # todo: r1.9.6.0
-    SHA512 900caf6d72d360bae4c7af769a8879507f7f727b40f61723ffed679ad22877fb37daed2a0dfcbf27e15ab3adc8afe3249530b95691ce489b3446e5d9a35f205a
+    REF ac3e70392feb6aef18a07314669f6af2ebc72787 # r1.9.5.4
+    SHA512 389b801ddc6f0b29269bcd1215fa9e63fe46a1f1a8778125c6439e34fe0925d5534b1cdbea30824a4a8aa008015124dc7cc4558daa9522fc6d85e00e8e41e4a9
     HEAD_REF master
     PATCHES
         fix-install.patch

--- a/ports/ms-gltf/portfile.cmake
+++ b/ports/ms-gltf/portfile.cmake
@@ -16,12 +16,12 @@ vcpkg_from_github(
 
 # note: Test/Sample executables won't be installed
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
         test    ENABLE_UNIT_TESTS
         samples ENABLE_SAMPLES
 )
 
 # note: Platform-native buildsystem will be more helpful to launch/debug the tests/samples.
-# note: The PDB file path is making Ninja fails to install. 
 #       For Windows, we rely on /MP. The other platforms should be able to build with PREFER_NINJA.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/ms-gltf/portfile.cmake
+++ b/ports/ms-gltf/portfile.cmake
@@ -22,9 +22,16 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 # note: Platform-native buildsystem will be more helpful to launch/debug the tests/samples.
+# note: The PDB file path is making Ninja fails to install.
 #       For Windows, we rely on /MP. The other platforms should be able to build with PREFER_NINJA.
+set(WINDOWS_USE_MSBUILD)
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(WINDOWS_USE_MSBUILD "WINDOWS_USE_MSBUILD")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    ${WINDOWS_USE_MSBUILD}
     OPTIONS
         ${FEATURE_OPTIONS}
 )

--- a/ports/ms-gltf/portfile.cmake
+++ b/ports/ms-gltf/portfile.cmake
@@ -23,19 +23,17 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 # note: Platform-native buildsystem will be more helpful to launch/debug the tests/samples.
 # note: The PDB file path is making Ninja fails to install. 
 #       For Windows, we rely on /MP. The other platforms should be able to build with PREFER_NINJA.
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
 )
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE
-     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
-)
-
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ms-gltf/vcpkg.json
+++ b/ports/ms-gltf/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "ms-gltf",
   "version-string": "r1.9.5.0",
+  "port-version": 1,
   "description": "glTF-SDK is a C++ Software Development Kit for glTF",
-  "homepage": "https://github.com/microsoft/ms-gltf",
+  "homepage": "https://github.com/microsoft/glTF-SDK",
   "supports": "!linux",
   "dependencies": [
-    "rapidjson"
+    "rapidjson",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ],
   "default-features": [
     "test"

--- a/ports/ms-gltf/vcpkg.json
+++ b/ports/ms-gltf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ms-gltf",
-  "version-string": "r1.9.5.0",
-  "port-version": 1,
+  "version-string": "r1.9.5.4",
   "description": "glTF-SDK is a C++ Software Development Kit for glTF",
   "homepage": "https://github.com/microsoft/glTF-SDK",
   "supports": "!linux",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4274,7 +4274,7 @@
     },
     "ms-gltf": {
       "baseline": "r1.9.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ms-gsl": {
       "baseline": "3.1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4273,8 +4273,8 @@
       "port-version": 0
     },
     "ms-gltf": {
-      "baseline": "r1.9.5.0",
-      "port-version": 1
+      "baseline": "r1.9.5.4",
+      "port-version": 0
     },
     "ms-gsl": {
       "baseline": "3.1.0",

--- a/versions/m-/ms-gltf.json
+++ b/versions/m-/ms-gltf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c0f341a9dd068937d96c825c607384bbbee0d35",
+      "version-string": "r1.9.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1c3bf009ece6942607e095c0088810b6dbf86d38",
       "version-string": "r1.9.5.0",
       "port-version": 0

--- a/versions/m-/ms-gltf.json
+++ b/versions/m-/ms-gltf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0291597bfe72db0a8b6f44b2632339174d955119",
+      "git-tree": "7fca6692d53ae0b0fa84e7bad6870e879df152b2",
       "version-string": "r1.9.5.0",
       "port-version": 1
     },

--- a/versions/m-/ms-gltf.json
+++ b/versions/m-/ms-gltf.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "7fca6692d53ae0b0fa84e7bad6870e879df152b2",
-      "version-string": "r1.9.5.0",
-      "port-version": 1
+      "git-tree": "aeeeac2de78af647be1312f6e9ab687c18369e99",
+      "version-string": "r1.9.5.4",
+      "port-version": 0
     },
     {
       "git-tree": "1c3bf009ece6942607e095c0088810b6dbf86d38",

--- a/versions/m-/ms-gltf.json
+++ b/versions/m-/ms-gltf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1c0f341a9dd068937d96c825c607384bbbee0d35",
+      "git-tree": "0291597bfe72db0a8b6f44b2632339174d955119",
       "version-string": "r1.9.5.0",
       "port-version": 1
     },


### PR DESCRIPTION
1. The origin homepage is wrong, we can't access it, we found this problem when run the scripts to get star of package in vcpkg website.
2.  Swith vcpkg_configure_cmake to vcpkg_cmake_configure, and pass WINDOWS_USE_MSBUILD vcpkg_cmake_configure to make sure to use msbuild.

```
# note: The PDB file path is making Ninja fails to install.
#       For Windows, we rely on /MP. The other platforms should be able to build with PREFER_NINJA.
```
3. Update to latest release r1.9.5.4