### PR TITLE
[qtkeychain(-qt6)] update to 0.13.2

### DIFF
--- a/ports/qtkeychain-qt6/portfile.cmake
+++ b/ports/qtkeychain-qt6/portfile.cmake
@@ -3,8 +3,8 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF v0.13.1
-    SHA512 552c1632a81f64b91dacdb0f5eb4122b4ddef53ba6621561db6c4fce9f3692761dbc4b452e578023e2882e049874148be1de014397675ce443cfc93fe96f6f70
+    REF v0.13.2
+    SHA512 10f8b1c959a126ba14614b797ea5640404a0b95c71e452225c74856eae90e966aac581ca393508a2106033c3d5ad70427ea6f7ef3f2997eddf6d09a7b4fa26eb
     HEAD_REF master
 )
 
@@ -18,12 +18,6 @@ if(VCPKG_CROSSCOMPILING)
 endif()
 
 list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TEST_APPLICATION:BOOL=OFF)
-# TODO: remove after next release since https://github.com/frankosterfeld/qtkeychain/pull/204 was merged
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=ON)
-else()
-    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=OFF)
-endif()
 
 # FIXME: Why does build translations fail on arm64-windows?
 if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_TARGET_ARCHITECTURE STREQUAL arm64)

--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qtkeychain-qt6",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -3,25 +3,17 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF v0.13.1
-    SHA512 552c1632a81f64b91dacdb0f5eb4122b4ddef53ba6621561db6c4fce9f3692761dbc4b452e578023e2882e049874148be1de014397675ce443cfc93fe96f6f70
+    REF v0.13.2
+    SHA512 10f8b1c959a126ba14614b797ea5640404a0b95c71e452225c74856eae90e966aac581ca393508a2106033c3d5ad70427ea6f7ef3f2997eddf6d09a7b4fa26eb
     HEAD_REF master
 )
-
-list(APPEND QTKEYCHAIN_OPTIONS -DBUILD_TEST_APPLICATION:BOOL=OFF)
-# TODO: remove after next release since https://github.com/frankosterfeld/qtkeychain/pull/204 was merged
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=ON)
-else()
-    list(APPEND QTKEYCHAIN_OPTIONS -DQTKEYCHAIN_STATIC:BOOL=OFF)
-endif()
 
 vcpkg_cmake_configure(
     DISABLE_PARALLEL_CONFIGURE
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DBUILD_WITH_QT6=OFF
-        ${QTKEYCHAIN_OPTIONS}
+        -DBUILD_TEST_APPLICATION=OFF
 )
 vcpkg_cmake_install()
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qtkeychain",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5685,11 +5685,11 @@
       "port-version": 0
     },
     "qtkeychain": {
-      "baseline": "0.13.1",
+      "baseline": "0.13.2",
       "port-version": 0
     },
     "qtkeychain-qt6": {
-      "baseline": "0.13.1",
+      "baseline": "0.13.2",
       "port-version": 0
     },
     "qtlocation": {

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3df36df3c274f528e53cd1f8366811231b15151",
+      "version": "0.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "29acc8309b4310f9b05f7c11cd81b0fd06dcbfff",
       "version": "0.13.1",
       "port-version": 0

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2dda8930cc8e73b1741effda2750a980c0209e24",
+      "version": "0.13.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ff34038b321dbfe954208b0ec4844c1066dde839",
       "version": "0.13.1",
       "port-version": 0


### PR DESCRIPTION


**Describe the pull request**

- #### What does your PR fix?  
This allows to remove the nonstandard QTKEYCHAIN_STATIC variable.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes