### PR TITLE
[Bullet3] Remove platform restrictions

### DIFF
--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -6,7 +6,9 @@ vcpkg_from_github(
     REF 3.17
     SHA512 a5105bf5f1dd365a64a350755c7d2c97942f74897a18dcdb3651e6732fd55cc1030a096f5808cf50575281f05e3ac09aa50a48d271a47b94cd61f5167a72b7cc
     HEAD_REF master
-    PATCHES cmake-fix.patch
+    PATCHES
+        cmake-fix.patch
+        windows-arm64-sse-fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/bullet3/portfile.cmake
+++ b/ports/bullet3/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         cmake-fix.patch
         windows-arm64-sse-fix.patch
+        uwp-deltav-fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/bullet3/uwp-deltav-fix.patch
+++ b/ports/bullet3/uwp-deltav-fix.patch
@@ -1,0 +1,26 @@
+From 35264f81bb63c4d4e5cf195e3b9db7ea6b761396 Mon Sep 17 00:00:00 2001
+From: Sandy Carter <bwrsandman@gmail.com>
+Date: Sun, 20 Mar 2022 15:46:58 -0400
+Subject: [PATCH] UWP: Fix potentially uninitialized local pointer variable
+ error
+
+---
+ src/BulletSoftBody/btSoftBody.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/BulletSoftBody/btSoftBody.cpp b/src/BulletSoftBody/btSoftBody.cpp
+index 933f3edc5..e91c1b9a4 100644
+--- a/src/BulletSoftBody/btSoftBody.cpp
++++ b/src/BulletSoftBody/btSoftBody.cpp
+@@ -3897,7 +3897,7 @@ void btSoftBody::PSolve_RContacts(btSoftBody* psb, btScalar kst, btScalar ti)
+ 			btVector3 va(0, 0, 0);
+ 			btRigidBody* rigidCol = 0;
+ 			btMultiBodyLinkCollider* multibodyLinkCol = 0;
+-			btScalar* deltaV;
++			btScalar* deltaV = NULL;
+ 
+ 			if (cti.m_colObj->getInternalType() == btCollisionObject::CO_RIGID_BODY)
+ 			{
+-- 
+2.35.1
+

--- a/ports/bullet3/vcpkg.json
+++ b/ports/bullet3/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "bullet3",
   "version": "3.17",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Bullet Physics is a professional collision detection, rigid body, and soft body dynamics library",
   "homepage": "https://github.com/bulletphysics/bullet3",
-  "supports": "osx | !(arm | uwp)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/bullet3/windows-arm64-sse-fix.patch
+++ b/ports/bullet3/windows-arm64-sse-fix.patch
@@ -1,0 +1,27 @@
+From e4414c80232d66f8a250aa83f934594bcba3c605 Mon Sep 17 00:00:00 2001
+From: Sandy <bwrsandman@gmail.com>
+Date: Sun, 20 Mar 2022 15:41:07 -0400
+Subject: [PATCH] Fix compile on windows 64 bit arm architecture
+
+When building 64 bit arm with visual studio, btScalar will try to include SSE headers meant for x86 and x64 architectures.
+This gives the following error in many source files:
+```
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.31.31103\include\emmintrin.h(20): fatal error C1189: #error:  This header is specific to X86 and X64 targets
+```
+---
+ src/LinearMath/btScalar.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/LinearMath/btScalar.h b/src/LinearMath/btScalar.h
+index 28c03b2868..e47baadd6b 100644
+--- a/src/LinearMath/btScalar.h
++++ b/src/LinearMath/btScalar.h
+@@ -107,7 +107,7 @@ inline int btIsDoublePrecision()
+  			#define btFsel(a,b,c) __fsel((a),(b),(c))
+ 		#else
+ 
+-#if defined (_M_ARM)
++#if defined (_M_ARM) || defined (_M_ARM64)
+             //Do not turn SSE on for ARM (may want to turn on BT_USE_NEON however)
+ #elif (defined (_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined (BT_USE_DOUBLE_PRECISION))
+ 

--- a/versions/b-/bullet3.json
+++ b/versions/b-/bullet3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f526f9d9698251590883fcc52ac8bf0f7ef9c5a4",
+      "version": "3.17",
+      "port-version": 5
+    },
+    {
       "git-tree": "d986cc96144fa3de5201d56a508f348db9b66e71",
       "version": "3.17",
       "port-version": 4

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1174,7 +1174,7 @@
     },
     "bullet3": {
       "baseline": "3.17",
-      "port-version": 4
+      "port-version": 5
     },
     "bustache": {
       "baseline": "1.1.0",


### PR DESCRIPTION
**Describe the pull request**

Bullet claims to support all platforms. ARM works on android and UWP seems to be taken into consideration.
Vcpkg's restrictions are historical and seem to date back to when the CI was unable to properly test all platforms.

Added restrictions for Windows ARM and UWP: https://github.com/microsoft/vcpkg/pull/9663
Was unable to test arm on linux (and android, I assume) and added more restrictions: https://github.com/microsoft/vcpkg/pull/21108
Removed the restriction for osx (M1 architecture, I assume) but didn't check others: #22729

**Test status**:
- [x] UWP:
    * error C4703: potentially uninitialized local pointer variable 'deltaV
    * Fixed with https://github.com/bulletphysics/bullet3/pull/4213
    * I am unable to properly test
- [x] arm64-windows: 
    * emmintrin.h(20): fatal error C1189: #error:  This header is specific to X86 and X64 targets
    * Fixed with https://github.com/bulletphysics/bullet3/pull/4212
- [x] Android: Built and used in a project (x64, x86, arm7, arm8)
- [x] arm-linux: Built on a raspberry pi 4
- [x] arm64-linux: Built on a raspberry pi 4
- [x] x86-windows: Built on a windows 10 x64 machine
- [x] arm-windows: Built on a windows 10 x64 machine

- #### What does your PR fix?  
  Fixes building Bullet for android platform - all currently supported architectures.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?  
All platforms are supposed to be supported

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
Yes

