### PR TITLE
[gsl-lite] Update to 0.39.0

### DIFF
--- a/ports/gsl-lite/portfile.cmake
+++ b/ports/gsl-lite/portfile.cmake
@@ -1,18 +1,18 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO gsl-lite/gsl-lite
-    REF e1c381746c2625a76227255f999ae9f14a062208
-    SHA512 36b7ee945e384f1d425287a780953bf979782aa799547d08fb32e05c4671050278de34d857807de4c7e42b215900457014c49e89b7f330d522609f7cc10d47f8
+    REF d0903fa87ff579c30f608bc363582e6563570342
+    SHA512 f4032404db0073a8ca162e627af8e2741b26a9a251499b0d0009c56ae34b69904d488a4f463c107e40ec495f79b5990c685008979b397d1b670c088ceb4508a0
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
 )
-
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/gsl-lite")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH "lib/cmake/gsl-lite"
+)
 
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/gsl-lite.hpp "#ifndef GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
 #define GSL_LITE_HPP_VCPKG_COMPAT_HEADER_INCLUDED
@@ -25,4 +25,8 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug"
 )
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL
+    "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+    RENAME copyright
+)

--- a/ports/gsl-lite/vcpkg.json
+++ b/ports/gsl-lite/vcpkg.json
@@ -1,6 +1,16 @@
 {
   "name": "gsl-lite",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "A single-file header-only implementation of ISO C++ Guidelines Support Library (GSL) for C++98, C++11 and later.",
-  "homepage": "https://github.com/gsl-lite/gsl-lite/"
+  "homepage": "https://github.com/gsl-lite/gsl-lite/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2537,7 +2537,7 @@
       "port-version": 0
     },
     "gsl-lite": {
-      "baseline": "0.38.1",
+      "baseline": "0.39.0",
       "port-version": 0
     },
     "gsoap": {

--- a/versions/g-/gsl-lite.json
+++ b/versions/g-/gsl-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "764fdd7f284e4cbc5f8f28473c3c241e9bfa8d9c",
+      "version": "0.39.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "2ce26ff116fc8b387a5b67f157a0363688b22e91",
       "version": "0.38.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Update [*gsl-lite*](https://github.com/gsl-lite/gsl-lite) to v0.39.0; update the portfile to no longer depend on deprecated functions

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All; yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, to the best of my knowledge

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
