### PR TITLE
[unixodbc] update to v2.3.9

### DIFF
--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -9,10 +9,16 @@ vcpkg_from_github(
 )
 
 set(ENV{CFLAGS} "$ENV{CFLAGS} -Wno-error=implicit-function-declaration")
+
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
+    list(APPEND OPTIONS --with-included-ltdl)
+endif()
+
 vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}"
         AUTOCONFIG
         COPY_SOURCE
+        OPTIONS ${OPTIONS}
 )
 
 vcpkg_install_make()

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -1,11 +1,10 @@
-vcpkg_fail_port_install(ON_TARGET "UWP" "Windows")
 
 vcpkg_from_github(
-        OUT_SOURCE_PATH SOURCE_PATH
-        REPO lurcher/unixODBC
-        REF v2.3.9
-        SHA512 473f8d39f5976b4c34394d880d6e511b73e33a1fbd6b828a0929787983cd9b5fe7e16776ed51776ce44b54aa61c62be689c0731489b3989acb99c135fb492ec5
-        HEAD_REF master
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lurcher/unixODBC
+    REF v2.3.9
+    SHA512 473f8d39f5976b4c34394d880d6e511b73e33a1fbd6b828a0929787983cd9b5fe7e16776ed51776ce44b54aa61c62be689c0731489b3989acb99c135fb492ec5
+    HEAD_REF master
 )
 
 set(ENV{CFLAGS} "$ENV{CFLAGS} -Wno-error=implicit-function-declaration")
@@ -15,10 +14,10 @@ if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_LINUX)
 endif()
 
 vcpkg_configure_make(
-        SOURCE_PATH "${SOURCE_PATH}"
-        AUTOCONFIG
-        COPY_SOURCE
-        OPTIONS ${OPTIONS}
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    COPY_SOURCE
+    OPTIONS ${OPTIONS}
 )
 
 vcpkg_install_make()

--- a/ports/unixodbc/portfile.cmake
+++ b/ports/unixodbc/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "UWP" "Windows")
 vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO lurcher/unixODBC
-        REF 2.3.7
-        SHA512 94e95730304990fc5ed4f76ebfb283d8327a59a3329badaba752a502a2d705549013fd95f0c92704828c301eae54081c8704acffb412fd1e1a71f4722314cec0
+        REF v2.3.9
+        SHA512 473f8d39f5976b4c34394d880d6e511b73e33a1fbd6b828a0929787983cd9b5fe7e16776ed51776ce44b54aa61c62be689c0731489b3989acb99c135fb492ec5
         HEAD_REF master
 )
 

--- a/ports/unixodbc/unixodbcConfig.cmake
+++ b/ports/unixodbc/unixodbcConfig.cmake
@@ -1,11 +1,26 @@
-function(set_library_target NAMESPACE LIB_NAME DEBUG_LIB_FILE_NAME RELEASE_LIB_FILE_NAME INCLUDE_DIR)
+function(set_library_target NAMESPACE LIB_NAME DEBUG_DIR RELEASE_DIR INCLUDE_DIR)
     add_library(${NAMESPACE}::${LIB_NAME} STATIC IMPORTED)
+    
+    find_library (RELEASE_LIB_FILE_NAME NAMES "lib${LIB_NAME}.a" PATHS ${RELEASE_DIR} NO_DEFAULT_PATH)
+    if (RELEASE_LIB_FILE_NAME)
+        set(LIBODBC_USE_STATIC_LIB true)
+    endif()
+    find_library (RELEASE_LIB_FILE_NAME NAMES ${LIB_NAME} PATHS ${RELEASE_DIR} NO_DEFAULT_PATH)
+    find_library (DEBUG_LIB_FILE_NAME NAMES "lib${LIB_NAME}.a" PATHS ${DEBUG_DIR} NO_DEFAULT_PATH)
+    if (DEBUG_LIB_FILE_NAME)
+        set(LIBODBC_USE_STATIC_LIB true)
+    endif()
+    find_library (DEBUG_LIB_FILE_NAME NAMES ${LIB_NAME} PATHS ${DEBUG_DIR} NO_DEFAULT_PATH)
     set_target_properties(${NAMESPACE}::${LIB_NAME} PROPERTIES
                           IMPORTED_CONFIGURATIONS "RELEASE;DEBUG"
                           IMPORTED_LOCATION_RELEASE "${RELEASE_LIB_FILE_NAME}"
                           IMPORTED_LOCATION_DEBUG "${DEBUG_LIB_FILE_NAME}"
                           INTERFACE_INCLUDE_DIRECTORIES "${INCLUDE_DIR}"
                           )
+    if(LIBODBC_USE_STATIC_LIB)
+        find_package(Iconv MODULE)
+        set_property(TARGET ${NAMESPACE}::${LIB_NAME} PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS} Iconv::Iconv)
+    endif()
     set(${NAMESPACE}_${LIB_NAME}_FOUND 1)
 endfunction()
 
@@ -13,4 +28,4 @@ get_filename_component(ROOT "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(ROOT "${ROOT}" PATH)
 get_filename_component(ROOT "${ROOT}" PATH)
 
-set_library_target("UNIX" "odbc" "${ROOT}/debug/lib/libodbc.so" "${ROOT}/lib/libodbc.so" "${ROOT}/include/")
+set_library_target("UNIX" "odbc" "${ROOT}/debug/lib/" "${ROOT}/lib/" "${ROOT}/include/")

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "unixodbc",
-  "version-string": "2.3.7",
-  "port-version": 4,
+  "version-string": "2.3.9",
   "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
   "homepage": "https://github.com/lurcher/unixODBC",
   "supports": "osx | linux"

--- a/ports/unixodbc/vcpkg.json
+++ b/ports/unixodbc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "unixodbc",
-  "version-string": "2.3.9",
+  "version": "2.3.9",
   "description": "unixODBC is an Open Source ODBC sub-system and an ODBC SDK for Linux, Mac OSX, and UNIX",
   "homepage": "https://github.com/lurcher/unixODBC",
   "supports": "osx | linux"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6889,8 +6889,8 @@
       "port-version": 3
     },
     "unixodbc": {
-      "baseline": "2.3.7",
-      "port-version": 4
+      "baseline": "2.3.9",
+      "port-version": 0
     },
     "unqlite": {
       "baseline": "1.1.9",

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3609bfead3dd24e7ef25064dfbcc5fa0145a5cfa",
+      "version-string": "2.3.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "d18b08c03d4a7b07f4bbbed662baac83955af86c",
       "version-string": "2.3.7",
       "port-version": 4

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3609bfead3dd24e7ef25064dfbcc5fa0145a5cfa",
+      "git-tree": "b87f6ac23b0ef58075924d70655a343e4a71264e",
       "version-string": "2.3.9",
       "port-version": 0
     },

--- a/versions/u-/unixodbc.json
+++ b/versions/u-/unixodbc.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "b87f6ac23b0ef58075924d70655a343e4a71264e",
-      "version-string": "2.3.9",
+      "git-tree": "7576aa3f19845c2388e7786118082d4cfa9efb49",
+      "version": "2.3.9",
       "port-version": 0
     },
     {


### PR DESCRIPTION
Update [unixodbc] to v2.3.9.
In addition, added convenience update for using the libodbc.a as static library

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
   No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
   Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
   Yes
