### PR TITLE
[pixel] Update to master

### DIFF
--- a/ports/pixel/001-prevent-examples.patch
+++ b/ports/pixel/001-prevent-examples.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b910231..8a3a777 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,6 +34,8 @@ else()
+   target_link_libraries(pixel PUBLIC SDL2::SDL2)
+ endif()
+ 
++option(BUILD_EXAMPLES "Build examples" OFF)
++if(BUILD_EXAMPLES)
+ add_executable(image_swap examples/image_swap/src/image_swap.cpp)
+ target_link_libraries(image_swap PRIVATE pixel)
+ add_executable(randomdots examples/randomdots/src/randomdots.cpp)
+@@ -50,7 +52,7 @@ add_executable(simple examples/simple/src/simple.cpp)
+ target_link_libraries(simple PRIVATE pixel)
+ add_executable(starfield examples/starfield/src/starfield.cpp)
+ target_link_libraries(starfield PRIVATE pixel)
+-
++endif()
+ 
+ # Install Section
+ include(GNUInstallDirs)

--- a/ports/pixel/001-prevent-examples.patch
+++ b/ports/pixel/001-prevent-examples.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b910231..ee571f0 100755
+index b910231..71f7ddf 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -34,6 +34,8 @@ else()
@@ -11,16 +11,19 @@ index b910231..ee571f0 100755
  add_executable(image_swap examples/image_swap/src/image_swap.cpp)
  target_link_libraries(image_swap PRIVATE pixel)
  add_executable(randomdots examples/randomdots/src/randomdots.cpp)
-@@ -50,7 +52,7 @@ add_executable(simple examples/simple/src/simple.cpp)
+@@ -50,7 +52,11 @@ add_executable(simple examples/simple/src/simple.cpp)
  target_link_libraries(simple PRIVATE pixel)
  add_executable(starfield examples/starfield/src/starfield.cpp)
  target_link_libraries(starfield PRIVATE pixel)
--
++endif()
+ 
++if(MSVC)
++  add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 +endif()
  
  # Install Section
  include(GNUInstallDirs)
-@@ -87,12 +89,6 @@ install(
+@@ -87,12 +93,6 @@ install(
    DESTINATION  ${CMAKE_INSTALL_PREFIX}
    )
  

--- a/ports/pixel/001-prevent-examples.patch
+++ b/ports/pixel/001-prevent-examples.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b910231..8a3a777 100755
+index b910231..ee571f0 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -34,6 +34,8 @@ else()
@@ -20,3 +20,16 @@ index b910231..8a3a777 100755
  
  # Install Section
  include(GNUInstallDirs)
+@@ -87,12 +89,6 @@ install(
+   DESTINATION  ${CMAKE_INSTALL_PREFIX}
+   )
+ 
+-install(
+-  FILES
+-  ${PROJECT_SOURCE_DIR}/LICENSE
+-  DESTINATION  ${CMAKE_INSTALL_DATADIR}/pixel/copyright
+-  )
+-
+ install(
+   FILES
+   ${PROJECT_BINARY_DIR}/pixelConfig.cmake

--- a/ports/pixel/portfile.cmake
+++ b/ports/pixel/portfile.cmake
@@ -6,19 +6,22 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dascandy/pixel
-    REF v0.3
-    SHA512 d7d622679195d0eb30c8ed411333711369b108e2171d1e4b0a93c7ae3bd1fb36a25fbe1f5771c858615c07ee139412e5353b8cb5489cb409dd94829253c18a7b
+    REF c4411f67746fdd811aa5f8c102ac340e9eaf4ec5 # latest commit on master, v0.3
+    SHA512 e4f704c076bb61220349524b0b1033a92c44128bb81e79dbd32ea2d1aa9d4abb0d6daab3617f69b59d1c1e50d750767153174fea015d8718804612f4d9f68ff6
     HEAD_REF master
+    PATCHES
+        001-prevent-examples.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_EXAMPLES=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_copy_pdbs()

--- a/ports/pixel/portfile.cmake
+++ b/ports/pixel/portfile.cmake
@@ -6,7 +6,7 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO dascandy/pixel
-    REF c4411f67746fdd811aa5f8c102ac340e9eaf4ec5 # latest commit on master, v0.3
+    REF c4411f67746fdd811aa5f8c102ac340e9eaf4ec5
     SHA512 e4f704c076bb61220349524b0b1033a92c44128bb81e79dbd32ea2d1aa9d4abb0d6daab3617f69b59d1c1e50d750767153174fea015d8718804612f4d9f68ff6
     HEAD_REF master
     PATCHES

--- a/ports/pixel/portfile.cmake
+++ b/ports/pixel/portfile.cmake
@@ -25,3 +25,5 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_copy_pdbs()
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${port}" RENAME copyright)

--- a/ports/pixel/portfile.cmake
+++ b/ports/pixel/portfile.cmake
@@ -26,4 +26,4 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 vcpkg_copy_pdbs()
 
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${port}" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/pixel/vcpkg.json
+++ b/ports/pixel/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "pixel",
-  "version": "0.3",
-  "port-version": 5,
+  "version-date": "2019-04-09",
   "description": "Simple 2D Graphics based on standard and portable OpenGL.",
   "homepage": "https://github.com/dascandy/pixel",
   "license": "Apache-2.0",

--- a/ports/pixel/vcpkg.json
+++ b/ports/pixel/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 5,
   "description": "Simple 2D Graphics based on standard and portable OpenGL.",
   "homepage": "https://github.com/dascandy/pixel",
+  "license": "Apache-2.0",
   "dependencies": [
     "glew",
     "opengl",

--- a/ports/pixel/vcpkg.json
+++ b/ports/pixel/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "pixel",
   "version": "0.3",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Simple 2D Graphics based on standard and portable OpenGL.",
   "homepage": "https://github.com/dascandy/pixel",
-  "supports": "!windows",
   "dependencies": [
     "glew",
     "opengl",
@@ -19,6 +18,10 @@
     {
       "name": "sdl2",
       "platform": "!linux"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
     }
   ]
 }

--- a/ports/pixel/vcpkg.json
+++ b/ports/pixel/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel",
-  "version-date": "2019-04-09",
+  "version-date": "2022-03-15",
   "description": "Simple 2D Graphics based on standard and portable OpenGL.",
   "homepage": "https://github.com/dascandy/pixel",
   "license": "Apache-2.0",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -968,11 +968,6 @@ pfring:x64-osx=fail
 # errors, and warnings trigger with the Linux kernel headers in the Azure images.
 pfring:x64-linux=fail
 physx:arm64-windows=fail
-pixel:x64-uwp=fail
-pixel:x64-windows=fail
-pixel:x64-windows-static=fail
-pixel:x64-windows-static-md=fail
-pixel:x86-windows=fail
 pixman:arm-uwp=fail
 platform-folders:arm-uwp=fail
 platform-folders:x64-uwp=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5353,8 +5353,8 @@
       "port-version": 3
     },
     "pixel": {
-      "baseline": "0.3",
-      "port-version": 5
+      "baseline": "2019-04-09",
+      "port-version": 0
     },
     "pixman": {
       "baseline": "0.40.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5353,7 +5353,7 @@
       "port-version": 3
     },
     "pixel": {
-      "baseline": "2019-04-09",
+      "baseline": "2022-03-15",
       "port-version": 0
     },
     "pixman": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5354,7 +5354,7 @@
     },
     "pixel": {
       "baseline": "0.3",
-      "port-version": 4
+      "port-version": 5
     },
     "pixman": {
       "baseline": "0.40.0",

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b16683fc6473c3db90ad7e1aa1f4b27b40be78ba",
+      "git-tree": "dbf76415a78802e7dc2717280e2a44123a04df69",
       "version-date": "2022-03-15",
       "port-version": 0
     },

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "5ed562db7dc2bbc53d42301eb92b7f108a3a462d",
-      "version": "0.3",
-      "port-version": 5
-    },
-    {
       "git-tree": "346ea5fe92b2cfe055a1cd242868605e56d94318",
       "version": "0.3",
       "port-version": 4

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bb6cffde45968aece92d44092545d7c3075d533d",
+      "git-tree": "b16683fc6473c3db90ad7e1aa1f4b27b40be78ba",
       "version-date": "2022-03-15",
       "port-version": 0
     },

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bb6cffde45968aece92d44092545d7c3075d533d",
+      "version-date": "2019-04-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "346ea5fe92b2cfe055a1cd242868605e56d94318",
       "version": "0.3",
       "port-version": 4

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "bc4221a69422d9780f98a7b1ed4412ddd9c1b581",
+      "git-tree": "c3d56a45240e252967450b33fdb0eec379a5e2f6",
       "version": "0.3",
       "port-version": 5
     },

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c3d56a45240e252967450b33fdb0eec379a5e2f6",
+      "git-tree": "5ed562db7dc2bbc53d42301eb92b7f108a3a462d",
       "version": "0.3",
       "port-version": 5
     },

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bc4221a69422d9780f98a7b1ed4412ddd9c1b581",
+      "version": "0.3",
+      "port-version": 5
+    },
+    {
       "git-tree": "346ea5fe92b2cfe055a1cd242868605e56d94318",
       "version": "0.3",
       "port-version": 4

--- a/versions/p-/pixel.json
+++ b/versions/p-/pixel.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "git-tree": "bb6cffde45968aece92d44092545d7c3075d533d",
-      "version-date": "2019-04-09",
+      "version-date": "2022-03-15",
       "port-version": 0
     },
     {


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #10590
  Don't build examples
  Handle license in `portfile.cmake` because the port's `CMakeLists.txt` doesn't properly copy the license
  Remove from CI baseline

Note that I updated pixel to the latest commit on master because it contains bugfixes (see linked issue).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  Yes, removed pixel for all triplets from CI baseline; may need to add uwp again if CI fails.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
