### PR TITLE
[LibJuice][Libdatachannel] Update v0.9.6 / Update v0.16.4

### DIFF
--- a/ports/libdatachannel/0001-fix-for-vcpkg.patch
+++ b/ports/libdatachannel/0001-fix-for-vcpkg.patch
@@ -68,8 +68,8 @@ index c0e59d1..1d71e38 100644
  		target_compile_definitions(datachannel-static PRIVATE RTC_SYSTEM_JUICE=0)
 -		target_link_libraries(datachannel PRIVATE LibJuice::LibJuiceStatic)
 -		target_link_libraries(datachannel-static PRIVATE LibJuice::LibJuiceStatic)
-+		target_link_libraries(datachannel PRIVATE LibJuice::juice)
-+		target_link_libraries(datachannel-static PRIVATE LibJuice::juice)
++		target_link_libraries(datachannel PRIVATE LibJuice::LibJuice)
++		target_link_libraries(datachannel-static PRIVATE LibJuice::LibJuice)
  	endif()
  endif()
  

--- a/ports/libdatachannel/portfile.cmake
+++ b/ports/libdatachannel/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libdatachannel
-    REF 6e1222c4def8b959eedc8b9e6da95072afe6ff78 #v0.16.0
-    SHA512 bfa21b1f55a18c6bd0473b2c80d6739e9f06d463246004f91b216423739c5fa04651a099ef995b4ab12f392784208cc0c7ab8662e3790ce4be6be36e37a944d7
+    REF 127f157fc00abeb6fe5a57ce56a7c4e092721203 #v0.16.4
+    SHA512 ef7d1f652af031c13260a4c436c949eb566d40d15dcde5b56ab782e9e9d7b5e287f4a6a61bc4eb3fcdbb835c102637b0368f3c43af6f9fa9c87cd99d15bde454
     HEAD_REF master
     PATCHES
         0001-fix-for-vcpkg.patch

--- a/ports/libdatachannel/vcpkg.json
+++ b/ports/libdatachannel/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libdatachannel",
-  "version-semver": "0.16.0",
+  "version-semver": "0.16.4",
   "description": "libdatachannel is a standalone implementation of WebRTC Data Channels, WebRTC Media Transport, and WebSockets in C++17 with C bindings for POSIX platforms (including GNU/Linux, Android, and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libdatachannel",
   "dependencies": [

--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
-    REF 026b3dd68db33143db8a5a9b16af3923733a8b61 #v0.9.1
-    SHA512 050e92df2e3f24da465ffd4e57d35ffc7a4e13042dc0b829627a09c3f8c7898c7b066f3e386004b579e7416adf4885f5f7a8da46f34c76e9bc63747616f34f9d
+    REF 3795466e704191dd35f8a46b82ca06cbbc395cd9 #v0.9.6
+    SHA512 3c931b47d852ead3027ed077f9ba930e9b5b77de1cf984023dd4bac3b52980f68419517e4edf11e8fd2741bfb2e154d3c748073ed302182e395df0b0acc1910c
     HEAD_REF master
     PATCHES
         fix-for-vcpkg.patch

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjuice",
-  "version": "0.9.1",
+  "version": "0.9.6",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3601,7 +3601,7 @@
       "port-version": 0
     },
     "libjuice": {
-      "baseline": "0.9.1",
+      "baseline": "0.9.6",
       "port-version": 0
     },
     "libjxl": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3401,7 +3401,7 @@
       "port-version": 1
     },
     "libdatachannel": {
-      "baseline": "0.16.0",
+      "baseline": "0.16.4",
       "port-version": 0
     },
     "libdatrie": {

--- a/versions/l-/libdatachannel.json
+++ b/versions/l-/libdatachannel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9f98aa660deca99a714ae3fc0e7a356c5d74cc8",
+      "version-semver": "0.16.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "d688c15b940166a1d8ecf701cafb7a060a7abd48",
       "version-semver": "0.16.0",
       "port-version": 0

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f544d762be0d7f9016b47f865843d0e575535166",
+      "version": "0.9.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "564ac624cbbabb45356d592264c090a0e6f64669",
       "version": "0.9.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Updates libdatachannel to 0.16.4 and libjuice to 0.9.6. libjuice is a dependency of libdatachannel.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
Same as before.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes.

To merge after #22530.
