### PR TITLE
[cnats] Add new port (C client for the NATS messaging system).

### DIFF
--- a/ports/cnats/portfile.cmake
+++ b/ports/cnats/portfile.cmake
@@ -1,0 +1,76 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO nats-io/nats.c
+    REF v3.2.0
+    SHA512 570bbd5b6ed25db17755f4cbd2df9449bf1f838450e29aaa1483c11e6131293490d302031e3039d710bbbc3563ce72fb72cd3ad2c98618977a4858a5a3f2abe3
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        "streaming"  NATS_BUILD_STREAMING
+)
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    list(APPEND OPTIONS -DNATS_BUILD_LIB_SHARED=ON)
+    list(APPEND OPTIONS -DNATS_BUILD_LIB_STATIC=OFF)
+    list(APPEND OPTIONS -DBUILD_TESTING=OFF)
+    list(APPEND OPTIONS -DNATS_BUILD_USE_SODIUM=ON)
+else()
+    list(APPEND OPTIONS -DNATS_BUILD_LIB_SHARED=OFF)
+    list(APPEND OPTIONS -DNATS_BUILD_LIB_STATIC=ON)
+    list(APPEND OPTIONS -DBUILD_TESTING=ON)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        list(APPEND OPTIONS -DNATS_BUILD_USE_SODIUM=OFF)
+    else()
+        list(APPEND OPTIONS -DNATS_BUILD_USE_SODIUM=ON)
+    endif()
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${OPTIONS}
+        -DNATS_BUILD_TLS_USE_OPENSSL_1_1_API=ON
+        -DNATS_BUILD_EXAMPLES=OFF
+)
+
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/nats.dll")
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/lib/nats.dll" "${CURRENT_PACKAGES_DIR}/bin/nats.dll")
+        endif()
+        if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/natsd.dll")
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/natsd.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/natsd.dll")
+        endif()
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        if(EXISTS "${CURRENT_PACKAGES_DIR}/share/cnats/cnats-config-debug.cmake")
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/cnats/cnats-config-debug.cmake" 
+                "\${_IMPORT_PREFIX}/debug/lib/natsd.dll" "\${_IMPORT_PREFIX}/debug/bin/natsd.dll")
+        endif()
+        if(EXISTS "${CURRENT_PACKAGES_DIR}/share/cnats/cnats-config-release.cmake")
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/cnats/cnats-config-release.cmake" 
+                "\${_IMPORT_PREFIX}/lib/nats.dll" "\${_IMPORT_PREFIX}/bin/nats.dll")
+        endif()
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+

--- a/ports/cnats/vcpkg.json
+++ b/ports/cnats/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "cnats",
+  "version": "3.2.0",
+  "description": "A C client for the NATS messaging system",
+  "homepage": "https://github.com/nats-io/nats.c",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "libsodium",
+    "openssl",
+    "protobuf-c",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "streaming": {
+      "description": "Include NATS Streaming APIs in the NATS library",
+      "supports": "!windows"
+    }
+  }
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1440,6 +1440,10 @@
       "baseline": "2020-08-01",
       "port-version": 1
     },
+    "cnats": {
+      "baseline": "3.2.0",
+      "port-version": 0
+    },
     "cnl": {
       "baseline": "1.1.7",
       "port-version": 1

--- a/versions/c-/cnats.json
+++ b/versions/c-/cnats.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ab962ebd7a13f87db7aea528cd4d5725b4fde292",
+      "version": "3.2.0",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
 Add nats.io C client port

- #### What does your PR fix?  
  Fixes #9709, #9182, #9743

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

(Hopefully CI is now fixed).