### PR TITLE
[vcpkg.targets] Fix _ZVcpkgInstalledDir in manifest mode

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -51,7 +51,7 @@
   <Choose>
     <When Condition="'$(VcpkgEnableManifest)' == 'true'">
       <PropertyGroup>
-        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
+        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\</_ZVcpkgInstalledDir>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
The $(VcpkgTriplet) in path duplicated when enable manifest in msbuild project.

```
 <!-- Determine the locations trees we want to consume. _ZVcpkgInstalledDir is special in that it doesn't have a default
  value in the .props because we normally derive it, but users may override the value. -->
  <Choose>
    <When Condition="'$(VcpkgEnableManifest)' == 'true'">
      <PropertyGroup>
        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
      </PropertyGroup>
    </When>
    <Otherwise>
      <PropertyGroup>
        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgRoot)installed\</_ZVcpkgInstalledDir>
      </PropertyGroup>
    </Otherwise>
  </Choose>

  <PropertyGroup>
    <_ZVcpkgCurrentInstalledDir>$(_ZVcpkgInstalledDir)$(VcpkgTriplet)\</_ZVcpkgCurrentInstalledDir>
...
 </PropertyGroup>
```