### PR TITLE
[capnproto] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/capnproto/portfile.cmake
+++ b/ports/capnproto/portfile.cmake
@@ -1,8 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET UWP)
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_fail_port_install(ON_ARCH arm arm64)
-endif()
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/capnproto/vcpkg.json
+++ b/ports/capnproto/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "capnproto",
   "version": "0.9.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Data interchange format and capability-based RPC system",
   "homepage": "https://capnproto.org/",
-  "supports": "!uwp & !((arm | arm64) & windows)",
+  "supports": "!uwp & (!windows | !arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/capnproto/vcpkg.json
+++ b/ports/capnproto/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "Data interchange format and capability-based RPC system",
   "homepage": "https://capnproto.org/",
-  "supports": "!uwp & (!windows | !arm)",
+  "supports": "!windows | (!uwp & !arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1226,7 +1226,7 @@
     },
     "capnproto": {
       "baseline": "0.9.1",
-      "port-version": 1
+      "port-version": 2
     },
     "capstone": {
       "baseline": "4.0.2",

--- a/versions/c-/capnproto.json
+++ b/versions/c-/capnproto.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8559f4ad612fa0cb1a06dbba49f2ee0bcec2cf19",
+      "git-tree": "17b054432f141c746019130d2b689d4fd4919938",
       "version": "0.9.1",
       "port-version": 2
     },

--- a/versions/c-/capnproto.json
+++ b/versions/c-/capnproto.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8559f4ad612fa0cb1a06dbba49f2ee0bcec2cf19",
+      "version": "0.9.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "129b6b745372d94f313df0989ad6a8980d7eaef7",
       "version": "0.9.1",
       "port-version": 1


### PR DESCRIPTION
The portfile and vcpkg.json disagreed.

```
vcpkg.json: !uwp & !((arm | arm64) & windows)
portfile:   !uwp & (!windows | !(arm | arm64))
```

If we demorgan the supports expression once they agree:

```
!uwp & (!(arm | arm64) | !windows)
```

Also, arm64 implies arm:

```
!uwp & (!arm | !windows)
```

In support of https://github.com/microsoft/vcpkg/pull/21502
