### PR TITLE
[libpq] Android compatibility

### DIFF
--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -278,6 +278,9 @@ else()
     else()
         list(APPEND BUILD_OPTS --without-readline)
     endif()
+    if(VCPKG_TARGET_IS_ANDROID) # AND CMAKE_SYSTEM_VERSION LESS 26)
+        list(APPEND BUILD_OPTS ac_cv_header_langinfo_h=no)
+    endif()
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
         COPY_SOURCE

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpq",
   "version": "12.2",
-  "port-version": 18,
+  "port-version": 19,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3730,7 +3730,7 @@
     },
     "libpq": {
       "baseline": "12.2",
-      "port-version": 18
+      "port-version": 19
     },
     "libpqxx": {
       "baseline": "7.6.0",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7ac8973569e75060efdb8091b83f64f429371a38",
+      "version": "12.2",
+      "port-version": 19
+    },
+    {
       "git-tree": "03c934a8004ec6c34842748d18c06a38e7a8aa3e",
       "version": "12.2",
       "port-version": 18


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes libpq cannot be linked on android < 26 because `nl_langinfo` isn't there.

I didn't find the proper condition to check for the required version. Improvements welcome.
Currently, 21 is the default on vcpkg and this version is broken.

Note that it's currently not possible to build libpq for android because the `make` integration for android is lacking. This patch is required anyways.