### PR TITLE
[vcpkg baseline][python2] fix bz2(d) search on Linux

### DIFF
--- a/ports/python2/008-bz2d.patch
+++ b/ports/python2/008-bz2d.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index f764223..9d863af 100644
+index f764223..d6a58e4 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -1506,6 +1506,14 @@ class PyBuildExt(build_ext):
@@ -11,7 +11,7 @@ index f764223..9d863af 100644
 +                bz2_extra_link_args = ('-Wl,-search_paths_first',)
 +            else:
 +                bz2_extra_link_args = ()
-+            self.add(Extension('bz2', ['bz2module.c'],
++            exts.append( Extension('bz2', ['bz2module.c'],
 +                               libraries=['bz2d'],
 +                               extra_link_args = bz2_extra_link_args) )
          else:

--- a/ports/python2/008-bz2d.patch
+++ b/ports/python2/008-bz2d.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index f764223..e0d0b7b 100644
+index f764223..9d863af 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -1506,6 +1506,14 @@ class PyBuildExt(build_ext):
@@ -7,7 +7,7 @@ index f764223..e0d0b7b 100644
                                     libraries = ['bz2'],
                                     extra_link_args = bz2_extra_link_args) )
 +        elif (self.compiler.find_library_file(lib_dirs, 'bz2d')):
-+            if MACOS:
++            if host_platform == "darwin":
 +                bz2_extra_link_args = ('-Wl,-search_paths_first',)
 +            else:
 +                bz2_extra_link_args = ()

--- a/ports/python2/008-bz2d.patch
+++ b/ports/python2/008-bz2d.patch
@@ -1,0 +1,19 @@
+diff --git a/setup.py b/setup.py
+index f764223..664ea05 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1506,6 +1506,14 @@ class PyBuildExt(build_ext):
+             exts.append( Extension('bz2', ['bz2module.c'],
+                                    libraries = ['bz2'],
+                                    extra_link_args = bz2_extra_link_args) )
++        elif (self.compiler.find_library_file(self.lib_dirs, 'bz2d')):
++            if MACOS:
++                bz2_extra_link_args = ('-Wl,-search_paths_first',)
++            else:
++                bz2_extra_link_args = ()
++            self.add(Extension('_bz2', ['_bz2module.c'],
++                               libraries=['bz2d'],
++                               extra_link_args=bz2_extra_link_args))
+         else:
+             missing.append('bz2')
+ 

--- a/ports/python2/008-bz2d.patch
+++ b/ports/python2/008-bz2d.patch
@@ -1,19 +1,19 @@
 diff --git a/setup.py b/setup.py
-index f764223..664ea05 100644
+index f764223..e0d0b7b 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -1506,6 +1506,14 @@ class PyBuildExt(build_ext):
              exts.append( Extension('bz2', ['bz2module.c'],
                                     libraries = ['bz2'],
                                     extra_link_args = bz2_extra_link_args) )
-+        elif (self.compiler.find_library_file(self.lib_dirs, 'bz2d')):
++        elif (self.compiler.find_library_file(lib_dirs, 'bz2d')):
 +            if MACOS:
 +                bz2_extra_link_args = ('-Wl,-search_paths_first',)
 +            else:
 +                bz2_extra_link_args = ()
-+            self.add(Extension('_bz2', ['_bz2module.c'],
++            self.add(Extension('bz2', ['bz2module.c'],
 +                               libraries=['bz2d'],
-+                               extra_link_args=bz2_extra_link_args))
++                               extra_link_args = bz2_extra_link_args) )
          else:
              missing.append('bz2')
  

--- a/ports/python2/portfile.cmake
+++ b/ports/python2/portfile.cmake
@@ -35,6 +35,10 @@ if (VCPKG_TARGET_IS_WINDOWS)
     list(APPEND _PYTHON_PATCHES
         ${CMAKE_CURRENT_LIST_DIR}/007-fix-build-path.patch
     )
+else()
+    list(APPEND _PYTHON_PATCHES
+        ${CMAKE_CURRENT_LIST_DIR}/008-bz2d.patch
+    )
 endif()
 
 

--- a/ports/python2/vcpkg.json
+++ b/ports/python2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "python2",
   "version": "2.7.18",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The Python programming language as an embeddable library",
   "homepage": "https://www.python.org",
   "license": "Python-2.0"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5578,7 +5578,7 @@
     },
     "python2": {
       "baseline": "2.7.18",
-      "port-version": 3
+      "port-version": 4
     },
     "python3": {
       "baseline": "3.10.2",

--- a/versions/p-/python2.json
+++ b/versions/p-/python2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6120345d88041c7743b086f8838e7cc214dedb2c",
+      "git-tree": "abc5b8034cce081e3b0cd0788a3a7abc73fafc8f",
       "version": "2.7.18",
       "port-version": 4
     },

--- a/versions/p-/python2.json
+++ b/versions/p-/python2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a0fb8f87378a7e1c5830f8b07616bf0689990d8b",
+      "git-tree": "6120345d88041c7743b086f8838e7cc214dedb2c",
       "version": "2.7.18",
       "port-version": 4
     },

--- a/versions/p-/python2.json
+++ b/versions/p-/python2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "abc5b8034cce081e3b0cd0788a3a7abc73fafc8f",
+      "git-tree": "355e949adaecb1603d0cdc3d690101e49ad9fb13",
       "version": "2.7.18",
       "port-version": 4
     },

--- a/versions/p-/python2.json
+++ b/versions/p-/python2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a0fb8f87378a7e1c5830f8b07616bf0689990d8b",
+      "version": "2.7.18",
+      "port-version": 4
+    },
+    {
       "git-tree": "2a9fb7f96d762e213e9901452492aee00f6fe049",
       "version": "2.7.18",
       "port-version": 3


### PR DESCRIPTION
Python2 has the same issue on Linux:
```
Mismatching number of debug and release binaries. Found 62 for debug but 63 for release.
Debug binaries

    /mnt/vcpkg-ci/packages/python2_x64-linux/debug/lib/python2.7/lib-dynload/cmath.so
    /mnt/vcpkg-ci/packages/python2_x64-linux/debug/lib/python2.7/lib-dynload/time.so
...
    /mnt/vcpkg-ci/packages/python2_x64-linux/debug/lib/libpython2.7.a

Release binaries

    /mnt/vcpkg-ci/packages/python2_x64-linux/lib/python2.7/lib-dynload/cmath.so
...
    /mnt/vcpkg-ci/packages/python2_x64-linux/lib/python2.7/lib-dynload/bz2.so
    /mnt/vcpkg-ci/packages/python2_x64-linux/lib/python2.7/config/libpython2.7.a
    /mnt/vcpkg-ci/packages/python2_x64-linux/lib/libpython2.7.a


Found 1 post-build check problem(s). To submit these ports to curated catalogs, please first correct the portfile:
    /agent/_work/1/s/ports/python2/portfile.cmake
```

Based on #23525. Thanks @Neumann-A !