### PR TITLE
[refl-cpp] Update to 0.12.2

### DIFF
--- a/ports/refl-cpp/portfile.cmake
+++ b/ports/refl-cpp/portfile.cmake
@@ -3,11 +3,11 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO veselink1/refl-cpp
-    REF v0.12.1
-    SHA512 7f1b9473512e305181f2c46940d34aa75a9cee65c69340ddb68b7e5bb2346206ff2c5b83c5d8460bac4a738258e4f6305b6fe8bc3044a1bcb69b30d79dcd5107
+    REF v0.12.2
+    SHA512 a124f12f2a491b3f2ea74bcf3b8cd3e14f1a4aa5ede105edbed90c3329af7d7fffa5c7a287f2e1e6079d9f0fad34190887700ae20a7d15f00299526317b41137
     HEAD_REF master
 )
 
-file(COPY "${SOURCE_PATH}/refl.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/include/refl.hpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
 configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/refl-cpp/vcpkg.json
+++ b/ports/refl-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "refl-cpp",
-  "version": "0.12.1",
-  "description": "A compile-time reflection library for modern C++ with support for overloads, templates, attributes and proxies",
+  "version": "0.12.2",
+  "description": "Static reflection for C++17 (compile-time enumeration, attributes, proxies, overloads, template functions, metaprogramming).",
   "homepage": "https://github.com/veselink1/refl-cpp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6005,7 +6005,7 @@
       "port-version": 1
     },
     "refl-cpp": {
-      "baseline": "0.12.1",
+      "baseline": "0.12.2",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/refl-cpp.json
+++ b/versions/r-/refl-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f5aea911f8cfd7c6eecadb50142f00205a2e7f57",
+      "version": "0.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "109d4729d1755ca3cc45a9b9e54b8e62e2ad20cd",
       "version": "0.12.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates refl-cpp to 0.12.2

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Unchanged, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes