### PR TITLE
Build fixes from 2021-09-28's nightly build.

### DIFF
--- a/ports/mosquitto/portfile.cmake
+++ b/ports/mosquitto/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_configure_cmake(
         -DWITH_THREADING=ON
         -DDOCUMENTATION=OFF
         -DWITH_PLUGINS=OFF
+        -DWITH_CJSON=OFF
 )
 
 vcpkg_install_cmake()

--- a/ports/mosquitto/vcpkg.json
+++ b/ports/mosquitto/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mosquitto",
   "version": "2.0.12",
+  "port-version": 1,
   "description": "Mosquitto is an open source message broker that implements the MQ Telemetry Transport protocol versions 3.1 and 3.1.1, MQTT provides a lightweight method of carrying out messaging using a publish/subscribe model, This makes it suitable for machine to machine messaging such as with low power sensors or mobile devices such as phones, embedded computers or microcontrollers like the Arduino",
   "homepage": "https://mosquitto.org/download/",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1466,7 +1466,6 @@ soqt:arm-uwp=fail
 soqt:x64-uwp=fail
 soundtouch:arm-uwp=fail
 soundtouch:x64-uwp=fail
-soundtouch:x64-windows-static=fail
 spaceland:arm64-windows=fail
 spaceland:arm-uwp=fail
 spaceland:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4362,7 +4362,7 @@
     },
     "mosquitto": {
       "baseline": "2.0.12",
-      "port-version": 0
+      "port-version": 1
     },
     "mozjpeg": {
       "baseline": "2021-09-27",

--- a/versions/m-/mosquitto.json
+++ b/versions/m-/mosquitto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef8ae230660456d039888e201ea521f58caf0951",
+      "version": "2.0.12",
+      "port-version": 1
+    },
+    {
       "git-tree": "90a1a4314b15a787186d515df048f77961a4c7f3",
       "version": "2.0.12",
       "port-version": 0


### PR DESCRIPTION
https://dev.azure.com/vcpkg/public/_build/results?buildId=60445

PASSING, REMOVE FROM FAIL LIST: soundtouch:x64-windows-static
Probably fixed by: https://github.com/microsoft/vcpkg/pull/20017

REGRESSION: mosquitto:x86-windows
REGRESSION: mosquitto:x64-windows
Probably broken by: https://github.com/microsoft/vcpkg/pull/20148/

```
The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    D:/packages/mosquitto_x86-windows/bin/mosquitto_ctrl.exe

The following EXEs were found in /bin or /debug/bin. EXEs are not valid distribution targets.

    D:/packages/mosquitto_x86-windows/debug/bin/mosquitto_ctrl.exe

Found 2 error(s). Please correct the portfile:
    C:\a\1\s\ports\mosquitto\portfile.cmake
-- Performing post-build validation done
```

The upstream build system has this:

```
option(WITH_CJSON "Build with cJSON support (required for dynamic security plugin and useful for mosquitto_sub)?" ON)
if (WITH_CJSON)
    FIND_PACKAGE(cJSON)
    if (CJSON_FOUND)
	    message(STATUS ${CJSON_FOUND})
    else (CJSON_FOUND)
	    message(STATUS "Optional dependency cJSON not found. Some features will be disabled.")
    endif(CJSON_FOUND)
endif()
```

and indeed, I repro the problem if cjson is installed first. Disable WITH_CJSON as a fix.

OSX never finishing: Hopefully fixed by https://github.com/microsoft/vcpkg/pull/20388
