### PR TITLE
[vk-bootstrap] New port

### DIFF
--- a/ports/vk-bootstrap/portfile.cmake
+++ b/ports/vk-bootstrap/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO charles-lunarg/vk-bootstrap
+    REF 142986cdb767037118b687387b097ff6b3e7fe7d
+    SHA512 1dc32f09f4548ffaf71d39d5200d60a9bd58971327039f2adb4327fdb885f984bbd91409d28dbfc24e5fdac8c241824e141a2558cddc1b86b84cf2376e7d7567
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/${PORT}-config.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-release.cmake" "${CMAKE_CURRENT_LIST_DIR}/${PORT}-targets-debug.cmake" DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+configure_file("${SOURCE_PATH}/LICENSE.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/vk-bootstrap/vcpkg.json
+++ b/ports/vk-bootstrap/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "vk-bootstrap",
+  "version": "0.5",
+  "description": "Vulkan bootstraping library",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    "vulkan"
+  ]
+}

--- a/ports/vk-bootstrap/vk-bootstrap-config.cmake
+++ b/ports/vk-bootstrap/vk-bootstrap-config.cmake
@@ -1,0 +1,14 @@
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+add_library(vk-bootstrap::vk-bootstrap SHARED IMPORTED)
+set_target_properties(vk-bootstrap::vk-bootstrap PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include"
+)
+
+get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(GLOB CONFIG_FILES "${_DIR}/vk-bootstrap-targets-*.cmake")
+foreach(f ${CONFIG_FILES})
+  include(${f})
+endforeach()

--- a/ports/vk-bootstrap/vk-bootstrap-targets-debug.cmake
+++ b/ports/vk-bootstrap/vk-bootstrap-targets-debug.cmake
@@ -1,0 +1,12 @@
+#----------------------------------------------------------------
+# Generated CMake target import file for configuration "Debug".
+#----------------------------------------------------------------
+
+set(CMAKE_IMPORT_FILE_VERSION 1)
+
+set_property(TARGET vk-bootstrap::vk-bootstrap APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+set_target_properties(vk-bootstrap::vk-bootstrap PROPERTIES
+    IMPORTED_IMPLIB_DEBUG "${_IMPORT_PREFIX}/debug/lib/vk-bootstrap.lib"
+)
+
+set(CMAKE_IMPORT_FILE_VERSION)

--- a/ports/vk-bootstrap/vk-bootstrap-targets-release.cmake
+++ b/ports/vk-bootstrap/vk-bootstrap-targets-release.cmake
@@ -1,0 +1,12 @@
+#----------------------------------------------------------------
+# Generated CMake target import file for configuration "Debug".
+#----------------------------------------------------------------
+
+set(CMAKE_IMPORT_FILE_VERSION 1)
+
+set_property(TARGET vk-bootstrap::vk-bootstrap APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+set_target_properties(vk-bootstrap::vk-bootstrap PROPERTIES
+    IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/vk-bootstrap.lib"
+)
+
+set(CMAKE_IMPORT_FILE_VERSION)

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7132,6 +7132,10 @@
       "baseline": "1.0",
       "port-version": 2
     },
+    "vk-bootstrap": {
+      "baseline": "0.5",
+      "port-version": 0
+    },
     "vlfeat": {
       "baseline": "2020-07-10",
       "port-version": 1

--- a/versions/v-/vk-bootstrap.json
+++ b/versions/v-/vk-bootstrap.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c882b9c4c2adf3ea8e63dae9d4ab03b4d34a4dc1",
+      "version": "0.5",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
This adds the commonly used [`vk-bootstrap`](https://github.com/charles-lunarg/vk-bootstrap) library as a port. `vk-bootstrap` is used to quickly and efficiently use Vulkan. This is based on the freshly released `0.5` version of the library.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All as far as I know.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
