### PR TITLE
[vcpkg baseline] [jsonnet] Fix dependency

### DIFF
--- a/ports/jsonnet/001-enable-msvc.patch
+++ b/ports/jsonnet/001-enable-msvc.patch
@@ -40,6 +40,7 @@ index c032f02..d80d2a0 100644
 +	install(TARGETS jsonnetfmt DESTINATION tools/jsonnet)
  endif()
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index e8ad830..83a95f4 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
 @@ -28,7 +28,7 @@ set(LIBJSONNET_SOURCE
@@ -61,20 +62,27 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
  target_include_directories(libjsonnet INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 diff --git a/stdlib/CMakeLists.txt b/stdlib/CMakeLists.txt
-index a481d9f..2f58d2f 100644
+index a481d9f..95bfd71 100644
 --- a/stdlib/CMakeLists.txt
 +++ b/stdlib/CMakeLists.txt
-@@ -2,6 +2,7 @@
+@@ -1,15 +1,15 @@
+ # Utility to convert file to a list of integeters.
  
  add_executable(to_c_array to_c_array.cpp)
- 
-+if(0)
+-
++
  # Custom command that will only build stdlib when it changes.
  add_custom_command(
- 	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
-@@ -13,3 +14,4 @@ add_custom_command(
+-	OUTPUT ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
++	OUTPUT ${CMAKE_BINARY_DIR}/core/std.jsonnet.h
+ 	COMMAND ${GLOBAL_OUTPUT_PATH}/to_c_array
+ 			    ${PROJECT_SOURCE_DIR}/stdlib/std.jsonnet
+-					${PROJECT_SOURCE_DIR}/core/std.jsonnet.h
++					${CMAKE_BINARY_DIR}/core/std.jsonnet.h
+ 	DEPENDS to_c_array std.jsonnet)
+ 
  # Standard library build target that libjsonnet can depend on.
  add_custom_target(stdlib ALL
- 	DEPENDS ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h)
-+endif()
+-	DEPENDS ${PROJECT_SOURCE_DIR}/core/std.jsonnet.h)
++	DEPENDS ${CMAKE_BINARY_DIR}/core/std.jsonnet.h)
 \ No newline at end of file

--- a/ports/jsonnet/002-fix-dependency-and-install.patch
+++ b/ports/jsonnet/002-fix-dependency-and-install.patch
@@ -1,4 +1,5 @@
 diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
+index 83a95f4..0c40944 100644
 --- a/core/CMakeLists.txt
 +++ b/core/CMakeLists.txt
 @@ -28,6 +28,7 @@ set(LIBJSONNET_SOURCE
@@ -9,7 +10,7 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
  add_library(libjsonnet ${LIBJSONNET_HEADERS} ${LIBJSONNET_SOURCE})
  add_dependencies(libjsonnet md5 stdlib)
  target_link_libraries(libjsonnet md5 nlohmann_json::nlohmann_json)
-@@ -48,6 +49,7 @@ install(TARGETS libjsonnet
+@@ -50,6 +51,7 @@ install(TARGETS libjsonnet
  	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
  target_include_directories(libjsonnet INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
@@ -17,13 +18,14 @@ diff --git a/core/CMakeLists.txt b/core/CMakeLists.txt
  
  if (BUILD_STATIC_LIBS)
      # Static library for jsonnet command-line tool.
-@@ -102,3 +104,5 @@ if (BUILD_TESTS)
+@@ -106,3 +108,5 @@ if (BUILD_TESTS)
      add_test(jsonnet_test_snippet
          ${GLOBAL_OUTPUT_PATH}/jsonnet -e ${TEST_SNIPPET})
  endif()
 +
 +install(FILES ${LIB_HEADER} DESTINATION include)
 diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 5549902..e048a2c 100644
 --- a/cpp/CMakeLists.txt
 +++ b/cpp/CMakeLists.txt
 @@ -8,9 +8,9 @@ set(LIBJSONNETPP_SOURCE
@@ -38,7 +40,7 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
  
  # CMake prepends CMAKE_SHARED_LIBRARY_PREFIX to shared libraries, so without
  # this step the output would be |liblibjsonnet|.
-@@ -24,6 +24,7 @@ install(TARGETS libjsonnet++
+@@ -24,11 +24,11 @@ install(TARGETS libjsonnet++
  	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
  target_include_directories(libjsonnet++ INTERFACE
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
@@ -46,7 +48,12 @@ diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
  
  if (BUILD_STATIC_LIBS)
      # Static library for jsonnet command-line tool.
-@@ -38,6 +39,7 @@ else()
+     add_library(libjsonnet++_static STATIC ${LIBJSONNETPP_SOURCE})
+-    add_dependencies(libjsonnet++_static jsonnet)
+     target_link_libraries(libjsonnet++_static libjsonnet_static)
+     set_target_properties(libjsonnet++_static PROPERTIES OUTPUT_NAME jsonnet++)
+     install(TARGETS libjsonnet++_static DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+@@ -42,6 +42,7 @@ else()
      add_library(libjsonnet++_for_binaries ALIAS libjsonnet++_static)
  endif()
  

--- a/ports/jsonnet/vcpkg.json
+++ b/ports/jsonnet/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "jsonnet",
   "version": "0.17.0",
+  "port-version": 1,
   "description": "Jsonnet - The data templating language",
   "homepage": "https://github.com/google/jsonnet",
+  "license": "Apache-2.0",
   "supports": "!(windows & !static)",
   "dependencies": [
     "nlohmann-json",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3018,7 +3018,7 @@
     },
     "jsonnet": {
       "baseline": "0.17.0",
-      "port-version": 0
+      "port-version": 1
     },
     "jwt-cpp": {
       "baseline": "0.5.1",

--- a/versions/j-/jsonnet.json
+++ b/versions/j-/jsonnet.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ee6e8e66b05792c50aa00b5a3a59b90b6613f0c7",
+      "version": "0.17.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "24a514c5bcece6b71ac13744ec40f92f285fc689",
       "version": "0.17.0",
       "port-version": 0


### PR DESCRIPTION
Related to https://github.com/microsoft/vcpkg/pull/23001

Update the patch for fix the dependency stdlib, remove dependency jsonnet from libjsonnet++_static since jsonnet is executable target.

Fixes 
```
-- Configuring done
CMake Error at core/CMakeLists.txt:61 (add_dependencies):
  The dependency target "stdlib" of target "libjsonnet_static" does not
  exist.
CMake Error at cpp/CMakeLists.txt:32 (add_dependencies):
  The dependency target "jsonnet" of target "libjsonnet++_static" does not
  exist.
```
