### PR TITLE
[fcl] Enable dynamic support

### DIFF
--- a/ports/fcl/vcpkg.json
+++ b/ports/fcl/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "fcl",
   "version": "0.7.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "a library for performing three types of proximity queries on a pair of geometric models composed of triangles",
   "homepage": "https://github.com/flexible-collision-library/fcl",
-  "supports": "static",
   "dependencies": [
     "ccd",
     "eigen3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2118,7 +2118,7 @@
     },
     "fcl": {
       "baseline": "0.7.0",
-      "port-version": 1
+      "port-version": 2
     },
     "fdk-aac": {
       "baseline": "2.0.2",

--- a/versions/f-/fcl.json
+++ b/versions/f-/fcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "11b59644379cbae75571423312e0c0971e6d3740",
+      "version": "0.7.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "63fe0d8f64a95e4eef52c44f1e2a6e6240ca53fe",
       "version": "0.7.0",
       "port-version": 1


### PR DESCRIPTION
In PR https://github.com/microsoft/vcpkg/pull/20917, fcl was be decleared as a staitc port only, that caused the downstream can't be built on dynamic triplet.
Since fcl is already defined as `ONLY_STATIC_LIBRARY`, remove the `support` keyword.
https://github.com/microsoft/vcpkg/blob/5bdb9d60123df20c247a1654e6a1def51d6c5140/ports/fcl/portfile.cmake#L1

Fixes #21083.

Please note that the current `supports` field will prevent triplet build outside of the allowed rules!