### PR TITLE
[fbgemm] fix find_package

### DIFF
--- a/ports/fbgemm/portfile.cmake
+++ b/ports/fbgemm/portfile.cmake
@@ -12,18 +12,20 @@ vcpkg_from_github(
         fix-cmakelists.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_SANITIZER=OFF
         -DFBGEMM_BUILD_TESTS=OFF
         -DFBGEMM_BUILD_BENCHMARKS=OFF
         -DPYTHON_EXECUTABLE=${PYTHON3} # inject the path instead of find_package(Python)
 )
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME fbgemmLibrary CONFIG_PATH share/cmake/${PORT})
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+# this internal header is required by pytorch
+file(INSTALL     "${SOURCE_PATH}/src/RefImplementations.h"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/include/fbgemm/src")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -16,13 +16,5 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ],
-  "features": {
-    "gpu": {
-      "description": "Build fbgemm-gpu sources with CUDA",
-      "dependencies": [
-        "cuda"
-      ]
-    }
-  }
+  ]
 }

--- a/ports/fbgemm/vcpkg.json
+++ b/ports/fbgemm/vcpkg.json
@@ -1,12 +1,28 @@
 {
   "name": "fbgemm",
   "version-date": "2021-03-18",
-  "port-version": 1,
+  "port-version": 2,
   "description": "FB (Facebook) + GEMM (General Matrix-Matrix Multiplication)",
   "homepage": "https://code.fb.com/ml-applications/fbgemm/",
   "supports": "!(x86 | uwp)",
   "dependencies": [
     "asmjit",
-    "cpuinfo"
-  ]
+    "cpuinfo",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "gpu": {
+      "description": "Build fbgemm-gpu sources with CUDA",
+      "dependencies": [
+        "cuda"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2018,7 +2018,7 @@
     },
     "fbgemm": {
       "baseline": "2021-03-18",
-      "port-version": 1
+      "port-version": 2
     },
     "fbthrift": {
       "baseline": "2021.06.14.00",

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1950a24570e9c8057ffefed700e195228c75addc",
+      "version-date": "2021-03-18",
+      "port-version": 2
+    },
+    {
       "git-tree": "6f3e815d3e806243cddff7b0e262d130ef702e98",
       "version-date": "2021-03-18",
       "port-version": 1

--- a/versions/f-/fbgemm.json
+++ b/versions/f-/fbgemm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1950a24570e9c8057ffefed700e195228c75addc",
+      "git-tree": "8707b988ad38aae04720ce3494ef09603bd67954",
       "version-date": "2021-03-18",
       "port-version": 2
     },


### PR DESCRIPTION
### What does your PR fix?  

Update portfile to use `vcpkg-cmake`, `vcpkg-cmake-config`

#### Install some private headers

The file was required for #17199 

#### find_package
Make CMake `find_package` work correctly.

```cmake
find_package(fbgemmLibrary CONFIG)
```

#### ~~Support GPU feature~~

~~The project contains sources that use CUDA. Trying to build/install it.~~

### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

All supported triplets

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.
