### PR TITLE
[python3] Add patch to fix Windows 11 SDK build failure.

### DIFF
--- a/ports/python3/0008-workaround-windows-11-sdk-rc-compiler-error.patch
+++ b/ports/python3/0008-workaround-windows-11-sdk-rc-compiler-error.patch
@@ -1,0 +1,30 @@
+From 0a72b7061ed79c5d6d37b41a5b1610e32fb371a4 Mon Sep 17 00:00:00 2001
+From: Adam Johnson <AdamJohnso@gmail.com>
+Date: Wed, 22 Sep 2021 21:04:21 -0400
+Subject: [PATCH] workaround windows 11 sdk rc compiler error
+
+winnt.h was changed to error if the `SYSTEM_CACHE_ALIGNMENT` cannot be
+determined. when the RC compiler is invoked, this seems to fail where
+previous SDKs silently set the ARM value.
+---
+ PC/python_ver_rc.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/PC/python_ver_rc.h b/PC/python_ver_rc.h
+index 90fc6ba1a1..e313a5138e 100644
+--- a/PC/python_ver_rc.h
++++ b/PC/python_ver_rc.h
+@@ -1,3 +1,10 @@
++// Temporarily workaround bug in Windows SDK 10.0.22000.0 winnt.h
++#ifdef RC_INVOKED
++#   ifndef SYSTEM_CACHE_ALIGNMENT_SIZE
++#       define SYSTEM_CACHE_ALIGNMENT_SIZE 64
++#   endif
++#endif
++
+ // Resource script for Python core DLL.
+ // Currently only holds version information.
+ //
+-- 
+2.33.0.windows.1
+

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
   "version-semver": "3.9.7",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -34,14 +34,6 @@
       "name": "sqlite3",
       "platform": "!(windows & static)"
     },
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    },
     "zlib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5278,7 +5278,7 @@
     },
     "python3": {
       "baseline": "3.9.7",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a1011c32aa2eb7de0b9a6184b2805e34c41f0b5",
+      "version-semver": "3.9.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "b3a545b39c982b7f0a12891765dd9909e364ebc6",
       "version-semver": "3.9.7",
       "port-version": 0


### PR DESCRIPTION
This adds a patch to work around a compile failure introduced by the Windows SDK 10.0.22000.0. The patch introduced by upstream at python/cpython#28393 is insufficient because vcpkg seems to prefer the usage of the latest (or whatever is set by the environment) Windows SDK. As of actions/virtual-environments#4014, this issue affects anyone trying to build the python3 port on the GitHub Actions windows-2019 (aka windows-latest) runners.

The specific problem is in the Windows SDK's `um/winnt.h` file. In 10.0.22000.0, it became an error if `SYSTEM_CACHE_ALIGNMENT_SIZE` could not be determined. It appears that the RC compiler does not perform certain defines that allow this to succeed. Here are the problematic lines in 10.22000.0:
```C
#ifndef SYSTEM_CACHE_ALIGNMENT_SIZE
#if defined(_AMD64_) || defined(_X86_)
#define SYSTEM_CACHE_ALIGNMENT_SIZE X86_CACHE_ALIGNMENT_SIZE
#elif defined(_ARM64_) || defined(_ARM_)
#define SYSTEM_CACHE_ALIGNMENT_SIZE ARM_CACHE_ALIGNMENT_SIZE
#else
#error Must define a target architecture.
#endif
#endif // SYSTEM_CACHE_ALIGNMENT_SIZE
```

Previously, this implicitly succeeded, as seen in 10.0.18362.0's `um/winnt.h`:
```C
#ifndef SYSTEM_CACHE_ALIGNMENT_SIZE
#if defined(_AMD64_) || defined(_X86_)
#define SYSTEM_CACHE_ALIGNMENT_SIZE 64
#else
#define SYSTEM_CACHE_ALIGNMENT_SIZE 128
#endif
#endif
```

Therefore I have added a patch that sets `SYSTEM_CACHE_ALIGNMENT_SIZE` to the x86 value when the resource compiler is invoked.

- #### What does your PR fix?  
  Fixes #17211

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
