### PR TITLE
[pbc] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/pbc/portfile.cmake
+++ b/ports/pbc/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_ARCH "arm" "arm64" ON_TARGET "UWP")
-
 set(PBC_VERSION 0.5.14)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)

--- a/ports/pbc/vcpkg.json
+++ b/ports/pbc/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "pbc",
-  "version-string": "0.5.14",
-  "port-version": 5,
+  "version": "0.5.14",
+  "port-version": 6,
   "description": "Pairing-Based Crypto library provides low-level routines for pairing-based cryptosystems.",
   "homepage": "https://crypto.stanford.edu/pbc",
-  "supports": "!uwp",
+  "supports": "!uwp & !arm",
   "dependencies": [
     {
       "name": "gmp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5210,7 +5210,7 @@
     },
     "pbc": {
       "baseline": "0.5.14",
-      "port-version": 5
+      "port-version": 6
     },
     "pcapplusplus": {
       "baseline": "21.11",

--- a/versions/p-/pbc.json
+++ b/versions/p-/pbc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23742abe8879e71a911c56845977ad2387e9bfa6",
+      "version": "0.5.14",
+      "port-version": 6
+    },
+    {
       "git-tree": "de531bdf83ba5c3a005655bde246d58074a28937",
       "version-string": "0.5.14",
       "port-version": 5


### PR DESCRIPTION
The support expression was missing the arm block, but there was no ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
