### PR TITLE
[qt5-base, qt5-declarative] fix build with GCC11

### DIFF
--- a/ports/qt5-base/patches/gcc11.patch
+++ b/ports/qt5-base/patches/gcc11.patch
@@ -1,0 +1,171 @@
+diff --git a/src/corelib/codecs/qtextcodec.cpp b/src/corelib/codecs/qtextcodec.cpp
+index 06fd88da..dbff3239 100644
+--- a/src/corelib/codecs/qtextcodec.cpp
++++ b/src/corelib/codecs/qtextcodec.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qplatformdefs.h"
+ 
+ #include "qtextcodec.h"
+diff --git a/src/corelib/codecs/qutfcodec.cpp b/src/corelib/codecs/qutfcodec.cpp
+index 8561f908..8128d3cf 100644
+--- a/src/corelib/codecs/qutfcodec.cpp
++++ b/src/corelib/codecs/qutfcodec.cpp
+@@ -38,6 +38,8 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
++
+ #include "qutfcodec_p.h"
+ #include "qlist.h"
+ #include "qendian.h"
+diff --git a/src/corelib/global/qendian.cpp b/src/corelib/global/qendian.cpp
+index eb08b2f8..6b41b3dd 100644
+--- a/src/corelib/global/qendian.cpp
++++ b/src/corelib/global/qendian.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qendian.h"
+ 
+ #include "qalgorithms.h"
+diff --git a/src/corelib/global/qfloat16.cpp b/src/corelib/global/qfloat16.cpp
+index c9733174..c62a1972 100644
+--- a/src/corelib/global/qfloat16.cpp
++++ b/src/corelib/global/qfloat16.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qfloat16.h"
+ #include "private/qsimd_p.h"
+ #include <cmath> // for fpclassify()'s return values
+diff --git a/src/corelib/global/qrandom.cpp b/src/corelib/global/qrandom.cpp
+index 10672c1f..6d5fd63e 100644
+--- a/src/corelib/global/qrandom.cpp
++++ b/src/corelib/global/qrandom.cpp
+@@ -40,6 +40,7 @@
+ // for rand_s
+ #define _CRT_RAND_S
+ 
++#include <limits>
+ #include "qrandom.h"
+ #include "qrandom_p.h"
+ #include <qobjectdefs.h>
+diff --git a/src/corelib/plugin/qelfparser_p.cpp b/src/corelib/plugin/qelfparser_p.cpp
+index 13eee353..9e7a7a41 100644
+--- a/src/corelib/plugin/qelfparser_p.cpp
++++ b/src/corelib/plugin/qelfparser_p.cpp
+@@ -37,6 +37,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qelfparser_p.h"
+ 
+ #if defined (Q_OF_ELF) && defined(Q_CC_GNU)
+diff --git a/src/corelib/plugin/qmachparser.cpp b/src/corelib/plugin/qmachparser.cpp
+index 11670caf..39f5596b 100644
+--- a/src/corelib/plugin/qmachparser.cpp
++++ b/src/corelib/plugin/qmachparser.cpp
+@@ -37,6 +37,8 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
++
+ #include "qmachparser_p.h"
+ 
+ #if defined(Q_OF_MACH_O)
+diff --git a/src/corelib/plugin/quuid.cpp b/src/corelib/plugin/quuid.cpp
+index 83873edf..5aafb4e5 100644
+--- a/src/corelib/plugin/quuid.cpp
++++ b/src/corelib/plugin/quuid.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "quuid.h"
+ 
+ #include "qcryptographichash.h"
+diff --git a/src/corelib/serialization/qdatastream.cpp b/src/corelib/serialization/qdatastream.cpp
+index 5082a8cb..7eecfcca 100644
+--- a/src/corelib/serialization/qdatastream.cpp
++++ b/src/corelib/serialization/qdatastream.cpp
+@@ -40,6 +40,8 @@
+ #include "qdatastream.h"
+ #include "qdatastream_p.h"
+ 
++#include <limits>
++
+ #if !defined(QT_NO_DATASTREAM) || defined(QT_BOOTSTRAPPED)
+ #include "qbuffer.h"
+ #include "qfloat16.h"
+diff --git a/src/corelib/text/qbytearray.cpp b/src/corelib/text/qbytearray.cpp
+index 9a72df58..6651ee98 100644
+--- a/src/corelib/text/qbytearray.cpp
++++ b/src/corelib/text/qbytearray.cpp
+@@ -39,6 +39,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qbytearray.h"
+ #include "qbytearraymatcher.h"
+ #include "private/qtools_p.h"
+diff --git a/src/corelib/text/qbytearraymatcher.cpp b/src/corelib/text/qbytearraymatcher.cpp
+index 72e09226..80511cb5 100644
+--- a/src/corelib/text/qbytearraymatcher.cpp
++++ b/src/corelib/text/qbytearraymatcher.cpp
+@@ -37,6 +37,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qbytearraymatcher.h"
+ 
+ #include <limits.h>
+diff --git a/src/corelib/tools/qbitarray.cpp b/src/corelib/tools/qbitarray.cpp
+index ab3054d5..22efb3a0 100644
+--- a/src/corelib/tools/qbitarray.cpp
++++ b/src/corelib/tools/qbitarray.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qbitarray.h"
+ #include <qalgorithms.h>
+ #include <qdatastream.h>
+diff --git a/src/corelib/tools/qcryptographichash.cpp b/src/corelib/tools/qcryptographichash.cpp
+index fa8d21e0..cd85956d 100644
+--- a/src/corelib/tools/qcryptographichash.cpp
++++ b/src/corelib/tools/qcryptographichash.cpp
+@@ -38,6 +38,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include <qcryptographichash.h>
+ #include <qiodevice.h>
+ 
+diff --git a/src/gui/text/qfontengine_qpf2.cpp b/src/gui/text/qfontengine_qpf2.cpp
+index e00f9d05..917ab5f9 100644
+--- a/src/gui/text/qfontengine_qpf2.cpp
++++ b/src/gui/text/qfontengine_qpf2.cpp
+@@ -37,6 +37,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qfontengine_qpf2_p.h"
+ 
+ #include <QtCore/QFile>

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -27,12 +27,14 @@ if("latest" IN_LIST FEATURES) # latest = core currently
         patches/Qt5BasicConfig.patch
         patches/Qt5PluginTarget.patch
         patches/create_cmake.patch
+        patches/gcc11.patch
         )
 else()
     set(PATCHES
         patches/Qt5BasicConfig.patch
         patches/Qt5PluginTarget.patch
         patches/create_cmake.patch
+        patches/gcc11.patch
     )
 endif()
 

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.15.2",
-  "port-version": 10,
+  "port-version": 11,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/ports/qt5-declarative/gcc11.patch
+++ b/ports/qt5-declarative/gcc11.patch
@@ -1,0 +1,25 @@
+diff --git a/src/qml/jsruntime/qv4regexp.cpp b/src/qml/jsruntime/qv4regexp.cpp
+index 76daead8..4f707703 100644
+--- a/src/qml/jsruntime/qv4regexp.cpp
++++ b/src/qml/jsruntime/qv4regexp.cpp
+@@ -37,6 +37,7 @@
+ **
+ ****************************************************************************/
+ 
++#include <limits>
+ #include "qv4regexp_p.h"
+ #include "qv4engine_p.h"
+ #include "qv4scopedvalue_p.h"
+diff --git a/src/qmldebug/qqmlprofilerevent_p.h b/src/qmldebug/qqmlprofilerevent_p.h
+index a7e37d19..21c3b465 100644
+--- a/src/qmldebug/qqmlprofilerevent_p.h
++++ b/src/qmldebug/qqmlprofilerevent_p.h
+@@ -40,6 +40,8 @@
+ #ifndef QQMLPROFILEREVENT_P_H
+ #define QQMLPROFILEREVENT_P_H
+ 
++#include <limits>
++
+ #include "qqmlprofilerclientdefinitions_p.h"
+ 
+ #include <QtCore/qstring.h>

--- a/ports/qt5-declarative/portfile.cmake
+++ b/ports/qt5-declarative/portfile.cmake
@@ -1,2 +1,5 @@
 include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation()
+qt_submodule_installation(
+  PATCHES
+    gcc11.patch
+)

--- a/ports/qt5-declarative/vcpkg.json
+++ b/ports/qt5-declarative/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-declarative",
   "version-string": "5.15.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt5 Declarative (Quick 2) Module. Includes QtQuick, QtQuickParticles, QtQuickWidgets, QtQml, and QtPacketProtocol.",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5314,7 +5314,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.2",
-      "port-version": 10
+      "port-version": 11
     },
     "qt5-canvas3d": {
       "baseline": "0",
@@ -5334,7 +5334,7 @@
     },
     "qt5-declarative": {
       "baseline": "5.15.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qt5-doc": {
       "baseline": "5.15.2",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67f3de23b856e70b8a2bb33221a7f087e8ced472",
+      "version-semver": "5.15.2",
+      "port-version": 11
+    },
+    {
       "git-tree": "13593d8640bdca2663ba5bd497243274e51c4dc3",
       "version-semver": "5.15.2",
       "port-version": 10

--- a/versions/q-/qt5-declarative.json
+++ b/versions/q-/qt5-declarative.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51a92d79f7007f0a09f87cf595b887c15a16e31b",
+      "version-string": "5.15.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "bf4313e778b98d69d3e0e3b881069357c3ef8b76",
       "version-string": "5.15.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
These patches come from Fedora's packages:
https://src.fedoraproject.org/rpms/qt5-qtbase/blob/rawhide/f/qt5-qtbase-gcc11.patch
https://src.fedoraproject.org/rpms/qt5-qtdeclarative/blob/rawhide/f/qt5-qtdeclarative-gcc11.patch

- #### What does your PR fix?  
  Fixes missing `#include <limits>` in several Qt files in the last stable Qt5 release.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
