### PR TITLE
[bfgroup-lyra] Update to 1.5.1

### DIFF
--- a/ports/bfgroup-lyra/portfile.cmake
+++ b/ports/bfgroup-lyra/portfile.cmake
@@ -1,22 +1,21 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO bfgroup/Lyra
-    REF 1.5
-    SHA512 1f8e505a487a9421a59afed0ee0c68894fb479117ac20c0bbb8d77ccf50ab938a68c93068f26871b9ddff0a21732d8bb1c6cc997b295a2a39c9363d32e320b3b
+    REF 1.5.1
+    SHA512 e349c57614fe18cfee49b6a3977f133de3e567aa6b1c148abf9510432f7db34b75488739850e48c7943a15151fe2eedb129179d8d73eb61fb4f9a11c54b61086
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME lyra
     CONFIG_PATH share/lyra/cmake
-    TARGET_PATH share/lyra
 )
 
 # Library is header-only, so no debug content.
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/bfgroup-lyra/vcpkg.json
+++ b/ports/bfgroup-lyra/vcpkg.json
@@ -1,7 +1,16 @@
 {
   "name": "bfgroup-lyra",
-  "version-string": "1.5",
-  "port-version": 1,
+  "version": "1.5.1",
   "description": "A simple to use, composable, command line parser for C++ 11 and beyond",
-  "homepage": "https://bfgroup.github.io/Lyra/"
+  "homepage": "https://bfgroup.github.io/Lyra/",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/b-/bfgroup-lyra.json
+++ b/versions/b-/bfgroup-lyra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d06d9dff4b3cb6ea57292cb81460f113a905e3ea",
+      "version": "1.5.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "0cfb523191016e3f686356b2d522034a2b7a47da",
       "version-string": "1.5",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -449,8 +449,8 @@
       "port-version": 0
     },
     "bfgroup-lyra": {
-      "baseline": "1.5",
-      "port-version": 1
+      "baseline": "1.5.1",
+      "port-version": 0
     },
     "bigint": {
       "baseline": "2010.04.30",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This updates the port bfgroup-lyra to version 1.5.1.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
