### PR TITLE
[libwebsockets] remove restriction for arm platform 

### DIFF
--- a/ports/libwebsockets/portfile.cmake
+++ b/ports/libwebsockets/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
+vcpkg_fail_port_install(ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libwebsockets",
   "version-semver": "4.2.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://github.com/warmcat/libwebsockets",
-  "supports": "!(arm | uwp)",
+  "supports": "!uwp ",
   "dependencies": [
     "libuv",
     "openssl",

--- a/ports/libwebsockets/vcpkg.json
+++ b/ports/libwebsockets/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "Libwebsockets is a lightweight pure C library built to use minimal CPU and memory resources, and provide fast throughput in both directions as client or server.",
   "homepage": "https://github.com/warmcat/libwebsockets",
-  "supports": "!uwp ",
+  "supports": "!uwp",
   "dependencies": [
     "libuv",
     "openssl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3958,7 +3958,7 @@
     },
     "libwebsockets": {
       "baseline": "4.2.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libxdiff": {
       "baseline": "0.23",

--- a/versions/l-/libwebsockets.json
+++ b/versions/l-/libwebsockets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea372a08d75d1a3a7c37a99b1daf9e85ba017ccf",
+      "version-semver": "4.2.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "30615e7ce9a1ce09d473a05260da695fb0ee56d3",
       "version-semver": "4.2.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20736

Currently,the libwebsocket port is marked as not supporting arm platform, changed to "supports": "!uwp" and vcpkg_fail_port_install(ON_TARGET "uwp").

Note: no feature need to test