### PR TITLE
fix(ports): use lib/cmake/mimalloc config path in mimalloc port file

### DIFF
--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -45,7 +45,7 @@ file(COPY
     "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
 )
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/mimalloc)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
     vcpkg_replace_string(

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mimalloc",
   "version": "2.0.3",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4390,7 +4390,7 @@
     },
     "mimalloc": {
       "baseline": "2.0.3",
-      "port-version": 0
+      "port-version": 1
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0b8064b8481fdeb88e2b4933c485ea0f6b99d779",
+      "version": "2.0.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "6e1b6fbd3bff2cae13325183c95aa07ed470b6ad",
       "version": "2.0.3",
       "port-version": 0


### PR DESCRIPTION
fixup in mimalloc portfile.cmake

**Describe the pull request**

- #### What does your PR fix?  
  Fixes vcpkg_cmake_config_fixup config path in mimalloc portfile. In mimalloc build, it's cmake files located in lib/cmake/mimalloc according to here https://github.com/microsoft/mimalloc/blob/03ba2620e3aa0330c0d223dd6156838048b3d489/CMakeLists.txt#L233-L237, same in v2.0.3


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all , No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
