### PR TITLE
[libsecret] add new port with version 0.20.4

### DIFF
--- a/ports/libsecret/portfile.cmake
+++ b/ports/libsecret/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.gnome.org
+    REPO GNOME/libsecret
+    REF 0.20.4
+    SHA512 b7357329e531ace536ac3c46ef51d022de9308181af227d2ff45c1ff6fe781a29fa93fe02e78f28c84eca8881c2cb90c92c675bcf9fd21b3d326dd84c5692ed5
+    HEAD_REF master
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dintrospection=false
+        -Dgtk_doc=false
+        -Dmanpage=false
+        -Dvapi=false
+    ADDITIONAL_NATIVE_BINARIES
+         gdbus-codegen='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gdbus-codegen'
+         glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
+vcpkg_install_meson()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+# There is no option to disable building secret-tool, so remove the executable.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libsecret/vcpkg.json
+++ b/ports/libsecret/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libsecret",
+  "version": "0.20.4",
+  "description": "libsecret is a GObject-based library for accessing the Secret Service API of the freedesktop.org project, a cross-desktop effort to access passwords, tokens and other types of secrets. libsecret provides a convenient wrapper for these methods so consumers do not have to call the low-level DBus methods.",
+  "homepage": "https://gitlab.gnome.org/GNOME/libsecret/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!(windows | uwp | osx)",
+  "dependencies": [
+    "glib",
+    "libgcrypt"
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3836,6 +3836,10 @@
       "baseline": "2.3.0",
       "port-version": 0
     },
+    "libsecret": {
+      "baseline": "0.20.4",
+      "port-version": 0
+    },
     "libsercomm": {
       "baseline": "1.3.2",
       "port-version": 0

--- a/versions/l-/libsecret.json
+++ b/versions/l-/libsecret.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7aad2a858c931c5d57edcecba4965f56820e8d78",
+      "version": "0.20.4",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Adds libsecret so it can be used by the qtkeychain port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
