### PR TITLE
[vcpkg_configure_make] Fix environment variable _LINK_

### DIFF
--- a/scripts/cmake/vcpkg_configure_make.cmake
+++ b/scripts/cmake/vcpkg_configure_make.cmake
@@ -783,9 +783,9 @@ function(vcpkg_configure_make)
             set(ENV{LDFLAGS} "-avoid-version $ENV{LDFLAGS}")
         endif()
 
-        if(LINK_ENV_${_VAR_SUFFIX})
+        if(LINK_ENV_${_buildtype})
             set(_LINK_CONFIG_BACKUP "$ENV{_LINK_}")
-            set(ENV{_LINK_} "${LINK_ENV_${_VAR_SUFFIX}}")
+            set(ENV{_LINK_} "${LINK_ENV_${_buildtype}}")
         endif()
         set(ENV{PKG_CONFIG} "${PKGCONFIG}")
 


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/blob/973a7d517c09c8cfb7e6a548fcc260ca34ba7b60/scripts/cmake/vcpkg_configure_make.cmake#L786-L789
`_VAR_SUFFIX` is not defined here and unset in front, so it should be `_buildtype`.
This will cause all dynamic libraries built in Windows using makefiles to not generate pdb.

Fixes: #19994.