### PR TITLE
[dimcli] Add supports field instead of written in ci.baseline, disable testing, support osx

### DIFF
--- a/ports/dimcli/fix-build.patch
+++ b/ports/dimcli/fix-build.patch
@@ -11,6 +11,16 @@ index 509e634..8b5a30b 100644
      if(NOT MSVC_VERSION LESS 1910)
          # /permissive-  // reject non-conforming backward compatibility-isms
          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+@@ -431,8 +431,8 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
+     if(BUILD_COVERAGE)
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+     endif()
+-elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
++elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5")
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
+     else()
 @@ -533,7 +533,6 @@ endforeach()
  # test targets
  if(BUILD_TESTING)

--- a/ports/dimcli/fix-build.patch
+++ b/ports/dimcli/fix-build.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 509e634..8b5a30b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -392,7 +392,7 @@ if(MSVC)
+     set(CMAKE_CXX_FLAGS "\
+         /EHsc /GF /nologo /std:c++latest /utf-8 /W4 /WX \
+         /Zc:inline /Zc:rvalueCast /Zc:strictStrings \
+-        /Fa$(IntDir)")
++        /Fa${CMAKE_SOURCE_DIR}/libs/dimcli")
+     if(NOT MSVC_VERSION LESS 1910)
+         # /permissive-  // reject non-conforming backward compatibility-isms
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+@@ -533,7 +533,6 @@ endforeach()
+ # test targets
+ if(BUILD_TESTING)
+     enable_testing()
+-endif()
+ file(GLOB allnames tests/*)
+ foreach(var ${allnames})
+     if(IS_DIRECTORY "${var}")
+@@ -548,6 +547,7 @@ foreach(var ${allnames})
+         endif()
+     endif()
+ endforeach()
++endif()
+ 
+ # update deps file
+ update_deps_file(${deps})

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -6,20 +6,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-set(staticCrt OFF)
-if(VCPKG_CRT_LINKAGE STREQUAL "static")
-    set(staticCrt ON)
-endif()
+string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" staticCrt)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DLINK_STATIC_RUNTIME:BOOL=${staticCrt}
         -DINSTALL_LIBS:BOOL=ON
         -DBUILD_PROJECT_NAME=dimcli
+        -DBUILD_TESTING=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
 # Remove includes from ${CMAKE_INSTALL_PREFIX}/debug
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/dimcli/portfile.cmake
+++ b/ports/dimcli/portfile.cmake
@@ -4,17 +4,21 @@ vcpkg_from_github(
     REF a4dbb4b1c8a3825fc304bbbad3438dbe1840feae # v5.0.2
     SHA512 25cc9002fd46856854545934f385d8578f207b1ce01802a172e49e008cdf1db0db11db7cefeef18258b99c13570af9193e83f5826613d8b0a118d7bae3f0d03f
     HEAD_REF master
+    PATCHES fix-build.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" staticCrt)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DLINK_STATIC_RUNTIME:BOOL=${staticCrt}
         -DINSTALL_LIBS:BOOL=ON
         -DBUILD_PROJECT_NAME=dimcli
         -DBUILD_TESTING=OFF
+        -DINSTALL_TOOLS=OFF
+        -DINSTALL_TESTS=OFF
 )
 
 vcpkg_cmake_install()

--- a/ports/dimcli/vcpkg.json
+++ b/ports/dimcli/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 3,
   "description": "C++ command line parser toolkit",
   "homepage": "https://github.com/gknowles/dimcli",
-  "supports": "!osx & !uwp",
+  "supports": "!uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/dimcli/vcpkg.json
+++ b/ports/dimcli/vcpkg.json
@@ -1,7 +1,14 @@
 {
   "name": "dimcli",
   "version-semver": "5.0.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "C++ command line parser toolkit",
-  "homepage": "https://github.com/gknowles/dimcli"
+  "homepage": "https://github.com/gknowles/dimcli",
+  "supports": "!osx & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -207,9 +207,6 @@ devicenameresolver:x64-linux=fail
 devicenameresolver:x64-osx=fail
 devicenameresolver:x64-uwp=fail
 devicenameresolver:x64-windows-static=fail
-dimcli:arm-uwp=fail
-dimcli:x64-osx=fail
-dimcli:x64-uwp=fail
 # legacy directxsdk which conflicts with dxsdk-d3dx
 directxsdk:x86-windows=skip
 directxsdk:x64-windows=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1818,7 +1818,7 @@
     },
     "dimcli": {
       "baseline": "5.0.2",
-      "port-version": 2
+      "port-version": 3
     },
     "directx-headers": {
       "baseline": "1.4.9",

--- a/versions/d-/dimcli.json
+++ b/versions/d-/dimcli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5cdb9bd32ecded11b7dd8a82f3cf0522dd955307",
+      "git-tree": "ce3707dd234f151049c62aee7843ef85618d0134",
       "version-semver": "5.0.2",
       "port-version": 3
     },

--- a/versions/d-/dimcli.json
+++ b/versions/d-/dimcli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ce3707dd234f151049c62aee7843ef85618d0134",
+      "git-tree": "5d3878991b69b5ed78b2d82c56c5d3a707e13eb0",
       "version-semver": "5.0.2",
       "port-version": 3
     },

--- a/versions/d-/dimcli.json
+++ b/versions/d-/dimcli.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5cdb9bd32ecded11b7dd8a82f3cf0522dd955307",
+      "version-semver": "5.0.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "9901ca1f1a121a702d4fb4c73ad6a482adff6c3f",
       "version-semver": "5.0.2",
       "port-version": 2


### PR DESCRIPTION
This port doesn't support osx officially:
```
  6 FAILED: CMakeFiles/ostrm.dir/tests/ostrm/ostrmtest.cpp.o
  7 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DDIMCLI_LIB_KEEP_MACROS -I/Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/libs -fPIC -g -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/    SDKs/MacOSX11.3.sdk -std=gnu++11 -MD -MT CMakeFiles/ostrm.dir/tests/ostrm/ostrmtest.cpp.o -MF CMakeFiles/ostrm.dir/tests/ostrm/ostrmtest.cpp.o.d -o CMakeFiles/ostrm.dir/tests/ostrm/ostrmtest.cpp.o -c /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp
  8 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:28: error: expected ';' in 'for' statement specifier
  9     for (auto i = 0; i < 10'000'000; ++i) {
 10                            ^
 11 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:28: warning: multi-character character constant [-Wmultichar]
 12 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:28: warning: expression result unused [-Wunused-value]
 13     for (auto i = 0; i < 10'000'000; ++i) {
 14                            ^~~~~
 15 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:33: error: expected ')'
 16     for (auto i = 0; i < 10'000'000; ++i) {
 17                                 ^
 18 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:9: note: to match this '('
 19     for (auto i = 0; i < 10'000'000; ++i) {
 20         ^
 21 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:41: error: expected ';' after expression
 22     for (auto i = 0; i < 10'000'000; ++i) {
 23                                         ^
 24                                         ;
 25 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:40: error: use of undeclared identifier 'i'
 26     for (auto i = 0; i < 10'000'000; ++i) {
 27                                        ^
 28 /Users/vcpkg/Documents/vcpkg/vcpkg/buildtrees/dimcli/src/be1840feae-eb4a4de173/tests/ostrm/ostrmtest.cpp:43:41: error: expected expression
 29     for (auto i = 0; i < 10'000'000; ++i) {
 30                                         ^
```

Related: #22570.