### PR TITLE
[x264] check exists before rename

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -71,7 +71,10 @@ endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic" AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     file(RENAME ${CURRENT_PACKAGES_DIR}/lib/libx264.dll.lib ${CURRENT_PACKAGES_DIR}/lib/libx264.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libx264.dll.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libx264.lib)
+
+    if (NOT VCPKG_BUILD_TYPE)
+        file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/libx264.dll.lib ${CURRENT_PACKAGES_DIR}/debug/lib/libx264.lib)
+    endif()
 elseif(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     # force U_STATIC_IMPLEMENTATION macro
     file(READ ${CURRENT_PACKAGES_DIR}/include/x264.h HEADER_CONTENTS)

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "x264",
   "version-string": "164-5db6aa6cab1b146",
+  "port-version": 1,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
   "supports": "!arm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7198,7 +7198,7 @@
     },
     "x264": {
       "baseline": "164-5db6aa6cab1b146",
-      "port-version": 0
+      "port-version": 1
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d6c7ba5815a0683a2915df5f95de5d06e938781",
+      "version-string": "164-5db6aa6cab1b146",
+      "port-version": 1
+    },
+    {
       "git-tree": "2280334f1235046e20f80586b7d83893f52b23b7",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #19792 where the `portfile.cmake` assumes both a debug and release build are present and tries to rename both. If the user is only building a release OR debug version, this will throw an error since one of the files will be missing. This PR adds conditionals to check the `VCPKG_BUILD_TYPE` to see what files should have been built. This was presumed to be better than simply checking if the file exists before renaming, so that an error could still be thrown if the files were erroneously missing for whatever reason.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All (this patches a Windows issue without affecting other platforms), no I have no updated the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I believe so. It is short, should be fairly readable, and makes no extraneous changes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes, a port has been updated and the version database has been updated too as a result.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
