### PR TITLE
[gstreamer] Support arm-windows and add features

### DIFF
--- a/ports/gstreamer/gstreamer-disable-hot-doc.patch
+++ b/ports/gstreamer/gstreamer-disable-hot-doc.patch
@@ -1,0 +1,34 @@
+diff --git a/meson.build b/meson.build
+index 4a2eb27..1316366 100644
+--- a/meson.build
++++ b/meson.build
+@@ -70,19 +70,19 @@ endif
+ 
+ # Ordered list of subprojects (dict has no ordering guarantees)
+ subprojects = [
+-  ['gstreamer', {'build-hotdoc': true}],
+-  ['gst-plugins-base', {'option': get_option('base'), 'build-hotdoc': true}],
+-  ['gst-plugins-good', {'option': get_option('good'), 'build-hotdoc': true}],
++  ['gstreamer', {'build-hotdoc': false}],
++  ['gst-plugins-base', {'option': get_option('base'), 'build-hotdoc': false}],
++  ['gst-plugins-good', {'option': get_option('good'), 'build-hotdoc': false}],
+   ['libnice', { 'option': get_option('libnice'), 'match_gst_version': false}],
+   ['gst-plugins-bad', { 'option': get_option('bad'), 'build-hotdoc': true}],
+-  ['gst-plugins-ugly', { 'option': get_option('ugly'), 'build-hotdoc': true}],
+-  ['gst-libav', { 'option': get_option('libav'), 'build-hotdoc': true}],
+-  ['gst-rtsp-server', { 'option': get_option('rtsp_server'), 'build-hotdoc': true}],
+-  ['gst-devtools', { 'option': get_option('devtools'), 'build-hotdoc': true }],
++  ['gst-plugins-ugly', { 'option': get_option('ugly'), 'build-hotdoc': false}],
++  ['gst-libav', { 'option': get_option('libav'), 'build-hotdoc': false}],
++  ['gst-rtsp-server', { 'option': get_option('rtsp_server'), 'build-hotdoc': false}],
++  ['gst-devtools', { 'option': get_option('devtools'), 'build-hotdoc': false }],
+   ['gst-integration-testsuites', { 'option': get_option('devtools') }],
+-  ['gst-editing-services', { 'option': get_option('ges'), 'build-hotdoc': true}],
+-  ['gstreamer-vaapi', { 'option': get_option('vaapi'), 'build-hotdoc': true}],
+-  ['gst-omx', { 'option': get_option('omx'), 'build-hotdoc': true}],
++  ['gst-editing-services', { 'option': get_option('ges'), 'build-hotdoc': false}],
++  ['gstreamer-vaapi', { 'option': get_option('vaapi'), 'build-hotdoc': false}],
++  ['gst-omx', { 'option': get_option('omx'), 'build-hotdoc': false}],
+   ['gstreamer-sharp', { 'option': get_option('sharp') }],
+   ['pygobject', { 'option': get_option('python'), 'match_gst_version': false }],
+   ['gst-python', { 'option': get_option('python')}],

--- a/ports/gstreamer/gstreamer-disable-no-unused.patch
+++ b/ports/gstreamer/gstreamer-disable-no-unused.patch
@@ -1,0 +1,15 @@
+diff --git a/meson.build b/meson.build
+index bed8c4e..772809e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -435,8 +435,9 @@ if cc.has_header('execinfo.h')
+   endif
+ endif
+ 
++build_system = build_machine.system()
+ gst_debug = get_option('gst_debug')
+-if not gst_debug
++if not gst_debug and build_system != 'windows'
+   add_project_arguments(['-Wno-unused'], language: 'c')
+ endif
+ 

--- a/ports/gstreamer/plugin-base-disable-no-unused.patch
+++ b/ports/gstreamer/plugin-base-disable-no-unused.patch
@@ -1,0 +1,26 @@
+diff --git a/meson.build b/meson.build
+index 9b00253..495671e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -388,10 +388,11 @@ int32x4_t testfunc(int16_t *a, int16_t *b) {
+   endif
+ endif
+ 
++build_system = build_machine.system()
+ if gst_dep.type_name() == 'internal'
+     gst_proj = subproject('gstreamer')
+ 
+-    if not gst_proj.get_variable('gst_debug')
++    if not gst_proj.get_variable('gst_debug') and build_system != 'windows'
+         message('GStreamer debug system is disabled')
+         add_project_arguments('-Wno-unused', language: 'c')
+     else
+@@ -404,7 +405,7 @@ else
+ #include <gst/gstconfig.h>
+ #ifdef GST_DISABLE_GST_DEBUG
+ #error "debugging disabled, make compiler fail"
+-#endif''' , dependencies: gst_dep)
++#endif''' , dependencies: gst_dep) and build_system != 'windows'
+         message('GStreamer debug system is disabled')
+         add_project_arguments('-Wno-unused', language: 'c')
+     else

--- a/ports/gstreamer/plugins-ugly-disable-doc.patch
+++ b/ports/gstreamer/plugins-ugly-disable-doc.patch
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index c5c78fc..14be48c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -281,7 +281,11 @@ if find_program('xgettext', required : get_option('nls')).found()
+   cdata.set('ENABLE_NLS', 1)
+   subdir('po')
+ endif
++
++enable_doc = get_option('doc')
++if enable_doc.enabled()
+ subdir('docs')
++endif
+ subdir('scripts')
+ 
+ # Set release date

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
 if(VCPKG_TARGET_IS_WINDOWS)
     list(APPEND PLUGIN_BASE_PATCHES plugins-base-use-zlib.patch)
     list(APPEND PLUGIN_GOOD_PATCHES plugins-good-use-zlib.patch)
+    list(APPEND PLUGIN_UGLY_PATCHES plugins-ugly-disable-doc.patch)
 endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH GST_PLUGIN_BASE_SOURCE_PATH
@@ -45,6 +46,7 @@ vcpkg_from_github(
     REF 1.19.2
     SHA512 70dcd4a36d3bd35f680eaa3c980842fbb57f55f17d1453c6a95640709b1b33a263689bf54caa367154267d281e5474686fedaa980de24094de91886a57b6547a
     HEAD_REF master
+    PATCHES ${PLUGIN_UGLY_PATCHES}
 )
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
@@ -55,12 +57,24 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
-file(RENAME ${GST_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer)
-file(RENAME ${GST_PLUGIN_BASE_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base)
-file(RENAME ${GST_PLUGIN_GOOD_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good)
-file(RENAME ${GST_PLUGIN_BAD_SOURCE_PATH}  ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad)
-file(RENAME ${GST_PLUGIN_UGLY_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly)
-file(RENAME ${GST_MESON_PORTS_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers)
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer")
+    file(RENAME "${GST_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer")
+endif()
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base")
+    file(RENAME "${GST_PLUGIN_BASE_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base")
+endif()
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good")
+    file(RENAME "${GST_PLUGIN_GOOD_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good")
+endif()
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad")
+    file(RENAME "${GST_PLUGIN_BAD_SOURCE_PATH}  ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad")
+endif()
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly")
+    file(RENAME "${GST_PLUGIN_UGLY_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly")
+endif()
+if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers")
+    file(RENAME "${GST_MESON_PORTS_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers")
+endif()
 
 if(VCPKG_TARGET_IS_OSX)
     # In Darwin platform, there can be an old version of `bison`,
@@ -80,10 +94,21 @@ if(VCPKG_TARGET_IS_OSX)
 endif()
 
 # make tools like 'glib-mkenums' visible
-get_filename_component(GLIB_TOOL_DIR ${CURRENT_INSTALLED_DIR}/tools/glib ABSOLUTE)
+get_filename_component(GLIB_TOOL_DIR "${CURRENT_INSTALLED_DIR}/tools/glib" ABSOLUTE)
 message(STATUS "Using glib tools: ${GLIB_TOOL_DIR}")
-vcpkg_add_to_path(PREPEND ${GLIB_TOOL_DIR})
+vcpkg_add_to_path(PREPEND "${GLIB_TOOL_DIR}")
 
+if ("x264" IN_LIST FEATURES)
+    set(PLUGIN_UGLY_X264 enabled)
+else()
+    set(PLUGIN_UGLY_X264 disabled)
+endif()
+
+if("plugins-base" IN_LIST FEATURES)
+    set(PLUGIN_BASE_SUPPORT enabled)
+else()
+    set(PLUGIN_BASE_SUPPORT disabled)
+endif()
 if("plugins-bad" IN_LIST FEATURES)
     # requires 'libdrm', 'dssim', 'libmicrodns'
     message(FATAL_ERROR "The feature 'plugins-bad' is not supported in this port version")
@@ -95,6 +120,18 @@ if("plugins-ugly" IN_LIST FEATURES)
     set(PLUGIN_UGLY_SUPPORT enabled)
 else()
     set(PLUGIN_UGLY_SUPPORT disabled)
+endif()
+
+if ("gl-graphene" IN_LIST FEATURES)
+    set(GL_GRAPHENE enabled)
+else()
+    set(GL_GRAPHENE disabled)
+endif()
+
+if ("flac" IN_LIST FEATURES)
+    set(PLUGIN_GOOD_FLAC enabled)
+else()
+    set(PLUGIN_GOOD_FLAC disabled)
 endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
@@ -120,7 +157,7 @@ vcpkg_add_to_path("${GIT_DIR}")
 #   https://github.com/GStreamer/gst-plugins-ugly/blob/1.18.4/meson_options.txt
 #
 vcpkg_configure_meson(
-    SOURCE_PATH ${GST_BUILD_SOURCE_PATH}
+    SOURCE_PATH "${GST_BUILD_SOURCE_PATH}"
     OPTIONS
         # gstreamer
         -Dgstreamer:default_library=${LIBRARY_LINKAGE}
@@ -134,17 +171,21 @@ vcpkg_configure_meson(
         -Dgstreamer:tests=disabled
         -Dgstreamer:benchmarks=disabled
         -Dgstreamer:tools=disabled
+        -Dgstreamer:doc=disabled
         -Dgstreamer:introspection=disabled
         -Dgstreamer:nls=disabled
         # gst-plugins-base
+        -Dbase=${PLUGIN_BASE_SUPPORT}
         -Dgst-plugins-base:default_library=${LIBRARY_LINKAGE}
         -Dgst-plugins-base:examples=disabled
         -Dgst-plugins-base:tests=disabled
+        -Dgst-plugins-base:doc=disabled
         -Dgst-plugins-base:tools=disabled
         -Dgst-plugins-base:introspection=disabled
         -Dgst-plugins-base:nls=disabled
         -Dgst-plugins-base:orc=disabled
         -Dgst-plugins-base:pango=disabled
+        -Dgst-plugins-base:gl-graphene=${GL_GRAPHENE}
         # gst-plugins-good
         -Dgst-plugins-good:default_library=${LIBRARY_LINKAGE}
         -Dgst-plugins-good:qt5=disabled
@@ -155,8 +196,10 @@ vcpkg_configure_meson(
         -Dgst-plugins-good:vpx=auto # libvpx
         -Dgst-plugins-good:examples=disabled
         -Dgst-plugins-good:tests=disabled
+        -Dgst-plugins-good:doc=disabled
         -Dgst-plugins-good:nls=disabled
         -Dgst-plugins-good:orc=disabled
+        -Dgst-plugins-good:flac=${PLUGIN_GOOD_FLAC}
         # gst-plugins-bad
         -Dbad=${PLUGIN_BAD_SUPPORT}
         -Dgst-plugins-bad:default_library=${LIBRARY_LINKAGE}
@@ -164,6 +207,7 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:hls-crypto=openssl
         -Dgst-plugins-bad:examples=disabled
         -Dgst-plugins-bad:tests=disabled
+        -Dgst-plugins-bad:doc=disabled
         -Dgst-plugins-bad:introspection=disabled
         -Dgst-plugins-bad:nls=${LIBRARY_LINKAGE}
         -Dgst-plugins-bad:orc=disabled
@@ -171,8 +215,10 @@ vcpkg_configure_meson(
         -Dugly=${PLUGIN_UGLY_SUPPORT}
         -Dgst-plugins-ugly:default_library=${LIBRARY_LINKAGE}
         -Dgst-plugins-ugly:tests=disabled
+        -Dgst-plugins-ugly:doc=disabled
         -Dgst-plugins-ugly:nls=disabled
         -Dgst-plugins-ugly:orc=disabled
+        -Dgst-plugins-ugly:x264=${PLUGIN_UGLY_X264}
         # see ${GST_BUILD_SOURCE_PATH}/meson_options.txt
         -Dpython=disabled
         -Dlibav=disabled
@@ -214,48 +260,48 @@ vcpkg_configure_meson(
 )
 if(VCPKG_TARGET_IS_WINDOWS)
     # note: can't find where z.lib comes from. replace it to appropriate library name manually
-    get_filename_component(BUILD_NINJA_DBG ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/build.ninja ABSOLUTE)
+    get_filename_component(BUILD_NINJA_DBG "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/build.ninja" ABSOLUTE)
     vcpkg_replace_string(${BUILD_NINJA_DBG} "z.lib" "zlibd.lib")
-    get_filename_component(BUILD_NINJA_REL ${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja ABSOLUTE)
+    get_filename_component(BUILD_NINJA_REL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja" ABSOLUTE)
     vcpkg_replace_string(${BUILD_NINJA_REL} "z.lib" "zlib.lib")
     vcpkg_replace_string(${BUILD_NINJA_REL} "\"-Wno-unused\"" "") # todo: may need a patch for `gst_debug=false`
 endif()
 vcpkg_install_meson()
 
 # Remove duplicated GL headers (we already have `opengl-registry`)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/KHR
-                    ${CURRENT_PACKAGES_DIR}/include/GL
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/KHR"
+                    "${CURRENT_PACKAGES_DIR}/include/GL"
 )
-file(RENAME ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include/gst/gl/gstglconfig.h
-            ${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gl/gstglconfig.h
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include/gst/gl/gstglconfig.h"
+            "${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gl/gstglconfig.h"
 )
 
-file(INSTALL ${GST_BUILD_SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share
-                    ${CURRENT_PACKAGES_DIR}/debug/libexec
-                    ${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/include
-                    ${CURRENT_PACKAGES_DIR}/libexec
-                    ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include
+file(INSTALL "${GST_BUILD_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/libexec"
+                    "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/include"
+                    "${CURRENT_PACKAGES_DIR}/libexec"
+                    "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include"
 )
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/bin
-                        ${CURRENT_PACKAGES_DIR}/bin
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin"
+                        "${CURRENT_PACKAGES_DIR}/bin"
     )
-    set(PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX})
-    set(SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX})
-    file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/lib/${PREFIX}gstreamer-full-1.0${SUFFIX}
-                ${CURRENT_PACKAGES_DIR}/lib/${PREFIX}gstreamer-full-1.0${SUFFIX}
+    set(PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}")
+    set(SUFFIX "${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/lib/${PREFIX}gstreamer-full-1.0${SUFFIX}"
+                "${CURRENT_PACKAGES_DIR}/lib/${PREFIX}gstreamer-full-1.0${SUFFIX}"
     )
 endif()
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-    file(GLOB DBG_BINS ${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.dll
-                       ${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb
+    file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.dll"
+                       "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb"
     )
-    file(COPY ${DBG_BINS} DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin)
-    file(GLOB REL_BINS ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.dll
-                       ${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.pdb
+    file(COPY ${DBG_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(GLOB REL_BINS "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.dll"
+                       "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/*.pdb"
     )
-    file(COPY ${REL_BINS} DESTINATION ${CURRENT_PACKAGES_DIR}/bin)
+    file(COPY ${REL_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(REMOVE ${DBG_BINS} ${REL_BINS})
 endif()
 vcpkg_fixup_pkgconfig()

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -259,14 +259,6 @@ vcpkg_configure_meson(
         -Dgst-plugins-bad:glib-asserts=disabled
         -Dgst-plugins-bad:glib-checks=disabled
 )
-if(VCPKG_TARGET_IS_WINDOWS)
-    # note: can't find where z.lib comes from. replace it to appropriate library name manually
-    get_filename_component(BUILD_NINJA_DBG "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/build.ninja" ABSOLUTE)
-    vcpkg_replace_string(${BUILD_NINJA_DBG} "z.lib" "zlibd.lib")
-    get_filename_component(BUILD_NINJA_REL "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/build.ninja" ABSOLUTE)
-    vcpkg_replace_string(${BUILD_NINJA_REL} "z.lib" "zlib.lib")
-    vcpkg_replace_string(${BUILD_NINJA_REL} "\"-Wno-unused\"" "") # todo: may need a patch for `gst_debug=false`
-endif()
 
 vcpkg_install_meson()
 

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -12,9 +12,10 @@ vcpkg_from_github(
     REF 1.19.2
     SHA512 6070f1febf2a1bcc6e68f1e03c1b76891db210773065696e26fac20f0bd3ff47e1634222a49f93a10f6e47717ff21084c9ae0feed6a20facb9650aeb879cc380
     HEAD_REF master
+    PATCHES gstreamer-disable-no-unused.patch
 )
 if(VCPKG_TARGET_IS_WINDOWS)
-    list(APPEND PLUGIN_BASE_PATCHES plugins-base-use-zlib.patch)
+    list(APPEND PLUGIN_BASE_PATCHES plugins-base-use-zlib.patch plugin-base-disable-no-unused.patch)
     list(APPEND PLUGIN_GOOD_PATCHES plugins-good-use-zlib.patch)
     list(APPEND PLUGIN_UGLY_PATCHES plugins-ugly-disable-doc.patch)
 endif()

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -58,22 +58,22 @@ vcpkg_from_gitlab(
 )
 
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer")
-    file(RENAME "${GST_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer")
+    file(RENAME "${GST_SOURCE_PATH}" "${GST_BUILD_SOURCE_PATH}/subprojects/gstreamer")
 endif()
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base")
-    file(RENAME "${GST_PLUGIN_BASE_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base")
+    file(RENAME "${GST_PLUGIN_BASE_SOURCE_PATH}" "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-base")
 endif()
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good")
-    file(RENAME "${GST_PLUGIN_GOOD_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good")
+    file(RENAME "${GST_PLUGIN_GOOD_SOURCE_PATH}" "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-good")
 endif()
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad")
-    file(RENAME "${GST_PLUGIN_BAD_SOURCE_PATH}  ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad")
+    file(RENAME "${GST_PLUGIN_BAD_SOURCE_PATH}"  "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-bad")
 endif()
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly")
-    file(RENAME "${GST_PLUGIN_UGLY_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly")
+    file(RENAME "${GST_PLUGIN_UGLY_SOURCE_PATH}" "${GST_BUILD_SOURCE_PATH}/subprojects/gst-plugins-ugly")
 endif()
 if (NOT EXISTS "${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers")
-    file(RENAME "${GST_MESON_PORTS_SOURCE_PATH} ${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers")
+    file(RENAME "${GST_MESON_PORTS_SOURCE_PATH}" "${GST_BUILD_SOURCE_PATH}/subprojects/gl-headers")
 endif()
 
 if(VCPKG_TARGET_IS_OSX)
@@ -266,6 +266,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_replace_string(${BUILD_NINJA_REL} "z.lib" "zlib.lib")
     vcpkg_replace_string(${BUILD_NINJA_REL} "\"-Wno-unused\"" "") # todo: may need a patch for `gst_debug=false`
 endif()
+
 vcpkg_install_meson()
 
 # Remove duplicated GL headers (we already have `opengl-registry`)
@@ -275,14 +276,13 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/KHR"
 file(RENAME "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include/gst/gl/gstglconfig.h"
             "${CURRENT_PACKAGES_DIR}/include/gstreamer-1.0/gst/gl/gstglconfig.h"
 )
-
-file(INSTALL "${GST_BUILD_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
                     "${CURRENT_PACKAGES_DIR}/debug/libexec"
                     "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/include"
                     "${CURRENT_PACKAGES_DIR}/libexec"
                     "${CURRENT_PACKAGES_DIR}/lib/gstreamer-1.0/include"
 )
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin"
                         "${CURRENT_PACKAGES_DIR}/bin"
@@ -293,6 +293,7 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
                 "${CURRENT_PACKAGES_DIR}/lib/${PREFIX}gstreamer-full-1.0${SUFFIX}"
     )
 endif()
+
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(GLOB DBG_BINS "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.dll"
                        "${CURRENT_PACKAGES_DIR}/debug/lib/gstreamer-1.0/*.pdb"
@@ -304,4 +305,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(COPY ${REL_BINS} DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(REMOVE ${DBG_BINS} ${REL_BINS})
 endif()
+
 vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${GST_BUILD_SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/gstreamer/portfile.cmake
+++ b/ports/gstreamer/portfile.cmake
@@ -4,6 +4,7 @@ vcpkg_from_github(
     REF 1.19.2
     SHA512 d6b8e9fc195a60dfb83fe8a49040c21ca5603e3ada2036d56851e6e61a1cd2653ad45f33e39388bde859dfb4806f4a60d9dbfac5fe41b6d2a8b395c44d4525e3
     HEAD_REF master
+    PATCHES gstreamer-disable-hot-doc.patch
 )
 vcpkg_from_github(
     OUT_SOURCE_PATH GST_SOURCE_PATH

--- a/ports/gstreamer/vcpkg.json
+++ b/ports/gstreamer/vcpkg.json
@@ -1,11 +1,11 @@
 {
   "name": "gstreamer",
   "version": "1.19.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "GStreamer open-source multimedia framework core library",
   "homepage": "https://gstreamer.freedesktop.org/",
   "license": "LGPL-2.0",
-  "supports": "(windows | osx) & (x64 | x86)",
+  "supports": "!linux & !uwp",
   "dependencies": [
     {
       "name": "cairo",
@@ -26,7 +26,6 @@
       "name": "glib",
       "host": true
     },
-    "graphene",
     "libnice",
     "libxml2",
     {
@@ -44,25 +43,68 @@
     }
   ],
   "default-features": [
+    "plugins-base",
     "plugins-good",
     "plugins-ugly"
   ],
   "features": {
+    "flac": {
+      "description": "FLAC audio codec plugin",
+      "supports": "!arm",
+      "dependencies": [
+        "libflac"
+      ]
+    },
+    "gl-graphene": {
+      "description": "Use Graphene in OpenGL plugin",
+      "supports": "!arm",
+      "dependencies": [
+        "graphene"
+      ]
+    },
     "plugins-bad": {
       "description": "'Bad' GStreamer plugins and helper libraries",
       "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "rawparse"
+          ],
+          "platform": "!arm"
+        },
         "openh264"
+      ]
+    },
+    "plugins-base": {
+      "description": "'Base' GStreamer plugins and helper libraries",
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "gl-graphene",
+            "rawparse"
+          ],
+          "platform": "!arm"
+        }
       ]
     },
     "plugins-good": {
       "description": "'Good' GStreamer plugins and helper libraries",
       "dependencies": [
         "bzip2",
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "flac"
+          ],
+          "platform": "!arm"
+        },
         "jack2",
-        "libflac",
         "libjpeg-turbo",
         "libpng",
-        "libraw",
         "libvpx",
         "mpg123",
         "speex",
@@ -71,6 +113,27 @@
     },
     "plugins-ugly": {
       "description": "'Ugly' GStreamer plugins and helper libraries",
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "features": [
+            "x264"
+          ],
+          "platform": "!arm"
+        }
+      ]
+    },
+    "rawparse": {
+      "description": "Build with libraw support",
+      "supports": "!arm",
+      "dependencies": [
+        "libraw"
+      ]
+    },
+    "x264": {
+      "description": "Colon separated list of additional x264 library paths, e.g. for 10-bit version",
+      "supports": "!arm",
       "dependencies": [
         "x264"
       ]

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2618,7 +2618,7 @@
     },
     "gstreamer": {
       "baseline": "1.19.2",
-      "port-version": 3
+      "port-version": 4
     },
     "gtest": {
       "baseline": "1.11.0",

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9b92cf3abc53611f8c0c0ab0e4017d95e2231170",
+      "git-tree": "f353729ab355a098aa18f564cf5ade0690861c7d",
       "version": "1.19.2",
       "port-version": 4
     },

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d9eb0e9346001ca2499296acdb309804238e5621",
+      "version": "1.19.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "25482001e85b34b144a67fc9cc86127f9e8c89ea",
       "version": "1.19.2",
       "port-version": 3

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b060940f30aad516d41f047ea452a8fd604ed37",
+      "git-tree": "9b92cf3abc53611f8c0c0ab0e4017d95e2231170",
       "version": "1.19.2",
       "port-version": 4
     },

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d9eb0e9346001ca2499296acdb309804238e5621",
+      "git-tree": "4b060940f30aad516d41f047ea452a8fd604ed37",
       "version": "1.19.2",
       "port-version": 4
     },

--- a/versions/g-/gstreamer.json
+++ b/versions/g-/gstreamer.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f353729ab355a098aa18f564cf5ade0690861c7d",
+      "git-tree": "78cacf62a38c4cfc4e399720463bef9312f115dc",
       "version": "1.19.2",
       "port-version": 4
     },


### PR DESCRIPTION
Some of gstreamer's dependencies do not support arm, so they are added as new features and automatically disabled when arm builds.

Fixes #19717.