### PR TITLE
[c89stringutils] New port

### DIFF
--- a/ports/c89stringutils/portfile.cmake
+++ b/ports/c89stringutils/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            offscale/c89stringutils
+    REF             375c87aaf50a945b17a76727f3314eb217897caf
+    SHA512          395d942a133209daf510094814830e35daf2047c35b0ff15b17051d7095e4598fd830e0e7f763cac6929b867ff3b0c03c5350c4c3cfc68ed98b69c9c68c04be0
+    HEAD_REF        master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTS=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/cmake/LICENSE.txt"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/c89stringutils"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/c89stringutils/vcpkg.json
+++ b/ports/c89stringutils/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "c89stringutils",
+  "version": "0.0.1",
+  "description": "string functions from newer standards / common non-standards for C89",
+  "license": "Apache-2.0 OR MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1200,6 +1200,10 @@
       "baseline": "2021-07-18",
       "port-version": 1
     },
+    "c89stringutils": {
+      "baseline": "0.0.1",
+      "port-version": 0
+    },
     "caf": {
       "baseline": "0.18.5",
       "port-version": 0

--- a/versions/c-/c89stringutils.json
+++ b/versions/c-/c89stringutils.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "9c5dcb3c6cf4442e2fdcb4cdea39f512db0ead54",
+      "version": "0.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
> string functions from newer standards / common non-standards for C89

https://github.com/offscale/c89stringutils

- #### What does your PR fix?  
New port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes