### PR TITLE
Arpack library

### DIFF
--- a/ports/arpack-ng/arpack-msc.patch
+++ b/ports/arpack-ng/arpack-msc.patch
@@ -1,0 +1,128 @@
+diff --git a/ICB/arpack.h b/ICB/arpack.h
+index 865e269..f9f1053 100644
+--- a/ICB/arpack.h
++++ b/ICB/arpack.h
+@@ -7,8 +7,8 @@
+ extern "C" {
+ #endif
+ 
+-void cnaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, float tol, float _Complex* resid, a_int ncv, float _Complex* v, a_int ldv, a_int* iparam, a_int* ipntr, float _Complex* workd, float _Complex* workl, a_int lworkl, float* rwork, a_int* info);
+-void cneupd_c(a_int rvec, char const* howmny, a_int const* select, float _Complex* d, float _Complex* z, a_int ldz, float _Complex sigma, float _Complex* workev, char const* bmat, a_int n, char const* which, a_int nev, float tol, float _Complex* resid, a_int ncv, float _Complex* v, a_int ldv, a_int* iparam, a_int* ipntr, float _Complex* workd, float _Complex* workl, a_int lworkl, float* rwork, a_int* info);
++void cnaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, float tol, a_fcomplex* resid, a_int ncv, a_fcomplex* v, a_int ldv, a_int* iparam, a_int* ipntr, a_fcomplex* workd, a_fcomplex* workl, a_int lworkl, float* rwork, a_int* info);
++void cneupd_c(a_int rvec, char const* howmny, a_int const* select, a_fcomplex* d, a_fcomplex* z, a_int ldz, a_fcomplex sigma, a_fcomplex* workev, char const* bmat, a_int n, char const* which, a_int nev, float tol, a_fcomplex* resid, a_int ncv, a_fcomplex* v, a_int ldv, a_int* iparam, a_int* ipntr, a_fcomplex* workd, a_fcomplex* workl, a_int lworkl, float* rwork, a_int* info);
+ void dnaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, double tol, double* resid, a_int ncv, double* v, a_int ldv, a_int* iparam, a_int* ipntr, double* workd, double* workl, a_int lworkl, a_int* info);
+ void dneupd_c(a_int rvec, char const* howmny, a_int const* select, double* dr, double* di, double* z, a_int ldz, double sigmar, double sigmai, double * workev, char const* bmat, a_int n, char const* which, a_int nev, double tol, double* resid, a_int ncv, double* v, a_int ldv, a_int* iparam, a_int* ipntr, double* workd, double* workl, a_int lworkl, a_int* info);
+ void dsaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, double tol, double* resid, a_int ncv, double* v, a_int ldv, a_int* iparam, a_int* ipntr, double* workd, double* workl, a_int lworkl, a_int* info);
+@@ -17,8 +17,8 @@ void snaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int ne
+ void sneupd_c(a_int rvec, char const* howmny, a_int const* select, float* dr, float* di, float* z, a_int ldz, float sigmar, float sigmai, float * workev, char const* bmat, a_int n, char const* which, a_int nev, float tol, float* resid, a_int ncv, float* v, a_int ldv, a_int* iparam, a_int* ipntr, float* workd, float* workl, a_int lworkl, a_int* info);
+ void ssaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, float tol, float* resid, a_int ncv, float* v, a_int ldv, a_int* iparam, a_int* ipntr, float* workd, float* workl, a_int lworkl, a_int* info);
+ void sseupd_c(a_int rvec, char const* howmny, a_int const* select, float* d, float* z, a_int ldz, float sigma, char const* bmat, a_int n, char const* which, a_int nev, float tol, float* resid, a_int ncv, float* v, a_int ldv, a_int* iparam, a_int* ipntr, float* workd, float* workl, a_int lworkl, a_int* info);
+-void znaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, double tol, double _Complex* resid, a_int ncv, double _Complex* v, a_int ldv, a_int* iparam, a_int* ipntr, double _Complex* workd, double _Complex* workl, a_int lworkl, double* rwork, a_int* info);
+-void zneupd_c(a_int rvec, char const* howmny, a_int const* select, double _Complex* d, double _Complex* z, a_int ldz, double _Complex sigma, double _Complex* workev, char const* bmat, a_int n, char const* which, a_int nev, double tol, double _Complex* resid, a_int ncv, double _Complex* v, a_int ldv, a_int* iparam, a_int* ipntr, double _Complex* workd, double _Complex* workl, a_int lworkl, double* rwork, a_int* info);
++void znaupd_c(a_int* ido, char const* bmat, a_int n, char const* which, a_int nev, double tol, a_dcomplex* resid, a_int ncv, a_dcomplex* v, a_int ldv, a_int* iparam, a_int* ipntr, a_dcomplex* workd, a_dcomplex* workl, a_int lworkl, double* rwork, a_int* info);
++void zneupd_c(a_int rvec, char const* howmny, a_int const* select, a_dcomplex* d, a_dcomplex* z, a_int ldz, a_dcomplex sigma, a_dcomplex* workev, char const* bmat, a_int n, char const* which, a_int nev, double tol, a_dcomplex* resid, a_int ncv, a_dcomplex* v, a_int ldv, a_int* iparam, a_int* ipntr, a_dcomplex* workd, a_dcomplex* workl, a_int lworkl, double* rwork, a_int* info);
+ 
+ #ifdef  __cplusplus
+ }
+diff --git a/ICB/arpack.hpp b/ICB/arpack.hpp
+index 4d753d1..7e16cee 100644
+--- a/ICB/arpack.hpp
++++ b/ICB/arpack.hpp
+@@ -186,10 +186,10 @@ inline void naupd(a_int& ido, bmat const bmat_option, a_int n,
+                   float* rwork, a_int& info) {
+   internal::cnaupd_c(&ido, internal::convert_to_char(bmat_option), n,
+                      internal::convert_to_char(ritz_option), nev, tol,
+-                     reinterpret_cast<_Complex float*>(resid), ncv,
+-                     reinterpret_cast<_Complex float*>(v), ldv, iparam, ipntr,
+-                     reinterpret_cast<_Complex float*>(workd),
+-                     reinterpret_cast<_Complex float*>(workl), lworkl,
++                     reinterpret_cast<a_fcomplex*>(resid), ncv,
++                     reinterpret_cast<a_fcomplex*>(v), ldv, iparam, ipntr,
++                     reinterpret_cast<a_fcomplex*>(workd),
++                     reinterpret_cast<a_fcomplex*>(workl), lworkl,
+                      rwork, &info);
+ }
+ 
+@@ -203,16 +203,16 @@ inline void neupd(a_int rvec, howmny const howmny_option, a_int* select,
+                   a_int lworkl, float* rwork, a_int& info) {
+   std::complex<float> sigma2 = sigma;
+   internal::cneupd_c(rvec, internal::convert_to_char(howmny_option), select,
+-                     reinterpret_cast<_Complex float*>(d),
+-                     reinterpret_cast<_Complex float*>(z), ldz,
+-                     *reinterpret_cast<_Complex float*>(&sigma2),
+-                     reinterpret_cast<_Complex float*>(workev),
++                     reinterpret_cast<a_fcomplex*>(d),
++                     reinterpret_cast<a_fcomplex*>(z), ldz,
++                     *reinterpret_cast<a_fcomplex*>(&sigma2),
++                     reinterpret_cast<a_fcomplex*>(workev),
+                      internal::convert_to_char(bmat_option), n,
+                      internal::convert_to_char(ritz_option), nev, tol,
+-                     reinterpret_cast<_Complex float*>(resid), ncv,
+-                     reinterpret_cast<_Complex float*>(v), ldv, iparam, ipntr,
+-                     reinterpret_cast<_Complex float*>(workd),
+-                     reinterpret_cast<_Complex float*>(workl), lworkl,
++                     reinterpret_cast<a_fcomplex*>(resid), ncv,
++                     reinterpret_cast<a_fcomplex*>(v), ldv, iparam, ipntr,
++                     reinterpret_cast<a_fcomplex*>(workd),
++                     reinterpret_cast<a_fcomplex*>(workl), lworkl,
+                      rwork, &info);
+ }
+ 
+@@ -224,10 +224,10 @@ inline void naupd(a_int& ido, bmat const bmat_option, a_int n,
+                   double* rwork, a_int& info) {
+   internal::znaupd_c(&ido, internal::convert_to_char(bmat_option), n,
+                      internal::convert_to_char(ritz_option), nev, tol,
+-                     reinterpret_cast<_Complex double*>(resid), ncv,
+-                     reinterpret_cast<_Complex double*>(v), ldv, iparam, ipntr,
+-                     reinterpret_cast<_Complex double*>(workd),
+-                     reinterpret_cast<_Complex double*>(workl), lworkl,
++                     reinterpret_cast<a_dcomplex*>(resid), ncv,
++                     reinterpret_cast<a_dcomplex*>(v), ldv, iparam, ipntr,
++                     reinterpret_cast<a_dcomplex*>(workd),
++                     reinterpret_cast<a_dcomplex*>(workl), lworkl,
+                      rwork, &info);
+ }
+ 
+@@ -241,16 +241,16 @@ inline void neupd(a_int rvec, howmny const howmny_option, a_int* select,
+                   a_int lworkl, double* rwork, a_int& info) {
+   std::complex<double> sigma2 = sigma;
+   internal::zneupd_c(rvec, internal::convert_to_char(howmny_option), select,
+-                     reinterpret_cast<_Complex double*>(d),
+-                     reinterpret_cast<_Complex double*>(z), ldz,
+-                     *reinterpret_cast<_Complex double*>(&sigma2),
+-                     reinterpret_cast<_Complex double*>(workev),
++                     reinterpret_cast<a_dcomplex*>(d),
++                     reinterpret_cast<a_dcomplex*>(z), ldz,
++                     *reinterpret_cast<a_dcomplex*>(&sigma2),
++                     reinterpret_cast<a_dcomplex*>(workev),
+                      internal::convert_to_char(bmat_option), n,
+                      internal::convert_to_char(ritz_option), nev, tol,
+-                     reinterpret_cast<_Complex double*>(resid), ncv,
+-                     reinterpret_cast<_Complex double*>(v), ldv, iparam, ipntr,
+-                     reinterpret_cast<_Complex double*>(workd),
+-                     reinterpret_cast<_Complex double*>(workl), lworkl,
++                     reinterpret_cast<a_dcomplex*>(resid), ncv,
++                     reinterpret_cast<a_dcomplex*>(v), ldv, iparam, ipntr,
++                     reinterpret_cast<a_dcomplex*>(workd),
++                     reinterpret_cast<a_dcomplex*>(workl), lworkl,
+                      rwork, &info);
+ }
+ }  // namespace arpack
+diff --git a/arpackdef.h.in b/arpackdef.h.in
+index d9e0143..9e604be 100644
+--- a/arpackdef.h.in
++++ b/arpackdef.h.in
+@@ -13,5 +13,13 @@
+ #define a_int            int
+ #define a_uint  unsigned int
+ #endif
++#ifdef _MSC_VER
++#include <complex.h>
++#define a_fcomplex _Fcomplex
++#define a_dcomplex _Dcomplex
++#else
++#define a_fcomplex float _Complex
++#define a_dcomplex double _Complex
++#endif
+ 
+ #endif

--- a/ports/arpack-ng/portfile.cmake
+++ b/ports/arpack-ng/portfile.cmake
@@ -1,0 +1,67 @@
+#TODO: Features to add:
+# USE_XBLAS??? extended precision blas. needs xblas
+# LAPACKE should be its own PORT
+# USE_OPTIMIZED_LAPACK (Probably not what we want. Does a find_package(LAPACK): probably for LAPACKE only builds _> own port?)
+# LAPACKE Builds LAPACKE
+# LAPACKE_WITH_TMG Build LAPACKE with tmglib routines
+include(vcpkg_find_fortran)
+SET(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+set(arpack_ver 3.8.0)
+
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO  "opencollab/arpack-ng"
+  REF "${arpack_ver}"
+  SHA512 "8969c74c4c0459ea2d29ea49d5260f668fd33f73886df0da78a42a94aea93c9f5fb70f5df035266db68807ab09a92c13487a7a4e6ca64922145aade8a148a2de"
+  HEAD_REF master
+  PATCHES "arpack-msc.patch" # Patch for support for MSVC compiler
+)
+
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+  set(ENV{FFLAGS} "$ENV{FFLAGS} -fPIC")
+endif()
+
+vcpkg_find_fortran(FORTRAN_CMAKE)
+
+vcpkg_configure_cmake(
+  SOURCE_PATH ${SOURCE_PATH}
+  PREFER_NINJA
+  OPTIONS
+  "-DICB=ON"
+  ${FORTRAN_CMAKE}
+  )
+
+vcpkg_install_cmake()
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME arpack-ng
+  CONFIG_PATH lib/cmake/arpack-ng
+  NO_PREFIX_CORRECTION)
+
+#
+# Add relocation information to the generated CMake files
+#
+set(fixedfile "${CURRENT_PACKAGES_DIR}/share/arpack-ng/arpack-ng-config.cmake")
+file(READ "${fixedfile}" _contents)
+string(REPLACE "\${_IMPORT_PREFIX}" "\${_ARPACK_SELF_DIR}/../../" _contents "${_contents}")
+string(REPLACE "INTERFACE_" "INTERFACE_LINK_DIRECTORIES \"\${libdir}\" INTERFACE_" _contents "${_contents}")
+set(_contents "get_filename_component(_ARPACK_SELF_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)\n${_contents}")
+file(WRITE "${fixedfile}" "${_contents}")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_fixup_pkgconfig()
+
+# remove debug includes
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/libarpack.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/libarpack.lib" "${CURRENT_PACKAGES_DIR}/lib/arpack.lib")
+  endif()
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/libarpack.lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/libarpack.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/arpack.lib")
+  endif()
+endif()

--- a/ports/arpack-ng/portfile.cmake
+++ b/ports/arpack-ng/portfile.cmake
@@ -24,15 +24,14 @@ endif()
 
 vcpkg_find_fortran(FORTRAN_CMAKE)
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
   SOURCE_PATH ${SOURCE_PATH}
-  PREFER_NINJA
   OPTIONS
   "-DICB=ON"
   ${FORTRAN_CMAKE}
   )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
   PACKAGE_NAME arpack-ng

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -5,7 +5,12 @@
   "description": "ARPACK",
   "homepage": "https://github.com/opencollab/arpack-ng",
   "dependencies": [
-	"blas",
+	  "blas",
+    "lapack",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake-config",
       "host": true

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "arpack-ng",
+  "version-semver": "3.8.0",
+  "port-version": 6,
+  "description": "ARPACK",
+  "homepage": "https://github.com/opencollab/arpack-ng",
+  "dependencies": [
+	"blas",
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-gfortran",
+      "platform": "windows"
+    }
+  ]
+}

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arpack-ng",
   "version-semver": "3.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "ARPACK",
   "homepage": "https://github.com/opencollab/arpack-ng",
   "dependencies": [

--- a/ports/arpack-ng/vcpkg.json
+++ b/ports/arpack-ng/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "arpack-ng",
   "version-semver": "3.8.0",
-  "port-version": 6,
+  "port-version": 1,
   "description": "ARPACK",
   "homepage": "https://github.com/opencollab/arpack-ng",
   "dependencies": [
-	  "blas",
+    "blas",
     "lapack",
     {
       "name": "vcpkg-cmake",

--- a/versions/a-/arpack-ng.json
+++ b/versions/a-/arpack-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "103fb9f66b42e9bfa5b501e7702b5ab1f0ced0ea",
+      "version-semver": "3.8.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "f94031ed62523e2055eb6af755ff19bafc2e39f5",
       "version-semver": "3.8.0",
       "port-version": 1

--- a/versions/a-/arpack-ng.json
+++ b/versions/a-/arpack-ng.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "f94031ed62523e2055eb6af755ff19bafc2e39f5",
+      "version-semver": "3.8.0",
+      "port-version": 1
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -164,6 +164,10 @@
       "baseline": "10.6.2",
       "port-version": 3
     },
+    "arpack-ng": {
+      "baseline": "3.8.0",
+      "port-version": 1
+    },
     "arrayfire": {
       "baseline": "3.8.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -166,7 +166,7 @@
     },
     "arpack-ng": {
       "baseline": "3.8.0",
-      "port-version": 1
+      "port-version": 2
     },
     "arrayfire": {
       "baseline": "3.8.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  This pull request adds a new port to vcpkg, including Arpack, a fortran library for solving eigenvalue problems.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Any on Windows, Arpack's cmake file is broken on other platforms. I am investigating whether a pkgconfig-based alternative would work there.
  I have not updated ci.baseline.txt

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes