### PR TITLE
Fix libgit2 ssh feature

### DIFF
--- a/ports/libgit2/0001-Fix-libssh2.patch
+++ b/ports/libgit2/0001-Fix-libssh2.patch
@@ -1,0 +1,25 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 45dec2796..313af3af6 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -231,15 +231,14 @@ ENDIF()
+ 
+ # Optional external dependency: libssh2
+ IF (USE_SSH)
+-       FIND_PKGLIBRARIES(LIBSSH2 libssh2)
++       FIND_PACKAGE(Libssh2 REQUIRED)
+ ENDIF()
+-IF (LIBSSH2_FOUND)
++IF (Libssh2_FOUND)
+        SET(GIT_SSH 1)
+-       LIST(APPEND LIBGIT2_SYSTEM_INCLUDES ${LIBSSH2_INCLUDE_DIRS})
+-       LIST(APPEND LIBGIT2_LIBS ${LIBSSH2_LIBRARIES})
+-       LIST(APPEND LIBGIT2_PC_LIBS ${LIBSSH2_LDFLAGS})
++       LIST(APPEND LIBGIT2_LIBS Libssh2::libssh2)
++       LIST(APPEND LIBGIT2_PC_LIBS -lssh2)
+ 
+-       CHECK_LIBRARY_EXISTS("${LIBSSH2_LIBRARIES}" libssh2_userauth_publickey_frommemory "${LIBSSH2_LIBRARY_DIRS}" HAVE_LIBSSH2_MEMORY_CREDENTIALS)
++       CHECK_LIBRARY_EXISTS(Libssh2::libssh2 libssh2_userauth_publickey_frommemory "" HAVE_LIBSSH2_MEMORY_CREDENTIALS)
+        IF (HAVE_LIBSSH2_MEMORY_CREDENTIALS)
+                SET(GIT_SSH_MEMORY_CREDENTIALS 1)
+        ENDIF()

--- a/ports/libgit2/CONTROL
+++ b/ports/libgit2/CONTROL
@@ -1,5 +1,6 @@
 Source: libgit2
 Version: 1.1.0
+Port-Version: 1
 Homepage: https://github.com/libgit2/libgit2
 Build-Depends: zlib, http-parser
 Description: Git linkable library

--- a/ports/libgit2/portfile.cmake
+++ b/ports/libgit2/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     REF 7f4fa178629d559c037a1f72f79f79af9c1ef8ce#version 1.1.0
     SHA512 2fdbbb263fe71dc6d04b64c2967e7acff1a5b6102e62d69c9a7ea1b6777ab74a1625e798438ea239d8b489648a9335833f937f893f73a66e16c658eae453ab62
     HEAD_REF master
+    PATCHES "${CMAKE_CURRENT_LIST_DIR}/0001-Fix-libssh2.patch"
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" STATIC_CRT)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3258,7 +3258,7 @@
     },
     "libgit2": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libgnutls": {
       "baseline": "3.6.15",

--- a/versions/l-/libgit2.json
+++ b/versions/l-/libgit2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "946c688976c15d17d8c08145eeb54f11b5ee19f8",
+      "version-string": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "23d98ed81409eaac3ae1abc9ddbc175564533d65",
       "version-string": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

I'm trying to use libgit2 with ssh feature but I wasn't able to get it to work, the reason is libssh2 from vcpkg doesn't have a `libssh2.pc` which is how libgit2 is trying to find it, so this package fixes it by introducing a patch file to fix it

I created a repo to reproduce the behavior https://github.com/JafarAbdi/test_libgit2, if you build without my fix it will print

```
GIT_FEATURE_THREADS: 1
GIT_FEATURE_HTTPS: 1
GIT_FEATURE_SSH: 0
GIT_FEATURE_NSEC: 1
```
After applying this fix I was able to get the ssh feature, and running the example prints
```
GIT_FEATURE_THREADS: 1
GIT_FEATURE_HTTPS: 1
GIT_FEATURE_SSH: 1
GIT_FEATURE_NSEC: 1
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  linux, No

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
