### PR TITLE
[libressl] Fix errors when using WinSDK 10.0.22000

### DIFF
--- a/ports/libressl/0003-remove-restrict-define.patch
+++ b/ports/libressl/0003-remove-restrict-define.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4183499..d06b913 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -113,7 +113,6 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+ endif()
+ 
+ if(WIN32)
+-	add_definitions(-Drestrict)
+ 	add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+ 	add_definitions(-D_CRT_DEPRECATED_NO_WARNINGS)
+ 	add_definitions(-D_REENTRANT -D_POSIX_THREAD_SAFE_FUNCTIONS)

--- a/ports/libressl/portfile.cmake
+++ b/ports/libressl/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         0001-enable-ocspcheck-on-msvc.patch
         0002-suppress-msvc-warnings.patch
+        0003-remove-restrict-define.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/libressl/vcpkg.json
+++ b/ports/libressl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libressl",
   "version": "3.3.4",
-  "port-version": 1,
+  "port-version": 2,
   "description": "LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.",
   "supports": "!(uwp | arm)",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3878,7 +3878,7 @@
     },
     "libressl": {
       "baseline": "3.3.4",
-      "port-version": 1
+      "port-version": 2
     },
     "librsvg": {
       "baseline": "2.40.20",

--- a/versions/l-/libressl.json
+++ b/versions/l-/libressl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7bde714f5baaacd678dc5a6c46cd67371733414a",
+      "version": "3.3.4",
+      "port-version": 2
+    },
+    {
       "git-tree": "1541c15439fdf9199c6796b51cd59fa644b7d9e4",
       "version": "3.3.4",
       "port-version": 1


### PR DESCRIPTION
This fixes build errors when using the latest compiler and Windows SDK in the current version of libressl (3.3.4).

- #### What does your PR fix?  
Building libressl 3.3.4 using latest Windows SDK and Microsoft compiler results in compile errors such as:
`corecrt_malloc.h(58): error C2485: 'constant': unrecognized extended attribute`

The error is fixed in later versions of libressl, but this patch fixes the error in the current port.

See https://github.com/libressl-portable/portable/commit/21ab73316fe56428b28ed53a2bd020cfa6924d6c

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
