### PR TITLE
[libpng] Add file usage.txt to describe the usage of port libpng

### DIFF
--- a/ports/libpng/usage.txt
+++ b/ports/libpng/usage.txt
@@ -1,0 +1,5 @@
+The package libpng is compatible with built-in CMake targets:
+
+    find_package(libpng REQUIRED)
+    target_link_libraries(main PRIVATE ${PNG_LIBRARY})
+    target_include_directories(main PRIVATE ${PNG_INCLUDE_DIR})


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Add usage.txt in directory ports/libpng to describe the usage of package libpng in CMake targets.

- #### Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

