### PR TITLE
[cairo] fix accidental dependency on system libbfd

### DIFF
--- a/ports/cairo/meson-fix-bfd.patch
+++ b/ports/cairo/meson-fix-bfd.patch
@@ -1,0 +1,11 @@
+--- a/meson.build
++++ b/meson.build
+@@ -656,7 +656,7 @@ endif
+ 
+ # Untested, libiberty.h is in a libiberty subfolder for me
+ # FIXME: automagic
+-bfd_dep = cc.find_library('bfd', required: false)
++bfd_dep = cc.find_library('', required: false)
+ if bfd_dep.found() and cc.has_function('bfd_openr', dependencies: [bfd_dep])
+   if cc.has_header('libiberty.h')
+     conf.set('HAVE_BFD', 1)

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_gitlab(
     HEAD_REF master
     PATCHES 0001-meson-fix-macOS-build-and-add-macOS-ci.patch
             cairo_static_fix.patch
+            meson-fix-bfd.patch
 )
 
 if("fontconfig" IN_LIST FEATURES)

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cairo",
   "version": "1.17.4",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
   "homepage": "https://cairographics.org",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1214,7 +1214,7 @@
     },
     "cairo": {
       "baseline": "1.17.4",
-      "port-version": 3
+      "port-version": 4
     },
     "cairomm": {
       "baseline": "1.16.0",

--- a/versions/c-/cairo.json
+++ b/versions/c-/cairo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c024050e140b5174c6ef3094bad3cb2d6a710f82",
+      "version": "1.17.4",
+      "port-version": 4
+    },
+    {
       "git-tree": "d8bed1ec84c641aad98858b6fb1151b09273227e",
       "version": "1.17.4",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
The build was broken if the system has bfd installed, it tried to use /usr/include/x86_64-pc-linux-gnu/bfd.h which in turn complained that "config.h" was not included.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  tested on x64-linux, and yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
