### PR TITLE
[qtbase] Make feature pcre2 to hard dependency when install static library

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -24,13 +24,8 @@ if(NOT VCPKG_USE_HEAD_VERSION AND NOT QT_IS_LATEST)
         )
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    if(NOT "doubleconversion" IN_LIST FEATURES)
-        message(FATAL_ERROR "${PORT} requires feature doubleconversion on windows!" )
-    endif()
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND NOT "pcre2" IN_LIST FEATURES)
-        message(FATAL_ERROR "${PORT} requires feature pcre2 on windows!" )
-    endif()
+if(VCPKG_TARGET_IS_WINDOWS AND NOT "doubleconversion" IN_LIST FEATURES)
+    message(FATAL_ERROR "${PORT} requires feature doubleconversion on windows!" )
 endif()
 
 # Features can be found via searching for qt_feature in all configure.cmake files in the source: 

--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -24,8 +24,13 @@ if(NOT VCPKG_USE_HEAD_VERSION AND NOT QT_IS_LATEST)
         )
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS AND NOT "doubleconversion" IN_LIST FEATURES)
-    message(FATAL_ERROR "${PORT} requires feature doubleconversion on windows!" )
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(NOT "doubleconversion" IN_LIST FEATURES)
+        message(FATAL_ERROR "${PORT} requires feature doubleconversion on windows!" )
+    endif()
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" AND NOT "pcre2" IN_LIST FEATURES)
+        message(FATAL_ERROR "${PORT} requires feature pcre2 on windows!" )
+    endif()
 endif()
 
 # Features can be found via searching for qt_feature in all configure.cmake files in the source: 

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -16,6 +16,14 @@
       "host": true,
       "default-features": false
     },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "pcre2"
+      ],
+      "platform": "windows"
+    },
     "zlib"
   ],
   "default-features": [

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version-semver": "6.2.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "dependencies": [

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -22,7 +22,7 @@
       "features": [
         "pcre2"
       ],
-      "platform": "windows"
+      "platform": "windows & static"
     },
     "zlib"
   ],

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -20,17 +20,17 @@
       "name": "qtbase",
       "default-features": false,
       "features": [
-        "pcre2"
+        "doubleconversion"
       ],
-      "platform": "windows & static"
+      "platform": "windows"
     },
     {
       "name": "qtbase",
       "default-features": false,
       "features": [
-        "doubleconversion"
+        "pcre2"
       ],
-      "platform": "windows"
+      "platform": "windows & static"
     },
     "zlib"
   ],

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -24,6 +24,14 @@
       ],
       "platform": "windows & static"
     },
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "doubleconversion"
+      ],
+      "platform": "windows"
+    },
     "zlib"
   ],
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5738,7 +5738,7 @@
     },
     "qtbase": {
       "baseline": "6.2.2",
-      "port-version": 2
+      "port-version": 3
     },
     "qtcharts": {
       "baseline": "6.2.2",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e9b20f990fd5c279e68dd1de2d0624e1de59ed1c",
+      "git-tree": "d72404384bb1740cd77719ac072ed6ec4bde75b6",
       "version-semver": "6.2.2",
       "port-version": 3
     },

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b449f8ef77d7e9f86c82be6530e168456b863705",
+      "git-tree": "e9b20f990fd5c279e68dd1de2d0624e1de59ed1c",
       "version-semver": "6.2.2",
       "port-version": 3
     },

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b449f8ef77d7e9f86c82be6530e168456b863705",
+      "version-semver": "6.2.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "bb6485a4e65e52d1a157f6e0c478a47bdc884726",
       "version-semver": "6.2.2",
       "port-version": 2

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d72404384bb1740cd77719ac072ed6ec4bde75b6",
+      "git-tree": "97f29b7c4139a014126e6da5ffdb61f1f04411dc",
       "version-semver": "6.2.2",
       "port-version": 3
     },

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97f29b7c4139a014126e6da5ffdb61f1f04411dc",
+      "git-tree": "e9fa18e04e930f9ada49aac4dca2e9fe4958b89a",
       "version-semver": "6.2.2",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #22482 
When install `qtbase[core,gui,doubleconversion]:x64-windows-static`, `qtbase` will build failed with the following error:
```
-- The following REQUIRED packages have not been found:
 * WrapPCRE2
-- The following OPTIONAL packages have not been found:
...
CMake Error at C:/Program Files/CMake/share/cmake-3.22/Modules/FeatureSummary.cmake:464 (message):
  feature_summary() Error: REQUIRED package(s) are missing, aborting CMake
  run.
```
This need install `qtbase[pcre2]`, add fatal error to remind install feature `pcre2`.
