### PR TITLE
[kf5xmlgui] fix loading resources when building statically

### DIFF
--- a/ports/kf5xmlgui/fix_static_resources.diff
+++ b/ports/kf5xmlgui/fix_static_resources.diff
@@ -1,0 +1,26 @@
+diff --git a/src/kxmlguiclient.cpp b/src/kxmlguiclient.cpp
+index a830ad0fa6b962654a0d1ebb161761a3afafb479..b2c9d0d21dce5f5d9ae4941ae4a909dfa9531155 100644
+--- a/src/kxmlguiclient.cpp
++++ b/src/kxmlguiclient.cpp
+@@ -70,6 +70,8 @@ KXMLGUIClient::KXMLGUIClient()
+ KXMLGUIClient::KXMLGUIClient(KXMLGUIClient *parent)
+     : d(new KXMLGUIClientPrivate)
+ {
++    Q_INIT_RESOURCE(kxmlgui);
++
+     parent->insertChildClient(this);
+ }
+ 
+diff --git a/src/kxmlguifactory.cpp b/src/kxmlguifactory.cpp
+index fc453cb2598dd36f8212cbccb3d4e777ffca4480..5c8dbda2b5700144e9aaf96f877615f874292640 100644
+--- a/src/kxmlguifactory.cpp
++++ b/src/kxmlguifactory.cpp
+@@ -172,6 +172,8 @@ KXMLGUIFactory::KXMLGUIFactory(KXMLGUIBuilder *builder, QObject *parent)
+     : QObject(parent)
+     , d(new KXMLGUIFactoryPrivate)
+ {
++    Q_INIT_RESOURCE(kxmlgui);
++
+     d->builder = builder;
+     d->guiClient = nullptr;
+     if (d->builder) {

--- a/ports/kf5xmlgui/portfile.cmake
+++ b/ports/kf5xmlgui/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         remove_explicit_shared_argument.patch # https://invent.kde.org/frameworks/kxmlgui/-/commit/d12e8f6266188ce7e221dc014a56071b8a5ef706
         add_support_for_static_builds.patch   # https://invent.kde.org/frameworks/kxmlgui/-/commit/2f1b948ad690942d4ec208c5676c11218f29181a
+        fix_static_resources.diff             # https://invent.kde.org/frameworks/kxmlgui/-/merge_requests/77
 )
 
 vcpkg_check_features(

--- a/ports/kf5xmlgui/vcpkg.json
+++ b/ports/kf5xmlgui/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5xmlgui",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Framework for managing menu and toolbar actions",
   "homepage": "https://api.kde.org/frameworks/kxmlgui/html/index.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3070,7 +3070,7 @@
     },
     "kf5xmlgui": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kfr": {
       "baseline": "4.2.1",

--- a/versions/k-/kf5xmlgui.json
+++ b/versions/k-/kf5xmlgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4fa462d8e9f3592a9ded89bb25ea21de65932112",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5cecdc03d8c8a9d399ef6aae83e26a9cd32d2f28",
       "version": "5.84.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes https://invent.kde.org/frameworks/kxmlgui/-/merge_requests/77

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
