### PR TITLE
[ezc3d] Update and fix port

### DIFF
--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(ARCHIVE
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pyomeca/ezc3d
-    REF Release_1.4.6
-    SHA512 f63da7e715c09c6a757fe923fd397c09e1cbd0a58a78b1d8fa52bd1a41230ecab2cbb17ecc3d4f66656f3234bfe4c8588164f1d4964dcce729da091e99daab2d
+    REF Release_1.4.7
+    SHA512 ba234be76b5d95b9527952c7e1bf67d9725fc280bf991f45e7cbd68f1aeeab7e963c8c4d928e720d02ebc02ec2b0e41f1c28036cd728ccb4c5a77c6fa81a74ad
     HEAD_REF dev
 )
 

--- a/ports/ezc3d/portfile.cmake
+++ b/ports/ezc3d/portfile.cmake
@@ -1,4 +1,4 @@
-vcpkg_from_github(ARCHIVE
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pyomeca/ezc3d
     REF Release_1.4.7
@@ -6,34 +6,22 @@ vcpkg_from_github(ARCHIVE
     HEAD_REF dev
 )
 
-if(WIN32)
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DBUILD_EXAMPLE=OFF
-            -Dezc3d_LIB_FOLDER="lib"
-            -Dezc3d_BIN_FOLDER="bin"
-    )
-else()
-    vcpkg_cmake_configure(
-        SOURCE_PATH "${SOURCE_PATH}"
-        OPTIONS
-            -DBUILD_EXAMPLE=OFF
-    )
-endif()
-
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-Dezc3d_BIN_FOLDER=bin"
+        "-Dezc3d_LIB_FOLDER=lib"
+        -DBUILD_EXAMPLE=OFF
+)
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
-if(WIN32)
+if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_cmake_config_fixup(CONFIG_PATH "CMake")
 else()
-    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/ezc3d")
 endif()
 
-# # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
-# # Remove duplicated include directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-vcpkg_copy_pdbs()
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/ezc3d/vcpkg.json
+++ b/ports/ezc3d/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "ezc3d",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "C3D reader/writer",
   "homepage": "https://github.com/pyomeca/ezc3d",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2097,7 +2097,7 @@
       "port-version": 2
     },
     "ezc3d": {
-      "baseline": "1.4.6",
+      "baseline": "1.4.7",
       "port-version": 0
     },
     "faad2": {

--- a/versions/e-/ezc3d.json
+++ b/versions/e-/ezc3d.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "21ec5f8371f785c406c466171aadff744e2b34e2",
+      "version": "1.4.7",
+      "port-version": 0
+    },
+    {
       "git-tree": "555219f96920ec01fc38ecd89e0a19188206be22",
       "version": "1.4.6",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Updates ezc3d to 1.4.7.
  Fixes a number of quirks in the portfile, including install location of lib and cmake file. (Noticed from build error in #21507.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
