### PR TITLE
[directxmath, directxtex, directxmesh, directxtk, directxtk12, uvatlas] ports updated

### DIFF
--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -6,13 +6,12 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(

--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -1,10 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMath
-    REF jan2021
-    SHA512 8288f9e4d30b4947e98122f298ca25b8e2f82091c1257d3a0fd4d8de44c4c9a97d4549c105b388afbefad11ad6f30429e875e3e70eb4aa7865be6d4c08d6d1f3
-    HEAD_REF master
-    FILE_DISAMBIGUATOR 2
+    REF jan2022
+    SHA512 8defaa693c8b8aed05791c83b99fa73aac2fc18475b0d51337a81f7d9807b53e426fdf530ed6f1d2d0ebd259e87cc42ac881bdb168387d883998f58a5c0a4886
+    HEAD_REF main
 )
 
 vcpkg_configure_cmake(

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -4,5 +4,15 @@
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/en-us/windows/win32/dxmath/directxmath-portal",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directxmath",
-  "version-string": "jan2021",
-  "port-version": 1,
+  "version-date": "2022-01-18",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/en-us/windows/win32/dxmath/directxmath-portal",

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -3,7 +3,7 @@
   "version-date": "2022-01-18",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
-  "documentation": "https://docs.microsoft.com/en-us/windows/win32/dxmath/directxmath-portal",
+  "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",
   "license": "MIT",
   "dependencies": [
     {

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF nov2021b
-    SHA512 be2137c02c7a5973eaf91eaacfc9174148ec6dc68b163507d8146beb87c1ffff512e2593f7fd000ea7be440529ed2deda415e0dacd53e4c7d9679e97c6440d3d
+    REF feb2022
+    SHA512 7a34ff8a484e5693efbc3e3f1ecb32978b32d71c6d795c0de14ee29fc61230213448039ac30f74d9836e1703cbcd6026b285e85984f0e30d8005c034d5419809
     HEAD_REF master
 )
 
@@ -35,9 +35,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/nov2021/meshconvert.exe"
-    FILENAME "meshconvert-nov2021.exe"
-    SHA512 0f97ac49ce292b1cb90372884f1d6a4fc10eb3e92125a854ee9b7030fd9d0564536cdd88199aa4838832ae2a1e9c2df2c9e32c106705b6b06f156994b9476360
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/feb2022/meshconvert.exe"
+    FILENAME "meshconvert-feb2022.exe"
+    SHA512 687bec9c9f6c5fc08fc86370bb5b247f751c96fbbf047293364c75c43ec63a769ad737898a3b36acd95f7c3f6b0e97c756043d7a7ccdf750090594e1e2b97271
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-nov2021.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-feb2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO Microsoft/DirectXMesh
     REF feb2022
     SHA512 7a34ff8a484e5693efbc3e3f1ecb32978b32d71c6d795c0de14ee29fc61230213448039ac30f74d9836e1703cbcd6026b285e85984f0e30d8005c034d5419809
-    HEAD_REF master
+    HEAD_REF main
 )
 
 vcpkg_check_features(

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directxmesh",
-  "version-date": "2021-11-08",
-  "port-version": 1,
+  "version-date": "2022-02-28",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/enable_openexr_support.patch
+++ b/ports/directxtex/enable_openexr_support.patch
@@ -1,5 +1,5 @@
 diff --git a/DirectXTexEXR.cpp b/DirectXTexEXR.cpp
-index 9ac601f..204bde2 100644
+index 17bd171..825cfe4 100644
 --- a/DirectXTex/DirectXTexEXR.cpp
 +++ b/DirectXTex/DirectXTexEXR.cpp
 @@ -8,7 +8,7 @@
@@ -11,7 +11,7 @@ index 9ac601f..204bde2 100644
  
  #include "DirectXTexEXR.h"
  
-@@ -56,7 +56,7 @@ using namespace DirectX;
+@@ -57,7 +57,7 @@ using namespace DirectX;
  using PackedVector::XMHALF4;
  
  // Comment out this first anonymous namespace if you add the include of DirectXTexP.h above
@@ -19,4 +19,4 @@ index 9ac601f..204bde2 100644
 +#if 0
  namespace
  {
-     struct handle_closer { void operator()(HANDLE h) { assert(h != INVALID_HANDLE_VALUE); if (h) CloseHandle(h); } };
+     struct handle_closer { void operator()(HANDLE h) noexcept { assert(h != INVALID_HANDLE_VALUE); if (h) CloseHandle(h); } };

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO Microsoft/DirectXTex
     REF feb2022
     SHA512 7e30e38f97e944e49f5d2a6d3035d201016ac7ec5ca1042475485f7cbac165d66f4c5a2c84f2a47dad755c59b3f8947e1251b00b3e577fbc3e58f1957d8a224e
-    HEAD_REF master
+    HEAD_REF main
 )
 
 if("openexr" IN_LIST FEATURES)

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF nov2021b
-    SHA512 7f9b17e265836933c02b98c613e7c0503a74a6c3c1d97552bfbaf2f060b500019c74def80694f5e2ad6250f8bcceeac17677f264f677ff46851a9020ab604353
+    REF feb2022
+    SHA512 7e30e38f97e944e49f5d2a6d3035d201016ac7ec5ca1042475485f7cbac165d66f4c5a2c84f2a47dad755c59b3f8947e1251b00b3e577fbc3e58f1957d8a224e
     HEAD_REF master
 )
 
@@ -12,21 +12,21 @@ if("openexr" IN_LIST FEATURES)
     vcpkg_download_distfile(
         DIRECTXTEX_EXR_HEADER
         URLS "https://raw.githubusercontent.com/wiki/Microsoft/DirectXTex/DirectXTexEXR.h"
-        FILENAME "DirectXTexEXR-2.h"
-        SHA512 54163820996f7f3c47d0e34da7d717ba51a4363458d77e8f3750d2b6b38bcf803f199b913b4fd7b8dcdd3f520cd0c2bb42a9f79d30f5805fccdece6af368dd12
+        FILENAME "DirectXTexEXR-3.h"
+        SHA512 b4c75fa0e3365d63beba0ba471f0ded124b2f0e20f2c11cef76a88e6af1582889abcf5aa2ec74270d7b9bde7f7b4bc36fd17f030357b4139d8c83c35060344be
     )
 
     vcpkg_download_distfile(
         DIRECTXTEX_EXR_SOURCE
         URLS "https://raw.githubusercontent.com/wiki/Microsoft/DirectXTex/DirectXTexEXR.cpp"
-        FILENAME "DirectXTexEXR-2.cpp"
-        SHA512 fbf5a330961f3ac80e4425e8451e9a696240cd89fabca744a19f1f110ae188bae7d8eb5b058aaf66015066d919d4f581b14494d78d280147b23355d8a32745b9
+        FILENAME "DirectXTexEXR-3.cpp"
+        SHA512 9192cfea01654b1537b444cc6e3369de2f721959ad749551ad06ba92a12fa61e12f2169cf412788b0156220bb8bacf531160f924a4744e43e875163463586620
     )
 
     file(COPY ${DIRECTXTEX_EXR_HEADER} DESTINATION "${SOURCE_PATH}/DirectXTex")
     file(COPY ${DIRECTXTEX_EXR_SOURCE} DESTINATION "${SOURCE_PATH}/DirectXTex")
-    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.h" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.h")
-    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-2.cpp" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp")
+    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-3.h" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.h")
+    file(RENAME "${SOURCE_PATH}/DirectXTex/DirectXTexEXR-3.cpp" "${SOURCE_PATH}/DirectXTex/DirectXTexEXR.cpp")
     vcpkg_apply_patches(SOURCE_PATH "${SOURCE_PATH}" PATCHES enable_openexr_support.patch)
 endif()
 
@@ -62,23 +62,23 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texassemble.exe"
-    FILENAME "texassemble-nov2021.exe"
-    SHA512 a31151d368d41f50b58b417e8d27987fe0e3caa2c4e0d0abe7bef472db51429526277b0c554df2825c6892bb2021111f59d3d8f321ad68c71c0a153852d2c81f
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texassemble.exe"
+    FILENAME "texassemble-feb2022.exe"
+    SHA512 ea1f9fff62a5ebc9c33221852a843063d58405be7529f663e4567b138bca79e73e47b1e0fb6054c4e024a630323c72aba505eee35414cf14970c331afa9ff43f
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texconv.exe"
-    FILENAME "texconv-nov2021.exe"
-    SHA512 7cb70b3cbf46c78b99aa18c28b043fc5930b6b254729efd447868fcf8cb8b77987d41b570082bdfb3bab01452e67d17e81b966bf2534036a3415fa918ddc2956
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texconv.exe"
+    FILENAME "texconv-feb2022.exe"
+    SHA512 1565f5a4bd08de88e01ece59df6658975bfd8551a912d65ac03c0ddd5ab536c8794811d3e49d14e8fe4c61fa2a6c9d50994d372f5d3efab7d9aeb6f3f92d56c9
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/nov2021/texdiag.exe"
-    FILENAME "texdiag-nov2021.exe"
-    SHA512 7826c594fa42978da8a15bd771fafe4d4f5b97d611ce62a806ddff77204cabf63eea6ac24e3409c2720631681260b7e3fa6ad5f33b2162d2266457462e6b13c9
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texdiag.exe"
+    FILENAME "texdiag-feb2022.exe"
+    SHA512 5dd93da696eff959b5c93ba8ac763ff6df52fbfc6ca3a3adf1b9da0121beaea2c16008e097f74d562b7a69ed20ada50fd5d35d47311338e6c819e3483bc54ee3
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -89,9 +89,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2021-11-08",
-  "port-version": 1,
+  "version-date": "2022-02-28",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO Microsoft/DirectXTK
     REF feb2022
     SHA512 18105ccf037b96b198fae086b17e678063efbed38c4212bc0c224090e7b6cd8c4197ae514f22c4b8da78f6a3e5cf6a6cd7437a79ff363baa740f01e3b1eed89b
-    HEAD_REF master
+    HEAD_REF main
 )
 
 vcpkg_check_features(

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF nov2021b
-    SHA512 d1c99cc7d1a95939b4dc28ee5c757e3b4eae2b7f923031b44f988b1ca93838e765d702f125a9a9fb38e6f5304721f88843e961b6ba9591066b511b530aad5280
+    REF feb2022
+    SHA512 18105ccf037b96b198fae086b17e678063efbed38c4212bc0c224090e7b6cd8c4197ae514f22c4b8da78f6a3e5cf6a6cd7437a79ff363baa740f01e3b1eed89b
     HEAD_REF master
 )
 
@@ -33,16 +33,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/nov2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-nov2021.exe"
-    SHA512 0aab40aced022588d9c1089c5b2f297b0521497d0ae559ead98f99e1e73f2daf9f38ebecadb413095abd2a6c207183fbca582d47528c6f21258df3ac391134e5
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/feb2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-feb2022.exe"
+    SHA512 d3454c679db269a29e845382f5cd9cceab2452aa91486238e38f79e71666718ea5d9fa1e676ffbe6875ee69310e17018690998dfb741530ea068fb0616fa4886
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/nov2021/XWBTool.exe"
-    FILENAME "xwbtool-nov2021.exe"
-    SHA512 f2f291c496500e593c0a4795fee9fafc685666682f23a38a25546bb67ec083533a26f2ce0562b819abea44bd8b403a2f246fbf978e366c457eb8a0f836fd5a2e
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/feb2022/XWBTool.exe"
+    FILENAME "xwbtool-feb2022.exe"
+    SHA512 f27170227be1268591757caaccda65d46ad81a2ac38ab1772d9e2d5c722a1d094a9b891f66fc6673d96a6b980a45c8fde501e2d9681f557039f8084ddf648aea
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -52,8 +52,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2021-11-08",
-  "port-version": 1,
+  "version-date": "2022-02-28",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO Microsoft/DirectXTK12
     REF feb2022
     SHA512 e61acd191b9ee5c7d76293f2feb158207f9e63d8f3d5a30144c04367c15d0c1d6a17d6905843d2ca80e9af713a83fa2ab2f52c206569993943997653ae6ad729
-    HEAD_REF master
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF nov2021b
-    SHA512 32afd3e3e6c122c80a4b1980482b6092e2723c2d691657385d699a01a6edb8339efd482f1c20ae32c5c6d3619f48ea749d5826b730952c619a6b053e6b780596
+    REF feb2022
+    SHA512 e61acd191b9ee5c7d76293f2feb158207f9e63d8f3d5a30144c04367c15d0c1d6a17d6905843d2ca80e9af713a83fa2ab2f52c206569993943997653ae6ad729
     HEAD_REF master
 )
 
@@ -19,16 +19,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/nov2021/MakeSpriteFont.exe"
-    FILENAME "makespritefont-nov2021.exe"
-    SHA512 0aab40aced022588d9c1089c5b2f297b0521497d0ae559ead98f99e1e73f2daf9f38ebecadb413095abd2a6c207183fbca582d47528c6f21258df3ac391134e5
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/feb2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-feb2022.exe"
+    SHA512 d3454c679db269a29e845382f5cd9cceab2452aa91486238e38f79e71666718ea5d9fa1e676ffbe6875ee69310e17018690998dfb741530ea068fb0616fa4886
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/nov2021/XWBTool.exe"
-    FILENAME "xwbtool-nov2021.exe"
-    SHA512 f2f291c496500e593c0a4795fee9fafc685666682f23a38a25546bb67ec083533a26f2ce0562b819abea44bd8b403a2f246fbf978e366c457eb8a0f836fd5a2e
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/feb2022/XWBTool.exe"
+    FILENAME "xwbtool-feb2022.exe"
+    SHA512 f27170227be1268591757caaccda65d46ad81a2ac38ab1772d9e2d5c722a1d094a9b891f66fc6673d96a6b980a45c8fde501e2d9681f557039f8084ddf648aea
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -38,8 +38,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-nov2021.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2021-11-08",
-  "port-version": 1,
+  "version-date": "2022-02-28",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF nov2021b
-    SHA512 14227447265c138359f3d189adde04daded386d061ad43128a97759e862005840e89b140f8a8f330808fa90035d8fdc2aa18437ac5447d2f849d8426f32b9cbb
+    REF feb2022
+    SHA512 20f9c38dd68edfca8179d26ab7f772b3190e843c01442ae3d7c7c1cd9a5a21a68455c124f0e8aab7efd3aacc9f6fb5907591b35a6a901683dad2a2f91d785106
     HEAD_REF master
 )
 
@@ -35,9 +35,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/nov2021/uvatlastool.exe"
-    FILENAME "uvatlastool-nov2021.exe"
-    SHA512 84de6bc74901f3ab888b90126cc1ac64de564eb33c605fffe37b2199ad132a53b01271f1f551fcc067c144c599380764b9e50884ce5df32f43b2c58777da0722
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/feb2022/uvatlastool.exe"
+    FILENAME "uvatlastool-feb2022.exe"
+    SHA512 bc7e00b67e9f7adda52882fdd6b0e54d3a34eb11164f189d5423efcbc7ee0dce5b2c0fbadce592e10917ab215f5d6c380bbc70597ac1001ea169364d563dff5f
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-nov2021.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-feb2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     REPO Microsoft/UVAtlas
     REF feb2022
     SHA512 20f9c38dd68edfca8179d26ab7f772b3190e843c01442ae3d7c7c1cd9a5a21a68455c124f0e8aab7efd3aacc9f6fb5907591b35a6a901683dad2a2f91d785106
-    HEAD_REF master
+    HEAD_REF main
 )
 
 if (VCPKG_HOST_IS_LINUX)

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2021-11-08",
-  "port-version": 1,
+  "version-date": "2022-02-28",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1833,28 +1833,28 @@
       "port-version": 1
     },
     "directxmath": {
-      "baseline": "jan2021",
-      "port-version": 1
+      "baseline": "2022-01-18",
+      "port-version": 0
     },
     "directxmesh": {
-      "baseline": "2021-11-08",
-      "port-version": 1
+      "baseline": "2022-02-28",
+      "port-version": 0
     },
     "directxsdk": {
       "baseline": "jun10",
       "port-version": 5
     },
     "directxtex": {
-      "baseline": "2021-11-08",
-      "port-version": 1
+      "baseline": "2022-02-28",
+      "port-version": 0
     },
     "directxtk": {
-      "baseline": "2021-11-08",
-      "port-version": 1
+      "baseline": "2022-02-28",
+      "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2021-11-08",
-      "port-version": 1
+      "baseline": "2022-02-28",
+      "port-version": 0
     },
     "dirent": {
       "baseline": "1.23.2",
@@ -7169,8 +7169,8 @@
       "port-version": 1
     },
     "uvatlas": {
-      "baseline": "2021-11-08",
-      "port-version": 1
+      "baseline": "2022-02-28",
+      "port-version": 0
     },
     "uvw": {
       "baseline": "2.7.0",

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "97ffa601d9e8d2b8b334ddd2591a5f7c5b5edc44",
+      "git-tree": "0d9415b44f78c66aa7f5a66e1e81211687501e5e",
       "version-date": "2022-01-18",
       "port-version": 0
     },

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0d9415b44f78c66aa7f5a66e1e81211687501e5e",
+      "git-tree": "ebf69755284c5ea16a26b4dbfa4534af962c96a0",
       "version-date": "2022-01-18",
       "port-version": 0
     },

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97ffa601d9e8d2b8b334ddd2591a5f7c5b5edc44",
+      "version-date": "2022-01-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "d02145b6ed0cbe882bfb75291f832a11ab0582ce",
       "version-string": "jan2021",
       "port-version": 1

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ef61e46809cff186d930b64c9c978bd995f0c736",
+      "version-date": "2022-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "a8cbbe307c2ac5a241a6ec4b1e76e121a1ffb2db",
       "version-date": "2021-11-08",
       "port-version": 1

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ef61e46809cff186d930b64c9c978bd995f0c736",
+      "git-tree": "aef77bf208f6e95c682fd8d41590c5b0516f1f0f",
       "version-date": "2022-02-28",
       "port-version": 0
     },

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c734c128f800a55c82b37d3a9591b5dc6fe23622",
+      "version-date": "2022-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec03f6fb3941d00726655dae315f09b6eb47d9ce",
       "version-date": "2021-11-08",
       "port-version": 1

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c734c128f800a55c82b37d3a9591b5dc6fe23622",
+      "git-tree": "424610ae5719fee5f738756146719d13d1483879",
       "version-date": "2022-02-28",
       "port-version": 0
     },

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60fb774e07b93ac5a07351ba8f2a4aef6899cbbd",
+      "version-date": "2022-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "34ecf07435420320f41c8aa7405926dc300359b2",
       "version-date": "2021-11-08",
       "port-version": 1

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60fb774e07b93ac5a07351ba8f2a4aef6899cbbd",
+      "git-tree": "64937ca8d8ec8cc57bfdea9fea74bd39cd0ea507",
       "version-date": "2022-02-28",
       "port-version": 0
     },

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "def28563ec6ca02df0efa09d339a330ba76d0a26",
+      "git-tree": "e324f5499354e15e49fa1c591ab864b114518e74",
       "version-date": "2022-02-28",
       "port-version": 0
     },

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "def28563ec6ca02df0efa09d339a330ba76d0a26",
+      "version-date": "2022-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "2019efd91b858e5075651d1ebbfa45dc1961aa2d",
       "version-date": "2021-11-08",
       "port-version": 1

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "665a2e5856a50518d27711a75f72868e8b599109",
+      "version-date": "2022-02-28",
+      "port-version": 0
+    },
+    {
       "git-tree": "4f353fc6ad423c0a9d95c7b2d2f6c7a150e43b25",
       "version-date": "2021-11-08",
       "port-version": 1

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "665a2e5856a50518d27711a75f72868e8b599109",
+      "git-tree": "fe5522a95b1f9ef72d43c019948fd94055b42410",
       "version-date": "2022-02-28",
       "port-version": 0
     },


### PR DESCRIPTION
Updating ports to support latest February 2022 GitHub releases of these libraries. Also updated for the fact that all these repos have had the master-to-main rename of their primary branch.

 > Changed to use ``version-date`` instead of ``version-string`` per request. **directxmath** port updated to no longer use deprecated VCPKG functions.