### PR TITLE
[libmt32emu] update from 2.5.3 to 2.6.2

### DIFF
--- a/ports/libmt32emu/portfile.cmake
+++ b/ports/libmt32emu/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO munt/munt
-    REF libmt32emu_2_5_3
-    SHA512 c801e22e861898281316109533ca6264f5a9cf778d4f0bb14b49bb6d04d53b7e60cd8320d5b29a63534f6c470b4feb67c881e86c49b7860a98639ce01b99debf
+    REF 004800c20b1edaab921e08f69133fc2a4bd3b8e8  #vlibmt32emu_2_6_2
+    SHA512 3a47c269d285f3930eefda4cae6f1c7e157fc4e88d7d64ad029542586b6592b32d5f9bf0e22344e27a21869aea2191051505f3727e52dff268cf2be4d52f15c3
     HEAD_REF master
 )
 
@@ -15,6 +15,11 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME MT32Emu CONFIG_PATH lib/cmake/MT32Emu)
+
+vcpkg_fixup_pkgconfig()
+
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
@@ -23,5 +28,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/doc")
 
 
 file(INSTALL "${SOURCE_PATH}/mt32emu/COPYING.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "2.6.2",
   "description": "A MT-32 emulator",
   "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
-  "license": "GPL-2.0",
+  "license": "GPL-2.0-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libmt32emu",
-  "version": "2.5.3",
-  "port-version": 1,
+  "version": "2.6.2",
   "description": "A MT-32 emulator",
   "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
   "dependencies": [

--- a/ports/libmt32emu/vcpkg.json
+++ b/ports/libmt32emu/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "2.6.2",
   "description": "A MT-32 emulator",
   "homepage": "https://github.com/munt/munt/tree/master/mt32emu",
+  "license": "GPL-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3765,8 +3765,8 @@
       "port-version": 4
     },
     "libmt32emu": {
-      "baseline": "2.5.3",
-      "port-version": 1
+      "baseline": "2.6.2",
+      "port-version": 0
     },
     "libmupdf": {
       "baseline": "1.19.0-rc2",

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "69fa1a4d2f8c8a97e3b603b2409f343de94bc027",
+      "version": "2.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "da8f12396b75ff5163acd190bf7f79a3d0b5098a",
       "version": "2.5.3",
       "port-version": 1

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "69fa1a4d2f8c8a97e3b603b2409f343de94bc027",
+      "git-tree": "14881349458d5ce531c13b1e006875e452a0b074",
       "version": "2.6.2",
       "port-version": 0
     },

--- a/versions/l-/libmt32emu.json
+++ b/versions/l-/libmt32emu.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14881349458d5ce531c13b1e006875e452a0b074",
+      "git-tree": "de283dae22ced9be75cf6356a02732fec8b4eb11",
       "version": "2.6.2",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #23795

Update libmt32emu to the latest version 2.6.2

Add vcpkg_cmake_config_fixup function 

Note: no feature need to test