### PR TITLE
[ixwebsocket] Update to v11.3.3

### DIFF
--- a/ports/ixwebsocket/portfile.cmake
+++ b/ports/ixwebsocket/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO machinezone/IXWebSocket
-    REF 2149ac7ed60d7713a86446c4b93c6004f66415ac #v11.2.6
-    SHA512 737667f6e89156168db771fd2a6d3686cd51ddc753fa083ae399a84c689770a09fd86643bb2d838e9ae5a729067236f1d9b4ceece912145cfb83b29541a3d2c1
+    REF f7eb3688ddcb7d555df91e97ce8804421378e3b4 #v11.3.3
+    SHA512 78eddce7d3f817632b2f48b7f7c8e767fe1995d6a91d9156b0683fafd89c00e898b09fdcaa40559df333fc63c9160fe03b2770e5e9afcfcf489e89871e12fb1c
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -18,16 +18,15 @@ if("sectransp" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_OSX)
     message(FATAL_ERROR "sectransp is not supported on non-Apple platforms")
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
 	${FEATURE_OPTIONS}
 	-DUSE_TLS=1
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/ixwebsocket)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ixwebsocket)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/ixwebsocket/vcpkg.json
+++ b/ports/ixwebsocket/vcpkg.json
@@ -1,9 +1,18 @@
 {
   "name": "ixwebsocket",
-  "version-semver": "11.2.6",
+  "version-semver": "11.3.3",
   "description": "Lightweight WebSocket Client and Server + HTTP Client and Server",
   "homepage": "https://github.com/machinezone/IXWebSocket",
+  "license": "BSD-3-Clause",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "default-features": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2957,7 +2957,7 @@
       "port-version": 8
     },
     "ixwebsocket": {
-      "baseline": "11.2.6",
+      "baseline": "11.3.3",
       "port-version": 0
     },
     "jack2": {

--- a/versions/i-/ixwebsocket.json
+++ b/versions/i-/ixwebsocket.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "59a791c16bb7cf163c801d50013cafd8ae9b94a7",
+      "version-semver": "11.3.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "23fff75b15231882eb9461ff479a9f6edba3a450",
       "version-semver": "11.2.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**
Update `ixwebsocket` to latest version, which also provides compatibility with newest mbedtls.

- #### What does your PR fix?  
  Related to #22957

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
