### PR TITLE
[lapack-reference] Fix issue when using an external Fortran compiler

### DIFF
--- a/ports/lapack-reference/portfile.cmake
+++ b/ports/lapack-reference/portfile.cmake
@@ -57,8 +57,6 @@ if(VCPKG_USE_INTERNAL_Fortran)
             message(FATAL_ERROR "Feature 'noblas' cannot be used without supplying an external fortran compiler")
         endif()
     endif()
-else()
-    set(USE_OPTIMIZED_BLAS ON)
 endif()
 
 vcpkg_configure_cmake(

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lapack-reference",
   "version-semver": "3.8.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "LAPACK — Linear Algebra PACKage",
   "homepage": "http://www.netlib.org/lapack/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3222,7 +3222,7 @@
     },
     "lapack-reference": {
       "baseline": "3.8.0",
-      "port-version": 6
+      "port-version": 7
     },
     "lastools": {
       "baseline": "2020-05-09",

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73710c5f3e127362dca71daf53b45611f5630348",
+      "version-semver": "3.8.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "10799c7ec42f8369179ba7a8e927235596cb8bb7",
       "version-semver": "3.8.0",
       "port-version": 6


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/21224


USE_OPTIMIZED_BLAS=ON always be set when using an external Fortran compiler, it should be controlled by feature noblas feature.