### PR TITLE
[x264] enable cross-compile settings propagation for arm64-linux

### DIFF
--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -29,20 +29,24 @@ if(VCPKG_TARGET_IS_UWP)
 endif()
 
 if(VCPKG_TARGET_IS_LINUX)
-    list(APPEND OPTIONS --enable-pic)
-endif()
 
-vcpkg_cmake_get_vars(cmake_vars_file)
-include("${cmake_vars_file}")
+    list(APPEND OPTIONS --enable-pic)    
 
-if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
-    if (VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
-        # attempt to determine the fully qualified prefix from VCPKG_DETECTED_CMAKE_C_COMPILER (using most common naming conventions for linux targets)
-        if (${VCPKG_DETECTED_CMAKE_C_COMPILER} MATCHES ".*-gcc")
-            string(REGEX REPLACE "gcc$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_C_COMPILER})
-            list(APPEND OPTIONS --cross-prefix=${full_cross_prefix})
-        endif()        
+    if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+
+        vcpkg_cmake_get_vars(cmake_vars_file)
+        include("${cmake_vars_file}")
+
+        if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
+            # Attempt to determine the fully qualified prefix from VCPKG_DETECTED_CMAKE_C_COMPILER (using most common naming conventions for linux targets)
+            # and if valid, use it to initialize --cross-prefix build-option of x264 package.
+            if (${VCPKG_DETECTED_CMAKE_C_COMPILER} MATCHES ".*-gcc")
+                string(REGEX REPLACE "gcc$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+                list(APPEND OPTIONS --cross-prefix=${full_cross_prefix})
+            endif()        
+        endif()
     endif()
+
 endif()
 
 vcpkg_configure_make(

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -32,6 +32,19 @@ if(VCPKG_TARGET_IS_LINUX)
     list(APPEND OPTIONS --enable-pic)
 endif()
 
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
+    if (VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        # attempt to determine the fully qualified prefix from VCPKG_DETECTED_CMAKE_C_COMPILER (using most common naming conventions for linux targets)
+        if (${VCPKG_DETECTED_CMAKE_C_COMPILER} MATCHES ".*-gcc")
+            string(REGEX REPLACE "gcc$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_C_COMPILER})
+            list(APPEND OPTIONS --cross-prefix=${full_cross_prefix})
+        endif()        
+    endif()
+endif()
+
 vcpkg_configure_make(
     SOURCE_PATH ${SOURCE_PATH}
     NO_ADDITIONAL_PATHS

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -30,20 +30,19 @@ endif()
 
 if(VCPKG_TARGET_IS_LINUX)
 
-    list(APPEND OPTIONS --enable-pic)    
+    list(APPEND OPTIONS --enable-pic)
 
     if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
 
         vcpkg_cmake_get_vars(cmake_vars_file)
         include("${cmake_vars_file}")
 
-        if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING STREQUAL "TRUE")
+        if (VCPKG_DETECTED_CMAKE_CROSSCOMPILING)
             # Attempt to determine the fully qualified prefix from VCPKG_DETECTED_CMAKE_C_COMPILER (using most common naming conventions for linux targets)
             # and if valid, use it to initialize --cross-prefix build-option of x264 package.
-            if (${VCPKG_DETECTED_CMAKE_C_COMPILER} MATCHES ".*-gcc")
-                string(REGEX REPLACE "gcc$" "" full_cross_prefix ${VCPKG_DETECTED_CMAKE_C_COMPILER})
-                list(APPEND OPTIONS --cross-prefix=${full_cross_prefix})
-            endif()        
+            if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "^(.*-)gcc\$")
+                list(APPEND OPTIONS "--cross-prefix=${CMAKE_MATCH_1}")
+            endif()
         endif()
     endif()
 

--- a/ports/x264/portfile.cmake
+++ b/ports/x264/portfile.cmake
@@ -61,7 +61,6 @@ vcpkg_configure_make(
         --disable-gpac
         --disable-lsmash
         --enable-debug
-
 )
 
 vcpkg_install_make()

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "x264",
   "version-string": "164-5db6aa6cab1b146",
-  "port-version": 4,
+  "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
   "supports": "!(arm & windows)",
@@ -9,6 +9,10 @@
     {
       "name": "pthread",
       "platform": "linux & osx"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ]
 }

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "x264",
-  "version": "164-5db6aa6cab1b146",
+  "version-string": "164-5db6aa6cab1b146",
   "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "supports": "!(arm & windows)",
   "dependencies": [
     {

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",
+  "license": "GPL-2.0",
   "supports": "!(arm & windows)",
   "dependencies": [
     {

--- a/ports/x264/vcpkg.json
+++ b/ports/x264/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "x264",
-  "version-string": "164-5db6aa6cab1b146",
+  "version": "164-5db6aa6cab1b146",
   "port-version": 5,
   "description": "x264 is a free software library and application for encoding video streams into the H.264/MPEG-4 AVC compression format",
   "homepage": "https://github.com/mirror/x264",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7438,7 +7438,7 @@
     },
     "x264": {
       "baseline": "164-5db6aa6cab1b146",
-      "port-version": 4
+      "port-version": 5
     },
     "x265": {
       "baseline": "3.4",

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dcbf30e217f86e4cc6b3c1d77b1f3a476af1ffea",
+      "git-tree": "edbf31ea17e38466a85fdae97a0df8c08b31ad5c",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 5
     },

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "edbf31ea17e38466a85fdae97a0df8c08b31ad5c",
-      "version-string": "164-5db6aa6cab1b146",
+      "git-tree": "c41df96f5b563f5ca75a965b0efc19f1daf05671",
+      "version": "164-5db6aa6cab1b146",
       "port-version": 5
     },
     {

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "f3b63adb4f2b6fba7a846ae55628ffd4a290fa2f",
-      "version-string": "164-5db6aa6cab1b146",
+      "git-tree": "3a86ac05ec2fb30670fda2334bf869e0081c25fb",
+      "version": "164-5db6aa6cab1b146",
       "port-version": 5
     },
     {

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "3a86ac05ec2fb30670fda2334bf869e0081c25fb",
-      "version": "164-5db6aa6cab1b146",
+      "git-tree": "dcbf30e217f86e4cc6b3c1d77b1f3a476af1ffea",
+      "version-string": "164-5db6aa6cab1b146",
       "port-version": 5
     },
     {

--- a/versions/x-/x264.json
+++ b/versions/x-/x264.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3b63adb4f2b6fba7a846ae55628ffd4a290fa2f",
+      "version-string": "164-5db6aa6cab1b146",
+      "port-version": 5
+    },
+    {
       "git-tree": "7eea109502309e62a578bcc69811ad0659e00f9d",
       "version-string": "164-5db6aa6cab1b146",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #22899 
  (follow-up of #22900)
  Result of X-compilation successfully tested on Jetson nano device.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  !(arm & windows), No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
