### PR TITLE
[vcpkg baseline][colmap] Temporary skip colmap osx test

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -138,6 +138,8 @@ cmcstl2:x86-windows        = skip
 coin:arm64-windows=fail
 coin:arm-uwp=fail
 coin:x64-uwp=fail
+# https://github.com/colmap/colmap/issues/1421
+colmap:x64-osx=fail
 concurrencpp:x64-linux=fail
 constexpr-contracts:x64-linux=fail
 coolprop:arm-uwp=fail


### PR DESCRIPTION
Temporary skip colmap:x64-osx pipeline test to resolve regression:
```
[276/277] : && /Library/Developer/CommandLineTools/usr/bin/c++ -fPIC -Wall -std=c++14 -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names -pthread src/exe/CMakeFiles/colmap_exe.dir/colmap.cc.o src/exe/CMakeFiles/colmap_exe.dir/database.cc.o src/exe/CMakeFiles/colmap_exe.dir/feature.cc.o src/exe/CMakeFiles/colmap_exe.dir/gui.cc.o src/exe/CMakeFiles/colmap_exe.dir/image.cc.o src/exe/CMakeFiles/colmap_exe.dir/model.cc.o src/exe/CMakeFiles/colmap_exe.dir/mvs.cc.o src/exe/CMakeFiles/colmap_exe.dir/sfm.cc.o src/exe/CMakeFiles/colmap_exe.dir/vocab_tree.cc.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QCocoaIntegrationPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5PrintSupport/Qt5PrintSupport_QCocoaPrinterSupportPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QGifPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QICNSPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QICOPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QJp2Plugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QJpegPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QMacHeifPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QSvgIconPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QSvgPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QTgaPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QTiffPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QWbmpPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QWebpPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Widgets/Qt5Widgets_QMacStylePlugin_Import.cpp.o -o src/exe/colmap -L/Users/vagrant/Data/installed/x64-osx/debug/lib -Wl,-rpath,/Users/vagrant/Data/installed/x64-osx/debug/lib  src/libcolmap.a  lib/FLANN/libflann.a  lib/Graclus/libgraclus.a  lib/LSD/liblsd.a  lib/PBA/libpba.a  lib/PoissonRecon/libpoisson_recon.a  lib/SQLite/libsqlite3.a  lib/SiftGPU/libsift_gpu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libGLEWd.a  lib/VLFeat/libvlfeat.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_filesystem.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_program_options.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_system.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglog.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libFreeImaged.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libopenjp2.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpdemuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpmuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpdecoderd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjxrglued.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpegxrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/librawd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjxrglued.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpegxrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/librawd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblcms2.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIlmImf-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libImath-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libHalf-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIexMath-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIlmThread-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIex-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libceres-debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglog.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgflags_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcxsparsed.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libklud.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbtfd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libldld.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libumfpackd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libspqrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcholmodd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libccolamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcolamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libsuitesparseconfigd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libopenblas.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libmetis.a  -lm  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcxsparsed.a  -framework  Accelerate  /Users/vagrant/Data/installed/x64-osx/lib/libopenblas.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5OpenGL_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Gui_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/styles/libqmacstyle_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/platforms/libqcocoa_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqgif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqicns_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqico_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjp2_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjpeg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqmacheif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/iconengines/libqsvgicon_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqsvg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtga_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtiff_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwbmp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwebp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/printsupport/libcocoaprintersupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Gui_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/styles/libqmacstyle_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/platforms/libqcocoa_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqgif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqicns_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqico_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjp2_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjpeg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqmacheif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/iconengines/libqsvgicon_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqsvg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtga_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtiff_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwbmp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwebp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/printsupport/libcocoaprintersupport_debug.a  -framework  Carbon  -framework  QuartzCore  -framework  CoreVideo  -framework  IOSurface  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libcups.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpdecoderd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpdemuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpmuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5DBus_debug.a  -framework  CoreText  /Users/vagrant/Data/installed/x64-osx/debug/lib//libfontconfig.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libexpat.a  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib//libfreetyped.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbrotlidec-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbrotlicommon-static.a  -framework  ImageIO  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Core_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Gui_debug.a  -framework  Metal  -framework  CoreGraphics  /Users/vagrant/Data/installed/x64-osx/debug/lib/libharfbuzz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libfreetyped.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbrotlidec-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbrotlicommon-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Core_debug.a  -framework  OpenGL  -framework  DiskArbitration  -framework  IOKit  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libm.tbd  -framework  AppKit  -framework  Security  -framework  ApplicationServices  -framework  CoreServices  -framework  CoreFoundation  -framework  Foundation  /Users/vagrant/Data/installed/x64-osx/debug/lib//libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libdouble-conversion.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpcre2-16.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libzstdd.a  -framework  AGL  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicui18n.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicutu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuuc.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuio.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicudata.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicui18n.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicutu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuuc.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuio.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicudata.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libzstdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmpxx.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libmpfr.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmp.a  -lpthread && :
FAILED: src/exe/colmap 
: && /Library/Developer/CommandLineTools/usr/bin/c++ -fPIC -Wall -std=c++14 -g -arch x86_64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names -pthread src/exe/CMakeFiles/colmap_exe.dir/colmap.cc.o src/exe/CMakeFiles/colmap_exe.dir/database.cc.o src/exe/CMakeFiles/colmap_exe.dir/feature.cc.o src/exe/CMakeFiles/colmap_exe.dir/gui.cc.o src/exe/CMakeFiles/colmap_exe.dir/image.cc.o src/exe/CMakeFiles/colmap_exe.dir/model.cc.o src/exe/CMakeFiles/colmap_exe.dir/mvs.cc.o src/exe/CMakeFiles/colmap_exe.dir/sfm.cc.o src/exe/CMakeFiles/colmap_exe.dir/vocab_tree.cc.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QCocoaIntegrationPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5PrintSupport/Qt5PrintSupport_QCocoaPrinterSupportPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QGifPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QICNSPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QICOPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QJp2Plugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QJpegPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QMacHeifPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QSvgIconPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QSvgPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QTgaPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QTiffPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QWbmpPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Gui/Qt5Gui_QWebpPlugin_Import.cpp.o src/exe/CMakeFiles/colmap_exe.dir/Users/vagrant/Data/installed/x64-osx/share/cmake/Qt5Widgets/Qt5Widgets_QMacStylePlugin_Import.cpp.o -o src/exe/colmap -L/Users/vagrant/Data/installed/x64-osx/debug/lib -Wl,-rpath,/Users/vagrant/Data/installed/x64-osx/debug/lib  src/libcolmap.a  lib/FLANN/libflann.a  lib/Graclus/libgraclus.a  lib/LSD/liblsd.a  lib/PBA/libpba.a  lib/PoissonRecon/libpoisson_recon.a  lib/SQLite/libsqlite3.a  lib/SiftGPU/libsift_gpu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libGLEWd.a  lib/VLFeat/libvlfeat.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_filesystem.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_program_options.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libboost_system.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglog.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libFreeImaged.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libopenjp2.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpdemuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpmuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libwebpdecoderd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjxrglued.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpegxrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/librawd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjxrglued.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjpegxrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/manual-link/librawd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/liblcms2.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIlmImf-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libImath-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libHalf-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIexMath-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIlmThread-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libIex-2_5_d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libceres-debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libglog.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgflags_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcxsparsed.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libklud.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbtfd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libldld.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libumfpackd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libspqrd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcholmodd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libccolamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcolamdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libsuitesparseconfigd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libopenblas.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libmetis.a  -lm  /Users/vagrant/Data/installed/x64-osx/debug/lib/libcxsparsed.a  -framework  Accelerate  /Users/vagrant/Data/installed/x64-osx/lib/libopenblas.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5OpenGL_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Gui_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/styles/libqmacstyle_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/platforms/libqcocoa_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqgif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqicns_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqico_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjp2_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjpeg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqmacheif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/iconengines/libqsvgicon_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqsvg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtga_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtiff_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwbmp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwebp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/printsupport/libcocoaprintersupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Gui_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/styles/libqmacstyle_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/platforms/libqcocoa_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqgif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqicns_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqico_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjp2_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqjpeg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqmacheif_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/iconengines/libqsvgicon_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqsvg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtga_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqtiff_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwbmp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/imageformats/libqwebp_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/plugins/printsupport/libcocoaprintersupport_debug.a  -framework  Carbon  -framework  QuartzCore  -framework  CoreVideo  -framework  IOSurface  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libcups.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5AccessibilitySupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5ThemeSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5FontDatabaseSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5GraphicsSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5ClipboardSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libjasperd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Svg_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libtiffd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//liblzmad.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libjpeg.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpdecoderd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpdemuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpmuxd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libwebpd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5DBus_debug.a  -framework  CoreText  /Users/vagrant/Data/installed/x64-osx/debug/lib//libfontconfig.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libexpat.a  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libiconv.tbd  /Users/vagrant/Data/installed/x64-osx/debug/lib//libfreetyped.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbrotlidec-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbrotlicommon-static.a  -framework  ImageIO  /Users/vagrant/Data/installed/x64-osx/debug/lib/libQt5Core_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5PrintSupport_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Widgets_debug.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Gui_debug.a  -framework  Metal  -framework  CoreGraphics  /Users/vagrant/Data/installed/x64-osx/debug/lib/libharfbuzz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libfreetyped.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbrotlidec-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libbrotlicommon-static.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libQt5Core_debug.a  -framework  OpenGL  -framework  DiskArbitration  -framework  IOKit  /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk/usr/lib/libm.tbd  -framework  AppKit  -framework  Security  -framework  ApplicationServices  -framework  CoreServices  -framework  CoreFoundation  -framework  Foundation  /Users/vagrant/Data/installed/x64-osx/debug/lib//libz.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libdouble-conversion.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpcre2-16.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libzstdd.a  -framework  AGL  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicui18n.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicutu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuuc.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuio.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicudata.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicui18n.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicutu.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuuc.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicuio.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libicudata.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libbz2d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libpng16d.a  /Users/vagrant/Data/installed/x64-osx/debug/lib//libzstdd.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmpxx.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libmpfr.a  /Users/vagrant/Data/installed/x64-osx/debug/lib/libgmp.a  -lpthread && :
duplicate symbol '_METIS_NodeND' in:
    lib/Graclus/libgraclus.a(ometis.c.o)
    /Users/vagrant/Data/installed/x64-osx/debug/lib/libmetis.a(ometis.c.o)
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

There are still some issues that need to be communicated with upstream to fully resolve the issue.
Upstream issue: https://github.com/colmap/colmap/issues/1421

Resolve #23010 #23009 #22798 #23018