### PR TITLE
[gobject-introspection] Fix x86-windows build

### DIFF
--- a/ports/gobject-introspection/portfile.cmake
+++ b/ports/gobject-introspection/portfile.cmake
@@ -22,7 +22,8 @@ vcpkg_find_acquire_program(BISON)
 
 set(OPTIONS_DEBUG -Dbuild_introspection_data=false)
 set(OPTIONS_RELEASE -Dbuild_introspection_data=true)
-if(NOT HOST_TRIPLET STREQUAL TARGET_TRIPLET)
+if(NOT HOST_TRIPLET STREQUAL TARGET_TRIPLET AND
+   NOT (CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86"))
     list(APPEND OPTIONS_RELEASE -Dgi_cross_use_prebuilt_gi=true)
 endif()
 

--- a/ports/gobject-introspection/vcpkg.json
+++ b/ports/gobject-introspection/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "gobject-introspection",
   "version": "1.70.0",
+  "port-version": 1,
   "description": "A middleware layer between C libraries (using GObject) and language bindings.",
   "homepage": "https://gi.readthedocs.io/en/latest/",
-  "supports": "!static & native",
+  "supports": "!static & (native | (windows & x86))",
   "dependencies": [
     {
       "name": "cairo",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2538,7 +2538,7 @@
     },
     "gobject-introspection": {
       "baseline": "1.70.0",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp": {
       "baseline": "1.36.0",

--- a/versions/g-/gobject-introspection.json
+++ b/versions/g-/gobject-introspection.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a39c3bd1142fd69e6dba29cf3bd4c7e93b049406",
+      "version": "1.70.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "5f162cfae947901b4110ea23cb5163699a079cfe",
       "version": "1.70.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

Fix x86-windows build (accidentally disabled when fixing build failures for the initial port PR)

- #### What does your PR fix?  

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
