### PR TITLE
[libslirp] add new port

### DIFF
--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_acquire_msys(MSYS_ROOT)
 vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
 
 vcpkg_configure_meson(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
 )
@@ -20,6 +20,6 @@ vcpkg_install_meson(ADD_BIN_TO_PATH)
 
 vcpkg_copy_pdbs()
 
-file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/libslirp RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libslirp" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -18,8 +18,8 @@ vcpkg_configure_meson(
 
 vcpkg_install_meson(ADD_BIN_TO_PATH)
 
+vcpkg_fixup_pkgconfig()
+
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/libslirp" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO slirp/libslirp
+    REF v4.6.1
+    SHA512 04a9dd88cd58c849a24b9cff405d951952760d99ea2bef0b070463dff088d79f44557a13c9427ba0043f58d4b9e06b68ff64a4f23a7b0d66df594e32e1521cae
+    HEAD_REF master
+)
+
+vcpkg_acquire_msys(MSYS_ROOT)
+vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+
+vcpkg_configure_meson(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${OPTIONS}
+)
+
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_copy_pdbs()
+
+file(INSTALL ${SOURCE_PATH}/COPYRIGHT DESTINATION ${CURRENT_PACKAGES_DIR}/share/libslirp RENAME copyright)
+
+vcpkg_fixup_pkgconfig()

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -3,6 +3,7 @@
   "version-semver": "4.6.1",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
+  "license": "BSD-3-Clause",
   "supports": "!windows | mingw",
   "dependencies": [
     "glib",

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libslirp",
+  "version": "4.6.1",
+  "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
+  "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
+  "dependencies": [
+    "glib",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libslirp",
-  "version": "4.6.1",
+  "version-semver": "4.6.1",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "supports": "!windows | mingw",

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "4.6.1",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
+  "supports": "!windows | mingw",
   "dependencies": [
     "glib",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3900,6 +3900,10 @@
       "baseline": "3.0.3",
       "port-version": 1
     },
+    "libslirp": {
+      "baseline": "4.6.1",
+      "port-version": 0
+    },
     "libsmb2": {
       "baseline": "2021-04-29",
       "port-version": 0

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68a905881900b6fd8aabe2ed3d4f5fee02b32192",
+      "git-tree": "5a7b734c0850f035d3eb2abc2d3dbf6389124be5",
       "version-semver": "4.6.1",
       "port-version": 0
     }

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "68a905881900b6fd8aabe2ed3d4f5fee02b32192",
+      "version-semver": "4.6.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Adds a [libslirp](https://gitlab.freedesktop.org/slirp/libslirp) port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All except non-MinGW Windows; yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
