### PR TITLE
[seal] Updated SEAL to version 3.7.0

### DIFF
--- a/ports/apsi/portfile.cmake
+++ b/ports/apsi/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/APSI
-    REF 2eba8a245872755a76282c4f1b14aefd67b1a199
-    SHA512 fd21e41b9a3241dc3454fadb54feb7843d9d4d4563da26d0f4a29b67ea22ead24ff6d89029050f5c54225cb95cb181f346f381b98873d3c55173444c0650d581
+    REF 7fbeefbd42f4884da95073d40de22ba46fc0f1f5
+    SHA512 dfa4b7571b355646004d5b8823f250b56cda6e84d348a6a013f45fbf5c119e49bda28ac8a75f8ec06738814c50e34e66805994c7bc780ddfd57cc2067ffa745a
     HEAD_REF main
 )
 
@@ -29,7 +29,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.2")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.3")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/apsi/vcpkg.json
+++ b/ports/apsi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "apsi",
-  "version-semver": "0.2.0",
+  "version-semver": "0.3.1",
   "description": "APSI is a research library for asymmetric private set intersection.",
   "homepage": "https://github.com/microsoft/APSI",
   "supports": "static",

--- a/ports/seal/portfile.cmake
+++ b/ports/seal/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/SEAL
-    REF d045f1beff96dff0fccc7fa0c5acb1493a65338c
-    SHA512 9b5d3c4342608d8e3d9826d3b52cbefc1c21eb0094d0cae4add8bb0960f931e9080f248eb8ad8385fc0a08e2a1da10020185148ffd2ef02e7a4fac879e27aa69
+    REF 2d2a25c916047d2f356d45ad50c98f0a9695905a
+    SHA512 81b2be39fca39dbd3a1246d0a1b8474d27eb6b1f3205f2107243bcd883b95814d2b642fa6807ed1f272d321233c2ec7992a256866ae1700c1203575594b42559
     HEAD_REF main
 )
 
@@ -31,13 +31,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "SEAL" CONFIG_PATH "lib/cmake/SEAL-3.6")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "SEAL" CONFIG_PATH "lib/cmake/SEAL-3.7")
 
-if("hexl" IN_LIST FEATURES)
-    vcpkg_fixup_pkgconfig(SKIP_CHECK)
-else()
-    vcpkg_fixup_pkgconfig()
-endif()
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/seal/vcpkg.json
+++ b/ports/seal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "seal",
-  "version-semver": "3.6.6",
-  "port-version": 1,
+  "version-semver": "3.7.0",
   "description": "Microsoft SEAL is an easy-to-use and powerful homomorphic encryption library.",
   "homepage": "https://github.com/microsoft/SEAL",
   "supports": "!windows | (windows & static)",

--- a/versions/a-/apsi.json
+++ b/versions/a-/apsi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cfe8c41e42a7aa179511d6f6ead1c47bb8f3327",
+      "version-semver": "0.3.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "2de75d2b02f3a434d3b95f53ca60b71598d9f8b5",
       "version-semver": "0.2.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -113,7 +113,7 @@
       "port-version": 4
     },
     "apsi": {
-      "baseline": "0.2.0",
+      "baseline": "0.3.1",
       "port-version": 0
     },
     "arb": {
@@ -5937,8 +5937,8 @@
       "port-version": 1
     },
     "seal": {
-      "baseline": "3.6.6",
-      "port-version": 1
+      "baseline": "3.7.0",
+      "port-version": 0
     },
     "secp256k1": {
       "baseline": "2017-19-10",

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e0c0c7900d62643f5e83af3a18401d9116d2696",
+      "version-semver": "3.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "89d120a6c3ac5306d90e29913048b518dc5a2c9b",
       "version-semver": "3.6.6",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  

Updated `ports/seal` to version 3.7.0.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

x64-windows/x86-windows are not supported as the library only supports static linkage in Windows.
No change to the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
