### PR TITLE
[libmount] New port

### DIFF
--- a/ports/ecm/fix_libmount.patch
+++ b/ports/ecm/fix_libmount.patch
@@ -1,0 +1,23 @@
+diff --git a/find-modules/FindLibMount.cmake b/find-modules/FindLibMount.cmake
+index 3fcde4c5435a79c61c53bbd27e1932441a056d98..1f53f0218faa82fdf9713ab768080ab7c1d72b4a 100644
+--- a/find-modules/FindLibMount.cmake
++++ b/find-modules/FindLibMount.cmake
+@@ -30,7 +30,7 @@ Since 5.83.0
+ #]=======================================================================]
+ 
+ find_package(PkgConfig QUIET)
+-pkg_check_modules(PC_LIBMOUNT QUIET mount)
++pkg_check_modules(PC_LIBMOUNT QUIET IMPORTED_TARGET mount)
+ 
+ find_path(LibMount_INCLUDE_DIRS NAMES libmount/libmount.h HINTS ${PC_LIBMOUNT_INCLUDE_DIRS})
+ find_library(LibMount_LIBRARIES NAMES mount HINTS ${PC_LIBMOUNT_LIBRARY_DIRS})
+@@ -62,6 +62,9 @@ if(LibMount_FOUND AND NOT TARGET LibMount::LibMount)
+         INTERFACE_INCLUDE_DIRECTORIES "${LibMount_INCLUDE_DIRS}"
+         INTERFACE_COMPILE_DEFINITIONS "${PC_LIBMOUNT_CFLAGS_OTHER}"
+     )
++    if (TARGET PkgConfig::PC_LIBMOUNT)
++        target_link_libraries(LibMount::LibMount INTERFACE PkgConfig::PC_LIBMOUNT)
++    endif()
+ endif()
+ 
+ include(FeatureSummary)

--- a/ports/ecm/portfile.cmake
+++ b/ports/ecm/portfile.cmake
@@ -5,7 +5,8 @@ vcpkg_from_github(
     SHA512 d49397bcf0d49a95c86c9d9a4e653015ee8b3ef1261b2842439bba7ff3363ac06351fa2df4035c2cb36397d2fc64375a14966ada29f231df51ba26d8e196d6ef
     HEAD_REF master
     PATCHES
-        fix_canberra.patch
+        fix_canberra.patch       # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/187
+        fix_libmount.patch       # https://invent.kde.org/frameworks/extra-cmake-modules/-/merge_requests/200
         fix_python_version.patch # Remove on next release
 )
 

--- a/ports/ecm/vcpkg.json
+++ b/ports/ecm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ecm",
   "version": "5.84.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Extra CMake Modules (ECM), extra modules and scripts for CMake",
   "homepage": "https://github.com/KDE/extra-cmake-modules",
   "dependencies": [

--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -33,6 +33,12 @@ else()
     list(APPEND OPTIONS -Dselinux=disabled)
 endif()
 
+if (libmount IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dlibmount=enabled)
+else()
+    list(APPEND OPTIONS -Dlibmount=disabled)
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND OPTIONS -Diconv=external)
 else()
@@ -49,7 +55,6 @@ vcpkg_configure_meson(
 )
 #-Dnls=true
 #-Dlibelf=false
-#-Dlibmount=false
 #-Dxattr=true?
 
 vcpkg_install_meson(ADD_BIN_TO_PATH)

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "glib",
   "version": "2.66.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "supports": "!uwp & !(windows & static)",
@@ -15,6 +15,13 @@
     "zlib"
   ],
   "features": {
+    "libmount": {
+      "description": "Build with libmount support.",
+      "supports": "linux",
+      "dependencies": [
+        "libmount"
+      ]
+    },
     "selinux": {
       "description": "Build with selinux support."
     }

--- a/ports/kf5kio/vcpkg.json
+++ b/ports/kf5kio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "kf5kio",
   "version": "5.84.0",
+  "port-version": 1,
   "description": "Network transparent access to files and data",
   "homepage": "https://api.kde.org/frameworks/kio/html/index.html",
   "dependencies": [
@@ -31,6 +32,13 @@
     "kf5jobwidgets",
     "kf5service",
     "kf5solid",
+    {
+      "name": "kf5solid",
+      "features": [
+        "libmount"
+      ],
+      "platform": "linux"
+    },
     "kf5textwidgets",
     "kf5widgetsaddons",
     "kf5windowsystem",
@@ -38,6 +46,10 @@
     {
       "name": "libiconv",
       "platform": "windows & static"
+    },
+    {
+      "name": "libmount",
+      "platform": "linux"
     },
     "qt5-base",
     {

--- a/ports/kf5kio/vcpkg.json
+++ b/ports/kf5kio/vcpkg.json
@@ -32,13 +32,6 @@
     "kf5jobwidgets",
     "kf5service",
     "kf5solid",
-    {
-      "name": "kf5solid",
-      "features": [
-        "libmount"
-      ],
-      "platform": "linux"
-    },
     "kf5textwidgets",
     "kf5widgetsaddons",
     "kf5windowsystem",

--- a/ports/kf5solid/portfile.cmake
+++ b/ports/kf5solid/portfile.cmake
@@ -37,11 +37,15 @@ vcpkg_add_to_path(PREPEND "${BISON_DIR}")
 # Prevent KDEClangFormat from writing to source effectively blocking parallel configure
 file(WRITE ${SOURCE_PATH}/.clang-format "DisableFormat: true\nSortIncludes: false\n")
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  INVERTED_FEATURES
+    "libmount"          CMAKE_DISABLE_FIND_PACKAGE_LibMount
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_TESTING=OFF
-        -DCMAKE_DISABLE_FIND_PACKAGE_LibMount=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kf5solid",
   "version": "5.84.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Desktop hardware abstraction",
   "homepage": "https://api.kde.org/frameworks/solid/html/index.html",
   "dependencies": [
@@ -16,5 +16,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "libmount": {
+      "description": "Used by the UDisks backend on Linux",
+      "supports": "linux",
+      "dependencies": [
+        "libmount"
+      ]
+    }
+  }
 }

--- a/ports/kf5solid/vcpkg.json
+++ b/ports/kf5solid/vcpkg.json
@@ -17,12 +17,27 @@
       "host": true
     }
   ],
+  "default-features": [
+    "platform-default-features"
+  ],
   "features": {
     "libmount": {
       "description": "Used by the UDisks backend on Linux",
       "supports": "linux",
       "dependencies": [
         "libmount"
+      ]
+    },
+    "platform-default-features": {
+      "description": "Enable platform-dependent default features",
+      "dependencies": [
+        {
+          "name": "kf5solid",
+          "features": [
+            "libmount"
+          ],
+          "platform": "linux"
+        }
       ]
     }
   }

--- a/ports/libmount/portfile.cmake
+++ b/ports/libmount/portfile.cmake
@@ -1,0 +1,40 @@
+set(VERSION_MAJOR 2)
+set(VERSION_MINOR 37)
+set(VERSION_PATCH 2)
+set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION_MAJOR}.${VERSION_MINOR}/util-linux-${VERSION}.tar.xz"
+    FILENAME "util-linux-${VERSION}.tar.xz"
+    SHA512 38f0fe820445e3bfa79550e6581c230f98c7661566ccc4daa51c7208a5f972c61b4e57dfc86bed074fdbc7c40bc79f856be8f6a05a8860c1c0cecc4208e8b81d
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    REF ${VERSION}
+)
+
+vcpkg_configure_make(
+    AUTOCONFIG
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        --disable-asciidoc
+        --disable-all-programs
+        --enable-libmount
+        --enable-libblkid
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/sbin" "${CURRENT_PACKAGES_DIR}/debug/sbin")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools") # empty folder
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libmount/vcpkg.json
+++ b/ports/libmount/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "libmount",
+  "version": "2.37.2",
+  "description": "Block device identification library from util-linux",
+  "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
+  "supports": "linux"
+}

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -54,9 +54,6 @@ APT_PACKAGES="$APT_PACKAGES guile-2.2-dev"
 # Additionally required by gtk
 APT_PACKAGES="$APT_PACKAGES libxdamage-dev"
 
-# Additionally required by kf5kio
-APT_PACKAGES="$APT_PACKAGES libmount-dev"
-
 # Additionally required/installed by Azure DevOps Scale Set Agents
 APT_PACKAGES="$APT_PACKAGES liblttng-ust0 libkrb5-3 zlib1g libicu66"
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3652,6 +3652,10 @@
       "baseline": "0.2.8",
       "port-version": 0
     },
+    "libmount": {
+      "baseline": "2.37.2",
+      "port-version": 0
+    },
     "libmpeg2": {
       "baseline": "0.5.1",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1962,7 +1962,7 @@
     },
     "ecm": {
       "baseline": "5.84.0",
-      "port-version": 2
+      "port-version": 3
     },
     "ecos": {
       "baseline": "2.0.8",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3114,7 +3114,7 @@
     },
     "kf5kio": {
       "baseline": "5.84.0",
-      "port-version": 0
+      "port-version": 1
     },
     "kf5newstuff": {
       "baseline": "5.84.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2462,7 +2462,7 @@
     },
     "glib": {
       "baseline": "2.66.4",
-      "port-version": 1
+      "port-version": 2
     },
     "glibmm": {
       "baseline": "2.68.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3138,7 +3138,7 @@
     },
     "kf5solid": {
       "baseline": "5.84.0",
-      "port-version": 3
+      "port-version": 4
     },
     "kf5sonnet": {
       "baseline": "5.84.0",

--- a/versions/e-/ecm.json
+++ b/versions/e-/ecm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edf27dcd688fc8cfd8a1c6dedddc3cfb0cb1556e",
+      "version": "5.84.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "e01bd7b91852c7fa2dffc588bad45167d8d45c6b",
       "version": "5.84.0",
       "port-version": 2

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8d7eeabc89610c8b583c319b572b16e07f3f035",
+      "version": "2.66.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "6207d9439567fbbc29f4468c831ef7c1fa2e6181",
       "version": "2.66.4",
       "port-version": 1

--- a/versions/k-/kf5kio.json
+++ b/versions/k-/kf5kio.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c6c9f884db8c976becefc1e3c745a3feef231e7",
+      "git-tree": "624eb17608cec7afe4c30bef29e16e18fe8d973e",
       "version": "5.84.0",
       "port-version": 1
     },

--- a/versions/k-/kf5kio.json
+++ b/versions/k-/kf5kio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7c6c9f884db8c976becefc1e3c745a3feef231e7",
+      "version": "5.84.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a9411ad4abdf7acb9b7a7ef98dd9b966f8b58d5",
       "version": "5.84.0",
       "port-version": 0

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "82d550bea0a40cdf57439c7ce177185e18337c5b",
+      "git-tree": "8b7f9e0e31cd5fd3a2720a8e71b1aa52b123cf98",
       "version": "5.84.0",
       "port-version": 4
     },

--- a/versions/k-/kf5solid.json
+++ b/versions/k-/kf5solid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "82d550bea0a40cdf57439c7ce177185e18337c5b",
+      "version": "5.84.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "77af969f1b19c937d7f41651b657a774cd3802c7",
       "version": "5.84.0",
       "port-version": 3

--- a/versions/l-/libmount.json
+++ b/versions/l-/libmount.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "0f746b3d702445fd2de54c25c08491cdaae45810",
+      "version": "2.37.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
    - Adds new port
    - Updates other ports (`kf5kio`, `kf5solid`, `glib`) to take advantage of it  
    - removes now redundant `libmount-dev` package from the linux VM
 
- #### What does your PR fix?  
  See #21344 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Linux.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes