### PR TITLE
[fribidi] Support new platform

### DIFF
--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -6,15 +6,11 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_configure_meson(
+vcpkg_configure_make(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-        -Ddocs=false
-        -Dbin=false
-        -Dtests=false
 )
 
-vcpkg_install_meson()
+vcpkg_install_make(DISABLE_PARALLEL)
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
@@ -26,6 +22,9 @@ else()
     string(REPLACE "#ifndef FRIBIDI_LIB_STATIC" "#if 1" FRIBIDI_COMMON_H "${FRIBIDI_COMMON_H}")
 endif()
 file(WRITE ${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h "${FRIBIDI_COMMON_H}")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fribidi",
   "version": "1.0.11",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
   "supports": "!uwp"
 }

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.11",
   "port-version": 1,
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
-  "supports": "!(uwp | arm)",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-tool-meson",

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -3,11 +3,5 @@
   "version": "1.0.11",
   "port-version": 1,
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
-  "supports": "!uwp",
-  "dependencies": [
-    {
-      "name": "vcpkg-tool-meson",
-      "host": true
-    }
-  ]
+  "supports": "!uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2290,7 +2290,7 @@
     },
     "fribidi": {
       "baseline": "1.0.11",
-      "port-version": 1
+      "port-version": 2
     },
     "frozen": {
       "baseline": "2021-04-22",

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "134c67f3f8db520442ed5bea02262f14d647f7ce",
+      "version": "1.0.11",
+      "port-version": 2
+    },
+    {
       "git-tree": "1555ac8e52ae978d26277e842322241a3da9c8ae",
       "version": "1.0.11",
       "port-version": 1

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1555ac8e52ae978d26277e842322241a3da9c8ae",
+      "git-tree": "f6331a576a7b0360759f267bc1a76bf28565e98a",
       "version": "1.0.11",
       "port-version": 1
     },

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f6331a576a7b0360759f267bc1a76bf28565e98a",
+      "git-tree": "1555ac8e52ae978d26277e842322241a3da9c8ae",
       "version": "1.0.11",
       "port-version": 1
     },


### PR DESCRIPTION
- **Describe the pull request**
   
  Support for package `fribidi` working on `arm` platforms. And use  `GNU Build System` instead of `Meson`, because `vcpkg-tool-meson` do not support for cross compile for now, which caused all packages depend on `fribidi` cross-compile failed.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  arm64-linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
