### PR TITLE
[ryml] Support osx

### DIFF
--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -34,21 +34,20 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         dbg           RYML_DBG
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
 if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/ryml")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ryml)
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ryml)
 endif()
 
 # Move headers and natvis to own dir
@@ -68,6 +67,4 @@ file(WRITE "${CURRENT_PACKAGES_DIR}/share/ryml/rymlConfig.cmake" "${_contents}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL
-    "${SOURCE_PATH}/LICENSE.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ryml/portfile.cmake
+++ b/ports/ryml/portfile.cmake
@@ -1,9 +1,5 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_fail_port_install(
-    ON_TARGET "OSX"
-)
-
 # Get rapidyaml src
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -39,7 +35,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
@@ -49,9 +45,9 @@ vcpkg_install_cmake()
 
 vcpkg_copy_pdbs()
 
-if(EXISTS ${CURRENT_PACKAGES_DIR}/cmake)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
     vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
-elseif(EXISTS ${CURRENT_PACKAGES_DIR}/lib/cmake/ryml)
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/ryml")
     vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ryml)
 endif()
 

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -4,7 +4,6 @@
   "port-version": 1,
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
-  "supports": "!osx",
   "dependencies": [
     {
       "name": "c4core",

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -9,6 +9,14 @@
     {
       "name": "c4core",
       "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "default-features": [

--- a/ports/ryml/vcpkg.json
+++ b/ports/ryml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ryml",
   "version-date": "2021-07-24",
+  "port-version": 1,
   "description": "Rapid YAML library",
   "homepage": "https://github.com/biojppm/rapidyaml",
   "supports": "!osx",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1350,7 +1350,6 @@ rtlsdr:x64-linux=fail
 rtlsdr:x64-osx=fail
 rttr:arm-uwp=fail
 rttr:x64-uwp=fail
-ryml:x64-osx=fail
 ryu:arm-uwp=fail
 ryu:x64-uwp=fail
 ryu:x64-windows-static=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5958,7 +5958,7 @@
     },
     "ryml": {
       "baseline": "2021-07-24",
-      "port-version": 0
+      "port-version": 1
     },
     "ryu": {
       "baseline": "2.0",

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ad023699247454ff2c8d8d325aac2616c2aaf626",
+      "git-tree": "5980fca6cf0377fea2b0fd5e4a40cb1debe0ec7b",
       "version-date": "2021-07-24",
       "port-version": 1
     },

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad023699247454ff2c8d8d325aac2616c2aaf626",
+      "version-date": "2021-07-24",
+      "port-version": 1
+    },
+    {
       "git-tree": "d97344132c58ae2aafb8c0ed1f23acde843404b5",
       "version-date": "2021-07-24",
       "port-version": 0

--- a/versions/r-/ryml.json
+++ b/versions/r-/ryml.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5980fca6cf0377fea2b0fd5e4a40cb1debe0ec7b",
+      "git-tree": "599ab36a18b1a0c439fdc6dc740bf0575a06641e",
       "version-date": "2021-07-24",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20640
 
Currently, `ryml `has supported osx, but we didn't remove the unsupported message.

Remove unsupported message.

Update deprecated functions.

Add quotes for path.

Remove `ryml:x64-osx=fail` from fail list in ci.baseline.txt.

Note: All features have passed on x64-osx.


