### PR TITLE
[libcurl-simple-https] New port

### DIFF
--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             aec6f0f0d2cafc9d9bc049701770c09ac6cd6a78
-    SHA512          c1b85adf91baf34373b7bbd907161cc4839c70b07f3219b510dc3ce3fceeddd325f81a0d1d633ffb4d46a49775869eeeddc47e9a84dff640251d90bdd61b54c1
+    REF             285ebd918e55f8bfd2291773f3f0611554ddf214
+    SHA512          3e613de7f011b24754767b3d07e7608a80e0c2440a98eaf5d812133a3062a4ea2b7eeedac603f231eae5acb7950312cabb0a144f430660e656c46c038c7364aa
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             61f7523e170106aea3a255a7e2133ae9ae5ab225
-    SHA512          eed179fee6d5cae5a860b6328cd4ba1f494f4fc5ead6099ea4ae1a82537c9befaee988c093b7cb4fa7a303757419deaab234e415c3451df89a41ea9b18158bcf
+    REF             5a115053ba4d249fc1af22c3673b4d014e56bcf5
+    SHA512          6274bfeec5235d39c627850b1b6ef03c3f1982c74f937b604137cf3cf87e982f971c4681760b42926a3fb15bc8268f2fa48c197919516066d73f53425aa24545
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             ef719bb086f06ee36c2652a47aea1a7aa7673351
-    SHA512          434eefb3db65b4d674466866e5523eb5ff6d9277fa93dffb181775421f5657833174e77182ac26ba297571bb7b882d404c3379dc6afbbf4b3a9cd4efc5145cff
+    REF             61f7523e170106aea3a255a7e2133ae9ae5ab225
+    SHA512          eed179fee6d5cae5a860b6328cd4ba1f494f4fc5ead6099ea4ae1a82537c9befaee988c093b7cb4fa7a303757419deaab234e415c3451df89a41ea9b18158bcf
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             fc79ebd6213e8339bac79b571c9784260c95a1e7
-    SHA512          b52ba4f389d1c289b2a3611826cfb76c2f0b22ac3eec2d012019e4b46a5a7052df487cfe55cbf367abe850d962d9fc2c9e19db344a764432252c467cc862ec79
+    REF             fd504fa3101d1a24369767972f32c2a9e97c0ae6
+    SHA512          9479eb05f3f0a78ce335033f6ae1e481a4bd557ae4e4b828f724503d630115654b44b5efb68e0ac0714c8111a7930ac842dffd84e234a756109811685f2ee016
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             040f626c4e004211373590fbc0d572a4e8126a83
-    SHA512          86f7aef50f5f5c80e5f4bf5466f9310605aa1fbbc56d59fed3db95450b31bca712a596298ea24674fb4d321644043f54c63e3b44e03a9e026316ae83827e68b0
+    REF             fc79ebd6213e8339bac79b571c9784260c95a1e7
+    SHA512          b52ba4f389d1c289b2a3611826cfb76c2f0b22ac3eec2d012019e4b46a5a7052df487cfe55cbf367abe850d962d9fc2c9e19db344a764432252c467cc862ec79
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             779400983379ebc254f1017bf6dae5ae07016af3
-    SHA512          c463d44ab8444eec2503762e60f7056ac936a8118fd1d3f6ad676beb52d1467e75caa86004b78daae581de84baad56f49d920b10a4b3332a5c84df9cb59e14af
+    REF             61cc5c43284d5d37296b93ecb8403bd1f05d55ca
+    SHA512          dace996b848cf4d14253f6b7a3130bcd1fbd31b6d2d2a85e83947c6c644d4ac45a8d7fbf05491658e449b25965c99f68fbbcb1b89d792e0fb2b1e7b727287f1c
     HEAD_REF        master
 )
 
@@ -16,7 +16,3 @@ file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif (VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             ad0bc2359696dab6f82cbf274c7d2a52c6f68060
-    SHA512          968b42500ec88fbf5f7a89fe35cd1887ef81277b2ce28b747638b2f50d8c1a7f620366f7b6a6a819f8aab7785fa01c26c8a99367899840e6af8ec5a8f25f9431
+    REF             aec6f0f0d2cafc9d9bc049701770c09ac6cd6a78
+    SHA512          c1b85adf91baf34373b7bbd907161cc4839c70b07f3219b510dc3ce3fceeddd325f81a0d1d633ffb4d46a49775869eeeddc47e9a84dff640251d90bdd61b54c1
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             a95355191cc42292e54a91b15657c5c129a73b89
-    SHA512          49f821f9fb96d7fcaceba98cb75bf97153a59463d7aa8b9fd3e6122a243c9aa632ea8d8c06bdb4dcec4aa4713c6fb80d28621e05ddab79b6883c6058b573f642
+    REF             d0908bccce80d978bab9bd43ead2acf18b5bfb94
+    SHA512          88005a64adf86f51eb977166b67f5b209dc3454567febdb0d725a4f7f2d18487d7942d1f15d83a949d6d6a65689f5bbed018b6dafaec93bc553428a14f95ec63
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             d0908bccce80d978bab9bd43ead2acf18b5bfb94
-    SHA512          88005a64adf86f51eb977166b67f5b209dc3454567febdb0d725a4f7f2d18487d7942d1f15d83a949d6d6a65689f5bbed018b6dafaec93bc553428a14f95ec63
+    REF             4b1c3f7553b285c7c13e551581068ec615eb04d3
+    SHA512          2c88369f53fc9dac467af0c605d5cc976de48f51175c773051e49511c89845f9370eba7a3f9f0da68546fb45738f3115acad936e798b74986daaa8d23f588b3d
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             285ebd918e55f8bfd2291773f3f0611554ddf214
-    SHA512          3e613de7f011b24754767b3d07e7608a80e0c2440a98eaf5d812133a3062a4ea2b7eeedac603f231eae5acb7950312cabb0a144f430660e656c46c038c7364aa
+    REF             985f2e0ff4e0bb50423a2c1319eb4981d957f146
+    SHA512          96319bfdcfed363522828f6036c14477499ed2132aaded34539050cd8c6a217a08f8ce6aee06d4ace0e882169897522bbad806df7e7c52b57b5da3454d15b7b1
     HEAD_REF        master
 )
 
@@ -15,6 +15,5 @@ vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
-foreach(_dir "include" "share")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/${_dir}")
-endforeach(_dir "include" "share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -15,4 +15,3 @@ vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
     REF             ef719bb086f06ee36c2652a47aea1a7aa7673351
-    SHA512          0
+    SHA512          434eefb3db65b4d674466866e5523eb5ff6d9277fa93dffb181775421f5657833174e77182ac26ba297571bb7b882d404c3379dc6afbbf4b3a9cd4efc5145cff
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             985f2e0ff4e0bb50423a2c1319eb4981d957f146
-    SHA512          96319bfdcfed363522828f6036c14477499ed2132aaded34539050cd8c6a217a08f8ce6aee06d4ace0e882169897522bbad806df7e7c52b57b5da3454d15b7b1
+    REF             040f626c4e004211373590fbc0d572a4e8126a83
+    SHA512          86f7aef50f5f5c80e5f4bf5466f9310605aa1fbbc56d59fed3db95450b31bca712a596298ea24674fb4d321644043f54c63e3b44e03a9e026316ae83827e68b0
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             06a2cce2b69c3ccdc3d184d0b3b0c3a001a906ab
-    SHA512          1d5a8f76a174cca8ed072194de6c268c22f6428f450bd45edc964fdc1c802b5a70e1cf0b7ed85691ba67f1a9d921bac3a94c68c8ed34be87cd350150beaa0b7d
+    REF             ad0bc2359696dab6f82cbf274c7d2a52c6f68060
+    SHA512          968b42500ec88fbf5f7a89fe35cd1887ef81277b2ce28b747638b2f50d8c1a7f620366f7b6a6a819f8aab7785fa01c26c8a99367899840e6af8ec5a8f25f9431
     HEAD_REF        master
 )
 
@@ -15,4 +15,4 @@ vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+#file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             4b1c3f7553b285c7c13e551581068ec615eb04d3
-    SHA512          2c88369f53fc9dac467af0c605d5cc976de48f51175c773051e49511c89845f9370eba7a3f9f0da68546fb45738f3115acad936e798b74986daaa8d23f588b3d
+    REF             06a2cce2b69c3ccdc3d184d0b3b0c3a001a906ab
+    SHA512          1d5a8f76a174cca8ed072194de6c268c22f6428f450bd45edc964fdc1c802b5a70e1cf0b7ed85691ba67f1a9d921bac3a94c68c8ed34be87cd350150beaa0b7d
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -16,5 +16,5 @@ file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
 foreach(_dir "include" "share")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/${dir}")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/${_dir}")
 endforeach(_dir "include" "share")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             fd504fa3101d1a24369767972f32c2a9e97c0ae6
-    SHA512          9479eb05f3f0a78ce335033f6ae1e481a4bd557ae4e4b828f724503d630115654b44b5efb68e0ac0714c8111a7930ac842dffd84e234a756109811685f2ee016
+    REF             ef719bb086f06ee36c2652a47aea1a7aa7673351
+    SHA512          0
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             61cc5c43284d5d37296b93ecb8403bd1f05d55ca
-    SHA512          dace996b848cf4d14253f6b7a3130bcd1fbd31b6d2d2a85e83947c6c644d4ac45a8d7fbf05491658e449b25965c99f68fbbcb1b89d792e0fb2b1e7b727287f1c
+    REF             a95355191cc42292e54a91b15657c5c129a73b89
+    SHA512          49f821f9fb96d7fcaceba98cb75bf97153a59463d7aa8b9fd3e6122a243c9aa632ea8d8c06bdb4dcec4aa4713c6fb80d28621e05ddab79b6883c6058b573f642
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -15,3 +15,6 @@ vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
+foreach(_dir "include" "share")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/${dir}")
+endforeach(_dir "include" "share")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -15,4 +15,4 @@ vcpkg_cmake_install()
 file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
-#file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             d459a09ea8cfae798dc6792fb929a1e722916ec0
-    SHA512          e29efdb714d58b1b34a7e29c09750344c060403527cadcb4d01117adf3f82de70f8db8f2a32224efba4fb3544d2f33ee25f1323e18222adddc3d9eb1ffc610a6
+    REF             d46a6dfb15b69beae53b1a74c46f4de57654ca45
+    SHA512          2b08fe83cf5a5f378d11d3580ccdad6930e3bfdefb6ec7e2470f68c04a105b0c2d3c3de0ef9bb542906fd3487375ea9148e70fdc538e1396e216afd000828604
     HEAD_REF        master
 )
 
@@ -12,7 +12,11 @@ vcpkg_cmake_configure(
         "-DBUILD_CLI=OFF"
 )
 vcpkg_cmake_install()
-file(INSTALL "${SOURCE_PATH}/License.txt"
+file(INSTALL "${SOURCE_PATH}/cmake/License.txt"
      DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
      RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif (VCPKG_LIBRARY_LINKAGE STREQUAL "static")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            SamuelMarks/curl-simple-https
+    REF             d459a09ea8cfae798dc6792fb929a1e722916ec0
+    SHA512          e29efdb714d58b1b34a7e29c09750344c060403527cadcb4d01117adf3f82de70f8db8f2a32224efba4fb3544d2f33ee25f1323e18222adddc3d9eb1ffc610a6
+    HEAD_REF        master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_CLI=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/License.txt"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             d46a6dfb15b69beae53b1a74c46f4de57654ca45
-    SHA512          2b08fe83cf5a5f378d11d3580ccdad6930e3bfdefb6ec7e2470f68c04a105b0c2d3c3de0ef9bb542906fd3487375ea9148e70fdc538e1396e216afd000828604
+    REF             efaaf74b8cebeeeebd93a6c4c3009c7d735aae7d
+    SHA512          65877df519af5d843c824a997adc466a1ece8a43ca392095e2c39f6f3e7237762515a1cf2db9b452fca7c10e63843ed4e7dc8ec6fe734dff61a2351f52f867c7
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/portfile.cmake
+++ b/ports/libcurl-simple-https/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            SamuelMarks/curl-simple-https
-    REF             efaaf74b8cebeeeebd93a6c4c3009c7d735aae7d
-    SHA512          65877df519af5d843c824a997adc466a1ece8a43ca392095e2c39f6f3e7237762515a1cf2db9b452fca7c10e63843ed4e7dc8ec6fe734dff61a2351f52f867c7
+    REF             779400983379ebc254f1017bf6dae5ae07016af3
+    SHA512          c463d44ab8444eec2503762e60f7056ac936a8118fd1d3f6ad676beb52d1467e75caa86004b78daae581de84baad56f49d920b10a4b3332a5c84df9cb59e14af
     HEAD_REF        master
 )
 

--- a/ports/libcurl-simple-https/vcpkg.json
+++ b/ports/libcurl-simple-https/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcurl-simple-https",
-  "version-date": "2022-02-04",
+  "version-date": "2022-02-06",
   "description": "Very simple HTTPS interface built atop libcurl",
   "license": "Apache-2.0 OR MIT",
   "supports": "!uwp",

--- a/ports/libcurl-simple-https/vcpkg.json
+++ b/ports/libcurl-simple-https/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcurl-simple-https",
-  "version-date": "2022-02-03",
+  "version-date": "2022-02-04",
   "description": "Very simple HTTPS interface built atop libcurl",
   "license": "Apache-2.0 OR MIT",
   "supports": "!uwp",

--- a/ports/libcurl-simple-https/vcpkg.json
+++ b/ports/libcurl-simple-https/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libcurl-simple-https",
-  "version-date": "2022-02-06",
+  "version-date": "2022-02-14",
   "description": "Very simple HTTPS interface built atop libcurl",
   "license": "Apache-2.0 OR MIT",
   "supports": "!uwp",

--- a/ports/libcurl-simple-https/vcpkg.json
+++ b/ports/libcurl-simple-https/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "libcurl-simple-https",
+  "version-date": "2022-02-03",
+  "description": "Very simple HTTPS interface built atop libcurl",
+  "license": "Apache-2.0 OR MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "curl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3409,7 +3409,7 @@
       "port-version": 1
     },
     "libcurl-simple-https": {
-      "baseline": "2022-02-04",
+      "baseline": "2022-02-06",
       "port-version": 0
     },
     "libdatachannel": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3409,7 +3409,7 @@
       "port-version": 1
     },
     "libcurl-simple-https": {
-      "baseline": "2022-02-06",
+      "baseline": "2022-02-14",
       "port-version": 0
     },
     "libdatachannel": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3408,6 +3408,10 @@
       "baseline": "0.3",
       "port-version": 1
     },
+    "libcurl-simple-https": {
+      "baseline": "2022-02-03",
+      "port-version": 0
+    },
     "libdatachannel": {
       "baseline": "0.16.4",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3409,7 +3409,7 @@
       "port-version": 1
     },
     "libcurl-simple-https": {
-      "baseline": "2022-02-03",
+      "baseline": "2022-02-04",
       "port-version": 0
     },
     "libdatachannel": {

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "681434161283ea64cbbacaa4abe04f7fca297359",
+      "git-tree": "053386a03d18d3e23b244d00261b41d5f6113f45",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "11470ffbddb9cf63065224e632f51954d096cfe2",
+      "git-tree": "b6273ebc8175a26c783f523b59bec6050da8c822",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b86bfbd34f8463710c8da5f0f6b5e6875bbdb251",
+      "git-tree": "6b22a1dafa22c05f8eed41236534a247a28c23d0",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c42500b2b6fabc38a7b74ec291e78a82439be72e",
+      "git-tree": "11470ffbddb9cf63065224e632f51954d096cfe2",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "51b6b8dbfcb7e719112ff17512dc71d906d077f8",
+      "git-tree": "d870259e4c0e4a7ca584b99bcfb68af333bb6989",
       "version-date": "2022-02-06",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "918fc5c4ae61c274f0b5890d82ac376842307389",
+      "git-tree": "51b6b8dbfcb7e719112ff17512dc71d906d077f8",
       "version-date": "2022-02-06",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4835584dfe4387f9d657e1f587f9eec6ac227fd7",
+      "git-tree": "c5be68b449fc24d929c397a94dda8f005b24fcbd",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c7f44ead8d38047a8532e30514251fc2b8d3a992",
+      "git-tree": "5869357174f1a5fb68721087266fdbaffccbdcb5",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "09c09721397bc01c7d484fbaadad52a40beb9b2f",
+      "git-tree": "918fc5c4ae61c274f0b5890d82ac376842307389",
       "version-date": "2022-02-06",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97bb3428906fd7f00f29d645e28f3dfa6ce8df59",
+      "git-tree": "c42500b2b6fabc38a7b74ec291e78a82439be72e",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f2ea674014558f5fc22fd203941c2644df36730b",
+      "git-tree": "b86bfbd34f8463710c8da5f0f6b5e6875bbdb251",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "d870259e4c0e4a7ca584b99bcfb68af333bb6989",
-      "version-date": "2022-02-06",
+      "git-tree": "4835584dfe4387f9d657e1f587f9eec6ac227fd7",
+      "version-date": "2022-02-14",
       "port-version": 0
     }
   ]

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b6273ebc8175a26c783f523b59bec6050da8c822",
+      "git-tree": "f2ea674014558f5fc22fd203941c2644df36730b",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5869357174f1a5fb68721087266fdbaffccbdcb5",
+      "git-tree": "681434161283ea64cbbacaa4abe04f7fca297359",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "053386a03d18d3e23b244d00261b41d5f6113f45",
+      "git-tree": "97bb3428906fd7f00f29d645e28f3dfa6ce8df59",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "138485c6f259961f79e94b73b66179ceafa4bab5",
-      "version-date": "2022-02-04",
+      "git-tree": "09c09721397bc01c7d484fbaadad52a40beb9b2f",
+      "version-date": "2022-02-06",
       "port-version": 0
     }
   ]

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c5be68b449fc24d929c397a94dda8f005b24fcbd",
+      "git-tree": "d8bbdaf639bdd302a0a2d60a13c5c17c8bfce471",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d8bbdaf639bdd302a0a2d60a13c5c17c8bfce471",
+      "git-tree": "c7f44ead8d38047a8532e30514251fc2b8d3a992",
       "version-date": "2022-02-14",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fa4aa5e3c692103fdb8e751367fff58f205f2d5c",
+      "git-tree": "ffb54a8141d0382d18cd2e8db8a7e6a7e53b585c",
       "version-date": "2022-02-03",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "b35dac3d35c3c068a04b360740050eabf1d4457d",
-      "version-date": "2022-02-03",
+      "git-tree": "138485c6f259961f79e94b73b66179ceafa4bab5",
+      "version-date": "2022-02-04",
       "port-version": 0
     }
   ]

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffb54a8141d0382d18cd2e8db8a7e6a7e53b585c",
+      "git-tree": "28933bde0bacc7b4f24758079680cdcd16c46448",
       "version-date": "2022-02-03",
       "port-version": 0
     }

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "fa4aa5e3c692103fdb8e751367fff58f205f2d5c",
+      "version-date": "2022-02-03",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libcurl-simple-https.json
+++ b/versions/l-/libcurl-simple-https.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "28933bde0bacc7b4f24758079680cdcd16c46448",
+      "git-tree": "b35dac3d35c3c068a04b360740050eabf1d4457d",
       "version-date": "2022-02-03",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**
>  Very simple HTTPS interface built atop libcurl 

https://github.com/SamuelMarks/curl-simple-https

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**

Possibly still a draft, need to see what your CI says