### PR TITLE
[libkeyfinder] update to 2.2.6

### DIFF
--- a/ports/libkeyfinder/portfile.cmake
+++ b/ports/libkeyfinder/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mixxxdj/libkeyfinder
-    REF v2.2.5
-    SHA512 54463d1f1111dc474d3e43723fddd5579ea1a3842f99f43e50e85622a1d6ee6fe42b22c300ce5ba5807cf6b2d7067af741773af95974a42c5d863c53165893eb
+    REF v2.2.6
+    SHA512 c1b771cebfb925db521a344e28fd1d3bc6e6e921e45dcc81f90926e5b2020fea201a4bc05a65177d3559208a45746fd7784eb6f37352bb10ab7d7b820b40c0b6
     HEAD_REF main
 )
 
@@ -19,9 +19,10 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME KeyFinder CONFIG_PATH lib/cmake/KeyFinder)
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_pkgconfig()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
-vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE
+  "${CURRENT_PACKAGES_DIR}/debug/include"
+  "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libkeyfinder/vcpkg.json
+++ b/ports/libkeyfinder/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libkeyfinder",
-  "version-string": "2.2.5",
-  "port-version": 1,
+  "version": "2.2.6",
   "description": "Musical key detection for digital audio",
   "homepage": "https://github.com/mixxxdj/libkeyfinder",
   "license": "GPL-3.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3605,8 +3605,8 @@
       "port-version": 1
     },
     "libkeyfinder": {
-      "baseline": "2.2.5",
-      "port-version": 1
+      "baseline": "2.2.6",
+      "port-version": 0
     },
     "libkml": {
       "baseline": "1.3.0",

--- a/versions/l-/libkeyfinder.json
+++ b/versions/l-/libkeyfinder.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "567c6574c6e38d9a10b7e08951c4c3a0fc72e3cb",
+      "version": "2.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "f4b04b3607199759e373764303378ab76ef9c158",
       "version-string": "2.2.5",
       "port-version": 1


### PR DESCRIPTION


**Describe the pull request**

- #### What does your PR fix?  
This fixes a few issues with the pkgconfig and CMake package
config files.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
