### PR TITLE
[proj4]: Make the tiff specific features configurable and don't requi…

### DIFF
--- a/ports/proj4/vcpkg.json
+++ b/ports/proj4/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "proj4",
   "version-semver": "8.2.1",
+  "port-version": 1,
   "description": "PROJ library for cartographic projections",
   "homepage": "https://proj.org/",
   "dependencies": [
@@ -39,7 +40,14 @@
     "tiff": {
       "description": "Enable TIFF support to read some grids",
       "dependencies": [
-        "tiff"
+        {
+          "name": "tiff",
+          "default-features": false,
+          "features": [
+            "lzma",
+            "zip"
+          ]
+        }
       ]
     },
     "tools": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5430,7 +5430,7 @@
     },
     "proj4": {
       "baseline": "8.2.1",
-      "port-version": 0
+      "port-version": 1
     },
     "prometheus-cpp": {
       "baseline": "1.0.0",

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de72240f9bceda0263f58b734ab6de4f97632dbe",
+      "version-semver": "8.2.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "97a7f5c2cabaf598c15dc357d0e53d5c44e10225",
       "version-semver": "8.2.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Proj4 uses geotiff files for grid shifts and uses libtiff to read the tiff files. But when using a
  standard configured libtiff this also includes the lossy jpeg compression, which isn't used
  by standard projection data.

See https://proj.org/specifications/geodetictiffgrids.html#geodetictiffgrids

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All triplets are supported.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
