### PR TITLE
[qt5-3d] Support Visual Studio 2022

### DIFF
--- a/ports/qt5-3d/portfile.cmake
+++ b/ports/qt5-3d/portfile.cmake
@@ -3,7 +3,7 @@ include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
 set(OPTIONS -system-assimp)
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(VCVER vc140 vc141 vc142 )
+    set(VCVER vc140 vc141 vc142 vc143 )
     set(CRT mt md)
     set(DBG_NAMES)
     set(REL_NAMES)

--- a/ports/qt5-3d/vcpkg.json
+++ b/ports/qt5-3d/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qt5-3d",
   "version-string": "5.15.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qt5 3d Module - Functionality for near-realtime simulation systems with support for 2D and 3D rendering",
   "dependencies": [
     "assimp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5550,7 +5550,7 @@
     },
     "qt5-3d": {
       "baseline": "5.15.2",
-      "port-version": 2
+      "port-version": 3
     },
     "qt5-activeqt": {
       "baseline": "5.15.2",

--- a/versions/q-/qt5-3d.json
+++ b/versions/q-/qt5-3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4c43f4aec27c0ac682f88d1edfcce7c28e4a9458",
+      "version-string": "5.15.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "f46ab15ed74e4680e16b61851b9eb41523a626f6",
       "version-string": "5.15.2",
       "port-version": 2


### PR DESCRIPTION
This PR was approved in https://github.com/microsoft/vcpkg/pull/22610 (Closed by me), I just made it cleaner here
**Describe the pull request**
The error shows related to the qt5-3d module when I'm compiling COLMAP 3.6 by vcpkg on Windows 10 with Visual Studio 2022 installed. After tracing the logs, I realized that only assimp-vc143-mt.lib available in VCPKG_ROOT\installed\x64-windows\lib

- #### What does your PR fix?  
  Not applicable

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**Host Environment**
OS: Windows 10
Compiler: Visual Studio 2022
**To Reproduce the error**
Steps to reproduce the behaviour:
vcpkg install qt5-3d:x64-windows
