### PR TITLE
Python 3.10: fix deprecated win7 support patch

### DIFF
--- a/ports/python3/0006-restore-support-for-windows-7.patch
+++ b/ports/python3/0006-restore-support-for-windows-7.patch
@@ -9,11 +9,11 @@ pathcch.
 
 The same mechanism is applied to fix posixmodule.c
 ---
+index 25ddc82..ff51042 100644
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index c984e2e..6c9787a 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
-@@ -18,7 +18,7 @@
+@@ -20,7 +20,7 @@
  
        FSCTL_GET_REPARSE_POINT is not exported with WIN32_LEAN_AND_MEAN. */
  #  include <windows.h>
@@ -21,26 +21,26 @@ index c984e2e..6c9787a 100644
 +#  include <Shlwapi.h>
  #endif
  
- #include "pycore_ceval.h"         // _PyEval_ReInitThreads()
-@@ -4371,6 +4371,10 @@ os._path_splitroot
- Removes everything after the root on Win32.
- [clinic start generated code]*/
+ #ifdef __VXWORKS__
+@@ -4410,6 +4410,10 @@ os__getvolumepathname_impl(PyObject *module, path_t *path)
+     return result;
+ }
  
 +static int _PathCchSkipRoot_Initialized = 0;
 +typedef HRESULT (__stdcall *PPathCchSkipRoot) (PCWSTR pszPath, PCWSTR *ppszRootEnd);
 +static PPathCchSkipRoot _PathCchSkipRoot;
 +
- static PyObject *
- os__path_splitroot_impl(PyObject *module, path_t *path)
- /*[clinic end generated code: output=ab7f1a88b654581c input=dc93b1d3984cffb6]*/
-@@ -4380,6 +4384,19 @@ os__path_splitroot_impl(PyObject *module, path_t *path)
+
+ /*[clinic input]
+ os._path_splitroot
+@@ -4428,6 +4432,19 @@ os__path_splitroot_impl(PyObject *module, path_t *path)
      PyObject *result = NULL;
      HRESULT ret;
  
 +    if (_PathCchSkipRoot_Initialized == 0) {
 +        HMODULE pathapi = LoadLibraryExW(L"api-ms-win-core-path-l1-1-0.dll", NULL,
 +                                         LOAD_LIBRARY_SEARCH_SYSTEM32);
-+        
++
 +        if (pathapi) {
 +            _PathCchSkipRoot = (PPathCchSkipRoot)GetProcAddress(pathapi, "PathCchSkipRoot");
 +        } else {
@@ -53,7 +53,7 @@ index c984e2e..6c9787a 100644
      buffer = (wchar_t*)PyMem_Malloc(sizeof(wchar_t) * (wcslen(path->wide) + 1));
      if (!buffer) {
          return NULL;
-@@ -4390,7 +4407,14 @@ os__path_splitroot_impl(PyObject *module, path_t *path)
+@@ -4438,7 +4455,14 @@ os__path_splitroot_impl(PyObject *module, path_t *path)
      }
  
      Py_BEGIN_ALLOW_THREADS

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-semver": "3.10.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5422,7 +5422,7 @@
     },
     "python3": {
       "baseline": "3.10.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8c0f995b8f1831fc7f345329c2ce0a80d717551",
+      "version-semver": "3.10.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b155976e5a0266f5f73e2ff642b5281303a6a73f",
       "version-semver": "3.10.0",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?  
Fixes building of python3 with win7 support

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
tested on x86-windows-static

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
I think yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes 
