### PR TITLE
[boost-modular-build-helper] fixup MinGW lib names for more GCC versions

### DIFF
--- a/ports/boost-modular-build-helper/boost-modular-build.cmake
+++ b/ports/boost-modular-build-helper/boost-modular-build.cmake
@@ -131,7 +131,7 @@ function(boost_modular_build)
         endif()
     endforeach()
     # Similar for mingw
-    file(GLOB INSTALLED_LIBS "${CURRENT_PACKAGES_DIR}/debug/lib/*-mgw10-*.a" "${CURRENT_PACKAGES_DIR}/lib/*-mgw10-*.a")
+    file(GLOB INSTALLED_LIBS "${CURRENT_PACKAGES_DIR}/debug/lib/*-mgw*-*.a" "${CURRENT_PACKAGES_DIR}/lib/*-mgw*-*.a")
     foreach(LIB IN LISTS INSTALLED_LIBS)
         get_filename_component(OLD_FILENAME "${LIB}" NAME)
         get_filename_component(DIRECTORY_OF_LIB_FILE "${LIB}" DIRECTORY)

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version": "1.77.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Internal vcpkg port used to build Boost libraries",
   "dependencies": [
     "boost-uninstall"

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aea8b4dbb8063db29d8ac843ef6aac35478bebaa",
+      "version": "1.77.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "7cc6728723151712d8007e882bc2ad9a4649b2cf",
       "version": "1.77.0",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -814,7 +814,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.77.0",
-      "port-version": 3
+      "port-version": 4
     },
     "boost-move": {
       "baseline": "1.77.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes building boost with MinGW and GCC11 on Windows by slightly improving the MinGW fix provided in https://github.com/microsoft/vcpkg/pull/20576, which had a glob statement that would unfortunately just work for GCC10.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all + mingw, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

Tested with x64-mingw static on windows.