### PR TITLE
[gdal] Workaround for `vcpkg clean` issue

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -20,6 +20,8 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES ${GDAL_PATCHES}
 )
+# `vcpkg clean` stumbles over one subdir
+file(REMOVE_RECURSE "${SOURCE_PATH}/autotest")
 
 if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(NATIVE_DATA_DIR "${CURRENT_PACKAGES_DIR}/share/gdal")

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.3.2",
+  "port-version": 1,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "supports": "!arm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2338,7 +2338,7 @@
     },
     "gdal": {
       "baseline": "3.3.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gdcm": {
       "baseline": "3.0.7",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e90412cd51170a5ea63a0067005bb3afc3c6c36",
+      "version-semver": "3.3.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "bcc73ebd09ec91402d610074046785d7432f99fa",
       "version-semver": "3.3.2",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Early removes the Autotest directory which causes issues with the vcpkg clean command in CI.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
