### PR TITLE
[imgui] Update to 1.86

### DIFF
--- a/ports/imgui/CMakeLists.txt
+++ b/ports/imgui/CMakeLists.txt
@@ -172,11 +172,6 @@ if(NOT IMGUI_SKIP_HEADERS)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glut.h DESTINATION include)
     endif()
 
-    if(IMGUI_COPY_MARMALADE_BINDING)
-        file(GLOB MARMALADE_BINDING_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_marmalade.*)
-        install(FILES ${MARMALADE_BINDING_SRCS} DESTINATION include/bindings)
-    endif()
-
     if(IMGUI_BUILD_METAL_BINDING)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.h DESTINATION include)
     endif()

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,22 +4,22 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF 1b215ecb018ba0fd170618366ddc4be9bd45f283
-       SHA512 afd79082c4439b47d5943df5f7ddbdf80dcf23cd120b8da99b67b2979728e604436dd656ef8e8ae0af2a9050f8ea56b2f8c109243326fb842d684027616843e7
+       REF 15b4a064f9244c430e65214f7249b615fb394321
+       SHA512 d83403caf37efbffb29d902f7ea7d52596525f1bf7d1258671ffd5ea17f810c63541b2142dee1c9cf12c16fde697373972cbabd3957b1fcb87c9e1aa22ebbc4e
        HEAD_REF docking
        )
 else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v1.85
-    SHA512 830ff36681a661d77754fb7818bb13cc63da58a293d343a8d6847a586f00c6e0bfc3ffe51cdf882849e5083d4ddca52cdbdc1b3abc9b794a96f89ae7628f1fc2
+    REF v1.86
+    SHA512 e84fdc0839e96e53dcbe3a5d13bbd0def860c09bafa709b22f8371d5c710f5c90f6957e5f12813156ed0c4d0fa2b56c5e3be701206f7770749ce169818697229
     HEAD_REF master
     )
 endif()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/imgui-config.cmake.in DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/imgui-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 if(("metal-binding" IN_LIST FEATURES OR "osx-binding" IN_LIST FEATURES) AND (NOT VCPKG_TARGET_IS_OSX))
     message(FATAL_ERROR "Feature metal-binding and osx-binding are only supported on osx.")
@@ -34,7 +34,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     dx12-binding                IMGUI_BUILD_DX12_BINDING
     glfw-binding                IMGUI_BUILD_GLFW_BINDING
     glut-binding                IMGUI_BUILD_GLUT_BINDING
-    marmalade-binding           IMGUI_COPY_MARMALADE_BINDING
     metal-binding               IMGUI_BUILD_METAL_BINDING
     opengl2-binding             IMGUI_BUILD_OPENGL2_BINDING
     opengl3-binding             IMGUI_BUILD_OPENGL3_BINDING
@@ -57,17 +56,15 @@ if ("libigl-imgui" IN_LIST FEATURES)
             abe9250c9a5989e0a3f2285bbcc83696ff8e38c1f5657c358e6fe616ff792d3c6e5ff2fa23c2eeae7d7b307392e0dc798a95d14f6d10f8e9bfbd7768d36d8b31
     )
 
-    file(INSTALL ${IMGUI_FONTS_DROID_SANS_H} DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+    file(INSTALL "${IMGUI_FONTS_DROID_SANS_H}" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 endif()
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
     OPTIONS_DEBUG
         -DIMGUI_SKIP_HEADERS=ON
-    MAYBE_UNUSED_VARIABLES
-        IMGUI_COPY_MARMALADE_BINDING
 )
 
 vcpkg_cmake_install()
@@ -82,4 +79,4 @@ endif()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.85",
+  "version": "1.86",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "dependencies": [
@@ -55,9 +55,6 @@
     },
     "libigl-imgui": {
       "description": "Install the libigl-imgui headers"
-    },
-    "marmalade-binding": {
-      "description": "Make available Marmalade binding"
     },
     "metal-binding": {
       "description": "Make available Metal binding"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2841,7 +2841,7 @@
       "port-version": 1
     },
     "imgui": {
-      "baseline": "1.85",
+      "baseline": "1.86",
       "port-version": 0
     },
     "imgui-sfml": {

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "afdf40a53f1f7d77248d9cdeb3f629698d0a72c5",
+      "version": "1.86",
+      "port-version": 0
+    },
+    {
       "git-tree": "9ae62261d966705924645bc3a057fe748c24d290",
       "version": "1.85",
       "port-version": 0


### PR DESCRIPTION
Update the imgui port from 1.85 to 1.86. I removed the marmalade feature because the corresponding backend was removed in imgui.

Changelog : https://github.com/ocornut/imgui/releases/tag/v1.86