### PR TITLE
[macos ci] fix bug in OnlyTest

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -133,9 +133,12 @@ if ($null -ne $OnlyTest)
     $OnlyTest | % {
         $portName = $_
         & "./vcpkg$executableExtension" install --triplet $Triplet @commonArgs $portName
-        [System.Console]::Error.WriteLine( `
-            "REGRESSION: ${portName}:$triplet. If expected, remove ${portName} from the OnlyTest list." `
-        )
+        if (-not $?)
+        {
+            [System.Console]::Error.WriteLine( `
+                "REGRESSION: ${portName}:$triplet. If expected, remove ${portName} from the OnlyTest list." `
+            )
+        }
     }
 }
 else


### PR DESCRIPTION
it always prints "regression" instead of checking the output of vcpkg.