### PR TITLE
[zkpp] Remove vcpkg_fail_port_install.

### DIFF
--- a/ports/zkpp/portfile.cmake
+++ b/ports/zkpp/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_fail_port_install(ON_TARGET "Windows")
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tgockel/zookeeper-cpp

--- a/ports/zkpp/vcpkg.json
+++ b/ports/zkpp/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "A ZooKeeper client for C++.",
   "homepage": "https://github.com/tgockel/zookeeper-cpp",
-  "supports": "windows",
+  "supports": "!windows",
   "dependencies": [
     "zookeeper"
   ]

--- a/ports/zkpp/vcpkg.json
+++ b/ports/zkpp/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "zkpp",
-  "version-string": "0.2.3",
-  "port-version": 1,
+  "version": "0.2.3",
+  "port-version": 2,
   "description": "A ZooKeeper client for C++.",
   "homepage": "https://github.com/tgockel/zookeeper-cpp",
+  "supports": "windows",
   "dependencies": [
     "zookeeper"
   ]

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1489,13 +1489,6 @@ yato:arm-uwp=fail
 yato:x64-uwp=fail
 z3:arm-uwp=fail
 z3:x64-uwp=fail
-zkpp:x86-windows=fail
-zkpp:x64-windows=fail
-zkpp:x64-windows-static=fail
-zkpp:x64-windows-static-md=fail
-zkpp:arm64-windows=fail
-zkpp:x64-uwp=fail
-zkpp:arm-uwp=fail
 
 # Official downloading server of CTP library is only guaranteed to be available during trading hours of China futures market
 # Skip CI to avoid random failures

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7510,7 +7510,7 @@
     },
     "zkpp": {
       "baseline": "0.2.3",
-      "port-version": 1
+      "port-version": 2
     },
     "zlib": {
       "baseline": "1.2.11",

--- a/versions/z-/zkpp.json
+++ b/versions/z-/zkpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e61eef9283c6b74c633a173a075dca50cefd2ca5",
+      "git-tree": "bcef2196b5ca1a1cc813c22eb903e5a9677f9eab",
       "version": "0.2.3",
       "port-version": 2
     },

--- a/versions/z-/zkpp.json
+++ b/versions/z-/zkpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e61eef9283c6b74c633a173a075dca50cefd2ca5",
+      "version": "0.2.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "5d45cca2392d1a09d62bc9e2d53e1296f0bd49fc",
       "version-string": "0.2.3",
       "port-version": 1


### PR DESCRIPTION
There was no supports expression before, and there is ci.baseline.txt impact.

In support of https://github.com/microsoft/vcpkg/pull/21502
