### PR TITLE
[gtest] Fix head ref

### DIFF
--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -7,7 +7,7 @@ vcpkg_from_github(
     REPO google/googletest
     REF release-1.11.0
     SHA512 6fcc7827e4c4d95e3ae643dd65e6c4fc0e3d04e1778b84f6e06e390410fe3d18026c131d828d949d2f20dde6327d30ecee24dcd3ef919e21c91e010d149f3a28
-    HEAD_REF master
+    HEAD_REF main
     PATCHES
         fix-main-lib-path.patch
 )

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtest",
   "version-semver": "1.11.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2590,7 +2590,7 @@
     },
     "gtest": {
       "baseline": "1.11.0",
-      "port-version": 2
+      "port-version": 3
     },
     "gtk": {
       "baseline": "4.3.0",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc195b45d4d766498fb51de96427835c7c4d5748",
+      "version-semver": "1.11.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c87cf62264002bc0cf2cb772a5588b36576323a9",
       "version-semver": "1.11.0",
       "port-version": 2


### PR DESCRIPTION
gtest recently renamed their head branch to `main`, breaking `vcpkg install gtest --head`. This fixes the issue.