### PR TITLE
[gettext] Remove `SUBPATH`, add iconv linking info

### DIFF
--- a/ports/gettext/Makefile
+++ b/ports/gettext/Makefile
@@ -6,6 +6,11 @@ install: install-gettext-runtime-intl install-gettext-runtime-po install-gettext
 install: install-gettext-tools install-gettext-tools-gnulib install-gettext-tools-its install-gettext-tools-m4 install-gettext-tools-misc install-gettext-tools-po install-gettext-tools-projects install-gettext-tools-styles
 install: install-libtextstyle
 
+build-intl:
+	$(MAKE) -C intl all
+install-intl:
+	$(MAKE) -C intl install
+
 build-gettext-runtime-gnulib: build-gettext-runtime-intl
 	$(MAKE) -C gettext-runtime/gnulib-lib all
 build-gettext-runtime-intl:

--- a/ports/gettext/gettext-tools_woe32dll_gettextsrc-exports.c.patch
+++ b/ports/gettext/gettext-tools_woe32dll_gettextsrc-exports.c.patch
@@ -1,0 +1,14 @@
+X-Git-Url: https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=blobdiff_plain;f=gettext-tools%2Fwoe32dll%2Fgettextsrc-exports.c;h=6d760895961db57e013552b6b3f248bfa8eb17c2;hp=4477ae8d4b2e887592d4019432b91ea31b84ba59;hb=7cf68dffb2adb76375bfb0781e277510523a1f3e;hpb=3564f5f885544514bd2e345c36b74e5d91cad3e8
+
+diff --git a/gettext-tools/woe32dll/gettextsrc-exports.c b/gettext-tools/woe32dll/gettextsrc-exports.c
+index 4477ae8..6d76089 100644
+--- a/gettext-tools/woe32dll/gettextsrc-exports.c
++++ b/gettext-tools/woe32dll/gettextsrc-exports.c
+@@ -50,6 +50,7 @@ VARIABLE(formatstring_python)
+ VARIABLE(formatstring_python_brace)
+ VARIABLE(formatstring_qt)
+ VARIABLE(formatstring_qt_plural)
++VARIABLE(formatstring_ruby)
+ VARIABLE(formatstring_scheme)
+ VARIABLE(formatstring_sh)
+ VARIABLE(formatstring_smalltalk)

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_extract_source_archive_ex(
         0003-Fix-win-unicode-paths.patch
         rel_path.patch
         android.patch
+        gettext-tools_woe32dll_gettextsrc-exports.c.patch
         ${PATCHES}
 )
 vcpkg_find_acquire_program(BISON)

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -87,7 +87,11 @@ function(build_libintl_only)
         OPTIONS
             ${OPTIONS}
     )
-    vcpkg_install_make(SUBPATH "/intl")
+    vcpkg_install_make(
+        MAKEFILE "${CMAKE_CURRENT_LIST_DIR}/Makefile"
+        BUILD_TARGET   build-intl
+        INSTALL_TARGET install-intl
+    )
 endfunction()
 
 if("tools" IN_LIST FEATURES)

--- a/ports/gettext/vcpkg-cmake-wrapper.cmake
+++ b/ports/gettext/vcpkg-cmake-wrapper.cmake
@@ -7,4 +7,8 @@ if(Intl_FOUND AND Intl_LIBRARIES)
     unset(Intl_LIBRARIES)
     unset(Intl_LIBRARIES CACHE)
     select_library_configurations(Intl)
+    find_package(Iconv) # Since CMake 3.11
+    if(Iconv_FOUND AND NOT Iconv_IS_BUILT_IN)
+        list(APPEND Intl_LIBRARIES ${Iconv_LIBRARIES})
+    endif()
 endif()

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 5,
+  "port-version": 6,
   "description": "GNU gettext provides libintl and a set of tools to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2306,7 +2306,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 5
+      "port-version": 6
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fb785bd6a1e87a9fc438f5cc4b4191a5b6a4bc87",
+      "git-tree": "72394a1e7b0ea6333d78849f864c4b7bc8c7e8dc",
       "version": "0.21",
       "port-version": 6
     },

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb785bd6a1e87a9fc438f5cc4b4191a5b6a4bc87",
+      "version": "0.21",
+      "port-version": 6
+    },
+    {
       "git-tree": "d1089dfcf335a94ca47c5b918c56a7ab6fc0ae92",
       "version": "0.21",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?  
  - [x] Replaces the `SUBPATH` argument to `vcpkg_build_make`, as discussed in  #19753 (CC @JackBoosY)
  - [x] Adds `Iconv_LIBRARIES` to `Intl_LIBRARIES` in Intl wrapper, as discussed in #19195 (CC @wrobelda)
    ~Reverts the kf5i18n patching for the gettext -> iconv dependency which is now handled in gettext (https://github.com/microsoft/vcpkg/pull/20090#issuecomment-919840095).~ (kf5i18n doesn't use `FindIntl.cmake`.)
  - [x] Fixes mingw-dynamic builds (from upstream).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no
  Tested locally in x64-mingw-static cross build.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
