### PR TITLE
[abseil] Support x86 and arm

### DIFF
--- a/ports/abseil/fix-32-bit-arm.patch
+++ b/ports/abseil/fix-32-bit-arm.patch
@@ -1,0 +1,23 @@
+diff --git a/absl/time/internal/cctz/src/zone_info_source.cc b/absl/time/internal/cctz/src/zone_info_source.cc
+index 7209533..5ab5a59 100644
+--- a/absl/time/internal/cctz/src/zone_info_source.cc
++++ b/absl/time/internal/cctz/src/zone_info_source.cc
+@@ -65,7 +65,7 @@ ZoneInfoSourceFactory zone_info_source_factory __attribute__((weak)) =
+ extern ZoneInfoSourceFactory zone_info_source_factory;
+ extern ZoneInfoSourceFactory default_factory;
+ ZoneInfoSourceFactory default_factory = DefaultFactory;
+-#if defined(_M_IX86)
++#if defined(_M_IX86) || defined(_M_ARM)
+ #pragma comment(                                                                                                         \
+     linker,                                                                                                              \
+     "/alternatename:?zone_info_source_factory@cctz_extension@time_internal@" ABSL_INTERNAL_MANGLED_NS                    \
+@@ -83,8 +83,7 @@ ZoneInfoSourceFactory default_factory = DefaultFactory;
+     "@@U?$default_delete@VZoneInfoSource@cctz@time_internal@" ABSL_INTERNAL_MANGLED_NS                                   \
+     "@@@std@@@std@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@2@@Z@" ABSL_INTERNAL_MANGLED_BACKREFERENCE \
+     "@@ZA")
+-#elif defined(_M_IA_64) || defined(_M_AMD64) || defined(_M_ARM) || \
+-    defined(_M_ARM64)
++#elif defined(_M_IA_64) || defined(_M_AMD64) || defined(_M_ARM64)
+ #pragma comment(                                                                                                          \
+     linker,                                                                                                               \
+     "/alternatename:?zone_info_source_factory@cctz_extension@time_internal@" ABSL_INTERNAL_MANGLED_NS                     \

--- a/ports/abseil/portfile.cmake
+++ b/ports/abseil/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         # detection can cause ABI issues depending on which compiler options
         # are enabled for consuming user code
         fix-cxx-standard.patch
+        fix-32-bit-arm.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -22,35 +23,34 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         cxx17 ABSL_USE_CXX17
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/absl TARGET_PATH share/absl)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME absl CONFIG_PATH lib/cmake/absl)
 vcpkg_fixup_pkgconfig()
 
 vcpkg_copy_pdbs()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/include
-                    ${CURRENT_PACKAGES_DIR}/include/absl/copts
-                    ${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata
-                    ${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/copts"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/strings/testdata"
+                    "${CURRENT_PACKAGES_DIR}/include/absl/time/internal/cctz/testdata"
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/config.h
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/config.h"
         "#elif defined(ABSL_CONSUME_DLL)" "#elif 1"
     )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/base/internal/thread_identity.h"
         "&& !defined(ABSL_CONSUME_DLL)" "&& 0"
     )
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/absl/container/internal/hashtablez_sampler.h
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/absl/container/internal/hashtablez_sampler.h"
         "!defined(ABSL_CONSUME_DLL)" "0"
     )
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/abseil/vcpkg.json
+++ b/ports/abseil/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "abseil",
   "version-string": "20210324.2",
+  "port-version": 1,
   "description": [
     "an open-source collection designed to augment the C++ standard library.",
     "Abseil is an open-source collection of C++ library code designed to augment the C++ standard library. The Abseil library code is collected from Google's own C++ code base, has been extensively tested and used in production, and is the same code we depend on in our daily coding lives.",
@@ -8,7 +9,16 @@
     "Abseil is not meant to be a competitor to the standard library; we've just found that many of these utilities serve a purpose within our code base, and we now want to provide those resources to the C++ community as a whole."
   ],
   "homepage": "https://github.com/abseil/abseil-cpp",
-  "supports": "(x64 | arm64) & (linux | osx | windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "cxx17": {
       "description": "Enable compiler C++17."

--- a/versions/a-/abseil.json
+++ b/versions/a-/abseil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10d137aa21adc696f8469d49f67b90ce0d50e1a1",
+      "version-string": "20210324.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "231cc80bbfb1e54466799ddb6a94dc6d15e7d39b",
       "version-string": "20210324.2",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -10,7 +10,7 @@
     },
     "abseil": {
       "baseline": "20210324.2",
-      "port-version": 0
+      "port-version": 1
     },
     "absent": {
       "baseline": "0.3.1",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #21077

Remove deprecated functions

Add the patch to support x86 and arm. The changes are from upstream https://github.com/abseil/abseil-cpp/commit/3b22e57740b8aec4920c4cfd76b78b3a4fcb2bb5,which has been merged to upstream now.

Note: The feature cxx17 has passed with the following triplets:

- x86-windows
- x64-windows-static

