### PR TITLE
[vcpkg baseline][rtaudio] Add feature alsa and fix dependency

### DIFF
--- a/ports/rtaudio/fix-alsa.patch
+++ b/ports/rtaudio/fix-alsa.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a59e8bb..1334f5a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,12 +123,12 @@ endif()
+ # ALSA
+ if (RTAUDIO_API_ALSA)
+   set(NEED_PTHREAD ON)
+-  find_package(ALSA)
++  find_package(ALSA REQUIRED)
+   if (NOT ALSA_FOUND)
+     message(FATAL_ERROR "ALSA API requested but no ALSA dev libraries found")
+   endif()
+   list(APPEND INCDIRS ${ALSA_INCLUDE_DIR})
+-  list(APPEND LINKLIBS ${ALSA_LIBRARY})
++  list(APPEND LINKLIBS ${ALSA_LIBRARY} dl)
+   list(APPEND PKGCONFIG_REQUIRES "alsa")
+   list(APPEND API_DEFS "-D__LINUX_ALSA__")
+   list(APPEND API_LIST "alsa")

--- a/ports/rtaudio/portfile.cmake
+++ b/ports/rtaudio/portfile.cmake
@@ -1,31 +1,22 @@
-vcpkg_fail_port_install(ON_TARGET "UWP")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO thestk/rtaudio
     REF bc7ad66581947f810ff4460396bbbd1846b1e7c8
     SHA512 ef5a41df15a8486550fb791ac21fcee4ecbf726fe9e91a56fcdd437cd554ea242f08c1061a9c6d5c261d721d86fbbcb32ce64db030976150862ed42a40137fc7
     HEAD_REF master
+    PATCHES fix-alsa.patch
 )
 
-if(VCPKG_HOST_IS_LINUX)
-    message(WARNING "rtaudio requires ALSA on Linux; this is available on ubuntu via apt install libasound2-dev")
-endif()
-
-if(VCPKG_CRT_LINKAGE STREQUAL static)
-    set(RTAUDIO_STATIC_MSVCRT ON)
-else()
-    set(RTAUDIO_STATIC_MSVCRT OFF)
-endif()
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" RTAUDIO_STATIC_MSVCRT)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         asio  RTAUDIO_API_ASIO
+        alsa  RTAUDIO_API_ALSA
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DRTAUDIO_STATIC_MSVCRT=${RTAUDIO_STATIC_MSVCRT}
         -DRTAUDIO_API_JACK=OFF
@@ -35,10 +26,9 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-
-vcpkg_fixup_pkgconfig()
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/rtaudio/vcpkg.json
+++ b/ports/rtaudio/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtaudio",
   "version-date": "2021-08-15",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of C++ classes that provide a common API for realtime audio input/output across Linux (native ALSA, JACK, PulseAudio and OSS), Macintosh OS X (CoreAudio and JACK), and Windows (DirectSound, ASIO and WASAPI) operating systems.",
   "homepage": "https://github.com/thestk/rtaudio",
   "supports": "!uwp",
@@ -16,6 +16,12 @@
     }
   ],
   "features": {
+    "alsa": {
+      "description": "Build ALSA API",
+      "dependencies": [
+        "alsa"
+      ]
+    },
     "asio": {
       "description": "Build with ASIO backend"
     }

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -36,9 +36,6 @@ APT_PACKAGES="$APT_PACKAGES python3-setuptools python3-mako"
 # Additionally required by some packages to install additional python packages
 APT_PACKAGES="$APT_PACKAGES python3-pip"
 
-# Additionally required by rtaudio
-APT_PACKAGES="$APT_PACKAGES libasound2-dev"
-
 # Additionally required by qtwebengine
 APT_PACKAGES="$APT_PACKAGES nodejs"
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6042,7 +6042,7 @@
     },
     "rtaudio": {
       "baseline": "2021-08-15",
-      "port-version": 1
+      "port-version": 2
     },
     "rtlsdr": {
       "baseline": "2020-04-16",

--- a/versions/r-/rtaudio.json
+++ b/versions/r-/rtaudio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "603a92374a5c37c3efb3bc48aaee17b64046f7be",
+      "version-date": "2021-08-15",
+      "port-version": 2
+    },
+    {
       "git-tree": "89b766b5d1b97a4e306dd358db18a2a5d0505824",
       "version-date": "2021-08-15",
       "port-version": 1


### PR DESCRIPTION
Fix baseline issue when automatic using dependency alsa:
```
[12/20] : && /usr/bin/c++ -fPIC -Wall -Werror -g  tests/CMakeFiles/testall.dir/testall.cpp.o -o tests/testall  librtaudio.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a  -lpthread && :
FAILED: tests/testall 
: && /usr/bin/c++ -fPIC -Wall -Werror -g  tests/CMakeFiles/testall.dir/testall.cpp.o -o tests/testall  librtaudio.a  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a  -lpthread && :
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(dlmisc.o): in function `snd_dlinfo_origin':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:72: undefined reference to `dladdr1'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:74: undefined reference to `dlinfo'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(dlmisc.o): in function `__snd_dlopen':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:155: undefined reference to `dlopen'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:161: undefined reference to `dlerror'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(dlmisc.o): in function `snd_dlclose':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:191: undefined reference to `dlclose'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(dlmisc.o): in function `snd_dlsym_verify':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:221: undefined reference to `dlsym'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(dlmisc.o): in function `snd_dlsym':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/.././../src/v1.2.5.1-98fc6d1525.clean/src/dlmisc.c:269: undefined reference to `dlsym'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(pcm_ladspa.o): in function `snd_pcm_ladspa_free_plugins':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:188: undefined reference to `dlclose'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(pcm_ladspa.o): in function `snd_pcm_ladspa_check_file':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:1094: undefined reference to `dlopen'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:1096: undefined reference to `dlsym'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:1114: undefined reference to `dlclose'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:1131: undefined reference to `dlclose'
/usr/bin/ld: /mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_ladspa.c:1139: undefined reference to `dlclose'
/usr/bin/ld: /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libasound.a(pcm_meter.o): in function `snd_pcm_meter_add_scope_conf':
/mnt/vcpkg-ci/buildtrees/alsa/x64-linux-dbg/src/pcm/../.././../src/v1.2.5.1-98fc6d1525.clean/src/pcm/pcm_meter.c:676: undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
```
Add alsa as a new feature to avoid this.

Already tested this feature successfully in x64-linux and this feature only support Linux.
No need to add warning message because the dependency alsa only support Linux.