### PR TITLE
[soundtouch] switch download to Codeberg

### DIFF
--- a/ports/soundtouch/portfile.cmake
+++ b/ports/soundtouch/portfile.cmake
@@ -1,11 +1,11 @@
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
-vcpkg_from_gitlab(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    GITLAB_URL https://gitlab.com
+    GITHUB_HOST https://codeberg.org
     REPO soundtouch/soundtouch
     REF 2.3.1
-    SHA512 1eea5c06dc5af633b5c16902c6a951593190daf75bd6aa12e00c745080f9363e9c45ab52ddc434bd905e4195b306cc38c9143e813430c15c19a275ae1a82df24
+    SHA512 c9d110b06cafb79968c94c4d206360b9ea9673d63eaf1470b097a39acf18b5b9cd53759f2656ff8963c6eee6a36fecdf1ea9aa7dc014fbf8bbee0dcfb8e4e438
     HEAD_REF master
 )
 

--- a/ports/soundtouch/vcpkg.json
+++ b/ports/soundtouch/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "soundtouch",
   "version": "2.3.1",
+  "port-version": 1,
   "description": "SoundTouch is an open-source audio processing library for changing the Tempo, Pitch and Playback Rates of audio streams or audio files.",
   "homepage": "https://www.surina.net/soundtouch",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6278,7 +6278,7 @@
     },
     "soundtouch": {
       "baseline": "2.3.1",
-      "port-version": 0
+      "port-version": 1
     },
     "soxr": {
       "baseline": "0.1.3",

--- a/versions/s-/soundtouch.json
+++ b/versions/s-/soundtouch.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a91341e5eb80526c64b263e5b10e0a6c800daa7e",
+      "version": "2.3.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "8b6b644eb3ae55d7e56413e9cd88ca5ccc814c33",
       "version": "2.3.1",
       "port-version": 0


### PR DESCRIPTION
https://gitlab.com/soundtouch/
has been banned from GitLab.com without explanation.
The maintainer moved the repository to
https://codeberg.org/soundtouch/soundtouch/

**Describe the pull request**

- #### What does your PR fix?  
  broken download

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
