### PR TITLE
[boost-build] Fix boost-exception for wasm32-emscripten

### DIFF
--- a/ports/boost-build/0002-fix-get-version.patch
+++ b/ports/boost-build/0002-fix-get-version.patch
@@ -1,7 +1,7 @@
-diff --git a/tools/clang-linux.jam b/tools/clang-linux.jam
+diff --git a/src/tools/clang-linux.jam b/src/tools/clang-linux.jam
 index 949e277..8934787 100644
---- a/tools/clang-linux.jam
-+++ b/tools/clang-linux.jam
+--- a/src/tools/clang-linux.jam
++++ b/src/tools/clang-linux.jam
 @@ -97,7 +97,7 @@ rule init ( version ? :  command * : options * ) {
  
  rule get-full-version ( command-string )

--- a/ports/boost-build/0002-fix-get-version.patch
+++ b/ports/boost-build/0002-fix-get-version.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/clang-linux.jam b/tools/clang-linux.jam
+index 949e277..8934787 100644
+--- a/tools/clang-linux.jam
++++ b/tools/clang-linux.jam
+@@ -97,7 +97,7 @@ rule init ( version ? :  command * : options * ) {
+ 
+ rule get-full-version ( command-string )
+ {
+-    return [ common.match-command-output version : "version ([0-9.]+)"
++    return [ common.match-command-output version : "([0-9]+.[0-9]+.[0-9]+)"
+            : "$(command-string) --version" ] ;
+ }
+ 

--- a/ports/boost-build/portfile.cmake
+++ b/ports/boost-build/portfile.cmake
@@ -12,7 +12,9 @@ vcpkg_from_github(
     REF boost-${BOOST_VERSION}
     SHA512 867966e3d254c0e996786587fb64ad1bda6f96546e5302c15231b17d66537798770bbd9e89f800d445a1f0a4d3be06dff8aed42dfd3a77b563d0f5d715e79324
     HEAD_REF master
-    PATCHES 0001-don-t-skip-install-targets.patch 0002-fix-get-version.patch
+    PATCHES
+        0001-don-t-skip-install-targets.patch
+        0002-fix-get-version.patch
 )
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/boost-build/portfile.cmake
+++ b/ports/boost-build/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_github(
     REF boost-${BOOST_VERSION}
     SHA512 867966e3d254c0e996786587fb64ad1bda6f96546e5302c15231b17d66537798770bbd9e89f800d445a1f0a4d3be06dff8aed42dfd3a77b563d0f5d715e79324
     HEAD_REF master
-    PATCHES 0001-don-t-skip-install-targets.patch
+    PATCHES 0001-don-t-skip-install-targets.patch 0002-fix-get-version.patch
 )
 
 vcpkg_download_distfile(ARCHIVE

--- a/ports/boost-build/vcpkg.json
+++ b/ports/boost-build/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "boost-build",
   "version": "1.78.0",
+  "port-version": 1,
   "description": "Boost.Build",
   "homepage": "https://github.com/boostorg/build",
   "dependencies": [

--- a/ports/boost-build/vcpkg.json
+++ b/ports/boost-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-build",
   "version": "1.78.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Boost.Build",
   "homepage": "https://github.com/boostorg/build",
   "dependencies": [

--- a/ports/boost-build/vcpkg.json
+++ b/ports/boost-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-build",
   "version": "1.78.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Boost.Build",
   "homepage": "https://github.com/boostorg/build",
   "dependencies": [

--- a/ports/boost-build/vcpkg.json
+++ b/ports/boost-build/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-build",
   "version": "1.78.0",
-  "port-version": 3,
+  "port-version": 1,
   "description": "Boost.Build",
   "homepage": "https://github.com/boostorg/build",
   "dependencies": [

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a97c74b446de1829ea4b11d0b0b99f7081267c4d",
+      "git-tree": "cf970c17a4bf6d59deff7ce7e7eb98cec74b544a",
       "version": "1.78.0",
       "port-version": 1
     },

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b056cc4ec512fda610c9a46ed074136f87fe5784",
+      "version": "1.78.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "2c0d3c35e95f99911a226c3e736c0988f1139e51",
       "version": "1.78.0",
       "port-version": 0

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caada466764a8c06ee4e856b8a1c32745e1b5174",
+      "version": "1.78.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b056cc4ec512fda610c9a46ed074136f87fe5784",
       "version": "1.78.0",
       "port-version": 1

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -3,16 +3,6 @@
     {
       "git-tree": "a97c74b446de1829ea4b11d0b0b99f7081267c4d",
       "version": "1.78.0",
-      "port-version": 3
-    },
-    {
-      "git-tree": "caada466764a8c06ee4e856b8a1c32745e1b5174",
-      "version": "1.78.0",
-      "port-version": 2
-    },
-    {
-      "git-tree": "b056cc4ec512fda610c9a46ed074136f87fe5784",
-      "version": "1.78.0",
       "port-version": 1
     },
     {

--- a/versions/b-/boost-build.json
+++ b/versions/b-/boost-build.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a97c74b446de1829ea4b11d0b0b99f7081267c4d",
+      "version": "1.78.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "caada466764a8c06ee4e856b8a1c32745e1b5174",
       "version": "1.78.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -574,7 +574,7 @@
     },
     "boost-build": {
       "baseline": "1.78.0",
-      "port-version": 0
+      "port-version": 1
     },
     "boost-callable-traits": {
       "baseline": "1.78.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -574,7 +574,7 @@
     },
     "boost-build": {
       "baseline": "1.78.0",
-      "port-version": 3
+      "port-version": 1
     },
     "boost-callable-traits": {
       "baseline": "1.78.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -574,7 +574,7 @@
     },
     "boost-build": {
       "baseline": "1.78.0",
-      "port-version": 1
+      "port-version": 2
     },
     "boost-callable-traits": {
       "baseline": "1.78.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -574,7 +574,7 @@
     },
     "boost-build": {
       "baseline": "1.78.0",
-      "port-version": 2
+      "port-version": 3
     },
     "boost-callable-traits": {
       "baseline": "1.78.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #22496

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Re-adds support for wasm32-emscripten, *should* not break any other build. The CI baseline did not seem to need an update.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  After re-reading, yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
