### PR TITLE
[google-cloud-cpp] Support abseil[cxx17]

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -8,6 +8,8 @@ vcpkg_from_github(
     REF v1.35.0
     SHA512 99eabb37ff32ddaf8f646415b50f3843e89fb119646428c16f03060c2787c8d86fa1ac0919ee60c4f6c7a3b71a14eb828ae26a7fc26d928543d72c7ba3268bff
     HEAD_REF main
+    PATCHES
+        support_absl_cxx17.patch
 )
 
 vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
@@ -74,7 +76,7 @@ endforeach()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake"
                     "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
-                    "${CURRENT_PACKAGES_DIR}/debug/share") 
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 369914e04..f89b256f4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,8 +28,14 @@ project(
+     VERSION 1.35.0
+     LANGUAGES CXX C)
+ 
++find_package(absl CONFIG REQUIRED)
++
++# Use CMAKE_CXX_STANDARD=17 if ABSL_USE_CXX17 is set
++if (ABSL_USE_CXX17)
++    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
++    set(CMAKE_CXX_STANDARD 17)
+ # Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
+-if (NOT CMAKE_CXX_STANDARD)
++elseif (NOT CMAKE_CXX_STANDARD)
+     set(CMAKE_CXX_STANDARD 11)
+ endif ()
+ if (CMAKE_CXX_STANDARD VERSION_LESS 11)
+diff --git a/google/cloud/internal/port_platform.h b/google/cloud/internal/port_platform.h
+index c9f34cf4c..e62400431 100644
+--- a/google/cloud/internal/port_platform.h
++++ b/google/cloud/internal/port_platform.h
+@@ -49,6 +49,8 @@
+ // Abort compilation if the compiler does not support C++11.
+ #if GOOGLE_CLOUD_CPP_CPP_VERSION < 201103L
+ #  error "C++11 or newer is required"
++#elif defined(ABSL_USE_CXX17) && GOOGLE_CLOUD_CPP_CPP_VERSION < 201703L
++#  error "Compiled to use Abseil with C++17 support, but using with C++ < C++17"
+ #endif  // GOOGLE_CLOUD_CPP_CPP_VERSION < 201103L
+ 
+ // Abort the build if the version of the compiler is too old. With CMake we

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "1.35.0",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2530,7 +2530,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.35.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5df9e36ebb6dd75abc2a5ff3aebdd61719739e8e",
+      "version": "1.35.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "171fbf69839919f9cbd18e7d1d3c4375920c4ae5",
       "version": "1.35.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Support building when using abseil[cxx17].

This will make sure this scenario works:
```
vcpkg install abseil[cxx17]
vcpkg install google-cloud-cpp
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes