### PR TITLE
[imgui] Support building as shared library

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -5,6 +5,12 @@ set(CMAKE_DEBUG_POSTFIX d)
 
 add_library(${PROJECT_NAME} "")
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    LINKER_LANGUAGE CXX
+    DEFINE_SYMBOL ""
+)
+
 target_include_directories(
     ${PROJECT_NAME}
     PUBLIC
@@ -98,6 +104,17 @@ endif()
 
 if(IMGUI_USE_WCHAR32)
     target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_USE_WCHAR32)
+endif()
+
+if(BUILD_SHARED_LIBS AND WIN32)
+	target_compile_definitions(${PROJECT_NAME}
+		INTERFACE
+            "IMGUI_API=__declspec(dllimport)"
+            "IMGUI_IMPL_API=__declspec(dllimport)"
+		PRIVATE
+            "IMGUI_API=__declspec(dllexport)"
+            "IMGUI_IMPL_API=__declspec(dllexport)"
+	)
 endif()
 
 list(REMOVE_DUPLICATES BINDINGS_SOURCES)

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui",
   "version": "1.84.2",
+  "port-version": 1,
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2754,7 +2754,7 @@
     },
     "imgui": {
       "baseline": "1.84.2",
-      "port-version": 0
+      "port-version": 1
     },
     "imgui-sfml": {
       "baseline": "2.1",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb157d474d8475ddec34cf063159c7807a76f9e0",
+      "version": "1.84.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c07b221daf49a22fc9e8e7571bb329485f618a7f",
       "version": "1.84.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Support building ImGui as a shared library.
  
  ImGui author does not recommend building the library as shared libraries, as the author is concerned about function call overhead of shared libraries, and also that the library uses global states throughout may cause problems. But anyway, it is better to have this option.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All; no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
