### PR TITLE
[mimalloc] Update to 2.0.5

### DIFF
--- a/ports/mimalloc/fix-cmake.patch
+++ b/ports/mimalloc/fix-cmake.patch
@@ -1,38 +1,21 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b56953c..d7ad3e7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -303,10 +303,13 @@ if(MI_BUILD_SHARED)
-     add_custom_command(TARGET mimalloc POST_BUILD
-       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
-       COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
-+    install (
-+      FILES $<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll
-+      DESTINATION ${CMAKE_INSTALL_BINDIR}
-+    )  
+@@ -318,8 +318,8 @@ COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
+     install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
    endif()
-
+ 
 -  install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  
--  install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
+   install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
 +  install(TARGETS mimalloc EXPORT mimalloc ARCHIVE DESTINATION lib RUNTIME DESTINATION bin LIBRARY DESTINATION lib NAMELINK_SKIP)
  endif()
  
  # static library
-@@ -332,6 +335,8 @@ if (MI_BUILD_STATIC)
-   install(TARGETS mimalloc-static EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)
- endif()
- 
-+install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
-+
- # install include files
- install(FILES include/mimalloc.h DESTINATION ${mi_install_incdir})
- install(FILES include/mimalloc-override.h DESTINATION ${mi_install_incdir})
-@@ -366,9 +371,6 @@ if (MI_BUILD_OBJECT)
+@@ -370,9 +370,6 @@ # install(TARGETS mimalloc-obj EXPORT mimalloc DESTINATION ${mi_install_objdir})
  
    # the FILES expression can also be: $<TARGET_OBJECTS:mimalloc-obj>
    # but that fails cmake versions less than 3.10 so we leave it as is for now
 -  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/mimalloc-obj.dir/src/static.c${CMAKE_C_OUTPUT_EXTENSION}
--          DESTINATION ${mi_install_libdir}
+-          DESTINATION ${mi_install_objdir}
 -          RENAME ${mi_basename}${CMAKE_C_OUTPUT_EXTENSION} )
  endif()
  

--- a/ports/mimalloc/fix-cmake.patch
+++ b/ports/mimalloc/fix-cmake.patch
@@ -1,7 +1,11 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -318,8 +318,8 @@ COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
-     install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
+@@ -315,11 +315,11 @@ target_link_libraries(mimalloc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.lib)
+     add_custom_command(TARGET mimalloc POST_BUILD
+       COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/bin/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" $<TARGET_FILE_DIR:mimalloc>
+       COMMENT "Copy mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll to output directory")
+-    install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${mi_install_libdir})
++    install(FILES "$<TARGET_FILE_DIR:mimalloc>/mimalloc-redirect${MIMALLOC_REDIRECT_SUFFIX}.dll" DESTINATION ${CMAKE_INSTALL_BINDIR})
    endif()
  
 -  install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/mimalloc
-    REF v2.0.3
-    SHA512 275a5249d09a57c9a039714fc6eef24ae778496954972419f3ac8e33f3d12e9837ba0691a3c08a4ab807c26b868aad3a5b2c28ee10ecaa60fe21ffe1d416f08f
+    REF v2.0.5
+    SHA512 d164392ace523a3fa0aa00fc58d8a9e8fbe913f07957e19ca977675b389e6d2a2eaf4772e72cae0d87aabb960f3fd6ea3923a066ece4ba4fdaa0c6860cfa414d
     HEAD_REF master
     PATCHES
         fix-cmake.patch

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "mimalloc",
-  "version": "2.0.3",
-  "port-version": 2,
+  "version": "2.0.5",
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
+  "license": "MIT",
   "supports": "!(arm | uwp)",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4429,8 +4429,8 @@
       "port-version": 4
     },
     "mimalloc": {
-      "baseline": "2.0.3",
-      "port-version": 2
+      "baseline": "2.0.5",
+      "port-version": 0
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "561edfd55fe93e37f3d0660d527d39612e2efdac",
+      "version": "2.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "e68a15fa535a3dcf4a1dba0f277eb239cc27b863",
       "version": "2.0.3",
       "port-version": 2

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "561edfd55fe93e37f3d0660d527d39612e2efdac",
+      "git-tree": "370692d9dc2cb2bc9f013041003e069e47febb67",
       "version": "2.0.5",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #23355

Update the mimalloc port from 2.0.3 to 2.0.5.

Changelog:
https://github.com/microsoft/mimalloc/releases/tag/v2.0.5