### PR TITLE
[kf5codecs] add explicit gperf dependency

### DIFF
--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -9,10 +9,13 @@ vcpkg_from_github(
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
 
+find_program(GPERF_EXE NAMES gperf PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/" NO_DEFAULT_PATHS)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
+        -DGperf_EXECUTABLE="${GPERF_EXE}"
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DGperf_EXECUTABLE=${GPERF_EXE}
+        "-DGperf_EXECUTABLE=${GPERF_EXE}"
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -6,10 +6,6 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_find_acquire_program(GPERF)
-get_filename_component(GPERF_EXE_PATH ${GPERF} DIRECTORY)
-vcpkg_add_to_path(${GPERF_EXE_PATH})
-
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
 

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -9,13 +9,13 @@ vcpkg_from_github(
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
 
-find_program(GPERF_EXE NAMES gperf PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools/" NO_DEFAULT_PATHS)
+find_program(GPERF_EXE NAMES gperf PATHS "${CURRENT_HOST_INSTALLED_DIR}/tools" NO_DEFAULT_PATH)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DGperf_EXECUTABLE="${GPERF_EXE}"
+        -DGperf_EXECUTABLE=${GPERF_EXE}
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5codecs/portfile.cmake
+++ b/ports/kf5codecs/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
 file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
 )
@@ -24,9 +24,8 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin/data)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/etc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/data")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSES/ DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSES/" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")

--- a/ports/kf5codecs/vcpkg.json
+++ b/ports/kf5codecs/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "kf5codecs",
   "version": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "String encoding library",
   "homepage": "https://api.kde.org/frameworks/kcodecs/html/index.html",
   "dependencies": [
     "ecm",
+    "gperf",
     "qt5-base",
     "qt5-tools",
     {

--- a/ports/kf5codecs/vcpkg.json
+++ b/ports/kf5codecs/vcpkg.json
@@ -6,7 +6,10 @@
   "homepage": "https://api.kde.org/frameworks/kcodecs/html/index.html",
   "dependencies": [
     "ecm",
-    "gperf",
+    {
+      "name": "gperf",
+      "host": true
+    },
     "qt5-base",
     "qt5-tools",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3014,7 +3014,7 @@
     },
     "kf5codecs": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5completion": {
       "baseline": "5.84.0",

--- a/versions/k-/kf5codecs.json
+++ b/versions/k-/kf5codecs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1d73ea7605ea09c70422ab94b8d3f7ce96739df2",
+      "git-tree": "6ba56994c4a0a859c77a8a33b0054ee61225cfaf",
       "version": "5.84.0",
       "port-version": 3
     },

--- a/versions/k-/kf5codecs.json
+++ b/versions/k-/kf5codecs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1d73ea7605ea09c70422ab94b8d3f7ce96739df2",
+      "version": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "0997fde9753e1e3c745eca599c116ef3a511bece",
       "version": "5.84.0",
       "port-version": 2

--- a/versions/k-/kf5codecs.json
+++ b/versions/k-/kf5codecs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6ba56994c4a0a859c77a8a33b0054ee61225cfaf",
+      "git-tree": "54b65a5af21a97ee1a73591b5e83d26cc6898d12",
       "version": "5.84.0",
       "port-version": 3
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This prevents built failures on macOS with its outdated `GNU gperf 3.0.3` that chokes on kf5codec's 'register' specifiers.
  Also wraps paths in quotes and removes the line deleting `/etc`, which isn't being populated.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  No change.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes