### PR TITLE
[vcpkg-ci] Modify task names

### DIFF
--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     inputs:
       filePath: bootstrap-vcpkg.sh
   - task: PowerShell@2
-    displayName: '*** Test Modified Ports and Prepare Test Logs ***'
+    displayName: '*** Test Modified Ports for ${{ parameters.triplet }}'
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'

--- a/scripts/azure-pipelines/linux/azure-pipelines.yml
+++ b/scripts/azure-pipelines/linux/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     inputs:
       filePath: bootstrap-vcpkg.sh
   - task: PowerShell@2
-    displayName: '*** Test Modified Ports for ${{ parameters.triplet }}'
+    displayName: '*** Test Modified Ports for x64-linux'
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
       exit 0
     displayName: 'Create ${{ variables.VCPKG_DOWNLOADS }}'
   - task: Bash@3
-    displayName: 'Build vcpkg'
+    displayName: 'Bootstrap vcpkg'
     inputs:
       filePath: bootstrap-vcpkg.sh
   - task: PowerShell@2

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     inputs:
       filePath: bootstrap-vcpkg.sh
   - task: PowerShell@2
-    displayName: '*** Test Modified Ports for ${{ parameters.triplet }}'
+    displayName: '*** Test Modified Ports for x64-osx'
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'

--- a/scripts/azure-pipelines/osx/azure-pipelines.yml
+++ b/scripts/azure-pipelines/osx/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
     inputs:
       filePath: bootstrap-vcpkg.sh
   - task: PowerShell@2
-    displayName: '*** Test Modified Ports and Prepare Test Logs ***'
+    displayName: '*** Test Modified Ports for ${{ parameters.triplet }}'
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -153,10 +153,13 @@ $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
     # Prefetch tools for better output
-    & "./vcpkg$executableExtension" fetch 7zip
-    & "./vcpkg$executableExtension" fetch cmake
-    & "./vcpkg$executableExtension" fetch ninja
-    & "./vcpkg$executableExtension" fetch git
+    foreach ($tool in @('7zip', 'cmake', 'ninja', 'git')) {
+        & "./vcpkg$executableExtension" fetch $tool
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Failed to fetch $tool"
+        }
+    }
 
     Write-Host "Determining parent hashes using HEAD~1"
     $parentHashesFile = Join-Path $WorkingRoot 'parent-hashes.json'

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -161,7 +161,7 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     Write-Host "Determining parent hashes using HEAD~1"
     $parentHashesFile = Join-Path $WorkingRoot 'parent-hashes.json'
     $parentHashes = @("--parent-hashes=$parentHashesFile")
-    & git revert -n -m 1 HEAD
+    & git revert -n -m 1 HEAD | Out-Null
     & "./vcpkg$executableExtension" ci $Triplet --dry-run --exclude=$skipList @hostArgs @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile" `
         | ForEach-Object { if ($_ -match ' dependency information| determine pass') { Write-Host $_ } }
     & git reset --hard HEAD

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -153,7 +153,7 @@ $parentHashes = @()
 if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 {
     # Prefetch tools for better output
-    foreach ($tool in @('7zip', 'cmake', 'ninja', 'git')) {
+    foreach ($tool in @('cmake', 'ninja', 'git')) {
         & "./vcpkg$executableExtension" fetch $tool
         if ($LASTEXITCODE -ne 0)
         {

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -164,9 +164,9 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     & git revert -n -m 1 HEAD | Out-Null
     & "./vcpkg$executableExtension" ci $Triplet --dry-run --exclude=$skipList @hostArgs @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile" `
         | ForEach-Object { if ($_ -match ' dependency information| determine pass') { Write-Host $_ } }
-    & git reset --hard HEAD
 
     Write-Host "Running CI using parent hashes"
+    & git reset --hard HEAD
 }
 
 & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @hostArgs @commonArgs @cachingArgs @parentHashes

--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       PathtoPublish: '$(DiffFile)'
       ArtifactName: 'format.diff'
   - task: PowerShell@2
-    displayName: '*** Test Modified Ports and Prepare Test Logs ***'
+    displayName: '*** Test Modified Ports for ${{ parameters.triplet }}'
     inputs:
       failOnStderr: true
       filePath: 'scripts/azure-pipelines/test-modified-ports.ps1'

--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cmake-user",
-  "version-date": "2022-03-03",
+  "version-date": "2022-02-28",
   "description": "Test port to verify the vcpkg toolchain in cmake user projects",
   "default-features": [
     "ci"

--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cmake-user",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-03",
   "description": "Test port to verify the vcpkg toolchain in cmake user projects",
   "default-features": [
     "ci"


### PR DESCRIPTION
- #### What does your PR fix?  
  Improves AZP analytics by adding the triplet name to main task ("Build test ports"). [Example](https://dev.azure.com/vcpkg/public/_pipeline/analytics/duration?definitionId=27&contextType=build).
  Reduces confusing output from determining the parent hashes.
  Update bootstrapping task name on osx where vcpkg is downloaded now, like on the other platforms.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, --

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  ---