### PR TITLE
[cityhash] Add feature sse for non-x86-Windows

### DIFF
--- a/ports/cityhash/CMakeLists.txt
+++ b/ports/cityhash/CMakeLists.txt
@@ -1,7 +1,51 @@
 cmake_minimum_required(VERSION 3.13)
 project(cityhash CXX)
 
+option(ENABLE_SSE "Build CityHash variants that depend on the _mm_crc32_u64 intrinsic." OFF)
+
+set(CMAKE_CXX_STANDARD 11)
+
+if (ENABLE_SSE)
+    include (CMakePushCheckState)
+    cmake_push_check_state()
+    if (MSVC)
+        include(CheckCXXSourceCompiles)
+        
+    check_cxx_source_compiles(
+    "#include <nmmintrin.h>
+    int main() {
+        _mm_crc32_u64(0, 0);
+        return 0;
+    }"
+    USE_SSE)
+    else()
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag ("-msse4.2" USE_SSE)
+        if (USE_SSE)
+            set (SSE2_FLAG "-msse4.2")
+        endif()
+    endif()
+    
+    cmake_pop_check_state()
+    
+    if (NOT USE_SSE)
+        message(FATAL_ERROR "This platform doesn't support feature SSE4.2")
+    endif()
+else()
+    set(USE_SSE OFF)
+endif()
+
 add_library(cityhash STATIC src/city.cc)
+
+list(APPEND CITY_HEADERS src/city.h)
+if (USE_SSE)
+    list(APPEND CITY_HEADERS src/citycrc.h)
+
+    target_compile_options(cityhash PRIVATE ${SSE2_FLAG})
+    if (MSVC)
+        target_compile_definitions(cityhash PRIVATE __SSE4_2__)
+    endif()
+endif()
 
 target_include_directories(cityhash PUBLIC
 	$<INSTALL_INTERFACE:include>
@@ -15,4 +59,4 @@ install(TARGETS cityhash EXPORT cityhash-config
 )
 
 install(EXPORT cityhash-config DESTINATION share/cmake/cityhash)
-install(FILES src/city.h DESTINATION include)
+install(FILES ${CITY_HEADERS} DESTINATION include)

--- a/ports/cityhash/vcpkg.json
+++ b/ports/cityhash/vcpkg.json
@@ -1,7 +1,12 @@
 {
   "name": "cityhash",
-  "version-string": "2013-01-08",
-  "port-version": 1,
+  "version-date": "2013-01-08",
+  "port-version": 2,
   "description": "CityHash, a family of hash functions for strings.",
-  "homepage": "https://github.com/google/cityhash"
+  "homepage": "https://github.com/google/cityhash",
+  "features": {
+    "sse": {
+      "description": "Build CityHash variants that depend on the _mm_crc32_u64 intrinsic."
+    }
+  }
 }

--- a/ports/cityhash/vcpkg.json
+++ b/ports/cityhash/vcpkg.json
@@ -4,6 +4,16 @@
   "port-version": 2,
   "description": "CityHash, a family of hash functions for strings.",
   "homepage": "https://github.com/google/cityhash",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "sse": {
       "description": "Build CityHash variants that depend on the _mm_crc32_u64 intrinsic."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1342,7 +1342,7 @@
     },
     "cityhash": {
       "baseline": "2013-01-08",
-      "port-version": 1
+      "port-version": 2
     },
     "civetweb": {
       "baseline": "1.15",

--- a/versions/c-/cityhash.json
+++ b/versions/c-/cityhash.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14120d53284417915947b8f59652abf5f448562e",
+      "version-date": "2013-01-08",
+      "port-version": 2
+    },
+    {
       "git-tree": "423306e7029cfac62069d751bb612e10b3777c13",
       "version-string": "2013-01-08",
       "port-version": 1

--- a/versions/c-/cityhash.json
+++ b/versions/c-/cityhash.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14120d53284417915947b8f59652abf5f448562e",
+      "git-tree": "9c1b6eaaf15c06d436ce42331b84566abd931f53",
       "version-date": "2013-01-08",
       "port-version": 2
     },


### PR DESCRIPTION
Add feature `sse` for non-x86-Windows since its required functions (`_mm_crc32_u64` etc.) are only declared on x64 triplet in Windows.

Fixes #20984.

Already tested this feature on `x64-windows`, `x64-windows-static` and `x64-linux`.