### PR TITLE
[OpenMVS] restore deprecated cmake scripts for configure, build & fixup targets

### DIFF
--- a/ports/openmvs/portfile.cmake
+++ b/ports/openmvs/portfile.cmake
@@ -21,9 +21,8 @@ file(REMOVE "${SOURCE_PATH}/build/Modules/FindCERES.cmake")
 file(REMOVE "${SOURCE_PATH}/build/Modules/FindCGAL.cmake")
 file(REMOVE "${SOURCE_PATH}/build/Modules/FindEIGEN.cmake")
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS}
         -DOpenMVS_USE_NONFREE=ON
         -DOpenMVS_USE_CERES=OFF
@@ -39,7 +38,7 @@ vcpkg_configure_cmake(
         -DOpenMVS_BUILD_TOOLS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/openmvs/portfile.cmake
+++ b/ports/openmvs/portfile.cmake
@@ -21,9 +21,9 @@ file(REMOVE "${SOURCE_PATH}/build/Modules/FindCERES.cmake")
 file(REMOVE "${SOURCE_PATH}/build/Modules/FindCGAL.cmake")
 file(REMOVE "${SOURCE_PATH}/build/Modules/FindEIGEN.cmake")
 
-vcpkg_cmake_configure(
+vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
-    GENERATOR Ninja
+    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS}
         -DOpenMVS_USE_NONFREE=ON
         -DOpenMVS_USE_CERES=OFF
@@ -39,11 +39,11 @@ vcpkg_cmake_configure(
         -DOpenMVS_BUILD_TOOLS=OFF
 )
 
-vcpkg_cmake_install()
+vcpkg_install_cmake()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-vcpkg_cmake_config_fixup()
+vcpkg_fixup_cmake_targets()
 file(READ ${CURRENT_PACKAGES_DIR}/share/openmvs/OpenMVSTargets-release.cmake TARGETS_CMAKE)
 string(REPLACE "bin/InterfaceCOLMAP" "tools/openmvs/InterfaceCOLMAP" TARGETS_CMAKE "${TARGETS_CMAKE}")
 string(REPLACE "bin/InterfaceVisualSFM" "tools/openmvs/InterfaceVisualSFM" TARGETS_CMAKE "${TARGETS_CMAKE}")

--- a/ports/openmvs/vcpkg.json
+++ b/ports/openmvs/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openmvs",
   "version": "1.1.1",
+  "port-version": 1,
   "description": "OpenMVS: open Multi-View Stereo reconstruction library",
   "homepage": "https://cdcseacave.github.io/openMVS",
   "dependencies": [
@@ -27,14 +28,6 @@
     },
     "tiff",
     "vcglib",
-    {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    },
     "zlib"
   ],
   "features": {

--- a/ports/openmvs/vcpkg.json
+++ b/ports/openmvs/vcpkg.json
@@ -28,6 +28,10 @@
     },
     "tiff",
     "vcglib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     "zlib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4862,7 +4862,7 @@
     },
     "openmvs": {
       "baseline": "1.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openni2": {
       "baseline": "2.2.0.33",

--- a/versions/o-/openmvs.json
+++ b/versions/o-/openmvs.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "054882d44e2b35b2301b634dacc410bb3c48665f",
+      "git-tree": "168233263a9b959a9a19f1eb2d6f462d5257d18f",
       "version": "1.1.1",
       "port-version": 1
     },

--- a/versions/o-/openmvs.json
+++ b/versions/o-/openmvs.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "054882d44e2b35b2301b634dacc410bb3c48665f",
+      "version": "1.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "cda3b971b05a5519ef36759d8f3f49045fa6445e",
       "version": "1.1.1",
       "port-version": 0


### PR DESCRIPTION
During boost 1.77 upgrade, openmvs was updated to new vcpkg-cmake port for configure, build & fixup.
Unfortunately, it does not work correctly and consuming the library since then is broken.

Inside `OpenMVSTargets.cmake` the fixup deprecated script works correctly and produces this line

```
set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../..")
```

while the new one produces this broken line

```
set(_IMPORT_PREFIX "${_IMPORT_PREFIX}")
```

We should fix the fixup script, but since i am not such an expert in dealing with regex-es, i suggest for now to revert the upgrade to a working script, while we try to understand what went wrong there (usually the new one works, but not with this port)

@strega-nil @strega-nil-ms 