### PR TITLE
[ci.baseline.txt] Baseline 20211012.1

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1593,7 +1593,6 @@ vxl:x64-windows-static = skip
 vxl:x64-windows-static-md=skip
 vxl:x86-windows        = skip
 wampcc:arm64-windows=fail
-wildmidi:x64-osx=fail
 wincrypt:x64-linux=fail
 wincrypt:x64-osx=fail
 winpcap:arm64-windows      = skip


### PR DESCRIPTION
Updates:
- CI test for `wildmidi` passed for `x64-osx` on 2021-10-12.