### PR TITLE
[imgui-sfml] Fix usage

### DIFF
--- a/ports/imgui-sfml/005-fix-imtextureid-define.patch
+++ b/ports/imgui-sfml/005-fix-imtextureid-define.patch
@@ -1,0 +1,9 @@
+diff --git a/imconfig-SFML.h b/imconfig-SFML.h
+index ddfe05d..bd7174e 100644
+--- a/imconfig-SFML.h
++++ b/imconfig-SFML.h
+@@ -24,4 +24,3 @@
+                          static_cast<sf::Uint8>(z * 255.f), static_cast<sf::Uint8>(w * 255.f));    \
+     }
+ 
+-#define ImTextureID unsigned int

--- a/ports/imgui-sfml/portfile.cmake
+++ b/ports/imgui-sfml/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         0001-fix_find_package.patch
         004-fix-find-sfml.patch
+        005-fix-imtextureid-define.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/imgui-sfml/vcpkg.json
+++ b/ports/imgui-sfml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui-sfml",
   "version": "2.4",
+  "port-version": 1,
   "description": "ImGui binding for use with SFML",
   "homepage": "https://github.com/eliasdaler/imgui-sfml",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2842,7 +2842,7 @@
     },
     "imgui-sfml": {
       "baseline": "2.4",
-      "port-version": 0
+      "port-version": 1
     },
     "imguizmo": {
       "baseline": "1.83",

--- a/versions/i-/imgui-sfml.json
+++ b/versions/i-/imgui-sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a40fbdee68d1f6157c8b5e0784fb701b290d0cc",
+      "version": "2.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "c81a9d0362c06279990e889cb56f9ebf71bde380",
       "version": "2.4",
       "port-version": 0


### PR DESCRIPTION
`imgui-sfml` redefines the macro `ImTextureID` in `imgui` to match the correct pointer type, which leads to inconsistent `ImTextureID` type errors when users use `imgui-sfml` and `imgui` at the same time.
After discussing with upstream, remove the redefinition code of `ImTextureID` in `imgui-sfml` to fix this issue.

Fixes #21530.

Already tested the usage.