### PR TITLE
[folly] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/folly/portfile.cmake
+++ b/ports/folly/portfile.cmake
@@ -1,9 +1,3 @@
-if (VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "x86" "arm" "arm64")
-else()
-    vcpkg_fail_port_install(ON_ARCH "x86" "arm")
-endif()
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 # Required to run build/generate_escape_tables.py et al.

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
-  "supports": "(windows & x64 & !uwp) | (!windows & x64 & arm64)",
+  "supports": "(windows & x64 & !uwp) | (!windows & (x64 | arm64))",
   "dependencies": [
     "boost-chrono",
     "boost-context",

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
-  "supports": "!uwp & (x64 | (arm64 & !windows))",
+  "supports": "(windows & x64 & !uwp) | (!windows & x64 & arm64)",
   "dependencies": [
     "boost-chrono",
     "boost-context",

--- a/ports/folly/vcpkg.json
+++ b/ports/folly/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "folly",
   "version-string": "2021.06.14.00",
-  "port-version": 3,
+  "port-version": 4,
   "description": "An open-source C++ library developed and used at Facebook. The library is UNSTABLE on Windows",
   "homepage": "https://github.com/facebook/folly",
-  "supports": "x64 | (arm64 & !windows)",
+  "supports": "!uwp & (x64 | (arm64 & !windows))",
   "dependencies": [
     "boost-chrono",
     "boost-context",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2230,7 +2230,7 @@
     },
     "folly": {
       "baseline": "2021.06.14.00",
-      "port-version": 3
+      "port-version": 4
     },
     "font-chef": {
       "baseline": "1.1.0",

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "313f1be43912dd5fa326e157ac9d2c5af1a970a7",
+      "git-tree": "695ba01277001a414cd11beccb8d7775137a1c46",
       "version-string": "2021.06.14.00",
       "port-version": 4
     },

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "313f1be43912dd5fa326e157ac9d2c5af1a970a7",
+      "version-string": "2021.06.14.00",
+      "port-version": 4
+    },
+    {
       "git-tree": "8bba15fddadde6b40f2984f6928aa24a50aa2b47",
       "version-string": "2021.06.14.00",
       "port-version": 3

--- a/versions/f-/folly.json
+++ b/versions/f-/folly.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "695ba01277001a414cd11beccb8d7775137a1c46",
+      "git-tree": "c31f74183da180ea71937f3c5b6ac0c8a3619b1b",
       "version-string": "2021.06.14.00",
       "port-version": 4
     },


### PR DESCRIPTION
vcpkg.json was missing the uwp skip but otherwise agreed. There is no ci.baseline.txt impact because:

     Error: libevent[core] is only supported on '!uwp'

In support of https://github.com/microsoft/vcpkg/pull/21502
