### PR TITLE
[nanodbc] enable unixODBC dependecy from vcpkg (fixes #13112)

### DIFF
--- a/ports/nanodbc/find-unixodbc.patch
+++ b/ports/nanodbc/find-unixodbc.patch
@@ -1,0 +1,24 @@
+--- "a/CMakeLists.txt"
++++ "b/CMakeLists.txt"
+@@ -110,6 +110,13 @@ message(STATUS "nanodbc feature: Enable SQL_NO_DATA bug workaround - ${NANODBC_E
+ ## find unixODBC or iODBC config binary
+ ########################################
+ if(UNIX)
++  # Try to find unixodbc package first
++  find_package(unixodbc)
++  if(unixodbc_FOUND)
++    message(STATUS "nanodbc build: unixODBC package found")
++    set(ODBCLIB UNIX::odbc)
++    set(ODBC_CONFIG true)
++  else()
+   # Try to find unixODBC first via odbc_config program.
+   find_program(ODBC_CONFIG odbc_config
+     PATHS $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin)
+@@ -158,6 +165,7 @@ if(UNIX)
+       endif()
+     endif()
+   endif()
++  endif()
+ 
+   if(NOT ODBC_CONFIG)
+     message(FATAL_ERROR "can not find a suitable odbc driver manager")

--- a/ports/nanodbc/portfile.cmake
+++ b/ports/nanodbc/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
     PATCHES
         rename-version.patch
         add-missing-include.patch
+        find-unixodbc.patch
 )
 file(RENAME "${SOURCE_PATH}/VERSION" "${SOURCE_PATH}/VERSION.txt")
 

--- a/ports/nanodbc/vcpkg.json
+++ b/ports/nanodbc/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nanodbc",
   "version": "2.13.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "A small C++ wrapper for the native C ODBC API.",
   "homepage": "https://github.com/nanodbc/nanodbc",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4570,7 +4570,7 @@
     },
     "nanodbc": {
       "baseline": "2.13.0",
-      "port-version": 5
+      "port-version": 6
     },
     "nanoflann": {
       "baseline": "1.3.2",

--- a/versions/n-/nanodbc.json
+++ b/versions/n-/nanodbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7de6296fc337f181517f8ed4c2e6ed35d749e414",
+      "version": "2.13.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "82bfc56de1430aa6fec9c27925d46a72e1b800a0",
       "version": "2.13.0",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes #13112

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
