### PR TITLE
[libde265] fix static linkage

### DIFF
--- a/ports/libde265/portfile.cmake
+++ b/ports/libde265/portfile.cmake
@@ -39,6 +39,9 @@ vcpkg_fixup_pkgconfig()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libde265/de265.h" "!defined(LIBDE265_STATIC_BUILD)" "0")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/libde265/de265.h" "!defined(LIBDE265_STATIC_BUILD)" "1")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libde265",
   "version-string": "1.0.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",
+  "license": "LGPL-3.0-only",
   "supports": "!(arm | uwp)",
   "dependencies": [
     {

--- a/ports/libde265/vcpkg.json
+++ b/ports/libde265/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libde265",
-  "version-string": "1.0.8",
+  "version": "1.0.8",
   "port-version": 4,
   "description": "Open h.265 video codec implementation.",
   "homepage": "https://www.libde265.org/",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3442,7 +3442,7 @@
     },
     "libde265": {
       "baseline": "1.0.8",
-      "port-version": 3
+      "port-version": 4
     },
     "libdisasm": {
       "baseline": "0.23",

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "94c690a80717344c07090164e898cc1554d50d85",
-      "version-string": "1.0.8",
+      "git-tree": "f69d985ecdaa897d5efd10422f739d450373e26d",
+      "version": "1.0.8",
       "port-version": 4
     },
     {

--- a/versions/l-/libde265.json
+++ b/versions/l-/libde265.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "94c690a80717344c07090164e898cc1554d50d85",
+      "version-string": "1.0.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "83f4bc2d067f213063ca93d6f1514d3f7278452c",
       "version-string": "1.0.8",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

Similar to https://github.com/microsoft/vcpkg/pull/22818/, this replaces a define that's required when the target linkage is `static`.

Also added license to manifest.

- #### What does your PR fix?  

Build failure when linking to static libde265

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 
Yes
