### PR TITLE
[vcpkg] Revise appdeploy and copy_tool_dependencies

### DIFF
--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -19,14 +19,19 @@ function computeHash([System.Security.Cryptography.HashAlgorithm]$alg, [string]$
 }
 
 function getMutex([string]$targetDir) {
-    $sha512Hash = [System.Security.Cryptography.SHA512]::Create()
-    if ($sha512Hash) {
-        $hash = computeHash $sha512Hash $targetDir
-        $mtxName = "VcpkgAppLocalDeployBinary-" + $hash
-        return New-Object System.Threading.Mutex($false, $mtxName)
-    }
+    try {
+        $sha512Hash = [System.Security.Cryptography.SHA512]::Create()
+        if ($sha512Hash) {
+            $hash = computeHash $sha512Hash $targetDir
+            $mtxName = "VcpkgAppLocalDeployBinary-" + $hash
+            return New-Object System.Threading.Mutex($false, $mtxName)
+        }
 
-    return New-Object System.Threading.Mutex($false, "VcpkgAppLocalDeployBinary")
+        return New-Object System.Threading.Mutex($false, "VcpkgAppLocalDeployBinary")
+    }
+    catch {
+        return 0
+    }
 }
 
 # Note: this function signature is depended upon by the qtdeploy.ps1 script introduced in 5.7.1-7

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -4,7 +4,7 @@ param([string]$targetBinary, [string]$installedDir, [string]$tlogFile, [string]$
 $g_searched = @{}
 # Note: installedDir is actually the bin\ directory.
 $g_install_root = Split-Path $installedDir -parent
-$g_is_debug = $g_install_root -match '(.*\\)?debug(\\)?$'
+$g_is_debug = (Split-Path $g_install_root -leaf) -eq 'debug'
 
 # Ensure we create the copied files log, even if we don't end up copying any files
 if ($copiedFilesLog)
@@ -42,22 +42,24 @@ function deployBinary([string]$targetBinaryDir, [string]$SourceDir, [string]$tar
             $mtx.WaitOne() | Out-Null
         }
 
-        if (Test-Path "$targetBinaryDir\$targetBinaryName") {
-            $sourceModTime = (Get-Item $SourceDir\$targetBinaryName).LastWriteTime
-            $destModTime = (Get-Item $targetBinaryDir\$targetBinaryName).LastWriteTime
+        $sourceBinaryFilePath = Join-Path $SourceDir $targetBinaryName
+        $targetBinaryFilePath = Join-Path $targetBinaryDir $targetBinaryName
+        if (Test-Path $targetBinaryFilePath) {
+            $sourceModTime = (Get-Item $sourceBinaryFilePath).LastWriteTime
+            $destModTime = (Get-Item $targetBinaryFilePath).LastWriteTime
             if ($destModTime -lt $sourceModTime) {
-                Write-Verbose "  ${targetBinaryName}: Updating $SourceDir\$targetBinaryName"
-                Copy-Item "$SourceDir\$targetBinaryName" $targetBinaryDir
+                Write-Verbose "  ${targetBinaryName}: Updating from $sourceBinaryFilePath"
+                Copy-Item $sourceBinaryFilePath $targetBinaryDir
             } else {
                 Write-Verbose "  ${targetBinaryName}: already present"
             }
         }
         else {
-            Write-Verbose "  ${targetBinaryName}: Copying $SourceDir\$targetBinaryName"
-            Copy-Item "$SourceDir\$targetBinaryName" $targetBinaryDir
+            Write-Verbose "  ${targetBinaryName}: Copying $sourceBinaryFilePath"
+            Copy-Item $sourceBinaryFilePath $targetBinaryDir
         }
-        if ($copiedFilesLog) { Add-Content $copiedFilesLog "$targetBinaryDir\$targetBinaryName" -Encoding UTF8 }
-        if ($tlogFile) { Add-Content $tlogFile "$targetBinaryDir\$targetBinaryName" -Encoding Unicode }
+        if ($copiedFilesLog) { Add-Content $copiedFilesLog targetBinaryFilePath -Encoding UTF8 }
+        if ($tlogFile) { Add-Content $tlogFile $targetBinaryFilePath -Encoding Unicode }
     } finally {
         if ($mtx) {
             $mtx.ReleaseMutex() | Out-Null
@@ -109,24 +111,26 @@ function resolve([string]$targetBinary) {
             return
         }
         $g_searched.Set_Item($_, $true)
-        if (Test-Path "$installedDir\$_") {
+        $installedItemFilePath = Join-Path $installedDir $_
+        $targetItemFilePath = Join-Path $targetBinaryDir $_
+        if (Test-Path $installedItemFilePath) {
             deployBinary $baseTargetBinaryDir $installedDir "$_"
-            if (Test-Path function:\deployPluginsIfQt) { deployPluginsIfQt $baseTargetBinaryDir "$g_install_root\plugins" "$_" }
+            if (Test-Path function:\deployPluginsIfQt) { deployPluginsIfQt $baseTargetBinaryDir (Join-Path $g_install_root 'plugins') "$_" }
             if (Test-Path function:\deployOpenNI2) { deployOpenNI2 $targetBinaryDir "$g_install_root" "$_" }
             if (Test-Path function:\deployPluginsIfMagnum) {
                 if ($g_is_debug) {
-                    deployPluginsIfMagnum $targetBinaryDir "$g_install_root\bin\magnum-d" "$_"
+                    deployPluginsIfMagnum $targetBinaryDir (Join-Path "$g_install_root" 'bin' 'magnum-d') "$_"
                 } else {
-                    deployPluginsIfMagnum $targetBinaryDir "$g_install_root\bin\magnum" "$_"
+                    deployPluginsIfMagnum $targetBinaryDir (Join-Path "$g_install_root" 'bin' 'magnum') "$_"
                 }
             }
             if (Test-Path function:\deployAzureKinectSensorSDK) { deployAzureKinectSensorSDK $targetBinaryDir "$g_install_root" "$_" }
-            resolve "$baseTargetBinaryDir\$_"
-        } elseif (Test-Path "$targetBinaryDir\$_") {
-            Write-Verbose "  ${_}: $_ not found in vcpkg; locally deployed"
-            resolve "$targetBinaryDir\$_"
+            resolve (Join-Path $baseTargetBinaryDir "$_")
+        } elseif (Test-Path $targetItemFilePath) {
+            Write-Verbose "  ${_}: $_ not found in $g_install_root; locally deployed"
+            resolve "$targetItemFilePath"
         } else {
-            Write-Verbose "  ${_}: $installedDir\$_ not found"
+            Write-Verbose "  ${_}: $installedItemFilePath not found"
         }
     }
     Write-Verbose "Done Resolving $targetBinary."

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -30,7 +30,7 @@ function getMutex([string]$targetDir) {
         return New-Object System.Threading.Mutex($false, "VcpkgAppLocalDeployBinary")
     }
     catch {
-        return 0
+        Write-Error -Message $_ -ErrorAction Stop
     }
 }
 

--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -22,7 +22,7 @@ function getMutex([string]$targetDir) {
     try {
         $sha512Hash = [System.Security.Cryptography.SHA512]::Create()
         if ($sha512Hash) {
-            $hash = computeHash $sha512Hash $targetDir
+            $hash = (computeHash $sha512Hash $targetDir) -replace ('/' ,'-')
             $mtxName = "VcpkgAppLocalDeployBinary-" + $hash
             return New-Object System.Threading.Mutex($false, $mtxName)
         }

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -50,7 +50,16 @@ function(vcpkg_copy_tool_dependencies tool_dir)
         if (NOT Z_VCPKG_POWERSHELL_CORE)
             message(FATAL_ERROR "Could not find PowerShell Core; please open an issue to report this.")
         endif()
-        z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_PACKAGES_DIR}/bin")
-        z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_INSTALLED_DIR}/bin")
+        cmake_path(RELATIVE_PATH tool_dir
+            BASE_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+            OUTPUT_VARIABLE relative_tool_dir
+        )
+        if(relative_tool_dir MATCHES "/debug/")
+            z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_PACKAGES_DIR}/debug/bin")
+            z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_INSTALLED_DIR}/debug/bin")
+        else()
+            z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_PACKAGES_DIR}/bin")
+            z_vcpkg_copy_tool_dependencies_search("${tool_dir}" "${CURRENT_INSTALLED_DIR}/bin")
+        endif()
     endif()
 endfunction()

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -25,6 +25,11 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
     else()
         set(count 0)
     endif()
+    if(PORT_DEBUG)
+        set(verbose "-verbose")
+    else()
+        set(verbose "")
+    endif()
     file(GLOB tools "${tool_dir}/*.exe" "${tool_dir}/*.dll" "${tool_dir}/*.pyd")
     foreach(tool IN LISTS tools)
         vcpkg_execute_required_process(
@@ -32,6 +37,7 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
                 -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
                 -targetBinary "${tool}"
                 -installedDir "${path_to_search}"
+                ${verbose}
             WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
             LOGNAME copy-tool-dependencies-${count}
         )

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -20,6 +20,11 @@ This command should always be called by portfiles after they have finished rearr
 #]===]
 
 function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
+    if(DEFINED Z_VCPKG_COPY_TOOL_DEPENDENCIES_COUNT)
+        set(count ${Z_VCPKG_COPY_TOOL_DEPENDENCIES_COUNT})
+    else()
+        set(count 0)
+    endif()
     file(GLOB tools "${tool_dir}/*.exe" "${tool_dir}/*.dll" "${tool_dir}/*.pyd")
     foreach(tool IN LISTS tools)
         vcpkg_execute_required_process(
@@ -28,9 +33,11 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
                 -targetBinary "${tool}"
                 -installedDir "${path_to_search}"
             WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
-            LOGNAME copy-tool-dependencies
+            LOGNAME copy-tool-dependencies-${count}
         )
+        math(EXPR count "${count} + 1")
     endforeach()
+    set(Z_VCPKG_COPY_TOOL_DEPENDENCIES_COUNT ${count} CACHE INTERNAL "")
 endfunction()
 
 function(vcpkg_copy_tool_dependencies tool_dir)

--- a/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
+++ b/scripts/cmake/vcpkg_copy_tool_dependencies.cmake
@@ -25,11 +25,6 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
     else()
         set(count 0)
     endif()
-    if(PORT_DEBUG)
-        set(verbose "-verbose")
-    else()
-        set(verbose "")
-    endif()
     file(GLOB tools "${tool_dir}/*.exe" "${tool_dir}/*.dll" "${tool_dir}/*.pyd")
     foreach(tool IN LISTS tools)
         vcpkg_execute_required_process(
@@ -37,7 +32,7 @@ function(z_vcpkg_copy_tool_dependencies_search tool_dir path_to_search)
                 -file "${SCRIPTS}/buildsystems/msbuild/applocal.ps1"
                 -targetBinary "${tool}"
                 -installedDir "${path_to_search}"
-                ${verbose}
+                -verbose
             WORKING_DIRECTORY "${VCPKG_ROOT_DIR}"
             LOGNAME copy-tool-dependencies-${count}
         )


### PR DESCRIPTION
- #### What does your PR fix?  
  - [appdeploy] Fixes deployment for mingw on linux by 
    - making path construction portable,
    - ~catching failing~ fixing mutex creation.
  - [copy_tool_dependencies] Enables deployment for debug config.
  - [copy_tool_dependencies] Fixes overwriting of log files within a single port build.
  - [copy_tool_dependencies] Enables actual logging ~at least when `DEBUG_PORT` is set (cf. `debug_message` in `ports.cmake`)~.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  --

- ### For discussion
  - ~Logging (`-verbose`) might always be enabled. It doesn't clutter output.~
  - ~If there is a better idea how to deal with the mutex creation issue...~
  - To correctly handle some port being set to a single config (via triplet file), it would be necessary to also search the alternative `bin` directory.
  - It is not efficient to call `appdeploy.ps1` twice. It should better take a list of directories as search path instead of a single directory.
    And it should also take a list of executables (or just a single directory).