### PR TITLE
[libical] New "glib" feature

### DIFF
--- a/ports/libical/glib.patch
+++ b/ports/libical/glib.patch
@@ -1,0 +1,45 @@
+diff --git a/src/libical-glib/CMakeLists.txt b/src/libical-glib/CMakeLists.txt
+index f734024e..de5e6210 100644
+--- a/src/libical-glib/CMakeLists.txt
++++ b/src/libical-glib/CMakeLists.txt
+@@ -121,7 +121,7 @@ add_dependencies(ical-glib ical-header)
+ target_compile_options(ical-glib PRIVATE ${GLIB_CFLAGS})
+ target_compile_definitions(ical-glib PRIVATE -DG_LOG_DOMAIN="libical-glib" -DLIBICAL_GLIB_COMPILATION)
+ target_link_libraries(ical-glib PRIVATE ical ${GLIB_LIBRARIES})
+-if(NOT SHARED_ONLY)
++if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
+   add_library(ical-glib-static STATIC ${LIBICAL_GLIB_SOURCES})
+   add_dependencies(ical-glib-static ical-header)
+   target_compile_options(ical-glib-static PUBLIC ${GLIB_CFLAGS} -DG_LOG_DOMAIN="libical-glib" -DLIBICAL_GLIB_COMPILATION)
+@@ -217,11 +217,11 @@ endif()
+ 
+ if(MSVC)
+   set_target_properties(ical-glib PROPERTIES PREFIX "lib")
+-  if(NOT SHARED_ONLY)
++  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
+     set_target_properties(ical-glib-static PROPERTIES PREFIX "lib")
+   endif()
+ else()
+-  if(NOT SHARED_ONLY)
++  if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
+     set_target_properties(ical-glib-static PROPERTIES OUTPUT_NAME "ical-glib")
+   endif()
+ endif()
+@@ -230,7 +230,7 @@ set_target_properties(ical-glib PROPERTIES
+   SOVERSION ${LIBICAL_LIB_MAJOR_VERSION}
+ )
+ set_target_properties(ical-glib PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+-if(NOT SHARED_ONLY)
++if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
+   set_target_properties(ical-glib-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+ endif()
+ 
+@@ -239,7 +239,7 @@ install(
+   EXPORT icalTargets
+   DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS}
+ )
+-if(NOT SHARED_ONLY)
++if(NOT SHARED_ONLY AND NOT STATIC_ONLY)
+   install(
+     TARGETS ical-glib-static
+     EXPORT icalTargets

--- a/ports/libical/portfile.cmake
+++ b/ports/libical/portfile.cmake
@@ -3,6 +3,8 @@ vcpkg_from_github(
     REPO libical/libical
     REF v3.0.11
     SHA512 cdee86c50edc2373ab2024d7d4ae26dd4b9a728dbc13083472c4923c67f61ff3cef7d43edca762c6a11979d2040fc1576a033eaa23a19e58af8f14a7d67fc139
+    PATCHES
+        glib.patch # https://github.com/libical/libical/pull/530
 )
 
 vcpkg_find_acquire_program(PERL)
@@ -10,6 +12,8 @@ get_filename_component(PERL_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path(${PERL_PATH})
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "glib"      ICAL_GLIB
     INVERTED_FEATURES
         "rscale"    CMAKE_DISABLE_FIND_PACKAGE_ICU
 )
@@ -24,8 +28,6 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCMAKE_DISABLE_FIND_PACKAGE_BDB=ON
-        -DUSE_BUILTIN_TZDATA=ON
-        -DICAL_GLIB=OFF
         -DICAL_BUILD_DOCS=OFF
         -DLIBICAL_BUILD_TESTING=OFF
         ${FEATURE_OPTIONS}

--- a/ports/libical/vcpkg.json
+++ b/ports/libical/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libical",
   "version": "3.0.11",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Reference implementation of the iCalendar data type and serialization format",
   "homepage": "https://github.com/libical/libical",
   "dependencies": [
@@ -15,6 +15,13 @@
     }
   ],
   "features": {
+    "glib": {
+      "description": "Build libical-glib (GObject) interface",
+      "dependencies": [
+        "glib",
+        "libxml2"
+      ]
+    },
     "rscale": {
       "description": "Support for RSCALE element",
       "supports": "!static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3534,7 +3534,7 @@
     },
     "libical": {
       "baseline": "3.0.11",
-      "port-version": 1
+      "port-version": 2
     },
     "libiconv": {
       "baseline": "1.16",

--- a/versions/l-/libical.json
+++ b/versions/l-/libical.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bdead750bf04aaab36809e36002670357713801",
+      "version": "3.0.11",
+      "port-version": 2
+    },
+    {
       "git-tree": "409bb4044895d73c1af9720e1d77f8ef46eafb73",
       "version": "3.0.11",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
    - add glib feauture, which enables compilation of libical-glib
    - don't explicitly enable BUILTIN_TZDATA, this gets enabled
      automatically depending on the system (currently on Windows only)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change. The `glib` feature, however, is limited by the `glib`'s own limitations.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
