### PR TITLE
[graphviz] Fix tools

### DIFF
--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -35,6 +35,11 @@ vcpkg_find_acquire_program(FLEX)
 vcpkg_find_acquire_program(GIT)
 vcpkg_find_acquire_program(PYTHON3)
 
+set(EXTRA_CMAKE_OPTIONS)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    set(EXTRA_CMAKE_OPTIONS "-DCMAKE_INSTALL_RPATH=${CURRENT_PACKAGES_DIR}/bin")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
@@ -45,6 +50,7 @@ vcpkg_cmake_configure(
         -DPython3_EXECUTABLE=${PYTHON3}
         -DPKG_CONFIG_EXECUTABLE=${CURRENT_INSTALLED_DIR}/tools/pkgconf/pkgconf
         ${LTDL_OPTION}
+        ${EXTRA_CMAKE_OPTIONS}
 )
 
 vcpkg_cmake_install()
@@ -63,7 +69,6 @@ if(VCPKG_HOST_IS_WINDOWS)
     set(DOT_COMMAND "dot")
 else()
     set(DOT_COMMAND "./dot")
-    set(ENV{LD_LIBRARY_PATH} "$ENV{LD_LIBRARY_PATH}:${CURRENT_PACKAGES_DIR}/bin")
 endif()
 
 vcpkg_execute_required_process(

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -56,8 +56,15 @@ vcpkg_copy_tools(
 file(GLOB PLUGINS "${CURRENT_PACKAGES_DIR}/bin/gvplugin_*")
 file(COPY ${PLUGINS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(DOT_COMMAND "dot")
+else()
+    set(DOT_COMMAND "./dot")
+endif()
+
 vcpkg_execute_required_process(
-    COMMAND dot -c
+    COMMAND ${DOT_COMMAND} -c
     WORKING_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/${PORT}
     LOGNAME configure-plugins
 )

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_from_gitlab(
     PATCHES
         0001-Fix-build.patch
 )
-
+set(LTDL_OPTION)
 if(VCPKG_TARGET_IS_OSX)
     message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with brew install libtool")
 elseif(VCPKG_TARGET_IS_LINUX)
@@ -21,6 +21,7 @@ else()
         SHA512 f2d20e849e35060536265f47014c40eb70e57dacd600a9db112fc465fbfa6a66217b44a8c3dc33039c260a27f09d9034b329b03cc28c32a22ec503fcd17b78cd
     )
     file(COPY ${LTDL_H_PATH} DESTINATION ${SOURCE_PATH}/lib/common)
+    set(LTDL_OPTION "-DLTDL_INCLUDE_DIR=${SOURCE_PATH}/lib/common")
 endif()
 
 vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk)
@@ -40,7 +41,7 @@ vcpkg_cmake_configure(
         -DGIT_EXECUTABLE=${GIT}
         -DPython3_EXECUTABLE=${PYTHON3}
         -DPKG_CONFIG_EXECUTABLE=${CURRENT_INSTALLED_DIR}/tools/pkgconf/pkgconf
-        -DLTDL_INCLUDE_DIR=${SOURCE_PATH}/lib/common
+        ${LTDL_OPTION}
 )
 
 vcpkg_cmake_install()

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -59,10 +59,11 @@ vcpkg_copy_tools(
 file(GLOB PLUGINS "${CURRENT_PACKAGES_DIR}/bin/gvplugin_*")
 file(COPY ${PLUGINS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-if(VCPKG_TARGET_IS_WINDOWS)
+if(VCPKG_HOST_IS_WINDOWS)
     set(DOT_COMMAND "dot")
 else()
     set(DOT_COMMAND "./dot")
+    set(ENV{LD_LIBRARY_PATH} "$ENV{LD_LIBRARY_PATH}:${CURRENT_PACKAGES_DIR}/bin")
 endif()
 
 vcpkg_execute_required_process(

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.com
     OUT_SOURCE_PATH SOURCE_PATH
@@ -8,6 +10,7 @@ vcpkg_from_gitlab(
     PATCHES
         0001-Fix-build.patch
 )
+
 set(LTDL_OPTION)
 if(VCPKG_TARGET_IS_OSX)
     message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with brew install libtool")
@@ -55,7 +58,6 @@ vcpkg_copy_tools(
 )
 file(GLOB PLUGINS "${CURRENT_PACKAGES_DIR}/bin/gvplugin_*")
 file(COPY ${PLUGINS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-
 
 if(VCPKG_TARGET_IS_WINDOWS)
     set(DOT_COMMAND "dot")

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -46,7 +46,7 @@ vcpkg_cmake_configure(
         -DFLEX_EXECUTABLE=${FLEX}
         -DGIT_EXECUTABLE=${GIT}
         -DPython3_EXECUTABLE=${PYTHON3}
-        -DPKG_CONFIG_EXECUTABLE=${CURRENT_INSTALLED_DIR}/tools/pkgconf/pkgconf
+        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf
         ${EXTRA_CMAKE_OPTION}
 )
 

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -9,6 +9,20 @@ vcpkg_from_gitlab(
         0001-Fix-build.patch
 )
 
+if(VCPKG_TARGET_IS_OSX)
+    message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with brew install libtool")
+elseif(VCPKG_TARGET_IS_LINUX)
+    message("${PORT} currently requires the following libraries from the system package manager:\n    libtool\n\nThey can be installed with apt-get install libtool")
+else()
+    vcpkg_download_distfile(
+        LTDL_H_PATH
+        URLS "https://gitlab.com/graphviz/graphviz-windows-dependencies/-/raw/141d3a21be904fa8dc2ae3ed01d36684db07a35d/${VCPKG_TARGET_ARCHITECTURE}/include/ltdl.h"
+        FILENAME ltdl.h
+        SHA512 f2d20e849e35060536265f47014c40eb70e57dacd600a9db112fc465fbfa6a66217b44a8c3dc33039c260a27f09d9034b329b03cc28c32a22ec503fcd17b78cd
+    )
+    file(COPY ${LTDL_H_PATH} DESTINATION ${SOURCE_PATH}/lib/common)
+endif()
+
 vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk)
 vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
 
@@ -19,7 +33,6 @@ vcpkg_find_acquire_program(PYTHON3)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DBISON_EXECUTABLE=${BISON}
@@ -27,7 +40,7 @@ vcpkg_cmake_configure(
         -DGIT_EXECUTABLE=${GIT}
         -DPython3_EXECUTABLE=${PYTHON3}
         -DPKG_CONFIG_EXECUTABLE=${CURRENT_INSTALLED_DIR}/tools/pkgconf/pkgconf
-        -Denable_ltdl=OFF
+        -DLTDL_INCLUDE_DIR=${SOURCE_PATH}/lib/common
 )
 
 vcpkg_cmake_install()
@@ -39,8 +52,17 @@ vcpkg_copy_tools(
     TOOL_NAMES acyclic bcomps ccomps circo dijkstra dot fdp gc gml2gv graphml2gv gv2gml gvcolor gvgen gvpack gvpr gxl2gv mm2gv neato nop osage patchwork sccmap sfdp tred twopi unflatten
     AUTO_CLEAN
 )
+file(GLOB PLUGINS "${CURRENT_PACKAGES_DIR}/bin/gvplugin_*")
+file(COPY ${PLUGINS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
-# # Handle copyright
+vcpkg_execute_required_process(
+    COMMAND dot -c
+    WORKING_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/${PORT}
+    LOGNAME configure-plugins
+)
+file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/config6" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+
+# Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "graphviz",
   "version-semver": "2.49.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "dependencies": [

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -11,7 +11,10 @@
     "libffi",
     "libgd",
     "pango",
-    "pkgconf",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 2,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
+  "license": "EPL-1.0",
   "dependencies": [
     "cairo",
     "getopt",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2586,7 +2586,7 @@
     },
     "graphviz": {
       "baseline": "2.49.1",
-      "port-version": 1
+      "port-version": 2
     },
     "greatest": {
       "baseline": "1.5.0",

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "93dade275cf5f6a3a89122b6d38068fd396d2dae",
+      "version-semver": "2.49.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "61316edc3deb64749cf84f70f5b0dbd669c06a9e",
       "version-semver": "2.49.1",
       "port-version": 1

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8d63422459c9adb6f5cf3fb15e1705be0b3ad85b",
+      "git-tree": "d20073911ce5cf658d682839c091bd0390663d70",
       "version-semver": "2.49.1",
       "port-version": 2
     },

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d20073911ce5cf658d682839c091bd0390663d70",
+      "git-tree": "1640101d8b7aef3e73e85f4beb6070dfad914aad",
       "version-semver": "2.49.1",
       "port-version": 2
     },

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "93dade275cf5f6a3a89122b6d38068fd396d2dae",
+      "git-tree": "a3b0b79ec2189ee63bdb25e05fc762a2d18575dd",
       "version-semver": "2.49.1",
       "port-version": 2
     },

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a3b0b79ec2189ee63bdb25e05fc762a2d18575dd",
+      "git-tree": "8d63422459c9adb6f5cf3fb15e1705be0b3ad85b",
       "version-semver": "2.49.1",
       "port-version": 2
     },

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1640101d8b7aef3e73e85f4beb6070dfad914aad",
+      "git-tree": "912ac6a1578bd9cf23c20ed7f3bc85c25058c872",
       "version-semver": "2.49.1",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

In order to properly use the tools, libtool must be used in order to dynamically load the graphviz plugins. The graphviz devs provide a libtool header for Windows in https://gitlab.com/graphviz/graphviz-windows-dependencies. For other platforms, I looked at the messages other ports like [libcanberra](https://github.com/microsoft/vcpkg/blob/master/ports/libcanberra/portfile.cmake#L13) and [fastcgi](https://github.com/microsoft/vcpkg/blob/master/ports/fastcgi/portfile.cmake#L48) have printed to require libtool.

- #### What does your PR fix?  
  Fixes #23146 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
