### PR TITLE
[vcpkg docs] Incorrect vcpkg clone path provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We recommend somewhere like `C:\src\vcpkg` or `C:\dev\vcpkg`,
 since otherwise you may run into path issues for some port build systems.
 
 ```cmd
-> git clone https://github.com/microsoft/vcpkg
+> git clone https://github.com/Microsoft/vcpkg.git
 > .\vcpkg\bootstrap-vcpkg.bat
 ```
 
@@ -144,7 +144,7 @@ First, download and bootstrap vcpkg itself; it can be installed anywhere,
 but generally we recommend using vcpkg as a submodule for CMake projects.
 
 ```sh
-$ git clone https://github.com/microsoft/vcpkg
+$ git clone https://github.com/Microsoft/vcpkg.git
 $ ./vcpkg/bootstrap-vcpkg.sh
 ```
 


### PR DESCRIPTION
Here, at 2 places, incorrect vcpkg git clone path provided and it ends up in no response error. For the better understanding of users, the incorrect git path is being replaced with the correct one.

**Describe the pull request**

- #### What does your PR fix?  
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
