### PR TITLE
[vcpkg baseline][wavelib] Fix parallel build

### DIFF
--- a/ports/wavelib/disable-test.patch
+++ b/ports/wavelib/disable-test.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e2e8a4d..d228001 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -48,7 +48,6 @@ endif()
+ 
+ add_subdirectory(src)
+ add_subdirectory(auxiliary)
+-add_subdirectory(test) 
+ 
+ install(DIRECTORY ${WAVELIB_SRC_ROOT}/header/
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/ports/wavelib/portfile.cmake
+++ b/ports/wavelib/portfile.cmake
@@ -6,11 +6,12 @@ vcpkg_from_github(
     REF a92456d2e20451772dd76c2a0a3368537ee94184
     SHA512 d14ebc0d96e86d9226fa346cb6ef157b2949985dfedf4228dd4356ccacaac48fde47edfcba31e7455b25dc95c7a1cb148ad6845143c17ae5972659c98e683865
     HEAD_REF master
+    PATCHES
+        disable-test.patch
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    DISABLE_PARALLEL_CONFIGURE
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_UT=OFF
 )

--- a/ports/wavelib/vcpkg.json
+++ b/ports/wavelib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wavelib",
-  "version-date": "2021-08-10",
+  "version-date": "2021-11-26",
   "description": "C implementation of wavelet transform (DWT,SWT and MODWT)",
   "homepage": "https://github.com/rafat/wavelib",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7137,7 +7137,7 @@
       "port-version": 0
     },
     "wavelib": {
-      "baseline": "2021-08-10",
+      "baseline": "2021-11-26",
       "port-version": 0
     },
     "wavpack": {

--- a/versions/w-/wavelib.json
+++ b/versions/w-/wavelib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d8428a438c8eaf72dae62ada2a5dd3ddc58ca1ed",
+      "version-date": "2021-11-26",
+      "port-version": 0
+    },
+    {
       "git-tree": "606ab10437c3dbfcd902fdedd5599dca471a6dde",
       "version-date": "2021-08-10",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes parallel builds by disabling the test dir which creates test executables in the source dir.
  (Assumed to fix msbuild issue in #21507.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes