### PR TITLE
[document] Doc fixes for utils in vcpkg-cmake port

### DIFF
--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,4 +1,5 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2021-09-13"
+  "version-date": "2021-09-13",
+  "port-version": 1
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_build.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_build.cmake
@@ -19,6 +19,8 @@ and this is something we recommend doing whenever possible.
 Otherwise, you can use `TARGET` to set the target to build.
 This function defaults to not passing a target to cmake.
 
+[`vcpkg_cmake_install()`]: vcpkg_cmake_install.md
+
 `LOGFILE_BASE` is used to set the base of the logfile names;
 by default, this is `build`, and thus the logfiles end up being something like
 `build-x86-windows-dbg.log`; if you use `vcpkg_cmake_install`,

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -86,7 +86,7 @@ This command supplies many common arguments to CMake. To see the full list, exam
 * [zlib](https://github.com/Microsoft/vcpkg/blob/master/ports/zlib/portfile.cmake)
 * [cpprestsdk](https://github.com/Microsoft/vcpkg/blob/master/ports/cpprestsdk/portfile.cmake)
 * [poco](https://github.com/Microsoft/vcpkg/blob/master/ports/poco/portfile.cmake)
-* [opencv](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv/portfile.cmake)
+* [opencv4](https://github.com/Microsoft/vcpkg/blob/master/ports/opencv4/portfile.cmake)
 #]===]
 if(Z_VCPKG_CMAKE_CONFIGURE_GUARD)
     return()

--- a/ports/vcpkg-cmake/vcpkg_cmake_install.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_install.cmake
@@ -14,7 +14,7 @@ vcpkg_cmake_install(
 with additional parameters to set the `TARGET` to `install`,
 and to set the `LOGFILE_ROOT` to `install` as well.
 
-[`vcpkg_cmake_build()`]: vcpkg_cmake_build.cmake
+[`vcpkg_cmake_build()`]: vcpkg_cmake_build.md
 
 ## Examples:
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7062,7 +7062,7 @@
     },
     "vcpkg-cmake": {
       "baseline": "2021-09-13",
-      "port-version": 0
+      "port-version": 1
     },
     "vcpkg-cmake-config": {
       "baseline": "2021-11-01",

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ea87dd784e57716ab97635ab750262cbbb6243e6",
+      "version-date": "2021-09-13",
+      "port-version": 1
+    },
+    {
       "git-tree": "fc4d9fcc5b8d2b97c083c6b70dd06df5174bd97b",
       "version-date": "2021-09-13",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
I changed the example link in documentation from opencv (empty portfile, alias of opencv4) to opencv4 proper.

- #### What does your PR fix?  
Fixes #21762 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

**N/A** doc change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  As much as it applies, yes.
