### PR TITLE
[vcpkg-ci] Explicitly fetch 7zip

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -153,6 +153,7 @@ $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
     # Prefetch tools for better output
+    & "./vcpkg$executableExtension" fetch 7zip
     & "./vcpkg$executableExtension" fetch cmake
     & "./vcpkg$executableExtension" fetch ninja
     & "./vcpkg$executableExtension" fetch git


### PR DESCRIPTION
- #### What does your PR fix?  
  Similar to other tools, explicitly pre-fetches 7zip. This is an attempt to improve the logging output from the current CI failure ( #23284), but also seems to fix the issue (i.e. its occurence, not its root cause):
~~~
A suitable version of cmake was not found (required v3.22.2). Downloading portable cmake v3.22.2...
Downloading cmake...
  https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-windows-i386.zip -> D:\downloads\cmake-3.22.2-windows-i386.zip
Extracting cmake...
A suitable version of 7zip was not found (required v19.0.0). Downloading portable 7zip v19.0.0...
Downloading 7zip...
  https://www.7-zip.org/a/7z1900-x64.msi -> D:\downloads\7z1900-x64.msi
Extracting 7zip...
msiexec failed while extracting 'D:\downloads\7z1900-x64.msi' with message:
T
A suitable version of ninja was not found (required v1.10.2). Downloading portable ninja v1.10.2...
Downloading ninja...
  https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip -> D:\downloads\ninja-win-1.10.2.zip
Extracting ninja...
A suitable version of 7zip was not found (required v19.0.0). Downloading portable 7zip v19.0.0...
Extracting 7zip...
msiexec failed while extracting 'D:\downloads\7z1900-x64.msi' with message:
T
A suitable version of git was not found (required v2.35.1). Downloading portable git v2.35.1...
Downloading git...
  https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-32-bit.7z.exe -> D:\downloads\PortableGit-2.35.1.2-32-bit.7z.exe
Extracting git...
A suitable version of 7zip was not found (required v19.0.0). Downloading portable 7zip v19.0.0...
Extracting 7zip...
msiexec failed while extracting 'D:\downloads\7z1900-x64.msi' with message:
T
~~~

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
   yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
