### PR TITLE
README updated to include tool repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ check out our [Getting Started](#getting-started) section for how to start using
 For short description of available commands, once you've installed vcpkg,
 you can run `vcpkg help`, or `vcpkg help [command]` for command-specific help.
 
-* Github: [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg)
+* Github: ports at [https://github.com/microsoft/vcpkg](https://github.com/microsoft/vcpkg), program at [https://github.com/microsoft/vcpkg-tool](https://github.com/microsoft/vcpkg-tool)
 * Slack: [https://cppalliance.org/slack/](https://cppalliance.org/slack/), the #vcpkg channel
 * Discord: [\#include \<C++\>](https://www.includecpp.org), the #🌏vcpkg channel
 * Docs: [Documentation](docs/README.md)


### PR DESCRIPTION
#### What does your PR fix?  
Fixes the missing "easy to find" information where to find the tool and its code.

I _think_ the tool was found here years ago (did it), in any case when reporting #21117 I've searched too long for the actual code because vcpkg point in its error message here. This simple additio to the README will help people finding the tool's code much faster.