### PR TITLE
[google-cloud-cpp] update to latest release (v1.36.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.35.0
-    SHA512 99eabb37ff32ddaf8f646415b50f3843e89fb119646428c16f03060c2787c8d86fa1ac0919ee60c4f6c7a3b71a14eb828ae26a7fc26d928543d72c7ba3268bff
+    REF v1.36.0
+    SHA512 a9885f9e0726de64eaee0376f3d1ed3a00c32919f2b9a911479206f2965a62eea5ff292b459f61eae97d5d2fe336c410c615296fcb0c7506faf45c57bd6f8871
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,25 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 369914e04..f89b256f4 100644
+index 0e2b703..7097f06 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,8 +28,14 @@ project(
-     VERSION 1.35.0
+@@ -28,8 +28,13 @@ project(
+     VERSION 1.36.0
      LANGUAGES CXX C)
  
+-# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
+-if (NOT CMAKE_CXX_STANDARD)
 +find_package(absl CONFIG REQUIRED)
 +
 +# Use CMAKE_CXX_STANDARD=17 if ABSL_USE_CXX17 is set
 +if (ABSL_USE_CXX17)
 +    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
 +    set(CMAKE_CXX_STANDARD 17)
- # Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
--if (NOT CMAKE_CXX_STANDARD)
 +elseif (NOT CMAKE_CXX_STANDARD)
      set(CMAKE_CXX_STANDARD 11)
  endif ()
  if (CMAKE_CXX_STANDARD VERSION_LESS 11)
 diff --git a/google/cloud/internal/port_platform.h b/google/cloud/internal/port_platform.h
-index c9f34cf4c..e62400431 100644
+index c9f34cf..e624004 100644
 --- a/google/cloud/internal/port_platform.h
 +++ b/google/cloud/internal/port_platform.h
 @@ -49,6 +49,8 @@

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.35.0",
-  "port-version": 2,
+  "version": "1.36.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2537,8 +2537,8 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "1.35.0",
-      "port-version": 2
+      "baseline": "1.36.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7b5a4cd75e98700c970afb3b0f6de808bc954ef3",
+      "version": "1.36.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "cb69d19a2e45c9dae1a8caa1ee5898b4344cb7f1",
       "version": "1.35.0",
       "port-version": 2


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.36.0)

I updated the patch for `abseil[cxx17]`. Unfortunately the patch
includes the version of `google-cloud-cpp`, I will try to fix things
upstream so we do not need to go through this on each release.

I tested each feature locally on `x64-linux`.

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
