### PR TITLE
[azure-iot-sdk-c, azure-c-shared-utility] Fix linking of parson, uhttp, CURL, OpenSSL; modernize

### DIFF
--- a/ports/azure-c-shared-utility/fix-install-location.patch
+++ b/ports/azure-c-shared-utility/fix-install-location.patch
@@ -2,15 +2,6 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index deeaae7d..c0c84275 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -675,7 +675,7 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-     set(CMAKE_INSTALL_LIBDIR "lib")
- endif()
- 
--set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-+set(package_location "cmake")
- 
- if(${build_as_dynamic})
-     set(targets aziotsharedutil aziotsharedutil_dll)
 @@ -689,7 +689,7 @@ install (TARGETS ${targets} EXPORT aziotsharedutilTargets
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/azureiot

--- a/ports/azure-c-shared-utility/improve-dependencies.patch
+++ b/ports/azure-c-shared-utility/improve-dependencies.patch
@@ -1,0 +1,67 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46334c1..aaeea20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -115,7 +115,6 @@ if(${use_openssl})
+     if (NOT TARGET OpenSSL::SSL OR NOT TARGET OpenSSL::Crypto OR NOT ${OPENSSL_INCLUDE_DIR})
+         find_package(OpenSSL REQUIRED)
+     endif()
+-    include_directories(${OPENSSL_INCLUDE_DIR})
+ endif()
+ 
+ if(${use_applessl})
+@@ -521,8 +520,7 @@ if(${use_http})
+             set(CURL_FIND_REQUIRED 1)
+             find_package_handle_standard_args(CURL DEFAULT_MSG CURL_LIBRARIES)
+ 
+-            include_directories(${CURL_INCLUDE_DIRS})
+-            set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${CURL_LIBRARIES})
++            set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} CURL::libcurl)
+         endif(NOT use_builtin_httpapi)
+     endif()
+ endif(${use_http})
+@@ -561,7 +559,7 @@ if(${use_bearssl})
+ endif()
+ 
+ if(${use_openssl})
+-    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} ${OPENSSL_LIBRARIES})
++    set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} OpenSSL::SSL)
+     if (WIN32)
+         set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 ws2_32 secur32)
+     endif()
+@@ -703,7 +701,7 @@ write_basic_package_version_file(
+ 
+ configure_file("configs/${PROJECT_NAME}Config.cmake"
+     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+-    COPYONLY
++    @ONLY
+ )
+ 
+ install(EXPORT aziotsharedutilTargets
+@@ -715,7 +713,7 @@ install(EXPORT aziotsharedutilTargets
+ 
+ install(
+ FILES
+-    "configs/${PROJECT_NAME}Config.cmake"
++    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake"
+     "configs/${PROJECT_NAME}Functions.cmake"
+     "configs/azure_iot_build_rules.cmake"
+     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
+diff --git a/configs/azure_c_shared_utilityConfig.cmake b/configs/azure_c_shared_utilityConfig.cmake
+index 416dd1c..0e1e4d4 100644
+--- a/configs/azure_c_shared_utilityConfig.cmake
++++ b/configs/azure_c_shared_utilityConfig.cmake
+@@ -1,8 +1,11 @@
+ #Copyright (c) Microsoft. All rights reserved.
+ #Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ 
+-if(UNIX)
+-    include(CMakeFindDependencyMacro)
++include(CMakeFindDependencyMacro)
++if("@use_openssl@")
++    find_dependency(OpenSSL)
++endif()
++if(UNIX AND NOT "@use_builtin_httpapi@")
+     find_dependency(CURL)
+ endif()
+ 

--- a/ports/azure-c-shared-utility/portfile.cmake
+++ b/ports/azure-c-shared-utility/portfile.cmake
@@ -28,9 +28,8 @@ else()
     )
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -Dskip_samples=ON
         -Duse_installed_dependencies=ON
@@ -38,14 +37,14 @@ vcpkg_configure_cmake(
         -Dbuild_as_dynamic=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/azure_c_shared_utility)
+vcpkg_cmake_config_fixup(PACKAGE_NAME azure_c_shared_utility CONFIG_PATH lib/cmake/azure_c_shared_utility)
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(COPY ${SOURCE_PATH}/configs/azure_iot_build_rules.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(COPY "${SOURCE_PATH}/configs/azure_iot_build_rules.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
 
 vcpkg_copy_pdbs()

--- a/ports/azure-c-shared-utility/portfile.cmake
+++ b/ports/azure-c-shared-utility/portfile.cmake
@@ -11,6 +11,7 @@ if("public-preview" IN_LIST FEATURES)
             fix-install-location.patch
             fix-utilityFunctions-conditions-preview.patch
             disable-error.patch
+            improve-dependencies.patch
     )
 else()
     vcpkg_from_github(
@@ -23,6 +24,7 @@ else()
             fix-install-location.patch
             fix-utilityFunctions-conditions.patch
             disable-error.patch
+            improve-dependencies.patch
     )
 endif()
 

--- a/ports/azure-c-shared-utility/vcpkg.json
+++ b/ports/azure-c-shared-utility/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-c-shared-utility",
   "version-date": "2022-01-21",
+  "port-version": 1,
   "description": "Azure C SDKs common code",
   "homepage": "https://github.com/Azure/azure-c-shared-utility",
   "supports": "!uwp",

--- a/ports/azure-c-shared-utility/vcpkg.json
+++ b/ports/azure-c-shared-utility/vcpkg.json
@@ -15,7 +15,15 @@
       "name": "openssl",
       "platform": "linux"
     },
-    "umock-c"
+    "umock-c",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "public-preview": {

--- a/ports/azure-iot-sdk-c/fix-install-location.patch
+++ b/ports/azure-iot-sdk-c/fix-install-location.patch
@@ -1,16 +1,3 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b72bd41ed..02d964fc6 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -388,7 +387,7 @@ endif()
- ########## Add install components ##########
- if (${use_installed_dependencies})
-     # Install azure_iot_sdks
--    set(package_location "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-+    set(package_location "cmake")
- 
-     include(CMakePackageConfigHelpers)
- 
 diff --git a/provisioning_client/CMakeLists.txt b/provisioning_client/CMakeLists.txt
 index 39f269d51..ff53ca32d 100644
 --- a/provisioning_client/CMakeLists.txt

--- a/ports/azure-iot-sdk-c/fix-iothubclient-includes.patch
+++ b/ports/azure-iot-sdk-c/fix-iothubclient-includes.patch
@@ -1,0 +1,13 @@
+diff --git a/iothub_client/CMakeLists.txt b/iothub_client/CMakeLists.txt
+index 07ab3b7..9769a08 100644
+--- a/iothub_client/CMakeLists.txt
++++ b/iothub_client/CMakeLists.txt
+@@ -441,7 +441,7 @@ add_library(iothub_client
+ target_include_directories(iothub_client
+     PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot/include>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/azureiot>
+ )
+ applyXcodeBuildFlagsIfNeeded(iothub_client)
+ target_link_libraries(iothub_client ${iothub_client_libs})

--- a/ports/azure-iot-sdk-c/improve-external-deps.patch
+++ b/ports/azure-iot-sdk-c/improve-external-deps.patch
@@ -50,21 +50,29 @@ diff --git a/deps/CMakeLists.txt b/deps/CMakeLists.txt
 index 22e24f851..7dc30beba 100644
 --- a/deps/CMakeLists.txt
 +++ b/deps/CMakeLists.txt
-@@ -37,5 +37,4 @@ endif()
+@@ -37,5 +37,8 @@ endif()
  if(NOT ${use_installed_dependencies})
      add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/parson)
  else()
 -    find_package(parson REQUIRED CONFIG)
++    find_package(unofficial-parson REQUIRED CONFIG)
++    if(NOT TARGET parson)
++        add_library(parson ALIAS unofficial::parson::parson)
++    endif()
  endif()
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index b72bd41ed..b2812f1fd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -242,7 +242,6 @@ endif()
+@@ -242,7 +242,10 @@ endif()
  
  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/deps)
  if(${use_installed_dependencies})
 -    find_package(parson REQUIRED CONFIG)
++    find_package(unofficial-parson REQUIRED CONFIG)
++    if(NOT TARGET parson)
++        add_library(parson ALIAS unofficial::parson::parson)
++    endif()
  endif()
  
  include_directories(${MACRO_UTILS_INC_FOLDER})

--- a/ports/azure-iot-sdk-c/improve-external-deps.patch
+++ b/ports/azure-iot-sdk-c/improve-external-deps.patch
@@ -2,12 +2,13 @@ diff --git a/configs/azure_iot_sdksConfig.cmake b/configs/azure_iot_sdksConfig.c
 index b9c62e8..edf5847 100644
 --- a/configs/azure_iot_sdksConfig.cmake
 +++ b/configs/azure_iot_sdksConfig.cmake
-@@ -1,5 +1,10 @@
+@@ -1,5 +1,11 @@
  #Copyright (c) Microsoft. All rights reserved.
  #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 +include(CMakeFindDependencyMacro)
 +find_dependency(unofficial-parson)
 +find_dependency(uamqp)
++find_dependency(uhttp)
 +find_dependency(umqtt)
 +find_dependency(azure_c_shared_utility)
  

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -32,12 +32,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         use-prov-client use_prov_client
 )
 
-file(COPY ${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake DESTINATION ${SOURCE_PATH}/deps/azure-c-shared-utility/configs/)
-file(COPY ${SOURCE_PATH}/configs/azure_iot_sdksFunctions.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/cmake/azure_iot_sdks/)
+file(COPY "${CURRENT_INSTALLED_DIR}/share/azure-c-shared-utility/azure_iot_build_rules.cmake" DESTINATION "${SOURCE_PATH}/deps/azure-c-shared-utility/configs/")
+file(COPY "${SOURCE_PATH}/configs/azure_iot_sdksFunctions.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/cmake/azure_iot_sdks/")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
         -Dskip_samples=ON
         -Duse_installed_dependencies=ON
@@ -47,12 +46,12 @@ vcpkg_configure_cmake(
         -Dwarnings_as_errors=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake TARGET_PATH share/azure_iot_sdks)
+vcpkg_cmake_config_fixup(PACKAGE_NAME azure_iot_sdks CONFIG_PATH "lib/cmake/azure_iot_sdks")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
 
 vcpkg_copy_pdbs()

--- a/ports/azure-iot-sdk-c/portfile.cmake
+++ b/ports/azure-iot-sdk-c/portfile.cmake
@@ -11,6 +11,7 @@ if("public-preview" IN_LIST FEATURES)
             fix-install-location.patch
             improve-external-deps.patch
             remove-werror.patch
+            fix-iothubclient-includes.patch
     )
 else()
     vcpkg_from_github(
@@ -23,6 +24,7 @@ else()
             fix-install-location.patch
             improve-external-deps.patch
             remove-werror.patch
+            fix-iothubclient-includes.patch
     )
 endif()
 

--- a/ports/azure-iot-sdk-c/vcpkg.json
+++ b/ports/azure-iot-sdk-c/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "azure-iot-sdk-c",
   "version-date": "2022-01-21",
+  "port-version": 1,
   "description": "A C99 SDK for connecting devices to Microsoft Azure IoT services",
   "homepage": "https://github.com/Azure/azure-iot-sdk-c",
   "dependencies": [

--- a/ports/azure-iot-sdk-c/vcpkg.json
+++ b/ports/azure-iot-sdk-c/vcpkg.json
@@ -11,7 +11,15 @@
     "azure-uhttp-c",
     "azure-umqtt-c",
     "parson",
-    "umock-c"
+    "umock-c",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ],
   "features": {
     "public-preview": {

--- a/versions/a-/azure-c-shared-utility.json
+++ b/versions/a-/azure-c-shared-utility.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aceee8533b4eeea6eb87371c4d37ae82859cefc7",
+      "version-date": "2022-01-21",
+      "port-version": 1
+    },
+    {
       "git-tree": "1d0590ad121eefc3af9ff13f67996ca8c3e39508",
       "version-date": "2022-01-21",
       "port-version": 0

--- a/versions/a-/azure-iot-sdk-c.json
+++ b/versions/a-/azure-iot-sdk-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0570fa462646f08bb3ed9a34ecb693082def3d3b",
+      "version-date": "2022-01-21",
+      "port-version": 1
+    },
+    {
       "git-tree": "77b1d419b740dd9738f237a6d52b1c161e99ee9d",
       "version-date": "2022-01-21",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -314,7 +314,7 @@
     },
     "azure-c-shared-utility": {
       "baseline": "2022-01-21",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-core-cpp": {
       "baseline": "1.3.1",
@@ -326,7 +326,7 @@
     },
     "azure-iot-sdk-c": {
       "baseline": "2022-01-21",
-      "port-version": 0
+      "port-version": 1
     },
     "azure-kinect-sensor-sdk": {
       "baseline": "1.4.1",


### PR DESCRIPTION
- #### What does your PR fix?  
  Fixes lookup and linking of parson and uhttp, https://github.com/microsoft/vcpkg/issues/22777#issuecomment-1025089400. 
  Fixes an non-existing including dir.
  Links CURL and OpenSSL using targets instead of variables. This lets CMake resolve CURL's OpenSSL usage, and avoid vcpkg's issue with release libs appearing in debug builds.
  Modernizes the portfiles.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

---

Locally validated with #22258, based on the test case in https://github.com/microsoft/vcpkg/issues/22777#issuecomment-1025089400, x64-linux. (This test needed the azure-c-shared-utility fixes.)
~~~
vcpkg_cmake_validate(
    CMAKE_MINIMUM_VERSION 3.9
    FIND_PACKAGE azure_iot_sdks CONFIG REQUIRED
    TARGETS iothub_client
    HEADERS iothub.h
    FUNCTIONS IoTHub_Init
)
~~~
