### PR TITLE
[cppgraphqlgen] Update to v4.1.1 for latest release

### DIFF
--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
-    REF v3.7.1
-    SHA512 ee8dc3bccdf0b01e4e4138e3d31e43702e2e08fa86805fa0bbef9009deca3bbdc807751e04f99033b517a0096d3b83d25dbd0356f195e0fb5a364cdd50af6ccd
-    HEAD_REF v3.x
+    REF v4.1.1
+    SHA512 20987f03719558cec2fac8aee5a94e59c5e833a318361aef802f39bc369af141fef0c7f2d3bb35324d44d289843564c2f7e890419f871bfd8e5d7d5de53b363e
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/cppgraphqlgen/portfile.cmake
+++ b/ports/cppgraphqlgen/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/cppgraphqlgen
-    REF v4.1.0
-    SHA512 530cbc21d43b918a8ad2d32f659dd20a8272a59952808c13f2fad9f9ca0bd3df1bb8b5296ab7d62f831d6d0c6197b9f5708ddda58f44332bfbfee6f6f2d116bb
-    HEAD_REF main
+    REF v3.7.1
+    SHA512 ee8dc3bccdf0b01e4e4138e3d31e43702e2e08fa86805fa0bbef9009deca3bbdc807751e04f99033b517a0096d3b83d25dbd0356f195e0fb5a364cdd50af6ccd
+    HEAD_REF v3.x
 )
 
 vcpkg_cmake_configure(

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppgraphqlgen",
-  "version-semver": "3.7.1",
+  "version-semver": "4.1.1",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "dependencies": [

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cppgraphqlgen",
-  "version-semver": "4.1.0",
+  "version-semver": "3.7.1",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
   "dependencies": [

--- a/ports/cppgraphqlgen/vcpkg.json
+++ b/ports/cppgraphqlgen/vcpkg.json
@@ -3,6 +3,7 @@
   "version-semver": "4.1.1",
   "description": "C++ GraphQL schema service generator",
   "homepage": "https://github.com/microsoft/cppgraphqlgen",
+  "license": "MIT",
   "dependencies": [
     "boost-program-options",
     "pegtl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 1
     },
     "cppgraphqlgen": {
-      "baseline": "4.1.0",
+      "baseline": "3.7.1",
       "port-version": 0
     },
     "cppitertools": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1573,7 +1573,7 @@
       "port-version": 1
     },
     "cppgraphqlgen": {
-      "baseline": "3.7.1",
+      "baseline": "4.1.1",
       "port-version": 0
     },
     "cppitertools": {

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -16,11 +16,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "c8481de46e09126a9b9c8a3a91a079ae61cd57bd",
-      "version-semver": "3.7.1",
-      "port-version": 0
-    },
-    {
       "git-tree": "0c1dadfa4133064be08120a65fd9e2ed3a339bb8",
       "version-semver": "3.6.0",
       "port-version": 0

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8481de46e09126a9b9c8a3a91a079ae61cd57bd",
+      "version-semver": "3.7.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "23ec5f0002e33dd6c76bab436dec806cfde33235",
       "version-semver": "4.1.0",
       "port-version": 0

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,13 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "2341ff609f645ac9ceac5e69383e996bef254076",
+      "git-tree": "95b14163e5e6caf3ae1795167c8ea9503c7a8153",
       "version-semver": "4.1.1",
-      "port-version": 0
-    },
-    {
-      "git-tree": "c8481de46e09126a9b9c8a3a91a079ae61cd57bd",
-      "version-semver": "3.7.1",
       "port-version": 0
     },
     {
@@ -18,6 +13,11 @@
     {
       "git-tree": "6f5eb4a891a143e9d56a8e4791fb87da321a561c",
       "version-semver": "4.0.0",
+      "port-version": 0
+    },
+    {
+      "git-tree": "c8481de46e09126a9b9c8a3a91a079ae61cd57bd",
+      "version-semver": "3.7.1",
       "port-version": 0
     },
     {

--- a/versions/c-/cppgraphqlgen.json
+++ b/versions/c-/cppgraphqlgen.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2341ff609f645ac9ceac5e69383e996bef254076",
+      "version-semver": "4.1.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "c8481de46e09126a9b9c8a3a91a079ae61cd57bd",
       "version-semver": "3.7.1",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Updates the latest version from v4.1.0 to v4.1.1.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  All triplets are supported, but ci.baseline.txt still has an exception for x64-linux because the version of GCC is not new enough in the CI workflow.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
