### PR TITLE
Suggest setting CMAKE_TOOLCHAIN_FILE in PreLoad.cmake to automatically pick up buildsystems/vcpkg.cmake in CLion in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,10 @@ Finally, in `CMake options`, add the following line:
 -DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
 ```
 
-Unfortunately, you'll have to add this to each profile.
+Alternatively you can add "PreLoad.cmake" file to the root of your project which contains the following line
+```cmake
+set(CMAKE_TOOLCHAIN_FILE /some/path/vcpkg/scripts/buildsystems/vcpkg.cmake CACHE INTERNAL "" FORCE)
+```
 
 ### Vcpkg as a Submodule
 


### PR DESCRIPTION
Fix CLion documentation which describes possible ways to integrate with `vcpkg`

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`
