### PR TITLE
[vcpkg] Remove cleaning steps on ephemeral VMs.

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -12,8 +12,6 @@ stages:
   pool: $(windows-pool)
   jobs:
   - job:
-    workspace:
-      clean: resources
     variables:
     - name: VCPKG_DOWNLOADS
       value: D:\downloads

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -6,8 +6,6 @@ jobs:
 - job: x64_linux
   pool:
     name: ${{ parameters.poolName }}
-  workspace:
-    clean: resources
   timeoutInMinutes: 1440 # 1 day
   variables:
   - name: WORKING_ROOT

--- a/scripts/azure-pipelines/windows-unstable/job.yml
+++ b/scripts/azure-pipelines/windows-unstable/job.yml
@@ -6,8 +6,6 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     name: $(unstable-pool)
-  workspace:
-    clean: resources
   timeoutInMinutes: 1440 # 1 day
   variables:
   - name: WORKING_ROOT

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -6,8 +6,6 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     name: ${{ parameters.poolName }}
-  workspace:
-    clean: resources
   timeoutInMinutes: 1440 # 1 day
   variables:
   - name: WORKING_ROOT
@@ -31,9 +29,6 @@ jobs:
   # Note: E: is the Azure machines' temporary disk.
   - script: .\bootstrap-vcpkg.bat
     displayName: 'Bootstrap vcpkg'
-  - script: |
-      if exist ${{ variables.VCPKG_DOWNLOADS }} rmdir /S /Q ${{ variables.VCPKG_DOWNLOADS }} 2>&1
-    displayName: 'Clean downloads'
   - task: PowerShell@2
     displayName: '*** Test Modified Ports and Prepare Test Logs ***'
     inputs:


### PR DESCRIPTION
We have transitioned all Windows and Linux testing to use ephemeral VMs which live only for 1 build, so we no longer need cleaning steps to be run each build.
