### PR TITLE
[kf5i18n] static builds fixes

### DIFF
--- a/ports/kf5i18n/fix_static_builds.patch
+++ b/ports/kf5i18n/fix_static_builds.patch
@@ -1,0 +1,30 @@
+diff --git a/KF5I18nConfig.cmake.in b/KF5I18nConfig.cmake.in
+index 364cc43..af7cd3b 100644
+--- a/KF5I18nConfig.cmake.in
++++ b/KF5I18nConfig.cmake.in
+@@ -8,3 +8,4 @@ include("${CMAKE_CURRENT_LIST_DIR}/KF5I18nTargets.cmake")
+ @PACKAGE_INCLUDE_QCHTARGETS@
+ include("${CMAKE_CURRENT_LIST_DIR}/KF5I18nMacros.cmake")
+ 
++find_dependency(Iconv)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c6b510c..0a25eca 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -38,12 +38,16 @@ ecm_generate_export_header(KF5I18n
+     EXCLUDE_DEPRECATED_BEFORE_AND_AT ${EXCLUDE_DEPRECATED_BEFORE_AND_AT}
+ )
+ 
++find_package(Iconv REQUIRED)
++
+ target_include_directories(KF5I18n INTERFACE "$<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR_KF5}/KI18n>")
+ target_include_directories(KF5I18n PRIVATE ${LibIntl_INCLUDE_DIRS})
++target_include_directories(KF5I18n PRIVATE ${Iconv_INCLUDE_DIRS})
+ 
+ target_link_libraries(KF5I18n PUBLIC Qt5::Core)
+ # This is only required for platforms which don't use glibc (with glibc LibIntl_LIBRARIES will be empty)
+ target_link_libraries(KF5I18n PRIVATE ${LibIntl_LIBRARIES})
++target_link_libraries(KF5I18n PRIVATE ${Iconv_LIBRARIES})
+ target_compile_options(KF5I18n PRIVATE -DTRANSLATION_DOMAIN=\"ki18n5\")
+ 
+ set_target_properties(KF5I18n PROPERTIES VERSION   ${KI18N_VERSION}

--- a/ports/kf5i18n/portfile.cmake
+++ b/ports/kf5i18n/portfile.cmake
@@ -1,8 +1,13 @@
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+     list(APPEND PATCHES fix_static_builds.patch)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO KDE/ki18n
     REF v5.84.0
     SHA512 611481b0d5f387b6e1201c1d38e050bd6c956607d059679c68f39d8560cdde666709f5aa1ae770e200fb81e902da85160eb3eeaf5c0bdb02c0ff13782df1d907
+    PATCHES ${PATCHES}
 )
 
 vcpkg_find_acquire_program(PYTHON3)

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5i18n",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [
@@ -14,6 +14,7 @@
         "tools"
       ]
     },
+    "libiconv",
     "qt5-declarative",
     "qt5-tools"
   ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2942,7 +2942,7 @@
     },
     "kf5i18n": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5itemmodels": {
       "baseline": "5.84.0",

--- a/versions/k-/kf5i18n.json
+++ b/versions/k-/kf5i18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d34c7c3f38d55f93bc26d146fcf656f7eb4be3c",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f0d01fec0fb56e9c2d95b743b0b13e544d5428a7",
       "version": "5.84.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
  Fixes static builds such that the LibIconv is correctly linked against and passed over as a transitive dependency.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
