### PR TITLE
[vcpkg baseline][kf5solid] Fix usage

### DIFF
--- a/ports/kf5solid/fix-libmount.patch
+++ b/ports/kf5solid/fix-libmount.patch
@@ -1,0 +1,15 @@
+diff --git a/KF5SolidConfig.cmake.in b/KF5SolidConfig.cmake.in
+index 0a23f44..0ad616c 100644
+--- a/KF5SolidConfig.cmake.in
++++ b/KF5SolidConfig.cmake.in
+@@ -22,6 +22,10 @@ find_dependency(Qt5Core @REQUIRED_QT_VERSION@)
+ if (NOT @BUILD_SHARED_LIBS@)
+     find_dependency(Qt5Xml @REQUIRED_QT_VERSION@)
+     find_dependency(Qt5Gui @REQUIRED_QT_VERSION@)
++    
++    if (CMAKE_SYSTEM_NAME MATCHES Linux)
++        find_dependency(LibMount)
++    endif()
+ 
+     if (@Qt5DBus_FOUND@)
+         find_dependency(Qt5DBus @REQUIRED_QT_VERSION@)

--- a/ports/kf5solid/fix-libmount.patch
+++ b/ports/kf5solid/fix-libmount.patch
@@ -1,15 +1,15 @@
 diff --git a/KF5SolidConfig.cmake.in b/KF5SolidConfig.cmake.in
-index 0a23f44..0ad616c 100644
+index 0a23f44..7020804 100644
 --- a/KF5SolidConfig.cmake.in
 +++ b/KF5SolidConfig.cmake.in
-@@ -22,6 +22,10 @@ find_dependency(Qt5Core @REQUIRED_QT_VERSION@)
- if (NOT @BUILD_SHARED_LIBS@)
+@@ -23,6 +23,10 @@ if (NOT @BUILD_SHARED_LIBS@)
      find_dependency(Qt5Xml @REQUIRED_QT_VERSION@)
      find_dependency(Qt5Gui @REQUIRED_QT_VERSION@)
-+    
-+    if (CMAKE_SYSTEM_NAME MATCHES Linux)
+ 
++    if (@HAVE_LIBMOUNT@)
 +        find_dependency(LibMount)
 +    endif()
- 
++
      if (@Qt5DBus_FOUND@)
          find_dependency(Qt5DBus @REQUIRED_QT_VERSION@)
+     endif()

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -39,8 +39,9 @@ file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: fals
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS 
+    OPTIONS
         -DBUILD_TESTING=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_LibMount=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix_config_cmake.patch # https://invent.kde.org/frameworks/solid/-/merge_requests/53
+        fix-libmount.patch
 )
 
 if(VCPKG_TARGET_IS_OSX)

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5solid",
   "version-semver": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kf5solid",
-  "version-semver": "5.84.0",
+  "version": "5.84.0",
   "port-version": 3,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3134,7 +3134,7 @@
     },
     "kf5solid": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "kf5sonnet": {
       "baseline": "5.84.0",

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "dd109dcec3c21761066fb09203a804b7d24e4bde",
-      "version-semver": "5.84.0",
+      "git-tree": "116e07f8f715288227f386971a304038bf6cb7b7",
+      "version": "5.84.0",
       "port-version": 3
     },
     {

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2336bf528bf83de4934d6d8bb7632b1ef00bebae",
+      "git-tree": "77af969f1b19c937d7f41651b657a774cd3802c7",
       "version": "5.84.0",
       "port-version": 3
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "116e07f8f715288227f386971a304038bf6cb7b7",
+      "git-tree": "2336bf528bf83de4934d6d8bb7632b1ef00bebae",
       "version": "5.84.0",
       "port-version": 3
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dd109dcec3c21761066fb09203a804b7d24e4bde",
+      "version-semver": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "f0a82387f00cd2a61e6f1751bb1c94c9d706fddb",
       "version-semver": "5.84.0",
       "port-version": 2


### PR DESCRIPTION
Kf5solid requires `libmount` in Liunx, but doesn't add `find_dependency(libmount)` in its config.cmake file.

Fix that.