### PR TITLE
[readosm] Revise portfile, install pc file for windows

### DIFF
--- a/ports/readosm/fix-makefiles.patch
+++ b/ports/readosm/fix-makefiles.patch
@@ -37,10 +37,8 @@ diff --git a/nmake.opt b/nmake.opt
 index 5e45c0e..61c44f9 100644
 --- a/nmake.opt
 +++ b/nmake.opt
-@@ -1,8 +1,8 @@
- # Directory tree where ReadOSM will be installed.
--INSTDIR=C:\OSGeo4W
-+INSTDIR=$(INST_DIR)
+@@ -2,7 +2,7 @@
+ INSTDIR=C:\OSGeo4W
  
  # Uncomment the first for an optimized build, or the second for debug.
 -OPTFLAGS=	/nologo /Ox /fp:precise /W3 /MD /D_CRT_SECURE_NO_WARNINGS \

--- a/ports/readosm/pc-file.patch
+++ b/ports/readosm/pc-file.patch
@@ -1,0 +1,12 @@
+diff --git a/readosm.pc.in b/readosm.pc.in
+index c1a0961..2417433 100644
+--- a/readosm.pc.in
++++ b/readosm.pc.in
+@@ -8,5 +8,6 @@ includedir=@includedir@
+ Name: readosm
+ Description: a simple library parsing Open Street Map files
+ Version: @VERSION@
+-Libs: -L${libdir} -lreadosm -lz -lexpat
++Requires.private: expat zlib
++Libs: -L${libdir} -lreadosm
+ Cflags: -I${includedir} 

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -1,89 +1,74 @@
 set(READOSM_VERSION_STR "1.1.0a")
 vcpkg_download_distfile(ARCHIVE
-    URLS "http://www.gaia-gis.it/gaia-sins/readosm-sources/readosm-${READOSM_VERSION_STR}.tar.gz"
+    URLS "https://www.gaia-gis.it/gaia-sins/readosm-sources/readosm-${READOSM_VERSION_STR}.tar.gz"
     FILENAME "readosm-${READOSM_VERSION_STR}.tar.gz"
     SHA512 ec8516cdd0b02027cef8674926653f8bc76e2082c778b02fb2ebcfa6d01e21757aaa4fd5d5104059e2f5ba97190183e60184f381bfd592a635805aa35cd7a682
 )
 
-if (VCPKG_TARGET_IS_WINDOWS)
-  vcpkg_extract_source_archive_ex(
-      OUT_SOURCE_PATH SOURCE_PATH
-      ARCHIVE ${ARCHIVE}
-      PATCHES
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
         fix-makefiles.patch
-  )
+)
 
-  if(VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    set(CL_FLAGS_DBG "/MDd /Zi")
-    set(CL_FLAGS_REL "/MD /Ox")
-    set(EXPAT_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/libexpat.lib")
-    set(EXPAT_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/libexpatd.lib")
-  else()
-    set(CL_FLAGS_DBG "/MTd /Zi")
-    set(CL_FLAGS_REL "/MT /Ox")
-    set(EXPAT_LIBS_REL "${CURRENT_INSTALLED_DIR}/lib/libexpatMD.lib")
-    set(EXPAT_LIBS_DBG "${CURRENT_INSTALLED_DIR}/debug/lib/libexpatdMD.lib")
-  endif()
+set(PKGCONFIG_MODULES expat zlib)
 
-  if(VCPKG_TARGET_IS_UWP)
-    set(UWP_LIBS windowsapp.lib)
-    set(UWP_LINK_FLAGS /APPCONTAINER)
-  endif()
+if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    x_vcpkg_pkgconfig_get_modules(
+        PREFIX PKGCONFIG
+        MODULES --msvc-syntax ${PKGCONFIG_MODULES}
+        LIBS
+    )
 
-  set(LIBS_ALL_DBG
-    "${CURRENT_INSTALLED_DIR}/debug/lib/zlibd.lib \
-    ${UWP_LIBS} \
-    ${EXPAT_LIBS_DBG}"
-  )
-  set(LIBS_ALL_REL
-    "${CURRENT_INSTALLED_DIR}/lib/zlib.lib \
-    ${UWP_LIBS} \
-    ${EXPAT_LIBS_REL}"
-  )
+    if(VCPKG_TARGET_IS_UWP)
+        set(UWP_LIBS windowsapp.lib)
+        set(UWP_LINK_FLAGS /APPCONTAINER)
+    endif()
 
-  string(REPLACE "/" "\\\\" INST_DIR ${CURRENT_PACKAGES_DIR})
-  list(APPEND OPTIONS_RELEASE
-    "LINK_FLAGS=${UWP_LINK_FLAGS}" "INST_DIR=${INST_DIR}" "CL_FLAGS=${CL_FLAGS_REL}" "LIBS_ALL=${LIBS_ALL_REL}"
-  )
-  list(APPEND OPTIONS_DEBUG
-    "LINK_FLAGS=${UWP_LINK_FLAGS} /debug" "INST_DIR=${INST_DIR}\\debug" "CL_FLAGS=${CL_FLAGS_DBG}" "LIBS_ALL=${LIBS_ALL_DBG}"
-   )
+    file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}" INST_DIR)
 
-  vcpkg_install_nmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS_RELEASE
-      ${OPTIONS_RELEASE}
-    OPTIONS_DEBUG
-      ${OPTIONS_DEBUG}
-  )
+    vcpkg_install_nmake(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS_RELEASE
+            "INSTDIR=${INST_DIR}"
+            "LINK_FLAGS=${UWP_LINK_FLAGS}"
+            "LIBS_ALL=${PKGCONFIG_LIBS_RELEASE} ${UWP_LIBS}"
+        OPTIONS_DEBUG
+            "INSTDIR=${INST_DIR}\\debug"
+            "LINK_FLAGS=${UWP_LINK_FLAGS} /debug"
+            "LIBS_ALL=${PKGCONFIG_LIBS_DEBUG} ${UWP_LIBS}"
+    )
 
-  if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib)
-  else()
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/lib/readosm.lib)
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib ${CURRENT_PACKAGES_DIR}/lib/readosm.lib)
-    file(RENAME ${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib ${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib)
-  endif()
-  file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX) # Build in UNIX
-  vcpkg_extract_source_archive_ex(
-    ARCHIVE ${ARCHIVE}
-    OUT_SOURCE_PATH SOURCE_PATH
-  )
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib")
+    else()
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/readosm.lib")
+        file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/readosm_i.lib" "${CURRENT_PACKAGES_DIR}/lib/readosm.lib")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/readosm_i.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/readosm.lib")
+    endif()
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-  vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
-    AUTOCONFIG
-    OPTIONS
-      "LIBS=-lpthread -ldl -lstdc++ -lm"
-  )
+else()
+    x_vcpkg_pkgconfig_get_modules(
+        PREFIX PKGCONFIG
+        MODULES ${PKGCONFIG_MODULES}
+        LIBS
+    )
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        AUTOCONFIG
+        OPTIONS_RELEASE
+            "LIBS=${PKGCONFIG_LIBS_RELEASE} \$LIBS"
+        OPTIONS_DEBUG
+            "LIBS=${PKGCONFIG_LIBS_DEBUG} \$LIBS"
+    )
 
-  vcpkg_install_make()
-  vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
+    vcpkg_install_make()
+    vcpkg_fixup_pkgconfig()
 endif()
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/readosm/portfile.cmake
+++ b/ports/readosm/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_extract_source_archive(SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
     PATCHES
         fix-makefiles.patch
+        pc-file.patch
 )
 
 set(PKGCONFIG_MODULES expat zlib)
@@ -51,6 +52,20 @@ if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     endif()
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+    set(infile "${SOURCE_PATH}/readosm.pc.in")
+    set(outfile "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/readosm.pc")
+    set(VERSION "${READOSM_VERSION_STR}")
+    set(exec_prefix [[${prefix}]])
+    set(libdir [[${prefix}/lib]])
+    set(includedir [[${prefix}/include]])
+    list(JOIN pkg_config_modules " " requires_private)
+    configure_file("${infile}" "${outfile}" @ONLY)
+    if(NOT DEFINED VCPKG_BUILD_TYPE)
+        set(outfile "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/readosm.pc")
+        set(includedir [[${prefix}/../include]])
+        configure_file("${infile}" "${outfile}" @ONLY)
+    endif()
+
 else()
     x_vcpkg_pkgconfig_get_modules(
         PREFIX PKGCONFIG
@@ -67,8 +82,9 @@ else()
     )
 
     vcpkg_install_make()
-    vcpkg_fixup_pkgconfig()
 endif()
+
+vcpkg_fixup_pkgconfig()
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/readosm/vcpkg.json
+++ b/ports/readosm/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "readosm",
   "version-string": "1.1.0a",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ReadOSM is an open source library to extract valid data from within an Open Street Map input file (.osm or .osm.pbf)",
   "homepage": "https://www.gaia-gis.it/gaia-sins/readosm-sources",
   "dependencies": [
     "expat",
+    {
+      "name": "vcpkg-pkgconfig-get-modules",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1664,6 +1664,7 @@ openscap:x64-windows-static-md=fail
 portmidi:x64-windows-static-md=fail
 quantlib:x64-windows-static-md=fail
 sentencepiece:x64-windows-static-md=fail
+spatialite-tools:x64-windows-static-md=fail
 symengine:x64-windows-static-md=fail
 teemo:x64-windows-static-md=fail
 unicorn:x64-windows-static-md=fail

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1663,7 +1663,6 @@ open62541:x64-windows-static-md=fail
 openscap:x64-windows-static-md=fail
 portmidi:x64-windows-static-md=fail
 quantlib:x64-windows-static-md=fail
-readosm:x64-windows-static-md=fail
 sentencepiece:x64-windows-static-md=fail
 symengine:x64-windows-static-md=fail
 teemo:x64-windows-static-md=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5914,7 +5914,7 @@
     },
     "readosm": {
       "baseline": "1.1.0a",
-      "port-version": 1
+      "port-version": 2
     },
     "realsense2": {
       "baseline": "2.49.0",

--- a/versions/r-/readosm.json
+++ b/versions/r-/readosm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f47d926f3c9e3d84c91fd903e5bc1533759cfcee",
+      "version-string": "1.1.0a",
+      "port-version": 2
+    },
+    {
       "git-tree": "32ab4a5c33cd4854b932547e791af28e39e4586e",
       "version-string": "1.1.0a",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?  
  Revises the portfile. Uses pkgconfig for nmake and autotools.
  Installs pc file also for windows. (Needed for #21594.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
