### PR TITLE
Enable arm64 build for Arrow

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -59,7 +59,7 @@ else()
     set(THRIFT_USE_SHARED ${ARROW_DEPENDENCY_USE_SHARED})
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}/cpp
     PREFER_NINJA
     OPTIONS
@@ -82,7 +82,7 @@ vcpkg_configure_cmake(
         -DZSTD_MSVC_LIB_PREFIX=
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
@@ -90,7 +90,7 @@ if(EXISTS ${CURRENT_PACKAGES_DIR}/lib/arrow_static.lib)
     message(FATAL_ERROR "Installed lib file should be named 'arrow.lib' via patching the upstream build.")
 endif()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/arrow)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/arrow)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib/cmake)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/lib/cmake)

--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "x86" "arm" "arm64")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO apache/arrow
@@ -67,6 +65,7 @@ vcpkg_configure_cmake(
     OPTIONS
         ${FEATURE_OPTIONS}
         ${MALLOC_OPTIONS}
+        -DCMAKE_SYSTEM_PROCESSOR=${VCPKG_TARGET_ARCHITECTURE}
         -DARROW_BUILD_SHARED=${ARROW_BUILD_SHARED}
         -DARROW_BUILD_STATIC=${ARROW_BUILD_STATIC}
         -DARROW_BUILD_TESTS=OFF

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
-  "supports": "x64",
+  "supports": "x64 | (arm64 & !windows)",
   "dependencies": [
     "boost-filesystem",
     "boost-multiprecision",

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version": "5.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "supports": "x64 | (arm64 & !windows)",

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -19,6 +19,14 @@
     "snappy",
     "thrift",
     "utf8proc",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib",
     "zstd"
   ],

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a30c7d6553216924aa3a3957ceb87d0fda39592",
+      "version": "5.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "79938475d53bb40ad7bf8d0fbda9e65f7630dde7",
       "version": "5.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -170,7 +170,7 @@
     },
     "arrow": {
       "baseline": "5.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ashes": {
       "baseline": "2021-06-18",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This PR adds support for building Arrow for arm64, and for cross-compilation to work (e.g. building `arm64-osx` from a `x64-osx` host). Building on `arm64-windows` is still not supported and would require a patch to Arrow (maybe for a future PR?).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Adding non-Windows `arm64` triplets to the current list (all `x64` triplets).
  No change to the CI baseline (The non-Windows `arm64` triplets are community supported anyway).

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes