### PR TITLE
[TinyCBOR] Add new port

### DIFF
--- a/ports/tinycbor/CMakeLists.txt
+++ b/ports/tinycbor/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.20)
+project(tinycbor C)
+
+file(GLOB sources src/cbor*.c)
+list(FILTER sources EXCLUDE REGEX "cbortojson.c$")
+add_library(tinycbor ${sources})
+
+install(TARGETS tinycbor)
+install(FILES src/cbor.h src/cborjson.h src/tinycbor-version.h DESTINATION include)

--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -1,3 +1,5 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/tinycbor
@@ -16,7 +18,3 @@ file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${
 
 # Remove duplicated include headers
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-# Remove empty folders
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib ${CURRENT_PACKAGES_DIR}/lib)
-SET(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
-SET(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)

--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -1,0 +1,15 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO intel/tinycbor
+    REF v0.6.0
+    SHA512 af1ed05c03d3aed56e35fdcaad3235992f96b5043b594c0246e600e4b1f085df78c5345beaac8758c2b5db2952ab83997019de5940857eecb81d84b6fb642093
+    HEAD_REF master
+)
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_install_cmake()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -13,3 +13,10 @@ vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
 vcpkg_cmake_install()
 
 file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+# Remove duplicated include headers
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+# Remove empty folders
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/lib ${CURRENT_PACKAGES_DIR}/lib)
+SET(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled)
+SET(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "tinycbor",
+  "version-semver": "0.6.0",
+  "description": "Concise Binary Object Representation (CBOR) Library"
+}

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "tinycbor",
   "version-semver": "0.6.0",
   "description": "Concise Binary Object Representation (CBOR) Library",
+  "homepage": "https://github.com/intel/tinycbor",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -1,5 +1,15 @@
 {
   "name": "tinycbor",
   "version-semver": "0.6.0",
-  "description": "Concise Binary Object Representation (CBOR) Library"
+  "description": "Concise Binary Object Representation (CBOR) Library",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6933,7 +6933,7 @@
       "port-version": 1
     },
     "tinycbor": {
-      "baseline": "0.4.1",
+      "baseline": "0.6.0",
       "port-version": 0
     },
     "tinycthread": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6932,6 +6932,10 @@
       "baseline": "2019-07-31",
       "port-version": 1
     },
+    "tinycbor": {
+      "baseline": "0.4.1",
+      "port-version": 0
+    },
     "tinycthread": {
       "baseline": "2019-08-06",
       "port-version": 1

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,7 +1,7 @@
 {
     "versions": [
       {
-        "git-tree": "c24a1390209fb9cf2152dc8036a4314480129ed9",
+        "git-tree": "13747f91007d02c2406cc1e57e99d66a66bd39ec",
         "version-semver": "0.6.0",
         "port-version": 0
       }

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,18 +1,8 @@
 {
     "versions": [
       {
-        "git-tree": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
+        "git-tree": "c24a1390209fb9cf2152dc8036a4314480129ed9",
         "version-semver": "0.6.0",
-        "port-version": 0
-      },
-      {
-        "git-tree": "11590e470dfc1a144eb5665655c7ff6627b8e0f6",
-        "version-semver": "0.5.4",
-        "port-version": 0
-      },
-      {
-        "git-tree": "acf202a38118ed049785d210b5de84effa43c3de",
-        "version-semver": "0.4.1",
         "port-version": 0
       }
     ]

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,10 +1,9 @@
 {
-    "versions": [
-      {
-        "git-tree": "ecf65457801ba4aa8d8ae75886f87e740fb04783",
-        "version-semver": "0.6.0",
-        "port-version": 0
-      }
-    ]
-  }
-  
+  "versions": [
+    {
+      "git-tree": "ecf65457801ba4aa8d8ae75886f87e740fb04783",
+      "version-semver": "0.6.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,7 +1,7 @@
 {
     "versions": [
       {
-        "git-tree": "13747f91007d02c2406cc1e57e99d66a66bd39ec",
+        "git-tree": "ecf65457801ba4aa8d8ae75886f87e740fb04783",
         "version-semver": "0.6.0",
         "port-version": 0
       }

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,0 +1,20 @@
+{
+    "versions": [
+      {
+        "git-tree": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
+        "version-string": "0.6.0",
+        "port-version": 0
+      },
+      {
+        "git-tree": "11590e470dfc1a144eb5665655c7ff6627b8e0f6",
+        "version-string": "0.5.4",
+        "port-version": 0
+      },
+      {
+        "git-tree": "acf202a38118ed049785d210b5de84effa43c3de",
+        "version-string": "0.4.1",
+        "port-version": 0
+      }
+    ]
+  }
+  

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -2,17 +2,17 @@
     "versions": [
       {
         "git-tree": "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7",
-        "version-string": "0.6.0",
+        "version-semver": "0.6.0",
         "port-version": 0
       },
       {
         "git-tree": "11590e470dfc1a144eb5665655c7ff6627b8e0f6",
-        "version-string": "0.5.4",
+        "version-semver": "0.5.4",
         "port-version": 0
       },
       {
         "git-tree": "acf202a38118ed049785d210b5de84effa43c3de",
-        "version-string": "0.4.1",
+        "version-semver": "0.4.1",
         "port-version": 0
       }
     ]


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #23465

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Windows only; I've only tried installing tinycbor:x86-windows locally myself.
  No, am I supposed to update the CI baseline..? By default the new port should build right, so I've not updated it.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes, if committed the result means using the commit hash in the `versions/t-/tinycbor.json`.