### PR TITLE
[functions-framework-cpp] update to the latest release (v1.1.0)

### DIFF
--- a/ports/functions-framework-cpp/portfile.cmake
+++ b/ports/functions-framework-cpp/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GoogleCloudPlatform/functions-framework-cpp
-    REF v1.0.0
-    SHA512 caaf39014cc651f0f929fce60059592ce17dfa67ac3d93104d97b96c7a1e06e85c0945dfdff6169ac5a5193be84631e27b35877a4d5b022a7319f6476efa17be
+    REF v1.1.0
+    SHA512 2dcedbded84fdd604724b4f2482ee531aaa640ebdbb69f77978e1af8943d9d7746152953953ebd89d8304ed3efbc334c620890142b0ba2e1239862e43a158364
     HEAD_REF main
 )
 

--- a/ports/functions-framework-cpp/vcpkg.json
+++ b/ports/functions-framework-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "functions-framework-cpp",
-  "version": "1.0.0",
-  "port-version": 1,
+  "version": "1.1.0",
   "description": "Functions Framework for C++.",
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2345,8 +2345,8 @@
       "port-version": 1
     },
     "functions-framework-cpp": {
-      "baseline": "1.0.0",
-      "port-version": 1
+      "baseline": "1.1.0",
+      "port-version": 0
     },
     "fuzzylite": {
       "baseline": "6.0",

--- a/versions/f-/functions-framework-cpp.json
+++ b/versions/f-/functions-framework-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a9e0ac94b09059d2a341c6f1614f8d9146732ed2",
+      "version": "1.1.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "45f93916767e8d79db63cc94b8274f98ee1bef1c",
       "version": "1.0.0",
       "port-version": 1


### PR DESCRIPTION
Updates `functions-framework-cpp` to the latest release (v1.1.0)

- #### What does your PR fix?  

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  

No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  

Yes
