### PR TITLE
[sqlcipher] bump version to 4.5.0

### DIFF
--- a/ports/sqlcipher/CMakeLists.txt
+++ b/ports/sqlcipher/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 target_include_directories(sqlcipher INTERFACE $<INSTALL_INTERFACE:include>)
 if(NOT WIN32)
     find_package(Threads REQUIRED)
-    target_link_libraries(sqlcipher PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+    target_link_libraries(sqlcipher PRIVATE Threads::Threads ${CMAKE_DL_LIBS} m)
 endif()
 
 target_link_libraries(sqlcipher PRIVATE ${OPENSSL_CRYPTO_LIBRARY})

--- a/ports/sqlcipher/portfile.cmake
+++ b/ports/sqlcipher/portfile.cmake
@@ -5,8 +5,8 @@ vcpkg_fail_port_install( ON_TARGET "UWP" "OSX" "Linux")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO sqlcipher/sqlcipher
-    REF v4.4.3
-    SHA512 d80177cf658c145f7328bafac14bc2779afa463fc94ef0a5e99b6654cf2eece3088ac296949130e7263f52948913ffeac253c47e33d91816e90caf1788301a9a
+    REF v4.5.0
+    SHA512 d4c4fd97269721cf6e6a3195f67ef8b23bfb91d38336e7e049e7dc5c6ace25909f456463ba4202bc715a768da6885127755b036c291c7fb599de84a0a4c4bb7f
     HEAD_REF master
 )
 

--- a/ports/sqlcipher/vcpkg.json
+++ b/ports/sqlcipher/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlcipher",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "description": "SQLCipher extends the SQLite database library to add security enhancements that make it more suitable for encrypted local data storage.",
   "homepage": "https://www.zetetic.net/sqlcipher",
   "supports": "windows & !uwp & !static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6533,7 +6533,7 @@
       "port-version": 1
     },
     "sqlcipher": {
-      "baseline": "4.4.3",
+      "baseline": "4.5.0",
       "port-version": 0
     },
     "sqlite-modern-cpp": {

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f7e9e9052397a0313dde44175a7840e36c9abf56",
+      "version": "4.5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3811f54932ce20be68bed2fed0cafcfb1d03be56",
       "version": "4.4.3",
       "port-version": 0

--- a/versions/s-/sqlcipher.json
+++ b/versions/s-/sqlcipher.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f7e9e9052397a0313dde44175a7840e36c9abf56",
+      "git-tree": "dd42a5be2c9409d8e5c35b9821765f504ef960ff",
       "version": "4.5.0",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #22088 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  no change

- #### Does your PR follow the [maintainer guide]
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
