### PR TITLE
[libLAS] Remove dependency on all of boost

### DIFF
--- a/ports/liblas/vcpkg.json
+++ b/ports/liblas/vcpkg.json
@@ -1,15 +1,19 @@
 {
   "name": "liblas",
   "version-string": "1.8.1",
-  "port-version": 7,
+  "port-version": 8,
   "description": "A C/C++ library for reading and writing the very common LAS LiDAR format.",
   "dependencies": [
-    "boost",
     "boost-detail",
     "boost-filesystem",
+    "boost-interprocess",
     "boost-iostreams",
+    "boost-lambda",
+    "boost-multi-index",
+    "boost-program-options",
     "boost-system",
     "boost-thread",
+    "boost-uuid",
     "libgeotiff"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3542,7 +3542,7 @@
     },
     "liblas": {
       "baseline": "1.8.1",
-      "port-version": 7
+      "port-version": 8
     },
     "liblbfgs": {
       "baseline": "1.10",

--- a/versions/l-/liblas.json
+++ b/versions/l-/liblas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cab66222be9c25d617f6da9160ca930e0cb069dd",
+      "version-string": "1.8.1",
+      "port-version": 8
+    },
+    {
       "git-tree": "508c56fc68703c0cf2b2c7fe99895fa6cfee5c6a",
       "version-string": "1.8.1",
       "port-version": 7


### PR DESCRIPTION
I suspect this was a shortcut for someone, but it's bloating our build. There's no need to pull in all of boost & all it's dependencies. 