### PR TITLE
[triton] Fix usage

### DIFF
--- a/ports/triton/fix-dependencies.patch
+++ b/ports/triton/fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7e82b5b..baf0ec3 100644
+index a8bbe47..966ded8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -98,9 +98,9 @@ list(APPEND CMAKE_MODULE_PATH "${TRITON_ROOT}/CMakeModules/")
+@@ -99,9 +99,9 @@ list(APPEND CMAKE_MODULE_PATH "${TRITON_ROOT}/CMakeModules/")
  # Find Z3
  if(Z3_INTERFACE)
      message(STATUS "Compiling with Z3 SMT solver")
@@ -15,13 +15,14 @@ index 7e82b5b..baf0ec3 100644
  
  # Find bitwuzla
 diff --git a/CMakeModules/FindCAPSTONE.cmake b/CMakeModules/FindCAPSTONE.cmake
-index ff2c63f..76a8ae6 100644
+index ff2c63f..4dcf9af 100644
 --- a/CMakeModules/FindCAPSTONE.cmake
 +++ b/CMakeModules/FindCAPSTONE.cmake
-@@ -26,9 +26,10 @@ if(NOT CAPSTONE_INCLUDE_DIRS AND NOT CAPSTONE_LIBRARIES)
+@@ -26,9 +26,11 @@ if(NOT CAPSTONE_INCLUDE_DIRS AND NOT CAPSTONE_LIBRARIES)
        NAMES capstone/capstone.h
        PATHS ${CAPSTONE_PKGCONF_INCLUDE_DIRS}
      )
++    
 +    string(APPEND CAPSTONE_INCLUDE_DIR "/capstone")
  
      find_library(CAPSTONE_LIBRARY

--- a/ports/triton/fix-dependencies.patch
+++ b/ports/triton/fix-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a8bbe47..966ded8 100644
+index 7e82b5b..baf0ec3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -99,9 +99,9 @@ list(APPEND CMAKE_MODULE_PATH "${TRITON_ROOT}/CMakeModules/")
+@@ -98,9 +98,9 @@ list(APPEND CMAKE_MODULE_PATH "${TRITON_ROOT}/CMakeModules/")
  # Find Z3
  if(Z3_INTERFACE)
      message(STATUS "Compiling with Z3 SMT solver")
@@ -15,14 +15,13 @@ index a8bbe47..966ded8 100644
  
  # Find bitwuzla
 diff --git a/CMakeModules/FindCAPSTONE.cmake b/CMakeModules/FindCAPSTONE.cmake
-index ff2c63f..4dcf9af 100644
+index ff2c63f..76a8ae6 100644
 --- a/CMakeModules/FindCAPSTONE.cmake
 +++ b/CMakeModules/FindCAPSTONE.cmake
-@@ -26,9 +26,11 @@ if(NOT CAPSTONE_INCLUDE_DIRS AND NOT CAPSTONE_LIBRARIES)
+@@ -26,9 +26,10 @@ if(NOT CAPSTONE_INCLUDE_DIRS AND NOT CAPSTONE_LIBRARIES)
        NAMES capstone/capstone.h
        PATHS ${CAPSTONE_PKGCONF_INCLUDE_DIRS}
      )
-+    
 +    string(APPEND CAPSTONE_INCLUDE_DIR "/capstone")
  
      find_library(CAPSTONE_LIBRARY
@@ -31,3 +30,18 @@ index ff2c63f..4dcf9af 100644
        PATHS ${CAPSTONE_PKGCONF_LIBRARY_DIRS}
      )
  
+diff --git a/src/libtriton/Config.cmake.in b/src/libtriton/Config.cmake.in
+index 94c58bc..115d697 100644
+--- a/src/libtriton/Config.cmake.in
++++ b/src/libtriton/Config.cmake.in
+@@ -40,10 +40,6 @@ if (TRITON_LLVM_INTERFACE)
+     include_directories("@LLVM_INCLUDE_DIRS@")
+ endif()
+ 
+-# Z3 include directories
+-if (TRITON_Z3_INTERFACE)
+-    include_directories("@Z3_INCLUDE_DIRS@")
+-endif()
+ 
+ # Bitwuzla include directories
+ if (TRITON_BITWUZLA_INTERFACE)

--- a/ports/triton/vcpkg.json
+++ b/ports/triton/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "triton",
   "version": "0.9",
+  "port-version": 1,
   "description": "Triton is a Dynamic Binary Analysis (DBA) framework. It provides internal components like a Dynamic Symbolic Execution (DSE) engine, a dynamic taint engine, AST representations of the x86, x86-64, ARM32 and AArch64 Instructions Set Architecture (ISA), SMT simplification passes, an SMT solver interface and, the last but not least, Python bindings.",
   "homepage": "https://github.com/JonathanSalwan/Triton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7022,7 +7022,7 @@
     },
     "triton": {
       "baseline": "0.9",
-      "port-version": 0
+      "port-version": 1
     },
     "trompeloeil": {
       "baseline": "41",

--- a/versions/t-/triton.json
+++ b/versions/t-/triton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ffdeb9617b061edaba314086af55d9b3241aa6ff",
+      "git-tree": "1463df6dd74dfea7d12a8610b23009259b5c1e57",
       "version": "0.9",
       "port-version": 1
     },

--- a/versions/t-/triton.json
+++ b/versions/t-/triton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ffdeb9617b061edaba314086af55d9b3241aa6ff",
+      "version": "0.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "168cc90ef1373fadb8b05ad53430eb37a022dd50",
       "version": "0.9",
       "port-version": 0


### PR DESCRIPTION
Since we use `z3Config.cmake`, the `Z3_INCLUDE_DIRS` is not needed to be inclued.

Already tested the usage in cmake.

Related: #23111.