### PR TITLE
[libevhtp] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/libevhtp/portfile.cmake
+++ b/ports/libevhtp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports Linux and Mac platform" ON_TARGET "Windows")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO criticalstack/libevhtp

--- a/ports/libevhtp/vcpkg.json
+++ b/ports/libevhtp/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libevhtp",
-  "version-string": "1.2.18",
-  "port-version": 2,
+  "version": "1.2.18",
+  "port-version": 3,
   "description": "Libevhtp was created as a replacement API for Libevent's current HTTP API.",
   "homepage": "https://github.com/criticalstack/libevhtp",
+  "supports": "!windows",
   "dependencies": [
     "libevent"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3454,7 +3454,7 @@
     },
     "libevhtp": {
       "baseline": "1.2.18",
-      "port-version": 2
+      "port-version": 3
     },
     "libexif": {
       "baseline": "0.6.22",

--- a/versions/l-/libevhtp.json
+++ b/versions/l-/libevhtp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2180aafd93f4089a276e9a5de9fe2d28d8e0f88d",
+      "version": "1.2.18",
+      "port-version": 3
+    },
+    {
       "git-tree": "c28b6abc864cbfff6270358471bf9e97fd063710",
       "version-string": "1.2.18",
       "port-version": 2


### PR DESCRIPTION
Previously there was no supports expression.

In support of https://github.com/microsoft/vcpkg/pull/21502
