### PR TITLE
[pcre] Remove download from ftp.pcre.org

### DIFF
--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -9,33 +9,17 @@ set(PATCHES
         pcre-8.45_fix_postfix_for_debug_Windows_builds.patch
         export-cmake-targets.patch)
 
-vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.zip"
+vcpkg_from_sourceforge(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO pcre/pcre
+    REF ${PCRE_VERSION}
     FILENAME "pcre-${PCRE_VERSION}.zip"
     SHA512 ${EXPECTED_SHA}
-    SILENT_EXIT
+    PATCHES ${PATCHES}
 )
 
-if (EXISTS "${ARCHIVE}")
-    vcpkg_extract_source_archive_ex(
-        OUT_SOURCE_PATH SOURCE_PATH
-        ARCHIVE ${ARCHIVE}
-        PATCHES ${PATCHES}
-    )
-else()
-    vcpkg_from_sourceforge(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO pcre/pcre
-        REF ${PCRE_VERSION}
-        FILENAME "pcre-${PCRE_VERSION}.zip"
-        SHA512 ${EXPECTED_SHA}
-        PATCHES ${PATCHES}
-    )
-endif()
-
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DPCRE_BUILD_TESTS=NO
         -DPCRE_BUILD_PCREGREP=NO
@@ -55,11 +39,11 @@ vcpkg_configure_cmake(
     # OPTIONS_DEBUG -DDEBUGGABLE=1
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-${PORT} TARGET_PATH share/unofficial-${PORT})
+vcpkg_cmake_config_fixup(PACKAGE_NAME "unofficial-${PORT}" CONFIG_PATH "share/unofficial-${PORT}")
 
-foreach(FILE ${CURRENT_PACKAGES_DIR}/include/pcre.h ${CURRENT_PACKAGES_DIR}/include/pcreposix.h)
+foreach(FILE "${CURRENT_PACKAGES_DIR}/include/pcre.h" "${CURRENT_PACKAGES_DIR}/include/pcreposix.h")
     file(READ ${FILE} PCRE_H)
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         string(REPLACE "defined(PCRE_STATIC)" "1" PCRE_H "${PCRE_H}")
@@ -71,18 +55,17 @@ endforeach()
 
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/man)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/man)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/doc)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/man")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/man")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 vcpkg_copy_pdbs()
-configure_file(${CMAKE_CURRENT_LIST_DIR}/unofficial-pcre-config.cmake ${CURRENT_PACKAGES_DIR}/share/unofficial-pcre/unofficial-pcre-config.cmake @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/unofficial-pcre-config.cmake" "${CURRENT_PACKAGES_DIR}/share/unofficial-pcre/unofficial-pcre-config.cmake" @ONLY)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pcre/vcpkg.json
+++ b/ports/pcre/vcpkg.json
@@ -1,6 +1,17 @@
 {
   "name": "pcre",
   "version": "8.45",
+  "port-version": 1,
   "description": "Perl Compatible Regular Expressions",
-  "homepage": "https://www.pcre.org/"
+  "homepage": "https://www.pcre.org/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5122,7 +5122,7 @@
     },
     "pcre": {
       "baseline": "8.45",
-      "port-version": 0
+      "port-version": 1
     },
     "pcre2": {
       "baseline": "10.37",

--- a/versions/p-/pcre.json
+++ b/versions/p-/pcre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1eb815e0c923baec32da26918e951b288adbaa5",
+      "version": "8.45",
+      "port-version": 1
+    },
+    {
       "git-tree": "665bab8c2bf878815782cff93dfff5720316ab88",
       "version": "8.45",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  The former ftp.pcre.org FTP site is no longer available [1].
  - Use sourceforge only for download
  - Fixes #21201
  - Remove deprecated functions from portfile
    `vcpkg_install_cmake` -> `vcpkg_cmake_install`
    `vcpkg_configure_cmake` -> `vcpkg_cmake_configure` (removed `PREFER_NINJA`)
    `vcpkg_fixup_cmake_targets` -> `vcpkg_cmake_config_fixup`
  - Add double quotes to files

  [1] https://www.pcre.org/

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  `all, No`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
