### PR TITLE
[vcpkg baseline][rtabmap] Set WITH_PDAL to OFF

### DIFF
--- a/ports/rtabmap/portfile.cmake
+++ b/ports/rtabmap/portfile.cmake
@@ -23,8 +23,11 @@ vcpkg_cmake_configure(
         -DBUILD_APP=OFF
         -DBUILD_EXAMPLES=OFF
         -DWITH_QT=OFF
-        -DWITH_SUPERPOINT_TORCH=OFF
-        -DWITH_PYMATCHER=OFF
+        -DWITH_ORB_OCTREE=OFF
+        -DWITH_TORCH=OFF
+        -DWITH_PYTHON=OFF
+        -DWITH_PYTHON_THREADING=OFF
+        -DWITH_PDAL=OFF
         -DWITH_FREENECT=OFF
         -DWITH_FREENECT2=OFF
         -DWITH_K4W2=OFF
@@ -37,13 +40,16 @@ vcpkg_cmake_configure(
         -DWITH_VERTIGO=OFF
         -DWITH_CVSBA=OFF
         -DWITH_POINTMATCHER=OFF
+        -DWITH_CCCORELIB=OFF
         -DWITH_LOAM=OFF
         -DWITH_FLYCAPTURE2=OFF
         -DWITH_ZED=OFF
+        -DWITH_ZEDOC=OFF
         -DWITH_REALSENSE=OFF
         -DWITH_REALSENSE_SLAM=OFF
         -DWITH_REALSENSE2=OFF
         -DWITH_MYNTEYE=OFF
+        -DWITH_DEPTHAI=OFF
         -DWITH_OCTOMAP=OFF
         -DWITH_CPUTSDF=OFF
         -DWITH_OPENCHISEL=OFF
@@ -51,10 +57,11 @@ vcpkg_cmake_configure(
         -DWITH_FOVIS=OFF
         -DWITH_VISO2=OFF
         -DWITH_DVO=OFF
-        -DWITH_ORB_SLAM2=OFF
         -DWITH_OKVIS=OFF
         -DWITH_MSCKF_VIO=OFF
         -DWITH_VINS=OFF
+        -DWITH_OPENVINS=OFF
+        -DWITH_MADGWICK=OFF
         -DWITH_FASTCV=OFF
 )
 

--- a/ports/rtabmap/vcpkg.json
+++ b/ports/rtabmap/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtabmap",
-  "version-string": "0.20.13",
-  "port-version": 1,
+  "version": "0.20.13",
+  "port-version": 2,
   "description": "Real-Time Appearance-Based Mapping",
   "homepage": "https://introlab.github.io/rtabmap/",
   "supports": "windows & !static",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6126,7 +6126,7 @@
     },
     "rtabmap": {
       "baseline": "0.20.13",
-      "port-version": 1
+      "port-version": 2
     },
     "rtaudio": {
       "baseline": "2021-11-16",

--- a/versions/r-/rtabmap.json
+++ b/versions/r-/rtabmap.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3dc228c0e837f979396a930bc24e8cf92f6190e3",
+      "version": "0.20.13",
+      "port-version": 2
+    },
+    {
       "git-tree": "93a792dbedcec5e900509396ebbe4461cde51320",
       "version-string": "0.20.13",
       "port-version": 1


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/22497

When pdal installed before rtabmap, it will cause the CI failures. pdal is an optional dependency for rtabmap. Disable it for resolving the multi errors. Remove the obsolete option and update new option for rtabmap which avoid potential failures.

Failures:
```
D:\installed\x64-windows\include\pdal\util\Inserter.hpp(40): error C2143: syntax error: missing ';' before '{'
D:\installed\x64-windows\include\pdal\util\Inserter.hpp(40): error C2447: '{': missing function header (old-style formal list?)
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(395): error C2065: 'ntohs': undeclared identifier
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(395): error C2568: '=': unable to resolve function overload
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(395): note: could be 'u_short ntohs(u_short)'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(409): error C2065: 'ntohs': undeclared identifier
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(409): warning C4302: 'type cast': truncation from 'u_short (__cdecl *)(u_short)' to 'int16_t'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(423): error C2065: 'ntohl': undeclared identifier
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(423): error C2568: '=': unable to resolve function overload
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(423): note: could be 'u_long ntohl(u_long)'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(437): error C2065: 'ntohl': undeclared identifier
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(437): warning C4311: 'type cast': pointer truncation from 'u_long (__cdecl *)(u_long)' to 'int32_t'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(437): warning C4302: 'type cast': truncation from 'u_long (__cdecl *)(u_long)' to 'int32_t'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(479): error C2065: 'ntohl': undeclared identifier
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(479): error C2440: 'initializing': cannot convert from 'u_long (__cdecl *)(u_long)' to 'uint32_t'
D:\installed\x64-windows\include\pdal\util\Extractor.hpp(479): note: There is no context in which this conversion is possible
...
```