### PR TITLE
[Qt-Advanced-Docking-System] update to version 3.8.0

### DIFF
--- a/ports/qt-advanced-docking-system/portfile.cmake
+++ b/ports/qt-advanced-docking-system/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO githubuser0xFFFF/Qt-Advanced-Docking-System
-    REF 487e23e190b8130de3b60e6e801f404edbedbf2f #v3.7.2
-    SHA512 da6d813267f242d4460d77808588f3bf11a8ea91183e2d8aa1040228cf5176556153d3c741c2f1c22f0a098de15ecc6c336f0b078fd0365c81cc27aa54868572 
+    REF ab4869a0e1c97fec1dfca29eeb84be67af182864 #v3.8.0
+    SHA512 220ec4604eda8a39cd7ba8839cee2ab420e8c5a0b247749afb85a7b4ec3286f6debd53c910637e84023af79319f0600eb48a6c037c3e4877708677fee3c62ce7 
     HEAD_REF master
     PATCHES
         hardcode_version.patch
@@ -13,7 +13,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS 
         -DBUILD_EXAMPLES=OFF
-        -DVERSION_SHORT=3.7.2
+        -DVERSION_SHORT=3.8.0
 )
 
 vcpkg_cmake_install()

--- a/ports/qt-advanced-docking-system/vcpkg.json
+++ b/ports/qt-advanced-docking-system/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qt-advanced-docking-system",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "description": "Create customizable layouts using an advanced window docking system similar to what is found in many popular IDEs such as Visual Studio",
   "homepage": "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5505,7 +5505,7 @@
       "port-version": 0
     },
     "qt-advanced-docking-system": {
-      "baseline": "3.7.2",
+      "baseline": "3.8.0",
       "port-version": 0
     },
     "qt5": {

--- a/versions/q-/qt-advanced-docking-system.json
+++ b/versions/q-/qt-advanced-docking-system.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "427efb4851b6f81f6301f6418d0e8d04bebbf557",
+      "version": "3.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "0b7978e662c15be190cef924f1cdc93d3a8492f9",
       "version": "3.7.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Update port to qt advanced docking system 3 8 0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  x64-windows, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  IDN

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes (without --all)

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**


This MR follow a previous update of port file de 3.7.2 #21801 