### PR TITLE
[boost-modular-build-helper] Unify boost builds across OS's

### DIFF
--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -1,14 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 project(boost CXX)
 
-find_path(ZLIB_INCLUDE zlib.h)
-find_path(BZIP2_INCLUDE bzlib.h)
-if(WIN32)
-    set(ICU_OPTION "--disable-icu")
-else()
-    find_path(ICU_PATH include/unicode/utf.h)
-    set(ICU_OPTION "-sICU_PATH=\"${ICU_PATH}\"")
-endif()
+set(B2_OPTIONS)
 
 if(MSVC)
     if(MSVC_VERSION LESS 1900)
@@ -20,7 +13,13 @@ else()
     set(VCPKG_PLATFORM_TOOLSET external)
 endif()
 
-set(B2_OPTIONS)
+#### Handle ICU
+if(WIN32)
+    list(APPEND B2_OPTIONS "--disable-icu")
+else()
+    find_path(ICU_PATH include/unicode/utf.h)
+    list(APPEND B2_OPTIONS "-sICU_PATH=\"${ICU_PATH}\"")
+endif()
 
 if(DEFINED BOOST_CMAKE_FRAGMENT)
     message(STATUS "Including ${BOOST_CMAKE_FRAGMENT}")
@@ -175,6 +174,7 @@ if(APPLE)
   string(APPEND LDFLAGS " <linkflags>-stdlib=libc++")
 endif()
 
+set(TOOLSET_OPTIONS)
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     # cl in b2 appears to not receive `LIBPATH` for finding winmd files, so we transform them to `/AI` options.
     set(libpath_args "$ENV{LIBPATH}")
@@ -187,9 +187,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     list(TRANSFORM libpath_args REPLACE "\\\"" "\\\\\"")
     list(JOIN libpath_args " " libpath_arg)
 
-    set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <cflags>-Zl <compileflags>\"${libpath_arg}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
+    set(TOOLSET_OPTIONS "<cflags>-Zl <compileflags>\"${libpath_arg}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
     list(APPEND B2_OPTIONS windows-api=store)
 endif()
+
+find_path(ZLIB_INCLUDE zlib.h)
+list(APPEND B2_OPTIONS -sZLIB_INCLUDE="${ZLIB_INCLUDE}")
+
+find_path(BZIP2_INCLUDE bzlib.h)
+list(APPEND B2_OPTIONS -sBZIP2_INCLUDE="${BZIP2_INCLUDE}")
 
 if(WIN32)
     if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -268,9 +274,6 @@ add_custom_target(boost ALL
         --with-system
         --with-thread
         --with-chrono
-        -sZLIB_INCLUDE="${ZLIB_INCLUDE}"
-        -sBZIP2_INCLUDE="${BZIP2_INCLUDE}"
-        ${ICU_OPTION}
         -j${NUMBER_OF_PROCESSORS}
         -sBOOST_ROOT=${BOOST_BUILD_PATH}
         -sBOOST_BUILD_PATH=${BOOST_BUILD_PATH}

--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -3,9 +3,22 @@ project(boost CXX)
 
 find_path(ZLIB_INCLUDE zlib.h)
 find_path(BZIP2_INCLUDE bzlib.h)
-find_path(ICU_PATH include/unicode/utf.h)
+if(WIN32)
+    set(ICU_OPTION "--disable-icu")
+else()
+    find_path(ICU_PATH include/unicode/utf.h)
+    set(ICU_OPTION "-sICU_PATH=\"${ICU_PATH}\"")
+endif()
 
-set(VCPKG_PLATFORM_TOOLSET external)
+if(MSVC)
+    if(MSVC_VERSION LESS 1900)
+        math(EXPR BOOST_MSVC_VERSION "${MSVC_VERSION} / 10 - 60")
+    else()
+        math(EXPR BOOST_MSVC_VERSION "${MSVC_VERSION} / 10 - 50")
+    endif()
+else()
+    set(VCPKG_PLATFORM_TOOLSET external)
+endif()
 
 set(B2_OPTIONS)
 
@@ -15,7 +28,7 @@ if(DEFINED BOOST_CMAKE_FRAGMENT)
 endif()
 
 # Add build type specific options
-if(BUILD_SHARED_LIBS)
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
     list(APPEND B2_OPTIONS runtime-link=shared)
     set(LIB_RUNTIME_LINK "shared")
 else()
@@ -45,7 +58,16 @@ else()
     list(APPEND B2_OPTIONS architecture=x86)
 endif()
 
-if(APPLE)
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86" AND WIN32)
+    list(APPEND B2_OPTIONS "asmflags=/safeseh")
+endif()
+
+file(TO_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/nothing.bat" NOTHING_BAT)
+
+if(MSVC)
+    set(B2_TOOLSET msvc)
+    list(APPEND B2_OPTIONS target-os=windows)
+elseif(APPLE)
     set(B2_TOOLSET clang)
     list(APPEND B2_OPTIONS target-os=darwin)
 elseif(WIN32)
@@ -120,57 +142,108 @@ if(NOT LDFLAGS STREQUAL "")
     string(REPLACE " " " <linkflags>" LDFLAGS "<linkflags>${LDFLAGS}")
 endif()
 
-#set(CXXFLAGS "${CXXFLAGS} <compileflags>-Wno-error=unused-command-line-argument")
 if(CMAKE_CXX_COMPILER_TARGET AND CMAKE_CXX_COMPILE_OPTIONS_TARGET)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET}${CMAKE_CXX_COMPILER_TARGET}")
-        set(LDFLAGS "${LDFLAGS} <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET}${CMAKE_CXX_COMPILER_TARGET}")
+        string(APPEND CXXFLAGS " <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET}${CMAKE_CXX_COMPILER_TARGET}")
+        string(APPEND LDFLAGS " <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET}${CMAKE_CXX_COMPILER_TARGET}")
     else()
-        set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET} <compileflags>${CMAKE_CXX_COMPILER_TARGET}")
-        set(LDFLAGS "${LDFLAGS} <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET} <linkflags>${CMAKE_CXX_COMPILER_TARGET}")
+        string(APPEND CXXFLAGS " <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET} <compileflags>${CMAKE_CXX_COMPILER_TARGET}")
+        string(APPEND LDFLAGS " <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_TARGET} <linkflags>${CMAKE_CXX_COMPILER_TARGET}")
     endif()
 endif()
+
 if(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN}${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
-        set(LDFLAGS "${LDFLAGS} <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN}${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
+        string(APPEND CXXFLAGS " <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN}${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
+        string(APPEND LDFLAGS " <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN}${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
     else()
-        set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN} <compileflags>${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
-        set(LDFLAGS "${LDFLAGS} <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN} <linkflags>${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
+        string(APPEND CXXFLAGS " <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN} <compileflags>${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
+        string(APPEND LDFLAGS " <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_EXTERNAL_TOOLCHAIN} <linkflags>${CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN}")
     endif()
 endif()
+
 if(CMAKE_SYSROOT AND CMAKE_CXX_COMPILE_OPTIONS_SYSROOT)
-    set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_SYSROOT}${CMAKE_SYSROOT}")
-    set(LDFLAGS "${LDFLAGS} <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_SYSROOT}${CMAKE_SYSROOT}")
+    string(APPEND CXXFLAGS " <compileflags>${CMAKE_CXX_COMPILE_OPTIONS_SYSROOT}${CMAKE_SYSROOT}")
+    string(APPEND LDFLAGS " <linkflags>${CMAKE_CXX_COMPILE_OPTIONS_SYSROOT}${CMAKE_SYSROOT}")
 endif()
-foreach(INCDIR ${CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES})
-    set(CXXFLAGS "${CXXFLAGS} <compileflags>${CMAKE_INCLUDE_FLAG_C}${CMAKE_INCLUDE_FLAG_C_SEP}${INCDIR}")
+foreach(INCDIR IN LISTS CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES)
+    string(APPEND CXXFLAGS " <compileflags>${CMAKE_INCLUDE_FLAG_C}${CMAKE_INCLUDE_FLAG_C_SEP}${INCDIR}")
 endforeach()
 
 if(APPLE)
-  set(CXXFLAGS "${CXXFLAGS} <compileflags>-D_DARWIN_C_SOURCE <cxxflags>-std=c++11 <cxxflags>-stdlib=libc++")
-  set(LDFLAGS "${LDFLAGS} <linkflags>-stdlib=libc++")
+  string(APPEND CXXFLAGS " <compileflags>-D_DARWIN_C_SOURCE <cxxflags>-std=c++11 <cxxflags>-stdlib=libc++")
+  string(APPEND LDFLAGS " <linkflags>-stdlib=libc++")
 endif()
 
-find_library(ZLIB_LIBPATH z)
-list(APPEND B2_OPTIONS
-    -sZLIB_BINARY=z
-    -sZLIB_LIBPATH="${ZLIB_LIBPATH}"
-)
+if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    # cl in b2 appears to not receive `LIBPATH` for finding winmd files, so we transform them to `/AI` options.
+    set(libpath_args "$ENV{LIBPATH}")
+    # Apply: {x -> /AI"x"}
+    list(TRANSFORM libpath_args PREPEND "/AI\"")
+    list(TRANSFORM libpath_args APPEND "\"")
+    # Apply: {\ -> \\}
+    list(TRANSFORM libpath_args REPLACE "\\\\" "\\\\\\\\")
+    # Apply: {" -> \"}
+    list(TRANSFORM libpath_args REPLACE "\\\"" "\\\\\"")
+    list(JOIN libpath_args " " libpath_arg)
+
+    set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <cflags>-Zl <compileflags>\"${libpath_arg}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
+    list(APPEND B2_OPTIONS windows-api=store)
+endif()
+
+if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        list(APPEND B2_OPTIONS
+            -sZLIB_BINARY=zlib
+            "-sZLIB_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+            -sBZIP2_BINARY=bz2
+            "-sBZIP2_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+            -sLZMA_BINARY=lzma
+            "-sLZMA_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+            -sZSTD_BINARY=zstd
+            "-sZSTD_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
+        )
+    else()
+        list(APPEND B2_OPTIONS
+            -sZLIB_BINARY=zlibd
+            "-sZLIB_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
+            -sBZIP2_BINARY=bz2d
+            "-sBZIP2_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
+            -sLZMA_BINARY=lzmad
+            "-sLZMA_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
+            -sZSTD_BINARY=zstdd
+            "-sZSTD_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
+        )
+    endif()
+else()
+    find_library(ZLIB_LIBPATH z)
+    list(APPEND B2_OPTIONS
+        -sZLIB_BINARY=z
+        -sZLIB_LIBPATH="${ZLIB_LIBPATH}"
+    )
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        find_library(BZIP2_LIBPATH bz2)
+        list(APPEND B2_OPTIONS
+            -sBZIP2_BINARY=bz2
+            -sBZIP2_LIBPATH="${BZIP2_LIBPATH}"
+        )
+    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        find_library(BZIP2_LIBPATH bz2d)
+        list(APPEND B2_OPTIONS
+            -sBZIP2_BINARY=bz2d
+            -sBZIP2_LIBPATH="${BZIP2_LIBPATH}"
+        )
+    endif()
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    find_library(BZIP2_LIBPATH bz2)
-    list(APPEND B2_OPTIONS
-        -sBZIP2_BINARY=bz2
-        -sBZIP2_LIBPATH="${BZIP2_LIBPATH}"
-        variant=release
-    )
-elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    find_library(BZIP2_LIBPATH bz2d)
-    list(APPEND B2_OPTIONS
-        -sBZIP2_BINARY=bz2d
-        -sBZIP2_LIBPATH="${BZIP2_LIBPATH}"
-        variant=debug
-    )
+    list(APPEND B2_OPTIONS variant=release)
+else()
+    list(APPEND B2_OPTIONS variant=debug)
+endif()
+
+if(NOT WIN32)
+    list(APPEND B2_OPTIONS "--layout=system")
 endif()
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/user-config.jam ${CMAKE_CURRENT_BINARY_DIR}/user-config.jam @ONLY)
@@ -188,7 +261,6 @@ add_custom_target(boost ALL
         --stagedir=${CMAKE_CURRENT_BINARY_DIR}/stage
         --build-dir=${CMAKE_CURRENT_BINARY_DIR}
         ${B2_OPTIONS}
-        --layout=system
         --with-atomic
         --with-random
         --with-date_time
@@ -198,17 +270,20 @@ add_custom_target(boost ALL
         --with-chrono
         -sZLIB_INCLUDE="${ZLIB_INCLUDE}"
         -sBZIP2_INCLUDE="${BZIP2_INCLUDE}"
-        -sICU_PATH="${ICU_PATH}"
+        ${ICU_OPTION}
         -j${NUMBER_OF_PROCESSORS}
         -sBOOST_ROOT=${BOOST_BUILD_PATH}
         -sBOOST_BUILD_PATH=${BOOST_BUILD_PATH}
         --debug-configuration
+        --debug-building
+        --debug-generators
         --ignore-site-config
         --hash
         -q
+        debug-symbols=on
+        -d +2
 
         threading=multi
-        debug-symbols=on
 
         stage
     WORKING_DIRECTORY ${SOURCE_PATH}/build
@@ -216,5 +291,14 @@ add_custom_target(boost ALL
 
 set(SUBDIR ${CMAKE_CURRENT_BINARY_DIR}/stage/lib)
 install(
-    CODE "file(GLOB LIBS ${SUBDIR}/*.so.* ${SUBDIR}/*.so ${SUBDIR}/*.a ${SUBDIR}/*.dylib ${SUBDIR}/*.dylib.*)\nif(LIBS)\nfile(INSTALL \${LIBS} DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib\")\nendif()"
+    CODE "
+file(GLOB LIBS ${SUBDIR}/*.so.* ${SUBDIR}/*.so ${SUBDIR}/*.a ${SUBDIR}/*.dylib ${SUBDIR}/*.dylib.* ${SUBDIR}/*.lib)
+if(LIBS)
+    file(INSTALL \${LIBS} DESTINATION \"\${CMAKE_INSTALL_PREFIX}/lib\")
+endif()
+file(GLOB DLLS ${SUBDIR}/*.dll)
+if(DLLS)
+    file(INSTALL \${DLLS} DESTINATION \"\${CMAKE_INSTALL_PREFIX}/bin\")
+endif()
+"
 )

--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -103,346 +103,26 @@ function(boost_modular_build)
         vcpkg_copy_pdbs()
     endfunction()
 
-    if(ON)
-        set(build_flag 0)
-        if(NOT DEFINED VCPKG_BUILD_TYPE)
-            set(build_flag 1)
-            set(VCPKG_BUILD_TYPE "release")
-        endif()
-
-        if(VCPKG_BUILD_TYPE STREQUAL "release")
-            unix_build(${BOOST_LIB_RELEASE_SUFFIX} "release" "lib/")
-        endif()
-
-        if(build_flag)
-            set(VCPKG_BUILD_TYPE "debug")
-        endif()
-
-        if(VCPKG_BUILD_TYPE STREQUAL "debug")
-            unix_build(${BOOST_LIB_DEBUG_SUFFIX} "debug" "debug/lib/")
-        endif()
-
-        file(GLOB INSTALLED_LIBS ${CURRENT_PACKAGES_DIR}/debug/lib/*.lib ${CURRENT_PACKAGES_DIR}/lib/*.lib)
-        foreach(LIB ${INSTALLED_LIBS})
-            get_filename_component(OLD_FILENAME ${LIB} NAME)
-            get_filename_component(DIRECTORY_OF_LIB_FILE ${LIB} DIRECTORY)
-            string(REPLACE "libboost_" "boost_" NEW_FILENAME ${OLD_FILENAME})
-            string(REPLACE "-s-" "-" NEW_FILENAME ${NEW_FILENAME}) # For Release libs
-            string(REPLACE "-vc141-" "-vc140-" NEW_FILENAME ${NEW_FILENAME}) # To merge VS2017 and VS2015 binaries
-            string(REPLACE "-vc142-" "-vc140-" NEW_FILENAME ${NEW_FILENAME}) # To merge VS2019 and VS2015 binaries
-            string(REPLACE "-vc143-" "-vc140-" NEW_FILENAME ${NEW_FILENAME}) # To merge VS2022 and VS2015 binaries
-            string(REPLACE "-sgd-" "-gd-" NEW_FILENAME ${NEW_FILENAME}) # For Debug libs
-            string(REPLACE "-sgyd-" "-gyd-" NEW_FILENAME ${NEW_FILENAME}) # For Debug libs
-            string(REPLACE "-x32-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
-            string(REPLACE "-x64-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
-            string(REPLACE "-a32-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
-            string(REPLACE "-a64-" "-" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake 3.10 and earlier to locate the binaries
-            string(REPLACE "-1_76" "" NEW_FILENAME ${NEW_FILENAME}) # To enable CMake > 3.10 to locate the binaries
-            if("${DIRECTORY_OF_LIB_FILE}/${NEW_FILENAME}" STREQUAL "${DIRECTORY_OF_LIB_FILE}/${OLD_FILENAME}")
-                # nothing to do
-            elseif(EXISTS ${DIRECTORY_OF_LIB_FILE}/${NEW_FILENAME})
-                file(REMOVE ${DIRECTORY_OF_LIB_FILE}/${OLD_FILENAME})
-            else()
-                file(RENAME ${DIRECTORY_OF_LIB_FILE}/${OLD_FILENAME} ${DIRECTORY_OF_LIB_FILE}/${NEW_FILENAME})
-            endif()
-        endforeach()
-
-        # boost-regex[icu] and boost-locale[icu] generate has_icu.lib
-        if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib")
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/has_icu.lib")
-        endif()
-        if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/has_icu.lib")
-            file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/has_icu.lib")
-        endif()
-
-        if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/lib)
-            message(FATAL_ERROR "No libraries were produced. This indicates a failure while building the boost library.")
-        endif()
-
-        configure_file(${BOOST_BUILD_INSTALLED_DIR}/share/boost-build/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage COPYONLY)
-        return()
+    set(build_flag 0)
+    if(NOT DEFINED VCPKG_BUILD_TYPE)
+        set(build_flag 1)
+        set(VCPKG_BUILD_TYPE "release")
     endif()
 
-    #####################
-    # Cleanup previous builds
-    ######################
-    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
-    if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
-        # It is possible for a file in this folder to be locked due to antivirus or vctip
-        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
-        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
-        if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
-            message(FATAL_ERROR "Unable to remove directory: ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel\n  Files are likely in use.")
-        endif()
+    if(VCPKG_BUILD_TYPE STREQUAL "release")
+        unix_build(${BOOST_LIB_RELEASE_SUFFIX} "release" "lib/")
     endif()
 
-    file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-    if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-        # It is possible for a file in this folder to be locked due to antivirus or vctip
-        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
-        file(REMOVE_RECURSE ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-        if(EXISTS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-            message(FATAL_ERROR "Unable to remove directory: ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg\n  Files are likely in use.")
-        endif()
+    if(build_flag)
+        set(VCPKG_BUILD_TYPE "debug")
     endif()
 
-    if(EXISTS ${CURRENT_PACKAGES_DIR}/debug)
-        message(FATAL_ERROR "Error: directory exists: ${CURRENT_PACKAGES_DIR}/debug\n  The previous package was not fully cleared. This is an internal error.")
-    endif()
-    file(MAKE_DIRECTORY
-        ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
-        ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
-    )
-
-    include(ProcessorCount)
-    ProcessorCount(NUMBER_OF_PROCESSORS)
-    if(NOT NUMBER_OF_PROCESSORS)
-        set(NUMBER_OF_PROCESSORS 1)
-    endif()
-
-    ######################
-    # Generate configuration
-    ######################
-    list(APPEND B2_OPTIONS
-        -j${NUMBER_OF_PROCESSORS}
-        --debug-configuration
-        --debug-building
-        --debug-generators
-        --disable-icu
-        --ignore-site-config
-        --hash
-        -q
-        "-sZLIB_INCLUDE=${CURRENT_INSTALLED_DIR}/include"
-        "-sBZIP2_INCLUDE=${CURRENT_INSTALLED_DIR}/include"
-        "-sLZMA_INCLUDE=${CURRENT_INSTALLED_DIR}/include"
-        "-sZSTD_INCLUDE=${CURRENT_INSTALLED_DIR}/include"
-        threading=multi
-    )
-    if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        list(APPEND B2_OPTIONS threadapi=win32)
-    else()
-        list(APPEND B2_OPTIONS threadapi=pthread)
-    endif()
-    list(APPEND B2_OPTIONS_DBG
-         -sZLIB_BINARY=zlibd
-         "-sZLIB_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
-         -sBZIP2_BINARY=bz2d
-         "-sBZIP2_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
-         -sLZMA_BINARY=lzmad
-         "-sLZMA_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
-         -sZSTD_BINARY=zstdd
-         "-sZSTD_LIBPATH=${CURRENT_INSTALLED_DIR}/debug/lib"
-    )
-
-    list(APPEND B2_OPTIONS_REL
-         -sZLIB_BINARY=zlib
-         "-sZLIB_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
-         -sBZIP2_BINARY=bz2
-         "-sBZIP2_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
-         -sLZMA_BINARY=lzma
-         "-sLZMA_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
-         -sZSTD_BINARY=zstd
-         "-sZSTD_LIBPATH=${CURRENT_INSTALLED_DIR}/lib"
-    )
-
-    # Properly handle compiler and linker flags passed by VCPKG
-    if(VCPKG_CXX_FLAGS)
-        list(APPEND B2_OPTIONS "cxxflags=${VCPKG_CXX_FLAGS}")
-    endif()
-
-    if(VCPKG_CXX_FLAGS_RELEASE)
-        list(APPEND B2_OPTIONS_REL "cxxflags=${VCPKG_CXX_FLAGS_RELEASE}")
-    endif()
-
-    if(VCPKG_CXX_FLAGS_DEBUG)
-        list(APPEND B2_OPTIONS_DBG "cxxflags=${VCPKG_CXX_FLAGS_DEBUG}")
-    endif()
-
-    if(VCPKG_C_FLAGS)
-        list(APPEND B2_OPTIONS "cflags=${VCPKG_C_FLAGS}")
-    endif()
-
-    if(VCPKG_C_FLAGS_RELEASE)
-        list(APPEND B2_OPTIONS_REL "cflags=${VCPKG_C_FLAGS_RELEASE}")
-    endif()
-
-    if(VCPKG_C_FLAGS_DEBUG)
-        list(APPEND B2_OPTIONS_DBG "cflags=${VCPKG_C_FLAGS_DEBUG}")
-    endif()
-
-    if(VCPKG_LINKER_FLAGS)
-        list(APPEND B2_OPTIONS "linkflags=${VCPKG_LINKER_FLAGS}")
-    endif()
-
-    if(VCPKG_LINKER_FLAGS_RELEASE)
-        list(APPEND B2_OPTIONS_REL "linkflags=${VCPKG_LINKER_FLAGS_RELEASE}")
-    endif()
-
-    if(VCPKG_LINKER_FLAGS_DEBUG)
-        list(APPEND B2_OPTIONS_DBG "linkflags=${VCPKG_LINKER_FLAGS_DEBUG}")
-    endif()
-
-    # Add build type specific options
-    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
-        list(APPEND B2_OPTIONS runtime-link=shared)
-    else()
-        list(APPEND B2_OPTIONS runtime-link=static)
-    endif()
-
-    if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-        list(APPEND B2_OPTIONS link=shared)
-    else()
-        list(APPEND B2_OPTIONS link=static)
-    endif()
-
-    if(VCPKG_TARGET_ARCHITECTURE MATCHES "x64")
-        list(APPEND B2_OPTIONS address-model=64 architecture=x86)
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
-        list(APPEND B2_OPTIONS address-model=32 architecture=arm)
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        list(APPEND B2_OPTIONS address-model=64 architecture=arm)
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "s390x")
-        list(APPEND B2_OPTIONS address-model=64 architecture=s390x)
-    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "ppc64le")
-        list(APPEND B2_OPTIONS address-model=64 architecture=power)
-    else()
-        list(APPEND B2_OPTIONS address-model=32 architecture=x86)
-
-        if(NOT VCPKG_CMAKE_SYSTEM_NAME OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-            list(APPEND B2_OPTIONS "asmflags=/safeseh")
-        endif()
-
-    endif()
-
-    file(TO_CMAKE_PATH "${_bm_DIR}/nothing.bat" NOTHING_BAT)
-    set(TOOLSET_OPTIONS "<cxxflags>/EHsc <compileflags>-Zm800 <compileflags>-nologo")
-    if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-        if(NOT VCPKG_PLATFORM_TOOLSET MATCHES "v140")
-            find_path(PATH_TO_CL cl.exe)
-            find_path(PLATFORM_WINMD_DIR platform.winmd PATHS "${PATH_TO_CL}/../../../lib/x86/store/references" NO_DEFAULT_PATH)
-            if(PLATFORM_WINMD_DIR MATCHES "NOTFOUND")
-                message(FATAL_ERROR "Could not find `platform.winmd` in VS. Do you have the Universal Windows Platform development workload installed?")
-            endif()
-        else()
-            find_path(PLATFORM_WINMD_DIR platform.winmd PATHS "$ENV{VS140COMNTOOLS}/../../VC/LIB/store/references")
-            if(PLATFORM_WINMD_DIR MATCHES "NOTFOUND")
-                message(FATAL_ERROR "Could not find `platform.winmd` in VS2015.")
-            endif()
-        endif()
-        file(TO_NATIVE_PATH "${PLATFORM_WINMD_DIR}" PLATFORM_WINMD_DIR)
-        string(REPLACE "\\" "/" PLATFORM_WINMD_DIR ${PLATFORM_WINMD_DIR}) # escape backslashes
-
-        set(TOOLSET_OPTIONS "${TOOLSET_OPTIONS} <cflags>-Zl <compileflags> /AI\"${PLATFORM_WINMD_DIR}\" <linkflags>WindowsApp.lib <cxxflags>/ZW <compileflags>-DVirtualAlloc=VirtualAllocFromApp <compileflags>-D_WIN32_WINNT=0x0A00")
-    endif()
-
-    set(MSVC_VERSION)
-    if(VCPKG_PLATFORM_TOOLSET MATCHES "v143")
-        list(APPEND _bm_OPTIONS toolset=msvc)
-        set(MSVC_VERSION 14.3)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v142")
-        list(APPEND _bm_OPTIONS toolset=msvc)
-        set(MSVC_VERSION 14.2)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v141")
-        list(APPEND _bm_OPTIONS toolset=msvc)
-        set(MSVC_VERSION 14.1)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v140")
-        list(APPEND _bm_OPTIONS toolset=msvc)
-        set(MSVC_VERSION 14.0)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "v120")
-        list(APPEND _bm_OPTIONS toolset=msvc)
-    elseif(VCPKG_PLATFORM_TOOLSET MATCHES "external")
-        list(APPEND B2_OPTIONS toolset=gcc)
-    else()
-        message(FATAL_ERROR "Unsupported value for VCPKG_PLATFORM_TOOLSET: '${VCPKG_PLATFORM_TOOLSET}'")
-    endif()
-
-    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/user-config.jam @ONLY)
-    configure_file(${_bm_DIR}/user-config.jam ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/user-config.jam @ONLY)
-
-    ######################
-    # Perform build + Package
-    ######################
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        message(STATUS "Building ${TARGET_TRIPLET}-rel")
-        set(BOOST_LIB_SUFFIX ${BOOST_LIB_RELEASE_SUFFIX})
-        set(VARIANT "release")
-        set(BUILD_LIB_PATH "lib/")
-        configure_file(${_bm_DIR}/Jamroot.jam ${_bm_SOURCE_PATH}/Jamroot.jam @ONLY)
-        set(ENV{BOOST_BUILD_PATH} "${BOOST_BUILD_PATH}")
-        vcpkg_execute_required_process(
-            COMMAND "${B2_EXE}"
-                --stagedir=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/stage
-                --build-dir=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel
-                --user-config=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/user-config.jam
-                ${B2_OPTIONS}
-                ${B2_OPTIONS_REL}
-                variant=release
-                debug-symbols=on
-            WORKING_DIRECTORY ${_bm_SOURCE_PATH}/build
-            LOGNAME build-${TARGET_TRIPLET}-rel
-        )
-        message(STATUS "Building ${TARGET_TRIPLET}-rel done")
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        message(STATUS "Building ${TARGET_TRIPLET}-dbg")
-        set(BOOST_LIB_SUFFIX ${BOOST_LIB_DEBUG_SUFFIX})
-        set(VARIANT debug)
-        set(BUILD_LIB_PATH "debug/lib/")
-        configure_file(${_bm_DIR}/Jamroot.jam ${_bm_SOURCE_PATH}/Jamroot.jam @ONLY)
-        set(ENV{BOOST_BUILD_PATH} "${BOOST_BUILD_PATH}")
-        vcpkg_execute_required_process(
-            COMMAND "${B2_EXE}"
-                --stagedir=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/stage
-                --build-dir=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg
-                --user-config=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/user-config.jam
-                ${B2_OPTIONS}
-                ${B2_OPTIONS_DBG}
-                variant=debug
-            WORKING_DIRECTORY ${_bm_SOURCE_PATH}/build
-            LOGNAME build-${TARGET_TRIPLET}-dbg
-        )
-        message(STATUS "Building ${TARGET_TRIPLET}-dbg done")
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-        message(STATUS "Packaging ${TARGET_TRIPLET}-rel")
-        file(GLOB REL_LIBS
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/boost/build/*/*.lib
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/boost/build/*/*.a
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/boost/build/*/*.so
-        )
-        file(COPY ${REL_LIBS}
-            DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-        if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-            file(GLOB REL_DLLS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/boost/build/*/*.dll)
-            file(COPY ${REL_DLLS}
-                DESTINATION ${CURRENT_PACKAGES_DIR}/bin
-                FILES_MATCHING PATTERN "*.dll")
-        endif()
-        message(STATUS "Packaging ${TARGET_TRIPLET}-rel done")
-    endif()
-
-    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-        message(STATUS "Packaging ${TARGET_TRIPLET}-dbg")
-        file(GLOB DBG_LIBS
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/boost/build/*/*.lib
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/boost/build/*/*.a
-            ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/boost/build/*/*.so
-        )
-        file(COPY ${DBG_LIBS}
-            DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-        if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-            file(GLOB DBG_DLLS ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/boost/build/*/*.dll)
-            file(COPY ${DBG_DLLS}
-                DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
-                FILES_MATCHING PATTERN "*.dll")
-        endif()
-        message(STATUS "Packaging ${TARGET_TRIPLET}-dbg done")
+    if(VCPKG_BUILD_TYPE STREQUAL "debug")
+        unix_build(${BOOST_LIB_DEBUG_SUFFIX} "debug" "debug/lib/")
     endif()
 
     file(GLOB INSTALLED_LIBS ${CURRENT_PACKAGES_DIR}/debug/lib/*.lib ${CURRENT_PACKAGES_DIR}/lib/*.lib)
-    foreach(LIB ${INSTALLED_LIBS})
+    foreach(LIB IN LISTS INSTALLED_LIBS)
         get_filename_component(OLD_FILENAME ${LIB} NAME)
         get_filename_component(DIRECTORY_OF_LIB_FILE ${LIB} DIRECTORY)
         string(REPLACE "libboost_" "boost_" NEW_FILENAME ${OLD_FILENAME})
@@ -474,6 +154,9 @@ function(boost_modular_build)
         file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/has_icu.lib")
     endif()
 
-    vcpkg_copy_pdbs()
+    if(NOT EXISTS ${CURRENT_PACKAGES_DIR}/lib)
+        message(FATAL_ERROR "No libraries were produced. This indicates a failure while building the boost library.")
+    endif()
+
     configure_file(${BOOST_BUILD_INSTALLED_DIR}/share/boost-build/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage COPYONLY)
 endfunction()

--- a/ports/boost-modular-build-helper/user-config.jam
+++ b/ports/boost-modular-build-helper/user-config.jam
@@ -2,9 +2,12 @@ import toolset ;
 
 if "@VCPKG_PLATFORM_TOOLSET@" != "external"
 {
-    using msvc : @MSVC_VERSION@ : cl.exe
+    using msvc : @BOOST_MSVC_VERSION@ : cl.exe
         :
         <setup>"@NOTHING_BAT@"
+        @CXXFLAGS@
+        @CFLAGS@
+        @LDFLAGS@
         @TOOLSET_OPTIONS@
         ;
 }

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version-string": "1.76.0",
-  "port-version": 1,
+  "port-version": 2,
   "dependencies": [
     "boost-build",
     "boost-uninstall"

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "eee8f7b8f4a2bbfd87c8713126011953bc65945a",
+      "git-tree": "fd1c08c606cabfe31c22e2677c383f8b5119fba6",
       "version-string": "1.76.0",
       "port-version": 2
     },

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eee8f7b8f4a2bbfd87c8713126011953bc65945a",
+      "version-string": "1.76.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f9cf6243049bf0abf8526fba57702a2122665549",
       "version-string": "1.76.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -798,7 +798,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.76.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-move": {
       "baseline": "1.76.0",


### PR DESCRIPTION
Today, boost does not respect settings set directly in the toolchain file on Windows -- it instead assumes the use of our `windows.cmake` and only considered additional flags set in the triplet.

This PR aims to move Windows to use the procedure currently used for non-Windows platforms, which performs a full CMake configure and therefore has access to the full set of flags.