### PR TITLE
[mongo-cxx-driver] Fix installation

### DIFF
--- a/ports/mongo-cxx-driver/vcpkg.json
+++ b/ports/mongo-cxx-driver/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mongo-cxx-driver",
   "version": "3.6.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "MongoDB C++ Driver.",
   "homepage": "https://github.com/mongodb/mongo-cxx-driver",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4458,7 +4458,7 @@
     },
     "mongo-cxx-driver": {
       "baseline": "3.6.5",
-      "port-version": 1
+      "port-version": 2
     },
     "mongoose": {
       "baseline": "7.1",

--- a/versions/m-/mongo-cxx-driver.json
+++ b/versions/m-/mongo-cxx-driver.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2c9183634ff53b6e76b201ad39abf63b5d26bc8a",
+      "version": "3.6.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "2fd38965003b9bc7a653ab8aaabb8172a043d9d0",
       "version": "3.6.5",
       "port-version": 1


### PR DESCRIPTION
As part of the upstream installation has been fixed after the update, unnecessary old code is deleted.

Fixes #21898.