### PR TITLE
[google-cloud-cpp] update to latest release (v1.34.1)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.34.0
-    SHA512 a7a23ba5a4f60676fddff86c6a42031e85c931b4ad6bc6637d90eea403bad7906b9ee945d78c18625ebf8909c7ae6f77ae6b44f30be282d68bea603ee52c9a5e
+    REF v1.34.1
+    SHA512 2a11fb5f4ee620312575281e7ee0b1caa1c110c411b623d7ae4e9bb87c5f34dcf4c63fcb238e5e943deb02e7fcbb8b0e294ec966b98aecd164dc40cf6b6ecc1b
     HEAD_REF main
 )
 

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2517,7 +2517,7 @@
       "port-version": 7
     },
     "google-cloud-cpp": {
-      "baseline": "1.34.0",
+      "baseline": "1.34.1",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3a3519f9f0fc9833e8f4dd815aea69b385ea6885",
+      "version": "1.34.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "d0975c563a68cf3d45c97c420e3e83af83620127",
       "version": "1.34.0",
       "port-version": 0


### PR DESCRIPTION
Updates the `google-cloud-cpp` port to the latest release: v1.34.1

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes

Tested all features with `x64-linux`
