### PR TITLE
[libarchive] Fix usage

### DIFF
--- a/ports/libarchive/usage
+++ b/ports/libarchive/usage
@@ -1,5 +1,5 @@
 The package libarchive is compatible with built-in CMake targets:
 
-    find_package(libarchive REQUIRED)
+    find_package(LibArchive REQUIRED)
     target_include_directories(main PRIVATE ${LibArchive_INCLUDE_DIRS})
     target_link_libraries(main PRIVATE ${LibArchive_LIBRARIES})

--- a/ports/libarchive/vcpkg.json
+++ b/ports/libarchive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libarchive",
   "version-semver": "3.5.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for reading and writing streaming archives",
   "homepage": "https://github.com/libarchive/libarchive",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3294,7 +3294,7 @@
     },
     "libarchive": {
       "baseline": "3.5.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libass": {
       "baseline": "0.15.2",

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d79d7deb863644fb2bd6570d17cfa88386fc4156",
+      "version-semver": "3.5.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "1fb5fbe606242275316a4368c88327e123ab01ad",
       "version-semver": "3.5.2",
       "port-version": 1


### PR DESCRIPTION
Fix usage, cmake provides `FindLibArchive.cmake`, so the `PACKAGE_NAME` should be `LibArchive`.

Fixes #21408.

Already tested the usage.