### PR TITLE
[vcpk-ci] Trigger some test ports from vcpkg.cmake changes

### DIFF
--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -167,8 +167,8 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     & git revert -n -m 1 HEAD | Out-Null
     # The vcpkg.cmake toolchain file is not part of ABI hashing,
     # but changes must trigger at least some testing.
+    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake"
     Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
-    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
     & "./vcpkg$executableExtension" ci $Triplet --dry-run --exclude=$skipList @hostArgs @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile" `
         | ForEach-Object { if ($_ -match ' dependency information| determine pass') { Write-Host $_ } }
 
@@ -178,8 +178,8 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
 
 # The vcpkg.cmake toolchain file is not part of ABI hashing,
 # but changes must trigger at least some testing.
+Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake"
 Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
-Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
 & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @hostArgs @commonArgs @cachingArgs @parentHashes
 
 $failureLogsEmpty = (-Not (Test-Path $failureLogs) -Or ((Get-ChildItem $failureLogs).count -eq 0))

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -121,11 +121,6 @@ $xmlFile = Join-Path $xmlResults "$Triplet.xml"
 
 $failureLogs = Join-Path $ArtifactStagingDirectory 'failure-logs'
 
-# The vcpkg.cmake toolchain file is not part of ABI hashing,
-# but changes must trigger at least some testing.
-Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
-Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
-
 if ($IsWindows)
 {
     mkdir empty
@@ -170,6 +165,10 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     $parentHashesFile = Join-Path $WorkingRoot 'parent-hashes.json'
     $parentHashes = @("--parent-hashes=$parentHashesFile")
     & git revert -n -m 1 HEAD | Out-Null
+    # The vcpkg.cmake toolchain file is not part of ABI hashing,
+    # but changes must trigger at least some testing.
+    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
+    Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
     & "./vcpkg$executableExtension" ci $Triplet --dry-run --exclude=$skipList @hostArgs @commonArgs --no-binarycaching "--output-hashes=$parentHashesFile" `
         | ForEach-Object { if ($_ -match ' dependency information| determine pass') { Write-Host $_ } }
 
@@ -177,6 +176,10 @@ if (($BuildReason -eq 'PullRequest') -and -not $NoParentHashes)
     & git reset --hard HEAD
 }
 
+# The vcpkg.cmake toolchain file is not part of ABI hashing,
+# but changes must trigger at least some testing.
+Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
+Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
 & "./vcpkg$executableExtension" ci $Triplet --x-xunit=$xmlFile --exclude=$skipList --failure-logs=$failureLogs @hostArgs @commonArgs @cachingArgs @parentHashes
 
 $failureLogsEmpty = (-Not (Test-Path $failureLogs) -Or ((Get-ChildItem $failureLogs).count -eq 0))

--- a/scripts/azure-pipelines/test-modified-ports.ps1
+++ b/scripts/azure-pipelines/test-modified-ports.ps1
@@ -121,6 +121,11 @@ $xmlFile = Join-Path $xmlResults "$Triplet.xml"
 
 $failureLogs = Join-Path $ArtifactStagingDirectory 'failure-logs'
 
+# The vcpkg.cmake toolchain file is not part of ABI hashing,
+# but changes must trigger at least some testing.
+Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/cmake-user"
+Copy-Item "scripts/buildsystems/vcpkg.cmake" -Destination "scripts/test_ports/vcpkg-ci-paraview"
+
 if ($IsWindows)
 {
     mkdir empty

--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -4,6 +4,8 @@ mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 # NOTE: to figure out what cmake versions are required for different things,
 # grep for `CMake 3`. All version requirement comments should follow that format.
 
+# Attention: Changes to this file do not affect ABI hashing.
+
 #[===[.md:
 # z_vcpkg_add_fatal_error
 Add a fatal error.

--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "cmake-user",
   "version-date": "2022-02-28",
-  "port-version": 1,
   "description": "Test port to verify the vcpkg toolchain in cmake user projects",
   "default-features": [
     "ci"

--- a/scripts/test_ports/cmake-user/vcpkg.json
+++ b/scripts/test_ports/cmake-user/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "cmake-user",
   "version-date": "2022-02-28",
+  "port-version": 1,
   "description": "Test port to verify the vcpkg toolchain in cmake user projects",
   "default-features": [
     "ci"


### PR DESCRIPTION
- #### What does your PR fix?  
   The vcpkg.cmake toolchain file is not part of ABI hashing, but changes must trigger at least some testing.
   In particular, there must be a test with the minimum supported version of cmake, to avoid issues like #23402.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  not needed