### PR TITLE
[minizip-ng] Make dependencies optional

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -11,11 +11,14 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        zlib MZ_ZLIB
+        crypto MZ_PKCRYPT
+        crypto MZ_SIGNING
+        crypto MZ_WZAES
+        openssl MZ_OPENSSL
         bzip2 MZ_BZIP2
         lzma MZ_LZMA
+        zlib MZ_ZLIB
         zstd MZ_ZSTD
-        openssl MZ_OPENSSL
 )
 
 vcpkg_cmake_configure(

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -11,9 +11,9 @@ vcpkg_from_github(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        crypto MZ_PKCRYPT
-        crypto MZ_SIGNING
-        crypto MZ_WZAES
+        pkcrypt MZ_PKCRYPT
+        signing MZ_SIGNING
+        wzaes MZ_WZAES
         openssl MZ_OPENSSL
         bzip2 MZ_BZIP2
         lzma MZ_LZMA

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -20,7 +20,6 @@ vcpkg_check_features(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA 
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
         ${FEATURE_OPTIONS}
@@ -31,10 +30,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/minizip-ng/copyright" COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -8,18 +8,30 @@ vcpkg_from_github(
         Modify-header-file-path.patch
 )
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        zlib MZ_ZLIB
+        bzip2 MZ_BZIP2
+        lzma MZ_LZMA
+        zstd MZ_ZSTD
+        openssl MZ_OPENSSL
+)
+
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA 
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS 
+        ${FEATURE_OPTIONS}
+        -DMZ_FETCH_LIBS=OFF
         -DMZ_PROJECT_SUFFIX:STRING=-ng
 )
 
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -17,8 +17,10 @@
   ],
   "default-features": [
     "bzip2",
-    "crypto",
     "lzma",
+    "pkcrypt",
+    "signing",
+    "wzaes",
     "zlib",
     "zstd"
   ],
@@ -27,19 +29,6 @@
       "description": "Enables BZIP2 compression",
       "dependencies": [
         "bzip2"
-      ]
-    },
-    "crypto": {
-      "description": "Enable cryptography features",
-      "dependencies": [
-        {
-          "name": "minizip-ng",
-          "default-features": false,
-          "features": [
-            "openssl"
-          ],
-          "platform": "linux"
-        }
       ]
     },
     "lzma": {
@@ -52,6 +41,35 @@
       "description": "Enables OpenSSL for encryption",
       "dependencies": [
         "openssl"
+      ]
+    },
+    "pkcrypt": {
+      "description": "Enables PKWARE traditional encryption"
+    },
+    "signing": {
+      "description": "Enables zip signing support",
+      "dependencies": [
+        {
+          "name": "minizip-ng",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ],
+          "platform": "!windows & !osx"
+        }
+      ]
+    },
+    "wzaes": {
+      "description": "Enables WinZIP AES encryption",
+      "dependencies": [
+        {
+          "name": "minizip-ng",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ],
+          "platform": "!windows & !osx"
+        }
       ]
     },
     "zlib": {

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -38,7 +38,7 @@
           "features": [
             "openssl"
           ],
-          "platform": "!(windows | uwp)"
+          "platform": "linux"
         }
       ]
     },

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,16 +1,11 @@
 {
   "name": "minizip-ng",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "supports": "!uwp",
   "dependencies": [
-    "bzip2",
-    "liblzma",
-    {
-      "name": "openssl",
-      "platform": "linux"
-    },
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -18,8 +13,58 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
+    }
+  ],
+  "default-features": [
+    "bzip2",
+    "crypto",
+    "lzma",
     "zlib",
     "zstd"
-  ]
+  ],
+  "features": {
+    "bzip2": {
+      "description": "Enables BZIP2 compression",
+      "dependencies": [
+        "bzip2"
+      ]
+    },
+    "crypto": {
+      "description": "Enable cryptography features",
+      "dependencies": [
+        {
+          "name": "minizip-ng",
+          "default-features": false,
+          "features": [
+            "openssl"
+          ],
+          "platform": "!(windows | uwp)"
+        }
+      ]
+    },
+    "lzma": {
+      "description": "Enables LZMA compression",
+      "dependencies": [
+        "liblzma"
+      ]
+    },
+    "openssl": {
+      "description": "Enables OpenSSL for encryption",
+      "dependencies": [
+        "openssl"
+      ]
+    },
+    "zlib": {
+      "description": "Enables ZLIB compression",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "zstd": {
+      "description": "Enables ZSTD compression",
+      "dependencies": [
+        "zstd"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4262,7 +4262,7 @@
     },
     "minizip-ng": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "mio": {
       "baseline": "2019-02-10",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd030d67ff2c81e94e4ec8eca1614fdac06188a9",
+      "git-tree": "255c97411f99c983aa3bbc9ebc3417d3ca8cd481",
       "version": "3.0.2",
       "port-version": 1
     },

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd934f66674b6e7215fc7f1b5ed8d97fdd5a04ed",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9c49a3f4d6bb3e5173cf17e1539b439dcf4bf6ea",
       "version": "3.0.2",
       "port-version": 0

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "255c97411f99c983aa3bbc9ebc3417d3ca8cd481",
+      "git-tree": "4a8de7f8609b758c48eea13b67d47c22efc832a3",
       "version": "3.0.2",
       "port-version": 1
     },

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bd934f66674b6e7215fc7f1b5ed8d97fdd5a04ed",
+      "git-tree": "bd030d67ff2c81e94e4ec8eca1614fdac06188a9",
       "version": "3.0.2",
       "port-version": 1
     },


### PR DESCRIPTION
The minizip-ng package currently has a lot of dependencies that are only needed when reading various file formats. These dependencies should be made optional through features. This PR does just that.

This does not expose all feature flags of minizip, only the ones that have external dependencies.

I enabled all features by default, because that is equivalent to the previous port version even though it is in conflict with [the maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md#default-features-should-enable-behaviors-not-apis)

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes