### PR TITLE
[directxtk, directxtk12, directxtex, directxmesh, uvatlas] ports updated for September 2021 release

### DIFF
--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF jun2021
-    SHA512 ed61e14bb217bdff803ad95bfffe31aac7ff0a3f78b963aac183c61233374def4c0b052d1bf9b0d03900fc5be052e1d8fe8de00e81f01349eff1a564d55be610
+    REF sept2021
+    SHA512 e07f944080dc7e0ffe154061057a81d7caee3c4612b9261ba5a4812b3cb45571dee0a1c9b01824ccfbe9566132eadef30b80164fefe6a3ead60a3762566e2604
     HEAD_REF master
 )
 
@@ -38,9 +38,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/jun2021/meshconvert.exe"
-    FILENAME "meshconvert-jun2021.exe"
-    SHA512 2a5e1eb69f24fd321d372dcd790970a15957757eacd0a861001299409ff56372bc890c2d8baba32368c81eeb63cdd7aef514c57bca1e7e4e3f7bdf494c3453a0
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/sept2021/meshconvert.exe"
+    FILENAME "meshconvert-sept2021.exe"
+    SHA512 9d527b95d3a37604ac3a4c05f8ef44e81cfd8044dd44eddc531116ee5110443679787e4719b0504dc60e406e28396e1f553388cf261b3df81103bd03391c32af
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -49,7 +49,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -26,14 +26,13 @@ else()
   set(EXTRA_OPTIONS -DBUILD_TOOLS=ON)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -8,7 +8,15 @@
   "supports": "windows | linux",
   "dependencies": [
     "directx-headers",
-    "directxmath"
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "dx12": {

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "directxmesh",
-  "version-string": "jun2021",
+  "version-string": "sept2021",
   "description": "DirectXMesh geometry processing library",
-  "homepage": "http://go.microsoft.com/fwlink/?LinkID=324981",
+  "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",
   "license": "MIT",
   "supports": "windows | linux",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF aug2021
-    SHA512 72b688848ad7645e018bb7dc3a3179ea3857e8349185ad53ad583b17aca555554ce44773a4b900ad163b2fd8551c28c3503b88333d8cff8f8d3ee03017bad35d
+    REF sept2021
+    SHA512 5fe5ed64fd58d9b881b186d3ca0fcac7980afc214eb219f842607d4b868b14c1411613a46d74d3cd9ab242d533dfa0ac8c181d083391c665a4577e4c3b931100
     HEAD_REF master
 )
 
@@ -65,23 +65,23 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texassemble.exe"
-    FILENAME "texassemble-aug2021.exe"
-    SHA512 11b07da257d7ea394fa789210b2985656bf28a0b6117d5380d9639ffc0a460a0e6c4bdbb24256dcf3b4d75088b4b5386951a7de856fecb99e73dfe326b4bfe45
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texassemble.exe"
+    FILENAME "texassemble-sept2021.exe"
+    SHA512 05539bae0f77bba1e6fa349ac483367d3f34f808857fd3c3bdecd2a956465101dbaec95cb4e61c15d5d65fd12cdc14fab17cede3a2719dc32bda8748b7a1c59a
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texconv.exe"
-    FILENAME "texconv-aug2021.exe"
-    SHA512 c11bc77a36d5989189519793f3a44c15f1e01b3e0a6254bffca4ee6f96c933a6add34ffc7e409f3c3f97d862816006d3ca440876a4af200f035353d096902c5b
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texconv.exe"
+    FILENAME "texconv-sept2021.exe"
+    SHA512 9ec2415d2d1b665a0a67c01c916afb5946dedede3518e3a029b83e4a8bb86d8f22b2dc0afdc7dbe0824f8f9843a86e555f3e4705570703d4447a47f2719f5b5a
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/aug2021/texdiag.exe"
-    FILENAME "texdiag-aug2021.exe"
-    SHA512 73ae5fbc20ff7d970891d8e4029f1400f5d16675912cc4af97f9ef0e563dc77fa89690989e80eec5fd033975cf67d350be5a547d08fc5fecbabd4577603eef80
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texdiag.exe"
+    FILENAME "texdiag-sept2021.exe"
+    SHA512 380660fa46438368a0f30684e0b9d9f4c267d76145bacbf4e5643889e00f869b0925250c1911397ce6a3890752de87f6105ef0e60d0e0334eb36fbc7f53deea7
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -92,9 +92,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtex/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-string": "aug2021",
+  "version-string": "sept2021",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF aug2021
-    SHA512 ed4ff5c8a1f12e2489a4ddb653a0d8097da4a901498852ada5595959f6e6275531e11ca20d8ce16da19f3ac37193b23edf7c9c1b6d6a78a8810e8f0d399ca4b8
+    REF sept2021
+    SHA512 57fb4cf54b09abee87ff2471c1b504b071a9d3229a09d01d5de58fa3e8bfc956262f21ace88cf05b13f4ff4184b2f7c3b018f9b95d0cac55825c4e3c6549ee89
     HEAD_REF master
 )
 
@@ -36,16 +36,16 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/aug2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-aug2021.exe"
-    SHA512 a84786f57f7f26c4ab0cd446136d79c19a74296f5074396854c81ad67aedfccfe76e15025ba9bcfcabb993f0bb7247ca536d55b4574192efb3e7c2069abf70d7
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/sept2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-sept2021.exe"
+    SHA512 a22ec8e7d283585574a5aec82c937c2844e89e66ded01fea92bb278beb7ff32c8070fa3016192029ed8c106db7ef0356f867521a2603a4de7c085cd8db693d0a
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/aug2021/XWBTool.exe"
-    FILENAME "xwbtool-aug2021.exe"
-    SHA512 3dd1ebd04db21517f74453727512783141b997d33efc1a47236c9ff343310da17b4add4c4ba6e138ad35095fb77f4207e7458a9e51ee3f4872fc0e0cf62be5b5
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/sept2021/XWBTool.exe"
+    FILENAME "xwbtool-sept2021.exe"
+    SHA512 40f33af95bfdaf60a41564dc347d51768774ad7caa8529046e3f87256e80e165aa124b21193d0ffa1e94644343006d6de01807df317dfdf13377a31275b973ef
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -55,8 +55,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-string": "aug2021",
+  "version-string": "sept2021",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,15 +5,15 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF aug2021
-    SHA512 9d0234d7f8d631fa7cb434487bb1fbb4a52760550962f8ebd5a8c09b33cc2b328651b0c0355057e9b172b7445c86b083f33967ee7918a5eeaf19b3e4915dfe00
+    REF sept2021
+    SHA512 bb8a8a81381a6638e33cefc0c058126843df79cf84fd9a248606e965048ba6faae23e8167eb91dd6b8e9a11a788b188067877ef26852c6530ef6fc3c50b221b4
     HEAD_REF master
 )
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
-    OPTIONS -DBUILD_XAUDIO_WIN10=ON
+    OPTIONS -DBUILD_XAUDIO_WIN10=ON -DBUILD_DXIL_SHADERS=ON
 )
 
 vcpkg_install_cmake()
@@ -22,16 +22,16 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/aug2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-aug2021.exe"
-    SHA512 a84786f57f7f26c4ab0cd446136d79c19a74296f5074396854c81ad67aedfccfe76e15025ba9bcfcabb993f0bb7247ca536d55b4574192efb3e7c2069abf70d7
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/sept2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-sept2021.exe"
+    SHA512 a22ec8e7d283585574a5aec82c937c2844e89e66ded01fea92bb278beb7ff32c8070fa3016192029ed8c106db7ef0356f867521a2603a4de7c085cd8db693d0a
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/aug2021/XWBTool.exe"
-    FILENAME "xwbtool-aug2021.exe"
-    SHA512 3dd1ebd04db21517f74453727512783141b997d33efc1a47236c9ff343310da17b4add4c4ba6e138ad35095fb77f4207e7458a9e51ee3f4872fc0e0cf62be5b5
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/sept2021/XWBTool.exe"
+    FILENAME "xwbtool-sept2021.exe"
+    SHA512 40f33af95bfdaf60a41564dc347d51768774ad7caa8529046e3f87256e80e165aa124b21193d0ffa1e94644343006d6de01807df317dfdf13377a31275b973ef
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -41,8 +41,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk12/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-aug2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-string": "aug2021",
+  "version-string": "sept2021",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF jun2021b
-    SHA512 d08bacacba324ddf60b003c5cbd5ad715bdbc1cf352a0dc9de58c40fd8f4bcbb562b8285ff1a443453399167a96e5b1af51d32ffc5e1e8f65391ef124c0706d4
+    REF sept2021
+    SHA512 bb2659e83aa04ad6a43b953f40535531f4f5766d3390b9ce8ea0d83b3146cb92fe27a44c7b744da91cc20f529aabf87794b3b19272c2bd27817e65b091ffe3f5
     HEAD_REF master
 )
 
@@ -38,9 +38,9 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/jun2021/uvatlastool.exe"
-    FILENAME "uvatlastool-jun2021.exe"
-    SHA512 af2e57a2d6aa41b53784c78ea8b5e181bb6ea6f66b23bfb3710ae3d7aebf3184c1739d02822a1eab438ebaac5fccb053bfac29b77d5ce81ae1f9c8e0bd396b49
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/sept2021/uvatlastool.exe"
+    FILENAME "uvatlastool-sept2021.exe"
+    SHA512 56e5ca39f5e1d4fd5fc0f23dee0b2c4b814a53848614d3a470a68821177662e068e0d4e3db93446d32e734af4a6bad0f729d0691b2a3bb127e0395c14aa5a1e7
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -49,7 +49,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-jun2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -26,14 +26,13 @@ else()
   set(EXTRA_OPTIONS -DBUILD_TOOLS=ON)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -16,6 +16,14 @@
     {
       "name": "directxtex",
       "platform": "!(uwp | linux)"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "features": {

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-string": "jun2021b",
+  "version-string": "sept2021",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1789,7 +1789,7 @@
       "port-version": 1
     },
     "directxmesh": {
-      "baseline": "jun2021",
+      "baseline": "sept2021",
       "port-version": 0
     },
     "directxsdk": {
@@ -1797,15 +1797,15 @@
       "port-version": 4
     },
     "directxtex": {
-      "baseline": "aug2021",
+      "baseline": "sept2021",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "aug2021",
+      "baseline": "sept2021",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "aug2021",
+      "baseline": "sept2021",
       "port-version": 0
     },
     "dirent": {
@@ -6817,7 +6817,7 @@
       "port-version": 1
     },
     "uvatlas": {
-      "baseline": "jun2021b",
+      "baseline": "sept2021",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "93dd74331b7096440e8dfb6e57c275f87e3cced6",
+      "git-tree": "c6e38f3e2c1f90556658d75ae6edd0e170ab0ac4",
       "version-string": "sept2021",
       "port-version": 0
     },

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93dd74331b7096440e8dfb6e57c275f87e3cced6",
+      "version-string": "sept2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "57ebdc7d52aef816917feb6d24ad2e6e67fa92ec",
       "version-string": "jun2021",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1dea5cbc125f2e87484afcd19c59b9c2955ce12d",
+      "version-string": "sept2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "fa15773926896a6f0b1f9eb47a5aed34f65175e4",
       "version-string": "aug2021",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8fa980b193db947e6a803ed413e87df23ee315c7",
+      "version-string": "sept2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "e7f8c6f80d18f82e3e5a6ab621f4e43d6a110b2b",
       "version-string": "aug2021",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "22e26ef3a716ae717ef2e972ce47ea6436d7025b",
+      "version-string": "sept2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "49693bbdb6a484add7a33c52cb54059beca228b9",
       "version-string": "aug2021",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "85bf7f2c835403d6946ffa6bcd1a7034d7b66c58",
+      "git-tree": "aa1c69c4376ea2d6332065397292b386d60984a4",
       "version-string": "sept2021",
       "port-version": 0
     },

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85bf7f2c835403d6946ffa6bcd1a7034d7b66c58",
+      "version-string": "sept2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "60f3026412b95786a91eadb5e97483cb9539b8c1",
       "version-string": "jun2021b",
       "port-version": 0


### PR DESCRIPTION
# DirectX Tool Kit
* Added ModelBone support for transformation hierarchies
  * Rigid-body & skinned animation Draw support added to Model
* Added type aliases ``ModelMeshPart::InputLayoutCollection``, ``GeometricPrimitive::VertexCollection`` and ``IndexCollection``.
* EnvironmentMapEffect and NormalMapEffect will now use default diffuse/normal textures if none are set
* VS 2017 projects updated to require the Windows 10 SDK (19401)
* Code review updates

# DirectX Tool Kit for DX12
* Added ModelBone support for transformation hierarchies
  * Rigid-body & skinned animation Draw support added to Model
* Support for loading Visual Studio ``CMO`` models added using BasicEffect or SkinnedEffect materials
* Added type aliases ``Model::EffectCollection``, ``ModelMeshPart::InputLayoutCollection``, ``GeometricPrimitive::VertexCollection`` and ``IndexCollection``
* Fixed handle leak in ResourceUploadBatch
* Updated ScopeBarrier to conform with C++14 ``std::initializer_list``
* VS 2017 projects updated to require the Windows 10 SDK (19401) and make use of Shader Model 6.0
* Code review updates

# DirectXMesh
* Fixed overflow case in meshlet generation with degenerate triangles
* Minor code review and project cleanup

# DirectXTex
* Minor code and project cleanup

# UVatlas
* Minor code and project cleanup

> directxtk12 port now opts into Shader Model 6 which is what all the other projects are doing with Sept 2021.

