### PR TITLE
[flatbuffers] Add cross-compilation support for flatc

### DIFF
--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -17,37 +17,35 @@ if(VCPKG_CROSSCOMPILING)
     list(APPEND options -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DFLATBUFFERS_BUILD_TESTS=OFF
         -DFLATBUFFERS_BUILD_GRPCTEST=OFF
         ${options}
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/flatbuffers)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/flatbuffers)
+vcpkg_fixup_pkgconfig()
 
 file(GLOB flatc_path ${CURRENT_PACKAGES_DIR}/bin/flatc*)
 if(flatc_path)
-    make_directory(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
+    make_directory("${CURRENT_PACKAGES_DIR}/tools/flatbuffers")
     get_filename_component(flatc_executable ${flatc_path} NAME)
     file(
         RENAME
         ${flatc_path}
         ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/${flatc_executable}
     )
-    vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
+    vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/flatbuffers")
 else()
     file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers/FlatbuffersConfig.cmake"
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers/FlatcTargets.cmake\")\n")
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-vcpkg_fixup_pkgconfig()
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/flatbuffers/portfile.cmake
+++ b/ports/flatbuffers/portfile.cmake
@@ -12,9 +12,9 @@ vcpkg_from_github(
         fix-uwp-build.patch
 )
 
-set(OPTIONS)
-if(VCPKG_TARGET_IS_UWP OR VCPKG_TARGET_IS_IOS)
-    list(APPEND OPTIONS -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF)
+set(options "")
+if(VCPKG_CROSSCOMPILING)
+    list(APPEND options -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_FLATHASH=OFF)
 endif()
 
 vcpkg_configure_cmake(
@@ -23,7 +23,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DFLATBUFFERS_BUILD_TESTS=OFF
         -DFLATBUFFERS_BUILD_GRPCTEST=OFF
-        ${OPTIONS}
+        ${options}
 )
 
 vcpkg_install_cmake()
@@ -39,6 +39,9 @@ if(flatc_path)
         ${CURRENT_PACKAGES_DIR}/tools/flatbuffers/${flatc_executable}
     )
     vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/flatbuffers)
+else()
+    file(APPEND "${CURRENT_PACKAGES_DIR}/share/flatbuffers/FlatbuffersConfig.cmake"
+"include(\"\${CMAKE_CURRENT_LIST_DIR}/../../../${HOST_TRIPLET}/share/flatbuffers/FlatcTargets.cmake\")\n")
 endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,10 +1,16 @@
 {
   "name": "flatbuffers",
   "version-string": "2.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": [
     "Memory Efficient Serialization Library",
     "FlatBuffers is an efficient cross platform serialization library for games and other memory constrained apps. It allows you to directly access serialized data without unpacking/parsing it first, while still having great forwards/backwards compatibility."
   ],
-  "homepage": "https://google.github.io/flatbuffers/"
+  "homepage": "https://google.github.io/flatbuffers/",
+  "dependencies": [
+    {
+      "name": "flatbuffers",
+      "host": true
+    }
+  ]
 }

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "flatbuffers",
-  "version-string": "2.0.0",
+  "version": "2.0.0",
   "port-version": 3,
   "description": [
     "Memory Efficient Serialization Library",

--- a/ports/flatbuffers/vcpkg.json
+++ b/ports/flatbuffers/vcpkg.json
@@ -11,6 +11,14 @@
     {
       "name": "flatbuffers",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2194,7 +2194,7 @@
     },
     "flatbuffers": {
       "baseline": "2.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "flint": {
       "baseline": "2.8.0",

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e688c7519b21a97c2adf590ace3fba3674c581fb",
+      "git-tree": "8713fce3bc50837e44d958ddc745471619c511c4",
       "version": "2.0.0",
       "port-version": 3
     },

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7fa7b39f29ddb416ac70898175ec23e85076bc50",
+      "version-string": "2.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "65234b189b0389dfa2f89f58f33e56037a03b519",
       "version-string": "2.0.0",
       "port-version": 2

--- a/versions/f-/flatbuffers.json
+++ b/versions/f-/flatbuffers.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "7fa7b39f29ddb416ac70898175ec23e85076bc50",
-      "version-string": "2.0.0",
+      "git-tree": "e688c7519b21a97c2adf590ace3fba3674c581fb",
+      "version": "2.0.0",
       "port-version": 3
     },
     {


### PR DESCRIPTION
`flatbuffers` produces both a runtime library and a code generator `flatc`. While it does not run `flatc` during its own build, consumers expect to find the tool via the import `Flatbuffers:flatc`.

In this PR, I have made the cross build of flatbuffers import the targets from the host build, enabling seamless access for consumers. I tested this with `apsi`, however it fails during compilation when targeting arm64-windows for other reasons.