### PR TITLE
[vcpkg baseline][gstreamer] Disable feature pango

### DIFF
--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -147,6 +147,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-base:introspection=disabled
         -Dgst-plugins-base:nls=disabled
         -Dgst-plugins-base:orc=disabled
+        -Dgst-plugins-base:pango=disabled
         # gst-plugins-good
         -Dgst-plugins-good:default_library=${LIBRARY_LINKAGE}
         -Dgst-plugins-good:qt5=disabled

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gstreamer",
   "version": "1.19.2",
+  "port-version": 1,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2558,7 +2558,7 @@
     },
     "gstreamer": {
       "baseline": "1.19.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gtest": {
       "baseline": "1.11.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e1e058b933a63ff71eeaa2a7a59fa713d0ba51b",
+      "version": "1.19.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "25482bf1d9dd85257c13e394b45745f77a29bf51",
       "version": "1.19.2",
       "port-version": 0


### PR DESCRIPTION
Fix baseline issue:
```
ninja: error: 'D:/installed/x86-windows/debug/lib/harfbuzzlibd.lib', needed by 'subprojects/gst-plugins-base/ext/pango/gstpango.dll', missing and no known rule to make it
```
This is because gstreamer automatically detects the dependency pango and active the feature pango, and pango relies on the internal harfbuzz.
```
gst-plugins-base| Run-time dependency pangocairo found: YES 1.48.4
```

Disable this feature now.