### PR TITLE
[ois] fix pkgconfig file not installed on windows

### DIFF
--- a/ports/ois/0001_install_pkgconfig_win32.patch
+++ b/ports/ois/0001_install_pkgconfig_win32.patch
@@ -1,11 +1,29 @@
 diff -Naur a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt	2021-05-14 03:09:42.000000000 +0800
-+++ b/CMakeLists.txt	2022-03-08 10:35:36.235998300 +0800
-@@ -255,7 +255,5 @@
++++ b/CMakeLists.txt	2022-03-08 12:48:17.012589000 +0800
+@@ -255,7 +255,12 @@
    install(FILES $<TARGET_PDB_FILE:OIS> DESTINATION bin OPTIONAL)
  endif(MSVC AND BUILD_SHARED_LIBS)
  
 -if(UNIX)
-     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/OIS.pc.in ${CMAKE_BINARY_DIR}/OIS.pc @ONLY)
-     install(FILES ${CMAKE_BINARY_DIR}/OIS.pc DESTINATION ${OIS_LIB_DIRECTORY}/pkgconfig)
--endif()
+-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/OIS.pc.in ${CMAKE_BINARY_DIR}/OIS.pc @ONLY)
+-    install(FILES ${CMAKE_BINARY_DIR}/OIS.pc DESTINATION ${OIS_LIB_DIRECTORY}/pkgconfig)
++if (CMAKE_DEBUG_POSTFIX AND CMAKE_BUILD_TYPE STREQUAL "Debug")
++    set(OIS_POSTFIX ${CMAKE_DEBUG_POSTFIX})
++else()
++    set(OIS_POSTFIX "")
+ endif()
++
++configure_file(${CMAKE_CURRENT_SOURCE_DIR}/OIS.pc.in ${CMAKE_BINARY_DIR}/OIS.pc @ONLY)
++install(FILES ${CMAKE_BINARY_DIR}/OIS.pc DESTINATION ${OIS_LIB_DIRECTORY}/pkgconfig)
++
+diff -Naur a/OIS.pc.in b/OIS.pc.in
+--- a/OIS.pc.in	2021-05-14 03:09:42.000000000 +0800
++++ b/OIS.pc.in	2022-03-08 12:48:33.599696300 +0800
+@@ -6,5 +6,5 @@
+ Name: OIS
+ Description: Cross platform C++ Input Framework
+ Version: @OIS_VERSION@
+-Libs: -L${libdir} -lOIS
++Libs: -L${libdir} -lOIS@OIS_POSTFIX@
+ Cflags: -I${includedir} -I${includedir}/ois

--- a/ports/ois/0001_install_pkgconfig_win32.patch
+++ b/ports/ois/0001_install_pkgconfig_win32.patch
@@ -1,0 +1,11 @@
+diff -Naur a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2021-05-14 03:09:42.000000000 +0800
++++ b/CMakeLists.txt	2022-03-08 10:35:36.235998300 +0800
+@@ -255,7 +255,5 @@
+   install(FILES $<TARGET_PDB_FILE:OIS> DESTINATION bin OPTIONAL)
+ endif(MSVC AND BUILD_SHARED_LIBS)
+ 
+-if(UNIX)
+     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/OIS.pc.in ${CMAKE_BINARY_DIR}/OIS.pc @ONLY)
+     install(FILES ${CMAKE_BINARY_DIR}/OIS.pc DESTINATION ${OIS_LIB_DIRECTORY}/pkgconfig)
+-endif()

--- a/ports/ois/portfile.cmake
+++ b/ports/ois/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.5.1
     SHA512 20598aef999a70900cb7f75ffaf62059acf8e811822971cb21986b5d25d28dacb79e4b4cf4770c70e00d3c55cdd01ef3e68a77c2dd148677784fc4df38891340
     HEAD_REF master
+    PATCHES
+        0001_install_pkgconfig_win32.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/ois/vcpkg.json
+++ b/ports/ois/vcpkg.json
@@ -4,8 +4,8 @@
   "port-version": 1,
   "description": "Cross Platform Object Oriented Input Lib System. Meant to be very robust and compatible with many systems and operating systems.",
   "homepage": "https://wgois.github.io/OIS/",
-  "supports": "!(arm | arm64 | uwp)",
   "license": "Zlib",
+  "supports": "!(arm | arm64 | uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/ois/vcpkg.json
+++ b/ports/ois/vcpkg.json
@@ -1,9 +1,11 @@
 {
   "name": "ois",
   "version": "1.5.1",
+  "port-version": 1,
   "description": "Cross Platform Object Oriented Input Lib System. Meant to be very robust and compatible with many systems and operating systems.",
   "homepage": "https://wgois.github.io/OIS/",
   "supports": "!(arm | arm64 | uwp)",
+  "license": "Zlib",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4934,7 +4934,7 @@
     },
     "ois": {
       "baseline": "1.5.1",
-      "port-version": 0
+      "port-version": 1
     },
     "ompl": {
       "baseline": "1.5.1",

--- a/versions/o-/ois.json
+++ b/versions/o-/ois.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "81da871c0f26427fd1612bdf027c8872bcab71b5",
+      "version": "1.5.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "05dc4bcc0372eaa7b8a86f89a268c5ef0c69c5bf",
       "version": "1.5.1",
       "port-version": 0

--- a/versions/o-/ois.json
+++ b/versions/o-/ois.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "81da871c0f26427fd1612bdf027c8872bcab71b5",
+      "git-tree": "79d79b0c5901492572044ad873cdf4df864accea",
       "version": "1.5.1",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes pkgconfig file not installed on windows

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  not updated, sould be same as before

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  <Yes>

