### PR TITLE
[boost-config] Fix boost builds for WebAssembly

### DIFF
--- a/ports/boost-config/fix-emscripten-compilation.patch
+++ b/ports/boost-config/fix-emscripten-compilation.patch
@@ -1,0 +1,31 @@
+From 85292621ece3409a80929add91c971400ba724f3 Mon Sep 17 00:00:00 2001
+From: jzmaddock <john@johnmaddock.co.uk>
+Date: Fri, 10 Sep 2021 11:36:29 +0100
+Subject: [PATCH] Add emscripten testing and support. (#403)
+
+* Tentatively add emscripten testing and support.
+Fixes https://github.com/boostorg/config/issues/402.
+---
+ include/boost/config/platform/wasm.hpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/include/boost/config/platform/wasm.hpp b/include/boost/config/platform/wasm.hpp
+index c307812d..682b8485 100644
+--- a/include/boost/config/platform/wasm.hpp
++++ b/include/boost/config/platform/wasm.hpp
+@@ -9,6 +9,12 @@
+ 
+ #define BOOST_PLATFORM "Wasm"
+ 
++#ifdef __has_include
++#if __has_include(<unistd.h>)
++#  define BOOST_HAS_UNISTD_H
++#endif
++#endif
++
+ // boilerplate code:
+ #include <boost/config/detail/posix_features.hpp>
+ //
+-- 
+2.21.1 (Apple Git-122.3)
+

--- a/ports/boost-config/portfile.cmake
+++ b/ports/boost-config/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF boost-1.77.0
     SHA512 c6df16825b7bb27412667e00b6b6cdecbf56ee0707aa1df3505637c7de5c39c87335fabd7cd4361b29625d71c7664e6af865fc271ad0b3e70cc8872825f6155e
     HEAD_REF master
+    PATCHES
+        fix-emscripten-compilation.patch
 )
 
 include(${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost-modular-headers.cmake)

--- a/ports/boost-config/vcpkg.json
+++ b/ports/boost-config/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-config",
   "version": "1.77.0",
+  "port-version": 1,
   "description": "Boost config module",
   "homepage": "https://github.com/boostorg/config",
   "dependencies": [

--- a/versions/b-/boost-config.json
+++ b/versions/b-/boost-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6aa6932068c1fbc812d545502f60c3a7cef80dde",
+      "version": "1.77.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2a93a4c962b961f617c133389c18a994e3c27af1",
       "version": "1.77.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -582,7 +582,7 @@
     },
     "boost-config": {
       "baseline": "1.77.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-container": {
       "baseline": "1.77.0",


### PR DESCRIPTION
This PR fixes the compilation of boost-config on WASM / emscripten (upstream patch)

- #### What does your PR fix?  
  Fixes #20536 
  Fixes #20537

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes