### PR TITLE
[libtins] Fix usage

### DIFF
--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -34,6 +34,12 @@ get_filename_component(LIBTINS_CMAKE_DIR "${LIBTINS_CMAKE_DIR}" PATH)
 set(LIBTINS_INCLUDE_DIRS "${LIBTINS_CMAKE_DIR}/include")
 ]])
 
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/tins/macros.h" "!defined(TINS_STATIC)" "1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/tins/macros.h" "!defined(TINS_STATIC)" "0")
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright

--- a/ports/libtins/vcpkg.json
+++ b/ports/libtins/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libtins",
   "version": "4.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "High-level, multiplatform C++ network packet sniffing and crafting library",
+  "license": "BSD-2-Clause",
   "supports": "!uwp",
   "dependencies": [
     "boost-any",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3994,7 +3994,7 @@
     },
     "libtins": {
       "baseline": "4.3",
-      "port-version": 4
+      "port-version": 5
     },
     "libtomcrypt": {
       "baseline": "1.18.2",

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9abc8b1a535ffaf99a680412cfd8f0c743c3fc6d",
+      "version": "4.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "de1a1dc51c90ca57412fe5f8d57eeef42a41ec74",
       "version": "4.3",
       "port-version": 4


### PR DESCRIPTION
Fix definiton `TINS_API` value.
```cpp
#if defined(_WIN32) && !defined(TINS_STATIC)
    // Export/import symbols, depending on whether we're compiling or consuming the lib
    #ifdef tins_EXPORTS
        #define TINS_API __declspec(dllexport)
    #else
        #define TINS_API __declspec(dllimport)
    #endif // tins_EXPORTS
#else 
    // Otherwise, default this to an empty macro
    #define TINS_API
#endif // _WIN32 && !TINS_STATIC
```

Fixes #11904.