### PR TITLE
[freeimage] Re-fix dependency libwebp

### DIFF
--- a/ports/freeimage/CMakeLists.txt
+++ b/ports/freeimage/CMakeLists.txt
@@ -9,15 +9,15 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "/wd4828 ${CMAKE_CXX_FLAGS}")
 endif()
 
-find_package(ZLIB     REQUIRED)
-find_package(PNG      REQUIRED)
-find_package(JPEG     REQUIRED)
-find_package(TIFF     REQUIRED)
-find_package(OpenJPEG REQUIRED)
-find_package(WebP     REQUIRED)
-find_package(JXR      REQUIRED)
-find_package(LibRaw   REQUIRED)
-find_package(OpenEXR  REQUIRED)
+find_package(ZLIB           REQUIRED)
+find_package(PNG            REQUIRED)
+find_package(JPEG           REQUIRED)
+find_package(TIFF           REQUIRED)
+find_package(OpenJPEG       REQUIRED)
+find_package(WebP CONFIG    REQUIRED)
+find_package(JXR            REQUIRED)
+find_package(LibRaw         REQUIRED)
+find_package(OpenEXR        REQUIRED)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(INSTALL_HEADERS "Install the development headers" ON)
@@ -93,7 +93,6 @@ target_include_directories(FreeImage PRIVATE ${REAL_SOURCE_DIR}
                                              ${TIFF_INCLUDE_DIRS}
                                              ${PNG_INCLUDE_DIRS}
                                              ${OPENJPEG_INCLUDE_DIRS}
-                                             ${WEBP_INCLUDE_DIRS}
                                              ${JXR_INCLUDE_DIRS}
                                              ${LibRaw_INCLUDE_DIRS}
                                              ${CMAKE_CURRENT_BINARY_DIR}
@@ -105,7 +104,7 @@ target_link_libraries(FreeImage ${ZLIB_LIBRARIES}
                                 ${TIFF_LIBRARIES}
                                 ${PNG_LIBRARIES}
                                 ${OPENJPEG_LIBRARIES}
-                                ${WEBP_LIBRARIES}
+                                WebP::webp WebP::webpdemux WebP::libwebpmux WebP::webpdecoder
                                 ${JXR_LIBRARIES}
                                 ${LibRaw_LIBRARIES}
                                 OpenEXR::IlmImf)
@@ -150,7 +149,7 @@ find_dependency(PNG)
 find_dependency(JPEG)
 find_dependency(TIFF)
 find_dependency(OpenJPEG)
-find_dependency(WebP)
+find_dependency(WebP CONFIG)
 find_dependency(JXR)
 find_dependency(LibRaw)
 find_dependency(OpenEXR)

--- a/ports/freeimage/vcpkg.json
+++ b/ports/freeimage/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "freeimage",
   "version": "3.18.0",
-  "port-version": 21,
+  "port-version": 22,
   "description": "Support library for graphics image formats",
   "homepage": "https://sourceforge.net/projects/freeimage/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2266,7 +2266,7 @@
     },
     "freeimage": {
       "baseline": "3.18.0",
-      "port-version": 21
+      "port-version": 22
     },
     "freeopcua": {
       "baseline": "20190125",

--- a/versions/f-/freeimage.json
+++ b/versions/f-/freeimage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9bad6f331c05331144e8bad4a2ef63d4c594cd5a",
+      "version": "3.18.0",
+      "port-version": 22
+    },
+    {
       "git-tree": "7d0f28dd10d54f1f11d09875fbfafd1579e948c4",
       "version": "3.18.0",
       "port-version": 21


### PR DESCRIPTION
Re-fix freeimage's dependency libwebp, use config mode:
```
/home/usr/work/vcpkg/installed/x64-linux/lib/libjpegxr.a(strenc.c.o): In function `StrIOEncInit':
strenc.c:(.text+0xe94): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/home/usr/work/vcpkg/installed/x64-linux/debug/lib/libFreeImaged.a(PluginWebP.cpp.o): In function `WebPMuxNew':
/home/usr/work/vcpkg/installed/x64-linux/include/webp/mux.h:114: undefined reference to `WebPNewInternal'
/home/usr/work/vcpkg/installed/x64-linux/debug/lib/libFreeImaged.a(PluginWebP.cpp.o): In function `WebPMuxCreate':
/home/usr/work/vcpkg/installed/x64-linux/include/webp/mux.h:138: undefined reference to `WebPMuxCreateInternal'
/home/usr/work/vcpkg/installed/x64-linux/debug/lib/libFreeImaged.a(PluginWebP.cpp.o): In function `Close(FreeImageIO*, void*, void*)':
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:203: undefined reference to `WebPMuxDelete'
/home/usr/work/vcpkg/installed/x64-linux/debug/lib/libFreeImaged.a(PluginWebP.cpp.o): In function `Load(FreeImageIO*, void*, int, int, void*)':
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:356: undefined reference to `WebPMuxGetFeatures'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:362: undefined reference to `WebPMuxGetFrame'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:373: undefined reference to `WebPMuxGetChunk'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:381: undefined reference to `WebPMuxGetChunk'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:403: undefined reference to `WebPMuxGetChunk'
/home/usr/work/vcpkg/installed/x64-linux/debug/lib/libFreeImaged.a(PluginWebP.cpp.o): In function `Save(FreeImageIO*, FIBITMAP*, void*, int, int, void*)':
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:591: undefined reference to `WebPMuxSetImage'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:608: undefined reference to `WebPMuxSetChunk'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:622: undefined reference to `WebPMuxSetChunk'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:636: undefined reference to `WebPMuxSetChunk'
/home/usr/work/vcpkg/buildtrees/freeimage/src/9d9cc7e2d5-e3148e0804.clean/Source/FreeImage/PluginWebP.cpp:644: undefined reference to `WebPMuxAssemble'
collect2: error: ld returned 1 exit status
```

Fixes #14498.