### PR TITLE
[qt5-winextras] remove unneeded dependencies

### DIFF
--- a/ports/qt5-winextras/patches/require_quick.patch
+++ b/ports/qt5-winextras/patches/require_quick.patch
@@ -1,0 +1,12 @@
+diff --git a/src/src.pro b/src/src.pro
+index fceeb21..8a242d0 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -2,6 +2,7 @@ win32 {
+     TEMPLATE = subdirs
+     CONFIG += ordered
+     SUBDIRS += winextras
++    SUBDIRS += imports
+ } else {
+     # fake project for creating the documentation
+     TEMPLATE = aux

--- a/ports/qt5-winextras/patches/unrequire_quick.patch
+++ b/ports/qt5-winextras/patches/unrequire_quick.patch
@@ -1,0 +1,12 @@
+diff --git a/src/src.pro b/src/src.pro
+index fceeb21..7e4835b 100644
+--- a/src/src.pro
++++ b/src/src.pro
+@@ -2,7 +2,6 @@ win32 {
+     TEMPLATE = subdirs
+     CONFIG += ordered
+     SUBDIRS += winextras
+-    qtHaveModule(quick): SUBDIRS += imports
+ } else {
+     # fake project for creating the documentation
+     TEMPLATE = aux

--- a/ports/qt5-winextras/portfile.cmake
+++ b/ports/qt5-winextras/portfile.cmake
@@ -1,5 +1,12 @@
-if (NOT VCPKG_TARGET_IS_WINDOWS)
-    message(FATAL_ERROR "qt5-winextras only support Windows.")
+include("${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake")
+
+vcpkg_list(SET _patches
+    "patches/unrequire_quick.patch"
+)
+if("declarative" IN_LIST FEATURES)
+    list(APPEND _patches
+        "patches/require_quick.patch"
+    )
 endif()
-include(${CURRENT_INSTALLED_DIR}/share/qt5/qt_port_functions.cmake)
-qt_submodule_installation()
+
+qt_submodule_installation(PATCHES ${_patches})

--- a/ports/qt5-winextras/vcpkg.json
+++ b/ports/qt5-winextras/vcpkg.json
@@ -1,19 +1,23 @@
 {
   "name": "qt5-winextras",
   "version": "5.15.3",
+  "port-version": 1,
   "description": "Qt5 Windows Extras Module. Provides platform-specific APIs for Windows.",
   "license": null,
   "supports": "windows",
   "dependencies": [
-    {
-      "name": "atlmfc",
-      "platform": "windows"
-    },
+    "atlmfc",
     {
       "name": "qt5-base",
       "default-features": false
-    },
-    "qt5-declarative",
-    "qt5-multimedia"
-  ]
+    }
+  ],
+  "features": {
+    "declarative": {
+      "description": "Build Qt.Quick imports",
+      "dependencies": [
+        "qt5-declarative"
+      ]
+    }
+  }
 }

--- a/ports/qt5/vcpkg.json
+++ b/ports/qt5/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qt5",
   "version": "5.15.3",
+  "port-version": 1,
   "description": "Qt5 Application Framework",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -162,6 +163,9 @@
         },
         {
           "name": "qt5-winextras",
+          "features": [
+            "declarative"
+          ],
           "platform": "windows"
         },
         {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5602,7 +5602,7 @@
     },
     "qt5": {
       "baseline": "5.15.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-3d": {
       "baseline": "5.15.3",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5762,7 +5762,7 @@
     },
     "qt5-winextras": {
       "baseline": "5.15.3",
-      "port-version": 0
+      "port-version": 1
     },
     "qt5-x11extras": {
       "baseline": "5.15.3",

--- a/versions/q-/qt5-winextras.json
+++ b/versions/q-/qt5-winextras.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5a7881475902048fa453bff04c347caa7e9a615b",
+      "version": "5.15.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "89250816793ceacdf74730157af6f287070b8bf1",
       "version": "5.15.3",
       "port-version": 0

--- a/versions/q-/qt5.json
+++ b/versions/q-/qt5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "979ef9acc281793cef4f43f1e1eaed177ed9b408",
+      "version": "5.15.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "428cdd43abdc1200e889c66b9c388b421d16bf58",
       "version": "5.15.3",
       "port-version": 0


### PR DESCRIPTION
`qt5-winextras` builds fine without `qt5-declarative` and `qt5-multimedia`

cc @Neumann-A 
