### PR TITLE
[kf5*] re-enable parallel configure, speed up compilation

### DIFF
--- a/ports/kf5archive/portfile.cmake
+++ b/ports/kf5archive/portfile.cmake
@@ -17,8 +17,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         "zstd"  CMAKE_DISABLE_FIND_PACKAGE_ZSTD
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5archive/vcpkg.json
+++ b/ports/kf5archive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5archive",
   "version-semver": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "File compression",
   "homepage": "https://api.kde.org/frameworks/karchive/html/index.html",
   "dependencies": [

--- a/ports/kf5attica/portfile.cmake
+++ b/ports/kf5attica/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5attica/vcpkg.json
+++ b/ports/kf5attica/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5attica",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "A Qt library that implements the Open Collaboration Services API",
   "homepage": "https://api.kde.org/frameworks/attica/html/index.html",
   "dependencies": [

--- a/ports/kf5auth/portfile.cmake
+++ b/ports/kf5auth/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5auth/vcpkg.json
+++ b/ports/kf5auth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5auth",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Execute actions as privileged user",
   "homepage": "https://api.kde.org/frameworks/kauth/html/index.html",
   "dependencies": [

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -10,8 +10,10 @@ vcpkg_find_acquire_program(GPERF)
 get_filename_component(GPERF_EXE_PATH ${GPERF} DIRECTORY)
 vcpkg_add_to_path(${GPERF_EXE_PATH})
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5codecs/vcpkg.json
+++ b/ports/kf5codecs/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5codecs",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "String encoding library",
   "homepage": "https://api.kde.org/frameworks/kcodecs/html/index.html",
   "dependencies": [

--- a/ports/kf5completion/portfile.cmake
+++ b/ports/kf5completion/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5completion/vcpkg.json
+++ b/ports/kf5completion/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5completion",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Text completion helpers and widgets",
   "homepage": "https://api.kde.org/frameworks/kcompletion/html/index.html",
   "dependencies": [

--- a/ports/kf5config/portfile.cmake
+++ b/ports/kf5config/portfile.cmake
@@ -6,10 +6,12 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5config/vcpkg.json
+++ b/ports/kf5config/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5config",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Configuration system",
   "homepage": "https://api.kde.org/frameworks/kconfig/html/index.html",
   "dependencies": [

--- a/ports/kf5configwidgets/portfile.cmake
+++ b/ports/kf5configwidgets/portfile.cmake
@@ -14,8 +14,10 @@ vcpkg_check_features(
         designerplugin BUILD_DESIGNERPLUGIN
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5configwidgets/vcpkg.json
+++ b/ports/kf5configwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5configwidgets",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "Widgets for configuration dialogs",
   "homepage": "https://api.kde.org/frameworks/kconfigwidgets/html/index.html",
   "dependencies": [

--- a/ports/kf5coreaddons/portfile.cmake
+++ b/ports/kf5coreaddons/portfile.cmake
@@ -8,9 +8,11 @@ vcpkg_from_github(
         fix_cmake_config.patch # https://invent.kde.org/frameworks/kcoreaddons/-/merge_requests/129
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5coreaddons/vcpkg.json
+++ b/ports/kf5coreaddons/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5coreaddons",
   "version-semver": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Addons to QtCore",
   "homepage": "https://api.kde.org/frameworks/kcoreaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5crash/portfile.cmake
+++ b/ports/kf5crash/portfile.cmake
@@ -8,9 +8,11 @@ vcpkg_from_github(
         support_static_builds.patch # https://invent.kde.org/frameworks/kcrash/-/merge_requests/23
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5crash/vcpkg.json
+++ b/ports/kf5crash/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5crash",
   "version-semver": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "KCrash provides support for intercepting and handling application crashes.",
   "homepage": "https://api.kde.org/frameworks/kcrash/html/index.html",
   "dependencies": [

--- a/ports/kf5dbusaddons/portfile.cmake
+++ b/ports/kf5dbusaddons/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5dbusaddons/vcpkg.json
+++ b/ports/kf5dbusaddons/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5dbusaddons",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Convenience classes for D-Bus",
   "homepage": "https://api.kde.org/frameworks/kdbusaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5globalaccel/portfile.cmake
+++ b/ports/kf5globalaccel/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5globalaccel/vcpkg.json
+++ b/ports/kf5globalaccel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5globalaccel",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "lobal desktop keyboard shortcuts",
   "homepage": "https://api.kde.org/frameworks/kglobalaccel/html/index.html",
   "dependencies": [

--- a/ports/kf5guiaddons/portfile.cmake
+++ b/ports/kf5guiaddons/portfile.cmake
@@ -18,8 +18,10 @@ if("wayland" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_LINUX)
     message(FATAL_ERROR "Feature wayland is only supported on Linux.")
 endif()
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5guiaddons/vcpkg.json
+++ b/ports/kf5guiaddons/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5guiaddons",
   "version-semver": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Addons to QtGui",
   "homepage": "https://api.kde.org/frameworks/kguiaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5holidays/portfile.cmake
+++ b/ports/kf5holidays/portfile.cmake
@@ -6,10 +6,12 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5holidays/vcpkg.json
+++ b/ports/kf5holidays/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5holidays",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Holiday calculation library",
   "dependencies": [
     "ecm",

--- a/ports/kf5i18n/portfile.cmake
+++ b/ports/kf5i18n/portfile.cmake
@@ -12,9 +12,11 @@ vcpkg_from_github(
 
 vcpkg_find_acquire_program(PYTHON3)
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5i18n/vcpkg.json
+++ b/ports/kf5i18n/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5i18n",
   "version": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Advanced internationalization framework",
   "homepage": "https://api.kde.org/frameworks/ki18n/html/index.html",
   "dependencies": [

--- a/ports/kf5iconthemes/portfile.cmake
+++ b/ports/kf5iconthemes/portfile.cmake
@@ -14,8 +14,10 @@ vcpkg_check_features(
          designerplugin BUILD_DESIGNERPLUGIN
  )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5iconthemes/vcpkg.json
+++ b/ports/kf5iconthemes/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5iconthemes",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Icon GUI utilities",
   "homepage": "https://api.kde.org/frameworks/kiconthemes/html/index.html",
   "dependencies": [

--- a/ports/kf5itemmodels/portfile.cmake
+++ b/ports/kf5itemmodels/portfile.cmake
@@ -5,9 +5,11 @@ vcpkg_from_github(
     SHA512 1fd6a6194a718184dcbed0131a2b93575382b3ef7620049cb7a1ac2e55f271113c880d90b76fd6967b720fc44762f10119e8629bda30e6dea10f61ce22f9e02c
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5itemmodels/vcpkg.json
+++ b/ports/kf5itemmodels/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5itemmodels",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Models for Qt Model/View system",
   "homepage": "https://api.kde.org/frameworks/kitemmodels/html/index.html",
   "dependencies": [

--- a/ports/kf5itemviews/portfile.cmake
+++ b/ports/kf5itemviews/portfile.cmake
@@ -5,9 +5,11 @@ vcpkg_from_github(
     SHA512 d6a16ebbe57b6ac1b766d77b8b262b0ec72a5e256e5b3fbf7b95d901b4e45300eda2933f74a5a66cb6b2fec062fb4a6c9253e3376b13ab889f0bfd52c23cf5d4
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5itemviews/vcpkg.json
+++ b/ports/kf5itemviews/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5itemviews",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Widget addons for Qt Model/View",
   "homepage": "https://api.kde.org/frameworks/kitemviews/html/index.html",
   "dependencies": [

--- a/ports/kf5jobwidgets/portfile.cmake
+++ b/ports/kf5jobwidgets/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5jobwidgets/vcpkg.json
+++ b/ports/kf5jobwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5jobwidgets",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "Widgets for showing progress of asynchronous jobs",
   "homepage": "https://api.kde.org/frameworks/kjobwidgets/html/index.html",
   "dependencies": [

--- a/ports/kf5package/portfile.cmake
+++ b/ports/kf5package/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5package/vcpkg.json
+++ b/ports/kf5package/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5package",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Installation and loading of additional content (ex: scripts, images...) as packages",
   "homepage": "https://api.kde.org/frameworks/kpackage/html/index.html",
   "dependencies": [

--- a/ports/kf5plotting/portfile.cmake
+++ b/ports/kf5plotting/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5plotting/vcpkg.json
+++ b/ports/kf5plotting/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5plotting",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Lightweight plotting framework",
   "homepage": "https://api.kde.org/frameworks/kplotting/html/index.html",
   "dependencies": [

--- a/ports/kf5service/portfile.cmake
+++ b/ports/kf5service/portfile.cmake
@@ -31,8 +31,10 @@ get_filename_component(BISON_DIR "${BISON}" DIRECTORY)
 vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
 vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5service/vcpkg.json
+++ b/ports/kf5service/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5service",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Plugin framework for desktop services",
   "homepage": "https://api.kde.org/frameworks/kservice/html/index.html",
   "dependencies": [

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -33,9 +33,11 @@ get_filename_component(BISON_DIR "${BISON}" DIRECTORY )
 vcpkg_add_to_path(PREPEND "${FLEX_DIR}")
 vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
 )

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5solid",
   "version-semver": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [

--- a/ports/kf5sonnet/portfile.cmake
+++ b/ports/kf5sonnet/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DKDE_INSTALL_PLUGINDIR=plugins

--- a/ports/kf5sonnet/vcpkg.json
+++ b/ports/kf5sonnet/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5sonnet",
   "version-semver": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Multi-language spell checker",
   "homepage": "https://api.kde.org/frameworks/sonnet/html/index.html",
   "dependencies": [

--- a/ports/kf5syntaxhighlighting/portfile.cmake
+++ b/ports/kf5syntaxhighlighting/portfile.cmake
@@ -10,8 +10,10 @@ vcpkg_find_acquire_program(PERL)
 get_filename_component(PERL_EXE_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path("${PERL_EXE_PATH}")
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
     OPTIONS 

--- a/ports/kf5syntaxhighlighting/vcpkg.json
+++ b/ports/kf5syntaxhighlighting/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5syntaxhighlighting",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Syntax highlighting engine for Kate syntax definitions",
   "homepage": "https://github.com/KDE/syntax-highlighting",
   "dependencies": [

--- a/ports/kf5textwidgets/portfile.cmake
+++ b/ports/kf5textwidgets/portfile.cmake
@@ -6,8 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF

--- a/ports/kf5textwidgets/vcpkg.json
+++ b/ports/kf5textwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5textwidgets",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Text editing widgets",
   "homepage": "https://api.kde.org/frameworks/ktextwidgets/html/index.html",
   "dependencies": [

--- a/ports/kf5wallet/portfile.cmake
+++ b/ports/kf5wallet/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DBUILD_KWALLETD=OFF

--- a/ports/kf5wallet/vcpkg.json
+++ b/ports/kf5wallet/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5wallet",
   "version-semver": "5.84.0",
+  "port-version": 1,
   "description": "Safe desktop-wide storage for passwords",
   "homepage": "https://api.kde.org/frameworks/kwallet/html/index.html",
   "dependencies": [

--- a/ports/kf5widgetsaddons/portfile.cmake
+++ b/ports/kf5widgetsaddons/portfile.cmake
@@ -6,9 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
     PREFER_NINJA
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5widgetsaddons/vcpkg.json
+++ b/ports/kf5widgetsaddons/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5widgetsaddons",
   "version": "5.84.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Addons to QtWidgets",
   "homepage": "https://api.kde.org/frameworks/kwidgetsaddons/html/index.html",
   "dependencies": [

--- a/ports/kf5windowsystem/portfile.cmake
+++ b/ports/kf5windowsystem/portfile.cmake
@@ -12,8 +12,10 @@ if (VCPKG_TARGET_IS_LINUX)
     message(WARNING "${PORT} currently requires the following libraries from the system package manager:\n    libxcb-res0-dev\n\nThese can be installed on Ubuntu systems via apt-get install libxcb-res0-dev")
 endif()
 
+# Prevent KDEClangFormat from writing to source effectively blocking parallel configure
+file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
+
 vcpkg_cmake_configure(
-    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS 
         -DBUILD_TESTING=OFF

--- a/ports/kf5windowsystem/vcpkg.json
+++ b/ports/kf5windowsystem/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5windowsystem",
   "version-semver": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Access to the windowing system",
   "homepage": "https://api.kde.org/frameworks/kwindowsystem/html/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2946,115 +2946,115 @@
     },
     "kf5archive": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5attica": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5auth": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5codecs": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5completion": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5config": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5configwidgets": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5coreaddons": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5crash": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5dbusaddons": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5globalaccel": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5guiaddons": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5holidays": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5i18n": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5iconthemes": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5itemmodels": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5itemviews": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5jobwidgets": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5package": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5plotting": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5service": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5solid": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5sonnet": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5syntaxhighlighting": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5textwidgets": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5wallet": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5widgetsaddons": {
       "baseline": "5.84.0",
-      "port-version": 1
+      "port-version": 2
     },
     "kf5windowsystem": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kfr": {
       "baseline": "4.2.1",

--- a/versions/k-/kf5archive.json
+++ b/versions/k-/kf5archive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1476ac82c0b38d83211053e22afbac2091dab2e3",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "03f6943556e1d7600443c1f30445560de3f9b2f7",
       "version-semver": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5attica.json
+++ b/versions/k-/kf5attica.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0d1c8f2256f2e831a4ba82551de6a55ee4565a6",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "196f1ae93b85efd88bb9fa4a245ed9e8cf044a4a",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5auth.json
+++ b/versions/k-/kf5auth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54c38c08e5c5af0745650a385a5cea5926748545",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5f1399e14100a7c100bc55f8d436224c680a7f52",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5codecs.json
+++ b/versions/k-/kf5codecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0997fde9753e1e3c745eca599c116ef3a511bece",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "cc839f57cba8b67ed071d5dc3a472b605033cd7a",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5completion.json
+++ b/versions/k-/kf5completion.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a184552295179e5f414d3166d8f6f40ce9c66347",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b32643e981f1d9bab04fd3526e9c6c4499d35d1f",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5config.json
+++ b/versions/k-/kf5config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f36f1f5a124bd2f3123e0dfd9f4d350f1f69e757",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "67fa669df81328489ba66231cef84fc17ae4f434",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5configwidgets.json
+++ b/versions/k-/kf5configwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eca836d8da743409afa20dfc372145a7a7e68d6",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "99dcbe4e7cb84be45f9869e441c274e44309291d",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5coreaddons.json
+++ b/versions/k-/kf5coreaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca84b488ea7914b621bf49006f03f4ce8221052c",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "001ac94bfbadcc7b05c30448bff3adc9e2dc08dd",
       "version-semver": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5crash.json
+++ b/versions/k-/kf5crash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e30fa89728c784663526f9ff9332021507b9ee8e",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "9b4122c60d561d232fbd5294a304be12509b736d",
       "version-semver": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5dbusaddons.json
+++ b/versions/k-/kf5dbusaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "497be7e1959fac395884422632328485883fd433",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "417fdf58b130c7e24794cf4d1d29336cb946f9fa",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5globalaccel.json
+++ b/versions/k-/kf5globalaccel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "541f3c0b90027dcb3837dec812f896dbc4786f46",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "de0672be2e76751be304b4856466b9df6deaa29f",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5guiaddons.json
+++ b/versions/k-/kf5guiaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1dfe4575612c8d7d2bff1d4b1ecf2d5601915060",
+      "version-semver": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "3ecd4e54210c93a999c1cf4ddc24aded8c0d7437",
       "version-semver": "5.84.0",
       "port-version": 2

--- a/versions/k-/kf5holidays.json
+++ b/versions/k-/kf5holidays.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8b6fefbcb219e7f1de19ffc4b30bc8fd199abc0",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b969d43d406c095970b4e98cc3b19c27567b557c",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5i18n.json
+++ b/versions/k-/kf5i18n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c866e11343fd709f33dba23075f00f64b62813b5",
+      "version": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "3d34c7c3f38d55f93bc26d146fcf656f7eb4be3c",
       "version": "5.84.0",
       "port-version": 2

--- a/versions/k-/kf5iconthemes.json
+++ b/versions/k-/kf5iconthemes.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dff2467b2980412adb042e6a9e2474eb5efba9f4",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "969df4c5b4230e480fcffa7d71a312e869a3660d",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5itemmodels.json
+++ b/versions/k-/kf5itemmodels.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ccd18253fc31dab2afa493a6150711036138da63",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b222a404755239053edfac06ee63bf3710719fe9",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5itemviews.json
+++ b/versions/k-/kf5itemviews.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a89dde646ac62a41ece78c8757964cdd4ceaed60",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "164cc5f1d9ccfdf89ef60c4b718b8f6777162ea5",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5jobwidgets.json
+++ b/versions/k-/kf5jobwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6772f49b473e205b1f3dadfe97705b178f8e0ef2",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "7405290b40e00636f2db4aa51f0ebfa24bfe0589",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5package.json
+++ b/versions/k-/kf5package.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "41b59faf036cdcc4d430a8bee7b4f87c4fa4e42f",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "aeff67d2d07a017d69a853037a12371683c5aa97",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5plotting.json
+++ b/versions/k-/kf5plotting.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "866d1f84848c54a924a542fc101895588ff895b0",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "39f28709c5b4d6e1c706c7e15617b7c052830122",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5service.json
+++ b/versions/k-/kf5service.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f6fb4f263f0fff296515f569565550c9805e65d",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "13315cd7dbaa61af6c16276f83a15ceaab5a1235",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f0a82387f00cd2a61e6f1751bb1c94c9d706fddb",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "1f726a86d2961fd90661f27469d1e77b2b75c612",
       "version-semver": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5sonnet.json
+++ b/versions/k-/kf5sonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dab7f45858de89e5cb13bd31875d2ba99bf94365",
+      "version-semver": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "de4fdcac67da4df0962414b4b1f71d98753d4c4e",
       "version-semver": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5syntaxhighlighting.json
+++ b/versions/k-/kf5syntaxhighlighting.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f86af1e17c47fb99ff1f4a662d2cf5c022408025",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "0bec703b0c5345b456bdbddf6e043d1c31dd2906",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5textwidgets.json
+++ b/versions/k-/kf5textwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b6c8dad63ee1e48b572b94623152569b1443c20c",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "bdc98a609f6b939514630fb39de377fdb09560c0",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5wallet.json
+++ b/versions/k-/kf5wallet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8e8401b12a23caa46bffec87b7f583771a55170d",
+      "version-semver": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "c954ed1f4277c1c7fef03a9736d83d1a2da5ee63",
       "version-semver": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5widgetsaddons.json
+++ b/versions/k-/kf5widgetsaddons.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b8ce78de33b2176f98f97f865494b520cdc37032",
+      "version": "5.84.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "de99d19b892fe1551e87c6dd3a1c2d353bfc3f76",
       "version": "5.84.0",
       "port-version": 1

--- a/versions/k-/kf5windowsystem.json
+++ b/versions/k-/kf5windowsystem.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ce30fb964e57b95c0a6afe4cacff6a28447c7649",
+      "version-semver": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "e8ec0d393c0ccf286aab3bbe310dd5c09eaecf88",
       "version-semver": "5.84.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**
   This re-enables parallel config by preventing the CMake from writing to source. 
   Note that I did *not* add any other improvements to the existing ports – this is a pure compilation time optimization only.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes. 

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.