### PR TITLE
[gdal] Update to 3.3.2

### DIFF
--- a/ports/gdal/0001-Fix-debug-crt-flags.patch
+++ b/ports/gdal/0001-Fix-debug-crt-flags.patch
@@ -1,7 +1,7 @@
-diff --git a/nmake.opt b/nmake.opt
-index 468d2ba1a..e75a081f7 100644
---- a/nmake.opt
-+++ b/nmake.opt
+diff --git a/gdal/nmake.opt b/gdal/nmake.opt
+index 8253ae2..9456b79 100644
+--- a/gdal/nmake.opt
++++ b/gdal/nmake.opt
 @@ -148,16 +148,26 @@ GDAL_PDB = $(GDAL_ROOT)\gdal$(VERSION)$(POSTFIX).pdb
  !ENDIF
  

--- a/ports/gdal/0002-Fix-build.patch
+++ b/ports/gdal/0002-Fix-build.patch
@@ -1,7 +1,7 @@
-diff --git a/makefile.vc b/makefile.vc
+diff --git a/gdal/makefile.vc b/gdal/makefile.vc
 index 9e0bd44..8559f79 100644
---- a/makefile.vc
-+++ b/makefile.vc
+--- a/gdal/makefile.vc
++++ b/gdal/makefile.vc
 @@ -84,7 +84,7 @@ staticlib:	$(LIB_DEPENDS)
  	call <<clean_main_build_output.bat
  $(CLEAN_MAIN_BUILD_OUTPUT_CMDS)

--- a/ports/gdal/0004-Fix-cfitsio.patch
+++ b/ports/gdal/0004-Fix-cfitsio.patch
@@ -1,7 +1,7 @@
-diff --git a/frmts/fits/fitsdataset.cpp b/frmts/fits/fitsdataset.cpp
-index c3f4a4e1f..eb29a92b1 100644
---- a/frmts/fits/fitsdataset.cpp
-+++ b/frmts/fits/fitsdataset.cpp
+diff --git a/gdal/frmts/fits/fitsdataset.cpp b/gdal/frmts/fits/fitsdataset.cpp
+index d6587d3..f913b08 100644
+--- a/gdal/frmts/fits/fitsdataset.cpp
++++ b/gdal/frmts/fits/fitsdataset.cpp
 @@ -38,7 +38,7 @@
  #include "ogrsf_frmts.h"
  

--- a/ports/gdal/0005-Fix-configure.patch
+++ b/ports/gdal/0005-Fix-configure.patch
@@ -1,7 +1,7 @@
-diff --git a/configure.ac b/configure.ac
-index bd85e06..b88676a 100644
---- a/configure.ac
-+++ b/configure.ac
+diff --git a/gdal/configure.ac b/gdal/configure.ac
+index 1f88370..1098b39 100644
+--- a/gdal/configure.ac
++++ b/gdal/configure.ac
 @@ -45,6 +45,8 @@ dnl Compute the canonical host-system (the system we are building for)
  dnl type variable $host
  AC_CANONICAL_HOST
@@ -11,7 +11,7 @@ index bd85e06..b88676a 100644
  dnl Enable as much warnings as possible
  AX_CFLAGS_WARN_ALL(C_WFLAGS)
  AX_CXXFLAGS_WARN_ALL(CXX_WFLAGS)
-@@ -1274,12 +1276,15 @@ AC_MSG_CHECKING([for libtiff])
+@@ -1343,12 +1345,15 @@ AC_MSG_CHECKING([for libtiff])
  
  if test "x${with_libtiff}" = "xyes" -o "x${with_libtiff}" = "x" ; then
  
@@ -30,7 +30,7 @@ index bd85e06..b88676a 100644
    else
      AC_MSG_RESULT([using internal TIFF code.])
    fi
-@@ -1333,22 +1338,28 @@ AC_ARG_WITH(curl,
+@@ -1402,22 +1407,28 @@ AC_ARG_WITH(curl,
  dnl Clear some cache variables
  unset ac_cv_path_LIBCURL
  
@@ -62,7 +62,7 @@ index bd85e06..b88676a 100644
  
  fi
  
-@@ -1362,7 +1373,9 @@ dnl Proj depends on it so it must appear before.
+@@ -1431,7 +1442,9 @@ dnl Proj depends on it so it must appear before.
  dnl ---------------------------------------------------------------------------
  
  SQLITE3_REQ_VERSION="3.0.0"
@@ -73,7 +73,7 @@ index bd85e06..b88676a 100644
  
  if test "$HAVE_SQLITE3" = "yes"; then
      LIBS="$SQLITE3_LDFLAGS $LIBS"
-@@ -1570,6 +1583,19 @@ dnl ---------------------------------------------------------------------------
+@@ -1639,6 +1652,19 @@ dnl ---------------------------------------------------------------------------
  AC_ARG_WITH(liblzma,[  --with-liblzma[=ARG]       Include liblzma support (ARG=yes/no)],,)
  
  if test "$with_liblzma" = "yes" ; then
@@ -93,7 +93,7 @@ index bd85e06..b88676a 100644
    AC_CHECK_LIB(lzma,lzma_code,LIBLZMA_SETTING=yes,LIBLZMA_SETTING=no,)
    AC_CHECK_HEADERS(lzma.h)
  
-@@ -1592,6 +1618,19 @@ dnl ---------------------------------------------------------------------------
+@@ -1661,6 +1687,19 @@ dnl ---------------------------------------------------------------------------
  AC_ARG_WITH(zstd,[  --with-zstd[=ARG]       Include zstd support (ARG=yes/no/installation_prefix)],,)
  
  if test "$with_zstd" = "" -o "$with_zstd" = "yes" ; then
@@ -113,7 +113,7 @@ index bd85e06..b88676a 100644
    AC_CHECK_LIB(zstd,ZSTD_decompressStream,ZSTD_SETTING=yes,ZSTD_SETTING=no,)
  
    if test "$ZSTD_SETTING" = "yes" ; then
-@@ -1893,6 +1932,12 @@ else
+@@ -1962,6 +2001,12 @@ else
      SAVED_LIBS="${LIBS}"
      LIBS="${PG_LIB}"
      AC_CHECK_LIB(pq,PQconnectdb,HAVE_PG=yes,HAVE_PG=no)
@@ -126,7 +126,7 @@ index bd85e06..b88676a 100644
      LIBS="${SAVED_LIBS}"
      if test "${HAVE_PG}" = "yes" ; then
        LIBS="${PG_LIB} ${LIBS}"
-@@ -2253,6 +2298,15 @@ AC_ARG_WITH(geotiff,[  --with-geotiff=ARG    Libgeotiff library to use (ARG=inte
+@@ -2322,6 +2367,15 @@ AC_ARG_WITH(geotiff,[  --with-geotiff=ARG    Libgeotiff library to use (ARG=inte
  
  if test "$with_geotiff" = "yes" -o "$with_geotiff" = "" ; then
  
@@ -142,7 +142,7 @@ index bd85e06..b88676a 100644
    if test "$TIFF_SETTING" = "internal" ; then
      GEOTIFF_SETTING=internal
    else
-@@ -3002,7 +3056,7 @@ elif test "$with_hdf5" = "yes" -o "$with_hdf5" = "" ; then
+@@ -3005,7 +3059,7 @@ elif test "$with_hdf5" = "yes" -o "$with_hdf5" = "" ; then
      # Test that the package found is for the right architecture
      saved_LIBS="$LIBS"
      LIBS="$HDF5_LIBS"
@@ -151,7 +151,7 @@ index bd85e06..b88676a 100644
      LIBS="$saved_LIBS"
  
      if test "$HAVE_HDF5" = "yes"; then
-@@ -3132,6 +3186,24 @@ if test "$with_netcdf" = "no" ; then
+@@ -3135,6 +3189,24 @@ if test "$with_netcdf" = "no" ; then
  
    echo "netCDF support disabled."
  
@@ -176,7 +176,7 @@ index bd85e06..b88676a 100644
  else
  
    dnl find nc-config location
-@@ -3352,6 +3424,21 @@ if test "$with_openjpeg" = "no" ; then
+@@ -3355,6 +3427,21 @@ if test "$with_openjpeg" = "no" ; then
  
    AC_MSG_NOTICE([OpenJPEG (JPEG2000) support disabled.])
  
@@ -198,7 +198,7 @@ index bd85e06..b88676a 100644
  else
  
    PKG_PROG_PKG_CONFIG([0.21])
-@@ -4043,7 +4130,9 @@ dnl ---------------------------------------------------------------------------
+@@ -4046,7 +4133,9 @@ dnl ---------------------------------------------------------------------------
  
  dnl Expat 1.95.0 released in 2000-09-28
  EXPAT_REQ_VERSION="1.95.0"
@@ -209,7 +209,7 @@ index bd85e06..b88676a 100644
  
  if test "$HAVE_EXPAT" = "yes"; then
      LIBS="$EXPAT_LDFLAGS $LIBS"
-@@ -4066,7 +4155,13 @@ dnl Check for Google libkml support.
+@@ -4069,7 +4158,13 @@ dnl Check for Google libkml support.
  dnl ---------------------------------------------------------------------------
  
  LIBKML_REQ_VERSION="1.3.0"
@@ -223,7 +223,7 @@ index bd85e06..b88676a 100644
  
  if test "$HAVE_LIBKML" = "yes"; then
      LIBS="$LIBKML_LDFLAGS $LIBS"
-@@ -4244,8 +4339,8 @@ else
+@@ -4252,8 +4347,8 @@ else
        dnl Add curl to LIBS; it might be local to DODS or generally installed
        if test -x $DODS_BIN/curl-config; then
            LIBS="$LIBS  `$DODS_BIN/curl-config --libs`"
@@ -234,7 +234,7 @@ index bd85e06..b88676a 100644
        else
            AC_MSG_ERROR([You gave a dods root, but I can't find curl!])
        fi
-@@ -4287,7 +4382,7 @@ if test "x$with_xml2" = "xyes" -o "x$with_xml2" = "x" ; then
+@@ -4295,7 +4390,7 @@ if test "x$with_xml2" = "xyes" -o "x$with_xml2" = "x" ; then
    if test "${HAVE_LIBXML2}" = "yes"; then
      SAVED_LIBS="${LIBS}"
      LIBS="${LIBXML2_LIBS}"
@@ -243,7 +243,7 @@ index bd85e06..b88676a 100644
      LIBS="${SAVED_LIBS}"
    fi
  
-@@ -4536,6 +4631,22 @@ WEBP_SETTING=no
+@@ -4509,6 +4604,22 @@ WEBP_SETTING=no
  
  if test "$with_webp" = "yes" -o "$with_webp" = "" ; then
  
@@ -266,16 +266,16 @@ index bd85e06..b88676a 100644
    AC_CHECK_LIB(webp,WebPDecodeRGB,WEBP_SETTING=yes,WEBP_SETTING=no,)
  
    if test "$WEBP_SETTING" = "yes" ; then
-@@ -4567,7 +4678,7 @@ dnl ---------------------------------------------------------------------------
+@@ -4540,7 +4651,7 @@ dnl ---------------------------------------------------------------------------
  dnl Check if geos library is available.
  dnl ---------------------------------------------------------------------------
  
 -GEOS_INIT(3.1.0)
 +PKG_CHECK_MODULES(GEOS,geos >= 3.1.0,HAVE_GEOS=yes,AC_MSG_ERROR([vcpkg geos not found]))
- HAVE_GEOS_RESULT="no"
  if test "${HAVE_GEOS}" = "yes" ; then
- 
-@@ -4812,6 +4923,16 @@ dnl ---------------------------------------------------------------------------
+   AC_MSG_NOTICE([Using C API from GEOS $GEOS_VERSION])
+   STRIP_SYSTEM_LIBRARY_PATHS("${GEOS_LIBS}")
+@@ -4779,6 +4890,16 @@ dnl ---------------------------------------------------------------------------
  
  AC_ARG_WITH(libjson-c,[  --with-libjson-c[=ARG]       Include libjson-c support (ARG=internal or libjson-c directory)],,)
  
@@ -292,7 +292,7 @@ index bd85e06..b88676a 100644
  if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjson_c" = "yes" ; then
    AC_CHECK_LIB(json-c,json_object_set_serializer,LIBJSONC_SETTING=external,LIBJSONC_SETTING=internal,)
  elif test "$with_libjson_c" = "internal" ; then
-@@ -4840,6 +4961,8 @@ else
+@@ -4807,6 +4928,8 @@ else
      AC_MSG_RESULT([using internal libjson-c code])
  fi
  

--- a/ports/gdal/0006-Fix-mingw-dllexport.patch
+++ b/ports/gdal/0006-Fix-mingw-dllexport.patch
@@ -1,7 +1,7 @@
-diff --git a/port/cpl_port.h b/port/cpl_port.h
-index 9e3ebbb..130af04 100644
---- a/port/cpl_port.h
-+++ b/port/cpl_port.h
+diff --git a/gdal/port/cpl_port.h b/gdal/port/cpl_port.h
+index 98805cf..a6a1846 100644
+--- a/gdal/port/cpl_port.h
++++ b/gdal/port/cpl_port.h
 @@ -343,7 +343,7 @@ typedef unsigned int  GUIntptr_t;
  #endif
  

--- a/ports/gdal/0007-Control-tools.patch
+++ b/ports/gdal/0007-Control-tools.patch
@@ -1,8 +1,8 @@
-diff --git a/GDALmake.opt.in b/GDALmake.opt.in
-index 07955b2..0d79ac3 100644
---- a/GDALmake.opt.in
-+++ b/GDALmake.opt.in
-@@ -660,3 +660,6 @@ O_OBJ =	$(foreach file,$(OBJ),../o/$(file))
+diff --git a/gdal/GDALmake.opt.in b/gdal/GDALmake.opt.in
+index e8d2b05..1f19a4b 100644
+--- a/gdal/GDALmake.opt.in
++++ b/gdal/GDALmake.opt.in
+@@ -662,3 +662,6 @@ O_OBJ =	$(foreach file,$(OBJ),../o/$(file))
  
  %-clean:
  	$(MAKE) -C $* clean
@@ -10,10 +10,10 @@ index 07955b2..0d79ac3 100644
 +
 +BUILD_TOOLS = @BUILD_TOOLS@
 \ No newline at end of file
-diff --git a/apps/GNUmakefile b/apps/GNUmakefile
+diff --git a/gdal/apps/GNUmakefile b/gdal/apps/GNUmakefile
 index 9624cf7..f91403d 100644
---- a/apps/GNUmakefile
-+++ b/apps/GNUmakefile
+--- a/gdal/apps/GNUmakefile
++++ b/gdal/apps/GNUmakefile
 @@ -43,6 +43,11 @@ NON_DEFAULT_LIST = 	multireadtest$(EXE) dumpoverviews$(EXE) \
  	gdaltorture$(EXE) gdal2ogr$(EXE) test_ogrsf$(EXE) \
  	gdalasyncread$(EXE) testreprojmulti$(EXE)
@@ -26,10 +26,10 @@ index 9624cf7..f91403d 100644
  default:	gdal-config-inst gdal-config $(BIN_LIST)
  
  all: default $(NON_DEFAULT_LIST)
-diff --git a/apps/makefile.vc b/apps/makefile.vc
+diff --git a/gdal/apps/makefile.vc b/gdal/apps/makefile.vc
 index 6e1fc9b..66f9b29 100644
---- a/apps/makefile.vc
-+++ b/apps/makefile.vc
+--- a/gdal/apps/makefile.vc
++++ b/gdal/apps/makefile.vc
 @@ -20,6 +20,7 @@ GNM_PROGRAMS =	gnmmanage.exe gnmanalyse.exe
  !ENDIF
  
@@ -60,11 +60,11 @@ index 6e1fc9b..66f9b29 100644
 +install:
 +!ENDIF
 \ No newline at end of file
-diff --git a/configure.ac b/configure.ac
-index b88676a..0a46a9c 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -6150,6 +6150,16 @@ case "${host_os}" in
+diff --git a/gdal/configure.ac b/gdal/configure.ac
+index 1098b39..e4d985e 100644
+--- a/gdal/configure.ac
++++ b/gdal/configure.ac
+@@ -6165,6 +6165,16 @@ case "${host_os}" in
          ;;
  esac
  

--- a/ports/gdal/0008-Fix-absl-string_view.patch
+++ b/ports/gdal/0008-Fix-absl-string_view.patch
@@ -1,0 +1,13 @@
+diff --git a/gdal/ogr/ogrsf_frmts/flatgeobuf/flatbuffers/base.h b/gdal/ogr/ogrsf_frmts/flatgeobuf/flatbuffers/base.h
+index 9557380..17edcf8 100644
+--- a/gdal/ogr/ogrsf_frmts/flatgeobuf/flatbuffers/base.h
++++ b/gdal/ogr/ogrsf_frmts/flatgeobuf/flatbuffers/base.h
+@@ -213,7 +213,7 @@ namespace flatbuffers {
+       }
+       #define FLATBUFFERS_HAS_STRING_VIEW 1
+     // Check for absl::string_view
+-    #elif __has_include("absl/strings/string_view.h")
++    #elif __has_include("absl/strings/string_view.h") && 0
+       #include "absl/strings/string_view.h"
+       namespace flatbuffers {
+         typedef absl::string_view string_view;

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -6,7 +6,8 @@ set(GDAL_PATCHES
     0004-Fix-cfitsio.patch
     0005-Fix-configure.patch
     0007-Control-tools.patch
-    )
+    0008-Fix-absl-string_view.patch
+)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND GDAL_PATCHES 0006-Fix-mingw-dllexport.patch)
 endif()

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -1,16 +1,5 @@
 vcpkg_fail_port_install(ON_ARCH "arm")
 
-# NOTE: update the version and checksum for new GDAL release
-set(GDAL_VERSION_STR "3.2.2")
-set(GDAL_VERSION_PKG "322")
-set(GDAL_PACKAGE_SUM "ce319e06c78bd076228b3710c127cdbd37c7d6fb23966b47df7287eaffe86a05d4ddcc78494c8bfcaf4db98a71f2ed50a01fb3ca2fe1c10cf0d2e812683c8e53")
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "http://download.osgeo.org/gdal/${GDAL_VERSION_STR}/gdal${GDAL_VERSION_PKG}.zip"
-    FILENAME "gdal${GDAL_VERSION_PKG}.zip"
-    SHA512 ${GDAL_PACKAGE_SUM}
-    )
-
 set(GDAL_PATCHES
     0001-Fix-debug-crt-flags.patch
     0002-Fix-build.patch
@@ -22,11 +11,14 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     list(APPEND GDAL_PATCHES 0006-Fix-mingw-dllexport.patch)
 endif()
 
-vcpkg_extract_source_archive_ex(
-    ARCHIVE "${ARCHIVE}"
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
+    REPO OSGeo/gdal
+    REF 348075f26f8e4c200a34818123beeb4abe53c876 # 3.3.2
+    SHA512 84bd7c74a079c4aa8cbefbbb1c4ab782e74a85d37d4c875a203760939f4f7c9175c40abc5184d8c1c521fd3b37bb90bc7bf046021ade22e510810535e3f61bd2
+    HEAD_REF master
     PATCHES ${GDAL_PATCHES}
-    )
+)
 
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(NATIVE_DATA_DIR "${CURRENT_PACKAGES_DIR}/share/gdal")
@@ -134,7 +126,7 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 
     # Begin build process
     vcpkg_install_nmake(
-        SOURCE_PATH "${SOURCE_PATH}"
+        SOURCE_PATH "${SOURCE_PATH}/gdal"
         TARGET devinstall
         OPTIONS_RELEASE
         "${NMAKE_OPTIONS_REL}"
@@ -191,7 +183,7 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
 
 else()
     # See https://github.com/microsoft/vcpkg/issues/16990
-    file(TOUCH "${SOURCE_PATH}/config.rpath")
+    file(TOUCH "${SOURCE_PATH}/gdal/config.rpath")
 
     set(CONF_OPTS
         --with-hide-internal-symbols=yes
@@ -323,7 +315,7 @@ else()
     endif()
 
     vcpkg_configure_make(
-        SOURCE_PATH "${SOURCE_PATH}"
+        SOURCE_PATH "${SOURCE_PATH}/gdal"
         AUTOCONFIG
         COPY_SOURCE
         OPTIONS
@@ -375,4 +367,4 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_D
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/gdal/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -13,7 +13,7 @@
     "hdf5",
     {
       "name": "json-c",
-      "platform": "!windows"
+      "platform": "!windows | mingw"
     },
     "libgeotiff",
     "libjpeg-turbo",

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdal",
-  "version-semver": "3.2.2",
-  "port-version": 6,
+  "version-semver": "3.3.2",
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "supports": "!arm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2325,8 +2325,8 @@
       "port-version": 1
     },
     "gdal": {
-      "baseline": "3.2.2",
-      "port-version": 6
+      "baseline": "3.3.2",
+      "port-version": 0
     },
     "gdcm": {
       "baseline": "3.0.7",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b4b009943c702bdcd2bf00b3f987ae9783478ebf",
+      "git-tree": "bcc73ebd09ec91402d610074046785d7432f99fa",
       "version-semver": "3.3.2",
       "port-version": 0
     },

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b4b009943c702bdcd2bf00b3f987ae9783478ebf",
+      "version-semver": "3.3.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "15009f5f5d2867c594d8148d79cccbe964432465",
       "version-semver": "3.2.2",
       "port-version": 6


### PR DESCRIPTION
- #### What does your PR fix?  
  - Updates gdal to 3.3.2 (#19861).
  - Switches to github download method which allows HEAD builds.
    Note that this increases download size, due to test data.
  - Prevent abseil dependency/build failure (#17609).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
