### PR TITLE
[x264] builds on arm

### DIFF
--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "x264",
   "version-string": "164-5db6aa6cab1b146",
-  "port-version": 2,
+  "port-version": 3,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
-  "supports": "!arm",
+  "supports": "!(arm & windows)",
   "dependencies": [
     {
       "name": "pthread",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7314,7 +7314,7 @@
     },
     "x264": {
       "baseline": "164-5db6aa6cab1b146",
-      "port-version": 2
+      "port-version": 3
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6021c139214cb74f8fcc2e89344f05210ea4826d",
+      "version-string": "164-5db6aa6cab1b146",
+      "port-version": 3
+    },
+    {
       "git-tree": "c449395a31c61601c5313e4f3e6040bee9c67fde",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 2


### PR DESCRIPTION
Fixes #21767

```
➜  vcpkg git:(x264-allow-arm) ✗ vcpkg install --enforce-port-checks --allow-unsupported                                          
Detecting compiler hash for triplet arm64-osx...
The following packages will be rebuilt:
    x264[core]:arm64-osx -> 164-5db6aa6cab1b146#3
Starting package 1/2: x264:arm64-osx
Removing package x264:arm64-osx...
Elapsed time for package x264:arm64-osx: 3.11 ms
Restored 0 packages from /Users/leanderSchulten/.cache/vcpkg/archives in 584.7 us. Use --debug to see more details.
Starting package 2/2: x264:arm64-osx
Building package x264[core]:arm64-osx...
-- Using community triplet arm64-osx. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/triplets/community/arm64-osx.cmake
-- Using cached mirror-x264-5db6aa6cab1b146e07b60cc1736a01f21da01154.tar.gz.
-- Cleaning sources at /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/x264/src/f21da01154-d285e80d59.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/downloads/mirror-x264-5db6aa6cab1b146e07b60cc1736a01f21da01154.tar.gz
-- Applying patch uwp-cflags.patch
-- Using source at /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/x264/src/f21da01154-d285e80d59.clean
-- Getting CMake variables for arm64-osx-dbg
-- Getting CMake variables for arm64-osx-rel
-- Configuring arm64-osx-dbg
-- Configuring arm64-osx-rel
-- Building arm64-osx-dbg
-- Installing arm64-osx-dbg
-- Building arm64-osx-rel
-- Installing arm64-osx-rel
-- Fixing pkgconfig file: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/x264_arm64-osx/lib/pkgconfig/x264.pc
-- Fixing pkgconfig file: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/x264_arm64-osx/debug/lib/pkgconfig/x264.pc
-- Installing: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/packages/x264_arm64-osx/share/x264/copyright
-- Performing post-build validation
-- Performing post-build validation done
Stored binary cache: /Users/leanderSchulten/.cache/vcpkg/archives/40/40013ffaef8d48b5a5ea3e46dce66587a00ea647e873728143c867c515b7e709.zip
Installing package x264[core]:arm64-osx...
Elapsed time for package x264:arm64-osx: 18.9 s

Total elapsed time: 20.89 s
```