### PR TITLE
[backward] new port

### DIFF
--- a/ports/backward/portfile.cmake
+++ b/ports/backward/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO bombela/backward-cpp
+  REF 3bb9240cb15459768adb3e7d963a20e1523a6294 # v1.6
+  SHA512 5f3998202e87e43ae60d3b3de70e8d48284284135183a85aa59aad25c77eea1f6664b37b65131b383270dfa51cfe205ea5b1707b922015ed88771073ad8e79e4
+  HEAD_REF master
+  )
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/backward)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
+
+# # Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/backward" RENAME copyright)

--- a/ports/backward/vcpkg.json
+++ b/ports/backward/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "backward",
+  "version": "1.6",
+  "description": "A beautiful stack trace pretty printer for C++",
+  "homepage": "https://github.com/bombela/backward-cpp",
+  "supports": "linux | osx | android | emscripten | (windows & (x86 | x64) & !uwp)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/b-/backward.json
+++ b/versions/b-/backward.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7b6f97f995696b1192d9904a67c72a1a843d6bdc",
+      "version": "1.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -392,6 +392,10 @@
       "baseline": "2.0.0.1",
       "port-version": 0
     },
+    "backward": {
+      "baseline": "1.6",
+      "port-version": 0
+    },
     "basisu": {
       "baseline": "1.11",
       "port-version": 5


### PR DESCRIPTION
**Describe the pull request**

This adds a port for the [backward](https://github.com/bombela/backward-cpp) library for printing nice stack traces.

- #### What does your PR fix?  
  Fixes this port not existing.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All, according to the project page. No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I think so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
