### PR TITLE
[mimalloc] Update the CMake configuration options

### DIFF
--- a/ports/mimalloc/fix-cmake.patch
+++ b/ports/mimalloc/fix-cmake.patch
@@ -9,18 +9,8 @@
    endif()
  
 -  install(TARGETS mimalloc EXPORT mimalloc DESTINATION ${mi_install_libdir} LIBRARY)  
++  install(TARGETS mimalloc EXPORT mimalloc ARCHIVE DESTINATION ${mi_install_libdir} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${mi_install_libdir} NAMELINK_SKIP)
    install(EXPORT mimalloc DESTINATION ${mi_install_cmakedir})
-+  install(TARGETS mimalloc EXPORT mimalloc ARCHIVE DESTINATION lib RUNTIME DESTINATION bin LIBRARY DESTINATION lib NAMELINK_SKIP)
  endif()
  
  # static library
-@@ -370,9 +370,6 @@ # install(TARGETS mimalloc-obj EXPORT mimalloc DESTINATION ${mi_install_objdir})
- 
-   # the FILES expression can also be: $<TARGET_OBJECTS:mimalloc-obj>
-   # but that fails cmake versions less than 3.10 so we leave it as is for now
--  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/mimalloc-obj.dir/src/static.c${CMAKE_C_OUTPUT_EXTENSION}
--          DESTINATION ${mi_install_objdir}
--          RENAME ${mi_basename}${CMAKE_C_OUTPUT_EXTENSION} )
- endif()
- 
- # -----------------------------------------------------------------------------

--- a/ports/mimalloc/portfile.cmake
+++ b/ports/mimalloc/portfile.cmake
@@ -24,15 +24,13 @@ vcpkg_cmake_configure(
     OPTIONS_RELEASE
         -DMI_DEBUG_FULL=OFF
     OPTIONS
-        -DMI_INTERPOSE=ON
-        -DMI_USE_CXX=OFF
+        -DMI_USE_CXX=ON
         -DMI_BUILD_TESTS=OFF
+        -DMI_BUILD_OBJECT=OFF
         ${FEATURE_OPTIONS}
         -DMI_BUILD_STATIC=${MI_BUILD_STATIC}
         -DMI_BUILD_SHARED=${MI_BUILD_SHARED}
         -DMI_INSTALL_TOPLEVEL=ON
-    MAYBE_UNUSED_VARIABLES
-        MI_INTERPOSE
 )
 
 vcpkg_cmake_install()

--- a/ports/mimalloc/vcpkg.json
+++ b/ports/mimalloc/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mimalloc",
   "version": "2.0.5",
+  "port-version": 1,
   "description": "Compact general purpose allocator with excellent performance",
   "homepage": "https://github.com/microsoft/mimalloc",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4470,7 +4470,7 @@
     },
     "mimalloc": {
       "baseline": "2.0.5",
-      "port-version": 0
+      "port-version": 1
     },
     "minc": {
       "baseline": "2.4.03",

--- a/versions/m-/mimalloc.json
+++ b/versions/m-/mimalloc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e4dc5fc89e8c1f860b9f07b3d449a5d67f56cfd4",
+      "version": "2.0.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "370692d9dc2cb2bc9f013041003e069e47febb67",
       "version": "2.0.5",
       "port-version": 0


### PR DESCRIPTION
The previous updates I did of this port were a bit hasty and I didn't realize the CMake configuration was partially outdated. I did the following changes to make it more up to date :
- Enable MI_USE_CXX because it can lead to better performances when overriding new and delete.
- Remove MI_INTERPOSE because it was renamed to MI_OSX_INTERPOSE and it is already enabled by default.
- Set MI_BUILD_OBJECT to OFF instead of disabling object files installation in the CMake file through the patch.