### PR TITLE
[libfido2] Update to 1.10.0

### DIFF
--- a/ports/libfido2/fix_cmakelists.patch
+++ b/ports/libfido2/fix_cmakelists.patch
@@ -1,27 +1,29 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1eb8726..b308597 100644
+index 11a51ac..33b9313 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -161,16 +161,20 @@ if(UNIX)
+@@ -156,18 +156,20 @@ if(UNIX)
  endif()
  
  if(MSVC)
 -	if((NOT CBOR_INCLUDE_DIRS) OR (NOT CBOR_LIBRARY_DIRS) OR
--	   (NOT CRYPTO_INCLUDE_DIRS) OR (NOT CRYPTO_LIBRARY_DIRS) OR
--	   (NOT ZLIB_INCLUDE_DIRS) OR (NOT ZLIB_LIBRARY_DIRS))
--		message(FATAL_ERROR "please provide definitions for "
--		   "{CBOR,CRYPTO,ZLIB}_{INCLUDE,LIBRARY}_DIRS when building "
--		    "under msvc")
+-	   (NOT CBOR_BIN_DIRS) OR (NOT CRYPTO_INCLUDE_DIRS) OR
+-	   (NOT CRYPTO_LIBRARY_DIRS) OR (NOT CRYPTO_BIN_DIRS) OR
+-	   (NOT ZLIB_INCLUDE_DIRS) OR (NOT ZLIB_LIBRARY_DIRS) OR
+-	   (NOT ZLIB_BIN_DIRS))
+-		message(FATAL_ERROR "please define "
+-		   "{CBOR,CRYPTO,ZLIB}_{INCLUDE,LIBRARY,BIN}_DIRS when "
+-		   "building under msvc")
 -	endif()
 -	set(CBOR_LIBRARIES cbor)
 -	set(ZLIB_LIBRARIES zlib)
--	set(CRYPTO_LIBRARIES crypto-46)
+-	set(CRYPTO_LIBRARIES crypto-47)
 +	include(FindPkgConfig)
-+	
++
 +	find_package(LIBCBOR REQUIRED)
 +	find_package(OpenSSL REQUIRED)
 +	find_package(ZLIB REQUIRED) 
-+	
++
 +	# Handling of different Packagenames in VCPKG
 +	set(CBOR_INCLUDE_DIRS ${LIBCBOR_INCLUDE_DIR})
 +	set(CRYPTO_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIRS})
@@ -31,18 +33,15 @@ index 1eb8726..b308597 100644
 +	set(CRYPTO_LIBRARIES ${OPENSSL_LIBRARIES})
 +	add_definitions("-D_CRT_SECURE_NO_WARNINGS" "-D_CRT_NONSTDC_NO_DEPRECATE")
  	set(MSVC_DISABLED_WARNINGS_LIST
- 		"C4200" # nonstandard extension used: zero-sized array in
- 			# struct/union;
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 11b0bb5..d820ff3 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -120,7 +120,7 @@ if(BUILD_SHARED_LIBS)
- 	install(TARGETS fido2_shared
- 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
- 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
--		RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
- endif()
+ 		"C4152" # nonstandard extension used: function/data pointer
+ 			# conversion in expression;
+@@ -403,6 +402,9 @@ message(STATUS "USE_HIDAPI: ${USE_HIDAPI}")
+ message(STATUS "USE_WINHELLO: ${USE_WINHELLO}")
+ message(STATUS "NFC_LINUX: ${NFC_LINUX}")
  
- install(FILES fido.h DESTINATION include)
++set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /wd4996")
++set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /wd4996")
++
+ subdirs(src)
+ if(BUILD_EXAMPLES)
+ 	subdirs(examples)

--- a/ports/libfido2/portfile.cmake
+++ b/ports/libfido2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Yubico/libfido2
-    REF 1.7.0
-    SHA512 f40d394883d909e9e3ea3308b32f7ca31a882c709e11b3b143ed5734d16b0c244d4932effe06965d566776b03d152b1fc280e73cdfeeb81b65d8414042af19fe
+    REF 1.10.0
+    SHA512 ba03e25d3f42f11cec74dee48c853ae35d03600f24ca06d2b751840408a132290fe22461372ae42ae31419061a63d9908c20a2c0cf3c0c9c8dbc46c34916784f
     HEAD_REF master
     PATCHES
         "fix_cmakelists.patch"
@@ -12,7 +12,7 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" LIBFIDO2_BUILD_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" LIBFIDO2_BUILD_SHARED)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXAMPLES=OFF
         -DBUILD_MANPAGES=OFF
@@ -26,4 +26,4 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/libfido2/vcpkg.json
+++ b/ports/libfido2/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libfido2",
-  "version": "1.7.0",
+  "version": "1.10.0",
   "description": "Provides library functionality to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.",
   "homepage": "https://developers.yubico.com/libfido2/",
+  "license": "BSD-2-Clause",
   "supports": "!uwp & (x86 | x64) & windows",
   "dependencies": [
     "libcbor",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3477,7 +3477,7 @@
       "port-version": 4
     },
     "libfido2": {
-      "baseline": "1.7.0",
+      "baseline": "1.10.0",
       "port-version": 0
     },
     "libflac": {

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0d3dc297cbc4c116910b6cb793bc3b5a06834e00",
+      "version": "1.10.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "170a0bcbc2f58e140205858db504ecfe7ade1a9f",
       "version": "1.7.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes compatibility issues with OpenSSL 3: #22878

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
