### PR TITLE
[boost-process] Add missing include on algorithm

### DIFF
--- a/ports/boost-process/fix_include.patch
+++ b/ports/boost-process/fix_include.patch
@@ -1,0 +1,13 @@
+diff --git a/include/boost/process/detail/traits/wchar_t.hpp b/include/boost/process/detail/traits/wchar_t.hpp
+index 812a92c..98026d3 100644
+--- a/include/boost/process/detail/traits/wchar_t.hpp
++++ b/include/boost/process/detail/traits/wchar_t.hpp
+@@ -12,6 +12,8 @@
+ #include <boost/process/detail/traits/env.hpp>
+ #include <boost/process/locale.hpp>
+ 
++#include <algorithm>
++
+ namespace boost { namespace process { namespace detail {
+ 
+ //template

--- a/ports/boost-process/portfile.cmake
+++ b/ports/boost-process/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF boost-1.77.0
     SHA512 00eb27f702f092a20fdf1669b8c9c993b751971592d0bc5aa50b02d99d985a75361621b624aa51eb550c9e7905e15877168ae9d0feb1957fc85f99c264b152fd
     HEAD_REF master
+    PATCHES
+        fix_include.patch
 )
 
 include(${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost-modular-headers.cmake)

--- a/ports/boost-process/vcpkg.json
+++ b/ports/boost-process/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-process",
   "version": "1.77.0",
+  "port-version": 1,
   "description": "Boost process module",
   "homepage": "https://github.com/boostorg/process",
   "supports": "!emscripten",

--- a/versions/b-/boost-process.json
+++ b/versions/b-/boost-process.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e70acbb855538f95200b341b1cf26d9c1dc6e6cd",
+      "version": "1.77.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6589096a03d4f8ea1590b1b9e1bdc41a47c2f907",
       "version": "1.77.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -898,7 +898,7 @@
     },
     "boost-process": {
       "baseline": "1.77.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-program-options": {
       "baseline": "1.77.0",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/20413

This change already in Upstream, related to https://github.com/boostorg/process/pull/215.

```
Error: boost/process/detail/traits/wchar_t.hpp(150,14): error : no member named 'transform' in namespace 'std'
Fix: include in wchar_t.hpp
```