### PR TITLE
Fix VS2022 testing of the compilers.

### DIFF
--- a/scripts/azure-pipelines/windows-unstable/rearrange-msvc-drop-layout.ps1
+++ b/scripts/azure-pipelines/windows-unstable/rearrange-msvc-drop-layout.ps1
@@ -54,7 +54,7 @@ Move-Item "$DropRoot\binaries.x86$BuildType\atlmfc\include" "$tempRoot\atlmfc\in
 Move-Item "$DropRoot\binaries.x86$BuildType\atlmfc\lib\i386" "$tempRoot\atlmfc\lib\x86"
 Move-Item "$DropRoot\binaries.amd64$BuildType\atlmfc\lib\amd64" "$tempRoot\atlmfc\lib\x64"
 
-$toolsets = Get-ChildItem -Path $MSVCRoot -Directory | Sort-Object -Descending
+$toolsets = [string[]](Get-ChildItem -Path $MSVCRoot -Directory | Sort-Object -Descending)
 if ($toolsets.Length -eq 0) {
     throw "Could not find Visual Studio toolset!"
 }

--- a/scripts/azure-pipelines/windows-unstable/rearrange-msvc-drop-layout.ps1
+++ b/scripts/azure-pipelines/windows-unstable/rearrange-msvc-drop-layout.ps1
@@ -54,7 +54,7 @@ Move-Item "$DropRoot\binaries.x86$BuildType\atlmfc\include" "$tempRoot\atlmfc\in
 Move-Item "$DropRoot\binaries.x86$BuildType\atlmfc\lib\i386" "$tempRoot\atlmfc\lib\x86"
 Move-Item "$DropRoot\binaries.amd64$BuildType\atlmfc\lib\amd64" "$tempRoot\atlmfc\lib\x64"
 
-$toolsets = [string[]](Get-ChildItem -Path $MSVCRoot -Directory | Sort-Object -Descending)
+[string[]]$toolsets = Get-ChildItem -Path $MSVCRoot -Directory | Sort-Object -Descending
 if ($toolsets.Length -eq 0) {
     throw "Could not find Visual Studio toolset!"
 }


### PR DESCRIPTION
Workaround GetChildItem returning a non-array when there's only one result.

Root cause is that GetChildItem returns the item rather than an array of items when there is only one result, and attempt to access `.Length` on that fails with an error when strict mode is on:
![image](https://user-images.githubusercontent.com/1544943/160491726-e39b14ff-5298-4e4c-b127-eb01c35810fb.png)

(Example output where this failed over the weekend)
![image](https://user-images.githubusercontent.com/1544943/160491779-b888cead-2e3d-463b-b6ed-08e06ce1a2f8.png)
