### PR TITLE
[plplot] Disable all language bindings but C++

### DIFF
--- a/ports/plplot/portfile.cmake
+++ b/ports/plplot/portfile.cmake
@@ -25,10 +25,8 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DENABLE_tcl=OFF
-        -DENABLE_d=OFF
-        -DENABLE_qt=OFF
-        -DENABLE_ocaml=OFF
+        -DDEFAULT_NO_BINDINGS=ON
+        -DENABLE_cxx=ON
         -DPL_HAVE_QHULL=OFF
         -DPLPLOT_USE_QT5=OFF
         -DPL_DOUBLE=ON

--- a/ports/plplot/vcpkg.json
+++ b/ports/plplot/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "plplot",
   "version-semver": "5.13.0",
-  "port-version": 14,
+  "port-version": 15,
   "description": "PLplot is a cross-platform software package for creating scientific plots whose (UTF-8) plot symbols and text are limited in practice only by what Unicode-aware system fonts are installed on a user's computer.",
   "dependencies": [
     "bzip2",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5318,7 +5318,7 @@
     },
     "plplot": {
       "baseline": "5.13.0",
-      "port-version": 14
+      "port-version": 15
     },
     "plustache": {
       "baseline": "0.4.0",

--- a/versions/p-/plplot.json
+++ b/versions/p-/plplot.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2bdc5ce1d9ab4085f8d1753de526830bee4bc92a",
+      "version-semver": "5.13.0",
+      "port-version": 15
+    },
+    {
       "git-tree": "9e9bda9b45cefac69d08bbb2f3e947deab8cac14",
       "version-semver": "5.13.0",
       "port-version": 14


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes the plplot build enabling bindings based on build-time system inspection, e.g. fortran for https://github.com/microsoft/vcpkg/pull/22124. CC @JackBoosY 
  C++ is the only language which can be assumed to be buildable without extra dependencies.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes