### PR TITLE
[libpqxx] Fix build issue with vs2017

### DIFF
--- a/ports/libpqxx/fix_build_with_vs2017.patch
+++ b/ports/libpqxx/fix_build_with_vs2017.patch
@@ -1,0 +1,103 @@
+diff --git a/include/pqxx/compiler-public.hxx b/include/pqxx/compiler-public.hxx
+index 5d24c7e..8087191 100644
+--- a/include/pqxx/compiler-public.hxx
++++ b/include/pqxx/compiler-public.hxx
+@@ -43,6 +43,11 @@
+ // Workarounds for Microsoft Visual C++
+ #  ifdef _MSC_VER
+ 
++// Workarounds for deprecated attribute syntax error in Visual Studio 2017.
++#    if _MSC_VER < 1920
++#      define PQXX_DEPRECATED(MESSAGE) __declspec(deprecated( #MESSAGE ))
++#    endif
++
+ // Suppress vtables on abstract classes.
+ #    define PQXX_NOVTABLE __declspec(novtable)
+ 
+@@ -112,6 +117,10 @@
+ #  define PQXX_NOVTABLE /* novtable */
+ #endif
+ 
++#ifndef PQXX_DEPRECATED
++#  define PQXX_DEPRECATED(MESSAGE) [[deprecated( #MESSAGE )]]
++#endif
++
+ // TODO: Assume support once we're on C++20.
+ #if defined(PQXX_HAVE_LIKELY)
+ #  define PQXX_LIKELY [[likely]]
+diff --git a/include/pqxx/stream_from.hxx b/include/pqxx/stream_from.hxx
+index f2dcc31..6a74b55 100644
+--- a/include/pqxx/stream_from.hxx
++++ b/include/pqxx/stream_from.hxx
+@@ -148,7 +148,7 @@ public:
+   /** @deprecated Use factory function @c table() or @c raw_table() instead.
+    */
+   template<typename Iter>
+-  [[deprecated("Use table() or raw_table() factory instead.")]] stream_from(
++  PQXX_DEPRECATED("Use table() or raw_table() factory instead.") stream_from(
+     transaction_base &, from_table_t, std::string_view table,
+     Iter columns_begin, Iter columns_end);
+ 
+@@ -156,13 +156,13 @@ public:
+   /** @deprecated Use factory function @c query() instead.
+    */
+   template<typename Columns>
+-  [[deprecated("Use table() or raw_table() factory instead.")]] stream_from(
++  PQXX_DEPRECATED("Use table() or raw_table() factory instead.") stream_from(
+     transaction_base &tx, from_table_t, std::string_view table,
+     Columns const &columns);
+ 
+ #include "pqxx/internal/ignore-deprecated-pre.hxx"
+   /// @deprecated Use factory function @c table() or @c raw_table() instead.
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
++  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+     transaction_base &tx, std::string_view table) :
+           stream_from{tx, from_table, table}
+   {}
+@@ -170,14 +170,14 @@ public:
+ 
+   /// @deprecated Use factory function @c table() or @c raw_table() instead.
+   template<typename Columns>
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
++  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+     transaction_base &tx, std::string_view table, Columns const &columns) :
+           stream_from{tx, from_table, table, columns}
+   {}
+ 
+   /// @deprecated Use factory function @c table() or @c raw_table() instead.
+   template<typename Iter>
+-  [[deprecated("Use the from_table_t overload instead.")]] stream_from(
++  PQXX_DEPRECATED("Use the from_table_t overload instead.") stream_from(
+     transaction_base &, std::string_view table, Iter columns_begin,
+     Iter columns_end);
+ 
+diff --git a/include/pqxx/stream_to.hxx b/include/pqxx/stream_to.hxx
+index 3ad0292..4b52e31 100644
+--- a/include/pqxx/stream_to.hxx
++++ b/include/pqxx/stream_to.hxx
+@@ -168,7 +168,7 @@ public:
+    * your data fields and the table is explicit in your code, and not hidden
+    * in an "implicit contract" between your code and your schema.
+    */
+-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
++  PQXX_DEPRECATED("Use table() or raw_table() factory.") stream_to(
+     transaction_base &tx, std::string_view table_name) :
+           stream_to{tx, table_name, ""sv}
+   {}
+@@ -177,14 +177,14 @@ public:
+   /** @deprecated Use @c table() or @c raw_table() as a factory.
+    */
+   template<typename Columns>
+-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
++ PQXX_DEPRECATED("Use table() or raw_table() factory.") stream_to(
+     transaction_base &, std::string_view table_name, Columns const &columns);
+ 
+   /// Create a stream, specifying column names as a sequence of strings.
+   /** @deprecated Use @c table() or @c raw_table() as a factory.
+    */
+   template<typename Iter>
+-  [[deprecated("Use table() or raw_table() factory.")]] stream_to(
++ PQXX_DEPRECATED("Use table() or raw_table() factory.") stream_to(
+     transaction_base &, std::string_view table_name, Iter columns_begin,
+     Iter columns_end);
+ 

--- a/ports/libpqxx/portfile.cmake
+++ b/ports/libpqxx/portfile.cmake
@@ -4,26 +4,23 @@ vcpkg_from_github(
     REF 221ddc8be329bafb376a3d83b9cd257fd52fc7b7 # 7.6.0
     SHA512 32a673bbae2f26fbc41bdcba007d9a5ded29680cb49ba434d1913cd5007bc1c1443bf38c88d9c5a6abe0a3ee519c0f691464c8d2b144cd3f16652447d644e400
     HEAD_REF master
-    #PATCHES
-    #    fix-build-with-vs2017.patch #https://github.com/jtv/libpqxx/pull/406
+    PATCHES
+        fix_build_with_vs2017.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/config-public-compiler.h.in DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/config-internal-compiler.h.in DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config-public-compiler.h.in" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/config-internal-compiler.h.in" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DSKIP_BUILD_TEST=ON
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSKIP_BUILD_TEST=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libpqxx)
-file(REMOVE_RECURSE 
-    ${CURRENT_PACKAGES_DIR}/debug/include
-    ${CURRENT_PACKAGES_DIR}/debug/share
-)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libpqxx)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libpqxx/vcpkg.json
+++ b/ports/libpqxx/vcpkg.json
@@ -1,9 +1,18 @@
 {
   "name": "libpqxx",
   "version-semver": "7.6.0",
+  "port-version": 1,
   "description": "The official C++ client API for PostgreSQL",
   "homepage": "https://www.postgresql.org/",
   "dependencies": [
-    "libpq"
+    "libpq",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3570,7 +3570,7 @@
     },
     "libpqxx": {
       "baseline": "7.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libprotobuf-mutator": {
       "baseline": "1.0",

--- a/versions/l-/libpqxx.json
+++ b/versions/l-/libpqxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "37cce5f0124f6f870793a650937ca978c1fc4750",
+      "version-semver": "7.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bbbc587d55d5d1ee059e417b045dfc82ca4897c2",
       "version-semver": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/19824

This issue only reprod with VS2017, it compiles fine with VS2019, the Upstream https://github.com/jtv/libpqxx/pull/406 already contains some parts of the fix, however, the latest release 7.6.0 doesn't contains the changes.

Failures:
C:\dev\vcpkg\buildtrees\libpqxx\src\7fd52fc7b7-63a53f1b3c.clean\include\pqxx/field.hxx(334): warning C5030: attribute 'unlikely' is not recognized
C:\dev\vcpkg\buildtrees\libpqxx\src\7fd52fc7b7-63a53f1b3c.clean\include\pqxx/stream_from.hxx(151): error C2061: syntax error: identifier 'stream_from'
C:\dev\vcpkg\buildtrees\libpqxx\src\7fd52fc7b7-63a53f1b3c.clean\include\pqxx/stream_from.hxx(153): error C2238: unexpected token(s) preceding ';'
C:\dev\vcpkg\buildtrees\libpqxx\src\7fd52fc7b7-63a53f1b3c.clean\include\pqxx/stream_from.hxx(159): error C2061: syntax error: identifier 'stream_from'