### PR TITLE
[OpenImageIO] Fix openjpeg linkage

### DIFF
--- a/ports/openimageio/fix-openjpeg-linkage.patch
+++ b/ports/openimageio/fix-openjpeg-linkage.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
+index 1fc2059..62c4efb 100644
+--- a/src/cmake/externalpackages.cmake
++++ b/src/cmake/externalpackages.cmake
+@@ -222,7 +222,7 @@ if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VER
+     # set (LIBRAW_FOUND 0)
+ endif ()
+ 
+-checked_find_package (OpenJPEG VERSION_MIN 2.0)
++checked_find_package (OpenJPEG PREFER_CONFIG VERSION_MIN 2.0)
+ 
+ checked_find_package (OpenVDB
+                       VERSION_MIN 5.0

--- a/ports/openimageio/portfile.cmake
+++ b/ports/openimageio/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-dependencies.patch
         fix-config-cmake.patch
+        fix-openjpeg-linkage.patch
 )
 
 file(REMOVE_RECURSE "${SOURCE_PATH}/ext")

--- a/ports/openimageio/vcpkg.json
+++ b/ports/openimageio/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "openimageio",
   "version": "2.3.10.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A library for reading and writing images, and a bunch of related classes, utilities, and application.",
   "homepage": "https://github.com/OpenImageIO/oiio",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "boost-algorithm",
     "boost-asio",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5082,7 +5082,7 @@
     },
     "openimageio": {
       "baseline": "2.3.10.1",
-      "port-version": 2
+      "port-version": 3
     },
     "openjpeg": {
       "baseline": "2.4.0",

--- a/versions/o-/openimageio.json
+++ b/versions/o-/openimageio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2fa8debd832d46f5ad96798be8a335b8a251c2ca",
+      "version": "2.3.10.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "a52afa5ed0495b47dd1c123d975746fdfa0b3459",
       "version": "2.3.10.1",
       "port-version": 2


### PR DESCRIPTION
Fix #23562

Error:
Added  the feature-flag `openjpeg`, but get the error message that `openjpeg cannot be found`.
Fix: change the search mode to `Config `mode will fix this issue.

All features have been tested successfullly in the following triplet:

x64-windows
x86-windows
x64-windows-static