### PR TITLE
[botan] no absolute paths

### DIFF
--- a/ports/botan/portfile.cmake
+++ b/ports/botan/portfile.cmake
@@ -176,6 +176,7 @@ endif()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/botan/build.h" "#define BOTAN_INSTALL_PREFIX R\"(${CURRENT_PACKAGES_DIR})\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/botan/build.h" "#define BOTAN_INSTALL_LIB_DIR R\"(${CURRENT_PACKAGES_DIR}\\lib)\"" "")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/botan/build.h" "#define BOTAN_INSTALL_LIB_DIR R\"(${CURRENT_PACKAGES_DIR}/lib)\"" "")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/botan/build.h" "--prefix=${CURRENT_PACKAGES_DIR}" "")
 
 file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/botan/vcpkg.json
+++ b/ports/botan/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "botan",
   "version": "2.18.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "A cryptography library written in C++11",
   "homepage": "https://botan.randombit.net",
+  "license": "BSD-2-Clause",
   "supports": "!(windows & arm)",
   "features": {
     "amalgamation": {

--- a/versions/b-/botan.json
+++ b/versions/b-/botan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dfbd885e94b11d3b8074d96c92e810a0f1a7be7a",
+      "version": "2.18.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "928c19e302d27840225477d4e4b183ca9bd76ea8",
       "version": "2.18.1",
       "port-version": 6

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1126,7 +1126,7 @@
     },
     "botan": {
       "baseline": "2.18.1",
-      "port-version": 6
+      "port-version": 7
     },
     "box2d": {
       "baseline": "2.4.1",


### PR DESCRIPTION
Partially reverts #22343. Replace both path separators.