### PR TITLE
[zlib] Update to 1.2.12 since 1.2.11 has been redacted by upstream

### DIFF
--- a/ports/zlib/cmake_dont_build_more_than_needed.patch
+++ b/ports/zlib/cmake_dont_build_more_than_needed.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 0fe939d..a1291d5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -7,6 +7,7 @@ set(VERSION "1.2.11")
+@@ -7,6 +7,7 @@ set(VERSION "1.2.12")
  
  option(ASM686 "Enable building i686 assembly implementation")
  option(AMD64 "Enable building amd64 assembly implementation")

--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,9 +1,9 @@
-set(VERSION 1.2.11)
+set(VERSION 1.2.12)
 
 vcpkg_download_distfile(ARCHIVE_FILE
-    URLS "https://www.zlib.net/zlib-${VERSION}.tar.gz" "https://downloads.sourceforge.net/project/libpng/zlib/${VERSION}/zlib-${VERSION}.tar.gz"
-    FILENAME "zlib1211.tar.gz"
-    SHA512 73fd3fff4adeccd4894084c15ddac89890cd10ef105dd5e1835e1e9bbb6a49ff229713bd197d203edfa17c2727700fce65a2a235f07568212d820dca88b528ae
+    URLS "https://www.zlib.net/zlib-${VERSION}.tar.gz"
+    FILENAME "zlib1212.tar.gz"
+    SHA512 cc2366fa45d5dfee1f983c8c51515e0cff959b61471e2e8d24350dea22d3f6fcc50723615a911b046ffc95f51ba337d39ae402131a55e6d1541d3b095d6c0a14
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "zlib",
-  "version": "1.2.11",
-  "port-version": 13,
+  "version": "1.2.12",
   "description": "A compression library",
   "homepage": "https://www.zlib.net/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7629,8 +7629,8 @@
       "port-version": 2
     },
     "zlib": {
-      "baseline": "1.2.11",
-      "port-version": 13
+      "baseline": "1.2.12",
+      "port-version": 0
     },
     "zlib-ng": {
       "baseline": "2.0.5",

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c4edb1fabbd87dd236a200ba55eaf241cd8c8d0",
+      "version": "1.2.12",
+      "port-version": 0
+    },
+    {
       "git-tree": "92cfe30c807d343c6359d272242f0765ad906740",
       "version": "1.2.11",
       "port-version": 13


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

zlib 1.2.11 has been redacted  and the tar ball has been removed from zlib.net:
> Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.


- #### Which triplets are supported/not supported? Have you updated the [CI baseline]

No changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`

