### PR TITLE
[ci] Remove unaffected ports from pull request builds

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -181,10 +181,10 @@ else
         Write-Host "Determining parent hashes using HEAD~1"
         $parentHashesFile = Join-Path $WorkingRoot 'parent-hashes.json'
         $parentHashes = @("--parent-hashes=$parentHashesFile")
-        & git checkout HEAD~1 -- .
+        & git revert -n -m 1 HEAD
         & "./vcpkg$executableExtension" ci $Triplet --dry-run --exclude=$skipList @hostArgs @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile" `
             | ForEach-Object { if ($_ -match ' dependency information| determine pass') { Write-Host $_ } }
-        & git checkout HEAD -- .
+        & git reset --hard HEAD
         
         Write-Host "Running CI using parent hashes"
     }

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -155,16 +155,15 @@ if ($null -ne $OnlyTest)
 }
 else
 {
+    $hostArgs = @()
     if ($Triplet -in @('x64-windows', 'x64-osx', 'x64-linux'))
     {
         # WORKAROUND: These triplets are native-targetting which triggers an issue in how vcpkg handles the skip list.
         # The workaround is to pass the skip list as host-excludes as well.
-        & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --host-exclude=$skipList --failure-logs=$failureLogs @commonArgs
+        $hostArgs = @("--host-exclude=$skipList")
     }
-    else
-    {
-        & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @commonArgs
-    }
+
+    & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @hostArgs @commonArgs
 
     $failureLogsEmpty = (-Not (Test-Path $failureLogs) -Or ((Get-ChildItem $failureLogs).count -eq 0))
     Write-Host "##vso[task.setvariable variable=FAILURE_LOGS_EMPTY]$failureLogsEmpty"


### PR DESCRIPTION
- #### What does your PR fix?
  Limits the impact of the cache state of vcpkg master on pull requests. The original state leads to a waste of build resources for pull request CI runs triggered shortly after significant changes to master. Cf. https://github.com/microsoft/vcpkg-tool/pull/210.

  Updates the documentation for the binary caching effect of the BuildReason parameter of the test script.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  --

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  --
