### PR TITLE
Enable tomlplusplus port for OSX and ARM

### DIFF
--- a/ports/tomlplusplus/portfile.cmake
+++ b/ports/tomlplusplus/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "osx" "uwp")
+vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/tomlplusplus/portfile.cmake
+++ b/ports/tomlplusplus/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO marzer/tomlplusplus
@@ -9,7 +7,7 @@ vcpkg_from_github(
 )
 
 vcpkg_configure_meson(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -Dgenerate_cmake_config=true
         -Dbuild_tests=false

--- a/ports/tomlplusplus/vcpkg.json
+++ b/ports/tomlplusplus/vcpkg.json
@@ -4,5 +4,5 @@
   "port-version": 1,
   "description": "Header-only TOML config file parser and serializer for modern C++.",
   "homepage": "https://marzer.github.io/tomlplusplus/",
-  "supports": "!(arm | uwp)"
+  "supports": "!uwp"
 }

--- a/ports/tomlplusplus/vcpkg.json
+++ b/ports/tomlplusplus/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tomlplusplus",
   "version": "2.5.0",
+  "port-version": 1,
   "description": "Header-only TOML config file parser and serializer for modern C++.",
   "homepage": "https://marzer.github.io/tomlplusplus/",
   "supports": "!(arm | uwp)"

--- a/ports/tomlplusplus/vcpkg.json
+++ b/ports/tomlplusplus/vcpkg.json
@@ -3,5 +3,5 @@
   "version": "2.5.0",
   "description": "Header-only TOML config file parser and serializer for modern C++.",
   "homepage": "https://marzer.github.io/tomlplusplus/",
-  "supports": "!(arm | uwp | osx)"
+  "supports": "!(arm | uwp)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6846,7 +6846,7 @@
     },
     "tomlplusplus": {
       "baseline": "2.5.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tool-meson": {
       "baseline": "0.58.1",

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6eeca4f5364d6ca8628aeecb25f005b31ccc2c14",
+      "git-tree": "be5f558a002098691a82ebb0c86fd19420f4ceaa",
       "version": "2.5.0",
       "port-version": 1
     },

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6a128968ba3461b10e1c0b633651e202413d2853",
+      "git-tree": "6eeca4f5364d6ca8628aeecb25f005b31ccc2c14",
       "version": "2.5.0",
       "port-version": 1
     },

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5e788e0b38a2700c7269dbe85f00b83a7e6859a4",
+      "git-tree": "6a128968ba3461b10e1c0b633651e202413d2853",
       "version": "2.5.0",
       "port-version": 1
     },

--- a/versions/t-/tomlplusplus.json
+++ b/versions/t-/tomlplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5e788e0b38a2700c7269dbe85f00b83a7e6859a4",
+      "version": "2.5.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "f28a45d07d6ff9059a273ab730c9bc36a57ef7aa",
       "version": "2.5.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  OSX was disabled in the original tomlplusplus port due to an [issue with meson](https://github.com/microsoft/vcpkg/issues/6645). That issue has been resolved and verified on OSX x64.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  
  Adds previously disabled support for:
  osx, Yes
 
The CI baseline does not contain entries for tomlplusplus, so it's left untouched.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes. Port version incremented to 1.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
