### PR TITLE
[bdwgc] Properly find Atomic_ops

### DIFF
--- a/ports/bdwgc/portfile.cmake
+++ b/ports/bdwgc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ivmai/bdwgc
-    REF 5fab1a01931a1a6934ccf1d5eaa1e51f0a8dac4d # v8.2.0-20211115
-    SHA512 b1a97aad10df33bb242985eb48f1bb2d3082d88f26c34014efce3d0f233bcd18a0f43f1bd960600ad9e22bcb19ebf04e573c74dfc1abfb771aa6b8525053c14b
+    REF abbb921e0af973809f45b2f78f9f0d843bdabb8d # v8.3.0-20211130
+    SHA512 f529cc0153379819710f4d84ee25d4d666a1d9c531fc01b2d9ce8091eca13a6f2fa8a06866cccfeec00b43e8c318036d5162a1bf79e1f22155dce1aab30ae70a
     HEAD_REF master
 )
 
@@ -11,8 +11,9 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS
         -Denable_cplusplus=ON
-        -DCFLAGS_EXTRA=-I${CURRENT_INSTALLED_DIR}/include # for libatomic_ops
+        -Dwith_libatomic_ops=ON
     OPTIONS_DEBUG
+        -Denable_gc_assertions=ON
         -Dinstall_headers=OFF
 )
 
@@ -21,7 +22,7 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/bdwgc)
 vcpkg_copy_pdbs()
 
 # Handle copyright
-file(INSTALL "${SOURCE_PATH}/README.QUICK" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 

--- a/ports/bdwgc/vcpkg.json
+++ b/ports/bdwgc/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "bdwgc",
-  "version": "8.2.0",
-  "port-version": 2,
+  "version": "8.3.0",
   "description": "The Boehm-Demers-Weiser conservative C/C++ Garbage Collector (libgc, bdwgc, boehm-gc)",
   "dependencies": [
     "libatomic-ops"

--- a/versions/b-/bdwgc.json
+++ b/versions/b-/bdwgc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b970400e0e8c37b27f5a83be4de504ce89cd1922",
+      "version": "8.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b7ec5e3585f7f7b71988cb7379c181a1fa9461cd",
       "version": "8.2.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -409,8 +409,8 @@
       "port-version": 4
     },
     "bdwgc": {
-      "baseline": "8.2.0",
-      "port-version": 2
+      "baseline": "8.3.0",
+      "port-version": 0
     },
     "beast": {
       "baseline": "0",


### PR DESCRIPTION
This is a draft PR!

* Change REF to point to master (dated 2021-11-30)

* Replace -DCFLAGS_EXTRA W/A with -Dwith_libatomic_ops=ON (which finds Atomic_ops package)

* Use LICENSE file as copyright one (instead of README.QUICK)

* Update version, reset port-version

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
