### PR TITLE
[png++] Fix compilation error in error.hpp on MSVC

### DIFF
--- a/ports/pngpp/portfile.cmake
+++ b/ports/pngpp/portfile.cmake
@@ -10,6 +10,9 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
+# Patch error.hpp: fix `strerror_r` not existing + `strerror_s` not being detected on MSVC
+vcpkg_replace_string(${SOURCE_PATH}/error.hpp "defined(__STDC_LIB_EXT1__)" "defined(__STDC_LIB_EXT1__) || defined(_MSC_VER)")
+
 file(GLOB HEADER_FILES ${SOURCE_PATH}/*.hpp)
 file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/png++)
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/pngpp/vcpkg.json
+++ b/ports/pngpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pngpp",
   "version-string": "0.2.10",
+  "port-version": 1,
   "description": "A C++ wrapper for libpng library.",
   "dependencies": [
     "libpng"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5038,7 +5038,7 @@
     },
     "pngpp": {
       "baseline": "0.2.10",
-      "port-version": 0
+      "port-version": 1
     },
     "pngwriter": {
       "baseline": "0.7.0-2",

--- a/versions/p-/pngpp.json
+++ b/versions/p-/pngpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6b2686a40e7353cf548ca82f8e0440d80807d01",
+      "version-string": "0.2.10",
+      "port-version": 1
+    },
+    {
       "git-tree": "4c162ef0d91f9415a77e44bd02f9bd3abf3684e1",
       "version-string": "0.2.10",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
This PR fixes a compilation issue on MSVC where programs that include png++ fail to compile with `error C3861: 'strerror_r': identifier not found`.

- #### What does your PR fix?  
  No GitHub issue posted.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
