### PR TITLE
[pangolin] Change ffmpeg as an optional feature

### DIFF
--- a/ports/pangolin/vcpkg.json
+++ b/ports/pangolin/vcpkg.json
@@ -6,12 +6,6 @@
   "supports": "!uwp",
   "dependencies": [
     "eigen3",
-    {
-      "name": "ffmpeg",
-      "features": [
-        "avformat"
-      ]
-    },
     "glew",
     "libjpeg-turbo",
     "libpng",
@@ -25,6 +19,17 @@
     }
   ],
   "features": {
+    "ffmpeg": {
+      "description": "For video decoding and image rescaling",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "features": [
+            "avformat"
+          ]
+        }
+      ]
+    },
     "examples": {
       "description": "Build Examples"
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Change ffmpeg as an optional feature, because ffmpeg is a heavy library.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
