### PR TITLE
[gmp] Enable C++ support on Unix

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -103,7 +103,8 @@ else()
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
         AUTOCONFIG
-        OPTIONS ${OPTIONS}
+        OPTIONS
+            --enable-cxx
     )
 
     vcpkg_install_make()

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version-string": "6.2.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "supports": "!(windows & (arm | arm64))",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2446,7 +2446,7 @@
     },
     "gmp": {
       "baseline": "6.2.1",
-      "port-version": 6
+      "port-version": 7
     },
     "google-cloud-cpp": {
       "baseline": "1.31.1",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d207c0d8a6481f96f2277fd3245f2a80456a706",
+      "version-string": "6.2.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "645878e32f8ab4e926f605107c761433515a17dd",
       "version-string": "6.2.1",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**
   GMP does *not* enable C++ bindings by default. This adds `--enable-cxx` switch so that `libgmpxx` is built on Unix platforms.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.