### PR TITLE
[seal] Support dynamic triplets

### DIFF
--- a/ports/seal/portfile.cmake
+++ b/ports/seal/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         gsl.patch
+        shared-zstd.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/seal/shared-zstd.patch
+++ b/ports/seal/shared-zstd.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4cc8a01..b8c92c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -205,7 +205,7 @@ if(SEAL_USE_ZSTD)
+                     message(FATAL_ERROR "Zstandard: must be static")
+                 endif()
+             elseif(TARGET zstd::libzstd_shared)
+-                message(FATAL_ERROR "Zstandard: must be static")
++                set(zstd_static "zstd::libzstd_shared")
+             else()
+                 message(FATAL_ERROR "Zstandard: not found")
+             endif()

--- a/ports/seal/vcpkg.json
+++ b/ports/seal/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "seal",
   "version-semver": "3.7.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Microsoft SEAL is an easy-to-use and powerful homomorphic encryption library.",
   "homepage": "https://github.com/microsoft/SEAL",
-  "supports": "!windows | (windows & static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6302,7 +6302,7 @@
     },
     "seal": {
       "baseline": "3.7.2",
-      "port-version": 1
+      "port-version": 2
     },
     "secp256k1": {
       "baseline": "2017-19-10",

--- a/versions/s-/seal.json
+++ b/versions/s-/seal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c3499eaa1c19049bc521c3d2799d8d7d6d032a8a",
+      "version-semver": "3.7.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "11dc6c4e8b720416ff6ce195e48287982a6131ec",
       "version-semver": "3.7.2",
       "port-version": 1


### PR DESCRIPTION
Seal had explicit unneeded code that failed on dynamic zstd. This PR adds a simple patch to remove that, enabling seal to build on all platforms.

Note that seal itself will still be built statically due to the check linkage at the top of the file.