### PR TITLE
[pcre2] fetch from github

### DIFF
--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -1,32 +1,14 @@
 set(PCRE2_VERSION 10.37)
 set(EXPECTED_SHA f91760a8e0747f52211612fb0e134d685e224d16bd884eb574718d077a586b1fd7b6435d4e3b75c879b12e02b252467ecc28cdc4bc2903c783dacab089f99c99)
-set(PATCHES
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO PhilipHazel/pcre2
+    REF pcre2-${PCRE2_VERSION}
+    SHA512   ${EXPECTED_SHA}
+    HEAD_REF master
+    PATCHES
         pcre2-10.35_fix-uwp.patch
 )
-
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.pcre.org/pub/pcre/pcre2-${PCRE2_VERSION}.zip"
-    FILENAME "pcre2-${PCRE2_VERSION}.zip"
-    SHA512 ${EXPECTED_SHA}
-    SILENT_EXIT
-)
-
-if (EXISTS "${ARCHIVE}")
-    vcpkg_extract_source_archive_ex(
-        OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE ${ARCHIVE}
-        PATCHES ${PATCHES}
-    )
-else()
-    vcpkg_from_sourceforge(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO pcre/pcre2
-        REF ${PCRE2_VERSION}
-        FILENAME "pcre2-${PCRE2_VERSION}.zip"
-        SHA512 ${EXPECTED_SHA}
-        PATCHES ${PATCHES}
-    )
-endif()
 
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Emscripten" OR VCPKG_CMAKE_SYSTEM_NAME STREQUAL "iOS")
     set(JIT OFF)

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pcre2",
   "version-string": "10.37",
+  "port-version": 1,
   "description": "PCRE2 is a re-working of the original Perl Compatible Regular Expressions library",
   "homepage": "https://pcre.org/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5118,7 +5118,7 @@
     },
     "pcre2": {
       "baseline": "10.37",
-      "port-version": 0
+      "port-version": 1
     },
     "pdal": {
       "baseline": "1.7.1",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f467ee4e8312b3536d9b7af3a181630c9956db5d",
+      "version-string": "10.37",
+      "port-version": 1
+    },
+    {
       "git-tree": "9f61b1640aff6d4d306d30338bbd360c223301b0",
       "version-string": "10.37",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Fixes current build errors of pcre2 because https://ftp.pcre.org is not reachable. This only changes the download source of the code.
According to https://www.pcre.org/ the home is now github, so there we go get it now.

This does not change the version even though a new one is available but that fails to build at the moment. Step by step.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
