### PR TITLE
[bdwgc] Turn on C++, cords an threads support

### DIFF
--- a/ports/bdwgc/portfile.cmake
+++ b/ports/bdwgc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ivmai/bdwgc
-    REF 59f15da55961928b05972d386054fb980bdc8cf0 # v8.2.0-20211013
-    SHA512 f6b91f0ad9691d02b04d609d06b9d9aaf30a6e0bb93a5985f9e178128bc3a0b180a3366ecddafab43697fb28c6d0d5e814f99a7bbacad8da4550d3b6ea92bef6
+    REF 5fab1a01931a1a6934ccf1d5eaa1e51f0a8dac4d # v8.2.0-20211115
+    SHA512 b1a97aad10df33bb242985eb48f1bb2d3082d88f26c34014efce3d0f233bcd18a0f43f1bd960600ad9e22bcb19ebf04e573c74dfc1abfb771aa6b8525053c14b
     HEAD_REF master
 )
 
@@ -10,8 +10,8 @@ vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
     OPTIONS
-        -Dbuild_cord=OFF
-        -Denable_threads=OFF # TODO: add libatomic_ops package and turn on threads
+        -Denable_cplusplus=ON
+        -DCFLAGS_EXTRA=-I${CURRENT_INSTALLED_DIR}/include # for libatomic_ops
     OPTIONS_DEBUG
         -Dinstall_headers=OFF
 )

--- a/ports/bdwgc/vcpkg.json
+++ b/ports/bdwgc/vcpkg.json
@@ -1,6 +1,9 @@
 {
   "name": "bdwgc",
   "version": "8.2.0",
-  "port-version": 1,
-  "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)"
+  "port-version": 2,
+  "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)",
+  "dependencies": [
+    "libatomic-ops"
+  ]
 }

--- a/versions/b-/bdwgc.json
+++ b/versions/b-/bdwgc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b7ec5e3585f7f7b71988cb7379c181a1fa9461cd",
+      "version": "8.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "84653790601fd0e28aaeb12a9a58292b7e3af1bc",
       "version": "8.2.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -410,7 +410,7 @@
     },
     "bdwgc": {
       "baseline": "8.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "beast": {
       "baseline": "0",


### PR DESCRIPTION
* Add -Denable_cplusplus=ON
* Remove -Dbuild_cord=OFF
* Remove -Denable_threads=OFF thus enabling threads
* Add libatomic-ops to dependencies

**Describe the pull request**

- #### What does your PR fix?  
Enables C++, cords API and multi-threaded support in bdwgc package

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
