### PR TITLE
[jasper] Revert changes to supports on freeglut

### DIFF
--- a/ports/jasper/vcpkg.json
+++ b/ports/jasper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "jasper",
   "version": "2.0.33",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open source implementation of the JPEG-2000 Part-1 standard",
   "homepage": "https://github.com/mdadams/jasper",
   "dependencies": [
@@ -22,7 +22,10 @@
     "opengl": {
       "description": "Enable the use of the OpenGL/GLUT Library",
       "dependencies": [
-        "freeglut",
+        {
+          "name": "freeglut",
+          "platform": "!osx"
+        },
         "opengl"
       ]
     }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2962,7 +2962,7 @@
     },
     "jasper": {
       "baseline": "2.0.33",
-      "port-version": 2
+      "port-version": 3
     },
     "jbig2dec": {
       "baseline": "0.19",

--- a/versions/j-/jasper.json
+++ b/versions/j-/jasper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "caf8b5e479138be21f8a7782806e9ef5c1dcdb37",
+      "version": "2.0.33",
+      "port-version": 3
+    },
+    {
       "git-tree": "59d44227795e2e5e31a0f3e327832e4013b1e255",
       "version": "2.0.33",
       "port-version": 2


### PR DESCRIPTION
Merging https://github.com/microsoft/vcpkg/pull/22895 resulted in new cascading failures for `jasper:x64-osx`. Previously, jasper was protected from cascading failures due to a platform condition that was removed.