### PR TITLE
[zeromq] Download patch files for GitHub PRs

### DIFF
--- a/ports/zeromq/portfile.cmake
+++ b/ports/zeromq/portfile.cmake
@@ -1,15 +1,3 @@
-vcpkg_download_distfile(patch4310
-    URLS "https://patch-diff.githubusercontent.com/raw/zeromq/libzmq/pull/4310.diff"
-    FILENAME "zeromq-libzmq-4310.diff"
-    SHA512 64e6d37ab843e5b9aa9e56ba7904423ce0a2c6b4101dbd86b7b8b22c52c384ed7ea9764f9e0a53be04e7ade09923ca95452104e9760b66ebc0ed3ffef08a75c5
-)
-
-vcpkg_download_distfile(patch4311
-    URLS "https://patch-diff.githubusercontent.com/raw/zeromq/libzmq/pull/4311.diff"
-    FILENAME "zeromq-libzmq-4311.diff"
-    SHA512 2b04e0ce4743d27070ea832c45e2d8fa0091c755757937cfa2a2bb43283ee38dc9f27343989e1ad8c45fda8a3cfaa012250b0c581e2f0407938cbb61b2a21e63
-)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zeromq/libzmq
@@ -17,8 +5,8 @@ vcpkg_from_github(
     SHA512 ad828b1ab5a87983285a6b44b08240816ed1c4e2c73306ab1a851bf80df1892b5e2f92064a49fbadc1f4c75043625ace77dd25b64d5d1c2a7d1d61cc916fba0b
     PATCHES 
         fix-arm.patch
-        ${patch4310}
-        ${patch4311}
+        zeromq-libzmq-4310-64e6d37ab8.diff # https://patch-diff.githubusercontent.com/raw/zeromq/libzmq/pull/4310.diff
+        zeromq-libzmq-4311-2b04e0ce47.diff # https://patch-diff.githubusercontent.com/raw/zeromq/libzmq/pull/4311.diff
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/zeromq/vcpkg.json
+++ b/ports/zeromq/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zeromq",
   "version": "4.3.4",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The ZeroMQ lightweight messaging kernel is a library which extends the standard socket interfaces with features traditionally provided by specialised messaging middleware products",
   "homepage": "https://github.com/zeromq/libzmq",
   "license": "LGPL-3.0-only",

--- a/ports/zeromq/zeromq-libzmq-4310-64e6d37ab8.diff
+++ b/ports/zeromq/zeromq-libzmq-4310-64e6d37ab8.diff
@@ -1,0 +1,55 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6c983c6698..21bcd414a0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,6 +15,7 @@ include(CheckCSourceCompiles)
+ include(CheckCSourceRuns)
+ include(CMakeDependentOption)
+ include(CheckCXXSymbolExists)
++include(CheckStructHasMember)
+ include(CheckTypeSize)
+ include(FindThreads)
+ include(GNUInstallDirs)
+@@ -495,8 +496,12 @@ endif()
+ 
+ if(NOT WIN32)
+   set(ZMQ_HAVE_IPC 1)
++  set(ZMQ_HAVE_STRUCT_SOCKADDR_UN 1)
+ else()
+   check_include_files("winsock2.h;afunix.h" ZMQ_HAVE_IPC)
++  if(ZMQ_HAVE_IPC)
++    check_struct_has_member("struct sockaddr_un" sun_path "winsock2.h;afunix.h" ZMQ_HAVE_STRUCT_SOCKADDR_UN)
++  endif()
+ endif()
+ 
+ # ##################### BEGIN condition_variable_t selection
+diff --git a/builds/cmake/platform.hpp.in b/builds/cmake/platform.hpp.in
+index 2d23e8b288..18064362fe 100644
+--- a/builds/cmake/platform.hpp.in
++++ b/builds/cmake/platform.hpp.in
+@@ -59,6 +59,7 @@
+ #cmakedefine ZMQ_HAVE_LIBBSD
+ 
+ #cmakedefine ZMQ_HAVE_IPC
++#cmakedefine ZMQ_HAVE_STRUCT_SOCKADDR_UN
+ 
+ #cmakedefine ZMQ_USE_BUILTIN_SHA1
+ #cmakedefine ZMQ_USE_NSS
+diff --git a/src/windows.hpp b/src/windows.hpp
+index 11c7581dee..24cce83d11 100644
+--- a/src/windows.hpp
++++ b/src/windows.hpp
+@@ -98,3 +98,13 @@ static inline int poll (struct pollfd *pfd, unsigned long nfds, int timeout)
+ #define snprintf(buffer_, count_, format_, ...)                                \
+     _snprintf_s (buffer_, count_, _TRUNCATE, format_, __VA_ARGS__)
+ #endif
++
++//  Workaround missing struct sockaddr_un in afunix.h.
++//  Fix #3949.
++#if defined(ZMQ_HAVE_IPC) && !defined(ZMQ_HAVE_STRUCT_SOCKADDR_UN)
++struct sockaddr_un
++{
++    ADDRESS_FAMILY sun_family; /* AF_UNIX */
++    char sun_path[108];        /* pathname */
++};
++#endif

--- a/ports/zeromq/zeromq-libzmq-4311-2b04e0ce47.diff
+++ b/ports/zeromq/zeromq-libzmq-4311-2b04e0ce47.diff
@@ -1,0 +1,18 @@
+diff --git a/src/windows.hpp b/src/windows.hpp
+index 24cce83d11..c6d625188d 100644
+--- a/src/windows.hpp
++++ b/src/windows.hpp
+@@ -90,7 +90,6 @@ static inline int poll (struct pollfd *pfd, unsigned long nfds, int timeout)
+ #ifndef AI_NUMERICSERV
+ #define AI_NUMERICSERV 0x0400
+ #endif
+-#endif
+ 
+ //  In MSVC prior to v14, snprintf is not available
+ //  The closest implementation is the _snprintf_s function
+@@ -108,3 +107,5 @@ struct sockaddr_un
+     char sun_path[108];        /* pathname */
+ };
+ #endif
++
++#endif

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7566,7 +7566,7 @@
     },
     "zeromq": {
       "baseline": "4.3.4",
-      "port-version": 4
+      "port-version": 5
     },
     "zfp": {
       "baseline": "0.5.5",

--- a/versions/z-/zeromq.json
+++ b/versions/z-/zeromq.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "246f585e58f536087c5f70f918459d5500a4dc43",
+      "version": "4.3.4",
+      "port-version": 5
+    },
+    {
       "git-tree": "efc9d6229adaef7b036d222004dd786353f8cd4e",
       "version": "4.3.4",
       "port-version": 4


### PR DESCRIPTION
This is needed to have a stable checksum for the patches because GitHub
is returning a different checksum for the patches now because the index
objects are abbreviated to 9 characters instead of 10 characters, e.g.
for patch4311:

```diff
+ index 24cce83d1..c6d625188 100644
- index 24cce83d11..c6d625188d 100644
```
Reported at <https://github.com/microsoft/vcpkg/pull/22681#issuecomment-1061312320>.

A possible long-term fix is reported to GitHub at
<https://github.com/github/feedback/discussions/12531>.

- #### What does your PR fix?

  Fixes checksum for patch.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

  No.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

  Yes.
