### PR TITLE
[libsercomm] Adding new port

### DIFF
--- a/ports/libsercomm/portfile.cmake
+++ b/ports/libsercomm/portfile.cmake
@@ -1,0 +1,42 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ingeniamc/sercomm
+    REF 1.3.2
+    SHA512 f1581f2dfa262ffb1b3aec5a1e6d32493c322c94541fbacc98efff23b3b42b14c9abdcfb063a78b7c54fb1f9d8dbf59d8064099601de2175af6c6d830708324c
+    HEAD_REF master
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        errdesc WITH_ERRDESC
+        devmon  WITH_DEVMON
+        pic     WITH_PIC
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+# Fix CMake files
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sercomm)
+
+vcpkg_fixup_pkgconfig()
+
+# Remove includes in debug
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Copy pdb files
+vcpkg_copy_pdbs()

--- a/ports/libsercomm/portfile.cmake
+++ b/ports/libsercomm/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_check_features(
         pic     WITH_PIC
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
     DISABLE_PARALLEL_CONFIGURE
@@ -22,10 +22,10 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Fix CMake files
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/sercomm)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/sercomm)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/libsercomm/portfile.cmake
+++ b/ports/libsercomm/portfile.cmake
@@ -11,12 +11,10 @@ vcpkg_check_features(
     FEATURES
         errdesc WITH_ERRDESC
         devmon  WITH_DEVMON
-        pic     WITH_PIC
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         ${FEATURE_OPTIONS}

--- a/ports/libsercomm/vcpkg.json
+++ b/ports/libsercomm/vcpkg.json
@@ -24,9 +24,6 @@
     },
     "errdesc": {
       "description": "When enabled, error details description can be obtained"
-    },
-    "pic": {
-      "description": "When enabled, generated code will be position independent. This may be useful if you want to embed sercomm into a dynamic library"
     }
   }
 }

--- a/ports/libsercomm/vcpkg.json
+++ b/ports/libsercomm/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libsercomm",
+  "version": "1.3.2",
+  "description": "Multiplatform serial communications library",
+  "homepage": "https://github.com/ingeniamc/sercomm",
+  "license": "MIT",
+  "default-features": [
+    "devmon",
+    "errdesc"
+  ],
+  "features": {
+    "devmon": {
+      "description": "When enabled, device listing and monitoring will be supported"
+    },
+    "errdesc": {
+      "description": "When enabled, error details description can be obtained"
+    },
+    "pic": {
+      "description": "When enabled, generated code will be position independent. This may be useful if you want to embed sercomm into a dynamic library"
+    }
+  }
+}

--- a/ports/libsercomm/vcpkg.json
+++ b/ports/libsercomm/vcpkg.json
@@ -4,6 +4,16 @@
   "description": "Multiplatform serial communications library",
   "homepage": "https://github.com/ingeniamc/sercomm",
   "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "default-features": [
     "devmon",
     "errdesc"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3808,6 +3808,10 @@
       "baseline": "2.3.0",
       "port-version": 0
     },
+    "libsercomm": {
+      "baseline": "1.3.2",
+      "port-version": 0
+    },
     "libsigcpp": {
       "baseline": "3.0.3",
       "port-version": 1

--- a/versions/l-/libsercomm.json
+++ b/versions/l-/libsercomm.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "85fa53c8aa1927afa7844c01b646a86de8803c30",
+      "version": "1.3.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new port, libsercomm

- #### What does your PR fix?  
  Fixes #21003 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
