### PR TITLE
[pcl] Re-fix feature visualization, fix use qhull

### DIFF
--- a/ports/pcl/fix-find-qhull.patch
+++ b/ports/pcl/fix-find-qhull.patch
@@ -1,18 +1,8 @@
-From 7e3117fb47f58c7b1fb83e3a062a630b787a43bc Mon Sep 17 00:00:00 2001
-From: raahilsha-z <raahil.sha@zimaging.io>
-Date: Wed, 7 Jul 2021 16:11:12 -0400
-Subject: [PATCH] fix find qhull
-
----
- CMakeLists.txt         | 5 +----
- surface/CMakeLists.txt | 9 +++++++--
- 2 files changed, 8 insertions(+), 6 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a1d9bb58f..7cf86f74b 100644
+index a1d9bb5..73b1465 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -359,10 +359,7 @@ if(WITH_QHULL)
+@@ -359,10 +359,8 @@ if(WITH_QHULL)
    if(NOT PCL_SHARED_LIBS OR ((WIN32 AND NOT MINGW) AND NOT PCL_BUILD_WITH_QHULL_DYNAMIC_LINKING_WIN32))
      set(QHULL_USE_STATIC ON)
    endif()
@@ -21,11 +11,12 @@ index a1d9bb58f..7cf86f74b 100644
 -    include_directories(SYSTEM ${QHULL_INCLUDE_DIRS})
 -  endif()
 +  find_package(Qhull CONFIG REQUIRED)
++  set(HAVE_QHULL ON)
  endif()
  
  # Cuda
 diff --git a/surface/CMakeLists.txt b/surface/CMakeLists.txt
-index d8a8566ea..1953c5566 100644
+index d8a8566..1953c55 100644
 --- a/surface/CMakeLists.txt
 +++ b/surface/CMakeLists.txt
 @@ -12,7 +12,7 @@ if(NOT build)
@@ -51,6 +42,3 @@ index d8a8566ea..1953c5566 100644
    target_link_libraries("${LIB_NAME}" ${QHULL_LIBRARIES})
  endif()
  
--- 
-2.32.0.windows.1
-

--- a/ports/pcl/portfile.cmake
+++ b/ports/pcl/portfile.cmake
@@ -42,14 +42,11 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         cuda            BUILD_GPU
         tools           BUILD_tools
         opengl          WITH_OPENGL
-        vtk             WITH_VTK
         libusb          WITH_LIBUSB
+        visualization   WITH_VTK
         visualization   BUILD_visualization
         examples        BUILD_examples
         apps            BUILD_apps
-        apps            BUILD_apps_cloud_composer
-        apps            BUILD_apps_modeler
-        apps            BUILD_apps_point_cloud_editor
         # These 2 apps need openni1
         #apps            BUILD_apps_in_hand_scanner
         #apps            BUILD_apps_3d_rec_framework

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 4,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
+  "license": "BSD-3-Clause",
   "supports": "!(arm64 & windows)",
   "dependencies": [
     "boost-asio",

--- a/ports/pcl/vcpkg.json
+++ b/ports/pcl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcl",
   "version": "1.12.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Point Cloud Library (PCL) is open source library for 2D/3D image and point cloud processing.",
   "homepage": "https://github.com/PointCloudLibrary/pcl",
   "supports": "!(arm64 & windows)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5238,7 +5238,7 @@
     },
     "pcl": {
       "baseline": "1.12.0",
-      "port-version": 3
+      "port-version": 4
     },
     "pcre": {
       "baseline": "8.45",

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3eb44f07f0155cf97aa0f3526606e0c7009466a3",
+      "version": "1.12.0",
+      "port-version": 4
+    },
+    {
       "git-tree": "0f0c24ef83692fbcc9434ec9622592ba9b16e0d5",
       "version": "1.12.0",
       "port-version": 3

--- a/versions/p-/pcl.json
+++ b/versions/p-/pcl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3eb44f07f0155cf97aa0f3526606e0c7009466a3",
+      "git-tree": "7e54ab86574dfc901275996e282f8db5c6c9c3fb",
       "version": "1.12.0",
       "port-version": 4
     },


### PR DESCRIPTION
1. Feature `visualization` needs set `WITH_VTK` to `ON` first, so change value `WITH_VTK`'s key to `visualization`, details please see https://github.com/microsoft/vcpkg/pull/21788#issuecomment-985233424.
2. `HAVE_QHULL` will be used in pcl_config.h:
```cpp
...
/* #undef HAVE_QHULL */
...
#ifdef DISABLE_QHULL
#undef HAVE_QHULL
#endif
...
```

Fixes #17662.