### PR TITLE
[muparser] update to 2.3.3-1

### DIFF
--- a/ports/muparser/portfile.cmake
+++ b/ports/muparser/portfile.cmake
@@ -3,25 +3,24 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO beltoforion/muparser
-    REF 207d5b77c05c9111ff51ab91082701221220c477 # v2.3.2
-    SHA512 75cebef831eeb08c92c08d2b29932a4af550edbda56c2adb6bc86b1228775294013a07d51974157b39460e60dab937b0b641553cd7ddeef72ba0b23f65c52bf4
+    REF 6d65387be8f4ef329829c6d6ace779b26942e075 # v2.3.3-1
+    SHA512 cda1133b534b1c77d80b15d50d71f372a423fab2bc7b9204d106589350b3cfc955dbfdcfe8c17890e3cfd747b559f4d3c4f0ea6c9c3c73e6aa159afc82bcc6c0
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-    OPTIONS 
+    OPTIONS
         -DENABLE_SAMPLES=OFF
         -DENABLE_OPENMP=OFF
-    OPTIONS_DEBUG 
-        -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/muparser")
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 
-file(INSTALL ${SOURCE_PATH}/License.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 vcpkg_fixup_pkgconfig()

--- a/ports/muparser/vcpkg.json
+++ b/ports/muparser/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "muparser",
-  "version-string": "2.3.2",
-  "port-version": 2,
+  "version": "2.3.3-1",
   "description": "Fast math parser library",
   "homepage": "https://github.com/beltoforion/muparser",
-  "supports": "!uwp"
+  "license": "BSD-2-Clause",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4613,8 +4613,8 @@
       "port-version": 4
     },
     "muparser": {
-      "baseline": "2.3.2",
-      "port-version": 2
+      "baseline": "2.3.3-1",
+      "port-version": 0
     },
     "murmurhash": {
       "baseline": "2016-01-09",

--- a/versions/m-/muparser.json
+++ b/versions/m-/muparser.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2e6e7754f6e242c497aca1dd784be15acc5c11f",
+      "version": "2.3.3-1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ffef8786866359a02e3e50d62bcda523967fddce",
       "version-string": "2.3.2",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Update muparser to 2.3.3-1

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
