### PR TITLE
[sdl2] Fix calling `find_packages` from different directories

### DIFF
--- a/ports/sdl2/0004-sdl2-alias-on-static-build.patch
+++ b/ports/sdl2/0004-sdl2-alias-on-static-build.patch
@@ -1,13 +1,16 @@
 --- a/SDL2Config.cmake
 +++ b/SDL2Config.cmake
-@@ -2,5 +2,14 @@
+@@ -1,5 +1,17 @@
  include("${CMAKE_CURRENT_LIST_DIR}/SDL2Targets.cmake")
  
 +# on static-only builds create an alias
 +if(NOT TARGET SDL2::SDL2 AND TARGET SDL2::SDL2-static)
-+  if(CMAKE_VERSION VERSION_LESS "3.18")
-+      # Aliasing local targets is not supported on CMake < 3.18, so make it global.
++  if(CMAKE_VERSION VERSION_LESS "3.11")
++      message(FATAL_ERROR "At least CMake 3.11 is required for this configuration.")
++  elseif(CMAKE_VERSION VERSION_LESS "3.18")
++      # Aliasing local targets is not supported on CMake < 3.18, so make all targets global.
 +      set_target_properties(SDL2::SDL2-static PROPERTIES IMPORTED_GLOBAL TRUE)
++      set_target_properties(SDL2::SDL2main PROPERTIES IMPORTED_GLOBAL TRUE)
 +  endif()
 +  add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
 +endif()

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.0.16",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6030,7 +6030,7 @@
     },
     "sdl2": {
       "baseline": "2.0.16",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f39203f93b1c068fca2dd7b7501891d8aca3b65d",
+      "version": "2.0.16",
+      "port-version": 1
+    },
+    {
       "git-tree": "66a51e068567b3b76ebb844ba7b4336abc7c35ce",
       "version": "2.0.16",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/19686.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes (but not modernizing the portfile this time)

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
