### PR TITLE
[libnoise] Export CMake files

### DIFF
--- a/ports/libnoise/fix-build.patch
+++ b/ports/libnoise/fix-build.patch
@@ -7,7 +7,7 @@ index 07747de..68db2a2 100644
  	set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
  	target_link_libraries(${TARGET_NAME} noise)
 -	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-+	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noiseutils.h> $<INSTALL_INTERFACE:include>)
++	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
  	
  	# install dynamic libraries (.dll or .so) into /bin
 -	install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
@@ -25,7 +25,7 @@ index 07747de..68db2a2 100644
  set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
  target_link_libraries(${TARGET_NAME} noise-static) 
 -target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src) 
-+target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noiseutils.h> $<INSTALL_INTERFACE:include>) 
++target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>) 
  # install static libraries (.lib) into /lib
 -install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
 +install(TARGETS ${TARGET_NAME} EXPORT unofficial-noiseutilsTargets DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")

--- a/ports/libnoise/fix-build.patch
+++ b/ports/libnoise/fix-build.patch
@@ -1,14 +1,18 @@
 diff --git a/noiseutils/CMakeLists.txt b/noiseutils/CMakeLists.txt
-index 07747de..08c0bda 100644
+index 07747de..68db2a2 100644
 --- a/noiseutils/CMakeLists.txt
 +++ b/noiseutils/CMakeLists.txt
-@@ -22,8 +22,11 @@ if(BUILD_SHARED_LIBS)
- 	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+@@ -19,11 +19,14 @@ if(BUILD_SHARED_LIBS)
+ 	
+ 	set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+ 	target_link_libraries(${TARGET_NAME} noise)
+-	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
++	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noiseutils.h> $<INSTALL_INTERFACE:include>)
  	
  	# install dynamic libraries (.dll or .so) into /bin
 -	install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 -endif()
-+	install(TARGETS ${TARGET_NAME}
++	install(TARGETS ${TARGET_NAME} EXPORT unofficial-noiseutilsTargets
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
 +        LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
 +        ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
@@ -16,27 +20,49 @@ index 07747de..08c0bda 100644
  
  #----------------------------------------
  # build static lib (it's good practice to include a lib file for the dll)
-@@ -35,7 +38,7 @@ target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+@@ -31,11 +34,22 @@ set(TARGET_NAME "${LIB_NAME}-static")
+ add_library(${TARGET_NAME} STATIC ${libSrcs})
+ set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+ target_link_libraries(${TARGET_NAME} noise-static) 
+-target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src) 
++target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noiseutils.h> $<INSTALL_INTERFACE:include>) 
  # install static libraries (.lib) into /lib
- install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+-install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
++install(TARGETS ${TARGET_NAME} EXPORT unofficial-noiseutilsTargets DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
  #----------------------------------------
 -
 +endif()
  # install include files into /include
  install( FILES "${PROJECT_SOURCE_DIR}/noiseutils/noiseutils.h" 
- 		DESTINATION "${CMAKE_INSTALL_PREFIX}/include/noise" )
+-		DESTINATION "${CMAKE_INSTALL_PREFIX}/include/noise" )
+\ No newline at end of file
++		DESTINATION "${CMAKE_INSTALL_PREFIX}/include/noise" )
++
++install(EXPORT unofficial-noiseutilsTargets
++	NAMESPACE unofficial::noiseutils::
++	DESTINATION share/unofficial-noiseutils
++)
++
++file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-noiseutils-config.cmake.in"
++[[include("${CMAKE_CURRENT_LIST_DIR}/unofficial-noiseutilsTargets.cmake")]])
++configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-noiseutils-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-noiseutils-config.cmake" @ONLY)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-noiseutils-config.cmake DESTINATION share/unofficial-noiseutils)
++		
 \ No newline at end of file
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 2757f30..7a135c2 100644
+index 2757f30..47dcc51 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -62,8 +62,11 @@ if(BUILD_SHARED_LIBS)
+@@ -60,10 +60,13 @@ if(BUILD_SHARED_LIBS)
+ 		add_library(${TARGET_NAME} SHARED ${libSrcs})
+     endif()
  	set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
- 	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+-	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
++	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noise> $<INSTALL_INTERFACE:include>)
  	target_compile_definitions(${TARGET_NAME} PRIVATE NOISE_BUILD_DLL)
 -	install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 -endif()
-+	install(TARGETS ${TARGET_NAME}
++	install(TARGETS ${TARGET_NAME} EXPORT unofficial-noiseTargets
 +        RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
 +        LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib"
 +        ARCHIVE DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
@@ -44,13 +70,31 @@ index 2757f30..7a135c2 100644
  
  #----------------------------------------
  # build static lib (it's good practice to include a lib file for the dll)
-@@ -76,7 +79,7 @@ target_compile_definitions(${TARGET_NAME} PUBLIC NOISE_STATIC)
+@@ -71,12 +74,22 @@ set(TARGET_NAME "${LIB_NAME}-static")
+ message(STATUS "build ${TARGET_NAME}")
+ add_library(${TARGET_NAME} STATIC ${libSrcs})
+ set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+-target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
++target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/noise> $<INSTALL_INTERFACE:include>)
+ target_compile_definitions(${TARGET_NAME} PUBLIC NOISE_STATIC)
  # install static libraries (.lib) into /lib
- install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+-install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
++install(TARGETS ${TARGET_NAME} EXPORT unofficial-noiseTargets DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
  #----------------------------------------
 -
 +endif()
  # install include files into /include
  install( DIRECTORY   "${PROJECT_SOURCE_DIR}/src/noise" 
- 		 DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
+-		 DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
 \ No newline at end of file
++		 DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
++
++install(EXPORT unofficial-noiseTargets
++	NAMESPACE unofficial::noise::
++	DESTINATION share/unofficial-noise
++)
++
++file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-noise-config.cmake.in"
++[[include("${CMAKE_CURRENT_LIST_DIR}/unofficial-noiseTargets.cmake")]])
++configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-noise-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-noise-config.cmake" @ONLY)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-noise-config.cmake DESTINATION share/unofficial-noise)

--- a/ports/libnoise/portfile.cmake
+++ b/ports/libnoise/portfile.cmake
@@ -10,9 +10,8 @@ vcpkg_from_github(
     PATCHES fix-build.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_WALL=ON
         -DBUILD_SPEED_OPTIMIZED=ON
@@ -21,15 +20,15 @@ vcpkg_configure_cmake(
         -DBUILD_LIBNOISE_EXAMPLES=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-noise CONFIG_PATH share/unofficial-noise)
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-noiseutils CONFIG_PATH share/unofficial-noiseutils)
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL static)
     vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/noise/module/modulebase.h
         "if NOISE_STATIC" "if 1" )
 endif()
 
-file(INSTALL ${SOURCE_PATH}/cmake/Modules/FindLibNoise.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-
-file(INSTALL ${SOURCE_PATH}/LICENSE.md DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libnoise/vcpkg.json
+++ b/ports/libnoise/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libnoise",
-  "version-string": "1.0.0",
+  "version": "1.0.0",
   "port-version": 3,
   "description": "A general-purpose library that generates three-dimensional coherent noise. Useful for terrain generation and procedural texture generation. Uses a broad number of techniques (Perlin noise, ridged multifractal, etc.) and combinations of those techniques.",
   "homepage": "https://github.com/RobertHue/libnoise",

--- a/ports/libnoise/vcpkg.json
+++ b/ports/libnoise/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "libnoise",
   "version-string": "1.0.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A general-purpose library that generates three-dimensional coherent noise. Useful for terrain generation and procedural texture generation. Uses a broad number of techniques (Perlin noise, ridged multifractal, etc.) and combinations of those techniques.",
-  "homepage": "https://github.com/RobertHue/libnoise"
+  "homepage": "https://github.com/RobertHue/libnoise",
+  "license": "LGPL-2.1",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3778,7 +3778,7 @@
     },
     "libnoise": {
       "baseline": "1.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libnop": {
       "baseline": "2021-03-01",

--- a/versions/l-/libnoise.json
+++ b/versions/l-/libnoise.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "5d62a21f79fac347de37df8e77cb97db92af4eed",
-      "version-string": "1.0.0",
+      "git-tree": "b838f3c57323188925ccbd5d94a95e98ed57e01c",
+      "version": "1.0.0",
       "port-version": 3
     },
     {

--- a/versions/l-/libnoise.json
+++ b/versions/l-/libnoise.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5d62a21f79fac347de37df8e77cb97db92af4eed",
+      "version-string": "1.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "d9a3fa0e4772f2c11fe3d177dea6ec8a23b06b07",
       "version-string": "1.0.0",
       "port-version": 2

--- a/versions/l-/libnoise.json
+++ b/versions/l-/libnoise.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b838f3c57323188925ccbd5d94a95e98ed57e01c",
+      "git-tree": "24b694017cb633bae1e071413648afdf3623fc38",
       "version": "1.0.0",
       "port-version": 3
     },


### PR DESCRIPTION
Fixes #21235
Export unofficial CMake files of `libnoise` and `libnoiseutils`.
