### PR TITLE
[eigen3] Fix usage in Linux

### DIFF
--- a/ports/eigen3/fix-vectorized-reductions-half.patch
+++ b/ports/eigen3/fix-vectorized-reductions-half.patch
@@ -1,0 +1,26 @@
+diff --git a/Eigen/src/Core/PartialReduxEvaluator.h b/Eigen/src/Core/PartialReduxEvaluator.h
+index 29abf35..4051fcf 100644
+--- a/Eigen/src/Core/PartialReduxEvaluator.h
++++ b/Eigen/src/Core/PartialReduxEvaluator.h
+@@ -54,12 +54,19 @@ struct packetwise_redux_traits
+ /* Value to be returned when size==0 , by default let's return 0 */
+ template<typename PacketType,typename Func>
+ EIGEN_DEVICE_FUNC
+-PacketType packetwise_redux_empty_value(const Func& ) { return pset1<PacketType>(0); }
++PacketType packetwise_redux_empty_value(const Func& ) {
++  const typename unpacket_traits<PacketType>::type zero(0);
++  return pset1<PacketType>(zero);
++}
++
+ 
+ /* For products the default is 1 */
+ template<typename PacketType,typename Scalar>
+ EIGEN_DEVICE_FUNC
+-PacketType packetwise_redux_empty_value(const scalar_product_op<Scalar,Scalar>& ) { return pset1<PacketType>(1); }
++PacketType packetwise_redux_empty_value(const scalar_product_op<Scalar,Scalar>& ) {
++  return pset1<PacketType>(Scalar(1));
++}
++
+ 
+ /* Perform the actual reduction */
+ template<typename Func, typename Evaluator,

--- a/ports/eigen3/portfile.cmake
+++ b/ports/eigen3/portfile.cmake
@@ -7,7 +7,9 @@ vcpkg_from_gitlab(
     REF 3.4.0
     SHA512 ba75ecb760e32acf4ceaf27115468e65d4f77c44f8d519b5a13e7940af2c03a304ad433368cb6d55431f307c5c39e2666ab41d34442db3cf441638e51f5c3b6a
     HEAD_REF master
-    PATCHES remove_configure_checks.patch # This removes unnecessary configure checks. Eigen3 just installs headers not anything more.
+    PATCHES
+        remove_configure_checks.patch # This removes unnecessary configure checks. Eigen3 just installs headers not anything more.
+        fix-vectorized-reductions-half.patch # Remove this patch in the next update
 )
 
 vcpkg_cmake_configure(

--- a/ports/eigen3/vcpkg.json
+++ b/ports/eigen3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "eigen3",
   "version": "3.4.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.",
   "homepage": "http://eigen.tuxfamily.org",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2026,7 +2026,7 @@
     },
     "eigen3": {
       "baseline": "3.4.0",
-      "port-version": 1
+      "port-version": 2
     },
     "elfio": {
       "baseline": "3.10",

--- a/versions/e-/eigen3.json
+++ b/versions/e-/eigen3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "250d10d414a5542aaf832350264498ba727c4c03",
+      "version": "3.4.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "4b40326590314e1f3a08c75e83a42d0738040b68",
       "version": "3.4.0",
       "port-version": 1


### PR DESCRIPTION
Use the upstream changes (https://gitlab.com/libeigen/eigen/-/commit/d0e3791b1a0e2db9edd5f1d1befdb2ac5a40efe0) to fix usage issue in Linux:
```
FAILED: CMakeFiles/onnxruntime_providers.dir/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc.o 
/usr/bin/c++ -DCPUINFO_SUPPORTED_PLATFORM=1 -DEIGEN_MPL2_ONLY -DEIGEN_USE_THREADS -DENABLE_CPU_FP16_TRAINING_OPS -DMLAS_NO_EXCEPTION -DNSYNC_ATOMIC_CPP11 -DONNX_ML=1 -DONNX_NAMESPACE=onnx -DONNX_NO_EXCEPTIONS -DORT_MINIMAL_BUILD -DORT_NO_EXCEPTIONS -DORT_NO_RTTI -DPLATFORM_POSIX -DREDUCED_OPS_BUILD -I/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/include/onnxruntime -I/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/include/onnxruntime/core/session -I/mnt/vcpkg-ci/installed/x64-linux/include -I/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/x64-linux-dbg -I/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime -I/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/cmake/external/nsync/public -I/mnt/vcpkg-ci/installed/x64-linux/include/boost -fPIC -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -march=native -mtune=native -g -DGSL_TERMINATE_ON_CONTRACT_VIOLATION -flto -fno-fat-lto-objects -fPIC -fno-rtti -Wall -Wextra -Wno-deprecated-copy -Wno-nonnull-compare -std=gnu++17 -MD -MT CMakeFiles/onnxruntime_providers.dir/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc.o -MF CMakeFiles/onnxruntime_providers.dir/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc.o.d -o CMakeFiles/onnxruntime_providers.dir/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc.o -c /mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc
In file included from /mnt/vcpkg-ci/installed/x64-linux/include/Eigen/Core:358,
                 from /mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/core/util/math_cpuonly.h:49,
                 from /mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc:7:
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/PartialReduxEvaluator.h: In instantiation of ‘PacketType Eigen::internal::packetwise_redux_empty_value(const Func&) [with PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 2>; Func = Eigen::internal::scalar_sum_op<Eigen::half, Eigen::half>]’:
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/PartialReduxEvaluator.h:112:54:   required from ‘static PacketType Eigen::internal::packetwise_redux_impl<Func, Evaluator, 0>::run(const Evaluator&, const Func&, Eigen::Index) [with PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 2>; Func = Eigen::internal::scalar_sum_op<Eigen::half, Eigen::half>; Evaluator = Eigen::internal::redux_evaluator<Eigen::Block<const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >, -1, 8, true> >; Eigen::Index = long int]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/PartialReduxEvaluator.h:219:102:   required from ‘PacketType Eigen::internal::evaluator<Eigen::PartialReduxExpr<MatrixType, MemberOp, Direction> >::packet(Eigen::Index) const [with int LoadMode = 0; PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 2>; ArgType = const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >; MemberOp = Eigen::internal::member_sum<Eigen::half, Eigen::half>; int Direction = 0; Eigen::Index = long int]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/Redux.h:251:20:   required from ‘static Eigen::internal::redux_impl<Func, Evaluator, 3, 0>::Scalar Eigen::internal::redux_impl<Func, Evaluator, 3, 0>::run(const Evaluator&, const Func&, const XprType&) [with XprType = Eigen::PartialReduxExpr<const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >, Eigen::internal::member_sum<Eigen::half, Eigen::half>, 0>; Func = Eigen::internal::scalar_max_op<Eigen::half, Eigen::half, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::PartialReduxExpr<const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >, Eigen::internal::member_sum<Eigen::half, Eigen::half>, 0> >; Eigen::internal::redux_impl<Func, Evaluator, 3, 0>::Scalar = Eigen::half]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/Redux.h:418:56:   required from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::redux(const Func&) const [with BinaryOp = Eigen::internal::scalar_max_op<Eigen::half, Eigen::half, 0>; Derived = Eigen::PartialReduxExpr<const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >, Eigen::internal::member_sum<Eigen::half, Eigen::half>, 0>; typename Eigen::internal::traits<T>::Scalar = Eigen::half]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/Redux.h:448:89:   required from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with int NaNPropagation = 0; Derived = Eigen::PartialReduxExpr<const Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<Eigen::half>, const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >, Eigen::internal::member_sum<Eigen::half, Eigen::half>, 0>; typename Eigen::internal::traits<T>::Scalar = Eigen::half]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/DenseBase.h:466:38:   [ skipping 6 instantiation contexts, use -ftemplate-backtrace-limit=0 to disable ]
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/LU/InverseImpl.h:322:60:   required from ‘static void Eigen::internal::Assignment<DstXprType, Eigen::Inverse<Rhs>, Eigen::internal::assign_op<typename DstXprType::Scalar, typename SrcXprType::Scalar>, Eigen::internal::Dense2Dense>::run(DstXprType&, const SrcXprType&, const Eigen::internal::assign_op<typename DstXprType::Scalar, typename SrcXprType::Scalar>&) [with DstXprType = Eigen::Map<Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1>, 0, Eigen::Stride<0, 0> >; XprType = Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> >; Eigen::internal::Assignment<DstXprType, Eigen::Inverse<Rhs>, Eigen::internal::assign_op<typename DstXprType::Scalar, typename SrcXprType::Scalar>, Eigen::internal::Dense2Dense>::SrcXprType = Eigen::Inverse<Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> > >; typename SrcXprType::Scalar = Eigen::half; typename DstXprType::Scalar = Eigen::half]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/AssignEvaluator.h:890:49:   required from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Map<Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1>, 0, Eigen::Stride<0, 0> >; Src = Eigen::Inverse<Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> > >; Func = Eigen::internal::assign_op<Eigen::half, Eigen::half>]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/AssignEvaluator.h:858:27:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Map<Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1>, 0, Eigen::Stride<0, 0> >; Src = Eigen::Inverse<Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> > >; Func = Eigen::internal::assign_op<Eigen::half, Eigen::half>; typename Eigen::internal::enable_if<(! Eigen::internal::evaluator_assume_aliasing<Src>::value), void*>::type = void*]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/AssignEvaluator.h:836:18:   required from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Map<Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1>, 0, Eigen::Stride<0, 0> >; Src = Eigen::Inverse<Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> > >]’
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/Assign.h:66:28:   required from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Inverse<Eigen::Map<const Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1> > >; Derived = Eigen::Map<Eigen::Matrix<Eigen::half, -1, -1, 1, -1, -1>, 0, Eigen::Stride<0, 0> >]’
/mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc:61:42:   required from here
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/PartialReduxEvaluator.h:57:82: error: invalid initialization of reference of type ‘const Eigen::half&’ from expression of type ‘int’
   57 | PacketType packetwise_redux_empty_value(const Func& ) { return pset1<PacketType>(0); }
      |                                                                                  ^
In file included from /mnt/vcpkg-ci/installed/x64-linux/include/Eigen/Core:199,
                 from /mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/core/util/math_cpuonly.h:49,
                 from /mnt/vcpkg-ci/buildtrees/onnxruntime-gpu/src/53c7b640c1-f4b419aa1b.clean/onnxruntime/contrib_ops/cpu/inverse.cc:7:
/mnt/vcpkg-ci/installed/x64-linux/include/Eigen/src/Core/arch/AVX/PacketMath.h:938:76: note: in passing argument 1 of ‘Packet Eigen::internal::pset1(const typename Eigen::internal::unpacket_traits<T>::type&) [with Packet = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 2>; typename Eigen::internal::unpacket_traits<T>::type = Eigen::half]’
  938 | template<> EIGEN_STRONG_INLINE Packet8h pset1<Packet8h>(const Eigen::half& from) {
      |                                                         ~~~~~~~~~~~~~~~~~~~^~~~
```

Related: https://github.com/microsoft/vcpkg/pull/23768