### PR TITLE
[geogram] Remove ci.baseline.txt skip.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -341,12 +341,6 @@ gainput:x64-uwp=fail
 gasol:arm64-windows=fail
 gasol:arm-uwp=fail
 gasol:x64-uwp=fail
-geogram:x64-linux=fail
-geogram:x64-osx=fail
-geogram:x64-windows-static-md=fail
-geogram:x64-windows-static=fail
-geogram:x64-windows=fail
-geogram:x86-windows=fail
 geos:arm-uwp=fail
 geos:x64-uwp=fail
 


### PR DESCRIPTION
Victor and I forgot to remove geogram from ci.baseline.txt in https://github.com/microsoft/vcpkg/pull/20778
