### PR TITLE
[grpc] Turn on codegen feature automatically when needed

### DIFF
--- a/ports/grpc/portfile.cmake
+++ b/ports/grpc/portfile.cmake
@@ -23,8 +23,18 @@ vcpkg_from_github(
         00014-pkgconfig-upbdefs.patch
 )
 
-if(NOT TARGET_TRIPLET STREQUAL HOST_TRIPLET)
-    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
+if(VCPKG_CROSSCOMPILING)
+    if(NOT VCPKG_CMAKE_SYSTEM_NAME 
+       AND (NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "arm") 
+       AND (NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64"))
+        # If both are windows on x86-64, turn on codegen feature automatically since it's not a crosscompiling.
+        # This is required because VCPKG_CROSSCOMPILING only checks if the triplets are different
+        # and does not care about the situations like HOST:x64-windows and TARGET:x64-windows-static
+        list(APPEND FEATURES codegen)
+    else()
+        # Add the path of generated plugins for host OS
+        vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
+    endif()
 endif()
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" gRPC_MSVC_STATIC_RUNTIME)

--- a/ports/grpc/vcpkg.json
+++ b/ports/grpc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "grpc",
   "version-semver": "1.41.0",
+  "port-version": 1,
   "description": "An RPC library and framework",
   "homepage": "https://github.com/grpc/grpc",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2578,7 +2578,7 @@
     },
     "grpc": {
       "baseline": "1.41.0",
-      "port-version": 0
+      "port-version": 1
     },
     "grppi": {
       "baseline": "0.4.0",

--- a/versions/g-/grpc.json
+++ b/versions/g-/grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e59d0419c509ef15306cfd3c8ae9b390edf94a2f",
+      "version-semver": "1.41.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5e3795bf43afe5243e47e18ac66a28bc722207f5",
       "version-semver": "1.41.0",
       "port-version": 0


### PR DESCRIPTION
This PR changes to turn on codegen feature when it is not an actual cross compiling like `Host: x64-windows, Target: x64-windows-static`.

- #### What does your PR fix?  
  Fixes #21514 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes