### PR TITLE
Increase timeout on Windows builds.

### DIFF
--- a/scripts/azure-pipelines/windows/azure-pipelines.yml
+++ b/scripts/azure-pipelines/windows/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ parameters.poolName }}
   workspace:
     clean: resources
-  timeoutInMinutes: 1440 # 1 day
+  timeoutInMinutes: 2880 # 2 days
   variables:
   - name: WORKING_ROOT
     value: D:\


### PR DESCRIPTION
We changed CI runs to run once every 2 days instead of nightly because x64-windows was taking longer than 24 hours but we didn't remove the actual cap.