### PR TITLE
[curl] Update to 7.80, fix exported config

### DIFF
--- a/ports/curl/0020-fix-pc-file.patch
+++ b/ports/curl/0020-fix-pc-file.patch
@@ -29,9 +29,9 @@ index 8b2e428..ea430f4 100644
 +foreach(_lib ${CURL_LIBS_FLAT})
    if(TARGET "${_lib}")
      set(_libname "${_lib}")
-     get_target_property(_libtype "${_libname}" TYPE)
-@@ -1473,12 +1492,26 @@ foreach(_lib ${CMAKE_C_IMPLICIT_LINK_LIBRARIES} ${CURL_LIBS})
-       # this information in the .pc file.
+     get_target_property(_imported "${_libname}" IMPORTED)
+@@ -1503,12 +1523,26 @@ foreach(_lib ${CMAKE_C_IMPLICIT_LINK_LIBRARIES} ${CURL_LIBS})
+       # Assume the user won't need this information in the .pc file.
        continue()
      endif()
 +    set(_lib NOTFOUND)

--- a/ports/curl/0023-fix-static-libs-export.patch
+++ b/ports/curl/0023-fix-static-libs-export.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 158d7a5..ae7b388 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1534,6 +1534,9 @@ foreach(_lib ${CURL_LIBS_FLAT})
+       set(_lib "-framework ${_lib}")
+     endif()
+   endif()
++  if(_lib MATCHES ".*/${CMAKE_STATIC_LIBRARY_PREFIX}([^/]*)${CMAKE_STATIC_LIBRARY_SUFFIX}")
++    set(_lib -l${CMAKE_MATCH_1})
++  endif()
+   if(_lib MATCHES ".*/.*" OR _lib MATCHES "^-")
+     set(LIBCURL_LIBS          "${LIBCURL_LIBS} ${_lib}")
+   else()

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         0020-fix-pc-file.patch
         0021-normaliz.patch # for mingw on case-sensitive file system
         0022-deduplicate-libs.patch
+        0023-fix-static-libs-export.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" CURL_STATICLIB)

--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO curl/curl
-    REF c7aef0a945f9b6fb6d3f91716a21dfe2f4ea635f #curl-7_79_1
-    SHA512 105e945e0acb47950d756382c7e45abbf0d0b12526eb0170af23e68653c1b7e3be27d547d537c4f36d099ebcb04870e8cd571d2baec996373b2032f8451b63e0
+    REF 9e560d11aad028de74addc0d1edfefa5667884f4 #curl-7_80_0
+    SHA512 f920f151e31f26de8d9a0f8f22aebe98435b0165c52bc169a1204f84f38671dea1eaa2833feceb8495e619b8b9becac0c8ad335ec6fe0c2c59e458bf9014c6c2
     HEAD_REF master
     PATCHES
         0002_fix_uwp.patch

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "curl",
-  "version": "7.79.1",
+  "version": "7.80.0",
   "description": "A library for transferring data with URLs",
   "homepage": "https://github.com/curl/curl",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1697,7 +1697,7 @@
       "port-version": 7
     },
     "curl": {
-      "baseline": "7.79.1",
+      "baseline": "7.80.0",
       "port-version": 0
     },
     "curlpp": {

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5e31dd4dad8fe760ef2fa0edae8a7e3bb9142d9",
+      "version": "7.80.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b2d22bb78a3e3d9d2775d98bf37580e8819ee8c3",
       "version": "7.79.1",
       "port-version": 0

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5e31dd4dad8fe760ef2fa0edae8a7e3bb9142d9",
+      "git-tree": "8e13da05c975cb6f5bed6cf3b8054a817a00b45d",
       "version": "7.80.0",
       "port-version": 0
     },


### PR DESCRIPTION
- #### What does your PR fix?  
  Updates port curl.

  Fixes the exported curl configuration (`libcurl.pc`, `curl-config`) on Windows. (Noticed with/needed for #20443.)

  Changes exported dependency `/.../libz.a` into `-lz` etc. (Fixes undesired inclusion of `libz.a` into `libspatialite.a`, breaking linking `libspatialite-tools`. (Similar to what is described for `libintl.a` in https://sourceware.org/bugzilla/show_bug.cgi?id=27297.) Needed for #20443.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
