### PR TITLE
[elfutils] provide static or shared libraries correctly

### DIFF
--- a/ports/elfutils/portfile.cmake
+++ b/ports/elfutils/portfile.cmake
@@ -37,11 +37,11 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/locale)
 
 # Remove files with wrong linkage
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    set(_lib_suffix "${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
-else()
     set(_lib_suffix "${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+else()
+    set(_lib_suffix "${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
 endif()
-file(GLOB_RECURSE TO_REMOVE "${CURRENT_PACKAGES_DIR}/lib/*${_lib_suffix}" "${CURRENT_PACKAGES_DIR}/debug/lib/*${_lib_suffix}")
+file(GLOB_RECURSE TO_REMOVE "${CURRENT_PACKAGES_DIR}/lib/*${_lib_suffix}" "${CURRENT_PACKAGES_DIR}/debug/lib/*${_lib_suffix}" "${CURRENT_PACKAGES_DIR}/lib/*${_lib_suffix}.*" "${CURRENT_PACKAGES_DIR}/debug/lib/*${_lib_suffix}.*")
 file(REMOVE ${TO_REMOVE})
  
 # # Handle copyright

--- a/ports/elfutils/vcpkg.json
+++ b/ports/elfutils/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "elfutils",
   "version-string": "0.182",
-  "port-version": 1,
+  "port-version": 2,
   "description": "elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.",
   "homepage": "https://sourceware.org/elfutils/",
   "supports": "!windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2006,7 +2006,7 @@
     },
     "elfutils": {
       "baseline": "0.182",
-      "port-version": 1
+      "port-version": 2
     },
     "embree2": {
       "baseline": "2.17.7",

--- a/versions/e-/elfutils.json
+++ b/versions/e-/elfutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9aa4fefa61893cd4b37c0f1a2f16ab255ab0c4bf",
+      "version-string": "0.182",
+      "port-version": 2
+    },
+    {
       "git-tree": "aa738c679581e92da4ec8a1662171ac5608e3744",
       "version-string": "0.182",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

This fixes a port bug where it was providing shared libraries instead of static libraries, and vice versa.

- #### What does your PR fix?  
  Fixes #22051 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
    The supported triplets should be unchanged, so I have not changed the CI baseline.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
    Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

Incidentally, there is a newer upstream version, 0.186 vs. the current 0.182; I thought I'd keep this PR minimal, but I could update that here if that'd be best.