### PR TITLE
[xerces-c] fix library name in pkg-config file under windows

### DIFF
--- a/ports/xerces-c/portfile.cmake
+++ b/ports/xerces-c/portfile.cmake
@@ -66,3 +66,13 @@ file(REMOVE_RECURSE
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_fixup_pkgconfig()
+if (VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    set(pc_file_release "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/xerces-c.pc")
+    set(pc_file_debug "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/xerces-c.pc")
+    if(EXISTS "${pc_file_release}")
+        vcpkg_replace_string("${pc_file_release}" "-lxerces-c" "-lxerces-c_3")
+    endif()
+    if(EXISTS "${pc_file_debug}")
+        vcpkg_replace_string("${pc_file_debug}" "-lxerces-c" "-lxerces-c_3D")
+    endif()
+endif()

--- a/ports/xerces-c/vcpkg.json
+++ b/ports/xerces-c/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "xerces-c",
-  "version-string": "3.2.3",
+  "version": "3.2.3",
   "port-version": 4,
   "description": "Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.",
   "homepage": "https://github.com/apache/xerces-c",
+  "license": "Apache-2.0",
   "features": {
     "icu": {
       "description": "ICU support",

--- a/ports/xerces-c/vcpkg.json
+++ b/ports/xerces-c/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "xerces-c",
   "version-string": "3.2.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Xerces-C++ is a XML parser, for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.",
   "homepage": "https://github.com/apache/xerces-c",
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7446,7 +7446,7 @@
     },
     "xerces-c": {
       "baseline": "3.2.3",
-      "port-version": 3
+      "port-version": 4
     },
     "xeus": {
       "baseline": "0.24.3",

--- a/versions/x-/xerces-c.json
+++ b/versions/x-/xerces-c.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04c0b7d0d92a6dea641400c36e14d02503f13764",
+      "version-string": "3.2.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "b920ebcb559e728e512c42e7e27ce5db58aba440",
       "version-string": "3.2.3",
       "port-version": 3

--- a/versions/x-/xerces-c.json
+++ b/versions/x-/xerces-c.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "04c0b7d0d92a6dea641400c36e14d02503f13764",
-      "version-string": "3.2.3",
+      "git-tree": "6e0b3743b100fd4c22291b3c55ff73aac8ae188c",
+      "version": "3.2.3",
       "port-version": 4
     },
     {


### PR DESCRIPTION
**Describe the pull request**

- xerces-c adds version number to library name when msvc is detected. This patch changes library name in pkg-config file correspondingly

- #### Which triplets are supported/not supported? Have you updated the [CI baseline] 
  same as before. No.

- #### Does your PR follow the [maintainer guide] 
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

