### PR TITLE
[llvm] Fix LLVM install for 'utils' feature

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_check_features(
         tools LLVM_INCLUDE_TOOLS
         utils LLVM_BUILD_UTILS
         utils LLVM_INCLUDE_UTILS
+        utils LLVM_INSTALL_UTILS
         enable-rtti LLVM_ENABLE_RTTI
         enable-ffi LLVM_ENABLE_FFI
         enable-terminfo LLVM_ENABLE_TERMINFO

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "13.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4198,7 +4198,7 @@
     },
     "llvm": {
       "baseline": "13.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "lmdb": {
       "baseline": "0.9.24",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15418b7e938058677963d920b616403240eca37f",
+      "version": "13.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "2c86dc65e952d8abe6140578df4db2c742180358",
       "version": "13.0.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

The portfile did not set the necessary CMake option to install the LLVM utility binaries like `FileCheck` and `not`.

- #### What does your PR fix?  
  N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Yes. Same as before.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
