### PR TITLE
[libraw] Add feature openmp and fix usage

### DIFF
--- a/ports/libraw/portfile.cmake
+++ b/ports/libraw/portfile.cmake
@@ -23,9 +23,16 @@ vcpkg_from_github(
 file(COPY "${LIBRAW_CMAKE_SOURCE_PATH}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 file(COPY "${LIBRAW_CMAKE_SOURCE_PATH}/cmake" DESTINATION "${SOURCE_PATH}")
 
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        openmp ENABLE_OPENMP
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DINSTALL_CMAKE_MODULE_PATH=share/${PORT}
         -DENABLE_EXAMPLES=OFF
         -DCMAKE_DEBUG_POSTFIX=d

--- a/ports/libraw/vcpkg-cmake-wrapper.cmake
+++ b/ports/libraw/vcpkg-cmake-wrapper.cmake
@@ -3,6 +3,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 _find_package(${ARGS})
 set(CMAKE_MODULE_PATH ${LIBRAW_PREV_MODULE_PATH})
 
+if (@ENABLE_OPENMP@)
+    find_package(OpenMP REQUIRED)
+    if (OpenMP_FOUND)
+        list(APPEND LibRaw_LIBRARIES gomp)
+    endif()
+endif()
+
 if (@VCPKG_LIBRARY_LINKAGE@ STREQUAL "static")
     find_package(Jasper REQUIRED)
     if (Jasper_FOUND)

--- a/ports/libraw/vcpkg-cmake-wrapper.cmake
+++ b/ports/libraw/vcpkg-cmake-wrapper.cmake
@@ -7,6 +7,7 @@ if (@ENABLE_OPENMP@)
     find_package(OpenMP REQUIRED)
     if (OpenMP_FOUND)
         list(APPEND LibRaw_LIBRARIES gomp)
+        list(APPEND LibRaw_r_LIBRARIES gomp)
     endif()
 endif()
 

--- a/ports/libraw/vcpkg.json
+++ b/ports/libraw/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libraw",
   "version-string": "201903",
-  "port-version": 5,
+  "port-version": 6,
   "description": "raw image decoder library",
   "homepage": "https://www.libraw.org",
   "dependencies": [
@@ -11,5 +11,10 @@
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "openmp": {
+      "description": "Build library with OpenMP support"
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3842,7 +3842,7 @@
     },
     "libraw": {
       "baseline": "201903",
-      "port-version": 5
+      "port-version": 6
     },
     "librdkafka": {
       "baseline": "1.8.2",

--- a/versions/l-/libraw.json
+++ b/versions/l-/libraw.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5e5fdaddb7f220205d8ee8120df397477c1de0f",
+      "version-string": "201903",
+      "port-version": 6
+    },
+    {
       "git-tree": "fa490349ec4e8e8d8854c18725068a8a8474b3ac",
       "version-string": "201903",
       "port-version": 5

--- a/versions/l-/libraw.json
+++ b/versions/l-/libraw.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a5e5fdaddb7f220205d8ee8120df397477c1de0f",
+      "git-tree": "e05fbd81dbe6b44b09c9aae106f4dc7df708ce49",
       "version-string": "201903",
       "port-version": 6
     },


### PR DESCRIPTION
Add feature `openmp` to fix the usage issue:
```
/usr/bin/ld: vcpkg_installed/x64-linux/lib/libraw.a(dcraw_common.cpp.o): in function `LibRaw::ppg_interpolate() [clone ._omp_fn.0]':
dcraw_common.cpp:(.text+0x234a): undefined reference to `omp_get_num_threads'
/usr/bin/ld: dcraw_common.cpp:(.text+0x2351): undefined reference to `omp_get_thread_num'
/usr/bin/ld: vcpkg_installed/x64-linux/lib/libraw.a(dcraw_common.cpp.o): in function `LibRaw::ppg_interpolate() [clone ._omp_fn.1]':
dcraw_common.cpp:(.text+0x25fa): undefined reference to `omp_get_num_threads'
/usr/bin/ld: dcraw_common.cpp:(.text+0x2601): undefined reference to `omp_get_thread_num'
/usr/bin/ld: vcpkg_installed/x64-linux/lib/libraw.a(dcraw_common.cpp.o): in function `LibRaw::ppg_interpolate() [clone ._omp_fn.2]':
dcraw_common.cpp:(.text+0x27aa): undefined reference to `omp_get_num_threads'
/usr/bin/ld: dcraw_common.cpp:(.text+0x27b1): undefined reference to `omp_get_thread_num'
/usr/bin/ld: vcpkg_installed/x64-linux/lib/libraw.a(dcraw_common.cpp.o): in function `LibRaw::wavelet_denoise() [clone ._omp_fn.0]':
dcraw_common.cpp:(.text+0x1611e): undefined reference to `GOMP_critical_start'
/usr/bin/ld: dcraw_common.cpp:(.text+0x16143): undefined reference to `GOMP_critical_end'
/usr/bin/ld: dcraw_common.cpp:(.text+0x16150): undefined reference to `omp_get_num_threads'
/usr/bin/ld: dcraw_common.cpp:(.text+0x1615c): undefined reference to `omp_get_thread_num'
/usr/bin/ld: dcraw_common.cpp:(.text+0x161f6): undefined reference to `GOMP_barrier'
/usr/bin/ld: dcraw_common.cpp:(.text+0x16253): undefined reference to `GOMP_barrier'
/usr/bin/ld: dcraw_common.cpp:(.text+0x16287): undefined reference to `GOMP_barrier'
/usr/bin/ld: dcraw_common.cpp:(.text+0x16296): undefined reference to `GOMP_barrier'
/usr/bin/ld: dcraw_common.cpp:(.text+0x162bf): undefined reference to `GOMP_barrier'
/usr/bin/ld: dcraw_common.cpp:(.text+0x162da): undefined reference to `GOMP_critical_start'
...
```
See libraw's official cmake configure:
```cmake
OPTION(ENABLE_OPENMP               "Build library with OpenMP support               (default=ON)"                 ON)
...
IF(ENABLE_OPENMP)
    # OpenMP library detection (requires CMake >= 2.6.3)
    # NOTE: OpenMP under MacOSX do not support multithreading.

    IF(NOT APPLE)
        MACRO_OPTIONAL_FIND_PACKAGE(OpenMP)

        IF(OPENMP_FOUND)
            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
            IF("${OpenMP_CXX_FLAGS}" STREQUAL "-fopenmp")
                SET(OPENMP_LDFLAGS "-lgomp")
            ENDIF()
            IF("${OpenMP_CXX_FLAGS}" STREQUAL "-xopenmp")
                SET(OPENMP_LDFLAGS "-xopenmp")
            ENDIF()
        ENDIF()
    ENDIF()
ENDIF()
```

Fixes #14498.