### PR TITLE
[randomstr] New port

### DIFF
--- a/ports/randomstr/portfile.cmake
+++ b/ports/randomstr/portfile.cmake
@@ -1,0 +1,18 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            offscale/c89randomstr
+    REF             9d577c4343913a330ef32b93ed12b8942808bbbc
+    SHA512          7adfac8000d9057b9ca230f794bff82e1628864140e08d393e3faff890848606fff72c3dd2b296a20bf3003ed035e9e4273a0599764f515b7a6ac7091e9d2949
+    HEAD_REF        master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTING=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/COPYING"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/randomstr/vcpkg.json
+++ b/ports/randomstr/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "randomstr",
+  "version-date": "2022-02-03",
+  "description": "Simple randomstr function in a header-only C89 library",
+  "license": "0BSD",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5952,6 +5952,10 @@
       "baseline": "6.10",
       "port-version": 4
     },
+    "randomstr": {
+      "baseline": "2022-02-03",
+      "port-version": 0
+    },
     "rang": {
       "baseline": "3.2",
       "port-version": 0

--- a/versions/r-/randomstr.json
+++ b/versions/r-/randomstr.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "231d69b973b9219271281ebe6d125c4c31380b87",
+      "version-date": "2022-02-03",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
> Simple randomstr function in a header-only C89 library

https://github.com/offscale/c89randomstr

- #### What does your PR fix?
New port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
Although… I do have this TODO:
```c
/* TODO:
 * - `BCryptGenRandom` on new Windows
 * - `CryptGenRandom` on old Windows
 * - `getrandom(2)` on Linux
 * - `arc4random` on BSD, macOS, and SunOS
 * */
```