### PR TITLE
[libdatrie]Fix usage of FindPkgConfig module

### DIFF
--- a/ports/libdatrie/usage
+++ b/ports/libdatrie/usage
@@ -7,7 +7,7 @@ The package libdatrie can be used via CMake:
 
 The package libdatrie can be imported via CMake FindPkgConfig module:
 
-    include(FindPkgConfig)
+    find_package(PkgConfig)
     pkg_check_modules(LIBDATRIE REQUIRED IMPORTED_TARGET datrie-0.2)
     
     target_link_libraries(main PRIVATE PkgConfig::LIBDATRIE)

--- a/ports/libdatrie/vcpkg.json
+++ b/ports/libdatrie/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libdatrie",
   "version": "0.2.13",
+  "port-version": 1,
   "description": "Implementation of double-array structure for representing trie",
   "homepage": "https://linux.thai.net/pub/ThaiLinux/software/libthai",
   "license": "LGPL-2.1-or-later",

--- a/ports/libfido2/fix_cmakelists.patch
+++ b/ports/libfido2/fix_cmakelists.patch
@@ -18,7 +18,7 @@ index 11a51ac..33b9313 100644
 -	set(CBOR_LIBRARIES cbor)
 -	set(ZLIB_LIBRARIES zlib)
 -	set(CRYPTO_LIBRARIES crypto-47)
-+	include(FindPkgConfig)
++	find_package(PkgConfig)
 +
 +	find_package(LIBCBOR REQUIRED)
 +	find_package(OpenSSL REQUIRED)

--- a/ports/libfido2/vcpkg.json
+++ b/ports/libfido2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libfido2",
   "version": "1.10.0",
+  "port-version": 1,
   "description": "Provides library functionality to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.",
   "homepage": "https://developers.yubico.com/libfido2/",
   "license": "BSD-2-Clause",

--- a/ports/liburing/usage
+++ b/ports/liburing/usage
@@ -1,6 +1,6 @@
 The package liburing can be imported via CMake FindPkgConfig module:
 
-    include(FindPkgConfig)
+    find_package(PkgConfig)
     pkg_check_modules(liburing REQUIRED IMPORTED_TARGET GLOBAL liburing>=2.0)
     
     target_link_libraries(main PRIVATE PkgConfig::liburing)

--- a/ports/liburing/vcpkg.json
+++ b/ports/liburing/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liburing",
   "version": "2.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Linux-native io_uring I/O access library",
   "homepage": "https://github.com/axboe/liburing",
   "supports": "linux"

--- a/ports/poppler/usage
+++ b/ports/poppler/usage
@@ -1,6 +1,6 @@
 The package poppler can be imported via CMake FindPkgConfig module:
 
-    include(FindPkgConfig)
+    find_package(PkgConfig)
     pkg_check_modules(POPPLER_CPP REQUIRED IMPORTED_TARGET poppler-cpp)
     
     target_link_libraries(main PRIVATE PkgConfig::POPPLER_CPP)

--- a/ports/poppler/vcpkg.json
+++ b/ports/poppler/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "poppler",
   "version": "22.3.0",
+  "port-version": 1,
   "description": "A PDF rendering library",
   "homepage": "https://poppler.freedesktop.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3454,7 +3454,7 @@
     },
     "libdatrie": {
       "baseline": "0.2.13",
-      "port-version": 0
+      "port-version": 1
     },
     "libdc1394": {
       "baseline": "2.2.6",
@@ -3518,7 +3518,7 @@
     },
     "libfido2": {
       "baseline": "1.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "libflac": {
       "baseline": "1.3.3",
@@ -4090,7 +4090,7 @@
     },
     "liburing": {
       "baseline": "2.0",
-      "port-version": 2
+      "port-version": 3
     },
     "libusb": {
       "baseline": "1.0.24",
@@ -5474,7 +5474,7 @@
     },
     "poppler": {
       "baseline": "22.3.0",
-      "port-version": 0
+      "port-version": 1
     },
     "popsift": {
       "baseline": "0.9",

--- a/versions/l-/libdatrie.json
+++ b/versions/l-/libdatrie.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "60d1568dadc94ddb1b894b33a8da7b20802a96e8",
+      "version": "0.2.13",
+      "port-version": 1
+    },
+    {
       "git-tree": "f8e0374439550fd870ff280c0a3321c202b42929",
       "version": "0.2.13",
       "port-version": 0

--- a/versions/l-/libfido2.json
+++ b/versions/l-/libfido2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ad26e81c6c119e160709c7e0ce7872d888ed5a57",
+      "version": "1.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0d3dc297cbc4c116910b6cb793bc3b5a06834e00",
       "version": "1.10.0",
       "port-version": 0

--- a/versions/l-/liburing.json
+++ b/versions/l-/liburing.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "10bf5144950610a1f587342c5107bf4fdfb52658",
+      "version": "2.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "65bbf5b3f642b9e76a659d78a9077d207c827b76",
       "version": "2.0",
       "port-version": 2

--- a/versions/p-/poppler.json
+++ b/versions/p-/poppler.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2d14bc508abd0861bda1a16290ad65b061a82b7c",
+      "version": "22.3.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "9928fbfbe44a32d0a4ff7efed4de2a7797958322",
       "version": "22.3.0",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Make use of `FindPkgConfig.cmake` via `find_package`, not `include`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
