### PR TITLE
[vcpkg] z_vcpkg_get_cmake_vars(): Use build-type-specific cache variable if VCPKG_BUILD_TYPE is defined

### DIFF
--- a/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
+++ b/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
@@ -39,8 +39,13 @@ function(z_vcpkg_get_cmake_vars out_file)
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
     endif()
 
-    if(NOT DEFINED CACHE{Z_VCPKG_GET_CMAKE_VARS_FILE})
-        set(Z_VCPKG_GET_CMAKE_VARS_FILE "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.cmake.log"
+    if(DEFINED VCPKG_BUILD_TYPE)
+        set(cache_var "Z_VCPKG_GET_CMAKE_VARS_FILE_${VCPKG_BUILD_TYPE}")
+    else()
+        set(cache_var Z_VCPKG_GET_CMAKE_VARS_FILE)
+    endif()
+    if(NOT DEFINED CACHE{${cache_var}})
+        set(${cache_var} "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.cmake.log"
             CACHE PATH "The file to include to access the CMake variables from a generated project.")
         vcpkg_configure_cmake(
             SOURCE_PATH "${SCRIPTS}/get_cmake_vars"
@@ -58,8 +63,8 @@ function(z_vcpkg_get_cmake_vars out_file)
         if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
             string(APPEND include_string "include(\"\${CMAKE_CURRENT_LIST_DIR}/cmake-vars-${TARGET_TRIPLET}-dbg.cmake.log\")\n")
         endif()
-        file(WRITE "${Z_VCPKG_GET_CMAKE_VARS_FILE}" "${include_string}")
+        file(WRITE "${${cache_var}}" "${include_string}")
     endif()
 
-    set("${out_file}" "${Z_VCPKG_GET_CMAKE_VARS_FILE}" PARENT_SCOPE)
+    set("${out_file}" "${${cache_var}}" PARENT_SCOPE)
 endfunction()

--- a/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
+++ b/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
@@ -40,12 +40,14 @@ function(z_vcpkg_get_cmake_vars out_file)
     endif()
 
     if(DEFINED VCPKG_BUILD_TYPE)
+        set(cmake_vars_file "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-${VCPKG_BUILD_TYPE}.cmake.log")
         set(cache_var "Z_VCPKG_GET_CMAKE_VARS_FILE_${VCPKG_BUILD_TYPE}")
     else()
+        set(cmake_vars_file "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.cmake.log")
         set(cache_var Z_VCPKG_GET_CMAKE_VARS_FILE)
     endif()
     if(NOT DEFINED CACHE{${cache_var}})
-        set(${cache_var} "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.cmake.log"
+        set(${cache_var}  "${cmake_vars_file}"
             CACHE PATH "The file to include to access the CMake variables from a generated project.")
         vcpkg_configure_cmake(
             SOURCE_PATH "${SCRIPTS}/get_cmake_vars"
@@ -63,7 +65,7 @@ function(z_vcpkg_get_cmake_vars out_file)
         if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
             string(APPEND include_string "include(\"\${CMAKE_CURRENT_LIST_DIR}/cmake-vars-${TARGET_TRIPLET}-dbg.cmake.log\")\n")
         endif()
-        file(WRITE "${${cache_var}}" "${include_string}")
+        file(WRITE "${cmake_vars_file}" "${include_string}")
     endif()
 
     set("${out_file}" "${${cache_var}}" PARENT_SCOPE)


### PR DESCRIPTION
**Describe the pull request**

Some ports (e.g. gettext) execute debug and release builds manually (with different options). If a globally cached copy of cmake vars file is used, the second build type has no cmake vars defined (e.g. CFLAGS is empty) because generated and globally cached cmake vars file includes only cmake vars for the first build type.

For example,

1) gettext[tools] build first runs build_libintl_and_tools(BUILD_TYPE "release") first which causes cmake vars file to be generated with the following contents (the example is for x64-windows-static):

```
include("${CMAKE_CURRENT_LIST_DIR}/cmake-vars-x64-windows-static-rel.cmake.log")
```

2) then build_libintl_only(BUILD_TYPE "debug") is run, but cmake vars file is cached and debug build vars include() is not generated and used

- #### What does your PR fix?  
Currently, gettext[tools] windows static builds fail with the following error (because CFLAGS for debug are lost and empty):

```
-- Performing post-build validation
Invalid crt linkage. Expected Debug,Static, but the following libs had:

    C:\vcpkg\packages\gettext_x64-windows-static\debug\lib\intl.lib: Release,Static

To inspect the lib files, use:
    dumpbin.exe /directives mylibfile.lib
Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile:
    C:\vcpkg\ports\gettext\portfile.cmake
-- Performing post-build validation done
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
