### PR TITLE
[fmt] fix invalid command

### DIFF
--- a/ports/fmt/fix-invalid-command.patch
+++ b/ports/fmt/fix-invalid-command.patch
@@ -1,0 +1,11 @@
+diff --git a/include/fmt/locale.h b/include/fmt/locale.h
+index 7571b52..0a34eb4 100644
+--- a/include/fmt/locale.h
++++ b/include/fmt/locale.h
+@@ -1,2 +1,6 @@
+ #include "xchar.h"
++#ifdef _WIN32
++#pragma message ("fmt/locale.h is deprecated, include fmt/format.h or fmt/xchar.h instead")
++#else
+ #warning fmt/locale.h is deprecated, include fmt/format.h or fmt/xchar.h instead
++#endif

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-write-batch.patch
+        fix-invalid-command.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fmt",
   "version": "8.1.1",
+  "port-version": 1,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2226,7 +2226,7 @@
     },
     "fmt": {
       "baseline": "8.1.1",
-      "port-version": 0
+      "port-version": 1
     },
     "folly": {
       "baseline": "2022.01.31.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "602d9743b7957c9e82a06d0e81d58637c6df5222",
+      "version": "8.1.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "9748716da169977423d02b3c3f0de7b7f274e34e",
       "version": "8.1.1",
       "port-version": 0


### PR DESCRIPTION
Fix #23316 

Failures:
`fatal error C1021: invalid preprocessor command 'warning' when compile using VS2019`

MSVC uses the syntax:
`#pragma message ( "your warning text here" )`
The usual #warning syntax generates a fatal error
`C1021: invalid preprocessor command 'warning'`

Add a patch in `fmt` to fix it.