### PR TITLE
[vcpkg_acquire_msys] Add gzip to default packages

### DIFF
--- a/docs/maintainers/vcpkg_acquire_msys.md
+++ b/docs/maintainers/vcpkg_acquire_msys.md
@@ -25,7 +25,7 @@ To ensure a package is available: `vcpkg_acquire_msys(MSYS_ROOT PACKAGES make au
 ### NO_DEFAULT_PACKAGES
 Exclude the normal base packages.
 
-The list of base packages includes: bash, coreutils, sed, grep, gawk, diffutils, make, and pkg-config
+The list of base packages includes: bash, coreutils, sed, grep, gawk, gzip, diffutils, make, and pkg-config
 
 ### DIRECT_PACKAGES
 A list of URL/SHA512 pairs to acquire in msys.

--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -24,7 +24,7 @@ To ensure a package is available: `vcpkg_acquire_msys(MSYS_ROOT PACKAGES make au
 ### NO_DEFAULT_PACKAGES
 Exclude the normal base packages.
 
-The list of base packages includes: bash, coreutils, sed, grep, gawk, diffutils, make, and pkg-config
+The list of base packages includes: bash, coreutils, sed, grep, gawk, gzip, diffutils, make, and pkg-config
 
 ### DIRECT_PACKAGES
 A list of URL/SHA512 pairs to acquire in msys.
@@ -150,7 +150,7 @@ function(vcpkg_acquire_msys out_msys_root)
     set(Z_VCPKG_MSYS_PACKAGES "${arg_PACKAGES}")
 
     if(NOT arg_NO_DEFAULT_PACKAGES)
-        list(APPEND Z_VCPKG_MSYS_PACKAGES bash coreutils sed grep gawk diffutils make pkg-config)
+        list(APPEND Z_VCPKG_MSYS_PACKAGES bash coreutils sed grep gawk gzip diffutils make pkg-config)
     endif()
 
     if(DEFINED arg_DIRECT_PACKAGES AND NOT arg_DIRECT_PACKAGES STREQUAL "")


### PR DESCRIPTION
**Describe the pull request**
Adds `gzip` to the list of default msys environment. `gzip` is used by `autopoint`, provided by `gettext` tools. 

- #### What does your PR fix?  
  Fixes #20392

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  N/A