### PR TITLE
[Graphicsmagick] update to 1.3.38

### DIFF
--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -1,11 +1,11 @@
-set(GM_VERSION 1.3.37)
+set(GM_VERSION 1.3.38)
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO graphicsmagick/graphicsmagick
     REF ${GM_VERSION}
     FILENAME "GraphicsMagick-${GM_VERSION}-windows.7z"
-    SHA512 2e465a290946d730c0da1b45602ebdebc256d9a0705d6d79784efcefb0760a923dd78c73f7a563ce6ec41e4199da66d3b31cc8c6b8f821ff993092d348aeaa2f
+	SHA512 f04502679f2d2f37bc660ca06cc075b458a86b1200c6ad00812e72f1ffd084a50d4a84a517d704bf91d736a30a37ccf9b3476c3d46514ee21a687502a59db140
     PATCHES
         # GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
         dynamic_bzip2.patch

--- a/ports/graphicsmagick/portfile.cmake
+++ b/ports/graphicsmagick/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_sourceforge(
     REPO graphicsmagick/graphicsmagick
     REF ${GM_VERSION}
     FILENAME "GraphicsMagick-${GM_VERSION}-windows.7z"
-	SHA512 f04502679f2d2f37bc660ca06cc075b458a86b1200c6ad00812e72f1ffd084a50d4a84a517d704bf91d736a30a37ccf9b3476c3d46514ee21a687502a59db140
+    SHA512 f04502679f2d2f37bc660ca06cc075b458a86b1200c6ad00812e72f1ffd084a50d4a84a517d704bf91d736a30a37ccf9b3476c3d46514ee21a687502a59db140
     PATCHES
         # GM always requires a dynamic BZIP2. This patch makes this dependent if _DLL is defined
         dynamic_bzip2.patch

--- a/ports/graphicsmagick/vcpkg.json
+++ b/ports/graphicsmagick/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.3.38",
   "description": "Image processing library",
   "homepage": "https://sourceforge.net/projects/graphicsmagick/",
+  "license": null,
   "dependencies": [
     "bzip2",
     "freetype",

--- a/ports/graphicsmagick/vcpkg.json
+++ b/ports/graphicsmagick/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "graphicsmagick",
   "version": "1.3.38",
+  "port-version": 1,
   "description": "Image processing library",
   "homepage": "https://sourceforge.net/projects/graphicsmagick/",
   "license": null,

--- a/ports/graphicsmagick/vcpkg.json
+++ b/ports/graphicsmagick/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "graphicsmagick",
-  "version": "1.3.37",
-  "port-version": 1,
+  "version": "1.3.38",
   "description": "Image processing library",
   "homepage": "https://sourceforge.net/projects/graphicsmagick/",
   "dependencies": [

--- a/ports/graphicsmagick/vcpkg.json
+++ b/ports/graphicsmagick/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "graphicsmagick",
   "version": "1.3.38",
-  "port-version": 1,
   "description": "Image processing library",
   "homepage": "https://sourceforge.net/projects/graphicsmagick/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2601,8 +2601,8 @@
       "port-version": 2
     },
     "graphicsmagick": {
-      "baseline": "1.3.37",
-      "port-version": 1
+      "baseline": "1.3.38",
+      "port-version": 0
     },
     "graphite2": {
       "baseline": "1.3.14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2602,7 +2602,7 @@
     },
     "graphicsmagick": {
       "baseline": "1.3.38",
-      "port-version": 1
+      "port-version": 0
     },
     "graphite2": {
       "baseline": "1.3.14",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2602,7 +2602,7 @@
     },
     "graphicsmagick": {
       "baseline": "1.3.38",
-      "port-version": 0
+      "port-version": 1
     },
     "graphite2": {
       "baseline": "1.3.14",

--- a/versions/g-/graphicsmagick.json
+++ b/versions/g-/graphicsmagick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0beed20f3a3d7a6d2fa09d5c6765acae74448998",
+      "version": "1.3.38",
+      "port-version": 1
+    },
+    {
       "git-tree": "85b3677dc314e7c073e5db84beb17e72678e42fe",
       "version": "1.3.38",
       "port-version": 0

--- a/versions/g-/graphicsmagick.json
+++ b/versions/g-/graphicsmagick.json
@@ -6,7 +6,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "85b3677dc314e7c073e5db84beb17e72678e42fe",
+      "git-tree": "e60f94bdb38ff8c9949e3f573cf6705c7b657699",
       "version": "1.3.38",
       "port-version": 0
     },

--- a/versions/g-/graphicsmagick.json
+++ b/versions/g-/graphicsmagick.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "85b3677dc314e7c073e5db84beb17e72678e42fe",
+      "version": "1.3.38",
+      "port-version": 0
+    },
+    {
       "git-tree": "c6ed21bf630e77483e7df659e7fd65eeefc6b543",
       "version": "1.3.37",
       "port-version": 1

--- a/versions/g-/graphicsmagick.json
+++ b/versions/g-/graphicsmagick.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "0beed20f3a3d7a6d2fa09d5c6765acae74448998",
-      "version": "1.3.38",
-      "port-version": 1
-    },
-    {
       "git-tree": "e60f94bdb38ff8c9949e3f573cf6705c7b657699",
       "version": "1.3.38",
       "port-version": 0


### PR DESCRIPTION
GraphicsMagick update to version 1.3.38

- #### What does your PR fix?
  See upstream changelog

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all supported

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes

