### PR TITLE
[gasol] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/gasol/portfile.cmake
+++ b/ports/gasol/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "UWP" ON_ARCH "arm" "arm64")
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/gasol/vcpkg.json
+++ b/ports/gasol/vcpkg.json
@@ -1,7 +1,8 @@
 {
   "name": "gasol",
-  "version-string": "2018-01-04",
-  "port-version": 1,
+  "version-date": "2018-01-04",
+  "port-version": 2,
   "description": "A general Genetic Algorithm Solver in C++",
-  "homepage": "https://github.com/PytLab/GASol "
+  "homepage": "https://github.com/PytLab/GASol",
+  "supports": "!uwp & !arm"
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -327,9 +327,6 @@ fuzzylite:x64-uwp=fail
 gainput:arm-uwp=fail
 gainput:x64-linux=fail
 gainput:x64-uwp=fail
-gasol:arm64-windows=fail
-gasol:arm-uwp=fail
-gasol:x64-uwp=fail
 
 # Requires ATL for ARM64 to be installed in CI
 gdal:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2366,7 +2366,7 @@
     },
     "gasol": {
       "baseline": "2018-01-04",
-      "port-version": 1
+      "port-version": 2
     },
     "gaussianlib": {
       "baseline": "2019-08-04",

--- a/versions/g-/gasol.json
+++ b/versions/g-/gasol.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "50bd4cd06666ebc284bb8d8157057c5a451bc11d",
+      "version-date": "2018-01-04",
+      "port-version": 2
+    },
+    {
       "git-tree": "2425692b7bd94282d858e19c2a1360c274cb3e4c",
       "version-string": "2018-01-04",
       "port-version": 1


### PR DESCRIPTION
There was no supports expression before. There was ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
