### PR TITLE
[libdatachannel] Export the include path to cmake configure file

### DIFF
--- a/ports/libdatachannel/0002-fix-export-include.patch
+++ b/ports/libdatachannel/0002-fix-export-include.patch
@@ -1,0 +1,66 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3c01184..0adff6f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -217,18 +217,22 @@ set_target_properties(datachannel-static PROPERTIES
+ 	VERSION ${PROJECT_VERSION}
+ 	CXX_STANDARD 17)
+ 
+-target_include_directories(datachannel PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
++target_include_directories(datachannel PUBLIC
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<INSTALL_INTERFACE:include>)
+ target_include_directories(datachannel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/rtc)
+ target_include_directories(datachannel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+ target_include_directories(datachannel PRIVATE ${PLOG_INCLUDE_DIRS})
+-target_link_libraries(datachannel PUBLIC Threads::Threads)
++target_link_libraries(datachannel PRIVATE Threads::Threads)
+ target_link_libraries(datachannel PRIVATE ${USRSCTP_LIBRARY})
+ 
+-target_include_directories(datachannel-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
++target_include_directories(datachannel-static PUBLIC 
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<INSTALL_INTERFACE:include>)
+ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/rtc)
+ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+ target_include_directories(datachannel PRIVATE ${PLOG_INCLUDE_DIRS})
+-target_link_libraries(datachannel-static PUBLIC Threads::Threads)
++target_link_libraries(datachannel-static PRIVATE Threads::Threads)
+ target_link_libraries(datachannel-static PRIVATE ${USRSCTP_LIBRARY})
+ 
+ if(WIN32)
+diff --git a/examples/client-benchmark/CMakeLists.txt b/examples/client-benchmark/CMakeLists.txt
+index ad0024c..a734db6 100644
+--- a/examples/client-benchmark/CMakeLists.txt
++++ b/examples/client-benchmark/CMakeLists.txt
+@@ -3,6 +3,7 @@ if(POLICY CMP0079)
+ 	cmake_policy(SET CMP0079 NEW)
+ endif()
+ 
++find_package(Threads)
+ if(WIN32)
+ 	add_executable(datachannel-client-benchmark main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h)
+ 	target_compile_definitions(datachannel-client-benchmark PUBLIC STATIC_GETOPT)
+@@ -15,7 +16,7 @@ set_target_properties(datachannel-client-benchmark PROPERTIES
+ 	OUTPUT_NAME client-benchmark)
+ set_target_properties(datachannel-client-benchmark PROPERTIES
+ 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.client.benchmark)
+-target_link_libraries(datachannel-client-benchmark datachannel nlohmann_json)
++target_link_libraries(datachannel-client-benchmark datachannel nlohmann_json Threads::Threads)
+ 
+ if(WIN32)
+ 	add_custom_command(TARGET datachannel-client-benchmark POST_BUILD
+diff --git a/examples/streamer/CMakeLists.txt b/examples/streamer/CMakeLists.txt
+index cebec95..3e73160 100644
+--- a/examples/streamer/CMakeLists.txt
++++ b/examples/streamer/CMakeLists.txt
+@@ -47,7 +47,8 @@ set_target_properties(streamer PROPERTIES
+ set_target_properties(streamer PROPERTIES
+ 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.streamer)
+ 
+-target_link_libraries(streamer datachannel nlohmann_json)
++find_package(Threads)
++target_link_libraries(streamer datachannel nlohmann_json Threads::Threads)
+ 
+ if(WIN32)
+ 	add_custom_command(TARGET streamer POST_BUILD

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -17,9 +17,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         srtp NO_MEDIA
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
         -DUSE_SYSTEM_SRTP=ON
@@ -27,11 +26,9 @@ vcpkg_configure_cmake(
         -DNO_TESTS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/libdatachannel)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/libdatachannel)
 vcpkg_fixup_pkgconfig()
 
 file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake DATACHANNEL_CONFIG)
@@ -41,5 +38,7 @@ find_dependency(Threads)
 find_dependency(OpenSSL)
 find_dependency(libjuice)
 ${DATACHANNEL_CONFIG}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-fix-for-vcpkg.patch
+        0002-fix-export-include.patch # Remove this patch in the next update
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -31,8 +31,8 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/libdatachannel)
 vcpkg_fixup_pkgconfig()
 
-file(READ ${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake DATACHANNEL_CONFIG)
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake "
+file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake" DATACHANNEL_CONFIG)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/libdatachannel-config.cmake" "
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(OpenSSL)
@@ -41,4 +41,4 @@ ${DATACHANNEL_CONFIG}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -8,7 +8,15 @@
     "libjuice",
     "openssl",
     "plog",
-    "usrsctp"
+    "usrsctp",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "default-features": [
     "ws"

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.14.3",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3242,7 +3242,7 @@
     },
     "libdatachannel": {
       "baseline": "0.14.3",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.10",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "86b0c25304d6e03c63ffc1605fe9719809ceb9d8",
+      "git-tree": "66b888218de8c7c7a14df4b1b84d21182f8e27db",
       "version-semver": "0.14.3",
       "port-version": 1
     },

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86b0c25304d6e03c63ffc1605fe9719809ceb9d8",
+      "version-semver": "0.14.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "9cb7fedbd9d94190697740000539fb124d2b57d4",
       "version-semver": "0.14.3",
       "port-version": 0

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "66b888218de8c7c7a14df4b1b84d21182f8e27db",
+      "git-tree": "4e6c861ece23dfcb6f777b4a63dd97592cd578db",
       "version-semver": "0.14.3",
       "port-version": 1
     },


### PR DESCRIPTION
Use upstream changes (https://github.com/paullouisageneau/libdatachannel/pull/446) to fix the usage issue: include path isn't exported to libdatachannelConfig.cmake.

Fixes #20223.