### PR TITLE
[cmake-user] Disable CI test with CMake 3.4

### DIFF
--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cmake-user",
-  "version-date": "2021-07-24",
+  "version-date": "2022-02-18",
   "description": "Test port to verify the vcpkg toolchain in cmake user projects",
   "default-features": [
     "ci"
@@ -15,14 +15,6 @@
           "features": [
             "find-package"
           ]
-        },
-        {
-          "name": "cmake-user",
-          "default-features": false,
-          "features": [
-            "cmake-3-4"
-          ],
-          "platform": "x64 & (windows | linux | osx) & !uwp"
         }
       ]
     },


### PR DESCRIPTION
- #### What does your PR fix?  
  Quick fix for CI errors for ports which trigger the explicit CMake 3.4 test in port cmake-user. E.g. #23001, #22856.
  (The proper fix is switching to CMake 3.7.2, but this can be done in another PR.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  test port