### PR TITLE
[vcpkg baseline][ffmpeg] Fix dependency alsa

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -279,8 +279,6 @@ endif()
 
 if (NOT "alsa" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --disable-alsa")
-else()
-    list(APPEND FFMPEG_PKGCONFIG_MODULES alsa)
 endif()
 
 if("avcodec" IN_LIST FEATURES)

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -278,7 +278,7 @@ else()
 endif()
 
 if (NOT "alsa" IN_LIST FEATURES)
-    set(OPTIONS "${OPTIONS} --disable-avcodec")
+    set(OPTIONS "${OPTIONS} --disable-alsa")
 else()
     list(APPEND FFMPEG_PKGCONFIG_MODULES alsa)
 endif()

--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -12,6 +12,9 @@ if("ffprobe" IN_LIST FEATURES)
     vcpkg_fail_port_install(ON_TARGET "UWP" MESSAGE "Feature 'ffprobe' does not support 'uwp'")
 endif()
 
+if ("alsa" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_LINUX)
+    message(FATAL_ERROR "Feature 'alsa' only support 'linux'")
+endif()
 
 if("aom" IN_LIST FEATURES)
     if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" OR VCPKG_TARGET_IS_UWP)
@@ -272,6 +275,12 @@ if("ffprobe" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-ffprobe")
 else()
     set(OPTIONS "${OPTIONS} --disable-ffprobe")
+endif()
+
+if (NOT "alsa" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --disable-avcodec")
+else()
+    list(APPEND FFMPEG_PKGCONFIG_MODULES alsa)
 endif()
 
 if("avcodec" IN_LIST FEATURES)

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -56,6 +56,14 @@
             "webp",
             "zlib"
           ]
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "alsa"
+          ],
+          "platform": "linux"
         },
         {
           "name": "ffmpeg",
@@ -238,6 +246,12 @@
             "openssl"
           ]
         }
+      ]
+    },
+    "alsa": {
+      "description": "Enable ALSA support",
+      "dependencies": [
+        "alsa"
       ]
     },
     "aom": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2142,7 +2142,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 2
+      "port-version": 3
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c65b88852753bdb51dbe5ba939cf0c71a4517f28",
+      "git-tree": "00480edd2a451f2a3a55452779f524709ee52585",
       "version": "4.4.1",
       "port-version": 3
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "34fa32502ab259e61a588aae4c6c25bd6c1af959",
+      "git-tree": "c65b88852753bdb51dbe5ba939cf0c71a4517f28",
       "version": "4.4.1",
       "port-version": 3
     },

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "34fa32502ab259e61a588aae4c6c25bd6c1af959",
+      "version": "4.4.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "7576aa6e0cfa9b2e58abe51484cab6fd16337465",
       "version": "4.4.1",
       "port-version": 2


### PR DESCRIPTION
Fix build issue when building opencv4:
```
CMake Error at /mnt/vcpkg-ci/installed/x64-linux/share/ffmpeg/FindFFMPEG.cmake:68 (find_library):
  Could not find FFMPEG_DEPENDENCY_asound_RELEASE using the following names:
  asound
```

In _FFMPEG_SOURCE/configure_ line 203:
```
  --disable-alsa           disable ALSA support [autodetect]
```
If we installed alsa first in x64-linux then build ffmepg, ffmpeg will enable alsa automaticly:
```
Enabled indevs:
alsa                    lavfi                   v4l2
fbdev                   oss                     xcbgrab
```
And `libasound` will be added into _share/ffmpeg/FindFFMPEG.cmake_:
```cmake
  append_dependencies(FFMPEG_DEPS_LIBRARY_RELEASE NAMES "xcb-shm;xcb-xfixes;xcb-render;xcb-shape;xcb;Xau;Xdmcp;asound;GL;dbus-1;SDL2;ass;harfbuzz;fribidi;fontconfig;expat;freetype;png16;brotlidec-static;brotlicommon-static;bz2;modplug;ssl;crypto;vpx;webpmux;lzma;dav1d;snappy;z;aom;fdk-aac;ilbc;mp3lame;openjp2;opus;speex;theoraenc;theoradec;vorbisenc;vorbis;ogg;webp;x264;x265;gcc_s;gcc;rt;numa;openh264;stdc++;pthread;soxr;m;OpenCL;-pthread;Xv;X11;Xext;dl")
  append_dependencies(FFMPEG_DEPS_LIBRARY_DEBUG   NAMES "xcb-shm;xcb-xfixes;xcb-render;xcb-shape;xcb;Xau;Xdmcp;asound;GL;dbus-1;SDL2d;ass;harfbuzz;fribidi;fontconfig;expat;freetyped;png16d;brotlidec-static;brotlicommon-static;bz2d;modplug;ssl;crypto;vpx;webpmuxd;lzmad;dav1d;snappyd;z;aom;fdk-aac;ilbc;mp3lame;openjp2;opus;speex;theoraenc;theoradec;vorbisenc;vorbis;ogg;webpd;x264;x265;gcc_s;gcc;rt;numa;openh264;stdc++;pthread;soxr;m;OpenCL;-pthread;Xv;X11;Xext;dl" DEBUG)
```

Obviously, in the previous pipeline test, `alsa` was automatically enabled, resulting in this code in our binary cache, and the port alsa was not involved in #21231, which caused the alsa library to not be automatically restored, which led to this issue.

Related: https://github.com/microsoft/vcpkg/pull/21231