### PR TITLE
[qwt] Restore patch to fix qwt link static library

### DIFF
--- a/ports/qwt/fix-dynamic-static.patch
+++ b/ports/qwt/fix-dynamic-static.patch
@@ -1,0 +1,15 @@
+diff --git a/qwtconfig.pri b/qwtconfig.pri
+index 0b054e0..f93fef6 100644
+--- a/qwtconfig.pri
++++ b/qwtconfig.pri
+@@ -72,7 +72,10 @@ QWT_INSTALL_FEATURES  = $${QWT_INSTALL_PREFIX}/features
+ # it will be a static library.
+ ######################################################################
+ 
++CONFIG(dynamic, dynamic|static) {
++
+ QWT_CONFIG           += QwtDll
++}
+ 
+ ######################################################################
+ # QwtPlot enables all classes, that are needed to use the QwtPlot

--- a/ports/qwt/portfile.cmake
+++ b/ports/qwt/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_sourceforge(
     REF 6.2.0
     FILENAME "qwt-6.2.0.zip"
     SHA512 a3946c6e23481b5a2193819a1c1298db5a069d514ca60de54accb3a249403f5acd778172ae6fae24fae252767b1e58deba524de6225462f1bafd7c947996aae9
+    PATCHES
+        fix-dynamic-static.patch
 )
 
 vcpkg_configure_qmake(

--- a/ports/qwt/vcpkg.json
+++ b/ports/qwt/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qwt",
   "version-semver": "6.2.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "qt widgets library for technical applications",
   "homepage": "https://sourceforge.net/projects/qwt",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5858,7 +5858,7 @@
     },
     "qwt": {
       "baseline": "6.2.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qwtw": {
       "baseline": "3.1.0",

--- a/versions/q-/qwt.json
+++ b/versions/q-/qwt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1e9f6474ec00dce373a287dcb04cca0a7398fa2",
+      "version-semver": "6.2.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "10d24bfb82979ffa078d34a17f976d2646e1cf5f",
       "version-semver": "6.2.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #20811 
When installing qwt with the x64-windows-static tripled, it is built as a dynamic library rather than a static one,
Revert fix-dynamic-static.patch to fix this error, I have tested successfully usage locally