### PR TITLE
[hunspell] Simplify supports and remove fail_port_install.

### DIFF
--- a/ports/hunspell/portfile.cmake
+++ b/ports/hunspell/portfile.cmake
@@ -1,12 +1,10 @@
-vcpkg_fail_port_install(ON_TARGET "UWP")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO hunspell/hunspell
     REF v1.7.0
     SHA512 8149b2e8b703a0610c9ca5160c2dfad3cf3b85b16b3f0f5cfcb7ebb802473b2d499e8e2d0a637a97a37a24d62424e82d3880809210d3f043fa17a4970d47c903
     HEAD_REF master
-    PATCHES 
+    PATCHES
         0001_fix_unistd.patch
         0002-disable-test.patch
         0003-fix-win-build.patch
@@ -19,7 +17,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     file(REMOVE "${SOURCE_PATH}/README") #README is a symlink
-    
+
     #architecture detection
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
         set(HUNSPELL_ARCH Win32)
@@ -28,19 +26,19 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     else()
         message(FATAL_ERROR "unsupported architecture")
     endif()
-    
+
     if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         set(HUNSPELL_CONFIGURATION _dll)
     else()
         set(HUNSPELL_CONFIGURATION )
     endif()
-    
+
     if("tools" IN_LIST FEATURES)
         set(HSP_TARGET hunspell)
     else()
         set(HSP_TARGET libhunspell)
     endif()
-    
+
     vcpkg_install_msbuild(
         SOURCE_PATH "${SOURCE_PATH}"
         PROJECT_SUBPATH "msvc/Hunspell.sln"
@@ -63,14 +61,14 @@ else()
     vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
     vcpkg_configure_make(
         SOURCE_PATH ${SOURCE_PATH}
-        OPTIONS 
+        OPTIONS
         AUTOCONFIG
         ADDITIONAL_MSYS_PACKAGES gzip
     )
     #install-pkgconfDATA:
     vcpkg_build_make(BUILD_TARGET dist LOGFILE_ROOT build-dist)
     vcpkg_install_make()
-    
+
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
     vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}/bin")
     vcpkg_fixup_pkgconfig()

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "hunspell",
   "version": "1.7.0",
-  "port-version": 6,
+  "port-version": 7,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
-  "supports": "!((arm | uwp) & windows)",
+  "supports": "!(arm & windows) & !uwp",
   "dependencies": [
     "libiconv"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2730,7 +2730,7 @@
     },
     "hunspell": {
       "baseline": "1.7.0",
-      "port-version": 6
+      "port-version": 7
     },
     "hwloc": {
       "baseline": "2.5.0",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7db92584496fe08ac10f8f32556ca89e14018aa",
+      "version": "1.7.0",
+      "port-version": 7
+    },
+    {
       "git-tree": "459909cbf52806ce8df547bed3265d7d5c4abfc2",
       "version": "1.7.0",
       "port-version": 6


### PR DESCRIPTION
```
!((arm | uwp) & windows)
!((arm & windows) | (uwp & windows))    distribute ands over ors
!((arm & windows) | uwp)                uwp implies windows
!(arm & windows) & !uwp                 demorgan
```

In support of https://github.com/microsoft/vcpkg/pull/21502
