### PR TITLE
[gherkin-c] Fix UNIX build, fix install path

### DIFF
--- a/ports/gherkin-c/fix-include-path.patch
+++ b/ports/gherkin-c/fix-include-path.patch
@@ -7,7 +7,7 @@ index 74b9ffb..6af4645 100644
  
  add_library(gherkin ${GHERKIN_SRS})
 -target_include_directories(gherkin PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
-+target_include_directories(gherkin PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>" "$<INSTALL_INTERFACE:include/gherkin_c>")
++target_include_directories(gherkin PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>" "$<INSTALL_INTERFACE:include/gherkin-c>")
  
  if (BUILD_GHERKIN_TESTS)
    LIST(APPEND GENERATE_TOKEN
@@ -16,7 +16,7 @@ index 74b9ffb..6af4645 100644
  endif()
  
 -set(include_install_dir "include")
-+set(include_install_dir "include/gherkin_c")
++set(include_install_dir "include/gherkin-c")
  set(lib_install_dir "lib/")
  set(bin_install_dir "bin/")
  set(config_install_dir "lib/cmake/")

--- a/ports/gherkin-c/fix-include-path.patch
+++ b/ports/gherkin-c/fix-include-path.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 74b9ffb..6af4645 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ LIST(APPEND GHERKIN_SRS
+         )
+ 
+ add_library(gherkin ${GHERKIN_SRS})
+-target_include_directories(gherkin PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
++target_include_directories(gherkin PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>" "$<INSTALL_INTERFACE:include/gherkin_c>")
+ 
+ if (BUILD_GHERKIN_TESTS)
+   LIST(APPEND GENERATE_TOKEN
+@@ -96,7 +96,7 @@ if (BUILD_GHERKIN_TESTS)
+   ENDFOREACH()
+ endif()
+ 
+-set(include_install_dir "include")
++set(include_install_dir "include/gherkin_c")
+ set(lib_install_dir "lib/")
+ set(bin_install_dir "bin/")
+ set(config_install_dir "lib/cmake/")

--- a/ports/gherkin-c/fix-install-error.patch
+++ b/ports/gherkin-c/fix-install-error.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3227bf5..74b9ffb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -131,7 +131,3 @@ install(
+ #    NAMESPACE "${namespace}"
+ #    DESTINATION "${config_install_dir}")
+ 
+-add_custom_target(install_${PROJECT_NAME}
+-        $(MAKE) install
+-        DEPENDS gherkin
+-        COMMENT "Installing ${PROJECT_NAME}")

--- a/ports/gherkin-c/portfile.cmake
+++ b/ports/gherkin-c/portfile.cmake
@@ -4,19 +4,20 @@ vcpkg_from_github(
     REF dd180edc7d092311f2e90a0c4957061156d39dd3
     SHA512 c6b38ab0e7a0fd1061d86b0ff9d9140f8c3d6f15cfc1673e947254c6c03a66d3e6aae5b267b074aa10fa30ba2850190c9e9ea7c12e340e4f8c5575b9bf31bab3
     HEAD_REF master
+    PATCHES
+        fix-install-error.patch
+        fix-include-path.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS 
         -DBUILD_GHERKIN_TESTS=OFF
 )
-vcpkg_install_cmake()
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/gherkin-c RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/gherkin-c" RENAME copyright)

--- a/ports/gherkin-c/vcpkg.json
+++ b/ports/gherkin-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gherkin-c",
-  "version-string": "2019-10-07",
+  "version-date": "2019-10-07",
   "port-version": 3,
   "description": "Gherkin parser/compiler in C",
   "dependencies": [

--- a/ports/gherkin-c/vcpkg.json
+++ b/ports/gherkin-c/vcpkg.json
@@ -1,6 +1,12 @@
 {
   "name": "gherkin-c",
   "version-string": "2019-10-07",
-  "port-version": 2,
-  "description": "Gherkin parser/compiler in C"
+  "port-version": 3,
+  "description": "Gherkin parser/compiler in C",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -363,15 +363,15 @@ gflags:arm-uwp=fail
 gflags:x64-uwp=fail
 
 # Conflicts with libevent
-gherkin-c:arm64-windows      = skip
-gherkin-c:arm-uwp            = skip
-gherkin-c:x64-linux=fail
-gherkin-c:x64-osx=fail
-gherkin-c:x64-uwp            = skip
-gherkin-c:x64-windows        = skip
-gherkin-c:x64-windows-static = skip
-gherkin-c:x64-windows-static-md=skip
-gherkin-c:x86-windows        = skip
+gherkin-c:arm64-windows         = skip
+gherkin-c:arm-uwp               = skip
+gherkin-c:x64-linux             = skip
+gherkin-c:x64-osx               = skip
+gherkin-c:x64-uwp               = skip
+gherkin-c:x64-windows           = skip
+gherkin-c:x64-windows-static    = skip
+gherkin-c:x64-windows-static-md = skip
+gherkin-c:x86-windows           = skip
 gl3w:arm64-windows=fail
 gl3w:arm-uwp=fail
 glew:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2442,7 +2442,7 @@
     },
     "gherkin-c": {
       "baseline": "2019-10-07",
-      "port-version": 2
+      "port-version": 3
     },
     "giflib": {
       "baseline": "5.2.1",

--- a/versions/g-/gherkin-c.json
+++ b/versions/g-/gherkin-c.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "27d09a0f7885f6f47ccc1a83b9103fb55422999e",
-      "version-string": "2019-10-07",
+      "git-tree": "87141daed8af9dab4f1891a0f5de8258ca866273",
+      "version-date": "2019-10-07",
       "port-version": 3
     },
     {

--- a/versions/g-/gherkin-c.json
+++ b/versions/g-/gherkin-c.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "87141daed8af9dab4f1891a0f5de8258ca866273",
+      "git-tree": "cb7cfa3a82651ab27840177189e5dc7938bf1241",
       "version-date": "2019-10-07",
       "port-version": 3
     },

--- a/versions/g-/gherkin-c.json
+++ b/versions/g-/gherkin-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27d09a0f7885f6f47ccc1a83b9103fb55422999e",
+      "version-string": "2019-10-07",
+      "port-version": 3
+    },
+    {
       "git-tree": "e59a73d00ecbf68ae14b61beec141128d8f94612",
       "version-string": "2019-10-07",
       "port-version": 2


### PR DESCRIPTION
The official CMakeLists uses make to install the project which is incorrect.
And fix the header files installation:
```
-- Performing post-build validation
Restricted headers paths are present. These files can prevent the core C++ runtime and other packages from compiling correctly:

    include/error.h
    include/parser.h
```

Fixes #22574.