### PR TITLE
[libtins] Fix bug in portfile.cmake

### DIFF
--- a/ports/libtins/portfile.cmake
+++ b/ports/libtins/portfile.cmake
@@ -34,6 +34,8 @@ get_filename_component(LIBTINS_CMAKE_DIR "${LIBTINS_CMAKE_DIR}" PATH)
 set(LIBTINS_INCLUDE_DIRS "${LIBTINS_CMAKE_DIR}/include")
 ]])
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/libtins/libtinsConfig.cmake" "\${LIBTINS_CMAKE_DIR}/libtinsTargets.cmake" "\${CMAKE_CURRENT_LIST_DIR}/libtinsTargets.cmake")
+
 if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/tins/macros.h" "!defined(TINS_STATIC)" "1")
 else()

--- a/ports/libtins/vcpkg.json
+++ b/ports/libtins/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libtins",
   "version": "4.3",
-  "port-version": 5,
+  "port-version": 6,
   "description": "High-level, multiplatform C++ network packet sniffing and crafting library",
   "license": "BSD-2-Clause",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4002,7 +4002,7 @@
     },
     "libtins": {
       "baseline": "4.3",
-      "port-version": 5
+      "port-version": 6
     },
     "libtomcrypt": {
       "baseline": "1.18.2",

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9f8ba13a13acb8f2b769dfb8aab279f59358642",
+      "version": "4.3",
+      "port-version": 6
+    },
+    {
       "git-tree": "9abc8b1a535ffaf99a680412cfd8f0c743c3fc6d",
       "version": "4.3",
       "port-version": 5

--- a/versions/l-/libtins.json
+++ b/versions/l-/libtins.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9f8ba13a13acb8f2b769dfb8aab279f59358642",
+      "git-tree": "4a1470befea5c6b5c7418f9b85f37d6f8733d7d5",
       "version": "4.3",
       "port-version": 6
     },


### PR DESCRIPTION
Fix bug in libtiins portfile.cmake.

- #### What does your PR fix?  
  Fixes #... bug while cmake install libtins library

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <all / linux, windows, ...>, <Yes/No>
all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
yes

