### PR TITLE
[vcpkg-tool] update to 2022-02-03

### DIFF
--- a/docs/maintainers/manifest-files.md
+++ b/docs/maintainers/manifest-files.md
@@ -456,10 +456,57 @@ This means "doesn't support uwp, nor arm32 (but does support arm64)".
 ### `"license"`
 
 The license of the port. This is an [SPDX license expression],
-using [SPDX license identifiers].
+or `null` for proprietary licenses and other licenses for which
+one should "just read the `copyright` file" (e.g., Qt).
 
 [SPDX license expression]: https://spdx.dev/ids/#how
-[SPDX license identifiers]: https://spdx.org/licenses/
+
+Additionally, you can find the list of [recognized license IDs]
+and [recognized license exception IDs] in Annex A of the SPDX specification.
+
+[recognized license IDs]: https://spdx.github.io/spdx-spec/SPDX-license-list/#a1-licenses-with-short-identifiers
+[recognized license exception IDs]: https://spdx.github.io/spdx-spec/SPDX-license-list/#a2-exceptions-list
+
+The following is an EBNF conversion of the ABNF located at
+<https://spdx.github.io/spdx-spec/SPDX-license-expressions/>,
+and this is what we actually parse in vcpkg.
+Note that vcpkg does not support DocumentRefs.
+
+```ebnf
+idchar = ? regex /[-.a-zA-Z0-9]/ ?
+idstring = ( idchar ), { idchar } ;
+
+(* note that unrecognized license and license exception IDs will be warned against *)
+license-id = idstring ;
+license-exception-id = idstring ;
+(* note that DocumentRefs are unsupported by this implementation *)
+license-ref = "LicenseRef-", idstring ;
+
+with = [ whitespace ], "WITH", [ whitespace ] ;
+and = [ whitespace ], "AND", [ whitespace ] ;
+or = [ whitespace ], "OR", [ whitespace ] ;
+
+simple-expression = [ whitespace ], (
+  | license-id
+  | license-id, "+"
+  | license-ref
+  ), [ whitespace ] ;
+
+(* the following are split up from compound-expression to make precedence obvious *)
+parenthesized-expression =
+  | simple-expression
+  | [ whitespace ], "(", or-expression, ")", [ whitespace ] ;
+
+with-expression =
+  | parenthesized-expression
+  | simple-expression, with, license-exception-id, [ whitespace ] ;
+
+(* note: "a AND b OR c" gets parsed as "(a AND b) OR c" *)
+and-expression = with-expression, { and, with-expression } ;
+or-expression = and-expression, { or, and-exression } ;
+
+license-expression = or-expression ;
+```
 
 #### Examples
 

--- a/ports/mailio/vcpkg.json
+++ b/ports/mailio/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "mailio",
   "version": "0.20.0",
-  "port-version": 1,
+  "port-version": 2,
   "maintainers": "Tomislav Karastojković <contact@alepho.com>",
   "description": "mailio is a cross platform C++ library for MIME format and SMTP, POP3 and IMAP protocols. It is based on the standard C++ 17 and Boost library.",
   "homepage": "https://github.com/karastojko/mailio",
-  "license": "BSD-2-clause",
+  "license": "BSD-2-Clause",
   "supports": "!uwp",
   "dependencies": [
     "boost-asio",

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -45,7 +45,7 @@ while (!($vcpkgRootDir -eq "") -and !(Test-Path "$vcpkgRootDir\.vcpkg-root"))
 
 Write-Verbose "Examining $vcpkgRootDir for .vcpkg-root - Found"
 
-$versionDate = '2022-02-01'
+$versionDate = '2022-02-03'
 if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64' -or $env:PROCESSOR_IDENTIFIER -match "ARMv[8,9] \(64-bit\)") {
     & "$scriptsDir/tls12-download.exe" github.com "/microsoft/vcpkg-tool/releases/download/$versionDate/vcpkg-arm64.exe" "$vcpkgRootDir\vcpkg.exe"
 } else {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -124,23 +124,23 @@ fi
 
 # Choose the vcpkg binary to download
 vcpkgDownloadTool="ON"
-vcpkgToolReleaseTag="2022-02-01"
+vcpkgToolReleaseTag="2022-02-03"
 if [ "$UNAME" = "Darwin" ]; then
     echo "Downloading vcpkg-macos..."
-    vcpkgToolReleaseSha="00c6070e77dd52367019a88f12ec915fb63e5ca2395f7a8e574f1327f716c3e4417b9e3ea794fb4d0fcbdb31918d2962692e22f78f05b4d72d7f168cd36985e9"
+    vcpkgToolReleaseSha="49d5ffcc96c03172826b5b6e3b1acab40fadae994a23c60188b6a7a9316f77a5761e49524dd29f2db8037e48c91b86fd67da03db5f8d8345a71b63f94ae4e472"
     vcpkgToolName="vcpkg-macos"
 elif [ "$vcpkgUseMuslC" = "ON" ]; then
     echo "Downloading vcpkg-muslc..."
-    vcpkgToolReleaseSha="baadf5907d07250d3168094ad38f34f31c8531bf30e2c996104e0bc6f90e7c74f07cd20373362b990928945dc0097c8357961f8bc271515892d7f89d36eddfa7"
+    vcpkgToolReleaseSha="8c28e617ba8b69fc3ba7e8dcfdeae15448b97b8f3ff4698a3f50140fc9e37c7e501484a4eeb2ecd3cd4cb6884ef523f73882988b2020df9621441947485f7c5f"
     vcpkgToolName="vcpkg-muslc"
 elif [ "$ARCH" = "x86_64" ]; then
     echo "Downloading vcpkg-glibc..."
-    vcpkgToolReleaseSha="a8b8311fc4a9c2d21e45d122664ae724130445db4911a6aad14d5ec49754b70065c3c59eee29f179f94051b2dc42fea3663b62036d30b0351b61f078a33a6d13"
+    vcpkgToolReleaseSha="1fae4c7c5b9f4a6b3e0c9e84f65385cebea47ef7af9c1acf4568a2b03270189608c67af7c42ca66706f7c90d0080881bff55848bb4e126282aad6f6ae11589b9"
     vcpkgToolName="vcpkg-glibc"
 else
     echo "Unable to determine a binary release of vcpkg; attempting to build from source."
     vcpkgDownloadTool="OFF"
-    vcpkgToolReleaseSha="f8f6646a1b063f078aa278ebb301dc96289d8008a51e1203248e65014085d7d47ec1dc76c61385dc822bb8607ac256d8009e180b2a4081c8a127eb15be4f9b0a"
+    vcpkgToolReleaseSha="005a6da80c3b6c6c9d8d7aa1671bf787b8c3fce783cab4a6fbd6064a8af525f5e87863c57521e90f07b7fdfa6f909c0ea99773e4591b325b32be854c60285ced"
 fi
 
 # Do the download or build.

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4278,7 +4278,7 @@
     },
     "mailio": {
       "baseline": "0.20.0",
-      "port-version": 1
+      "port-version": 2
     },
     "mapbox-geojson-cpp": {
       "baseline": "0.5.1",

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "452f51edc1d79104f3cf968477176d155666cb46",
+      "version": "0.20.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "819040f9644957f597a2429bb3365cbf4f58e35d",
       "version": "0.20.0",
       "port-version": 1


### PR DESCRIPTION
this adds the feature of `"license": null`, important to silence warnings

waiting on CI from <https://dev.azure.com/vcpkg/public/_build/results?buildId=66868&view=results>

cc @Neumann-A 