### PR TITLE
[xmlsec] Bump to 1.2.33

### DIFF
--- a/ports/xmlsec/portfile.cmake
+++ b/ports/xmlsec/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lsh123/xmlsec
-    REF xmlsec-1_2_32
-    SHA512 45e2efc6bdf6ec09db6ff01b521c3fbcf44aa9804d5692bea5296e80d7fc2f05fac322868f82840a7b67e0abd4233222098aa94a29ec9a6a7d049180cf131c57
+    REF e628e70040cb0d81a561462472806aeaac1d1bc7 #xmlsec-1_2_33
+    SHA512 2d4485941d354160f7fabd84394c61eef9dcea8be572d78bf7da7370880747f86ff76127fa000f8b0de06f462abef17d653270dee680fa35d96cc8200fb4d1a6
     HEAD_REF master
     PATCHES 
         pkgconfig_fixes.patch
@@ -10,18 +10,15 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-	OPTIONS -DPORT_DIR=${CMAKE_CURRENT_LIST_DIR}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS_DEBUG -DINSTALL_HEADERS_TOOLS=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL ${SOURCE_PATH}/Copyright DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/Copyright" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_copy_pdbs()

--- a/ports/xmlsec/vcpkg.json
+++ b/ports/xmlsec/vcpkg.json
@@ -1,10 +1,18 @@
 {
   "name": "xmlsec",
-  "version": "1.2.32",
+  "version": "1.2.33",
   "description": "XML Security Library is a C library based on LibXML2. The library supports major XML security standards.",
   "homepage": "https://www.aleksey.com/xmlsec/",
   "dependencies": [
     "libxml2",
-    "openssl"
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7517,7 +7517,7 @@
       "port-version": 0
     },
     "xmlsec": {
-      "baseline": "1.2.32",
+      "baseline": "1.2.33",
       "port-version": 0
     },
     "xnnpack": {

--- a/versions/x-/xmlsec.json
+++ b/versions/x-/xmlsec.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "635a9b0883829c524cc712d552d9a265ef984bf7",
+      "version": "1.2.33",
+      "port-version": 0
+    },
+    {
       "git-tree": "f15cb0d0c8dd69a916421866901a7bce6d81666c",
       "version": "1.2.32",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updating version.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  no change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
