### PR TITLE
[qtkeychain] update to 0.13.1

### DIFF
--- a/ports/qtkeychain-qt6/portfile.cmake
+++ b/ports/qtkeychain-qt6/portfile.cmake
@@ -1,0 +1,54 @@
+message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliated with The Qt Company")
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO frankosterfeld/qtkeychain
+    REF v0.13.1
+    SHA512 552c1632a81f64b91dacdb0f5eb4122b4ddef53ba6621561db6c4fce9f3692761dbc4b452e578023e2882e049874148be1de014397675ce443cfc93fe96f6f70
+    HEAD_REF master
+)
+
+if(VCPKG_CROSSCOMPILING)
+   list(APPEND QTKEYCHAIN_OPTIONS -DQT_HOST_PATH=${CURRENT_HOST_INSTALLED_DIR})
+   list(APPEND QTKEYCHAIN_OPTIONS -DQT_HOST_PATH_CMAKE_DIR:PATH=${CURRENT_HOST_INSTALLED_DIR}/share)
+   # remove when https://github.com/microsoft/vcpkg/pull/16111 is merged
+   if(VCPKG_TARGET_ARCHITECTURE STREQUAL arm64 AND VCPKG_TARGET_IS_WINDOWS)
+       list(APPEND QTKEYCHAIN_OPTIONS -DCMAKE_CROSSCOMPILING=ON -DCMAKE_SYSTEM_PROCESSOR:STRING=ARM64 -DCMAKE_SYSTEM_NAME:STRING=Windows)
+   endif()
+endif()
+
+list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TEST_APPLICATION:BOOL=OFF)
+# TODO: remove after next release since https://github.com/frankosterfeld/qtkeychain/pull/204 was merged
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=ON)
+else()
+    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=OFF)
+endif()
+
+# FIXME: Why does build translations fail on arm64-windows?
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)
+     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=OFF)
+else()
+     list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=ON)
+endif()
+
+vcpkg_cmake_configure(
+    DISABLE_PARALLEL_CONFIGURE
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBUILD_WITH_QT6=ON
+         ${QTKEYCHAIN_OPTIONS}
+)
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Qt6Keychain PACKAGE_NAME Qt6Keychain)
+
+# Remove unneeded dirs
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,7 +1,7 @@
 {
-  "name": "qtkeychain",
+  "name": "qtkeychain-qt6",
   "version": "0.13.1",
-  "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
+  "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",
   "dependencies": [
@@ -9,7 +9,12 @@
       "name": "libsecret",
       "platform": "!(windows | uwp | osx)"
     },
-    "qt5-tools",
+    {
+      "name": "qttools",
+      "features": [
+        "linguist"
+      ]
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -1,40 +1,38 @@
+message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliated with The Qt Company")
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF 6743abd98586fbabd01da9839f53f61ccfb7f83c # v0.11.1
-    SHA512 0ad6b82b972ca1cc5f1f8318899637ce0a6786f912b7f9efc1b7eea132ccefbe9a5dc0eb82d0dc9a020bcd55cd538d9e962fc40eb5c828142a7f2186b19633b1
+    REF v0.13.1
+    SHA512 552c1632a81f64b91dacdb0f5eb4122b4ddef53ba6621561db6c4fce9f3692761dbc4b452e578023e2882e049874148be1de014397675ce443cfc93fe96f6f70
     HEAD_REF master
 )
 
-list(APPEND QTKEYCHAIN_OPTIONS -DCMAKE_DEBUG_POSTFIX=d)
 list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TEST_APPLICATION:BOOL=OFF)
+# TODO: remove after next release since https://github.com/frankosterfeld/qtkeychain/pull/204 was merged
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=ON)
 else()
     list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=OFF)
 endif()
 
-if (CMAKE_HOST_WIN32)
-    list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=ON)
-else()
-    list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TRANSLATIONS:BOOL=OFF)
-endif()
-
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
+    DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
-	OPTIONS ${QTKEYCHAIN_OPTIONS}
+    OPTIONS
+        -DBUILD_WITH_QT6=OFF
+        ${QTKEYCHAIN_OPTIONS}
 )
-
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Qt5Keychain PACKAGE_NAME Qt5Keychain)
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/Qt5Keychain TARGET_PATH share/Qt5Keychain)
 # Remove unneeded dirs
-file(REMOVE_RECURSE 
-	${CURRENT_PACKAGES_DIR}/debug/include
-      ${CURRENT_PACKAGES_DIR}/debug/share
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5685,8 +5685,12 @@
       "port-version": 0
     },
     "qtkeychain": {
-      "baseline": "0.11.1",
-      "port-version": 1
+      "baseline": "0.13.1",
+      "port-version": 0
+    },
+    "qtkeychain-qt6": {
+      "baseline": "0.13.1",
+      "port-version": 0
     },
     "qtlocation": {
       "baseline": "6.2.1",

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "29acc8309b4310f9b05f7c11cd81b0fd06dcbfff",
+      "version": "0.13.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff34038b321dbfe954208b0ec4844c1066dde839",
+      "version": "0.13.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "477977da90b66a24d95b42e3776d17fd8e2735e0",
       "version-string": "0.11.1",
       "port-version": 1


### PR DESCRIPTION
Cherry-picked from https://github.com/microsoft/vcpkg/pull/20185 with:
1. Warning and adjusted description to better inform users that qtkeychain is not affiliated with The Qt Company
2. Revert to original port names -- while it would be nice to have qtkeychain's naming match with qttools vs qt5-tools, that is absolutely not worth breaking customers on upgrade that currently expect `qtkeychain` to come with qt5.