### PR TITLE
[tinyspline] Fix target "tinysplinecxx::tinysplinecxx" was not found

### DIFF
--- a/ports/tinyspline/portfile.cmake
+++ b/ports/tinyspline/portfile.cmake
@@ -18,7 +18,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tinyspline DO_NOT_DELETE_PARENT_CONFIG_PATH)
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/tinysplinecxx)
+vcpkg_cmake_config_fixup(PACKAGE_NAME tinysplinecxx CONFIG_PATH lib/cmake/tinysplinecxx)
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/tinyspline/vcpkg.json
+++ b/ports/tinyspline/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tinyspline",
   "version": "0.3.0",
+  "port-version": 1,
   "description": "Library for NURBS, B-Splines, and Bézier curves, allowing you to handle splines with ease",
   "homepage": "https://github.com/msteinbeck/tinyspline",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6770,7 +6770,7 @@
     },
     "tinyspline": {
       "baseline": "0.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tinythread": {
       "baseline": "1.1",

--- a/versions/t-/tinyspline.json
+++ b/versions/t-/tinyspline.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6ad4ac2f1aa4dc253ada4023358286ab6bdc24a6",
+      "version": "0.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4e3b92c86bcbdd44171e07b3421d56f07e302fe4",
       "version": "0.3.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #21558 
  Fix cmake error as below, already test usage, pass.
```
CMake Error at /Users/USER/vcpkg/scripts/buildsystems/vcpkg.cmake:540 (_add_executable):
   Target "tinytest" links to target "tinysplinecxx::tinysplinecxx" but the target was not found.  Perhaps a find_package() call is missing for an IMPORTED target, or an ALIAS target is missing?
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <As before, Yes>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`
