### PR TITLE
[POCO] update to v1.11.1

### DIFF
--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF f81a38057f1d240fe7b7a069612776f788bc88ea # poco-1.11.0-release
-    SHA512 c5f39aca8b5464959b9337b0cbd8ee86d81f195f5a5ba864692c71b2bdbffdecef0537b6e6a2d9f41829bcd58f78825b10565d0c4ee7b3c856a4886a9e328118
+    REF de61f0049175a941cc83c2615c3bdc5e947b89f9 # poco-1.11.1-release
+    SHA512 0290eeeca8a85286efe8f583224062ea97668c2730f8f7db4e075ce75e997b0a0c969159d4034c27fbb2e8d4b9c6504888d8ffa001193f7eb0e450bca2d5d7a2
     HEAD_REF master
     PATCHES
         # Fix embedded copy of pcre in static linking mode

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "poco",
-  "version-semver": "1.11.0",
-  "port-version": 2,
+  "version": "1.11.1",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
+  "license": "BSL-1.0",
   "supports": "!uwp",
   "dependencies": [
     "expat",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5433,8 +5433,8 @@
       "port-version": 3
     },
     "poco": {
-      "baseline": "1.11.0",
-      "port-version": 2
+      "baseline": "1.11.1",
+      "port-version": 0
     },
     "podofo": {
       "baseline": "0.9.7",

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ae7e310067c34beca24a055b9b25e24fe1b42190",
+      "version": "1.11.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6dec8737e7e8e89f212ae2ab75c55c6e977d8ab8",
       "version-semver": "1.11.0",
       "port-version": 2


### PR DESCRIPTION
Fix #23616 

update POCO to latest version v1.11.1

All features have been tested successfullly in the following triplet:

x64-windows
x86-windows
x64-windows-static