### PR TITLE
[minizip-ng] Updated minizip version and fixed windows build for previous version

### DIFF
--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
-    REF 3.0.2
-    SHA512 eee4d35d273ab0a32972b119c8faabd8c242e2d9f506fab0dd21fdd24c78b932c01bf7f15e9cf7c452776fc4c2e27a5ff09e376adb7a706336d11114929182fc
+    REF 3.0.5
+    SHA512 da0c230951caafd986331300b840d09a4c27a677183174f8b1782c2515209b51cf00133dd5fc5f9fc88a349134db7f93d3daa7c05b7d0270be99b9cf85a6c133
     HEAD_REF master
     PATCHES 
         Modify-header-file-path.patch

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -21,6 +21,10 @@ vcpkg_check_features(
         zstd MZ_ZSTD
 )
 
+if(WIN32)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
@@ -29,7 +33,6 @@ vcpkg_cmake_configure(
         -DMZ_FETCH_LIBS=OFF
         -DMZ_PROJECT_SUFFIX:STRING=-ng
 )
-
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/minizip-ng/portfile.cmake
+++ b/ports/minizip-ng/portfile.cmake
@@ -1,3 +1,7 @@
+if (VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO zlib-ng/minizip-ng
@@ -21,10 +25,6 @@ vcpkg_check_features(
         zstd MZ_ZSTD
 )
 
-if(WIN32)
-    vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
@@ -33,6 +33,7 @@ vcpkg_cmake_configure(
         -DMZ_FETCH_LIBS=OFF
         -DMZ_PROJECT_SUFFIX:STRING=-ng
 )
+
 vcpkg_cmake_install()
 
 vcpkg_fixup_pkgconfig()

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "minizip-ng",
   "version": "3.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "supports": "!uwp",

--- a/ports/minizip-ng/vcpkg.json
+++ b/ports/minizip-ng/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "minizip-ng",
-  "version": "3.0.2",
-  "port-version": 2,
+  "version": "3.0.5",
   "description": "minizip-ng is a zip manipulation library written in C that is supported on Windows, macOS, and Linux.",
   "homepage": "https://github.com/zlib-ng/minizip-ng",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4481,8 +4481,8 @@
       "port-version": 10
     },
     "minizip-ng": {
-      "baseline": "3.0.2",
-      "port-version": 1
+      "baseline": "3.0.5",
+      "port-version": 0
     },
     "mio": {
       "baseline": "2019-02-10",

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4b630863d08d630b64c928505a3fc9f9c7fe6dec",
+      "git-tree": "36ef459c57047fcfc0ddbfc97d7360d7307acb24",
       "version": "3.0.5",
       "port-version": 0
     },

--- a/versions/m-/minizip-ng.json
+++ b/versions/m-/minizip-ng.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4b630863d08d630b64c928505a3fc9f9c7fe6dec",
+      "version": "3.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "4a8de7f8609b758c48eea13b67d47c22efc832a3",
       "version": "3.0.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
   Updated minizip version 
   Fixed windows build for the previous version( was only exporting symbols for compat header, [Suggested fix by author](https://github.com/zlib-ng/minizip-ng/issues/475))

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
   all except uwp, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?  
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?  
  Yes
