### PR TITLE
[wil] update

### DIFF
--- a/ports/wil/portfile.cmake
+++ b/ports/wil/portfile.cmake
@@ -2,8 +2,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/wil
-    REF 5a21cac10640f54b7ef886031f4d9ed427bef4c5
-    SHA512 b1a6703dd75eee66f81c54bb5c01bc9acc7354c113fd556afb2dd95361db7e9f94c9e958d9a0b897359084c9c08cb725bbe214fdaccf2e662c1ca4aa73c3345a
+    REF f9284c19c9873664978b873b8858d7dfacc6af1e
+    SHA512 df81e7f12f15f8e382f537f783c33c9833bb83c4d86d571bd47503e7400698686f51a8a50efd2224c95a5409ab8ef719186d806afbfc4ea2af8d4fd7f8dce024
     HEAD_REF master
 )
 
@@ -17,8 +17,6 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/WIL)
-# Remove this line in the next update
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/WIL-config.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/wilConfig.cmake")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 

--- a/ports/wil/vcpkg.json
+++ b/ports/wil/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "wil",
-  "version-date": "2021-08-03",
-  "port-version": 2,
+  "version-date": "2021-12-25",
   "description": "The Windows Implementation Libraries (WIL) is a header-only C++ library created to make life easier for developers on Windows through readable type-safe C++ interfaces for common Windows coding patterns.",
   "homepage": "https://github.com/microsoft/wil",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7237,8 +7237,8 @@
       "port-version": 1
     },
     "wil": {
-      "baseline": "2021-08-03",
-      "port-version": 2
+      "baseline": "2021-12-25",
+      "port-version": 0
     },
     "wildmidi": {
       "baseline": "0.4.4",

--- a/versions/w-/wil.json
+++ b/versions/w-/wil.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c918f3ae742f41c096f5758afd5af98fe7a194b5",
+      "version-date": "2021-12-25",
+      "port-version": 0
+    },
+    {
       "git-tree": "287e04f5640f1793bdb27bc477dea1ca0e727961",
       "version-date": "2021-08-03",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes `--head` builds of `wil`, due to https://github.com/microsoft/wil/pull/218 being merged these would fail at the RENAME command. Solve this issue by making an updated version.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Windows, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
