### PR TITLE
[lv2] Fix installation of headers to legacy paths

### DIFF
--- a/ports/lv2/CMakeLists.txt
+++ b/ports/lv2/CMakeLists.txt
@@ -18,9 +18,9 @@ install(FILES lv2/core/lv2.h DESTINATION include)
 
 # Install headers to old URI-style paths, using mapping from wscript
 file(READ wscript WSCRIPT)
-string(REGEX MATCHALL "'[^']+' *: 'lv2/[^']+'" SPEC_MAP "${WSCRIPT}")
+string(REGEX MATCHALL "'[^']+' *: *'lv2/[^']+'" SPEC_MAP "${WSCRIPT}")
 foreach(PAIR ${SPEC_MAP})
-    string(REGEX MATCH "'([^']+)' *: '([^']+)'" _ "${PAIR}")
+    string(REGEX MATCH "'([^']+)' *: *'([^']+)'" _ "${PAIR}")
     install(
         DIRECTORY "lv2/${CMAKE_MATCH_1}/"
         DESTINATION "include/${CMAKE_MATCH_2}"

--- a/ports/lv2/vcpkg.json
+++ b/ports/lv2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lv2",
   "version-semver": "1.18.2",
+  "port-version": 1,
   "description": "LV2 is a plugin standard for audio systems. It defines a minimal yet extensible C API for plugin code and a format for plugin \"bundles\".",
   "homepage": "https://lv2plug.in",
   "license": "ISC",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3966,7 +3966,7 @@
     },
     "lv2": {
       "baseline": "1.18.2",
-      "port-version": 0
+      "port-version": 1
     },
     "lz4": {
       "baseline": "1.9.3",

--- a/versions/l-/lv2.json
+++ b/versions/l-/lv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f78e5138684d16deb9657062f3c28606853f9919",
+      "version-semver": "1.18.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "3a811ec51d55cce1d5eaf4a430a8e274f1916bb9",
       "version-semver": "1.18.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  LV2 changed the formatting of its `wscript` file when it updated to 1.18.2, breaking a regular expression in this port. As a result, most header files were no longer additionally installed to their legacy locations. This PR fixes that regular expression.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change to supported triplets. CI baseline not updated.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I believe so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.