### PR TITLE
[vcpkg baseline][rsocket] Use C++17.

### DIFF
--- a/ports/rsocket/portfile.cmake
+++ b/ports/rsocket/portfile.cmake
@@ -5,13 +5,14 @@ endif()
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
-  REPO rsocket/rsocket-cpp #v2020.05.04.00
-  REF 8038d05e741c3d3ecd6adb069b4a1b3daa230e14
-  SHA512 d7bc93af7b6130d73fa0823f534ad57a531dfa7d7aa990a2a1a1b72b6761db7eeb60573d0d38f55daa991554e3ab4ac507047f8051a4390b3343cd708a48efbb
+  REPO rsocket/rsocket-cpp
+  REF 45ed594ebd6701f40795c31ec922d784ec7fc921
+  SHA512 51871253524b93a9622fa0f562019605b6034e4089cd955810050b4d43ff020813d632ea1e91bcaca0a8659638908c51df6eb686ba4f6583d4c15c04d5dc35bd
   HEAD_REF master
   PATCHES
     fix-cmake-config.patch
     fix-find-dependencies.patch
+    use-cpp-17.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/rsocket/use-cpp-17.patch
+++ b/ports/rsocket/use-cpp-17.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 22570b5..15a750b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -154,7 +154,7 @@ if(BUILD_TESTS)
+ 
+ endif()
+ 
+-set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
+ 
+ include(CheckCXXCompilerFlag)
+ 

--- a/ports/rsocket/vcpkg.json
+++ b/ports/rsocket/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rsocket",
-  "version-string": "2020.05.04.00",
-  "port-version": 3,
+  "version-string": "2021.08.30.00",
   "description": "C++ implementation of RSocket http://rsocket.io",
   "homepage": "https://github.com/rsocket/rsocket-cpp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6073,8 +6073,8 @@
       "port-version": 1
     },
     "rsocket": {
-      "baseline": "2020.05.04.00",
-      "port-version": 3
+      "baseline": "2021.08.30.00",
+      "port-version": 0
     },
     "rtabmap": {
       "baseline": "0.20.13",

--- a/versions/r-/rsocket.json
+++ b/versions/r-/rsocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9dbf0f51130cc7c6e2c23a2ca3a104e22384f4e7",
+      "version-string": "2021.08.30.00",
+      "port-version": 0
+    },
+    {
       "git-tree": "79beeb5c846c3ecdb386e7b3445adf1ac42314df",
       "version-string": "2020.05.04.00",
       "port-version": 3


### PR DESCRIPTION
Resolves CI failure:

```
C:\PROGRA~2\MICROS~3\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe   /TP -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE -DDEBUG -DFMT_LOCALE -DGFLAGS_DLL_DECLARE_FLAG="" -DGFLAGS_DLL_DEFINE_FLAG="" -DGFLAGS_IS_A_DLL=0 -DGLOG_NO_ABBREVIATED_SEVERITIES -DGOOGLE_GLOG_DLL_DECL="" -DNOMINMAX -DWIN32_LEAN_AND_MEAN -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_ENABLE_EXTENDED_ALIGNED_STORAGE -D_SCL_SECURE_NO_WARNINGS -D_STL_EXTRA_DISABLED_WARNINGS="4774 4987" -ID:\buildtrees\rsocket\src\3daa230e14-e3a6381b1c.clean -ID:\buildtrees\rsocket\src\3daa230e14-e3a6381b1c.clean\yarpl\.. -ID:\installed\x64-windows-static\include /nologo /DWIN32 /D_WINDOWS /W3 /utf-8 /GR /EHsc /MP  /D_DEBUG /MTd /Z7 /Ob0 /Od /RTC1  /EHs /GF /Zc:referenceBinding /Zc:rvalueCast /Zc:implicitNoexcept /Zc:strictStrings /Zc:threadSafeInit /Zc:throwingNew /permissive- /std:c++17 /wd4191 /wd4291 /wd4309 /wd4310 /wd4366 /wd4587 /wd4592 /wd4628 /wd4723 /wd4724 /wd4868 /wd4996 /wd4068 /wd4091 /wd4146 /wd4800 /wd4018 /wd4365 /wd4388 /wd4389 /wd4100 /wd4459 /wd4505 /wd4701 /wd4702 /wd4061 /wd4127 /wd4200 /wd4201 /wd4296 /wd4316 /wd4324 /wd4355 /wd4371 /wd4435 /wd4514 /wd4548 /wd4571 /wd4574 /wd4582 /wd4583 /wd4619 /wd4623 /wd4625 /wd4626 /wd4643 /wd4647 /wd4668 /wd4706 /wd4710 /wd4711 /wd4714 /wd4820 /wd5026 /wd5027 /wd5031 /wd5045 /we4099 /we4129 /we4566 -std:c++14 /showIncludes /FoCMakeFiles\ReactiveSocket.dir\rsocket\internal\ScheduledSingleSubscription.cpp.obj /FdCMakeFiles\ReactiveSocket.dir\ReactiveSocket.pdb /FS -c D:\buildtrees\rsocket\src\3daa230e14-e3a6381b1c.clean\rsocket\internal\ScheduledSingleSubscription.cpp
cl : Command line warning D9025 : overriding '/std:c++17' with '/std:c++14'
D:\installed\x64-windows-static\include\folly/portability/Windows.h(42): warning C4005: '_CRT_INTERNAL_NONSTDC_NAMES': macro redefinition
C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt\corecrt.h(401): note: see previous definition of '_CRT_INTERNAL_NONSTDC_NAMES'
D:\installed\x64-windows-static\include\range/v3/detail/config.hpp(225): fatal error C1189: #error:  range-v3 requires Visual Studio 2019 with the /std:c++17 (or /std:c++latest) and /permissive- options.
ninja: build stopped: subcommand failed.
```
