### PR TITLE
[boost-modular-build-helper] Add self to host dependency

### DIFF
--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,9 +1,13 @@
 {
   "name": "boost-modular-build-helper",
   "version": "1.77.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Internal vcpkg port used to build Boost libraries",
   "dependencies": [
+    {
+      "name": "boost-modular-build-helper",
+      "host": true
+    },
     "boost-uninstall"
   ]
 }

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "209dbfc4b3a370da362fe0d3dae8a72d56a8c41d",
+      "version": "1.77.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "aea8b4dbb8063db29d8ac843ef6aac35478bebaa",
       "version": "1.77.0",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -826,7 +826,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.77.0",
-      "port-version": 4
+      "port-version": 5
     },
     "boost-move": {
       "baseline": "1.77.0",


### PR DESCRIPTION
Since the boost components all use the `boost-modular-build.cmake` installed in the host triplet, add itself to host triplet dependencies to avoid missing script issues when building with unofficial triplet:
```
Starting package 1/59: boost-context:arm-linux
Building package boost-context[core]:arm-linux...
-- Using community triplet arm-linux. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /home/test/package/vcpkg/triplets/community/arm-linux.cmake
-- Using cached boostorg-context-boost-1.77.0.tar.gz.
-- Cleaning sources at /home/test/package/vcpkg/buildtrees/boost-context/src/ost-1.77.0-7a375ea06d.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source /home/test/package/vcpkg/downloads/boostorg-context-boost-1.77.0.tar.gz
-- Using source at /home/test/package/vcpkg/buildtrees/boost-context/src/ost-1.77.0-7a375ea06d.clean
CMake Error at ports/boost-context/portfile.cmake:19 (include):
  include could not find requested file:

    /home/test/package/vcpkg/installed/x64-linux/share/boost-build/boost-modular-build.cmake
Call Stack (most recent call first):
  scripts/ports.cmake:142 (include)
```

Examples:
- boost-atomic
https://github.com/microsoft/vcpkg/blob/3a68454afa67bde8b6e9e741536daa95d3785966/ports/boost-atomic/portfile.cmake#L22
- boost-chrono
https://github.com/microsoft/vcpkg/blob/3a68454afa67bde8b6e9e741536daa95d3785966/ports/boost-chrono/portfile.cmake#L14
- boost-container
https://github.com/microsoft/vcpkg/blob/master/ports/boost-container/portfile.cmake#L14

Related: #21740.