### PR TITLE
[gtest] Fix clang-tidy error in gtest

### DIFF
--- a/ports/gtest/clang-tidy-no-lint.patch
+++ b/ports/gtest/clang-tidy-no-lint.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/include/gtest/gtest-matchers.h b/googletest/include/gtest/gtest-matchers.h
+index 2bd3dcf6..12cd60f6 100644
+--- a/googletest/include/gtest/gtest-matchers.h
++++ b/googletest/include/gtest/gtest-matchers.h
+@@ -403,6 +403,7 @@ class MatcherBase : private MatcherDescriberInterface {
+   };
+ 
+   void Destroy() {
++    // NOLINTNEXTLINE
+     if (IsShared() && buffer_.shared->Unref()) {
+       vtable_->shared_destroy(buffer_.shared);
+     }
+

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -9,7 +9,7 @@ vcpkg_from_github(
     SHA512 6fcc7827e4c4d95e3ae643dd65e6c4fc0e3d04e1778b84f6e06e390410fe3d18026c131d828d949d2f20dde6327d30ecee24dcd3ef919e21c91e010d149f3a28
     HEAD_REF main
     PATCHES
-        clang-tidy-no-lint.path
+        clang-tidy-no-lint.patch
         fix-main-lib-path.patch
         remove-werror.patch
 )

--- a/ports/gtest/portfile.cmake
+++ b/ports/gtest/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     SHA512 6fcc7827e4c4d95e3ae643dd65e6c4fc0e3d04e1778b84f6e06e390410fe3d18026c131d828d949d2f20dde6327d30ecee24dcd3ef919e21c91e010d149f3a28
     HEAD_REF main
     PATCHES
+        clang-tidy-no-lint.path
         fix-main-lib-path.patch
         remove-werror.patch
 )

--- a/ports/gtest/vcpkg.json
+++ b/ports/gtest/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gtest",
   "version-semver": "1.11.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "GoogleTest and GoogleMock testing frameworks",
   "homepage": "https://github.com/google/googletest",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2650,7 +2650,7 @@
     },
     "gtest": {
       "baseline": "1.11.0",
-      "port-version": 4
+      "port-version": 5
     },
     "gtk": {
       "baseline": "4.6.0",

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e63baca3da9732400c47ce2e0db995b6a156dc77",
+      "git-tree": "9731f44f8b0ecbc67eafccd0440700357d2cdfc4",
       "version-semver": "1.11.0",
       "port-version": 5
     },

--- a/versions/g-/gtest.json
+++ b/versions/g-/gtest.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e63baca3da9732400c47ce2e0db995b6a156dc77",
+      "version-semver": "1.11.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "9b9432e429e940c2d86eeef6fcf03bc74418c4c5",
       "version-semver": "1.11.0",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes clang-tidy in gtest, marked as "won't fix" by the maintainers: https://github.com/google/googletest/issues/3553

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
I didn't add or update any port.
