### PR TITLE
[gl3w] Use khrplatform.h from the egl-registry port

### DIFF
--- a/ports/gl3w/portfile.cmake
+++ b/ports/gl3w/portfile.cmake
@@ -20,15 +20,14 @@ vcpkg_execute_required_process(
   LOGNAME gl3w-gen
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
-  PREFER_NINJA
   OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_config_fixup()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
   vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/GL/gl3w.h" "#define GL3W_API" "#define GL3W_API __declspec(dllimport)")

--- a/ports/gl3w/portfile.cmake
+++ b/ports/gl3w/portfile.cmake
@@ -8,16 +8,9 @@ vcpkg_from_github(
       0001-enable-shared-build.patch
 )
 
-# Download khrplatform.h with vcpkg instead of gl3w_gen.py so that our downloader settings are used
-vcpkg_download_distfile(KHRPLATFORM_H
-  URLS "https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h"
-  FILENAME khrplatform.h
-  SHA512 93d9075718eddb69c44482acdc72bbbd3511741272a6124d05ab1ef0702ef03e918501403b6fd334faf2c61f3332f34b7730158aa090db3d448c32b5dd9d9e67
-  )
-
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${CURRENT_INSTALLED_DIR}/include/GL/glcorearb.h" DESTINATION "${SOURCE_PATH}/include/GL")
-file(COPY "${KHRPLATFORM_H}" DESTINATION "${SOURCE_PATH}/include/KHR")
+file(COPY "${CURRENT_INSTALLED_DIR}/include/KHR/khrplatform.h" DESTINATION "${SOURCE_PATH}/include/KHR")
 
 vcpkg_find_acquire_program(PYTHON3)
 

--- a/ports/gl3w/vcpkg.json
+++ b/ports/gl3w/vcpkg.json
@@ -6,6 +6,14 @@
   "homepage": "https://github.com/skaslev/gl3w",
   "dependencies": [
     "egl-registry",
-    "opengl-registry"
+    "opengl-registry",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/gl3w/vcpkg.json
+++ b/ports/gl3w/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "gl3w",
   "version-date": "2018-05-31",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Simple OpenGL core profile loading",
   "homepage": "https://github.com/skaslev/gl3w",
   "dependencies": [
+    "egl-registry",
     "opengl-registry"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2450,7 +2450,7 @@
     },
     "gl3w": {
       "baseline": "2018-05-31",
-      "port-version": 3
+      "port-version": 4
     },
     "glad": {
       "baseline": "0.1.34",

--- a/versions/g-/gl3w.json
+++ b/versions/g-/gl3w.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "618626b6f1118dc2c80fa7bd2aae497c0d83b7c1",
+      "version-date": "2018-05-31",
+      "port-version": 4
+    },
+    {
       "git-tree": "bbd82479631534cfe954646d63d29734c3b7728f",
       "version-date": "2018-05-31",
       "port-version": 3


### PR DESCRIPTION
The gl3w port checks the hash of the downloaded file khrplatform.h since #18858. That file was modified yesterday (KhronosGroup/EGL-Registry@57b4876de0f33677ece92dd9de0ef105ce69139d), requiring the hash to be updated.

This fixes the following error when installing gl3w:

```
Starting package 41/41: gl3w:x64-windows-static
Building package gl3w[core]:x64-windows-static...
-- Downloading https://github.com/skaslev/gl3w/archive/99ed321100d37032cb6bfa7dd8dea85f10c86132.tar.gz -> skaslev-gl3w-99ed321100d37032cb6bfa7dd8dea85f10c86132.tar.gz...
-- Extracting source C:/Tools/vcpkg/downloads/skaslev-gl3w-99ed321100d37032cb6bfa7dd8dea85f10c86132.tar.gz
-- Applying patch 0001-enable-shared-build.patch
-- Using source at C:/Tools/vcpkg/buildtrees/gl3w/src/5f10c86132-7e24c6e824.clean
-- Downloading https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h -> khrplatform.h...
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'manifests' = off
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Downloading https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h
Error: Failed to download from mirror set:
File does not have the expected hash:
             url : [ https://www.khronos.org/registry/EGL/api/KHR/khrplatform.h ]
       File path : [ C:\Tools\vcpkg\downloads\khrplatform.h.1560.part ]
   Expected hash : [ 93d9075718eddb69c44482acdc72bbbd3511741272a6124d05ab1ef0702ef03e918501403b6fd334faf2c61f3332f34b7730158aa090db3d448c32b5dd9d9e67 ]
     Actual hash : [ 0adf658c45095bf31bb1cca4b9eb6fe944550d1ee7f95b5601494869c57b4b43f544e8160933a1b7d6d63c975de08191f27f9f16d50bf3b7c7e209f28a4bcfb5 ]
```