### PR TITLE
Remove patches for UWP

### DIFF
--- a/ports/binn/portfile.cmake
+++ b/ports/binn/portfile.cmake
@@ -6,9 +6,14 @@ vcpkg_from_github(
     REF b657ef3f38b37aa1e5dea88a9332889d0fbf3a81 # 3.0
     SHA512 14bf572152ec5343a161dea9ebfd2b63cd5ce48c0db3decf5591aa94ae7766771cf521ba22978e9ae8855feef694bad85951f3c4a29cb9ddd881918fc6d3722a
     HEAD_REF master
-    PATCHES
-        0001_fix_uwp.patch
 )
+
+if (VCPKG_IS_UWP)
+    vcpkg_execute_required_process(
+        COMMAND "$ENV{VCToolsInstallDir}\\..\\..\\..\\Auxiliary\\Build\\vcvarsall.bat" ${VCPKG_TARGET_ARCHITECTURE} uwp
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME prepare-${TARGET_TRIPLET})
+endif()
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 


### PR DESCRIPTION
**Describe the pull request**
The goal is to remove patches for UWP and replace them with
```cmake
vcpkg_execute_required_process(
    COMMAND "$ENV{VCToolsInstallDir}\\..\\..\\..\\Auxiliary\\Build\\vcvarsall.bat" ${VCPKG_TARGET_ARCHITECTURE} uwp
    WORKING_DIRECTORY "${SOURCE_PATH}"
    LOGNAME prepare-${TARGET_TRIPLET})
```

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
