### PR TITLE
[sentry-native] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
+  "license": "MIT",
   "supports": "osx | (!arm & !uwp)",
   "dependencies": [
     {

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "sentry-native",
   "version-semver": "0.4.13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
   "supports": "!(arm | (arm64 & !osx) | uwp)",

--- a/ports/sentry-native/vcpkg.json
+++ b/ports/sentry-native/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "Sentry SDK for C, C++ and native applications.",
   "homepage": "https://sentry.io/",
-  "supports": "!(arm | (arm64 & !osx) | uwp)",
+  "supports": "osx | (!arm & !uwp)",
   "dependencies": [
     {
       "name": "curl",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6302,7 +6302,7 @@
     },
     "sentry-native": {
       "baseline": "0.4.13",
-      "port-version": 1
+      "port-version": 2
     },
     "septag-sx": {
       "baseline": "2019-05-07",

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "70d6ba1e2b717da8b2e0b057f75196ae43e1ddcc",
+      "git-tree": "0a759092f6f9e1fed6c5ea4a545b495c64a6d22c",
       "version-semver": "0.4.13",
       "port-version": 2
     },

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0a759092f6f9e1fed6c5ea4a545b495c64a6d22c",
+      "git-tree": "02e695aa00b661662dfae906a4cd55c0d8371f73",
       "version-semver": "0.4.13",
       "port-version": 2
     },

--- a/versions/s-/sentry-native.json
+++ b/versions/s-/sentry-native.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70d6ba1e2b717da8b2e0b057f75196ae43e1ddcc",
+      "version-semver": "0.4.13",
+      "port-version": 2
+    },
+    {
       "git-tree": "9fb136cdde824d2f306a1afbd99830af76446158",
       "version-semver": "0.4.13",
       "port-version": 1


### PR DESCRIPTION
vcpkg.json and portfile.cmake don't agree, but given that vcpkg.json is more restrictive than portfile.cmake, I just deleted the call.

vcpkg.json: !(arm | (arm64 & !osx) | uwp)
portfile.cmake: osx | !(arm32 | arm64 | uwp)

Putting `!(arm | (arm64 & !osx) | uwp)` into DNF:
```
!(arm | (arm64 & !osx) | uwp)                             given
!arm & !(arm64 & !osx) & !uwp                             demorgan
!arm & (!arm64 | osx) & !uwp                              demorgan
(!arm & !uwp & !arm64) | (!arm & !uwp & osx)              distribute ands over ors
(!arm32 & !arm64 & !uwp) | (!arm32 & !arm64 & !uwp & osx) definition of arm
(!arm32 & !arm64 & !uwp) | (!arm32 & !arm64 & osx)        osx implies !uwp
```

Putting `osx | !(arm32 | arm64 | uwp)` into DNF:
```
osx | !(arm32 | arm64 | uwp)                     given
osx | (!arm32 & !arm64 & !uwp)                   demorgan
```

(at which point one of the conjunctions is identical and the other is just more conditions on osx)

In support of https://github.com/microsoft/vcpkg/pull/21502
