### PR TITLE
[curlpp] fix single config builds

### DIFF
--- a/ports/curlpp/portfile.cmake
+++ b/ports/curlpp/portfile.cmake
@@ -24,13 +24,17 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
         "${CURRENT_PACKAGES_DIR}/bin"
         "${CURRENT_PACKAGES_DIR}/debug/bin"
     )
-elseif(VCPKG_TARGET_IS_WINDOWS)
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/bin/curlpp-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/..")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/bin/curlpp-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
+    if(NOT VCPKG_BUILD_TYPE)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/bin/curlpp-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
+    endif()
 endif()
 
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL "${SOURCE_PATH}/doc/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-${PORT}")
+file(INSTALL "${SOURCE_PATH}/doc/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/curlpp/portfile.cmake
+++ b/ports/curlpp/portfile.cmake
@@ -26,7 +26,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     )
 endif()
 
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_TARGET_IS_WINDOWS AND NOT (VCPKG_LIBRARY_LINKAGE STREQUAL static))
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/bin/curlpp-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/..")
     if(NOT VCPKG_BUILD_TYPE)
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/bin/curlpp-config" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")

--- a/ports/curlpp/vcpkg.json
+++ b/ports/curlpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curlpp",
   "version-date": "2018-06-15",
-  "port-version": 6,
+  "port-version": 7,
   "description": "C++ wrapper around libcURL",
   "dependencies": [
     "curl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1710,7 +1710,7 @@
     },
     "curlpp": {
       "baseline": "2018-06-15",
-      "port-version": 6
+      "port-version": 7
     },
     "cute-headers": {
       "baseline": "2019-09-20",

--- a/versions/c-/curlpp.json
+++ b/versions/c-/curlpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "32d1fc0ce976b93900a1aa01b23c0b5ffb2021db",
+      "git-tree": "ebde1c1d303f750ce06e530295a820787878e6cd",
       "version-date": "2018-06-15",
       "port-version": 7
     },

--- a/versions/c-/curlpp.json
+++ b/versions/c-/curlpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "32d1fc0ce976b93900a1aa01b23c0b5ffb2021db",
+      "version-date": "2018-06-15",
+      "port-version": 7
+    },
+    {
       "git-tree": "a4cea77cfb3429b1ea778167d06c39a691b97e13",
       "version-date": "2018-06-15",
       "port-version": 6


### PR DESCRIPTION
Otherwise port fails in single-config triplets

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

