### PR TITLE
[soxr] Add features, fix VCRT runtime linkage

### DIFF
--- a/ports/soxr/portfile.cmake
+++ b/ports/soxr/portfile.cmake
@@ -3,16 +3,16 @@ vcpkg_from_sourceforge(
     REPO soxr
     FILENAME "soxr-0.1.3-Source.tar.xz"
     SHA512 f4883ed298d5650399283238aac3dbe78d605b988246bea51fa343d4a8ce5ce97c6e143f6c3f50a3ff81795d9c19e7a07217c586d4020f6ced102aceac46aaa8
-	PATCHES
-		001_initialize-resampler.patch
-		002_disable_warning.patch
-		003_detect_arm_on_windows.patch
+    PATCHES
+        001_initialize-resampler.patch
+        002_disable_warning.patch
+        003_detect_arm_on_windows.patch
 )
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-	    openmp WITH_OPENMP
+        openmp WITH_OPENMP
         lsr-bindings WITH_LSR_BINDINGS
 )
 
@@ -23,12 +23,12 @@ else()
 endif()
 
 vcpkg_cmake_configure(
-	SOURCE_PATH "${SOURCE_PATH}"
-	OPTIONS
-		-DBUILD_TESTS=OFF
-		-DBUILD_EXAMPLES=OFF
-		-DBUILD_SHARED_RUNTIME=${BUILD_SHARED_RUNTIME}
-		${FEATURE_OPTIONS}
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DBUILD_EXAMPLES=OFF
+        -DBUILD_SHARED_RUNTIME=${BUILD_SHARED_RUNTIME}
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/soxr/portfile.cmake
+++ b/ports/soxr/portfile.cmake
@@ -16,11 +16,7 @@ vcpkg_check_features(
         lsr-bindings WITH_LSR_BINDINGS
 )
 
-if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(BUILD_SHARED_RUNTIME ON)
-else()
-    set(BUILD_SHARED_RUNTIME OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" BUILD_SHARED_RUNTIME)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/soxr/portfile.cmake
+++ b/ports/soxr/portfile.cmake
@@ -9,21 +9,33 @@ vcpkg_from_sourceforge(
 		003_detect_arm_on_windows.patch
 )
 
-vcpkg_configure_cmake(
-	SOURCE_PATH ${SOURCE_PATH}
-	PREFER_NINJA
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+	    openmp WITH_OPENMP
+        lsr-bindings WITH_LSR_BINDINGS
+)
+
+if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
+    set(BUILD_SHARED_RUNTIME ON)
+else()
+    set(BUILD_SHARED_RUNTIME OFF)
+endif()
+
+vcpkg_cmake_configure(
+	SOURCE_PATH "${SOURCE_PATH}"
 	OPTIONS
 		-DBUILD_TESTS=OFF
 		-DBUILD_EXAMPLES=OFF
-		-DWITH_OPENMP=OFF
-		-DWITH_LSR_BINDINGS=OFF
+		-DBUILD_SHARED_RUNTIME=${BUILD_SHARED_RUNTIME}
+		${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/soxr RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENCE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/doc)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/doc)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/doc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/doc")

--- a/ports/soxr/vcpkg.json
+++ b/ports/soxr/vcpkg.json
@@ -1,7 +1,21 @@
 {
   "name": "soxr",
-  "version-string": "0.1.3",
-  "port-version": 4,
+  "version": "0.1.3",
+  "port-version": 5,
   "description": "High quality audio resampling",
-  "homepage": "https://sourceforge.net/projects/soxr/"
+  "homepage": "https://sourceforge.net/projects/soxr/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "features": {
+    "lsr-bindings": {
+      "description": "Include a `libsamplerate'-like interface."
+    },
+    "openmp": {
+      "description": "Include OpenMP threading."
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6290,7 +6290,7 @@
     },
     "soxr": {
       "baseline": "0.1.3",
-      "port-version": 4
+      "port-version": 5
     },
     "spaceland": {
       "baseline": "7.8.2",

--- a/versions/s-/soxr.json
+++ b/versions/s-/soxr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "17fd1015c1d054d5f8a1eec6d5966ed3ffd722cd",
+      "git-tree": "0ea0e47df2ab6381e68ffae49c05c4de0a37f665",
       "version": "0.1.3",
       "port-version": 5
     },

--- a/versions/s-/soxr.json
+++ b/versions/s-/soxr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87fd959ef66ac3643be137ac2811aa646bb81db1",
+      "git-tree": "17fd1015c1d054d5f8a1eec6d5966ed3ffd722cd",
       "version": "0.1.3",
       "port-version": 5
     },

--- a/versions/s-/soxr.json
+++ b/versions/s-/soxr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "87fd959ef66ac3643be137ac2811aa646bb81db1",
+      "version": "0.1.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "5719977bf7a0fcc0ac88151327dcddda23648594",
       "version-string": "0.1.3",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This adds two optional features to `soxr` and also correctly sets the VCRT runtime linkage. Both features have been tested on all Windows triplets.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
