### PR TITLE
[directxtex, directxtk, directxtk12] port updates for October 2021 releases

### DIFF
--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF sept2021
-    SHA512 5fe5ed64fd58d9b881b186d3ca0fcac7980afc214eb219f842607d4b868b14c1411613a46d74d3cd9ab242d533dfa0ac8c181d083391c665a4577e4c3b931100
+    REF oct2021
+    SHA512 3fc1f8267a4708babe91e94f2062cd9d475b3682273e5c4f704cdb6093a5aae269cf573ad75fdd3dce59a6a79e6892a4cf5630a3160257e542edde9eb9dbb51a
     HEAD_REF master
 )
 
@@ -49,9 +49,8 @@ else()
   set(EXTRA_OPTIONS -DBUILD_TOOLS=ON)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         ${FEATURE_OPTIONS}
         ${EXTRA_OPTIONS}
@@ -59,8 +58,8 @@ vcpkg_configure_cmake(
         -DBUILD_DX11=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -25,11 +25,11 @@ if("openexr" IN_LIST FEATURES)
         SHA512 fbf5a330961f3ac80e4425e8451e9a696240cd89fabca744a19f1f110ae188bae7d8eb5b058aaf66015066d919d4f581b14494d78d280147b23355d8a32745b9
     )
 
-    file(COPY ${DIRECTXTEX_EXR_HEADER} DESTINATION ${SOURCE_PATH}/DirectXTex)
-    file(COPY ${DIRECTXTEX_EXR_SOURCE} DESTINATION ${SOURCE_PATH}/DirectXTex)
-    file(RENAME ${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.h ${SOURCE_PATH}/DirectXTex/DirectXTexEXR.h)
-    file(RENAME ${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.cpp ${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp)
-    vcpkg_apply_patches(SOURCE_PATH ${SOURCE_PATH} PATCHES enable_openexr_support.patch)
+    file(COPY ${DIRECTXTEX_EXR_HEADER} DESTINATION "${SOURCE_PATH}/DirectXTex")
+    file(COPY ${DIRECTXTEX_EXR_SOURCE} DESTINATION "${SOURCE_PATH}/DirectXTex")
+    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.h" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.h")
+    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.cpp" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp")
+    vcpkg_apply_patches(SOURCE_PATH "${SOURCE_PATH}" PATCHES enable_openexr_support.patch)
 endif()
 
 vcpkg_check_features(
@@ -50,7 +50,7 @@ else()
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         ${EXTRA_OPTIONS}
@@ -89,21 +89,21 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXASSEMBLE_EXE}
     ${TEXCONV_EXE}
     ${TEXDIAG_EXE}
-    DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtex/)
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe)
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 
   vcpkg_copy_tools(
         TOOL_NAMES texassemble texconv texdiag
-        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake"
     )
 
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-string": "sept2021",
+  "version-string": "oct2021",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",
@@ -8,7 +8,15 @@
   "supports": "windows | linux",
   "dependencies": [
     "directx-headers",
-    "directxmath"
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "dx12": {

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -25,7 +25,7 @@ else()
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
@@ -52,20 +52,20 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   file(INSTALL
     ${MAKESPRITEFONT_EXE}
     ${XWBTOOL_EXE}
-    DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 
   vcpkg_copy_tools(
         TOOL_NAMES XWBTool
-        SEARCH_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake
+        SEARCH_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/CMake"
     )
 
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF sept2021
-    SHA512 57fb4cf54b09abee87ff2471c1b504b071a9d3229a09d01d5de58fa3e8bfc956262f21ace88cf05b13f4ff4184b2f7c3b018f9b95d0cac55825c4e3c6549ee89
+    REF oct2021
+    SHA512 5203ca6fe479359615e9d775d3e378669d1fbbb828915ed6b475d58e85f597cbbdbe23425e3c77df33291a806a3865131e7c1d1001ec92f16747958f3cf251bf
     HEAD_REF master
 )
 
@@ -24,28 +24,27 @@ else()
   set(EXTRA_OPTIONS -DBUILD_TOOLS=ON)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS ${FEATURE_OPTIONS} ${EXTRA_OPTIONS}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/sept2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-sept2021.exe"
-    SHA512 a22ec8e7d283585574a5aec82c937c2844e89e66ded01fea92bb278beb7ff32c8070fa3016192029ed8c106db7ef0356f867521a2603a4de7c085cd8db693d0a
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/oct2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-oct2021.exe"
+    SHA512 abff446bfd4cbddbca45816ec3a2230e52d9afb81c100966e4bce7e52a6e02620fd8cdcb416943090564885f63d33c4a246f43ff585c8f5686c2c9877ec50698
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/sept2021/XWBTool.exe"
-    FILENAME "xwbtool-sept2021.exe"
-    SHA512 40f33af95bfdaf60a41564dc347d51768774ad7caa8529046e3f87256e80e165aa124b21193d0ffa1e94644343006d6de01807df317dfdf13377a31275b973ef
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/oct2021/XWBTool.exe"
+    FILENAME "xwbtool-oct2021.exe"
+    SHA512 fda62e06fb9998c41795c6be42f00a1048dcae302b20437f2a39350215789f77acfc77c0f1ebbc5bedeb986229c94f35bd1a03be37cdf4fcf4c007110f7efaa4
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -55,8 +54,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe)
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,13 +1,21 @@
 {
   "name": "directxtk",
-  "version-string": "sept2021",
+  "version-string": "oct2021",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
   "license": "MIT",
   "supports": "windows",
   "dependencies": [
-    "directxmath"
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "xaudio2-8": {

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,33 +5,32 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF sept2021
-    SHA512 bb8a8a81381a6638e33cefc0c058126843df79cf84fd9a248606e965048ba6faae23e8167eb91dd6b8e9a11a788b188067877ef26852c6530ef6fc3c50b221b4
+    REF oct2021
+    SHA512 b5b6b7d42967463bf941b41c9407417068761000344506b720e038f82b3a1aa6f44893695b2391075495d6a63eeb1d80cb011ed87e8f54430de3a77baa8cb570
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS -DBUILD_XAUDIO_WIN10=ON -DBUILD_DXIL_SHADERS=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/sept2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-sept2021.exe"
-    SHA512 a22ec8e7d283585574a5aec82c937c2844e89e66ded01fea92bb278beb7ff32c8070fa3016192029ed8c106db7ef0356f867521a2603a4de7c085cd8db693d0a
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/oct2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-oct2021.exe"
+    SHA512 abff446bfd4cbddbca45816ec3a2230e52d9afb81c100966e4bce7e52a6e02620fd8cdcb416943090564885f63d33c4a246f43ff585c8f5686c2c9877ec50698
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/sept2021/XWBTool.exe"
-    FILENAME "xwbtool-sept2021.exe"
-    SHA512 40f33af95bfdaf60a41564dc347d51768774ad7caa8529046e3f87256e80e165aa124b21193d0ffa1e94644343006d6de01807df317dfdf13377a31275b973ef
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/oct2021/XWBTool.exe"
+    FILENAME "xwbtool-oct2021.exe"
+    SHA512 fda62e06fb9998c41795c6be42f00a1048dcae302b20437f2a39350215789f77acfc77c0f1ebbc5bedeb986229c94f35bd1a03be37cdf4fcf4c007110f7efaa4
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -41,8 +40,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk12/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS -DBUILD_XAUDIO_WIN10=ON -DBUILD_DXIL_SHADERS=ON
 )
 
@@ -38,12 +38,12 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   file(INSTALL
     ${MAKESPRITEFONT_EXE}
     ${XWBTOOL_EXE}
-    DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxtk12/)
+    DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe)
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-oct2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe)
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-string": "sept2021",
+  "version-string": "oct2021",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -8,6 +8,14 @@
   "supports": "windows",
   "dependencies": [
     "directx-headers",
-    "directxmath"
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1801,15 +1801,15 @@
       "port-version": 4
     },
     "directxtex": {
-      "baseline": "sept2021",
+      "baseline": "oct2021",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "sept2021",
+      "baseline": "oct2021",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "sept2021",
+      "baseline": "oct2021",
       "port-version": 0
     },
     "dirent": {

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a3a91e8182d61e97581011aefdf6780a30928cc",
+      "version-string": "oct2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "1dea5cbc125f2e87484afcd19c59b9c2955ce12d",
       "version-string": "sept2021",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a3a91e8182d61e97581011aefdf6780a30928cc",
+      "git-tree": "02cba4df9bb3dab0d73b32a41dcfaa624ef53044",
       "version-string": "oct2021",
       "port-version": 0
     },

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "304527074e0babd47049899bfbea4e0e4c45cc82",
+      "git-tree": "e6356a5599a11c8670068358b150033e9da82b55",
       "version-string": "oct2021",
       "port-version": 0
     },

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "304527074e0babd47049899bfbea4e0e4c45cc82",
+      "version-string": "oct2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "8fa980b193db947e6a803ed413e87df23ee315c7",
       "version-string": "sept2021",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a9f952d640bffed7a36f5e3b87922e2386dd5e67",
+      "git-tree": "c3c3a04e2a9b6d1b85341e3d2dcc09d5a04df160",
       "version-string": "oct2021",
       "port-version": 0
     },

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9f952d640bffed7a36f5e3b87922e2386dd5e67",
+      "version-string": "oct2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "22e26ef3a716ae717ef2e972ce47ea6436d7025b",
       "version-string": "sept2021",
       "port-version": 0


### PR DESCRIPTION
* _DirectX Tool Kit for DX11/DX12_ have new October 2021 releases with new features

* _DirectXTex_ was only updated for CMake external shaders needed for new vcpkg build system (that's why it still refers to the previous built EXEs)

* Converted directxtex, directxtk, and directxtk12 ports to use cpkg-cmake