### PR TITLE
[leveldb] Fix homepage

### DIFF
--- a/ports/leveldb/vcpkg.json
+++ b/ports/leveldb/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "leveldb",
-  "version-string": "1.22",
-  "port-version": 4,
+  "version": "1.22",
+  "port-version": 5,
   "description": "LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.",
-  "homepage": "https://github.com/bitcoin-core/leveldb",
+  "homepage": "https://github.com/google/leveldb",
   "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3314,7 +3314,7 @@
     },
     "leveldb": {
       "baseline": "1.22",
-      "port-version": 4
+      "port-version": 5
     },
     "levmar": {
       "baseline": "2.6",

--- a/versions/l-/leveldb.json
+++ b/versions/l-/leveldb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ca11f66c6efa417b28755759b6c67670524f532",
+      "version": "1.22",
+      "port-version": 5
+    },
+    {
       "git-tree": "c41d96d2e0f6f6301e2370bc00fa7390cdd94330",
       "version-string": "1.22",
       "port-version": 4


### PR DESCRIPTION
leveldb is written by google, not bitcoin-core. This is a follow-up to commit 578139ece7607c3697d1db59dfe3a030993f767c, which changed the upstream.