### PR TITLE
[crossguid] fix mac build

### DIFF
--- a/ports/crossguid/portfile.cmake
+++ b/ports/crossguid/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF ca1bf4b810e2d188d04cb6286f957008ee1b7681 #2021-10-22
     SHA512 f0a80d8e99b10473bcfdfde3d1c5fd7b766959819f0d1c0595ac84ce46db9007a5fbfde9a55aca60530c46cb7f8ef4c7e472c6191559ded92f868589c141ccaf
     HEAD_REF master
+    PATCHES
+        warnings.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/crossguid/vcpkg.json
+++ b/ports/crossguid/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "crossguid",
   "version-date": "2021-10-22",
-  "port-version": 1,
+  "port-version": 2,
   "description": "CrossGuid is a minimal, cross platform, C++ GUID library.",
   "dependencies": [
     {
       "name": "libuuid",
-      "platform": "!windows & !uwp & !osx & !android"
+      "platform": "!windows & !osx & !android"
     },
     {
       "name": "vcpkg-cmake",

--- a/ports/crossguid/warnings.patch
+++ b/ports/crossguid/warnings.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 76b5a62..174d981 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,15 +40,6 @@ else()
+     target_compile_definitions(crossguid PRIVATE GUID_LIBUUID)
+ endif()
+ 
+-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+-    set(WARNINGS "-Werror" "-Wall")
+-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(WARNINGS "-Werror" "-Wall")
+-elseif(MSVC)
+-    set(WARNINGS "/WX" "/W4")
+-endif()
+-target_compile_options(crossguid PRIVATE ${WARNINGS})
+-
+ set_target_properties(crossguid
+ 					  PROPERTIES
+ 					  VERSION ${PROJECT_VERSION}

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -176,7 +176,6 @@ crashpad:arm-uwp=fail
 crashpad:x64-linux=fail
 crashpad:x64-uwp=fail
 crashpad:x86-windows=fail
-crossguid:x64-osx=fail
 ctemplate:arm64-windows=fail
 ctemplate:arm-uwp=fail
 ctemplate:x64-linux=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1658,7 +1658,7 @@
     },
     "crossguid": {
       "baseline": "2021-10-22",
-      "port-version": 1
+      "port-version": 2
     },
     "crow": {
       "baseline": "0.3.4",

--- a/versions/c-/crossguid.json
+++ b/versions/c-/crossguid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93714099ddf83b2f3437a080c8acc08ff74cbe37",
+      "version-date": "2021-10-22",
+      "port-version": 2
+    },
+    {
       "git-tree": "4e53633ff35a2bcfb9076aee3e0d740406e788d3",
       "version-date": "2021-10-22",
       "port-version": 1


### PR DESCRIPTION
Fixes #15594.  
Using `-Werror` without an option to disable it is simply not the smartest move :)