### PR TITLE
[python3] Install pkg-config files on Windows platforms

### DIFF
--- a/ports/python3/0009-python-embed.pc.patch
+++ b/ports/python3/0009-python-embed.pc.patch
@@ -1,0 +1,11 @@
+diff --git a/Misc/python-embed.pc.in b/Misc/python-embed.pc.in
+index 2be9df8..a2e5ff7 100644
+--- a/Misc/python-embed.pc.in
++++ b/Misc/python-embed.pc.in
+@@ -9,5 +9,5 @@ Description: Embed Python into an application
+ Requires:
+ Version: @VERSION@
+ Libs.private: @LIBS@
+-Libs: -L${libdir} -lpython@VERSION@@ABIFLAGS@
++Libs: -L${libdir} -lpython@ABIVERSION@@ABIFLAGS@@ABISUFFIX@
+ Cflags: -I${includedir}/python@VERSION@@ABIFLAGS@

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version-semver": "3.10.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5490,7 +5490,7 @@
     },
     "python3": {
       "baseline": "3.10.1",
-      "port-version": 3
+      "port-version": 4
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75172bc36c45d15ee298de1803625af1770cb805",
+      "version-semver": "3.10.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "35f071d147af8c4d8dfac5eaa95ad41e395448a5",
       "version-semver": "3.10.1",
       "port-version": 3


### PR DESCRIPTION
Install pkg-config configuration files on Windows platforms (msbuild builds)

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
