### PR TITLE
[python3] Bootstrap pip with ${CURRENT_INSTALLED_DIR} embedded

### DIFF
--- a/ports/python3/0010-ensurepip.patch
+++ b/ports/python3/0010-ensurepip.patch
@@ -1,0 +1,10 @@
+--- a/Lib/ensurepip/__init__.py	2021-10-05 00:40:46.000000000 +0700
++++ b/Lib/ensurepip/__init__.py	2022-01-11 15:22:54.001498300 +0700
+@@ -86,6 +86,7 @@
+     code = f"""
+ import runpy
+ import sys
++sys.executable = @sys_executable@
+ sys.path = {additional_paths or []} + sys.path
+ sys.argv[1:] = {args}
+ runpy.run_module("pip", run_name="__main__", alter_sys=True)

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -29,11 +29,22 @@ elseif(VCPKG_TARGET_IS_WINDOWS AND CMAKE_SYSTEM_VERSION EQUAL 6.1)
     message(FATAL_ERROR "python3 requires the feature deprecated-win7-support when building on Windows 7.")
 endif()
 
-# The Windows 11 SDK has a problem that causes it to error on the resource files, so we patch that.
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
+    string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" PYTHON_ALLOW_EXTENSIONS)
+    if(PYTHON_ALLOW_EXTENSIONS AND (NOT VCPKG_CROSSCOMPILING OR TARGET_TRIPLET MATCHES "^${HOST_TRIPLET}-"))
+        set(PYTHON_ENSUREPIP TRUE)
+    else()
+        set(PYTHON_ENSUREPIP FALSE)
+    endif()
+
+    # The Windows 11 SDK has a problem that causes it to error on the resource files, so we patch that.
     vcpkg_get_windows_sdk(WINSDK_VERSION)
     if("${WINSDK_VERSION}" VERSION_GREATER_EQUAL "10.0.22000")
         list(APPEND PATCHES "0007-workaround-windows-11-sdk-rc-compiler-error.patch")
+    endif()
+
+    if(PYTHON_ENSUREPIP)
+        list(APPEND PATCHES "0010-ensurepip.patch")
     endif()
 endif()
 
@@ -70,7 +81,6 @@ endfunction()
 if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
     # Due to the way Python handles C extension modules on Windows, a static python core cannot
     # load extension modules.
-    string(COMPARE EQUAL ${VCPKG_LIBRARY_LINKAGE} "dynamic" PYTHON_ALLOW_EXTENSIONS)
     if(PYTHON_ALLOW_EXTENSIONS)
         find_library(BZ2_RELEASE NAMES bz2 PATHS "${CURRENT_INSTALLED_DIR}/lib" NO_DEFAULT_PATH)
         find_library(BZ2_DEBUG NAMES bz2d PATHS "${CURRENT_INSTALLED_DIR}/debug/lib" NO_DEFAULT_PATH)
@@ -172,8 +182,10 @@ if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_UWP)
     file(REMOVE ${PYTHON_LIBS} ${PYTHON_INSTALLERS})
 
     # The generated python executable must match the host arch
-    if(PYTHON_ALLOW_EXTENSIONS AND NOT VCPKG_CROSSCOMPILING)
+    if(PYTHON_ENSUREPIP)
         message(STATUS "Bootstrapping pip")
+        set(sys_executable "'${CURRENT_INSTALLED_DIR}/tools/${PORT}/python.exe'")
+        configure_file("${SOURCE_PATH}/Lib/ensurepip/__init__.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/Lib/ensurepip/__init__.py" @ONLY)
         vcpkg_execute_required_process(COMMAND python -m ensurepip
             WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
             LOGNAME "ensurepip-${TARGET_TRIPLET}"

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python3",
   "version": "3.10.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5634,7 +5634,7 @@
     },
     "python3": {
       "baseline": "3.10.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "89ec84c1f5e3e62bcfac0642b77ac4bf610af1b9",
+      "version": "3.10.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "4e348bd50d8c4252bda83903ce22f1e60d34be88",
       "version": "3.10.2",
       "port-version": 1


### PR DESCRIPTION
[python3] Do not bootstrap pip: bootstrapped pip executables
have ${CURRENT_PACKAGES_DIR} embedded so that pip.exe even if
executed from ${CURRENT_INSTALLED_DIR} installs packages into
${CURRENT_PACKAGES_DIR}

pip should be bootstrapped in post-install step (which vcpkg
does not currently implement)

Users can always bootstrap pip manually by runing "python -m ensurepip"

**Describe the pull request**

- #### What does your PR fix?  
None

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**