### PR TITLE
[aws-lambda-cpp] Update to 0.2.7

### DIFF
--- a/ports/aws-lambda-cpp/portfile.cmake
+++ b/ports/aws-lambda-cpp/portfile.cmake
@@ -3,22 +3,26 @@ vcpkg_fail_port_install(ON_TARGET "Windows" "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO awslabs/aws-lambda-cpp
-    REF 55276cef2efe18fe13457ebf85df53a81d68be59 # v0.2.6
-    SHA512 a865b8c5715e884c0aeb0972d88919084a37b4837ade55d7f4373422c1ffa06a550f6bfe62b6f69b9eb3a352b9a1d4114c72d754bce2d6d3727bebd029fe6631
+    REF 8bcd8a201f9da613581a2748ca737ab09adbdae5 # v0.2.7
+    SHA512 c59310dd839622cfc9ac2a1df5a492e9a6d629b671ed929813dbe51dfe76d4a4e381e78b11b206b66c2bee131a1544c3c8dfc4644981b708b589492763c7ed59
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
 vcpkg_copy_pdbs()
 
+vcpkg_cmake_config_fixup(PACKAGE_NAME aws-lambda-runtime CONFIG_PATH lib/aws-lambda-runtime/cmake)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/aws-lambda-runtime")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/aws-lambda-runtime")
+
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-

--- a/ports/aws-lambda-cpp/vcpkg.json
+++ b/ports/aws-lambda-cpp/vcpkg.json
@@ -1,10 +1,17 @@
 {
   "name": "aws-lambda-cpp",
-  "version-string": "0.2.6",
-  "port-version": 1,
+  "version-string": "0.2.7",
   "description": "C++ Runtime for AWS Lambda.",
   "supports": "linux",
   "dependencies": [
-    "curl"
+    "curl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/a-/aws-lambda-cpp.json
+++ b/versions/a-/aws-lambda-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9c58661b9a838e782997f03ee3af449260ece4f",
+      "version-string": "0.2.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "3e586ea66476a0d9ce91ae630e1966724794ef2f",
       "version-string": "0.2.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -297,8 +297,8 @@
       "port-version": 1
     },
     "aws-lambda-cpp": {
-      "baseline": "0.2.6",
-      "port-version": 1
+      "baseline": "0.2.7",
+      "port-version": 0
     },
     "aws-sdk-cpp": {
       "baseline": "1.9.96",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  - Update aws-lambda-cpp to 0.2.7
  - Replace deprecated cmake functions
  - Fix cmake config file locations so that `find_package(aws-lambda-runtime)` works

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  - No changes here

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  - I think so, yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  - I have run the command and committed the result

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
