### PR TITLE
[popsift] Fix missing Thrust include, already merged upstream.

### DIFF
--- a/ports/popsift/fix_missing_thrust_include.patch
+++ b/ports/popsift/fix_missing_thrust_include.patch
@@ -1,0 +1,21 @@
+From 273adb1c375b12f285694488280e04efd251a76a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Sch=C3=B6ps?= <tom.schoeps@gmail.com>
+Date: Sat, 28 Aug 2021 16:52:25 +0200
+Subject: [PATCH] Add missing thrust include
+
+---
+ src/popsift/s_filtergrid.cu | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/popsift/s_filtergrid.cu b/src/popsift/s_filtergrid.cu
+index 078eb114..301c6a96 100644
+--- a/src/popsift/s_filtergrid.cu
++++ b/src/popsift/s_filtergrid.cu
+@@ -21,6 +21,7 @@
+ #include <thrust/copy.h>
+ #include <thrust/device_vector.h>
+ #include <thrust/execution_policy.h>
++#include <thrust/host_vector.h>
+ #include <thrust/iterator/discard_iterator.h>
+ #include <thrust/sequence.h>
+ #include <thrust/sort.h>

--- a/ports/popsift/portfile.cmake
+++ b/ports/popsift/portfile.cmake
@@ -1,15 +1,15 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO alicevision/popsift	
+    REPO alicevision/popsift
     REF v0.9
     SHA512 56789520872203eea86e07e8210e00c0b67d85486af16df9d620b1aff10f8d9ef5d910cf1dda6c68af7ca2ed11658ab5414ac79117b543f91a7d8d6a96a17ce0
     HEAD_REF develop
+    PATCHES
+        fix_missing_thrust_include.patch
 )
 
-include(${CURRENT_INSTALLED_DIR}/share/cuda/vcpkg_find_cuda.cmake)
+include("${CURRENT_INSTALLED_DIR}/share/cuda/vcpkg_find_cuda.cmake")
 vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT CUDA_TOOLKIT_ROOT)
-
-message(STATUS "CUDA_TOOLKIT_ROOT ${CUDA_TOOLKIT_ROOT}")
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
@@ -29,11 +29,11 @@ vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/PopSift)
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
- # copy the apps in tools directory
- if ("apps" IN_LIST FEATURES)
-     vcpkg_copy_tools(TOOL_NAMES popsift-demo AUTO_CLEAN)
- endif()
+# copy the apps in tools directory
+if ("apps" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES popsift-demo AUTO_CLEAN)
+endif()
 
-file(INSTALL ${SOURCE_PATH}/COPYING.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/popsift/vcpkg.json
+++ b/ports/popsift/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "popsift",
-  "version-string": "0.9",
-  "port-version": 2,
+  "version": "0.9",
+  "port-version": 3,
   "description": "PopSift is an implementation of the SIFT algorithm in CUDA.",
   "homepage": "https://github.com/alicevision/popsift",
   "supports": "!(uwp | arm | arm64 | android | x86)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5414,7 +5414,7 @@
     },
     "popsift": {
       "baseline": "0.9",
-      "port-version": 2
+      "port-version": 3
     },
     "portable-snippets": {
       "baseline": "2019-09-20",

--- a/versions/p-/popsift.json
+++ b/versions/p-/popsift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b3c9c601da86fd7d73cf3cb8b00c08ddb390acdd",
+      "version": "0.9",
+      "port-version": 3
+    },
+    {
       "git-tree": "c4901cdc3f98676dba684b75fd292b6570a46d35",
       "version-string": "0.9",
       "port-version": 2


### PR DESCRIPTION
This was discovered attempting to upgrade CUDA to 11.6 to upgrade to VS2022.
