### PR TITLE
[folly] Change from master branch to main branch

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -16,7 +16,7 @@ vcpkg_from_github(
     REPO facebook/folly
     REF v2021.06.14.00
     SHA512 aee5adc1a44d9b193f3f41b5fc9fa7575c677d8bf27ed3a3b612a2fbe53505f82481ce78f13fb41ae3ca81ca25446426fbdfdc578f503f919b4af5abe56ad71c
-    HEAD_REF master
+    HEAD_REF main
     PATCHES
         reorder-glog-gflags.patch
         disable-non-underscore-posix-names.patch

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "folly",
   "version-string": "2021.06.14.00",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
   "supports": "x64 | (arm64 & !windows)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2194,7 +2194,7 @@
     },
     "folly": {
       "baseline": "2021.06.14.00",
-      "port-version": 1
+      "port-version": 2
     },
     "font-chef": {
       "baseline": "1.0.1",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "747fc5abd957e03e89acad08f28925927fb5f33b",
+      "version-string": "2021.06.14.00",
+      "port-version": 2
+    },
+    {
       "git-tree": "92b7d618fda609b74ea8862c9950e40a9f03418d",
       "version-string": "2021.06.14.00",
       "port-version": 1


### PR DESCRIPTION
Folly has switched from master branch to the main branch, see https://github.com/facebook/folly. Update VCPKG folly port.