### PR TITLE
[vcpkg] add wait 1 second before renaming in WSL

### DIFF
--- a/scripts/cmake/vcpkg_extract_source_archive.cmake
+++ b/scripts/cmake/vcpkg_extract_source_archive.cmake
@@ -233,6 +233,11 @@ function(vcpkg_extract_source_archive)
         ${quiet_param}
     )
 
+    if(DEFINED ENV{WSL_DISTRO_NAME})
+    #    message( "Executing 'bash -c \"sleep 1\"', for antivirus locked folders on WSL. Otherwise rename folder fails")
+        execute_process (COMMAND bash -c "sleep 1")
+    endif()
+    
     file(RENAME "${temp_source_path}" "${source_path}")
     file(REMOVE_RECURSE "${temp_dir}")
 


### PR DESCRIPTION

this is my current solution, the wait is working.

https://github.com/shimondoodkin/vcpkg/blob/wsl-bash-wait/scripts/cmake/vcpkg_extract_source_archive.cmake#L236-L239

    if(DEFINED ENV{WSL_DISTRO_NAME})
        message( "Executing 'bash -c \"sleep 1\"', for antivirus locked folders on WSL. Otherwise rename folder fails")
        execute_process (COMMAND bash -c "sleep 1")
    endif()
        
not sure if this code is good enough to make a pull request

- #### What does your PR fix?  
  Fixes #11283 #12204



