### PR TITLE
[baseline] [python3] fix bz2(d) search on linux

### DIFF
--- a/ports/python3/0010-bz2d.patch
+++ b/ports/python3/0010-bz2d.patch
@@ -1,7 +1,7 @@
-diff --git a/ setup.py b/ setup.py
+diff --git a/setup.py b/setup.py
 index 43e807f20..df4d43d3d 100644
---- a/ setup.py
-+++ b/ setup.py
+--- a/setup.py
++++ b/setup.py
 @@ -1741,6 +1741,14 @@ def detect_compress_exts(self):
              self.add(Extension('_bz2', ['_bz2module.c'],
                                 libraries=['bz2'],

--- a/ports/python3/0010-bz2d.patch
+++ b/ports/python3/0010-bz2d.patch
@@ -1,0 +1,19 @@
+diff --git a/ setup.py b/ setup.py
+index 43e807f20..df4d43d3d 100644
+--- a/ setup.py
++++ b/ setup.py
+@@ -1741,6 +1741,14 @@ def detect_compress_exts(self):
+             self.add(Extension('_bz2', ['_bz2module.c'],
+                                libraries=['bz2'],
+                                extra_link_args=bz2_extra_link_args))
++        elif (self.compiler.find_library_file(self.lib_dirs, 'bz2d')):
++            if MACOS:
++                bz2_extra_link_args = ('-Wl,-search_paths_first',)
++            else:
++                bz2_extra_link_args = ()
++            self.add(Extension('_bz2', ['_bz2module.c'],
++                               libraries=['bz2d'],
++                               extra_link_args=bz2_extra_link_args))
+         else:
+             self.missing.append('_bz2')
+ 

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -14,6 +14,7 @@ set(PATCHES
     0004-dont-copy-vcruntime.patch
     0005-only-build-required-projects.patch
     0009-python.pc.patch
+    0010-bz2d.patch
 )
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     list(PREPEND PATCHES 0001-static-library.patch)

--- a/ports/python3/portfile.cmake
+++ b/ports/python3/portfile.cmake
@@ -217,6 +217,8 @@ else()
         "--with-ensurepip"
         "--with-suffix="
         "--with-system-expat"
+        "--without-readline"
+        "--disable-test-modules"
     )
     if(VCPKG_TARGET_IS_OSX)
         list(APPEND OPTIONS "LIBS=-liconv -lintl")

--- a/ports/python3/vcpkg.json
+++ b/ports/python3/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "python3",
-  "version-semver": "3.10.2",
+  "version": "3.10.2",
+  "port-version": 1,
   "description": "The Python programming language",
   "homepage": "https://github.com/python/cpython",
   "license": "Python-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5574,7 +5574,7 @@
     },
     "python3": {
       "baseline": "3.10.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qca": {
       "baseline": "2.3.4",

--- a/versions/p-/python3.json
+++ b/versions/p-/python3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4e348bd50d8c4252bda83903ce22f1e60d34be88",
+      "version": "3.10.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "0cf2e0bbf8fd712f82ed1997be82b136f1c13108",
       "version-semver": "3.10.2",
       "port-version": 0


### PR DESCRIPTION
- bonus 1: disable test modules used to test python.
- bonus 2; disable dependency on readline explicitly. 
