### PR TITLE
Fix include error in android cmake example

### DIFF
--- a/docs/examples/vcpkg_android_example_cmake_script/CMakeLists.txt
+++ b/docs/examples/vcpkg_android_example_cmake_script/CMakeLists.txt
@@ -10,4 +10,4 @@ project(test)
 
 find_package(jsoncpp CONFIG REQUIRED)
 add_library(my_lib my_lib.cpp)
-target_link_libraries(my_lib jsoncpp_lib)
+target_link_libraries(my_lib JsonCpp::JsonCpp)


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
The android cross compile example has an include error when running compile.sh
```
my_lib.cpp:1:10: fatal error: 'json/json.h' file not found
[build] #include <json/json.h>
[build]          ^~~~~~~~~~~~~
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All android
