### PR TITLE
[nss] Version bump to 3.77

### DIFF
--- a/ports/nss/portfile.cmake
+++ b/ports/nss/portfile.cmake
@@ -1,10 +1,10 @@
-set(NSS_VERSION "3.76.1")
+set(NSS_VERSION "3.77")
 string(REPLACE "." "_" V_URL ${NSS_VERSION})
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.mozilla.org/pub/security/nss/releases/NSS_${V_URL}_RTM/src/nss-${NSS_VERSION}.tar.gz"
     FILENAME "nss-${NSS_VERSION}.tar.gz"
-    SHA512 80d32a97501cbc05312caa5cec54fe6dd8708f01e6d15693e36a40d70433be7a35565fcc5fadfc324c998ee9093b10b2f7a89643882f06a850eda4ffd3b19c54
+    SHA512 bd62eeb8f90ecd2d3999fd78fea6652736c02a6530f29e98d0cad0707f3b901b30409132eb6a6d53b9f5c05c6b464615a946a2a3e255553c793e44d0ed93179e
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/nss/vcpkg.json
+++ b/ports/nss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nss",
-  "version": "3.76.1",
+  "version": "3.77",
   "description": "Network Security Services from Mozilla",
   "homepage": "https://ftp.mozilla.org/pub/security/nss/releases/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4857,7 +4857,7 @@
       "port-version": 0
     },
     "nss": {
-      "baseline": "3.76.1",
+      "baseline": "3.77",
       "port-version": 0
     },
     "nsync": {

--- a/versions/n-/nss.json
+++ b/versions/n-/nss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "06e7680df336bb6be816c75e42c6304d11566a3d",
+      "version": "3.77",
+      "port-version": 0
+    },
+    {
       "git-tree": "a5eabb67b345be280f94a3615aa3e08886ad4ec7",
       "version": "3.76.1",
       "port-version": 0


### PR DESCRIPTION
NSS 3.77 was released:

https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/zOd5WWPcPkc/m/2rVl77IkBQAJ