### PR TITLE
[directxtk, directxtk12, directxtex, directxmesh, uvatlas] updated ports to November 2021 releases

### DIFF
--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF sept2021
-    SHA512 e07f944080dc7e0ffe154061057a81d7caee3c4612b9261ba5a4812b3cb45571dee0a1c9b01824ccfbe9566132eadef30b80164fefe6a3ead60a3762566e2604
+    REF nov2021
+    SHA512 d33ae04b5fc7dae715a0b9ceadcde02bb10807a8d26362b074caa31a631fba173f773ee49a143c44a1bdfdad19893bcca69a3bc806fbb26f74ca39194821a953
     HEAD_REF master
 )
 
@@ -37,9 +37,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/sept2021/meshconvert.exe"
-    FILENAME "meshconvert-sept2021.exe"
-    SHA512 9d527b95d3a37604ac3a4c05f8ef44e81cfd8044dd44eddc531116ee5110443679787e4719b0504dc60e406e28396e1f553388cf261b3df81103bd03391c32af
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/nov2021/meshconvert.exe"
+    FILENAME "meshconvert-nov2021.exe"
+    SHA512 0f97ac49ce292b1cb90372884f1d6a4fc10eb3e92125a854ee9b7030fd9d0564536cdd88199aa4838832ae2a1e9c2df2c9e32c106705b6b06f156994b9476360
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -48,7 +48,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-nov2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmesh",
-  "version-string": "sept2021",
+  "version-string": "nov2021",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF oct2021
-    SHA512 3fc1f8267a4708babe91e94f2062cd9d475b3682273e5c4f704cdb6093a5aae269cf573ad75fdd3dce59a6a79e6892a4cf5630a3160257e542edde9eb9dbb51a
+    REF nov2021
+    SHA512 c96a35c6959caaa3ea6a033404889460363a71f8035a43c91db19d7b608c38adcebe59c428b480b6c6f2e1519a3cd72ce1a828a3771a2c301d831e5b7a4212b9
     HEAD_REF master
 )
 
@@ -64,23 +64,23 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texassemble.exe"
-    FILENAME "texassemble-sept2021.exe"
-    SHA512 05539bae0f77bba1e6fa349ac483367d3f34f808857fd3c3bdecd2a956465101dbaec95cb4e61c15d5d65fd12cdc14fab17cede3a2719dc32bda8748b7a1c59a
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texassemble.exe"
+    FILENAME "texassemble-nov2021.exe"
+    SHA512 a31151d368d41f50b58b417e8d27987fe0e3caa2c4e0d0abe7bef472db51429526277b0c554df2825c6892bb2021111f59d3d8f321ad68c71c0a153852d2c81f
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texconv.exe"
-    FILENAME "texconv-sept2021.exe"
-    SHA512 9ec2415d2d1b665a0a67c01c916afb5946dedede3518e3a029b83e4a8bb86d8f22b2dc0afdc7dbe0824f8f9843a86e555f3e4705570703d4447a47f2719f5b5a
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texconv.exe"
+    FILENAME "texconv-nov2021.exe"
+    SHA512 7cb70b3cbf46c78b99aa18c28b043fc5930b6b254729efd447868fcf8cb8b77987d41b570082bdfb3bab01452e67d17e81b966bf2534036a3415fa918ddc2956
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/sept2021/texdiag.exe"
-    FILENAME "texdiag-sept2021.exe"
-    SHA512 380660fa46438368a0f30684e0b9d9f4c267d76145bacbf4e5643889e00f869b0925250c1911397ce6a3890752de87f6105ef0e60d0e0334eb36fbc7f53deea7
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texdiag.exe"
+    FILENAME "texdiag-nov2021.exe"
+    SHA512 7826c594fa42978da8a15bd771fafe4d4f5b97d611ce62a806ddff77204cabf63eea6ac24e3409c2720631681260b7e3fa6ad5f33b2162d2266457462e6b13c9
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -91,9 +91,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-sept2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-string": "oct2021",
+  "version-string": "nov2021",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF oct2021b
-    SHA512 203e930a9d7fb8dbf3a9e9266f00ee847ceaecb462a3c0450fac54fa2e36fda206d35ab7a1eac59eb83dd433f64e4c353a38dfa40691cd7326ba76b052931bf2
+    REF nov2021
+    SHA512 bf9297c88b4c80e70562593d0f2a7d8cf438b0bbc731f4725287ff1155e8879e538d339e72dfb4eceb2c94a8f410ff24421a12560013ea65c4e43fe57756109c
     HEAD_REF master
 )
 
@@ -35,16 +35,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/oct2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-oct2021.exe"
-    SHA512 abff446bfd4cbddbca45816ec3a2230e52d9afb81c100966e4bce7e52a6e02620fd8cdcb416943090564885f63d33c4a246f43ff585c8f5686c2c9877ec50698
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/nov2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-nov2021.exe"
+    SHA512 0aab40aced022588d9c1089c5b2f297b0521497d0ae559ead98f99e1e73f2daf9f38ebecadb413095abd2a6c207183fbca582d47528c6f21258df3ac391134e5
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/oct2021/XWBTool.exe"
-    FILENAME "xwbtool-oct2021.exe"
-    SHA512 fda62e06fb9998c41795c6be42f00a1048dcae302b20437f2a39350215789f77acfc77c0f1ebbc5bedeb986229c94f35bd1a03be37cdf4fcf4c007110f7efaa4
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/nov2021/XWBTool.exe"
+    FILENAME "xwbtool-nov2021.exe"
+    SHA512 f2f291c496500e593c0a4795fee9fafc685666682f23a38a25546bb67ec083533a26f2ce0562b819abea44bd8b403a2f246fbf978e366c457eb8a0f836fd5a2e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -54,8 +54,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-string": "oct2021b",
+  "version-string": "nov2021",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF oct2021
-    SHA512 b5b6b7d42967463bf941b41c9407417068761000344506b720e038f82b3a1aa6f44893695b2391075495d6a63eeb1d80cb011ed87e8f54430de3a77baa8cb570
+    REF nov2021
+    SHA512 c47dbc877599ad09240d182301198e0d8074ce319abf38958372d13c06a2a1921e2aff6c3acfb0a37a44be681933d1e86542da8491a5ca3f2b9c33fdca73beef
     HEAD_REF master
 )
 
@@ -21,16 +21,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/oct2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-oct2021.exe"
-    SHA512 abff446bfd4cbddbca45816ec3a2230e52d9afb81c100966e4bce7e52a6e02620fd8cdcb416943090564885f63d33c4a246f43ff585c8f5686c2c9877ec50698
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/nov2021/MakeSpriteFont.exe"
+    FILENAME "makespritefont-nov2021.exe"
+    SHA512 0aab40aced022588d9c1089c5b2f297b0521497d0ae559ead98f99e1e73f2daf9f38ebecadb413095abd2a6c207183fbca582d47528c6f21258df3ac391134e5
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/oct2021/XWBTool.exe"
-    FILENAME "xwbtool-oct2021.exe"
-    SHA512 fda62e06fb9998c41795c6be42f00a1048dcae302b20437f2a39350215789f77acfc77c0f1ebbc5bedeb986229c94f35bd1a03be37cdf4fcf4c007110f7efaa4
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/nov2021/XWBTool.exe"
+    FILENAME "xwbtool-nov2021.exe"
+    SHA512 f2f291c496500e593c0a4795fee9fafc685666682f23a38a25546bb67ec083533a26f2ce0562b819abea44bd8b403a2f246fbf978e366c457eb8a0f836fd5a2e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -40,8 +40,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-oct2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-string": "oct2021",
+  "version-string": "nov2021",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install(ON_TARGET "OSX")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF sept2021
-    SHA512 bb2659e83aa04ad6a43b953f40535531f4f5766d3390b9ce8ea0d83b3146cb92fe27a44c7b744da91cc20f529aabf87794b3b19272c2bd27817e65b091ffe3f5
+    REF nov2021
+    SHA512 06fe3eb50abd95f35741b8b7d27abbf1eb4f77e13e5c88aa199e29e0ddb979b7913d7eb766afe52382dc0bf94552b20f089681aa1cd52bb88469961d9029d5b0
     HEAD_REF master
 )
 
@@ -37,9 +37,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/sept2021/uvatlastool.exe"
-    FILENAME "uvatlastool-sept2021.exe"
-    SHA512 56e5ca39f5e1d4fd5fc0f23dee0b2c4b814a53848614d3a470a68821177662e068e0d4e3db93446d32e734af4a6bad0f729d0691b2a3bb127e0395c14aa5a1e7
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/nov2021/uvatlastool.exe"
+    FILENAME "uvatlastool-nov2021.exe"
+    SHA512 84de6bc74901f3ab888b90126cc1ac64de564eb33c605fffe37b2199ad132a53b01271f1f551fcc067c144c599380764b9e50884ce5df32f43b2c58777da0722
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -48,7 +48,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-sept2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-nov2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-string": "sept2021",
+  "version-string": "nov2021",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1817,7 +1817,7 @@
       "port-version": 1
     },
     "directxmesh": {
-      "baseline": "sept2021",
+      "baseline": "nov2021",
       "port-version": 0
     },
     "directxsdk": {
@@ -1825,15 +1825,15 @@
       "port-version": 4
     },
     "directxtex": {
-      "baseline": "oct2021",
+      "baseline": "nov2021",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "oct2021b",
+      "baseline": "nov2021",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "oct2021",
+      "baseline": "nov2021",
       "port-version": 0
     },
     "dirent": {
@@ -6953,7 +6953,7 @@
       "port-version": 0
     },
     "uvatlas": {
-      "baseline": "sept2021",
+      "baseline": "nov2021",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "66d8a04c67c2ceabf4b3a6fbca5a088bf68b2663",
+      "version-string": "nov2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6e38f3e2c1f90556658d75ae6edd0e170ab0ac4",
       "version-string": "sept2021",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0323aa2d24df2bb704905d709a72bd6f57571d19",
+      "version-string": "nov2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "02cba4df9bb3dab0d73b32a41dcfaa624ef53044",
       "version-string": "oct2021",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b5087f78eea490106b9afd934e023a284a6b8b45",
+      "version-string": "nov2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "09200c3486444bbcce57ec680606781b5e16175c",
       "version-string": "oct2021b",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2edb55441546d26caa15d12504be4f1cbd87986d",
+      "version-string": "nov2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "c3c3a04e2a9b6d1b85341e3d2dcc09d5a04df160",
       "version-string": "oct2021",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4ac15c488e3c856748164899355d3d619f4dc810",
+      "version-string": "nov2021",
+      "port-version": 0
+    },
+    {
       "git-tree": "aa1c69c4376ea2d6332065397292b386d60984a4",
       "version-string": "sept2021",
       "port-version": 0


### PR DESCRIPTION
Have new releases on GitHub for these five libraries. This updates the ports to use the latest.

https://github.com/microsoft/DirectXTK/releases/tag/nov2021

https://github.com/microsoft/DirectXTK12/releases/tag/nov2021

https://github.com/microsoft/DirectXTex/releases/tag/nov2021

https://github.com/microsoft/DirectXMesh/releases/tag/nov2021

https://github.com/microsoft/UVAtlas/releases/tag/nov2021