### PR TITLE
[proj4] Retain former features (fixes `vcpkg upgrade`)

### DIFF
--- a/ports/proj4/vcpkg.json
+++ b/ports/proj4/vcpkg.json
@@ -1,12 +1,56 @@
 {
   "name": "proj4",
   "version-semver": "8.9.9",
+  "port-version": 1,
   "description": "A stub package that pulls in proj. Do not depend on this package.",
   "license": "MIT",
   "dependencies": [
     {
       "name": "proj",
+      "default-features": false,
       "version>=": "9.0.0"
     }
-  ]
+  ],
+  "default-features": [
+    "net",
+    "tiff"
+  ],
+  "features": {
+    "net": {
+      "description": "Enable network support",
+      "dependencies": [
+        {
+          "name": "proj",
+          "default-features": false,
+          "features": [
+            "net"
+          ]
+        }
+      ]
+    },
+    "tiff": {
+      "description": "Enable TIFF support to read some grids",
+      "dependencies": [
+        {
+          "name": "proj",
+          "default-features": false,
+          "features": [
+            "tiff"
+          ]
+        }
+      ]
+    },
+    "tools": {
+      "description": "Build tools",
+      "dependencies": [
+        {
+          "name": "proj",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5490,7 +5490,7 @@
     },
     "proj4": {
       "baseline": "8.9.9",
-      "port-version": 0
+      "port-version": 1
     },
     "prometheus-cpp": {
       "baseline": "1.0.0",

--- a/versions/p-/proj4.json
+++ b/versions/p-/proj4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "284d584afb127d11beb4126bf1ee7eccef413229",
+      "version-semver": "8.9.9",
+      "port-version": 1
+    },
+    {
       "git-tree": "4ccf46b756dabd4cd841b866dcd5491d84a946e1",
       "version-semver": "8.9.9",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?  
  Retain the former features, now as dependencies on `proj`, to unbreak `vcpkg upgrade`.
  Fixes #23486 (confirmed by https://github.com/microsoft/vcpkg/issues/23486#issuecomment-1064045727).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes