### PR TITLE
[libproxy] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "UWP")
-
 # Enable static build in UNIX
 if (VCPKG_TARGET_IS_WINDOWS)
     vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)

--- a/ports/libproxy/vcpkg.json
+++ b/ports/libproxy/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libproxy",
   "version": "0.4.17",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libproxy is a library that provides automatic proxy configuration management.",
   "homepage": "https://github.com/libproxy/libproxy",
+  "supports": "!uwp",
   "dependencies": [
     "libmodman",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3826,7 +3826,7 @@
     },
     "libproxy": {
       "baseline": "0.4.17",
-      "port-version": 1
+      "port-version": 2
     },
     "libqcow": {
       "baseline": "20210419",

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a44c6a0f0d04d6ea82c7a29c879dfd13cadb38ca",
+      "version": "0.4.17",
+      "port-version": 2
+    },
+    {
       "git-tree": "159dadd3ff9a4ba3ce1fec74a933980aa895ee02",
       "version": "0.4.17",
       "port-version": 1


### PR DESCRIPTION
There was no previous supports expression; I'm assuming given that the only block was for UWP that a dependency already did that.

In support of https://github.com/microsoft/vcpkg/pull/21502
