### PR TITLE
[pfring] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/pfring/portfile.cmake
+++ b/ports/pfring/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(MESSAGE "${PORT} currently only supports Linux and Mac platforms" ON_TARGET "Windows") 
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ntop/PF_RING
@@ -10,7 +8,7 @@ vcpkg_from_github(
         use-vcpkg-libpcap.patch
         makefile.patch
 )
- 
+
 file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     file(COPY "${SOURCE_PATH}/" DESTINATION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
@@ -27,17 +25,17 @@ vcpkg_copy_pdbs()
 # Install manually because pfring cannot set prefix
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL debug)
     set(PFRING_OBJ_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg)
-    
+
     if (VCPKG_BUILD_TYPE STREQUAL debug)
         file(GLOB_RECURSE PFRING_KO_FILES "${PFRING_OBJ_DIR}/*.ko")
         file(INSTALL ${PFRING_KO_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/share/${PORT})
-        
+
         file(INSTALL ${SOURCE_PATH}/userland/lib/pfring.h DESTINATION ${CURRENT_PACKAGES_DIR}/debug/include)
     endif()
-    
+
     file(GLOB_RECURSE PFRING_LIBS "${PFRING_OBJ_DIR}/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
     file(INSTALL ${PFRING_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-    
+
     if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         file(GLOB_RECURSE PFRING_DLLS "${PFRING_OBJ_DIR}/*${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
         file(INSTALL ${PFRING_DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
@@ -46,18 +44,18 @@ endif()
 
 if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL release)
     set(PFRING_OBJ_DIR ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel)
-    
+
     file(GLOB_RECURSE PFRING_KO_FILES "${PFRING_OBJ_DIR}/*.ko")
     file(INSTALL ${PFRING_KO_FILES} DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-    
+
     file(GLOB_RECURSE PFRING_LIBS "${PFRING_OBJ_DIR}/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
     file(INSTALL ${PFRING_LIBS} DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-    
+
     if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
         file(GLOB_RECURSE PFRING_DLLS "${PFRING_OBJ_DIR}/*${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
         file(INSTALL ${PFRING_DLLS} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
     endif()
-    
+
     file(INSTALL ${SOURCE_PATH}/userland/lib/pfring.h DESTINATION ${CURRENT_PACKAGES_DIR}/include)
 endif()
 

--- a/ports/pfring/vcpkg.json
+++ b/ports/pfring/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "pfring",
-  "version-string": "2019-10-17",
-  "port-version": 3,
+  "version-date": "2019-10-17",
+  "port-version": 4,
   "description": "PF_RING™ is a Linux kernel module and user-space framework that allows you to process packets at high-rates while providing you a consistent API for packet processing applications.",
   "homepage": "https://github.com/ntop/PF_RING",
+  "supports": "!windows",
   "dependencies": [
     "libpcap"
   ]

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1047,13 +1047,6 @@ paho-mqtt:arm-uwp=fail
 paho-mqtt:x64-uwp=fail
 pango:x64-windows-static=fail
 pango:x64-windows-static-md=fail
-pfring:arm64-windows=fail
-pfring:arm-uwp=fail
-pfring:x64-uwp=fail
-pfring:x64-windows=fail
-pfring:x64-windows-static=fail
-pfring:x64-windows-static-md=fail
-pfring:x86-windows=fail
 pfring:x64-osx=fail
 # pfring on Linux currently fails because its build scripts enable warnings as
 # errors, and warnings trigger with the Linux kernel headers in the Azure images.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5266,7 +5266,7 @@
     },
     "pfring": {
       "baseline": "2019-10-17",
-      "port-version": 3
+      "port-version": 4
     },
     "pfultz2-linq": {
       "baseline": "2019-05-14",

--- a/versions/p-/pfring.json
+++ b/versions/p-/pfring.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed3dbffb4364b80331f2b986435bad956f39ad09",
+      "version-date": "2019-10-17",
+      "port-version": 4
+    },
+    {
       "git-tree": "cc03f1b404adc6a550e8d7b9d5d36795fac6b4b7",
       "version-string": "2019-10-17",
       "port-version": 3


### PR DESCRIPTION
There was no supports expression before so there was ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
