### PR TITLE
[plplot] Correct control of wxwidgets

### DIFF
--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -18,7 +18,8 @@ vcpkg_from_sourceforge(
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        wxwidgets BUILD_with_wxwidgets
+        wxwidgets PLD_wxwidgets
+        wxwidgets ENABLE_wxwidgets
 )
 
 vcpkg_cmake_configure(

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.13.0",
-  "port-version": 12,
+  "port-version": 13,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "dependencies": [
     "bzip2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5278,7 +5278,7 @@
     },
     "plplot": {
       "baseline": "5.13.0",
-      "port-version": 12
+      "port-version": 13
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d3cf98f0e002ea3b2f196af0c43a8a4cc885255c",
+      "version-semver": "5.13.0",
+      "port-version": 13
+    },
+    {
       "git-tree": "81172e3761f2638245de863b13d8e13cbf08188d",
       "version-semver": "5.13.0",
       "port-version": 12


### PR DESCRIPTION
probably broken by https://github.com/microsoft/vcpkg/pull/21303/

This caused wxwidgets to get set on as far as the upstream build system cares if wxwidgets was built first regardless of the feature setting, which broke in CI with unresolved external symbol errors in wxwidgets' internals.
