### PR TITLE
[sdl2] Fix wasm32-emscripten declaration-after-statement error

### DIFF
--- a/ports/sdl2/0007-timer-Fix-Emscripten-declaration-after-statement-err.patch
+++ b/ports/sdl2/0007-timer-Fix-Emscripten-declaration-after-statement-err.patch
@@ -1,0 +1,45 @@
+From 99af3281ee11ff947a82c561c2a275627ccea90c Mon Sep 17 00:00:00 2001
+From: Charlie Birks <charlie@daft.games>
+Date: Sat, 22 Jan 2022 12:27:43 +0000
+Subject: [PATCH] timer: Fix Emscripten declaration-after-statement error
+
+---
+ src/timer/unix/SDL_systimer.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/src/timer/unix/SDL_systimer.c b/src/timer/unix/SDL_systimer.c
+index 57fdab09c..2cf26764c 100644
+--- a/src/timer/unix/SDL_systimer.c
++++ b/src/timer/unix/SDL_systimer.c
+@@ -187,13 +187,6 @@ SDL_GetPerformanceFrequency(void)
+ void
+ SDL_Delay(Uint32 ms)
+ {
+-#ifdef __EMSCRIPTEN__
+-    if (emscripten_has_asyncify() && SDL_GetHintBoolean(SDL_HINT_EMSCRIPTEN_ASYNCIFY, SDL_TRUE)) {
+-        /* pseudo-synchronous pause, used directly or through e.g. SDL_WaitEvent */
+-        emscripten_sleep(ms);
+-        return;
+-    }
+-#endif
+     int was_error;
+ 
+ #if HAVE_NANOSLEEP
+@@ -203,6 +196,14 @@ SDL_Delay(Uint32 ms)
+     Uint64 then, now, elapsed;
+ #endif
+ 
++#ifdef __EMSCRIPTEN__
++    if (emscripten_has_asyncify() && SDL_GetHintBoolean(SDL_HINT_EMSCRIPTEN_ASYNCIFY, SDL_TRUE)) {
++        /* pseudo-synchronous pause, used directly or through e.g. SDL_WaitEvent */
++        emscripten_sleep(ms);
++        return;
++    }
++#endif
++
+     /* Set the timeout interval */
+ #if HAVE_NANOSLEEP
+     elapsed.tv_sec = ms / 1000;
+-- 
+2.35.1
+

--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         0004-Define-crt-macros.patch
         0005-Fix-uwp-joystick.patch
         0006-Update-SDL_sysurl.cpp.patch
+        0007-timer-Fix-Emscripten-declaration-after-statement-err.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.0.20",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6326,7 +6326,7 @@
     },
     "sdl2": {
       "baseline": "2.0.20",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9900463f2847ed86e25bac1688c527ae3486a024",
+      "version": "2.0.20",
+      "port-version": 1
+    },
+    {
       "git-tree": "d5865b5fb9c52f255629f4c015f37df9ca788a33",
       "version": "2.0.20",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes building sdl2 with emscripten with patch from SDL2 dev branch

```
vcpkg/buildtrees/sdl2/src/ase-2.0.20-4d7f28b96f/src/timer/unix/SDL_systimer.c:197:9: error: mixing declarations and code is incompatible with standards before C99 [-Werror,-Wdeclaration-after-statement]
    int was_error;
        ^
1 error generated.
```

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes