### PR TITLE
[librdkafka] disable debug option

### DIFF
--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -28,7 +28,7 @@ vcpkg_cmake_configure(
     OPTIONS_DEBUG
         -DENABLE_SHAREDPTR_DEBUG=ON
         -DENABLE_DEVEL=ON
-        -DENABLE_REFCNT_DEBUG=ON
+        -DENABLE_REFCNT_DEBUG=OFF
         -DENABLE_SHAREDPTR_DEBUG=ON
         -DWITHOUT_OPTIMIZATION=ON
     OPTIONS_RELEASE
@@ -50,21 +50,21 @@ vcpkg_cmake_config_fixup(
 
 if("lz4" IN_LIST FEATURES)
     vcpkg_replace_string(
-        ${CURRENT_PACKAGES_DIR}/share/rdkafka/RdKafkaConfig.cmake
+        "${CURRENT_PACKAGES_DIR}/share/rdkafka/RdKafkaConfig.cmake"
         "find_dependency(LZ4)"
         "include(\"\${CMAKE_CURRENT_LIST_DIR}/FindLZ4.cmake\")\n  find_dependency(LZ4)"
     )
 endif()
 
 file(REMOVE_RECURSE
-    ${CURRENT_PACKAGES_DIR}/debug/include
-    ${CURRENT_PACKAGES_DIR}/debug/share
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     foreach(hdr rdkafka.h rdkafkacpp.h)
         vcpkg_replace_string(
-            ${CURRENT_PACKAGES_DIR}/include/librdkafka/${hdr}
+            "${CURRENT_PACKAGES_DIR}/include/librdkafka/${hdr}"
             "#ifdef LIBRDKAFKA_STATICLIB"
             "#if 1 // #ifdef LIBRDKAFKA_STATICLIB"
         )
@@ -72,9 +72,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
 endif()
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSES.txt ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSES.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
 
 # Install usage
-configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "librdkafka",
   "version": "1.8.2",
+  "port-version": 1,
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/edenhill/librdkafka",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3886,7 +3886,7 @@
     },
     "librdkafka": {
       "baseline": "1.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "libressl": {
       "baseline": "3.4.2",

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2f7a6da2edf664e544914466d1cc8994d1ea475a",
+      "version": "1.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "dc5076b17ce1f54f6e61560036325ca9f24cda64",
       "version": "1.8.2",
       "port-version": 0


### PR DESCRIPTION
Fix #22622
option `ENABLE_REFCNT_DEBUG` is only used for development of librdkafka itself. refer to https://github.com/edenhill/librdkafka/issues/3654#issuecomment-1015447105