### PR TITLE
[lodepng] Fix cannot open include file "lodepng.h"

### DIFF
--- a/ports/lodepng/CMakeLists.txt
+++ b/ports/lodepng/CMakeLists.txt
@@ -3,7 +3,7 @@ project(lodepng)
 
 add_library(lodepng lodepng.cpp)
 target_include_directories(lodepng PUBLIC
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<INSTALL_INTERFACE:include>
 )
 
 file(WRITE "${CMAKE_BINARY_DIR}/lodepng-config.cmake" "include(\"\${CMAKE_CURRENT_LIST_DIR}/lodepng-targets.cmake\")")
@@ -15,7 +15,7 @@ install(EXPORT lodepng-targets DESTINATION share/lodepng/)
 
 add_library(lodepng-c lodepng.c)
 target_include_directories(lodepng-c PUBLIC
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<INSTALL_INTERFACE:include>
 )
 
 file(WRITE "${CMAKE_BINARY_DIR}/lodepng-c-config.cmake" "include(\"\${CMAKE_CURRENT_LIST_DIR}/lodepng-c-targets.cmake\")")

--- a/ports/lodepng/vcpkg.json
+++ b/ports/lodepng/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lodepng",
   "version-date": "2021-12-04",
+  "port-version": 1,
   "description": "PNG encoder and decoder in C++",
   "homepage": "https://github.com/lvandeve/lodepng",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4150,7 +4150,7 @@
     },
     "lodepng": {
       "baseline": "2021-12-04",
-      "port-version": 0
+      "port-version": 1
     },
     "lodepng-c": {
       "baseline": "deprecated",

--- a/versions/l-/lodepng.json
+++ b/versions/l-/lodepng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "744376b1eace2fdab47d24858d7d1e79f32eefa3",
+      "version-date": "2021-12-04",
+      "port-version": 1
+    },
+    {
       "git-tree": "454b1276a4855fba7699cbb07ca783d32d1baf7c",
       "version-date": "2021-12-04",
       "port-version": 0


### PR DESCRIPTION
Fixes #21961 
Due to `lodepng` exports incorrect include path, use `lodepng` in project will appear error: `fatal error C1083: Cannot open include file: 'lodepng.h': No such file or directory`