### PR TITLE
[tool-meson] fix dependency. 

### DIFF
--- a/ports/tool-meson/vcpkg.json
+++ b/ports/tool-meson/vcpkg.json
@@ -1,9 +1,12 @@
 {
   "name": "tool-meson",
-  "version-date": "2021-11-19",
+  "version-date": "2022-01-21",
   "description": "Meson build system",
   "homepage": "https://github.com/mesonbuild/meson",
   "dependencies": [
-    "vcpkg-tool-meson"
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6949,7 +6949,7 @@
       "port-version": 3
     },
     "tool-meson": {
-      "baseline": "2021-11-19",
+      "baseline": "2022-01-21",
       "port-version": 0
     },
     "torch-th": {

--- a/versions/t-/tool-meson.json
+++ b/versions/t-/tool-meson.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cb1118e5da831de1c511424b6aaa7949777733a3",
+      "version-date": "2022-01-21",
+      "port-version": 0
+    },
+    {
       "git-tree": "924a9b5b5dc11ea420a1be748873f8b252fd1417",
       "version-date": "2021-11-19",
       "port-version": 0


### PR DESCRIPTION
since `tool-meson` existed before `host` and `vcpkg-tool-meson` only supports `native` `tool-meson` needs to have a host dependency on `vcpkg-tool-meson` to be correct and not break users on upgrade or similar. 
