### PR TITLE
[vcpkg] Revise the file lists script

### DIFF
--- a/scripts/file_script.py
+++ b/scripts/file_script.py
@@ -3,7 +3,7 @@ import os.path
 import sys
 
 
-keyword = "include/"
+keyword = "/include/"
 
 def getFiles(path):
     files = os.listdir(path)
@@ -15,12 +15,12 @@ def gen_all_file_strings(path, files, headers, output):
         package = components[0] + ":" + components[2].replace(".list", "")
         f = open(path + file)
         for line in f:
-            idx = line.strip().find(keyword)
-            if idx >= 0 and line.strip()[-1] != "/":
-                headers.write(package + ":" + line[idx + len(keyword):])
-                output.write(package + ":" + line[idx-1:])
-            elif line.strip()[-1] != "/":
-                output.write(package + ":" + line[line.find("/"):])
+            if line.strip()[-1] == "/":
+                continue
+            filepath = line[line.find("/"):]
+            output.write(package + ":" + filepath)
+            if filepath.startswith(keyword):
+                headers.write(package + ":" + filepath[len(keyword):])
         f.close()
 
 def main(path):

--- a/scripts/file_script.py
+++ b/scripts/file_script.py
@@ -11,7 +11,8 @@ def getFiles(path):
 
 def gen_all_file_strings(path, files, headers, output):
     for file in files:
-        package = file[:file.find("_")]
+        components = file.split("_")
+        package = components[0] + ":" + components[2].replace(".list", "")
         f = open(path + file)
         for line in f:
             idx = line.strip().find(keyword)


### PR DESCRIPTION
- #### What does your PR fix?  
  - Modifies the output to print `:<triplet>` after each filename.
    This is relevant for cross builds. Before this change, DLL might be listed even for x64-windows-static due to the x64-windows host triplet. This problem includes vcpkg CI. Not to mention mingw on linux...
  - Modifies the output to not blur the location of headers.
    - `VCPKGHeadersDatabase.txt` now only list contents in the top-level `/include` subtree.
      This is the only path directly available with build system integration. Other subtrees are still in `VCPKGDatabase.txt`.
    - But the actual problem was that files in `include` dirs in other subtrees of a port were listed in `VCPKGDatabase.txt` as if they were in the top-level include dir. This is a source of confusion, example: 
      `lib/glib-2.0/include/glibconfig.h` appearing as `glib:/include/glibconfig.h` in `VCPKGDatabase.txt`, cf. https://github.com/microsoft/vcpkg/issues/20483#issuecomment-947503700 :boom: 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all / not needed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed

- #### Example output

~~~
$ python3 scripts/file_script.py ./installed/vcpkg/info/

$ grep zlib: scripts/list_files/VCPKGDatabase.txt 
zlib:x64-mingw-dynamic:/bin/libzlib1.dll
zlib:x64-mingw-dynamic:/debug/bin/libzlibd1.dll
zlib:x64-mingw-dynamic:/debug/lib/libzlibd.dll.a
zlib:x64-mingw-dynamic:/debug/lib/pkgconfig/zlib.pc
zlib:x64-mingw-dynamic:/include/zconf.h
zlib:x64-mingw-dynamic:/include/zlib.h
zlib:x64-mingw-dynamic:/lib/libzlib.dll.a
zlib:x64-mingw-dynamic:/lib/pkgconfig/zlib.pc
zlib:x64-mingw-dynamic:/share/zlib/copyright
zlib:x64-mingw-dynamic:/share/zlib/usage
zlib:x64-mingw-dynamic:/share/zlib/vcpkg-cmake-wrapper.cmake
zlib:x64-mingw-dynamic:/share/zlib/vcpkg_abi_info.txt
zlib:x64-linux:/debug/lib/libz.a
zlib:x64-linux:/debug/lib/pkgconfig/zlib.pc
zlib:x64-linux:/include/zconf.h
zlib:x64-linux:/include/zlib.h
zlib:x64-linux:/lib/libz.a
zlib:x64-linux:/lib/pkgconfig/zlib.pc
zlib:x64-linux:/share/zlib/copyright
zlib:x64-linux:/share/zlib/usage
zlib:x64-linux:/share/zlib/vcpkg-cmake-wrapper.cmake
zlib:x64-linux:/share/zlib/vcpkg_abi_info.txt

$ grep zlib: scripts/list_files/VCPKGHeadersDatabase.txt 
zlib:x64-mingw-dynamic:zconf.h
zlib:x64-mingw-dynamic:zlib.h
zlib:x64-linux:zconf.h
zlib:x64-linux:zlib.h
