### PR TITLE
[glslang] Restore version removed in #15719

### DIFF
--- a/versions/g-/glslang.json
+++ b/versions/g-/glslang.json
@@ -11,6 +11,11 @@
       "port-version": 0
     },
     {
+      "git-tree": "a7d9b6a3d936d273c6b1966eb3b8fe8cb1ba28d1",
+      "version-string": "2019-03-05",
+      "port-version": 3
+    },
+    {
       "git-tree": "29f2d736c8273c412c4fcf0fd50da379d1ec9a0b",
       "version-string": "2019-03-05",
       "port-version": 2


### PR DESCRIPTION
Entries in the version database must never be removed or altered, however PR #15719 did exactly that.