### PR TITLE
[pangomm] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/pangomm/portfile.cmake
+++ b/ports/pangomm/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64")
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.50/pangomm-2.50.0.tar.xz"
     FILENAME "pangomm-2.50.0.tar.xz"

--- a/ports/pangomm/vcpkg.json
+++ b/ports/pangomm/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "pangomm",
   "version": "2.50.0",
+  "port-version": 1,
   "description": "pangomm is the official C++ interface for the Pango font layout library. See, for instance, the Pango::Layout class.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pangomm",
+  "supports": "!arm",
   "dependencies": [
     "cairo",
     "cairomm",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1066,7 +1066,6 @@ paho-mqtt:arm-uwp=fail
 paho-mqtt:x64-uwp=fail
 pango:x64-windows-static=fail
 pango:x64-windows-static-md=fail
-pangomm:arm64-windows=fail
 pfring:arm64-windows=fail
 pfring:arm-uwp=fail
 pfring:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5182,7 +5182,7 @@
     },
     "pangomm": {
       "baseline": "2.50.0",
-      "port-version": 0
+      "port-version": 1
     },
     "parallel-hashmap": {
       "baseline": "1.33",

--- a/versions/p-/pangomm.json
+++ b/versions/p-/pangomm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5aebede0dd324cd7e5db1460e1d9be26d18685ba",
+      "version": "2.50.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "72d0e19b3eb2fdb5d8c60c1ae78bafc51866325d",
       "version": "2.50.0",
       "port-version": 0


### PR DESCRIPTION
There was no supports expression before so this did have ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
