### PR TITLE
[vcpkg_from_github] Fix parse error on OSX

### DIFF
--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -160,7 +160,7 @@ function(vcpkg_from_github)
         # Parse the github refs response with regex.
         # TODO: add json-pointer support to vcpkg
         file(READ "${archive_version}" version_contents)
-        if(NOT version_contents MATCHES [["sha":"([a-f0-9]+)"]])
+        if(NOT version_contents MATCHES [["sha":(\ *)"([a-f0-9]+)"]])
             message(FATAL_ERROR "Failed to parse API response from '${version_url}':
 
 ${version_contents}


### PR DESCRIPTION
When using `--head`, the github server will return the following json:
```json
  {

    "ref": "refs/heads/master",
    "node_id": "MDM6UmVmMjg2MzkwOTpyZWZzL2hlYWRzL21hc3Rlcg==",
    "url": "https://api.github.com/repos/mosra/corrade/git/refs/heads/master",
    "object": {
      "sha": "bb626d650c7d76dd2846945ef22e9eb0003b6ea9",
      "type": "commit",
      "url": "https://api.github.com/repos/mosra/corrade/git/commits/bb626d650c7d76dd2846945ef22e9eb0003b6ea9"
    }

  }
```
There is a space after `"sha":`, causing the parsing to fail:
```
CMake Error at scripts/cmake/vcpkg_from_github.cmake:164 (message):
  Failed to parse API response from '':
```
So add parsing zero or more spaces after the `:`.

Fixes #20644.