### PR TITLE
Fix build issues on OSX when these flags are enabled: osx-bindings, metal-bindings

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -1,7 +1,12 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(imgui CXX)
 
 set(CMAKE_DEBUG_POSTFIX d)
+
+if(APPLE)
+    set(CMAKE_CXX_STANDARD 11)
+    enable_language(OBJCXX)
+endif()
 
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -59,6 +64,7 @@ endif()
 
 if(IMGUI_BUILD_METAL_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.mm)
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.mm PROPERTIES COMPILE_FLAGS -fobjc-weak)
 endif()
 
 if(IMGUI_BUILD_OPENGL2_BINDING)

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui",
   "version": "1.84.2",
-  "port-version": "2",
+  "port-version": "1",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.84.2",
+  "port-version": "2",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "imgui",
   "version": "1.84.2",
-  "port-version": "1",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2754,7 +2754,7 @@
     },
     "imgui": {
       "baseline": "1.84.2",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.1",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d0f402c97029e9c2021ca776e2bebc645cc5ecc",
+      "version": "1.84.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c07b221daf49a22fc9e8e7571bb329485f618a7f",
       "version": "1.84.2",
       "port-version": 0


### PR DESCRIPTION
 * bump required cmake version because OBJCXX support has been introduced in 3.16

 * set C++ standard to c++11 on Apple.  Imgui own examples use c++14, however c++11 was found to be sufficient

 * enable Objective-C++ mode for *.mm sources

 * add `-fobjc-weak` flag for imgui_impl_metal.mm to fix compile error

**Describe the pull request**

- #### What does your PR fix?  
  Fixes build issues on OSX when these bindings are enabled: `osx-bindings`, `metal-bindings`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  `x64-osx`, `Yes`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
