### PR TITLE
Fix windows git-bash boostrap missing quotes

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -46,7 +46,7 @@ if [ "$unixName" = "MINGW_NT" ]; then
     fi
 
     vcpkgRootDir=$(cygpath -aw "$vcpkgRootDir")
-    cmd "/C $vcpkgRootDir\\bootstrap-vcpkg.bat $args" || exit 1
+    cmd "/C "$vcpkgRootDir\\bootstrap-vcpkg.bat $args"" || exit 1
     exit 0
 fi
 


### PR DESCRIPTION
Add quotes around call to boostrap-vcpkg.bat inside boostrap-vcpkg.sh when run on Windows from git-bash. This is required if run from a directory with spaces.

- #### What does your PR fix?  
  Fixes boostrap script on Windows when running ./vcpkg/boostrap.sh from git-bash. Without this fix if it is run from a directory with spaces the bat script is not referenced correctly. This is becuase directories with spaces need additional quotes around command.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  No
