### PR TITLE
[cpr] update repository location

### DIFF
--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -15,9 +15,8 @@ vcpkg_from_github(
         ${UWP_PATCH}
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS 
         -DCPR_BUILD_TESTS=OFF
         -DCPR_FORCE_USE_SYSTEM_CURL=ON
@@ -25,10 +24,10 @@ vcpkg_configure_cmake(
         -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/cprConfig.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/lib/cmake/cpr)
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/cpr)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cpr)
 
 vcpkg_copy_pdbs()
 

--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -6,9 +6,9 @@ endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO whoshuu/cpr
-    REF f4622efcb59d84071ae11404ae61bd821c1c344b # v1.6.2
-    SHA512 7835b7613529798b5edaefc99c907bbc7144133a1fac62a2c9af09c8c7a09b2ea1864544c4c0385969ad3dc64806b8d258abbcd39add2004ed8428741286ff20
+    REPO libcpr/cpr
+    REF 1.6.2
+    SHA512 77afd1dc81274aa1d37bf17abaf2614b63802f17fc08bdf8453d96d8fa2bd4b025511db9fadbde51160d7dde31a0363694422d3407ca9cdac3cd79b744a82888
     HEAD_REF master
     PATCHES
         001-cpr-config.patch

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -7,6 +7,14 @@
     {
       "name": "curl",
       "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "cpr",
   "version-semver": "1.6.2",
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
-  "homepage": "https://github.com/whoshuu/cpr",
+  "homepage": "https://github.com/libcpr/cpr",
   "dependencies": [
     {
       "name": "curl",

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cpr",
   "version-semver": "1.6.2",
+  "port-version": 1,
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1586,7 +1586,7 @@
     },
     "cpr": {
       "baseline": "1.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "cpu-features": {
       "baseline": "0.6.0",

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc224c4615958fa1105b29a9d973555fda345de8",
+      "version-semver": "1.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "96762dddaeb7d520833ddc1d47a30f26c35c9f67",
       "version-semver": "1.6.2",
       "port-version": 0


### PR DESCRIPTION
The cpr repository has moved to libcpr/cpr, this updates the location and removes uses of deprecated functions.

- #### What does your PR fix?  
  Updates the location of the cpr repository to libcpr/cpr

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes?

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes