### PR TITLE
[getdns] Disable install COPYING in CMakeLists.txt of source

### DIFF
--- a/ports/getdns/disable-install-COPYING-in-config-step.patch
+++ b/ports/getdns/disable-install-COPYING-in-config-step.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 413709d..cbe330b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1102,7 +1102,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/getdns DESTINATION ${CMAKE_INSTALL
+ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man3 DESTINATION share/man)
+ 
+ set(docdir share/doc/getdns)
+-install(FILES AUTHORS ChangeLog COPYING LICENSE NEWS README.md DESTINATION ${docdir})
++#install(FILES AUTHORS ChangeLog COPYING LICENSE NEWS README.md DESTINATION ${docdir})
+ install(FILES spec/index.html DESTINATION ${docdir}/spec)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/getdns.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 

--- a/ports/getdns/portfile.cmake
+++ b/ports/getdns/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 set(GETDNS_VERSION 1.7.0)
 set(GETDNS_HASH d09b8bdd0b4a3df2d25b9689166226da83a5a7eb2c7436487dc637539ac6077624a4d66cf684c4e6c4911561872c6bd191af3afd90d275b1662e4c6c47773ef6)
 
@@ -12,10 +10,10 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 ${GETDNS_HASH}
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${GETDNS_VERSION}
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES disable-install-COPYING-in-config-step.patch
 )
 
 vcpkg_check_features(

--- a/ports/getdns/vcpkg.json
+++ b/ports/getdns/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "getdns",
   "version": "1.7.0",
+  "port-version": 1,
   "description": "GetDNS is a modern asynchronous DNS API",
   "homepage": "https://getdnsapi.net/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2410,7 +2410,7 @@
     },
     "getdns": {
       "baseline": "1.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "getopt": {
       "baseline": "0",

--- a/versions/g-/getdns.json
+++ b/versions/g-/getdns.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fc05946f698399983a44d1c9a173df743c7bacf",
+      "version": "1.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "fd966770afa413f4502ba69f0c2e0a860b08f967",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/21910

  Local user account is unable to generate symbolic link file: COPYING when using 7zip to extract files, which results in a file not found error when installing COPYING.
  Disable install COPYING to fix this issue.
