### PR TITLE
[opencv4] Disable building cpufeatures since it conflict with libwebp

### DIFF
--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -469,6 +469,7 @@ vcpkg_cmake_configure(
         -DWITH_OPENCLAMDBLAS=OFF
         -DWITH_TBB=${WITH_TBB}
         -DWITH_OPENJPEG=OFF
+        -DWITH_CPUFEATURES=OFF
         ###### BUILD_options (mainly modules which require additional libraries)
         -DBUILD_opencv_ovis=${BUILD_opencv_ovis}
         -DBUILD_opencv_dnn=${BUILD_opencv_dnn}

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.4",
-  "port-version": 2,
+  "port-version": 3,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4994,7 +4994,7 @@
     },
     "opencv4": {
       "baseline": "4.5.4",
-      "port-version": 2
+      "port-version": 3
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b170a087d34521462cd247a24f230627a272975e",
+      "version": "4.5.4",
+      "port-version": 3
+    },
+    {
       "git-tree": "537abba5a070d173cf42510f86ff4ffe057dd77f",
       "version": "4.5.4",
       "port-version": 2


### PR DESCRIPTION
Disable building cpufeatures as it is the same as provided by libwebp.
They are use the same source (in Android NDK),

Upstream issue: https://github.com/opencv/opencv/issues/9155 but it didn't completely fix it.

Fixes https://github.com/microsoft/vcpkg/issues/19106. 