### PR TITLE
[expected-lite] Update port to 0.5.0

### DIFF
--- a/ports/expected-lite/portfile.cmake
+++ b/ports/expected-lite/portfile.cmake
@@ -3,6 +3,7 @@ vcpkg_from_github(
     REPO martinmoene/expected-lite
     REF v0.5.0
     SHA512 6dd8974d518db0c79fe7bd0e407a85436c6ad222f8e5ed84efb34925d9a665b5b83ff08529b3e985034ed9a9201c80575f6a956132408ef6577c9c47cac55eae
+    HEAD_REF master
 )
 
 vcpkg_cmake_configure(

--- a/ports/expected-lite/portfile.cmake
+++ b/ports/expected-lite/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_github(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DEXPECTED_LITE_OPT_BUILD_TESTS=OFF
         -DEXPECTED_LITE_OPT_BUILD_EXAMPLES=OFF
@@ -19,10 +19,10 @@ vcpkg_cmake_config_fixup(
 )
 
 file(REMOVE_RECURSE
-    ${CURRENT_PACKAGES_DIR}/debug
-    ${CURRENT_PACKAGES_DIR}/lib
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
 )
 
 file(INSTALL
-    ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright
+    "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright
 )

--- a/ports/expected-lite/portfile.cmake
+++ b/ports/expected-lite/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO martinmoene/expected-lite
-    REF v0.3.0
-    SHA512 b24b58ff7bd6d5f355935854b6b5e67c7e9b2f1b6383ecdd2a1655833f414fd1189a07000b40c45a6df8a8641602c5eca19eb5e8639ac6cfe59e3d94bc102ab3
+    REF v0.5.0
+    SHA512 6dd8974d518db0c79fe7bd0e407a85436c6ad222f8e5ed84efb34925d9a665b5b83ff08529b3e985034ed9a9201c80575f6a956132408ef6577c9c47cac55eae
 )
 
 vcpkg_configure_cmake(

--- a/ports/expected-lite/portfile.cmake
+++ b/ports/expected-lite/portfile.cmake
@@ -5,17 +5,16 @@ vcpkg_from_github(
     SHA512 6dd8974d518db0c79fe7bd0e407a85436c6ad222f8e5ed84efb34925d9a665b5b83ff08529b3e985034ed9a9201c80575f6a956132408ef6577c9c47cac55eae
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DEXPECTED_LITE_OPT_BUILD_TESTS=OFF
         -DEXPECTED_LITE_OPT_BUILD_EXAMPLES=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(
+vcpkg_cmake_config_fixup(
     CONFIG_PATH lib/cmake/${PORT}
 )
 

--- a/ports/expected-lite/vcpkg.json
+++ b/ports/expected-lite/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "expected-lite",
   "version-semver": "0.5.0",
   "description": "Expected objects in C++11 and later in a single-file header-only library",
+  "homepage": "https://github.com/martinmoene/expected-lite",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/expected-lite/vcpkg.json
+++ b/ports/expected-lite/vcpkg.json
@@ -1,6 +1,5 @@
 {
   "name": "expected-lite",
-  "version-string": "0.3.0",
-  "port-version": 1,
+  "version-string": "0.5.0",
   "description": "Expected objects in C++11 and later in a single-file header-only library"
 }

--- a/ports/expected-lite/vcpkg.json
+++ b/ports/expected-lite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "expected-lite",
-  "version-string": "0.5.0",
+  "version-semver": "0.5.0",
   "description": "Expected objects in C++11 and later in a single-file header-only library",
   "dependencies": [
     {

--- a/ports/expected-lite/vcpkg.json
+++ b/ports/expected-lite/vcpkg.json
@@ -1,5 +1,15 @@
 {
   "name": "expected-lite",
   "version-string": "0.5.0",
-  "description": "Expected objects in C++11 and later in a single-file header-only library"
+  "description": "Expected objects in C++11 and later in a single-file header-only library",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/expected-lite/vcpkg.json
+++ b/ports/expected-lite/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "expected-lite",
-  "version-semver": "0.5.0",
+  "version": "0.5.0",
   "description": "Expected objects in C++11 and later in a single-file header-only library",
   "homepage": "https://github.com/martinmoene/expected-lite",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2017,8 +2017,8 @@
       "port-version": 0
     },
     "expected-lite": {
-      "baseline": "0.3.0",
-      "port-version": 1
+      "baseline": "0.5.0",
+      "port-version": 0
     },
     "exprtk": {
       "baseline": "2021-01-01",

--- a/versions/e-/expected-lite.json
+++ b/versions/e-/expected-lite.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3f6fe1626ef478e14df1b03a9f1c356bf8f84394",
+      "git-tree": "df62548b190bf9313144a9b7535459f187c8e851",
       "version-semver": "0.5.0",
       "port-version": 0
     },

--- a/versions/e-/expected-lite.json
+++ b/versions/e-/expected-lite.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f6fe1626ef478e14df1b03a9f1c356bf8f84394",
+      "version-semver": "0.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "877f85638b2a3f618c48729a2e39149effbcb851",
       "version-string": "0.3.0",
       "port-version": 1

--- a/versions/e-/expected-lite.json
+++ b/versions/e-/expected-lite.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "df62548b190bf9313144a9b7535459f187c8e851",
-      "version-semver": "0.5.0",
+      "git-tree": "a1e36e579144b5ebf1231aac06fbfc89c300351f",
+      "version": "0.5.0",
       "port-version": 0
     },
     {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates [expected-lite](https://github.com/martinmoene/expected-lite) to 0.5.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Just a port update

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes