### PR TITLE
[libgpg-error] Support VS2022

### DIFF
--- a/ports/libgpg-error/portfile.cmake
+++ b/ports/libgpg-error/portfile.cmake
@@ -11,6 +11,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
         PATCHES 
             outdir.patch
             runtime.patch
+            support-VS2022.patch
     )
 
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")

--- a/ports/libgpg-error/support-VS2022.patch
+++ b/ports/libgpg-error/support-VS2022.patch
@@ -1,0 +1,32 @@
+diff --git a/SMP/smp.props b/SMP/smp.props
+index 49bad30..33754d5 100644
+--- a/SMP/smp.props
++++ b/SMP/smp.props
+@@ -35,6 +35,7 @@
+     </ProjectConfiguration>
+   </ItemGroup>
+   <PropertyGroup Label="Globals">
++    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+diff --git a/SMP/smp_winrt.props b/SMP/smp_winrt.props
+index da2e19c..bb3ba4a 100644
+--- a/SMP/smp_winrt.props
++++ b/SMP/smp_winrt.props
+@@ -37,6 +37,7 @@
+   <PropertyGroup Label="Globals">
+     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' != ''">$(WindowsTargetPlatformVersion)</WindowsTargetPlatformVersion>
+     <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)'&gt;= '16.0'">10.0</WindowsTargetPlatformVersion>
++    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+@@ -47,6 +48,7 @@
+     <AppContainerApplication>true</AppContainerApplication>
+     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+     <ApplicationType>Windows Store</ApplicationType>
++    <ApplicationTypeRevision Condition="'$(VisualStudioVersion)' == '17.0'">10.0</ApplicationTypeRevision>
+     <ApplicationTypeRevision Condition="'$(VisualStudioVersion)' == '16.0'">10.0</ApplicationTypeRevision>
+     <ApplicationTypeRevision Condition="'$(VisualStudioVersion)' == '15.0'">10.0</ApplicationTypeRevision>
+     <ApplicationTypeRevision Condition="'$(VisualStudioVersion)' == '14.0'">8.1</ApplicationTypeRevision>

--- a/ports/libgpg-error/vcpkg.json
+++ b/ports/libgpg-error/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "libgpg-error",
   "version": "1.42",
-  "port-version": 3,
+  "port-version": 4,
   "description": "A common dependency of all GnuPG components",
   "homepage": "https://gnupg.org/software/libgpg-error/index.html",
+  "license": "GPL-2.0-or-later",
   "supports": "!(windows & (arm | arm64))"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3566,7 +3566,7 @@
     },
     "libgpg-error": {
       "baseline": "1.42",
-      "port-version": 3
+      "port-version": 4
     },
     "libgpiod": {
       "baseline": "1.6.3",

--- a/versions/l-/libgpg-error.json
+++ b/versions/l-/libgpg-error.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1a02aec1b536490ea94add199f1d10629f58495e",
+      "version": "1.42",
+      "port-version": 4
+    },
+    {
       "git-tree": "1ced42ca6160e2283326366e1c1132fe50acfb97",
       "version": "1.42",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?  
  Fixes https://github.com/microsoft/vcpkg/issues/23657

  This issue has been fixed by https://github.com/ShiftMediaProject/libgpg-error/commit/77efb34b6746d74c526e8665895fbba9f63f0d6f, and this commit has been release in libgpg-error-1.44.
  
  **Why don't update the port to the 1.44?**
  This port uses gpg/libgpg-error resources under non-windows. The current release version of this repository is 1.42. Because it is not possible to upgrade only the version under one platform, a patch is added to fix the problem.

  No feature need to test.