### PR TITLE
[fltk] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/fltk/portfile.cmake
+++ b/ports/fltk/portfile.cmake
@@ -1,13 +1,11 @@
 # FLTK has many improperly shared global variables that get duplicated into every DLL
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_fail_port_install(ON_TARGET "UWP")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fltk/fltk
     REF release-1.3.8
-    SHA512 197848d3b80a65cca936daf4f0b74609f0fe8332a4cd11af53385fb2aa45ad698b1e239a48732b118cd3cb189bc531711b72fb2eeeb85be887dc6c5a558fa4b3 
+    SHA512 197848d3b80a65cca936daf4f0b74609f0fe8332a4cd11af53385fb2aa45ad698b1e239a48732b118cd3cb189bc531711b72fb2eeeb85be887dc6c5a558fa4b3
     PATCHES
         findlibsfix.patch
         config-path.patch

--- a/ports/fltk/vcpkg.json
+++ b/ports/fltk/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "fltk",
   "version": "1.3.8",
+  "port-version": 1,
   "description": "FLTK (pronounced fulltick) is a cross-platform C++ GUI toolkit for UNIX/Linux (X11), Microsoft Windows, and MacOS X. FLTK provides modern GUI functionality without the bloat and supports 3D graphics via OpenGL and its built-in GLUT emulation.",
   "homepage": "https://www.fltk.org/",
+  "supports": "!uwp",
   "dependencies": [
     "libjpeg-turbo",
     "libpng",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -283,8 +283,6 @@ fdlibm:arm-uwp=fail
 fdlibm:x64-uwp=fail
 fftw3:arm-uwp=fail
 fftw3:x64-uwp=fail
-fltk:arm-uwp=fail
-fltk:x64-uwp=fail
 # fluidlite conflicts with fluidsynth; we test fluidsynth rather than fluidlite because
 # fluidlite has no dependencies and thus is less likely to be broken by another package.
 fluidlite:arm-uwp=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2202,7 +2202,7 @@
     },
     "fltk": {
       "baseline": "1.3.8",
-      "port-version": 0
+      "port-version": 1
     },
     "fluidlite": {
       "baseline": "2020-08-27",

--- a/versions/f-/fltk.json
+++ b/versions/f-/fltk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86da5d186aa27c3a6a9a9903eaa2806edde44bd8",
+      "version": "1.3.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "0a6f2dbd574e17da82e99414a644fca8f8efce52",
       "version": "1.3.8",
       "port-version": 0


### PR DESCRIPTION
There was no supports expression before.

In support of https://github.com/microsoft/vcpkg/pull/21502
