### PR TITLE
[libheif] fix license

### DIFF
--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libheif",
   "version": "1.12.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
   "license": "LGPL-3.0-only",

--- a/ports/libheif/vcpkg.json
+++ b/ports/libheif/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 2,
   "description": "Open h.265 video codec implementation.",
   "homepage": "http://www.libheif.org/",
-  "license": "GPL-3.0-only",
+  "license": "LGPL-3.0-only",
   "dependencies": [
     {
       "name": "gdk-pixbuf",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3582,7 +3582,7 @@
     },
     "libheif": {
       "baseline": "1.12.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libhsplasma": {
       "baseline": "2021.06.08",

--- a/versions/l-/libheif.json
+++ b/versions/l-/libheif.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9638a1f823a06ad68484b408f5640ac2204b5262",
+      "version": "1.12.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "73b2b4b29035aa22da5ccd0c4c46dbb6e5516424",
       "version": "1.12.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  

The license in the manifest is incorrect.  Should be SPDX `LGPL-3.0-only`
https://github.com/strukturag/libheif/blob/master/COPYING

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Is this necessary for a manifest change only?
