### PR TITLE
Provision autoconf-archive on osx

### DIFF
--- a/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
+++ b/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
@@ -2,6 +2,7 @@
   "$schema": "./vagrant-vm-configuration.schema.json",
   "brew": [
     "autoconf",
+    "autoconf-archive",
     "automake",
     "bison",
     "gettext",


### PR DESCRIPTION
- #### What does your PR fix?  
  `autoconf-archive` is needed for port mpfr. It is provided from `vcpkg_configure_make` via msys2 for windows and via image for linux. This PR adds provisioning via the osx image.
  Fixes PR #22859

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  changes osx, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  --

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  --