### PR TITLE
UPDATE Qt-Advanced-Docking-System to v3.7.2

### DIFF
--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -23,4 +23,4 @@ file(INSTALL ${SOURCE_PATH}/gnu-lgpl-v2.1.md DESTINATION ${CURRENT_PACKAGES_DIR}
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/license)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/qtadvanceddocking TARGET_PATH share/qtadvanceddocking)
+vcpkg_cmake_config_fixup(PACKAGE_NAME qtadvanceddocking CONFIG_PATH lib/cmake/qtadvanceddocking)

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -9,19 +9,18 @@ vcpkg_from_github(
         config_changes.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS 
         -DBUILD_EXAMPLES=OFF
         -DVERSION_SHORT=3.7.2
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 file(INSTALL ${SOURCE_PATH}/gnu-lgpl-v2.1.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/license)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/qtadvanceddocking TARGET_PATH share/qtadvanceddocking)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/qtadvanceddocking TARGET_PATH share/qtadvanceddocking)

--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
-    REF 44dc76bd19853dcb18d37d5be231af526c8f709e #v3.6.3
-    SHA512 ff50cd65f82736eae90f823d332d63c5c024ecb9e510f95fb8d776a0763bbd0143094b789516193c4037ca2a82eba33d73a68193bb6777e285c8a1e397b3958c 
+    REF 487e23e190b8130de3b60e6e801f404edbedbf2f #v3.7.2
+    SHA512 da6d813267f242d4460d77808588f3bf11a8ea91183e2d8aa1040228cf5176556153d3c741c2f1c22f0a098de15ecc6c336f0b078fd0365c81cc27aa54868572 
     HEAD_REF master
     PATCHES
         hardcode_version.patch
@@ -14,7 +14,7 @@ vcpkg_configure_cmake(
     PREFER_NINJA
     OPTIONS 
         -DBUILD_EXAMPLES=OFF
-        -DVERSION_SHORT=3.6.3
+        -DVERSION_SHORT=3.7.2
 )
 
 vcpkg_install_cmake()

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt-advanced-docking-system",
-  "version-string": "3.6.3",
-  "port-version": 2,
+  "version-string": "3.7.2",
+  "port-version": 3,
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "dependencies": [

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "qt-advanced-docking-system",
   "version": "3.7.2",
-  "port-version": 0,
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "dependencies": [
@@ -13,6 +12,14 @@
     {
       "name": "qt5-x11extras",
       "platform": "!windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     },
     "zlib"
   ]

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt-advanced-docking-system",
-  "version-string": "3.7.2",
-  "port-version": 3,
+  "version": "3.7.2",
+  "port-version": 0,
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5497,8 +5497,8 @@
       "port-version": 0
     },
     "qt-advanced-docking-system": {
-      "baseline": "3.6.3",
-      "port-version": 2
+      "baseline": "3.7.2",
+      "port-version": 3
     },
     "qt5": {
       "baseline": "5.15.2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5498,7 +5498,7 @@
     },
     "qt-advanced-docking-system": {
       "baseline": "3.7.2",
-      "port-version": 3
+      "port-version": 0
     },
     "qt5": {
       "baseline": "5.15.2",

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5ba1526b520f4708707d72ff25ddd7499159d83",
+      "version-string": "3.7.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "1f19c23c1d05692cdf45c9876efc195412945dae",
       "version-string": "3.6.3",
       "port-version": 2

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e18dfbb6896d48b0b717d7007726e82e202d835a",
+      "git-tree": "0b7978e662c15be190cef924f1cdc93d3a8492f9",
       "version": "3.7.2",
       "port-version": 0
     },

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9dc3ede77818576258a02882ac59a93751af4b94",
+      "git-tree": "e18dfbb6896d48b0b717d7007726e82e202d835a",
       "version": "3.7.2",
       "port-version": 0
     },

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "f5ba1526b520f4708707d72ff25ddd7499159d83",
-      "version-string": "3.7.2",
-      "port-version": 3
+      "git-tree": "9dc3ede77818576258a02882ac59a93751af4b94",
+      "version": "3.7.2",
+      "port-version": 0
     },
     {
       "git-tree": "1f19c23c1d05692cdf45c9876efc195412945dae",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
UPDATE Qt-Advanced-Docking-System to v3.7.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
x64-windows, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  IDN

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
vcpkg x-add-version done

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
