### PR TITLE
[buck-yeh-bux] Fix error C7595

### DIFF
--- a/ports/buck-yeh-bux/fix-errorC7595.patch
+++ b/ports/buck-yeh-bux/fix-errorC7595.patch
@@ -1,0 +1,15 @@
+diff --git a/src/XException.cpp b/src/XException.cpp
+index 6a66347..53a0087 100644
+--- a/src/XException.cpp
++++ b/src/XException.cpp
+@@ -49,8 +49,8 @@ LONG WINAPI usrSEH(_EXCEPTION_POINTERS *pInfo)
+             RUNTIME_ERROR("code 0x{:x}, flags 0x{:x}, extra 0x{:x}, ip 0x{:x}, arg#{:x}",
+                 er->ExceptionCode,
+                 er->ExceptionFlags,
+-                static_cast<void*>(er->ExceptionRecord),
+-                static_cast<void*>(er->ExceptionAddress),
++                (size_t)static_cast<void*>(er->ExceptionRecord),
++                (size_t)static_cast<void*>(er->ExceptionAddress),
+                 er->NumberParameters);
+     }
+     return EXCEPTION_CONTINUE_SEARCH;

--- a/ports/buck-yeh-bux/portfile.cmake
+++ b/ports/buck-yeh-bux/portfile.cmake
@@ -1,10 +1,10 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "uwp" "osx")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO buck-yeh/bux
     REF 8788509f0281e9a2af34c0399a45a5c9e66a4664 # v1.6.3
     SHA512 a7045a93d91e497ca2b60965bb2f098eae714d00feef0d252747178739cdd981f44cb8983278c679761f61e037da05889f22fa161d26fca05af511fc56c1ac8f
     HEAD_REF main
+	PATCHES fix-errorC7595.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/buck-yeh-bux/vcpkg.json
+++ b/ports/buck-yeh-bux/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "buck-yeh-bux",
   "version": "1.6.3",
+  "port-version": 1,
   "description": "A supplemental C++ library with functionalities not directly supported from Modern C++ standard.",
   "homepage": "https://github.com/buck-yeh/bux",
   "supports": "!(arm | uwp | osx)",

--- a/versions/b-/buck-yeh-bux.json
+++ b/versions/b-/buck-yeh-bux.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "54886a840d4c55d27047321af6de1a5a01ed888e",
+      "version": "1.6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "19d56bb09ecc37268afec6a5384282e562491af4",
       "version": "1.6.3",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1170,7 +1170,7 @@
     },
     "buck-yeh-bux": {
       "baseline": "1.6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "buck-yeh-bux-mariadb-client": {
       "baseline": "1.0.1",


### PR DESCRIPTION
In an internal version of Visual Studio, buck-yeh-bux install failed with following error:
`E:\0110\vcpkg\buildtrees\buck-yeh-bux\src\c9e66a4664-c1c802f90b.clean\src\XException.cpp(49): error C7595: 'fmt::v8::basic_format_string<char,int,const char (&)[30],const DWORD &,const DWORD &,void *,void *,const DWORD &>::basic_format_string': call to immediate function is not a constant expression`
The reason is the format string is incorrect, add `(size_t)` to fix it.
I have submitted an issue on upstream: https://github.com/buck-yeh/bux/issues/4