### PR TITLE
[effolkronium-random] Fix the usage

### DIFF
--- a/ports/effolkronium-random/portfile.cmake
+++ b/ports/effolkronium-random/portfile.cmake
@@ -9,11 +9,11 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-		-DRandom_BuildTests=OFF
+        -DRandom_BuildTests=OFF
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(PACKAGE_NAME effolkronium_random CONFIG_PATH cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
 file(INSTALL "${SOURCE_PATH}/LICENSE.MIT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/effolkronium-random/vcpkg.json
+++ b/ports/effolkronium-random/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "effolkronium-random",
   "version": "1.4.0",
+  "port-version": 1,
   "description": "Random with a modern C++ API",
   "homepage": "https://github.com/effolkronium/random",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1958,7 +1958,7 @@
     },
     "effolkronium-random": {
       "baseline": "1.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "efsw": {
       "baseline": "2020-06-08",

--- a/versions/e-/effolkronium-random.json
+++ b/versions/e-/effolkronium-random.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0083b3439b06f6c6e2b5fbd48260cd5b54692bad",
+      "version": "1.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "6f870445e1974665f94fd66bc79c4bec3f33d090",
       "version": "1.4.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20795

  Since upstream use `${PROJECT_NAME})` https://github.com/effolkronium/random/blob/master/CMakeLists.txt#L4 as the prefix 
  name of cmake export files. 

  Pass `PACKAGE_NAME effolkronium_random` in `vcpkg_cmake_config_fixup` to fix the usage.

Note: No feature needs to test.


