### PR TITLE
Remove teemo from ci.baseline.txt.

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1669,7 +1669,6 @@ quantlib:x64-windows-static-md=fail
 readosm:x64-windows-static-md=fail
 sentencepiece:x64-windows-static-md=fail
 symengine:x64-windows-static-md=fail
-teemo:x64-windows-static-md=fail
 unicorn:x64-windows-static-md=fail
 v8:x64-windows-static-md=fail
 yato:x64-windows-static-md=fail


### PR DESCRIPTION
Resolves PASSING, REMOVE FROM FAIL LIST: teemo:x64-windows-static-md

in https://dev.azure.com/vcpkg/public/_build/results?buildId=63779