### PR TITLE
[pdcurses] metadata: fix homepage

### DIFF
--- a/ports/pdcurses/vcpkg.json
+++ b/ports/pdcurses/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pdcurses",
   "version-string": "3.9",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Public Domain Curses - a curses library for environments that don't fit the termcap/terminfo model.",
   "homepage": "https://pdcurses.org/"
 }

--- a/ports/pdcurses/vcpkg.json
+++ b/ports/pdcurses/vcpkg.json
@@ -3,5 +3,5 @@
   "version-string": "3.9",
   "port-version": 1,
   "description": "Public Domain Curses - a curses library for environments that don't fit the termcap/terminfo model.",
-  "homepage": "https://sourceforge.net/projects/pdcurses/"
+  "homepage": "https://pdcurses.org/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5014,7 +5014,7 @@
     },
     "pdcurses": {
       "baseline": "3.9",
-      "port-version": 1
+      "port-version": 2
     },
     "pdqsort": {
       "baseline": "2019-07-30",

--- a/versions/p-/pdcurses.json
+++ b/versions/p-/pdcurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ba3df274e70a15b1df907d3f594ddc71b99c2ec1",
+      "git-tree": "c36e9724c22b95cd29aa16aa0792ea156ed5c76c",
       "version-string": "3.9",
       "port-version": 1
     },

--- a/versions/p-/pdcurses.json
+++ b/versions/p-/pdcurses.json
@@ -6,7 +6,7 @@
       "port-version": 2
     },
     {
-      "git-tree": "c36e9724c22b95cd29aa16aa0792ea156ed5c76c",
+      "git-tree": "ba3df274e70a15b1df907d3f594ddc71b99c2ec1",
       "version-string": "3.9",
       "port-version": 1
     },

--- a/versions/p-/pdcurses.json
+++ b/versions/p-/pdcurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "190eafb5554bf1f484edff1aa94598bac3ff9830",
+      "version-string": "3.9",
+      "port-version": 2
+    },
+    {
       "git-tree": "c36e9724c22b95cd29aa16aa0792ea156ed5c76c",
       "version-string": "3.9",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
The current port definition points to a half-official release-only mirror.
As an alternative the official GitHub home https://github.com/wmcbrine/PDCurses could be used - but the homepage seems to be the more reasonable place.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
only metadata changed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes (port version not updated because it should not be rebuild just because of that)
