### PR TITLE
[vcpkg] Small fixes to vcpkg_build_make

### DIFF
--- a/docs/maintainers/vcpkg_build_make.md
+++ b/docs/maintainers/vcpkg_build_make.md
@@ -7,15 +7,21 @@ Build a linux makefile project.
 ## Usage:
 ```cmake
 vcpkg_build_make([BUILD_TARGET <target>]
+                 [INSTALL_TARGET <target>]
                  [ADD_BIN_TO_PATH]
                  [ENABLE_INSTALL]
                  [MAKEFILE <makefileName>]
-                 [LOGFILE_ROOT <logfileroot>])
+                 [LOGFILE_ROOT <logfileroot>]
+                 [DISABLE_PARALLEL]
+                 [SUBPATH <path>])
 ```
 
 ### BUILD_TARGET
 The target passed to the make build command (`./make <target>`). If not specified, the 'all' target will
 be passed.
+
+### INSTALL_TARGET
+The target passed to the make build command (`./make <target>`) if `ENABLE_INSTALL` is used. Defaults to 'install'.
 
 ### ADD_BIN_TO_PATH
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
@@ -26,11 +32,8 @@ IF the port supports the install target use vcpkg_install_make() instead of vcpk
 ### MAKEFILE
 Specifies the Makefile as a relative path from the root of the sources passed to `vcpkg_configure_make()`
 
-### BUILD_TARGET
-The target passed to the make build command (`./make <target>`). Defaults to 'all'.
-
-### INSTALL_TARGET
-The target passed to the make build command (`./make <target>`) if `ENABLE_INSTALL` is used. Defaults to 'install'.
+### LOGFILE_ROOT
+Specifies a log file prefix.
 
 ### DISABLE_PARALLEL
 The underlying buildsystem will be instructed to not parallelize

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -6,15 +6,21 @@ Build a linux makefile project.
 ## Usage:
 ```cmake
 vcpkg_build_make([BUILD_TARGET <target>]
+                 [INSTALL_TARGET <target>]
                  [ADD_BIN_TO_PATH]
                  [ENABLE_INSTALL]
                  [MAKEFILE <makefileName>]
-                 [LOGFILE_ROOT <logfileroot>])
+                 [LOGFILE_ROOT <logfileroot>]
+                 [DISABLE_PARALLEL]
+                 [SUBPATH <path>])
 ```
 
 ### BUILD_TARGET
 The target passed to the make build command (`./make <target>`). If not specified, the 'all' target will
 be passed.
+
+### INSTALL_TARGET
+The target passed to the make build command (`./make <target>`) if `ENABLE_INSTALL` is used. Defaults to 'install'.
 
 ### ADD_BIN_TO_PATH
 Adds the appropriate Release and Debug `bin\` directories to the path during the build such that executables can run against the in-tree DLLs.
@@ -25,11 +31,8 @@ IF the port supports the install target use vcpkg_install_make() instead of vcpk
 ### MAKEFILE
 Specifies the Makefile as a relative path from the root of the sources passed to `vcpkg_configure_make()`
 
-### BUILD_TARGET
-The target passed to the make build command (`./make <target>`). Defaults to 'all'.
-
-### INSTALL_TARGET
-The target passed to the make build command (`./make <target>`) if `ENABLE_INSTALL` is used. Defaults to 'install'.
+### LOGFILE_ROOT
+Specifies a log file prefix.
 
 ### DISABLE_PARALLEL
 The underlying buildsystem will be instructed to not parallelize

--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -107,6 +107,7 @@ function(vcpkg_build_make)
         string(REGEX REPLACE [[([a-zA-Z]):/]] [[/\1/]] vcpkg_package_prefix "${vcpkg_package_prefix}")
         vcpkg_list(SET install_opts -j ${VCPKG_CONCURRENCY} --trace -f ${arg_MAKEFILE} ${arg_INSTALL_TARGET} DESTDIR=${vcpkg_package_prefix})
         #TODO: optimize for install-data (release) and install-exec (release/debug)
+
     else()
         if(VCPKG_HOST_IS_OPENBSD)
             find_program(Z_VCPKG_MAKE gmake REQUIRED)
@@ -135,7 +136,7 @@ function(vcpkg_build_make)
                 set(path_suffix "")
             endif()
 
-            set(working_directory "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${short_buildtype}${arg_SUBPATH}")
+            set(working_directory "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}${short_buildtype}/${arg_SUBPATH}")
             message(STATUS "Building ${TARGET_TRIPLET}${short_buildtype}")
 
             z_vcpkg_extract_cpp_flags_and_set_cflags_and_cxxflags("${cmake_buildtype}")


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
    * vcpkg_build_make docs
    * a small typo in the handling of the subpath parameter

- #### Which triplets are supported?
    all

- #### Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
    no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  seems so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  no port additions