### PR TITLE
[macos ci] 2022-02-04 update

### DIFF
--- a/scripts/azure-pipelines/azure-pipelines.yml
+++ b/scripts/azure-pipelines/azure-pipelines.yml
@@ -4,7 +4,7 @@
 variables:
   windows-pool: 'PrWin-2022-01-11'
   linux-pool: 'PrLin-2021-12-13'
-  osx-pool: 'PrOsx-2022-01-03'
+  osx-pool: 'PrOsx-2022-02-04'
 
 jobs:
 - template: windows/azure-pipelines.yml

--- a/scripts/azure-pipelines/osx/README.md
+++ b/scripts/azure-pipelines/osx/README.md
@@ -123,7 +123,10 @@ Once you've done that, add the software versions under [VM Software Versions](#v
 
 #### VM Software Versions
 
-* 2022-03-01:
+* 2022-02-04 (minor update to 2022-01-03)
+  * macOS: 12.1
+  * Xcode CLTs: 13.2
+* 2022-01-03:
   * macOS: 12.1
   * Xcode CLTs: 13.2
 * 2021-07-27:

--- a/scripts/azure-pipelines/osx/configuration/Vagrantfile-vm.rb
+++ b/scripts/azure-pipelines/osx/configuration/Vagrantfile-vm.rb
@@ -6,7 +6,7 @@ server = {
   :machine_name => configuration['machine_name'],
   :box => configuration['box_name'],
   :box_version => configuration['box_version'],
-  :ram => 12000,
+  :ram => 24000,
   :cpu => 11
 }
 

--- a/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
+++ b/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
@@ -2,6 +2,7 @@
   "$schema": "./vagrant-vm-configuration.schema.json",
   "brew": [
     "autoconf",
+    "autoconf-archive",
     "automake",
     "bison",
     "gettext",

--- a/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
+++ b/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
@@ -14,6 +14,7 @@
     "mono",
     "nasm",
     "pkg-config",
+    "texinfo",
     "yasm"
   ],
   "brew-cask": [

--- a/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
+++ b/scripts/azure-pipelines/osx/configuration/vagrant-box-configuration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./vagrant-vm-configuration.schema.json",
+  "$schema": "./vagrant-box-configuration.schema.json",
   "brew": [
     "autoconf",
     "autoconf-archive",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -797,7 +797,6 @@ mpir:x64-windows-static-md=skip
 mpir:arm64-windows=skip
 mpir:x64-osx=skip
 mpir:x64-linux=skip
-mpfr:x64-osx=fail
 mpfr:x64-linux=fail
 msix:x64-linux=fail
 msix:x64-osx=fail


### PR DESCRIPTION
* add moar RAM (12Go -> 24Go)
* Provision autoconf-archive on osx (PR #22872)
* [mpfr] Support Linux and OSX (PR #22845)
* fix minor schema bug

waiting on @strega-nil to add more machines to the pool