### PR TITLE
[functions-framework-cpp] update to latest version (v1.0.0)

### DIFF
--- a/ports/functions-framework-cpp/portfile.cmake
+++ b/ports/functions-framework-cpp/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GoogleCloudPlatform/functions-framework-cpp
-    REF v0.6.0
-    SHA512 57d6ec2467d1f9e12c14c3d2c361be15e5c5cfa4a12f3a184a99b8b0e91b2224a9156bfd875c98e8ad0ea44b7f84524fac35c536718fa039941647616a9e8586
+    REF v1.0.0
+    SHA512 caaf39014cc651f0f929fce60059592ce17dfa67ac3d93104d97b96c7a1e06e85c0945dfdff6169ac5a5193be84631e27b35877a4d5b022a7319f6476efa17be
     HEAD_REF main
 )
 

--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "functions-framework-cpp",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Functions Framework for C++.",
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2205,7 +2205,7 @@
       "port-version": 1
     },
     "functions-framework-cpp": {
-      "baseline": "0.6.0",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "fuzzylite": {

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea5cc9295e63419251720c34b2bbd02d710333c0",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "137edc9b4dd9a58f50ae9db1671d4608748088e7",
       "version": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
Updates `functions-framework-cpp` to the latest release (v1.0.0)

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
