### PR TITLE
[opencolorio] Update to 2.1.1

### DIFF
--- a/ports/opencolorio/fix-dependency.patch
+++ b/ports/opencolorio/fix-dependency.patch
@@ -1,5 +1,5 @@
 diff --git a/share/cmake/modules/FindExtPackages.cmake b/share/cmake/modules/FindExtPackages.cmake
-index 86a0225..4df4656 100644
+index 8787b87..f953ceb 100644
 --- a/share/cmake/modules/FindExtPackages.cmake
 +++ b/share/cmake/modules/FindExtPackages.cmake
 @@ -26,15 +26,15 @@ set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL
@@ -30,7 +30,16 @@ index 86a0225..4df4656 100644
      
      set(OCIO_HALF_LIB Imath::Imath CACHE STRING "Half library target" FORCE)
      set(OCIO_USE_IMATH_HALF "1" CACHE STRING "Whether 'half' type will be sourced from the Imath library (>=v3.0)" FORCE)
-@@ -65,7 +65,7 @@ if(OCIO_BUILD_APPS)
+@@ -50,7 +50,7 @@ else()
+ 
+     # OpenEXR/IlmBase (<=2.5)
+     # https://github.com/AcademySoftwareFoundation/openexr
+-    find_package(Half 2.4.0 REQUIRED)
++    find_package(Half CONFIG REQUIRED)
+ 
+     set(OCIO_HALF_LIB IlmBase::Half CACHE STRING "Half library target" FORCE)
+     set(OCIO_USE_IMATH_HALF "0" CACHE STRING "Whether 'half' type will be sourced from the Imath library (>=v3.0)" FORCE)
+@@ -65,13 +65,13 @@ if(OCIO_BUILD_APPS)
  
      # lcms2
      # https://github.com/mm2/Little-CMS
@@ -39,47 +48,53 @@ index 86a0225..4df4656 100644
  endif()
  
  if(OCIO_BUILD_OPENFX)
-diff --git a/src/OpenColorIO/CMakeLists.txt b/src/OpenColorIO/CMakeLists.txt
-index be50b7b..c66191e 100644
---- a/src/OpenColorIO/CMakeLists.txt
-+++ b/src/OpenColorIO/CMakeLists.txt
-@@ -204,7 +204,9 @@ if(BUILD_SHARED_LIBS AND WIN32)
+     # openfx
+     # https://github.com/ofxa/openfx
+-    find_package(openfx 1.4 REQUIRED)
++    find_package(openfx CONFIG REQUIRED)
  endif()
  
- target_include_directories(OpenColorIO
--    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-+    PUBLIC
-+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-+    "$<INSTALL_INTERFACE:include>"
+ if (OCIO_PYTHON_VERSION AND NOT OCIO_BUILD_PYTHON)
+@@ -100,6 +100,6 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
+     if(OCIO_BUILD_PYTHON)
+         # pybind11
+         # https://github.com/pybind/pybind11
+-        find_package(pybind11 2.6.1 REQUIRED)
++        find_package(pybind11 CONFIG REQUIRED)
+     endif()
+ endif()
+diff --git a/src/OpenColorIO/CMakeLists.txt b/src/OpenColorIO/CMakeLists.txt
+index 034185d..b992bbc 100755
+--- a/src/OpenColorIO/CMakeLists.txt
++++ b/src/OpenColorIO/CMakeLists.txt
+@@ -226,9 +226,9 @@ target_link_libraries(OpenColorIO
+         expat::expat
+         ${OCIO_HALF_LIB}
+         pystring::pystring
+-        sampleicc::sampleicc
+-        utils::from_chars
+-        utils::strings
++        "$<BUILD_INTERFACE:sampleicc::sampleicc>"
++        "$<BUILD_INTERFACE:utils::from_chars>"
++        "$<BUILD_INTERFACE:utils::strings>"
+         yaml-cpp
  )
  
- target_link_libraries(OpenColorIO
-@@ -214,8 +216,8 @@ target_link_libraries(OpenColorIO
- 		expat::expat
- 		${OCIO_HALF_LIB}
- 		pystring::pystring
--		sampleicc::sampleicc
--		utils::strings
-+		"$<BUILD_INTERFACE:sampleicc::sampleicc>"
-+		"$<BUILD_INTERFACE:utils::strings>"
- 		yaml-cpp
- )
- 
-@@ -229,13 +231,13 @@ endif()
+@@ -242,13 +242,13 @@ endif()
  
  if(NOT BUILD_SHARED_LIBS)
- 	target_compile_definitions(OpenColorIO
--		PRIVATE
-+		PUBLIC
- 			OpenColorIO_SKIP_IMPORTS
- 	)
+     target_compile_definitions(OpenColorIO
+-        PRIVATE
++        PUBLIC
+             OpenColorIO_SKIP_IMPORTS
+     )
  else()
- 	# Only exports selected symbols.
- 	target_compile_definitions(OpenColorIO
--		PRIVATE
-+		PUBLIC
- 			OpenColorIO_EXPORTS
- 	)
+     # Only exports selected symbols.
+     target_compile_definitions(OpenColorIO
+-        PRIVATE
++        PUBLIC
+             OpenColorIO_EXPORTS
+     )
  endif()
 diff --git a/src/cmake/Config.cmake.in b/src/cmake/Config.cmake.in
 index eebb2c1..7147dc3 100644

--- a/ports/opencolorio/portfile.cmake
+++ b/ports/opencolorio/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO AcademySoftwareFoundation/OpenColorIO
-    REF v2.1.0
-    SHA512 a0f4fb62c768b392ca1129e2046df96d670d785fc057d4103768440b7adb65d8faf5b7d39729060791794e83e6cd4e67821aed9b30f3f04b410c60809cd72267
+    REF v2.1.1
+    SHA512 86585ec860d460b158f24efb82f202deced7ce96a6bfefd42f39cad9c112add68cca6935f383f5d718c07fe1c121d8ed8b0d2069321f1dafb8ce68b49bc75194
     HEAD_REF master
     PATCHES
         fix-dependency.patch

--- a/ports/opencolorio/vcpkg.json
+++ b/ports/opencolorio/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "opencolorio",
-  "version-semver": "2.1.0",
-  "port-version": 2,
+  "version-semver": "2.1.1",
   "description": "OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation. OCIO provides a straightforward and consistent user experience across all supporting applications while allowing for sophisticated back-end configuration options suitable for high-end production usage. OCIO is compatible with the Academy Color Encoding Specification (ACES) and is LUT-format agnostic, supporting many popular formats.",
   "homepage": "https://opencolorio.org/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4957,8 +4957,8 @@
       "port-version": 8
     },
     "opencolorio": {
-      "baseline": "2.1.0",
-      "port-version": 2
+      "baseline": "2.1.1",
+      "port-version": 0
     },
     "opencolorio-tools": {
       "baseline": "1.1.1",

--- a/versions/o-/opencolorio.json
+++ b/versions/o-/opencolorio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5027649e2b69070030097c754018913b6ae0d8b0",
+      "version-semver": "2.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "5b4c12d0a01185796534d2925a87fe3b874f1b91",
       "version-semver": "2.1.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates OCIO to version 2.1.1. Fixes issues like olive-editor/olive#1838 since v2.1.1 fixes a Unicode bug on Win32.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  I believe so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes, version database has been updated.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
