### PR TITLE
[hunspell] move gettext dependency to `tools` feature

### DIFF
--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -6,18 +6,20 @@
   "homepage": "https://github.com/hunspell/hunspell",
   "supports": "!((arm | uwp) & windows)",
   "dependencies": [
-    {
-      "name": "gettext",
-      "host": true,
-      "features": [
-        "tools"
-      ]
-    },
     "libiconv"
   ],
   "features": {
     "tools": {
-      "description": "Build hunspell tools"
+      "description": "Build hunspell tools",
+      "dependencies": [
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
     }
   }
 }

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hunspell",
   "version": "1.7.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
   "supports": "!((arm | uwp) & windows)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2702,7 +2702,7 @@
     },
     "hunspell": {
       "baseline": "1.7.0",
-      "port-version": 5
+      "port-version": 6
     },
     "hwloc": {
       "baseline": "2.5.0",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "459909cbf52806ce8df547bed3265d7d5c4abfc2",
+      "version": "1.7.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "2a0514dd8b3893b6d3a502fbf55156e9e971d6f7",
       "version": "1.7.0",
       "port-version": 5


### PR DESCRIPTION


- #### What does your PR fix?  
 Hunspell requires gettext only for tools. It's not necessary to install gettext for core feature.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
