### PR TITLE
[easyhook] Update target .NET Framework version to 4.7.2.

### DIFF
--- a/ports/easyhook/portfile.cmake
+++ b/ports/easyhook/portfile.cmake
@@ -1,4 +1,4 @@
-message(WARNING ".Net framework 4.0 is required, please install it before installing easyhook.")
+message(WARNING ".Net framework 4.7.2 is required, please install it before installing easyhook.")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -34,6 +34,40 @@ foreach(VCXPROJ IN ITEMS
     vcpkg_replace_string(
         "${VCXPROJ}"
         "<MinimalRebuild>true</MinimalRebuild>"
+        ""
+    )
+endforeach()
+
+# Use modern .NET Framework
+foreach(CSPROJ IN ITEMS
+    "${SOURCE_PATH}/EasyHook/EasyHook.csproj"
+    "${SOURCE_PATH}/EasyHookSvc/EasyHookSvc.csproj"
+    "${SOURCE_PATH}/EasyLoad/EasyLoad.csproj"
+    "${SOURCE_PATH}/Examples/FileMon/FileMon.csproj"
+    "${SOURCE_PATH}/Examples/FileMonInject/FileMonInject.csproj"
+    "${SOURCE_PATH}/Examples/FileMonitorController/FileMonitorController.csproj"
+    "${SOURCE_PATH}/Examples/FileMonitorInterceptor/FileMonitorInterceptor.csproj"
+    "${SOURCE_PATH}/Examples/FileMonitorInterface/FileMonitorInterface.csproj"
+    "${SOURCE_PATH}/Examples/ProcessMonitor/ProcessMonitor.csproj"
+    "${SOURCE_PATH}/Examples/ProcMonInject/ProcMonInject.csproj"
+    "${SOURCE_PATH}/Test/ComplexParameterInject/ComplexParameterInject.csproj"
+    "${SOURCE_PATH}/Test/ComplexParameterTest/ComplexParameterTest.csproj"
+    "${SOURCE_PATH}/Test/EasyHook.Tests/EasyHook.Tests.csproj"
+    "${SOURCE_PATH}/Test/ManagedTarget/ManagedTarget.csproj"
+    "${SOURCE_PATH}/Test/ManagedTest/ManagedTest.csproj"
+    "${SOURCE_PATH}/Test/MultipleHooks/MultipleHooks/MultipleHooks.csproj"
+    "${SOURCE_PATH}/Test/MultipleHooks/SimpleHook1/SimpleHook1.csproj"
+    "${SOURCE_PATH}/Test/MultipleHooks/SimpleHook2/SimpleHook2.csproj"
+    "${SOURCE_PATH}/Test/TestFuncHooks/TestFuncHooks.csproj")
+
+    vcpkg_replace_string(
+        "${CSPROJ}"
+        "<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>"
+        "<TargetFrameworkVersion>4.7.2</TargetFrameworkVersion>"
+    )
+    vcpkg_replace_string(
+        "${CSPROJ}"
+        "<TargetFrameworkProfile>Client</TargetFrameworkProfile>"
         ""
     )
 endforeach()

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -4,5 +4,5 @@
   "port-version": 5,
   "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
   "homepage": "https://github.com/EasyHook/EasyHook",
-  "supports": "windows & !static & (x86 | x64)"
+  "supports": "windows & !static & !uwp & (x86 | x64)"
 }

--- a/ports/easyhook/vcpkg.json
+++ b/ports/easyhook/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "name": "easyhook",
   "version": "2.7.7097.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "This project supports extending (hooking) unmanaged code (APIs) with pure managed ones, from within a fully managed environment on 32- or 64-bit Windows Vista x64, Windows Server 2008 x64, Windows 7, Windows 8.1, and Windows 10.",
   "homepage": "https://github.com/EasyHook/EasyHook",
-  "supports": "windows & !(static | arm | uwp)"
+  "supports": "windows & !static & (x86 | x64)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1958,7 +1958,7 @@
     },
     "easyhook": {
       "baseline": "2.7.7097.0",
-      "port-version": 4
+      "port-version": 5
     },
     "easyloggingpp": {
       "baseline": "9.97.0",

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f831a56dad150fcbd7819e5997286be54f86ea18",
+      "git-tree": "71b209c038081c700231ebc3be136c6976f22c4b",
       "version": "2.7.7097.0",
       "port-version": 5
     },

--- a/versions/e-/easyhook.json
+++ b/versions/e-/easyhook.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f831a56dad150fcbd7819e5997286be54f86ea18",
+      "version": "2.7.7097.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "54eb13c17af41e5e869503410d13f67e6886c8ff",
       "version": "2.7.7097.0",
       "port-version": 4


### PR DESCRIPTION
This is the .NET Framework version for VS2017, and is accepted by VS2019 and VS2022. See https://docs.microsoft.com/en-us/dotnet/framework/install/guide-for-developers

VS2022 does not support targeting 4.0 Client Profile, so this is necessary to un-break easyhook on VS2022.
