### PR TITLE
[fontconfig] Fix dead link to homepage

### DIFF
--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "fontconfig",
   "version": "2.13.94",
+  "port-version": 1
   "description": "Library for configuring and customizing font access.",
-  "homepage": "https://www.freedesktop.org/software/fontconfig/front.html",
+  "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "dependencies": [
     "dirent",
     "expat",

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fontconfig",
   "version": "2.13.94",
-  "port-version": 1
+  "port-version": 1,
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2218,7 +2218,7 @@
     },
     "fontconfig": {
       "baseline": "2.13.94",
-      "port-version": 0
+      "port-version": 1
     },
     "foonathan-memory": {
       "baseline": "2019-07-21",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a63fba442981df4301600b20be46da00aff5b300",
+      "git-tree": "606b2d7ca0ba11e29552311100b66d8c5052faeb",
       "version": "2.13.94",
       "port-version": 1
     },

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a63fba442981df4301600b20be46da00aff5b300",
+      "version": "2.13.94",
+      "port-version": 1
+    },
+    {
       "git-tree": "73929965b1d7992064fec1f69c6225a3d73a262b",
       "version": "2.13.94",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes a 404'd link to the Fontconfig homepage. I noticed the issue on [repology](https://repology.org/repository/vcpkg/problems).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not applicable.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes, nothing to commit.

