### PR TITLE
[vcpkg_execute_*_process] Add support for build profiling

### DIFF
--- a/scripts/cmake/vcpkg_execute_build_process.cmake
+++ b/scripts/cmake/vcpkg_execute_build_process.cmake
@@ -73,6 +73,13 @@ function(vcpkg_execute_build_process)
     set(log_err "${log_prefix}-err.log")
     set(all_logs "${log_out}" "${log_err}")
 
+    if(X_PORT_PROFILE)
+        vcpkg_list(PREPEND arg_COMMAND "${CMAKE_COMMAND}" "-E" "time")
+        if(DEFINED arg_NO_PARALLEL_COMMAND)
+            vcpkg_list(PREPEND arg_NO_PARALLEL_COMMAND "${CMAKE_COMMAND}" "-E" "time")
+        endif()
+    endif()
+
     execute_process(
         COMMAND ${arg_COMMAND}
         WORKING_DIRECTORY "${arg_WORKING_DIRECTORY}"

--- a/scripts/cmake/vcpkg_execute_required_process.cmake
+++ b/scripts/cmake/vcpkg_execute_required_process.cmake
@@ -100,6 +100,10 @@ Halting portfile execution.
         endif()
     endif()
 
+    if(X_PORT_PROFILE AND NOT arg_ALLOW_IN_DOWNLOAD_MODE)
+        vcpkg_list(PREPEND arg_COMMAND "${CMAKE_COMMAND}" "-E" "time")
+    endif()
+
     vcpkg_execute_in_download_mode(
         COMMAND ${arg_COMMAND}
         OUTPUT_FILE "${log_out}"

--- a/scripts/cmake/vcpkg_execute_required_process_repeat.cmake
+++ b/scripts/cmake/vcpkg_execute_required_process_repeat.cmake
@@ -44,6 +44,10 @@ Halting portfile execution.
 ]])
     endif()
 
+    if(X_PORT_PROFILE AND NOT arg_ALLOW_IN_DOWNLOAD_MODE)
+        vcpkg_list(PREPEND arg_COMMAND "${CMAKE_COMMAND}" "-E" "time")
+    endif()
+
     set(all_logs "")
     foreach(loop_count RANGE 1 ${arg_COUNT})
         set(out_log "${CURRENT_BUILDTREES_DIR}/${arg_LOGNAME}-out-${loop_count}.log")


### PR DESCRIPTION
**Describe the pull request**

Use _--x-cmake-args=-DX_PORT_PROFILE=TRUE_ to enable profiling

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
