### PR TITLE
[qtkeychain] Update to 0.13.1

### DIFF
--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF 6743abd98586fbabd01da9839f53f61ccfb7f83c # v0.11.1
-    SHA512 0ad6b82b972ca1cc5f1f8318899637ce0a6786f912b7f9efc1b7eea132ccefbe9a5dc0eb82d0dc9a020bcd55cd538d9e962fc40eb5c828142a7f2186b19633b1
+    REF v0.13.1
+    SHA512 552c1632a81f64b91dacdb0f5eb4122b4ddef53ba6621561db6c4fce9f3692761dbc4b452e578023e2882e049874148be1de014397675ce443cfc93fe96f6f70
     HEAD_REF master
 )
 
@@ -14,27 +14,28 @@ else()
     list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=OFF)
 endif()
 
-if (CMAKE_HOST_WIN32)
+if(CMAKE_HOST_WIN32)
     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=ON)
 else()
     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=OFF)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 	OPTIONS ${QTKEYCHAIN_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Qt5Keychain TARGET_PATH share/Qt5Keychain)
+vcpkg_cmake_config_fixup(PACKAGE_NAME Qt5Keychain CONFIG_PATH lib/cmake/Qt5Keychain)
+
 # Remove unneeded dirs
 file(REMOVE_RECURSE 
-	${CURRENT_PACKAGES_DIR}/debug/include
-      ${CURRENT_PACKAGES_DIR}/debug/share
+	"${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -22,7 +22,7 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-	OPTIONS ${QTKEYCHAIN_OPTIONS}
+    OPTIONS ${QTKEYCHAIN_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -33,7 +33,7 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME Qt5Keychain CONFIG_PATH lib/cmake/Qt5Keych
 
 # Remove unneeded dirs
 file(REMOVE_RECURSE 
-	"${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qtkeychain",
-  "version-string": "0.11.1",
-  "port-version": 1,
+  "version": "0.13.1",
   "description": "qtkeychain - Platform-independent Qt API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "dependencies": [
@@ -9,6 +8,14 @@
       "name": "qt5-base",
       "default-features": false
     },
-    "qt5-tools"
+    "qt5-tools",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5677,8 +5677,8 @@
       "port-version": 0
     },
     "qtkeychain": {
-      "baseline": "0.11.1",
-      "port-version": 1
+      "baseline": "0.13.1",
+      "port-version": 0
     },
     "qtlocation": {
       "baseline": "6.2.1",

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5f99ab05100587a1fc634a27cf14fdb4e5de120a",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "477977da90b66a24d95b42e3776d17fd8e2735e0",
       "version-string": "0.11.1",
       "port-version": 1

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5f99ab05100587a1fc634a27cf14fdb4e5de120a",
+      "git-tree": "bd83042957e111068497f0f868f31887970f6cdc",
       "version": "0.13.1",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates qtkeychain to 0.13.1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?  
  Yes