### PR TITLE
[eventpp] Add new port - eventpp

### DIFF
--- a/ports/eventpp/portfile.cmake
+++ b/ports/eventpp/portfile.cmake
@@ -1,0 +1,22 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wqking/eventpp
+    REF v0.1.2
+    SHA512 01fd536024dfef8c4025fc184f6b6326a901849dbf73d81430d7cfadeff25c9c140ab6a28b0143a4090703668c1d9e743a54e874c0321c3453cf40aeb4583db3
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/eventpp")
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+
+file(INSTALL "${SOURCE_PATH}/license" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/eventpp/vcpkg.json
+++ b/ports/eventpp/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "eventpp",
+  "version-semver": "0.1.2",
+  "description": "C++ library for event dispatcher and callback list",
+  "homepage": "https://github.com/wqking/eventpp",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2056,6 +2056,10 @@
       "baseline": "2021-10-16",
       "port-version": 0
     },
+    "eventpp": {
+      "baseline": "0.1.2",
+      "port-version": 0
+    },
     "evpp": {
       "baseline": "0.7.0",
       "port-version": 5

--- a/versions/e-/eventpp.json
+++ b/versions/e-/eventpp.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "3f11cacc8b5a6f9f2951992d29cee39e52ef601f",
+      "version-semver": "0.1.2",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Add new port: eventpp -- C++ library for event dispatcher and callback list

eventpp is a C++ event library for callbacks, event dispatcher, and event queue. With eventpp you can easily implement signal and slot mechanism, publisher and subscriber pattern, or observer pattern.  
eventpp is header only library. It doesn't need configuration or building.  

- #### What does your PR fix?  

New port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  <linux/windows/macos>, <No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes, I think so.

