### PR TITLE
[eigen3] Disable Eigen3 configure checks

### DIFF
--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_gitlab(
     REF 3.4.0
     SHA512 ba75ecb760e32acf4ceaf27115468e65d4f77c44f8d519b5a13e7940af2c03a304ad433368cb6d55431f307c5c39e2666ab41d34442db3cf441638e51f5c3b6a
     HEAD_REF master
+    PATCHES remove_configure_checks.patch # This removes unnecessary configure checks. Eigen3 just installs headers not anything more.
 )
 
 vcpkg_cmake_configure(

--- a/ports/eigen3/remove_configure_checks.patch
+++ b/ports/eigen3/remove_configure_checks.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f3e69b845..12fb2188d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,12 +66,14 @@ option(EIGEN_TEST_CXX11 "Enable testing with C++11 and C++11 features (e.g. Tens
+ 
+ 
+ macro(ei_add_cxx_compiler_flag FLAG)
++  if(FALSE) # Since eigen3 is header only and vcpkg does not build tests this can be disabled by default. 
+   string(REGEX REPLACE "-" "" SFLAG1 ${FLAG})
+   string(REGEX REPLACE "\\+" "p" SFLAG ${SFLAG1})
+   check_cxx_compiler_flag(${FLAG} COMPILER_SUPPORT_${SFLAG})
+   if(COMPILER_SUPPORT_${SFLAG})
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+   endif()
++  endif()
+ endmacro()
+ 
+ check_cxx_compiler_flag("-std=c++11" EIGEN_COMPILER_SUPPORT_CPP11)
+@@ -142,7 +144,7 @@ endif()
+ 
+ set(EIGEN_TEST_MAX_SIZE "320" CACHE STRING "Maximal matrix/vector size, default is 320")
+ 
+-if(NOT MSVC)
++if(NOT MSVC AND FALSE)
+   # We assume that other compilers are partly compatible with GNUCC
+ 
+   # clang outputs some warnings for unknown flags that are not caught by check_cxx_compiler_flag
+@@ -330,7 +332,7 @@ if(NOT MSVC)
+     endif()
+   endif()
+ 
+-else()
++elseif(FALSE)
+ 
+   # C4127 - conditional expression is constant
+   # C4714 - marked as __forceinline not inlined (I failed to deactivate it selectively)

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "eigen3",
   "version": "3.4.0",
+  "port-version": 1,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
+  "license": "MPL-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2018,7 +2018,7 @@
     },
     "eigen3": {
       "baseline": "3.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "elfio": {
       "baseline": "3.10",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b40326590314e1f3a08c75e83a42d0738040b68",
+      "version": "3.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0475ed327bda734cad0acd35978cde9379bc8619",
       "version": "3.4.0",
       "port-version": 0


### PR DESCRIPTION
yesterday I was trying to install Eigen3 in WSL to /mnt/ and it was extremly slow.
Turns out Eigen3 does a lot of compiler flag checks at configure which are really not necessary if Eigen3 is not building any tests.
As such, disable the checks and be a lot faster. At the end eigen3 just installs headers and cmake files. No compilation at all which means no compiler checks necessary (except for `-lm` which it still does).  