### PR TITLE
[Nss] Update to version 3.76.1

### DIFF
--- a/ports/nss/portfile.cmake
+++ b/ports/nss/portfile.cmake
@@ -1,10 +1,10 @@
-set(NSS_VERSION "3.76")
+set(NSS_VERSION "3.76.1")
 string(REPLACE "." "_" V_URL ${NSS_VERSION})
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.mozilla.org/pub/security/nss/releases/NSS_${V_URL}_RTM/src/nss-${NSS_VERSION}.tar.gz"
     FILENAME "nss-${NSS_VERSION}.tar.gz"
-    SHA512 ffbdd8a27f60b796e1204912cde2fa62ac99747ce550258ccdd6fe96d60a46c6ac3f82758a7aba3c7ee58da4e7bf09f1bf817fb9f0fa4e62faaea08a6301b8bd
+    SHA512 80d32a97501cbc05312caa5cec54fe6dd8708f01e6d15693e36a40d70433be7a35565fcc5fadfc324c998ee9093b10b2f7a89643882f06a850eda4ffd3b19c54
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/nss/vcpkg.json
+++ b/ports/nss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nss",
-  "version": "3.76",
+  "version": "3.76.1",
   "description": "Network Security Services from Mozilla",
   "homepage": "https://ftp.mozilla.org/pub/security/nss/releases/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4857,7 +4857,7 @@
       "port-version": 0
     },
     "nss": {
-      "baseline": "3.76",
+      "baseline": "3.76.1",
       "port-version": 0
     },
     "nsync": {

--- a/versions/n-/nss.json
+++ b/versions/n-/nss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a5eabb67b345be280f94a3615aa3e08886ad4ec7",
+      "version": "3.76.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "ffcb42dbcb29e96a2e367dbbe473f447d67f54ce",
       "version": "3.76",
       "port-version": 0


### PR DESCRIPTION
Version bump for NSS 3.76.1

Fixes CVE-2022-1097

https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/4hzOfxOC-qU/m/0LUIvF7FAAAJ