### PR TITLE
[pegtl] Update from v3.2.2 to v3.2.5

### DIFF
--- a/ports/pegtl/portfile.cmake
+++ b/ports/pegtl/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taocpp/pegtl
-    REF 3.2.2
-    SHA512 7ad055e38b362d6b90a49d5deb400948febfbcc30898e05548424bc758f38ffb3f69ca0db41e4480697f8916c90bdb3e48927a4db0caa7a20c8012b1a6d1fe08
-    HEAD_REF master
+    REF 3.2.5
+    SHA512 e531eaeef614d822e4bddbc6662fbe116cc1536fa308109f28ce5433607e6102f4e754a31094f9c349e4319914da6c83450dd2e8fa10dcfc3eee5a5dca547c14
+    HEAD_REF main
 )
 
 vcpkg_cmake_configure(
@@ -22,4 +22,4 @@ vcpkg_cmake_config_fixup(CONFIG_PATH share/pegtl/cmake)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 # Handle copyright
-file(RENAME "${CURRENT_PACKAGES_DIR}/share/pegtl/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")

--- a/ports/pegtl/vcpkg.json
+++ b/ports/pegtl/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "pegtl",
-  "version-semver": "3.2.2",
+  "version-semver": "3.2.5",
   "description": "The Parsing Expression Grammar Template Library (PEGTL) is a zero-dependency C++ header-only parser combinator library for creating parsers according to a Parsing Expression Grammar (PEG).",
   "homepage": "https://github.com/taocpp/PEGTL",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5285,7 +5285,7 @@
       "port-version": 0
     },
     "pegtl": {
-      "baseline": "3.2.2",
+      "baseline": "3.2.5",
       "port-version": 0
     },
     "pegtl-2": {

--- a/versions/p-/pegtl.json
+++ b/versions/p-/pegtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "43adc8ee136a8dd0ea88b54a6a7fdc7325cf7327",
+      "version-semver": "3.2.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "9e9bdd7c1860ebc540ca2df7ab8451e596dfff3a",
       "version-semver": "3.2.2",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
Bumps the version of PEGTL from 3.2.2 to 3.2.5, which includes a fix for a static_assert with recent versions of MSVC that breaks the build of the cppgraphqlgen port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
