### PR TITLE
Fixed cmake error BUILD_FAILED when building pcre2 and sqlite3

### DIFF
--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -16,7 +16,7 @@ else()
     set(JIT ON)
 endif()
 
-vcpkg_cmake_configure(
+vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_STATIC_LIBS=${BUILD_STATIC}
@@ -29,7 +29,7 @@ vcpkg_cmake_configure(
         -DPCRE2_BUILD_PCRE2GREP=OFF
 )
 
-vcpkg_cmake_install()
+vcpkg_install_cmake()
 vcpkg_copy_pdbs()
 
 file(READ "${CURRENT_PACKAGES_DIR}/include/pcre2.h" PCRE2_H)

--- a/ports/sqlite3/portfile.cmake
+++ b/ports/sqlite3/portfile.cmake
@@ -38,7 +38,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         tool                SQLITE3_SKIP_TOOLS
 )
 
-vcpkg_cmake_configure(
+vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
@@ -47,9 +47,8 @@ vcpkg_cmake_configure(
         -DSQLITE3_SKIP_TOOLS=ON
 )
 
-vcpkg_cmake_install()
+vcpkg_install_cmake()
 vcpkg_copy_pdbs()
-vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-${PORT} CONFIG_PATH share/unofficial-${PORT})
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 


### PR DESCRIPTION
Changed the targets vcpkg_cmake_configure to vcpkg_configure_cmake and vcpkg_cmake_install to vcpkg_install_cmake for both sqlite3 and pcre2, so cmake is able to build them properly. 
And I removed vcpkg_cmake_config_fixup target from the portfile.cmake for sqlite3, because this target doesn't exist anymore.
Now they can be build properly.