### PR TITLE
[cppgraphqlgen] Update from v4.0.0 to v4.1.0

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
-    REF v4.0.0
-    SHA512 5e356234e9e47977077f36fdd4a811fe140559a6961b2c8f1a4cd56559df444e890da1863d6b020b1afcec81cd82f7bf91d907a635089459b98da9b74613aae0
+    REF v4.1.0
+    SHA512 530cbc21d43b918a8ad2d32f659dd20a8272a59952808c13f2fad9f9ca0bd3df1bb8b5296ab7d62f831d6d0c6197b9f5708ddda58f44332bfbfee6f6f2d116bb
     HEAD_REF main
 )
 

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppgraphqlgen",
-  "version-semver": "4.0.0",
+  "version-semver": "4.1.0",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 1
     },
     "cppgraphqlgen": {
-      "baseline": "4.0.0",
+      "baseline": "4.1.0",
       "port-version": 0
     },
     "cppitertools": {

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23ec5f0002e33dd6c76bab436dec806cfde33235",
+      "version-semver": "4.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6f5eb4a891a143e9d56a8e4791fb87da321a561c",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Updates cppgraphqlgen from v4.0.0 to v4.1.0.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All triplets are supported, as long as the toolchain supports C++20 coroutines. I previously updated ci.baseline.txt for v4.0.0 since the CI build for x64-linux uses an older version of `gcc` and fails. Otherwise, CI should pass.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
