### PR TITLE
[vcpkg-cmake][libpng] Add "OSX_SPLIT_BUILD" feature

### DIFF
--- a/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_install.md
+++ b/docs/maintainers/ports/vcpkg-cmake/vcpkg_cmake_install.md
@@ -15,6 +15,7 @@ vcpkg_cmake_install(
 with additional parameters to set the `TARGET` to `install`,
 and to set the `LOGFILE_ROOT` to `install` as well.
 
+
 [`vcpkg_cmake_build()`]: vcpkg_cmake_build.md
 
 ## Examples:

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -63,6 +63,7 @@ else()
 endif()
 
 vcpkg_cmake_configure(
+    OSX_SPLIT_BUILD
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${LIBPNG_APNG_OPTION}

--- a/ports/libpng/vcpkg.json
+++ b/ports/libpng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libpng",
   "version": "1.6.37",
-  "port-version": 18,
+  "port-version": 19,
   "description": "libpng is a library implementing an interface for reading and writing PNG (Portable Network Graphics) format files",
   "homepage": "https://github.com/glennrp/libpng",
   "license": "libpng-2.0",

--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2022-07-18",
+  "version-date": "2022-08-01",
   "documentation": "https://vcpkg.io/en/docs/maintainers/ports/vcpkg-cmake.html",
   "license": "MIT"
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_build.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_build.cmake
@@ -62,25 +62,50 @@ function(vcpkg_cmake_build)
                 endif()
             endif()
 
-            if(arg_DISABLE_PARALLEL)
-                vcpkg_execute_build_process(
-                    COMMAND
-                        "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
-                        -- ${build_param} ${no_parallel_param}
-                    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}"
-                    LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_type}"
-                )
+            if (Z_VCPKG_OSX_SPLIT_BUILD)
+                foreach(OSX_ARCHITECTURE ${VCPKG_OSX_ARCHITECTURES})
+                    if (arg_DISABLE_PARALLEL)
+                        vcpkg_execute_build_process(
+                            COMMAND
+                                "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                                -- ${build_param} ${no_parallel_param}
+                            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}-${OSX_ARCHITECTURE}"
+                            LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_ttype}-${OSX_ARCHITECTURE}"
+                        )
+                    else()
+                        vcpkg_execute_build_process(
+                            COMMAND
+                                "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                                -- ${build_param} ${parallel_param}
+                            NO_PARALLEL_COMMAND
+                                "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                                -- ${build_param} ${no_parallel_param}
+                            WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}-${OSX_ARCHITECTURE}"
+                            LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_type}-${OSX_ARCHITECTURE}"
+                        )
+                    endif()
+                endforeach()
             else()
-                vcpkg_execute_build_process(
-                    COMMAND
-                        "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
-                        -- ${build_param} ${parallel_param}
-                    NO_PARALLEL_COMMAND
-                        "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
-                        -- ${build_param} ${no_parallel_param}
-                    WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}"
-                    LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_type}"
-                )
+                if(arg_DISABLE_PARALLEL)
+                    vcpkg_execute_build_process(
+                        COMMAND
+                            "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                            -- ${build_param} ${no_parallel_param}
+                        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}"
+                        LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_type}"
+                    )
+                else()
+                    vcpkg_execute_build_process(
+                        COMMAND
+                            "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                            -- ${build_param} ${parallel_param}
+                        NO_PARALLEL_COMMAND
+                            "${CMAKE_COMMAND}" --build . --config "${config}" ${target_param}
+                            -- ${build_param} ${no_parallel_param}
+                        WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${short_build_type}"
+                        LOGNAME "${arg_LOGFILE_BASE}-${TARGET_TRIPLET}-${short_build_type}"
+                    )
+                endif()
             endif()
 
             if(arg_ADD_BIN_TO_PATH)

--- a/ports/vcpkg-cmake/vcpkg_cmake_install.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_install.cmake
@@ -18,4 +18,68 @@ function(vcpkg_cmake_install)
         LOGFILE_BASE install
         TARGET install
     )
+
+    # check whether a split build was requested and executed
+    if (Z_VCPKG_OSX_SPLIT_BUILD)
+        list(LENGTH VCPKG_OSX_ARCHITECTURES ARCHITECTURE_LENGTH)
+        if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin" AND ${ARCHITECTURE_LENGTH} GREATER 1)
+            # if we performed a split build, we'll need to zip those up
+            # using the lipo tool, start by looking that up
+            find_program(LIPO_EXECUTABLE lipo REQUIRED)
+
+            foreach(buildtype IN ITEMS debug release)
+                if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL buildtype)
+                    if(buildtype STREQUAL "debug")
+                        set(SHORT_BUILD_TYPE "dbg")
+                        set(PACKAGE_DIR_SUFFIX "/debug")
+                    else()
+                        set(SHORT_BUILD_TYPE "rel")
+                        set(PACKAGE_DIR_SUFFIX "")
+                    endif()
+
+                    set(INSTALL_DIRECTORIES)
+
+                    foreach(OSX_ARCHITECTURE ${VCPKG_OSX_ARCHITECTURES})
+                        if (NOT INSTALL_DIRECTORIES)
+                            set(INSTALL_DIRECTORY "${CURRENT_PACKAGES_DIR}${PACKAGE_DIR_SUFFIX}")
+                        else()
+                            set(INSTALL_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-${OSX_ARCHITECTURE}-${SHORT_BUILD_TYPE}-install")
+                        endif()
+
+                        list(APPEND INSTALL_DIRECTORIES "${INSTALL_DIRECTORY}")
+                    endforeach()
+
+                    # note: we cannot glob the library files in a single operation, due to a cmake
+                    # bug in file globbing, a pattern like "*.{a,dylib}" does not work.
+                    # also note that we are using the _last_ directory set, which is inside the
+                    # buildtree, and not the normal packages directory, since that would likely
+                    # also contain other installed libraries
+                    file(GLOB_RECURSE STATIC_LIBS RELATIVE "${INSTALL_DIRECTORY}" "${INSTALL_DIRECTORY}/lib/*.a")
+                    file(GLOB_RECURSE SHARED_LIBS RELATIVE "${INSTALL_DIRECTORY}" "${INSTALL_DIRECTORY}/lib/*.dylib")
+                    file(GLOB_RECURSE EXECUTABLES RELATIVE "${INSTALL_DIRECTORY}" "${INSTALL_DIRECTORY}/bin/*")
+
+                    # filter out symlinks to get the real libraries to process
+                    foreach (FOUND_LIBRARY ${STATIC_LIBS} ${SHARED_LIBS} ${EXECUTABLES})
+                        if (NOT IS_SYMLINK "${INSTALL_DIRECTORY}/${FOUND_LIBRARY}")
+                            # now build the command to join the files
+                            set(LIPO_ARGUMENTS "-create" "-output" "${CURRENT_PACKAGES_DIR}${PACKAGE_DIR_SUFFIX}/${FOUND_LIBRARY}")
+
+                            # add all architectures to the library
+                            foreach (OSX_ARCHITECTURE ${VCPKG_OSX_ARCHITECTURES})
+                                list(POP_FRONT INSTALL_DIRECTORIES ARCH_INSTALL_DIRECTORY)
+                                list(APPEND LIPO_ARGUMENTS "-arch" "${OSX_ARCHITECTURE}" "${ARCH_INSTALL_DIRECTORY}/${FOUND_LIBRARY}")
+                            endforeach()
+
+                            # now join the found libraries
+                            vcpkg_execute_required_process(
+                                COMMAND ${LIPO_EXECUTABLE} ${LIPO_ARGUMENTS}
+                                WORKING_DIRECTORY ${CURRENT_PACKAGES_DIR}
+                                LOGNAME "lipo-${TARGET_TRIPLET}"
+                            )
+                        endif()
+                    endforeach()
+                endif()
+            endforeach()
+        endif()
+    endif()
 endfunction()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3966,7 +3966,7 @@
     },
     "libpng": {
       "baseline": "1.6.37",
-      "port-version": 18
+      "port-version": 19
     },
     "libpopt": {
       "baseline": "1.16",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7425,7 +7425,7 @@
       "port-version": 0
     },
     "vcpkg-cmake": {
-      "baseline": "2022-07-18",
+      "baseline": "2022-08-01",
       "port-version": 0
     },
     "vcpkg-cmake-config": {

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fc1b58241158751d241956b7b0e2ffb4d612016",
+      "version": "1.6.37",
+      "port-version": 19
+    },
+    {
       "git-tree": "5e3ec787e7c6f09dd162648b700aeb712af0ffd2",
       "version": "1.6.37",
       "port-version": 18

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73b8a4a2a1220d2f3d167e552fcb617f5cfdf9cb",
+      "version-date": "2022-08-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "a7b618b7782f3c841d7fd2d84a6ba3619815362a",
       "version-date": "2022-07-18",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
It enabled universal binaries for cmake-based ports that somehow don't support it (e.g. because they use NASM). One such example is libpng, which now works with this PR

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All. It also works for libpng when you set VCPKG_OSX_ARCHITECTURES to both arm64 and x86_64

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
