### PR TITLE
[Fizz] fix libsodium dependency

### DIFF
--- a/ports/fizz/0001-fix-libsodium.patch
+++ b/ports/fizz/0001-fix-libsodium.patch
@@ -1,0 +1,35 @@
+diff --git a/fizz/CMakeLists.txt b/fizz/CMakeLists.txt
+index 471d61a..b3cfed2 100644
+--- a/fizz/CMakeLists.txt
++++ b/fizz/CMakeLists.txt
+@@ -61,7 +61,7 @@ endif()
+ 
+ include(CheckAtomic)
+ 
+-find_package(Sodium REQUIRED)
++find_package(unofficial-sodium CONFIG REQUIRED)
+ 
+ SET(FIZZ_SHINY_DEPENDENCIES "")
+ SET(FIZZ_LINK_LIBRARIES "")
+@@ -246,7 +246,7 @@ target_link_libraries(fizz
+   PUBLIC
+     ${FOLLY_LIBRARIES}
+     ${OPENSSL_LIBRARIES}
+-    sodium
++    unofficial-sodium::sodium
+     Threads::Threads
+     ZLIB::ZLIB
+   PRIVATE
+diff --git a/fizz/cmake/fizz-config.cmake.in b/fizz/cmake/fizz-config.cmake.in
+index 679b0e6..b28750f 100644
+--- a/fizz/cmake/fizz-config.cmake.in
++++ b/fizz/cmake/fizz-config.cmake.in
+@@ -26,7 +26,7 @@ endif()
+ set(FIZZ_LIBRARIES fizz::fizz)
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(Sodium)
++find_dependency(unofficial-sodium CONFIG REQUIRED)
+ find_dependency(folly CONFIG)
+ find_dependency(ZLIB)
+ 

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -30,24 +30,6 @@ vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/fizz)
 vcpkg_copy_pdbs()
 
-# Release fizz-targets.cmake does not link to the right libraries in debug mode.
-# We substitute with generator expressions so that the right libraries are linked for debug and release.
-set(FIZZ_TARGETS_CMAKE "${CURRENT_PACKAGES_DIR}/share/fizz/fizz-targets.cmake")
-FILE(READ ${FIZZ_TARGETS_CMAKE} _contents)
-STRING(REPLACE "\${_IMPORT_PREFIX}/lib/glog.lib" "glog::glog" _contents "${_contents}")
-STRING(REPLACE "\${_IMPORT_PREFIX}/lib/" "\${_IMPORT_PREFIX}/\$<\$<CONFIG:DEBUG>:debug/>lib/" _contents "${_contents}")
-STRING(REPLACE "\${_IMPORT_PREFIX}/debug/lib/" "\${_IMPORT_PREFIX}/\$<\$<CONFIG:DEBUG>:debug/>lib/" _contents "${_contents}")
-STRING(REPLACE "-vc140-mt.lib" "-vc140-mt\$<\$<CONFIG:DEBUG>:-gd>.lib" _contents "${_contents}")
-FILE(WRITE ${FIZZ_TARGETS_CMAKE} "${_contents}")
-FILE(READ ${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake _contents)
-FILE(WRITE ${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake
-"include(CMakeFindDependencyMacro)
-find_dependency(Threads)
-find_dependency(glog CONFIG)
-find_dependency(gflags CONFIG REQUIRED)
-find_dependency(ZLIB)
-${_contents}")
-
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake" "lib/cmake/fizz" "share/fizz")
 
 file(REMOVE_RECURSE

--- a/ports/fizz/portfile.cmake
+++ b/ports/fizz/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-zlib.patch
+        0001-fix-libsodium.patch
 )
 
 # Prefer installed config files
@@ -28,6 +29,24 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/fizz)
 vcpkg_copy_pdbs()
+
+# Release fizz-targets.cmake does not link to the right libraries in debug mode.
+# We substitute with generator expressions so that the right libraries are linked for debug and release.
+set(FIZZ_TARGETS_CMAKE "${CURRENT_PACKAGES_DIR}/share/fizz/fizz-targets.cmake")
+FILE(READ ${FIZZ_TARGETS_CMAKE} _contents)
+STRING(REPLACE "\${_IMPORT_PREFIX}/lib/glog.lib" "glog::glog" _contents "${_contents}")
+STRING(REPLACE "\${_IMPORT_PREFIX}/lib/" "\${_IMPORT_PREFIX}/\$<\$<CONFIG:DEBUG>:debug/>lib/" _contents "${_contents}")
+STRING(REPLACE "\${_IMPORT_PREFIX}/debug/lib/" "\${_IMPORT_PREFIX}/\$<\$<CONFIG:DEBUG>:debug/>lib/" _contents "${_contents}")
+STRING(REPLACE "-vc140-mt.lib" "-vc140-mt\$<\$<CONFIG:DEBUG>:-gd>.lib" _contents "${_contents}")
+FILE(WRITE ${FIZZ_TARGETS_CMAKE} "${_contents}")
+FILE(READ ${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake _contents)
+FILE(WRITE ${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake
+"include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+find_dependency(glog CONFIG)
+find_dependency(gflags CONFIG REQUIRED)
+find_dependency(ZLIB)
+${_contents}")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fizz/fizz-config.cmake" "lib/cmake/fizz" "share/fizz")
 

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fizz",
   "version-string": "2021.06.14.00",
+  "port-version": 1,
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",
   "dependencies": [

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fizz",
-  "version-string": "2021.06.14.00",
+  "version-date": "2021.06.14.00",
   "port-version": 1,
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",

--- a/ports/fizz/vcpkg.json
+++ b/ports/fizz/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "fizz",
-  "version-date": "2021.06.14.00",
+  "version-string": "2021.06.14.00",
   "port-version": 1,
   "description": "a TLS 1.3 implementation by Facebook",
   "homepage": "https://github.com/facebookincubator/fizz",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2174,7 +2174,7 @@
     },
     "fizz": {
       "baseline": "2021.06.14.00",
-      "port-version": 0
+      "port-version": 1
     },
     "flann": {
       "baseline": "2019-04-07",

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e9c79812af8e00ec6bc386ff641cf3c2daaca42",
+      "version-string": "2021.06.14.00",
+      "port-version": 1
+    },
+    {
       "git-tree": "522047f79c1dde2cfbc509a21b4f1faf910efb12",
       "version-string": "2021.06.14.00",
       "port-version": 0

--- a/versions/f-/fizz.json
+++ b/versions/f-/fizz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1e9c79812af8e00ec6bc386ff641cf3c2daaca42",
+      "git-tree": "8472de52ae8a7914ab4c87e23be8250ae497a0aa",
       "version-string": "2021.06.14.00",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes fizz libsodium dependency  #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <linux>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
