### PR TITLE
[libgpiod] Add new port.

### DIFF
--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,0 +1,46 @@
+
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
+    REF dfc5d361e6748d5f48b706e5c4ac949d133b5470 # v1.6.3
+    PATCHES
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    list(APPEND OPTIONS --enable-shared=yes)
+    list(APPEND OPTIONS --enable-static=no)
+else()
+    list(APPEND OPTIONS --enable-shared=no)
+    list(APPEND OPTIONS --enable-static=yes)
+endif()
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
+    list(APPEND OPTIONS CC=${VCPKG_DETECTED_CMAKE_C_COMPILER})
+    if (VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        list(APPEND OPTIONS ac_cv_func_malloc_0_nonnull=yes)
+        list(APPEND OPTIONS ac_cv_func_realloc_0_nonnull=yes)
+    endif()
+endif()
+
+vcpkg_configure_make(
+    AUTOCONFIG
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${OPTIONS}
+        --enable-tools=no
+        --enable-tests=no
+        --enable-bindings-cxx=no
+        --enable-bindings-python=no
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig() 
+vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+

--- a/ports/libgpiod/portfile.cmake
+++ b/ports/libgpiod/portfile.cmake
@@ -1,5 +1,3 @@
-
-
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
@@ -42,5 +40,3 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libgpiod",
+  "version": "1.6.3",
+  "description": "C library and tools for interacting with the linux GPIO character device",
+  "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
+  "license": "LGPL-2.1-or-later",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
+  "supports": "linux & (x64 | arm64)"
+}

--- a/ports/libgpiod/vcpkg.json
+++ b/ports/libgpiod/vcpkg.json
@@ -4,11 +4,11 @@
   "description": "C library and tools for interacting with the linux GPIO character device",
   "homepage": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git",
   "license": "LGPL-2.1-or-later",
+  "supports": "linux & (x64 | arm64)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
       "host": true
     }
-  ],
-  "supports": "linux & (x64 | arm64)"
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3532,6 +3532,10 @@
       "baseline": "1.42",
       "port-version": 3
     },
+    "libgpiod": {
+      "baseline": "1.6.3",
+      "port-version": 0
+    },
     "libgpod": {
       "baseline": "2019-08-29",
       "port-version": 4

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "98b005671873a0755f4e3135e53fa6d2caf92197",
+      "git-tree": "bee35d9df1cadb1f55fa8db8219c3f450944c33a",
       "version": "1.6.3",
       "port-version": 0
     }

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "98b005671873a0755f4e3135e53fa6d2caf92197",
+      "version": "1.6.3",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/libgpiod.json
+++ b/versions/l-/libgpiod.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bee35d9df1cadb1f55fa8db8219c3f450944c33a",
+      "git-tree": "9a8b2a2d891f2435ff9ce3fbcea0bd870327bad0",
       "version": "1.6.3",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**
Add [libgpiod] port

- #### What does your PR fix?  
New Port - add support for libgpiod package (https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/).
**libgpio**: C library and tools for interacting with the linux GPIO character device (gpiod stands for GPIO device).
This port _only_ builds the library part to keep licensing under LGPLv2.1-or-later.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
linux, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
