### PR TITLE
[google-cloud-cpp] update to latest release (v1.38.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.37.0
-    SHA512 4174bfa7d911b8f09411962af53607d3536f2eaa0af8bce02b847e7fee87df9fd46683f4314d2df0cea23994e094845ead485314387814791cd39647cac0c546
+    REF v1.38.0
+    SHA512 8d13450d5d669c8f736a6b8cb57291e7de997ab8dcd3dbce8dabd6d71ff81096ef92f02cf64711d40a1465b47f8fd5ce21a355c9526c5900adc076e25b062fa7
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -3,7 +3,7 @@ index 0e2b703..7097f06 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -28,8 +28,13 @@ project(
-     VERSION 1.37.0
+     VERSION 1.38.0
      LANGUAGES CXX C)
  
 -# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2541,7 +2541,7 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "1.37.0",
+      "baseline": "1.38.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f67a7068dcb56bb2a97b03a6960d522b71eb28f5",
+      "version": "1.38.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "b986c9bce793574d2a4936c1b23e705aa8b29abc",
       "version": "1.37.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.38.0).

Yes, there was a release a couple of days ago.  It had some problems, big enough that we think a patch release is not appropriate.


- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
