### PR TITLE
[bext-sml] Adding new port of boost::sml

### DIFF
--- a/ports/bext-sml/portfile.cmake
+++ b/ports/bext-sml/portfile.cmake
@@ -1,0 +1,15 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO boost-ext/sml
+    REF v1.1.4
+    SHA512 0ded162e5d9d7cc9d8769fd9131d7a5cfc98187c8e9d98393eda9e0804c282e510707de38fe7229d2fe16aea70c9a8e300f14e992fff3ddedd0fa1b6a66ab1ba
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/include/boost/sml.hpp"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/boost"
+)
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/bext-sml/vcpkg.json
+++ b/ports/bext-sml/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "bext-sml",
+  "version": "1.1.4",
+  "description": "Your scalable C++14 one header only State Machine Library with no dependencies",
+  "homepage": "https://github.com/boost-ext/sml"
+}

--- a/versions/b-/bext-sml.json
+++ b/versions/b-/bext-sml.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5e5941cb1ecd7988a9f52c1ace73823a4a20743c",
+      "version": "1.1.4",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -428,6 +428,10 @@
       "baseline": "1.2.0",
       "port-version": 0
     },
+    "bext-sml": {
+      "baseline": "1.1.4",
+      "port-version": 0
+    },
     "bext-ut": {
       "baseline": "1.1.8",
       "port-version": 0


### PR DESCRIPTION
Adding new port of boost::sml

- #### What does your PR fix?  
  #20799 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
