### PR TITLE
[font-chef] Update to 1.1.0

### DIFF
--- a/ports/font-chef/disable-warnings-as-errors.patch
+++ b/ports/font-chef/disable-warnings-as-errors.patch
@@ -1,0 +1,12 @@
+diff --git a/src/font-chef/CMakeLists.txt b/src/font-chef/CMakeLists.txt
+--- a/src/font-chef/CMakeLists.txt
++++ b/src/font-chef/CMakeLists.txt
+@@ -68,7 +68,7 @@ target_include_directories(font-chef++ INTERFACE
+ if (NOT CMAKE_BUILD_TYPE MATCHES "Release")
+   target_compile_options(font-chef PRIVATE
+     $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:GNU>>:-Wall -Wextra -pedantic -fvisibility=hidden -Werror>
+-    $<$<C_COMPILER_ID:MSVC>:/W3 /WX /wd4820 /wd4668 /wd4204>
++    $<$<C_COMPILER_ID:MSVC>:/W3 /wd4820 /wd4668 /wd4204>
+   )
+ endif()
+ 

--- a/ports/font-chef/portfile.cmake
+++ b/ports/font-chef/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.1.0
     SHA512 3df1e31e4405bcbb05ffed8fe618eb953498389adef3d83d337ac570644008bee031e08cd64382443ad123c4abf7e0acca5e3e16288caf6225672d6796a9494f
     HEAD_REF master
+    PATCHES
+        disable-warnings-as-errors.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/font-chef/portfile.cmake
+++ b/ports/font-chef/portfile.cmake
@@ -1,23 +1,22 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mobius3/font-chef
-    REF v1.0.1
-    SHA512 0d73d095a2f6346cde5fc58a07be7cbe2c180ab5c83a4af21f765a6be1e9dcc5a403fa1d4c64f71dad5609eb72c8b05df8606b4035fceadca74fe6a87bb8efef 
+    REF v1.1.0
+    SHA512 3df1e31e4405bcbb05ffed8fe618eb953498389adef3d83d337ac570644008bee031e08cd64382443ad123c4abf7e0acca5e3e16288caf6225672d6796a9494f
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/font-chef/portfile.cmake
+++ b/ports/font-chef/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     SHA512 3df1e31e4405bcbb05ffed8fe618eb953498389adef3d83d337ac570644008bee031e08cd64382443ad123c4abf7e0acca5e3e16288caf6225672d6796a9494f
     HEAD_REF master
     PATCHES
-        disable-warnings-as-errors.patch
+        disable-warnings-as-errors.patch # to workaround https://github.com/mobius3/font-chef/issues/3
 )
 
 vcpkg_cmake_configure(

--- a/ports/font-chef/vcpkg.json
+++ b/ports/font-chef/vcpkg.json
@@ -1,7 +1,16 @@
 {
   "name": "font-chef",
-  "version-string": "1.0.1",
-  "port-version": 1,
+  "version": "1.1.0",
   "description": "A font cooking library",
-  "homepage": "https://github.com/mobius3/font-chef"
+  "homepage": "https://github.com/mobius3/font-chef",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2213,8 +2213,8 @@
       "port-version": 3
     },
     "font-chef": {
-      "baseline": "1.0.1",
-      "port-version": 1
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "fontconfig": {
       "baseline": "2.13.94",

--- a/versions/f-/font-chef.json
+++ b/versions/f-/font-chef.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cf77604ab0655d76d8593c3368f953ade10f703",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "907533e8f03e495fcddd47a6c0cd59cc73dfcc0b",
       "version-string": "1.0.1",
       "port-version": 1

--- a/versions/f-/font-chef.json
+++ b/versions/f-/font-chef.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "023bb7192dbab6aa23199673cf9953fe45abf380",
+      "git-tree": "38744fa5fa1e86217669332c7860e193550b1a81",
       "version": "1.1.0",
       "port-version": 0
     },

--- a/versions/f-/font-chef.json
+++ b/versions/f-/font-chef.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7cf77604ab0655d76d8593c3368f953ade10f703",
+      "git-tree": "023bb7192dbab6aa23199673cf9953fe45abf380",
       "version": "1.1.0",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates font-chef to 1.1.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?  
  Yes