### PR TITLE
[eastl] update to 3.18.00 

### DIFF
--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -7,30 +7,29 @@ vcpkg_from_github(
     SHA512 3011a0a08701b683e22cc624167b4f65fce8b16d0f7a03675f6a1d5b02313c5b763bcc6c8091f65728ed60ceee8d585cbdb1968a35fb24954f4f66afabb23865
     HEAD_REF master
     PATCHES 
-    fix_cmake_install.patch
+        fix_cmake_install.patch
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/EASTLConfig.cmake.in DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/EASTLConfig.cmake.in" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
     -DEASTL_BUILD_TESTS=OFF
     -DEASTL_BUILD_BENCHMARK=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/EASTL)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/EASTL)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(INSTALL ${SOURCE_PATH}/3RDPARTYLICENSES.TXT DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/3RDPARTYLICENSES.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # CommonCppFlags used by EAThread
-file(INSTALL ${SOURCE_PATH}/scripts/CMake/CommonCppFlags.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/scripts/CMake/CommonCppFlags.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/eastl/portfile.cmake
+++ b/ports/eastl/portfile.cmake
@@ -15,8 +15,8 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/EASTLConfig.cmake.in" DESTINATION "${SOURCE
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-    -DEASTL_BUILD_TESTS=OFF
-    -DEASTL_BUILD_BENCHMARK=OFF
+        -DEASTL_BUILD_TESTS=OFF
+        -DEASTL_BUILD_BENCHMARK=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/eastl/vcpkg.json
+++ b/ports/eastl/vcpkg.json
@@ -1,10 +1,17 @@
 {
   "name": "eastl",
-  "version-string": "3.17.03",
-  "port-version": 1,
+  "version-string": "3.18.00",
   "description": "Electronic Arts Standard Template Library. It is a C++ template library of containers, algorithms, and iterators useful for runtime and tool development across multiple platforms. It is a fairly extensive and robust implementation of such a library and has an emphasis on high performance above all other considerations.",
   "homepage": "https://github.com/electronicarts/EASTL",
   "dependencies": [
-    "eabase"
+    "eabase",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1929,8 +1929,8 @@
       "port-version": 2
     },
     "eastl": {
-      "baseline": "3.17.03",
-      "port-version": 1
+      "baseline": "3.18.00",
+      "port-version": 0
     },
     "easycl": {
       "baseline": "0.3",

--- a/versions/e-/eastl.json
+++ b/versions/e-/eastl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e621de50cabfa08aa8357064c1bf29ae125d9b06",
+      "version-string": "3.18.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "63d695972dd9861a2726ca90361aaafac0f710f6",
       "version-string": "3.17.03",
       "port-version": 1

--- a/versions/e-/eastl.json
+++ b/versions/e-/eastl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e621de50cabfa08aa8357064c1bf29ae125d9b06",
+      "git-tree": "a9f54d0c4a7a571329fd2ee5e8788c2a5a5414ca",
       "version-string": "3.18.00",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #21010 

Update eastl to the latest version 3.18.00

Note: no feature need to test