### PR TITLE
[nlohmann-json] Add option to control implicit conversions behaviour

### DIFF
--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -40,3 +40,6 @@ file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/nlohmann_json.natvis")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.MIT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+# Handle usage
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/nlohmann-json/portfile.cmake
+++ b/ports/nlohmann-json/portfile.cmake
@@ -6,12 +6,17 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
+if(NOT DEFINED nlohmann-json_IMPLICIT_CONVERSIONS)
+    set(nlohmann-json_IMPLICIT_CONVERSIONS ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         -DJSON_Install=ON
         -DJSON_MultipleHeaders=ON
         -DJSON_BuildTests=OFF
+        -DJSON_ImplicitConversions=${nlohmann-json_IMPLICIT_CONVERSIONS}
 )
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "nlohmann_json" CONFIG_PATH "lib/cmake/nlohmann_json")

--- a/ports/nlohmann-json/usage
+++ b/ports/nlohmann-json/usage
@@ -1,0 +1,12 @@
+The package nlohmann-json provides CMake targets:
+
+    find_package(nlohmann_json CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE nlohmann_json::nlohmann_json)
+
+The package nlohmann-json can be configured to not provide implicit conversions via a custom triplet file:
+
+    set(nlohmann_json_JSON_ImplicitConversions OFF)
+
+For more information, see the docs here:
+    
+    https://json.nlohmann.me/features/macros/#json_use_implicit_conversions

--- a/ports/nlohmann-json/vcpkg.json
+++ b/ports/nlohmann-json/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nlohmann-json",
   "version-semver": "3.10.5",
+  "port-version": 1,
   "description": "JSON for Modern C++",
   "homepage": "https://github.com/nlohmann/json",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4798,7 +4798,7 @@
     },
     "nlohmann-json": {
       "baseline": "3.10.5",
-      "port-version": 0
+      "port-version": 1
     },
     "nlopt": {
       "baseline": "2.7.0",

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fa0a087d0444a7f2c79a44bce91c51550d5f2e47",
+      "version-semver": "3.10.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "d1fe747457714c4c43b12502de05b2d006b440d4",
       "version-semver": "3.10.5",
       "port-version": 0


### PR DESCRIPTION
This adds an inverse feature `disable-implicit-conversions` to the nlohmann-json port as described in the associated issue (#22408)

#### What does your PR fix?  
  Fixes #22408

#### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No changes required

#### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

#### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
