### PR TITLE
[mdspan] Add new port for kokkos/mdspan

### DIFF
--- a/ports/mdspan/portfile.cmake
+++ b/ports/mdspan/portfile.cmake
@@ -4,9 +4,9 @@ vcpkg_from_github(
   REPO
   kokkos/mdspan
   REF
-  9d1acac543053cbe6839273f550b1ece218e9696 # v0.1.0
+  aced2cebd362a1e15830da030bd16748131d28bd # stable as of 2021-11-03
   SHA512
-  fcb75063e22367f830dee2b7ecbccb0c0682d03e5b8959f4c3a8d3ba5f3e259b7a44ce42ade999e4c39273c34adb286f69f2ca94ce15cfbe294184983880975f
+  a1950430be537497fb84c4a8c5e681cacead93512775098f38ea6c1a20b95d0f7110d9d0802fbdcf8ce3c40ade766cc697773f6ea6fcf8c363b3ebee55620f7c
   HEAD_REF
   stable)
 

--- a/ports/mdspan/portfile.cmake
+++ b/ports/mdspan/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH
+  SOURCE_PATH
+  REPO
+  kokkos/mdspan
+  REF
+  9d1acac543053cbe6839273f550b1ece218e9696 # v0.1.0
+  SHA512
+  fcb75063e22367f830dee2b7ecbccb0c0682d03e5b8959f4c3a8d3ba5f3e259b7a44ce42ade999e4c39273c34adb286f69f2ca94ce15cfbe294184983880975f
+  HEAD_REF
+  stable)
+
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mdspan)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib"
+     "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_copy_pdbs()
+
+file(
+  INSTALL ${SOURCE_PATH}/LICENSE
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+  RENAME copyright)

--- a/ports/mdspan/portfile.cmake
+++ b/ports/mdspan/portfile.cmake
@@ -1,27 +1,19 @@
 vcpkg_from_github(
-  OUT_SOURCE_PATH
-  SOURCE_PATH
-  REPO
-  kokkos/mdspan
-  REF
-  aced2cebd362a1e15830da030bd16748131d28bd # stable as of 2021-11-03
-  SHA512
-  a1950430be537497fb84c4a8c5e681cacead93512775098f38ea6c1a20b95d0f7110d9d0802fbdcf8ce3c40ade766cc697773f6ea6fcf8c363b3ebee55620f7c
-  HEAD_REF
-  stable)
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kokkos/mdspan
+    REF aced2cebd362a1e15830da030bd16748131d28bd # stable as of 2021-11-03
+    SHA512 a1950430be537497fb84c4a8c5e681cacead93512775098f38ea6c1a20b95d0f7110d9d0802fbdcf8ce3c40ade766cc697773f6ea6fcf8c363b3ebee55620f7c
+    HEAD_REF stable
+)
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mdspan)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib"
-     "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
 
 vcpkg_copy_pdbs()
 
-file(
-  INSTALL ${SOURCE_PATH}/LICENSE
-  DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
-  RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/mdspan/vcpkg.json
+++ b/ports/mdspan/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mdspan",
   "version-date": "2021-11-03",
-  "description": "Provide a production-quality implementation of the P0009 proposal as written in preparation for the addition of mdspan to the c++ standard library.",
+  "description": "A non-owning multi-dimensional array reference type.",
   "homepage": "https://github.com/kokkos/mdspan",
   "dependencies": [
     {

--- a/ports/mdspan/vcpkg.json
+++ b/ports/mdspan/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mdspan",
-  "version-semver": "0.1.0",
+  "version-date": "2021-11-03",
   "description": "Provide a production-quality implementation of the P0009 proposal as written in preparation for the addition of mdspan to the c++ standard library.",
   "homepage": "https://github.com/kokkos/mdspan",
   "dependencies": [

--- a/ports/mdspan/vcpkg.json
+++ b/ports/mdspan/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "mdspan",
+  "version-semver": "0.1.0",
+  "description": "Provide a production-quality implementation of the P0009 proposal as written in preparation for the addition of mdspan to the c++ standard library.",
+  "homepage": "https://github.com/kokkos/mdspan",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4269,7 +4269,7 @@
       "port-version": 0
     },
     "mdspan": {
-      "baseline": "0.1.0",
+      "baseline": "2021-11-03",
       "port-version": 0
     },
     "mecab": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4268,6 +4268,10 @@
       "baseline": "878.270.2",
       "port-version": 0
     },
+    "mdspan": {
+      "baseline": "0.1.0",
+      "port-version": 0
+    },
     "mecab": {
       "baseline": "2019-09-25",
       "port-version": 2

--- a/versions/m-/mdspan.json
+++ b/versions/m-/mdspan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2272b577f0fa7bcccc5a881299fba96cf2c89e7c",
+      "git-tree": "3e312b5c0220a832b0deebd7478f044481ebe79c",
       "version-date": "2021-11-03",
       "port-version": 0
     }

--- a/versions/m-/mdspan.json
+++ b/versions/m-/mdspan.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "34e491bda53341d93d2cb0e88603955b32d59b00",
-      "version-semver": "0.1.0",
+      "git-tree": "2272b577f0fa7bcccc5a881299fba96cf2c89e7c",
+      "version-date": "2021-11-03",
       "port-version": 0
     }
   ]

--- a/versions/m-/mdspan.json
+++ b/versions/m-/mdspan.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "34e491bda53341d93d2cb0e88603955b32d59b00",
+      "version-semver": "0.1.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Adds new port for [mdspan](https://github.com/kokkos/mdspan)

- #### What does your PR fix?  
  Fixes #21183 , adds new port for mdspan

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
