### PR TITLE
[Quantlib]  Update port to v1.25

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lballabio/QuantLib
-    REF QuantLib-v1.24
-    SHA512 1a63d90363cda69e20e40a60a2d6357f632fac997df520b949e73feb256dac8a999395d0ebe94734ac630e9104e512b0a545f6a2111b287a41e9128127aa5bb0
+    REF QuantLib-v1.25
+    SHA512 9a08c3d825f85c93e7db74b31dc93d03d7ec487b7a09f86b6f3efb0404791e1b3e1ea19e06cea19fd04ab190d2e8eb7bad889660d47eb9988c36609967646aa3
     HEAD_REF master
 )
 
@@ -11,20 +11,20 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DQL_BUILD_BENCHMARK=OFF
         -DQL_BUILD_EXAMPLES=OFF
         -DQL_BUILD_TEST_SUITE=OFF
 )
 
-vcpkg_install_cmake()
-
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME QuantLib CONFIG_PATH lib/cmake/QuantLib)
 vcpkg_copy_pdbs()
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+# Install custom usage
+configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE.TXT" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/quantlib/usage
+++ b/ports/quantlib/usage
@@ -1,0 +1,4 @@
+The package quantlib provides CMake targets:
+
+    find_package(QuantLib CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE QuantLib::QuantLib)

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quantlib",
-  "version": "1.24",
+  "version": "1.25",
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "supports": "!(windows & !static)",
@@ -31,12 +31,19 @@
     "boost-serialization",
     "boost-signals2",
     "boost-smart-ptr",
-    "boost-test",
     "boost-thread",
     "boost-tuple",
     "boost-type-traits",
     "boost-ublas",
     "boost-unordered",
-    "boost-utility"
+    "boost-utility",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5889,7 +5889,7 @@
       "port-version": 1
     },
     "quantlib": {
-      "baseline": "1.24",
+      "baseline": "1.25",
       "port-version": 0
     },
     "quaternions": {

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d702f6d14c1a91b83a4950dd05e3b200700cfd8",
+      "version": "1.25",
+      "port-version": 0
+    },
+    {
       "git-tree": "d8519a43e706ff22152e65942f48e5abd75bb76f",
       "version": "1.24",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Placeholder for QuantLib v1.25 upgrade

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
All except windows dynamic, No

- #### Does your PR follow the [maintainer guide]
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes