### PR TITLE
[libuv] Remove the platform restrictions for threads

### DIFF
--- a/ports/libuv/unofficial-libuv-config.in.cmake
+++ b/ports/libuv/unofficial-libuv-config.in.cmake
@@ -1,4 +1,7 @@
-include(CMakeFindDependencyMacro)
-find_dependency(Threads)
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+    include(CMakeFindDependencyMacro)
+    find_dependency(Threads)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/unofficial-libuv-targets.cmake)

--- a/ports/libuv/unofficial-libuv-config.in.cmake
+++ b/ports/libuv/unofficial-libuv-config.in.cmake
@@ -1,7 +1,4 @@
-
-if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT WIN32)
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
-endif()
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
 
 include(${CMAKE_CURRENT_LIST_DIR}/unofficial-libuv-targets.cmake)

--- a/ports/libuv/vcpkg.json
+++ b/ports/libuv/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libuv",
   "version-semver": "1.42.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libuv is a multi-platform support library with a focus on asynchronous I/O.",
   "homepage": "https://github.com/libuv/libuv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3938,7 +3938,7 @@
     },
     "libuv": {
       "baseline": "1.42.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libuvc": {
       "baseline": "2020-11-24",

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1af4137c9fcbbb879d3d800df9722ad23330ad9d",
+      "version-semver": "1.42.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "41003bf038eb10b7fd29029954d42a05fb3c1a86",
       "version-semver": "1.42.0",
       "port-version": 1

--- a/versions/l-/libuv.json
+++ b/versions/l-/libuv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1af4137c9fcbbb879d3d800df9722ad23330ad9d",
+      "git-tree": "2cb9ed135277e1b121fbf0a391be6a8d5cb2ddcf",
       "version-semver": "1.42.0",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20829

In CMakeLists.txt, there is no any platform for `threads`.
https://github.com/microsoft/vcpkg/blob/a79d4a8ec7ae4464eb22f6af23e277882a67595d/ports/libuv/CMakeLists.txt#L4

But in unofficial-libuv-config.in.cmake, threads is only required to be dependent on non Windows platform.

https://github.com/microsoft/vcpkg/blob/a79d4a8ec7ae4464eb22f6af23e277882a67595d/ports/libuv/unofficial-libuv-config.in.cmake#L2-L5

After investigation, found that `threads `is also used on Windows in FindThreads, but will leave `Threads::Threads` as an empty INTERFACE target.

https://github.com/Kitware/CMake/blob/master/Modules/FindThreads.cmake

So remove the condition` NOT WIN32 `for `threads`.

Note: No feature needs to test.