### PR TITLE
[highfive] Fix usage

### DIFF
--- a/ports/highfive/portfile.cmake
+++ b/ports/highfive/portfile.cmake
@@ -41,9 +41,6 @@ endif()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/HighFive/CMake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-if(NOT VCPKG_TARGET_IS_UWP AND NOT VCPKG_TARGET_IS_OSX)
-  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/HighFive")
-endif()
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/highfive/portfile.cmake
+++ b/ports/highfive/portfile.cmake
@@ -38,7 +38,8 @@ if("tests" IN_LIST FEATURES)
     )
 endif()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH share/HighFive/CMake)
+# Use PACKAGE_NAME to avoid folder HighFive and highfive are exist at same time
+vcpkg_cmake_config_fixup(PACKAGE_NAME HighFive CONFIG_PATH share/HighFive/CMake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/highfive/vcpkg.json
+++ b/ports/highfive/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "highfive",
   "version": "2.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "HighFive is a modern header-only C++/C++11 friendly interface for libhdf5",
   "homepage": "https://github.com/BlueBrain/HighFive",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2694,7 +2694,7 @@
     },
     "highfive": {
       "baseline": "2.3",
-      "port-version": 1
+      "port-version": 2
     },
     "highway": {
       "baseline": "0.14.2",

--- a/versions/h-/highfive.json
+++ b/versions/h-/highfive.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4f5ec6de3867a92d3d1be9ecb0eb7919864f0e88",
+      "version": "2.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "e2f9f257e00960a16a162c1f279406f48528db5a",
       "version": "2.3",
       "port-version": 1

--- a/versions/h-/highfive.json
+++ b/versions/h-/highfive.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4f5ec6de3867a92d3d1be9ecb0eb7919864f0e88",
+      "git-tree": "b1ecca066cce62dd0fbdf760151ee0c3ccc70b81",
       "version": "2.3",
       "port-version": 2
     },


### PR DESCRIPTION
Currently cmake generated by highfive can be used in all triplets. Remove the conditional code snippet and add `PACKAGE_NAME` to `vcpkg_cmake_config_fixup`.

Fixes #22142 

Already tested the usage in Windows and OSX.