### PR TITLE
[OpenSSL] Allow customization of openssldir

### DIFF
--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version-string": "1.1.1l",
-  "port-version": 4,
+  "port-version": 5,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org"
 }

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version-string": "1.1.1l",
-  "port-version": 3,
+  "port-version": 4,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org"
 }

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -52,6 +52,11 @@ set(OPENSSL_MAKEFILE "makefile")
 file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel"
                     "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
 
+set(OPENSSL_INSTALL_TARGETS install_sw)
+if(NOT DEFINED OPENSSL_NO_INSTALL_SSLDIRS)
+    set(OPENSSL_INSTALL_TARGETS ${OPENSSL_INSTALL_TARGETS} install_ssldirs)
+endif()
+
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
     # Copy openssl sources.
@@ -63,11 +68,15 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
     message(STATUS "Copying openssl release source files... done")
     set(SOURCE_PATH_RELEASE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
 
-    set(OPENSSLDIR_RELEASE ${CURRENT_PACKAGES_DIR})
+    if (DEFINED OPENSSL_OPENSSLDIR)
+        set(OPENSSLDIR_RELEASE ${OPENSSL_OPENSSLDIR})
+    else()
+        set(OPENSSLDIR_RELEASE ${CURRENT_PACKAGES_DIR})
+    endif()
 
     message(STATUS "Configure ${TARGET_TRIPLET}-rel")
     vcpkg_execute_required_process(
-        COMMAND ${CONFIGURE_COMMAND} ${OPENSSL_ARCH} "--prefix=${OPENSSLDIR_RELEASE}" "--openssldir=${OPENSSLDIR_RELEASE}" -FS
+        COMMAND ${CONFIGURE_COMMAND} ${OPENSSL_ARCH} "--prefix=${CURRENT_PACKAGES_DIR}" "--openssldir=${OPENSSLDIR_RELEASE}" -FS
         WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
         LOGNAME configure-perl-${TARGET_TRIPLET}-rel
     )
@@ -84,7 +93,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         ERROR_FILE ${CURRENT_BUILDTREES_DIR}/build-${TARGET_TRIPLET}-rel-0-err.log
     )
     vcpkg_execute_required_process(
-        COMMAND nmake -f ${OPENSSL_MAKEFILE} install_sw install_ssldirs
+        COMMAND nmake -f ${OPENSSL_MAKEFILE} ${OPENSSL_INSTALL_TARGETS}
         WORKING_DIRECTORY ${SOURCE_PATH_RELEASE}
         LOGNAME build-${TARGET_TRIPLET}-rel-1)
 
@@ -102,11 +111,15 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     message(STATUS "Copying openssl debug source files... done")
     set(SOURCE_PATH_DEBUG "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
 
-    set(OPENSSLDIR_DEBUG ${CURRENT_PACKAGES_DIR}/debug)
+    if (DEFINED OPENSSL_OPENSSLDIR)
+        set(OPENSSLDIR_DEBUG ${OPENSSL_OPENSSLDIR}/debug)
+    else()
+        set(OPENSSLDIR_DEBUG ${CURRENT_PACKAGES_DIR}/debug)
+    endif()
 
     message(STATUS "Configure ${TARGET_TRIPLET}-dbg")
     vcpkg_execute_required_process(
-        COMMAND ${CONFIGURE_COMMAND} debug-${OPENSSL_ARCH} "--prefix=${OPENSSLDIR_DEBUG}" "--openssldir=${OPENSSLDIR_DEBUG}" -FS
+        COMMAND ${CONFIGURE_COMMAND} debug-${OPENSSL_ARCH} "--prefix=${CURRENT_PACKAGES_DIR}/debug" "--openssldir=${OPENSSLDIR_DEBUG}" -FS
         WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
         LOGNAME configure-perl-${TARGET_TRIPLET}-dbg
     )
@@ -121,7 +134,7 @@ if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         ERROR_FILE ${CURRENT_BUILDTREES_DIR}/build-${TARGET_TRIPLET}-dbg-0-err.log
     )
     vcpkg_execute_required_process(
-        COMMAND nmake -f "${OPENSSL_MAKEFILE}" install_sw install_ssldirs
+        COMMAND nmake -f "${OPENSSL_MAKEFILE}" ${OPENSSL_INSTALL_TARGETS}
         WORKING_DIRECTORY ${SOURCE_PATH_DEBUG}
         LOGNAME build-${TARGET_TRIPLET}-dbg-1)
 
@@ -149,7 +162,10 @@ file(REMOVE
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/openssl/")
 file(RENAME "${CURRENT_PACKAGES_DIR}/bin/openssl.exe" "${CURRENT_PACKAGES_DIR}/tools/openssl/openssl.exe")
-file(RENAME "${CURRENT_PACKAGES_DIR}/openssl.cnf" "${CURRENT_PACKAGES_DIR}/tools/openssl/openssl.cnf")
+
+if(NOT DEFINED OPENSSL_NO_INSTALL_SSLDIRS)
+    file(RENAME "${CURRENT_PACKAGES_DIR}/openssl.cnf" "${CURRENT_PACKAGES_DIR}/tools/openssl/openssl.cnf")
+endif()
 
 vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/openssl")
 

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -57,6 +57,13 @@ if(NOT DEFINED OPENSSL_NO_INSTALL_SSLDIRS)
     set(OPENSSL_INSTALL_TARGETS ${OPENSSL_INSTALL_TARGETS} install_ssldirs)
 endif()
 
+if (DEFINED OPENSSL_ENGINESDIR)
+    vcpkg_replace_string("${SOURCE_PATH}/Configurations/windows-makefile.tmpl"
+        "ENGINESDIR=\\\"\$enginesdir"
+        "ENGINESDIR=\\\"${OPENSSL_ENGINESDIR}"
+    )
+endif()
+
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
 
     # Copy openssl sources.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4954,7 +4954,7 @@
     },
     "openssl": {
       "baseline": "1.1.1l",
-      "port-version": 3
+      "port-version": 5
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00096c07a533353823d0d79396520f627bb9948f",
+      "version-string": "1.1.1l",
+      "port-version": 5
+    },
+    {
       "git-tree": "83369bdefab234d8570ac2c0f3b616b0c4ab6cdf",
       "version-string": "1.1.1l",
       "port-version": 3


### PR DESCRIPTION
OpenSSL searches for config file in openssldir at runtime. By default
openssldir is set to current build directory.

When an app, which uses vcpkg for building dependencies, is
distributed to another machine, searching for openssl config
in build directory on build machine doesn't make much sense.

This enables OpenSSL port users to customize this directory
with custom triplet, for example:

    set(OPENSSL_OPENSSLDIR "c:\\Program Files\\SSL")

In this case config is searched in directory which is not writable
by default.

Since vcpkg utilizes install_ssldirs target to copy config etc
to abovementioned directory, a build may fail if a directory is
read-only. To fix that, add OPENSSL_NO_INSTALL_SSLDIRS
boolean flag which makes vcpkg skip install_ssldirs target:

  set(OPENSSL_NO_INSTALL_SSLDIRS ON)

Signed-off-by: Lev Stipakov <lev@openvpn.net>

- #### What does your PR fix?  
  See commit message above.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  Windows triplets are affected. No, haven't updated CI baseline.

- #### Does your PR follow the [maintainer guide]
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
