### PR TITLE
[winsparkle] Intitial commit with binary copy 

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/vslavik/winsparkle/releases/download/v0.7.0/WinSparkle-0.7.0.zip"
+    FILENAME "winsparkle-070.zip"
+    SHA512 c2cf29e1880534c170110f8e5a966939aecc9a9e05afc87868400074f1492fcac949b61e2ce4636eadd2f127caad3660e0f763476e9523aad3834d673f6edd77
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE}
+)
+
+file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+file(INSTALL "${SOURCE_PATH}/bin" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}" FILES_MATCHING PATTERN "*.bat")
+
+
+# Note: It is an explicit design goal for WinSparkle to be a single 
+# self-contained DLL with no external dependencies (to the point that 
+# it even links to static CRT!). This matters for e.g. in-app delta updates 
+# or re-launching the app after update. It is not statically linked even if a 
+# static linking is used for everything else. 
+
+if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/lib")
+elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+
+    # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/lib")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+

--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -17,7 +17,8 @@ file(INSTALL "${SOURCE_PATH}/bin" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${P
 # self-contained DLL with no external dependencies (to the point that 
 # it even links to static CRT!). This matters for e.g. in-app delta updates 
 # or re-launching the app after update. It is not statically linked even if a 
-# static linking is used for everything else. 
+# static linking is used for everything else.
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 
 if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "winsparkle",
+  "version": "0.7.0",
+  "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
+  "homepage": "https://winsparkle.org",
+  "license": "MIT",
+  "supports": "windows & !(arm | uwp)"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7344,6 +7344,10 @@
       "baseline": "0.0",
       "port-version": 4
     },
+    "winsparkle": {
+      "baseline": "0.7.0",
+      "port-version": 0
+    },
     "wintoast": {
       "baseline": "1.2.0",
       "port-version": 2

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3de12a4bb10bb91edb9bb06ce6d089340cd488eb",
+      "git-tree": "0d756f506e6a79a2a79706f9080c05b45e7df882",
       "version": "0.7.0",
       "port-version": 0
     }

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3de12a4bb10bb91edb9bb06ce6d089340cd488eb",
+      "version": "0.7.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds winsparkle to the ports. This is the alternative solution, copying the prebuild binaries as suggested here: 
https://github.com/microsoft/vcpkg/pull/17563

Fixes  #16607

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

Only windows x64 and x86 targets are supported. Other triplet settings are ignored because this is a binary copy of the recompiled binaries. 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes