### PR TITLE
Change minimum CMake version to 3.7.2.

### DIFF
--- a/docs/maintainers/cmake-guidelines.md
+++ b/docs/maintainers/cmake-guidelines.md
@@ -138,7 +138,7 @@ We hope that they will make both forwards and backwards compatibility easier.
   - This `cmake_minimum_required` should be bumped every time a new version
     of CMake is added to `vcpkgTools.xml`, as should the
     `cmake_minimum_required` in all of the helper `CMakeLists.txt` files.
-- `vcpkg.cmake` must assume a version of CMake back to 3.1 in general
+- `vcpkg.cmake` must assume a version of CMake back to 3.7.2 in general
   - Specific functions and options may assume a greater CMake version;
     if they do, make sure to comment that function or option
     with the required CMake version.

--- a/ports/faad2/CMakeLists.txt
+++ b/ports/faad2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7.2)
 project (faad VERSION 2.9.1)
 
 option(FAAD_BUILD_BINARIES "Build faad2 binaries" OFF)

--- a/ports/faad2/vcpkg.json
+++ b/ports/faad2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "faad2",
   "version": "2.9.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Freeware Advanced Audio (AAC) Decoder",
   "homepage": "https://sourceforge.net/projects/faac/",
   "supports": "windows",

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -30,11 +30,11 @@ function(z_vcpkg_add_fatal_error ERROR)
     endif()
 endfunction()
 
-set(Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION "3.1")
+set(Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION "3.7.2")
 if(CMAKE_VERSION VERSION_LESS Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION)
     message(FATAL_ERROR "vcpkg.cmake requires at least CMake ${Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION}.")
 endif()
-# this policy is required for this file; thus, CMake 3.1 is required.
+# this policy is required for this file; thus, CMake 3.7.2 is required.
 cmake_policy(PUSH)
 cmake_policy(SET CMP0054 NEW)
 
@@ -200,16 +200,6 @@ endfunction()
 
 # Determine whether the toolchain is loaded during a try-compile configuration
 get_property(Z_VCPKG_CMAKE_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE)
-
-if(CMAKE_VERSION VERSION_LESS "3.6.0")
-    set(Z_VCPKG_CMAKE_EMULATE_TRY_COMPILE_PLATFORM_VARIABLES ON)
-else()
-    set(Z_VCPKG_CMAKE_EMULATE_TRY_COMPILE_PLATFORM_VARIABLES OFF)
-endif()
-
-if(Z_VCPKG_CMAKE_IN_TRY_COMPILE AND Z_VCPKG_CMAKE_EMULATE_TRY_COMPILE_PLATFORM_VARIABLES)
-    include("${CMAKE_CURRENT_SOURCE_DIR}/../vcpkg.config.cmake" OPTIONAL)
-endif()
 
 if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
     include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
@@ -807,25 +797,13 @@ set(Z_VCPKG_UNUSED "${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP}")
 
 # Propogate these values to try-compile configurations so the triplet and toolchain load
 if(NOT Z_VCPKG_CMAKE_IN_TRY_COMPILE)
-    if(Z_VCPKG_CMAKE_EMULATE_TRY_COMPILE_PLATFORM_VARIABLES)
-        file(TO_CMAKE_PATH "${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}" Z_VCPKG_CHAINLOAD_FILE_CMAKE)
-        file(TO_CMAKE_PATH "${Z_VCPKG_ROOT_DIR}" Z_VCPKG_ROOT_DIR_CMAKE)
-        file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vcpkg.config.cmake"
-            "set(VCPKG_TARGET_TRIPLET \"${VCPKG_TARGET_TRIPLET}\" CACHE STRING \"\")\n"
-            "set(VCPKG_TARGET_ARCHITECTURE \"${VCPKG_TARGET_ARCHITECTURE}\" CACHE STRING \"\")\n"
-            "set(VCPKG_APPLOCAL_DEPS \"${VCPKG_APPLOCAL_DEPS}\" CACHE STRING \"\")\n"
-            "set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE \"${Z_VCPKG_CHAINLOAD_FILE_CMAKE}\" CACHE STRING \"\")\n"
-            "set(Z_VCPKG_ROOT_DIR \"${Z_VCPKG_ROOT_DIR_CMAKE}\" CACHE STRING \"\")\n"
-        )
-    else()
-        list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
-            VCPKG_TARGET_TRIPLET
-            VCPKG_TARGET_ARCHITECTURE
-            VCPKG_APPLOCAL_DEPS
-            VCPKG_CHAINLOAD_TOOLCHAIN_FILE
-            Z_VCPKG_ROOT_DIR
-        )
-    endif()
+    list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+        VCPKG_TARGET_TRIPLET
+        VCPKG_TARGET_ARCHITECTURE
+        VCPKG_APPLOCAL_DEPS
+        VCPKG_CHAINLOAD_TOOLCHAIN_FILE
+        Z_VCPKG_ROOT_DIR
+    )
 endif()
 
 if(Z_VCPKG_HAS_FATAL_ERROR)

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -34,9 +34,8 @@ set(Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION "3.7.2")
 if(CMAKE_VERSION VERSION_LESS Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION)
     message(FATAL_ERROR "vcpkg.cmake requires at least CMake ${Z_VCPKG_CMAKE_REQUIRED_MINIMUM_VERSION}.")
 endif()
-# this policy is required for this file; thus, CMake 3.7.2 is required.
 cmake_policy(PUSH)
-cmake_policy(SET CMP0054 NEW)
+cmake_policy(VERSION 3.7.2)
 
 include(CMakeDependentOption)
 
@@ -616,7 +615,7 @@ function(x_vcpkg_install_local_dependencies)
 
     if(Z_VCPKG_TARGET_TRIPLET_PLAT MATCHES "^(windows|uwp)$")
         # Install CODE|SCRIPT allow the use of generator expressions
-        cmake_policy(SET CMP0087 NEW)
+        cmake_policy(SET CMP0087 NEW) # CMake 3.14
 
         z_vcpkg_set_powershell_path()
         if(NOT IS_ABSOLUTE "${arg_DESTINATION}")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2078,7 +2078,7 @@
     },
     "faad2": {
       "baseline": "2.9.1",
-      "port-version": 4
+      "port-version": 5
     },
     "fadbad": {
       "baseline": "2.1.0",

--- a/versions/f-/faad2.json
+++ b/versions/f-/faad2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "67b420585d5f99b7dec259912abd2d7edcfb9492",
+      "version": "2.9.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "a1ec8e5247412b2ba6584c63307f88fe91d12251",
       "version": "2.9.1",
       "port-version": 4


### PR DESCRIPTION
This moves our oldest supported Linux back up to today minus 5 years, Debian 9 from 2017 comes with 3.7.2.

See https://github.com/microsoft/vcpkg/discussions/19048