### PR TITLE
[chakracore] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/chakracore/portfile.cmake
+++ b/ports/chakracore/portfile.cmake
@@ -1,7 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET osx uwp)
-if(WIN32)
-    vcpkg_fail_port_install(ON_CRT_LINKAGE static ON_LIBRARY_LINKAGE static)
-endif()
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/chakracore/vcpkg.json
+++ b/ports/chakracore/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "chakracore",
   "version-date": "2021-04-22",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Core part of the Chakra Javascript engine",
   "homepage": "https://github.com/Microsoft/ChakraCore",
-  "supports": "!osx & !uwp & (linux | !static)"
+  "supports": "!osx & !uwp & (linux | (!static & !staticcrt))"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1318,7 +1318,7 @@
     },
     "chakracore": {
       "baseline": "2021-04-22",
-      "port-version": 1
+      "port-version": 2
     },
     "charls": {
       "baseline": "2.2.0",

--- a/versions/c-/chakracore.json
+++ b/versions/c-/chakracore.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "614248322cae7f18cd412cc90848a9f140ec9f60",
+      "version-date": "2021-04-22",
+      "port-version": 2
+    },
+    {
       "git-tree": "8ce7ea484830cdf24c8af45ebad35ba10e76f61c",
       "version-date": "2021-04-22",
       "port-version": 1


### PR DESCRIPTION
vcpkg.json and portfile.cmake disagreed.

```
vcpkg.json:     !osx & !uwp & (linux | !static)
portfile.cmake: !osx & !uwp & (!windows | !(static | staticcrt))
```

Trying to get portfile.cmake to agree:

```
!osx & !uwp & (!windows | !(static | staticcrt))             given
!osx & !uwp & (!windows | (!static & !staticcrt))            demorgan
```

Considering !osx is earlier, I'm assuming Linux and !Windows are equivalent here:

```
!osx & !uwp & (linux | (!static & !staticcrt))               (above)
```

I'm assuming that portfile.cmake just never considered staticrt and linux, so I'm adding that condition.

In support of https://github.com/microsoft/vcpkg/pull/21502
