### PR TITLE
[Hunspell] Add Windows ARM64 Support

### DIFF
--- a/ports/hunspell/0004-add-win-arm64.patch
+++ b/ports/hunspell/0004-add-win-arm64.patch
@@ -1,0 +1,529 @@
+diff --git a/msvc/Hunspell.sln b/msvc/Hunspell.sln
+index dabd755..9b0d996 100644
+--- a/msvc/Hunspell.sln
++++ b/msvc/Hunspell.sln
+@@ -11,46 +11,66 @@ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug_dll|Win32 = Debug_dll|Win32
+ 		Debug_dll|x64 = Debug_dll|x64
++		Debug_dll|ARM64 = Debug_dll|ARM64
+ 		Debug|Win32 = Debug|Win32
+ 		Debug|x64 = Debug|x64
++		Debug|ARM64 = Debug|ARM64
+ 		Release_dll|Win32 = Release_dll|Win32
+ 		Release_dll|x64 = Release_dll|x64
++		Release_dll|ARM64 = Release_dll|ARM64
+ 		Release|Win32 = Release|Win32
+ 		Release|x64 = Release|x64
++		Release|ARM64 = Release|ARM64
+ 	EndGlobalSection
+ 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|Win32.ActiveCfg = Debug_dll|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|Win32.Build.0 = Debug_dll|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|x64.ActiveCfg = Debug_dll|x64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|x64.Build.0 = Debug_dll|x64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|ARM64.ActiveCfg = Debug_dll|ARM64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug_dll|ARM64.Build.0 = Debug_dll|ARM64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|Win32.Build.0 = Debug|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|x64.ActiveCfg = Debug|x64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|x64.Build.0 = Debug|x64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|ARM64.ActiveCfg = Debug|ARM64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Debug|ARM64.Build.0 = Debug|ARM64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|Win32.ActiveCfg = Release_dll|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|Win32.Build.0 = Release_dll|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|x64.ActiveCfg = Release_dll|x64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|x64.Build.0 = Release_dll|x64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|ARM64.ActiveCfg = Release_dll|ARM64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release_dll|ARM64.Build.0 = Release_dll|ARM64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|Win32.ActiveCfg = Release|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|Win32.Build.0 = Release|Win32
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|x64.ActiveCfg = Release|x64
+ 		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|x64.Build.0 = Release|x64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|ARM64.ActiveCfg = Release|ARM64
++		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|ARM64.Build.0 = Release|ARM64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|Win32.ActiveCfg = Debug|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|Win32.Build.0 = Debug|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|x64.ActiveCfg = Debug|x64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|x64.Build.0 = Debug|x64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|ARM64.ActiveCfg = Debug|ARM64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug_dll|ARM64.Build.0 = Debug|ARM64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|Win32.ActiveCfg = Debug|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|Win32.Build.0 = Debug|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|x64.ActiveCfg = Debug|x64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|x64.Build.0 = Debug|x64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|ARM64.ActiveCfg = Debug|ARM64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Debug|ARM64.Build.0 = Debug|ARM64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|Win32.ActiveCfg = Release|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|Win32.Build.0 = Release|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|x64.ActiveCfg = Release|x64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|x64.Build.0 = Release|x64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|ARM64.ActiveCfg = Release|ARM64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release_dll|ARM64.Build.0 = Release|ARM64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|Win32.ActiveCfg = Release|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|Win32.Build.0 = Release|Win32
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|x64.ActiveCfg = Release|x64
+ 		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|x64.Build.0 = Release|x64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|ARM64.ActiveCfg = Release|ARM64
++		{6A0453F4-B12A-4810-B9A2-8AB059316ED7}.Release|ARM64.Build.0 = Release|ARM64
+ 	EndGlobalSection
+ 	GlobalSection(SolutionProperties) = preSolution
+ 		HideSolutionNode = FALSE
+diff --git a/msvc/hunspell.vcxproj b/msvc/hunspell.vcxproj
+index d4817a5..b8afa73 100644
+--- a/msvc/hunspell.vcxproj
++++ b/msvc/hunspell.vcxproj
+@@ -9,6 +9,10 @@
+       <Configuration>Debug</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Debug|ARM64">
++      <Configuration>Debug</Configuration>
++      <Platform>ARM64</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|Win32">
+       <Configuration>Release</Configuration>
+       <Platform>Win32</Platform>
+@@ -17,6 +21,10 @@
+       <Configuration>Release</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|ARM64">
++      <Configuration>Release</Configuration>
++      <Platform>ARM64</Platform>
++    </ProjectConfiguration>
+   </ItemGroup>
+   <PropertyGroup Label="Globals">
+     <ProjectGuid>{6A0453F4-B12A-4810-B9A2-8AB059316ED7}</ProjectGuid>
+@@ -37,6 +45,12 @@
+     <CharacterSet>MultiByte</CharacterSet>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
++    <ConfigurationType>Application</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
++    <CharacterSet>MultiByte</CharacterSet>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+     <PlatformToolset>v140_xp</PlatformToolset>
+@@ -47,6 +61,11 @@
+     <PlatformToolset>v140_xp</PlatformToolset>
+     <CharacterSet>MultiByte</CharacterSet>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
++    <ConfigurationType>Application</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
++    <CharacterSet>MultiByte</CharacterSet>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+   </ImportGroup>
+@@ -56,12 +75,18 @@
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+     <_ProjectFileVersion>14.0.25420.1</_ProjectFileVersion>
+@@ -75,6 +100,10 @@
+     <LinkIncremental>true</LinkIncremental>
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
++    <LinkIncremental>true</LinkIncremental>
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
+     <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+@@ -84,6 +113,10 @@
+     <LinkIncremental>false</LinkIncremental>
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
++    <LinkIncremental>false</LinkIncremental>
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <ClCompile>
+       <Optimization>Disabled</Optimization>
+@@ -128,6 +161,27 @@
+       </DataExecutionPrevention>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <AdditionalIncludeDirectories>..\src\hunspell;..\src\parsers;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>W32;WIN32;_DEBUG;_CONSOLE;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
++      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
++    </ClCompile>
++    <Link>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Console</SubSystem>
++      <DataExecutionPrevention>
++      </DataExecutionPrevention>
++    </Link>
++  </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <ClCompile>
+       <Optimization>Full</Optimization>
+@@ -176,6 +230,30 @@
+       </DataExecutionPrevention>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
++    <ClCompile>
++      <Optimization>Full</Optimization>
++      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
++      <AdditionalIncludeDirectories>..\src\hunspell;..\src\parsers;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>W32;WIN32;NDEBUG;_CONSOLE;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>
++      </DebugInformationFormat>
++      <DisableSpecificWarnings>4127;4267;4706</DisableSpecificWarnings>
++    </ClCompile>
++    <Link>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Console</SubSystem>
++      <OptimizeReferences>true</OptimizeReferences>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <DataExecutionPrevention>
++      </DataExecutionPrevention>
++    </Link>
++  </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClCompile Include="..\src\parsers\firstparser.cxx" />
+     <ClCompile Include="..\src\parsers\htmlparser.cxx" />
+diff --git a/msvc/libhunspell.vcxproj b/msvc/libhunspell.vcxproj
+index 9a875ca..b7ed6b2 100644
+--- a/msvc/libhunspell.vcxproj
++++ b/msvc/libhunspell.vcxproj
+@@ -9,6 +9,10 @@
+       <Configuration>Debug_dll</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Debug_dll|ARM64">
++      <Configuration>Debug_dll</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Debug|Win32">
+       <Configuration>Debug</Configuration>
+       <Platform>Win32</Platform>
+@@ -17,6 +21,10 @@
+       <Configuration>Debug</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Debug|ARM64">
++      <Configuration>Debug</Configuration>
++      <Platform>ARM64</Platform>
++    </ProjectConfiguration>
+     <ProjectConfiguration Include="Release_dll|Win32">
+       <Configuration>Release_dll</Configuration>
+       <Platform>Win32</Platform>
+@@ -24,6 +32,10 @@
+     <ProjectConfiguration Include="Release_dll|x64">
+       <Configuration>Release_dll</Configuration>
+       <Platform>x64</Platform>
++    </ProjectConfiguration>
++        <ProjectConfiguration Include="Release_dll|ARM64">
++      <Configuration>Release_dll</Configuration>
++      <Platform>ARM64</Platform>
+     </ProjectConfiguration>
+     <ProjectConfiguration Include="Release|Win32">
+       <Configuration>Release</Configuration>
+@@ -33,6 +45,10 @@
+       <Configuration>Release</Configuration>
+       <Platform>x64</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|ARM64">
++      <Configuration>Release</Configuration>
++      <Platform>ARM64</Platform>
++    </ProjectConfiguration>
+   </ItemGroup>
+   <PropertyGroup Label="Globals">
+     <ProjectGuid>{53609BB3-D874-465C-AF7B-DF626DB0D89B}</ProjectGuid>
+@@ -53,6 +69,12 @@
+     <UseOfMfc>false</UseOfMfc>
+     <CharacterSet>MultiByte</CharacterSet>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|ARM64'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <PlatformToolset>v140_xp</PlatformToolset>
+@@ -67,6 +89,13 @@
+     <CharacterSet>MultiByte</CharacterSet>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|ARM64'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+     <PlatformToolset>v140_xp</PlatformToolset>
+@@ -80,6 +109,13 @@
+     <UseOfMfc>false</UseOfMfc>
+     <CharacterSet>MultiByte</CharacterSet>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
++    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+@@ -93,6 +129,12 @@
+     <UseOfMfc>false</UseOfMfc>
+     <CharacterSet>MultiByte</CharacterSet>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
++    <ConfigurationType>StaticLibrary</ConfigurationType>
++    <PlatformToolset>v140_xp</PlatformToolset>
++    <UseOfMfc>false</UseOfMfc>
++    <CharacterSet>MultiByte</CharacterSet>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+   </ImportGroup>
+@@ -102,24 +144,36 @@
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+     <_ProjectFileVersion>14.0.25420.1</_ProjectFileVersion>
+@@ -141,6 +195,10 @@
+     <LinkIncremental />
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|ARM64'">
++    <LinkIncremental />
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
+     <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+@@ -150,12 +208,23 @@
+     <LinkIncremental>true</LinkIncremental>
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|ARM64'">
++    <LinkIncremental>true</LinkIncremental>
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++  </PropertyGroup>
++  
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <PreBuildEvent>
+       <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
+@@ -196,6 +265,25 @@
+     </ClCompile>
+     <Lib />
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
++    <PreBuildEvent>
++      <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
++    </PreBuildEvent>
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <AdditionalIncludeDirectories>..\src\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <MinimalRebuild>false</MinimalRebuild>
++      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
++    </ClCompile>
++    <Lib />
++  </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <PreBuildEvent>
+       <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
+@@ -250,6 +338,34 @@
+       <SuppressStartupBanner>false</SuppressStartupBanner>
+     </Bscmake>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
++    <PreBuildEvent>
++      <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
++    </PreBuildEvent>
++    <ClCompile>
++      <Optimization>Full</Optimization>
++      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
++      <AdditionalIncludeDirectories>..\src\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <StringPooling>true</StringPooling>
++      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <FunctionLevelLinking>true</FunctionLevelLinking>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>
++      </DebugInformationFormat>
++      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
++    </ClCompile>
++    <ResourceCompile>
++      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <Culture>0x0409</Culture>
++    </ResourceCompile>
++    <Bscmake>
++      <SuppressStartupBanner>false</SuppressStartupBanner>
++    </Bscmake>
++  </ItemDefinitionGroup>  
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|Win32'">
+     <PreBuildEvent>
+       <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
+@@ -315,6 +431,39 @@
+       <SubSystem>Windows</SubSystem>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_dll|ARM64'">
++    <PreBuildEvent>
++      <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
++    </PreBuildEvent>
++    <ClCompile>
++      <Optimization>Full</Optimization>
++      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
++      <AdditionalIncludeDirectories>..\src\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;BUILDING_LIBHUNSPELL;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <StringPooling>true</StringPooling>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <FunctionLevelLinking>true</FunctionLevelLinking>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>
++      </DebugInformationFormat>
++      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
++    </ClCompile>
++    <ResourceCompile>
++      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <Culture>0x0409</Culture>
++    </ResourceCompile>
++    <Link>
++      <GenerateDebugInformation>false</GenerateDebugInformation>
++      <OptimizeReferences>true</OptimizeReferences>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <DataExecutionPrevention>
++      </DataExecutionPrevention>
++      <SubSystem>Windows</SubSystem>
++    </Link>
++  </ItemDefinitionGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|Win32'">
+     <PreBuildEvent>
+       <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
+@@ -366,6 +515,31 @@
+       </DataExecutionPrevention>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_dll|ARM64'">
++    <PreBuildEvent>
++      <Command>echo N | copy /-Y ..\src\hunspell\hunvisapi.h.in ..\src\hunspell\hunvisapi.h</Command>
++    </PreBuildEvent>
++    <ClCompile>
++      <Optimization>Disabled</Optimization>
++      <AdditionalIncludeDirectories>..\src\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;BUILDING_LIBHUNSPELL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <MinimalRebuild>false</MinimalRebuild>
++      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
++      <PrecompiledHeader>
++      </PrecompiledHeader>
++      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <DisableSpecificWarnings>4706;4251;4267</DisableSpecificWarnings>
++    </ClCompile>
++    <Link>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Windows</SubSystem>
++      <DataExecutionPrevention>
++      </DataExecutionPrevention>
++    </Link>
++  </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClInclude Include="..\src\hunspell\affentry.hxx" />
+     <ClInclude Include="..\src\hunspell\affixmgr.hxx" />

--- a/ports/hunspell/portfile.cmake
+++ b/ports/hunspell/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         0001_fix_unistd.patch
         0002-disable-test.patch
         0003-fix-win-build.patch
+        0004-add-win-arm64.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -23,6 +24,8 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
         set(HUNSPELL_ARCH Win32)
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
         set(HUNSPELL_ARCH x64)
+     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        set(HUNSPELL_ARCH ARM64)
     else()
         message(FATAL_ERROR "unsupported architecture")
     endif()

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 7,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
-  "supports": "!(arm & windows) & !uwp",
+  "supports": "!uwp",
   "dependencies": [
     "libiconv"
   ],

--- a/ports/hunspell/vcpkg.json
+++ b/ports/hunspell/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hunspell",
   "version": "1.7.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "The most popular spellchecking library.",
   "homepage": "https://github.com/hunspell/hunspell",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2738,7 +2738,7 @@
     },
     "hunspell": {
       "baseline": "1.7.0",
-      "port-version": 7
+      "port-version": 8
     },
     "hwloc": {
       "baseline": "2.5.0",

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "acbcd068664bed1cdf8e71999b7ccc5f894b9671",
+      "git-tree": "9beac8cd192fb54839925b083fa72e611d7bcfee",
       "version": "1.7.0",
       "port-version": 8
     },

--- a/versions/h-/hunspell.json
+++ b/versions/h-/hunspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "acbcd068664bed1cdf8e71999b7ccc5f894b9671",
+      "version": "1.7.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "a7db92584496fe08ac10f8f32556ca89e14018aa",
       "version": "1.7.0",
       "port-version": 7


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Adds Windows ARM64 Support

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Added **arm64-windows** and **arm64-windows-static**, **No** (I did not see arm64-windows marked as fail)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes 

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
