### PR TITLE
[pixman] build on M1 macs

### DIFF
--- a/ports/pixman/portfile.cmake
+++ b/ports/pixman/portfile.cmake
@@ -14,12 +14,6 @@ elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
             -Dmmx=enabled
             -Dsse2=enabled
             -Dssse3=enabled)
-elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    #x64 in general has all those intrinsics. (except for UWP for some reason)
-    list(APPEND OPTIONS
-            -Dmmx=enabled
-            -Dsse2=enabled
-            -Dssse3=enabled)
 elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "arm")
    list(APPEND OPTIONS
                #-Darm-simd=enabled does not work with arm64-windows

--- a/ports/pixman/vcpkg.json
+++ b/ports/pixman/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pixman",
   "version": "0.40.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Pixman is a low-level software library for pixel manipulation, providing features such as image compositing and trapezoid rasterization.",
   "homepage": "https://www.cairographics.org/releases",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5290,7 +5290,7 @@
     },
     "pixman": {
       "baseline": "0.40.0",
-      "port-version": 1
+      "port-version": 2
     },
     "pkgconf": {
       "baseline": "1.8.0",

--- a/versions/p-/pixman.json
+++ b/versions/p-/pixman.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1d143541921faad62fab97c7f29704e066b9c98",
+      "version": "0.40.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "c2dd7fec404954b43ad0da4ee86c29a4cfdd8fc1",
       "version": "0.40.0",
       "port-version": 1


### PR DESCRIPTION
@Neumann-A   
Otherwise I get the following error when I try to build for x64-osx:
```
DEPRECATION: c_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: c_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
WARNING: Recommend using either -Dbuildtype or -Doptimization + -Ddebug. Using both is redundant since they override each other. See: https://mesonbuild.com/Builtin-options.html#build-type-options
The Meson build system
Version: 0.60.2
Source dir: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/pixman/src/0.40.0-9a8e17d6df.clean
Build dir: /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/pixman/x64-osx-dbg
Build type: native build
Project name: pixman
Project version: 0.40.0
C compiler for the host machine: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc (clang 13.0.0 "Apple clang version 13.0.0 (clang-1300.0.29.30)")
C linker for the host machine: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc ld64 711
Host machine cpu family: aarch64
Host machine cpu: arm64
Compiler for C supports arguments -Wdeclaration-after-statement: YES 
Compiler for C supports arguments -fno-strict-aliasing: YES 
Compiler for C supports arguments -fvisibility=hidden: YES 
Compiler for C supports arguments -Wundef: YES 
Compiler for C supports arguments -Wunused-local-typedefs: YES 

../src/0.40.0-9a8e17d6df.clean/meson.build:145:2: ERROR: Problem encountered: MMX Support unavailable, but required

A full log can be found at /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/pixman/x64-osx-dbg/meson-logs/meson-log.txt
```