### PR TITLE
[vcpkg baseline][qtiterfaceframework] Change fail to skip

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1021,7 +1021,7 @@ qt5-base:arm64-windows=fail
 qtwebengine:x64-windows=fail
 
 # upstream bug, see https://github.com/microsoft/vcpkg/issues/23766
-qtinterfaceframework:x64-windows=fail
+qtinterfaceframework:x64-windows=skip
 
 # Skip deprecated Qt module
 # (remove after 1 year or longer due to vcpkg upgrade not handling removed ports correctly)


### PR DESCRIPTION
It looks like the regression is random:
```
REGRESSIONS:
PASSING, REMOVE FROM FAIL LIST: qtinterfaceframework:x64-windows (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
REGRESSION: qtinterfaceframework:x86-windows failed with BUILD_FAILED. If expected, add qtinterfaceframework:x86-windows=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
```
Change `fail` to `skip` now.
