### PR TITLE
[vcpkg] Fix name clash (e.g. "all" build for triplet x64-windows-release and "release" build for triplet x64-windows)

### DIFF
--- a/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
+++ b/scripts/cmake/z_vcpkg_get_cmake_vars.cmake
@@ -40,7 +40,7 @@ function(z_vcpkg_get_cmake_vars out_file)
     endif()
 
     if(DEFINED VCPKG_BUILD_TYPE)
-        set(cmake_vars_file "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}-${VCPKG_BUILD_TYPE}.cmake.log")
+        set(cmake_vars_file "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.${VCPKG_BUILD_TYPE}.cmake.log")
         set(cache_var "Z_VCPKG_GET_CMAKE_VARS_FILE_${VCPKG_BUILD_TYPE}")
     else()
         set(cmake_vars_file "${CURRENT_BUILDTREES_DIR}/cmake-vars-${TARGET_TRIPLET}.cmake.log")


### PR DESCRIPTION
**Describe the pull request**

This fixes name clash still left after 7534d241b08dc0c80d14c09f955c161e7cf5f92f

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
