### PR TITLE
[Openssl] Add message for installing linux-headers on alpine linux

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -3,7 +3,12 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/share/libressl/copyright"
     message(FATAL_ERROR "Can't build openssl if libressl/boringssl is installed. Please remove libressl/boringssl, and try install openssl again if you need it.")
 endif()
 
+if (VCPKG_TARGET_IS_LINUX)
+    message(WARNING "Openssl currently requires the following library from the system package manager:\n    linux-headers\n\nIt can be installed on alpine systems via apk add linux-headers.")
+endif()
+
 set(OPENSSL_VERSION 3.0.2)
+
 vcpkg_download_distfile(
     ARCHIVE
     URLS "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
@@ -23,10 +28,6 @@ elseif(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     include("${CMAKE_CURRENT_LIST_DIR}/install-pc-files.cmake")
 else()
     include("${CMAKE_CURRENT_LIST_DIR}/unix/portfile.cmake")
-endif()
-
-if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "Openssl currently requires the following library from the system package manager:\n    linux-headers\n\nIt can be installed on alpine systems via apk add linux-headers.")
 endif()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -4,7 +4,11 @@ if(EXISTS "${CURRENT_INSTALLED_DIR}/share/libressl/copyright"
 endif()
 
 if (VCPKG_TARGET_IS_LINUX)
-    message(WARNING "Openssl currently requires the following library from the system package manager:\n    linux-headers\n\nIt can be installed on alpine systems via apk add linux-headers.")
+    message(WARNING
+[[openssl currently requires the following library from the system package manager:
+    linux-headers
+It can be installed on alpine systems via apk add linux-headers.]]
+    )
 endif()
 
 set(OPENSSL_VERSION 3.0.2)

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -25,5 +25,9 @@ else()
     include("${CMAKE_CURRENT_LIST_DIR}/unix/portfile.cmake")
 endif()
 
+if (VCPKG_TARGET_IS_LINUX)
+    message(WARNING "Openssl currently requires the following library from the system package manager:\n    linux-headers\n\nIt can be installed on alpine systems via apk add linux-headers.")
+endif()
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openssl",
   "version": "3.0.2",
+  "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "OpenSSL",

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
-  "license": "OpenSSL",
+  "license": "Apache-2.0",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5138,7 +5138,7 @@
     },
     "openssl": {
       "baseline": "3.0.2",
-      "port-version": 0
+      "port-version": 1
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "30575153173c6b110f79e2466fd58e14ad94d4fa",
+      "git-tree": "4995232cb051d1979e4f1b3ccbc6989ae6a66bd9",
       "version": "3.0.2",
       "port-version": 1
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9b90a20e44bcce61ccf2ea634c0b9c77e4d74d2b",
+      "git-tree": "4bb8958909f1df964d0f5ed8ca8089b3b1b235ad",
       "version": "3.0.2",
       "port-version": 1
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9b90a20e44bcce61ccf2ea634c0b9c77e4d74d2b",
+      "version": "3.0.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "2ba2e59ee4f32c11e30aeccc0ecabc09b69c5d22",
       "version": "3.0.2",
       "port-version": 0

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bb8958909f1df964d0f5ed8ca8089b3b1b235ad",
+      "git-tree": "30575153173c6b110f79e2466fd58e14ad94d4fa",
       "version": "3.0.2",
       "port-version": 1
     },


### PR DESCRIPTION
Fix #23889 

[Openssl] requires linux-headers on alpine linux.

Add message to remind alpine linux users.