### PR TITLE
[pango] Update to 1.48.10 (microsoft#21747)

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/pango
-    REF  386639c3b118cc973f714eb485877f480391f31f #v1.48.4
-    SHA512 d7de3bc3108826de9f0b34ca888e0c1eb97c1d0723b2dd68cfb1030fb78d1367e3ac4df88e4a5dea66b08854ef85ecf562d149a58f070351768d6ac144da8520
+    REF  dc5bde2a20cbb025c9d0ed29ed687740a4d027da #v1.48.10
+    SHA512 8454b2cb81fd57e140372b5c1e5786542e92bcad85d4718b7976dccbf694cfe0fec62938edc32e5de50991e2cda2b00e8d4e976921881069ca29976fe973f4ac
     HEAD_REF master # branch name
 ) 
 
@@ -28,7 +28,7 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-vcpkg_copy_tools(TOOL_NAMES pango-view pango-list AUTO_CLEAN)
+vcpkg_copy_tools(TOOL_NAMES pango-view pango-list pango-segmentation AUTO_CLEAN)
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pango",
-  "version": "1.48.4",
-  "port-version": 1,
+  "version": "1.48.10",
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5121,8 +5121,8 @@
       "port-version": 0
     },
     "pango": {
-      "baseline": "1.48.4",
-      "port-version": 1
+      "baseline": "1.48.10",
+      "port-version": 0
     },
     "pangolin": {
       "baseline": "0.6",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a411f99ebac4507806d3824364cc766f578850e5",
+      "version": "1.48.10",
+      "port-version": 0
+    },
+    {
       "git-tree": "a130f1c74d2e337d2f9405fbb57f3b1fe46f173a",
       "version": "1.48.4",
       "port-version": 1


### PR DESCRIPTION
Update Pango to Version 1.48.10

See https://gitlab.gnome.org/GNOME/pango/-/blob/pango-1-48/NEWS
for a list of changes

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #21747 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, No (x64-windows-static remains unbuildable over glib not being buildable)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
