### PR TITLE
[vcpkg baseline][python3] Fix race during parallel install

### DIFF
--- a/ports/python3/0008-fix-parallel-install.patch
+++ b/ports/python3/0008-fix-parallel-install.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 790d974..88fc444 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -2019,6 +2019,10 @@ Python/thread.o: @THREADHEADERS@ $(srcdir)/Python/condvar.h
+ .PHONY: build_all_generate_profile build_all_merge_profile
+ .PHONY: gdbhooks
+ 
++# Serialize targets which may create <prefix>/lib
++libinstall:  altbininstall
++libainstall: altbininstall
++
+ # IF YOU PUT ANYTHING HERE IT WILL GO AWAY
+ # Local Variables:
+ # mode: makefile

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -13,6 +13,7 @@ set(PATCHES
     0003-devendor-external-dependencies.patch
     0004-dont-copy-vcruntime.patch
     0005-only-build-required-projects.patch
+    0008-fix-parallel-install.patch
 )
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(PREPEND PATCHES 0001-static-library.patch)

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-semver": "3.10.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5466,7 +5466,7 @@
     },
     "python3": {
       "baseline": "3.10.0",
-      "port-version": 2
+      "port-version": 3
     },
     "qca": {
       "baseline": "2.3.1",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f2b8029e8ffdc1cbbff8a40346ef5fa82c811616",
+      "version-semver": "3.10.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c8c0f995b8f1831fc7f345329c2ce0a80d717551",
       "version-semver": "3.10.0",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes a race between three targets that may want to create `<prefix>/lib>` (https://github.com/microsoft/vcpkg/pull/21507#issuecomment-979930815).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes