### PR TITLE
[tcb-span] Add new port

### DIFF
--- a/ports/tcb-span/portfile.cmake
+++ b/ports/tcb-span/portfile.cmake
@@ -15,6 +15,6 @@ file(
 # Handle copyright
 file(
     INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/share/tcb-span"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright
 )

--- a/ports/tcb-span/portfile.cmake
+++ b/ports/tcb-span/portfile.cmake
@@ -1,0 +1,20 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tcbrindle/span
+    REF 427f6bd0bbf36ad46aec4d8bdd7760beeb10dd33 # master commit 2021-12-15
+    SHA512 c775bd50bc68d98fcde5e99bb9b6594c8ac9ef15fa15efe89c253b4135df77d83e58743d3c7e90d3aff03429251497a7d56d1900f6e258416c0664a82326243c
+    HEAD_REF master
+)
+
+# Just a single header
+file(
+    INSTALL "${SOURCE_PATH}/include/tcb/span.hpp"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/tcb"
+)
+
+# Handle copyright
+file(
+    INSTALL "${SOURCE_PATH}/LICENSE_1_0.txt"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/tcb-span"
+    RENAME copyright
+)

--- a/ports/tcb-span/vcpkg.json
+++ b/ports/tcb-span/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "tcb-span",
+  "version-date": "2021-12-15",
+  "description": "Implementation of C++20's std::span for older compilers",
+  "homepage": "https://github.com/tcbrindle/span",
+  "license": "BSL-1.0"
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6780,6 +6780,10 @@
       "baseline": "2020_U3",
       "port-version": 7
     },
+    "tcb-span": {
+      "baseline": "2021-12-15",
+      "port-version": 0
+    },
     "tcl": {
       "baseline": "core-9-0-a1",
       "port-version": 5

--- a/versions/t-/tcb-span.json
+++ b/versions/t-/tcb-span.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "00ba8c132e11b588c344827cd437e14e260dbdc5",
+      "git-tree": "191bf0b7971f5aac50a5d81224d04e8f9aef7e38",
       "version-date": "2021-12-15",
       "port-version": 0
     }

--- a/versions/t-/tcb-span.json
+++ b/versions/t-/tcb-span.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "00ba8c132e11b588c344827cd437e14e260dbdc5",
+      "version-date": "2021-12-15",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**

New port for [tcb-span](https://github.com/tcbrindle/span). The project doesn't support installation through CMake, so I just install it in the portfile.

- #### What does your PR fix?  
  N/A (needed for WIP https://github.com/microsoft/vcpkg/pull/22957)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Header-only library

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes, I think so

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
