### PR TITLE
[highway] Add new port

### DIFF
--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -16,6 +16,10 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+# remove test-related pkg-config files that break vcpkg_fixup_pkgconfig
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libhwy-test.pc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libhwy-test.pc")
+
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/highway/portfile.cmake
+++ b/ports/highway/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/highway
+    REF 0.14.2
+    SHA512 fc1a35463c95c45b646c53f91a9996112726de1d588dcd4d25a7d366840f704ad9a4c0bb6e0a001e929409f04aad6922cbffcf93774a0c360aff875956c7cc8d
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/highway/vcpkg.json
+++ b/ports/highway/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "highway",
+  "version-semver": "0.14.2",
+  "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
+  "homepage": "https://github.com/google/highway",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2676,6 +2676,10 @@
       "baseline": "2.3",
       "port-version": 0
     },
+    "highway": {
+      "baseline": "0.14.2",
+      "port-version": 0
+    },
     "hiredis": {
       "baseline": "1.0.2",
       "port-version": 1

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f4835f454cfb12c52a80ce11c685ae6c6213505a",
+      "version-semver": "0.14.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/h-/highway.json
+++ b/versions/h-/highway.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f4835f454cfb12c52a80ce11c685ae6c6213505a",
+      "git-tree": "5167bd4fba072a5f09398d913d5e575241c67c5e",
       "version-semver": "0.14.2",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This adds a new port for [highway](https://github.com/google/highway) (aka libhwy) 0.14.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not sure yet, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
