### PR TITLE
[opendnp3] Update to 3.1.1

### DIFF
--- a/ports/opendnp3/portfile.cmake
+++ b/ports/opendnp3/portfile.cmake
@@ -4,30 +4,37 @@ if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" STATICLIBS)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dnp3/opendnp3
-    REF 3.1.0
-    SHA512 838a816a8d65d3c99dc489e0e3e4d25f0acdbe0f6f3cc21a6fdbaea11f84f7b1f54958097763d0eae8e1860ba209da4e5377cd3ea6ab08a48a25429860063179
+    REF 3.1.1
+    SHA512 2d7b26753fa03596ab73944236e5f1d82656f38248cc23fd00f7a2cdac27f481e5fe51e68b5896b6740db1a6d9560f0262e473648e001601125f4af8b4a652c2
     HEAD_REF master
 )
 
-file(COPY ${CURRENT_PORT_DIR}/opendnp3-config.cmake.in DESTINATION ${SOURCE_PATH})
+file(COPY "${CURRENT_PORT_DIR}/opendnp3-config.cmake.in" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS -DSTATICLIBS=${STATICLIBS} -DDNP3_TLS=ON
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" STATICLIBS)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tls DNP3_TLS
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDNP3_STATIC_LIBS=${STATICLIBS}
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share/opendnp3)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/opendnp3/portfile.cmake
+++ b/ports/opendnp3/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()

--- a/ports/opendnp3/vcpkg.json
+++ b/ports/opendnp3/vcpkg.json
@@ -1,10 +1,25 @@
 {
   "name": "opendnp3",
-  "version-string": "3.1.0",
+  "version": "3.1.1",
   "description": "DNP3 (IEEE-1815) protocol stack. Modern C++ with bindings for .NET and Java.",
   "homepage": "https://github.com/dnp3/opendnp3/",
+  "features": {
+    "tls": {
+      "description": "Build TLS client/server support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  },
   "dependencies": [
     "asio",
-    "openssl"
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/opendnp3/vcpkg.json
+++ b/ports/opendnp3/vcpkg.json
@@ -3,14 +3,6 @@
   "version": "3.1.1",
   "description": "DNP3 (IEEE-1815) protocol stack. Modern C++ with bindings for .NET and Java.",
   "homepage": "https://github.com/dnp3/opendnp3/",
-  "features": {
-    "tls": {
-      "description": "Build TLS client/server support",
-      "dependencies": [
-        "openssl"
-      ]
-    }
-  },
   "dependencies": [
     "asio",
     {
@@ -21,5 +13,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tls": {
+      "description": "Build TLS client/server support",
+      "dependencies": [
+        "openssl"
+      ]
+    }
+  }
 }

--- a/ports/opendnp3/vcpkg.json
+++ b/ports/opendnp3/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "3.1.1",
   "description": "DNP3 (IEEE-1815) protocol stack. Modern C++ with bindings for .NET and Java.",
   "homepage": "https://github.com/dnp3/opendnp3/",
+  "supports": "!uwp",
   "dependencies": [
     "asio",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4925,7 +4925,7 @@
       "port-version": 3
     },
     "opendnp3": {
-      "baseline": "3.1.0",
+      "baseline": "3.1.1",
       "port-version": 0
     },
     "openexr": {

--- a/versions/o-/opendnp3.json
+++ b/versions/o-/opendnp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1b334334b78541f7ceab4fe6c8cfa2dae97fb3fd",
+      "git-tree": "bf6ee46efb76af8f7f317fabfb24358fd82312de",
       "version": "3.1.1",
       "port-version": 0
     },

--- a/versions/o-/opendnp3.json
+++ b/versions/o-/opendnp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b334334b78541f7ceab4fe6c8cfa2dae97fb3fd",
+      "version": "3.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "3659f9f4ee54aa9d6d51ef3cd42f256c28c7c73e",
       "version-string": "3.1.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates opendnp3 to 3.1.1. Makes TLS support optional as a feature.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  As before, Yes. All features have been tested on Windows.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?  
  Yes