### PR TITLE
[amqpcpp] Update to 4.3.15

### DIFF
--- a/ports/amqpcpp/portfile.cmake
+++ b/ports/amqpcpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO CopernicaMarketingSoftware/AMQP-CPP
-    REF 2749d36a9cf9def86fc8a30eceb0e3a11d85815d #v4.3.14
-    SHA512 ee6df360963bb5714c7503e27a9ed0682d704a267ef615fa922bd1cb637d1c0867c9074d5aeef084621840ef39f495a4103f22bfd80b6b1dd325bc6061e9c2ca
+    REF b891cc37a6ff63fcff59a112de281f5964344c91 #v4.3.15
+    SHA512 5c55285e2445752669bfe51a276c3c9cb294eeae74e05124fa7427737e43419493b8a8e199bedba9ab7fba5822a8da530ca442afdbe45d12c2c0c54f9fd59a0c
     HEAD_REF master
     PATCHES
         find-openssl.patch

--- a/ports/amqpcpp/vcpkg.json
+++ b/ports/amqpcpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "amqpcpp",
-  "version": "4.3.14",
-  "port-version": 1,
+  "version": "4.3.15",
   "description": "AMQP-CPP is a C++ library for communicating with a RabbitMQ message broker",
   "homepage": "https://github.com/CopernicaMarketingSoftware/AMQP-CPP",
   "supports": "!uwp",

--- a/versions/a-/amqpcpp.json
+++ b/versions/a-/amqpcpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f2e1a0132721d9cdb8515d40010eaba97ecc8de",
+      "version": "4.3.15",
+      "port-version": 0
+    },
+    {
       "git-tree": "bb3c11de2e142fc43d0c3bbcddc2a56b563de733",
       "version": "4.3.14",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -73,8 +73,8 @@
       "port-version": 1
     },
     "amqpcpp": {
-      "baseline": "4.3.14",
-      "port-version": 1
+      "baseline": "4.3.15",
+      "port-version": 0
     },
     "anax": {
       "baseline": "2.1.0",


### PR DESCRIPTION
Update amqpcpp from 4.3.14 to 4.3.15

- #### What does your PR fix?  
  This notably fixes a compilation failure (missing header): https://github.com/CopernicaMarketingSoftware/AMQP-CPP/issues/415

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As I’m just upgrading a version, I don’t think triplet support would change. Nor did I modified the ci.baseline.txt.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
