### PR TITLE
[winsparkle] Fix header file and debug path

### DIFF
--- a/ports/winsparkle/portfile.cmake
+++ b/ports/winsparkle/portfile.cmake
@@ -9,8 +9,10 @@ vcpkg_extract_source_archive_ex(
     ARCHIVE ${ARCHIVE}
 )
 
-file(INSTALL "${SOURCE_PATH}/include" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
-file(INSTALL "${SOURCE_PATH}/bin" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}" FILES_MATCHING PATTERN "*.bat")
+file(GLOB HEADER_LIST "${SOURCE_PATH}/include/*.h")
+file(INSTALL ${HEADER_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(GLOB TOOLS_LIST "${SOURCE_PATH}/bin/*.bat")
+file(INSTALL ${TOOLS_LIST} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
 
 # Note: It is an explicit design goal for WinSparkle to be a single 
@@ -26,18 +28,18 @@ if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
     file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
     # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
-    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/lib")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SOURCE_PATH}/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
     file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
     # We have no debug, but since Winsparkle is a self-contained dll, we can copy it to the Debug folder as well  
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/bin")
-    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/Debug/lib")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.pdb" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(INSTALL "${SOURCE_PATH}/x64/Release/WinSparkle.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
 else()
     message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
 endif()

--- a/ports/winsparkle/vcpkg.json
+++ b/ports/winsparkle/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "winsparkle",
   "version": "0.7.0",
+  "port-version": 1,
   "description": "WinSparkle is an easy-to-use software update library for Windows developers.",
   "homepage": "https://winsparkle.org",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7430,7 +7430,7 @@
     },
     "winsparkle": {
       "baseline": "0.7.0",
-      "port-version": 0
+      "port-version": 1
     },
     "wintoast": {
       "baseline": "1.2.0",

--- a/versions/w-/winsparkle.json
+++ b/versions/w-/winsparkle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8f1aed9d3a5aac4c967bc6e8be9b8bbe0ce09a76",
+      "version": "0.7.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "0d756f506e6a79a2a79706f9080c05b45e7df882",
       "version": "0.7.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #23737
  Change header files path from `include/include` to `include/winsparkle`, and change `Debug` path name to `debug`.