### PR TITLE
[docs] document that vcpkg_from_github works with Gitea

### DIFF
--- a/docs/maintainers/vcpkg_from_github.md
+++ b/docs/maintainers/vcpkg_from_github.md
@@ -4,6 +4,8 @@ The latest version of this document lives in the [vcpkg repo](https://github.com
 
 Download and extract a project from GitHub. Enables support for `install --head`.
 
+This also works with Gitea by specifying the Gitea server with the `GITHUB_HOST` option.
+
 ## Usage:
 ```cmake
 vcpkg_from_github(

--- a/scripts/cmake/vcpkg_from_github.cmake
+++ b/scripts/cmake/vcpkg_from_github.cmake
@@ -3,6 +3,8 @@
 
 Download and extract a project from GitHub. Enables support for `install --head`.
 
+This also works with Gitea by specifying the Gitea server with the `GITHUB_HOST` option.
+
 ## Usage:
 ```cmake
 vcpkg_from_github(


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/20747#pullrequestreview-779956592

**Describe the pull request**

- #### What does your PR fix?  
  How to download sources from Gitea servers was not previously documented.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  N/A

