### PR TITLE
[openimageio] Re-fix the usage

### DIFF
--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -21,7 +21,6 @@ vcpkg_from_github(
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")
 
 file(REMOVE "${SOURCE_PATH}/src/cmake/modules/FindLibRaw.cmake"
-            "${SOURCE_PATH}/src/cmake/modules/FindOpenEXR.cmake"
             "${SOURCE_PATH}/src/cmake/modules/FindOpenCV.cmake"
             "${SOURCE_PATH}/src/cmake/modules/FindFFmpeg.cmake")
 
@@ -85,8 +84,8 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/doc"
                     "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(COPY "${SOURCE_PATH}/src/cmake/modules/FindOpenImageIO.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/OpenImageIO")
-file(COPY "${SOURCE_PATH}/src/cmake/modules/FindLibsquish.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/openimageio")
+file(COPY "${SOURCE_PATH}/src/cmake/modules/FindLibsquish.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/OpenImageIO")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openimageio",
   "version": "2.3.7.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4718,7 +4718,7 @@
     },
     "openimageio": {
       "baseline": "2.3.7.2",
-      "port-version": 1
+      "port-version": 2
     },
     "openjpeg": {
       "baseline": "2.3.1",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6084a6398514fc24fd450a7b9290937b1274d7b6",
+      "version": "2.3.7.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "799ea36f0486224257ecfea149b429d81e74a879",
       "version": "2.3.7.2",
       "port-version": 1


### PR DESCRIPTION
Merging to master caused all my changes in portfile.cmake to be rolled back.
Re-fix them:
1. Restore `FindOpenEXR.cmake` since it calls find_dependency(OpenEXR CONFIG) and it contains the required macro `FOUND_OPENEXR_WITH_CONFIG` in OpenImageIOConfig.cmake.
2. Correct `FindLibsquish.cmake` and `vcpkg-cmake-wrapper.cmake` installation path.

Related: #19916.