### PR TITLE
[bootstrap-vcpkg.sh] Fixes a build error due to missing log linkage

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -232,6 +232,11 @@ else
     vcpkgExtractTar "$tarballPath" "$srcBaseDir"
     cmakeConfigOptions="-DCMAKE_BUILD_TYPE=Release -G 'Ninja' -DVCPKG_DEVELOPMENT_WARNINGS=OFF"
 
+    # Add Android log library if we're in Termux.
+    if [ "${TERMUX_VERSION}" != "" ] ; then
+        cmakeConfigOptions="$cmakeConfigOptions -DCMAKE_CXX_STANDARD_LIBRARIES=-llog"
+    fi
+
     if [ "${VCPKG_MAX_CONCURRENCY}" != "" ] ; then
         cmakeConfigOptions=" $cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=$VCPKG_MAX_CONCURRENCY;link=$VCPKG_MAX_CONCURRENCY' "
     fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -230,15 +230,10 @@ else
     rm -rf "$baseBuildDir"
     mkdir -p "$buildDir"
     vcpkgExtractTar "$tarballPath" "$srcBaseDir"
-    cmakeConfigOptions="-DCMAKE_BUILD_TYPE=Release -G 'Ninja' -DVCPKG_DEVELOPMENT_WARNINGS=OFF"
-
-    # Add Android log library if we're in Termux.
-    if [ "${TERMUX_VERSION}" != "" ] ; then
-        cmakeConfigOptions="$cmakeConfigOptions -DCMAKE_CXX_STANDARD_LIBRARIES=-llog"
-    fi
+    cmakeConfigOptions="-DCMAKE_BUILD_TYPE=Release -G 'Ninja' -DVCPKG_DEVELOPMENT_WARNINGS=OFF -DBUILD_TESTING=OFF"
 
     if [ "${VCPKG_MAX_CONCURRENCY}" != "" ] ; then
-        cmakeConfigOptions=" $cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=$VCPKG_MAX_CONCURRENCY;link=$VCPKG_MAX_CONCURRENCY' "
+        cmakeConfigOptions="$cmakeConfigOptions '-DCMAKE_JOB_POOL_COMPILE:STRING=compile' '-DCMAKE_JOB_POOL_LINK:STRING=link' '-DCMAKE_JOB_POOLS:STRING=compile=$VCPKG_MAX_CONCURRENCY;link=$VCPKG_MAX_CONCURRENCY'"
     fi
 
     (cd "$buildDir" && CXX="$CXX" eval cmake "$srcDir" $cmakeConfigOptions) || exit 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes building in termux failing due to missing log library.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
 `N/A`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  `N/A`

