### PR TITLE
[poppler] Update to 22.03.0

### DIFF
--- a/ports/poppler/export-unofficial-poppler.patch
+++ b/ports/poppler/export-unofficial-poppler.patch
@@ -2,22 +2,24 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 9a0dcb1..c1f2f02 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -585,7 +585,14 @@ if(MINGW AND BUILD_SHARED_LIBS)
+@@ -585,9 +585,16 @@ if(MINGW AND BUILD_SHARED_LIBS)
      set_target_properties(poppler PROPERTIES SUFFIX "-${POPPLER_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
  endif()
  target_link_libraries(poppler LINK_PRIVATE ${poppler_LIBS})
 -install(TARGETS poppler RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-+target_include_directories(poppler PUBLIC
-+    $<INSTALL_INTERFACE:include/poppler>
-+    $<INSTALL_INTERFACE:include/poppler/fofi>
-+    $<INSTALL_INTERFACE:include/poppler/goo>
-+)
++target_include_directories(poppler PUBLIC $<INSTALL_INTERFACE:include/poppler>)
 +set_target_properties(poppler PROPERTIES EXPORT_NAME poppler-private)
 +install(TARGETS poppler EXPORT unofficial-poppler-targets RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +install(EXPORT unofficial-poppler-targets NAMESPACE unofficial::poppler:: DESTINATION share/unofficial-poppler)
  
  if(ENABLE_UNSTABLE_API_ABI_HEADERS)
++  target_include_directories(poppler PUBLIC
++      $<INSTALL_INTERFACE:include/poppler/fofi>
++      $<INSTALL_INTERFACE:include/poppler/goo>
++  )
    install(FILES
+     poppler/Annot.h
+     poppler/AnnotStampImageHelper.h
 diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
 index c37936b..344933c 100644
 --- a/cpp/CMakeLists.txt

--- a/ports/poppler/export-unofficial-poppler.patch
+++ b/ports/poppler/export-unofficial-poppler.patch
@@ -2,10 +2,10 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 9a0dcb1..c1f2f02 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -600,7 +600,14 @@ target_link_libraries(poppler LINK_PRIVATE ${poppler_LIBS})
- if(CMAKE_USE_PTHREADS_INIT)
-    target_link_libraries(poppler LINK_PRIVATE Threads::Threads)
+@@ -585,7 +585,14 @@ if(MINGW AND BUILD_SHARED_LIBS)
+     set_target_properties(poppler PROPERTIES SUFFIX "-${POPPLER_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
  endif()
+ target_link_libraries(poppler LINK_PRIVATE ${poppler_LIBS})
 -install(TARGETS poppler RUNTIME DESTINATION bin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 +target_include_directories(poppler PUBLIC
 +    $<INSTALL_INTERFACE:include/poppler>

--- a/ports/poppler/portfile.cmake
+++ b/ports/poppler/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org
     OUT_SOURCE_PATH SOURCE_PATH
     REPO poppler/poppler
-    REF poppler-22.02.0
-    SHA512 693b813ef80656e7078f8830ec38e23520c6abd307befbb1721ba883233c92099704a7f02557807b28560f9c7ea1aa27192aea620b2ce4e9062a0b8790e93225
+    REF poppler-22.03.0
+    SHA512 0229e50bbf21154f398480730649fd15ca37c7edae5abd63ed41ab722852d09e4dc2b9df66b13b1cfe3e7a0da945916e1bd39c75c4879ded2759eb465f69424a
     HEAD_REF master
     PATCHES
         export-unofficial-poppler.patch

--- a/ports/poppler/usage
+++ b/ports/poppler/usage
@@ -3,4 +3,4 @@ The package poppler can be imported via CMake FindPkgConfig module:
     include(FindPkgConfig)
     pkg_check_modules(POPPLER_CPP REQUIRED IMPORTED_TARGET poppler-cpp)
     
-    target_link_libraries(main PRIVATE PkgConfig::poppler-cpp)
+    target_link_libraries(main PRIVATE PkgConfig::POPPLER_CPP)

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poppler",
-  "version": "22.2.0",
+  "version": "22.3.0",
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5465,7 +5465,7 @@
       "port-version": 4
     },
     "poppler": {
-      "baseline": "22.2.0",
+      "baseline": "22.3.0",
       "port-version": 0
     },
     "popsift": {

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3aea941a3b9f5fa2d7ec7a82dda764630d768dbc",
+      "version": "22.3.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "139058e4ec62f875c5538cbd1577c95938183364",
       "version": "22.2.0",
       "port-version": 0

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3aea941a3b9f5fa2d7ec7a82dda764630d768dbc",
+      "git-tree": "9928fbfbe44a32d0a4ff7efed4de2a7797958322",
       "version": "22.3.0",
       "port-version": 0
     },


### PR DESCRIPTION
- #### What does your PR fix?  
  Updates poppler to 22.03.0
  Fixes #23646.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  yes