### PR TITLE
[influxdb-cxx] Fix build error, fix usage

### DIFF
--- a/ports/influxdb-cxx/include-stringview.patch
+++ b/ports/influxdb-cxx/include-stringview.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Point.cxx b/src/Point.cxx
+index 8f7fc10..95b119e 100644
+--- a/src/Point.cxx
++++ b/src/Point.cxx
+@@ -30,6 +30,7 @@
+ #include <memory>
+ #include <sstream>
+ #include <iomanip>
++#include <string_view>
+ 
+ namespace influxdb
+ {

--- a/ports/influxdb-cxx/portfile.cmake
+++ b/ports/influxdb-cxx/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF v0.6.7
     SHA512 4e871c6d06c94b24b45aeedb7c74c75aed17332fbde76fc1e6c2ad06aeb41e268a95f4cab1c12c4402765c11811feb84bf48d60b138717c485327848782e402c
     HEAD_REF master
+    PATCHES include-stringview.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -23,6 +24,6 @@ vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(PACKAGE_NAME InfluxDB CONFIG_PATH lib/cmake/InfluxDB)
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/influxdb-cxx/vcpkg.json
+++ b/ports/influxdb-cxx/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "influxdb-cxx",
   "version": "0.6.7",
+  "port-version": 1,
   "description": "InfluxDB C++ client library",
   "homepage": "https://github.com/offa/influxdb-cxx",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2858,7 +2858,7 @@
     },
     "influxdb-cxx": {
       "baseline": "0.6.7",
-      "port-version": 0
+      "port-version": 1
     },
     "infoware": {
       "baseline": "2021-06-16",

--- a/versions/i-/influxdb-cxx.json
+++ b/versions/i-/influxdb-cxx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9403a6547a2dbd42b86d686c2ecd7a3e7344f13a",
+      "version": "0.6.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "ddcc844c034b136efc1bd9946e37fb98617acd88",
       "version": "0.6.7",
       "port-version": 0


### PR DESCRIPTION
Fix build error:
```
F:\vcpkg\buildtrees\influxdb-cxx\src\v0.6.7-1d6a39a436.clean\src\Point.cxx(60): error C2679: binary '<<': no operator found which takes a right-hand operand of type 'std::string_view' (or there is no acceptable conversion)
```

Since the cmake config file is _lib/cmake/InfluxDB_, fix the search path of `vcpkg_cmake_config_fixup`.

Fixes #21535.