### PR TITLE
[ci] Skip directxsdk:...windows and embree2:x64-linux in CI.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -214,6 +214,9 @@ devicenameresolver:x64-windows-static=fail
 dimcli:arm-uwp=fail
 dimcli:x64-osx=fail
 dimcli:x64-uwp=fail
+# legacy directxsdk which conflicts with dxsdk-d3dx
+directxsdk:x86-windows=skip
+directxsdk:x64-windows=skip
 discord-game-sdk:x64-windows-static=fail
 discord-game-sdk:x64-windows-static-md=fail
 discord-rpc:arm-uwp=fail
@@ -271,6 +274,8 @@ elfutils:x64-osx=fail
 # https://github.com/embree/embree/issues/331
 embree2:x64-windows-static=skip
 embree2:x64-windows-static-md=skip
+# embree2 conflicts with embree3 on Linux
+embree2:x64-linux=skip
 enet:arm-uwp=fail
 enet:x64-uwp=fail
 epsilon:arm-uwp=fail


### PR DESCRIPTION
Looked at most recent build https://dev.azure.com/vcpkg/public/_build/results?buildId=59859

REGRESSION: dxsdk-d3dx:x86-windows
REGRESSION: dxsdk-d3dx:x64-windows

```
The following files are already installed in D:/installed/x86-windows and are in conflict with dxsdk-d3dx:x86-windows

Installed by directxsdk:x86-windows
    debug/lib/d3dx10d.lib
    debug/lib/d3dx11d.lib
    debug/lib/d3dx9d.lib
    lib/d3dx10.lib
    lib/d3dx11.lib
    lib/d3dx9.lib
```

Probably caused by https://github.com/microsoft/vcpkg/pull/20053/ which removed windows & !windows from the directxsdk supports field. Skip these in ci.baseline.txt.

PASSING, REMOVE FROM FAIL LIST: cmark:x64-windows-static

Already filed https://github.com/microsoft/vcpkg/pull/20216 last week about this.

ARM: vcpkg crashed. Reported to team chat.
OSX: agent died: ##[error]We stopped hearing from agent vcpkg-eg-mac-02.
  Looks to be the same outstanding tensorflow problem :(

REGRESSION: embree3:x64-linux

```
Starting package 640/1653: embree3:x64-linux
Building package embree3[avx,avx2,core,sse2,sse42]:x64-linux...
-- Downloading https://github.com/embree/embree/archive/v3.12.2.tar.gz -> embree-embree-v3.12.2.tar.gz...
-- Extracting source /mnt/vcpkg-ci/downloads/embree-embree-v3.12.2.tar.gz
-- Applying patch fix-path.patch
-- Applying patch fix-static-usage.patch
-- Applying patch cmake_policy.patch
-- Applying patch fix-targets-file-not-found.patch
-- Using source at /mnt/vcpkg-ci/buildtrees/embree3/src/v3.12.2-cbae4ce8b1.clean
-- Configuring x64-linux-dbg
-- Configuring x64-linux-rel
CMake Warning at scripts/cmake/vcpkg_configure_cmake.cmake:433 (message):
  The following variables are not used in CMakeLists.txt:

      EMBREE_STATIC_RUNTIME

  Please recheck them and remove the unnecessary options from the
  `vcpkg_configure_cmake` call.

  If these options should still be passed for whatever reason, please use the
  `MAYBE_UNUSED_VARIABLES` argument.
Call Stack (most recent call first):
  ports/embree3/portfile.cmake:50 (vcpkg_configure_cmake)
  scripts/ports.cmake:140 (include)

-- Building x64-linux-dbg
-- Building x64-linux-rel
-- Installing: /mnt/vcpkg-ci/packages/embree3_x64-linux/share/embree3/copyright
-- Performing post-build validation
```

Probably caused by https://github.com/microsoft/vcpkg/pull/20053 which removed supports:windows from embree2. Skip in ci.baseline.txt.
