### PR TITLE
[libass] link flags for generated .pc

### DIFF
--- a/ports/libass/CMakeLists.txt
+++ b/ports/libass/CMakeLists.txt
@@ -82,7 +82,12 @@ if(WIN32 OR APPLE)
 else()
   set(PKG_REQUIRES_PRIVATE "fontconfig >= 2.10.92, harfbuzz >= 1.2.3, fribidi >= 0.19.0, freetype2 >= 9.10.3")
 endif()
-set(PKG_LIBS_PRIVATE -lm)
+# patch comes from original repository, use lrint to judge whether to link libm 
+include(CheckFunctionExists)
+check_function_exists(lrint HAVE_LRINT)
+if(NOT HAVE_LRINT)
+  set(PKG_LIBS_PRIVATE -lm)
+endif()
 configure_file(libass.pc.in libass.pc @ONLY)
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/libass.pc

--- a/ports/libass/vcpkg.json
+++ b/ports/libass/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libass",
-  "version": "0.15.1",
-  "port-version": 1,
+  "version-semver": "0.15.1",
+  "port-version": 2,
   "description": "libass is a portable subtitle renderer for the ASS/SSA (Advanced Substation Alpha/Substation Alpha) subtitle format",
   "homepage": "https://github.com/libass/libass",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3106,7 +3106,7 @@
     },
     "libass": {
       "baseline": "0.15.1",
-      "port-version": 1
+      "port-version": 2
     },
     "libassuan": {
       "baseline": "2.5.3",

--- a/versions/l-/libass.json
+++ b/versions/l-/libass.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bbc8c60f41ff62aef7fe801df3a234666f564182",
+      "version-semver": "0.15.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "7c9d2203cb8e0f912847cdd70a9ba1142b1ab32f",
       "version": "0.15.1",
       "port-version": 1


### PR DESCRIPTION
libass does not need to link libm on windows but previous version of .pc links m. This pr add a check before generate .pc