### PR TITLE
[magnum-plugins] Update head features and bundled dependency

### DIFF
--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -34,8 +34,8 @@ if("basisimporter" IN_LIST FEATURES OR "basisimageconverter" IN_LIST FEATURES)
         FILENAME "basis-universal-${_BASIS_VERSION}.tar.gz"
         SHA512 ${_BASIS_SHA512}
     )
-    vcpkg_extract_source_archive_ex(
-        OUT_SOURCE_PATH _BASIS_UNIVERSAL_SOURCE
+    vcpkg_extract_source_archive(
+        _BASIS_UNIVERSAL_SOURCE
         ARCHIVE ${_BASIS_UNIVERSAL_ARCHIVE}
         WORKING_DIRECTORY "${SOURCE_PATH}/src/external"
         ${_BASIS_UNIVERSAL_PATCHES})

--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -74,9 +74,8 @@ endforeach()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES ${_COMPONENTS})
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         ${FEATURE_OPTIONS}
         -DBUILD_STATIC=${BUILD_PLUGINS_STATIC}
@@ -85,7 +84,7 @@ vcpkg_configure_cmake(
         -DMAGNUM_PLUGINS_RELEASE_DIR=${CURRENT_INSTALLED_DIR}/bin/magnum
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Debug includes and share are the same as release
 file(REMOVE_RECURSE

--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -9,22 +9,20 @@ vcpkg_from_github(
 )
 
 if("basisimporter" IN_LIST FEATURES OR "basisimageconverter" IN_LIST FEATURES)
-    # Bundle Basis Universal
+    # Bundle Basis Universal. The repo has big unrequired files in its
+    # history, so we're downloading just a snapshot instead of a git clone.
     if(VCPKG_USE_HEAD_VERSION)
         # v1_15_update2
         set(_BASIS_VERSION "v1_15_update2")
         set(_BASIS_SHA512 "a898a057b57ac64f6c0bf5fce0b599e23421ccdd015ea7bb668bce8b9292ef55b098f3d05854a2fb5363959932b75cd0a842664ae7d4f71f3537dc11301c1b32")
     else()
-        # A commit that's before the UASTC support (which
-        # is not implemented yet). The repo has big unrequired files in its
-        # history, so we're downloading just a snapshot instead of a git clone.
+        # A commit that's before the UASTC support (which is not implemented yet)
         vcpkg_download_distfile(
             _BASIS_UNIVERSAL_PATCHES
             URLS "https://github.com/BinomialLLC/basis_universal/commit/e9c55faac7745ebf38d08cd3b4f71aaf542f8191.diff"
             FILENAME "e9c55faac7745ebf38d08cd3b4f71aaf542f8191.patch"
             SHA512 e5dda11de2ba8cfd39728e69c74a7656bb522e509786fe5673c94b26be9bd4bee897510096479ee6323f5276d34cba1c44c60804a515c0b35ff7b6ac9d625b88
         )
-        set(_BASIS_UNIVERSAL_PATCHES PATCHES ${_BASIS_UNIVERSAL_PATCHES})
         set(_BASIS_VERSION "8565af680d1bd2ad56ab227ca7d96c56dfbe93ed")
         set(_BASIS_SHA512 "65062ab3ba675c46760f56475a7528189ed4097fb9bab8316e25d9e23ffec2a9560eb9a6897468baf2a6ab2bd698b5907283e96deaeaef178085a47f9d371bb2")
     endif()
@@ -38,7 +36,8 @@ if("basisimporter" IN_LIST FEATURES OR "basisimageconverter" IN_LIST FEATURES)
         _BASIS_UNIVERSAL_SOURCE
         ARCHIVE ${_BASIS_UNIVERSAL_ARCHIVE}
         WORKING_DIRECTORY "${SOURCE_PATH}/src/external"
-        ${_BASIS_UNIVERSAL_PATCHES})
+        PATCHES
+            ${_BASIS_UNIVERSAL_PATCHES})
     # Remove potentially cached directory which would cause renaming to fail
     file(REMOVE_RECURSE "${SOURCE_PATH}/src/external/basis-universal")
     # Rename the output folder so that magnum auto-detects it

--- a/ports/magnum-plugins/portfile.cmake
+++ b/ports/magnum-plugins/portfile.cmake
@@ -9,28 +9,36 @@ vcpkg_from_github(
 )
 
 if("basisimporter" IN_LIST FEATURES OR "basisimageconverter" IN_LIST FEATURES)
-    # Bundle Basis Universal, a commit that's before the UASTC support (which
-    # is not implemented yet). The repo has big unrequired files in its
-    # history, so we're downloading just a snapshot instead of a git clone.
-    vcpkg_download_distfile(
-        _BASIS_UNIVERSAL_PATCHES
-        URLS "https://github.com/BinomialLLC/basis_universal/commit/e9c55faac7745ebf38d08cd3b4f71aaf542f8191.diff"
-        FILENAME "e9c55faac7745ebf38d08cd3b4f71aaf542f8191.patch"
-        SHA512 e5dda11de2ba8cfd39728e69c74a7656bb522e509786fe5673c94b26be9bd4bee897510096479ee6323f5276d34cba1c44c60804a515c0b35ff7b6ac9d625b88
-    )
-    set(_BASIS_VERSION "8565af680d1bd2ad56ab227ca7d96c56dfbe93ed")
+    # Bundle Basis Universal
+    if(VCPKG_USE_HEAD_VERSION)
+        # v1_15_update2
+        set(_BASIS_VERSION "v1_15_update2")
+        set(_BASIS_SHA512 "a898a057b57ac64f6c0bf5fce0b599e23421ccdd015ea7bb668bce8b9292ef55b098f3d05854a2fb5363959932b75cd0a842664ae7d4f71f3537dc11301c1b32")
+    else()
+        # A commit that's before the UASTC support (which
+        # is not implemented yet). The repo has big unrequired files in its
+        # history, so we're downloading just a snapshot instead of a git clone.
+        vcpkg_download_distfile(
+            _BASIS_UNIVERSAL_PATCHES
+            URLS "https://github.com/BinomialLLC/basis_universal/commit/e9c55faac7745ebf38d08cd3b4f71aaf542f8191.diff"
+            FILENAME "e9c55faac7745ebf38d08cd3b4f71aaf542f8191.patch"
+            SHA512 e5dda11de2ba8cfd39728e69c74a7656bb522e509786fe5673c94b26be9bd4bee897510096479ee6323f5276d34cba1c44c60804a515c0b35ff7b6ac9d625b88
+        )
+        set(_BASIS_UNIVERSAL_PATCHES PATCHES ${_BASIS_UNIVERSAL_PATCHES})
+        set(_BASIS_VERSION "8565af680d1bd2ad56ab227ca7d96c56dfbe93ed")
+        set(_BASIS_SHA512 "65062ab3ba675c46760f56475a7528189ed4097fb9bab8316e25d9e23ffec2a9560eb9a6897468baf2a6ab2bd698b5907283e96deaeaef178085a47f9d371bb2")
+    endif()
     vcpkg_download_distfile(
         _BASIS_UNIVERSAL_ARCHIVE
         URLS "https://github.com/BinomialLLC/basis_universal/archive/${_BASIS_VERSION}.tar.gz"
         FILENAME "basis-universal-${_BASIS_VERSION}.tar.gz"
-        SHA512 65062ab3ba675c46760f56475a7528189ed4097fb9bab8316e25d9e23ffec2a9560eb9a6897468baf2a6ab2bd698b5907283e96deaeaef178085a47f9d371bb2
+        SHA512 ${_BASIS_SHA512}
     )
     vcpkg_extract_source_archive_ex(
         OUT_SOURCE_PATH _BASIS_UNIVERSAL_SOURCE
         ARCHIVE ${_BASIS_UNIVERSAL_ARCHIVE}
         WORKING_DIRECTORY "${SOURCE_PATH}/src/external"
-        PATCHES
-            ${_BASIS_UNIVERSAL_PATCHES})
+        ${_BASIS_UNIVERSAL_PATCHES})
     # Remove potentially cached directory which would cause renaming to fail
     file(REMOVE_RECURSE "${SOURCE_PATH}/src/external/basis-universal")
     # Rename the output folder so that magnum auto-detects it
@@ -46,8 +54,10 @@ endif()
 # Head only features
 set(ALL_SUPPORTED_FEATURES ${ALL_FEATURES})
 if(NOT VCPKG_USE_HEAD_VERSION)
-    list(REMOVE_ITEM ALL_SUPPORTED_FEATURES glslangshaderconverter spirvtoolsshaderconverter)
-    message(WARNING "Features glslangshaderconverter and spirvtoolsshaderconverter are not avaliable when building non-head version.")
+    list(REMOVE_ITEM ALL_SUPPORTED_FEATURES cgltfimporter glslangshaderconverter
+        ktximageconverter ktximporter openexrimageconverter openexrimporter
+        spirvtoolsshaderconverter stbdxtimageconverter)
+    message(WARNING "Features cgltfimporter, glslangshaderconverter, ktximageconverter, ktximporter, openexrimageconverter, openexrimporter, spirvtoolsshaderconverter and stbdxtimageconverter are not available when building non-head version.")
 endif()
 
 set(_COMPONENTS "")

--- a/ports/magnum-plugins/vcpkg.json
+++ b/ports/magnum-plugins/vcpkg.json
@@ -58,7 +58,8 @@
           "features": [
             "trade"
           ]
-        }
+        },
+        "zstd"
       ]
     },
     "basisimporter": {
@@ -70,7 +71,8 @@
           "features": [
             "trade"
           ]
-        }
+        },
+        "zstd"
       ]
     },
     "cgltfimporter": {

--- a/ports/magnum-plugins/vcpkg.json
+++ b/ports/magnum-plugins/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum-plugins",
   "version-string": "2020.06",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Plugins for magnum, C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "dependencies": [
@@ -11,8 +11,11 @@
     }
   ],
   "default-features": [
+    "cgltfimporter",
     "ddsimporter",
     "icoimporter",
+    "ktximageconverter",
+    "ktximporter",
     "miniexrimageconverter",
     "opengeximporter",
     "stanfordimporter",
@@ -57,6 +60,25 @@
     "basisimporter": {
       "description": "BasisImporter plugin",
       "dependencies": [
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
+    },
+    "cgltfimporter": {
+      "description": "CgltfImporter plugin",
+      "dependencies": [
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "anyimageimporter"
+          ]
+        },
         {
           "name": "magnum",
           "default-features": false,
@@ -204,6 +226,30 @@
         }
       ]
     },
+    "ktximageconverter": {
+      "description": "KtxImageConverter plugin",
+      "dependencies": [
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
+    },
+    "ktximporter": {
+      "description": "KtxImporter plugin",
+      "dependencies": [
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
+    },
     "meshoptimizersceneconverter": {
       "description": "MeshOptimizerSceneConverter plugin",
       "dependencies": [
@@ -231,6 +277,32 @@
     },
     "openddl": {
       "description": "OpenDdl library"
+    },
+    "openexrimageconverter": {
+      "description": "OpenExrImageConverter plugin",
+      "dependencies": [
+        "openexr",
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
+    },
+    "openexrimporter": {
+      "description": "OpenExrImporter plugin",
+      "dependencies": [
+        "openexr",
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
     },
     "opengeximporter": {
       "description": "OpenGexImporter plugin",
@@ -321,6 +393,18 @@
         }
       ]
     },
+    "stbdxtimageconverter": {
+      "description": "StbDxtImageConverter plugin",
+      "dependencies": [
+        {
+          "name": "magnum",
+          "default-features": false,
+          "features": [
+            "trade"
+          ]
+        }
+      ]
+    },
     "stbimageconverter": {
       "description": "StbImageConverter plugin",
       "dependencies": [
@@ -396,13 +480,6 @@
           "default-features": false,
           "features": [
             "trade"
-          ]
-        },
-        {
-          "name": "magnum-plugins",
-          "default-features": false,
-          "features": [
-            "stbimageimporter"
           ]
         }
       ]

--- a/ports/magnum-plugins/vcpkg.json
+++ b/ports/magnum-plugins/vcpkg.json
@@ -8,6 +8,10 @@
     {
       "name": "magnum",
       "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ],
   "default-features": [

--- a/ports/magnum-plugins/vcpkg.json
+++ b/ports/magnum-plugins/vcpkg.json
@@ -281,27 +281,27 @@
     "openexrimageconverter": {
       "description": "OpenExrImageConverter plugin",
       "dependencies": [
-        "openexr",
         {
           "name": "magnum",
           "default-features": false,
           "features": [
             "trade"
           ]
-        }
+        },
+        "openexr"
       ]
     },
     "openexrimporter": {
       "description": "OpenExrImporter plugin",
       "dependencies": [
-        "openexr",
         {
           "name": "magnum",
           "default-features": false,
           "features": [
             "trade"
           ]
-        }
+        },
+        "openexr"
       ]
     },
     "opengeximporter": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4190,7 +4190,7 @@
     },
     "magnum-plugins": {
       "baseline": "2020.06",
-      "port-version": 7
+      "port-version": 8
     },
     "mailio": {
       "baseline": "0.20.0",

--- a/versions/m-/magnum-plugins.json
+++ b/versions/m-/magnum-plugins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a4d77bfcdfaad1b288a26ad6ac7fe086e356f71",
+      "version-string": "2020.06",
+      "port-version": 8
+    },
+    {
       "git-tree": "241189f2a82d541c88b682f409518b5802dcb39e",
       "version-string": "2020.06",
       "port-version": 7


### PR DESCRIPTION
This PR updates magnum-plugins with new features available when compiling with `--head`, along with an update to a bundled dependency required to compile.

Note: the `spirvtoolsshaderconverter` feature is currently broken due to https://github.com/microsoft/vcpkg/issues/18612

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  There shouldn't be any changes compared to the current port version

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  To the best of my knowledge, yes :eyes:

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yessss