### PR TITLE
[vcpkg baseline][llfio] Fix arm build

### DIFF
--- a/ports/llfio/fix-arm64-build.patch
+++ b/ports/llfio/fix-arm64-build.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b51a873..6705915 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -208,7 +208,7 @@ function(check_cxx_source_linkage prog var)
+   endif()
+   if(CMAKE_CXX_STANDARD)
+     if(MSVC)
+-      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} /std:c++${CMAKE_CXX_STANDARD}")
++      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} /std:c++${CMAKE_CXX_STANDARD} /MTd")
+     else()
+       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
+     endif()

--- a/ports/llfio/portfile.cmake
+++ b/ports/llfio/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         # https://github.com/ned14/llfio/issues/83
         # To be removed on next update
         issue-83-fix-backport.patch
+        fix-arm64-build.patch
 )
 
 vcpkg_from_github(
@@ -59,7 +60,6 @@ endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS
         -DPROJECT_IS_DEPENDENCY=On
         -Dquickcpplib_DIR=${CURRENT_INSTALLED_DIR}/share/quickcpplib

--- a/ports/llfio/vcpkg.json
+++ b/ports/llfio/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "llfio",
   "version-string": "2.0-20220112",
+  "port-version": 1,
   "description": "P1031 low level file i/o and filesystem library for the C++ standard",
   "homepage": "https://github.com/ned14/llfio",
   "supports": "!uwp",
@@ -14,6 +15,9 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
+  ],
+  "default-features": [
+    "cxx17"
   ],
   "features": {
     "cxx17": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4170,7 +4170,7 @@
     },
     "llfio": {
       "baseline": "2.0-20220112",
-      "port-version": 0
+      "port-version": 1
     },
     "llgl": {
       "baseline": "2019-08-15",

--- a/versions/l-/llfio.json
+++ b/versions/l-/llfio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "64983838b051699afafbaaf552472431e21f11bb",
+      "version-string": "2.0-20220112",
+      "port-version": 1
+    },
+    {
       "git-tree": "aaacb49264f3175de57367f28c90bd3904d7209f",
       "version-string": "2.0-20220112",
       "port-version": 0


### PR DESCRIPTION
Fix:
```
CMake Error at D:/installed/arm64-windows/share/ned14-internal-quickcpplib/cmakelib/QuickCppLibUtils.cmake:84 (message):
  FATAL: <filesystem> is not available, and neither libstdc++ nor libc++ STLs
  will link a program
Call Stack (most recent call first):
  CMakeLists.txt:265 (indented_message)
```

Related: https://github.com/microsoft/vcpkg/pull/23001