### PR TITLE
[libe57] update to 1.1.332; fix debug library lookup

### DIFF
--- a/ports/libe57/0001_cmake.patch
+++ b/ports/libe57/0001_cmake.patch
@@ -86,3 +86,22 @@ diff -Naur a/CMakeLists.txt b/CMakeLists.txt
  )
  
  #include (InstallRequiredSystemLibraries)
+--- a/src/refimpl/E57RefImplConfig.cmake	2011-10-06 16:01:00.000000000 +0800
++++ b/src/refimpl/E57RefImplConfig.cmake	2022-03-01 16:48:29.117485600 +0800
+@@ -49,6 +49,8 @@
+ # NOTE: You will also need to include the boost and xerces libraries to your
+ # project.
+ 
++get_filename_component(E57RefImpl_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
++
+ IF (NOT "${E57RefImpl_DIR}/include" EQUAL "${E57RefImpl_INCLUDE_DIR}")
+     SET(E57RefImpl_LIBRARY_DEBUG E57RefImpl_LIBRARY_DEBUG-NOTFOUND)
+     SET(E57RefImpl_LIBRARY_RELEASE E57RefImpl_LIBRARY_RELEASE-NOTFOUND)
+@@ -78,6 +80,6 @@
+     NAMES   libE57RefImpl-d
+             E57RefImpl-d
+-    HINTS  ${E57RefImpl_DIR}/lib
++    HINTS  ${E57RefImpl_DIR}/debug/lib
+     DOC "E57 debug library"
+ )
+ 

--- a/ports/libe57/0002_replace_tr1_with_cpp11.patch
+++ b/ports/libe57/0002_replace_tr1_with_cpp11.patch
@@ -1,20 +1,20 @@
-diff -Naur a/CMakeLists.txt b/CMakeLists.txt
---- a/CMakeLists.txt	2021-06-16 22:53:02.033465000 +0800
-+++ b/CMakeLists.txt	2021-06-16 23:01:31.542323600 +0800
-@@ -25,7 +25,9 @@
- # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- # DEALINGS IN THE SOFTWARE.
+diff --color -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2013-04-03 22:24:08.000000000 +0800
++++ b/CMakeLists.txt	2022-03-01 17:23:01.210728200 +0800
+@@ -36,8 +36,9 @@
+ # If you find any errors or have suggestion to improve the build script:
+ # patches are most welcome! Please send them to the development mailing list.
+ 
++cmake_minimum_required(VERSION 3.1)
  
 -cmake_minimum_required(VERSION 2.8.2)
-+cmake_minimum_required(VERSION 3.1)
-+
 +set(CMAKE_CXX_STANDARD 11)
  
  # Override flags to enable prepare for linking to static runtime
  set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/c_flag_overrides.cmake)
-diff -Naur a/src/tools/e57fields.cpp b/src/tools/e57fields.cpp
+diff --color -Naur a/src/tools/e57fields.cpp b/src/tools/e57fields.cpp
 --- a/src/tools/e57fields.cpp	2012-04-04 17:19:01.000000000 +0800
-+++ b/src/tools/e57fields.cpp	2021-06-16 22:55:02.789463000 +0800
++++ b/src/tools/e57fields.cpp	2022-03-01 17:24:17.904911600 +0800
 @@ -30,11 +30,7 @@
  #include <iomanip>
  #include <float.h>
@@ -49,10 +49,10 @@ diff -Naur a/src/tools/e57fields.cpp b/src/tools/e57fields.cpp
  
      /// The precalculated parts of the element path name.
      /// The only part that is missing is the record number which goes in between.
-diff -Naur a/src/tools/e57unpack.cpp b/src/tools/e57unpack.cpp
---- a/src/tools/e57unpack.cpp	2011-10-06 16:01:00.000000000 +0800
-+++ b/src/tools/e57unpack.cpp	2021-06-16 22:56:57.150323800 +0800
-@@ -41,12 +41,8 @@
+diff --color -Naur a/src/tools/e57unpack.cpp b/src/tools/e57unpack.cpp
+--- a/src/tools/e57unpack.cpp	2013-04-03 22:24:08.000000000 +0800
++++ b/src/tools/e57unpack.cpp	2022-03-01 17:25:15.206260200 +0800
+@@ -45,12 +45,8 @@
  #include <stdexcept>
  using std::runtime_error;
  
@@ -67,10 +67,10 @@ diff -Naur a/src/tools/e57unpack.cpp b/src/tools/e57unpack.cpp
  
  #include <string>
  using std::string;
-diff -Naur a/src/tools/e57validate.cpp b/src/tools/e57validate.cpp
+diff --color -Naur a/src/tools/e57validate.cpp b/src/tools/e57validate.cpp
 --- a/src/tools/e57validate.cpp	2011-10-06 16:01:00.000000000 +0800
-+++ b/src/tools/e57validate.cpp	2021-06-16 22:58:19.365323700 +0800
-@@ -66,11 +66,8 @@
++++ b/src/tools/e57validate.cpp	2022-03-01 17:25:46.220771800 +0800
+@@ -66,11 +66,7 @@
  
  
  ================================================================*/
@@ -79,13 +79,12 @@ diff -Naur a/src/tools/e57validate.cpp b/src/tools/e57validate.cpp
 -#else
 -#   include <tr1/unordered_map>
 -using std::tr1::unordered_map;
-+
+-#endif
 +#include <unordered_map>
 +using std::unordered_map;
--#endif
  #include <cstring>
  using std::strlen;
-@@ -694,7 +692,7 @@
+@@ -694,7 +691,7 @@
      void        dump(int indent = 0, std::ostream& os = std::cout);
  //================
  private:

--- a/ports/libe57/portfile.cmake
+++ b/ports/libe57/portfile.cmake
@@ -1,11 +1,11 @@
-set(VERSION 1.1.312)
+set(VERSION 1.1.332)
 set(SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/E57RefImpl_src-${VERSION})
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO e57-3d-imgfmt
     FILENAME "E57RefImpl_src-${VERSION}.zip"
-    SHA512 c729cc3094131f115ddf9b8c24a9420c4ab9d16a4343acfefb42f997f4bf25247cd5563126271df2af95f103093b7f6b360dbade52c9e66ec39dd2f06e041eb7
+    SHA512 86adb88cff32d72905e923b1205d609a2bce2eabd78995c59a7957395b233766a5ce31481db08977117abc1a70bbed90d2ce0cdb9897704a8c63d992e91a3907
     PATCHES 
         "0001_cmake.patch"
         "0002_replace_tr1_with_cpp11.patch"

--- a/ports/libe57/vcpkg.json
+++ b/ports/libe57/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libe57",
-  "version-semver": "1.1.312",
+  "version-semver": "1.1.332",
   "port-version": 1,
   "description": "An open source implementation of the ASTM E2807 Standard Specification for 3D Imaging Data Exchange in the C++ language.",
   "homepage": "http://www.libe57.org/",

--- a/ports/libe57/vcpkg.json
+++ b/ports/libe57/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "An open source implementation of the ASTM E2807 Standard Specification for 3D Imaging Data Exchange in the C++ language.",
   "homepage": "http://www.libe57.org/",
+  "license": "BSL-1.0",
   "dependencies": [
     "boost-crc",
     "boost-filesystem",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3453,7 +3453,7 @@
       "port-version": 3
     },
     "libe57": {
-      "baseline": "1.1.312",
+      "baseline": "1.1.332",
       "port-version": 1
     },
     "libe57format": {

--- a/versions/l-/libe57.json
+++ b/versions/l-/libe57.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cce3615484f983290c375729780146d180e22b19",
+      "version-semver": "1.1.332",
+      "port-version": 0
+    },
+    {
       "git-tree": "ed9a20551a07f8dbcb637af8394653c326e95aac",
       "version-semver": "1.1.312",
       "port-version": 1

--- a/versions/l-/libe57.json
+++ b/versions/l-/libe57.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "7ed0fc0acd9c79e683a8ff2632f1b975782a4412",
+      "git-tree": "e38a82bc97129e317606207d234101aefe7dcb17",
       "version-semver": "1.1.332",
       "port-version": 1
     },
     {
-      "git-tree": "cce3615484f983290c375729780146d180e22b19",
+      "git-tree": "ed9a20551a07f8dbcb637af8394653c326e95aac",
       "version-semver": "1.1.312",
       "port-version": 1
     },

--- a/versions/l-/libe57.json
+++ b/versions/l-/libe57.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "git-tree": "cce3615484f983290c375729780146d180e22b19",
+      "git-tree": "7ed0fc0acd9c79e683a8ff2632f1b975782a4412",
       "version-semver": "1.1.332",
-      "port-version": 0
+      "port-version": 1
     },
     {
-      "git-tree": "ed9a20551a07f8dbcb637af8394653c326e95aac",
+      "git-tree": "cce3615484f983290c375729780146d180e22b19",
       "version-semver": "1.1.312",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  update to 1.1.332
  fix debug library lookup problem in cmake

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
  all 

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

