### PR TITLE
[baseline][quickfix] Don't build tests

### DIFF
--- a/ports/quickfix/00001-fix-build.patch
+++ b/ports/quickfix/00001-fix-build.patch
@@ -1,8 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 48908ead..5022a019 100644
+index 48908ead..90c17759 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -96,9 +96,12 @@ add_subdirectory(UnitTest++)
+@@ -92,13 +92,13 @@ include_directories(${PYTHON_INCLUDE_DIRS})
+ endif ()
+ 
+ if( WIN32 OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
+-add_subdirectory(UnitTest++)
++#add_subdirectory(UnitTest++)
  endif()
  
  add_subdirectory(src)
@@ -11,12 +16,21 @@ index 48908ead..5022a019 100644
  if( WIN32)
 -add_subdirectory(test)
 +#add_subdirectory(test)
-+target_compile_definitions(TestUnitTest++ PRIVATE _CRT_SECURE_NO_WARNINGS)
-+target_compile_definitions(UnitTest++ PRIVATE _CRT_SECURE_NO_WARNINGS)
-+target_compile_definitions(ut PRIVATE _WINSOCK_DEPRECATED_NO_WARNINGS)
  endif()
  
  install(DIRECTORY ${CMAKE_SOURCE_DIR}/spec/ DESTINATION share/quickfix
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index cb4a60c6..d21fa995 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ add_subdirectory(C++)
+ 
+-if( WIN32 OR ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
++if(0)
+ 
+ add_executable(at at.cpp getopt.c)
+ 
 diff --git a/src/C++/CMakeLists.txt b/src/C++/CMakeLists.txt
 index 07774c97..27692631 100644
 --- a/src/C++/CMakeLists.txt

--- a/ports/quickfix/vcpkg.json
+++ b/ports/quickfix/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "quickfix",
   "version": "1.15.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "QuickFIX is a free and open source implementation of the FIX protocol.",
   "homepage": "https://github.com/quickfix/quickfix",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5994,7 +5994,7 @@
     },
     "quickfix": {
       "baseline": "1.15.1",
-      "port-version": 6
+      "port-version": 7
     },
     "quill": {
       "baseline": "1.6.3",

--- a/versions/q-/quickfix.json
+++ b/versions/q-/quickfix.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "73e9e7e7bcc08f6f0f491d68cd2ff93f5571353f",
+      "version": "1.15.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "a9ec8c3d5dfd310a3f5d5c54bebc6030b4cad0c6",
       "version": "1.15.1",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  See https://dev.azure.com/vcpkg/public/_build/results?buildId=69982&view=logs&j=84da4f4a-968a-5b5c-16e9-f444c845396d&t=80e5e0c8-bb3b-5216-9f3f-2618d4e9f3f4

  `quickfix` still built tests via https://github.com/quickfix/quickfix/blob/master/src/CMakeLists.txt
  I disabled those tests as well. Baseline failed likely because `quickfix`'s build system picks up testing libraries provided by other ports.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
