### PR TITLE
[openjpeg] Update version to 2.4.0

### DIFF
--- a/ports/openjpeg/Enable-tools-of-each-features.patch
+++ b/ports/openjpeg/Enable-tools-of-each-features.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5a41078..747c61c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -277,7 +277,7 @@ mark_as_advanced(BUILD_VIEWER)
+ mark_as_advanced(BUILD_JAVA)
+ mark_as_advanced(BUILD_JP3D)
+ 
+-if(BUILD_CODEC OR BUILD_MJ2)
++if(BUILD_CODEC OR BUILD_JPWL OR BUILD_MJ2 OR BUILD_JPIP OR BUILD_JP3D)
+   # OFF: It will only build 3rd party libs if they are not found on the system
+   # ON: 3rd party libs will ALWAYS be build, and used
+   option(BUILD_THIRDPARTY "Build the thirdparty executables if it is needed" OFF)

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES 
         dll.location.patch
         fix-lrintf-to-opj_lrintf.patch
+        Enable-tools-of-each-features.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)
@@ -46,13 +47,23 @@ else()
     endif()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libopenjp2.pc" "-lm" "-lm -pthread")
 endif()
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 set(TOOL_NAMES)
+if("jpwl" IN_LIST FEATURES)
+    list(APPEND TOOL_NAMES opj_compress opj_decompress opj_dump opj_jpwl_compress opj_jpwl_decompress)
+endif()
 if("mj2" IN_LIST FEATURES)
     list(APPEND TOOL_NAMES opj_compress opj_decompress opj_dump opj_mj2_compress opj_mj2_decompress opj_mj2_extract opj_mj2_wrap)
+endif()
+if("jpip" IN_LIST FEATURES)
+    list(APPEND TOOL_NAMES opj_compress opj_decompress opj_dump opj_dec_server opj_jpip_addxml opj_jpip_test opj_jpip_transcode)
+endif()
+if("jp3d" IN_LIST FEATURES)
+    list(APPEND TOOL_NAMES opj_jp3d_compress opj_jp3d_decompress)
 endif()
 if(TOOL_NAMES)
     vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO uclouvain/openjpeg
-    REF v2.3.1
-    SHA512 339fbc899bddf2393d214df71ed5d6070a3a76b933b1e75576c8a0ae9dfcc4adec40bdc544f599e4b8d0bc173e4e9e7352408497b5b3c9356985605830c26c03
+    REF 37ac30ceff6640bbab502388c5e0fa0bff23f505 #v2.4.0
+    SHA512 7554d64701f1b51501a977bc165e61e4696d97f1f40e4c784c729824878a716c13ac378c6b2dd0d23a11d9e3fa316ff6fc817ca5a614ef4d6530db06a8f83971
     HEAD_REF master
     PATCHES 
         dll.location.patch
@@ -18,27 +18,29 @@ else()
 endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    "jpwl"          BUILD_JPWL
-    "mj2"           BUILD_MJ2
-    "jpip"          BUILD_JPIP
-    "jp3d"          BUILD_JP3D
-    )
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DBUILD_CODEC:BOOL=OFF
-            -DBUILD_DOC:BOOL=OFF
-            -DOPENJPEG_INSTALL_PACKAGE_DIR=share/openjpeg
-            -DOPENJPEG_INSTALL_INCLUDE_DIR=include
-            -DEXECUTABLE_OUTPUT_PATH=tools/${PORT}
-            -DBUILD_PKGCONFIG_FILES=ON
-            ${FEATURE_OPTIONS}
-            ${OPTIONS}
+    FEATURES
+        "jpwl"          BUILD_JPWL
+        "mj2"           BUILD_MJ2
+        "jpip"          BUILD_JPIP
+        "jp3d"          BUILD_JP3D
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_CODEC:BOOL=OFF
+        -DBUILD_DOC:BOOL=OFF
+        -DOPENJPEG_INSTALL_PACKAGE_DIR=share/openjpeg
+        -DOPENJPEG_INSTALL_INCLUDE_DIR=include
+        -DEXECUTABLE_OUTPUT_PATH=tools/${PORT}
+        -DBUILD_PKGCONFIG_FILES=ON
+        ${FEATURE_OPTIONS}
+        ${OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
+
 if(VCPKG_TARGET_IS_WINDOWS AND (NOT VCPKG_CMAKE_SYSTEM_NAME STREQUAL MinGW))
     if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libopenjp2.pc" "-lm" "")
@@ -52,32 +54,24 @@ else()
 endif()
 vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 set(TOOL_NAMES)
-if("jpwl" IN_LIST FEATURES)
-    list(APPEND TOOL_NAMES  opj_dec_server opj_jpwl_compress opj_jpwl_decompress)
-endif()  
 if("mj2" IN_LIST FEATURES)
     list(APPEND TOOL_NAMES opj_compress opj_decompress opj_dump opj_mj2_compress opj_mj2_decompress opj_mj2_extract opj_mj2_wrap)
-endif()  
-if("jpip" IN_LIST FEATURES)
-    list(APPEND TOOL_NAMES opj_jpip_addxml opj_jpip_test opj_jpip_transcode)
-endif()
-if("jp3d" IN_LIST FEATURES)
-    list(APPEND TOOL_NAMES opj_jp3d_compress opj_jp3d_decompress)
 endif()
 if(TOOL_NAMES)
     vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
 endif()
-file(READ ${CURRENT_PACKAGES_DIR}/include/openjpeg.h OPENJPEG_H)
+
+file(READ "${CURRENT_PACKAGES_DIR}/include/openjpeg.h" OPENJPEG_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     string(REPLACE "defined(OPJ_STATIC)" "1" OPENJPEG_H "${OPENJPEG_H}")
 else()
     string(REPLACE "defined(OPJ_STATIC)" "0" OPENJPEG_H "${OPENJPEG_H}")
 endif()
 string(REPLACE "defined(DLL_EXPORT)" "0" OPENJPEG_H "${OPENJPEG_H}")
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/openjpeg.h "${OPENJPEG_H}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/openjpeg.h" "${OPENJPEG_H}")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -9,13 +9,7 @@ vcpkg_from_github(
         fix-lrintf-to-opj_lrintf.patch
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    list(APPEND OPTIONS "-DBUILD_SHARED_LIBS=OFF"
-                        "-DBUILD_STATIC_LIBS=ON")
-else()
-    list(APPEND OPTIONS "-DBUILD_SHARED_LIBS=ON"
-                        "-DBUILD_STATIC_LIBS=OFF")
-endif()
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC_LIBS)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -35,7 +29,7 @@ vcpkg_cmake_configure(
         -DEXECUTABLE_OUTPUT_PATH=tools/${PORT}
         -DBUILD_PKGCONFIG_FILES=ON
         ${FEATURE_OPTIONS}
-        ${OPTIONS}
+        -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
 )
 
 vcpkg_cmake_install()
@@ -52,7 +46,7 @@ else()
     endif()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libopenjp2.pc" "-lm" "-lm -pthread")
 endif()
-vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/openjpeg/vcpkg.json
+++ b/ports/openjpeg/vcpkg.json
@@ -1,9 +1,18 @@
 {
   "name": "openjpeg",
-  "version-semver": "2.3.1",
-  "port-version": 4,
+  "version-semver": "2.4.0",
   "description": "OpenJPEG is an open-source JPEG 2000 codec written in C language. It has been developed in order to promote the use of JPEG 2000, a still-image compression standard from the Joint Photographic Experts Group (JPEG). Since April 2015, it is officially recognized by ISO/IEC and ITU-T as a JPEG 2000 Reference Software.",
   "homepage": "https://github.com/uclouvain/openjpeg",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "jp3d": {
       "description": "Build optional component jp3d"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4709,8 +4709,8 @@
       "port-version": 1
     },
     "openjpeg": {
-      "baseline": "2.3.1",
-      "port-version": 4
+      "baseline": "2.4.0",
+      "port-version": 0
     },
     "openmama": {
       "baseline": "6.3.1",

--- a/versions/o-/openjpeg.json
+++ b/versions/o-/openjpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "383b12405beaa82435609863d2765ff654d8bc0b",
+      "git-tree": "858a4cd9f210e083c900a65228fdc085f7a0921e",
       "version-semver": "2.4.0",
       "port-version": 0
     },

--- a/versions/o-/openjpeg.json
+++ b/versions/o-/openjpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "383b12405beaa82435609863d2765ff654d8bc0b",
+      "version-semver": "2.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a11a593758d57ee96493bd2cb667ac1aa88e972c",
       "version-semver": "2.3.1",
       "port-version": 4

--- a/versions/o-/openjpeg.json
+++ b/versions/o-/openjpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "858a4cd9f210e083c900a65228fdc085f7a0921e",
+      "git-tree": "ffb3c981c0026662feded28db73c177a739773d2",
       "version-semver": "2.4.0",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/19968

- #### Features test:
  1. All features can be independently passed with following triplets:
      x86-windows
      x64-windows
      x64-windows-static
  2. mj2 and jp3d cannot be installed at the same time. 
     This issue is a known issue https://github.com/uclouvain/openjpeg/issues/1327 and it has been fixed by upstream's PR https://github.com/uclouvain/openjpeg/pull/1350 . 
     Because our current update does not include this PR, we are keeping these features instead of removing them.