### PR TITLE
[sdformat6] Disable test

### DIFF
--- a/ports/sdformat6/disable-test.patch
+++ b/ports/sdformat6/disable-test.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 78e72e6..c103dba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -252,7 +252,9 @@ else (buid_errors)
+ 
+     link_directories(${PROJECT_BINARY_DIR}/src)
+ 
++    if (BUILD_TEST)
+     add_subdirectory(test)
++    endif()
+     add_subdirectory(src)
+     add_subdirectory(include/sdf)
+     add_subdirectory(sdf)

--- a/ports/sdformat6/disable-test.patch
+++ b/ports/sdformat6/disable-test.patch
@@ -1,14 +1,34 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 78e72e6..c103dba 100644
+index 78e72e6..8f97304 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -252,7 +252,9 @@ else (buid_errors)
  
      link_directories(${PROJECT_BINARY_DIR}/src)
  
-+    if (BUILD_TEST)
++    if (BUILD_TESTING)
      add_subdirectory(test)
 +    endif()
      add_subdirectory(src)
      add_subdirectory(include/sdf)
      add_subdirectory(sdf)
+diff --git a/cmake/SDFUtils.cmake b/cmake/SDFUtils.cmake
+index acd57f8..3626e68 100644
+--- a/cmake/SDFUtils.cmake
++++ b/cmake/SDFUtils.cmake
+@@ -119,6 +119,7 @@ endmacro()
+ include_directories(${PROJECT_SOURCE_DIR}/test/gtest/include)
+ macro (sdf_build_tests)
+   # Build all the tests
++  if (BUILD_TESTING)
+   foreach(GTEST_SOURCE_file ${ARGN})
+     string(REGEX REPLACE ".cc" "" BINARY_NAME ${GTEST_SOURCE_file})
+     set(BINARY_NAME ${TEST_TYPE}_${BINARY_NAME})
+@@ -205,6 +206,7 @@ macro (sdf_build_tests)
+                --error-exitcode=1 --show-leak-kinds=all ${CMAKE_CURRENT_BINARY_DIR}/${BINARY_NAME})
+     endif()
+   endforeach()
++  endif()
+ endmacro()
+ 
+ #################################################

--- a/ports/sdformat6/fix-dependency-urdfdom.patch
+++ b/ports/sdformat6/fix-dependency-urdfdom.patch
@@ -1,0 +1,34 @@
+diff --git a/cmake/SearchForStuff.cmake b/cmake/SearchForStuff.cmake
+index 2735a07..6721de4 100644
+--- a/cmake/SearchForStuff.cmake
++++ b/cmake/SearchForStuff.cmake
+@@ -62,16 +62,16 @@ if (NOT PKG_CONFIG_FOUND)
+   if (NOT DEFINED USE_INTERNAL_URDF)
+     BUILD_WARNING("Couldn't find pkg-config for urdfdom, using internal copy")
+     set(USE_INTERNAL_URDF true)
+-  elseif(NOT USE_INTERNAL_URDF)
++  elseif(0)
+     BUILD_ERROR("Couldn't find pkg-config for urdfdom")
+   endif()
+ endif()
+ 
+ if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
+   # check for urdfdom with pkg-config
+-  pkg_check_modules(URDF urdfdom>=1.0)
++  find_package(urdfdom CONFIG REQUIRED)
+ 
+-  if (NOT URDF_FOUND)
++  if (NOT urdfdom_FOUND)
+     if (NOT DEFINED USE_INTERNAL_URDF)
+       message(STATUS "Couldn't find urdfdom >= 1.0, using internal copy")
+       set(USE_INTERNAL_URDF true)
+@@ -80,8 +80,7 @@ if (NOT DEFINED USE_INTERNAL_URDF OR NOT USE_INTERNAL_URDF)
+     endif()
+   else()
+     # what am I doing here? pkg-config and cmake
+-    set(URDF_INCLUDE_DIRS ${URDF_INCLUDEDIR})
+-    set(URDF_LIBRARY_DIRS ${URDF_LIBDIR})
++    set(URDF_LIBRARIES urdfdom::urdfdom_model urdfdom::urdfdom_world urdfdom::urdfdom_sensor urdfdom::urdfdom_model_state)
+   endif()
+ endif()
+ 

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF sdf6
     PATCHES
         disable-unneeded-include-findboost.patch
+        fix-dependency-urdfdom.patch
         disable-test.patch
 )
 

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -17,9 +17,10 @@ vcpkg_add_to_path(${RUBY_PATH})
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DBUILD_TESTING=OFF
-            -DUSE_EXTERNAL_URDF=ON
-            -DUSE_EXTERNAL_TINYXML=ON
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DUSE_INTERNAL_URDF=OFF
+        -DUSE_EXTERNAL_TINYXML=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/sdformat6/portfile.cmake
+++ b/ports/sdformat6/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF sdf6
     PATCHES
         disable-unneeded-include-findboost.patch
+        disable-test.patch
 )
 
 # Ruby is required by the sdformat build process

--- a/ports/sdformat6/vcpkg.json
+++ b/ports/sdformat6/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "sdformat6",
   "version": "6.2.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Simulation Description Format (SDF) parser and description files.",
   "homepage": "http://sdformat.org/",
+  "license": "Apache-2.0",
   "supports": "!(arm | uwp)",
   "dependencies": [
     "boost-any",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6262,7 +6262,7 @@
     },
     "sdformat6": {
       "baseline": "6.2.0",
-      "port-version": 5
+      "port-version": 6
     },
     "sdformat9": {
       "baseline": "9.4.0",

--- a/versions/s-/sdformat6.json
+++ b/versions/s-/sdformat6.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b50303e972bc2eba5fec92c63a3cd57ae1b64c7c",
+      "git-tree": "bdc0f927266aa4195c3795075c9e07c426c4556c",
       "version": "6.2.0",
       "port-version": 6
     },

--- a/versions/s-/sdformat6.json
+++ b/versions/s-/sdformat6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f41b689296552ada97fbd99ee5c4df4a1c82ceef",
+      "version": "6.2.0",
+      "port-version": 6
+    },
+    {
       "git-tree": "f3ec7ce50f9e64316ed940878271ade6cea1c0e3",
       "version": "6.2.0",
       "port-version": 5

--- a/versions/s-/sdformat6.json
+++ b/versions/s-/sdformat6.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f41b689296552ada97fbd99ee5c4df4a1c82ceef",
+      "git-tree": "b50303e972bc2eba5fec92c63a3cd57ae1b64c7c",
       "version": "6.2.0",
       "port-version": 6
     },


### PR DESCRIPTION
Fixes
```
FAILED: test/integration/INTEGRATION_locale_fix.exe 
cmd.exe /C "cd . && D:\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=test\integration\CMakeFiles\INTEGRATION_locale_fix.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~3\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe  test\integration\CMakeFiles\INTEGRATION_locale_fix.dir\locale_fix.cc.obj test\integration\CMakeFiles\INTEGRATION_locale_fix.dir\__\__\src\win\tinyxml\tinystr.cpp.obj test\integration\CMakeFiles\INTEGRATION_locale_fix.dir\__\__\src\win\tinyxml\tinyxmlerror.cpp.obj test\integration\CMakeFiles\INTEGRATION_locale_fix.dir\__\__\src\win\tinyxml\tinyxml.cpp.obj test\integration\CMakeFiles\INTEGRATION_locale_fix.dir\__\__\src\win\tinyxml\tinyxmlparser.cpp.obj  /out:test\integration\INTEGRATION_locale_fix.exe /implib:test\integration\INTEGRATION_locale_fix.lib /pdb:test\integration\INTEGRATION_locale_fix.pdb /version:0.0 /nologo /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF   /subsystem:console -LIBPATH:D:\buildtrees\sdformat6\x64-windows-rel\src   -LIBPATH:D:\buildtrees\sdformat6\x64-windows-rel\test gtest.lib  gtest_main.lib  sdformat.lib  D:\installed\x64-windows\lib\ignition-math4.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cmd.exe /C "cd /D D:\buildtrees\sdformat6\x64-windows-rel\test\integration && D:\downloads\tools\cmake-3.21.1-windows\cmake-3.21.1-windows-i386\bin\cmake.exe -E copy_if_different D:/buildtrees/sdformat6/x64-windows-rel/src/sdformat.dll D:/buildtrees/sdformat6/x64-windows-rel/test/integration""
Error copying file (if different) from "D:/buildtrees/sdformat6/x64-windows-rel/src/sdformat.dll" to "D:/buildtrees/sdformat6/x64-windows-rel/test/integration".
```

Related: #22676.