### PR TITLE
[bullet3] Add support for OSX arm triplet

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -18,9 +18,8 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         multithreading       BULLET2_MULTITHREADING
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DUSE_MSVC_RUNTIME_LIBRARY_DLL=ON
         -DBUILD_CPU_DEMOS=OFF
@@ -32,16 +31,15 @@ vcpkg_configure_cmake(
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/bullet TARGET_PATH share/bullet)
+vcpkg_cmake_config_fixup(PACKAGE_NAME bullet CONFIG_PATH share/bullet)
+
+vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/bullet/BulletInverseDynamics/details")
 
-vcpkg_copy_pdbs()
-
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+if (NOT VCPKG_TARGET_IS_OSX)
+    vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
+endif()
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -5,6 +5,16 @@
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
   "supports": "!((windows | linux) & (arm | uwp))",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "multithreading": {
       "description": "Multithreading functionality for bullet3"

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "bullet3",
   "version": "3.17",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
+  "supports": "!((windows | linux) & (arm | uwp))",
   "features": {
     "multithreading": {
       "description": "Multithreading functionality for bullet3"

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28578c32a4ac8cd357a96df13cdd8072fd9376fe",
+      "git-tree": "88add55351bf89f89e584924663861c0a827bdf5",
       "version": "3.17",
       "port-version": 3
     },

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "28578c32a4ac8cd357a96df13cdd8072fd9376fe",
+      "version": "3.17",
+      "port-version": 3
+    },
+    {
       "git-tree": "bcc42d2c8eb5fc4134c31f6176bc0c0ae3bc46e1",
       "version": "3.17",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1170,7 +1170,7 @@
     },
     "bullet3": {
       "baseline": "3.17",
-      "port-version": 2
+      "port-version": 3
     },
     "bustache": {
       "baseline": "1.1.0",


### PR DESCRIPTION
bullet3 can be built successfully on arm64-osx, enable this triplet.
Cannot test arm64-linux because there is no arm-linux machine.

Fixes #21091.