### PR TITLE
[opencascade] Fix link the debug of freetype.dll

### DIFF
--- a/ports/opencascade/fix-depend-freetype.patch
+++ b/ports/opencascade/fix-depend-freetype.patch
@@ -1,13 +1,17 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbcede5..2e96a25 100644
+index fbcede5..7b94f13 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -563,7 +563,7 @@ if (CAN_USE_FREETYPE)
+@@ -563,7 +563,11 @@ if (CAN_USE_FREETYPE)
    if (USE_FREETYPE)
      message (STATUS "Info: FreeType is used by OCCT")
      add_definitions (-DHAVE_FREETYPE)
 -    OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/freetype")
 +    find_package(freetype CONFIG REQUIRED)
++    find_path(FREETYPE_INCLUDE_DIR freetype.h PATH_SUFFIXES freetype)
++    find_path(FT2BUILD_INCLUDE_DIR ft2build.h PATH_SUFFIXES include)
++    list (APPEND 3RDPARTY_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
++    list (APPEND 3RDPARTY_INCLUDE_DIRS "${FT2BUILD_INCLUDE_DIR}")
    else()
      OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")
      OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2")

--- a/ports/opencascade/fix-depend-freetype.patch
+++ b/ports/opencascade/fix-depend-freetype.patch
@@ -1,17 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fbcede5..7b94f13 100644
+index fbcede5..66b127d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -563,7 +563,11 @@ if (CAN_USE_FREETYPE)
+@@ -563,7 +563,9 @@ if (CAN_USE_FREETYPE)
    if (USE_FREETYPE)
      message (STATUS "Info: FreeType is used by OCCT")
      add_definitions (-DHAVE_FREETYPE)
 -    OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/freetype")
 +    find_package(freetype CONFIG REQUIRED)
-+    find_path(FREETYPE_INCLUDE_DIR freetype.h PATH_SUFFIXES freetype)
-+    find_path(FT2BUILD_INCLUDE_DIR ft2build.h PATH_SUFFIXES include)
++	get_target_property(FREETYPE_INCLUDE_DIR freetype INTERFACE_INCLUDE_DIRECTORIES)
 +    list (APPEND 3RDPARTY_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR}")
-+    list (APPEND 3RDPARTY_INCLUDE_DIRS "${FT2BUILD_INCLUDE_DIR}")
    else()
      OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")
      OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2")

--- a/ports/opencascade/fix-depend-freetype.patch
+++ b/ports/opencascade/fix-depend-freetype.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fbcede5..2e96a25 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -563,7 +563,7 @@ if (CAN_USE_FREETYPE)
+   if (USE_FREETYPE)
+     message (STATUS "Info: FreeType is used by OCCT")
+     add_definitions (-DHAVE_FREETYPE)
+-    OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/freetype")
++    find_package(freetype CONFIG REQUIRED)
+   else()
+     OCCT_CHECK_AND_UNSET_GROUP ("3RDPARTY_FREETYPE")
+     OCCT_CHECK_AND_UNSET ("3RDPARTY_FREETYPE_INCLUDE_DIR_freetype2")

--- a/ports/opencascade/portfile.cmake
+++ b/ports/opencascade/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
         fix-pdb-find.patch
         fix-install-prefix-path.patch
         install-include-dir.patch
+        fix-depend-freetype.patch
 )
 
 if (VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
@@ -49,22 +50,22 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/opencascade)
 #make occt includes relative to source_file
 list(APPEND ADDITIONAL_HEADERS 
       "ExprIntrp.tab.h"
-	  "FlexLexer.h"
-	  "glext.h"
-	  "igesread.h"
-	  "NCollection_Haft.h"
-	  "OSD_PerfMeter.h"
-	  "Standard_values.h"
+      "FlexLexer.h"
+      "glext.h"
+      "igesread.h"
+      "NCollection_Haft.h"
+      "OSD_PerfMeter.h"
+      "Standard_values.h"
     )
 
 file(GLOB files "${CURRENT_PACKAGES_DIR}/include/opencascade/[a-zA-Z0-9_]*\.[hgl]xx")
 foreach(file_name IN LISTS files)
-	file(READ "${file_name}" filedata)
-	string(REGEX REPLACE "# *include \<([a-zA-Z0-9_]*\.[hgl]xx)\>" "#include \"\\1\"" filedata "${filedata}")
-	foreach(extra_header IN LISTS ADDITIONAL_HEADERS)
-		string(REGEX REPLACE "# *include \<${extra_header}\>" "#include \"${extra_header}\"" filedata "${filedata}")
-	endforeach()
-	file(WRITE "${file_name}" "${filedata}")
+    file(READ "${file_name}" filedata)
+    string(REGEX REPLACE "# *include \<([a-zA-Z0-9_]*\.[hgl]xx)\>" "#include \"\\1\"" filedata "${filedata}")
+    foreach(extra_header IN LISTS ADDITIONAL_HEADERS)
+        string(REGEX REPLACE "# *include \<${extra_header}\>" "#include \"${extra_header}\"" filedata "${filedata}")
+    endforeach()
+    file(WRITE "${file_name}" "${filedata}")
 endforeach()
 
 # Remove libd to lib, libd just has cmake files we dont want too

--- a/ports/opencascade/vcpkg.json
+++ b/ports/opencascade/vcpkg.json
@@ -1,8 +1,10 @@
 {
   "name": "opencascade",
   "version": "7.6.0",
+  "port-version": 1,
   "description": "Open CASCADE Technology (OCCT) is an open-source software development platform for 3D CAD, CAM, CAE.",
   "homepage": "https://github.com/Open-Cascade-SAS/OCCT",
+  "license": "LGPL-2.1",
   "supports": "!(uwp | osx | linux | arm)",
   "dependencies": [
     "freetype",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5026,7 +5026,7 @@
     },
     "opencascade": {
       "baseline": "7.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "opencc": {
       "baseline": "2020-04-26",

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "86ca05bbb647a8b18d7fb387d762dc78d2607873",
+      "git-tree": "8eb377a63015041caaee69b9560ec5ed5cc4fc49",
       "version": "7.6.0",
       "port-version": 1
     },

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8eb377a63015041caaee69b9560ec5ed5cc4fc49",
+      "git-tree": "0b043af5fd55a990d23a36523c82b005422ba75c",
       "version": "7.6.0",
       "port-version": 1
     },

--- a/versions/o-/opencascade.json
+++ b/versions/o-/opencascade.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "86ca05bbb647a8b18d7fb387d762dc78d2607873",
+      "version": "7.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "a1f9f32c2e0778573a20d4b59fda9be37cf6134d",
       "version": "7.6.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #16648
  Change `opencascade` use `freetype` provided by VCPKG, because the internal `freetype` will search debug dll which name is `freetype.dll`, it can't found. The correct debug dll name is `freetyped.dll`.


