### PR TITLE
[libatomic-ops] New port

### DIFF
--- a/ports/libatomic-ops/portfile.cmake
+++ b/ports/libatomic-ops/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ivmai/libatomic_ops
+    REF 7a8de3bd9c6c61c68a866b849e7b1d17d76d2d36 # v7.7.0-20211109
+    SHA512 05555792a199526d8e164833f590cc57c5ee34672d81952787a09dd7008e947e4e8b6ad63fb6b8ee315294b98fdf743639622b3d9156d8a8f8363b431e875c45
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PREFER_NINJA
+    OPTIONS_DEBUG
+        -Dinstall_headers=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/atomic_ops)
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_fixup_pkgconfig()

--- a/ports/libatomic-ops/portfile.cmake
+++ b/ports/libatomic-ops/portfile.cmake
@@ -6,15 +6,15 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
     OPTIONS_DEBUG
         -Dinstall_headers=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/atomic_ops)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME atomic_ops CONFIG_PATH lib/cmake/atomic_ops)
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libatomic-ops/vcpkg.json
+++ b/ports/libatomic-ops/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "libatomic-ops",
+  "version": "7.7.0",
+  "description": "The atomic_ops project (Atomic memory update operations portable implementation)"
+}

--- a/ports/libatomic-ops/vcpkg.json
+++ b/ports/libatomic-ops/vcpkg.json
@@ -1,5 +1,15 @@
 {
   "name": "libatomic-ops",
   "version": "7.7.0",
-  "description": "The atomic_ops project (Atomic memory update operations portable implementation)"
+  "description": "The atomic_ops project (Atomic memory update operations portable implementation)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3292,6 +3292,10 @@
       "baseline": "2.5.3",
       "port-version": 2
     },
+    "libatomic-ops": {
+      "baseline": "7.7.0",
+      "port-version": 0
+    },
     "libavif": {
       "baseline": "0.9.2",
       "port-version": 0

--- a/versions/l-/libatomic-ops.json
+++ b/versions/l-/libatomic-ops.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "190e60a8fc88f307a5fd036acbce1716cd941367",
+      "git-tree": "6d7b45bb0c10342d8e43900fab12f2baab4eb6a1",
       "version": "7.7.0",
       "port-version": 0
     }

--- a/versions/l-/libatomic-ops.json
+++ b/versions/l-/libatomic-ops.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "190e60a8fc88f307a5fd036acbce1716cd941367",
+      "version": "7.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION

- #### What does your PR fix?  
Adds libatomic-ops port (it will be needed for bdwgc port with multi-threading support).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
