### PR TITLE
[prometheus-cpp] Update to version 1.0.0

### DIFF
--- a/ports/prometheus-cpp/portfile.cmake
+++ b/ports/prometheus-cpp/portfile.cmake
@@ -3,40 +3,35 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO jupp0r/prometheus-cpp
-    REF 342de5e93bd0cbafde77ec801f9dd35a03bceb3f # v0.13.0
-    SHA512 2edd093dff57109f4e7050f7d870010e696642f0445a8d50f689a9a7e8f4704e74659846c1afcdfcd700ceeb64b48ea83159e87ca00ca58de4866dd39975590b
+    REF 4ea303fa66e4c26dc4df67045fa0edf09c2f3077 # v1.0.0
+    SHA512 f97f380182cb7d8576f444e263159d5cc4572d71020b14a2d599041a6a4e5e2cb677a80c637b5a2bca55d4f0e570e87c2863d5dd48e317e9a912cca5a192e81a
     HEAD_REF master
 )
 
-macro(feature FEATURENAME OPTIONNAME)
-    if("${FEATURENAME}" IN_LIST FEATURES)
-        list(APPEND FEATURE_OPTIONS -D${OPTIONNAME}=TRUE)
-    else()
-        list(APPEND FEATURE_OPTIONS -D${OPTIONNAME}=FALSE)
-    endif()
-endmacro()
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        compression ENABLE_COMPRESSION
+        pull ENABLE_PULL
+        push ENABLE_PUSH
+        tests ENABLE_TESTING
+)
 
-feature(compression ENABLE_COMPRESSION)
-feature(pull ENABLE_PULL)
-feature(push ENABLE_PUSH)
-feature(tests ENABLE_TESTING)
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DUSE_THIRDPARTY_LIBRARIES=OFF # use vcpkg packages
         -DGENERATE_PKGCONFIG=OFF
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/prometheus-cpp)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/prometheus-cpp")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/prometheus-cpp/vcpkg.json
+++ b/ports/prometheus-cpp/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "prometheus-cpp",
-  "version-semver": "0.13.0",
+  "version-semver": "1.0.0",
   "description": "Prometheus Client Library for Modern C++",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "default-features": [
     "compression",
     "pull"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5369,7 +5369,7 @@
       "port-version": 7
     },
     "prometheus-cpp": {
-      "baseline": "0.13.0",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "promise-cpp": {

--- a/versions/p-/prometheus-cpp.json
+++ b/versions/p-/prometheus-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f679ed963f525e155342a6be082d02e03c96856",
+      "version-semver": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae46bbdb51c6ff3e330c607e46b911b79e0ce7e3",
       "version-semver": "0.13.0",
       "port-version": 0


### PR DESCRIPTION
Update prometheus-cpp to 1.0.0. Locally tested all the features on macOS.