### PR TITLE
[nativefiledialog] Upgrade port to release 116

### DIFF
--- a/ports/nativefiledialog/portfile.cmake
+++ b/ports/nativefiledialog/portfile.cmake
@@ -7,8 +7,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO mlabbe/nativefiledialog
-    REF ceb75f7abf30736aa8ee4800cde0d444c798f8b9
-    SHA512 dd2bff28bb08fb1f6b07ad28530da039f176fb641e300b816040a2b2b840611e418cad44fdaf395ec565c50149ce58c80f88f6a77b403b843f2b14f1f2c91d7d
+    REF 67345b80ebb429ecc2aeda94c478b3bcc5f7888e
+    SHA512 55edb3730b718b18d4fee7ec9bb479794d0e193ff13f05f26cbcf9ff44c43adb93e228ed7fd708e30c08476366f098bf69139031a84f5e4d6a85eba096fe4654
     HEAD_REF master
 )
 

--- a/ports/nativefiledialog/portfile.cmake
+++ b/ports/nativefiledialog/portfile.cmake
@@ -20,8 +20,7 @@ vcpkg_check_features(
 )
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
 )
@@ -31,8 +30,8 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/nativefiledialog/vcpkg.json
+++ b/ports/nativefiledialog/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "nativefiledialog",
-  "version-date": "2019-09-30",
-  "port-version": 1,
+  "version-date": "2022-01-20",
   "description": "A tiny, neat C library that portably invokes native file open and save dialogs",
   "homepage": "https://github.com/mlabbe/nativefiledialog",
   "supports": "!uwp",

--- a/ports/nativefiledialog/vcpkg.json
+++ b/ports/nativefiledialog/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nativefiledialog",
-  "version-date": "2019-08-28",
+  "version-date": "2019-09-30",
   "port-version": 1,
   "description": "A tiny, neat C library that portably invokes native file open and save dialogs",
   "homepage": "https://github.com/mlabbe/nativefiledialog",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4673,7 +4673,7 @@
       "port-version": 4
     },
     "nativefiledialog": {
-      "baseline": "2019-08-28",
+      "baseline": "2019-09-30",
       "port-version": 1
     },
     "nayuki-qr-code-generator": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4673,8 +4673,8 @@
       "port-version": 4
     },
     "nativefiledialog": {
-      "baseline": "2019-09-30",
-      "port-version": 1
+      "baseline": "2022-01-20",
+      "port-version": 0
     },
     "nayuki-qr-code-generator": {
       "baseline": "1.7.0",

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "c8e10503da15e7f16ec6267c0f0dd88e427ac253",
-      "version-date": "2019-09-30",
-      "port-version": 1
+      "git-tree": "a74fcf99cb59fc1094b1b40622cead632c0df81a",
+      "version-date": "2022-01-20",
+      "port-version": 0
     },
     {
       "git-tree": "d765a8f84ba49c18701f68b7471f1b93b7313ddc",

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c251998771d19b12c93436b63fb37132ec8969c6",
+      "git-tree": "c8e10503da15e7f16ec6267c0f0dd88e427ac253",
       "version-date": "2019-09-30",
       "port-version": 1
     },

--- a/versions/n-/nativefiledialog.json
+++ b/versions/n-/nativefiledialog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c251998771d19b12c93436b63fb37132ec8969c6",
+      "version-date": "2019-09-30",
+      "port-version": 1
+    },
+    {
       "git-tree": "d765a8f84ba49c18701f68b7471f1b93b7313ddc",
       "version-date": "2019-08-28",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Upgrades the port to use the latest release 116 of the `nativefiledialog` library, which includes some bug fixes. For example, the error when opening file dialog with Linux Zenity was fixed in this newer release.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
```
  arm64-windows          Yes
  arm-uwp                No
  x64-linux              Yes
  x64-osx                Yes
  x64-uwp                No
  x64-windows            Yes
  x64-windows-static     Yes
  x64-windows-static-md  Yes
  x86-windows            Yes
```

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
