### PR TITLE
[mlpack] Add dependency boost-format to feature tools

### DIFF
--- a/ports/mlpack/vcpkg.json
+++ b/ports/mlpack/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "mlpack",
   "version": "3.4.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "mlpack is a fast, flexible machine learning library, written in C++, that aims to provide fast, extensible implementations of cutting-edge machine learning algorithms.",
   "homepage": "https://github.com/mlpack/mlpack",
   "supports": "!uwp",
@@ -29,7 +29,10 @@
       "description": "use OpenMP for parallelization."
     },
     "tools": {
-      "description": "Build command-line executables."
+      "description": "Build command-line executables.",
+      "dependencies": [
+        "boost-format"
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4438,7 +4438,7 @@
     },
     "mlpack": {
       "baseline": "3.4.1",
-      "port-version": 4
+      "port-version": 5
     },
     "mman": {
       "baseline": "git-f5ff813",

--- a/versions/m-/mlpack.json
+++ b/versions/m-/mlpack.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1ba342c0a0a5e88c4424207c3296b8db8c7062fc",
+      "version": "3.4.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "eb3aaa9dbc3991962b70c2c819d66e5c018ad41a",
       "version": "3.4.1",
       "port-version": 4


### PR DESCRIPTION
```
G:\22047\vcpkg\buildtrees\mlpack\src\82feaae439-787f7149b5.clean\src\mlpack\methods\preprocess\preprocess_describe_main.cpp(16): fatal error C1083: Cannot open include file: 'boost/format.hpp': No such file or directory
```
`preprocess_describe_main.cpp` is used in _src\mlpack\methods\preprocess\CMakeLists.txt_:
```cmake
add_cli_executable(preprocess_describe)
add_python_binding(preprocess_describe)
add_julia_binding(preprocess_describe)
add_go_binding(preprocess_describe)
add_r_binding(preprocess_describe)
add_markdown_docs(preprocess_describe "cli;python;julia;go;r" "preprocessing")
```
Which can be enabled by option `BUILD_CLI_EXECUTABLES`.

Fixes #22208.