### PR TITLE
[fribidi] Fix cross-compilation in meson. Re-enable arm64-windows.

### DIFF
--- a/ports/fribidi/meson-crosscompile.patch
+++ b/ports/fribidi/meson-crosscompile.patch
@@ -1,0 +1,36 @@
+diff --git a/gen.tab/meson.build b/gen.tab/meson.build
+index 8c21e98..1cd9960 100644
+--- a/gen.tab/meson.build
++++ b/gen.tab/meson.build
+@@ -1,5 +1,10 @@
+ # gen.tab
+ 
++if get_option('pregenerated_tab') != ''
++  generated_tab_include_files = []
++  fribidi_unicode_version_h = files()
++  add_project_arguments('-I' + get_option('pregenerated_tab'), language: 'c')
++else
+ native_cc = meson.get_compiler('c')
+ 
+ # Don't pick up top-level config.h, as that has defines for the cross-compiler
+@@ -75,7 +80,10 @@ foreach tab : tabs
+     input: gen_prog_inputs,
+     output: gen_prog_out,
+     command: [gen_exe, COMPRESSION, '@INPUT@', gen_prog_name],
++    install: true,
++    install_dir: 'share/fribidi/gen.tab',
+     capture: true)
+ 
+   generated_tab_include_files += [tab_inc_file]
+ endforeach
++endif
+diff --git a/meson_options.txt b/meson_options.txt
+index f54a639..8f60205 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -8,3 +8,5 @@ option('tests', type : 'boolean', value : true,
+   description: 'Build tests')
+ option('fuzzer_ldflags', type : 'string',
+   description: 'Extra LDFLAGS used during linking of fuzzing binaries')
++option('pregenerated_tab', type: 'string',
++  description: 'Path to pregenerated table sources')

--- a/ports/fribidi/portfile.cmake
+++ b/ports/fribidi/portfile.cmake
@@ -4,27 +4,53 @@ vcpkg_from_github(
     REF v1.0.11
     SHA512 9ddb0dbfb28ee4f1d9dd5d46fe1fff75c5446bfdacaabf8647847c36ef72eec823f6e6d6d1369d67c292d680004f7113c9e69114a8fae1d73ab11a58c66a8b8a
     HEAD_REF master
+    PATCHES meson-crosscompile.patch
 )
 
-vcpkg_configure_make(
-    SOURCE_PATH ${SOURCE_PATH}
+set(gen_tab_subdir "share/${PORT}/gen.tab")
+
+set(options "")
+if(VCPKG_CROSSCOMPILING)
+    set(gen_tab "${CURRENT_HOST_INSTALLED_DIR}/${gen_tab_subdir}")
+    cmake_path(NATIVE_PATH gen_tab gen_tab)
+    set(options "-Dpregenerated_tab=${gen_tab}")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+        -Ddocs=false
+        -Dbin=false
+        -Dtests=false
 )
 
-vcpkg_install_make(DISABLE_PARALLEL)
+vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 # Define static macro
-file(READ ${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h FRIBIDI_COMMON_H)
+file(READ "${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" FRIBIDI_COMMON_H)
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     string(REPLACE "#ifndef FRIBIDI_LIB_STATIC" "#if 0" FRIBIDI_COMMON_H "${FRIBIDI_COMMON_H}")
 else()
     string(REPLACE "#ifndef FRIBIDI_LIB_STATIC" "#if 1" FRIBIDI_COMMON_H "${FRIBIDI_COMMON_H}")
 endif()
-file(WRITE ${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h "${FRIBIDI_COMMON_H}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-common.h" "${FRIBIDI_COMMON_H}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+if(VCPKG_CROSSCOMPILING)
+    file(
+        COPY "${gen_tab}/fribidi-unicode-version.h"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/include/fribidi"
+    )
+else()
+    file(
+        COPY "${CURRENT_PACKAGES_DIR}/include/fribidi/fribidi-unicode-version.h"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/${gen_tab_subdir}"
+    )
+endif()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/fribidi/vcpkg.json
+++ b/ports/fribidi/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "fribidi",
   "version": "1.0.11",
-  "port-version": 2,
+  "port-version": 3,
   "description": "GNU FriBidi is an implementation of the Unicode Bidirectional Algorithm (bidi)",
-  "supports": "!uwp"
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "fribidi",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -289,9 +289,6 @@ freeglut:x64-osx=fail
 # Needs /bigobj
 freeopcua:arm64-windows=fail
 freetype-gl:x64-uwp=fail
-fribidi:arm64-windows=fail
-fribidi:arm-uwp=fail
-fribidi:x64-uwp=fail
 ftgl:x64-uwp=fail
 # https://github.com/GoogleCloudPlatform/functions-framework-cpp/issues/207
 functions-framework-cpp:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2302,7 +2302,7 @@
     },
     "fribidi": {
       "baseline": "1.0.11",
-      "port-version": 2
+      "port-version": 3
     },
     "frozen": {
       "baseline": "2021-04-22",

--- a/versions/f-/fribidi.json
+++ b/versions/f-/fribidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "038a02d8e9a403f61bd3d45ce0f6f626a67d72f3",
+      "version": "1.0.11",
+      "port-version": 3
+    },
+    {
       "git-tree": "134c67f3f8db520442ed5bea02262f14d647f7ce",
       "version": "1.0.11",
       "port-version": 2


### PR DESCRIPTION
The buildsystem revert back to autoconf in https://github.com/microsoft/vcpkg/pull/21948 did not actually fix cross-compilation; rather it just allowed the build to stumble forward hoping that the cross-built executables would run.

This PR actually fixes cross-compilation by adding a proper host dependency and reusing the tables generated from that host build.

This PR is specifically in pursuit of reenabling ffmpeg:arm64-windows.