### PR TITLE
[mimalloc] Update to 2.0.3

### DIFF
--- a/ports/mimalloc/fix-cmake.patch
+++ b/ports/mimalloc/fix-cmake.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b56953c..d7ad3e7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -279,10 +279,12 @@ if(MI_BUILD_SHARED)
+@@ -303,10 +303,13 @@ if(MI_BUILD_SHARED)
      add_custom_command(TARGET mimalloc POST_BUILD
        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
        COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
@@ -11,14 +11,14 @@ index b56953c..d7ad3e7 100644
 +      DESTINATION ${CMAKE_INSTALL_BINDIR}
 +    )  
    endif()
--
+
 -  install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  
 -  install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
 +  install(TARGETS mimalloc EXPORT mimalloc ARCHIVE DESTINATION lib RUNTIME DESTINATION bin LIBRARY DESTINATION lib NAMELINK_SKIP)
  endif()
  
  # static library
-@@ -308,6 +310,8 @@ if (MI_BUILD_STATIC)
+@@ -332,6 +335,8 @@ if (MI_BUILD_STATIC)
    install(TARGETS mimalloc-static EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)
  endif()
  
@@ -27,7 +27,7 @@ index b56953c..d7ad3e7 100644
  # install include files
  install(FILES include/mimalloc.h DESTINATION ${mi_install_incdir})
  install(FILES include/mimalloc-override.h DESTINATION ${mi_install_incdir})
-@@ -342,9 +346,6 @@ if (MI_BUILD_OBJECT)
+@@ -366,9 +371,6 @@ if (MI_BUILD_OBJECT)
  
    # the FILES expression can also be: $<TARGET_OBJECTS:mimalloc-obj>
    # but that fails cmake versions less than 3.10 so we leave it as is for now

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/mimalloc
-    REF v2.0.2
-    SHA512 d6f1749a6df86346220fc190a3fd6aa67deff5439b26846c33ff95e91ce5fea73837ee39348dd432db3592575298e6e87856329d0236d2c6959abd8bf7756cdc
+    REF v2.0.3
+    SHA512 275a5249d09a57c9a039714fc6eef24ae778496954972419f3ac8e33f3d12e9837ba0691a3c08a4ab807c26b868aad3a5b2c28ee10ecaa60fe21ffe1d416f08f
     HEAD_REF master
     PATCHES
         fix-cmake.patch
@@ -33,6 +33,8 @@ vcpkg_cmake_configure(
         -DMI_BUILD_STATIC=${MI_BUILD_STATIC}
         -DMI_BUILD_SHARED=${MI_BUILD_SHARED}
         -DMI_INSTALL_TOPLEVEL=ON
+    MAYBE_UNUSED_VARIABLES
+        MI_INTERPOSE
 )
 
 vcpkg_cmake_install()
@@ -43,7 +45,7 @@ file(COPY
     "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     vcpkg_replace_string(

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mimalloc",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4377,7 +4377,7 @@
       "port-version": 3
     },
     "mimalloc": {
-      "baseline": "2.0.2",
+      "baseline": "2.0.3",
       "port-version": 0
     },
     "minc": {

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6e1b6fbd3bff2cae13325183c95aa07ed470b6ad",
+      "version": "2.0.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "dab9a2e508bca4575fc8f26df59f3f01735a3dbb",
       "version": "2.0.2",
       "port-version": 0


### PR DESCRIPTION
Update the mimalloc port from 2.0.2 to 2.0.3.

Changelog :

> Improved WASM support, improved macOS support and performance (including M1), improved performance for v2 for large objects, Python integration improvements, more standard installation directories, various small fixes.