### PR TITLE
[vcpkg_cmake_config_fixup] Fix variable name

### DIFF
--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-09-27",
+  "version-date": "2021-09-27"
 }

--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,5 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-05-22",
-  "port-version": 1
+  "version-date": "2021-09-27",
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -216,7 +216,7 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)]]
 
         # Patch out any remaining absolute references
         file(TO_CMAKE_PATH "${CURRENT_PACKAGES_DIR}" cmake_current_packages_dir)
-        string(REPLACE "${CMAKE_CURRENT_PACKAGES_DIR}" [[${_IMPORT_PREFIX}]] contents "${contents}")
+        string(REPLACE "${cmake_current_packages_dir}" [[${_IMPORT_PREFIX}]] contents "${contents}")
 
         file(WRITE "${main_cmake}" "${contents}")
     endforeach()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6813,8 +6813,8 @@
       "port-version": 0
     },
     "vcpkg-cmake-config": {
-      "baseline": "2021-05-22",
-      "port-version": 1
+      "baseline": "2021-09-27",
+      "port-version": 0
     },
     "vcpkg-gfortran": {
       "baseline": "3",

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9ae99981abcd01b092344f85ef6e1de3c1f9856a",
+      "version-date": "2021-09-27",
+      "port-version": 0
+    },
+    {
       "git-tree": "330cc51bc99c6b71ed5fb51901f6f838684015a5",
       "version-date": "2021-05-22",
       "port-version": 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/20318

vcpkg_cmake_config_fixup doesn't fix up the ${_IMPORT_PREFIX} in cmake config and targets file, I found the variable name CMAKE_CURRENT_PACKAGES_DIR haven't been repalced with cmake_current_packages_dir.


Test with cjson and libzen port, it solved the problems.