### PR TITLE
[vcpkg baseline][qtinterfaceframework] Temporary set to fail in baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1023,6 +1023,9 @@ qt5-base:arm64-windows=fail
 # qtwebengine:x64-windows has an ICE in VS2022
 qtwebengine:x64-windows=fail
 
+# upstream bug, see https://github.com/microsoft/vcpkg/issues/23766
+qtinterfaceframework:x64-windows=fail
+
 # Skip deprecated Qt module
 # (remove after 1 year or longer due to vcpkg upgrade not handling removed ports correctly)
 qt5-canvas3d:x64-linux=skip


### PR DESCRIPTION
This issue blocked more and more PRs.

Upstream issue: https://bugreports.qt.io/browse/QTBUG-102048?jql=text%20~%20%22qtinterfaceframework%22

Fixes: https://github.com/microsoft/vcpkg/issues/23766

