### PR TITLE
[hiredis] Support windows dynamic build

### DIFF
--- a/ports/hiredis/portfile.cmake
+++ b/ports/hiredis/portfile.cmake
@@ -1,5 +1,5 @@
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if (VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(HIREDIS_PATCHES support-static-in-win.patch)
 endif()
 
 vcpkg_from_github(
@@ -10,10 +10,10 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-feature-example.patch
-        support-static-in-win.patch
         fix-timeval.patch
         fix-include-path.patch
         fix-ssize_t.patch
+        ${HIREDIS_PATCHES}
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -31,6 +31,8 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 
+vcpkg_fixup_pkgconfig()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_cmake_config_fixup()
 if("ssl" IN_LIST FEATURES)
@@ -39,4 +41,3 @@ endif()
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-vcpkg_fixup_pkgconfig()

--- a/ports/hiredis/vcpkg.json
+++ b/ports/hiredis/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "hiredis",
   "version": "1.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Hiredis is a minimalistic C client library for the Redis database.",
   "homepage": "https://github.com/redis/hiredis",
-  "supports": "!(windows & !static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2698,7 +2698,7 @@
     },
     "hiredis": {
       "baseline": "1.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "hpx": {
       "baseline": "1.7.1",

--- a/versions/h-/hiredis.json
+++ b/versions/h-/hiredis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b651b36e6488f1eaaafc33d15d73d94751919f03",
+      "version": "1.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "0c7e16c5c3a9f612e1b46f96be41389b8ba11e6a",
       "version": "1.0.2",
       "port-version": 1


### PR DESCRIPTION
According to the upstream code:
https://github.com/redis/hiredis/blob/da5a4ff3622e8744b772a76f6ce580dc9134fb38/CMakeLists.txt#L52-L54
```cmake
SET_TARGET_PROPERTIES(hiredis
    PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE
    VERSION "${HIREDIS_SONAME}")
```

The upstream does support Windows.

In order to prevent the conflict of dynamic CRT linkage in static build, patch is still used to support windows static build.

Fixes #21687.