### PR TITLE
[vcpkg baseline][uchardet] Fix download error

### DIFF
--- a/ports/uchardet/portfile.cmake
+++ b/ports/uchardet/portfile.cmake
@@ -1,10 +1,13 @@
-vcpkg_from_git(
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://gitlab.freedesktop.org/uchardet/uchardet
+    REPO uchardet/uchardet
     REF 6f38ab95f55afd45ee6ccefcb92d21034b4a2521
-    PATCHES
-        fix-uwp-build.patch
+    SHA512 a2e655d6e1eb6934cf93d99d27dfebc382eb01b6e62021f56b3fa71d269a851e7d68fe57536d40470e0329b3aa035467a9cdd9e11698f8ff76f06611ea7a58d1
+    HEAD_REF master
+    PATCHES fix-uwp-build.patch
 )
+
 
 vcpkg_check_features(
     OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/uchardet/vcpkg.json
+++ b/ports/uchardet/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "uchardet",
   "version-date": "2021-09-03",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An encoding detector library ported from Mozilla.",
   "homepage": "https://cgit.freedesktop.org/uchardet/uchardet/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6978,7 +6978,7 @@
     },
     "uchardet": {
       "baseline": "2021-09-03",
-      "port-version": 1
+      "port-version": 2
     },
     "umock-c": {
       "baseline": "2020-06-17",

--- a/versions/u-/uchardet.json
+++ b/versions/u-/uchardet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8333800cb0daceea8448ca6d20a91a1944b31559",
+      "version-date": "2021-09-03",
+      "port-version": 2
+    },
+    {
       "git-tree": "bef8f2cbbb385ec635dbca67e3783496a15cb4a0",
       "version-date": "2021-09-03",
       "port-version": 1


### PR DESCRIPTION
Change `vcpkg_from_git` to `vcpkg_from_gitlab`, fix `uchardet` build error:
`fatal: unable to access 'https://gitlab.freedesktop.org/uchardet/uchardet/': The requested URL returned error: 504`