### PR TITLE
Add notice about how to export unofficial CMake targets.

### DIFF
--- a/docs/maintainers/maintainer-guide.md
+++ b/docs/maintainers/maintainer-guide.md
@@ -95,13 +95,13 @@ In the entire vcpkg system, no two ports a user is expected to use concurrently 
 
 ### Add CMake exports in an unofficial- namespace
 
-A core design ideal of vcpkg is to not create "lock-in" for customers, and provide bindings in build systems the same way one would consume dependencies if they get them manually, or through `apt`, or similar. To that end, we avoid taking "the obvious name" in the CMake `find_package` namespace or targets, to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
+A core design ideal of vcpkg is to not create "lock-in" for customers. In the build system, there should be no difference between depending on a library from the system, and depend on a library from vcpkg. To that end, we avoid adding CMake exports or targets to existing libraries with "the obvious name", to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
 
-To that end, exported CMake configs when not matching upstream should be changed to add `unofficial-` as a prefix, and place the resulting targets in an `unofficial::PORT::` namespace.
+To that end, any CMake configs that the port exports, which are not in the upstream library, should have `unofficial-` as a prefix. The added exported targets should be in the `unofficial::<port>::` namespace.
 
 This means that the user should see:
- * `find_package(unofficial-PORT CONFIG)` as the way to get at the unique-to-vcpkg package
- * `unofficial::PORT::TARGET` as the way to get an exported target from that port.
+ * `find_package(unofficial-<port> CONFIG)` as the way to get at the unique-to-vcpkg package
+ * `unofficial::<port>::<target>` as an exported target from that port.
 
 Examples:
  * [`brotli`](https://github.com/microsoft/vcpkg/blob/4f0a640e4c5b74166b759a862d7527c930eff32e/ports/brotli/install.patch) creates the `unofficial-brotli` package, producing target `unofficial::brotli::brotli`.

--- a/docs/maintainers/maintainer-guide.md
+++ b/docs/maintainers/maintainer-guide.md
@@ -93,6 +93,19 @@ the files installed by `b` must be the same, regardless of influence by the prev
 
 In the entire vcpkg system, no two ports a user is expected to use concurrently may provide the same file. If a port tries to install a file already provided by another file, installation will fail. If a port wants to use an extremely common name for a header, for example, it should place those headers in a subdirectory rather than in `include`.
 
+### Add CMake exports in an unofficial- namespace
+
+A core design ideal of vcpkg is to not create "lock-in" for customers, and provide bindings in build systems the same way one would consume dependencies if they get them manually, or through `apt`, or similar. To that end, we avoid taking "the obvious name" in the CMake `find_package` namespace or targets, to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
+
+To that end, exported CMake configs when not matching upstream should be changed to add `unofficial-` as a prefix, and place the resulting targets in an `unofficial::PORT::` namespace.
+
+This means that the user should see:
+ * `find_package(unofficial-PORT CONFIG)` as the way to get at the unique-to-vcpkg package
+ * `unofficial::PORT::TARGET` as the way to get an exported target from that port.
+
+Examples:
+ * [`brotli`](https://github.com/microsoft/vcpkg/blob/4f0a640e4c5b74166b759a862d7527c930eff32e/ports/brotli/install.patch) creates the `unofficial-brotli` package, producing target `unofficial::brotli::brotli`.
+
 ## Features
 
 ### Do not use features to implement alternatives

--- a/docs/maintainers/maintainer-guide.md
+++ b/docs/maintainers/maintainer-guide.md
@@ -95,9 +95,9 @@ In the entire vcpkg system, no two ports a user is expected to use concurrently 
 
 ### Add CMake exports in an unofficial- namespace
 
-A core design ideal of vcpkg is to not create "lock-in" for customers. In the build system, there should be no difference between depending on a library from the system, and depend on a library from vcpkg. To that end, we avoid adding CMake exports or targets to existing libraries with "the obvious name", to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
+A core design ideal of vcpkg is to not create "lock-in" for customers. In the build system, there should be no difference between depending on a library from the system, and depending on a library from vcpkg. To that end, we avoid adding CMake exports or targets to existing libraries with "the obvious name", to allow upstreams to add their own official CMake exports without conflicting with vcpkg.
 
-To that end, any CMake configs that the port exports, which are not in the upstream library, should have `unofficial-` as a prefix. The added exported targets should be in the `unofficial::<port>::` namespace.
+To that end, any CMake configs that the port exports, which are not in the upstream library, should have `unofficial-` as a prefix. Any additional targets should be in the `unofficial::<port>::` namespace.
 
 This means that the user should see:
  * `find_package(unofficial-<port> CONFIG)` as the way to get at the unique-to-vcpkg package


### PR DESCRIPTION
Adds documentation about how to add CMake targets when upstream does not provide such exported targets.
