### PR TITLE
[new port] gobject-introspection 1.70.0 port

### DIFF
--- a/ports/gobject-introspection/0001-g-ir-tool-template.in.patch
+++ b/ports/gobject-introspection/0001-g-ir-tool-template.in.patch
@@ -1,0 +1,23 @@
+--- a/tools/g-ir-tool-template.in	2021-09-17 23:02:42.601052000 +0700
++++ b/tools/g-ir-tool-template.in	2021-12-29 21:41:52.987141900 +0700
+@@ -59,7 +59,7 @@
+ builtins.__dict__['GIRDIR'] = [girdir]
+ 
+ # Again, relative paths first so that the installation prefix is relocatable
+-pylibdir = os.path.abspath(os.path.join(filedir, '..', 'lib', 'gobject-introspection'))
++pylibdir = os.path.abspath(os.path.join(filedir, '..', '..', 'lib', 'gobject-introspection'))
+ 
+ # EXT_SUFFIX for py3 SO for py2
+ py_mod_suffix = sysconfig.get_config_var('EXT_SUFFIX') or sysconfig.get_config_var('SO')
+@@ -91,6 +91,11 @@
+ 
+ sys.path.insert(0, pylibdir)
+ 
++pkg_config_path = os.getenv('PKG_CONFIG_PATH', '')
++if pkg_config_path:
++    pkg_config_path = os.pathsep + pkg_config_path 
++os.environ['PKG_CONFIG_PATH'] = os.path.normpath(os.path.join(pylibdir, '..', 'pkgconfig')) + pkg_config_path
++
+ from giscanner.utils import dll_dirs
+ dll_dirs = dll_dirs()
+ dll_dirs.add_dll_dirs(['gio-2.0'])

--- a/ports/gobject-introspection/0002-cross-build.patch
+++ b/ports/gobject-introspection/0002-cross-build.patch
@@ -1,0 +1,60 @@
+--- a/gir/meson.build	2021-09-17 23:02:42.502052000 +0700
++++ b/gir/meson.build	2022-01-05 02:31:25.960457800 +0700
+@@ -42,7 +42,7 @@
+ install_data(gir_files, install_dir: girdir)
+ 
+ scanner_command = [
+-  find_program('g-ir-scanner', native: true),
++  find_program('g-ir-scanner'),
+   '--output=@OUTPUT@',
+   '--no-libtool',
+   '--quiet',
+@@ -495,6 +495,7 @@
+ )
+ 
+ typelibs = []
++gircompiler = find_program('g-ir-compiler')
+ if get_option('gi_cross_binary_wrapper') != ''
+     gircompiler_command = [get_option('gi_cross_binary_wrapper'), gircompiler.full_path(), ]
+ else
+@@ -510,7 +511,7 @@
+   typelibs += custom_target('generate-typelib-@0@'.format(gir).underscorify(),
+     input: gir,
+     output: '@BASENAME@.typelib',
+-    depends: [gobject_gir, gircompiler, ],
++    depends: [gobject_gir, ],
+     command: gircompiler_command,
+     install: true,
+     install_dir: typelibdir,
+--- a/tools/meson.build	2021-09-17 23:02:42.601052000 +0700
++++ b/tools/meson.build	2022-01-05 02:36:06.103763400 +0700
+@@ -64,7 +64,9 @@
+   install: true,
+   c_args: custom_c_args,
+ )
+-meson.override_find_program('g-ir-compiler', gircompiler)
++if not get_option('gi_cross_use_prebuilt_gi')
++  meson.override_find_program('g-ir-compiler', gircompiler)
++endif
+ 
+ girgenerate = executable('g-ir-generate', 'generate.c',
+   dependencies: [
+@@ -74,11 +76,15 @@
+   install: true,
+   c_args: custom_c_args,
+ )
+-meson.override_find_program('g-ir-generate', girgenerate)
++if not get_option('gi_cross_use_prebuilt_gi')
++  meson.override_find_program('g-ir-generate', girgenerate)
++endif
+ 
+ girinspect = executable('g-ir-inspect', 'g-ir-inspect.c',
+   dependencies: girepo_dep,
+   install: true,
+   c_args: custom_c_args,
+ )
+-meson.override_find_program('g-ir-inspect', girinspect)
++if not get_option('gi_cross_use_prebuilt_gi')
++  meson.override_find_program('g-ir-inspect', girinspect)
++endif
+\ No newline at end of file

--- a/ports/gobject-introspection/portfile.cmake
+++ b/ports/gobject-introspection/portfile.cmake
@@ -1,0 +1,81 @@
+
+set(GI_MAJOR_MINOR 1.70)
+set(GI_PATCH 0)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/gobject-introspection/${GI_MAJOR_MINOR}/gobject-introspection-${GI_MAJOR_MINOR}.${GI_PATCH}.tar.xz"
+    FILENAME "gobject-introspection-${GI_MAJOR_MINOR}.${GI_PATCH}.tar.xz"
+    SHA512 216b376ed423f607e36c723dd6b67975dbfb63c253f2d8bd0b3661e3d69f8c8059cf221db8c5260b0262fad1b7d738f3b2e5fbd51fdbc31e40ccb115c209baf0
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+    PATCHES
+        0001-g-ir-tool-template.in.patch
+        0002-cross-build.patch
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+vcpkg_find_acquire_program(FLEX)
+vcpkg_find_acquire_program(BISON)
+
+set(OPTIONS_DEBUG -Dbuild_introspection_data=false)
+set(OPTIONS_RELEASE -Dbuild_introspection_data=true)
+if(NOT HOST_TRIPLET STREQUAL TARGET_TRIPLET)
+    list(APPEND OPTIONS_RELEASE -Dgi_cross_use_prebuilt_gi=true)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS_DEBUG
+        ${OPTIONS_DEBUG}
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    ADDITIONAL_NATIVE_BINARIES
+        flex='${FLEX}'
+        bison='${BISON}'
+    ADDITIONAL_CROSS_BINARIES
+        flex='${FLEX}'
+        bison='${BISON}'
+        g-ir-annotation-tool='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-annotation-tool'
+        g-ir-compiler='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'
+        g-ir-scanner='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-scanner'
+)
+
+vcpkg_host_path_list(APPEND ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
+vcpkg_host_path_list(APPEND ENV{LIB} "${CURRENT_INSTALLED_DIR}/lib")
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+set(GI_TOOLS
+        g-ir-compiler
+        g-ir-generate
+        g-ir-inspect
+)
+set(GI_SCRIPTS
+        g-ir-annotation-tool
+        g-ir-scanner
+)
+
+vcpkg_copy_tools(TOOL_NAMES ${GI_TOOLS} AUTO_CLEAN)
+foreach(script IN LISTS GI_SCRIPTS)
+    file(READ "${CURRENT_PACKAGES_DIR}/bin/${script}" _contents)
+    string(REPLACE "#!/usr/bin/env ${PYTHON3}" "#!/usr/bin/env python3" _contents "${_contents}")
+    string(REPLACE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_INSTALLED_DIR}/lib" _contents "${_contents}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/${script}" "${_contents}")
+
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/${script}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${script}")
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/man")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled) # _giscanner.lib

--- a/ports/gobject-introspection/vcpkg.json
+++ b/ports/gobject-introspection/vcpkg.json
@@ -1,0 +1,30 @@
+{
+  "name": "gobject-introspection",
+  "version": "1.70.0",
+  "description": "A middleware layer between C libraries (using GObject) and language bindings.",
+  "homepage": "https://gi.readthedocs.io/en/latest/",
+  "supports": "!static & native",
+  "dependencies": [
+    {
+      "name": "cairo",
+      "default-features": false,
+      "features": [
+        "gobject"
+      ]
+    },
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "gobject-introspection",
+      "host": true
+    },
+    "python3",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2524,6 +2524,10 @@
       "baseline": "4.9.0",
       "port-version": 0
     },
+    "gobject-introspection": {
+      "baseline": "1.70.0",
+      "port-version": 0
+    },
     "google-cloud-cpp": {
       "baseline": "1.34.1",
       "port-version": 0

--- a/versions/g-/gobject-introspection.json
+++ b/versions/g-/gobject-introspection.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "5f162cfae947901b4110ea23cb5163699a079cfe",
+      "version": "1.70.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
New port: gobject-introspection

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
