### PR TITLE
[google-cloud-cpp] migrate to vcpkg_cmake_config_fixup()

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -31,9 +31,49 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+foreach(feature IN LISTS FEATURES)
+    set(config_path "lib/cmake/google_cloud_cpp_${feature}")
+    # Most features get their own package in `google-cloud-cpp`.
+    # The exceptions are captured by this `if()` command, basically
+    # things like `core` and `experimental-storage-grpc` are skipped.
+    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
+        continue()
+    endif()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "google_cloud_cpp_${feature}"
+                             CONFIG_PATH "${config_path}"
+                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+# These packages are automatically installed depending on what features are
+# enabled.
+foreach(suffix common googleapis grpc_utils)
+    set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
+    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
+        continue()
+    endif()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "google_cloud_cpp_${suffix}"
+                             CONFIG_PATH "${config_path}"
+                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+# These packages are only for backwards compability. The google-cloud-cpp team
+# is planning to remove them around 2022-02-15.
+foreach(package
+        googleapis
+        bigtable_client
+        pubsub_client
+        spanner_client
+        storage_client)
+    if(NOT IS_DIRECTORY "${config_path}")
+        continue()
+    endif()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "${package}"
+                             CONFIG_PATH "${config_path}"
+                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/share") 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -63,6 +63,7 @@ foreach(package
         pubsub_client
         spanner_client
         storage_client)
+    set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${config_path}")
         continue()
     endif()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "1.32.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -9,6 +10,10 @@
     "abseil",
     {
       "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
       "host": true
     }
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2474,7 +2474,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.32.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cdff1fe8258594a75d0a36aabc07faf66c318532",
+      "version": "1.32.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d138daefe227de160954ecdce23178fa659edb36",
       "version": "1.32.0",
       "port-version": 0

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cdff1fe8258594a75d0a36aabc07faf66c318532",
+      "git-tree": "2b53c52b812f1d7fe8ada0a6d938b047b5a3dbd2",
       "version": "1.32.0",
       "port-version": 1
     },


### PR DESCRIPTION
Migrates `google-cloud-cpp` to use `vcpkg_cmake_config_fixup()`.

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.

Thanks to @Osyotr for suggesting this solution.