### PR TITLE
[vcpkg baseline][activemq-cpp] Added missing libuuid dependency

### DIFF
--- a/ports/activemq-cpp/vcpkg.json
+++ b/ports/activemq-cpp/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "activemq-cpp",
   "version-semver": "3.9.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server.",
   "supports": "!(uwp | osx)",
   "dependencies": [
-    "apr"
+    "apr",
+    "libuuid"
   ]
 }

--- a/versions/a-/activemq-cpp.json
+++ b/versions/a-/activemq-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d1c131172bea536490960f632ac287b3db73edb",
+      "version-semver": "3.9.5",
+      "port-version": 6
+    },
+    {
       "git-tree": "bce9f87e7df6f4e8a9c3121018ffc032e3d2603e",
       "version-semver": "3.9.5",
       "port-version": 5

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "activemq-cpp": {
       "baseline": "3.9.5",
-      "port-version": 5
+      "port-version": 6
     },
     "ade": {
       "baseline": "0.1.1f",


### PR DESCRIPTION
This is a mandatory dependency according to
https://github.com/apache/activemq-cpp/blob/master/README.txt

**Describe the pull request**

- #### What does your PR fix?  
  Fixes building on x64-linux

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Not changed

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
    `Yes`