### PR TITLE
[sail] Update to 0.9.0-pre18

### DIFF
--- a/ports/sail/portfile.cmake
+++ b/ports/sail/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "UWP")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO HappySeaFox/sail
-    REF v0.9.0-pre17
-    SHA512 5efa1d56049d84515a92ae2df76476afcfd53ed4ea1f406851bcd86683c3b5390ee53fcd5d1dac233b855a1445496fda7fd7612a157596b0b4d088bacb5dd0fd
+    REF v0.9.0-pre18
+    SHA512 711dd34617982427155eaa4cb39d0d0004ef6bb31ac29ee07899ac0b132ed868ea30d39f424dffd8dd0e1ad8bc1c733dd1ab9e3713b5772100ae1953b4ce6e08
     HEAD_REF master
 )
 
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DSAIL_STATIC=${SAIL_STATIC}
         -DSAIL_COMBINE_CODECS=ON
+        -DSAIL_BUILD_APPS=OFF
         -DSAIL_BUILD_EXAMPLES=OFF
         -DSAIL_BUILD_TESTS=OFF
 )

--- a/ports/sail/vcpkg.json
+++ b/ports/sail/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sail",
-  "version-semver": "0.9.0-pre17",
+  "version-semver": "0.9.0-pre18",
   "description": "The missing small and fast image decoding library for humans (not for machines)",
   "homepage": "https://github.com/HappySeaFox/sail",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6009,7 +6009,7 @@
       "port-version": 0
     },
     "sail": {
-      "baseline": "0.9.0-pre17",
+      "baseline": "0.9.0-pre18",
       "port-version": 0
     },
     "sais": {

--- a/versions/s-/sail.json
+++ b/versions/s-/sail.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "33ba821b47bf709df78c48f302640cbdfac9860b",
+      "version-semver": "0.9.0-pre18",
+      "port-version": 0
+    },
+    {
       "git-tree": "38fab5a13ed3f5e76ec41af54676cd6c5aa4047d",
       "version-semver": "0.9.0-pre17",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- Fixed copying an invalid palette in C++
- Added new constructors for palette in C++
- Fixed linking against debug `jasper` and `webp`
- And more... (https://github.com/HappySeaFox/sail/releases/tag/v0.9.0-pre18)

- #### What does your PR fix?  
  \-

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Same as before

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
