### PR TITLE
[easyhook] Also disable /ZI

### DIFF
--- a/ports/easyhook/portfile.cmake
+++ b/ports/easyhook/portfile.cmake
@@ -28,6 +28,16 @@ foreach(VCXPROJ IN ITEMS
         "<DebugInformationFormat>ProgramDatabase</DebugInformationFormat>"
         "<DebugInformationFormat>OldStyle</DebugInformationFormat>"
     )
+    vcpkg_replace_string(
+        "${VCXPROJ}"
+        "<DebugInformationFormat>EditAndContinue</DebugInformationFormat>"
+        "<DebugInformationFormat>OldStyle</DebugInformationFormat>"
+    )
+    vcpkg_replace_string(
+        "${VCXPROJ}"
+        "<MinimalRebuild>true</MinimalRebuild>"
+        ""
+    )
 endforeach()
 
 vcpkg_install_msbuild(

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "easyhook",
   "version": "2.7.7097.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
   "homepage": "https://github.com/EasyHook/EasyHook",
   "supports": "windows & !(static | arm | uwp)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1926,7 +1926,7 @@
     },
     "easyhook": {
       "baseline": "2.7.7097.0",
-      "port-version": 1
+      "port-version": 2
     },
     "easyloggingpp": {
       "baseline": "9.97.0",

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c217a47b595d2a002a72ff621846a7445329b42f",
+      "version": "2.7.7097.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "5dc14a4f006221297cad1ea84143aeae33f30284",
       "version": "2.7.7097.0",
       "port-version": 1


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/20757 I patch easyhook to remove /Zi in release builds, but in our most recent nightly build we got another failure https://dev.azure.com/vcpkg/public/_build/results?buildId=61519&view=artifacts&pathAsName=false&type=publishedArtifacts

```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\cderr.h : fatal error C1073: Internal error involving incremental compilation(compiler file 'd:\a01\_work\6\s\src\vctools\Compiler\CxxFE\sl\p1\c\p0io.c', line 1257) [D:\buildtrees\easyhook\x86-windows-dbg\2.7.7097.0-e2e62d41f5.clean\EasyHookDll\EasyHookDll.vcxproj]
         C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um\ddeml.h(37,1): fatal error C1001: Internal compiler error. [D:\buildtrees\easyhook\x86-windows-dbg\2.7.7097.0-e2e62d41f5.clean\EasyHookDll\EasyHookDll.vcxproj]
         D:\buildtrees\easyhook\x86-windows-dbg\2.7.7097.0-e2e62d41f5.clean\DriverShared\LocalHook\install.c(618,1): error C2471: cannot update program database '???' [D:\buildtrees\easyhook\x86-windows-dbg\2.7.7097.0-e2e62d41f5.clean\EasyHookDll\EasyHookDll.vcxproj]
```

This change also removes /ZI (which was used in debug builds) and /Gm (which is irrelevant since we aren't doing development work on Easyhook)
