### PR TITLE
[vcpkg] Fix termination of vcpkg root search

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -357,18 +357,23 @@ endif()
 set(VCPKG_TARGET_TRIPLET "${Z_VCPKG_TARGET_TRIPLET_ARCH}-${Z_VCPKG_TARGET_TRIPLET_PLAT}" CACHE STRING "Vcpkg target triplet (ex. x86-windows)")
 set(Z_VCPKG_TOOLCHAIN_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-if(NOT DEFINED Z_VCPKG_ROOT_DIR)
-    # Detect .vcpkg-root to figure VCPKG_ROOT_DIR
-    set(Z_VCPKG_ROOT_DIR_CANDIDATE "${CMAKE_CURRENT_LIST_DIR}")
-    while(IS_DIRECTORY "${Z_VCPKG_ROOT_DIR_CANDIDATE}" AND NOT EXISTS "${Z_VCPKG_ROOT_DIR_CANDIDATE}/.vcpkg-root")
+# Detect .vcpkg-root to figure VCPKG_ROOT_DIR
+set(Z_VCPKG_ROOT_DIR_CANDIDATE "${CMAKE_CURRENT_LIST_DIR}")
+while(NOT DEFINED Z_VCPKG_ROOT_DIR)
+    if(EXISTS "${Z_VCPKG_ROOT_DIR_CANDIDATE}/.vcpkg-root")
+        set(Z_VCPKG_ROOT_DIR "${Z_VCPKG_ROOT_DIR_CANDIDATE}" CACHE INTERNAL "Vcpkg root directory")
+    elseif(IS_DIRECTORY "${Z_VCPKG_ROOT_DIR_CANDIDATE}")
         get_filename_component(Z_VCPKG_ROOT_DIR_TEMP "${Z_VCPKG_ROOT_DIR_CANDIDATE}" DIRECTORY)
-        if(Z_VCPKG_ROOT_DIR_TEMP STREQUAL Z_VCPKG_ROOT_DIR_CANDIDATE) # If unchanged, we have reached the root of the drive
-        else()
-            SET(Z_VCPKG_ROOT_DIR_CANDIDATE "${Z_VCPKG_ROOT_DIR_TEMP}")
+        if(Z_VCPKG_ROOT_DIR_TEMP STREQUAL Z_VCPKG_ROOT_DIR_CANDIDATE)
+            break() # If unchanged, we have reached the root of the drive wihout find vcpkg.
         endif()
-    endwhile()
-    set(Z_VCPKG_ROOT_DIR "${Z_VCPKG_ROOT_DIR_CANDIDATE}" CACHE INTERNAL "Vcpkg root directory")
-endif()
+        SET(Z_VCPKG_ROOT_DIR_CANDIDATE "${Z_VCPKG_ROOT_DIR_TEMP}")
+        unset(Z_VCPKG_ROOT_DIR_TEMP)
+    else()
+        break()
+    endif()
+endwhile()
+unset(Z_VCPKG_ROOT_DIR_CANDIDATE)
 
 if(NOT Z_VCPKG_ROOT_DIR)
     z_vcpkg_add_fatal_error("Could not find .vcpkg-root")

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -365,7 +365,7 @@ while(NOT DEFINED Z_VCPKG_ROOT_DIR)
     elseif(IS_DIRECTORY "${Z_VCPKG_ROOT_DIR_CANDIDATE}")
         get_filename_component(Z_VCPKG_ROOT_DIR_TEMP "${Z_VCPKG_ROOT_DIR_CANDIDATE}" DIRECTORY)
         if(Z_VCPKG_ROOT_DIR_TEMP STREQUAL Z_VCPKG_ROOT_DIR_CANDIDATE)
-            break() # If unchanged, we have reached the root of the drive wihout find vcpkg.
+            break() # If unchanged, we have reached the root of the drive without finding vcpkg.
         endif()
         SET(Z_VCPKG_ROOT_DIR_CANDIDATE "${Z_VCPKG_ROOT_DIR_TEMP}")
         unset(Z_VCPKG_ROOT_DIR_TEMP)


### PR DESCRIPTION
**Describe the pull request**
- #### What does your PR fix?  
  Fixes live-lock when not finding `.vcpkg-root`: #22690, #20125.
  (Probably broken since  #11757 when the `FATAL_ERROR` was moved out of the loop.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  ---

CC @strega-nil-ms 