### PR TITLE
[amqpcpp] Fix linking amqpcpp on macOS

### DIFF
--- a/ports/amqpcpp/portfile.cmake
+++ b/ports/amqpcpp/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
         find-openssl.patch
 )
 
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Linux" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(LINUX_TCP ON)
 else()
     set(LINUX_TCP OFF)

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "amqpcpp",
-  "version-string": "4.3.11",
+  "version-string": "4.3.12",
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
   "supports": "!uwp",

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "amqpcpp",
-  "version-string": "4.3.12",
+  "version": "4.3.11",
+  "port-version": 1,
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
   "supports": "!uwp",

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8aad1d96b969068666c0b1894d385915ed838400",
+      "version": "4.3.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "87bc718df7e295b38613a809cad2c16877e4e71a",
       "version-string": "4.3.12",
       "port-version": 0

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87bc718df7e295b38613a809cad2c16877e4e71a",
+      "version-string": "4.3.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f99b7612476d68b1cd6a026696741da9b90c230",
       "version-string": "4.3.11",
       "port-version": 0

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -6,11 +6,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "87bc718df7e295b38613a809cad2c16877e4e71a",
-      "version-string": "4.3.12",
-      "port-version": 0
-    },
-    {
       "git-tree": "7f99b7612476d68b1cd6a026696741da9b90c230",
       "version-string": "4.3.11",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -69,8 +69,8 @@
       "port-version": 1
     },
     "amqpcpp": {
-      "baseline": "4.3.12",
-      "port-version": 0
+      "baseline": "4.3.11",
+      "port-version": 1
     },
     "anax": {
       "baseline": "2.1.0-6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -69,7 +69,7 @@
       "port-version": 1
     },
     "amqpcpp": {
-      "baseline": "4.3.11",
+      "baseline": "4.3.12",
       "port-version": 0
     },
     "anax": {


### PR DESCRIPTION
**When you try to link your app with amqpcpp lib you'll see errors for unsupported architecture**

- #### What does your PR fix?  
  #19975

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
 All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

