### PR TITLE
[drogon] Fix libmariadb import/export and usage

### DIFF
--- a/ports/drogon/portfile.cmake
+++ b/ports/drogon/portfile.cmake
@@ -56,7 +56,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
-# Handle copyright
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 # Copy pdb files

--- a/ports/drogon/portfile.cmake
+++ b/ports/drogon/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         drogon_config.patch
         static-brotli.patch
         fs.patch
+        use-libmariadb.patch
 )
 
 vcpkg_check_features(

--- a/ports/drogon/usage
+++ b/ports/drogon/usage
@@ -1,0 +1,4 @@
+The package drogon provides CMake targets:
+
+    find_package(Drogon CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Drogon::Drogon)

--- a/ports/drogon/use-libmariadb.patch
+++ b/ports/drogon/use-libmariadb.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 70b2a0d..7f35626 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -363,10 +363,11 @@ endif (BUILD_POSTGRESQL)
+ 
+ if (BUILD_MYSQL)
+     # Find mysql, only mariadb client liberary is supported
+-    find_package(MySQL)
++    find_package(unofficial-libmariadb CONFIG REQUIRED)
++    set(MySQL_FOUND TRUE)
+     if (MySQL_FOUND)
+         message(STATUS "Ok! We find the mariadb!")
+-        target_link_libraries(${PROJECT_NAME} PRIVATE MySQL_lib)
++        target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::libmariadb)
+         set(DROGON_SOURCES
+             ${DROGON_SOURCES}
+             orm_lib/src/mysql_impl/MysqlConnection.cc
+diff --git a/cmake/templates/DrogonConfig.cmake.in b/cmake/templates/DrogonConfig.cmake.in
+index 72d9622..026f1a5 100644
+--- a/cmake/templates/DrogonConfig.cmake.in
++++ b/cmake/templates/DrogonConfig.cmake.in
+@@ -25,7 +25,7 @@ if(@SQLite3_FOUND@)
+ find_dependency(SQLite3)
+ endif()
+ if(@MySQL_FOUND@)
+-find_dependency(MySQL)
++find_dependency(unofficial-libmariadb CONFIG REQUIRED)
+ endif()
+ if(@Boost_FOUND@)
+ find_dependency(Boost)

--- a/ports/drogon/vcpkg.json
+++ b/ports/drogon/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "drogon",
   "version-semver": "1.7.4",
+  "port-version": 1,
   "description": "A C++14/17 based HTTP web application framework running on Linux/macOS/Unix/Windows",
   "homepage": "https://github.com/an-tao/drogon",
   "documentation": "https://drogon.docsforge.com/master/overview/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1906,7 +1906,7 @@
     },
     "drogon": {
       "baseline": "1.7.4",
-      "port-version": 0
+      "port-version": 1
     },
     "dtl": {
       "baseline": "1.19",

--- a/versions/d-/drogon.json
+++ b/versions/d-/drogon.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5e1c950e966613f9b867570346f9458bff71826",
+      "version-semver": "1.7.4",
+      "port-version": 1
+    },
+    {
       "git-tree": "275d55a78bb61a79f0d66cd4f71e6b5892566666",
       "version-semver": "1.7.4",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes building and using drogon with libmariadb. Cf. #22378 for previous work and discussion. CC @kotori2.
  Fixes the reported usage, cf. https://github.com/microsoft/vcpkg/issues/20190#issuecomment-1008044822.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged

  Tested on x64-linux (port build logs and building a minimal test project).

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
