### PR TITLE
[irrlicht] Add the remind of libraries which needed by Linux

### DIFF
--- a/ports/irrlicht/portfile.cmake
+++ b/ports/irrlicht/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
-
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO irrlicht/Irrlicht%20SDK
@@ -12,7 +10,16 @@ vcpkg_from_sourceforge(
         fix-osx-compilation.patch
 )
 
-configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt ${SOURCE_PATH}/CMakeLists.txt COPYONLY)
+if(VCPKG_TARGET_IS_LINUX)
+    message(
+"GLFW3 currently requires the following libraries from the system package manager:
+    libgl1-mesa
+    xf86vmode
+
+These can be installed on Ubuntu systems via sudo apt install libgl1-mesa-dev libxxf86vm-dev")
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${SOURCE_PATH}/CMakeLists.txt" COPYONLY)
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -25,7 +32,7 @@ vcpkg_check_features(
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SHARED_LIB)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DIRR_SHARED_LIB=${SHARED_LIB}
         ${FEATURE_OPTIONS}
@@ -36,15 +43,15 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
 
 if("tools" IN_LIST FEATURES)
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/irrlicht/)
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/irrlicht/")
 endif()
 
-file(WRITE ${CURRENT_PACKAGES_DIR}/share/irrlicht/irrlicht-config.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/irrlicht-targets.cmake)")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/irrlicht/irrlicht-config.cmake" "include(\${CMAKE_CURRENT_LIST_DIR}/irrlicht-targets.cmake)")
 
 vcpkg_copy_pdbs()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/irrlicht)
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/irrlicht")
 endif()
 
-file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/irrlicht/portfile.cmake
+++ b/ports/irrlicht/portfile.cmake
@@ -12,8 +12,7 @@ vcpkg_from_sourceforge(
 
 if(VCPKG_TARGET_IS_LINUX)
     message(
-"GLFW3 currently requires the following libraries from the system package manager:
-    libgl1-mesa
+"Irrlicht currently requires the following libraries from the system package manager:
     xf86vmode
 
 These can be installed on Ubuntu systems via sudo apt install libgl1-mesa-dev libxxf86vm-dev")

--- a/ports/irrlicht/portfile.cmake
+++ b/ports/irrlicht/portfile.cmake
@@ -13,9 +13,10 @@ vcpkg_from_sourceforge(
 if(VCPKG_TARGET_IS_LINUX)
     message(
 "Irrlicht currently requires the following libraries from the system package manager:
+    libgl1-mesa
     xf86vmode
 
-These can be installed on Ubuntu systems via sudo apt install libgl1-mesa-dev libxxf86vm-dev")
+These can be installed on Ubuntu systems via sudo apt-get install libgl1-mesa-dev libxxf86vm-dev")
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${SOURCE_PATH}/CMakeLists.txt" COPYONLY)

--- a/ports/irrlicht/vcpkg.json
+++ b/ports/irrlicht/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "irrlicht",
   "version-string": "1.8.4",
-  "port-version": 12,
+  "port-version": 13,
   "description": "The Irrlicht Engine is an open source realtime 3D engine written in C++. It is cross-platform, using D3D, OpenGL and its own software renderers.",
   "homepage": "http://irrlicht.sourceforge.net",
   "supports": "!(arm | uwp)",

--- a/ports/irrlicht/vcpkg.json
+++ b/ports/irrlicht/vcpkg.json
@@ -6,13 +6,13 @@
   "homepage": "http://irrlicht.sourceforge.net",
   "supports": "!(arm | uwp)",
   "dependencies": [
+    "bzip2",
+    "libjpeg-turbo",
+    "libpng",
     {
       "name": "mesa",
       "platform": "linux"
     },
-    "bzip2",
-    "libjpeg-turbo",
-    "libpng",
     "vcpkg-cmake",
     "vcpkg-cmake-config",
     "zlib"

--- a/ports/irrlicht/vcpkg.json
+++ b/ports/irrlicht/vcpkg.json
@@ -6,6 +6,10 @@
   "homepage": "http://irrlicht.sourceforge.net",
   "supports": "!(arm | uwp)",
   "dependencies": [
+    {
+      "name": "mesa",
+      "platform": "linux"
+    },
     "bzip2",
     "libjpeg-turbo",
     "libpng",

--- a/ports/irrlicht/vcpkg.json
+++ b/ports/irrlicht/vcpkg.json
@@ -9,10 +9,6 @@
     "bzip2",
     "libjpeg-turbo",
     "libpng",
-    {
-      "name": "mesa",
-      "platform": "linux"
-    },
     "vcpkg-cmake",
     "vcpkg-cmake-config",
     "zlib"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2886,7 +2886,7 @@
     },
     "irrlicht": {
       "baseline": "1.8.4",
-      "port-version": 12
+      "port-version": 13
     },
     "irrxml": {
       "baseline": "0",

--- a/versions/i-/irrlicht.json
+++ b/versions/i-/irrlicht.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "55fc26f087d9eade6179f87d382f263e59fc1b99",
+      "version-string": "1.8.4",
+      "port-version": 13
+    },
+    {
       "git-tree": "fd24be00084e5387a0ae764c42621977340ec74b",
       "version-string": "1.8.4",
       "port-version": 12

--- a/versions/i-/irrlicht.json
+++ b/versions/i-/irrlicht.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b63321a94ddc9a6c1e02db16512a332825d2a34b",
+      "git-tree": "e0744d1f5eb72f855041277c56a2ddb17439e1b5",
       "version-string": "1.8.4",
       "port-version": 13
     },

--- a/versions/i-/irrlicht.json
+++ b/versions/i-/irrlicht.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55fc26f087d9eade6179f87d382f263e59fc1b99",
+      "git-tree": "b63321a94ddc9a6c1e02db16512a332825d2a34b",
       "version-string": "1.8.4",
       "port-version": 13
     },

--- a/versions/i-/irrlicht.json
+++ b/versions/i-/irrlicht.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e0744d1f5eb72f855041277c56a2ddb17439e1b5",
+      "git-tree": "a824dffa239fccbb9b780c9926c91f1a25d000df",
       "version-string": "1.8.4",
       "port-version": 13
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  When installing Irrlicht:x64-linux, it need install `libgl1-mesa` and `xf86vmode` first. This PR add the remind in **portfile.cmake**.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  `Yes`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
