### PR TITLE
[vcpkg] Fix vcpkg_cmake_config_fixup.cmake

### DIFF
--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-  "version-date": "2021-12-01"
+    "version-date": "2021-12-28"
 }

--- a/ports/vcpkg-cmake-config/vcpkg.json
+++ b/ports/vcpkg-cmake-config/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vcpkg-cmake-config",
-    "version-date": "2021-12-28"
+  "version-date": "2021-12-28"
 }

--- a/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
+++ b/ports/vcpkg-cmake-config/vcpkg_cmake_config_fixup.cmake
@@ -213,7 +213,7 @@ get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)]]
             get_filename_component(main_cmake_dir "${main_cmake}" DIRECTORY)
             # Calculate relative to be a sequence of "../"
             file(RELATIVE_PATH relative "${main_cmake_dir}" "${cmake_current_packages_dir}")
-            string(PREPEND contents "get_filename_component(VCPKG_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}\/${relative}\" ABSOLUTE)")
+            string(PREPEND contents "get_filename_component(VCPKG_IMPORT_PREFIX \"\${CMAKE_CURRENT_LIST_DIR}\/${relative}\" ABSOLUTE)\n")
         endif()
 
         file(WRITE "${main_cmake}" "${contents}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7121,7 +7121,7 @@
       "port-version": 0
     },
     "vcpkg-cmake-config": {
-      "baseline": "2021-12-01",
+      "baseline": "2021-12-28",
       "port-version": 0
     },
     "vcpkg-gfortran": {

--- a/versions/v-/vcpkg-cmake-config.json
+++ b/versions/v-/vcpkg-cmake-config.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e33152002c946b93a0262931ba8bf54a2e6ab9ad",
+      "version-date": "2021-12-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "51df1bbddb22782b9e7f23f9b3588674184e991a",
       "version-date": "2021-12-01",
       "port-version": 0


### PR DESCRIPTION
The PR #22235 exposed a bug in `vcpkg_cmake_config_fixup.cmake`, that incorrectly preprends a string without a end-of-line. That creates CMake syntax errors, like this one:

```
get_filename_component(VCPKG_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)set(CGAL_ROOT ${VCPKG_IMPORT_PREFIX})
```

The fix is simple: add a `\n` at the end of the prepended string.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
