### PR TITLE
[vcpkg baseline][many ports] Fix build failures

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -129,6 +129,12 @@ file(RENAME "${CURRENT_PACKAGES_DIR}/include/botan-2/botan" "${CURRENT_PACKAGES_
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
     file(RENAME "${CURRENT_PACKAGES_DIR}/lib/botan-2.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/botan-2.pc")
+    if (VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/botan-2.pc"
+            [[\lib]]
+            [[/lib]]
+        )
+    endif()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/botan-2.pc"
         [[${prefix}/include/botan-2]]
         [[${prefix}/include]]
@@ -137,6 +143,12 @@ endif()
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/botan-2.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/botan-2.pc")
+    if (VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/botan-2.pc"
+            [[\lib]]
+            [[/lib]]
+        )
+    endif()
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/botan-2.pc"
         [[${prefix}/include/botan-2]]
         [[${prefix}/include]]

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "botan",
   "version": "2.18.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
   "supports": "!(windows & arm)",

--- a/ports/ignition-math6/fix-isspace.patch
+++ b/ports/ignition-math6/fix-isspace.patch
@@ -1,0 +1,12 @@
+diff --git a/include/ignition/math/Color.hh b/include/ignition/math/Color.hh
+index faf7a08..16758c5 100644
+--- a/include/ignition/math/Color.hh
++++ b/include/ignition/math/Color.hh
+@@ -18,6 +18,7 @@
+ #define IGNITION_MATH_COLOR_HH_
+ 
+ #include <iostream>
++#include <cctype>
+ 
+ #include <ignition/math/Helpers.hh>
+ #include <ignition/math/Vector3.hh>

--- a/ports/ignition-math6/portfile.cmake
+++ b/ports/ignition-math6/portfile.cmake
@@ -2,4 +2,5 @@ include(${CURRENT_INSTALLED_DIR}/share/ignitionmodularscripts/ignition_modular_l
 
 ignition_modular_library(NAME math
                          VERSION "6.6.0"
-                         SHA512 1b5f59b45256daa81cbfb7da4727200d0d6cb4a75fbc3b83b512c18ec6307b5bd78b8ee7a84f0f8a8c334717a1480766f62658bd213e9021c09c0ed22caa921d)
+                         SHA512 1b5f59b45256daa81cbfb7da4727200d0d6cb4a75fbc3b83b512c18ec6307b5bd78b8ee7a84f0f8a8c334717a1480766f62658bd213e9021c09c0ed22caa921d
+                         PATCHES fix-isspace.patch)

--- a/ports/ignition-math6/vcpkg.json
+++ b/ports/ignition-math6/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ignition-math6",
   "version-string": "6.6.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Math API for robotic applications",
   "homepage": "https://ignitionrobotics.org/libs/math",
   "dependencies": [

--- a/ports/omplapp/fix_boost_static_link.patch
+++ b/ports/omplapp/fix_boost_static_link.patch
@@ -1,5 +1,5 @@
-﻿diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f5c3c88..3a4a7d4 100644
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4b391b5..24d2c66 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -36,10 +36,10 @@ set(OMPL_DEMO_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/ompl/demos"

--- a/ports/omplapp/fix_dependency.patch
+++ b/ports/omplapp/fix_dependency.patch
@@ -1,32 +1,128 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 4c7e6901..a433b7da 100644
+index 4c7e690..4b391b5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -136,7 +136,7 @@ find_package(Drawstuff QUIET)
+@@ -73,12 +73,15 @@ set_package_properties(OpenGL PROPERTIES
+     URL "http://opengl.org"
+     PURPOSE "Used to render graphics in ompl_app.")
+ set(OpenGL_GL_PREFERENCE GLVND)
+-find_package(OpenGL)
++if (OMPLAPP_WITH_OPENGL)
++find_package(OpenGL REQUIRED)
++endif()
+ set_package_properties(Python PROPERTIES
+     URL "http://python.org"
+     PURPOSE "Used for python bindings.")
+ # This includes our own FindPython.cmake in ompl/CMakeModules. It defines,
+ # among other things, the find_python_module() function used below.
++if (OMPLAPP_WITH_PYTHON)
+ find_package(Python)
+ find_boost_python()
+ 
+@@ -105,55 +108,76 @@ find_python_module(OpenGL)
+ if (NOT OPENGL_FOUND OR NOT PY_OPENGL)
+     message(WARNING "Both OpenGL and the Python OpenGL module need to be installed to use the GUI")
+ endif()
++endif()
+ set_package_properties(Eigen3 PROPERTIES
+     URL "http://eigen.tuxfamily.org"
+     PURPOSE "A linear algebra library used throughout OMPL.")
+-find_package(Eigen3 REQUIRED)
++find_package(Eigen3 CONFIG REQUIRED)
+ set_package_properties(Triangle PROPERTIES
+     URL "http://www.cs.cmu.edu/~quake/triangle.html"
+     PURPOSE "Used to create triangular decompositions of polygonal 2D environments.")
++if (OMPLAPP_WITH_TRIANGLE)
+ find_package(Triangle QUIET)
++endif()
+ set_package_properties(flann PROPERTIES
+     URL "https://github.com/mariusmuja/flann"
+     PURPOSE "If detetected, FLANN can be used for nearest neighbor queries by OMPL.")
++if (OMPLAPP_WITH_FLANN)
+ find_package(flann 1.8.3 QUIET)
++endif()
+ set_package_properties(spot PROPERTIES
+     URL "http://spot.lrde.epita.fr"
+     PURPOSE "Used for constructing finite automata from LTL formulae.")
++if (OMPLAPP_WITH_SPOT)
+ find_package(spot)
++endif()
+ set_package_properties(MORSE PROPERTIES
+     URL "https://www.openrobots.org/wiki/morse"
+     PURPOSE "OMPL includes a plugin for the MORSE Robot Simulation engine.")
++if (OMPLAPP_WITH_MORSE)
+ find_package(MORSE QUIET)
++endif()
+ set_package_properties(ODE PROPERTIES
+     URL "http://ode.org"
+     PURPOSE "The Open Dynamics Engine can be used as a \"black box\" for kinodynamic planning.")
+-find_package(ODE QUIET)
++if (OMPLAPP_WITH_ODE)
++find_package(ODE CONFIG REQUIRED)
++set(ODE_LIBRARIES ODE::ODE)
++endif()
+ set_package_properties(Drawstuff PROPERTIES
+     URL "http://ode.org"
+     PURPOSE "Part of the ODE source distribution, used in one demo program.")
++if (OMPLAPP_WITH_DRAWSTUFF)
+ find_package(Drawstuff QUIET)
++endif()
  set_package_properties(assimp PROPERTIES
      URL "http://assimp.org"
      PURPOSE "Used in ompl_app for reading meshes representing robots and environments.")
 -find_package(assimp REQUIRED)
 +find_package(assimp CONFIG REQUIRED)
++set(ASSIMP_LIBRARIES assimp::assimp)
  set_package_properties(ccd PROPERTIES
      URL "https://github.com/danfis/libccd"
      PURPOSE "Collision detection library used by fcl.")
-@@ -178,8 +178,7 @@ include_directories(
+-find_package(ccd REQUIRED)
++find_package(ccd CONFIG REQUIRED)
+ set_package_properties(fcl PROPERTIES
+     URL "https://github.com/flexible-collision-library/fcl"
+     PURPOSE "The default collision checking library.")
++if (OMPLAPP_WITH_OCTOMAP)
+ find_package(octomap QUIET)
++endif()
+ find_package(fcl REQUIRED)
+ set_package_properties(Threads PROPERTIES
+     URL "https://en.wikipedia.org/wiki/POSIX_Threads"
+     PURPOSE "Pthreads is sometimes needed, depending on OS / compiler.")
++if (OMPLAPP_WITH_THREADS)
+ find_package(Threads QUIET)
++endif()
+ set_package_properties(Doxygen PROPERTIES
+     URL "http://doxygen.org"
+     PURPOSE "Used to create the OMPL documentation (i.e., http://ompl.kavrakilab.org).")
++if (OMPLAPP_WITH_DOXYGEN)
+ find_package(Doxygen)
++endif()
+ 
+ enable_testing()
+ 
+@@ -177,9 +201,7 @@ include_directories(SYSTEM "${Boost_INCLUDE_DIR}")
+ include_directories(
      "${OMPLAPP_INCLUDE_DIRS}"
      "${OMPL_INCLUDE_DIRS}"
-     "${EIGEN3_INCLUDE_DIR}"
+-    "${EIGEN3_INCLUDE_DIR}"
 -    "${FCL_INCLUDE_DIRS}"
 -    "${ASSIMP_INCLUDE_DIRS}")
 +    "${FCL_INCLUDE_DIRS}")
  
  # ROS installs fcl in /usr. In /usr/include/fcl/config.h it says octomap was
  # enabled. Octomap is installed in /opt/ros/${ROS_DISTRO}/include (most
-@@ -195,7 +194,7 @@ set(OMPLAPP_MODULE_LIBRARIES
-     ${FCL_LIBRARIES})
- set(OMPLAPP_LIBRARIES
-     ${OPENGL_LIBRARIES}
--    ${ASSIMP_LIBRARIES}
-+    assimp::assimp
-     ${FCL_LIBRARIES})
- link_directories(${ASSIMP_LIBRARY_DIRS} ${CCD_LIBRARY_DIRS} ${OCTOMAP_LIBRARY_DIRS} ${FCL_LIBRARY_DIRS})
+@@ -242,12 +264,14 @@ endif()
+ set_package_properties(PQP PROPERTIES
+     URL "http://gamma.cs.unc.edu/SSV/"
+     PURPOSE "Used as an alternative, additional collision checking library (the default is FCL).")
++IF (OMPLAPP_WITH_PQP)
+ find_package(PQP QUIET)
+ if(PQP_FOUND)
+     include_directories("${PQP_INCLUDE_DIR}")
+     set(OMPLAPP_MODULE_LIBRARIES ${OMPLAPP_MODULE_LIBRARIES} ${PQP_LIBRARY})
+     set(OMPLAPP_LIBRARIES ${OMPLAPP_LIBRARIES} ${PQP_LIBRARY})
+ endif()
++endif()
  
+ add_subdirectory(ompl/doc)
+ add_subdirectory(ompl/src)

--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -21,20 +21,35 @@ vcpkg_extract_source_archive_ex(
         ${STATIC_PATCH}
 )
 
-# Based on selected features different files get downloaded, so use the following command instead of patch.
-vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" "find_package(Eigen3 REQUIRED)" "find_package(Eigen3 REQUIRED CONFIG)")
-vcpkg_replace_string("${SOURCE_PATH}/CMakeLists.txt" "find_package(ccd REQUIRED)" "find_package(ccd REQUIRED CONFIG)")
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        ode     OMPLAPP_WITH_ODE
+        opengl  OMPLAPP_WITH_OPENGL
+        threads OMPLAPP_WITH_THREADS
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DOMPL_VERSIONED_INSTALL=OFF
         -DOMPL_REGISTRATION=OFF
         -DOMPL_BUILD_DEMOS=OFF
         -DOMPL_BUILD_TESTS=OFF
         -DOMPL_BUILD_PYBINDINGS=OFF
         -DOMPL_BUILD_PYTESTS=OFF
+        # Not implement
+        -DOMPLAPP_WITH_PYTHON=OFF
+        -DOMPLAPP_WITH_TRIANGLE=OFF
+        -DOMPLAPP_WITH_OCTOMAP=OFF
+        -DOMPLAPP_WITH_FLANN=OFF # Requires 1.8.3
+        # Missing dependencies in vcpkg
+        -DOMPLAPP_WITH_SPOT=OFF
+        -DOMPLAPP_WITH_MORSE=OFF
+        -DOMPLAPP_WITH_DRAWSTUFF=OFF
+        -DOMPLAPP_WITH_PQP=OFF
+        -DOMPLAPP_WITH_DOXYGEN=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/omplapp/vcpkg.json
+++ b/ports/omplapp/vcpkg.json
@@ -1,11 +1,17 @@
 {
   "name": "omplapp",
   "version": "1.5.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Use OMPL for reading meshes and performing collision checking",
   "homepage": "https://ompl.kavrakilab.org/",
   "dependencies": [
     "assimp",
+    "boost-filesystem",
+    "boost-program-options",
+    "boost-serialization",
+    "boost-system",
+    "ccd",
+    "eigen3",
     "fcl",
     "ompl",
     {
@@ -16,5 +22,25 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "ode": {
+      "description": "Build with Open Dynamics Engine support",
+      "dependencies": [
+        "ode"
+      ]
+    },
+    "opengl": {
+      "description": "Build with OpenGL support",
+      "dependencies": [
+        "opengl"
+      ]
+    },
+    "threads": {
+      "description": "Build with Threads support",
+      "dependencies": [
+        "pthreads"
+      ]
+    }
+  }
 }

--- a/ports/sdformat9/portfile.cmake
+++ b/ports/sdformat9/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "linux" "uwp")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO osrf/sdformat
@@ -14,30 +12,29 @@ vcpkg_from_github(
 vcpkg_find_acquire_program(RUBY)
 get_filename_component(RUBY_PATH ${RUBY} DIRECTORY)
 set(_path $ENV{PATH})
-vcpkg_add_to_path(${RUBY_PATH})
+vcpkg_add_to_path("${RUBY_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_TESTING=OFF
         -DUSE_EXTERNAL_URDF=ON
         -DUSE_EXTERNAL_TINYXML=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 # Restore original path
 set(ENV{PATH} ${_path})
 
 # Fix cmake targets and pkg-config file location
-vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/sdformat9")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/sdformat9")
 vcpkg_fixup_pkgconfig()
 
 # Remove debug files
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
-                    ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/sdformat9/vcpkg.json
+++ b/ports/sdformat9/vcpkg.json
@@ -1,13 +1,22 @@
 {
   "name": "sdformat9",
   "version-string": "9.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
   "supports": "!(linux | uwp)",
   "dependencies": [
     "ignition-math6",
     "tinyxml",
-    "urdfdom"
+    "urdfdom",
+    "urdfdom-headers",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7a800cf24fcc51e57dedfb8782753c50305880e1",
+      "version": "2.18.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "477e259691b81a016da459532f616b5fca230a91",
       "version": "2.18.1",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4882,7 +4882,7 @@
     },
     "omplapp": {
       "baseline": "1.5.1",
-      "port-version": 2
+      "port-version": 3
     },
     "onednn": {
       "baseline": "2.4.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1130,7 +1130,7 @@
     },
     "botan": {
       "baseline": "2.18.1",
-      "port-version": 4
+      "port-version": 5
     },
     "box2d": {
       "baseline": "2.4.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2786,7 +2786,7 @@
     },
     "ignition-math6": {
       "baseline": "6.6.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ignition-modularscripts": {
       "baseline": "2020-11-23",
@@ -6202,7 +6202,7 @@
     },
     "sdformat9": {
       "baseline": "9.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "sdl1": {
       "baseline": "1.2.15",

--- a/versions/i-/ignition-math6.json
+++ b/versions/i-/ignition-math6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fda0a4d654c39cd30c400919981ea71675f696f",
+      "version-string": "6.6.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "20a34c6dd45c4cb0a5638ded5eb9b2dd8113a0ba",
       "version-string": "6.6.0",
       "port-version": 1

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3f243c859f1597f18da61a472684c113e2ed150d",
+      "version": "1.5.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "f048abe6cf0219fa09fd9024188c54a3b5c289c3",
       "version": "1.5.1",
       "port-version": 2

--- a/versions/s-/sdformat9.json
+++ b/versions/s-/sdformat9.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0ae3b0b53c638614e4a03164b1a5d1b70796e55e",
+      "version-string": "9.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d8e35870677a08dcb88753aa2ef446b75a9646f2",
       "version-string": "9.4.0",
       "port-version": 1


### PR DESCRIPTION
1. omplapp: add feature options to avoid the dependencies are found by default.
```
-- Checking for module 'ode'
--   Found ode, version 0.16.1
```
```
LINK : fatal error LNK1104: cannot open file 'ode.lib'
```
Note: already test all features on x86-windows.

2. ignition-math6: fix build failure
```
F:\vcpkg\buildtrees\ignition-math6\src\ath6_6.6.0-1f015548fd.clean\include\ignition/math/Color.hh(259): error C2672: 'std::isspace': no matching overloaded function found
F:\vcpkg\buildtrees\ignition-math6\src\ath6_6.6.0-1f015548fd.clean\include\ignition/math/Color.hh(259): error C2780: 'bool std::isspace(_Elem,const std::locale &)': expects 2 arguments - 1 provided
```
This issue was fixed by the upstream PR https://github.com/ignitionrobotics/ign-math/pull/162

3. sdformat9: add the required dependency urdfdom-headers
```
D:\buildtrees\sdformat9\src\mat9_9.4.0-e90e994b02.clean\src\parser_urdf.cc(30): fatal error C1083: Cannot open include file: 'urdf_model/model.h': No such file or directory
```

4. botan: fix the absolute path in pkgconfig files:
```pc
libdir=${prefix}\lib
includedir=${prefix}/include
```
The pkgconfig files are generated by the official script, so I think this is a upstream issue.


Related: https://github.com/microsoft/vcpkg/pull/21456