### PR TITLE
[sentencepiece] Clarify supported triplets

### DIFF
--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "0.1.96",
   "port-version": 1,
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
-  "supports": "!((windows | uwp) & !static))",
+  "supports": "!((windows | uwp) & !static)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/sentencepiece/vcpkg.json
+++ b/ports/sentencepiece/vcpkg.json
@@ -1,7 +1,9 @@
 {
   "name": "sentencepiece",
   "version": "0.1.96",
+  "port-version": 1,
   "description": "SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems where the vocabulary size is predetermined prior to the neural model training",
+  "supports": "!((windows | uwp) & !static))",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1167,11 +1167,6 @@ sdl2-net:x64-uwp=fail
 # https://github.com/microsoft/vcpkg/issues/10918
 seal:arm-uwp=fail
 seal:x64-uwp=fail
-sentencepiece:arm64-windows=fail
-sentencepiece:arm-uwp=fail
-sentencepiece:x64-uwp=fail
-sentencepiece:x64-windows=fail
-sentencepiece:x86-windows=fail
 septag-sx:arm64-windows=fail
 septag-sx:arm-uwp=fail
 septag-sx:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6338,7 +6338,7 @@
     },
     "sentencepiece": {
       "baseline": "0.1.96",
-      "port-version": 0
+      "port-version": 1
     },
     "sentry-native": {
       "baseline": "0.4.15",

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a49c37df8b6b5a30cadbfd32b69b876185bfcaed",
+      "git-tree": "b243e85760f8f59100632997fdc34cdae47bcfd4",
       "version": "0.1.96",
       "port-version": 1
     },

--- a/versions/s-/sentencepiece.json
+++ b/versions/s-/sentencepiece.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a49c37df8b6b5a30cadbfd32b69b876185bfcaed",
+      "version": "0.1.96",
+      "port-version": 1
+    },
+    {
       "git-tree": "b83e7b28dc28e405cfee3c94385e2039c8564040",
       "version": "0.1.96",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #23436

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Only windows-static, Linux and Macos are supportet.

  Removed sentencepiece from CI baseline:
```
sentencepiece:arm64-windows=fail
sentencepiece:arm-uwp=fail
sentencepiece:x64-uwp=fail
sentencepiece:x64-windows=fail
sentencepiece:x86-windows=fail
```

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 Yes, but still working on this PR
