### PR TITLE
[v8] msys git succeeds but returns error code 255 which is neglible as far as I can tell.

### DIFF
--- a/ports/v8/portfile.cmake
+++ b/ports/v8/portfile.cmake
@@ -48,9 +48,10 @@ function(v8_fetch)
                 LOGNAME build-${TARGET_TRIPLET})
   else()
         vcpkg_execute_required_process(
-                COMMAND ${GIT} clone --depth 1 ${V8_URL} ${V8_DESTINATION}
+                COMMAND ${GIT} clone --no-checkout --depth 1 ${V8_URL} ${V8_DESTINATION}
                 WORKING_DIRECTORY ${V8_SOURCE}
-                LOGNAME build-${TARGET_TRIPLET})
+                LOGNAME build-${TARGET_TRIPLET}
+                VALID_EXIT_CODE 255)
         vcpkg_execute_required_process(
                 COMMAND ${GIT} fetch --depth 1 origin ${V8_REF}
                 WORKING_DIRECTORY ${V8_SOURCE}/${V8_DESTINATION}

--- a/ports/v8/vcpkg.json
+++ b/ports/v8/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "v8",
   "version": "9.1.269.39",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Google Chrome's JavaScript engine",
   "homepage": "https://v8.dev",
   "supports": "!(arm | arm64 | uwp | osx)",

--- a/scripts/cmake/vcpkg_execute_required_process.cmake
+++ b/scripts/cmake/vcpkg_execute_required_process.cmake
@@ -50,7 +50,7 @@ This should be a unique name for different triplets so that the logs don't confl
 function(vcpkg_execute_required_process)
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "ALLOW_IN_DOWNLOAD_MODE"
-        "WORKING_DIRECTORY;LOGNAME;TIMEOUT;OUTPUT_VARIABLE;ERROR_VARIABLE"
+        "WORKING_DIRECTORY;LOGNAME;TIMEOUT;OUTPUT_VARIABLE;ERROR_VARIABLE;VALID_EXIT_CODE"
         "COMMAND"
     )
 
@@ -110,7 +110,10 @@ Halting portfile execution.
         ${output_variable_param}
         ${error_variable_param}
     )
-    if(NOT error_code EQUAL 0)
+    if(NOT DEFINED arg_VALID_EXIT_CODE)
+        set(arg_VALID_EXIT_CODE 0)
+    endif()
+    if(NOT error_code EQUAL 0 AND NOT error_code EQUAL ${arg_VALID_EXIT_CODE})
         set(stringified_logs "")
         foreach(log IN ITEMS "${log_out}" "${log_err}")
             if(NOT EXISTS "${log}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7018,7 +7018,7 @@
     },
     "v8": {
       "baseline": "9.1.269.39",
-      "port-version": 1
+      "port-version": 2
     },
     "valijson": {
       "baseline": "0.6",

--- a/versions/v-/v8.json
+++ b/versions/v-/v8.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "512492e8af89bfe86da3000bb123645fdffb596b",
+      "version": "9.1.269.39",
+      "port-version": 2
+    },
+    {
       "git-tree": "d179f8f99ecce385eab497b2850e605976f4d9d5",
       "version": "9.1.269.39",
       "port-version": 1


### PR DESCRIPTION
Fixes v8. The git tool returns a 255 when trying to checkout the googletest repo which itself has an issue with finding the default branch to checkout. Adding the --no-checkout seems to resolve any error associated with finding the default branch but git still returns 255. After looking through the code, it seems the 255 is not really relevant to any error and only seems to happen on the msys git version.

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
