### PR TITLE
[fbthrift] Fix incorrect path in FBThriftConfig.cmake

### DIFF
--- a/ports/fbthrift/portfile.cmake
+++ b/ports/fbthrift/portfile.cmake
@@ -49,5 +49,14 @@ file(REMOVE_RECURSE
 vcpkg_copy_tools(TOOL_NAMES thrift1 AUTO_CLEAN)
 vcpkg_copy_pdbs()
 
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/fbthrift/FBThriftConfig.cmake")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fbthrift/FBThriftConfig.cmake" 
+        "${PACKAGE_PREFIX_DIR}/lib/cmake/fbthrift" "${PACKAGE_PREFIX_DIR}/share/fbthrift")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fbthrift/FBThriftConfig.cmake" 
+        "${PACKAGE_PREFIX_DIR}/bin/thrift1.exe" "${PACKAGE_PREFIX_DIR}/tools/fbthrift/thrift1.exe")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/fbthrift/FBThriftConfig.cmake" 
+        "${PACKAGE_PREFIX_DIR}/bin/thrift1" "${PACKAGE_PREFIX_DIR}/tools/fbthrift/thrift1")
+endif()
+
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/fbthrift/vcpkg.json
+++ b/ports/fbthrift/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "fbthrift",
   "version-string": "2022.01.31.00",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Facebook's branch of Apache Thrift, including a new C++ server.",
   "homepage": "https://github.com/facebook/fbthrift",
+  "license": "Apache-2.0",
   "supports": "x64 & static",
   "dependencies": [
     "boost-context",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2158,7 +2158,7 @@
     },
     "fbthrift": {
       "baseline": "2022.01.31.00",
-      "port-version": 1
+      "port-version": 2
     },
     "fcl": {
       "baseline": "0.7.0",

--- a/versions/f-/fbthrift.json
+++ b/versions/f-/fbthrift.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "228608a7708d80532948eec3a0987f2e85e4a43c",
+      "version-string": "2022.01.31.00",
+      "port-version": 2
+    },
+    {
       "git-tree": "bf1148604c897c7727621feb13713eac7e782497",
       "version-string": "2022.01.31.00",
       "port-version": 1


### PR DESCRIPTION
Fixes #23631
Fix incorrect path in FBThriftConfig.cmake:
```
set_and_check(FBTHRIFT_CMAKE_DIR "${PACKAGE_PREFIX_DIR}/lib/cmake/fbthrift")
set_and_check(FBTHRIFT_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
if (WIN32)
  set_and_check(FBTHRIFT_COMPILER "${PACKAGE_PREFIX_DIR}/bin/thrift1.exe")
else()
  set_and_check(FBTHRIFT_COMPILER "${PACKAGE_PREFIX_DIR}/bin/thrift1")
endif()
```