### PR TITLE
[tgbot-cpp] Update to v1.3

### DIFF
--- a/ports/tgbot-cpp/portfile.cmake
+++ b/ports/tgbot-cpp/portfile.cmake
@@ -1,17 +1,16 @@
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO reo7sp/tgbot-cpp
-  REF v1.2.1
-  SHA512 b094f9c80dd15b7930b7d7250169b3199d9c84b84826adececa8237111f5ba384ec790dbe969999f362ca2fb35b93950d053777ce5f167007e33c3e4eb133453
+  REF v1.3
+  SHA512 1b992c7705a5f7bb081df3eb032feb78b2b5eb2e73a7be822cd12552702a4d18ac9eecbd0c842f2d6c48757e91d3f8ceb5965237264b9ec18657e51c3bde7f79
   HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)

--- a/ports/tgbot-cpp/vcpkg.json
+++ b/ports/tgbot-cpp/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "tgbot-cpp",
-  "version-string": "1.2.1",
-  "port-version": 1,
+  "version": "1.3",
   "description": "C++14 library for Telegram bot API.",
   "homepage": "https://github.com/reo7sp/tgbot-cpp",
+  "license": "MIT",
   "dependencies": [
     "boost-algorithm",
     "boost-asio",
@@ -14,6 +14,10 @@
     "boost-variant",
     "curl",
     "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
     "zlib"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6869,8 +6869,8 @@
       "port-version": 3
     },
     "tgbot-cpp": {
-      "baseline": "1.2.1",
-      "port-version": 1
+      "baseline": "1.3",
+      "port-version": 0
     },
     "tgc": {
       "baseline": "2019-08-11",

--- a/versions/t-/tgbot-cpp.json
+++ b/versions/t-/tgbot-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e6256e56c77c074f61eaf4dda7bb2962e13e8e4b",
+      "version": "1.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "a48e654a56a7017acf3d0f0b119a96e9235119f9",
       "version-string": "1.2.1",
       "port-version": 1


### PR DESCRIPTION
Updates `tgbot-cpp` port to version `1.3`. Also updates `manifest` and `portfile` to match new maintainer guidelines.
