### PR TITLE
[ffmpeg] Block "tensorflow" and others for the "all" feature on non-x64.

### DIFF
--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 7,
+  "port-version": 8,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -120,14 +120,6 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "tensorflow"
-          ],
-          "platform": "!static"
-        },
-        {
-          "name": "ffmpeg",
-          "default-features": false,
-          "features": [
             "ilbc"
           ],
           "platform": "!(arm & uwp)"
@@ -139,6 +131,14 @@
             "ssh"
           ],
           "platform": "!(uwp | arm)"
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "tensorflow"
+          ],
+          "platform": "x64 & !static"
         },
         {
           "name": "ffmpeg",

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -33,14 +33,12 @@
           "name": "ffmpeg",
           "default-features": false,
           "features": [
-            "ass",
             "avcodec",
             "avdevice",
             "avfilter",
             "avformat",
             "avresample",
             "bzip2",
-            "fontconfig",
             "freetype",
             "iconv",
             "lzma",
@@ -75,6 +73,22 @@
             "sdl2"
           ],
           "platform": "!osx"
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "ass"
+          ],
+          "platform": "!uwp"
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "fontconfig"
+          ],
+          "platform": "!uwp"
         },
         {
           "name": "ffmpeg",
@@ -138,7 +152,7 @@
           "features": [
             "tensorflow"
           ],
-          "platform": "x64 & !static"
+          "platform": "x64 & !static & !uwp"
         },
         {
           "name": "ffmpeg",
@@ -170,7 +184,7 @@
           "features": [
             "tesseract"
           ],
-          "platform": "!(windows & arm) & !static"
+          "platform": "!(windows & arm) & !static & !uwp"
         }
       ]
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2154,7 +2154,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 7
+      "port-version": 8
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9bb644f2550ed939679d226aa25ba4c2c789092",
+      "version": "4.4.1",
+      "port-version": 8
+    },
+    {
       "git-tree": "8b692478001452049ea19d32ec199f58c5de3a77",
       "version": "4.4.1",
       "port-version": 7

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d9bb644f2550ed939679d226aa25ba4c2c789092",
+      "git-tree": "03b7a2329bc927de9637d45738c23e607e4f4387",
       "version": "4.4.1",
       "port-version": 8
     },


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/21980/ , we removed all the blocks for tensorflow which were merely replicating that upstream's "supports" expression. That is the correct behavior: if upstream adds support for a thing, it should start being tested downstream. However, the "all" and "all-nonfree" features of ffmpeg attempt to turn on what is really "all supported" rather than "all", so the feature-dependency needs to be guarded.

Note that the ffmpeg[tensorflow] feature remains unguarded! It is ffmpeg[all]'s *dependency* on ffmpeg[tensorflow] that is guarded.
