### PR TITLE
2022 03 19 glib update

### DIFF
--- a/ports/glib/portfile.cmake
+++ b/ports/glib/portfile.cmake
@@ -5,11 +5,11 @@ if (VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 set(GLIB_MAJOR_MINOR 2.70)
-set(GLIB_PATCH 1)
+set(GLIB_PATCH 5)
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnome.org/pub/gnome/sources/glib/${GLIB_MAJOR_MINOR}/glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
     FILENAME "glib-${GLIB_MAJOR_MINOR}.${GLIB_PATCH}.tar.xz"
-    SHA512 639317c98ab72ad853608ab4d395484daff135c0222556c51ca93fd8533c5759db14478beda964e4feb02bb2737a46a4eda25063f98a9c6ba6ae4bc5d74bf5e1)
+    SHA512 3dfb45a9b6fe67fcf185f5cbb3985b6f1da17caf9c6f01e638d8fe4a6271ea1a30b0cf4ca8f43728bd29a8ac13b05a34e1cf262ade7795f0c0d0a2c0b90b1ff8)
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/glib/vcpkg.json
+++ b/ports/glib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glib",
-  "version": "2.70.1",
-  "port-version": 2,
+  "version": "2.70.5",
   "description": "Portable, general-purpose utility library.",
   "homepage": "https://developer.gnome.org/glib/",
   "supports": "!uwp & !(windows & static)",

--- a/ports/glibmm/build-support-vs2022-builds.patch
+++ b/ports/glibmm/build-support-vs2022-builds.patch
@@ -1,0 +1,41 @@
+commit b3a77c3f0b7dd2e1405a781ac9a76f648779d7fa
+Author: Chun-wei Fan <fanchunwei@src.gnome.org>
+Date:   Tue Nov 9 14:28:14 2021 +0800
+
+    Build: Support VS2022 builds
+    
+    Make these builds distinct from the Visual Studio 2019 builds.
+
+diff --git a/MSVC_NMake/detectenv-msvc.mak b/MSVC_NMake/detectenv-msvc.mak
+index 6933505d..16d57810 100644
+--- a/MSVC_NMake/detectenv-msvc.mak
++++ b/MSVC_NMake/detectenv-msvc.mak
+@@ -98,9 +98,12 @@ PDBVER = 14
+ !if $(VCVERSION) > 1909 && $(VCVERSION) < 1920
+ VSVER_SUFFIX = 1
+ VSVER = 15
+-!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 2000
++!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 1930
+ VSVER_SUFFIX = 2
+ VSVER = 16
++!elseif $(VCVERSION) > 1929 && $(VCVERSION) < 2000
++VSVER_SUFFIX = 3
++VSVER = 17
+ !else
+ VSVER = $(PDBVER)
+ !endif
+diff --git a/meson.build b/meson.build
+index b7c7f77e..a2ee5ef3 100644
+--- a/meson.build
++++ b/meson.build
+@@ -231,7 +231,9 @@ if is_msvc
+   add_project_arguments(disabled_warnings, language: 'cpp')
+ 
+   if use_msvc14x_toolset_ver
+-    if cpp_compiler.version().version_compare('>=19.20')
++    if cpp_compiler.version().version_compare('>=19.30')
++      msvc14x_toolset_ver = '-vc143'
++    elif cpp_compiler.version().version_compare('>=19.20')
+       msvc14x_toolset_ver = '-vc142'
+     elif cpp_compiler.version().version_compare('>=19.10')
+       msvc14x_toolset_ver = '-vc141'

--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -9,6 +9,8 @@ vcpkg_download_distfile(ARCHIVE
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
     ARCHIVE ${ARCHIVE}
+    PATCHES
+        build-support-vs2022-builds.patch
 )
 
 vcpkg_configure_meson(

--- a/ports/glibmm/portfile.cmake
+++ b/ports/glibmm/portfile.cmake
@@ -1,9 +1,9 @@
 # Glib uses winapi functions not available in WindowsStore
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.68/glibmm-2.68.1.tar.xz"
-    FILENAME "glibmm-2.68.1.tar.xz"
-    SHA512 ca164f986da651e66bb5b98a760853e73d57ff84e035809d4c3b2c0a1b6ddf8ca68ffc49a71d0e0b2e14eca1c00e2e727e3bf3821e0b2b3a808397c3d33c6d5c
+    URLS "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.70/glibmm-2.70.0.tar.xz"
+    FILENAME "glibmm-2.70.0.tar.xz"
+    SHA512 059cab7f0b865303cef3cba6c4f3a29ae4e359aba428f5e79cea6fedd3f1e082199f673323cf804902cee14b91739598fbc6ff706ec36f19c4d793d032782518
 )
 
 vcpkg_extract_source_archive_ex(
@@ -20,7 +20,7 @@ vcpkg_configure_meson(
 vcpkg_install_meson()
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/glibmm-2.68/proc" "${CURRENT_PACKAGES_DIR}/lib/glibmm-2.68/proc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/glibmm-2.70/proc" "${CURRENT_PACKAGES_DIR}/lib/glibmm-2.70/proc")
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/glibmm/vcpkg.json
+++ b/ports/glibmm/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "glibmm",
-  "version": "2.68.1",
-  "port-version": 2,
+  "version": "2.70.0",
   "description": "This is glibmm, a C++ API for parts of glib that are useful for C++.",
   "homepage": "https://www.gtkmm.org.",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2513,8 +2513,8 @@
       "port-version": 0
     },
     "glibmm": {
-      "baseline": "2.68.1",
-      "port-version": 2
+      "baseline": "2.70.0",
+      "port-version": 0
     },
     "glm": {
       "baseline": "0.9.9.8",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2509,8 +2509,8 @@
       "port-version": 0
     },
     "glib": {
-      "baseline": "2.70.1",
-      "port-version": 2
+      "baseline": "2.70.5",
+      "port-version": 0
     },
     "glibmm": {
       "baseline": "2.68.1",

--- a/versions/g-/glib.json
+++ b/versions/g-/glib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c9d76755634e72f74de67a04e2713ba0278e772a",
+      "version": "2.70.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "83e2d36acbf39c01a33df90c4e65fee0221008aa",
       "version": "2.70.1",
       "port-version": 2

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2415a1f5e1f84bee308cb2ff1c5776b6a645ab6f",
+      "version": "2.70.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "dd76481f04a2d3747dcd2c5eef0333ce5c6d61e5",
       "version": "2.68.1",
       "port-version": 2

--- a/versions/g-/glibmm.json
+++ b/versions/g-/glibmm.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2415a1f5e1f84bee308cb2ff1c5776b6a645ab6f",
+      "git-tree": "d485de58180f1755b67cb2b829c7c73e4dfae13a",
       "version": "2.70.0",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**
Update glib and it's C++ wrapper (glibmm).

- #### What does your PR fix?  
  Fixes #23647 , #23649 and #23650 .

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
(https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
  any linux and non-static windows, CI baseline was not updated

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
