### PR TITLE
 [leveldb] Fix target "Threads::Threads" was not found

### DIFF
--- a/ports/leveldb/leveldbConfig.cmake.in
+++ b/ports/leveldb/leveldbConfig.cmake.in
@@ -2,12 +2,13 @@
 include(CMakeFindDependencyMacro)
 
 set_and_check(leveldb_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+find_dependency(Threads)
 
 if (@WITH_CRC32C@)
-    find_depedency(Crc32c CONFIG)
+    find_dependency(Crc32c CONFIG)
 endif()
 if (@WITH_SNAPPY@)
-    find_depedency(Snappy CONFIG)
+    find_dependency(Snappy CONFIG)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/leveldbTargets.cmake")

--- a/ports/leveldb/vcpkg.json
+++ b/ports/leveldb/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "leveldb",
   "version-string": "1.22",
-  "port-version": 3,
+  "port-version": 4,
   "description": "LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.",
   "homepage": "https://github.com/bitcoin-core/leveldb",
   "license": "BSD-3-Clause",

--- a/ports/leveldb/vcpkg.json
+++ b/ports/leveldb/vcpkg.json
@@ -7,7 +7,6 @@
   "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
-    "pthreads",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/leveldb/vcpkg.json
+++ b/ports/leveldb/vcpkg.json
@@ -7,6 +7,7 @@
   "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
+    "pthreads",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3314,7 +3314,7 @@
     },
     "leveldb": {
       "baseline": "1.22",
-      "port-version": 3
+      "port-version": 4
     },
     "levmar": {
       "baseline": "2.6",

--- a/versions/l-/leveldb.json
+++ b/versions/l-/leveldb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c41d96d2e0f6f6301e2370bc00fa7390cdd94330",
+      "version-string": "1.22",
+      "port-version": 4
+    },
+    {
       "git-tree": "55e42f74e1f541143900887a64661c8c8e4ea713",
       "version-string": "1.22",
       "port-version": 3

--- a/versions/l-/leveldb.json
+++ b/versions/l-/leveldb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c41d96d2e0f6f6301e2370bc00fa7390cdd94330",
+      "git-tree": "9e30edfe3a59592d34a5d3d20906e406b94a8edd",
       "version-string": "1.22",
       "port-version": 4
     },

--- a/versions/l-/leveldb.json
+++ b/versions/l-/leveldb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9e30edfe3a59592d34a5d3d20906e406b94a8edd",
+      "git-tree": "c41d96d2e0f6f6301e2370bc00fa7390cdd94330",
       "version-string": "1.22",
       "port-version": 4
     },


### PR DESCRIPTION
Fixes #23099
Fix error: 
```
1> [CMake] CMake Error at /Users/xyz/vcpkg/scripts/buildsystems/vcpkg.cmake:558 (_add_executable):
1> [CMake]   Target "testleveldb" links to target "Threads::Threads" but the target was
1> [CMake]   not found.  Perhaps a find_package() call is missing for an IMPORTED
1> [CMake]   target, or an ALIAS target is missing?
```

