### PR TITLE
[vcpkg] Speed up Windows configure builds

### DIFF
--- a/docs/maintainers/internal/z_vcpkg_apply_patches.md
+++ b/docs/maintainers/internal/z_vcpkg_apply_patches.md
@@ -9,6 +9,7 @@ Apply a set of patches to a source tree.
 ```cmake
 z_vcpkg_apply_patches(
     SOURCE_PATH <path-to-source>
+    [RESULT <result-var>]
     [QUIET]
     PATCHES <patch>...
 )
@@ -16,6 +17,8 @@ z_vcpkg_apply_patches(
 
 The `<path-to-source>` should be set to `${SOURCE_PATH}` by convention,
 and is the path to apply the patches in.
+
+If `RESULT` is passed the result (TRUE/FALSE) is saved in the output variable.
 
 `z_vcpkg_apply_patches` will take the list of `<patch>`es,
 which are by default relative to the port directory,

--- a/ports/gettext/portfile.cmake
+++ b/ports/gettext/portfile.cmake
@@ -83,7 +83,7 @@ function(build_libintl_only)
     if(DEFINED arg_BUILD_TYPE)
         set(VCPKG_BUILD_TYPE "${arg_BUILD_TYPE}")
     endif()
-    vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}/gettext-runtime"
+    vcpkg_configure_make(SOURCE_PATH "${SOURCE_PATH}" PROJECT_SUBPATH "gettext-runtime"
         DETERMINE_BUILD_TRIPLET
         USE_WRAPPERS
         ADD_BIN_TO_PATH # So configure can check for working iconv

--- a/ports/gettext/vcpkg.json
+++ b/ports/gettext/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gettext",
   "version": "0.21",
-  "port-version": 9,
+  "port-version": 10,
   "description": "GNU gettext provides libintl and a set of tools to help produce multi-lingual messages.",
   "homepage": "https://www.gnu.org/software/gettext/",
   "dependencies": [

--- a/scripts/Makefile.in.patch
+++ b/scripts/Makefile.in.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile.in b/Makefile.in
+index 03de1f1..daacada 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -774,7 +774,6 @@ distclean-compile:
+ 
+-$(am__depfiles_remade):
++$(am__depfiles_remade)&:
+- 	@$(MKDIR_P) $(@D)
+-	@echo '# dummy' >$@-t && $(am__mv) $@-t $@
++	@for f in $(am__depfiles_remade); do if ! test -f $$f; then test -d $${f%/*} || $(MKDIR_P) $${f%/*}; echo '# dummy' >$$f; fi; done
+ 
+ am--depfiles: $(am__depfiles_remade)
+ 

--- a/scripts/ltmain.sh.patch
+++ b/scripts/ltmain.sh.patch
@@ -1,0 +1,25 @@
+diff --git a/ltmain.sh b/ltmain.sh
+index 000f40a..3898fca 100644
+--- a/ltmain.sh
++++ b/ltmain.sh
+@@ -31,3 +31,20 @@ func_relative_path ()
+ 
++quote_subst()
++{
++    var=$1
++    arg=$2
++
++    quote_subst_result=
++    for ((i = 0; i < ${#arg}; i++)) do
++        c=${arg:$i:1}
++        case $c in
++        [\\\'\"\$])
++            c=\\$c;;
++        esac
++        quote_subst_result+=$c
++    done
++    eval "$var=\$quote_subst_result"
++}
++
+ PROGRAM=libtool
+ PACKAGE=libtool

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2482,7 +2482,7 @@
     },
     "gettext": {
       "baseline": "0.21",
-      "port-version": 9
+      "port-version": 10
     },
     "gettimeofday": {
       "baseline": "2017-10-14",

--- a/versions/g-/gettext.json
+++ b/versions/g-/gettext.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e977e27521670aa684f7e2416329c5ad9be7d5e",
+      "version": "0.21",
+      "port-version": 10
+    },
+    {
       "git-tree": "5bf45743516e2ae999eb14017370828e237ad533",
       "version": "0.21",
       "port-version": 9


### PR DESCRIPTION
**Describe the pull request**
- patch am__depfiles to create all .Plo files in one external program execution
- patch libtool to not execute sed on every argument containing quotes (")
  libtool does that multiple time for each such argument
- use deplibs_check_method=pass_all so that libtool does not iterate over LIBPATH
  for each -lfoo argument
- use libpath=none so that libtool does not iterate over PATH when linking

Some numbers:

- gettext build stage executes 8.5x faster (libtool patch)
- gettext[tools] build stage executes 3x faster (libtool patch)
- libmagic build stage executes 2x faster (libtool patch)
- libiconv and hwloc build stage executes almost 2x faster (libtool patch)
- mpfr build stage executes 2.5x faster (libtool patch)
- libmesh configure stage executes 3x faster (am__depfiles patch) - runs for 1.5 hours without the patch

The following table lists stage execution times for "x64-windows-release" triplet (only release builds):

<google-sheets-html-origin style="font-style: normal; font-variant-caps: normal; font-weight: normal; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">

port | config | build | total (min) | config | build | total (min) | total (%%)
-- | -- | -- | -- | -- | -- | -- | --
  | baseline | baseline | baseline | final | final | final |  
farmhash | 326.013 | 44.684 | 10.29 | 273.686 | 39.77 | 7.577 | 73.64
fribidi | 241.129 | 729.832 | 19.92 | 257.61 | 619.219 | 17.37 | 87.2
gettext[tools] | 3311.679 | 6872.753 | 176.82 | 2460.31 | **1963.48** | 78.72 | 44.52
gettext | 1269.961 | 420.861 | 29.01 | 1068.38 | **50.934** | 19.61 | 67.6
hwloc | 1013.627 | 389.889 | 31.95 | 765.975 | **216.194** | 22.86 | 71.55
libiconv | 707.266 | 110.424 | 15.48 | 735.485 | **68.35** | 14.6 | 94.32
libmagic | 368.796 | 259.655 | 14.6 | 402.885 | **121.963** | 11.81 | 80.9
libmesh | 4876.267 | 3365.17 | 144.68 | **1638.81** | 3472.62 | 92.88 | 64.2
libsass | 373.646 | 365.037 | 16.13 | 365.167 | 277.348 | 13.3 | 82.46
libtasn1 | 450.998 | 195.746 | 16.19 | 327.73 | 130.357 | 11.84 | 73.14
mpc | 372.706 | 231.925 | 13.94 | 244.956 | 144.253 | 9.426 | 67.62
mpfr | 390.432 | 1000.014 | 27.44 | 352.408 | **423.136** | 16.36 | 59.63
sassc | 283.043 | 33.923 | 8.056 | 288.729 | 31.969 | 7.896 | 98.02
starlink-ast | 294.171 | 461.441 | 14.16 | 327.433 | 363.031 | 12.13 | 85.67

</google-sheets-html-origin>

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
