### PR TITLE
[vcpkg baseline] Fix ports build on Linux

### DIFF
--- a/ports/libgnutls/portfile.cmake
+++ b/ports/libgnutls/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_configure_make(
         --disable-maintainer-mode
         --disable-rpath
         --disable-libdane
+        --disable-guile
         --with-included-unistring
         --without-p11-kit
         --without-tpm

--- a/ports/libgnutls/vcpkg.json
+++ b/ports/libgnutls/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libgnutls",
   "version": "3.6.15",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A secure communications library implementing the SSL, TLS and DTLS protocols",
   "homepage": "https://www.gnutls.org/",
+  "license": "LGPL-2.1-or-later",
   "supports": "!windows",
   "dependencies": [
     "gettext",

--- a/ports/ncurses/portfile.cmake
+++ b/ports/ncurses/portfile.cmake
@@ -41,10 +41,12 @@ endif()
 set(OPTIONS_DEBUG
     "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig"
     --with-debug
+    --without-normal
 )
 set(OPTIONS_RELEASE
     "--with-pkg-config-libdir=${CURRENT_INSTALLED_DIR}/lib/pkgconfig"
     --without-debug
+    --with-normal
 )
 
 vcpkg_configure_make(

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "6.3",
   "port-version": 1,
   "description": "free software emulation of curses in System V Release 4.0",
-  "homepage": "https://invisible-island.net/ncurses/announce.htm",
+  "homepage": "https://invisible-island.net/ncurses/announce.html",
   "license": "MIT",
   "supports": "!windows | mingw"
 }

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ncurses",
-  "version-string": "6.3",
+  "version": "6.3",
   "port-version": 1,
   "description": "free software emulation of curses in System V Release 4.0",
   "homepage": "https://invisible-island.net/ncurses/announce.html",

--- a/ports/ncurses/vcpkg.json
+++ b/ports/ncurses/vcpkg.json
@@ -1,6 +1,9 @@
 {
   "name": "ncurses",
   "version-string": "6.3",
+  "port-version": 1,
   "description": "free software emulation of curses in System V Release 4.0",
+  "homepage": "https://invisible-island.net/ncurses/announce.htm",
+  "license": "MIT",
   "supports": "!windows | mingw"
 }

--- a/ports/pcapplusplus/CMakeLists.txt
+++ b/ports/pcapplusplus/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(pcapplusplus CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+if (WIN32)
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
+# dependencies
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+if (WIN32)
+    find_path(PCAP_INCLUDES NAMES pcap.h)
+    find_library(PCAP_LIBRARY_RELEASE NAMES wpcap PATH_SUFFIXES lib REQUIRED)
+    find_library(PCAP_LIBRARY_DEBUG NAMES wpcap PATH_SUFFIXES lib REQUIRED)
+    find_library(PACKET_LIBRARY_RELEASE NAMES Packet PATH_SUFFIXES lib REQUIRED)
+    find_library(PACKET_LIBRARY_DEBUG NAMES Packet PATH_SUFFIXES lib REQUIRED)
+    select_library_configurations(PCAP)
+    select_library_configurations(PACKET)
+    list(APPEND PCAP_LIBRARIES ${PACKET_LIBRARIES})
+else()
+    find_path(PCAP_INCLUDES NAMES pcap.h)
+    find_library(PCAP_LIBRARY_RELEASE NAMES pcap PATH_SUFFIXES lib REQUIRED)
+    find_library(PCAP_LIBRARY_DEBUG NAMES pcap PATH_SUFFIXES lib REQUIRED)
+    select_library_configurations(PCAP)
+endif()
+
+find_package(Threads REQUIRED)
+
+# common++
+file(GLOB COMMONPP_HEADERS "${CMAKE_CURRENT_LIST_DIR}/Common++/header/*.h")
+file(GLOB COMMONPP_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Common++/src/*.cpp")
+
+add_library(commonpp ${COMMONPP_SOURCES})
+
+target_include_directories(commonpp PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Common++/header"
+    "${CMAKE_CURRENT_LIST_DIR}/3rdParty/EndianPortable/include")
+set_target_properties(commonpp PROPERTIES OUTPUT_NAME Common++)
+if (WIN32)
+    target_compile_definitions(commonpp PRIVATE WPCAP HAVE_REMOTE _CRT_SECURE_NO_WARNINGS)
+elseif (UNIX AND NOT APPLE)
+    target_compile_definitions(commonpp PRIVATE LINUX)
+elseif (APPLE)
+    target_compile_definitions(commonpp PRIVATE MAC_OS_X)
+endif()
+
+# packet++
+file(GLOB PACKETPP_HEADERS "${CMAKE_CURRENT_LIST_DIR}/Packet++/header/*.h")
+file(GLOB PACKETPP_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Packet++/src/*.cpp")
+list(APPEND PACKETPP_SOURCES "${CMAKE_CURRENT_LIST_DIR}/3rdParty/hash-library/md5.cpp")
+
+add_library(packetpp ${PACKETPP_SOURCES})
+
+target_include_directories(packetpp PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Packet++/header"
+    "${CMAKE_CURRENT_LIST_DIR}/3rdParty/hash-library")
+target_link_libraries(packetpp PRIVATE commonpp)
+set_target_properties(packetpp PROPERTIES OUTPUT_NAME Packet++)
+if (WIN32)
+    target_compile_definitions(packetpp PRIVATE WPCAP HAVE_REMOTE _CRT_SECURE_NO_WARNINGS)
+elseif (UNIX AND NOT APPLE)
+    target_compile_definitions(packetpp PRIVATE LINUX)
+elseif (APPLE)
+    target_compile_definitions(packetpp PRIVATE MAC_OS_X)
+endif()
+
+# pcap++
+file(GLOB PCAPPP_HEADERS "${CMAKE_CURRENT_LIST_DIR}/Pcap++/header/*.h")
+file(GLOB PCAPPP_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Pcap++/src/*.cpp")
+file(GLOB LIGHTPCAPNG_SOURCES "${CMAKE_CURRENT_LIST_DIR}/3rdParty/LightPcapNg/LightPcapNg/src/*.cpp")
+
+add_library(pcappp ${PCAPPP_SOURCES})
+
+target_include_directories(pcappp PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Pcap++/header" "${PCAP_INCLUDES}"
+    "${CMAKE_CURRENT_LIST_DIR}/3rdParty/LightPcapNg/LightPcapNg/include")
+target_link_libraries(pcappp PUBLIC commonpp packetpp ${PCAP_LIBRARIES} Threads::Threads)
+
+if (WIN32)
+    target_link_libraries(pcappp PUBLIC ws2_32 iphlpapi)
+elseif (APPLE)
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    find_library(SYSTEMCONFIGURATION_LIBRARY SystemConfiguration)
+    target_link_libraries(pcappp PUBLIC ${COREFOUNDATION_LIBRARY} ${SYSTEMCONFIGURATION_LIBRARY})
+endif()
+
+if (WIN32)
+    target_compile_definitions(pcappp PRIVATE WPCAP HAVE_REMOTE HAVE_STRUCT_TIMESPEC _CRT_SECURE_NO_WARNINGS)
+elseif (UNIX AND NOT APPLE)
+    target_compile_definitions(pcappp PRIVATE LINUX)
+elseif (APPLE)
+    target_compile_definitions(pcappp PRIVATE MAC_OS_X)
+endif()
+
+set_target_properties(pcappp PROPERTIES OUTPUT_NAME Pcap++)
+
+# Install
+install(FILES ${PCAPPP_HEADERS} ${COMMONPP_HEADERS} ${PACKETPP_HEADERS} DESTINATION include)
+install(FILES "${CMAKE_CURRENT_LIST_DIR}/LICENSE" DESTINATION share/pcapplusplus)
+
+install(
+  TARGETS pcappp commonpp packetpp
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/ports/pcapplusplus/portfile.cmake
+++ b/ports/pcapplusplus/portfile.cmake
@@ -1,4 +1,6 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -7,97 +9,15 @@ vcpkg_from_github(
     SHA512 ad10034950c0c3e6a4638e8b314c8983ce42609948d7d8d40ad0ff678820a2469807bd29aff77e657a150008602475b50cea84a0766ad87ea203985519cb38ac
     HEAD_REF master
 )
+file(COPY "${CURRENT_PORT_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    if(VCPKG_PLATFORM_TOOLSET STREQUAL "v140")
-        set(VS_VERSION "vs2015")
-    elseif(VCPKG_PLATFORM_TOOLSET STREQUAL "v141")
-        set(VS_VERSION "vs2017")
-    elseif(VCPKG_PLATFORM_TOOLSET STREQUAL "v142")
-        set(VS_VERSION "vs2019")
-    else()
-        message(FATAL_ERROR "Unsupported visual studio version")
-    endif()
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
 
-    vcpkg_execute_required_process(
-        COMMAND configure-windows-visual-studio.bat -v ${VS_VERSION} -w . -p .
-        WORKING_DIRECTORY ${SOURCE_PATH}
-    )
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
-    vcpkg_install_msbuild(
-        SOURCE_PATH "${SOURCE_PATH}"
-        PROJECT_SUBPATH "mk/${VS_VERSION}/Common++.vcxproj"
-        PLATFORM ${TRIPLET_SYSTEM_ARCH}
-        INCLUDES_SUBPATH Dist/header
-        ALLOW_ROOT_INCLUDES
-        USE_VCPKG_INTEGRATION
-    )
-    vcpkg_install_msbuild(
-        SOURCE_PATH "${SOURCE_PATH}"
-        PROJECT_SUBPATH "mk/${VS_VERSION}/Packet++.vcxproj"
-        PLATFORM ${TRIPLET_SYSTEM_ARCH}
-        INCLUDES_SUBPATH Dist/header
-        ALLOW_ROOT_INCLUDES
-        USE_VCPKG_INTEGRATION
-    )
-    vcpkg_install_msbuild(
-        SOURCE_PATH "${SOURCE_PATH}"
-        PROJECT_SUBPATH "mk/${VS_VERSION}/Pcap++.vcxproj"
-        PLATFORM ${TRIPLET_SYSTEM_ARCH}
-        USE_VCPKG_INTEGRATION
-        INCLUDES_SUBPATH Dist/header
-        ALLOW_ROOT_INCLUDES
-        LICENSE_SUBPATH LICENSE
-    )
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-    # Lib
-    file(GLOB LIB_FILES_RELEASE "${SOURCE_PATH}/Dist/**/Release/*")
-    file(
-        INSTALL ${LIB_FILES_RELEASE}
-        DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    )
-    file(GLOB LIB_FILES_RELEASE "${SOURCE_PATH}/Dist/**/Debug/*")
-    file(
-        INSTALL ${LIB_FILES_RELEASE}
-        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib
-    )
-
-    file(
-        REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin" "${CURRENT_PACKAGES_DIR}/tools" "${CURRENT_PACKAGES_DIR}/lib/LightPcapNg.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/LightPcapNg.lib"
-    )
-else()
-    if(VCPKG_TARGET_IS_LINUX)
-        set(CONFIG_CMD "./configure-linux.sh")
-    elseif(VCPKG_TARGET_IS_OSX)
-        set(CONFIG_CMD "./configure-mac_os_x.sh")
-    else()
-        message(FATAL_ERROR "Unsupported platform")
-    endif()
-
-    vcpkg_execute_required_process(
-	COMMAND ${SOURCE_PATH}/${CONFIG_CMD} --libpcap-include-dir ${CURRENT_INSTALLED_DIR}/include
-        WORKING_DIRECTORY ${SOURCE_PATH}
-    )
-
-    vcpkg_execute_build_process(
-	COMMAND make libs
-	WORKING_DIRECTORY ${SOURCE_PATH}
-    )
-
-    # Lib
-    file(GLOB LIB_FILES "${SOURCE_PATH}/Dist/*.a")
-    file(
-        INSTALL ${LIB_FILES}
-	    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
-    )
-
-    # Include
-    file(GLOB HEADER_FILES "${SOURCE_PATH}/Dist/header/*.h")
-    file(
-        INSTALL ${HEADER_FILES}
-        DESTINATION ${CURRENT_PACKAGES_DIR}/include
-    )
-
-    # Copyright
-    file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-endif()
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "pcapplusplus",
   "version-string": "21.11",
+  "port-version": 1,
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",
+  "license": null,
   "dependencies": [
     {
       "name": "libpcap",
@@ -11,6 +13,10 @@
     {
       "name": "pthreads",
       "platform": "windows"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
       "name": "winpcap",

--- a/ports/pcapplusplus/vcpkg.json
+++ b/ports/pcapplusplus/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pcapplusplus",
-  "version-string": "21.11",
+  "version": "21.11",
   "port-version": 1,
   "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
   "homepage": "https://github.com/seladb/PcapPlusPlus",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5254,7 +5254,7 @@
     },
     "pcapplusplus": {
       "baseline": "21.11",
-      "port-version": 0
+      "port-version": 1
     },
     "pcg": {
       "baseline": "2021-04-06",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3538,7 +3538,7 @@
     },
     "libgnutls": {
       "baseline": "3.6.15",
-      "port-version": 2
+      "port-version": 3
     },
     "libgo": {
       "baseline": "3.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4730,7 +4730,7 @@
     },
     "ncurses": {
       "baseline": "6.3",
-      "port-version": 0
+      "port-version": 1
     },
     "neargye-semver": {
       "baseline": "0.3.0",

--- a/versions/l-/libgnutls.json
+++ b/versions/l-/libgnutls.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f041c07b59c7ac2389ac1fd6d8a175466bb648b7",
+      "version": "3.6.15",
+      "port-version": 3
+    },
+    {
       "git-tree": "c03a1c452fa39d1b6d884aa3ef12c0c98a11f0a3",
       "version": "3.6.15",
       "port-version": 2

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "46f36d51c287c33525346dcf6fb903ddeea5a4d7",
-      "version-string": "6.3",
+      "git-tree": "ea7aecbf38cef7f64f929c679d55812e679ca496",
+      "version": "6.3",
       "port-version": 1
     },
     {

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "390e9c0f2b1c9deb0fc0155c1a24ec0ea3a17a38",
+      "version-string": "6.3",
+      "port-version": 1
+    },
+    {
       "git-tree": "68d49e9492a5a00c0b04cfbe2985ed99fc33973a",
       "version-string": "6.3",
       "port-version": 0

--- a/versions/n-/ncurses.json
+++ b/versions/n-/ncurses.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "390e9c0f2b1c9deb0fc0155c1a24ec0ea3a17a38",
+      "git-tree": "46f36d51c287c33525346dcf6fb903ddeea5a4d7",
       "version-string": "6.3",
       "port-version": 1
     },

--- a/versions/p-/pcapplusplus.json
+++ b/versions/p-/pcapplusplus.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f1f63c9365f0cb128761835ebceeafb6b162c815",
+      "version": "21.11",
+      "port-version": 1
+    },
+    {
       "git-tree": "e0480fc24edf7b699eb027d24c3737026dd1128c",
       "version-string": "21.11",
       "port-version": 0


### PR DESCRIPTION
1. Fix ncurses:x64-linux build:
```
Mismatching number of debug and release binaries. Found 10 for debug but 5 for release.
Debug binaries

    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libpanel_g.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libncurses++_g.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libform_g.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libpanel.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libncurses++.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libncurses.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libmenu_g.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libform.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libncurses_g.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/debug/lib/libmenu.a

Release binaries

    /home/usr/work/vcpkg/packages/ncurses_x64-linux/lib/libpanel.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/lib/libncurses++.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/lib/libncurses.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/lib/libform.a
    /home/usr/work/vcpkg/packages/ncurses_x64-linux/lib/libmenu.a
```

2. Fix libgnutls:x64-linux build:
```
In ice-9/boot-9.scm:
   752:25  0 (dispatch-exception _ _ _)

ice-9/boot-9.scm:752:25: In procedure dispatch-exception:
In procedure dynamic-link: file: "/mnt/vcpkg-ci/buildtrees/libgnutls/x64-linux-dbg/guile/src/guile-gnutls-v-2", message: "file not found"
make[3]: *** [Makefile:2520: modules/gnutls.go] Error 1
make[3]: *** Waiting for unfinished jobs....
```

3. Fix pcapplusplus:x64-linux build:
```
Release binaries

    /Users/vagrant/Data/packages/pcapplusplus_x64-osx/lib/libPcap++.a
    /Users/vagrant/Data/packages/pcapplusplus_x64-osx/lib/libCommon++.a
    /Users/vagrant/Data/packages/pcapplusplus_x64-osx/lib/libPacket++.a

Debug binaries were not found
```
That's because this port can only be built as release. Use cmake build system instead.

Related: #23476 #23429