### PR TITLE
[arb] Support dynamic build

### DIFF
--- a/ports/arb/portfile.cmake
+++ b/ports/arb/portfile.cmake
@@ -1,5 +1,3 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO fredrik-johansson/arb

--- a/ports/arb/vcpkg.json
+++ b/ports/arb/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "arb",
   "version": "2.21.1",
+  "port-version": 1,
   "description": "a C library for arbitrary-precision interval arithmetic",
   "homepage": "https://github.com/fredrik-johansson/arb",
+  "license": "LGPL-2.1",
   "dependencies": [
     "flint",
     {

--- a/versions/a-/arb.json
+++ b/versions/a-/arb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e1b560a5a2aa835d54da9fdabac5eea48255e93d",
+      "version": "2.21.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "06326497117fb757651649225284d2fe4100ef79",
       "version": "2.21.1",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -122,7 +122,7 @@
     },
     "arb": {
       "baseline": "2.21.1",
-      "port-version": 0
+      "port-version": 1
     },
     "arcus": {
       "baseline": "4.10.0",


### PR DESCRIPTION
Adds dynamic build support for arb since gmp fixes symbols issue, since arb's exported symbol declaration depends on flint's exported symbol declaration:
```cpp
#if defined(_MSC_VER) && defined(ARB_BUILD_DLL)
#define ARB_DLL __declspec(dllexport)
#else
#define ARB_DLL FLINT_DLL
#endif
```

Fixes #23699.