### PR TITLE
[glew] fix static installation target

### DIFF
--- a/ports/glew/install-static.patch
+++ b/ports/glew/install-static.patch
@@ -1,0 +1,12 @@
+diff --git a/build/cmake/CMakeLists.txt b/build/cmake/CMakeLists.txt
+index f81fab4..31aced9 100644
+--- a/build/cmake/CMakeLists.txt
++++ b/build/cmake/CMakeLists.txt
+@@ -161,6 +161,7 @@ endif()
+ set(targets_to_install "")
+ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+   list(APPEND targets_to_install glew)
++  list(APPEND targets_to_install glew_s)
+ endif()
+ 
+ if(NOT DEFINED BUILD_SHARED_LIBS OR NOT BUILD_SHARED_LIBS)

--- a/ports/glew/portfile.cmake
+++ b/ports/glew/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_extract_source_archive_ex(
     REF glew
     PATCHES
         fix-LNK2019.patch
+        install-static.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "glew",
   "version-string": "2.2.0",
+  "port-version": 1,
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",
   "dependencies": [

--- a/ports/glew/vcpkg.json
+++ b/ports/glew/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "glew",
-  "version-string": "2.2.0",
+  "version": "2.2.0",
   "port-version": 1,
   "description": "The OpenGL Extension Wrangler Library (GLEW) is a cross-platform open-source C/C++ extension loading library.",
   "homepage": "https://github.com/nigels-com/glew",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2502,7 +2502,7 @@
     },
     "glew": {
       "baseline": "2.2.0",
-      "port-version": 0
+      "port-version": 1
     },
     "glfw3": {
       "baseline": "3.3.6",

--- a/versions/g-/glew.json
+++ b/versions/g-/glew.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52b445b12a81fc802185624d0032b819e4e622d6",
+      "version": "2.2.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "3211ed09c36542372ab3f1f690a42e2edbb072bc",
       "version-string": "2.2.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
static and dynamic libraries are build unabhängig from the target configuration. However only dynamic or static are installed depending on the triplet. https://cmake.org/cmake/help/latest/module/FindGLEW.html defines a way to find explicitly the static variant of glew. For a port I'm currently working on, I would need this behavior as it is a `privat` dependency of the port.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
yes
**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
