### PR TITLE
[approval-tests-cpp] Update to 10.12.2

### DIFF
--- a/ports/approval-tests-cpp/portfile.cmake
+++ b/ports/approval-tests-cpp/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_download_distfile(single_header
-    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.12.1/ApprovalTests.v.10.12.1.hpp
-    FILENAME ApprovalTests.v.10.12.1.hpp
-    SHA512 80921b8334c4c48380306a285e4f18f55872bced7a5f7f4c1a9db9c4fbd1cebf7c0ed8cca28e80b3024e34e2b41799976b1d36ecbf8d40e2bcfe45efab20d138
+    URLS https://github.com/approvals/ApprovalTests.cpp/releases/download/v.10.12.2/ApprovalTests.v.10.12.2.hpp
+    FILENAME ApprovalTests.v.10.12.2.hpp
+    SHA512 ed59736f52afff246409dcf435ad12a8f15697ae80962c456ca877fbf8adcb99af1bb71424ebcb214df719506015aac27006c1cfec174700b1833db64efb3568
 )
 
 vcpkg_download_distfile(license_file
-    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.12.1/LICENSE
-    FILENAME ApprovalTestsLicense.v.10.12.1
+    URLS https://raw.githubusercontent.com/approvals/ApprovalTests.cpp/v.10.12.2/LICENSE
+    FILENAME ApprovalTestsLicense.v.10.12.2
     SHA512 dc6b68d13b8cf959644b935f1192b02c71aa7a5cf653bd43b4480fa89eec8d4d3f16a2278ec8c3b40ab1fdb233b3173a78fd83590d6f739e0c9e8ff56c282557
 )
 

--- a/ports/approval-tests-cpp/vcpkg.json
+++ b/ports/approval-tests-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "approval-tests-cpp",
-  "version": "10.12.1",
+  "version": "10.12.2",
   "description": "Approval Tests allow you to verify a chunk of output (such as a file) in one operation as opposed to writing test assertions for each element.",
   "homepage": "https://github.com/approvals/ApprovalTests.cpp"
 }

--- a/versions/a-/approval-tests-cpp.json
+++ b/versions/a-/approval-tests-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "84c554ce63a6fb5ba80ecf7b3b27bf7c577471a2",
+      "version": "10.12.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "af4597332ca8387f85fa3eef5c853d47d8745d23",
       "version": "10.12.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -105,7 +105,7 @@
       "port-version": 2
     },
     "approval-tests-cpp": {
-      "baseline": "10.12.1",
+      "baseline": "10.12.2",
       "port-version": 0
     },
     "apr": {


### PR DESCRIPTION
[approval-tests-cpp] Update to 10.12.2

What does your PR fix?
adds support for new release

Which triplets are supported/not supported? Have you updated the [CI baseline]
single header library

Does your PR follow the [maintainer guide]
yes

If you have added/updated a port: Have you run ./vcpkg x-add-version --all and committed the result?
Yes, but only for our library

If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/
not a draft