### PR TITLE
[vcpkg_install_meson] Don't touch mingw static lib .a suffix

### DIFF
--- a/scripts/cmake/vcpkg_install_meson.cmake
+++ b/scripts/cmake/vcpkg_install_meson.cmake
@@ -65,8 +65,8 @@ function(vcpkg_install_meson)
         endif()
     endforeach()
 
-    set(RENAMED_LIBS)
-    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    set(RENAMED_LIBS "")
+    if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL static AND NOT VCPKG_TARGET_IS_MINGW)
         # Meson names all static libraries lib<name>.a which basically breaks the world
         file(GLOB_RECURSE LIBRARIES "${CURRENT_PACKAGES_DIR}*/**/lib*.a")
         foreach(_library IN LISTS LIBRARIES)


### PR DESCRIPTION
- #### What does your PR fix?  
  This PR fixes post-build check errors "Could not find proper second linker member" when building for *-mingw-static. Mingw uses `.a` suffix for static libraries, so no renaming to `.lib` is needed.
 Previously hidden by the linker problem fixed in #18927.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no
  Test port: pkgconf:x64-mingw-static

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed
