### PR TITLE
Add missing '$' in applocal.ps1

### DIFF
--- a/scripts/buildsystems/msbuild/applocal.ps1
+++ b/scripts/buildsystems/msbuild/applocal.ps1
@@ -58,7 +58,7 @@ function deployBinary([string]$targetBinaryDir, [string]$SourceDir, [string]$tar
             Write-Verbose "  ${targetBinaryName}: Copying $sourceBinaryFilePath"
             Copy-Item $sourceBinaryFilePath $targetBinaryDir
         }
-        if ($copiedFilesLog) { Add-Content $copiedFilesLog targetBinaryFilePath -Encoding UTF8 }
+        if ($copiedFilesLog) { Add-Content $copiedFilesLog $targetBinaryFilePath -Encoding UTF8 }
         if ($tlogFile) { Add-Content $tlogFile $targetBinaryFilePath -Encoding Unicode }
     } finally {
         if ($mtx) {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes a bug from the recent change to `applocal.ps1` (#21092).
  Resolves #21425

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  windows, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed.
