### PR TITLE
[mpfr] Add warning message on Linux

### DIFF
--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -1,3 +1,7 @@
+if (VCPKG_TARGET_IS_LINUX)
+    message(WARNING "${PORT} currently requires the following tools from the system package manager:\n    autoconf-archive\n    texinfo\nThese can be installed on Ubuntu systems via\n    sudo apt-get update -y\n    sudo apt-get install -y autoconf-archive texinfo\n")
+endif()
+
 set(VERSION 4.1.0)
 vcpkg_download_distfile(ARCHIVE
     URLS "http://www.mpfr.org/mpfr-${VERSION}/mpfr-${VERSION}.tar.xz" "https://ftp.gnu.org/gnu/mpfr/mpfr-${VERSION}.tar.xz"
@@ -15,7 +19,7 @@ vcpkg_extract_source_archive_ex(
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/m4")
 vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     AUTOCONFIG
     ADDITIONAL_MSYS_PACKAGES texinfo gettext autoconf-archive
 )
@@ -32,4 +36,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/mpfr/portfile.cmake
+++ b/ports/mpfr/portfile.cmake
@@ -1,5 +1,5 @@
 if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "${PORT} currently requires the following tools from the system package manager:\n    autoconf-archive\n    texinfo\nThese can be installed on Ubuntu systems via\n    sudo apt-get update -y\n    sudo apt-get install -y autoconf-archive texinfo\n")
+    message(WARNING "${PORT} currently requires the following packages:\n    autoconf-archive\n    texinfo\nThese can be installed on Ubuntu systems via\n    sudo apt-get update -y\n    sudo apt-get install -y autoconf-archive texinfo\n")
 endif()
 
 set(VERSION 4.1.0)

--- a/ports/mpfr/vcpkg.json
+++ b/ports/mpfr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mpfr",
   "version-string": "4.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The MPFR library is a C library for multiple-precision floating-point computations with correct rounding",
   "homepage": "https://www.mpfr.org",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4510,7 +4510,7 @@
     },
     "mpfr": {
       "baseline": "4.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "mpg123": {
       "baseline": "1.29.2",

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "92e0b9f1e3548a29a47196abda9aeb21bdc17b6a",
+      "version-string": "4.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "54544af431b7f178bc7bbe6604f103c40b7aa93b",
       "version-string": "4.1.0",
       "port-version": 1

--- a/versions/m-/mpfr.json
+++ b/versions/m-/mpfr.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "92e0b9f1e3548a29a47196abda9aeb21bdc17b6a",
+      "git-tree": "655c136cd8328e30476ae39a3fd5ff99c915907c",
       "version-string": "4.1.0",
       "port-version": 2
     },


### PR DESCRIPTION
Installing mpfr on Linux need install `autoconf-archive` and `texinfo` first. Add warning message for mpfr.
Fixes #21833
