### PR TITLE
[getopt-win32] Rename "extern C" macros as MS VC C++ headers use _END_EXTERN_C macro

### DIFF
--- a/ports/getopt-win32/getopt.h.patch
+++ b/ports/getopt-win32/getopt.h.patch
@@ -1,0 +1,50 @@
+commit 81c35ed14e07138e44b5b30f52fbc2bb26ae1fed
+Author: Max Khon <fjoe@samodelkin.net>
+Date:   Mon Jan 24 23:05:24 2022 +0700
+
+    Rename "extern C" macros as MS VC C++ headers use _END_EXTERN_C macro
+
+diff --git a/getopt.h b/getopt.h
+index 5ed4a46..5e33682 100644
+--- a/getopt.h
++++ b/getopt.h
+@@ -57,12 +57,12 @@ EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ 
+ 	// Change behavior for C\C++
+ 	#ifdef __cplusplus
+-		#define _BEGIN_EXTERN_C extern "C" {
+-		#define _END_EXTERN_C }
++		#define _GETOPT_BEGIN_EXTERN_C extern "C" {
++		#define _GETOPT_END_EXTERN_C }
+ 		#define _GETOPT_THROW throw()
+ 	#else
+-		#define _BEGIN_EXTERN_C
+-		#define _END_EXTERN_C
++		#define _GETOPT_BEGIN_EXTERN_C
++		#define _GETOPT_END_EXTERN_C
+ 		#define _GETOPT_THROW
+ 	#endif
+ 
+@@ -81,7 +81,7 @@ EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ 	#include <string.h>
+ 	#include <wchar.h>
+ 
+-_BEGIN_EXTERN_C
++_GETOPT_BEGIN_EXTERN_C
+ 
+ 	extern _GETOPT_API int optind;
+ 	extern _GETOPT_API int opterr;
+@@ -113,10 +113,10 @@ _BEGIN_EXTERN_C
+ 	extern _GETOPT_API int getopt_long_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;
+ 	extern _GETOPT_API int getopt_long_only_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;	
+ 	
+-_END_EXTERN_C
++_GETOPT_END_EXTERN_C
+ 
+-	#undef _BEGIN_EXTERN_C
+-	#undef _END_EXTERN_C
++	#undef _GETOPT_BEGIN_EXTERN_C
++	#undef _GETOPT_END_EXTERN_C
+ 	#undef _GETOPT_THROW
+ 	#undef _GETOPT_API
+ 

--- a/ports/getopt-win32/portfile.cmake
+++ b/ports/getopt-win32/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     REF 0.1
     SHA512 40e2a901241a5d751cec741e5de423c8f19b105572c7cae18adb6e69be0b408efc6c9a2ecaeb62f117745eac0d093f30d6b91d88c1a27e1f7be91f0e84fdf199
     HEAD_REF master
+    PATCHES getopt.h.patch
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)

--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "getopt-win32",
   "version-string": "0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "An implementation of getopt.",
   "homepage": "https://github.com/libimobiledevice-win32",
+  "license": "LGPL-3.0-only",
   "supports": "windows"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2422,7 +2422,7 @@
     },
     "getopt-win32": {
       "baseline": "0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "gettext": {
       "baseline": "0.21",

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93d03f637c26f2efa154dfd7c3efb02074cf5eda",
+      "version-string": "0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "d4b235f13a89dbec23f09caa05c7b71c176cfab8",
       "version-string": "0.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

Example (\<memory> header):

```
// SPIN LOCKS
_EXTERN_C
_CRTIMP2_PURE void __cdecl _Lock_shared_ptr_spin_lock();
_CRTIMP2_PURE void __cdecl _Unlock_shared_ptr_spin_lock();
_END_EXTERN_C
```

- #### What does your PR fix?  
Fixes the use of getopt-win32 in C++ programs

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
