### PR TITLE
[benchmark] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,6 +1,3 @@
-#https://github.com/google/benchmark/issues/661
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,6 +1,8 @@
 {
+  "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
   "name": "benchmark",
   "version-semver": "1.6.0",
+  "port-version": 1,
   "description": "A library to support the benchmarking of functions, similar to unit-tests.",
   "homepage": "https://github.com/google/benchmark",
   "supports": "!uwp",

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7856168d2b0dcaf058c077798ca47f767c6444f5",
+      "version-semver": "1.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4a77547715562fcaa95568226f79af88d859d2c1",
       "version-semver": "1.6.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -418,7 +418,7 @@
     },
     "benchmark": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "bento4": {
       "baseline": "1.5.1",


### PR DESCRIPTION
A comment was moved from portfile.cmake to vcpkg.json.

In support of https://github.com/microsoft/vcpkg/pull/21502
