### PR TITLE
[quill] Fix compile error in internal version of Visual Studio

### DIFF
--- a/ports/quill/fix-c4189-warning.patch
+++ b/ports/quill/fix-c4189-warning.patch
@@ -1,0 +1,15 @@
+diff --git a/quill/CMakeLists.txt b/quill/CMakeLists.txt
+index 76872c2..c173804 100644
+--- a/quill/CMakeLists.txt
++++ b/quill/CMakeLists.txt
+@@ -148,6 +148,10 @@ if (QUILL_NO_EXCEPTIONS)
+     endif ()
+ endif ()
+ 
++if (MSVC)
++    add_definitions(/wd4189)
++endif()
++
+ # Add target sources
+ target_sources(${TARGET_NAME} PRIVATE ${SOURCE_FILES} ${HEADER_FILES})
+ 

--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -8,19 +8,20 @@ vcpkg_from_github(
     REF v1.6.3
     SHA512 e75aca827fe0833422da0d38df482cbc39db0e43dcc3cb791f3e2649f7022dcc448831a5ede85daf6feada60a2d5eaf312a3411abbba92fb9d76466336a7244d
     HEAD_REF master
+	PATCHES
+	    fix-c4189-warning.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DQUILL_FMT_EXTERNAL=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/quill)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/quill)
 
-vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h "// #define QUILL_FMT_EXTERNAL" "#define QUILL_FMT_EXTERNAL")
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/quill/TweakMe.h" "// #define QUILL_FMT_EXTERNAL" "#define QUILL_FMT_EXTERNAL")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,10 +1,19 @@
 {
   "name": "quill",
   "version-semver": "1.6.3",
+  "port-version": 1,
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "supports": "!(uwp | android)",
   "dependencies": [
-    "fmt"
+    "fmt",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5546,7 +5546,7 @@
     },
     "quill": {
       "baseline": "1.6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "quirc": {
       "baseline": "1.1",

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "53bbd43b741956bcb2d1e74cb34bca27b51b7d11",
+      "version-semver": "1.6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "e6ee8372d06d69dda719c955d24baa1f61924f86",
       "version-semver": "1.6.3",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  `quill `failed on our [unstable CI testing](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5195570&view=logs&j=7922e5c4-0103-5f8f-ad17-45ce9bb98e80&t=491b9f02-7edc-5990-cda1-511e95a3768e&l=36098) with the following errors:

```
D:\buildtrees\quill\src\v1.6.3-e54ea7a2b3.clean\quill\src\Quill.cpp(21): error C2220: the following warning is treated as an error
D:\buildtrees\quill\src\v1.6.3-e54ea7a2b3.clean\quill\src\Quill.cpp(21): warning C4189: 'x': local variable is initialized but not referenced
D:\buildtrees\quill\src\v1.6.3-e54ea7a2b3.clean\quill\include\quill/detail/spsc_queue/UnboundedSPSCEventQueue.h(129): warning C4189: 'emplaced_': local variable is initialized but not referenced
D:\buildtrees\quill\src\v1.6.3-e54ea7a2b3.clean\quill\include\quill/Logger.h(259): note: see reference to function template instantiation 'void quill::detail::UnboundedSPSCEventQueue<quill::detail::BaseEvent>::emplace<event_t,_Ty*,uint32_t&>(_Ty *&&,uint32_t &) noexcept' being compiled
        with
        [
            _Ty=quill::detail::LoggerDetails
        ]
D:\buildtrees\quill\src\v1.6.3-e54ea7a2b3.clean\quill\include\quill/Logger.h(258): note: see reference to function template instantiation 'void quill::detail::UnboundedSPSCEventQueue<quill::detail::BaseEvent>::emplace<event_t,_Ty*,uint32_t&>(_Ty *&&,uint32_t &) noexcept' being compiled
        with
        [
            _Ty=quill::detail::LoggerDetails
        ]
```

The error was caused by the warning C4189. After checking the sources, `emplaced_` is not referenced anywhere in sources.

`emplaced_ ` was also declared as `QUILL_MAYBE_UNUSED `, this should be intended behavior by upstream. 
https://github.com/odygrd/quill/blob/1386bff42eea9411600e58b9ddd682f1ec685c5a/quill/include/quill/detail/spsc_queue/UnboundedSPSCEventQueue.h#L129

So try to disable c4189 to fix this problem.

Note: No feature needs to test.





