### PR TITLE
[vcpkg_configure_qmake] update to use qmake from Qt6

### DIFF
--- a/docs/maintainers/vcpkg_configure_qmake.md
+++ b/docs/maintainers/vcpkg_configure_qmake.md
@@ -7,6 +7,7 @@ Configure a qmake-based project.
 ```cmake
 vcpkg_configure_qmake(
     SOURCE_PATH <pro_file_path>
+    QT_VERSION <qt-version>
     [OPTIONS arg1 [arg2 ...]]
     [OPTIONS_RELEASE arg1 [arg2 ...]]
     [OPTIONS_DEBUG arg1 [arg2 ...]]
@@ -15,6 +16,9 @@ vcpkg_configure_qmake(
 
 ### SOURCE_PATH
 The path to the *.pro qmake project file.
+
+### QT_VERSION
+Select the required Qt version (5 or 6)
 
 ### OPTIONS, OPTIONS\_RELEASE, OPTIONS\_DEBUG
 The options passed to qmake.

--- a/ports/libqglviewer/portfile.cmake
+++ b/ports/libqglviewer/portfile.cmake
@@ -15,6 +15,7 @@ endif()
 
 vcpkg_configure_qmake(
     SOURCE_PATH ${SOURCE_PATH}/QGLViewer/QGLViewer.pro
+    QT_VERSION 5
     OPTIONS ${OPTIONS}
 )
 

--- a/ports/libqglviewer/vcpkg.json
+++ b/ports/libqglviewer/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libqglviewer",
   "version-string": "2.7.2",
-  "port-version": 4,
+  "port-version": 5,
   "description": "libQGLViewer is an open source C++ library based on Qt that eases the creation of OpenGL 3D viewers.",
   "dependencies": [
     {

--- a/ports/qcustomplot/portfile.cmake
+++ b/ports/qcustomplot/portfile.cmake
@@ -20,8 +20,9 @@ vcpkg_extract_source_archive(SharedLib_SOURCE_PATH ARCHIVE "${ARCHIVE}")
 file(RENAME "${SharedLib_SOURCE_PATH}" "${SOURCE_PATH}/qcustomplot-sharedlib")
 
 
-vcpkg_configure_qmake(SOURCE_PATH
-    ${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro
+vcpkg_configure_qmake(
+    SOURCE_PATH ${SOURCE_PATH}/qcustomplot-sharedlib/sharedlib-compilation/sharedlib-compilation.pro
+    QT_VERSION 5
 )
 
 vcpkg_install_qmake(

--- a/ports/qcustomplot/vcpkg.json
+++ b/ports/qcustomplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qcustomplot",
   "version": "2.0.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "QCustomPlot is a Qt C++ widget for plotting and data visualization.",
   "dependencies": [
     {

--- a/ports/qscintilla/portfile.cmake
+++ b/ports/qscintilla/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_add_to_path(${PYTHON3_PATH})
 
 vcpkg_configure_qmake(
     SOURCE_PATH ${SOURCE_PATH}/src
+    QT_VERSION 5
     OPTIONS
         CONFIG+=build_all
         CONFIG-=hide_symbols

--- a/ports/qscintilla/vcpkg.json
+++ b/ports/qscintilla/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qscintilla",
   "version": "2.12.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "QScintilla is a port to Qt of the Scintilla editing component. Features syntax highlighting, code-completion and much more (Barebone build without python bindings (missing dependeny PyQt) and without QtDesigner plugin)",
   "homepage": "https://www.riverbankcomputing.com/software/qscintilla",
   "supports": "!(windows & (arm | arm64))",

--- a/ports/qt5-base/cmake/qt_build_submodule.cmake
+++ b/ports/qt5-base/cmake/qt_build_submodule.cmake
@@ -7,7 +7,7 @@ function(qt_build_submodule SOURCE_PATH)
     get_filename_component(PYTHON2_EXE_PATH ${PYTHON2} DIRECTORY)
     vcpkg_add_to_path("${PYTHON2_EXE_PATH}")
 
-    vcpkg_configure_qmake(SOURCE_PATH ${SOURCE_PATH} ${ARGV})
+    vcpkg_configure_qmake(SOURCE_PATH ${SOURCE_PATH} QT_VERSION 5 ${ARGV})
 
     vcpkg_build_qmake(SKIP_MAKEFILES)
 

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.15.2",
-  "port-version": 11,
+  "port-version": 12,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/ports/qwt/portfile.cmake
+++ b/ports/qwt/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_sourceforge(
 
 vcpkg_configure_qmake(
     SOURCE_PATH "${SOURCE_PATH}"
+    QT_VERSION 5
     OPTIONS
         CONFIG+=${VCPKG_LIBRARY_LINKAGE}
 )

--- a/ports/qwt/vcpkg.json
+++ b/ports/qwt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qwt",
   "version-semver": "6.2.0",
+  "port-version": 1,
   "description": "qt widgets library for technical applications",
   "homepage": "https://sourceforge.net/projects/qwt",
   "dependencies": [

--- a/scripts/cmake/vcpkg_configure_qmake.cmake
+++ b/scripts/cmake/vcpkg_configure_qmake.cmake
@@ -6,6 +6,7 @@ Configure a qmake-based project.
 ```cmake
 vcpkg_configure_qmake(
     SOURCE_PATH <pro_file_path>
+    QT_VERSION <qt-version>
     [OPTIONS arg1 [arg2 ...]]
     [OPTIONS_RELEASE arg1 [arg2 ...]]
     [OPTIONS_DEBUG arg1 [arg2 ...]]
@@ -15,20 +16,28 @@ vcpkg_configure_qmake(
 ### SOURCE_PATH
 The path to the *.pro qmake project file.
 
+### QT_VERSION
+Select the required Qt version (5 or 6)
+
 ### OPTIONS, OPTIONS\_RELEASE, OPTIONS\_DEBUG
 The options passed to qmake.
 #]===]
 
 function(vcpkg_configure_qmake)
     # parse parameters such that semicolons in options arguments to COMMAND don't get erased
-    cmake_parse_arguments(PARSE_ARGV 0 _csc "" "SOURCE_PATH" "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG")
-     
+    cmake_parse_arguments(PARSE_ARGV 0 _csc "" "SOURCE_PATH;QT_VERSION" "OPTIONS;OPTIONS_RELEASE;OPTIONS_DEBUG;BUILD_OPTIONS;BUILD_OPTIONS_RELEASE;BUILD_OPTIONS_DEBUG")
+
     # Find qmake executable
-    set(_triplet_hostbindir ${CURRENT_INSTALLED_DIR}/tools/qt5/bin)
-    if(DEFINED VCPKG_QT_HOST_TOOLS_ROOT_DIR)
-        find_program(QMAKE_COMMAND NAMES qmake PATHS ${VCPKG_QT_HOST_TOOLS_ROOT_DIR}/bin ${_triplet_hostbindir} NO_DEFAULT_PATH)
+    if(${_csc_QT_VERSION} EQUAL 6)
+      set(QT_TOOLS_PATH ${CURRENT_INSTALLED_DIR}/tools/Qt6)
     else()
-        find_program(QMAKE_COMMAND NAMES qmake PATHS ${_triplet_hostbindir} NO_DEFAULT_PATH)
+      set(QT_TOOLS_PATH ${CURRENT_INSTALLED_DIR}/tools/qt5)
+    endif()
+    set(_triplet_hostbindir ${QT_TOOLS_PATH}/bin)
+    if(DEFINED VCPKG_QT_HOST_TOOLS_ROOT_DIR)
+        find_program(QMAKE_COMMAND NAMES qmake qmake6 PATHS ${VCPKG_QT_HOST_TOOLS_ROOT_DIR}/bin ${_triplet_hostbindir} NO_DEFAULT_PATH)
+    else()
+        find_program(QMAKE_COMMAND NAMES qmake qmake6 PATHS ${_triplet_hostbindir} NO_DEFAULT_PATH)
     endif()
 
     if(NOT QMAKE_COMMAND)
@@ -43,7 +52,7 @@ function(vcpkg_configure_qmake)
         list(APPEND _csc_OPTIONS "CONFIG*=shared")
         list(APPEND _csc_OPTIONS_DEBUG "CONFIG*=separate_debug_info")
     endif()
-    
+
     if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_CRT_LINKAGE STREQUAL "static")
         list(APPEND _csc_OPTIONS "CONFIG*=static-runtime")
     endif()
@@ -73,8 +82,8 @@ function(vcpkg_configure_qmake)
             set(ENV{PKG_CONFIG_PATH} "${PKGCONFIG_INSTALLED_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_INSTALLED_SHARE_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_SHARE_DIR}")
         endif()
 
-        configure_file(${CURRENT_INSTALLED_DIR}/tools/qt5/qt_release.conf ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/qt.conf)
-    
+        configure_file(${QT_TOOLS_PATH}/qt_release.conf ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/qt.conf)
+
         message(STATUS "Configuring ${TARGET_TRIPLET}-rel")
         file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
         if(DEFINED _csc_BUILD_OPTIONS OR DEFINED _csc_BUILD_OPTIONS_RELEASE)
@@ -109,7 +118,7 @@ function(vcpkg_configure_qmake)
             set(ENV{PKG_CONFIG_PATH} "${PKGCONFIG_INSTALLED_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_INSTALLED_SHARE_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_SHARE_DIR}")
         endif()
 
-        configure_file(${CURRENT_INSTALLED_DIR}/tools/qt5/qt_debug.conf ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/qt.conf)
+        configure_file(${QT_TOOLS_PATH}/qt_debug.conf ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/qt.conf)
 
         message(STATUS "Configuring ${TARGET_TRIPLET}-dbg")
         file(MAKE_DIRECTORY ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3742,7 +3742,7 @@
     },
     "libqglviewer": {
       "baseline": "2.7.2",
-      "port-version": 4
+      "port-version": 5
     },
     "libqrencode": {
       "baseline": "4.1.1",
@@ -5386,7 +5386,7 @@
     },
     "qcustomplot": {
       "baseline": "2.0.1",
-      "port-version": 5
+      "port-version": 6
     },
     "qhull": {
       "baseline": "8.0.2",
@@ -5402,7 +5402,7 @@
     },
     "qscintilla": {
       "baseline": "2.12.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qt": {
       "baseline": "6.2.0",
@@ -5430,7 +5430,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.2",
-      "port-version": 11
+      "port-version": 12
     },
     "qt5-canvas3d": {
       "baseline": "0",
@@ -5762,7 +5762,7 @@
     },
     "qwt": {
       "baseline": "6.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qwtw": {
       "baseline": "3.1.0",

--- a/versions/l-/libqglviewer.json
+++ b/versions/l-/libqglviewer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b972350914c86302366511cc1ef1beb9ffd45559",
+      "version-string": "2.7.2",
+      "port-version": 5
+    },
+    {
       "git-tree": "af8c797ea264a95603d8d825a75d73d5cc408d4d",
       "version-string": "2.7.2",
       "port-version": 4

--- a/versions/q-/qcustomplot.json
+++ b/versions/q-/qcustomplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "07a6e33f9e05bda794d5292610a8323b52415c27",
+      "version": "2.0.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "7fcc18d2987ed5b3af803d5e0ac5c9afd026fc37",
       "version": "2.0.1",
       "port-version": 5

--- a/versions/q-/qscintilla.json
+++ b/versions/q-/qscintilla.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "90e1e68642c1f54b5ab2c1930b95ae1d0573e047",
+      "version": "2.12.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "63f2d1f0287a6d61b5c85b428920b0fbe102adec",
       "version": "2.12.0",
       "port-version": 1

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fa567b6ecdef452fac76e2e10670390271ef098",
+      "version-semver": "5.15.2",
+      "port-version": 12
+    },
+    {
       "git-tree": "72ca286ac98e08f2fef35f85a6e393795428d033",
       "version-semver": "5.15.2",
       "port-version": 11

--- a/versions/q-/qwt.json
+++ b/versions/q-/qwt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4406090ddc112e9e8e0cac390aff7472e201e233",
+      "version-semver": "6.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "e7204097fda082c43e704e356702fd77aa3c9a52",
       "version-semver": "6.2.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes 20933 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
