### PR TITLE
[baseline] as of 2.0.2, portmidi:x64-windows-static-md passes

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1634,7 +1634,6 @@ mmloader:x64-windows-static-md=fail
 netcdf-cxx4:x64-windows-static-md=fail
 open62541:x64-windows-static-md=fail
 openscap:x64-windows-static-md=fail
-portmidi:x64-windows-static-md=fail
 quantlib:x64-windows-static-md=fail
 sentencepiece:x64-windows-static-md=fail
 symengine:x64-windows-static-md=fail


### PR DESCRIPTION
see above, change ci.baseline.txt