### PR TITLE
[lapack-reference] update to 3.10.0

### DIFF
--- a/ports/lapack-reference/portfile.cmake
+++ b/ports/lapack-reference/portfile.cmake
@@ -11,13 +11,13 @@ endif()
 include(vcpkg_find_fortran)
 SET(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
-set(lapack_ver 3.8.0)
+set(lapack_ver 3.10.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO  "Reference-LAPACK/lapack"
     REF "v${lapack_ver}"
-    SHA512 17786cb7306fccdc9b4a242de7f64fc261ebe6a10b6ec55f519deb4cb673cb137e8742aa5698fd2dc52f1cd56d3bd116af3f593a01dcf6770c4dcc86c50b2a7f
+    SHA512 56055000c241bab8f318ebd79249ea012c33be0c4c3eca6a78e247f35ad9e8088f46605a0ba52fd5ad3e7898be3b7bc6c50ceb3af327c4986a266b06fe768cbf
     HEAD_REF master
 )
 
@@ -61,16 +61,15 @@ else()
     set(USE_OPTIMIZED_BLAS ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DUSE_OPTIMIZED_BLAS=${USE_OPTIMIZED_BLAS}"
         "-DCBLAS=${CBLAS}"
         ${FORTRAN_CMAKE}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(PACKAGE_NAME lapack-${lapack_ver} CONFIG_PATH lib/cmake/lapack-${lapack_ver}) #Should the target path be lapack and not lapack-reference?
 
@@ -139,5 +138,5 @@ if(VCPKG_TARGET_IS_WINDOWS)
     endif()
 endif()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/lapack)
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/FindLAPACK.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/lapack)
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/lapack")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/FindLAPACK.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/lapack")

--- a/ports/lapack-reference/vcpkg.json
+++ b/ports/lapack-reference/vcpkg.json
@@ -1,10 +1,13 @@
 {
   "name": "lapack-reference",
-  "version-semver": "3.8.0",
-  "port-version": 6,
+  "version-semver": "3.10.0",
   "description": "LAPACK — Linear Algebra PACKage",
   "homepage": "http://www.netlib.org/lapack/",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake-config",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3253,8 +3253,8 @@
       "port-version": 2
     },
     "lapack-reference": {
-      "baseline": "3.8.0",
-      "port-version": 6
+      "baseline": "3.10.0",
+      "port-version": 0
     },
     "lastools": {
       "baseline": "2020-05-09",

--- a/versions/l-/lapack-reference.json
+++ b/versions/l-/lapack-reference.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1188100f733ebde0df40447ac68fd8d2cdc069e1",
+      "version-semver": "3.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "10799c7ec42f8369179ba7a8e927235596cb8bb7",
       "version-semver": "3.8.0",
       "port-version": 6


### PR DESCRIPTION
Fix #19983

Update lapack-reference to the latest version 3.10.0

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static