### PR TITLE
Fix the dependency of installing arrow with the parquet feature

### DIFF
--- a/ports/arrow/vcpkg.json
+++ b/ports/arrow/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "arrow",
   "version": "7.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Cross-language development platform for in-memory analytics",
   "homepage": "https://arrow.apache.org",
   "license": "Apache-2.0",
@@ -75,7 +75,10 @@
       ]
     },
     "parquet": {
-      "description": "Parquet support"
+      "description": "Parquet support",
+      "dependencies": [
+        "rapidjson"
+      ]
     },
     "plasma": {
       "description": "Plasma support",

--- a/versions/a-/arrow.json
+++ b/versions/a-/arrow.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3d3371b4741fc81354b2033d584c48a1929373f4",
+      "version": "7.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "71eea8dac175d368506f19bb246b40bf4829846a",
       "version": "7.0.0",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -170,7 +170,7 @@
     },
     "arrow": {
       "baseline": "7.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ashes": {
       "baseline": "2021-06-18",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
 Enabling the parquet feature will set the PARQUET_REQUIRE_ENCRYPTION flag. But building with this flag depends on RapidJSON: https://github.com/apache/arrow/blob/apache-arrow-7.0.0/cpp/cmake_modules/ThirdpartyToolchain.cmake#L271-L273

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes
