### PR TITLE
[tiff] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -17,13 +17,6 @@ if(VCPKG_TARGET_IS_UWP)
     list(APPEND EXTRA_OPTIONS "-DUSE_WIN32_FILEIO=OFF")  # On UWP we use the unix I/O api.
 endif()
 
-if("cxx" IN_LIST FEATURES)
-    vcpkg_fail_port_install(
-        MESSAGE "Feature 'cxx' is not supported on ${VCPKG_TARGET_ARCHITECTURE}."
-        ON_ARCH arm arm64
-    )
-endif()
-
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         cxx     cxx

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "tiff",
   "version": "4.3.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "dependencies": [
@@ -17,7 +17,8 @@
   ],
   "features": {
     "cxx": {
-      "description": "Build C++ libtiffxx library"
+      "description": "Build C++ libtiffxx library",
+      "supports": "!arm"
     },
     "jpeg": {
       "description": "Support JPEG compression in TIFF image files",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6814,7 +6814,7 @@
     },
     "tiff": {
       "baseline": "4.3.0",
-      "port-version": 4
+      "port-version": 5
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29af46222dc88425d734288253d807f1a9b96419",
+      "version": "4.3.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "b416d3e62450590e19a43f04b573c65555f3bc62",
       "version": "4.3.0",
       "port-version": 4


### PR DESCRIPTION
Separated out because it adds supports to a feature.

In support of https://github.com/microsoft/vcpkg/pull/21502
