### PR TITLE
[vcpkg-ci-llvm] Reduce llvm artifact to cacheable size

### DIFF
--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "vcpkg-ci-llvm",
   "version-string": "0",
   "description": "LLVM features testing within CI.",
+  "license": null,
   "supports": "!uwp & !(arm & windows)",
   "dependencies": [
     {
@@ -9,9 +10,9 @@
       "default-features": false,
       "features": [
         "clang",
-        "enable-abi-breaking-checks",
         "disable-assertions",
         "disable-clang-static-analyzer",
+        "enable-abi-breaking-checks",
         "enable-bindings",
         "enable-eh",
         "enable-rtti",
@@ -21,10 +22,23 @@
         "lld",
         "lldb",
         "polly",
-        "target-all",
+        "target-aarch64",
+        "target-amdgpu",
+        "target-arm",
+        "target-mips",
+        "target-webassembly",
+        "target-x86",
         "tools",
         "utils"
       ]
+    },
+    {
+      "name": "llvm",
+      "default-features": false,
+      "features": [
+        "target-all"
+      ],
+      "platform": "!windows"
     },
     {
       "name": "llvm",

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -22,31 +22,19 @@
         "lld",
         "lldb",
         "polly",
-        "target-aarch64",
-        "target-amdgpu",
-        "target-arm",
-        "target-mips",
-        "target-webassembly",
-        "target-x86",
+        "target-all",
         "tools",
         "utils"
       ]
     },
     {
-      "name": "llvm",
-      "default-features": false,
-      "features": [
-        "target-all"
-      ],
-      "platform": "!windows"
-    },
-    {
+      "$comment": "Only for osx artifact upload in CI succeeds when flang is enabled",
       "name": "llvm",
       "default-features": false,
       "features": [
         "flang"
       ],
-      "platform": "!(x86 & windows)"
+      "platform": "osx"
     }
   ]
 }

--- a/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
+++ b/scripts/test_ports/vcpkg-ci-llvm/vcpkg.json
@@ -22,17 +22,22 @@
         "lld",
         "lldb",
         "polly",
-        "target-all",
-        "tools",
-        "utils"
+        "target-aarch64",
+        "target-amdgpu",
+        "target-arm",
+        "target-webassembly",
+        "target-x86",
+        "tools"
       ]
     },
     {
-      "$comment": "Only for osx artifact upload in CI succeeds when flang is enabled",
+      "$comment": "Only for osx artifact upload in CI succeeds when these features are enabled",
       "name": "llvm",
       "default-features": false,
       "features": [
-        "flang"
+        "flang",
+        "target-all",
+        "utils"
       ],
       "platform": "osx"
     }


### PR DESCRIPTION
- #### What does your PR fix?
  Cf. https://github.com/microsoft/vcpkg/issues/21905#issuecomment-1013422776:
  The `llvm:x64-windows` binary artifact couldn't be uploaded to binary caching. So it was rebuilt (2 h!) whenever needed, even for PRs which were unrelated to llvm but triggered `vcpkg-ci-opencv:x64-windows`.
  This is an attempt to mitigate the issue (until resolved in vcpkg tool) by removing some llvm features from windows CI.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  not needed
