### PR TITLE
[rsocket] Remove keyword supports

### DIFF
--- a/ports/rsocket/portfile.cmake
+++ b/ports/rsocket/portfile.cmake
@@ -1,6 +1,5 @@
 # yarpl only support static build in Windows
 if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_fail_port_install(ON_ARCH "x64")
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
@@ -15,30 +14,29 @@ vcpkg_from_github(
     fix-find-dependencies.patch
 )
 
-vcpkg_configure_cmake(
-  SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS
     -DBUILD_EXAMPLES=OFF
     -DBUILD_TESTS=OFF
     -DBUILD_BENCHMARKS=OFF
 )
 
-vcpkg_install_cmake()
-
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-
-file(REMOVE_RECURSE
-  ${CURRENT_PACKAGES_DIR}/include/yarpl/perf
-  ${CURRENT_PACKAGES_DIR}/include/yarpl/cmake
-  ${CURRENT_PACKAGES_DIR}/include/yarpl/test
-  ${CURRENT_PACKAGES_DIR}/include/rsocket/examples
-  ${CURRENT_PACKAGES_DIR}/include/rsocket/test
-)
+vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_cmake_config_fixup(PACKAGE_NAME yarpl CONFIG_PATH lib/cmake/yarpl DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/rsocket)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(REMOVE_RECURSE
+  "${CURRENT_PACKAGES_DIR}/include/yarpl/perf"
+  "${CURRENT_PACKAGES_DIR}/include/yarpl/cmake"
+  "${CURRENT_PACKAGES_DIR}/include/yarpl/test"
+  "${CURRENT_PACKAGES_DIR}/include/rsocket/examples"
+  "${CURRENT_PACKAGES_DIR}/include/rsocket/test"
+)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rsocket/vcpkg.json
+++ b/ports/rsocket/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "rsocket",
   "version-string": "2020.05.04.00",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++ implementation of RSocket http://rsocket.io",
   "homepage": "https://github.com/rsocket/rsocket-cpp",
-  "supports": "!(windows & x64)",
   "dependencies": [
     "boost-context",
     "boost-filesystem",
@@ -18,6 +17,14 @@
     "gflags",
     "glog",
     "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1302,9 +1302,6 @@ rsasynccpp:x64-osx=fail
 rsm-binary-io:x64-linux=fail
 # Requires g++10 but CI compiler only has g++9
 rsm-bsa:x64-linux=fail
-rsocket:x64-windows=fail
-rsocket:x64-windows-static=fail
-rsocket:x64-windows-static-md=fail
 rtlsdr:x64-uwp=fail
 rtlsdr:arm64-windows=fail
 rtlsdr:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6074,7 +6074,7 @@
     },
     "rsocket": {
       "baseline": "2020.05.04.00",
-      "port-version": 2
+      "port-version": 3
     },
     "rtabmap": {
       "baseline": "0.20.13",

--- a/versions/r-/rsocket.json
+++ b/versions/r-/rsocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "79beeb5c846c3ecdb386e7b3445adf1ac42314df",
+      "version-string": "2020.05.04.00",
+      "port-version": 3
+    },
+    {
       "git-tree": "c7ad735194f400692ba373c493c23778cbfe2c79",
       "version-string": "2020.05.04.00",
       "port-version": 2


### PR DESCRIPTION
Wrong `supports` caused rsocket to never be built on Windows, because its dependent folly only supports `x64`.

Fixes #21088.
Related: #11021