### PR TITLE
[libjuice] Update to 0.9.1

### DIFF
--- a/ports/libdatachannel/0001-fix-for-vcpkg.patch
+++ b/ports/libdatachannel/0001-fix-for-vcpkg.patch
@@ -60,7 +60,7 @@ index 02b688c..03b185f 100644
  		target_link_libraries(datachannel-static PRIVATE LibJuice::LibJuice)
  	else()
 -		add_subdirectory(deps/libjuice EXCLUDE_FROM_ALL)
-+		find_package(libjuice CONFIG REQUIRED)
++		find_package(LibJuice CONFIG REQUIRED)
  		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_JUICE=0)
  		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=0)
 -		target_link_libraries(datachannel PRIVATE LibJuice::LibJuiceStatic)

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -35,7 +35,7 @@ file(WRITE "${CURRENT_PACKAGES_DIR}/share/LibDataChannel/LibDataChannelConfig.cm
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(OpenSSL)
-find_dependency(libjuice)
+find_dependency(LibJuice)
 ${DATACHANNEL_CONFIG}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.15.1",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "dependencies": [

--- a/ports/libjuice/fix-for-vcpkg.patch
+++ b/ports/libjuice/fix-for-vcpkg.patch
@@ -1,26 +1,26 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index aedb557..89c701b 100644
+index 3e2a2dc..011a4ca 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -72,7 +72,7 @@ set(TESTS_SOURCES
+@@ -66,7 +66,7 @@ set(TESTS_SOURCES
  set(THREADS_PREFER_PTHREAD_FLAG ON)
  find_package(Threads REQUIRED)
  
 -add_library(juice SHARED ${LIBJUICE_SOURCES})
 +add_library(juice ${LIBJUICE_SOURCES})
  set_target_properties(juice PROPERTIES VERSION ${PROJECT_VERSION})
- target_compile_definitions(juice PRIVATE $<$<CONFIG:Release>:RELEASE=1>)
- 
-@@ -100,11 +100,15 @@ if(WIN32)
+ target_include_directories(juice PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+@@ -96,11 +96,15 @@ if(WIN32)
  endif()
  
  if (USE_NETTLE)
 -	find_package(Nettle REQUIRED)
-+    find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
++	find_path(NETTLE_INCLUDE_PATH "nettle/hmac.h" REQUIRED)
 +    find_library(NETTLE_LIBRARY_PATH NAMES nettle libnettle REQUIRED) 
 +    target_include_directories(juice PRIVATE ${NETTLE_INCLUDE_PATH})
 +    target_include_directories(juice-static PRIVATE ${NETTLE_INCLUDE_PATH})
-+
++    
      target_compile_definitions(juice PRIVATE USE_NETTLE=1)
 -    target_link_libraries(juice PRIVATE Nettle::Nettle)
 +    target_link_libraries(juice PRIVATE ${NETTLE_LIBRARY_PATH})
@@ -30,4 +30,3 @@ index aedb557..89c701b 100644
  else()
      target_compile_definitions(juice PRIVATE USE_NETTLE=0)
      target_compile_definitions(juice-static PRIVATE USE_NETTLE=0)
-

--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -1,31 +1,30 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
-    REF v0.8.4
-    SHA512 c33fc237ff0acb6b9cb37143d1f5a22f20670c8e32200d79c45c8473e1b0e1174926706876a1c37a51ba9ec6ec935337fd87512211eaaf8652f73d4934038834
+    REF 026b3dd68db33143db8a5a9b16af3923733a8b61 #v0.9.1
+    SHA512 050e92df2e3f24da465ffd4e57d35ffc7a4e13042dc0b829627a09c3f8c7898c7b066f3e386004b579e7416adf4885f5f7a8da46f34c76e9bc63747616f34f9d
     HEAD_REF master
     PATCHES
-        fix-for-vcpkg.patch
+        #fix-for-vcpkg.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-    nettle USE_NETTLE
+        nettle USE_NETTLE
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DNO_TESTS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/cmake/libjuice)
+vcpkg_cmake_config_fixup(PACKAGE_NAME LibJuice CONFIG_PATH lib/cmake/LibJuice)
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 050e92df2e3f24da465ffd4e57d35ffc7a4e13042dc0b829627a09c3f8c7898c7b066f3e386004b579e7416adf4885f5f7a8da46f34c76e9bc63747616f34f9d
     HEAD_REF master
     PATCHES
-        #fix-for-vcpkg.patch
+        fix-for-vcpkg.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "libjuice",
-  "version": "0.8.4",
+  "version": "0.9.1",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "nettle": {
       "description": "Use nettle for HMAC computation instead of the Builtin",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3497,7 +3497,7 @@
       "port-version": 2
     },
     "libjuice": {
-      "baseline": "0.8.4",
+      "baseline": "0.9.1",
       "port-version": 0
     },
     "libkeyfinder": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3306,7 +3306,7 @@
     },
     "libdatachannel": {
       "baseline": "0.15.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.10",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ef71c270b3ea4205b878248ade5e50c03fd54b4",
+      "version-semver": "0.15.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb99868eb60c37127a98ff943da771edb8002a29",
       "version-semver": "0.15.1",
       "port-version": 0

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dbae3ef60a18e5a5877793271357d80c41de8d59",
+      "git-tree": "564ac624cbbabb45356d592264c090a0e6f64669",
       "version": "0.9.1",
       "port-version": 0
     },

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dbae3ef60a18e5a5877793271357d80c41de8d59",
+      "version": "0.9.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "077151e85bf11cabc11d0f1c46b778b5a21829dd",
       "version": "0.8.4",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20635

Update to 0.9.1 and update patch to apply the new version.

Update the deprecated functions.

Note: The feature nettle ha passed with the following triplets:

- x86-windows
- x64-windows-static


