### PR TITLE
[EasyHook] Fix the build failure "cannot open include file 'afxres.h'" when MFC SDK is not installed

### DIFF
--- a/ports/easyhook/fix-build.patch
+++ b/ports/easyhook/fix-build.patch
@@ -126,3 +126,29 @@ index ec66f91..5773555 100644
      <MASM>
        <GenerateDebugInformation>false</GenerateDebugInformation>
        <UseSafeExceptionHandlers>false</UseSafeExceptionHandlers>
+diff --git a/EasyHookDll/EasyHookDll_32.rc b/EasyHookDll/EasyHookDll_32.rc
+index 2a8dfb6..abf5ae3 100644
+--- a/EasyHookDll/EasyHookDll_32.rc
++++ b/EasyHookDll/EasyHookDll_32.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "afxres.h"
++#include "windows.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+diff --git a/EasyHookDll/EasyHookDll_64.rc b/EasyHookDll/EasyHookDll_64.rc
+index 163a2f0..b32a4d4 100644
+--- a/EasyHookDll/EasyHookDll_64.rc
++++ b/EasyHookDll/EasyHookDll_64.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "afxres.h"
++#include "windows.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "easyhook",
   "version": "2.7.7097.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
   "homepage": "https://github.com/EasyHook/EasyHook",
   "supports": "windows & !(static | arm | uwp)"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1942,7 +1942,7 @@
     },
     "easyhook": {
       "baseline": "2.7.7097.0",
-      "port-version": 2
+      "port-version": 3
     },
     "easyloggingpp": {
       "baseline": "9.97.0",

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6fefce9309d25f4fdd8675a3168cbfd049f9b863",
+      "version": "2.7.7097.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c217a47b595d2a002a72ff621846a7445329b42f",
       "version": "2.7.7097.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes the build failure of EasyHook when MFC SDK is not installed 
  See https://github.com/EasyHook/EasyHook/issues/210
  https://github.com/microsoft/vcpkg/issues/21011

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  the supported triplets should have remained unchanged; No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `I guess yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
