### PR TITLE
[itk] Fix dependency gtest usage

### DIFF
--- a/ports/itk/gtest.patch
+++ b/ports/itk/gtest.patch
@@ -1,0 +1,34 @@
+diff --git a/Modules/ThirdParty/GoogleTest/CMakeLists.txt b/Modules/ThirdParty/GoogleTest/CMakeLists.txt
+index 9276d7e..3392eac 100644
+--- a/Modules/ThirdParty/GoogleTest/CMakeLists.txt
++++ b/Modules/ThirdParty/GoogleTest/CMakeLists.txt
+@@ -4,11 +4,15 @@ set(ITKGoogleTest_THIRD_PARTY 1)
+ if(ITK_USE_SYSTEM_GOOGLETEST)
+   if( NOT DEFINED GTEST_ROOT OR NOT EXISTS "${GTEST_ROOT}/CMakeLists.txt")
+     set(ITKGoogleTest_NO_SRC 1)
+-    set(ITKGoogleTest_LIBRARIES GTest::GTest GTest::Main)
++    set(ITKGoogleTest_LIBRARIES GTest::gtest GTest::gtest_main)
++    set(ITKGoogleTest_EXPORT_CODE_INSTALL "
++set(ITK_USE_SYSTEM_GOOGLETEST \"${ITK_USE_SYSTEM_GOOGLETEST}\")
++find_package(GTest CONFIG REQUIRED)
++")
+     set(ITKGoogleTest_EXPORT_CODE_BUILD "
+ if(NOT ITK_BINARY_DIR)
+   set(GTEST_ROOT \"${GTEST_ROOT}\")
+-  find_package(GTest REQUIRED)
++  find_package(GTest CONFIG REQUIRED)
+ endif()
+ ")
+   endif()
+diff --git a/Modules/ThirdParty/GoogleTest/itk-module-init.cmake b/Modules/ThirdParty/GoogleTest/itk-module-init.cmake
+index 15cd556..f9a24c6 100644
+--- a/Modules/ThirdParty/GoogleTest/itk-module-init.cmake
++++ b/Modules/ThirdParty/GoogleTest/itk-module-init.cmake
+@@ -33,6 +33,6 @@ if(ITK_USE_SYSTEM_GOOGLETEST)
+      endif()
+ 
+    else()
+-     find_package( GTest REQUIRED )
++     find_package( GTest CONFIG REQUIRED )
+    endif ()
+ endif()

--- a/ports/itk/gtest.patch
+++ b/ports/itk/gtest.patch
@@ -1,3 +1,16 @@
+diff --git a/CMake/ITKModuleTest.cmake b/CMake/ITKModuleTest.cmake
+index f882c87..48287c3 100644
+--- a/CMake/ITKModuleTest.cmake
++++ b/CMake/ITKModuleTest.cmake
+@@ -245,7 +245,7 @@ endfunction()
+ function(CreateGoogleTestDriver KIT KIT_LIBS KitTests)
+   set(exe "${KIT}GTestDriver")
+   add_executable(${exe} ${KitTests} )
+-  target_link_libraries(${exe} ${KIT_LIBS} GTest::GTest GTest::Main)
++  target_link_libraries(${exe} ${KIT_LIBS} GTest::gtest GTest::gtest_main)
+   itk_module_target_label(${exe})
+ 
+   include(GoogleTest)
 diff --git a/Modules/ThirdParty/GoogleTest/CMakeLists.txt b/Modules/ThirdParty/GoogleTest/CMakeLists.txt
 index 9276d7e..3392eac 100644
 --- a/Modules/ThirdParty/GoogleTest/CMakeLists.txt

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -197,6 +197,7 @@ vcpkg_cmake_config_fixup()
 file(READ "${CURRENT_PACKAGES_DIR}/share/${PORT}/ITKModuleAPI.cmake" ITKModuleAPI_CMAKE)
 string(PREPEND ITKModuleAPI_CMAKE
 [[
+if (NOT DEFINED _IMPORT_PREFIX AND NOT _IMPORT_PREFIX)
     get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
     get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
     get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -205,6 +205,7 @@ if (NOT DEFINED _IMPORT_PREFIX AND NOT _IMPORT_PREFIX)
     set(_IMPORT_PREFIX "")
     endif()
 endif()
+set(_IMPORT_PREFIX "${_IMPORT_PREFIX}" CACHE PATH "" FORCE)
 ]])
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/ITKModuleAPI.cmake" "${ITKModuleAPI_CMAKE}")
 

--- a/ports/itk/portfile.cmake
+++ b/ports/itk/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
         opencl.patch
         cufftw.patch
         use-the-lrintf-intrinsic.patch
+        gtest.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -177,6 +178,14 @@ vcpkg_configure_cmake(
 
     OPTIONS_DEBUG   ${OPTIONS_DEBUG}
     OPTIONS_RELEASE ${OPTIONS_RELEASE}
+    MAYBE_UNUSED_VARIABLES
+        BUILD_PKGCONFIG_FILES
+        DCMTK_USE_ICU
+        INSTALL_GTEST
+        ITK_USE_SYSTEM_ICU
+        ITK_USE_SYSTEM_SWIG
+        Module_ITKCudaCommon
+        RTK_BUILD_APPLICATIONS
 )
 if(BUILD_RTK) # Remote Modules are only downloaded on configure.
     # TODO: In the future try to download via vcpkg_from_github and move the files. That way patching does not need this workaround

--- a/ports/itk/vcpkg.json
+++ b/ports/itk/vcpkg.json
@@ -30,6 +30,14 @@
       "default-features": false
     },
     "tiff",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "features": {

--- a/ports/itk/vcpkg.json
+++ b/ports/itk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "itk",
   "version-string": "5.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Insight Segmentation and Registration Toolkit (ITK) is used for image processing and analysis.",
   "homepage": "https://github.com/InsightSoftwareConsortium/ITK",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2834,7 +2834,7 @@
     },
     "itk": {
       "baseline": "5.1.0",
-      "port-version": 5
+      "port-version": 6
     },
     "itpp": {
       "baseline": "4.3.1",

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fbd22503ffd11b3ab4bf5779497b6cbd7b2bc999",
+      "version-string": "5.1.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "58ababb668655a11289755a8069265656a2758f4",
       "version-string": "5.1.0",
       "port-version": 5

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a57c8b3ad907db2606f6fba0fa353835c03c437c",
+      "git-tree": "858cee8b83e9996c99ad73dfbabd95bb3abed2ea",
       "version-string": "5.1.0",
       "port-version": 6
     },

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fbd22503ffd11b3ab4bf5779497b6cbd7b2bc999",
+      "git-tree": "a57c8b3ad907db2606f6fba0fa353835c03c437c",
       "version-string": "5.1.0",
       "port-version": 6
     },

--- a/versions/i-/itk.json
+++ b/versions/i-/itk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "858cee8b83e9996c99ad73dfbabd95bb3abed2ea",
+      "git-tree": "aa0d3d9ff1540d3dc927dbbb84f2f06784b1c6ae",
       "version-string": "5.1.0",
       "port-version": 6
     },


### PR DESCRIPTION
- Fix usage issue:
```
Target "Reconstruction" links to target "GTest::GTest" but the target was 1 not found.
```
This is because the file `ITKGoogleTest.cmake` which is generated by `ITKModuleMacros.cmake` using template `ITKModuleInfo.cmake.in` doesn't contain the find code (macro `itk-module-EXPORT_CODE`).
`ITKConfig.cmake` will call `ITKGoogleTest.cmake` and find & set the required dependencies.
- Fix usage issue:
```
error : '/debug/lib/double-conversion.lib'
```
This is because we have fixed more `ITK*.cmake` and fixed the absolute path to a relative path, but the definition of `_IMPORT_PREFIX` does not exist when it is used. So add the defination `_IMPORT_PREFIX` to `ITKModuleAPI.cmake` to avoid this.

Fixes #20337.