### PR TITLE
[gtkmm] update to 4.6.0

### DIFF
--- a/ports/gtkmm/portfile.cmake
+++ b/ports/gtkmm/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/4.4/gtkmm-4.4.0.tar.xz"
-    FILENAME "gtkmm-4.4.0.tar.xz"
-    SHA512 d6f20213e9ea7a13e2b9822f220a5cdeaef9a9406abee813e0eebdb540839f25f4c19cc7669c24184bef471f5529a7897cd16ee679266148f3181dd2cfa39eb4
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/4.6/gtkmm-4.6.0.tar.xz"
+    FILENAME "gtkmm-4.6.0.tar.xz"
+    SHA512 d1040be44d133cfa016efc581b79c5303806d0d441b57dcc22bd84a05c3e7934f9b7b894e71d7f4a0be332daba3dd58ef558f58070b83bf8a9de7d1027d92199
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/gtkmm/vcpkg.json
+++ b/ports/gtkmm/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "gtkmm",
-  "version": "4.4.0",
-  "port-version": 1,
+  "version": "4.6.0",
   "description": "gtkmm is the official C++ interface for the popular GUI library GTK+.",
   "homepage": "https://www.gtkmm.org/",
+  "license": "LGPL-3.0-or-later",
   "supports": "!uwp",
   "dependencies": [
     "atk",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2633,8 +2633,8 @@
       "port-version": 1
     },
     "gtkmm": {
-      "baseline": "4.4.0",
-      "port-version": 1
+      "baseline": "4.6.0",
+      "port-version": 0
     },
     "gts": {
       "baseline": "0.7.6",

--- a/versions/g-/gtkmm.json
+++ b/versions/g-/gtkmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f39d8f061ae7242baf2b1b78b76253b2ee21c936",
+      "version": "4.6.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "8e30c6169ae3b7778ba17649312e6fc064fe1b43",
       "version": "4.4.0",
       "port-version": 1


### PR DESCRIPTION
Fix #23017 

Update gtkmm to the latest version 4.6.0

Note : no feature need to test