### PR TITLE
[magnum] Move static debug libraries to root lib/ folder

### DIFF
--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -112,6 +112,27 @@ endif()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
 
+# Special handling for plugins.
+#
+# For static plugins, in order to make MSBuild auto-linking magic work, where 
+# the linker implicitly takes everything from the root lib/ folder, the 
+# static libraries have to be moved out of lib/magnum/blah/ directly to lib/.
+# Possibly would be enough to do this just for Windows, doing it also on other
+# platforms for consistency.
+#
+# For dynamic plugins, auto-linking is not desirable as those are meant to be 
+# loaded dynamically at runtime instead. In order to prevent that, on Windows 
+# the *.lib files corresponding to the plugin *.dlls are removed. However, we 
+# cannot remove the *.lib files entirely here, as plugins from magnum-plugins 
+# are linked to them on Windows (e.g. AssimpImporter depends on 
+# AnyImageImporter). Thus the Any* plugin lib files are kept, but also not 
+# moved to the root lib/ folder, to prevent autolinking. A consequence of the 
+# *.lib file removal is that downstream projects can't implement Magnum plugins
+# that would depend on (and thus link to) these, but that's considered a very 
+# rare use case and so it's fine.
+#
+# See https://github.com/microsoft/vcpkg/pull/1235#issuecomment-308805989 for 
+# futher info.
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin)
@@ -120,24 +141,10 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(COPY ${LIB_TO_MOVE} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/magnum)
 
-    file(GLOB_RECURSE LIB_TO_MOVE_DBG ${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d/*)
+    file(GLOB_RECURSE LIB_TO_MOVE_DBG ${CURRENT_PACKAGES_DIR}/debug/lib/magnum/*)
     file(COPY ${LIB_TO_MOVE_DBG} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/magnum-d)
+    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/magnum)
 else()
-    # Unlike the magnum-plugins port, we cannot remove the lib files entirely here,
-    # As other importers might depend on them (e.g. AssimpImporter depends on AnyImageImporter)
-    # and modules are not allowed to have unresolved symbols, hence simply loading the
-    # dependencies in advance like on Unix does not work on Windows.
-    #
-    # On windows, plugins are "Modules" that cannot be linked as shared
-    # libraries, but are meant to be loaded at runtime.
-    # While this is handled adequately through the CMake project, the auto-magic
-    # linking with visual studio might try to link the import libs anyway.
-    #
-    # We delete most of the import libraries here to avoid the auto-magic linking
-    # for plugins which are loaded at runtime, but keep the afforementioned Any* plugins.
-    #
-    # See https://github.com/microsoft/vcpkg/pull/1235#issuecomment-308805989 for futher info.
     if(WIN32)
         file(GLOB_RECURSE LIB_TO_REMOVE ${CURRENT_PACKAGES_DIR}/lib/magnum/*)
         file(GLOB_RECURSE LIB_TO_KEEP ${CURRENT_PACKAGES_DIR}/lib/magnum/*Any*)

--- a/ports/magnum/portfile.cmake
+++ b/ports/magnum/portfile.cmake
@@ -70,9 +70,8 @@ endforeach()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS FEATURES ${_COMPONENTS})
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
     OPTIONS
         ${FEATURE_OPTIONS}
         -DBUILD_STATIC=${BUILD_STATIC}
@@ -81,7 +80,7 @@ vcpkg_configure_cmake(
         -DMAGNUM_PLUGINS_RELEASE_DIR=${CURRENT_INSTALLED_DIR}/bin/magnum
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 

--- a/ports/magnum/vcpkg.json
+++ b/ports/magnum/vcpkg.json
@@ -10,6 +10,10 @@
       "features": [
         "utility"
       ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ],
   "default-features": [

--- a/ports/magnum/vcpkg.json
+++ b/ports/magnum/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "magnum",
   "version-string": "2020.06",
-  "port-version": 7,
+  "port-version": 8,
   "description": "C++11/C++14 graphics middleware for games and data visualization",
   "homepage": "https://magnum.graphics/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4186,7 +4186,7 @@
     },
     "magnum": {
       "baseline": "2020.06",
-      "port-version": 7
+      "port-version": 8
     },
     "magnum-extras": {
       "baseline": "2020.06",

--- a/versions/m-/magnum.json
+++ b/versions/m-/magnum.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f68058291469a1b9d3c62e766279c8f00cd479ec",
+      "version-string": "2020.06",
+      "port-version": 8
+    },
+    {
       "git-tree": "02916da34e2db9343355653309cbab7d8ff85f21",
       "version-string": "2020.06",
       "port-version": 7


### PR DESCRIPTION
:wave: This PR fixes an issue with static debug libraries not being moved to the root lib/ folder correctly. This is inconsistent with static release libraries and breaks MSBuild integration.

I also went ahead and replaced the deprecated `_cmake()` functions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes to the current port version

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
