### PR TITLE
extend platform expressions to support media query syntax - terminals…

### DIFF
--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -386,7 +386,7 @@ platform-expression-simple =
 
 platform-expression-unary-keyword-operand =
 | required-whitespace, platform-expression-simple
-| platform-expression-grouped ;
+| optional-whitespace, platform-expression-grouped ;
 
 platform-expression-not =
 | platform-expression-simple

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -365,6 +365,9 @@ identifier-character =
 | lowercase-alpha
 | digit ;
 
+platform-expression-list =
+| platform-expression { ",", optional-whitespace, platform-expression } ;
+
 platform-expression =
 | platform-expression-not
 | platform-expression-and
@@ -380,14 +383,17 @@ platform-expression-simple =
 platform-expression-not =
 | platform-expression-simple
 | "!", optional-whitespace, platform-expression-simple ;
+| "not", optional-whitespace, platform-expression-simple ;
 
 platform-expression-and =
 | platform-expression-not, { "&", optional-whitespace, platform-expression-not } ;
+| platform-expression-not, { "and", optional-whitespace, platform-expression-not } ;
 
 platform-expression-or =
 | platform-expression-not, { "|", optional-whitespace, platform-expression-not } ;
+| platform-expression-not, { "or", optional-whitespace, platform-expression-not } (* to allow for future extension *) ;
 
-top-level-platform-expression = optional-whitespace, platform-expression ;
+top-level-platform-expression = optional-whitespace, platform-expression-list ;
 ```
 
 Basically, there are four kinds of expressions -- identifiers, negations, ands, and ors.

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -385,28 +385,28 @@ platform-expression-simple =
 | platform-expression-grouped ;
 
 platform-expression-unary-keyword-operand =
-| required-whitespace, platform-expression-simple ;
+| required-whitespace, platform-expression-simple
 | platform-expression-grouped ;
 
 platform-expression-not =
 | platform-expression-simple
-| "!", optional-whitespace, platform-expression-simple ;
+| "!", optional-whitespace, platform-expression-simple
 | "not", platform-expression-unary-keyword-operand ;
 
 platform-expression-binary-keyword-first-operand =
-| platform-expression-not, required-whitespace ;
+| platform-expression-not, required-whitespace
 | platform-expression-grouped ;
 
 platform-expression-binary-keyword-second-operand =
-| required-whitespace, platform-expression-not ;
+| required-whitespace, platform-expression-not
 | platform-expression-grouped ;
 
 platform-expression-and =
-| platform-expression-not, { "&", optional-whitespace, platform-expression-not } ;
+| platform-expression-not, { "&", optional-whitespace, platform-expression-not }
 | platform-expression-binary-keyword-first-operand, { "and", platform-expression-binary-keyword-second-operand } ;
 
 platform-expression-or =
-| platform-expression-not, { "|", optional-whitespace, platform-expression-not } ;
+| platform-expression-not, { "|", optional-whitespace, platform-expression-not }
 | platform-expression-binary-keyword-first-operand, { "or", platform-expression-binary-keyword-second-operand } (* to allow for future extension *) ;
 
 top-level-platform-expression = optional-whitespace, platform-expression-list ;

--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -354,6 +354,7 @@ whitespace-character =
 | ? U+000D "CARRIAGE RETURN" ?
 | ? U+0020 "SPACE" ? ;
 optional-whitespace = { whitespace-character } ;
+required-whitespace = whitespace-character, { optional-whitespace } ;
 
 lowercase-alpha =
 | "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m"
@@ -376,22 +377,37 @@ platform-expression =
 platform-expression-identifier =
 | identifier-character, { identifier-character }, optional-whitespace ;
 
+platform-expression-grouped =
+| "(", optional-whitespace, platform-expression, ")", optional-whitespace ;
+
 platform-expression-simple =
 | platform-expression-identifier
-| "(", optional-whitespace, platform-expression, ")", optional-whitespace ;
+| platform-expression-grouped ;
+
+platform-expression-unary-keyword-operand =
+| required-whitespace, platform-expression-simple ;
+| platform-expression-grouped ;
 
 platform-expression-not =
 | platform-expression-simple
 | "!", optional-whitespace, platform-expression-simple ;
-| "not", optional-whitespace, platform-expression-simple ;
+| "not", platform-expression-unary-keyword-operand ;
+
+platform-expression-binary-keyword-first-operand =
+| platform-expression-not, required-whitespace ;
+| platform-expression-grouped ;
+
+platform-expression-binary-keyword-second-operand =
+| required-whitespace, platform-expression-not ;
+| platform-expression-grouped ;
 
 platform-expression-and =
 | platform-expression-not, { "&", optional-whitespace, platform-expression-not } ;
-| platform-expression-not, { "and", optional-whitespace, platform-expression-not } ;
+| platform-expression-binary-keyword-first-operand, { "and", platform-expression-binary-keyword-second-operand } ;
 
 platform-expression-or =
 | platform-expression-not, { "|", optional-whitespace, platform-expression-not } ;
-| platform-expression-not, { "or", optional-whitespace, platform-expression-not } (* to allow for future extension *) ;
+| platform-expression-binary-keyword-first-operand, { "or", platform-expression-binary-keyword-second-operand } (* to allow for future extension *) ;
 
 top-level-platform-expression = optional-whitespace, platform-expression-list ;
 ```


### PR DESCRIPTION
Update documentation to support media queries syntax in platform expressions.

In media queries syntax ([Media Queries](https://www.w3.org/TR/css3-mediaqueries/#syntax)):
- "not" represents logical-not
- "and" represents logical-and
- "," represents a logical-or, but with lower precedence than logical-and
- media queries syntax expresses precedence by treating "," as a list-separator

This change extends platform expressions by using the same list-separator model for "," and by adding the other terminals ("and", "not") as synonyms for the corresponding operators that are already supported ("&", "!"). This change also adds "or" as a synonym for "|" as a potential future extension. 

Open question: does the EBNF need to disambiguate "and", "not", "or" as keywords and not identifiers?