### PR TITLE
[azure-kinect-sensor-sdk] Fix supports and build issue in feature 'tool'

### DIFF
--- a/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
+++ b/ports/azure-kinect-sensor-sdk/fix-build-imgui.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/k4aviewer/k4alogdockcontrol.cpp b/tools/k4aviewer/k4alogdockcontrol.cpp
+index 4289f71..407e912 100644
+--- a/tools/k4aviewer/k4alogdockcontrol.cpp
++++ b/tools/k4aviewer/k4alogdockcontrol.cpp
+@@ -161,7 +161,7 @@ K4ADockControlStatus K4ALogDockControl::Show()
+ 
+     if (updated)
+     {
+-        ImGui::SetScrollHere(1.0f);
++        ImGui::SetScrollHereY(1.0f);
+     }
+ 
+     ImGui::EndChild();

--- a/ports/azure-kinect-sensor-sdk/vcpkg.json
+++ b/ports/azure-kinect-sensor-sdk/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "azure-kinect-sensor-sdk",
   "version": "1.4.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Azure Kinect SDK is a cross platform (Linux and Windows) user mode SDK to read data from your Azure Kinect device.",
   "homepage": "https://github.com/microsoft/Azure-Kinect-Sensor-SDK",
-  "supports": "linux & windows",
+  "supports": "linux | windows",
   "dependencies": [
     "azure-c-shared-utility",
     "cjson",
@@ -21,7 +21,15 @@
     },
     "libyuv",
     "matroska",
-    "spdlog"
+    "spdlog",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "docs": {
@@ -36,7 +44,7 @@
           "name": "imgui",
           "features": [
             "glfw-binding",
-            "opengl3-glew-binding"
+            "opengl3-binding"
           ]
         }
       ]

--- a/versions/a-/azure-kinect-sensor-sdk.json
+++ b/versions/a-/azure-kinect-sensor-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "379c37baf28190bb33ccf1d512c22a21c664e41e",
+      "version": "1.4.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "11fbd98a9560da0ad96abf61d8731778db6e5b8b",
       "version": "1.4.1",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -330,7 +330,7 @@
     },
     "azure-kinect-sensor-sdk": {
       "baseline": "1.4.1",
-      "port-version": 3
+      "port-version": 4
     },
     "azure-macro-utils-c": {
       "baseline": "2020-06-17",


### PR DESCRIPTION
Fix https://github.com/microsoft/vcpkg/issues/22623

1. Fix supports issue 
2. Fix feature 'tool': the dependency imgui feature "opengl3-glew-binding" has been removed by PR https://github.com/microsoft/vcpkg/pull/19677, and use imgui feature "opengl3-binding" instead. I have double confirmed, except azure-kinect-sensor-sdk, there is no port that depends on it.
3. Imgui function `SetScrollHere` renamed to `SetScrollHereY` from 'https://github.com/ocornut/imgui/commit/61d94ff88e480e9a76c85709de68b59b0906cb3a, so update it by fix build issue.

All features test pass with x64-windows.