### PR TITLE
[rsm-mmio] Fix port installation

### DIFF
--- a/ports/rsm-mmio/portfile.cmake
+++ b/ports/rsm-mmio/portfile.cmake
@@ -14,7 +14,10 @@ vcpkg_cmake_configure(
         -DBUILD_TESTING=OFF
 )
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/mmio")
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME "mmio"
+    CONFIG_PATH "lib/cmake/mmio"
+)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/rsm-mmio/vcpkg.json
+++ b/ports/rsm-mmio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rsm-mmio",
   "version-semver": "1.1.0",
+  "port-version": 1,
   "description": "A cross-platform memory-mapped io library for C++ ",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/mmio",
   "supports": "!osx & !uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5854,7 +5854,7 @@
     },
     "rsm-mmio": {
       "baseline": "1.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rsocket": {
       "baseline": "2020.05.04.00",

--- a/versions/r-/rsm-mmio.json
+++ b/versions/r-/rsm-mmio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "634597e88010f239748fafb52c6e8f431242b53a",
+      "version-semver": "1.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "8a7d738a20500733ea97af87e6f83df5558856c9",
       "version-semver": "1.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  The post fixup command places the cmake files in the wrong directory. This corrects that.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Just a port update.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
