### PR TITLE
[google-cloud-cpp] update to latest release (v1.37.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.36.0
-    SHA512 a9885f9e0726de64eaee0376f3d1ed3a00c32919f2b9a911479206f2965a62eea5ff292b459f61eae97d5d2fe336c410c615296fcb0c7506faf45c57bd6f8871
+    REF v1.37.0
+    SHA512 4174bfa7d911b8f09411962af53607d3536f2eaa0af8bce02b847e7fee87df9fd46683f4314d2df0cea23994e094845ead485314387814791cd39647cac0c546
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -3,7 +3,7 @@ index 0e2b703..7097f06 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -28,8 +28,13 @@ project(
-     VERSION 1.36.0
+     VERSION 1.37.0
      LANGUAGES CXX C)
  
 -# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.36.0",
-  "port-version": 1,
+  "version": "1.37.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2541,8 +2541,8 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "1.36.0",
-      "port-version": 1
+      "baseline": "1.37.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b986c9bce793574d2a4936c1b23e705aa8b29abc",
+      "version": "1.37.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "15cf3b112010a1f5c8ec0948f135a5e1863a2246",
       "version": "1.36.0",
       "port-version": 1


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.37.0)

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
 
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes.
