### PR TITLE
add InitializeVcpkg CMake module

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,18 +275,17 @@ Unfortunately, you'll have to add this to each profile.
 
 ### Vcpkg as a Submodule
 
-When using vcpkg as a submodule of your project,
-you can add the following to your CMakeLists.txt before the first `project()` call,
-instead of passing `CMAKE_TOOLCHAIN_FILE` to the cmake invocation.
+When using vcpkg as a submodule of your project, copy the
+`docs/examples/InitializeVcpkg.cmake` module into your project and add
 
 ```cmake
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
-  CACHE STRING "Vcpkg toolchain file")
+include(InitializeVcpkg)
 ```
 
-This will still allow people to not use vcpkg,
-by passing the `CMAKE_TOOLCHAIN_FILE` directly,
-but it will make the configure-build step slightly easier.
+before the first `project()` call. This automatically clones the submodule
+and sets `CMAKE_TOOLCHAIN_FILE`. It also allows users to use a vcpkg
+repository at a path specified by `VCPKG_ROOT` instead of the submodule or
+disable vcpkg by setting `VCPKG=OFF`.
 
 [getting-started:using-a-package]: docs/examples/installing-and-using-packages.md
 [getting-started:integration]: docs/users/integration.md

--- a/docs/examples/InitializeVcpkg.cmake
+++ b/docs/examples/InitializeVcpkg.cmake
@@ -1,0 +1,48 @@
+#[=======================================================================[.rst:
+InitializeVcpkg
+---------------
+
+Initialize a vcpkg Git submodule, or alternatively use a vcpkg repository
+at a path specified by ``VCPKG_ROOT``. Whether vcpkg is used is controlled
+by the ``VCPKG`` option, which defaults to `ON`.
+
+This module must be included before the first call to `project()`.
+
+#]=======================================================================]
+
+option(VCPKG "Use vcpkg for dependencies" ON)
+set(VCPKG_ROOT "${CMAKE_SOURCE_DIR}/vcpkg" CACHE STRING "Path to the vcpkg Git repository")
+
+if(VCPKG)
+  if(NOT VCPKG_ROOT STREQUAL "${CMAKE_SOURCE_DIR}/vcpkg")
+    message(STATUS "Using dependencies from vcpkg repository at ${VCPKG_ROOT}")
+
+    if(NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
+      message(FATAL_ERROR "${VCPKG_ROOT} is not a valid vcpkg root directory. Set VCPKG_ROOT to a root directory of a vcpkg Git repository.")
+    endif()
+  else()
+    message(STATUS "Using dependencies from vcpkg Git submodule")
+    set(VCPKG_ROOT "${CMAKE_SOURCE_DIR}/vcpkg")
+
+    if(NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
+      find_package(Git)
+      if(NOT GIT_FOUND)
+        message(FATAL_ERROR "Unable to initialize vcpkg Git submodule because CMake was unable to find a git executable.")
+      endif()
+
+      message(STATUS "Initializing vcpkg Git submodule")
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule init
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      )
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule update
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      )
+    endif()
+  endif()
+
+  set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+else()
+  message(STATUS "Using dependencies from system")
+endif()


### PR DESCRIPTION
This CMake module can be included to automatically initialize a vcpkg Git submodule, or alternatively allow the user to specify a `VCPKG_ROOT` path manually to use a vcpkg repository outside the repository of the CMake project. This is intended to be copied verbatim into a CMake project because the presence of the vcpkg repository is not yet established when this is used.

I don't know if `docs/examples` is the best place for this, but nowhere else seemed better.