### PR TITLE
[crashrpt] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/crashrpt/portfile.cmake
+++ b/ports/crashrpt/portfile.cmake
@@ -1,11 +1,9 @@
-vcpkg_fail_port_install(ON_TARGET "OSX" "Linux" "UWP")
-
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL x86)
     set(ARCH_DIR "")
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
     set(ARCH_DIR "x64/")
 else()
-    vcpkg_fail_port_install(MESSAGE "${PORT} only supports x86 and x64 architectures" ALWAYS)
+    message(FATAL_ERROR "${PORT} only supports x86 and x64 architectures")
 endif()
 
 vcpkg_from_git(

--- a/ports/crashrpt/vcpkg.json
+++ b/ports/crashrpt/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "crashrpt",
   "version": "1.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A crash reporting system for Windows applications",
   "homepage": "http://crashrpt.sourceforge.net/",
+  "supports": "!osx & !linux & !uwp & (x86 | x64)",
   "dependencies": [
     "dbghelp",
     "libjpeg-turbo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1642,7 +1642,7 @@
     },
     "crashrpt": {
       "baseline": "1.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "crc32c": {
       "baseline": "1.1.2",

--- a/versions/c-/crashrpt.json
+++ b/versions/c-/crashrpt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "896d96ee0613edabd92048142803845fa11baa68",
+      "version": "1.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "ad55102e0d167bb457349e5b2b4cec75efc45a91",
       "version": "1.4.3",
       "port-version": 1


### PR DESCRIPTION
There previously was no supports expression.

In support of https://github.com/microsoft/vcpkg/pull/21502
