### PR TITLE
[imgui] Update to 1.85

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -85,6 +85,12 @@ if(IMGUI_BUILD_SDL2_BINDING)
     target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl.cpp)
 endif()
 
+if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC SDL2::SDL2)
+    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer.cpp)
+endif()
+
 if(IMGUI_BUILD_VULKAN_BINDING)
     find_package(Vulkan REQUIRED)
     target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
@@ -195,6 +201,10 @@ if(NOT IMGUI_SKIP_HEADERS)
 
     if(IMGUI_BUILD_SDL2_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl.h DESTINATION include)
+    endif()
+
+    if(IMGUI_BUILD_SDL2_RENDERER_BINDING)
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer.h DESTINATION include)
     endif()
 
     if(IMGUI_BUILD_VULKAN_BINDING)

--- a/ports/imgui/imgui-config.cmake.in
+++ b/ports/imgui/imgui-config.cmake.in
@@ -12,7 +12,7 @@ if (@IMGUI_BUILD_GLUT_BINDING@)
     find_dependency(GLUT)
 endif()
 
-if (@IMGUI_BUILD_SDL2_BINDING@)
+if (@IMGUI_BUILD_SDL2_BINDING@ OR @IMGUI_BUILD_SDL2_RENDERER_BINDING@)
     find_dependency(SDL2 CONFIG)
 endif()
 

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,16 +4,16 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF dedb381c510cc0b87164e16b9e7ef6bf50ffccec
-       SHA512 0b331cbf81fed15cdceb84ccf1962b5db19af1b6dc75a19460810919b7f61088a9ba46acf3e6fcadfda6297204b03f1be0ab08fa427f89e504d70be8da1f2281
+       REF 1b215ecb018ba0fd170618366ddc4be9bd45f283
+       SHA512 afd79082c4439b47d5943df5f7ddbdf80dcf23cd120b8da99b67b2979728e604436dd656ef8e8ae0af2a9050f8ea56b2f8c109243326fb842d684027616843e7
        HEAD_REF docking
        )
 else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v1.84.2
-    SHA512 ea62d03ffc4c8d3dbc6be0076fb93158d464f4f02e88028c2bc64768f72e3117297854816bb7a776bd750c003013fe1d2871a1b505d04dd0922dfb2f214dd0a3
+    REF v1.85
+    SHA512 830ff36681a661d77754fb7818bb13cc63da58a293d343a8d6847a586f00c6e0bfc3ffe51cdf882849e5083d4ddca52cdbdc1b3abc9b794a96f89ae7628f1fc2
     HEAD_REF master
     )
 endif()
@@ -40,6 +40,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     opengl3-binding             IMGUI_BUILD_OPENGL3_BINDING
     osx-binding                 IMGUI_BUILD_OSX_BINDING
     sdl2-binding                IMGUI_BUILD_SDL2_BINDING
+    sdl2-renderer-binding       IMGUI_BUILD_SDL2_RENDERER_BINDING
     vulkan-binding              IMGUI_BUILD_VULKAN_BINDING
     win32-binding               IMGUI_BUILD_WIN32_BINDING
     freetype                    IMGUI_FREETYPE

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -60,9 +60,8 @@ if ("libigl-imgui" IN_LIST FEATURES)
     file(INSTALL ${IMGUI_FONTS_DROID_SANS_H} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
@@ -71,7 +70,7 @@ vcpkg_configure_cmake(
         IMGUI_COPY_MARMALADE_BINDING
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 if ("freetype" IN_LIST FEATURES)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/imconfig.h" "//#define IMGUI_ENABLE_FREETYPE" "#define IMGUI_ENABLE_FREETYPE")
@@ -81,6 +80,6 @@ if ("wchar32" IN_LIST FEATURES)
 endif()
 
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.84.2",
-  "port-version": 1,
+  "version": "1.85",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "features": {
@@ -64,6 +63,12 @@
     },
     "sdl2-binding": {
       "description": "Make available SDL2 binding",
+      "dependencies": [
+        "sdl2"
+      ]
+    },
+    "sdl2-renderer-binding": {
+      "description": "Make available SDL2 Renderer binding",
       "dependencies": [
         "sdl2"
       ]

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -3,6 +3,16 @@
   "version": "1.85",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "allegro5-binding": {
       "description": "Make available Allegro5 binding",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2785,8 +2785,8 @@
       "port-version": 1
     },
     "imgui": {
-      "baseline": "1.84.2",
-      "port-version": 1
+      "baseline": "1.85",
+      "port-version": 0
     },
     "imgui-sfml": {
       "baseline": "2.1",

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "08f81edd52316c769c3b9c3505ee82d123269c40",
+      "version": "1.85",
+      "port-version": 0
+    },
+    {
       "git-tree": "0d0f402c97029e9c2021ca776e2bebc645cc5ecc",
       "version": "1.84.2",
       "port-version": 1

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "08f81edd52316c769c3b9c3505ee82d123269c40",
+      "git-tree": "9ae62261d966705924645bc3a057fe748c24d290",
       "version": "1.85",
       "port-version": 0
     },


### PR DESCRIPTION
Update the imgui port from 1.84.2 to 1.85. They added a new renderer backend for upcoming SDL 2.0.18. I added the corresponding feature, but it won't build until the SDL 2.0.18 is out.

Changelog : https://github.com/ocornut/imgui/releases/tag/v1.85
