### PR TITLE
[vcpkg] Fix ci: suggest vcpkg_*_cmake -> vcpkg_cmake_* migration

### DIFF
--- a/.github/workflows/untrustedPR.yml
+++ b/.github/workflows/untrustedPR.yml
@@ -38,8 +38,7 @@ jobs:
           git config user.email github-actions
           git config user.name github-actions@github.com
 
-          # HEAD^^ refers to the second parent of the merge commit
-          git diff --name-status --merge-base HEAD^^ HEAD --diff-filter=MAR -- '*portfile.cmake' | sed 's/[MAR]\t*//' | while read filename; do grep -s '(vcpkg_install_cmake|vcpkg_build_cmake|vcpkg_configure_cmake|vcpkg_fixup_cmake_targets)' "$filename" || echo " - \`$filename\`"; done > .github-pr.deprecated-cmake
+          git diff --name-status --merge-base HEAD^ HEAD --diff-filter=MAR -- '*portfile.cmake' | sed 's/[MAR]\t*//' | while read filename; do grep -q -E '(vcpkg_install_cmake|vcpkg_build_cmake|vcpkg_configure_cmake|vcpkg_fixup_cmake_targets)' "$filename" && echo " - \`$filename\`"; done > .github-pr.deprecated-cmake
           ./vcpkg format-manifest --all --convert-control
           git diff > .github-pr.format-manifest
           git add -u


### PR DESCRIPTION
Fixes the bugs reported in #20142

HEAD^^ refers to the parent of the parent (HEAD^2 refers to the second parent)  
If the ci is running, the branch is merged into the master branch, so we for example have the following graph:
```git
*   c21dd13cb (HEAD -> master) Merge branch 'document-deprecated-functions'
|\  
| * aa8e5cc56 (document-deprecated-functions) Document deprecated functions from #20142 in the maintainer guide.
|/  
* 574c125d6 [openimageio] Re-fix the usage (#20092)
* fbe07843a [gettext] Remove `SUBPATH`, add iconv linking info (#20090)
```
The command  `git diff --name-status --merge-base HEAD^^ HEAD` now compared `c21dd13cb`(HEAD) against the base `fbe07843a`, so it detects the file changes in `aa8e5cc56` and `574c125d6`, which is wrong (it always also included the changes of the latest master commit). Now it compares `c21dd13cb`(HEAD) against `574c125d6`(latest master). This explains the suggestion in #20217