### PR TITLE
[hidapi] Fix cmake error

### DIFF
--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -16,6 +16,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/hidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")
+
 file(INSTALL "${SOURCE_PATH}/LICENSE-bsd.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hidapi",
   "version-semver": "0.11.2",
+  "port-version": 1,
   "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
   "homepage": "https://github.com/libusb/hidapi",
   "license": "BSD-3-Clause-Clear",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2694,7 +2694,7 @@
     },
     "hidapi": {
       "baseline": "0.11.2",
-      "port-version": 0
+      "port-version": 1
     },
     "highfive": {
       "baseline": "2.3",

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "145fcc6e2c3aa564666793d494a6b90c1323e0ac",
+      "version-semver": "0.11.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "afa485fda08f51ccd3fbf54327ba44aa11b8cb32",
       "version-semver": "0.11.2",
       "port-version": 0


### PR DESCRIPTION
Fixes #22280
Fix CMake error:
```
[cmake]   Imported target "hidapi::hidapi" includes non-existent path
[cmake] 
[cmake]     "/include"
[cmake] 
[cmake]   in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:
[cmake] 
[cmake]   * The path was deleted, renamed, or moved to another location.
[cmake] 
[cmake]   * An install or uninstall procedure did not complete successfully.
[cmake] 
[cmake]   * The installation package was faulty and references files it does not
[cmake]   provide.
```