### PR TITLE
[nanodbc] Add missing include

### DIFF
--- a/ports/nanodbc/add-missing-include.patch
+++ b/ports/nanodbc/add-missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/nanodbc/nanodbc.cpp b/nanodbc/nanodbc.cpp
+index e6ca73f..3ad724a 100644
+--- a/nanodbc/nanodbc.cpp
++++ b/nanodbc/nanodbc.cpp
+@@ -23,6 +23,7 @@
+ #include <cstring>
+ #include <ctime>
+ #include <iomanip>
++#include <limits>
+ #include <map>
+ #include <type_traits>
+ 

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -8,7 +8,9 @@ vcpkg_from_github(
     REF 7404a4dd7697e188df5724ab95a7553d2fc404eb # v2.13.0
     SHA512 35ca098e783d771f3df611bce84e9b8207a6a5b72c492d2f3909977bc91a7c22bb262c34768b0d97ebfbdf12eeda0214064a8ea171e7bdda7b759f93ff346f45
     HEAD_REF master
-    PATCHES rename-version.patch
+    PATCHES
+        rename-version.patch
+        add-missing-include.patch
 )
 file(RENAME "${SOURCE_PATH}/VERSION" "${SOURCE_PATH}/VERSION.txt")
 
@@ -16,9 +18,8 @@ if(DEFINED NANODBC_ODBC_VERSION)
     set(NANODBC_ODBC_VERSION -DNANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION})
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DNANODBC_DISABLE_EXAMPLES=ON
         -DNANODBC_DISABLE_TESTS=ON
@@ -26,13 +27,13 @@ vcpkg_configure_cmake(
         ${NANODBC_ODBC_VERSION}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 else()
-    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nanodbc/vcpkg.json
+++ b/ports/nanodbc/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "nanodbc",
   "version": "2.13.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A small C++ wrapper for the native C ODBC API.",
   "homepage": "https://github.com/nanodbc/nanodbc",
   "dependencies": [
     {
       "name": "unixodbc",
       "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4502,7 +4502,7 @@
     },
     "nanodbc": {
       "baseline": "2.13.0",
-      "port-version": 4
+      "port-version": 5
     },
     "nanoflann": {
       "baseline": "1.3.2",

--- a/versions/n-/nanodbc.json
+++ b/versions/n-/nanodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82bfc56de1430aa6fec9c27925d46a72e1b800a0",
+      "version": "2.13.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "3549b9a15615f77ec718e9071309482707ad3779",
       "version": "2.13.0",
       "port-version": 4


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/20621

Since the header dependncy changes, the <limits> need to be included explicitly when compiled with GCC 11. The Upstream already contains this change. See https://github.com/nanodbc/nanodbc/blob/master/nanodbc/nanodbc.cpp#L26.


Failures:
```
/home/olm/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-cb02a6c19b.clean/nanodbc/nanodbc.cpp:1732:57: error: ‘numeric_limits’ is not a member of ‘std’
 1732 |         NANODBC_ASSERT(rows <= static_cast<SQLLEN>(std::numeric_limits<long>::max()));
      |                                                         ^~~~~~~~~~~~~~
/home/olm/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-cb02a6c19b.clean/nanodbc/nanodbc.cpp:1732:9: note: in expansion of macro ‘NANODBC_ASSERT’
 1732 |         NANODBC_ASSERT(rows <= static_cast<SQLLEN>(std::numeric_limits<long>::max()));
      |         ^~~~~~~~~~~~~~
/home/olm/vcpkg/buildtrees/nanodbc/src/3d2fc404eb-cb02a6c19b.clean/nanodbc/nanodbc.cpp:1732:72: error: expected primary-expression before ‘long’
 1732 |         NANODBC_ASSERT(rows <= static_cast<SQLLEN>(std::numeric_limits<long>::max()));
...
```