### PR TITLE
[openssl] update to 1.1.1n

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -2,12 +2,12 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/include/openssl/ssl.h")
     message(FATAL_ERROR "Can't build openssl if libressl/boringssl is installed. Please remove libressl/boringssl, and try install openssl again if you need it.")
 endif()
 
-set(OPENSSL_VERSION 1.1.1m)
+set(OPENSSL_VERSION 1.1.1n)
 vcpkg_download_distfile(
     ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz" "https://www.openssl.org/source/old/1.1.1/openssl-${OPENSSL_VERSION}.tar.gz"
     FILENAME "openssl-${OPENSSL_VERSION}.tar.gz"
-    SHA512 ba0ef99b321546c13385966e4a607734df38b96f6ed45c4c67063a5f8d1482986855279797a6920d9f86c2ec31ce3e104dcc62c37328caacdd78aec59aa66156
+    SHA512 1937796736613dcf4105a54e42ecb61f95a1cea74677156f9459aea0f2c95159359e766089632bf364ee6b0d28d661eb9957bce8fecc9d2436378d8d79e8d0a4
 )
 
 vcpkg_find_acquire_program(PERL)

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "openssl",
-  "version-string": "1.1.1m",
-  "port-version": 2,
+  "version-string": "1.1.1n",
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "OpenSSL",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5113,8 +5113,8 @@
       "port-version": 1
     },
     "openssl": {
-      "baseline": "1.1.1m",
-      "port-version": 2
+      "baseline": "1.1.1n",
+      "port-version": 0
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7e4d802e3bde4154c227c0dd1da75c719be9f07a",
+      "version-string": "1.1.1n",
+      "port-version": 0
+    },
+    {
       "git-tree": "29c9d32a703896143a51c55f0b7ae4298684afd6",
       "version-string": "1.1.1m",
       "port-version": 2


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>

 Upgrade OpenSSL port to 1.1.1n

- #### What does your PR fix?  
  Fixes OpenSSL CVE-2022-0778
  https://www.openssl.org/news/secadv/20220315.txt

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  all, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
