### PR TITLE
[physx] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/physx/portfile.cmake
+++ b/ports/physx/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET MINGW)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVIDIAGameWorks/PhysX

--- a/ports/physx/vcpkg.json
+++ b/ports/physx/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "physx",
   "version-semver": "4.1.2",
+  "port-version": 1,
   "description": "The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs",
   "homepage": "https://github.com/NVIDIAGameWorks/PhysX",
+  "supports": "!mingw",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5282,7 +5282,7 @@
     },
     "physx": {
       "baseline": "4.1.2",
-      "port-version": 0
+      "port-version": 1
     },
     "picojson": {
       "baseline": "1.3.0",

--- a/versions/p-/physx.json
+++ b/versions/p-/physx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3efd7a1c7727eec4a15ba3ac6f8f013550750760",
+      "version-semver": "4.1.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "c2731461cec1f38b720c3db1038e3096957244a4",
       "version-semver": "4.1.2",
       "port-version": 0


### PR DESCRIPTION
There was no supports expression before. There was no ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
