### PR TITLE
[spirv-cross] Fix iOS triplet build

### DIFF
--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -27,7 +27,7 @@ vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 foreach(COMPONENT core c cpp glsl hlsl msl reflect util)
-    vcpkg_cmake_config_fixup(CONFIG_PATH "share/spirv_cross_${COMPONENT}/cmake" PACKAGE_NAME "spirv_cross_${COMPONENT}")
+    vcpkg_cmake_config_fixup(CONFIG_PATH share/spirv_cross_${COMPONENT}/cmake PACKAGE_NAME spirv_cross_${COMPONENT})
 endforeach()
 
 if(BUILD_CLI)

--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -16,7 +16,7 @@ else()
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=OFF
         -DSPIRV_CROSS_CLI=${BUILD_CLI}

--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -15,28 +15,28 @@ else()
     set(BUILD_CLI ON)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS=OFF
         -DSPIRV_CROSS_CLI=${BUILD_CLI}
         -DSPIRV_CROSS_SKIP_INSTALL=OFF
         -DSPIRV_CROSS_ENABLE_C_API=ON
 )
-
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 foreach(COMPONENT core c cpp glsl hlsl msl reflect util)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH share/spirv_cross_${COMPONENT}/cmake TARGET_PATH share/spirv_cross_${COMPONENT})
+    vcpkg_cmake_config_fixup(CONFIG_PATH "share/spirv_cross_${COMPONENT}/cmake" PACKAGE_NAME "spirv_cross_${COMPONENT}")
 endforeach()
 
 if(BUILD_CLI)
     vcpkg_copy_tools(TOOL_NAMES spirv-cross AUTO_CLEAN)
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")

--- a/ports/spirv-cross/portfile.cmake
+++ b/ports/spirv-cross/portfile.cmake
@@ -32,10 +32,9 @@ foreach(COMPONENT core c cpp glsl hlsl msl reflect util)
     vcpkg_fixup_cmake_targets(CONFIG_PATH share/spirv_cross_${COMPONENT}/cmake TARGET_PATH share/spirv_cross_${COMPONENT})
 endforeach()
 
-vcpkg_copy_tools(
-    TOOL_NAMES spirv-cross
-    AUTO_CLEAN
-)
+if(BUILD_CLI)
+    vcpkg_copy_tools(TOOL_NAMES spirv-cross AUTO_CLEAN)
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/spirv-cross/vcpkg.json
+++ b/ports/spirv-cross/vcpkg.json
@@ -5,6 +5,14 @@
   "description": "SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Cross",
   "dependencies": [
-    "spirv-headers"
+    "spirv-headers",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/spirv-cross/vcpkg.json
+++ b/ports/spirv-cross/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "spirv-cross",
   "version-date": "2021-01-15",
-  "port-version": 1,
+  "port-version": 2,
   "description": "SPIRV-Cross is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.",
   "homepage": "https://github.com/KhronosGroup/SPIRV-Cross",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6434,7 +6434,7 @@
     },
     "spirv-cross": {
       "baseline": "2021-01-15",
-      "port-version": 1
+      "port-version": 2
     },
     "spirv-headers": {
       "baseline": "2021-03-25",

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9fd391bcfaa13ffa80c32851e4fc7c2fbebc3873",
+      "git-tree": "9adc9e1ab78dd956558b40aa39767262a251eca6",
       "version-date": "2021-01-15",
       "port-version": 2
     },

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f4744c7652c6a3d082d81dc279ba8d31a1799648",
+      "git-tree": "9fd391bcfaa13ffa80c32851e4fc7c2fbebc3873",
       "version-date": "2021-01-15",
       "port-version": 2
     },

--- a/versions/s-/spirv-cross.json
+++ b/versions/s-/spirv-cross.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f4744c7652c6a3d082d81dc279ba8d31a1799648",
+      "version-date": "2021-01-15",
+      "port-version": 2
+    },
+    {
       "git-tree": "ea4c1654c9909ec0b4cba6abdf37dbd1ac6bba53",
       "version-date": "2021-01-15",
       "port-version": 1


### PR DESCRIPTION
### What does your PR fix?  

1. Fix port bug. It tries to install CLI tools which are not built with iOS triplets.
2. Use `vcpkg-cmake`, `vcpkg-cmake-config`

### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Only several community triplets.

* `arm64-ios`
* `x64-ios`

### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes :D
