### PR TITLE
[cpuid] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/cpuid/portfile.cmake
+++ b/ports/cpuid/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "arm" "arm64")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/cpuid/vcpkg.json
+++ b/ports/cpuid/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "cpuid",
   "version": "0.5.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Provides CPU identification for the x86 (and x86_64)",
   "homepage": "https://github.com/anrieff/libcpuid",
-  "supports": "x86 | x64",
+  "supports": "(x86 | x64) & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -528,9 +528,6 @@ libcopp:arm-uwp=fail
 # Missing system libraries on linux to run/prepare autoconf
 libgpod:x64-linux=fail
 libgpod:x64-osx=fail
-cpuid:arm-uwp=fail
-cpuid:x64-uwp=fail
-cpuid:arm64-windows=fail
 libdatrie:x64-linux=fail
 libdatrie:x64-osx=fail
 libepoxy:arm-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1626,7 +1626,7 @@
     },
     "cpuid": {
       "baseline": "0.5.1",
-      "port-version": 2
+      "port-version": 3
     },
     "cpuinfo": {
       "baseline": "2021-04-04",

--- a/versions/c-/cpuid.json
+++ b/versions/c-/cpuid.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa97f1bac97c79fa1595ed1a4b141c209fc375e8",
+      "version": "0.5.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "ad9738f7afc11f1fa0cea524f4d79dd6cc644e7c",
       "version": "0.5.1",
       "port-version": 2


### PR DESCRIPTION
The supports expression was missing a block for UWP that was in portfile.cmake. Also updates ci.baseline.txt.

In support of https://github.com/microsoft/vcpkg/pull/21502
