### PR TITLE
[fastcgi] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/fastcgi/portfile.cmake
+++ b/ports/fastcgi/portfile.cmake
@@ -62,7 +62,7 @@ elseif (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX) # Build in UNIX
   file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
   vcpkg_fixup_pkgconfig()
 else() # Other build system
-  vcpkg_fail_port_install(ALWAYS)
+  message(FATAL_ERROR "fastcgi only supports Windows, Linux, and MacOS.")
 endif()
 
 # Handle copyright

--- a/ports/fastcgi/vcpkg.json
+++ b/ports/fastcgi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fastcgi",
   "version-date": "2020-09-11",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The FastCGI interface combines the best aspects of CGI and vendor APIs. Like CGI, FastCGI applications run in separate, isolated processes.",
   "homepage": "https://fastcgi-archives.github.io/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2110,7 +2110,7 @@
     },
     "fastcgi": {
       "baseline": "2020-09-11",
-      "port-version": 2
+      "port-version": 3
     },
     "fastfeat": {
       "baseline": "391d5e9",

--- a/versions/f-/fastcgi.json
+++ b/versions/f-/fastcgi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3d35715764de0b692fb70742856d39b75bb625d",
+      "version-date": "2020-09-11",
+      "port-version": 3
+    },
+    {
       "git-tree": "f99bded0b957390244bb1c1327dd84dbd5a43634",
       "version-date": "2020-09-11",
       "port-version": 2


### PR DESCRIPTION
This used plain ALWAYS which is identical to `message(FATAL_ERROR`.

In support of https://github.com/microsoft/vcpkg/pull/21502
