### PR TITLE
[pango] Use C standard 11

### DIFF
--- a/ports/pango/fix-macosbuild.patch
+++ b/ports/pango/fix-macosbuild.patch
@@ -1,0 +1,12 @@
+diff --git a/pango/pangofc-fontmap.c b/pango/pangofc-fontmap.c
+index d198df4..a9ea63e 100644
+--- a/pango/pangofc-fontmap.c
++++ b/pango/pangofc-fontmap.c
+@@ -34,6 +34,7 @@
+ 
+ #include "config.h"
+ #include <math.h>
++#include <fontconfig/fontconfig.h>
+ 
+ #include <gio/gio.h>
+

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -5,11 +5,8 @@ vcpkg_from_gitlab(
     REF  26aadb2508f9022cbfc72e73b558c6791f5d46d9 #v1.50.3
     SHA512 09c2578300d391b406c14dfbf7f28968d326c6861f7eb1a3a8d1d8c4700d6e9f74c8621a3f2d181abe1f695324c6e5fc3a55eb038ebbe53a53be086983e3a186
     HEAD_REF master # branch name
+	PATCHES fix-macosbuild.patch
 ) 
-
-if (VCPKG_TARGET_IS_OSX)
-    list(APPEND OPTIONS -Dc_std=gnu11)
-endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH ${SOURCE_PATH}
@@ -22,7 +19,6 @@ vcpkg_configure_meson(
         -Dxft=disabled # Build with xft support
         -Dfreetype=enabled # Build with freetype support
         -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
-        ${OPTIONS}
     ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
                                glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
     ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_configure_meson(
         -Dxft=disabled # Build with xft support
         -Dfreetype=enabled # Build with freetype support
         -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
+        -Dc_std=c11 #Set C standard to avoid implicit declaration is invalid in C99
     ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
                                glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
     ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
@@ -30,7 +31,7 @@ vcpkg_copy_pdbs()
 
 vcpkg_copy_tools(TOOL_NAMES pango-view pango-list pango-segmentation AUTO_CLEAN)
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/pango.pc")
 if(EXISTS "${_file}")

--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -7,6 +7,10 @@ vcpkg_from_gitlab(
     HEAD_REF master # branch name
 ) 
 
+if (VCPKG_TARGET_IS_OSX)
+    list(APPEND OPTIONS -Dc_std=gnu11)
+endif()
+
 vcpkg_configure_meson(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -18,7 +22,7 @@ vcpkg_configure_meson(
         -Dxft=disabled # Build with xft support
         -Dfreetype=enabled # Build with freetype support
         -Dgtk_doc=false #Build API reference for Pango using GTK-Doc
-        -Dc_std=c11 #Set C standard to avoid implicit declaration is invalid in C99
+        ${OPTIONS}
     ADDITIONAL_NATIVE_BINARIES glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
                                glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
     ADDITIONAL_CROSS_BINARIES  glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pango",
   "version": "1.50.3",
+  "port-version": 1,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5158,7 +5158,7 @@
     },
     "pango": {
       "baseline": "1.50.3",
-      "port-version": 0
+      "port-version": 1
     },
     "pangolin": {
       "baseline": "0.6",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7f73c9cbec7002e235ca5675b8646b5b2981f528",
+      "git-tree": "e7476356f183491cef816a288996843f6c7da132",
       "version": "1.50.3",
       "port-version": 1
     },

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f73c9cbec7002e235ca5675b8646b5b2981f528",
+      "version": "1.50.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "024f716f80c8454769393287ef14a75de4785f32",
       "version": "1.50.3",
       "port-version": 0

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e7476356f183491cef816a288996843f6c7da132",
+      "git-tree": "f88dcddbc62031974d4c03e56fd01f79adf6302f",
       "version": "1.50.3",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes #20367
Adding option `-Dc_std=c11` to resolve build error on MACOS:
```
../src/480391f31f-4c049f225c.clean/pango/pangofc-fontmap.c:1778:10: error: implicit declaration of function 'FcWeightFromOpenTypeDouble' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  return FcWeightFromOpenTypeDouble (pango_weight);
         ^
../src/480391f31f-4c049f225c.clean/pango/pangofc-fontmap.c:2535:3: error: implicit declaration of function 'FcStrListFirst' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  FcStrListFirst (list);
```
I have submitted an issue on upstream: https://gitlab.gnome.org/GNOME/pango/-/issues/657