### PR TITLE
[openxr-loader] Fix build failure in world rebuild CI.

### DIFF
--- a/ports/openxr-loader/fix-jinja2.patch
+++ b/ports/openxr-loader/fix-jinja2.patch
@@ -1,0 +1,23 @@
+From d80c7dc3f4810fc49e4444590d39ef71e8a9b01c Mon Sep 17 00:00:00 2001
+From: Adam Johnson <AdamJohnso@gmail.com>
+Date: Sat, 19 Feb 2022 19:42:31 -0500
+Subject: [PATCH] Fix bad import in jinja2
+
+---
+ external/python/jinja2/utils.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/external/python/jinja2/utils.py b/external/python/jinja2/utils.py
+index db9c5d06..f198e3ef 100644
+--- a/external/python/jinja2/utils.py
++++ b/external/python/jinja2/utils.py
+@@ -639,4 +639,8 @@ def __repr__(self):
+ 
+ 
+ # Imported here because that's where it was in the past
+-from markupsafe import Markup, escape, soft_unicode
++from markupsafe import Markup, escape
++try:
++    from markupsafe import soft_unicode
++except ImportError:
++    from markupsafe import soft_str as soft_unicode

--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -17,6 +17,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-openxr-sdk-jsoncpp.patch
+        fix-jinja2.patch
 )
 
 vcpkg_from_github(

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openxr-loader",
   "version": "1.0.22",
+  "port-version": 1,
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
   "supports": "!(arm | uwp)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5114,7 +5114,7 @@
     },
     "openxr-loader": {
       "baseline": "1.0.22",
-      "port-version": 0
+      "port-version": 1
     },
     "optimus-cpp": {
       "baseline": "0.3.0",

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9d673fe500c4b38f0806bd4b3c23a82bba897967",
+      "version": "1.0.22",
+      "port-version": 1
+    },
+    {
       "git-tree": "445bbc9debe9866fad35544bd948d54fda4e72c4",
       "version": "1.0.22",
       "port-version": 0


### PR DESCRIPTION
Fixes an observed failure in CI when #23156 triggered a world rebuild. Evidently the markupsafe Python package renamed `soft_unicode` to `soft_str` at some point,

- #### What does your PR fix?  
  Observed failure:
```
Traceback (most recent call last):
  File "D:\buildtrees\openxr-loader\src\ase-1.0.21-8166c3773a.clean\scripts\hpp_genxr.py", line 220, in 
    genTarget(args)
  File "D:\buildtrees\openxr-loader\src\ase-1.0.21-8166c3773a.clean\scripts\hpp_genxr.py", line 116, in genTarget
    gen = CppGenerator(errFile=errWarn,
  File "D:\buildtrees\openxr-loader\src\ase-1.0.21-8166c3773a.clean\scripts\cpp_generator.py", line 427, in __init__
    self.env = make_jinja_environment(file_with_templates_as_sibs=__file__, trim_blocks=False)
  File "D:\buildtrees\openxr-loader\src\ase-1.0.21-8166c3773a.clean\scripts\jinja_helpers.py", line 140, in make_jinja_environment
    from jinja2 import Environment, FileSystemLoader
  File "D:\buildtrees\openxr-loader\src\ase-1.0.22-27be7bd21f.clean\external\python\jinja2\__init__.py", line 33, in 
    from jinja2.environment import Environment, Template
  File "D:\buildtrees\openxr-loader\src\ase-1.0.22-27be7bd21f.clean\external\python\jinja2\environment.py", line 15, in 
    from jinja2 import nodes
  File "D:\buildtrees\openxr-loader\src\ase-1.0.22-27be7bd21f.clean\external\python\jinja2\nodes.py", line 19, in 
    from jinja2.utils import Markup
  File "D:\buildtrees\openxr-loader\src\ase-1.0.22-27be7bd21f.clean\external\python\jinja2\utils.py", line 642, in 
    from markupsafe import Markup, escape, soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (D:\downloads\tools\python\python-3.10.2-x86\lib\site-packages\markupsafe\__init__.py)
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
