### PR TITLE
[libdatachannel] Fix LibDataChannel Broken SRTP Feature

### DIFF
--- a/ports/libdatachannel/0002-fix-for-srtp.patch
+++ b/ports/libdatachannel/0002-fix-for-srtp.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 45f3e40..0c2ef37 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -268,18 +268,11 @@ else()
+ 	target_compile_definitions(datachannel PUBLIC RTC_ENABLE_MEDIA=1)
+ 	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_MEDIA=1)
+ 	if(USE_SYSTEM_SRTP)
+-		find_package(SRTP REQUIRED)
+-		if(NOT TARGET SRTP::SRTP)
+-			add_library(SRTP::SRTP UNKNOWN IMPORTED)
+-			set_target_properties(SRTP::SRTP PROPERTIES
+-				INTERFACE_INCLUDE_DIRECTORIES ${SRTP_INCLUDE_DIRS}
+-				IMPORTED_LINK_INTERFACE_LANGUAGES C
+-				IMPORTED_LOCATION ${SRTP_LIBRARIES})
+-		endif()
++		find_package(libsrtp CONFIG REQUIRED)
+ 		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_SRTP=1)
+ 		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_SRTP=1)
+-		target_link_libraries(datachannel PRIVATE SRTP::SRTP)
+-		target_link_libraries(datachannel-static PRIVATE SRTP::SRTP)
++		target_link_libraries(datachannel PRIVATE LibSRTP::srtp2)
++		target_link_libraries(datachannel-static PRIVATE LibSRTP::srtp2)
+ 	else()
+ 		add_subdirectory(deps/libsrtp EXCLUDE_FROM_ALL)
+ 		target_compile_definitions(datachannel PRIVATE RTC_SYSTEM_SRTP=0)

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         0001-fix-for-vcpkg.patch
+        0002-fix-for-srtp.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -36,6 +37,11 @@ include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(OpenSSL)
 find_dependency(libjuice)
+
+if(NOT ${NO_MEDIA})
+    find_dependency(libsrtp)
+endif()
+
 ${DATACHANNEL_CONFIG}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatachannel",
   "version-semver": "0.15.1",
+  "port-version": 1,
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3310,7 +3310,7 @@
     },
     "libdatachannel": {
       "baseline": "0.15.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libdatrie": {
       "baseline": "0.2.10",

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e89792f13a7257bcee941582faa7cce970fd8bf3",
+      "version-semver": "0.15.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "eb99868eb60c37127a98ff943da771edb8002a29",
       "version-semver": "0.15.1",
       "port-version": 0


### PR DESCRIPTION
# Depends on #20720 

**Describe the pull request**

This issue updates the `libdatachannel` port to support the changes to `libsrtp` found in the following pull request: #20720

- #### What does your PR fix?  
  Fixes #20721

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
