### PR TITLE
[mathgl] fix deadlock

### DIFF
--- a/ports/mathgl/omp_deadlock_fix.patch
+++ b/ports/mathgl/omp_deadlock_fix.patch
@@ -1,0 +1,12 @@
+--- a/src/font.cpp	2019-03-14 14:16:47.000000000 +0800
++++ b/src/font.cpp	2021-11-14 17:37:04.109018600 +0800
+@@ -731,7 +731,9 @@
+ //-----------------------------------------------------------------------------
+ void mglFont::FillY12()
+ {
++#ifndef WIN32	// win32 don't initialized threads before main()
+ #pragma omp parallel
++#endif
+ 	for(long i=0;i<long(glyphs.size());i++)
+ 	{
+ 		for(int s=0;s<4;s++)

--- a/ports/mathgl/portfile.cmake
+++ b/ports/mathgl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_sourceforge(
     PATCHES
         type_fix.patch
         fix_cmakelists_and_cpp.patch
+        omp_deadlock_fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/mathgl/vcpkg.json
+++ b/ports/mathgl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mathgl",
-  "version-string": "2.4.3",
+  "version": "2.4.3",
   "port-version": 8,
   "description": "MathGL is a free library of fast C++ routines for the plotting of the data varied in one or more dimensions",
   "default-features": [

--- a/ports/mathgl/vcpkg.json
+++ b/ports/mathgl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mathgl",
   "version-string": "2.4.3",
-  "port-version": 7,
+  "port-version": 8,
   "description": "MathGL is a free library of fast C++ routines for the plotting of the data varied in one or more dimensions",
   "default-features": [
     "jpeg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4258,7 +4258,7 @@
     },
     "mathgl": {
       "baseline": "2.4.3",
-      "port-version": 7
+      "port-version": 8
     },
     "matio": {
       "baseline": "1.5.19",

--- a/versions/m-/mathgl.json
+++ b/versions/m-/mathgl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a435bdc75990648a6cf3c7a17aa421bb14b425a1",
+      "version": "2.4.3",
+      "port-version": 8
+    },
+    {
       "git-tree": "4af49c54047fc9b315b888d5f51aef8748aba132",
       "version-string": "2.4.3",
       "port-version": 7


### PR DESCRIPTION
Disables OpenMP parallel in mglFont::FillY12. This function is called in dllmain, so it causes deadlock on windows.

This is not a vcpkg-only issue, so I'm not sure if I should fix here, but this should be quicker than waiting for the upstream update.

- #### What does your PR fix?  
  Fixes deadlock on windows

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
