### PR TITLE
[levmar] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/levmar/portfile.cmake
+++ b/ports/levmar/portfile.cmake
@@ -1,7 +1,3 @@
-vcpkg_fail_port_install(MESSAGE "levmar currently only checked on Windows" 
-    ON_TARGET "OSX" "Linux" "UWP"
-)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "http://users.ics.forth.gr/~lourakis/levmar/levmar-2.6.tgz"
     FILENAME "levmar-2.6.tgz"

--- a/ports/levmar/vcpkg.json
+++ b/ports/levmar/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "levmar",
-  "version-string": "2.6",
+  "version": "2.6",
+  "port-version": 1,
   "description": "Levenberg-Marquardt nonlinear least squares optimization algorithm",
   "homepage": "http://users.ics.forth.gr/~lourakis/levmar/",
-  "supports": "!(uwp | osx | linux)"
+  "supports": "windows & !uwp"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3314,7 +3314,7 @@
     },
     "levmar": {
       "baseline": "2.6",
-      "port-version": 0
+      "port-version": 1
     },
     "libaaplus": {
       "baseline": "2.36",

--- a/versions/l-/levmar.json
+++ b/versions/l-/levmar.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a869430352021a5fcecdd780a25e5ee0a4d769f5",
+      "version": "2.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "cbd0d2a467f781175f1900ca6857ddff74ab1cc5",
       "version-string": "2.6",
       "port-version": 0


### PR DESCRIPTION
I changed the supports to speak "positively" rather than "negatively" because it seems like that was the intent based on the message.

In support of https://github.com/microsoft/vcpkg/pull/21502