### PR TITLE
[s2n] update to 1.1.0

### DIFF
--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO aws/s2n-tls
-    REF b5b313b9ccddf268b30c642798f1d2a58d49ecd6 # v1.0.17
-    SHA512 59750c9a3c9330e2b26b84d45665b222d23475090736d8299f81352c839a09af10be0d49d34ced1dadae65ca255e819df45b648387e26b7dca31d74782fdb834
+    REF 4de98dcf20c476519c15241f92122b99fd2a9297 # v1.1.0
+    SHA512 99c973912dc1a4db5ef36c24aa69134bf901101ce2ef749f7492f965f65f62b76c0e3935075881530f0828025ce20caa392afd9ad3bbdba157173dd5bb9f8163
     PATCHES fix-cmake-target-path.patch
 )
 
@@ -11,18 +11,11 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-file(GLOB SHARED_CMAKE_FILES
-     "${CURRENT_PACKAGES_DIR}/debug/lib/s2n"
-     "${CURRENT_PACKAGES_DIR}/lib/s2n"
-     )
-
-foreach(FILE ${SHARED_CMAKE_FILES})
-    file(COPY "${FILE}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/")
-endforeach()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/s2n/cmake)
 
 file(REMOVE_RECURSE
-    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/s2n"
 	"${CURRENT_PACKAGES_DIR}/lib/s2n"
 	)
 

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "s2n",
-  "version": "1.0.17",
-  "port-version": 1,
+  "version": "1.1.0",
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "supports": "!uwp & !windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5849,8 +5849,8 @@
       "port-version": 5
     },
     "s2n": {
-      "baseline": "1.0.17",
-      "port-version": 1
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "safeint": {
       "baseline": "3.0.26",

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "13b9d04cbee992cf866560de89551ceaf7dfc277",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8df5dce6a28decc5f853d2efd6d657374709d1b2",
       "version": "1.0.17",
       "port-version": 1


### PR DESCRIPTION
Update port to latest version 1.1.0.
Also Debug target was pointing to release lib location. Cleaned the portfile and used vcpkg_cmake_config_fixup() instead to generate good debug/release targets.