### PR TITLE
[vamp-sdk] fix library filenames to match upstream build systems

### DIFF
--- a/ports/vamp-sdk/CMakeLists.txt
+++ b/ports/vamp-sdk/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(vamp-cmake)
 
-set(CMAKE_DEBUG_POSTFIX d)
-
 find_package(SndFile REQUIRED)
 
 set(VAMP_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/vamp/vamp.h)
@@ -64,6 +62,14 @@ message(${SDK_HEADERS})
 set_target_properties(vamp-sdk PROPERTIES PUBLIC_HEADER "${SDK_HEADERS}")
 set_target_properties(vamp-hostsdk PROPERTIES PUBLIC_HEADER
                                               "${HOST_SDK_HEADERS}")
+
+# The Visual Studio project files upstream intentionally output different
+# library file names than autotools.
+# https://github.com/tenacityteam/tenacity/pull/577#discussion_r702328284
+if(WIN32)
+    set_target_properties(vamp-sdk PROPERTIES OUTPUT_NAME VampPluginSDK)
+    set_target_properties(vamp-hostsdk PROPERTIES OUTPUT_NAME VampHostSDK)
+endif()
 
 set_property(TARGET vamp-sdk PROPERTY CXX_STANDARD 11)
 set_property(TARGET vamp-hostsdk PROPERTY CXX_STANDARD 11)

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -3,7 +3,7 @@
   "name": "vamp-sdk",
   "version": "2.10",
   "port-version": 1,
-  "description": "Library for VAMP plugins",
+  "description": "Library for Vamp plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
   "supports": "!uwp",
   "dependencies": [

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "vamp-sdk",
   "version": "2.10",
+  "port-version": 1,
   "description": "Library for VAMP plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6666,7 +6666,7 @@
     },
     "vamp-sdk": {
       "baseline": "2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "variant-lite": {
       "baseline": "1.2.2",

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7674662edffbe9b9a0dbc90698137599f648f9f8",
+      "version": "2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "da7ad3424d8266657eec1b28b16a8d389e50b67c",
       "version": "2.10",
       "port-version": 0

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7674662edffbe9b9a0dbc90698137599f648f9f8",
+      "git-tree": "1c71927e1997998f40a9d051d65ba4e5760f4257",
       "version": "2.10",
       "port-version": 1
     },


### PR DESCRIPTION
There were two problems:
1. The port added a `d` suffix for debug builds that upstream did
not. This caused
`find_library(VampHostSDK_LIBRARY NAMES vamp-sdk)`
to fail to find the debug library.
2. The port used the same file name for libraries on every OS but
that is not what upstream does.

**Describe the pull request**

- #### What does your PR fix?  
  Fixes https://github.com/tenacityteam/tenacity/issues/526

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

