### PR TITLE
[apsi ]Updated to version 0.7.0

### DIFF
--- a/ports/apsi/portfile.cmake
+++ b/ports/apsi/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/APSI
-    REF 4e412e6c89a2729a09aa2a998b212dec0fa9a0fc
-    SHA512 8cabe842884a90bd3de5156af964f68efe77c55c1ff773ce3a64a0c4e3380868dd5ee79f4db2033278eba2c7cf5561c225b1625313a7ac89f068218d5cb9f40c
+    REF 6365cb774b81a2a731334c656db21e5fdfb92870
+    SHA512 f21d710a345663aeb35035565c55fd900076589d087a03a1ad7df8b8004ae0e059196f3c94ee63b5ad815a858e5404eea34ae203f7778d4190fd323fd08b7084
     HEAD_REF main
 )
 
@@ -29,7 +29,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.5")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "APSI" CONFIG_PATH "lib/cmake/APSI-0.7")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/apsi/vcpkg.json
+++ b/ports/apsi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "apsi",
-  "version-semver": "0.5.0",
+  "version-semver": "0.7.0",
   "description": "APSI is a research library for asymmetric private set intersection.",
   "homepage": "https://github.com/microsoft/APSI",
   "supports": "static",

--- a/versions/a-/apsi.json
+++ b/versions/a-/apsi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "652d69df44a689fa55f1b757db46c97bcb840c13",
+      "version-semver": "0.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff4f1e6dfc87696ea2da4bd557e15b1f2034f340",
       "version-semver": "0.5.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -117,7 +117,7 @@
       "port-version": 4
     },
     "apsi": {
-      "baseline": "0.5.0",
+      "baseline": "0.7.0",
       "port-version": 0
     },
     "arb": {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updated `ports/apsi` to version 0.7.0.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Supports all static.
  No change to the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.
