### PR TITLE
[vcpkg baseline][libde265] Remove optional dependency on sdl and modernize.

### DIFF
--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_TARGET "uwp")
-
 # Used for .pc file
 set(VERSION "1.0.8")
 vcpkg_from_github(
@@ -12,13 +10,14 @@ vcpkg_from_github(
         fix-libde265-headers.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_DISABLE_FIND_PACKAGE_SDL=ON
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/libde265/)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/libde265)
 vcpkg_copy_tools(TOOL_NAMES dec265 enc265 AUTO_CLEAN)
 
 set(prefix "")
@@ -43,4 +42,4 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "libde265",
   "version-string": "1.0.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
-  "supports": "!(arm | uwp)"
+  "supports": "!(arm | uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3398,7 +3398,7 @@
     },
     "libde265": {
       "baseline": "1.0.8",
-      "port-version": 2
+      "port-version": 3
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "83f4bc2d067f213063ca93d6f1514d3f7278452c",
+      "version-string": "1.0.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "81ba07f30c6c2a068f8b9f017e437d0062920e4a",
       "version-string": "1.0.8",
       "port-version": 2


### PR DESCRIPTION
This works around an optional dependency in libde265 where it doesn't link with the correct libraries when `sdl1` is installed first. Example: https://github.com/microsoft/vcpkg/pull/21456

Also updates to modern helpers.