### PR TITLE
[chakracore] Add flag to use all available CPUs

### DIFF
--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -49,7 +49,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         list(APPEND configs "debug")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "-j"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
 
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
@@ -62,7 +62,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         list(APPEND configs "release")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "-j"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
             ERROR_VARIABLE CHAKRA_BUILD_SH_ERR

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -4,12 +4,6 @@ if(WIN32)
 endif()
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
-if(NOT "$ENV{VCPKG_MAX_CONCURRENCY}" STREQUAL "")
-    set(NUM_CORES_FLAG "-j=$ENV{VCPKG_MAX_CONCURRENCY}")
-else()
-    set(NUM_CORES_FLAG "-j")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/ChakraCore
@@ -55,7 +49,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         list(APPEND configs "debug")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "${NUM_CORES_FLAG}"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "-j=${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
 
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
@@ -68,7 +62,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         list(APPEND configs "release")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "${NUM_CORES_FLAG}"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "-j=${VCPKG_CONCURRENCY}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
             ERROR_VARIABLE CHAKRA_BUILD_SH_ERR

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -5,9 +5,9 @@ endif()
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 if(NOT "$ENV{VCPKG_MAX_CONCURRENCY}" STREQUAL "")
-  set(NUM_CORES_FLAG "-j=$ENV{VCPKG_MAX_CONCURRENCY}")
+    set(NUM_CORES_FLAG "-j=$ENV{VCPKG_MAX_CONCURRENCY}")
 else()
-  set(NUM_CORES_FLAG "-j")
+    set(NUM_CORES_FLAG "-j")
 endif()
 
 vcpkg_from_github(

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -49,7 +49,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         list(APPEND configs "debug")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "-j"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "-j=${VCPKG_MAX_CONCURRENCY}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
 
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
@@ -62,7 +62,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         list(APPEND configs "release")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "-j"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "-j=${VCPKG_MAX_CONCURRENCY}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
             ERROR_VARIABLE CHAKRA_BUILD_SH_ERR

--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -4,6 +4,12 @@ if(WIN32)
 endif()
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+if(NOT "$ENV{VCPKG_MAX_CONCURRENCY}" STREQUAL "")
+  set(NUM_CORES_FLAG "-j=$ENV{VCPKG_MAX_CONCURRENCY}")
+else()
+  set(NUM_CORES_FLAG "-j")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/ChakraCore
@@ -49,7 +55,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
         list(APPEND configs "debug")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "-j=${VCPKG_MAX_CONCURRENCY}"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "--debug" "${NUM_CORES_FLAG}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
 
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
@@ -62,7 +68,7 @@ else()
     if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
         list(APPEND configs "release")
         execute_process(
-            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "-j=${VCPKG_MAX_CONCURRENCY}"
+            COMMAND bash "build.sh" "--arch=${CHAKRACORE_TARGET_ARCH}" "${NUM_CORES_FLAG}"
             WORKING_DIRECTORY "${BUILDTREE_PATH}"
             OUTPUT_VARIABLE CHAKRA_BUILD_SH_OUT
             ERROR_VARIABLE CHAKRA_BUILD_SH_ERR

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "chakracore",
   "version-string": "2021-04-22",
+  "port-version": 1,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
   "supports": "!osx & !uwp & (linux | !static)"

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "chakracore",
-  "version-string": "2021-04-22",
+  "version-date": "2021-04-22",
   "port-version": 1,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1322,7 +1322,7 @@
     },
     "chakracore": {
       "baseline": "2021-04-22",
-      "port-version": 0
+      "port-version": 1
     },
     "charls": {
       "baseline": "2.2.0",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8153c80dc5cfc7c45bb4a3d445aa964570ac302e",
+      "version-string": "2021-04-22",
+      "port-version": 1
+    },
+    {
       "git-tree": "0aa775c085b114b0ec67ea23ee99ece252d9e498",
       "version-string": "2021-04-22",
       "port-version": 0

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8153c80dc5cfc7c45bb4a3d445aa964570ac302e",
+      "git-tree": "2f4aa550def0b4d0462cbc797341d83f0b26df47",
       "version-string": "2021-04-22",
       "port-version": 1
     },

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c267f7a3d3aa9d8972e3dd306ac08c2c703c9af7",
+      "git-tree": "9e9d1a55573910d6e4c6fe0a9dca0e601df2929c",
       "version-string": "2021-04-22",
       "port-version": 1
     },

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "9e9d1a55573910d6e4c6fe0a9dca0e601df2929c",
-      "version-string": "2021-04-22",
+      "git-tree": "8ce7ea484830cdf24c8af45ebad35ba10e76f61c",
+      "version-date": "2021-04-22",
       "port-version": 1
     },
     {

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2f4aa550def0b4d0462cbc797341d83f0b26df47",
+      "git-tree": "c267f7a3d3aa9d8972e3dd306ac08c2c703c9af7",
       "version-string": "2021-04-22",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  My PR adds `-j` option when building ChakraCore on Linux to use all CPUs. It speedups building of the port significantly.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  nothing changed here

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
