### PR TITLE
[gettext] Fix tools build

### DIFF
--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -56,6 +56,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         ac_cv_func_memset=yes             # not detected in release builds
         ac_cv_header_pthread_h=no
         ac_cv_header_dirent_h=no
+        ac_cv_header_getopt_h=no
     )
 endif()
 

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 7,
+  "port-version": 8,
   "description": "GNU gettext provides libintl and a set of tools to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2418,7 +2418,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 7
+      "port-version": 8
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d1dc6ee2684911bfcb6f63c498413a118c235ba5",
+      "version": "0.21",
+      "port-version": 8
+    },
+    {
       "git-tree": "f843c5eedf82612df5fef2bfadfe4df8426301a6",
       "version": "0.21",
       "port-version": 7


### PR DESCRIPTION
Fix gettext-tools build when gnuwin32 is installed:

msginit-msginit.obj : error LNK2019: unresolved external symbol __imp_optarg_a referenced in function main
.libs\msginit.exe : fatal error LNK1120: 1 unresolved externals

All the other gettext tools #include bundled getopt after getopt.h so that optarg & friends gets properly overridden to bundled versions

- #### What does your PR fix?  
  Fixes #18270 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
