### PR TITLE
[qt5-base] Fix incorrect QMAKE_MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -316,10 +316,10 @@ elseif(VCPKG_TARGET_IS_OSX)
     if(DEFINED VCPKG_OSX_DEPLOYMENT_TARGET)
         set(ENV{QMAKE_MACOSX_DEPLOYMENT_TARGET} ${VCPKG_OSX_DEPLOYMENT_TARGET})
     else()
-        execute_process(COMMAND xcrun --show-sdk-version
-                            OUTPUT_FILE OSX_SDK_VER.txt
+        execute_process(COMMAND sw_vers -productVersion
+                            OUTPUT_FILE OSX_SYS_VER.txt
                             WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR})
-        FILE(STRINGS "${CURRENT_BUILDTREES_DIR}/OSX_SDK_VER.txt" VCPKG_OSX_DEPLOYMENT_TARGET REGEX "^[0-9][0-9]\.[0-9][0-9]*")
+        FILE(STRINGS "${CURRENT_BUILDTREES_DIR}/OSX_SYS_VER.txt" VCPKG_OSX_DEPLOYMENT_TARGET REGEX "^[0-9][0-9]\.[0-9][0-9]*")
         message(STATUS "Detected OSX SDK Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")
         string(REGEX MATCH "^[0-9][0-9]\.[0-9][0-9]*" VCPKG_OSX_DEPLOYMENT_TARGET ${VCPKG_OSX_DEPLOYMENT_TARGET})
         message(STATUS "Major.Minor OSX SDK Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")

--- a/ports/qt5-base/portfile.cmake
+++ b/ports/qt5-base/portfile.cmake
@@ -316,13 +316,22 @@ elseif(VCPKG_TARGET_IS_OSX)
     if(DEFINED VCPKG_OSX_DEPLOYMENT_TARGET)
         set(ENV{QMAKE_MACOSX_DEPLOYMENT_TARGET} ${VCPKG_OSX_DEPLOYMENT_TARGET})
     else()
+        execute_process(COMMAND xcrun --show-sdk-version
+                            OUTPUT_FILE OSX_SDK_VER.txt
+                            WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR})
+        FILE(STRINGS "${CURRENT_BUILDTREES_DIR}/OSX_SDK_VER.txt" OSX_SDK_VERSION REGEX "^[0-9][0-9]\.[0-9][0-9]*")
+        message(STATUS "Detected OSX SDK Version: ${OSX_SDK_VERSION}")
+        string(REGEX MATCH "^[0-9][0-9]\.[0-9][0-9]*" OSX_SDK_VERSION ${OSX_SDK_VERSION})
+        message(STATUS "Major.Minor OSX SDK Version: ${OSX_SDK_VERSION}")
+
         execute_process(COMMAND sw_vers -productVersion
                             OUTPUT_FILE OSX_SYS_VER.txt
                             WORKING_DIRECTORY ${CURRENT_BUILDTREES_DIR})
         FILE(STRINGS "${CURRENT_BUILDTREES_DIR}/OSX_SYS_VER.txt" VCPKG_OSX_DEPLOYMENT_TARGET REGEX "^[0-9][0-9]\.[0-9][0-9]*")
-        message(STATUS "Detected OSX SDK Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")
+        message(STATUS "Detected OSX system Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")
         string(REGEX MATCH "^[0-9][0-9]\.[0-9][0-9]*" VCPKG_OSX_DEPLOYMENT_TARGET ${VCPKG_OSX_DEPLOYMENT_TARGET})
-        message(STATUS "Major.Minor OSX SDK Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")
+        message(STATUS "Major.Minor OSX system Version: ${VCPKG_OSX_DEPLOYMENT_TARGET}")
+
         set(ENV{QMAKE_MACOSX_DEPLOYMENT_TARGET} ${VCPKG_OSX_DEPLOYMENT_TARGET})
         if(${VCPKG_OSX_DEPLOYMENT_TARGET} GREATER "10.15") # Max Version supported by QT. This version is defined in mkspecs/common/macx.conf as QT_MAC_SDK_VERSION_MAX
             message(STATUS "Qt ${QT_MAJOR_MINOR_VER}.${QT_PATCH_VER} only support OSX_DEPLOYMENT_TARGET up to 10.15")

--- a/ports/qt5-base/vcpkg.json
+++ b/ports/qt5-base/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-base",
   "version-semver": "5.15.2",
-  "port-version": 14,
+  "port-version": 15,
   "description": "Qt5 Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5486,7 +5486,7 @@
     },
     "qt5-base": {
       "baseline": "5.15.2",
-      "port-version": 14
+      "port-version": 15
     },
     "qt5-canvas3d": {
       "baseline": "0",

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c84b685125a80fb9d2bccfeba30146a8f4548e62",
+      "git-tree": "3f339b7160586f33649b2bee10a48b4629d6d1f2",
       "version-semver": "5.15.2",
       "port-version": 15
     },

--- a/versions/q-/qt5-base.json
+++ b/versions/q-/qt5-base.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c84b685125a80fb9d2bccfeba30146a8f4548e62",
+      "version-semver": "5.15.2",
+      "port-version": 15
+    },
+    {
       "git-tree": "1e5756de068474651dc8ee50fb14be3d4c236b05",
       "version-semver": "5.15.2",
       "port-version": 14


### PR DESCRIPTION
According to the [discussion](https://github.com/microsoft/vcpkg/issues/10209#issuecomment-591367382) in #10209, `QMAKE_MACOSX_DEPLOYMENT_TARGET` should be MacOS system version instead of MacOS SDK version.
That caused qt5 fail to build.

There are two places involving `QMAKE_MACOSX_DEPLOYMENT_TARGET`:
1. https://github.com/microsoft/vcpkg/blob/c32ccbb34caacea28ba2d2b3df232ee36359c9f6/ports/qt5-base/portfile.cmake#L316-L336

2. https://github.com/microsoft/vcpkg/blob/66c39e113a348a6ae80419fae5a629b951b00f1a/scripts/cmake/vcpkg_configure_qmake.cmake#L54-L56

Temporary only changed the first one.

Fixse #10209.