### PR TITLE
[dxsdk-d3dx/directxsdk] Add message to handle the conflicts between these two ports

### DIFF
--- a/ports/directxsdk/portfile.cmake
+++ b/ports/directxsdk/portfile.cmake
@@ -1,5 +1,9 @@
 vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/dxsdk-d3dx/copyright")
+    message(FATAL_ERROR "Can't build ${PORT} if dxsdk-d3dx is installed. Please remove dxsdk-d3dx, and try to install ${PORT} again if you need it.")
+endif()
+
 message(WARNING "Build ${PORT} is deprecated, untested in CI, and requires the use of the DirectSetup legacy REDIST solution. See https://aka.ms/dxsdk for more information.")
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/directxsdk/vcpkg.json
+++ b/ports/directxsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "directxsdk",
   "version-string": "jun10",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Legacy DirectX SDK",
   "homepage": "https://docs.microsoft.com/en-us/windows/win32/directx-sdk--august-2009-",
   "supports": "windows & !uwp & !arm",

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -1,5 +1,9 @@
 vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 
+if(EXISTS "${CURRENT_INSTALLED_DIR}/share/directxsdk/copyright")
+    message(FATAL_ERROR "Can't build ${PORT} if directxsdk is installed. Please remove directxsdk, and try to install ${PORT} again if you need it.")
+endif()
+
 message(WARNING "Use of ${PORT} is not recommended for new projects. See https://aka.ms/dxsdk for more information.")
 
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
@@ -22,15 +26,15 @@ file(GLOB HEADER_FILES "${PACKAGE_PATH}/build/native/include/*.h" "${PACKAGE_PAT
 file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 file(GLOB RELEASE_LIB_FILES "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
-file(INSTALL ${RELEASE_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/${PORT}")
+file(INSTALL ${RELEASE_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/")
 
 file(GLOB DEBUG_LIB_FILES "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
-file(INSTALL ${DEBUG_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}")
+file(INSTALL ${DEBUG_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/")
 
 file(GLOB RELEASE_DLL_FILES "${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
-file(INSTALL ${RELEASE_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/${PORT}")
+file(INSTALL ${RELEASE_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/")
 
 file(GLOB DEBUG_DLL_FILES "${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
-file(INSTALL ${DEBUG_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/${PORT}")
+file(INSTALL ${DEBUG_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/")
 
 file(INSTALL "${PACKAGE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/dxsdk-d3dx/portfile.cmake
+++ b/ports/dxsdk-d3dx/portfile.cmake
@@ -1,8 +1,4 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
-
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "${PORT} only supports Windows.")
-endif()
+vcpkg_fail_port_install(ON_TARGET "LINUX" "OSX" "UWP" "ANDROID" ON_ARCH "arm")
 
 message(WARNING "Use of ${PORT} is not recommended for new projects. See https://aka.ms/dxsdk for more information.")
 
@@ -22,23 +18,19 @@ vcpkg_extract_source_archive_ex(
     NO_REMOVE_ONE_LEVEL
 )
 
-file(GLOB HEADER_FILES ${PACKAGE_PATH}/build/native/include/*.h ${PACKAGE_PATH}/build/native/include/*.inl)
-file(INSTALL ${HEADER_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(GLOB HEADER_FILES "${PACKAGE_PATH}/build/native/include/*.h" "${PACKAGE_PATH}/build/native/include/*.inl")
+file(INSTALL ${HEADER_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
-file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx9.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx10.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-file(COPY ${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx11.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx9d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx10d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/d3dx11d.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib/)
+file(GLOB RELEASE_LIB_FILES "${PACKAGE_PATH}/build/native/release/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
+file(INSTALL ${RELEASE_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/lib/${PORT}")
 
-file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DCompiler_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX9_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/d3dx10_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/d3dx11_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DCompiler_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX9d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX10d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
-file(COPY ${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/D3DX11d_43.dll DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin/)
+file(GLOB DEBUG_LIB_FILES "${PACKAGE_PATH}/build/native/debug/lib/${VCPKG_TARGET_ARCHITECTURE}/*.lib")
+file(INSTALL ${DEBUG_LIB_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}")
 
-file(INSTALL ${PACKAGE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(GLOB RELEASE_DLL_FILES "${PACKAGE_PATH}/build/native/release/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
+file(INSTALL ${RELEASE_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/bin/${PORT}")
+
+file(GLOB DEBUG_DLL_FILES "${PACKAGE_PATH}/build/native/debug/bin/${VCPKG_TARGET_ARCHITECTURE}/*.dll")
+file(INSTALL ${DEBUG_DLL_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin/${PORT}")
+
+file(INSTALL "${PACKAGE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "dxsdk-d3dx",
   "version": "9.29.952.8",
+  "port-version": 1,
   "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
   "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
   "supports": "windows & !arm & !uwp & !static"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1878,7 +1878,7 @@
     },
     "dxsdk-d3dx": {
       "baseline": "9.29.952.8",
-      "port-version": 0
+      "port-version": 1
     },
     "dxut": {
       "baseline": "11.26",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1778,7 +1778,7 @@
     },
     "directxsdk": {
       "baseline": "jun10",
-      "port-version": 3
+      "port-version": 4
     },
     "directxtex": {
       "baseline": "aug2021",

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "440a5b43febdcc709d9ae1d768371c0b184ca92e",
+      "version-string": "jun10",
+      "port-version": 4
+    },
+    {
       "git-tree": "49dc911dc7c69f6e0eee0279afcf53187d547ae5",
       "version-string": "jun10",
       "port-version": 3

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "481c29124b05c5fad00b1fa5bb76ffb316ea73b2",
+      "version": "9.29.952.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "38ff04dcf269c835a7f5c03d50a1a457350bde49",
       "version": "9.29.952.8",
       "port-version": 0

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "481c29124b05c5fad00b1fa5bb76ffb316ea73b2",
+      "git-tree": "81aeb21cd027336b00f758ece5371f0c4930be2e",
       "version": "9.29.952.8",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  In our CI test, dxsdk-d3dx failed with following error:
```
  The following files are already installed in D:/installed/x64-windows and are in conflict with dxsdk-d3dx:x64-windows
  Installed by directxsdk:x64-windows
      debug/lib/d3dx10d.lib
      debug/lib/d3dx11d.lib
      debug/lib/d3dx9d.lib
      lib/d3dx10.lib
      lib/d3dx11.lib
      lib/d3dx9.lib
```
For fixing this issue, I add message to handle the conflicts between these two ports .

BTW, directxsdk:x64-windows and directxsdk:x86-windows has been skipped in ci.baseline.txt.

No feature need to be tested.