### PR TITLE
[hpx] Turn back on on Linux.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -421,7 +421,6 @@ hiredis:arm-uwp=fail
 hiredis:x64-uwp=fail
 hpx:x64-windows-static=fail
 hpx:arm64-windows=fail
-hpx:x64-linux=fail
 hunspell:x64-windows-static-md=fail
 ideviceinstaller:x64-windows-static-md=fail
 idevicerestore:x64-linux=fail


### PR DESCRIPTION
Probably fixed by https://github.com/microsoft/vcpkg/pull/21135/ or https://github.com/microsoft/vcpkg/pull/19585
