### PR TITLE
[vcpkg baseline] [qtbase] Update the hash of qtinterfaceframework

### DIFF
--- a/ports/qtbase/cmake/qt_port_details.cmake
+++ b/ports/qtbase/cmake/qt_port_details.cmake
@@ -105,7 +105,7 @@ set(qtwebview_REF               eb5a94f20e77a9639b07ae3d59c9d67529ffed66)
 set(qtpositioning_REF           1294c29be50fa5cdf2d78afffac0451f7b4bc16a)
 ### New in Qt 6.2.2
 set(qtapplicationmanager_REF    1009f73d1f5c07947cdc2318150279ad43fc4b04)
-set(qtinterfaceframework_REF    118fa138186144cf2d802405255f08662ed76d43)
+set(qtinterfaceframework_REF    c39926232ee04ded0ebbe971aeb047b6d92ee4d8)
 
 
 if(QT_UPDATE_VERSION)

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtbase",
   "version-semver": "6.2.2",
+  "port-version": 1,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5698,7 +5698,7 @@
     },
     "qtbase": {
       "baseline": "6.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtcharts": {
       "baseline": "6.2.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b589c663257547e0ae21fd71d6502c8905d90a5b",
+      "version-semver": "6.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c314a6af00c3a57bbd887c834cc0b5f80bfd65fc",
       "version-semver": "6.2.2",
       "port-version": 0


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/20439

qtinterfaceframework:x64-windows failed in CI testing.
Failures:
error: Server does not allow request for unadvertised object 118fa138186144cf2d802405255f08662ed76d43
