### PR TITLE
[mp3Lame] Changed ImageHasSafeExceptionHandlers set to true for x86

### DIFF
--- a/ports/mp3lame/00001-msvc-upgrade-solution-up-to-vc11.patch
+++ b/ports/mp3lame/00001-msvc-upgrade-solution-up-to-vc11.patch
@@ -223,7 +223,7 @@ index 0000000..faf101a
 +      <OutputFile>$(OutDir)lame.exe</OutputFile>
 +      <GenerateDebugInformation>true</GenerateDebugInformation>
 +      <SubSystem>Console</SubSystem>
-+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
++      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
 +      <AdditionalOptions>/APPCONTAINER /machine:x86 %(AdditionalOptions)</AdditionalOptions>
 +      <TargetMachine>NotSet</TargetMachine>
 +    </Link>
@@ -249,7 +249,7 @@ index 0000000..faf101a
 +    <Link>
 +      <OutputFile>$(OutDir)lame.exe</OutputFile>
 +      <SubSystem>Console</SubSystem>
-+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
++      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
 +      <AdditionalOptions>/APPCONTAINER /machine:x86 %(AdditionalOptions)</AdditionalOptions>
 +      <TargetMachine>NotSet</TargetMachine>
 +    </Link>
@@ -560,7 +560,7 @@ index 0000000..9dad9d5
 +      <ModuleDefinitionFile>..\include\lame.def</ModuleDefinitionFile>
 +      <ImportLibrary>$(OutDir)libmp3lame.lib</ImportLibrary>
 +      <AdditionalOptions>/APPCONTAINER /machine:x86 %(AdditionalOptions)</AdditionalOptions>
-+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
++      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
 +      <TargetMachine>NotSet</TargetMachine>
 +    </Link>
 +  </ItemDefinitionGroup>
@@ -589,7 +589,7 @@ index 0000000..9dad9d5
 +      <GenerateDebugInformation>true</GenerateDebugInformation>
 +      <ImportLibrary>$(OutDir)libmp3lame.lib</ImportLibrary>
 +      <AdditionalOptions>/APPCONTAINER /machine:x86 %(AdditionalOptions)</AdditionalOptions>
-+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
++      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
 +      <TargetMachine>NotSet</TargetMachine>
 +    </Link>
 +  </ItemDefinitionGroup>

--- a/ports/mp3lame/vcpkg.json
+++ b/ports/mp3lame/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mp3lame",
   "version-string": "3.100",
-  "port-version": 7,
+  "port-version": 8,
   "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL.",
   "homepage": "http://lame.sourceforge.net/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4506,7 +4506,7 @@
     },
     "mp3lame": {
       "baseline": "3.100",
-      "port-version": 7
+      "port-version": 8
     },
     "mpark-variant": {
       "baseline": "1.4.0",

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "39e7416c8083fc6ab64f12234355b264936928b2",
+      "version-string": "3.100",
+      "port-version": 8
+    },
+    {
       "git-tree": "ead40ed860e86cd8c3c5492b9bb3fcc7c8a2770e",
       "version-string": "3.100",
       "port-version": 7

--- a/versions/m-/mp3lame.json
+++ b/versions/m-/mp3lame.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39e7416c8083fc6ab64f12234355b264936928b2",
+      "git-tree": "913f7c04241b2b99c514caa4b2d173678d6de096",
       "version-string": "3.100",
       "port-version": 8
     },


### PR DESCRIPTION
Fixes mp3lame: x86-UWP build for the certification test by updating the ImageHasSafeExceptionHandlers to true for x86 in 00001-msvc-upgrade-solution-up-to-vc11 patch

related to issue #22186 

