### PR TITLE
[blend2d] Update to 2022-02-19

### DIFF
--- a/ports/blend2d/portfile.cmake
+++ b/ports/blend2d/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO blend2d/blend2d
-  REF 92ba4eaa2f22331bc9823ddb47f53dd8ce683c8b
-  SHA512 bb5585d0b73c2acc815a96d613c53c334b5f0d398e99cbaa7b7cf0c63b7a17d36a9f505779d9f5b549b6c6de69414183aadf1b2b8117552bdb273ad7167d761e
+  REF 63db360c7eb2c1c3ca9cd92a867dbb23dc95ca7d
+  SHA512 cf83dd36e51fc92587633dec315b3ad8570137ab0b58836c43b8c73ba934dfc0ad03a58e633bd76b79753b12831007c2a5b3fde237d671594c62a3919507c39a
   HEAD_REF master
 )
 
@@ -10,6 +10,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BLEND2D_STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
   INVERTED_FEATURES
+    futex      BLEND2D_NO_FUTEX
     jit        BLEND2D_NO_JIT
     logging    BLEND2D_NO_JIT_LOGGING
     tls        BLEND2D_NO_TLS
@@ -19,8 +20,8 @@ if(NOT BLEND2D_NO_JIT)
   vcpkg_from_github(
     OUT_SOURCE_PATH ASMJIT_SOURCE_PATH
     REPO asmjit/asmjit
-    REF e7a728018e5d88ffa477430fa63bdebbf480fb02
-    SHA512 99e0f40d6d90ff194cb9e3238c5090a7fb09f871eeaad24283c461214ef584002d4b00c066b303698f71c55b2ccdb926704ec485956d35fc70ea829eff4888a7
+    REF a4e1e88374142f4a842892f9c4bd0b0776fdcd0a
+    SHA512 c8588e2185502c9d045a63ebf722d1cf14eb7373423ef36f0e410525837430f117ad6c841aac16af17246c4d348c3e9094a848b917985de3f677098c1e32606f
     HEAD_REF master
   )
 
@@ -31,18 +32,17 @@ if(NOT BLEND2D_NO_JIT)
   file(RENAME ${SOURCE_PATH}/3rdparty/${ASMJIT_SOURCE_DIR_NAME} ${SOURCE_PATH}/3rdparty/asmjit)
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DBLEND2D_STATIC=${BLEND2D_STATIC}
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/blend2d/vcpkg.json
+++ b/ports/blend2d/vcpkg.json
@@ -1,17 +1,31 @@
 {
   "name": "blend2d",
-  "version-date": "2021-03-17",
-  "port-version": 1,
+  "version-date": "2022-02-19",
   "description": "Beta 2D Vector Graphics Powered by a JIT Compiler",
   "homepage": "https://github.com/blend2d/blend2d",
   "documentation": "https://blend2d.com/doc/index.html",
+  "license": "Zlib",
   "supports": "!arm & !uwp & !wasm32",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "default-features": [
+    "futex",
     "jit",
     "logging",
     "tls"
   ],
   "features": {
+    "futex": {
+      "description": "Default feature. Enables use of futex."
+    },
     "jit": {
       "description": "Default feature. Enables jit pipeline compilation. Not supported for ARM and UWP."
     },

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ceedb664deed987cc4e4493554ae3aa58088f08c",
+      "version-date": "2022-02-19",
+      "port-version": 0
+    },
+    {
       "git-tree": "401153e8f3407e68e96c4ea60f8c71c633b08e1d",
       "version-date": "2021-03-17",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -493,8 +493,8 @@
       "port-version": 2
     },
     "blend2d": {
-      "baseline": "2021-03-17",
-      "port-version": 1
+      "baseline": "2022-02-19",
+      "port-version": 0
     },
     "blitz": {
       "baseline": "2020-03-25",


### PR DESCRIPTION
 - Updated `blend2d` to `2022-02-19` and embedded `asmjit` library to `2022-02-20`.
 - Added new **default** feature [`futex`](https://github.com/blend2d/blend2d/blob/master/src/blend2d/threading/futex_p.h).
 - Used `vcpkg-cmake` as required
 - Added `license` field
 - Resolved conflicts with #22741