### PR TITLE
Unskip cmark:x64-windows-static in ci.baseline.txt.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -134,7 +134,6 @@ clblast:x64-windows-static=fail
 clblast:x64-windows-static-md=fail
 clockutils:x64-linux=fail
 clockutils:x64-osx=fail
-cmark:x64-windows-static=fail
 cmcstl2:arm64-windows      = skip
 cmcstl2:arm-uwp            = skip
 cmcstl2:x64-linux          = skip


### PR DESCRIPTION
In last night's CI run: https://dev.azure.com/vcpkg/public/_build/results?buildId=59667

PASSING, REMOVE FROM FAIL LIST: cmark:x64-windows-static
