### PR TITLE
[x264] enable cross-compile settings propagation for arm64-linux.

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -32,6 +32,35 @@ if(VCPKG_TARGET_IS_LINUX)
     list(APPEND OPTIONS --enable-pic)
 endif()
 
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
+    if (VCPKG_TARGET_IS_LINUX)
+        if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+            list(APPEND OPTIONS --host=aarch64-linux)
+            if (DEFINED ENV{CROSS_PREFIX})
+                # allow toolchain to specify the cross-prefix
+                set(cross_prefix $ENV{CROSS_PREFIX})                
+            else()
+                # attempt to determine the cross-prefix from VCPKG_DETECTED_CMAKE_C/CXX_COMPILER using the most likely naming conventions
+                if (${VCPKG_DETECTED_CMAKE_C_COMPILER} MATCHES ".*-gcc")
+                    string(REGEX REPLACE "gcc$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+                    get_filename_component(cross_prefix ${full_cross_prefix} NAME)                
+                elseif (${VCPKG_DETECTED_CMAKE_CXX_COMPILER} MATCHES ".*-g\\+\\+")
+                    string(REGEX REPLACE "g\\+\\+$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_CXX_COMPILER})
+                    get_filename_component(cross_prefix ${full_cross_prefix} NAME)
+                else()
+                    message(AUTHOR_WARNING "Could not self-determine cross-prefix. Will attempt to use 'aarch64-linux-gnu-'. You should use ENV{CROSS_PREFIX} in your toolchain to override it.")
+                    set(cross_prefix "aarch64-linux-gnu-")
+                endif()                
+            endif()            
+            list(APPEND OPTIONS --cross-prefix=${cross_prefix})
+            list(APPEND OPTIONS --disable-asm)
+        endif()
+    endif()
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH ${SOURCE_PATH}
     NO_ADDITIONAL_PATHS

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -7,12 +7,12 @@
   "supports": "!(arm & windows)",
   "dependencies": [
     {
-      "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
       "name": "pthread",
       "platform": "linux & osx"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ]
 }

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "x264",
   "version-string": "164-5db6aa6cab1b146",
-  "port-version": 4,
+  "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
   "supports": "!(arm & windows)",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     {
       "name": "pthread",
       "platform": "linux & osx"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7366,7 +7366,7 @@
     },
     "x264": {
       "baseline": "164-5db6aa6cab1b146",
-      "port-version": 4
+      "port-version": 5
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "387ccad820c889bcffccfa2d74fac3b0d41197b1",
+      "git-tree": "063705300826104f0616ff931ff1b0dadb279c77",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 5
     },

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "387ccad820c889bcffccfa2d74fac3b0d41197b1",
+      "version-string": "164-5db6aa6cab1b146",
+      "port-version": 5
+    },
+    {
       "git-tree": "7eea109502309e62a578bcc69811ad0659e00f9d",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 4


### PR DESCRIPTION

- #### What does your PR fix?  
  Fixes #22899 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all>, <No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes>


