### PR TITLE
[HPX] Don't remove HPXCacheVariables.cmake during install

### DIFF
--- a/ports/hpx/fix-cmakecache-paths.patch
+++ b/ports/hpx/fix-cmakecache-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/cmake/HPX_ForwardCacheVariables.cmake b/cmake/HPX_ForwardCacheVariables.cmake
+index 7c434085a76..34cc47c7750 100644
+--- a/cmake/HPX_ForwardCacheVariables.cmake
++++ b/cmake/HPX_ForwardCacheVariables.cmake
+@@ -23,6 +23,17 @@ set(_cache_var_file_template
+ )
+ set(_cache_variables)
+ foreach(_var IN LISTS cache_vars)
++  if(HPX_WITH_VCPKG)
++    # avoid writing directory names into cache file
++    string(FIND ${_var} "_DIR" _pos)
++    if(NOT ${_pos} EQUAL -1)
++      continue()
++    endif()
++    string(FIND ${_var} "_PATH" _pos)
++    if(NOT ${_pos} EQUAL -1)
++      continue()
++    endif()
++  endif()
+   set(_cache_variables "${_cache_variables}set(${_var} ${${_var}})\n")
+ endforeach()
+ 

--- a/ports/hpx/portfile.cmake
+++ b/ports/hpx/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF 1.7.1
     SHA512 6bdb294da393a198abf81d5f63799a066334755eed0fda40bbfc4e9a774b6e19a3e5ad7ab45c989d31f3797e7b547bb552c29f51b552d9a79d166f86aee375a3
     HEAD_REF stable
-    PATCHES fix-dependency-hwloc.patch
+    PATCHES
+        fix-dependency-hwloc.patch
+        fix-cmakecache-paths.patch
 )
 
 set(HPX_WITH_MALLOC system)
@@ -93,6 +95,5 @@ vcpkg_fixup_pkgconfig()
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/bin/hpxcxx" "\"${CURRENT_PACKAGES_DIR}\"" "os.path.dirname(os.path.dirname(os.path.realpath(__file__)))")
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/bin/hpxcxx" "\"${CURRENT_PACKAGES_DIR}/debug\"" "os.path.dirname(os.path.dirname(os.path.realpath(__file__)))")
-file(REMOVE "${CURRENT_PACKAGES_DIR}/share/hpx/HPXCacheVariables.cmake")
 
 vcpkg_copy_pdbs()

--- a/ports/hpx/vcpkg.json
+++ b/ports/hpx/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hpx",
   "version-semver": "1.7.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": [
     "The C++ Standards Library for Concurrency and Parallelism",
     "HPX is a C++ Standards Library for Concurrency and Parallelism. It implements all of the corresponding facilities as defined by the C++ Standard. Additionally, in HPX we implement functionalities proposed as part of the ongoing C++ standardization process. We also extend the C++ Standard APIs to the distributed case."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2722,7 +2722,7 @@
     },
     "hpx": {
       "baseline": "1.7.1",
-      "port-version": 4
+      "port-version": 5
     },
     "http-parser": {
       "baseline": "2.9.4",

--- a/versions/h-/hpx.json
+++ b/versions/h-/hpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "48d153f2932b01257af5a799676268abdfb35fac",
+      "version-semver": "1.7.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "815641d6119376c546119a841f6c035e8f27b8da",
       "version-semver": "1.7.1",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes project builds that depend on HPX installed using vcpkg

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes


