### PR TITLE
[Libuv] Fix iOS Build

### DIFF
--- a/ports/libuv/CMakeLists.txt
+++ b/ports/libuv/CMakeLists.txt
@@ -55,7 +55,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsSt
     add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_WIN})
     target_compile_definitions(libuv PRIVATE WIN32_LEAN_AND_MEAN "_WIN32_WINNT=0x0600")
     target_link_libraries(libuv PRIVATE iphlpapi psapi shell32 userenv ws2_32)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif(APPLE)
     add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_UNIX} ${UV_SOURCES_DARWIN})
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     add_library(libuv ${UV_SOURCES_COMMON} ${UV_SOURCES_UNIX} ${UV_SOURCES_FREEBSD})

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libuv",
   "version-semver": "1.42.0",
+  "port-version": 1,
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3806,7 +3806,7 @@
     },
     "libuv": {
       "baseline": "1.42.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libuvc": {
       "baseline": "2020-11-24",

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ce4bb930c6429f5b95d2b3a13d5f23aec676745",
+      "version-semver": "1.42.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "cf96a59d9d41035fe89515464b3f93bcb9b84f27",
       "version-semver": "1.42.0",
       "port-version": 0

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ce4bb930c6429f5b95d2b3a13d5f23aec676745",
+      "git-tree": "41003bf038eb10b7fd29029954d42a05fb3c1a86",
       "version-semver": "1.42.0",
       "port-version": 1
     },


### PR DESCRIPTION
  Uses MacOS source files for building iOS version iOS version

- #### What does your PR fix?  
 Building of iOS version

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  x64-ios

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
