### PR TITLE
[cpp-redis] Fix ‘sleep_for’ is not a member of ‘std::this_thread’

### DIFF
--- a/ports/cpp-redis/fix-sleep_for.patch
+++ b/ports/cpp-redis/fix-sleep_for.patch
@@ -1,0 +1,12 @@
+diff --git a/sources/core/client.cpp b/sources/core/client.cpp
+index 7ea20e2..c5d2c40 100644
+--- a/sources/core/client.cpp
++++ b/sources/core/client.cpp
+@@ -23,6 +23,7 @@
+ #include <cpp_redis/core/client.hpp>
+ #include <cpp_redis/misc/error.hpp>
+ #include <cpp_redis/misc/macro.hpp>
++#include <thread>
+ 
+ namespace cpp_redis {
+ 

--- a/ports/cpp-redis/portfile.cmake
+++ b/ports/cpp-redis/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF 4.3.1
     SHA512 abf372542c53f37f504b3211b840b100d07a8f4b2e7f5584cc7550ab16ed617838e2df79064374c7a409458d8567f4834686318ea3a40249c767e36c744c7a47
     HEAD_REF master
+    PATCHES 
+        "fix-sleep_for.patch"
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/tacopie/CMakeLists.txt DESTINATION ${SOURCE_PATH}/tacopie)

--- a/ports/cpp-redis/portfile.cmake
+++ b/ports/cpp-redis/portfile.cmake
@@ -24,14 +24,13 @@ if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR NOT VCPKG_CMAKE_SYSTEM_NAM
     set(VCPKG_C_FLAGS_DEBUG "${VCPKG_C_FLAGS_DEBUG} -RTC1")
 endif()
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS
         -DMSVC_RUNTIME_LIBRARY_CONFIG=${MSVC_RUNTIME_LIBRARY_CONFIG}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpp-redis",
   "version": "4.3.1",
-  "port-version": 5,
+  "port-version": 6,
   "description": "cpp-redis is a C++11 Asynchronous Multi-Platform Lightweight Redis Client, with support for synchronous operations and pipelining.",
   "homepage": "https://github.com/cpp-redis/cpp_redis",
   "license": "MIT",

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpp-redis",
   "version-string": "4.3.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "cpp-redis is a C++11 Asynchronous Multi-Platform Lightweight Redis Client, with support for synchronous operations and pipelining.",
   "homepage": "https://github.com/cpp-redis/cpp_redis",
   "dependencies": [

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/cpp-redis/cpp_redis",
   "license": "MIT",
   "dependencies": [
+    "tacopie",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -13,7 +14,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    "tacopie"
+    }
   ]
 }

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpp-redis",
-  "version-string": "4.3.1",
+  "version": "4.3.1",
   "port-version": 5,
   "description": "cpp-redis is a C++11 Asynchronous Multi-Platform Lightweight Redis Client, with support for synchronous operations and pipelining.",
   "homepage": "https://github.com/cpp-redis/cpp_redis",

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpp-redis",
   "version": "4.3.1",
-  "port-version": 6,
+  "port-version": 5,
   "description": "cpp-redis is a C++11 Asynchronous Multi-Platform Lightweight Redis Client, with support for synchronous operations and pipelining.",
   "homepage": "https://github.com/cpp-redis/cpp_redis",
   "license": "MIT",

--- a/ports/cpp-redis/vcpkg.json
+++ b/ports/cpp-redis/vcpkg.json
@@ -4,7 +4,16 @@
   "port-version": 5,
   "description": "cpp-redis is a C++11 Asynchronous Multi-Platform Lightweight Redis Client, with support for synchronous operations and pipelining.",
   "homepage": "https://github.com/cpp-redis/cpp_redis",
+  "license": "MIT",
   "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "tacopie"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1562,7 +1562,7 @@
     },
     "cpp-redis": {
       "baseline": "4.3.1",
-      "port-version": 4
+      "port-version": 5
     },
     "cpp-taskflow": {
       "baseline": "2.6.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1562,7 +1562,7 @@
     },
     "cpp-redis": {
       "baseline": "4.3.1",
-      "port-version": 6
+      "port-version": 5
     },
     "cpp-taskflow": {
       "baseline": "2.6.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1562,7 +1562,7 @@
     },
     "cpp-redis": {
       "baseline": "4.3.1",
-      "port-version": 5
+      "port-version": 6
     },
     "cpp-taskflow": {
       "baseline": "2.6.0",

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9714d8cf0b5557d4362f54f0906295b10a154832",
+      "git-tree": "f3507ff3a30f8d0c4a4438a014c1f1e8761964d8",
       "version": "4.3.1",
       "port-version": 6
     },

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c8a0fd88cbd2adf8e6d501c28b0eaa3e9d3d4aa6",
+      "version-string": "4.3.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "5ba5958862c17ab2f3943b0134b2ad756ae73613",
       "version-string": "4.3.1",
       "port-version": 4

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f3507ff3a30f8d0c4a4438a014c1f1e8761964d8",
+      "version": "4.3.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "5ba5958862c17ab2f3943b0134b2ad756ae73613",
       "version-string": "4.3.1",
       "port-version": 4

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c8a0fd88cbd2adf8e6d501c28b0eaa3e9d3d4aa6",
-      "version-string": "4.3.1",
+      "git-tree": "52a89d46c40ec4646f6f7cf98f24a0281847144b",
+      "version": "4.3.1",
       "port-version": 5
     },
     {

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "ec1922dba0c1f0ee807a5b6448c196dd16ee0f02",
-      "version": "4.3.1",
-      "port-version": 5
-    },
-    {
       "git-tree": "5ba5958862c17ab2f3943b0134b2ad756ae73613",
       "version-string": "4.3.1",
       "port-version": 4

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "f3507ff3a30f8d0c4a4438a014c1f1e8761964d8",
-      "version": "4.3.1",
-      "port-version": 6
-    },
-    {
       "git-tree": "ec1922dba0c1f0ee807a5b6448c196dd16ee0f02",
       "version": "4.3.1",
       "port-version": 5

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "52a89d46c40ec4646f6f7cf98f24a0281847144b",
+      "git-tree": "ec1922dba0c1f0ee807a5b6448c196dd16ee0f02",
       "version": "4.3.1",
       "port-version": 5
     },

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9714d8cf0b5557d4362f54f0906295b10a154832",
+      "version": "4.3.1",
+      "port-version": 6
+    },
+    {
       "git-tree": "ec1922dba0c1f0ee807a5b6448c196dd16ee0f02",
       "version": "4.3.1",
       "port-version": 5

--- a/versions/c-/cpp-redis.json
+++ b/versions/c-/cpp-redis.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f3507ff3a30f8d0c4a4438a014c1f1e8761964d8",
+      "git-tree": "9714d8cf0b5557d4362f54f0906295b10a154832",
       "version": "4.3.1",
       "port-version": 5
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/23763#issue-1180368747

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
