### PR TITLE
[qpid-proton] Fix qpid proton #23580

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -16,8 +16,6 @@ vcpkg_cmake_configure(
         -DPYTHON_EXECUTABLE=${PYTHON3}
         -DLIB_SUFFIX=
         -DBUILD_GO=no
-        -DBUILD_RUBY=no
-        -DBUILD_PYTHON=no
         -DENABLE_JSONCPP=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_CyrusSASL=ON
 )
@@ -26,8 +24,24 @@ vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+set(configFiles
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/Proton/ProtonConfig.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/ProtonCpp/ProtonCppConfig.cmake"
+)
+foreach(configFile IN LISTS configFiles)
+    vcpkg_replace_string("${configFile}"
+        "IMPORTED_LOCATION_DEBUG \"\${_IMPORT_PREFIX}/lib"
+        "IMPORTED_LOCATION_DEBUG \"\${_IMPORT_PREFIX}/debug/lib"
+    )
+    vcpkg_replace_string("${configFile}"
+        "debug \${_IMPORT_PREFIX}/lib"
+        "debug \${_IMPORT_PREFIX}/debug/lib"
+    )
+endforeach()
 vcpkg_fixup_pkgconfig()
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/qpid-protonConfig.cmake
+    ${CURRENT_PACKAGES_DIR}/share/${PORT}/qpid-protonConfig.cmake COPYONLY)
 file(RENAME "${CURRENT_PACKAGES_DIR}/share/proton/LICENSE.txt"
             "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright")
 

--- a/ports/qpid-proton/qpid-protonConfig.cmake
+++ b/ports/qpid-proton/qpid-protonConfig.cmake
@@ -1,0 +1,4 @@
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+set(_IMPORT_PREFIX "${PACKAGE_PREFIX_DIR}")
+include(${CMAKE_CURRENT_LIST_DIR}/Proton/ProtonConfig.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ProtonCpp/ProtonCppConfig.cmake)

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.32.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5606,7 +5606,7 @@
     },
     "qpid-proton": {
       "baseline": "0.32.0",
-      "port-version": 2
+      "port-version": 3
     },
     "qscintilla": {
       "baseline": "2.12.0",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "109a9bb4fac5d5c5a52cd620d7ddb22da6fe47f7",
+      "version": "0.32.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "c6ab0bd896fa44681e2c3d4b325915ddacb38a1a",
       "version": "0.32.0",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes #23580

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  The same ones as before, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
 Yes

- #### How did you test?
 I made sure that a `find_package(qpid-proton CONFIG REQUIRED)` was working in my project (CMake configuration, generation and build succeeded). Tested both on Ubuntu 20.04 and Windows.