### PR TITLE
[field3d] Adapt port to use imath dependency

### DIFF
--- a/ports/field3d/0001_fix_build_errors.patch
+++ b/ports/field3d/0001_fix_build_errors.patch
@@ -28,16 +28,17 @@ index 1610c2e..b012008 100644
 +FIND_PACKAGE (Boost COMPONENTS regex thread program_options system REQUIRED)
  
 -FIND_PACKAGE (ILMBase)
-+FIND_PACKAGE (OpenEXR REQUIRED)
++FIND_PACKAGE (Imath CONFIG REQUIRED)
  
  # Allow the developer to select if Dynamic or Static libraries are built
  OPTION (BUILD_SHARED_LIBS "Build Shared Libraries" ON)
-@@ -79,26 +71,14 @@ IF ( CMAKE_HOST_UNIX )
+@@ -79,26 +71,15 @@ IF ( CMAKE_HOST_UNIX )
  ENDIF ( )
  IF ( CMAKE_HOST_WIN32 )
    ADD_DEFINITIONS (
 -    -D_HAS_ITERATOR_DEBUGGING=0 
      -D_CRT_SECURE_NO_WARNINGS=1
++    -DNOMINMAX
      )
  ENDIF ( )
  
@@ -83,7 +84,7 @@ index 1610c2e..b012008 100644
  ENDIF ()
  
 -TARGET_LINK_LIBRARIES ( Field3D ${Field3D_DSO_Libraries} ${Boost_LIBRARIES})
-+TARGET_LINK_LIBRARIES ( Field3D ${Field3D_DSO_Libraries} ${Boost_LIBRARIES} OpenEXR::IlmImf)
++TARGET_LINK_LIBRARIES ( Field3D ${Field3D_DSO_Libraries} ${Boost_LIBRARIES} Imath::Imath)
  
  # Parase version and soversion from export/ns.h
  
@@ -121,28 +122,3 @@ index 1610c2e..b012008 100644
  
  IF (DOXYGEN_FOUND)
    ADD_CUSTOM_TARGET ( doc
-@@ -249,7 +202,7 @@ IF (DOXYGEN_FOUND)
-     WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
-     )
-   IF (INSTALL_DOCS)
--    INSTALL (DIRECTORY 
-+    INSTALL (DIRECTORY
-       ${CMAKE_HOME_DIRECTORY}/docs
-       DESTINATION ${CMAKE_INSTALL_PREFIX}
-     )
-@@ -263,12 +216,11 @@ INSTALL ( TARGETS
- 
- FILE(GLOB Field3d_Includes  "${CMAKE_CURRENT_SOURCE_DIR}/export/*.h")
- 
--INSTALL ( FILES 
--  ${Field3d_Includes} 
-+INSTALL ( FILES
-+  ${Field3d_Includes}
-   DESTINATION include/Field3D
- )
- 
--INSTALL ( TARGETS f3dinfo 
-+INSTALL ( TARGETS f3dinfo
-   RUNTIME DESTINATION bin
- )
--

--- a/ports/field3d/0002_improve_win_compatibility.patch
+++ b/ports/field3d/0002_improve_win_compatibility.patch
@@ -1,17 +1,3 @@
-diff --git a/include/UtilFoundation.h b/include/UtilFoundation.h
-index 2eb6290..a449b5b 100644
---- a/include/UtilFoundation.h
-+++ b/include/UtilFoundation.h
-@@ -90,6 +90,9 @@
- #ifndef WIN32_LEAN_AND_MEAN
- #define WIN32_LEAN_AND_MEAN
- #endif
-+#ifndef NOMINMAX
-+#define NOMINMAX
-+#endif
- 
- // needed for mutex stuff
- #include <Windows.h>
 diff --git a/src/FieldMapping.cpp b/src/FieldMapping.cpp
 index b1f1a1f..90612b1 100644
 --- a/src/FieldMapping.cpp

--- a/ports/field3d/0004_fix_imath_includes.patch
+++ b/ports/field3d/0004_fix_imath_includes.patch
@@ -1,0 +1,136 @@
+--- a/export/StdMathLib.h
++++ b/export/StdMathLib.h
+@@ -38,17 +38,17 @@
+ #ifndef _INCLUDED_Field3D_StdMathLib_H_
+ #define _INCLUDED_Field3D_StdMathLib_H_
+ 
+-#include <OpenEXR/ImathBox.h> 
+-#include <OpenEXR/ImathBoxAlgo.h>
+-#include <OpenEXR/ImathColor.h>
+-#include <OpenEXR/ImathHalfLimits.h>
+-#include <OpenEXR/ImathMatrix.h>
+-#include <OpenEXR/ImathMatrixAlgo.h>
+-#include <OpenEXR/ImathPlane.h>
+-#include <OpenEXR/ImathRandom.h> 
+-#include <OpenEXR/ImathRoots.h>
+-#include <OpenEXR/ImathVec.h>
+-#include <OpenEXR/half.h> 
++#include <Imath/ImathBox.h>
++#include <Imath/ImathBoxAlgo.h>
++#include <Imath/ImathColor.h>
++#include <Imath/ImathMatrix.h>
++#include <Imath/ImathMatrixAlgo.h>
++#include <Imath/ImathPlane.h>
++#include <Imath/ImathRandom.h>
++#include <Imath/ImathRoots.h>
++#include <Imath/ImathVec.h>
++#include <Imath/half.h>
++#include <Imath/halfLimits.h>
+ 
+ //----------------------------------------------------------------------------//
+ 
+--- a/export/Curve.h
++++ b/export/Curve.h
+@@ -53,8 +53,8 @@
+ 
+ #include <boost/lexical_cast.hpp>
+ 
+-#include <OpenEXR/ImathFun.h>
+-#include <OpenEXR/ImathMatrix.h>
++#include <Imath/ImathFun.h>
++#include <Imath/ImathMatrix.h>
+ 
+ //----------------------------------------------------------------------------//
+ 
+--- a/export/FieldWrapper.h
++++ b/export/FieldWrapper.h
+@@ -6,7 +6,7 @@
+ //------------------------------------------------------------------------------
+ 
+ // Library includes
+-#include <OpenEXR/ImathMatrixAlgo.h>
++#include <Imath/ImathMatrixAlgo.h>
+ 
+ // Project includes
+ #include "DenseField.h"
+--- a/export/SpiMathLib.h
++++ b/export/SpiMathLib.h
+@@ -38,20 +38,20 @@
+ #ifndef _INCLUDED_Field3D_SpiMathLib_H_
+ #define _INCLUDED_Field3D_SpiMathLib_H_
+ 
+-#include <OpenEXR/half.h>
+-#include <OpenEXR/ImathHalfLimits.h>
+-
+-#include <OpenEXR/ImathBox.h>
+-#include <OpenEXR/ImathBoxAlgo.h>
+-#include <OpenEXR/ImathColor.h>
+-#include <OpenEXR/ImathMatrix.h>
+-#include <OpenEXR/ImathVec.h>
+-
+-#include <OpenEXR/ImathRoots.h>
+-#include <OpenEXR/ImathMatrixAlgo.h>
+-#include <OpenEXR/ImathRandom.h>
+-#include <OpenEXR/ImathPlane.h>
+-#include <OpenEXR/ImathQuat.h>
++#include <Imath/half.h>
++#include <Imath/halfLimits.h>
++
++#include <Imath/ImathBox.h>
++#include <Imath/ImathBoxAlgo.h>
++#include <Imath/ImathColor.h>
++#include <Imath/ImathMatrix.h>
++#include <Imath/ImathVec.h>
++
++#include <Imath/ImathRoots.h>
++#include <Imath/ImathMatrixAlgo.h>
++#include <Imath/ImathRandom.h>
++#include <Imath/ImathPlane.h>
++#include <Imath/ImathQuat.h>
+ 
+ //----------------------------------------------------------------------------//
+ 
+--- a/include/OgUtil.h
++++ b/include/OgUtil.h
+@@ -10,7 +10,7 @@
+ #include <iostream>
+ #include <string>
+ 
+-#include <OpenEXR/ImathVec.h>
++#include <Imath/ImathVec.h>
+ 
+ #include "All.h"
+ #include "UtilFoundation.h"
+--- a/include/UtilFoundation.h
++++ b/include/UtilFoundation.h
+@@ -68,7 +68,7 @@
+ 
+ #include <memory>
+ 
+-#include <half.h>
++#include <Imath/half.h>
+ 
+ #include <iomanip>
+ #include <iostream>
+--- a/include/OgIAttribute.h
++++ b/include/OgIAttribute.h
+@@ -9,7 +9,7 @@
+ 
+ #include "OgUtil.h"
+ 
+-#include <OpenEXR/ImathMatrix.h>
++#include <Imath/ImathMatrix.h>
+ 
+ //----------------------------------------------------------------------------//
+ 
+--- a/test/unit_tests/UnitTest.cpp
++++ b/test/unit_tests/UnitTest.cpp
+@@ -44,7 +44,7 @@
+ #include <boost/thread/thread.hpp>
+ #include <boost/thread/mutex.hpp>
+ 
+-#include <OpenEXR/ImathFrustum.h>
++#include <Imath/ImathFrustum.h>
+ 
+ #include "Field3D/DenseField.h"
+ #include "Field3D/EmptyField.h"

--- a/ports/field3d/portfile.cmake
+++ b/ports/field3d/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
 if(VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
 vcpkg_from_github(
@@ -14,22 +14,24 @@ vcpkg_from_github(
         0001_fix_build_errors.patch
         0002_improve_win_compatibility.patch
         0003_hdf5_api.patch # Switches the HDF5 default API for this port to 1.10
+        0004_fix_imath_includes.patch
 )
 
-file(REMOVE ${SOURCE_PATH}/cmake/FindILMBase.cmake)
+file(REMOVE "${SOURCE_PATH}/cmake/FindILMBase.cmake")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DINSTALL_DOCS:BOOL=OFF"
+    MAYBE_UNUSED_VARIABLES
+        INSTALL_DOCS
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/field3d/vcpkg.json
+++ b/ports/field3d/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "field3d",
-  "version-string": "1.7.3",
-  "port-version": 2,
+  "version": "1.7.3",
+  "port-version": 3,
   "description": "An open source library for storing voxel data. It provides C++ classes that handle in-memory storage and a file format based on HDF5 that allows the C++ objects to be written to and read from disk.",
   "homepage": "https://github.com/imageworks/Field3D",
   "supports": "!uwp",
@@ -15,6 +15,14 @@
     "boost-thread",
     "boost-timer",
     "hdf5",
-    "openexr"
+    "imath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2146,7 +2146,7 @@
     },
     "field3d": {
       "baseline": "1.7.3",
-      "port-version": 2
+      "port-version": 3
     },
     "fixed-string": {
       "baseline": "0.1.0",

--- a/versions/f-/field3d.json
+++ b/versions/f-/field3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b19cb6d7c640245d1fb4979935fd1fd955d16365",
+      "version": "1.7.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "54a68f2c7d892d5876ff65ad373907bdcfc1b17e",
       "version-string": "1.7.3",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This updates port `field3d` to use the newer `imath` package instead of `openexr`, in preparation to update `openexr` later.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
