### PR TITLE
docs: CMake toolchain needs `vcpkg integrate install` first

### DIFF
--- a/docs/examples/installing-and-using-packages.md
+++ b/docs/examples/installing-and-using-packages.md
@@ -90,7 +90,7 @@ To remove the integration for your user, you can use `.\vcpkg integrate remove`.
 #### CMake (Toolchain File)
 
 The best way to use installed libraries with cmake is via the toolchain file `scripts\buildsystems\vcpkg.cmake`. To use this file, you simply need to add it onto your CMake command line as:  
-`-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.
+`-DCMAKE_TOOLCHAIN_FILE=D:\src\vcpkg\scripts\buildsystems\vcpkg.cmake`.  Be sure to run `vcpkg integrate install` first.
 
 If you are using CMake through Open Folder with Visual Studio you can define `CMAKE_TOOLCHAIN_FILE` by adding a "variables" section to each of your `CMakeSettings.json` configurations:
 

--- a/docs/users/integration.md
+++ b/docs/users/integration.md
@@ -73,6 +73,7 @@ To override the automatically chosen [triplet][], you can specify the MSBuild pr
 
 ## CMake Integration
 ```no-highlight
+vcpkg integrate install
 cmake ../my/project -DCMAKE_TOOLCHAIN_FILE=[vcpkg-root]/scripts/buildsystems/vcpkg.cmake
 ```
 Projects configured with the Vcpkg toolchain file will have the appropriate Vcpkg folders added to the cmake search paths. This makes all libraries available to be found through `find_package()`, `find_path()`, and `find_library()`.


### PR DESCRIPTION
Perhaps this is obvious to someone who has been using this tool for a long time, but as a newcomer, I read all these sections as an either-or: if you use MSBuild, do this, and if you use CMake, you're good to go just using the `.toolchain` file. Well, that's not the case, CMake's `find_path` et al won't find the *installed* packages, they also have to be *integrated* like this.

- #### What does your PR fix?  
    Instructions on how to use `vcpkg` with CMake were incomplete.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
    Not applicable.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yup.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Not applicable.