### PR TITLE
[nvtt] Fix build failed with Visual Studio 2022

### DIFF
--- a/ports/nvtt/fix-intrinsic-function.patch
+++ b/ports/nvtt/fix-intrinsic-function.patch
@@ -1,0 +1,19 @@
+diff --git a/src/nvmath/nvmath.h b/src/nvmath/nvmath.h
+index 38532eb..e68d8f8 100644
+--- a/src/nvmath/nvmath.h
++++ b/src/nvmath/nvmath.h
+@@ -118,12 +118,12 @@ inline float asinf_assert(const float f)
+ #endif
+ 
+ #if NV_CC_MSVC
+-NV_FORCEINLINE float log2f(float x)
++NV_FORCEINLINE float nv_log2f(float x)
+ {
+     nvCheck(x >= 0);
+     return logf(x) / logf(2.0f);
+ }
+-NV_FORCEINLINE float exp2f(float x)
++NV_FORCEINLINE float nv_exp2f(float x)
+ {
+     return powf(2.0f, x);
+ }

--- a/ports/nvtt/portfile.cmake
+++ b/ports/nvtt/portfile.cmake
@@ -14,27 +14,27 @@ vcpkg_from_github(
         fix-build-error.patch
         add-compile-options-for-osx.patch
         skip-building-libsquish.patch
+        fix-intrinsic-function.patch
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DNVTT_SHARED=0
         -DCMAKE_DEBUG_POSTFIX=_d # required by OSG
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
 
 vcpkg_copy_pdbs()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
-file(REMOVE ${CURRENT_PACKAGES_DIR}/share/doc/nvtt/LICENSE)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(REMOVE "${CURRENT_PACKAGES_DIR}/share/doc/nvtt/LICENSE")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nvtt/vcpkg.json
+++ b/ports/nvtt/vcpkg.json
@@ -1,11 +1,16 @@
 {
   "name": "nvtt",
   "version": "2.1.2",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Texture processing tools with support for Direct3D 10 and 11 formats.",
   "homepage": "https://github.com/castano/nvidia-texture-tools",
+  "license": "MIT",
   "supports": "!x86",
   "dependencies": [
-    "libsquish"
+    "libsquish",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4890,7 +4890,7 @@
     },
     "nvtt": {
       "baseline": "2.1.2",
-      "port-version": 3
+      "port-version": 4
     },
     "oatpp": {
       "baseline": "1.3.0",

--- a/versions/n-/nvtt.json
+++ b/versions/n-/nvtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5889b2b68d1c3b13bf681c75e0b8347fff3d72fc",
+      "version": "2.1.2",
+      "port-version": 4
+    },
+    {
       "git-tree": "e2db690561d6b3d44308bd53e0da9d3dc5794ea1",
       "version": "2.1.2",
       "port-version": 3


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes nvtt build failed with Visual Studio, due to the [upstream](https://github.com/castano/nvidia-texture-tools) is discontinued, so I just add a patch to fix this error on VCPKG.
```
D:\buildtrees\nvtt\src\2188752e3f-f52a2f5d6f.clean\src\nvmath\nvmath.h(122): error C2169: 'log2f': intrinsic function, cannot be defined

```


