### PR TITLE
[python3] Fix feature deprecated-win7-support.

### DIFF
--- a/ports/python3/0006-restore-support-for-windows-7.patch
+++ b/ports/python3/0006-restore-support-for-windows-7.patch
@@ -73,7 +73,16 @@ diff --git a/PC/getpathp.c b/PC/getpathp.c
 index 53da3a6..3d58bbf 100644
 --- a/PC/getpathp.c
 +++ b/PC/getpathp.c
-@@ -250,14 +250,43 @@ ismodule(wchar_t *filename, int update_filename)
+@@ -90,7 +90,7 @@
+ #endif
+ 
+ #include <windows.h>
+-#include <pathcch.h>
++#include <Shlwapi.h>
+ 
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+@@ -249,14 +249,43 @@ ismodule(wchar_t *filename, int update_filename)
     stuff as fits will be appended.
  */
  
@@ -164,15 +173,15 @@ index d7d3cf0..6e9c090 100644
  /* We only set these values when building Python - we don't want to force
     these values on extensions, as that will affect the prototypes and
 diff --git a/PCbuild/pythoncore.vcxproj b/PCbuild/pythoncore.vcxproj
-index 2625d02..20e3d6e 100644
+index c39ba3e1a9..0ef3a05fb6 100644
 --- a/PCbuild/pythoncore.vcxproj
 +++ b/PCbuild/pythoncore.vcxproj
 @@ -106,7 +106,7 @@
        <PreprocessorDefinitions Condition="$(IncludeExternals)">_Py_HAVE_ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
      </ClCompile>
      <Link>
--      <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
-+      <AdditionalDependencies>version.lib;shlwapi.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+-      <AdditionalDependencies>version.lib;ws2_32.lib;pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
++      <AdditionalDependencies>version.lib;ws2_32.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
    </ItemDefinitionGroup>
    <ItemGroup>

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-semver": "3.10.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5486,7 +5486,7 @@
     },
     "python3": {
       "baseline": "3.10.1",
-      "port-version": 2
+      "port-version": 3
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "35f071d147af8c4d8dfac5eaa95ad41e395448a5",
+      "version-semver": "3.10.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "198663bdc6b156d4423eb6ebf085c803f83babf8",
       "version-semver": "3.10.1",
       "port-version": 2


### PR DESCRIPTION
Patch `0006-restore-support-for-windows-7.patch` no longer applies, presumably due to the aftermath of the update to Python 3.10.1. This fixes that.

- #### What does your PR fix?  
  See above

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes
- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
