### PR TITLE
[geographiclib] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/geographiclib/portfile.cmake
+++ b/ports/geographiclib/portfile.cmake
@@ -19,13 +19,6 @@ else ()
   set (LIB_TYPE "STATIC")
 endif ()
 
-if (tools IN_LIST FEATURES)
-  vcpkg_fail_port_install (
-    MESSAGE "Cannot build GeographicLib tools for UWP"
-    ON_TARGET uwp
-  )
-endif ()
-
 vcpkg_configure_cmake (
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS

--- a/ports/geographiclib/vcpkg.json
+++ b/ports/geographiclib/vcpkg.json
@@ -1,12 +1,13 @@
 {
   "name": "geographiclib",
   "version": "1.52",
-  "port-version": 1,
+  "port-version": 2,
   "description": "GeographicLib, a C++ library for performing geographic conversions",
   "homepage": "https://geographiclib.sourceforge.io",
   "features": {
     "tools": {
-      "description": "The GeographicLib tools"
+      "description": "The GeographicLib tools",
+      "supports": "!uwp"
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2406,7 +2406,7 @@
     },
     "geographiclib": {
       "baseline": "1.52",
-      "port-version": 1
+      "port-version": 2
     },
     "geos": {
       "baseline": "3.10.0",

--- a/versions/g-/geographiclib.json
+++ b/versions/g-/geographiclib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "907cce8f399c32730fa20954780e16187bb28bd0",
+      "version": "1.52",
+      "port-version": 2
+    },
+    {
       "git-tree": "7ffcb729874bc667cba2368b92d64dc04effb73c",
       "version": "1.52",
       "port-version": 1


### PR DESCRIPTION
Separated out into its own PR because it needed to add to a "supports" in a feature.

In support of https://github.com/microsoft/vcpkg/pull/21502
