### PR TITLE
Libpq update and VCPKG_OSX_SYSROOT fix

### DIFF
--- a/ports/libpq/patches/windows/Solution_DEBUG.patch
+++ b/ports/libpq/patches/windows/Solution_DEBUG.patch
@@ -7,85 +7,30 @@ index 51711c2bf..d33fdc3b0 100644
  	{
  		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
 -		$proj->AddLibrary($self->{options}->{zlib} . '\lib\zdll.lib');
-+		$proj->AddLibrary($self->{options}->{zlib} . '\debug\lib\zlibd.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{zlib} . '\debug\lib\zlibd.lib');
  	}
  	if ($self->{options}->{openssl})
  	{
-@@ -670,7 +670,7 @@ sub AddProject
- 		# - libeay to libcrypto
- 		# - ssleay to libssl
- 		if (   ($digit1 >= '3' && $digit2 >= '0' && $digit3 >= '0')
--			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
-+			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')) # This must be updated
- 		{
- 			my $dbgsuffix;
- 			my $libsslpath;
-@@ -679,27 +679,27 @@ sub AddProject
- 			# The format name of the libraries is slightly
- 			# different between the Win32 and Win64 platform, so
- 			# adapt.
--			if (-e "$self->{options}->{openssl}/lib/VC/sslcrypto32MD.lib")
-+			if (-e "$self->{options}->{openssl}/lib/VC/sslcrypto32MD.lib") # This must be updated
- 			{
- 				# Win32 here, with a debugging library set.
- 				$dbgsuffix     = 1;
--				$libsslpath    = '\lib\VC\libssl32.lib';
--				$libcryptopath = '\lib\VC\libcrypto32.lib';
-+				$libsslpath    = '\lib\VC\libssl32.lib'; # This must be updated
-+				$libcryptopath = '\lib\VC\libcrypto32.lib'; # This must be updated
- 			}
--			elsif (-e "$self->{options}->{openssl}/lib/VC/sslcrypto64MD.lib")
-+			elsif (-e "$self->{options}->{openssl}/lib/VC/sslcrypto64MD.lib") # This must be updated
- 			{
- 				# Win64 here, with a debugging library set.
- 				$dbgsuffix     = 1;
--				$libsslpath    = '\lib\VC\libssl64.lib';
--				$libcryptopath = '\lib\VC\libcrypto64.lib';
-+				$libsslpath    = '\lib\VC\libssl64.lib'; # This must be updated
-+				$libcryptopath = '\lib\VC\libcrypto64.lib'; # This must be updated
- 			}
- 			else
- 			{
+@@ -698,8 +698,8 @@ sub AddProject
  				# On both Win32 and Win64 the same library
  				# names are used without a debugging context.
  				$dbgsuffix     = 0;
 -				$libsslpath    = '\lib\libssl.lib';
 -				$libcryptopath = '\lib\libcrypto.lib';
-+				$libsslpath    = '\debug\lib\libssl.lib'; # This must be updated
-+				$libcryptopath = '\debug\lib\libcrypto.lib'; # This must be updated
++				$libsslpath    = '\debug\lib\libssl.lib';
++				$libcryptopath = '\debug\lib\libcrypto.lib';
  			}
  
  			$proj->AddLibrary($self->{options}->{openssl} . $libsslpath,
-@@ -707,16 +707,16 @@ sub AddProject
- 			$proj->AddLibrary($self->{options}->{openssl} . $libcryptopath,
- 				$dbgsuffix);
- 		}
--		else
-+		else 
- 		{
- 			# Choose which set of libraries to use depending on if
- 			# debugging libraries are in place in the installer.
--			if (-e "$self->{options}->{openssl}/lib/VC/ssleay32MD.lib")
-+			if (-e "$self->{options}->{openssl}/lib/VC/ssleay32MD.lib") # This must be updated
- 			{
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\VC\ssleay32.lib', 1);
-+					$self->{options}->{openssl} . '\lib\VC\ssleay32.lib', 1); # This must be updated
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\VC\libeay32.lib', 1);
-+					$self->{options}->{openssl} . '\lib\VC\libeay32.lib', 1); # This must be updated
- 			}
- 			else
- 			{
-@@ -715,76 +715,76 @@ sub AddProject
+@@ -715,16 +715,16 @@ sub AddProject
  				# to be here, so don't ask for it in last
  				# parameter.
  				$proj->AddLibrary(
 -					$self->{options}->{openssl} . '\lib\ssleay32.lib', 0);
-+					$self->{options}->{openssl} . '\debug\lib\ssleay32.lib', 0); # This must be updated
++					$self->{options}->{openssl} . '\debug\lib\ssleay32.lib', 0);
  				$proj->AddLibrary(
 -					$self->{options}->{openssl} . '\lib\libeay32.lib', 0);
-+					$self->{options}->{openssl} . '\debug\lib\libeay32.lib', 0); # This must be updated
++					$self->{options}->{openssl} . '\debug\lib\libeay32.lib', 0);
  			}
  		}
  	}
@@ -93,44 +38,16 @@ index 51711c2bf..d33fdc3b0 100644
  	{
  		$proj->AddIncludeDir($self->{options}->{nls} . '\include');
 -		$proj->AddLibrary($self->{options}->{nls} . '\lib\libintl.lib');
-+		$proj->AddLibrary($self->{options}->{nls} . '\debug\lib\intl.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{nls} . '\debug\lib\intl.lib');
  	}
  	if ($self->{options}->{gss})
  	{
--		$proj->AddIncludeDir($self->{options}->{gss} . '\include');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\include');  # This must be updated
--		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5'); # This must be updated
- 		if ($self->{platform} eq 'Win32')
- 		{
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\krb5_32.lib');
-+				$self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\comerr32.lib');
-+				$self->{options}->{gss} . '\lib\i386\comerr32.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\gssapi32.lib');
-+				$self->{options}->{gss} . '\lib\i386\gssapi32.lib'); # This must be updated
- 		}
- 		else
- 		{
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\comerr64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\comerr64.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib'); # This must be updated
- 		}
-  	}
+@@ -752,39 +752,39 @@ sub AddProject
  	if ($self->{options}->{iconv})
  	{
  		$proj->AddIncludeDir($self->{options}->{iconv} . '\include');
 -		$proj->AddLibrary($self->{options}->{iconv} . '\lib\iconv.lib');
-+		$proj->AddLibrary($self->{options}->{iconv} . '\debug\lib\iconv.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{iconv} . '\debug\lib\iconv.lib');
  	}
  	if ($self->{options}->{icu})
  	{
@@ -140,18 +57,18 @@ index 51711c2bf..d33fdc3b0 100644
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuuc.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib\icudt.lib');
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuind.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuucd.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icudtd.lib'); # This must be updated
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuind.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuucd.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icudtd.lib');
  		}
  		else
  		{
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icuin.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icuuc.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icudt.lib');
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuind.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuucd.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icudtd.lib'); # This must be updated
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuind.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icuucd.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\debug\lib\icudtd.lib');
  		}
  	}
  	if ($self->{options}->{xml})
@@ -159,19 +76,19 @@ index 51711c2bf..d33fdc3b0 100644
  		$proj->AddIncludeDir($self->{options}->{xml} . '\include');
  		$proj->AddIncludeDir($self->{options}->{xml} . '\include\libxml2');
 -		$proj->AddLibrary($self->{options}->{xml} . '\lib\libxml2.lib');
-+		$proj->AddLibrary($self->{options}->{xml} . '\debug\lib\libxml2.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{xml} . '\debug\lib\libxml2.lib');
  	}
  	if ($self->{options}->{xslt})
  	{
  		$proj->AddIncludeDir($self->{options}->{xslt} . '\include');
 -		$proj->AddLibrary($self->{options}->{xslt} . '\lib\libxslt.lib');
-+		$proj->AddLibrary($self->{options}->{xslt} . '\debug\lib\libxslt.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{xslt} . '\debug\lib\libxslt.lib');
  	}
  	if ($self->{options}->{uuid})
  	{
  		$proj->AddIncludeDir($self->{options}->{uuid} . '\include');
 -		$proj->AddLibrary($self->{options}->{uuid} . '\lib\uuid.lib');
-+		$proj->AddLibrary($self->{options}->{uuid} . '\debug\lib\uuid.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{uuid} . '\debug\lib\uuid.lib');
  	}
  	return $proj;
  }

--- a/ports/libpq/patches/windows/Solution_DEBUG.patch
+++ b/ports/libpq/patches/windows/Solution_DEBUG.patch
@@ -2,7 +2,7 @@ diff --git a/src/tools/msvc/Solution.pm b/src/tools/msvc/Solution.pm
 index 51711c2bf..d33fdc3b0 100644
 --- a/src/tools/msvc/Solution.pm	
 +++ b/src/tools/msvc/Solution.pm
-@@ -650,7 +650,7 @@ sub AddProject
+@@ -658,7 +658,7 @@ sub AddProject
  	if ($self->{options}->{zlib})
  	{
  		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
@@ -11,16 +11,16 @@ index 51711c2bf..d33fdc3b0 100644
  	}
  	if ($self->{options}->{openssl})
  	{
-@@ -661,7 +661,7 @@ sub AddProject
- 		# changed their library names from:
+@@ -670,7 +670,7 @@ sub AddProject
  		# - libeay to libcrypto
  		# - ssleay to libssl
--		if ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')
-+		if ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0') # This must be updated
+ 		if (   ($digit1 >= '3' && $digit2 >= '0' && $digit3 >= '0')
+-			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
++			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')) # This must be updated
  		{
  			my $dbgsuffix;
  			my $libsslpath;
-@@ -670,27 +670,27 @@ sub AddProject
+@@ -679,27 +679,27 @@ sub AddProject
  			# The format name of the libraries is slightly
  			# different between the Win32 and Win64 platform, so
  			# adapt.
@@ -56,7 +56,7 @@ index 51711c2bf..d33fdc3b0 100644
  			}
  
  			$proj->AddLibrary($self->{options}->{openssl} . $libsslpath,
-@@ -698,16 +698,16 @@ sub AddProject
+@@ -707,16 +707,16 @@ sub AddProject
  			$proj->AddLibrary($self->{options}->{openssl} . $libcryptopath,
  				$dbgsuffix);
  		}
@@ -77,7 +77,7 @@ index 51711c2bf..d33fdc3b0 100644
  			}
  			else
  			{
-@@ -715,60 +715,60 @@ sub AddProject
+@@ -715,76 +715,76 @@ sub AddProject
  				# to be here, so don't ask for it in last
  				# parameter.
  				$proj->AddLibrary(
@@ -97,15 +97,35 @@ index 51711c2bf..d33fdc3b0 100644
  	}
  	if ($self->{options}->{gss})
  	{
--		$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');  # This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');# This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');# This must be updated
- 	}
+-		$proj->AddIncludeDir($self->{options}->{gss} . '\include');
++		$proj->AddIncludeDir($self->{options}->{gss} . '\include');  # This must be updated
+-		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5');
++		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5'); # This must be updated
+ 		if ($self->{platform} eq 'Win32')
+ 		{
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\krb5_32.lib');
++				$self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\comerr32.lib');
++				$self->{options}->{gss} . '\lib\i386\comerr32.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\gssapi32.lib');
++				$self->{options}->{gss} . '\lib\i386\gssapi32.lib'); # This must be updated
+ 		}
+ 		else
+ 		{
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib');
++				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\comerr64.lib');
++				$self->{options}->{gss} . '\lib\amd64\comerr64.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib');
++				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib'); # This must be updated
+ 		}
+  	}
  	if ($self->{options}->{iconv})
  	{
  		$proj->AddIncludeDir($self->{options}->{iconv} . '\include');

--- a/ports/libpq/patches/windows/Solution_RELEASE.patch
+++ b/ports/libpq/patches/windows/Solution_RELEASE.patch
@@ -2,7 +2,7 @@ diff --git a/src/tools/msvc/Solution.pm b/src/tools/msvc/Solution.pm
 index 51711c2bf..d33fdc3b0 100644
 --- a/src/tools/msvc/Solution.pm	
 +++ b/src/tools/msvc/Solution.pm
-@@ -650,7 +650,7 @@ sub AddProject
+@@ -658,7 +658,7 @@ sub AddProject
  	if ($self->{options}->{zlib})
  	{
  		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
@@ -11,16 +11,16 @@ index 51711c2bf..d33fdc3b0 100644
  	}
  	if ($self->{options}->{openssl})
  	{
-@@ -661,7 +661,7 @@ sub AddProject
- 		# changed their library names from:
+@@ -670,7 +670,7 @@ sub AddProject
  		# - libeay to libcrypto
  		# - ssleay to libssl
--		if ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')
-+		if ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0') # This must be updated
+ 		if (   ($digit1 >= '3' && $digit2 >= '0' && $digit3 >= '0')
+-			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
++			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')) # This must be updated
  		{
  			my $dbgsuffix;
  			my $libsslpath;
-@@ -670,27 +670,27 @@ sub AddProject
+@@ -679,27 +679,27 @@ sub AddProject
  			# The format name of the libraries is slightly
  			# different between the Win32 and Win64 platform, so
  			# adapt.
@@ -56,7 +56,7 @@ index 51711c2bf..d33fdc3b0 100644
  			}
  
  			$proj->AddLibrary($self->{options}->{openssl} . $libsslpath,
-@@ -698,16 +698,16 @@ sub AddProject
+@@ -707,16 +707,16 @@ sub AddProject
  			$proj->AddLibrary($self->{options}->{openssl} . $libcryptopath,
  				$dbgsuffix);
  		}
@@ -77,7 +77,7 @@ index 51711c2bf..d33fdc3b0 100644
  			}
  			else
  			{
-@@ -715,60 +715,60 @@ sub AddProject
+@@ -715,76 +715,76 @@ sub AddProject
  				# to be here, so don't ask for it in last
  				# parameter.
  				$proj->AddLibrary(
@@ -97,15 +97,35 @@ index 51711c2bf..d33fdc3b0 100644
  	}
  	if ($self->{options}->{gss})
  	{
--		$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');
--		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\inc\krb5');  # This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\comerr32.lib');# This must be updated
-+		$proj->AddLibrary($self->{options}->{gss} . '\lib\i386\gssapi32.lib');# This must be updated
- 	}
+-		$proj->AddIncludeDir($self->{options}->{gss} . '\include');
++		$proj->AddIncludeDir($self->{options}->{gss} . '\include'); # This must be updated
+-		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5');
++		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5'); # This must be updated
+ 		if ($self->{platform} eq 'Win32')
+ 		{
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\krb5_32.lib');
++				$self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\comerr32.lib');
++				$self->{options}->{gss} . '\lib\i386\comerr32.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\i386\gssapi32.lib');
++				$self->{options}->{gss} . '\lib\i386\gssapi32.lib'); # This must be updated
+ 		}
+ 		else
+ 		{
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib');
++				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\comerr64.lib');
++				$self->{options}->{gss} . '\lib\amd64\comerr64.lib'); # This must be updated
+ 			$proj->AddLibrary(
+-				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib');
++				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib'); # This must be updated
+ 		}
+  	}
  	if ($self->{options}->{iconv})
  	{
  		$proj->AddIncludeDir($self->{options}->{iconv} . '\include');

--- a/ports/libpq/patches/windows/Solution_RELEASE.patch
+++ b/ports/libpq/patches/windows/Solution_RELEASE.patch
@@ -7,171 +7,29 @@ index 51711c2bf..d33fdc3b0 100644
  	{
  		$proj->AddIncludeDir($self->{options}->{zlib} . '\include');
 -		$proj->AddLibrary($self->{options}->{zlib} . '\lib\zdll.lib');
-+		$proj->AddLibrary($self->{options}->{zlib} . '\lib\zlib.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{zlib} . '\lib\zlib.lib');
  	}
  	if ($self->{options}->{openssl})
  	{
-@@ -670,7 +670,7 @@ sub AddProject
- 		# - libeay to libcrypto
- 		# - ssleay to libssl
- 		if (   ($digit1 >= '3' && $digit2 >= '0' && $digit3 >= '0')
--			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0'))
-+			|| ($digit1 >= '1' && $digit2 >= '1' && $digit3 >= '0')) # This must be updated
- 		{
- 			my $dbgsuffix;
- 			my $libsslpath;
-@@ -679,27 +679,27 @@ sub AddProject
- 			# The format name of the libraries is slightly
- 			# different between the Win32 and Win64 platform, so
- 			# adapt.
--			if (-e "$self->{options}->{openssl}/lib/VC/sslcrypto32MD.lib")
-+			if (-e "$self->{options}->{openssl}/lib/VC/sslcrypto32MD.lib") # This must be updated
- 			{
- 				# Win32 here, with a debugging library set.
- 				$dbgsuffix     = 1;
--				$libsslpath    = '\lib\VC\libssl32.lib';
--				$libcryptopath = '\lib\VC\libcrypto32.lib';
-+				$libsslpath    = '\lib\VC\libssl32.lib'; # This must be updated
-+				$libcryptopath = '\lib\VC\libcrypto32.lib'; # This must be updated
- 			}
--			elsif (-e "$self->{options}->{openssl}/lib/VC/sslcrypto64MD.lib")
-+			elsif (-e "$self->{options}->{openssl}/lib/VC/sslcrypto64MD.lib") # This must be updated
- 			{
- 				# Win64 here, with a debugging library set.
- 				$dbgsuffix     = 1;
--				$libsslpath    = '\lib\VC\libssl64.lib';
--				$libcryptopath = '\lib\VC\libcrypto64.lib';
-+				$libsslpath    = '\lib\VC\libssl64.lib'; # This must be updated
-+				$libcryptopath = '\lib\VC\libcrypto64.lib'; # This must be updated
- 			}
- 			else
- 			{
- 				# On both Win32 and Win64 the same library
- 				# names are used without a debugging context.
- 				$dbgsuffix     = 0;
--				$libsslpath    = '\lib\libssl.lib';
--				$libcryptopath = '\lib\libcrypto.lib';
-+				$libsslpath    = '\lib\libssl.lib'; # This must be updated
-+				$libcryptopath = '\lib\libcrypto.lib'; # This must be updated
- 			}
- 
- 			$proj->AddLibrary($self->{options}->{openssl} . $libsslpath,
-@@ -707,16 +707,16 @@ sub AddProject
- 			$proj->AddLibrary($self->{options}->{openssl} . $libcryptopath,
- 				$dbgsuffix);
- 		}
--		else
-+		else 
- 		{
- 			# Choose which set of libraries to use depending on if
- 			# debugging libraries are in place in the installer.
--			if (-e "$self->{options}->{openssl}/lib/VC/ssleay32MD.lib")
-+			if (-e "$self->{options}->{openssl}/lib/VC/ssleay32MD.lib") # This must be updated
- 			{
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\VC\ssleay32.lib', 1);
-+					$self->{options}->{openssl} . '\lib\VC\ssleay32.lib', 1); # This must be updated
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\VC\libeay32.lib', 1);
-+					$self->{options}->{openssl} . '\lib\VC\libeay32.lib', 1); # This must be updated
- 			}
- 			else
- 			{
-@@ -715,76 +715,76 @@ sub AddProject
- 				# to be here, so don't ask for it in last
- 				# parameter.
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\ssleay32.lib', 0);
-+					$self->{options}->{openssl} . '\lib\ssleay32.lib', 0); # This must be updated
- 				$proj->AddLibrary(
--					$self->{options}->{openssl} . '\lib\libeay32.lib', 0);
-+					$self->{options}->{openssl} . '\lib\libeay32.lib', 0); # This must be updated
- 			}
- 		}
- 	}
+@@ -724,7 +724,7 @@ sub AddProject
  	if ($self->{options}->{nls})
  	{
  		$proj->AddIncludeDir($self->{options}->{nls} . '\include');
 -		$proj->AddLibrary($self->{options}->{nls} . '\lib\libintl.lib');
-+		$proj->AddLibrary($self->{options}->{nls} . '\lib\intl.lib'); # This must be updated
++		$proj->AddLibrary($self->{options}->{nls} . '\lib\intl.lib');
  	}
  	if ($self->{options}->{gss})
  	{
--		$proj->AddIncludeDir($self->{options}->{gss} . '\include');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\include'); # This must be updated
--		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5');
-+		$proj->AddIncludeDir($self->{options}->{gss} . '\include\krb5'); # This must be updated
- 		if ($self->{platform} eq 'Win32')
- 		{
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\krb5_32.lib');
-+				$self->{options}->{gss} . '\lib\i386\krb5_32.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\comerr32.lib');
-+				$self->{options}->{gss} . '\lib\i386\comerr32.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\i386\gssapi32.lib');
-+				$self->{options}->{gss} . '\lib\i386\gssapi32.lib'); # This must be updated
- 		}
- 		else
- 		{
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\comerr64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\comerr64.lib'); # This must be updated
- 			$proj->AddLibrary(
--				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib');
-+				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib'); # This must be updated
- 		}
-  	}
- 	if ($self->{options}->{iconv})
- 	{
- 		$proj->AddIncludeDir($self->{options}->{iconv} . '\include');
--		$proj->AddLibrary($self->{options}->{iconv} . '\lib\iconv.lib');
-+		$proj->AddLibrary($self->{options}->{iconv} . '\lib\iconv.lib'); # This must be updated
- 	}
- 	if ($self->{options}->{icu})
- 	{
- 		$proj->AddIncludeDir($self->{options}->{icu} . '\include');
- 		if ($self->{platform} eq 'Win32')
- 		{
--			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib');
--			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuuc.lib');
--			$proj->AddLibrary($self->{options}->{icu} . '\lib\icudt.lib');
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuuc.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icudt.lib'); # This must be updated
+@@ -765,9 +765,9 @@ sub AddProject
  		}
  		else
  		{
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icuin.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icuuc.lib');
 -			$proj->AddLibrary($self->{options}->{icu} . '\lib64\icudt.lib');
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuuc.lib'); # This must be updated
-+			$proj->AddLibrary($self->{options}->{icu} . '\lib\icudt.lib'); # This must be updated
++			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuin.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\lib\icuuc.lib');
++			$proj->AddLibrary($self->{options}->{icu} . '\lib\icudt.lib');
  		}
  	}
  	if ($self->{options}->{xml})
- 	{
- 		$proj->AddIncludeDir($self->{options}->{xml} . '\include');
- 		$proj->AddIncludeDir($self->{options}->{xml} . '\include\libxml2');
--		$proj->AddLibrary($self->{options}->{xml} . '\lib\libxml2.lib');
-+		$proj->AddLibrary($self->{options}->{xml} . '\lib\libxml2.lib'); # This must be updated
- 	}
- 	if ($self->{options}->{xslt})
- 	{
- 		$proj->AddIncludeDir($self->{options}->{xslt} . '\include');
--		$proj->AddLibrary($self->{options}->{xslt} . '\lib\libxslt.lib');
-+		$proj->AddLibrary($self->{options}->{xslt} . '\lib\libxslt.lib'); # This must be updated
- 	}
- 	if ($self->{options}->{uuid})
- 	{
- 		$proj->AddIncludeDir($self->{options}->{uuid} . '\include');
--		$proj->AddLibrary($self->{options}->{uuid} . '\lib\uuid.lib');
-+		$proj->AddLibrary($self->{options}->{uuid} . '\lib\uuid.lib'); # This must be updated
- 	}
- 	return $proj;
- }

--- a/ports/libpq/patches/windows/install.patch
+++ b/ports/libpq/patches/windows/install.patch
@@ -2,35 +2,7 @@ diff --git a/src/tools/msvc/Install.pm b/src/tools/msvc/Install.pm
 index d109b2c90..75c7446e6 100644
 --- a/src/tools/msvc/Install.pm
 +++ b/src/tools/msvc/Install.pm
-@@ -63,8 +63,16 @@ sub Install
- 		do "./config.pl" if (-f "config.pl");
- 	}
- 
--	chdir("../../..")    if (-f "../../../configure");
--	chdir("../../../..") if (-f "../../../../configure");
-+	# Move to the root path depending on the current location.
-+	if (-f "../../../configure")
-+	{
-+		chdir("../../..");
-+	}
-+	elsif (-f "../../../../configure")
-+	{
-+		chdir("../../../..");
-+	}
-+
- 	my $conf = "";
- 	if (-d "debug")
- 	{
-@@ -106,7 +106,7 @@ sub Install
- 			}
- 		},
- 		@top_dir);
--	CopySetOfFiles('config files', $sample_files, $target . '/share/');
-+	CopySetOfFiles('config files', $sample_files, $target . '/share/libpq/');
- 	CopyFiles(
- 		'Import libraries',
- 		$target . '/lib/',
-@@ -78,10 +78,10 @@ sub Install
+@@ -86,10 +86,10 @@ sub Install
  	my $majorver = DetermineMajorVersion();
  	print "Installing version $majorver for $conf in $target\n";
  
@@ -44,7 +16,16 @@ index d109b2c90..75c7446e6 100644
  	if ($insttype eq "client")
  	{
  		EnsureDirectories($target, @client_dirs);
-@@ -120,35 +120,35 @@ sub Install
+@@ -114,7 +114,7 @@ sub Install
+ 			}
+ 		},
+ 		@top_dir);
+-	CopySetOfFiles('config files', $sample_files, $target . '/share/');
++	CopySetOfFiles('config files', $sample_files, $target . '/share/libpq/');
+ 	CopyFiles(
+ 		'Import libraries',
+ 		$target . '/lib/',
+@@ -128,35 +128,35 @@ sub Install
  		CopySetOfFiles(
  			'timezone names',
  			[ glob('src\timezone\tznames\*.txt') ],
@@ -88,7 +69,7 @@ index d109b2c90..75c7446e6 100644
  
  		my $pl_extension_files = [];
  		my @pldirs             = ('src/pl/plpgsql/src');
-@@ -167,7 +167,7 @@ sub Install
+@@ -175,7 +175,7 @@ sub Install
  			},
  			@pldirs);
  		CopySetOfFiles('PL Extension files',
@@ -97,7 +78,7 @@ index d109b2c90..75c7446e6 100644
  	}
  
  	GenerateNLSFiles($target, $config->{nls}, $majorver) if ($config->{nls});
-@@ -282,23 +282,26 @@ sub CopySolutionOutput
+@@ -290,23 +290,26 @@ sub CopySolutionOutput
  		{
  			if ($1 == 1)
  			{
@@ -128,7 +109,7 @@ index d109b2c90..75c7446e6 100644
  			}
  		}
  		elsif ($vcproj eq 'vcxproj'
-@@ -306,11 +309,11 @@ sub CopySolutionOutput
+@@ -317,11 +317,11 @@ sub CopySolutionOutput
  		{
  			if ($1 eq 'Application')
  			{
@@ -142,7 +123,7 @@ index d109b2c90..75c7446e6 100644
  				if ($is_sharedlib)
  				{
  					push(@{ $install_list{'bin'} }, "dll");
-@@ -319,10 +322,9 @@ sub CopySolutionOutput
+@@ -327,10 +330,9 @@ sub CopySolutionOutput
  			}
  			else    # 'StaticLibrary'
  			{
@@ -154,7 +135,7 @@ index d109b2c90..75c7446e6 100644
  			}
  		}
  		else
-@@ -339,7 +339,7 @@ sub CopySolutionOutput
+@@ -349,7 +349,7 @@ sub CopySolutionOutput
  				  || croak "Could not copy $pf.$ext\n";
  			}
  		}
@@ -167,11 +148,11 @@ index d109b2c90..75c7446e6 100644
  	print "Generating timezone files...";
  
  	my @args =
--	  ("$conf/zic/zic", '-d', "$target/share/timezone", '-p', "$posixrules");
-+	  ("$conf/zic/zic", '-d', "$target/share/libpq/timezone", '-p', "$posixrules");
+-	  ("$conf/zic/zic", '-d', "$target/share/timezone",
++	  ("$conf/zic/zic", '-d', "$target/share/libpq/timezone",
+ 	   '-p', "$posixrules", '-b', 'fat');
  	foreach (@tzfiles)
  	{
- 		my $tzfile = $_;
 @@ -391,7 +391,7 @@ sub GenerateTsearchFiles
  	$mf =~ /^LANGUAGES\s*=\s*(.*)$/m
  	  || die "Could not find LANGUAGES line in snowball Makefile\n";

--- a/ports/libpq/patches/windows/python3_build_DEBUG.patch
+++ b/ports/libpq/patches/windows/python3_build_DEBUG.patch
@@ -9,7 +9,7 @@ index 99f39caa5..21b5559d6 100644
 -		my $pythonprog = "import sys;print(sys.prefix);"
 -		  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
 -		my $prefixcmd =
--		  $solution->{options}->{python} . "\\python -c \"$pythonprog\"";
+-		  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
 -		my $pyout = `$prefixcmd`;
 -		die "Could not query for python version!\n" if $?;
 -		my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);
@@ -17,7 +17,7 @@ index 99f39caa5..21b5559d6 100644
 +		#my $pythonprog = "import sys;print(sys.prefix);"
 +		#  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
 +		#my $prefixcmd =
-+		#  $solution->{options}->{python} . "\\python -c \"$pythonprog\"";
++		#  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
 +		#my $pyout = `$prefixcmd`;
 +		#die "Could not query for python version!\n" if $?;
 +		#my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);

--- a/ports/libpq/patches/windows/python3_build_RELEASE.patch
+++ b/ports/libpq/patches/windows/python3_build_RELEASE.patch
@@ -9,7 +9,7 @@ index 99f39caa5..21b5559d6 100644
 -		my $pythonprog = "import sys;print(sys.prefix);"
 -		  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
 -		my $prefixcmd =
--		  $solution->{options}->{python} . "\\python -c \"$pythonprog\"";
+-		  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
 -		my $pyout = `$prefixcmd`;
 -		die "Could not query for python version!\n" if $?;
 -		my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);
@@ -17,7 +17,7 @@ index 99f39caa5..21b5559d6 100644
 +		#my $pythonprog = "import sys;print(sys.prefix);"
 +		#  . "print(str(sys.version_info[0])+str(sys.version_info[1]))";
 +		#my $prefixcmd =
-+		#  $solution->{options}->{python} . "\\python -c \"$pythonprog\"";
++		#  qq("$solution->{options}->{python}\\python" -c "$pythonprog");
 +		#my $pyout = `$prefixcmd`;
 +		#die "Could not query for python version!\n" if $?;
 +		#my ($pyprefix, $pyver) = split(/\r?\n/, $pyout);

--- a/ports/libpq/patches/windows/win_bison_flex.patch
+++ b/ports/libpq/patches/windows/win_bison_flex.patch
@@ -11,7 +11,7 @@ index aceed5ffd..f6ed215e8 100644
  $flexver = (split(/\s+/, $flexver))[1];
  $flexver =~ s/[^0-9.]//g;
  my @verparts = split(/\./, $flexver);
-@@ -48,7 +47,7 @@ close($mf);
+@@ -48,7 +48,7 @@ close($mf);
  my $basetarg = basename($output);
  my $flexflags = ($make =~ /^$basetarg:\s*FLEXFLAGS\s*=\s*(\S.*)/m ? $1 : '');
  
@@ -34,10 +34,10 @@ index 895e398c0..f5b524a5d 100644
  
  unless ($bisonver eq '1.875' || $bisonver ge '2.2')
 @@ -45,5 +45,5 @@ close($mf);
- my $basetarg = basename($output);
- my $headerflag = ($make =~ /^$basetarg:\s+BISONFLAGS\b.*-d/m ? '-d' : '');
-
--system("bison $headerflag $input -o $output");
-+system("win_bison $headerflag $input -o $output");
+ 
+ my $nodep = $bisonver ge '3.0' ? "-Wno-deprecated" : "";
+ 
+-system("bison $nodep $headerflag $input -o $output");
++system("win_bison $nodep $headerflag $input -o $output");
  exit $? >> 8;
 

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -1,4 +1,4 @@
-set(PORT_VERSION 12.2)
+set(PORT_VERSION 12.9)
 # NOTE: the python patches must be regenerated on version update
 
 macro(feature_unsupported)
@@ -32,7 +32,7 @@ endif()
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.postgresql.org/pub/source/v${PORT_VERSION}/postgresql-${PORT_VERSION}.tar.bz2"
     FILENAME "postgresql-${PORT_VERSION}.tar.bz2"
-    SHA512 0e0ce8e21856e8f43e58b840c10c4e3ffae6d5207e0d778e9176e36f8e20e34633cbb06f0030a7c963c3491bb7e941456d91b55444c561cfc6f283fba76f33ee
+    SHA512 11697d8283f5df5a9c74c2406e94d1b6da6df8358ad48f3b773825aab98e8395f9fd4e3fc8b1e6ebad3743c3dadbda8b795d4fe84a447d7913223e136cf2b88f
 )
 
 set(PATCHES

--- a/ports/libpq/portfile.cmake
+++ b/ports/libpq/portfile.cmake
@@ -281,6 +281,9 @@ else()
     if(VCPKG_TARGET_IS_ANDROID) # AND CMAKE_SYSTEM_VERSION LESS 26)
         list(APPEND BUILD_OPTS ac_cv_header_langinfo_h=no)
     endif()
+    if(VCPKG_OSX_SYSROOT)
+        list(APPEND BUILD_OPTS "PG_SYSROOT=${VCPKG_OSX_SYSROOT}")
+    endif()
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
         COPY_SOURCE

--- a/ports/libpq/vcpkg.json
+++ b/ports/libpq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpq",
-  "version": "12.2",
-  "port-version": 20,
+  "version": "12.9",
+  "port-version": 1,
   "description": "The official database access API of postgresql",
   "homepage": "https://www.postgresql.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3785,8 +3785,8 @@
       "port-version": 14
     },
     "libpq": {
-      "baseline": "12.2",
-      "port-version": 20
+      "baseline": "12.9",
+      "port-version": 1
     },
     "libpqxx": {
       "baseline": "7.6.0",

--- a/versions/l-/libpq.json
+++ b/versions/l-/libpq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "099cade84111279ffa4a909061cb8f4f36137842",
+      "version": "12.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "bd369bc003e7ebebb688ee536065a356f1658260",
       "version": "12.2",
       "port-version": 20


### PR DESCRIPTION
This updates libpq to version 12.9, the most recent version of the 12er branch. 
This also fixes the build with a not default VCPKG_OSX_SYSROOT 

- #### What does your PR fix?  
  Building with VCPKG_OSX_SYSROOT

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No changes "supports": "!uwp"

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `Yes`