### PR TITLE
[blaze] support automatic configuration of BLAS 

### DIFF
--- a/ports/blaze/portfile.cmake
+++ b/ports/blaze/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_bitbucket(
         fix-vm-build.patch
 )
 
+# TODO use target_link_blaze
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA

--- a/ports/blaze/target_link_blaze.cmake
+++ b/ports/blaze/target_link_blaze.cmake
@@ -1,0 +1,105 @@
+# Link the given target to BLAZE. It supports an optional BLAS argument, which can be set to use a BLAS library.
+# Examples:
+#     target_configure_blaze(main)
+#     target_configure_blaze(main BLAS "OpenBLAS")
+#     target_configure_blaze(main BLAS "MKL")
+function(target_configure_blaze target)
+  set(oneValueArgs BLAS)
+  cmake_parse_arguments(
+    LinkBlaze
+    ""
+    "${oneValueArgs}"
+    ""
+    ${ARGN}
+  )
+
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL AMD64)
+    set(BLAS_64Bit 1)
+    # use inside openblas_common.h
+    # fix for https://github.com/microsoft/vcpkg/issues/21072
+    if(WIN32)
+      target_compile_definitions(${target} PRIVATE OS_WINNT=1)
+    endif()
+    target_compile_definitions(${target} PRIVATE __64BIT__=1)
+  else()
+    set(BLAS_64Bit 0)
+  endif()
+
+  if(NOT
+     "${LinkBlaze_BLAS}"
+     STREQUAL
+     ""
+  )
+    if("${LinkBlaze_BLAS}" STREQUAL "OpenBLAS")
+      find_package(OpenBLAS REQUIRED)
+      target_link_libraries(${target} PRIVATE OpenBLAS::OpenBLAS)
+
+      # cblas.h
+      find_path(CBLAS_DIR cblas.h)
+      if(NOT
+         "${CBLAS_DIR}"
+         STREQUAL
+         "NOTFOUND"
+      )
+        set(BLAZE_BLAS_INCLUDE_FILE ${CBLAS_DIR}/cblas.h)
+      else()
+        list(
+          GET
+          OpenBLAS_INCLUDE_DIR
+          1
+          ACTUAL_OpenBLAS_INCLUDE_DIR
+        )
+        set(BLAZE_BLAS_INCLUDE_FILE "${ACTUAL_OpenBLAS_INCLUDE_DIR}/cblas.h")
+      endif()
+
+      set(BLAZE_BLAS_MODE 1)
+      set(BLAZE_BLAS_IS_PARALLEL 1)
+      message(STATUS "Building Blaze with OpenBLAS.")
+    elseif("${LinkBlaze_BLAS}" STREQUAL "MKL")
+      find_package(MKL REQUIRED)
+      target_link_libraries(${target} PRIVATE MKL::MKL)
+
+      # cblas.h
+      find_path(CBLAS_DIR cblas.h)
+      if(NOT
+         "${CBLAS_DIR}"
+         STREQUAL
+         "NOTFOUND"
+      )
+        message(STATUS "Found cblas.h in ${CBLAS_DIR}.")
+        set(BLAZE_BLAS_INCLUDE_FILE ${CBLAS_DIR}/cblas.h)
+      else()
+        list(
+          GET
+          MKL_INCLUDE_DIR
+          1
+          ACTUAL_MKL_INCLUDE_DIR
+        )
+        set(BLAZE_BLAS_INCLUDE_FILE "${ACTUAL_MKL_INCLUDE_DIR}/cblas.h")
+      endif()
+      set(BLAZE_BLAS_MODE 1)
+      set(BLAZE_BLAS_IS_PARALLEL 1)
+      message(STATUS "Building Blaze with MKL.")
+    else()
+      message(
+        WARNING
+          "${LinkBlaze_BLAS} is not a supported. You should configure the BLAS library yourself. The Supported BLAS libraries are: OpenBLAS, MKL"
+      )
+      return()
+    endif()
+  else()
+    message(STATUS "Building Blaze without BLAS.")
+    set(BLAZE_BLAS_MODE 0)
+    set(BLAZE_BLAS_IS_PARALLEL 0)
+  endif()
+
+  target_compile_definitions(
+    ${target}
+    PRIVATE
+      BLAZE_BLAS_MODE=${BLAZE_BLAS_MODE} # Enable BLAS
+      BLAZE_BLAS_INCLUDE_FILE="${BLAZE_BLAS_INCLUDE_FILE}" # BLAS lib (the Blaze's default is <cblas.h>)
+      BLAZE_BLAS_IS_64BIT=${BLAS_64Bit} # 64Bit BLAS
+      BLAZE_BLAS_IS_PARALLEL=${BLAZE_BLAS_IS_PARALLEL} # If the BLAS itself is parallel, disable the Blaze's internal parallelization
+      BLAZE_USE_VECTORIZATION=1 # Vectorization
+  )
+endfunction()

--- a/ports/blaze/vcpkg.json
+++ b/ports/blaze/vcpkg.json
@@ -7,5 +7,25 @@
   "dependencies": [
     "boost-exception",
     "lapack"
-  ]
+  ],
+  "default-features": [
+    "noblas"
+  ],
+  "features": {
+    "noblas": {
+      "description": "Do not use BLAS"
+    },
+    "openblas": {
+      "description": "Use OpenBLAS",
+      "dependencies": [
+          "openblas"
+      ]
+    },
+    "intel-mkl": {
+      "description": "Use MKL",
+      "dependencies": [
+        "intel-mkl"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
**Describe the pull request**

This pull request adds support for the automatic configuration of BLAS features for Blaze.

TODO: I am not much familiar with port files in vcpkg. I am trying to understand how to use my `target_configure_blaze` function. In my own project, I used it like this:
```cmake
set(BLAS_OPTION
    "OpenBLAS"
    CACHE STRING "The BLAS library to use. Can be OpenBLAS, MKL, or None"
)
if("${BLAS_OPTION}" STREQUAL "OpenBLAS")
  list(APPEND VCPKG_MANIFEST_FEATURES "openblas")
  target_configure_blaze(main BLAS OpenBLAS)
elseif("${BLAS_OPTION}" STREQUAL "MKL")
  list(APPEND VCPKG_MANIFEST_FEATURES "mkl")
  target_configure_blaze(main BLAS MKL)
else()
  list(APPEND VCPKG_MANIFEST_FEATURES "noblas")
  target_configure_blaze(main)
endif()

```

- #### What does your PR fix?  
  Fixes #20030
  Indirectly related to #21072

  Also related to https://bitbucket.org/blaze-lib/blaze/issues/419/automatic-blas-cmake-configuration

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  TODO `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
