### PR TITLE
[string-theory] Update to 3.5

### DIFF
--- a/ports/string-theory/portfile.cmake
+++ b/ports/string-theory/portfile.cmake
@@ -1,25 +1,19 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zrax/string_theory
-    REF 3.4
-    SHA512 36ad82c6da276b7cb66d350ceb4bed2a66f768a6604b2981331ceec6a96d03cc3a7e7e5f733de88ec15e0ea41f99f8657b959a51149c540f530d06268c5657ff
+    REF 3.5
+    SHA512 30300155e64ace8197ed531baffe4e835c269ac10d6857ac9f29501e0a1f69965994d6f2fa2e64544e7d441de635e2d370be24efcf00a0d24066730d19f022a6
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/string_theory)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/string_theory)
 
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/string-theory ${CURRENT_PACKAGES_DIR}/share/string_theory)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)
-
-# Handle copyright
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/string-theory)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/string-theory/LICENSE ${CURRENT_PACKAGES_DIR}/share/string-theory/copyright)
-file(COPY ${CURRENT_PACKAGES_DIR}/share/string-theory/copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/string_theory/copyright)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/string-theory/portfile.cmake
+++ b/ports/string-theory/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/string_theory)
+vcpkg_cmake_config_fixup(PACKAGE_NAME string_theory CONFIG_PATH lib/cmake/string_theory)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/string-theory/vcpkg.json
+++ b/ports/string-theory/vcpkg.json
@@ -1,7 +1,16 @@
 {
   "name": "string-theory",
-  "version-string": "3.4",
-  "port-version": 1,
+  "version": "3.5",
   "description": "Flexible modern C++ string library with type-safe formatting.",
-  "homepage": "https://github.com/zrax/string_theory"
+  "homepage": "https://github.com/zrax/string_theory",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6497,8 +6497,8 @@
       "port-version": 1
     },
     "string-theory": {
-      "baseline": "3.4",
-      "port-version": 1
+      "baseline": "3.5",
+      "port-version": 0
     },
     "string-view-lite": {
       "baseline": "1.6.0",

--- a/versions/s-/string-theory.json
+++ b/versions/s-/string-theory.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "99db394766828382434999c344063743484825a2",
+      "git-tree": "6c02a14bfc014ccb0e31c944aac072ed64eb1136",
       "version": "3.5",
       "port-version": 0
     },

--- a/versions/s-/string-theory.json
+++ b/versions/s-/string-theory.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99db394766828382434999c344063743484825a2",
+      "version": "3.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "8af1cbe5e5d6b5d098b15f4e5548d4e315afb4b0",
       "version-string": "3.4",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates string-theory to 3.5

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?  
  Yes