### PR TITLE
[cimg/libgd/libfabric] Update to latest release version

### DIFF
--- a/ports/cimg/portfile.cmake
+++ b/ports/cimg/portfile.cmake
@@ -1,21 +1,21 @@
 vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
-    REPO "dtschump/CImg"
-    REF a0e7ecb55130bdf90756033c1e1470eae4b88c1a #v2.9.4
+    REPO dtschump/CImg
+    REF b33dcc8f9f1acf1f276ded92c04f8231f6c23fcd # v2.9.9
+    SHA512 327c72320e7cac386ba72d417c45b9e8b40df34650370c34e687c362731919af1b447b2ee498f21278d4af155f0d9dbfabd222856d5f18c2e05569fa638a5909
     HEAD_REF master
-    SHA512 0fc814b67ce9f035a68308850117b40cb54d731cb559bf1b6f46e1ec1e29d473e805818018ac411529b51510468cfbe4427aa52a354f919d7f1ce84bd285a47d)
-
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
 )
 
-vcpkg_install_cmake()
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
 
 # Move cmake files, ensuring they will be 3 directories up the import prefix
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL ${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/Licence_CeCILL_V2-en.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright2)
+file(INSTALL "${SOURCE_PATH}/Licence_CeCILL-C_V1-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/Licence_CeCILL_V2-en.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright2)

--- a/ports/cimg/vcpkg.json
+++ b/ports/cimg/vcpkg.json
@@ -1,7 +1,12 @@
 {
   "name": "cimg",
-  "version-string": "2.9.4",
-  "port-version": 1,
+  "version": "2.9.9",
   "description": "The CImg Library is a small, open-source, and modern C++ toolkit for image processing",
-  "homepage": "https://github.com/dtschump/CImg"
+  "homepage": "https://github.com/dtschump/CImg",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/ports/libfabric/add_additional_includes.patch
+++ b/ports/libfabric/add_additional_includes.patch
@@ -1,17 +1,8 @@
 diff --git a/libfabric.vcxproj b/libfabric.vcxproj
-index 43a05e7..ceb596f 100644
+index c1e1792..3acbc81 100644
 --- a/libfabric.vcxproj
 +++ b/libfabric.vcxproj
-@@ -125,7 +125,7 @@
-       <Optimization>Disabled</Optimization>
-       <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-       <SDLCheck>true</SDLCheck>
--      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect;$(ProjectDir)prov\hook\src;$(ProjectDir)prov\hook\include;$(ProjectDir)prov\hook\perf\include</AdditionalIncludeDirectories>
-+      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect;$(ProjectDir)prov\hook\src;$(ProjectDir)prov\hook\include;$(ProjectDir)prov\hook\perf\include;$(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
-       <CompileAs>CompileAsC</CompileAs>
-       <DisableSpecificWarnings>4127;4200;4204;4221;4115;4201;4100</DisableSpecificWarnings>
-       <C99Support>true</C99Support>
-@@ -148,7 +148,7 @@
+@@ -187,7 +187,7 @@
        <Optimization>Disabled</Optimization>
        <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <SDLCheck>true</SDLCheck>
@@ -20,7 +11,7 @@ index 43a05e7..ceb596f 100644
        <CompileAs>CompileAsC</CompileAs>
        <DisableSpecificWarnings>4127;4200;4204;4221;4115;4201;4100</DisableSpecificWarnings>
        <C99Support>true</C99Support>
-@@ -171,7 +171,7 @@
+@@ -215,7 +215,7 @@
        <Optimization>Disabled</Optimization>
        <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <SDLCheck>true</SDLCheck>
@@ -29,7 +20,7 @@ index 43a05e7..ceb596f 100644
        <CompileAs>CompileAsC</CompileAs>
        <DisableSpecificWarnings>4127;4200;94;4204;4221;869</DisableSpecificWarnings>
        <C99Support>true</C99Support>
-@@ -195,7 +195,7 @@
+@@ -239,7 +239,7 @@
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <SDLCheck>true</SDLCheck>
@@ -38,7 +29,7 @@ index 43a05e7..ceb596f 100644
        <DisableSpecificWarnings>4127;4200;4204;4221;4115;4201;4100</DisableSpecificWarnings>
        <C99Support>true</C99Support>
        <ShowIncludes>false</ShowIncludes>
-@@ -220,7 +220,7 @@
+@@ -265,7 +265,7 @@
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <SDLCheck>true</SDLCheck>
@@ -47,7 +38,16 @@ index 43a05e7..ceb596f 100644
        <DisableSpecificWarnings>4127;4200;4204;4221;4115;4201;4100</DisableSpecificWarnings>
        <C99Support>true</C99Support>
        <ShowIncludes>false</ShowIncludes>
-@@ -245,7 +245,7 @@
+@@ -285,7 +285,7 @@
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect;$(ProjectDir)prov\hook\src;$(ProjectDir)prov\hook\include;$(ProjectDir)prov\hook\perf\include;</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect;$(ProjectDir)prov\hook\src;$(ProjectDir)prov\hook\include;$(ProjectDir)prov\hook\perf\include;$(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
+       <DisableSpecificWarnings>4127;4200;4204;4221;4115;4201;4100</DisableSpecificWarnings>
+       <SDLCheck>true</SDLCheck>
+       <C99Support>true</C99Support>
+@@ -307,7 +307,7 @@
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <PreprocessorDefinitions>WIN32;_WINSOCKAPI_=;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <SDLCheck>true</SDLCheck>

--- a/ports/libfabric/portfile.cmake
+++ b/ports/libfabric/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_install_msbuild(
     ALLOW_ROOT_INCLUDES
     OPTIONS
       /p:SolutionDir=${SOURCE_PATH}
-      /p:AdditionalIncludeDirectories=${CURRENT_INSTALLED_DIR}/include
+      /p:AdditionalIncludeDirectories="${CURRENT_INSTALLED_DIR}/include"
 )
 
 #Move includes under subdirectory to avoid colisions with other libraries

--- a/ports/libfabric/portfile.cmake
+++ b/ports/libfabric/portfile.cmake
@@ -5,15 +5,15 @@ vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ofiwg/libfabric
-    REF v1.8.1
+    REF 9682913a72c982b4a872b6b18cf2889e158a029b # v1.13.1
     HEAD_REF master
-    SHA512 7c3879af3ad7dbda9e9bf9f43a2d213a8e41d50212008f29e912d3d0946efc381e6833c08206106e9f486c37eaef16103198247b328297209ef80dc66ca1b6e5
+    SHA512 a484126d5f2b6ada1a081af4ae4b60ca00da84814f485cd39746f2ab82948dc68fac5fb47cda39510996e61765d3cf07c409f7a8646f33922d2486b6fb7ee2ab
     PATCHES
-      add_additional_includes.patch
+        add_additional_includes.patch
 )
 
-set(LIBFABRIC_RELEASE_CONFIGURATION "Release-v141")
-set(LIBFABRIC_DEBUG_CONFIGURATION "Debug-v141")
+set(LIBFABRIC_RELEASE_CONFIGURATION "Release-v142")
+set(LIBFABRIC_DEBUG_CONFIGURATION "Debug-v142")
 
 vcpkg_install_msbuild(
     SOURCE_PATH ${SOURCE_PATH}
@@ -27,13 +27,12 @@ vcpkg_install_msbuild(
     ALLOW_ROOT_INCLUDES
     OPTIONS
       /p:SolutionDir=${SOURCE_PATH}
-      /p:AdditionalIncludeDirectories="${CURRENT_INSTALLED_DIR}/include"
+      /p:AdditionalIncludeDirectories=${CURRENT_INSTALLED_DIR}/include
 )
 
 #Move includes under subdirectory to avoid colisions with other libraries
-file(RENAME ${CURRENT_PACKAGES_DIR}/include ${CURRENT_PACKAGES_DIR}/includetemp)
-file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/include)
-file(RENAME ${CURRENT_PACKAGES_DIR}/includetemp ${CURRENT_PACKAGES_DIR}/include/libfabric)
+file(RENAME "${CURRENT_PACKAGES_DIR}/include" "${CURRENT_PACKAGES_DIR}/includetemp")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include")
+file(RENAME "${CURRENT_PACKAGES_DIR}/includetemp" "${CURRENT_PACKAGES_DIR}/include/libfabric")
 
-# Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libfabric/vcpkg.json
+++ b/ports/libfabric/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libfabric",
-  "version-string": "1.8.1",
-  "port-version": 2,
+  "version-semver": "1.13.1",
   "description": "The OpenFabrics Interfaces Working Group (OFIWG) and the Libfabric open-source community are pleased to announce the release of version v1.6.2 of libfabric. See NEWS.md for the list of features and enhancements that have been added since the last release.",
   "homepage": "https://github.com/ofiwg/libfabric",
   "supports": "windows & x64 & !static",

--- a/ports/libgd/0001-fix-cmake.patch
+++ b/ports/libgd/0001-fix-cmake.patch
@@ -1,173 +1,77 @@
-From 26fdb0f43b2d994de9a3d62f85fc650e8c495f18 Mon Sep 17 00:00:00 2001
-From: Mikhail Paulyshka <me@mixaill.tk>
-Date: Sat, 1 Apr 2017 23:16:18 +0300
-Subject: [PATCH] fix cmake
-
----
- CMakeLists.txt     | 53 +++++++++++++++++++++++----------------------
- src/CMakeLists.txt | 63 +++++++++++++++++++++++++++++-------------------------
- 2 files changed, 62 insertions(+), 54 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 42934d0..796fa47 100644
+index 57cd95d..50d5b9a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -223,8 +223,10 @@ else (USE_EXT_GD)
+@@ -280,8 +280,10 @@ else (USE_EXT_GD)
  	add_subdirectory(src)
  endif (USE_EXT_GD)
  
 -add_subdirectory(tests)
 -add_subdirectory(examples)
 +if(BUILD_TEST)
-+	add_subdirectory(tests)
-+	add_subdirectory(examples)
++    add_subdirectory(tests)
++    add_subdirectory(examples)
 +endif()
  
  add_custom_target(distclean ${GD_SOURCE_DIR}/cmake/distclean.sh)
  
-@@ -246,29 +248,30 @@ IF (ENABLE_LIQ AND LIQ_BUILD)
-     ADD_DEPENDENCIES(${GD_LIB_STATIC} libimagequant)
- ENDIF(ENABLE_LIQ AND LIQ_BUILD)
+@@ -298,7 +300,7 @@ else(WIN32)
+ 	set(CPACK_GENERATOR TGZ)
+ endif(WIN32)
  
 -
--INSTALL(FILES docs/INSTALL DESTINATION share/docs)
--INSTALL(FILES docs/README.JPN DESTINATION share/docs)
--INSTALL(FILES docs/README.CMAKE DESTINATION share/docs)
--INSTALL(FILES docs/README.TESTING DESTINATION share/docs)
--INSTALL(FILES docs/README.TXT DESTINATION share/docs)
++if(0)
+ INSTALL(FILES docs/INSTALL DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
+ INSTALL(FILES docs/README.JPN DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
+ INSTALL(FILES docs/README.CMAKE DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
+@@ -320,7 +322,7 @@ INSTALL(FILES examples/test_crop_threshold.png DESTINATION share/doc/gd-${GDLIB_
+ INSTALL(FILES examples/tgaread.c DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
+ INSTALL(FILES examples/tiffread.c DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
+ INSTALL(FILES examples/windows.c DESTINATION share/doc/gd-${GDLIB_MAJOR}.${GDLIB_MINOR})
 -
--
--INSTALL(FILES examples/arc.c DESTINATION share/docs)
--INSTALL(FILES examples/copyrotated.c DESTINATION share/docs)
--INSTALL(FILES examples/crop.c DESTINATION share/docs)
--INSTALL(FILES examples/flip.c DESTINATION share/docs)
--INSTALL(FILES examples/gif.c DESTINATION share/docs)
--INSTALL(FILES examples/nnquant.c DESTINATION share/docs)
--INSTALL(FILES examples/noIcon.pic DESTINATION share/docs)
--INSTALL(FILES examples/noIcon.sgi DESTINATION share/docs)
--INSTALL(FILES examples/noIcon.tga DESTINATION share/docs)
--INSTALL(FILES examples/noIconAlpha.tga DESTINATION share/docs)
--INSTALL(FILES examples/test_crop_threshold.png DESTINATION share/docs)
--INSTALL(FILES examples/tgaread.c DESTINATION share/docs)
--INSTALL(FILES examples/tiffread.c DESTINATION share/docs)
--INSTALL(FILES examples/windows.c DESTINATION share/docs)
--
-+if(BUILD_DOCS)
-+	INSTALL(FILES docs/INSTALL DESTINATION share/docs)
-+	INSTALL(FILES docs/README.JPN DESTINATION share/docs)
-+	INSTALL(FILES docs/README.CMAKE DESTINATION share/docs)
-+	INSTALL(FILES docs/README.TESTING DESTINATION share/docs)
-+	INSTALL(FILES docs/README.TXT DESTINATION share/docs)
-+endif()
-+
-+if(BUILD_EXAMPLES)
-+	INSTALL(FILES examples/arc.c DESTINATION share/docs)
-+	INSTALL(FILES examples/copyrotated.c DESTINATION share/docs)
-+	INSTALL(FILES examples/crop.c DESTINATION share/docs)
-+	INSTALL(FILES examples/flip.c DESTINATION share/docs)
-+	INSTALL(FILES examples/gif.c DESTINATION share/docs)
-+	INSTALL(FILES examples/nnquant.c DESTINATION share/docs)
-+	INSTALL(FILES examples/noIcon.pic DESTINATION share/docs)
-+	INSTALL(FILES examples/noIcon.sgi DESTINATION share/docs)
-+	INSTALL(FILES examples/noIcon.tga DESTINATION share/docs)
-+	INSTALL(FILES examples/noIconAlpha.tga DESTINATION share/docs)
-+	INSTALL(FILES examples/test_crop_threshold.png DESTINATION share/docs)
-+	INSTALL(FILES examples/tgaread.c DESTINATION share/docs)
-+	INSTALL(FILES examples/tiffread.c DESTINATION share/docs)
-+	INSTALL(FILES examples/windows.c DESTINATION share/docs)
 +endif()
  
  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
  
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 08fd699..497dd93 100644
+index 509c422..97a2976 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -90,17 +90,17 @@ if (BUILD_STATIC_LIBS)
+@@ -96,7 +96,6 @@ if (BUILD_STATIC_LIBS)
  	if (UNIX)
  		set_target_properties(${GD_LIB_STATIC} PROPERTIES OUTPUT_NAME ${GD_LIB})
  	endif()
 -endif()
  
--if (WIN32 AND NOT MINGW AND NOT MSYS)
--  #	SET_TARGET_PROPERTIES(${GD_LIB} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:msvcrt.lib")
--  SET_PROPERTY(TARGET ${GD_LIB_STATIC} APPEND PROPERTY COMPILE_DEFINITIONS NONDLL=1)
--ENDIF(WIN32 AND NOT MINGW AND NOT MSYS)
-+	if (WIN32 AND NOT MINGW AND NOT MSYS)
-+    #	SET_TARGET_PROPERTIES(${GD_LIB} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:msvcrt.lib")
-+        SET_PROPERTY(TARGET ${GD_LIB_STATIC} APPEND PROPERTY COMPILE_DEFINITIONS NONDLL=1)
-+    ENDIF(WIN32 AND NOT MINGW AND NOT MSYS)
- 
--if (MINGW OR MSYS)
--	ADD_DEFINITIONS("-mms-bitfields")
--	set_target_properties(${GD_LIB_STATIC} PROPERTIES OUTPUT_NAME ${GD_LIB})
--endif (MINGW OR MSYS)
-+    if (MINGW OR MSYS)
-+	   ADD_DEFINITIONS("-mms-bitfields")
-+	   set_target_properties(${GD_LIB_STATIC} PROPERTIES OUTPUT_NAME ${GD_LIB})
-+    endif (MINGW OR MSYS)
+ if (NOT "${GD_PROGRAMS_LIB_SRC_FILES}" STREQUAL "")
+ 	add_library(gd_programs_lib STATIC ${GD_PROGRAMS_LIB_SRC_FILES})
+@@ -117,6 +116,7 @@ if (MINGW OR MSYS)
+ 		set_target_properties(${GD_LIB_STATIC} PROPERTIES OUTPUT_NAME ${GD_LIB})
+ 	endif()
+ endif (MINGW OR MSYS)
 +endif()
  
  INCLUDE_DIRECTORIES(BEFORE "${PROJECT_BINARY_DIR}" "${CMAKE_BINARY_DIR}" "${GD_SOURCE_DIR}/src")
  
-@@ -123,32 +123,37 @@ if (BUILD_STATIC_LIBS)
- 	target_link_libraries(${GD_LIB_STATIC} ${LIBGD_DEP_LIBS})
- endif()
+@@ -148,6 +148,7 @@ SET(LIBS_PRIVATES
+ 	${WEBP_LIBRARIES}
+ )
  
--set(GD_PROGRAMS gdcmpgif)
- 
--if (PNG_FOUND)
--	set(GD_PROGRAMS ${GD_PROGRAMS} gdtopng pngtogd webpng)
 +if(BUILD_PROGRAMS)
-+	set(GD_PROGRAMS gdcmpgif)
-+
-+	if (PNG_FOUND)
-+		set(GD_PROGRAMS ${GD_PROGRAMS} gdtopng pngtogd webpng)
-+		if (ZLIB_FOUND)
-+			set(GD_PROGRAMS ${GD_PROGRAMS} gdparttopng gd2topng pngtogd2)
-+		endif()
-+	endif()
-+
-+	if (FREETYPE_FOUND)
-+		set(GD_PROGRAMS ${GD_PROGRAMS} annotate)
-+	endif()
-+
- 	if (ZLIB_FOUND)
--		set(GD_PROGRAMS ${GD_PROGRAMS} gdparttopng gd2topng pngtogd2)
-+		set(GD_PROGRAMS ${GD_PROGRAMS} gd2copypal gd2togif giftogd2)
+ set(GD_PROGRAMS gdcmpgif)
+ 
+ if (PNG_FOUND)
+@@ -177,6 +178,9 @@ foreach(program ${GD_PROGRAMS})
  	endif()
--endif()
+ endforeach(program)
  
--if (FREETYPE_FOUND)
--	set(GD_PROGRAMS ${GD_PROGRAMS} annotate)
--endif()
-+	foreach(program ${GD_PROGRAMS})
-+		add_executable(${program} ${program}.c)
-+		if (BUILD_SHARED_LIBS)
-+			target_link_libraries(${program} ${GD_LIB})
-+		else()
-+			target_link_libraries(${program} ${GD_LIB_STATIC})
-+		endif()
-+	endforeach(program)
- 
--if (ZLIB_FOUND)
--	set(GD_PROGRAMS ${GD_PROGRAMS} gd2copypal gd2togif giftogd2)
-+	install(PROGRAMS bdftogd DESTINATION bin)
- endif()
- 
--foreach(program ${GD_PROGRAMS})
--    add_executable(${program} ${program}.c)
--    if (BUILD_SHARED_LIBS)
--        target_link_libraries(${program} ${GD_LIB})
--    else()
--        target_link_libraries(${program} ${GD_LIB_STATIC})
--    endif()
--endforeach(program)
--
++install(PROGRAMS bdftogd DESTINATION bin)
++endif()
++
  set(GD_INSTALL_TARGETS ${GD_PROGRAMS})
  if (BUILD_SHARED_LIBS)
  	set(GD_INSTALL_TARGETS ${GD_INSTALL_TARGETS} ${GD_LIB})
-@@ -161,7 +166,7 @@ install(TARGETS ${GD_INSTALL_TARGETS}
+@@ -189,7 +193,7 @@ install(TARGETS ${GD_INSTALL_TARGETS}
          RUNTIME DESTINATION bin
          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -176,6 +80,3 @@ index 08fd699..497dd93 100644
  install(FILES
  	entities.h
  	gd.h
--- 
-2.11.0.windows.1
-

--- a/ports/libgd/fix_msvc_build.patch
+++ b/ports/libgd/fix_msvc_build.patch
@@ -44,3 +44,18 @@ index f8f3b5d..380f4db 100644
  #include "gd.h"
  
  #define MIN(a,b) ((a)<(b)?(a):(b))
+diff --git a/src/getopt.c b/src/getopt.c
+index 8651b87..00bccde 100644
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -33,7 +33,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++
++#ifndef _WIN32
+ #include <unistd.h>
++#endif
+ 
+ int	opterr = 1,		/* if error message should be printed */
+ 	optind = 1,		/* index into parent argv vector */

--- a/ports/libgd/fix_msvc_build.patch
+++ b/ports/libgd/fix_msvc_build.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17ddf6b..7fe1e6b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -118,7 +118,7 @@ else (USE_EXT_GD)
+ 	endif (ENABLE_ICONV)
+ 
+ 	IF (ENABLE_WEBP)
+-		FIND_PACKAGE(WEBP REQUIRED)
++		FIND_PACKAGE(WebP CONFIG REQUIRED)
+ 	ENDIF (ENABLE_WEBP)
+ 
+ 	IF (ENABLE_HEIF)
+diff --git a/src/config.h.cmake b/src/config.h.cmake
+index 2b46a17..af98d23 100644
+--- a/src/config.h.cmake
++++ b/src/config.h.cmake
+@@ -139,3 +139,8 @@
+ 
+ /* Version number of package */
+ #cmakedefine VERSION
++
++#ifdef _MSC_VER
++    #define ssize_t SSIZE_T
++    #define SSIZE_MAX MAXSSIZE_T
++#endif
+\ No newline at end of file
+diff --git a/src/gd_intern.h b/src/gd_intern.h
+index f8f3b5d..380f4db 100644
+--- a/src/gd_intern.h
++++ b/src/gd_intern.h
+@@ -29,6 +29,14 @@
+ # endif
+ #endif
+ 
++#ifdef _MSC_VER
++#define  ssize_t SSIZE_T
++#define MAXSIZE_T ((SIZE_T)~ ((SIZE_T)0))
++#define MAXSSIZE_T ((SSIZE_T) (MAXSIZE_T >> 1))
++#define MINSSIZE_T ((SSIZE_T)~MAXSSIZE_T)
++#define SSIZE_MAX MAXSSIZE_T
++#endif
++
+ #include "gd.h"
+ 
+ #define MIN(a,b) ((a)<(b)?(a):(b))

--- a/ports/libgd/intrin.patch
+++ b/ports/libgd/intrin.patch
@@ -1,5 +1,5 @@
 diff --git a/src/gd_interpolation.c b/src/gd_interpolation.c
-index b9a206551..f75469329 100644
+index ce27220..8895072 100644
 --- a/src/gd_interpolation.c
 +++ b/src/gd_interpolation.c
 @@ -75,7 +75,7 @@ TODO:
@@ -10,4 +10,4 @@ index b9a206551..f75469329 100644
 +# include <intrin.h>
  #endif
  
- static gdImagePtr gdImageScaleBilinear(gdImagePtr im, 
+ static gdImagePtr gdImageScaleBilinear(gdImagePtr im,

--- a/ports/libgd/no-write-source-dir.patch
+++ b/ports/libgd/no-write-source-dir.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b16d4a4..5126085 100644
+index 50d5b9a..17ddf6b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -191,7 +191,8 @@ else (USE_EXT_GD)
+@@ -248,7 +248,8 @@ else (USE_EXT_GD)
  	CHECK_INCLUDE_FILE("stdint.h"	HAVE_STDINT_H)
  	CHECK_INCLUDE_FILE("inttypes.h"	HAVE_INTTYPES_H)
  

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -19,7 +19,6 @@ file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindPackageHandleStandardArgs.
 file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindPNG.cmake")
 file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindWEBP.cmake")
 
-
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES

--- a/ports/libgd/portfile.cmake
+++ b/ports/libgd/portfile.cmake
@@ -1,51 +1,35 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libgd/libgd
-    REF gd-2.2.5
-    SHA512 e4ee4c0d1064c93640c29b5741f710872297f42bcc883026a63124807b6ff23bd79ae66bb9148a30811907756c4566ba8f1c0560673ccafc20fee38d82ca838f
+    REF 2e40f55bfb460fc9d8cbcd290a0c9eb908d5af7e # gd-2.3.2
+    SHA512 c3f2db40f774b44e3fd3fbc743efe70916a71ecd948bf8cb4aeb8a9b9fefd9f17e02d82a9481bac6fcc3624f057b5a308925b4196fb612b65bb7304747d33ffa
     HEAD_REF master
     PATCHES
         0001-fix-cmake.patch
         no-write-source-dir.patch
         intrin.patch
+        fix_msvc_build.patch
 )
 
 #delete CMake builtins modules
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/CMakeParseArguments.cmake)
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/FindFreetype.cmake)
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/FindJPEG.cmake)
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/FindPackageHandleStandardArgs.cmake)
-file(REMOVE_RECURSE ${SOURCE_PATH}/cmake/modules/FindPNG.cmake)
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/CMakeParseArguments.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindFreetype.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindJPEG.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindPackageHandleStandardArgs.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindPNG.cmake")
+file(REMOVE_RECURSE "${SOURCE_PATH}/cmake/modules/FindWEBP.cmake")
 
-set(ENABLE_PNG OFF)
-if("png" IN_LIST FEATURES)
-    set(ENABLE_PNG ON)
-endif()
 
-set(ENABLE_JPEG OFF)
-if("jpeg" IN_LIST FEATURES)
-    set(ENABLE_JPEG ON)
-endif()
-
-set(ENABLE_TIFF OFF)
-if("tiff" IN_LIST FEATURES)
-    set(ENABLE_TIFF ON)
-endif()
-
-set(ENABLE_FREETYPE OFF)
-if("freetype" IN_LIST FEATURES)
-    set(ENABLE_FREETYPE ON)
-endif()
-
-set(ENABLE_WEBP OFF)
-if("webp" IN_LIST FEATURES)
-    set(ENABLE_WEBP ON)
-endif()
-
-set(ENABLE_FONTCONFIG OFF)
-if("fontconfig" IN_LIST FEATURES)
-    set(ENABLE_FONTCONFIG ON)
-endif()
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        png          ENABLE_PNG
+        jpeg         ENABLE_JPEG
+        tiff         ENABLE_TIFF
+        freetype     ENABLE_FREETYPE
+        webp         ENABLE_WEBP
+        fontconfig   ENABLE_FONTCONFIG
+)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
   set(LIBGD_SHARED_LIBS ON)
@@ -55,22 +39,18 @@ else()
   set(LIBGD_STATIC_LIBS ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DENABLE_PNG=${ENABLE_PNG}
-            -DENABLE_JPEG=${ENABLE_JPEG}
-            -DENABLE_TIFF=${ENABLE_TIFF}
-            -DENABLE_FREETYPE=${ENABLE_FREETYPE}
-            -DENABLE_WEBP=${ENABLE_WEBP}
-            -DENABLE_FONTCONFIG=${ENABLE_FONTCONFIG}
-            -DBUILD_STATIC_LIBS=${LIBGD_STATIC_LIBS}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DLIBGD_SHARED_LIBS=${LIBGD_SHARED_LIBS}
+        -DBUILD_STATIC_LIBS=${LIBGD_STATIC_LIBS}
+        -DBUILD_TEST=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(COPY ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/libgd)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/libgd/COPYING ${CURRENT_PACKAGES_DIR}/share/libgd/copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libgd/vcpkg.json
+++ b/ports/libgd/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libgd",
-  "version-string": "2.3.2",
+  "version-semver": "2.3.2",
   "description": "Open source code library for the dynamic creation of images by programmers.",
   "homepage": "https://github.com/libgd/libgd",
   "dependencies": [

--- a/ports/libgd/vcpkg.json
+++ b/ports/libgd/vcpkg.json
@@ -1,9 +1,14 @@
 {
   "name": "libgd",
-  "version-string": "2.2.5",
-  "port-version": 5,
+  "version-string": "2.3.2",
   "description": "Open source code library for the dynamic creation of images by programmers.",
   "homepage": "https://github.com/libgd/libgd",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
   "default-features": [
     "fontconfig",
     "freetype",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1269,8 +1269,8 @@
       "port-version": 2
     },
     "cimg": {
-      "baseline": "2.9.4",
-      "port-version": 1
+      "baseline": "2.9.9",
+      "port-version": 0
     },
     "cityhash": {
       "baseline": "2013-01-08",
@@ -3229,8 +3229,8 @@
       "port-version": 1
     },
     "libfabric": {
-      "baseline": "1.8.1",
-      "port-version": 2
+      "baseline": "1.13.1",
+      "port-version": 0
     },
     "libffi": {
       "baseline": "3.4.2",
@@ -3265,8 +3265,8 @@
       "port-version": 2
     },
     "libgd": {
-      "baseline": "2.2.5",
-      "port-version": 5
+      "baseline": "2.3.2",
+      "port-version": 0
     },
     "libgeotiff": {
       "baseline": "1.6.0",

--- a/versions/c-/cimg.json
+++ b/versions/c-/cimg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2eac332b873f6a2b9108c3e71e59feec8efe5026",
+      "version": "2.9.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "4ec4b920b2c754563d9daf835412f1143c127e97",
       "version-string": "2.9.4",
       "port-version": 1

--- a/versions/l-/libfabric.json
+++ b/versions/l-/libfabric.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "18ef2d7a676256aa9990242149a8f7db9e5c8082",
+      "git-tree": "98605d765b6373e091da7f21b3d43667a9fc9da3",
       "version-semver": "1.13.1",
       "port-version": 0
     },

--- a/versions/l-/libfabric.json
+++ b/versions/l-/libfabric.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "18ef2d7a676256aa9990242149a8f7db9e5c8082",
+      "version-semver": "1.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8eef6aae49aa30fcba5286829a5abc03c53a7580",
       "version-string": "1.8.1",
       "port-version": 2

--- a/versions/l-/libgd.json
+++ b/versions/l-/libgd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dfdaa465c662e05e1e58e7afa6c589b8baaf179e",
+      "git-tree": "9f54daf082df8c95b3420e98a4077cd5231e814d",
       "version-string": "2.3.2",
       "port-version": 0
     },

--- a/versions/l-/libgd.json
+++ b/versions/l-/libgd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9f54daf082df8c95b3420e98a4077cd5231e814d",
+      "git-tree": "ccf3c159b5aae3ca802d912644b4902b7ffec7cb",
       "version-string": "2.3.2",
       "port-version": 0
     },

--- a/versions/l-/libgd.json
+++ b/versions/l-/libgd.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "ccf3c159b5aae3ca802d912644b4902b7ffec7cb",
-      "version-string": "2.3.2",
+      "git-tree": "e1e99522d139bf2f72dc030d433117e8f430885f",
+      "version-semver": "2.3.2",
       "port-version": 0
     },
     {

--- a/versions/l-/libgd.json
+++ b/versions/l-/libgd.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfdaa465c662e05e1e58e7afa6c589b8baaf179e",
+      "version-string": "2.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "40171bc92f5cead1423ede203de8ad2752cb16b8",
       "version-string": "2.2.5",
       "port-version": 5


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/19870
Fixes https://github.com/microsoft/vcpkg/issues/19451
Fixes https://github.com/microsoft/vcpkg/issues/19927

libfabric: Update patch to match the source changes.
cimg: Update to latest release.
libgd: 
1. Update exist 3 patches to match the source changes.
2. Add new patch fix_msvc_build.patch to fix source issue https://github.com/libgd/libgd/issues/679 and find dependency port webp. This issue has been fixed in Upstream, will be included in future release 2.3.4.
