### PR TITLE
[enet] Export config, support BUILD_SHARED_LIBS, and add usage

### DIFF
--- a/ports/enet/CMakeLists.txt
+++ b/ports/enet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(enet)
 
@@ -55,9 +55,7 @@ if(HAS_SOCKLEN_T)
     add_definitions(-DHAS_SOCKLEN_T=1)
 endif()
  
-include_directories(${PROJECT_SOURCE_DIR}/include)
- 
-add_library(enet STATIC
+add_library(enet
         callbacks.c
         compress.c
         host.c
@@ -69,13 +67,42 @@ add_library(enet STATIC
         win32.c
     )
 
+add_library(enet::enet ALIAS enet)
+
+target_include_directories(enet PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(enet
+        PUBLIC ENET_DLL
+        PRIVATE ENET_BUILDING_LIB
+    )
+endif()
+	
+
 if (WIN32)
     target_link_libraries(enet winmm ws2_32)
 endif()
 
-install(TARGETS enet ARCHIVE DESTINATION lib
+set(INSTALL_TARGETS enet)
+set(ENET_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/enet)
+
+install(TARGETS enet EXPORT enetConfig
+                     ARCHIVE DESTINATION lib
                      LIBRARY DESTINATION lib
                      RUNTIME DESTINATION bin)
+
+export(TARGETS ${INSTALL_TARGETS}
+    NAMESPACE enet::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/enetConfig.cmake"
+)
+
+install(EXPORT
+    enetConfig DESTINATION ${ENET_CMAKE_DIR}
+    NAMESPACE enet::
+)
 
 install(DIRECTORY include/
         DESTINATION include)

--- a/ports/enet/CMakeLists.txt
+++ b/ports/enet/CMakeLists.txt
@@ -86,22 +86,17 @@ if (WIN32)
     target_link_libraries(enet winmm ws2_32)
 endif()
 
-set(INSTALL_TARGETS enet)
 set(ENET_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/enet)
 
-install(TARGETS enet EXPORT enetConfig
+install(TARGETS enet EXPORT unofficial-enet-config
                      ARCHIVE DESTINATION lib
                      LIBRARY DESTINATION lib
                      RUNTIME DESTINATION bin)
 
-export(TARGETS ${INSTALL_TARGETS}
-    NAMESPACE enet::
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/enetConfig.cmake"
-)
-
-install(EXPORT
-    enetConfig DESTINATION ${ENET_CMAKE_DIR}
-    NAMESPACE enet::
+INSTALL(EXPORT unofficial-enet-config
+    NAMESPACE unofficial::enet::
+    FILE unofficial-enet-config.cmake
+    DESTINATION share/unofficial-enet
 )
 
 install(DIRECTORY include/

--- a/ports/enet/portfile.cmake
+++ b/ports/enet/portfile.cmake
@@ -5,21 +5,20 @@ vcpkg_from_github(OUT_SOURCE_PATH SOURCE_PATH
     SHA512 006a78edcc2059d8cee47a163d308dd02120a54f9c203401b83eb6cb4ab3e56cf09988d3c35b436a1e9f74c01296995ae6fdd46f6d354fe8261cf19cdde3df5d
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     # OPTIONS -DUSE_THIS_IN_ALL_BUILDS=1 -DUSE_THIS_TOO=2
     # OPTIONS_RELEASE -DOPTIMIZE=1
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-enet)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-enet CONFIG_PATH share/unofficial-enet)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/enet/portfile.cmake
+++ b/ports/enet/portfile.cmake
@@ -16,11 +16,10 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-enet)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/enet/portfile.cmake
+++ b/ports/enet/portfile.cmake
@@ -16,9 +16,11 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_copy_pdbs()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ports/enet/usage
+++ b/ports/enet/usage
@@ -1,4 +1,0 @@
-The package enet provides CMake targets:
-
-    find_package(enet CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE enet::enet)

--- a/ports/enet/usage
+++ b/ports/enet/usage
@@ -1,0 +1,4 @@
+The package enet provides CMake targets:
+
+    find_package(enet CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE enet::enet)

--- a/ports/enet/vcpkg.json
+++ b/ports/enet/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "enet",
   "version": "1.3.17",
+  "port-version": 1,
   "description": "Reliable UDP networking library",
   "homepage": "https://github.com/lsalzman/enet"
 }

--- a/ports/enet/vcpkg.json
+++ b/ports/enet/vcpkg.json
@@ -3,5 +3,15 @@
   "version": "1.3.17",
   "port-version": 1,
   "description": "Reliable UDP networking library",
-  "homepage": "https://github.com/lsalzman/enet"
+  "homepage": "https://github.com/lsalzman/enet",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1966,7 +1966,7 @@
     },
     "enet": {
       "baseline": "1.3.17",
-      "port-version": 0
+      "port-version": 1
     },
     "ensmallen": {
       "baseline": "2.17.0",

--- a/versions/e-/enet.json
+++ b/versions/e-/enet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fe2375f7ce85792dae4b9ad06196c89efd386a7",
+      "version": "1.3.17",
+      "port-version": 1
+    },
+    {
       "git-tree": "004a06d1e158f14059f597a1848b8f4a8d0a42f8",
       "version": "1.3.17",
       "port-version": 0

--- a/versions/e-/enet.json
+++ b/versions/e-/enet.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5fe2375f7ce85792dae4b9ad06196c89efd386a7",
+      "git-tree": "a31699670612c88cdf69dd80af975d44c10ac1f6",
       "version": "1.3.17",
       "port-version": 1
     },


### PR DESCRIPTION
This pull request addresses issue #20230 which I opened.

As the title says, this adds support for building enet as a shared library using CMake's built in BUILD_SHARED_LIBS. This also exports a config and outputs usage to make it more friendly to use.

I'm not certain that this matters with vcpkg, but I also bumped the CMake minimum version to 3.0.2 which I believe is the minimum version to support what was needed based on reading CMake documentation.


Extra Info:
I did open an issue on the enet repository here: https://github.com/lsalzman/enet/issues/174 to ask about hopefully improving their existing CMakeLists.txt to be more vcpkg friendly. and it does seem that they are not against that, but it seems all previous efforts have gone without feedback anyway.