### PR TITLE
[realsense2] Update to 2.49.0

### DIFF
--- a/ports/realsense2/portfile.cmake
+++ b/ports/realsense2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO IntelRealSense/librealsense
-    REF bc0910f8ba3c33307ff247a29dd2b9e9ef1b269d #v2.42.0
-    SHA512 b2a2d24df4bdf4853df626942b1931bbe011a4e3faaa4e3c4bcb3f76506ae8edb955a458219fdc300018e640e2ffe4cd34f459786b909cf9aab71a767d691178
+    REF e9f05c55f88f6876633bd59fd1cb3848da64b699 #v2.49.0
+    SHA512 dfd7012eb96f7d4a8054c8cc1141cd2c743255b7783d16565e02b2c688ea9d81cd61f3824f999c2c9d4ed1f44b3866b5bd399fab376ba8f16369989bda4bda85
     HEAD_REF master
     PATCHES
         fix_openni2.patch
@@ -10,18 +10,14 @@ vcpkg_from_github(
         fix_config_osx.patch
 )
 
-file(COPY ${SOURCE_PATH}/src/win7/drivers/IntelRealSense_D400_series_win7.inf DESTINATION ${SOURCE_PATH})
+file(COPY "${SOURCE_PATH}/src/win7/drivers/IntelRealSense_D400_series_win7.inf" DESTINATION "${SOURCE_PATH}")
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" BUILD_CRT_LINKAGE)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         tm2   BUILD_WITH_TM2
+        tools BUILD_TOOLS
 )
-
-set(BUILD_TOOLS OFF)
-if("tools" IN_LIST FEATURES)
-    set(BUILD_TOOLS ON)
-endif()
 
 set(BUILD_OPENNI2_BINDINGS OFF)
 if(("openni2" IN_LIST FEATURES) AND (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic"))
@@ -33,9 +29,8 @@ if (VCPKG_TARGET_IS_ANDROID)
     list(APPEND PLATFORM_OPTIONS -DFORCE_RSUSB_BACKEND=ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
         -DENFORCE_METADATA=ON
         -DBUILD_WITH_OPENMP=OFF
@@ -44,52 +39,32 @@ vcpkg_configure_cmake(
         -DBUILD_OPENNI2_BINDINGS=${BUILD_OPENNI2_BINDINGS}
         -DOPENNI2_DIR=${CURRENT_INSTALLED_DIR}/include/openni2
         ${PLATFORM_OPTIONS}
-    OPTIONS_RELEASE
-        -DBUILD_EXAMPLES=${BUILD_TOOLS}
-        -DBUILD_GRAPHICAL_EXAMPLES=${BUILD_TOOLS}
-    OPTIONS_DEBUG
         -DBUILD_EXAMPLES=OFF
         -DBUILD_GRAPHICAL_EXAMPLES=OFF
+    MAYBE_UNUSED_VARIABLES
+        OPENNI2_DIR
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/realsense2)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/realsense2)
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if(BUILD_TOOLS)
-    file(GLOB EXEFILES_RELEASE 
-        ${CURRENT_PACKAGES_DIR}/bin/rs-* 
-        ${CURRENT_PACKAGES_DIR}/bin/realsense-*
-    )
-
-    if (EXEFILES_RELEASE)
-        file(COPY ${EXEFILES_RELEASE} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/realsense2)
-        file(REMOVE ${EXEFILES_RELEASE})
-    endif()
-
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/realsense2)
-
-    file(GLOB BINS ${CURRENT_PACKAGES_DIR}/bin/*)
-    if(NOT BINS)
-        file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    endif()
-    
-    # Issue#7109, remove mismatched dlls and libs when build with tools, this workaround should be removed when the post-build checks related feature implemented.
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/realsense2-gl.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/realsense2-gl.dll)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/bin/realsense2-gl.pdb)
+    set(TOOL_NAMES)
+    list(APPEND TOOL_NAMES rs-convert rs-enumerate-devices rs-fw-logger rs-fw-update rs-record rs-terminal)
+    vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
 endif()
 
 if(BUILD_OPENNI2_BINDINGS)
-    file(GLOB RS2DRIVER ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/_out/rs2driver*)
+    file(GLOB RS2DRIVER "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/_out/rs2driver*")
     if(RS2DRIVER)
-        file(COPY ${RS2DRIVER} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/openni2/OpenNI2/Drivers)
+        file(COPY ${RS2DRIVER} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/openni2/OpenNI2/Drivers")
     endif()
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/realsense2/vcpkg.json
+++ b/ports/realsense2/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "name": "realsense2",
-  "version": "2.42.0",
-  "port-version": 1,
+  "version": "2.49.0",
   "description": "Intel® RealSense™ SDK 2.0 is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).",
   "homepage": "https://github.com/IntelRealSense/librealsense",
   "dependencies": [
     {
       "name": "libusb",
       "platform": "linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "features": {
@@ -21,7 +28,7 @@
       "description": "Build Intel® RealSense™ T265 device"
     },
     "tools": {
-      "description": "Build Intel® RealSense™ examples and tools",
+      "description": "Build Intel® RealSense™ tools",
       "dependencies": [
         "glfw3",
         "opengl"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5717,8 +5717,8 @@
       "port-version": 1
     },
     "realsense2": {
-      "baseline": "2.42.0",
-      "port-version": 1
+      "baseline": "2.49.0",
+      "port-version": 0
     },
     "recast": {
       "baseline": "1.5.1",

--- a/versions/r-/realsense2.json
+++ b/versions/r-/realsense2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "196cd1829bb74acd275abdcbc5344238b5414661",
+      "version": "2.49.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "7126a8b0d6dffc469da9a7aeccca58d48f05b1d2",
       "version": "2.42.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/19964

Since the PR https://github.com/IntelRealSense/librealsense/pull/8802, upstream has separated BUILD_TOOL and BUILD_EXAMPLES into two separate units, so now build tools don't need to work with build examples at the same time. In vcpkg, I disabled the options related to BUILD_EXAMPLES, and removed the workaround for Issue#7109 which onlu occurs when example option enable. 

All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 