### PR TITLE
[speex] fix build on osx by disableing example binaries

### DIFF
--- a/ports/speex/portfile.cmake
+++ b/ports/speex/portfile.cmake
@@ -14,12 +14,11 @@ vcpkg_from_github(
 if(VCPKG_TARGET_IS_WINDOWS)
   file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
   
-  vcpkg_configure_cmake(
+  vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
   )
-  vcpkg_install_cmake()
+  vcpkg_cmake_install()
 
   if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/speex/speex.h"

--- a/ports/speex/portfile.cmake
+++ b/ports/speex/portfile.cmake
@@ -31,6 +31,7 @@ else()
   vcpkg_configure_make(
     SOURCE_PATH ${SOURCE_PATH}
     AUTOCONFIG
+    OPTIONS --disable-binaries # no example programs (require libogg)
   )
   vcpkg_install_make()
 

--- a/ports/speex/vcpkg.json
+++ b/ports/speex/vcpkg.json
@@ -1,7 +1,14 @@
 {
   "name": "speex",
-  "version-string": "1.2.0",
-  "port-version": 9,
+  "version": "1.2.0",
+  "port-version": 10,
   "description": "Speex is an Open Source/Free Software patent-free audio compression format designed for speech.",
-  "homepage": "https://github.com/xiph/speex"
+  "homepage": "https://github.com/xiph/speex",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true,
+      "platform": "windows"
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6534,7 +6534,7 @@
     },
     "speex": {
       "baseline": "1.2.0",
-      "port-version": 9
+      "port-version": 10
     },
     "speexdsp": {
       "baseline": "1.2.0",

--- a/versions/s-/speex.json
+++ b/versions/s-/speex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0f443cef71fd44439aa559063a219da440f6665d",
+      "version": "1.2.0",
+      "port-version": 10
+    },
+    {
       "git-tree": "8713e87cf40c60307dfdef2102392b97cb3b4c3d",
       "version-string": "1.2.0",
       "port-version": 9


### PR DESCRIPTION
Building fails because of the missing libogg it is required for building the example programs. 
Since the are also not build in the windows case, I have just disabled them. 

- #### What does your PR fix?  
Building on OSX

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
no change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes>