### PR TITLE
[approval-tests-cpp] Update to 10.12.0

### DIFF
--- a/ports/approval-tests-cpp/portfile.cmake
+++ b/ports/approval-tests-cpp/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_download_distfile(single_header
-    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.11.0/ApprovalTests.v.10.11.0.hpp
-    FILENAME ApprovalTests.v.10.11.0.hpp
-    SHA512 2b43792b28a1dd44d76584c4d3bb9cb99563f92fdeafefd747516a8cfe0baf118b27ad235e1b023b3f5f3a34ecf920c12ab8a6d337776efc036456f4277142ae
+    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.12.0/ApprovalTests.v.10.12.0.hpp
+    FILENAME ApprovalTests.v.10.12.0.hpp
+    SHA512 a6a5030cc4f438f218bb55c25124ed3df749d36a0f032ff21b3a68ee4334eb4562944a0f5f73d0c253d674517f8a819349371e248eca271ce5577236f1598b8c
 )
 
 vcpkg_download_distfile(license_file
-    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.11.0/LICENSE
-    FILENAME ApprovalTestsLicense.v.10.11.0
+    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.12.0/LICENSE
+    FILENAME ApprovalTestsLicense.v.10.12.0
     SHA512 dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557
 )
 

--- a/ports/approval-tests-cpp/vcpkg.json
+++ b/ports/approval-tests-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "approval-tests-cpp",
-  "version": "10.11.0",
+  "version": "10.12.0",
   "description": "Approval Tests allow you to verify a chunk of output (such as a file) in one operation as opposed to writing test assertions for each element.",
   "homepage": "https://github.com/approvals/ApprovalTests.cpp"
 }

--- a/versions/a-/approval-tests-cpp.json
+++ b/versions/a-/approval-tests-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab883d6b40593e4e14a28110865e55745d7d5768",
+      "version": "10.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "42def472fd3039fb2e54a41a6980822a20518eff",
       "version": "10.11.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -101,7 +101,7 @@
       "port-version": 0
     },
     "approval-tests-cpp": {
-      "baseline": "10.11.0",
+      "baseline": "10.12.0",
       "port-version": 0
     },
     "apr": {


### PR DESCRIPTION
released new version of Header only library


- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
YES

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes, but only for our library

