### PR TITLE
[s2n] disable -Werror for gcc 11 build

### DIFF
--- a/ports/s2n/portfile.cmake
+++ b/ports/s2n/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
+        -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/s2n/vcpkg.json
+++ b/ports/s2n/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "s2n",
   "version": "1.3.0",
+  "port-version": 1,
   "description": "C99 implementation of the TLS/SSL protocols.",
   "homepage": "https://github.com/aws/s2n-tls",
   "supports": "!uwp & !windows",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6166,7 +6166,7 @@
     },
     "s2n": {
       "baseline": "1.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "safeint": {
       "baseline": "3.0.26",

--- a/versions/s-/s2n.json
+++ b/versions/s-/s2n.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7cb2325defd326de178cf524bd5db039ff1dc112",
+      "version": "1.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a8252a918117164e1f6472663244fda74690f849",
       "version": "1.3.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

s2n fails to build with gcc 11 (see https://github.com/aws/s2n-tls/issues/2989) due to problematic type declarations which generate compiler warnings, coupled with the fact that s2n builds with -Werror by default. This prevents gcc 11 users from building the AWS SDK via vcpkg. This PR uses an s2n build option to disable building with -Werror. Building with -Werror is not helpful for an end user trying to use s2n from vcpkg, since a build failure like this is not actionable. 

The underlying bug is not yet fixed upstream, so this change leaves the port at version 1.3.0, although 1.3.3 is available. If desired, I could add the update to 1.3.3 to this PR.

- #### What does your PR fix?  
  Fixes #21882 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
   Should be unchanged. (Perhaps it would be worth adding gcc 11 to the CI matrix?)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

