### PR TITLE
[qmake] Check build type for debug/release

### DIFF
--- a/scripts/cmake/vcpkg_build_qmake.cmake
+++ b/scripts/cmake/vcpkg_build_qmake.cmake
@@ -62,7 +62,12 @@ function(vcpkg_build_qmake)
     set(path_suffix_release "")
     set(targets_release "${arg_RELEASE_TARGETS}")
 
-    foreach(build_type IN ITEMS debug release)
+    if(NOT DEFINED VCPKG_BUILD_TYPE)
+        set(items debug release)
+    else()
+        set(items release)
+    endif()
+    foreach(build_type IN ITEMS ${items})
         set(current_installed_prefix "${CURRENT_INSTALLED_DIR}${path_suffix_${build_type}}")
 
         vcpkg_add_to_path(PREPEND "${current_installed_prefix}/lib" "${current_installed_prefix}/bin")


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  The existing qmake build script assumes that both a debug and release build will be made and would throw errors if only a release build was being made (notably with qt5-*). This PR checks the `VCPKG_BUILD_TYPE` to ensure those errors don't occur.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  I have not updated a port.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
