### PR TITLE
[openxr-loader] Fix package name and enable arm

### DIFF
--- a/ports/openxr-loader/portfile.cmake
+++ b/ports/openxr-loader/portfile.cmake
@@ -69,9 +69,9 @@ foreach(HEADER ${HEADER_LIST})
 endforeach()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
-else(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/openxr)
+    vcpkg_cmake_config_fixup(PACKAGE_NAME OpenXR CONFIG_PATH cmake)
+else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME OpenXR CONFIG_PATH lib/cmake/openxr)
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/openxr-loader/vcpkg.json
+++ b/ports/openxr-loader/vcpkg.json
@@ -1,10 +1,11 @@
 {
   "name": "openxr-loader",
   "version": "1.0.22",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices",
   "homepage": "https://github.com/KhronosGroup/OpenXR-SDK",
-  "supports": "!(arm | uwp)",
+  "license": "Apache-2.0",
+  "supports": "!uwp",
   "dependencies": [
     "jsoncpp",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5170,7 +5170,7 @@
     },
     "openxr-loader": {
       "baseline": "1.0.22",
-      "port-version": 1
+      "port-version": 2
     },
     "optimus-cpp": {
       "baseline": "0.3.0",

--- a/versions/o-/openxr-loader.json
+++ b/versions/o-/openxr-loader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27baef30397d0db0e6cc01d6f60a86e2ff4df238",
+      "version": "1.0.22",
+      "port-version": 2
+    },
+    {
       "git-tree": "9d673fe500c4b38f0806bd4b3c23a82bba897967",
       "version": "1.0.22",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Makes it easier to use openxr-loader and enabled arm

Previously it prints this with `find_package(openxr-loader` which is wrong and should have `OpenXR`.
```
[cmake] The package openxr-loader provides CMake targets:
[cmake] 
[cmake]     find_package(openxr-loader CONFIG REQUIRED)
[cmake]     target_link_libraries(main PRIVATE OpenXR::headers OpenXR::openxr_loader)
```

Now it prints:
```
[cmake] The package openxr-loader provides CMake targets:
[cmake] 
[cmake]     find_package(OpenXR CONFIG REQUIRED)
[cmake]     target_link_libraries(main PRIVATE OpenXR::headers OpenXR::openxr_loader)
```

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
I have removed the arm restriction after testing cross compiling to android and host compiling on linux arm

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
