### PR TITLE
[opendnp3] Disable FetchContent in favor of predownloading

### DIFF
--- a/ports/opendnp3/deps/asio.cmake
+++ b/ports/opendnp3/deps/asio.cmake
@@ -1,0 +1,1 @@
+find_package(asio CONFIG REQUIRED)

--- a/ports/opendnp3/portfile.cmake
+++ b/ports/opendnp3/portfile.cmake
@@ -7,10 +7,34 @@ vcpkg_from_github(
     REPO dnp3/opendnp3
     REF 3.1.1
     SHA512 2d7b26753fa03596ab73944236e5f1d82656f38248cc23fd00f7a2cdac27f481e5fe51e68b5896b6740db1a6d9560f0262e473648e001601125f4af8b4a652c2
-    HEAD_REF master
 )
 
-file(COPY "${CURRENT_PORT_DIR}/opendnp3-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+file(READ "${SOURCE_PATH}/deps/ser4cpp.cmake" ser4cpp_cmake)
+if(ser4cpp_cmake MATCHES "https://github\\.com/automatak/ser4cpp/archive/([0-9a-f]*)\\.zip")
+    vcpkg_from_github(
+        OUT_SOURCE_PATH ser4cpp_src
+        REPO automatak/ser4cpp
+        REF "${CMAKE_MATCH_1}"
+        SHA512 cd8d634c0e9fadda357bdd832c382189461f4707ced4834604668df0aa4e396333cce8d676d4f98ba1b414664228518e9a24c6456204b9d96a5f2df078bada2c
+    )
+else()
+    message(FATAL_ERROR "Unable to determine version of ser4cpp")
+endif()
+
+file(READ "${SOURCE_PATH}/deps/exe4cpp.cmake" exe4cpp_cmake)
+if(exe4cpp_cmake MATCHES "https://github\\.com/automatak/exe4cpp/archive/([0-9a-f]*)\\.zip")
+    vcpkg_from_github(
+        OUT_SOURCE_PATH exe4cpp_src
+        REPO automatak/exe4cpp
+        REF "${CMAKE_MATCH_1}"
+        SHA512 c8946db752c0f8499d21c2da96b84676b8768954bcb1964f4c444c731d9871d8978cb96fe89b1125e91b861aef0984bdd943a4dccb91d17ba43f22c57673b7b2
+    )
+else()
+    message(FATAL_ERROR "Unable to determine version of exe4cpp")
+endif()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/opendnp3-config.cmake.in" DESTINATION "${SOURCE_PATH}")
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/deps/" DESTINATION "${SOURCE_PATH}/deps/")
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" STATICLIBS)
 
@@ -23,6 +47,9 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DDNP3_STATIC_LIBS=${STATICLIBS}
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+        -DFETCHCONTENT_SOURCE_DIR_SER4CPP=${ser4cpp_src}
+        -DFETCHCONTENT_SOURCE_DIR_EXE4CPP=${exe4cpp_src}
         ${FEATURE_OPTIONS}
 )
 

--- a/ports/opendnp3/vcpkg.json
+++ b/ports/opendnp3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "opendnp3",
   "version": "3.1.1",
+  "port-version": 1,
   "description": "DNP3 (IEEE-1815) protocol stack. Modern C++ with bindings for .NET and Java.",
   "homepage": "https://github.com/dnp3/opendnp3/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5002,7 +5002,7 @@
     },
     "opendnp3": {
       "baseline": "3.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "openexr": {
       "baseline": "2.5.0",

--- a/versions/o-/opendnp3.json
+++ b/versions/o-/opendnp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e9315f4a8ad7564c1fc8b81c4a9f4c7b0305c0b3",
+      "version": "3.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf6ee46efb76af8f7f317fabfb24358fd82312de",
       "version": "3.1.1",
       "port-version": 0


### PR DESCRIPTION
`opendnp3` currently uses FetchContent to get dependencies which violates vcpkg policy. This PR:
1. Actually uses the vcpkg `asio` dependency
2. Elevates the downloads of exe4cpp and ser4cpp to the portfile, ensuring that the use adheres to all of our policies (proxies, asset caching, etc). These libraries are not currently in vcpkg so it isn't pressing to de-vendor them at this time.