### PR TITLE
[omplapp] Fix build failed on Linux and OSX

### DIFF
--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -63,11 +63,17 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/bin"
     "${CURRENT_PACKAGES_DIR}/include/omplapp/CMakeFiles"
     "${CURRENT_PACKAGES_DIR}/lib/ompl.lib"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.so"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.so.1.5.1"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.so.16"
     "${CURRENT_PACKAGES_DIR}/share/ompl"
     "${CURRENT_PACKAGES_DIR}/share/man"
     "${CURRENT_PACKAGES_DIR}/debug/bin"
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/lib/ompl.lib"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so.1.5.1"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so.16"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 
@@ -75,14 +81,6 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/omplapp/config.h" "#define
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-endif()
-
-if(NOT VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ompl.pc" "assimp::assimp" "assimp")
-    if(NOT VCPKG_BUILD_TYPE)
-        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ompl.pc" "assimp::assimp" "assimp")
-    endif()
-    vcpkg_fixup_pkgconfig()
 endif()
 
 # Handle copyright

--- a/ports/omplapp/portfile.cmake
+++ b/ports/omplapp/portfile.cmake
@@ -66,6 +66,9 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/lib/libompl.so"
     "${CURRENT_PACKAGES_DIR}/lib/libompl.so.1.5.1"
     "${CURRENT_PACKAGES_DIR}/lib/libompl.so.16"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.1.5.1.dylib"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.16.dylib"
+    "${CURRENT_PACKAGES_DIR}/lib/libompl.dylib"
     "${CURRENT_PACKAGES_DIR}/share/ompl"
     "${CURRENT_PACKAGES_DIR}/share/man"
     "${CURRENT_PACKAGES_DIR}/debug/bin"
@@ -74,6 +77,9 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so"
     "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so.1.5.1"
     "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.so.16"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.1.5.1.dylib"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.16.dylib"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/libompl.dylib"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
 

--- a/ports/omplapp/vcpkg.json
+++ b/ports/omplapp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "omplapp",
   "version": "1.5.1",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Use OMPL for reading meshes and performing collision checking",
   "homepage": "https://ompl.kavrakilab.org/",
   "dependencies": [

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -877,17 +877,6 @@ ogre-next:x64-windows        = skip
 ogre-next:x64-windows-static = skip
 ogre-next:x64-windows-static-md=skip
 ogre-next:x86-windows        = skip
-# ompl is vulnerable to some form of race in its dependent ports, and adding 'ode' as a dependency
-# does not resolve the issue
-# src/ompl/CMakeFiles/ompl.dir/extensions/ode/src/OpenDEStateValidityChecker.cpp.o
-# -L/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib   -L/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib
-# -Wl,-rpath,/mnt/vcpkg-ci/packages/flann_x64-linux/debug/lib:/mnt/vcpkg-ci/packages/ode_x64-linux/debug/lib::::::::::::::::::::::::::::::::::::::::::::::::
-# -lode  /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_serialization.a
-# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_filesystem.a
-# /mnt/vcpkg-ci/installed/x64-linux/debug/lib/libboost_system.a  -lpthread && :
-# /usr/bin/ld: cannot find -lode
-ompl:x64-osx=fail
-ompl:x64-linux=fail
 openal-soft:arm-uwp=fail
 openal-soft:x64-uwp=fail
 openblas:arm64-windows=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4986,7 +4986,7 @@
     },
     "omplapp": {
       "baseline": "1.5.1",
-      "port-version": 3
+      "port-version": 4
     },
     "onednn": {
       "baseline": "2.4.3",

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b41d77505fc75d8501c7c98efe175327344e47a2",
+      "version": "1.5.1",
+      "port-version": 4
+    },
+    {
       "git-tree": "3f243c859f1597f18da61a472684c113e2ed150d",
       "version": "1.5.1",
       "port-version": 3

--- a/versions/o-/omplapp.json
+++ b/versions/o-/omplapp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b41d77505fc75d8501c7c98efe175327344e47a2",
+      "git-tree": "026107637855d7adc08feb42a6fe32b42c42b9da",
       "version": "1.5.1",
       "port-version": 4
     },


### PR DESCRIPTION
Fixes omplapp build failed with the following error:
```
CMake Error at scripts/cmake/vcpkg_replace_string.cmake:12 (file):
  file failed to open for reading (No such file or directory):

    /home/vlilywang/Lily/vcpkg/packages/omplapp_x64-linux/lib/pkgconfig/ompl.pc
```
The pkgconfig file **ompl.pc** will installed by **ompl**. And it doesn't have the related content about `assimp`.