### PR TITLE
[directxtk, directxtk12, directxmesh, directxtex, uvatlas] ports updates March 2022

### DIFF
--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF feb2022
-    SHA512 7a34ff8a484e5693efbc3e3f1ecb32978b32d71c6d795c0de14ee29fc61230213448039ac30f74d9836e1703cbcd6026b285e85984f0e30d8005c034d5419809
+    REF mar2022
+    SHA512 ec5cfcbba0f361a2a7d572284c77a88464fcf38a10b113f12b1e51a1c0c42a651abd6f8bbf257a3470b35c62c8d25af9a79925f2e0c79eb33a8b1c9ca6a9191b
     HEAD_REF main
 )
 
@@ -35,9 +35,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/feb2022/meshconvert.exe"
-    FILENAME "meshconvert-feb2022.exe"
-    SHA512 687bec9c9f6c5fc08fc86370bb5b247f751c96fbbf047293364c75c43ec63a769ad737898a3b36acd95f7c3f6b0e97c756043d7a7ccdf750090594e1e2b97271
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/mar2022/meshconvert.exe"
+    FILENAME "meshconvert-mar2022.exe"
+    SHA512 43b4305b73994eccc086bf1812147a5156359f5d927475b915bbf8edde70189cc419b96703aeb736f76d9d52037657f10ba0c104f9713c1f0defb28ce7a46ac1
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-feb2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-mar2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmesh",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-24",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF feb2022
-    SHA512 7e30e38f97e944e49f5d2a6d3035d201016ac7ec5ca1042475485f7cbac165d66f4c5a2c84f2a47dad755c59b3f8947e1251b00b3e577fbc3e58f1957d8a224e
+    REF mar2022
+    SHA512 04f898b2cf2c76edd400147db9144e196fc8441739de3293f8851952ce8153bab033deba52a0d35e51c4fbc9705ffe183f1606a0fae29970dc2babe65ed78e19
     HEAD_REF main
 )
 
@@ -62,23 +62,23 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texassemble.exe"
-    FILENAME "texassemble-feb2022.exe"
-    SHA512 ea1f9fff62a5ebc9c33221852a843063d58405be7529f663e4567b138bca79e73e47b1e0fb6054c4e024a630323c72aba505eee35414cf14970c331afa9ff43f
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texassemble.exe"
+    FILENAME "texassemble-mar2022.exe"
+    SHA512 2a2bec1f012ba6778d99f53a3b4f015f84e4ab76dd68a1980d77cdac588c60a21b30abbfc0de9f0b0ef790ef5ed8444f1648b80990053f8a1f967a04d20d3c33
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texconv.exe"
-    FILENAME "texconv-feb2022.exe"
-    SHA512 1565f5a4bd08de88e01ece59df6658975bfd8551a912d65ac03c0ddd5ab536c8794811d3e49d14e8fe4c61fa2a6c9d50994d372f5d3efab7d9aeb6f3f92d56c9
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texconv.exe"
+    FILENAME "texconv-mar2022.exe"
+    SHA512 fa0b12dcc7e4688f356bb591dedd07dcb27b6029c6490438b39368f72b77f90112360544e035f89e1098dc09b26fb921840ecae851ad5eba6a339cd46316c4e3
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/feb2022/texdiag.exe"
-    FILENAME "texdiag-feb2022.exe"
-    SHA512 5dd93da696eff959b5c93ba8ac763ff6df52fbfc6ca3a3adf1b9da0121beaea2c16008e097f74d562b7a69ed20ada50fd5d35d47311338e6c819e3483bc54ee3
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texdiag.exe"
+    FILENAME "texdiag-mar2022.exe"
+    SHA512 7fe074a08599edca9ad8ad5ff930c9c4dbc74faad6502c288e9a555a4a79f51affbce51758c99518d54c4698457e0edb379ffaebfd3dcae0bd16a343195f8292
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -89,9 +89,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-24",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF feb2022
-    SHA512 18105ccf037b96b198fae086b17e678063efbed38c4212bc0c224090e7b6cd8c4197ae514f22c4b8da78f6a3e5cf6a6cd7437a79ff363baa740f01e3b1eed89b
+    REF mar2022
+    SHA512 09264e19ff786b1f8cf56f0a789ce9df60b3682adba6dbb3e9c8c8c7d869b464c0ad869299fc5cda2d535db19c7a96b43cba2fd40d8cb6aa9dc14914b181d410
     HEAD_REF main
 )
 
@@ -33,16 +33,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/feb2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-feb2022.exe"
-    SHA512 d3454c679db269a29e845382f5cd9cceab2452aa91486238e38f79e71666718ea5d9fa1e676ffbe6875ee69310e17018690998dfb741530ea068fb0616fa4886
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/mar2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-mar2022.exe"
+    SHA512 a24f76781ddb2c9baa2550d3ef26bf4cf6cb03bfd97caa3b202232a04730fd81e299a9f3549c3ff58c03fda827e44deac5e0b311e8e3fc795e393651ecb51752
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/feb2022/XWBTool.exe"
-    FILENAME "xwbtool-feb2022.exe"
-    SHA512 f27170227be1268591757caaccda65d46ad81a2ac38ab1772d9e2d5c722a1d094a9b891f66fc6673d96a6b980a45c8fde501e2d9681f557039f8084ddf648aea
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/mar2022/XWBTool.exe"
+    FILENAME "xwbtool-mar2022.exe"
+    SHA512 32dd88e742211deaf0ca83e51ec510490456473c07fabbd6627960dc9abfa32289d99f2c8f53d7590a6a6733b3068ba25bff9a512fcf7d1072791dce931d463f
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -52,8 +52,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-24",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF feb2022
-    SHA512 e61acd191b9ee5c7d76293f2feb158207f9e63d8f3d5a30144c04367c15d0c1d6a17d6905843d2ca80e9af713a83fa2ab2f52c206569993943997653ae6ad729
+    REF mar2022
+    SHA512 fc41450aad51491f4ac89f87bfd76a62179052db1b98ee626561ef3edb8716578c8dfee01613731cdd9fd91f03ed54a8ec73595374ae16e217cfc87d6f11eca4
     HEAD_REF main
 )
 
@@ -19,16 +19,16 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/feb2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-feb2022.exe"
-    SHA512 d3454c679db269a29e845382f5cd9cceab2452aa91486238e38f79e71666718ea5d9fa1e676ffbe6875ee69310e17018690998dfb741530ea068fb0616fa4886
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/mar2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-mar2022.exe"
+    SHA512 a24f76781ddb2c9baa2550d3ef26bf4cf6cb03bfd97caa3b202232a04730fd81e299a9f3549c3ff58c03fda827e44deac5e0b311e8e3fc795e393651ecb51752
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/feb2022/XWBTool.exe"
-    FILENAME "xwbtool-feb2022.exe"
-    SHA512 f27170227be1268591757caaccda65d46ad81a2ac38ab1772d9e2d5c722a1d094a9b891f66fc6673d96a6b980a45c8fde501e2d9681f557039f8084ddf648aea
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/mar2022/XWBTool.exe"
+    FILENAME "xwbtool-mar2022.exe"
+    SHA512 32dd88e742211deaf0ca83e51ec510490456473c07fabbd6627960dc9abfa32289d99f2c8f53d7590a6a6733b3068ba25bff9a512fcf7d1072791dce931d463f
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -38,8 +38,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-feb2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-24",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF feb2022
-    SHA512 20f9c38dd68edfca8179d26ab7f772b3190e843c01442ae3d7c7c1cd9a5a21a68455c124f0e8aab7efd3aacc9f6fb5907591b35a6a901683dad2a2f91d785106
+    REF mar2022
+    SHA512 8e532a754d1b07108c98e099221a1c6eb39e1386e2e61d8694e041fcdf0556d1aeaed703018b18aa0cc2972c1b874fedd4d7b5e5694c504e70d623a78e6eb421
     HEAD_REF main
 )
 
@@ -35,9 +35,9 @@ vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/feb2022/uvatlastool.exe"
-    FILENAME "uvatlastool-feb2022.exe"
-    SHA512 bc7e00b67e9f7adda52882fdd6b0e54d3a34eb11164f189d5423efcbc7ee0dce5b2c0fbadce592e10917ab215f5d6c380bbc70597ac1001ea169364d563dff5f
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/mar2022/uvatlastool.exe"
+    FILENAME "uvatlastool-mar2022.exe"
+    SHA512 d4179b755a9f8d81c180c86ae7e2d177dd0842f78fc81d96b87fa6551407a038edb8250529e45a9b783514e27cbe2a806bac4af47c3db5c34a6e4adc602f5ff4
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-feb2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-mar2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2022-02-28",
+  "version-date": "2022-03-24",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1849,7 +1849,7 @@
       "port-version": 0
     },
     "directxmesh": {
-      "baseline": "2022-02-28",
+      "baseline": "2022-03-24",
       "port-version": 0
     },
     "directxsdk": {
@@ -1857,15 +1857,15 @@
       "port-version": 5
     },
     "directxtex": {
-      "baseline": "2022-02-28",
+      "baseline": "2022-03-24",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2022-02-28",
+      "baseline": "2022-03-24",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2022-02-28",
+      "baseline": "2022-03-24",
       "port-version": 0
     },
     "dirent": {
@@ -7217,7 +7217,7 @@
       "port-version": 1
     },
     "uvatlas": {
-      "baseline": "2022-02-28",
+      "baseline": "2022-03-24",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "799bc935afc5a0b5d8d50037f28807512fc7c38e",
+      "version-date": "2022-03-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "aef77bf208f6e95c682fd8d41590c5b0516f1f0f",
       "version-date": "2022-02-28",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "15870041c7dc7d9db536c8770c6334f96af9f92c",
+      "version-date": "2022-03-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "424610ae5719fee5f738756146719d13d1483879",
       "version-date": "2022-02-28",
       "port-version": 0

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6e54dc5cc77469ecc88f949b6c149cb01f5a335",
+      "version-date": "2022-03-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "64937ca8d8ec8cc57bfdea9fea74bd39cd0ea507",
       "version-date": "2022-02-28",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c89638b81272f98ae99cfb782c1269ad7b1836a5",
+      "version-date": "2022-03-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "e324f5499354e15e49fa1c591ab864b114518e74",
       "version-date": "2022-02-28",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "100ee1b04f5da317153da9c52eb0c0def30e9b49",
+      "version-date": "2022-03-24",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe5522a95b1f9ef72d43c019948fd94055b42410",
       "version-date": "2022-02-28",
       "port-version": 0


### PR DESCRIPTION
Updated **directxtk**, **directxtk12**, **directxmesh**, **directxtex**, and **uvatlas** ports for the March 24, 2022 GitHub releases.

### All projects
* Updated CMake projects to use latest recommended SDL switches where applicable

### DirectX Tool Kit
* Fixed bug in UWP implementation of Mouse that combined vertical/horizontal scroll-wheel input

### DirectXTex
* Fixed end-point bounds issue with BC6H CPU compressor if none of the pixels are in 0-1 range
* Fixed bug in alpha-to-coverage computation
* Add support for installable WIC codecs for HEIF and WEBP (if present)
* Optional C++17 usage in a few places


