### PR TITLE
[opencv2] Fix build failure when vcpkg folder path include "++"

### DIFF
--- a/ports/opencv2/fix-path-contains-++-error.patch
+++ b/ports/opencv2/fix-path-contains-++-error.patch
@@ -1,0 +1,49 @@
+diff --git a/cmake/OpenCVUtils.cmake b/cmake/OpenCVUtils.cmake
+index 72df4d4..7d45974 100644
+--- a/cmake/OpenCVUtils.cmake
++++ b/cmake/OpenCVUtils.cmake
+@@ -82,12 +82,42 @@ macro(ocv_check_environment_variables)
+   endforeach()
+ endmacro()
+ 
++# check if "sub" (file or dir) is below "dir"
++function(is_subdir res dir sub )
++  get_filename_component(dir "${dir}" ABSOLUTE)
++  get_filename_component(sub "${sub}" ABSOLUTE)
++  file(TO_CMAKE_PATH "${dir}" dir)
++  file(TO_CMAKE_PATH "${sub}" sub)
++  set(dir "${dir}/")
++  string(LENGTH "${dir}" len)
++  string(LENGTH "${sub}" len_sub)
++  if(NOT len GREATER len_sub)
++    string(SUBSTRING "${sub}" 0 ${len} prefix)
++  endif()
++  if(prefix AND prefix STREQUAL dir)
++    set(${res} TRUE PARENT_SCOPE)
++  else()
++    set(${res} FALSE PARENT_SCOPE)
++  endif()
++endfunction()
++
++function(ocv_is_opencv_directory result_var dir)
++  set(result FALSE)
++  foreach(parent ${OpenCV_SOURCE_DIR} ${OpenCV_BINARY_DIR} ${OPENCV_EXTRA_MODULES_PATH})
++    is_subdir(result "${parent}" "${dir}")
++    if(result)
++      break()
++    endif()
++  endforeach()
++  set(${result_var} ${result} PARENT_SCOPE)
++endfunction()
++
+ # adds include directories in such a way that directories from the OpenCV source tree go first
+ function(ocv_include_directories)
+   set(__add_before "")
+   foreach(dir ${ARGN})
+-    get_filename_component(__abs_dir "${dir}" ABSOLUTE)
+-    if("${__abs_dir}" MATCHES "^${OpenCV_SOURCE_DIR}" OR "${__abs_dir}" MATCHES "^${OpenCV_BINARY_DIR}")
++    ocv_is_opencv_directory(__is_opencv_dir "${dir}")
++    if(__is_opencv_dir)
+       list(APPEND __add_before "${dir}")
+     elseif(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0" AND
+            dir MATCHES "/usr/include$")

--- a/ports/opencv2/portfile.cmake
+++ b/ports/opencv2/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_from_github(
       0003-force-package-requirements.patch
       0004-add-ffmpeg-missing-defines.patch
       0005-fix-cuda.patch
+      fix-path-contains-++-error.patch
 )
 
 file(REMOVE "${SOURCE_PATH}/cmake/FindCUDA.cmake")

--- a/ports/opencv2/vcpkg.json
+++ b/ports/opencv2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv2",
   "version": "2.4.13.7",
-  "port-version": 6,
+  "port-version": 7,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "opencv2": {
       "baseline": "2.4.13.7",
-      "port-version": 6
+      "port-version": 7
     },
     "opencv3": {
       "baseline": "3.4.15",

--- a/versions/o-/opencv2.json
+++ b/versions/o-/opencv2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6ccb4fb79829bcf58dd79950529d7086d6b277c",
+      "version": "2.4.13.7",
+      "port-version": 7
+    },
+    {
       "git-tree": "e85a45aa17a47da9f965b93cb0c6fc8273a7ca04",
       "version": "2.4.13.7",
       "port-version": 6


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/21154


All features passed with following triplets:
x86-windows 
x64-windows 
x64-windows-static 
