### PR TITLE
[protobuf] fix protobuf-3.18 mingw build failure

### DIFF
--- a/ports/protobuf/fix-mingw-build.patch
+++ b/ports/protobuf/fix-mingw-build.patch
@@ -1,0 +1,20 @@
+--- a/src/google/protobuf/io/zero_copy_stream_impl.cc	2021-09-15 00:48:28.000000000 +0800
++++ b/src/google/protobuf/io/zero_copy_stream_impl.cc	2022-01-05 09:42:35.632457100 +0800
+@@ -32,7 +32,7 @@
+ //  Based on original Protocol Buffers design by
+ //  Sanjay Ghemawat, Jeff Dean, and others.
+ 
+-#ifndef _MSC_VER
++#ifndef _WIN32
+ #include <fcntl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+@@ -104,7 +104,7 @@
+       is_closed_(false),
+       errno_(0),
+       previous_seek_failed_(false) {
+-#ifndef _MSC_VER
++#ifndef _WIN32
+   int flags = fcntl(file_, F_GETFL);
+   flags &= ~O_NONBLOCK;
+   fcntl(file_, F_SETFL, flags);

--- a/ports/protobuf/fix-mingw-build.patch
+++ b/ports/protobuf/fix-mingw-build.patch
@@ -1,14 +1,5 @@
 --- a/src/google/protobuf/io/zero_copy_stream_impl.cc	2021-09-15 00:48:28.000000000 +0800
-+++ b/src/google/protobuf/io/zero_copy_stream_impl.cc	2022-01-05 09:42:35.632457100 +0800
-@@ -32,7 +32,7 @@
- //  Based on original Protocol Buffers design by
- //  Sanjay Ghemawat, Jeff Dean, and others.
- 
--#ifndef _MSC_VER
-+#ifndef _WIN32
- #include <fcntl.h>
- #include <sys/stat.h>
- #include <sys/types.h>
++++ b/src/google/protobuf/io/zero_copy_stream_impl.cc	2022-01-06 15:19:12.657413400 +0800
 @@ -104,7 +104,7 @@
        is_closed_(false),
        errno_(0),

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-static-build.patch
         fix-default-proto-file-path.patch
         fix-uwp-build.patch
+        fix-mingw-build.patch
 )
 
 string(COMPARE EQUAL "${TARGET_TRIPLET}" "${HOST_TRIPLET}" protobuf_BUILD_PROTOC_BINARIES)

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "protobuf",
   "version-semver": "3.18.0",
+  "port-version": 1,
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5442,7 +5442,7 @@
     },
     "protobuf": {
       "baseline": "3.18.0",
-      "port-version": 0
+      "port-version": 1
     },
     "protobuf-c": {
       "baseline": "1.4.0",

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "166c456962720a9382505f3d0cdf6b2fc986c167",
+      "git-tree": "5f6aa04d94e184b89c1887946fb4684bc51c4611",
       "version-semver": "3.18.0",
       "port-version": 1
     },

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "166c456962720a9382505f3d0cdf6b2fc986c167",
+      "version-semver": "3.18.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "19c2bf45c235e6126161bae36aa7ff7e1fcda479",
       "version-semver": "3.18.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes [this issue](https://github.com/protocolbuffers/protobuf/issues/8992)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
