### PR TITLE
[nlohmann-json] Fix usage text

### DIFF
--- a/ports/nlohmann-json/usage
+++ b/ports/nlohmann-json/usage
@@ -5,7 +5,7 @@ The package nlohmann-json provides CMake targets:
 
 The package nlohmann-json can be configured to not provide implicit conversions via a custom triplet file:
 
-    set(nlohmann_json_JSON_ImplicitConversions OFF)
+    set(nlohmann-json_IMPLICIT_CONVERSIONS OFF)
 
 For more information, see the docs here:
     

--- a/ports/nlohmann-json/vcpkg.json
+++ b/ports/nlohmann-json/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nlohmann-json",
   "version-semver": "3.10.5",
-  "port-version": 1,
+  "port-version": 2,
   "description": "JSON for Modern C++",
   "homepage": "https://github.com/nlohmann/json",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4814,7 +4814,7 @@
     },
     "nlohmann-json": {
       "baseline": "3.10.5",
-      "port-version": 1
+      "port-version": 2
     },
     "nlopt": {
       "baseline": "2.7.0",

--- a/versions/n-/nlohmann-json.json
+++ b/versions/n-/nlohmann-json.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "becf6a86f7e28342840fc807840c68b133c6fad8",
+      "version-semver": "3.10.5",
+      "port-version": 2
+    },
+    {
       "git-tree": "fa0a087d0444a7f2c79a44bce91c51550d5f2e47",
       "version-semver": "3.10.5",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

This PR updates the nlohmann-json usage text.

- #### What does your PR fix?

This PR fixes an error in the usage text that I added to the nlohmann-json port, as identified by @cenit [here](https://github.com/microsoft/vcpkg/pull/22409#issuecomment-1077782180).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
