### PR TITLE
[vcpkg docs][ES] Sync with English readme (#20412)

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -25,25 +25,25 @@ una vez instalado Vcpkg puede ejecutar `vcpkg help`, o
 
 ## Tabla de contenido
 
-* [Vcpkg: General](#vcpkg-general)
-* [Tabla de contenidos](#tabla-de-contenidos)
-* ["Primeros pasos"](#primeros-pasos)
-  + [Inicio rápido: Windows](#inicio-rápido-windows)
-  + [Inicio rápido: Unix](#inicio-rápido-unix)
-  + [Instalando herramientas de desarrollo en Linux](#instalando-herramientas-de-desarrollo-en-Linux)
-  + [Instalando herramientas de desarrollo en macOS](#instalando-herramientas-de-desarrollo-en-macos)
-    - [Instalando GCC en MacOS previo a 10.15](#instalando-gcc-en-macos-previo-a-10.15)
-  + [Usando Vcpkg con CMake](#usando-vcpkg-con-cmake)
-    - [Visual Studio Code con CMake Tools](#visual-studio-code-con-cmake-tools)
-    - [Vcpkg con proyectos de Visual Studio (CMake)](#vcpkg-con-proyectos-de-visual-studio\(CMake\))
-    - [Vcpkg con CLion](#vcpkg-con-clion)
-    - [Vcpkg como submódulo](#vcpkg-como-submódulo)
-  + [Inicio rápido: archivos de Manifiesto](#inicio-rápido-manifiestos)
-* [Tab-Completado/Autocompletado](#Completado-TabAutocompletado)
-* [Ejemplos](#ejemplos)
-* [Contribuyendo](#contribuyendo)
-* [Licencia](#licencia)
-* [telemetría](#telemetría)
+- [Vcpkg](#vcpkg)
+  - [Tabla de contenido](#tabla-de-contenido)
+  - [Primeros pasos](#primeros-pasos)
+    - [Inicio Rápido: Windows](#inicio-rápido-windows)
+    - [Inicio rápido: Unix](#inicio-rápido-unix)
+    - [Instalando Herramientas de desarrollo en Linux](#instalando-herramientas-de-desarrollo-en-linux)
+    - [Instalando Herramientas de desarrollo en macOS](#instalando-herramientas-de-desarrollo-en-macos)
+      - [Instalando GCC en macOS previo a 10.15](#instalando-gcc-en-macos-previo-a-1015)
+    - [Usando Vcpkg con CMake](#usando-vcpkg-con-cmake)
+      - [Visual Studio Code con CMake Tools](#visual-studio-code-con-cmake-tools)
+      - [Vcpkg con proyectos de Visual Studio(CMake)](#vcpkg-con-proyectos-de-visual-studiocmake)
+      - [Vcpkg con CLion](#vcpkg-con-clion)
+      - [Vcpkg como Submódulo](#vcpkg-como-submódulo)
+    - [Inicio rápido: Manifiestos](#inicio-rápido-manifiestos)
+  - [Completado-Tab/Autocompletado](#completado-tabautocompletado)
+  - [Ejemplos](#ejemplos)
+  - [Contribuyendo](#contribuyendo)
+  - [Licencia](#licencia)
+  - [Telemetría](#telemetría)
 
 ## Primeros pasos
 
@@ -411,8 +411,10 @@ El código en este repositorio se encuentra licenciado mediante la [Licencia MIT
 
 vcpkg recolecta datos de uso para mejorar su experiencia.
 La información obtenida por Microsoft es anónima.
-puede ser dado de baja de la telemetría ejecutando de nuevo el script `bootstrap-vcpkg` con `-disableMetrics`,
-pasando `--disable-metrics` a vcpkg en la línea de comandos,
-o creando la variable de entorno `VCPKG_DISABLE_METRICS`.
+puede ser dado de baja de la telemetría realizando lo siguiente:
+
+- ejecutar el script `bootstrap-vcpkg` con el parametro `-disableMetrics`
+- agregar el parametro `--disable-metrics` a vcpkg en la línea de comandos
+- agregar la variable de entorno `VCPKG_DISABLE_METRICS`
 
 Se puede leer más sobre la telemetría de vcpkg en docs/about/privacy.md


### PR DESCRIPTION
Update the Spanish readme with the latest changes of English readme PR (#20412)

What does your PR fix?
It keeps in sync the Spanish readme with the mainstream readme

Which triplets are supported/not supported? Have you updated the [CI baseline]
N/A [L10N][Documentation]

Does your PR follow the maintainer guide?
Yes
