### PR TITLE
[clblast] Fix static build

### DIFF
--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -17,8 +17,11 @@ vcpkg_cmake_install()
 if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
     file(RENAME "${CURRENT_PACKAGES_DIR}/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/bin/clblast.dll")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
+    
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
+    endif()
 endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CLBLast)

--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -8,27 +8,17 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DTUNERS=OFF
 )
 
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
-
-if(VCPKG_TARGET_IS_WINDOWS)
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/clblast.dll")
-        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/bin/clblast.dll")
-    endif()
-    if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll")
-        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
-        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
-    endif()
-    file(GLOB EXE "${CURRENT_PACKAGES_DIR}/bin/*.exe")
-    file(GLOB DEBUG_EXE "${CURRENT_PACKAGES_DIR}/debug/bin/*.exe")
-    if(EXE OR DEBUG_EXE)
-        file(REMOVE ${EXE} ${DEBUG_EXE})
-    endif()
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/bin/clblast.dll")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
 endif()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/clblast)

--- a/ports/clblast/portfile.cmake
+++ b/ports/clblast/portfile.cmake
@@ -21,7 +21,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/clblast.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/clblast.dll")
 endif()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/clblast)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/CLBLast)
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/clblast/vcpkg.json
+++ b/ports/clblast/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "clblast",
   "version": "1.5.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A modern, lightweight, performant and tunable OpenCL BLAS library written in C++11.",
   "homepage": "https://github.com/CNugteren/CLBlast",
-  "supports": "!static",
+  "license": "Apache-2.0",
   "dependencies": [
     "opencl",
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1394,7 +1394,7 @@
     },
     "clblast": {
       "baseline": "1.5.2",
-      "port-version": 1
+      "port-version": 2
     },
     "clfft": {
       "baseline": "2.12.2",

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "207ebf751be0456317f83265517f4a5e58f0d33c",
+      "git-tree": "8ad15a647294fd67eb2771d461ce228bee7ae7d4",
       "version": "1.5.2",
       "port-version": 2
     },

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "207ebf751be0456317f83265517f4a5e58f0d33c",
+      "version": "1.5.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "e85773ea54da7675b468d6fd479871899667aa3a",
       "version": "1.5.2",
       "port-version": 1

--- a/versions/c-/clblast.json
+++ b/versions/c-/clblast.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8ad15a647294fd67eb2771d461ce228bee7ae7d4",
+      "git-tree": "f3fc8c351cba8b45e06d835b27101617a5ba74b0",
       "version": "1.5.2",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  By default, some executables are built. I disabled this behaviour via `-DTUNERS=OFF`
  I noticed that this port supports static builds although it was disabled in #20915, so I re-enabled it.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

