### PR TITLE
[msbuild] add vcpkg to <Lib> search path

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -83,6 +83,9 @@
 
   <!-- Install settings to get headers and import libs for the currently selected _ZVcpkgCurrentInstalledDir -->
   <ItemDefinitionGroup Condition="'$(VcpkgEnabled)' == 'true'">
+    <Lib>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(_ZVcpkgCurrentInstalledDir)$(_ZVcpkgConfigSubdir)lib;$(_ZVcpkgCurrentInstalledDir)$(_ZVcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
+    </Lib>
     <Link>
       <AdditionalDependencies Condition="'$(VcpkgAutoLink)' != 'false'">%(AdditionalDependencies);$(_ZVcpkgCurrentInstalledDir)$(_ZVcpkgConfigSubdir)lib\*.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(_ZVcpkgCurrentInstalledDir)$(_ZVcpkgConfigSubdir)lib;$(_ZVcpkgCurrentInstalledDir)$(_ZVcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>


### PR DESCRIPTION
Adds vcpkg to the [Lib Tasks](https://docs.microsoft.com/en-us/visualstudio/msbuild/lib-task?view=vs-2019) `<AdditionalLibraryDirectories>`lib search path. 

In our company we have to add some vcpkg libs to `Librarian` -> `Additional Dependencies`, but the vcpkg lib dir is missing from `Librarian` -> `Additional Library Directories`.  

@BillyONeal 