### PR TITLE
[arrow] Fix CMake link error

### DIFF
--- a/ports/arrow/portfile.cmake
+++ b/ports/arrow/portfile.cmake
@@ -97,7 +97,14 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/arrow)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake")
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake ${CURRENT_PACKAGES_DIR}/share/${PORT} @ONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(GLOB PARQUET_FILES ${CURRENT_PACKAGES_DIR}/share/${PORT}/Parquet*)
+file(COPY ${PARQUET_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/parquet")
+file(REMOVE_RECURSE ${PARQUET_FILES})
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/${PORT}/FindParquet.cmake ${CURRENT_PACKAGES_DIR}/share/parquet/FindParquet.cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/arrow/usage
+++ b/ports/arrow/usage
@@ -1,0 +1,7 @@
+The package arrow provides CMake targets:
+
+    find_package(Arrow CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE ${ARROW_LIBRARIES})
+
+    find_package(Parquet CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE ${PARQUET_LIBRARIES})

--- a/ports/arrow/vcpkg-cmake-wrapper.cmake
+++ b/ports/arrow/vcpkg-cmake-wrapper.cmake
@@ -1,9 +1,9 @@
 _find_package(${ARGS})
 
-if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+if(TARGET arrow_static)
     list(APPEND ARROW_LIBRARIES arrow_static)
     list(APPEND PARQUET_LIBRARIES parquet_static)
-else()
+elseif (TARGET arrow_shared)
     list(APPEND ARROW_LIBRARIES arrow_shared)
     list(APPEND PARQUET_LIBRARIES parquet_shared)
 endif()

--- a/ports/arrow/vcpkg-cmake-wrapper.cmake
+++ b/ports/arrow/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,9 @@
+_find_package(${ARGS})
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+    list(APPEND ARROW_LIBRARIES arrow_static)
+    list(APPEND PARQUET_LIBRARIES parquet_static)
+else()
+    list(APPEND ARROW_LIBRARIES arrow_shared)
+    list(APPEND PARQUET_LIBRARIES parquet_shared)
+endif()

--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "arrow",
   "version": "6.0.1",
+  "port-version": 1,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "supports": "x64 | (arm64 & !windows)",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1436e770bb4ee7370fd3bdf43814c9b0a35b7ef3",
+      "version": "6.0.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "a192a94717139642a1e9304cdc1ae86850398fb9",
       "version": "6.0.1",
       "port-version": 0

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1436e770bb4ee7370fd3bdf43814c9b0a35b7ef3",
+      "git-tree": "b12626f29cb0ba8a049241153af0dfeca9a810d7",
       "version": "6.0.1",
       "port-version": 1
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -170,7 +170,7 @@
     },
     "arrow": {
       "baseline": "6.0.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ashes": {
       "baseline": "2021-06-18",


### PR DESCRIPTION
Fixes #20459 Fixes #18538

1. Modify `find_package(arrow CONFIG REQUIRED)` to `find_package(Arrow CONFIG REQUIRED)`, fix CMake configuage error on Linux:
```
CMake Warning at /home/vlilywang/Lily/vcpkg/installed/x64-linux/share/arrow/arrow-config.cmake:18 (message):
  find_package(arrow) is deprecated.  Use find_package(Arrow) instead.
Call Stack (most recent call first):
  /home/vlilywang/Lily/vcpkg/installed/x64-linux/share/arrow/vcpkg-cmake-wrapper.cmake:1 (_find_package)
  /home/vlilywang/Lily/vcpkg/scripts/buildsystems/vcpkg.cmake:742 (include)
  CMakeLists.txt:5 (find_package)

-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- Found OpenSSL: /home/vlilywang/Lily/vcpkg/installed/x64-linux/debug/lib/libcrypto.a (found version "1.1.1l")
-- Found thrift: /home/vlilywang/Lily/vcpkg/installed/x64-linux
-- Found ZLIB: /home/vlilywang/Lily/vcpkg/installed/x64-linux/lib/libz.a (found version "1.2.11")
-- Found BZip2: /home/vlilywang/Lily/vcpkg/installed/x64-linux/lib/libbz2.a (found version "1.0.8")
-- Looking for BZ2_bzCompressInit
-- Looking for BZ2_bzCompressInit - found
CMake Error at /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find arrow (missing: ARROW_INCLUDE_DIR) (found version "6.0.1")
```
2. Fix CMake build error as below, install the files *config.cmake and *target.cmake of `parquet` to correct directory. Remove link libraries `arrow_bundled_dependencies`, because this is the dependencies of `arrow`, VCPKG will find these dependencies which installing by VCPKG.
```
/usr/bin/ld: cannot find -lparquet_static
/usr/bin/ld: cannot find -larrow_bundled_dependencies
```

