### PR TITLE
[libgxps] Add new port

### DIFF
--- a/ports/libgxps/libgxps-0.3.2_fix_meson_warnings.patch
+++ b/ports/libgxps/libgxps-0.3.2_fix_meson_warnings.patch
@@ -1,0 +1,55 @@
+From a18e12604d2cab13146a357c7fd3b80909b65efd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Wolfgang=20St=C3=B6ggl?= <c72578@yahoo.de>
+Date: Thu, 9 Sep 2021 17:59:13 +0200
+Subject: [PATCH] Fix meson warnings
+
+- Deduplicate "libraries" in pkgg.generate()
+  Fixes:
+    libgxps/meson.build:101: WARNING: Keyword argument "libraries"
+    defined multiple times.
+    WARNING: This will be an error in future Meson releases.
+- Increase required meson_version from 0.43.0 to 0.50.0 due to usage
+  of install arg in libgxps/meson.build:63:
+  Fixes:
+    WARNING: Project targeting '>= 0.43.0' but tried to use feature
+    introduced in '0.50.0': install arg in configure_file.
+---
+ libgxps/meson.build | 5 ++---
+ meson.build         | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/libgxps/meson.build b/libgxps/meson.build
+index 29b044e..52d53d0 100644
+--- a/libgxps/meson.build
++++ b/libgxps/meson.build
+@@ -98,12 +98,11 @@ pkgg = import('pkgconfig')
+ cairo_dep_str = cairo_pc_found ? ', cairo >= ' + cairo_req : ''
+ cairo_dep_libs = cairo_pc_found ? [] : cairo_dep
+ 
+-pkgg.generate(libraries: gxps,
++pkgg.generate(libraries: [gxps, cairo_dep_libs],
+               version: gxps_version,
+               name: 'libgxps',
+               description: 'XPS Documents library',
+-              requires: 'gobject-2.0 >= ' + glib_req + ', gio-2.0 >= ' + glib_req + ', libarchive >= ' + archive_req + cairo_dep_str,
+-              libraries: [gxps, cairo_dep_libs])
++              requires: 'gobject-2.0 >= ' + glib_req + ', gio-2.0 >= ' + glib_req + ', libarchive >= ' + archive_req + cairo_dep_str)
+ 
+ if build_gir
+   gir_extra_args = [
+diff --git a/meson.build b/meson.build
+index 07c8cc2..c6780c9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -4,7 +4,7 @@ project('libgxps', 'c',
+           'buildtype=debugoptimized'
+         ],
+         license: 'LGPL2+',
+-        meson_version: '>= 0.43.0')
++        meson_version: '>= 0.50.0')
+ 
+ gxps_version = meson.project_version()
+ version_array = gxps_version.split('.')
+-- 
+GitLab
+

--- a/ports/libgxps/portfile.cmake
+++ b/ports/libgxps/portfile.cmake
@@ -1,0 +1,34 @@
+set(LIBGXPS_VERSION 0.3.2)
+string(SUBSTRING ${LIBGXPS_VERSION} 0 3 MAJOR_MINOR) # e.g. 0.3
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/${PORT}/${MAJOR_MINOR}/${PORT}-${LIBGXPS_VERSION}.tar.xz"
+    FILENAME "${PORT}-${LIBGXPS_VERSION}.tar.xz"
+    SHA512 d3d56e4906477b68d088bf83bde666f9ea8bf383add592772aad53dd571e727f1bc0410dd020e12212ede5ff8e26cb46150a9860a6f7af29c4d195f03e946fe9
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    REF ${LIBGXPS_VERSION}
+    PATCHES
+        "${CMAKE_CURRENT_LIST_DIR}/libgxps-0.3.2_fix_meson_warnings.patch" # https://gitlab.gnome.org/GNOME/libgxps/-/commit/a18e1260
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${OPTIONS}
+        -Ddisable-introspection=true
+        -Denable-test=false
+        -Dwith-libjpeg=true
+        -Dwith-liblcms2=true
+        -Dwith-libtiff=true
+)
+
+vcpkg_install_meson()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_tools(TOOL_NAMES xpstojpeg xpstopdf xpstopng xpstops xpstosvg AUTO_CLEAN)
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libgxps/vcpkg.json
+++ b/ports/libgxps/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libgxps",
+  "version": "0.3.2",
+  "description": "libgxps is a GObject based library for handling and rendering XPS documents.",
+  "homepage": "https://wiki.gnome.org/Projects/libgxps",
+  "dependencies": [
+    "cairo",
+    "glib",
+    "lcms",
+    "libarchive",
+    "libjpeg-turbo",
+    "libpng",
+    "libxslt",
+    "tiff",
+    "tool-meson"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3388,6 +3388,10 @@
       "baseline": "5.6.0",
       "port-version": 0
     },
+    "libgxps": {
+      "baseline": "0.3.2",
+      "port-version": 0
+    },
     "libharu": {
       "baseline": "2017-08-15",
       "port-version": 10

--- a/versions/l-/libgxps.json
+++ b/versions/l-/libgxps.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "aa14ea859cee510d9c738fbdb5a1955531aabb87",
+      "version": "0.3.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Add new port libgxps, version 0.3.2
  libgxps is a GObject based library for handling and rendering XPS documents.
  https://gitlab.gnome.org/GNOME/libgxps

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No
  - [x] `x64-linux` (fixed by #20146)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
