### PR TITLE
[gdal] Make available on arm

### DIFF
--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm")
-
 set(GDAL_PATCHES
     0001-Fix-debug-crt-flags.patch
     0002-Fix-build.patch

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "gdal",
   "version-semver": "3.3.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
-  "supports": "!arm",
   "dependencies": [
     "curl",
     "expat",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2350,7 +2350,7 @@
     },
     "gdal": {
       "baseline": "3.3.2",
-      "port-version": 3
+      "port-version": 4
     },
     "gdcm": {
       "baseline": "3.0.7",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8993e298aaf4863c80576a61916ae0e79dedd13d",
+      "version-semver": "3.3.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "5173c609fafae13d948b1417064517be5bd78c7f",
       "version-semver": "3.3.2",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Removes exclusion of gdal on arm.
This has been around forever, and it's hard to tell why it has been put there originally.
Builds fine here for android-arm, so I assume the cpu is not an issue.
If there are good reasons not to support arm, this PR shall be closed and a descriptive comment added instead, so once the issue has been fixed the port can be adapted accordingly.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes
