### PR TITLE
[rsm-bsa] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/rsm-bsa/portfile.cmake
+++ b/ports/rsm-bsa/portfile.cmake
@@ -1,4 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "OSX" "UWP" ON_ARCH "x86")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -17,13 +16,6 @@ vcpkg_check_features(
     FEATURES
         xmem BSA_SUPPORT_XMEM
 )
-
-if (BSA_SUPPORT_XMEM)
-    vcpkg_fail_port_install(
-        ON_TARGET "LINUX"
-        MESSAGE "XMem support is only available for windows"
-    )
-endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/rsm-bsa/vcpkg.json
+++ b/ports/rsm-bsa/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rsm-bsa",
   "version-semver": "4.0.0",
+  "port-version": 1,
   "description": "A C++ library for working with the Bethesda archive file format",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/bsa",
   "documentation": "https://ryan-rsm-mckenzie.github.io/bsa/",
@@ -26,6 +27,7 @@
   "features": {
     "xmem": {
       "description": "Compression support for the xmem codec",
+      "supports": "windows",
       "dependencies": [
         "reproc"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6126,7 +6126,7 @@
     },
     "rsm-bsa": {
       "baseline": "4.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rsm-mmio": {
       "baseline": "1.1.0",

--- a/versions/r-/rsm-bsa.json
+++ b/versions/r-/rsm-bsa.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ab00b90abe4a8c06ede41183ef67b2208ae42297",
+      "version-semver": "4.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a41057388bf027523e46eed7031efc1fb3920c17",
       "version-semver": "4.0.0",
       "port-version": 0


### PR DESCRIPTION
Separated out because it adds a supports: to a feature.

In support of https://github.com/microsoft/vcpkg/pull/21502
