### PR TITLE
[ffmpeg] Add `libsrt` as option to `ffmpeg` port

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -307,6 +307,12 @@ else()
     set(OPTIONS "${OPTIONS} --disable-lzma")
 endif()
 
+if("libsrt" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-libsrt")
+else()
+    set(OPTIONS "${OPTIONS} --disable-libsrt")
+endif()
+
 if("mp3lame" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-libmp3lame")
 else()

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 13,
+  "port-version": 14,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -96,6 +96,14 @@
           "default-features": false,
           "features": [
             "fribidi"
+          ],
+          "platform": "!uwp"
+        },
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "libsrt"
           ],
           "platform": "!uwp"
         },
@@ -418,6 +426,13 @@
       "description": "iLBC de/encoding via libilbc",
       "dependencies": [
         "libilbc"
+      ]
+    },
+    "libsrt": {
+      "description": "libsrt (Haivision) support",
+      "supports": "!uwp",
+      "dependencies": [
+        "libsrt"
       ]
     },
     "lzma": {

--- a/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "vcpkg-ci-ffmpeg",
   "version-string": "1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Port to force features of certain ports within CI",
   "homepage": "https://github.com/microsoft/vcpkg",
   "dependencies": [
@@ -54,6 +54,14 @@
         "sdl2"
       ],
       "platform": "!osx"
+    },
+    {
+      "name": "ffmpeg",
+      "default-features": false,
+      "features": [
+        "libsrt"
+      ],
+      "platform": "!uwp"
     },
     {
       "name": "ffmpeg",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2206,7 +2206,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 13
+      "port-version": 14
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "786be09f58491acf42173d0f0c74aecd25b6f9a2",
+      "version": "4.4.1",
+      "port-version": 14
+    },
+    {
       "git-tree": "ad64f5ffe64b5fcd97e2e6d98273b70d498d6af0",
       "version": "4.4.1",
       "port-version": 13


### PR DESCRIPTION
**Describe the pull request**

This pull request adds the `libsrt` option to the build of `ffmpeg`. This is trivially implemented because `libsrt` is an existing port in vcpkg.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
UWP is not supported (see `libsrt` port support)

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
 Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
