### PR TITLE
[libcanberra] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/libcanberra/portfile.cmake
+++ b/ports/libcanberra/portfile.cmake
@@ -1,6 +1,5 @@
-vcpkg_fail_port_install(ON_TARGET "Windows" "UWP")
 set(VERSION 0.30)
-set(PATCHES 
+set(PATCHES
     pkgconfig.patch
     undefined_reference.diff  # https://sources.debian.org/patches/libcanberra/0.30-7/
     gtk_dont_assume_x11.patch # likewise

--- a/ports/libcanberra/vcpkg.json
+++ b/ports/libcanberra/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "libcanberra",
   "version": "0.30",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An implementation of the XDG Sound Theme and Name Specifications, for generating event sounds on free desktops",
   "homepage": "http://0pointer.de/lennart/projects/libcanberra/",
-  "supports": "!(windows | uwp)",
+  "supports": "!windows",
   "dependencies": [
     "libvorbis"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3366,7 +3366,7 @@
     },
     "libcanberra": {
       "baseline": "0.30",
-      "port-version": 1
+      "port-version": 2
     },
     "libcbor": {
       "baseline": "0.8.0",

--- a/versions/l-/libcanberra.json
+++ b/versions/l-/libcanberra.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3246364c5030e3201740f6bdf5d8bb87cc984daf",
+      "version": "0.30",
+      "port-version": 2
+    },
+    {
       "git-tree": "18398f54e696bb43cf68dc7efc3e32304487057e",
       "version": "0.30",
       "port-version": 1


### PR DESCRIPTION
Supports expression simplified because uwp implies windows.

In support of https://github.com/microsoft/vcpkg/pull/21502
