### PR TITLE
[bcg729] Fix cmake, fix parallel build on linux

### DIFF
--- a/ports/bcg729/disable-alt-packaging.patch
+++ b/ports/bcg729/disable-alt-packaging.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 69dbaef..695f4d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -125,5 +125,4 @@ install(FILES
+ 	DESTINATION ${CONFIG_PACKAGE_LOCATION}
+ )
+ 
+-add_subdirectory(build)
+ 

--- a/ports/bcg729/portfile.cmake
+++ b/ports/bcg729/portfile.cmake
@@ -29,9 +29,18 @@ if(NOT remaining_files)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Bcg729")
 endif()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_fixup_pkgconfig()
+
+file(READ "${SOURCE_PATH}/LICENSE.txt" GPL3)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" [[
+bcg729 is dual licensed, and is available either:
+ - under a GNU/GPLv3 license, for free (open source). See below.
+ - under a proprietary license, for a fee, to be used in closed source applications.
+   Contact Belledonne Communications (https://www.linphone.org/contact)
+   for any question about costs and services.
+
+
+]] ${GPL3})

--- a/ports/bcg729/portfile.cmake
+++ b/ports/bcg729/portfile.cmake
@@ -21,6 +21,13 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME Bcg729)
+file(GLOB cmake_files "${CURRENT_PACKAGES_DIR}/share/Bcg729/cmake/*.cmake")
+file(COPY ${cmake_files} DESTINATION "${CURRENT_PACKAGES_DIR}/share/bcg729")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Bcg729/cmake")
+file(GLOB_RECURSE remaining_files "${CURRENT_PACKAGES_DIR}/share/Bcg729/*")
+if(NOT remaining_files)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/Bcg729")
+endif()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 

--- a/ports/bcg729/portfile.cmake
+++ b/ports/bcg729/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF 1.1.1
     SHA512 e8cc4b7486a9a29fb729ab9fd9e3c4a2155573f38cec16f5a53db3b416fc1119ea5f5a61243a8d37cb0b64580c5df1b632ff165dc7ff47421fa567dafffaacd8
     HEAD_REF master
+    PATCHES
+        disable-alt-packaging.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" ENABLE_STATIC)

--- a/ports/bcg729/vcpkg.json
+++ b/ports/bcg729/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "bcg729",
   "version": "1.1.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Bcg729 is an open source implementation of the ITU G.729 Annex A and B codec.",
   "homepage": "https://github.com/BelledonneCommunications/bcg729",
   "dependencies": [

--- a/versions/b-/bcg729.json
+++ b/versions/b-/bcg729.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3ab650b9aee68c1967ab35c8890ffcfd721b485",
+      "version": "1.1.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "d515bbfce335039dc7edaa083d7ab334888f8254",
       "version": "1.1.1",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -398,7 +398,7 @@
     },
     "bcg729": {
       "baseline": "1.1.1",
-      "port-version": 2
+      "port-version": 3
     },
     "bddisasm": {
       "baseline": "1.34.7",


### PR DESCRIPTION
- #### What does your PR fix?  
  Moves the cmake config so that paths match installation. Resolves the wrong auto-generated usage (part of #20190).
  Adds dual-license info to copyright file.
  Disables source writes (from CPack/RPM packaging code) which would break parallel build (related to #21507).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes