### PR TITLE
[libgpg-error] Release-only build support

### DIFF
--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -92,13 +92,13 @@ else()
     vcpkg_fixup_pkgconfig() 
     vcpkg_copy_pdbs()
 	
-	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
-	endif()
+    endif()
 
-	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/debug/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
-	endif()
+    endif()
 
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/locale" "${CURRENT_PACKAGES_DIR}/debug/share")
     file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -91,8 +91,15 @@ else()
     vcpkg_install_make()
     vcpkg_fixup_pkgconfig() 
     vcpkg_copy_pdbs()
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/debug/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
+	
+	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../..")
+	endif()
+
+	if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/libgpg-error/debug/bin/gpg-error-config" "${CURRENT_INSTALLED_DIR}" "`dirname $0`/../../../..")
+	endif()
+
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/locale" "${CURRENT_PACKAGES_DIR}/debug/share")
     file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 endif()

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libgpg-error",
   "version": "1.42",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
   "supports": "!(windows & (arm | arm64))"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3498,7 +3498,7 @@
     },
     "libgpg-error": {
       "baseline": "1.42",
-      "port-version": 2
+      "port-version": 3
     },
     "libgpod": {
       "baseline": "2019-08-29",

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23741fd17cfc7e77d0be728ce287129affc88d58",
+      "version": "1.42",
+      "port-version": 3
+    },
+    {
       "git-tree": "f6c78e927a70ff136576abd61f1125861824bfd2",
       "version": "1.42",
       "port-version": 2

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23741fd17cfc7e77d0be728ce287129affc88d58",
+      "git-tree": "1ced42ca6160e2283326366e1c1132fe50acfb97",
       "version": "1.42",
       "port-version": 3
     },


### PR DESCRIPTION
When added `set(VCPKG_BUILD_TYPE release)` to the triplet file, this port starts failing on install because of `No such file /vcpkg/packages/libgpg-error_x64-linux/tools/libgpg-error/debug/bin/gpg-error-config`

```
Starting package 1/2: libgpg-error:x64-linux
Building package libgpg-error[core]:x64-linux...
-- Downloading https://github.com/gpg/libgpg-error/archive/libgpg-error-1.42.tar.gz -> gpg-libgpg-error-libgpg-error-1.42.tar.gz...
-- Extracting source /vcpkg/downloads/gpg-libgpg-error-libgpg-error-1.42.tar.gz
-- Applying patch add_cflags_to_tools.patch
-- Using source at /vcpkg/buildtrees/libgpg-error/src/error-1.42-cadb77cd6c.clean
-- Getting CMake variables for x64-linux-rel
-- Generating configure for x64-linux
-- Finished generating configure for x64-linux
-- Configuring x64-linux-rel
-- Building x64-linux-rel
-- Installing x64-linux-rel
-- Fixing pkgconfig file: /vcpkg/packages/libgpg-error_x64-linux/lib/pkgconfig/gpg-error.pc
CMake Error at scripts/cmake/vcpkg_replace_string.cmake:12 (file):
  file failed to open for reading (No such file or directory):

    /vcpkg/packages/libgpg-error_x64-linux/tools/libgpg-error/debug/bin/gpg-error-config
Call Stack (most recent call first):
  ports/libgpg-error/portfile.cmake:95 (vcpkg_replace_string)
  scripts/ports.cmake:142 (include)


Error: Building package libgpg-error:x64-linux failed with: BUILD_FAILED
Please ensure you're using the latest portfiles with `git pull` and `./vcpkg update`.
Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+libgpg-error
You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?template=report-package-build-failure.md&title=[libgpg-error]+Build+error
including:
  package: libgpg-error[core]:x64-linux -> 1.42#2
    vcpkg-tool version: 2999-12-31-unknownhash
    vcpkg-scripts version: 4ffe8b020 2021-12-14 (11 hours ago)

Additionally, attach any relevant sections from the log files above.
```