### PR TITLE
[vcpkg|scripts] correctly restore env vars

### DIFF
--- a/scripts/cmake/vcpkg_build_make.cmake
+++ b/scripts/cmake/vcpkg_build_make.cmake
@@ -216,6 +216,8 @@ function(vcpkg_build_make)
                 set(ENV{PATH} "${env_backup_path}")
             endif()
         endif()
+
+        vcpkg_restore_env_variables(VARS LIB LIBPATH LIBRARY_PATH)
     endforeach()
 
     if (arg_ENABLE_INSTALL)


### PR DESCRIPTION
just common bugs from the scripts audit..... previously the backup vars were used in the loop, now vcpkg_host_path_list is used which will be wrong if the variables are not restored to their previous values