### PR TITLE
[libmupdf/liblinear/libkeyfinder] Update to latest version

### DIFF
--- a/ports/libkeyfinder/portfile.cmake
+++ b/ports/libkeyfinder/portfile.cmake
@@ -1,24 +1,25 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mixxxdj/libkeyfinder
-    REF v2.2.4
-    SHA512 6673b9a81dbfa3693fc4e7af4e5fc0f351f0c60b00fdafeb9e3437e2f77b5fec7d1e78e3989ff1daca72770a1d3cdbe3837508718b8e8aba3ac3f3d56af81a56
+    REF v2.2.5
+    SHA512 54463d1f1111dc474d3e43723fddd5579ea1a3842f99f43e50e85622a1d6ee6fe42b22c300ce5ba5807cf6b2d7067af741773af95974a42c5d863c53165893eb
     HEAD_REF main
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    test BUILD_TESTING
+    FEATURES
+      test BUILD_TESTING
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/KeyFinder TARGET_PATH share/KeyFinder)
+vcpkg_cmake_config_fixup(PACKAGE_NAME KeyFinder CONFIG_PATH lib/cmake/KeyFinder)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libkeyfinder/vcpkg.json
+++ b/ports/libkeyfinder/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "libkeyfinder",
-  "version-string": "2.2.4",
+  "version-string": "2.2.5",
   "description": "Musical key detection for digital audio",
   "homepage": "https://github.com/mixxxdj/libkeyfinder",
   "license": "GPL-3.0-or-later",
   "dependencies": [
-    "fftw3"
+    "fftw3",
+    {
+      "name": "vcpkg-cmake",
+      "host": true      
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true      
+    }
   ],
   "features": {
     "test": {

--- a/ports/libkeyfinder/vcpkg.json
+++ b/ports/libkeyfinder/vcpkg.json
@@ -8,11 +8,11 @@
     "fftw3",
     {
       "name": "vcpkg-cmake",
-      "host": true      
+      "host": true
     },
     {
       "name": "vcpkg-cmake-config",
-      "host": true      
+      "host": true
     }
   ],
   "features": {

--- a/ports/liblinear/CONTROL
+++ b/ports/liblinear/CONTROL
@@ -1,5 +1,0 @@
-Source: liblinear
-Version: 241
-Homepage: https://github.com/cjlin1/liblinear
-Description: A Library for Large Linear Classification
-Supports: !uwp

--- a/ports/liblinear/portfile.cmake
+++ b/ports/liblinear/portfile.cmake
@@ -3,27 +3,26 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO cjlin1/liblinear
-    REF 2381122d05bbb1e4ee24b522298dd548f0ec0d24 #v241
-    SHA512 ee784b6325681b3d9e3dc0b59f4a703d87be35fb898cc16df93e4a814a959d530736a8451be4f0f2c856769d81e3f5acbcd6f0f8677425e700597e3502f9f36d
+    REF 60f1adf6f35d6f3e031c334b33dfe8399d6f8a9d #v243
+    SHA512 0f88f8dd768313d0a9b3bb82e7b878d7173ea43ef609e993dc79e94398897373faf2688249b17111e2b6e06e78e26a50570a1b746dc4e73fb7416ccc24936c66
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS_DEBUG
         -DDISABLE_INSTALL_HEADERS=ON
         -DDISABLE_INSTALL_TOOLS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if(NOT DISABLE_INSTALL_TOOLS)
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/liblinear)
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/liblinear")
 endif()
 
-file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/liblinear/vcpkg.json
+++ b/ports/liblinear/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "liblinear",
+  "version-string": "243",
+  "description": "A Library for Large Linear Classification",
+  "homepage": "https://github.com/cjlin1/liblinear",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/libmupdf/CONTROL
+++ b/ports/libmupdf/CONTROL
@@ -1,6 +1,0 @@
-Source: libmupdf
-Version: 1.18.0
-Build-Depends: freetype, libjpeg-turbo, harfbuzz, zlib, curl, glfw3, openjpeg, jbig2dec, gumbo
-Homepage: https://github.com/ArtifexSoftware/mupdf
-Description: a lightweight PDF, XPS, and E-book library
-Supports: !osx

--- a/ports/libmupdf/portfile.cmake
+++ b/ports/libmupdf/portfile.cmake
@@ -5,25 +5,24 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ArtifexSoftware/mupdf
-    REF ea5799e01730c4aa15cddd1023700e4f7b78cc27 # 1.18.0
-    SHA512 4904565e900970939f93bf4326df86851e699699c8e49df7abdbedf6ba3e9d26b74691710b2019d04bba2dea11c7880fe4418b643866128828e388500aa666c2
+    REF af0e25cec567868a04eaacf6410c395712fe4b90 #1.18.1-so-3.11.14
+    SHA512 3dc6b75964d93af84921ee30a5b14e0ab84d16afa31f97a0fbf62e2006ace62f9c0366d1c3872cd678dab71eb23a422daeca0eb0b5db58e434f27657bbf9b5bc
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
-    PREFER_NINJA
     OPTIONS
         -DBUILD_EXAMPLES=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(COPY ${SOURCE_PATH}/include/mupdf DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+file(COPY "${SOURCE_PATH}/include/mupdf" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "libmupdf",
+  "version-string": "1.18.1-so-3.11.14",
+  "description": "a lightweight PDF, XPS, and E-book library",
+  "homepage": "https://github.com/ArtifexSoftware/mupdf",
+  "supports": "!osx",
+  "dependencies": [
+    "curl",
+    "freetype",
+    "glfw3",
+    "gumbo",
+    "harfbuzz",
+    "jbig2dec",
+    "libjpeg-turbo",
+    "openjpeg",
+    "zlib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true      
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true      
+    }
+  ]
+}

--- a/ports/libmupdf/vcpkg.json
+++ b/ports/libmupdf/vcpkg.json
@@ -13,14 +13,14 @@
     "jbig2dec",
     "libjpeg-turbo",
     "openjpeg",
-    "zlib",
     {
       "name": "vcpkg-cmake",
-      "host": true      
+      "host": true
     },
     {
       "name": "vcpkg-cmake-config",
-      "host": true      
-    }
+      "host": true
+    },
+    "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3353,7 +3353,7 @@
       "port-version": 0
     },
     "libkeyfinder": {
-      "baseline": "2.2.4",
+      "baseline": "2.2.5",
       "port-version": 0
     },
     "libkml": {
@@ -3373,7 +3373,7 @@
       "port-version": 0
     },
     "liblinear": {
-      "baseline": "241",
+      "baseline": "243",
       "port-version": 0
     },
     "liblo": {
@@ -3449,7 +3449,7 @@
       "port-version": 0
     },
     "libmupdf": {
-      "baseline": "1.18.0",
+      "baseline": "1.18.1-so-3.11.14",
       "port-version": 0
     },
     "libmysql": {

--- a/versions/l-/libkeyfinder.json
+++ b/versions/l-/libkeyfinder.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1da49d266f784b6c144bc115ab6a6d6938fab5e2",
+      "git-tree": "d2f8022bca9bc70894c26b7d73437eadfa9b9bca",
       "version-string": "2.2.5",
       "port-version": 0
     },

--- a/versions/l-/libkeyfinder.json
+++ b/versions/l-/libkeyfinder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1da49d266f784b6c144bc115ab6a6d6938fab5e2",
+      "version-string": "2.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "0ea7e74c79c626ed0185ee546a684293663cf651",
       "version-string": "2.2.4",
       "port-version": 0

--- a/versions/l-/liblinear.json
+++ b/versions/l-/liblinear.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a1acaef662beb37406c20bf6293109025f8df1b",
+      "version-string": "243",
+      "port-version": 0
+    },
+    {
       "git-tree": "32c7a7c42530041f778e5a00b54c43ebcc0839d9",
       "version-string": "241",
       "port-version": 0

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "964313c9bdde23b257ce9a7d75d73302e7871f79",
+      "git-tree": "20a08f46ae4e7bd7afa7eaad146a2709bd782ea3",
       "version-string": "1.18.1-so-3.11.14",
       "port-version": 0
     },

--- a/versions/l-/libmupdf.json
+++ b/versions/l-/libmupdf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "964313c9bdde23b257ce9a7d75d73302e7871f79",
+      "version-string": "1.18.1-so-3.11.14",
+      "port-version": 0
+    },
+    {
       "git-tree": "df4714ec8c7080d91b3fc0ed0db8c91557d1bfbf",
       "version-string": "1.18.0",
       "port-version": 0


### PR DESCRIPTION
Fix #19934 #19932 #19931

Update libmupdf、liblinear、libkeyfinder  to latest version

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static