### PR TITLE
[osgearth] port patch

### DIFF
--- a/ports/osgearth/blend2d-fix.patch
+++ b/ports/osgearth/blend2d-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/src/osgEarth/FeatureRasterizer.cpp b/src/osgEarth/FeatureRasterizer.cpp
+index 84007aee9..de8e511df 100644
+--- a/src/osgEarth/FeatureRasterizer.cpp
++++ b/src/osgEarth/FeatureRasterizer.cpp
+@@ -245,8 +245,8 @@ namespace osgEarth {
+             });
+ 
+             Color color(Color::White);
+-            uint32_t cap = BL_STROKE_CAP_ROUND;
+-            uint32_t join = BL_STROKE_JOIN_ROUND;
++            auto cap = BL_STROKE_CAP_ROUND;
++            auto join = BL_STROKE_JOIN_ROUND;
+ 
+             if (symbol->stroke().isSet())
+             {

--- a/ports/osgearth/portfile.cmake
+++ b/ports/osgearth/portfile.cmake
@@ -21,6 +21,7 @@ vcpkg_from_github(
         remove-tool-debug-suffix.patch
         fix-imgui.patch
         fix-gcc11-compilation.patch
+        blend2d-fix.patch
 )
 
 # Upstream bug, see https://github.com/gwaldron/osgearth/issues/1002

--- a/ports/osgearth/vcpkg.json
+++ b/ports/osgearth/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osgearth",
   "version": "3.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "osgEarth - Dynamic map generation toolkit for OpenSceneGraph Copyright 2021 Pelican Mapping.",
   "homepage": "https://github.com/gwaldron/osgearth",
   "supports": "!(x86 | wasm32)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5210,7 +5210,7 @@
     },
     "osgearth": {
       "baseline": "3.2",
-      "port-version": 3
+      "port-version": 4
     },
     "osi": {
       "baseline": "0.108.6",

--- a/versions/o-/osgearth.json
+++ b/versions/o-/osgearth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "99b20c5ff2821870694fdc973b7f44d4b54db2ba",
+      "version": "3.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "2e3d8cf49728cdb23060f31152768a2292c24ab8",
       "version": "3.2",
       "port-version": 3


### PR DESCRIPTION
Patch for `blend2d` port. Required by #22138, see comment https://github.com/microsoft/vcpkg/pull/22138#issuecomment-999230349.
