### PR TITLE
[benchmark] Update port to v1.6.0

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,28 +1,26 @@
 #https://github.com/google/benchmark/issues/661
-vcpkg_fail_port_install(ON_TARGET "uwp") 
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO google/benchmark
-    REF e991355c02b93fe17713efe04cbc2e278e00fdbd # v1.5.5
-    SHA512 aa4455fa0f8546ec5762f14065e0be6667b5874e6991ca6dd21dc7b29e38c7c74cfddb2c99c7a1ed2f7636aa7bdec8fc0fc1523967b179f5642c2dc2e968089c
+    REF f91b6b42b1b9854772a90ae9501464a161707d1e # v1.6.0
+    SHA512 5e3db75fcaa86b766d33e368f58cec5c5b2b9ba7fde658d13868d577679c13069756e68e86323b972daccc4f7d5e392d24d2d42e5308c1ae7e9955e651d45866
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DBENCHMARK_ENABLE_TESTING=OFF
 )
 
-vcpkg_install_cmake()
-
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/benchmark)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/benchmark)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "benchmark",
-  "version-semver": "1.5.5",
+  "version-semver": "1.6.0",
   "description": "A library to support the benchmarking of functions, similar to unit-tests.",
   "homepage": "https://github.com/google/benchmark",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4a77547715562fcaa95568226f79af88d859d2c1",
+      "version-semver": "1.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "e47bb1810fa9570b6b87eba79bb95c749763e1e0",
       "version-semver": "1.5.5",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -409,7 +409,7 @@
       "port-version": 1
     },
     "benchmark": {
-      "baseline": "1.5.5",
+      "baseline": "1.6.0",
       "port-version": 0
     },
     "bento4": {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Updates `benchmark` (Google Benchmark) port from 1.5.5 to 1.6.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

There should be no changes.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
