### PR TITLE
[activemq-cpp] Add platform for dependency libuuid

### DIFF
--- a/ports/activemq-cpp/vcpkg.json
+++ b/ports/activemq-cpp/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "activemq-cpp",
   "version-semver": "3.9.5",
-  "port-version": 6,
+  "port-version": 7,
   "description": "Apache ActiveMQ is the most popular and powerful open source messaging and Integration Patterns server.",
   "supports": "!(uwp | osx)",
   "dependencies": [
     "apr",
-    "libuuid"
+    {
+      "name": "libuuid",
+      "platform": "!windows"
+    }
   ]
 }

--- a/versions/a-/activemq-cpp.json
+++ b/versions/a-/activemq-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "531d21bab7c2d9e9e2ecb1c84e6cf9f1c6173a51",
+      "version-semver": "3.9.5",
+      "port-version": 7
+    },
+    {
       "git-tree": "0d1c131172bea536490960f632ac287b3db73edb",
       "version-semver": "3.9.5",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -22,7 +22,7 @@
     },
     "activemq-cpp": {
       "baseline": "3.9.5",
-      "port-version": 6
+      "port-version": 7
     },
     "ade": {
       "baseline": "0.1.1f",


### PR DESCRIPTION
The dependency `libuuid` is only support non-Windows, and the vcxproj doesn't contain dependency uuid.

Fixes https://github.com/microsoft/vcpkg/pull/22059#issuecomment-998953063.