### PR TITLE
[casclib] Add option CASC_UNICODE

### DIFF
--- a/ports/casclib/portfile.cmake
+++ b/ports/casclib/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
     OPTIONS
         -DCASC_BUILD_SHARED_LIB=${CASC_BUILD_SHARED_LIB}
         -DCASC_BUILD_STATIC_LIB=${CASC_BUILD_STATIC_LIB}
+        -DCASC_UNICODE=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/casclib/vcpkg.json
+++ b/ports/casclib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "casclib",
   "version-date": "2021-11-16",
+  "port-version": 1,
   "description": "An open-source implementation of library for reading CASC storage from Blizzard games since 2014",
   "homepage": "http://www.zezula.net/en/casc/casclib.html",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1242,7 +1242,7 @@
     },
     "casclib": {
       "baseline": "2021-11-16",
-      "port-version": 0
+      "port-version": 1
     },
     "catch": {
       "baseline": "alias",

--- a/versions/c-/casclib.json
+++ b/versions/c-/casclib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3bb7640c26eb7b742883277db2325a69c6c790aa",
+      "version-date": "2021-11-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "20768d4f95c896b3b416aab76cc04c8dfa6e1244",
       "version-date": "2021-11-16",
       "port-version": 0


### PR DESCRIPTION
Fixes #21682 
PR https://github.com/microsoft/vcpkg/pull/21472 update casclib to new version, it change VCPKG use CMakeLists.txt which provide by source. This PR breaks unicode support for the library on Windows, set option CASC_UNICODE for casclib.