### PR TITLE
[pe-parse] Update to 1.3.0, [uthenticode] Update to 1.0.6

### DIFF
--- a/ports/pe-parse/arm64-windows-fix.patch
+++ b/ports/pe-parse/arm64-windows-fix.patch
@@ -1,0 +1,13 @@
+find_package(Filesystem) fails on arm64 Windows.
+We can remove it as it is only used for tests which are not built in vcpkg.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,6 @@ endif ()
+ include(cmake/compilation_flags.cmake)
+ # Greater c++17 filesystem compatibility (like with experimental)
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+-find_package(Filesystem COMPONENTS Experimental Final REQUIRED)
+ list(APPEND GLOBAL_CXXFLAGS ${DEFAULT_CXX_FLAGS})
+ 
+ option(BUILD_SHARED_LIBS "Build Shared Libraries" ON)

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -1,27 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/pe-parse
-    REF v1.2.0
-    SHA512 916ec515585ba1e83e2c6ae29667fd25bd4cac90c39e587ae6847dc9d503186e8853bd80f4e2a99177a3214f5c51eceff85fa610cadbc2bc1d3a79251e8ce942
+    REF v1.3.0
+    SHA512 b723e90821e0ac67b4d6b15e5a46cf13544f21380a4d2add013eedcaa309e1be2cff6789247397c6fb4a938e4a240a835cbe21c8221bd558a4fccf8e93ce1548
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DBUILD_COMMAND_LINE_TOOLS=OFF
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_COMMAND_LINE_TOOLS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/pe-parse TARGET_PATH share/pe-parse)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/pe-parse")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(
-    INSTALL
-    "${SOURCE_PATH}/LICENSE"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/pe-parse"
-    RENAME copyright
-)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pe-parse/portfile.cmake
+++ b/ports/pe-parse/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.3.0
     SHA512 b723e90821e0ac67b4d6b15e5a46cf13544f21380a4d2add013eedcaa309e1be2cff6789247397c6fb4a938e4a240a835cbe21c8221bd558a4fccf8e93ce1548
     HEAD_REF master
+    PATCHES
+        arm64-windows-fix.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/pe-parse/vcpkg.json
+++ b/ports/pe-parse/vcpkg.json
@@ -1,8 +1,17 @@
 {
   "name": "pe-parse",
-  "version-string": "1.2.0",
-  "port-version": 1,
+  "version": "1.3.0",
   "description": "pe-parse is a principled, lightweight C/C++ PE parser",
   "homepage": "https://github.com/trailofbits/pe-parse",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/uthenticode/portfile.cmake
+++ b/ports/uthenticode/portfile.cmake
@@ -3,26 +3,25 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO trailofbits/uthenticode
-    REF v1.0.4
-    SHA512 82d5ff61071adefec886a140d253b733cb2318ccf34e831087973b05f7e274b207031e606303f65269a5ed1b45c3c599d79e217cf6229d60c8cc2396e842f32e
+    REF v1.0.6
+    SHA512 6C9C4DD9E1FE7C329E10BC39E41927C8B82DD004275A88385C691AD85EF4079EBE2922083D5252019B8B25CC540F48E544B42B8178F256AE987D6B677713B063
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+# compatibility fix for newer versions of pe-parse
+foreach(FILE IN ITEMS test/wincert-test.cpp test/signeddata-test.cpp test/uthenticode-test.cpp test/certificate-test.cpp src/include/uthenticode.h)
+    vcpkg_replace_string("${SOURCE_PATH}/${FILE}" "#include <parser-library/parse.h>" "#include <pe-parse/parse.h>")
+endforeach()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/uthenticode TARGET_PATH share/uthenticode)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/uthenticode)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(
-    INSTALL
-    ${SOURCE_PATH}/LICENSE
-    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-    RENAME copyright
-)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/uthenticode/vcpkg.json
+++ b/ports/uthenticode/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "uthenticode",
-  "version-string": "1.0.4",
-  "port-version": 1,
+  "version-string": "1.0.6",
   "description": "A cross-platform library for verifying Authenticode signatures",
   "homepage": "https://github.com/trailofbits/uthenticode",
   "supports": "!uwp",
   "dependencies": [
     "openssl",
-    "pe-parse"
+    "pe-parse",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5105,8 +5105,8 @@
       "port-version": 1
     },
     "pe-parse": {
-      "baseline": "1.2.0",
-      "port-version": 1
+      "baseline": "1.3.0",
+      "port-version": 0
     },
     "pegtl": {
       "baseline": "3.2.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6901,8 +6901,8 @@
       "port-version": 0
     },
     "uthenticode": {
-      "baseline": "1.0.4",
-      "port-version": 1
+      "baseline": "1.0.6",
+      "port-version": 0
     },
     "uvatlas": {
       "baseline": "sept2021",

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "378e993b6be6ea69797a0f63ef859ba0c1f1bb9c",
+      "version": "1.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "10de7a27c9512d2267067cc442507ee91839fb07",
       "version-string": "1.2.0",
       "port-version": 1

--- a/versions/p-/pe-parse.json
+++ b/versions/p-/pe-parse.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "378e993b6be6ea69797a0f63ef859ba0c1f1bb9c",
+      "git-tree": "46ac74f817dcb2fed549ac83eca39761bae2c4ae",
       "version": "1.3.0",
       "port-version": 0
     },

--- a/versions/u-/uthenticode.json
+++ b/versions/u-/uthenticode.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bd27c0f342a4c62251b30f323be232c86bc999af",
+      "version-string": "1.0.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c815664232505dde8a5dd299d4ad562f47b7d43",
       "version-string": "1.0.4",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates pe-parse to 1.3.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?  
  Yes