### PR TITLE
[aws-c-mqtt] Fix dependencies

### DIFF
--- a/ports/aws-c-mqtt/vcpkg.json
+++ b/ports/aws-c-mqtt/vcpkg.json
@@ -1,11 +1,14 @@
 {
   "name": "aws-c-mqtt",
   "version": "0.7.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C99 implementation of the MQTT 3.1.1 specification.",
   "homepage": "https://github.com/awslabs/aws-c-mqtt",
   "supports": "!arm & !uwp",
   "dependencies": [
+    "aws-c-common",
+    "aws-c-http",
+    "aws-c-io",
     {
       "name": "s2n",
       "platform": "!uwp & !windows"

--- a/versions/a-/aws-c-mqtt.json
+++ b/versions/a-/aws-c-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "834a199cf4560cbdd8e6dac09074b9b5b1d57d53",
+      "version": "0.7.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "6dc42a5ba915723bed2997c39222b166a9f0a084",
       "version": "0.7.6",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -286,7 +286,7 @@
     },
     "aws-c-mqtt": {
       "baseline": "0.7.6",
-      "port-version": 1
+      "port-version": 2
     },
     "aws-c-s3": {
       "baseline": "0.1.25",


### PR DESCRIPTION
- #### What does your PR fix?  
  Adds required dependencies of aws-c-mqtt. (Discovered on aws-c-common build error in #22546.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes
