### PR TITLE
[google-cloud-cpp] fix backwards compatibility package files

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -63,8 +63,8 @@ foreach(package
         pubsub_client
         spanner_client
         storage_client)
-    set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
-    if(NOT IS_DIRECTORY "${config_path}")
+    set(config_path "lib/cmake/${package}")
+    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()
     endif()
     vcpkg_cmake_config_fixup(PACKAGE_NAME "${package}"

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "1.32.1",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2478,7 +2478,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.32.1",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "793c4f8aafbed21274611812020a3a4c01517fc2",
+      "version": "1.32.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "42240e5f4653d8ce17158c706e232de8a57a4c6e",
       "version": "1.32.1",
       "port-version": 0


### PR DESCRIPTION
Fixes a bug in the `google-cloud-cpp` portfile, I introduced this bug in #20521.

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
