### PR TITLE
[openmpi] Disable fortran mpi bindings explicitly

### DIFF
--- a/ports/openmpi/portfile.cmake
+++ b/ports/openmpi/portfile.cmake
@@ -15,7 +15,7 @@ vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
     PATCHES 
-	keep_isystem.patch
+        keep_isystem.patch
 )
 
 vcpkg_find_acquire_program(PERL)
@@ -28,6 +28,7 @@ vcpkg_configure_make(
         OPTIONS
             --with-hwloc=internal
             --with-libevent=internal
+            --disable-mpi-fortran
         OPTIONS_DEBUG
             --enable-debug
 )
@@ -37,4 +38,4 @@ vcpkg_install_make(DISABLE_PARALLEL)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/openmpi/vcpkg.json
+++ b/ports/openmpi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openmpi",
   "version-string": "4.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Open MPI Project is an open source Message Passing Interface implementation that is developed and maintained by a consortium of academic, research, and industry partners. Open MPI is therefore able to combine the expertise, technologies, and resources from all across the High Performance Computing community in order to build the best MPI library available. Open MPI offers advantages for system and software vendors, application developers and computer science researchers.",
   "homepage": "https://www.open-mpi.org/",
   "supports": "!(windows | uwp)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4818,7 +4818,7 @@
     },
     "openmpi": {
       "baseline": "4.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "openmvg": {
       "baseline": "1.6",

--- a/versions/o-/openmpi.json
+++ b/versions/o-/openmpi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c4b5b526fe4b6a8de9fa88eea30d3a1ddc7878e",
+      "version-string": "4.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "bcc3284d0c3730ee4237efff0cd32df0be272d8e",
       "version-string": "4.1.0",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/11990

When gfortran installed on osx and linux machine, openmpi will fail to configure. From https://github.com/open-mpi/ompi/blob/master/configure.ac#L634, the Fortran bindings looks disabled by default. This issue can be resolved when disable fortran mpi bindings explicitly.
