### PR TITLE
[OpenCV3] fix build with latest protobuf

### DIFF
--- a/ports/opencv3/0011-fix-caffe-io.patch
+++ b/ports/opencv3/0011-fix-caffe-io.patch
@@ -1,0 +1,11 @@
+--- a/modules/dnn/src/caffe/caffe_io.cpp
++++ b/modules/dnn/src/caffe/caffe_io.cpp
+@@ -1111,7 +1111,7 @@ static const int kProtoReadBytesLimit = INT_MAX;  // Max size of 2 GB minus 1 by
+ 
+ bool ReadProtoFromBinary(ZeroCopyInputStream* input, Message *proto) {
+     CodedInputStream coded_input(input);
+-    coded_input.SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
++    coded_input.SetTotalBytesLimit(kProtoReadBytesLimit);
+ 
+     return proto->ParseFromCodedStream(&coded_input);
+ }

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -24,6 +24,7 @@ vcpkg_from_github(
       0008-devendor-quirc.patch
       0009-fix-protobuf.patch
       0010-fix-uwp-tiff-imgcodecs.patch
+      0011-fix-caffe-io.patch
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.15",
-  "port-version": 1,
+  "port-version": 2,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4770,7 +4770,7 @@
     },
     "opencv3": {
       "baseline": "3.4.15",
-      "port-version": 1
+      "port-version": 2
     },
     "opencv4": {
       "baseline": "4.5.3",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27a6a94907d72955e9d473dfbce89ae851ee1bda",
+      "version": "3.4.15",
+      "port-version": 2
+    },
+    {
       "git-tree": "47b6ae97aeb00ba20b231fdbb2fa043cdc5de2c5",
       "version": "3.4.15",
       "port-version": 1


### PR DESCRIPTION
OpenCV 3 is skipped in CI because incompatible with OpenCV 4, so this regression was not catched in #20208 