### PR TITLE
[blend2d] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/blend2d/portfile.cmake
+++ b/ports/blend2d/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" ON_ARCH "wasm32" ON_TARGET "uwp")
-
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO blend2d/blend2d

--- a/ports/blend2d/vcpkg.json
+++ b/ports/blend2d/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "blend2d",
   "version-date": "2021-03-17",
+  "port-version": 1,
   "description": "Beta 2D Vector Graphics Powered by a JIT Compiler",
   "homepage": "https://github.com/blend2d/blend2d",
   "documentation": "https://blend2d.com/doc/index.html",
-  "supports": "!(arm | uwp)",
+  "supports": "!arm & !uwp & !wasm32",
   "default-features": [
     "jit",
     "logging",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -55,9 +55,6 @@ aubio:x64-uwp=fail
 # broken when `python` is python3, https://github.com/microsoft/vcpkg/issues/18937
 bde:x64-linux=fail
 bitserializer:x64-osx=fail
-blend2d:arm64-windows=fail
-blend2d:arm-uwp=fail
-blend2d:x64-uwp=fail
 blitz:x64-uwp=fail
 blitz:arm64-windows=fail
 blitz:arm-uwp=fail

--- a/versions/b-/blend2d.json
+++ b/versions/b-/blend2d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "401153e8f3407e68e96c4ea60f8c71c633b08e1d",
+      "version-date": "2021-03-17",
+      "port-version": 1
+    },
+    {
       "git-tree": "e322c9917356f15d6370ff8f2f0bd380d1f08661",
       "version-date": "2021-03-17",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -494,7 +494,7 @@
     },
     "blend2d": {
       "baseline": "2021-03-17",
-      "port-version": 0
+      "port-version": 1
     },
     "blitz": {
       "baseline": "2020-03-25",


### PR DESCRIPTION
Only wasm32 was missing.

Also ci.baseline.txt was out of date.

In support of https://github.com/microsoft/vcpkg/pull/21502
