### PR TITLE
[comms] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/comms/portfile.cmake
+++ b/ports/comms/portfile.cmake
@@ -1,5 +1,4 @@
 #header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO commschamp/comms_champion
@@ -16,11 +15,6 @@ vcpkg_check_features(
         tools   CC_BUILD_TOOLS
         tools   CC_INSTALL_TOOLS
 )
-
-# check before configure
-if("tools" IN_LIST FEATURES)
-    vcpkg_fail_port_install(ON_LIBRARY_LINKAGE "static" MESSAGE "Feature 'Tools' can't be built statically") 
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
@@ -42,7 +36,8 @@ if("tools" IN_LIST FEATURES)
         TOOL_NAMES cc_dump cc_view
         AUTO_CLEAN
     )
-    file(INSTALL "${CURRENT_PACKAGES_DIR}/lib/CommsChampion/plugin" 
+
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/lib/CommsChampion/plugin"
          DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/lib/CommsChampion/plugin")
     vcpkg_cmake_config_fixup(PACKAGE_NAME "CommsChampion" CONFIG_PATH "lib/CommsChampion/cmake")
 

--- a/ports/comms/vcpkg.json
+++ b/ports/comms/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "comms",
   "version-semver": "3.4.0",
+  "port-version": 1,
   "description": "COMMS is the C++(11) headers only, platform independent library, which makes the implementation of a communication protocol to be an easy and relatively quick process.",
   "homepage": "https://commschamp.github.io/",
   "documentation": "https://github.com/commschamp/comms_champion",
@@ -17,6 +18,7 @@
   "features": {
     "tools": {
       "description": "Builds CommsChampion tools",
+      "supports": "!static",
       "dependencies": [
         "qt5-base"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1466,7 +1466,7 @@
     },
     "comms": {
       "baseline": "3.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "comms-ublox": {
       "baseline": "0.20.2",

--- a/versions/c-/comms.json
+++ b/versions/c-/comms.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "377ae2ef208c319a5b1360f6dbce38ddae897466",
+      "version-semver": "3.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "05c5eff9612ccbb544cdcbc8f453e12394956ed8",
       "version-semver": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
Separated from the bulk PR because it adds to a feature.

In support of https://github.com/microsoft/vcpkg/pull/21502
