### PR TITLE
[giflib] use a vcpkg wrapper for cmake to circumvent bad cmake integrated module

### DIFF
--- a/ports/giflib/portfile.cmake
+++ b/ports/giflib/portfile.cmake
@@ -29,4 +29,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/gif)
+
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/giflib/vcpkg-cmake-wrapper.cmake
+++ b/ports/giflib/vcpkg-cmake-wrapper.cmake
@@ -1,24 +1,3 @@
-include(SelectLibraryConfigurations)
 find_path(GIF_INCLUDE_DIR gif_lib.h PATH_SUFFIXES include PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH)
 
-find_library(GIF_LIBRARY_DEBUG NAMES gif libgif ungif libungif giflib giflib4 gifd libgifd ungifd libungifd giflibd giflib4d NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH)
-find_library(GIF_LIBRARY_RELEASE NAMES gif libgif ungif libungif giflib giflib4 NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH)
-select_library_configurations(GIF)
-set(GIF_INCLUDE_DIRS ${GIF_INCLUDE_DIR})
-set(GIF_LIBRARIES ${GIF_LIBRARY})
-set(GIF_VERSION 5)
-
-include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(GIF  REQUIRED_VARS  GIF_LIBRARY  GIF_INCLUDE_DIR
-                                       VERSION_VAR GIF_VERSION )
-
-if(NOT TARGET GIF::GIF)
-  add_library(GIF::GIF UNKNOWN IMPORTED)
-  set_target_properties(GIF::GIF PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${GIF_INCLUDE_DIRS}")
-  if(EXISTS "${GIF_LIBRARY}")
-    set_target_properties(GIF::GIF PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-      IMPORTED_LOCATION "${GIF_LIBRARY}")
-  endif()
-endif()
+_find_package(${ARGS})

--- a/ports/giflib/vcpkg-cmake-wrapper.cmake
+++ b/ports/giflib/vcpkg-cmake-wrapper.cmake
@@ -1,8 +1,8 @@
 include(SelectLibraryConfigurations)
 find_path(GIF_INCLUDE_DIR gif_lib.h PATH_SUFFIXES include PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH)
 
-find_library(GIF_LIBRARY_DEBUG NAMES gif libgif ungif libungif giflib giflib4 gifd libgifd ungifd libungifd giflibd giflib4d NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH REQUIRED)
-find_library(GIF_LIBRARY_RELEASE NAMES gif libgif ungif libungif giflib giflib4 NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH REQUIRED)
+find_library(GIF_LIBRARY_DEBUG NAMES gif libgif ungif libungif giflib giflib4 gifd libgifd ungifd libungifd giflibd giflib4d NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH)
+find_library(GIF_LIBRARY_RELEASE NAMES gif libgif ungif libungif giflib giflib4 NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH)
 select_library_configurations(GIF)
 set(GIF_INCLUDE_DIRS ${GIF_INCLUDE_DIR})
 set(GIF_LIBRARIES ${GIF_LIBRARY})

--- a/ports/giflib/vcpkg-cmake-wrapper.cmake
+++ b/ports/giflib/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,24 @@
+include(SelectLibraryConfigurations)
+find_path(GIF_INCLUDE_DIR gif_lib.h PATH_SUFFIXES include PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH)
+
+find_library(GIF_LIBRARY_DEBUG NAMES gif libgif ungif libungif giflib giflib4 gifd libgifd ungifd libungifd giflibd giflib4d NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" NO_DEFAULT_PATH REQUIRED)
+find_library(GIF_LIBRARY_RELEASE NAMES gif libgif ungif libungif giflib giflib4 NAMES_PER_DIR PATH_SUFFIXES lib PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" NO_DEFAULT_PATH REQUIRED)
+select_library_configurations(GIF)
+set(GIF_INCLUDE_DIRS ${GIF_INCLUDE_DIR})
+set(GIF_LIBRARIES ${GIF_LIBRARY})
+set(GIF_VERSION 5)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GIF  REQUIRED_VARS  GIF_LIBRARY  GIF_INCLUDE_DIR
+                                       VERSION_VAR GIF_VERSION )
+
+if(NOT TARGET GIF::GIF)
+  add_library(GIF::GIF UNKNOWN IMPORTED)
+  set_target_properties(GIF::GIF PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${GIF_INCLUDE_DIRS}")
+  if(EXISTS "${GIF_LIBRARY}")
+    set_target_properties(GIF::GIF PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${GIF_LIBRARY}")
+  endif()
+endif()

--- a/ports/giflib/vcpkg.json
+++ b/ports/giflib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "giflib",
   "version": "5.2.1",
+  "port-version": 1,
   "description": "A library for reading and writing gif images.",
   "homepage": "https://sourceforge.net/projects/giflib/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2438,7 +2438,7 @@
     },
     "giflib": {
       "baseline": "5.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ginkgo": {
       "baseline": "1.4.0",

--- a/versions/g-/giflib.json
+++ b/versions/g-/giflib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "713f564217c63b30a1490f40a15bf751197c3211",
+      "version": "5.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "7cfc37d67d8662dd5fa5bf698a61ebbd657060cc",
       "version": "5.2.1",
       "port-version": 0

--- a/versions/g-/giflib.json
+++ b/versions/g-/giflib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "713f564217c63b30a1490f40a15bf751197c3211",
+      "git-tree": "653b0e6b20c7a4c0374831aa43f0213d79cc8178",
       "version": "5.2.1",
       "port-version": 1
     },

--- a/versions/g-/giflib.json
+++ b/versions/g-/giflib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "653b0e6b20c7a4c0374831aa43f0213d79cc8178",
+      "git-tree": "14178ec83d76a40e314adcf9bba75b63e99bc56d",
       "version": "5.2.1",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
If not using this wrapper, CMake modules does not find correctly gif_lib.h in many cases when installed through vcpkg (e.g. in a GitHub Actions macOS runner default agent).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes

