### PR TITLE
[docs] binarycaching.md: NuGet requires to set API Key for source

### DIFF
--- a/docs/users/binarycaching.md
+++ b/docs/users/binarycaching.md
@@ -96,14 +96,17 @@ steps:
   - name: 'Setup NuGet Credentials'
     shell: 'bash'
     # Replace <OWNER> with your organization name
-    run: >
-      ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
-      sources add
-      -source "https://nuget.pkg.github.com/<OWNER>/index.json"
-      -storepasswordincleartext
-      -name "GitHub"
-      -username "<OWNER>"
-      -password "${{ secrets.GITHUB_TOKEN }}"
+    run: |
+      ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1` \
+        sources add \
+        -source "https://nuget.pkg.github.com/<OWNER>/index.json" \
+        -storepasswordincleartext \
+        -name "GitHub" \
+        -username "<OWNER>" \
+        -password "${{ secrets.GITHUB_TOKEN }}"
+      ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1` \
+        setapikey "${{ secrets.GITHUB_TOKEN }}" \
+        -source "https://nuget.pkg.github.com/<OWNER>/index.json"
 
   # Omit this step if you're using manifests
   - name: 'vcpkg package restore'


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #21851

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`
