### PR TITLE
[catch2] Update to 3.0.0-preview4

### DIFF
--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -2,16 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 0370ea3..7cef01a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -146,7 +146,7 @@ if (NOT_SUBPROJECT)
-       EXPORT
-         Catch2Targets
-       DESTINATION
--        ${CMAKE_INSTALL_LIBDIR}
-+        ${CMAKE_INSTALL_LIBDIR}/manual-link
-     )
- 
- 
-@@ -226,7 +226,7 @@ if (NOT_SUBPROJECT)
+@@ -161,7 +161,7 @@
  
      ## Provide some pkg-config integration
      set(PKGCONFIG_INSTALL_DIR

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -1,42 +1,28 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
-    REF v2.13.8
-    SHA512 68a45efa47beb3c85d2d7b8a8eba89b8ec1664b4a72bb223227fef1632778aeaf5cf5cc09f40e47aef50426c8661c7d6a69c2dab0b88fbbf7d9a6b2974d6e32e
+    REF v3.0.0-preview4
+    SHA512 3a879da07dd5f4e2bcd0d5e1be0de5b0128930c3a5a343805b308ddc788618bb0a9d5ea6de673cf8745f7997eebafabb65d29ee39120bf82218f8df0f47be039
     HEAD_REF devel
     PATCHES 
         fix-install-path.patch
 )
 
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DBUILD_TESTING=OFF
-        -DCATCH_BUILD_EXAMPLES=OFF
-        -DCATCH_BUILD_STATIC_LIBRARY=${BUILD_STATIC}
+        -DCATCH_INSTALL_DOCS=OFF
+        -DCATCH_INSTALL_EXTRAS=OFF
 )
 
 vcpkg_cmake_install()
-if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/share/Catch2" "${CURRENT_PACKAGES_DIR}/share/catch2_")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/share/catch2_" "${CURRENT_PACKAGES_DIR}/share/catch2")
-endif()
-if (NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/Catch2" "${CURRENT_PACKAGES_DIR}/debug/share/catch2_")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/catch2_" "${CURRENT_PACKAGES_DIR}/debug/share/catch2")
-endif()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/Catch2")
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Catch2)
 vcpkg_fixup_pkgconfig()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/catch2/benchmark/internal")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/catch2/generators/internal")
 
-if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/include/catch2/catch.hpp")
-    message(FATAL_ERROR "Main includes have moved. Please update the forwarder.")
-endif()
-
-file(WRITE "${CURRENT_PACKAGES_DIR}/include/catch.hpp" "#include <catch2/catch.hpp>")
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -25,4 +25,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/catch2/benchmark/internal")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/catch2/generators/internal")
 
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/catch.hpp" "#include <catch2/catch_all.hpp>")
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "2.13.8",
+  "version-semver": "3.0.0-preview4",
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1253,7 +1253,7 @@
       "port-version": 1
     },
     "catch2": {
-      "baseline": "2.13.8",
+      "baseline": "3.0.0-preview4",
       "port-version": 0
     },
     "cccapstone": {

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "579064bb37067d1605d8aa79b460164b0612c1f7",
+      "version-semver": "3.0.0-preview4",
+      "port-version": 0
+    },
+    {
       "git-tree": "b58473cdc953ae1d09f30f0ba1e641c6cc34719f",
       "version-semver": "2.13.8",
       "port-version": 0

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "579064bb37067d1605d8aa79b460164b0612c1f7",
+      "git-tree": "1a89f1d4a804829b41ecf8159d18ded6b5a93b6c",
       "version-semver": "3.0.0-preview4",
       "port-version": 0
     },


### PR DESCRIPTION
Catch 3.0.0 have been in development for quite some time now. Even if it's still in preview, I think it deserves a vcpkg port because it brings massive compile time improvements. Many people will probably want to stay on the 2.0 version, but I thought that this shouldn't be a problem now that vcpkg support package versioning.

Changelog : https://github.com/catchorg/Catch2/releases/tag/v3.0.0-preview4