### PR TITLE
[corrade] Fix build error on vs2019

### DIFF
--- a/ports/corrade/fix-vs2019.patch
+++ b/ports/corrade/fix-vs2019.patch
@@ -7,7 +7,7 @@ index e0cc288..e5a4648 100644
              message(WARNING "MSVC 2017 detected, automatically enabling MSVC2017_COMPATIBILITY. Note that some features may not be available with this compiler.")
          endif()
 -    elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.30")
-+    elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.31")
++    elseif(CMAKE_CXX_COMPILER_VERSION GREATER "19.20")
          if(NOT MSVC2019_COMPATIBILITY)
              set(MSVC2019_COMPATIBILITY ON)
              message(WARNING "MSVC 2019 detected, automatically enabling MSVC2019_COMPATIBILITY. Note that some features may not be available with this compiler.")

--- a/ports/corrade/portfile.cmake
+++ b/ports/corrade/portfile.cmake
@@ -25,7 +25,7 @@ endforeach()
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES ${_COMPONENTS})
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         ${FEATURE_OPTIONS}
@@ -36,8 +36,8 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 # Debug includes and share are the same as release
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Install tools
 if("utility" IN_LIST FEATURES)
@@ -49,22 +49,22 @@ endif()
 if(NOT FEATURES)
     # No features, no binaries (only Corrade.h).
     file(REMOVE_RECURSE
-        ${CURRENT_PACKAGES_DIR}/bin
-        ${CURRENT_PACKAGES_DIR}/lib
-        ${CURRENT_PACKAGES_DIR}/debug)
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/lib"
+        "${CURRENT_PACKAGES_DIR}/debug")
     # debug is completely empty, as include and share
     # have already been removed.
 
 elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     # No dlls
     file(REMOVE_RECURSE
-        ${CURRENT_PACKAGES_DIR}/bin
-        ${CURRENT_PACKAGES_DIR}/debug/bin)
+        "${CURRENT_PACKAGES_DIR}/bin"
+        "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+file(INSTALL "${SOURCE_PATH}/COPYING"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/corrade/vcpkg.json
+++ b/ports/corrade/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "corrade",
   "version-string": "2020.06",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++11/C++14 multiplatform utility library.",
   "homepage": "https://magnum.graphics/corrade/",
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1482,7 +1482,7 @@
     },
     "corrade": {
       "baseline": "2020.06",
-      "port-version": 2
+      "port-version": 3
     },
     "cpp-base64": {
       "baseline": "V2.rc.08",

--- a/versions/c-/corrade.json
+++ b/versions/c-/corrade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "087770e2a196c44cb1b56473bd57797ed9b9bc87",
+      "version-string": "2020.06",
+      "port-version": 3
+    },
+    {
       "git-tree": "ec9f53411152ed98e9d591afed7e34e65fb7abeb",
       "version-string": "2020.06",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  On our unstable test, corrade failed with the following error:
```
FAILED: src/Corrade/Utility/CMakeFiles/CorradeUtilityObjects.dir/TweakableParser.cpp.obj 
"E:\Visual Studio\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\cl.exe"   /TP -DCORRADE_IS_DEBUG_BUILD -DCorradeUtilityObjects_EXPORTS -DNOMINMAX -DUNICODE -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -IC:\vcpkg_1011\vcpkg\buildtrees\corrade\src\v2020.06-2e11614b58\src -IC:\vcpkg_1011\vcpkg\buildtrees\corrade\x64-windows-dbg\src /nologo /DWIN32 /D_WINDOWS  /utf-8 /GR /EHsc /MP  /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1  /W4 /wd4251 /wd4244 /wd4267 /wd4351 /wd4373 /wd4510 /wd4610 /wd4512 /wd4661 /wd4702 /wd4706 /wd4800 /wd4910 /showIncludes /Fosrc\Corrade\Utility\CMakeFiles\CorradeUtilityObjects.dir\TweakableParser.cpp.obj /Fdsrc\Corrade\Utility\CMakeFiles\CorradeUtilityObjects.dir\ /FS -c C:\vcpkg_1011\vcpkg\buildtrees\corrade\src\v2020.06-2e11614b58\src\Corrade\Utility\TweakableParser.cpp
C:\vcpkg_1011\vcpkg\buildtrees\corrade\src\v2020.06-2e11614b58\src\Corrade\Utility\TweakableParser.cpp(40): error C2666: '+': 2 overloads have similar conversions
C:\vcpkg_1011\vcpkg\buildtrees\corrade\src\v2020.06-2e11614b58\src\Corrade\Utility\TweakableParser.cpp(40): note: could be 'built-in C++ operator+(bool, int)'
C:\vcpkg_1011\vcpkg\buildtrees\corrade\src\v2020.06-2e11614b58\src\Corrade\Utility\TweakableParser.cpp(40): note: or       'built-in C++ operator+(const T, __int64)'
        with
        [
            T=const char
        ]
```
This is caused by the value of `CMAKE_CXX_COMPILER_VERSION` is greater than 19.30.

In order to make sure corrade can work normally on vs2019, I update the patch to fix this problem temporarily.

This patch should be removed if upstream can support vs2022.

Upstream issue https://github.com/mosra/corrade/issues/124



