### PR TITLE
[librdkafka] fix find_dependency LZ4.

### DIFF
--- a/ports/librdkafka/lz4.patch
+++ b/ports/librdkafka/lz4.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -152,7 +152,7 @@ # LZ4 {
+ option(ENABLE_LZ4_EXT "Enable external LZ4 library support" ON)
+ set(WITH_LZ4_EXT OFF)
+-if(ENABLE_LZ4_EXT)
+-  find_package(LZ4)
+-  if(LZ4_FOUND)
++if(1)
++  find_package(lz4 CONFIG REQUIRED)
++  if(1)
+     set(WITH_LZ4_EXT ON)
+     list(APPEND BUILT_WITH "LZ4_EXT")
+@@ -248,4 +248,4 @@ # LZ4 {
+ install(
+-    FILES "${project_config}" "${project_version}" "packaging/cmake/Modules/FindLZ4.cmake"
++    FILES "${project_config}" "${project_version}"
+     DESTINATION "${config_install_dir}"
+ )
+
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -241,4 +241,3 @@
+ if(WITH_LZ4_EXT)
+-  target_include_directories(rdkafka PRIVATE ${LZ4_INCLUDE_DIRS})
+-  target_link_libraries(rdkafka PUBLIC LZ4::LZ4)
++  target_link_libraries(rdkafka PUBLIC lz4::lz4)
+ endif()

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -52,7 +52,7 @@ if("lz4" IN_LIST FEATURES)
     vcpkg_replace_string(
         "${CURRENT_PACKAGES_DIR}/share/rdkafka/RdKafkaConfig.cmake"
         "find_dependency(LZ4)"
-        "include(\"\${CMAKE_CURRENT_LIST_DIR}/FindLZ4.cmake\")\n  find_dependency(LZ4)"
+        "list(APPEND CMAKE_MODULE_PATH \"\${CMAKE_CURRENT_LIST_DIR}\")\n  find_dependency(LZ4)"
     )
 endif()
 

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -52,7 +52,9 @@ if("lz4" IN_LIST FEATURES)
     vcpkg_replace_string(
         "${CURRENT_PACKAGES_DIR}/share/RdKafka/RdKafkaConfig.cmake"
         "find_dependency(LZ4)"
-        "list(INSERT CMAKE_MODULE_PATH 0 \"\${CMAKE_CURRENT_LIST_DIR}\")\n  find_dependency(LZ4)\n  list(REMOVE_AT CMAKE_MODULE_PATH 0)"
+        [[list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
+  find_dependency(LZ4)
+  list(REMOVE_AT CMAKE_MODULE_PATH 0)]]
     )
 endif()
 

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -4,13 +4,13 @@ vcpkg_from_github(
     REF v1.8.2
     SHA512 8c8ae291129b78e3b8367307ad1b1715af1438cd76d7160d64d13a58adf84c7c9f51efeba4656f55e101c25e4cb744db0d8bb5c01a2decb229e4567d16bdcb22
     HEAD_REF master
+    PATCHES lz4.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" RDKAFKA_BUILD_STATIC)
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        lz4     ENABLE_LZ4_EXT
         ssl     WITH_SSL
         zlib    WITH_ZLIB
         zstd    WITH_ZSTD
@@ -47,16 +47,6 @@ vcpkg_cmake_config_fixup(
     PACKAGE_NAME RdKafka
     CONFIG_PATH lib/cmake/RdKafka
 )
-
-if("lz4" IN_LIST FEATURES)
-    vcpkg_replace_string(
-        "${CURRENT_PACKAGES_DIR}/share/RdKafka/RdKafkaConfig.cmake"
-        "find_dependency(LZ4)"
-        [[list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
-  find_dependency(LZ4)
-  list(REMOVE_AT CMAKE_MODULE_PATH 0)]]
-    )
-endif()
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/librdkafka/portfile.cmake
+++ b/ports/librdkafka/portfile.cmake
@@ -50,9 +50,9 @@ vcpkg_cmake_config_fixup(
 
 if("lz4" IN_LIST FEATURES)
     vcpkg_replace_string(
-        "${CURRENT_PACKAGES_DIR}/share/rdkafka/RdKafkaConfig.cmake"
+        "${CURRENT_PACKAGES_DIR}/share/RdKafka/RdKafkaConfig.cmake"
         "find_dependency(LZ4)"
-        "list(APPEND CMAKE_MODULE_PATH \"\${CMAKE_CURRENT_LIST_DIR}\")\n  find_dependency(LZ4)"
+        "list(INSERT CMAKE_MODULE_PATH 0 \"\${CMAKE_CURRENT_LIST_DIR}\")\n  find_dependency(LZ4)\n  list(REMOVE_AT CMAKE_MODULE_PATH 0)"
     )
 endif()
 

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librdkafka",
   "version": "1.8.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Apache Kafka C/C++ library",
   "homepage": "https://github.com/edenhill/librdkafka",
   "license": null,

--- a/ports/librdkafka/vcpkg.json
+++ b/ports/librdkafka/vcpkg.json
@@ -7,6 +7,7 @@
   "license": null,
   "supports": "!uwp",
   "dependencies": [
+    "lz4",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -17,12 +18,6 @@
     }
   ],
   "features": {
-    "lz4": {
-      "description": "Enable external LZ4 library support",
-      "dependencies": [
-        "lz4"
-      ]
-    },
     "snappy": {
       "description": "Build with snappy"
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3910,7 +3910,7 @@
     },
     "librdkafka": {
       "baseline": "1.8.2",
-      "port-version": 1
+      "port-version": 2
     },
     "libressl": {
       "baseline": "3.4.2",

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "921ebfa01ef854c957dbec73a140f31fd4f2c267",
+      "git-tree": "b05bf7fa67bede0919ade9edc763db606ddce5d2",
       "version": "1.8.2",
       "port-version": 2
     },

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b05bf7fa67bede0919ade9edc763db606ddce5d2",
+      "git-tree": "0583e5dcb6a79a29685250e2b43ca1cd2a798d96",
       "version": "1.8.2",
       "port-version": 2
     },

--- a/versions/l-/librdkafka.json
+++ b/versions/l-/librdkafka.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "921ebfa01ef854c957dbec73a140f31fd4f2c267",
+      "version": "1.8.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "2f7a6da2edf664e544914466d1cc8994d1ea475a",
       "version": "1.8.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

Include `FindLZ4.cmake` will result following error message:

```
CMake Warning (dev) at /usr/local/lib/python3.6/dist-packages/cmake/data/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (LZ4) does
  not match the name of the calling package (RdKafka).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
```

I'm following the fix in vcpkg to solve problems encounted when calling `find_package(RdKafka)`. But the fix in vcpkg does not work.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

Sorry I don't actually use vcpkg, so I don't know if I need to update other files.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`