### PR TITLE
[benchmark] Remove vcpkg_fail_port_install. (#22728)

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,6 +1,3 @@
-#https://github.com/google/benchmark/issues/661
-vcpkg_fail_port_install(ON_TARGET "uwp")
-
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,6 +1,8 @@
 {
+  "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
   "name": "benchmark",
   "version-semver": "1.6.0",
+  "port-version": 1,
   "description": "A library to support the benchmarking of functions, similar to unit-tests.",
   "homepage": "https://github.com/google/benchmark",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -418,7 +418,7 @@
     },
     "benchmark": {
       "baseline": "1.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "bento4": {
       "baseline": "1.5.1",


### PR DESCRIPTION
A comment was moved from portfile.cmake to vcpkg.json.

In support of https://github.com/microsoft/vcpkg/pull/21502

This replays https://github.com/microsoft/vcpkg/pull/22728 which was accidentially reverted in a merge conflict resolution in https://github.com/microsoft/vcpkg/pull/22770
