### PR TITLE
[fluidsynth] Always install to "lib" rather than "lib64".

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -11,31 +11,33 @@ vcpkg_from_github(
 set(feature_list dbus jack libinstpatch libsndfile midishare opensles oboe oss sdl2 pulseaudio readline lash alsa systemd coreaudio coremidi dart)
 set(FEATURE_OPTIONS)
 foreach(_feature IN LISTS feature_list)
-    list(APPEND FEATURE_OPTIONS -Denable-${_feature}:BOOL=OFF)
+    list(APPEND FEATURE_OPTIONS "-Denable-${_feature}:BOOL=OFF")
 endforeach()
 
 vcpkg_find_acquire_program(PKGCONFIG)
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS 
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
         ${FEATURE_OPTIONS}
+        -DLIB_INSTALL_DIR=lib
         -DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}
     OPTIONS_DEBUG
         -Denable-debug:BOOL=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Copy fluidsynth.exe to tools dir
 vcpkg_copy_tools(TOOL_NAMES fluidsynth AUTO_CLEAN)
 
 # Remove unnecessary files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,9 +1,14 @@
 {
   "name": "fluidsynth",
   "version": "2.2.1",
+  "port-version": 1,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "dependencies": [
-    "glib"
+    "glib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2174,7 +2174,7 @@
     },
     "fluidsynth": {
       "baseline": "2.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b718c067dba577d8843add12ce7a593b14f722f6",
+      "version": "2.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "226d8e9bba548bfb4592dfe5979797e3ffde0f69",
       "version": "2.2.1",
       "port-version": 0


### PR DESCRIPTION
Fixes this failure:

```
-- Performing post-build validation
There should be no pkgconfig directories outside of lib and debug/lib.
The following misplaced pkgconfig files were found:

    /mnt/vcpkg-ci/packages/fluidsynth_x64-linux/lib64/pkgconfig/fluidsynth.pc
    /mnt/vcpkg-ci/packages/fluidsynth_x64-linux/debug/lib64/pkgconfig/fluidsynth.pc

You can move the pkgconfig files with the following commands:

    file(INSTALL "${CURRENT_PACKAGES_DIR}/a/path/pkgconfig/name.pc" DESTINATION "${CURRENT_PACKAGES_DIR}/a/path/pkgconfig")
    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/a/path/pkgconfig")

Found 1 error(s). Please correct the portfile:
    /agent/_work/2/s/ports/fluidsynth/portfile.cmake
-- Performing post-build validation done
```

/cc @autoantwort 