### PR TITLE
[libvorbis] Fix mingw-dynamic, modernize port

### DIFF
--- a/ports/libvorbis/0003-def-mingw-compat.patch
+++ b/ports/libvorbis/0003-def-mingw-compat.patch
@@ -1,0 +1,33 @@
+diff --git a/win32/vorbis.def b/win32/vorbis.def
+index 1310b6c..de14385 100644
+--- a/win32/vorbis.def
++++ b/win32/vorbis.def
+@@ -1,6 +1,5 @@
+ ; vorbis.def
+ ; 
+-LIBRARY
+ EXPORTS
+ _floor_P
+ _mapping_P
+diff --git a/win32/vorbisenc.def b/win32/vorbisenc.def
+index 79af064..40a3e39 100644
+--- a/win32/vorbisenc.def
++++ b/win32/vorbisenc.def
+@@ -1,6 +1,5 @@
+ ; vorbisenc.def
+ ;
+-LIBRARY
+ 
+ EXPORTS
+ vorbis_encode_init
+diff --git a/win32/vorbisfile.def b/win32/vorbisfile.def
+index 4dc5549..243795d 100644
+--- a/win32/vorbisfile.def
++++ b/win32/vorbisfile.def
+@@ -1,6 +1,5 @@
+ ; vorbisfile.def
+ ;
+-LIBRARY
+ EXPORTS
+ ov_clear
+ ov_open

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         0001-Dont-export-vorbisenc-functions.patch
         0002-Fixup-pkgconfig-libs.patch
+        0003-def-mingw-compat.patch
 )
 
 vcpkg_configure_cmake(

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -12,7 +12,6 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
 )
 
 vcpkg_cmake_install()

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -10,22 +10,17 @@ vcpkg_from_github(
         0003-def-mingw-compat.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     PREFER_NINJA
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(
-    CONFIG_PATH lib/cmake/Vorbis
-    TARGET_PATH share/Vorbis
-)
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-# Handle copyright
-configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
-
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME Vorbis CONFIG_PATH "lib/cmake/Vorbis")
+vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-vcpkg_fixup_pkgconfig()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libvorbis/portfile.cmake
+++ b/ports/libvorbis/portfile.cmake
@@ -22,5 +22,5 @@ vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# Handle copyright
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libvorbis/usage
+++ b/ports/libvorbis/usage
@@ -1,0 +1,13 @@
+The package libvorbis provides CMake targets:
+
+    # Vorbis reference encoder and decoder, low-level API
+    find_package(Vorbis CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Vorbis::vorbis)
+
+    # Audio stream decoding and basic manipulation, high-level API
+    find_package(Vorbis CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Vorbis::vorbisfile)
+
+    # Convenience API for setting up an encoding environment
+    find_package(Vorbis CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Vorbis::vorbisenc)

--- a/ports/libvorbis/vcpkg.json
+++ b/ports/libvorbis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libvorbis",
   "version-string": "1.3.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
   "homepage": "https://github.com/xiph/vorbis",
   "license": "BSD-3-Clause",

--- a/ports/libvorbis/vcpkg.json
+++ b/ports/libvorbis/vcpkg.json
@@ -1,11 +1,19 @@
 {
   "name": "libvorbis",
-  "version-string": "1.3.7",
+  "version": "1.3.7",
   "port-version": 2,
   "description": "Ogg Vorbis is a fully open, non-proprietary, patent-and-royalty-free, general-purpose compressed audio format",
   "homepage": "https://github.com/xiph/vorbis",
   "license": "BSD-3-Clause",
   "dependencies": [
-    "libogg"
+    "libogg",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4126,7 +4126,7 @@
     },
     "libvorbis": {
       "baseline": "1.3.7",
-      "port-version": 1
+      "port-version": 2
     },
     "libvpx": {
       "baseline": "1.10.0",

--- a/versions/l-/libvorbis.json
+++ b/versions/l-/libvorbis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "75830541f31d64e059859f1348337eeae5571ae7",
+      "git-tree": "c4c646a26ce3e6ad63992d3e4a55cb185159b23c",
       "version": "1.3.7",
       "port-version": 2
     },

--- a/versions/l-/libvorbis.json
+++ b/versions/l-/libvorbis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75830541f31d64e059859f1348337eeae5571ae7",
+      "version": "1.3.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "54dcb5ab354422e9518a905d501ccc22dcb69098",
       "version-string": "1.3.7",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes #22990.
  Modernizes the portfile.
  Adds usage file.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes