### PR TITLE
[libheif] Fix usage

### DIFF
--- a/ports/libheif/portfile.cmake
+++ b/ports/libheif/portfile.cmake
@@ -25,6 +25,12 @@ if(NOT VCPKG_BUILD_TYPE)
 endif()
 vcpkg_fixup_pkgconfig()
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif.h" "!defined(LIBHEIF_STATIC_BUILD)" "1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libheif/heif.h" "!defined(LIBHEIF_STATIC_BUILD)" "0")
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libheif",
   "version": "1.12.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
   "dependencies": [

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
+  "license": "GPL-3.0-only",
   "dependencies": [
     {
       "name": "gdk-pixbuf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3554,7 +3554,7 @@
     },
     "libheif": {
       "baseline": "1.12.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libhsplasma": {
       "baseline": "2021.06.08",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e4e446a1e44ae10312f84f304438f287f468f199",
+      "git-tree": "73b2b4b29035aa22da5ccd0c4c46dbb6e5516424",
       "version": "1.12.0",
       "port-version": 2
     },

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4e446a1e44ae10312f84f304438f287f468f199",
+      "version": "1.12.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "738b6fc8b77a7fa90cd5966358dc3be684a832c1",
       "version": "1.12.0",
       "port-version": 1


### PR DESCRIPTION
Fix definiton `LIBHEIF_API` value.
```cpp
#if defined(_MSC_VER) && !defined(LIBHEIF_STATIC_BUILD)
#ifdef LIBHEIF_EXPORTS
#define LIBHEIF_API __declspec(dllexport)
#else
#define LIBHEIF_API __declspec(dllimport)
#endif
#elif defined(HAVE_VISIBILITY) && HAVE_VISIBILITY
#ifdef LIBHEIF_EXPORTS
#define LIBHEIF_API __attribute__((__visibility__("default")))
#else
#define LIBHEIF_API
#endif
#else
#define LIBHEIF_API
#endif
```

Fixes #13354 #18107.