### PR TITLE
[clockutils] Fix x64-windows-static-md

### DIFF
--- a/ports/clockutils/portfile.cmake
+++ b/ports/clockutils/portfile.cmake
@@ -5,17 +5,19 @@ vcpkg_from_github(
     SHA512 ddb70cae9ced25de77a2df1854dac15e58a77347042ba3ee9c691f85f49edbc6539c84929a7477d429fb9161ba24c57d24d767793b8b1180216d5ddfc5d3ed6a
     HEAD_REF dev-1.2
     PATCHES
-        "${CURRENT_PORT_DIR}/fix-warningC4643.patch"
+        fix-warningC4643.patch
 )
 
-if (VCPKG_CRT_LINKAGE STREQUAL dynamic)
-    SET(SHARED_FLAG ON)
-else()
-    SET(SHARED_FLAG OFF)
+set(SHARED_FLAG OFF)
+set(USE_MSBUILD "")
+if("${VCPKG_LIBRARY_LINKAGE}" STREQUAL "dynamic")
+    set(SHARED_FLAG ON)
+    set(USE_MSBUILD WINDOWS_USE_MSBUILD) # MS Build only required for dynamic builds
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    ${USE_MSBUILD}
     OPTIONS
         -DWITH_LIBRARY_ARGPARSER=ON
         -DWITH_LIBRARY_COMPRESSION=ON
@@ -26,13 +28,11 @@ vcpkg_configure_cmake(
         -DCLOCKUTILS_BUILD_SHARED=${SHARED_FLAG}
 )
 
-vcpkg_install_cmake()
-
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-
-file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/clockUtils)
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/clockUtils/LICENSE ${CURRENT_PACKAGES_DIR}/share/clockUtils/copyright)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/LICENSE)
-file(REMOVE ${CURRENT_PACKAGES_DIR}/debug/LICENSE)
-
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/LICENSE")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/LICENSE")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/clockutils/vcpkg.json
+++ b/ports/clockutils/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "clockutils",
-  "version-string": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
-  "port-version": 5,
+  "version-date": "2017-02-18",
   "description": "A lightweight c++ library for commonly needed tasks. Optimized for simplicity and speed.",
   "homepage": "https://github.com/ClockworkOrigins/clockUtils",
   "license": "MIT",

--- a/ports/clockutils/vcpkg.json
+++ b/ports/clockutils/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "clockutils",
-  "version-date": "2017-02-18",
+  "version": "1.1.1",
+  "port-version": 1,
   "description": "A lightweight c++ library for commonly needed tasks. Optimized for simplicity and speed.",
   "homepage": "https://github.com/ClockworkOrigins/clockUtils",
   "license": "MIT",

--- a/ports/clockutils/vcpkg.json
+++ b/ports/clockutils/vcpkg.json
@@ -1,7 +1,14 @@
 {
   "name": "clockutils",
   "version-string": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "A lightweight c++ library for commonly needed tasks. Optimized for simplicity and speed.",
-  "homepage": "https://github.com/ClockworkOrigins/clockUtils"
+  "homepage": "https://github.com/ClockworkOrigins/clockUtils",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1401,7 +1401,6 @@ lapack-reference:x64-uwp=skip
 # failures for x64-windows-static-md
 ace:x64-windows-static-md=fail
 akali:x64-windows-static-md=fail
-clockutils:x64-windows-static-md=fail
 fastcgi:x64-windows-static-md=fail
 ijg-libjpeg:x64-windows-static-md=fail
 libcerf:x64-windows-static-md=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1417,8 +1417,8 @@
       "port-version": 1
     },
     "clockutils": {
-      "baseline": "2017-02-18",
-      "port-version": 0
+      "baseline": "1.1.1",
+      "port-version": 1
     },
     "clp": {
       "baseline": "1.17.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1418,7 +1418,7 @@
     },
     "clockutils": {
       "baseline": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
-      "port-version": 4
+      "port-version": 5
     },
     "clp": {
       "baseline": "1.17.6",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1417,8 +1417,8 @@
       "port-version": 1
     },
     "clockutils": {
-      "baseline": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
-      "port-version": 5
+      "baseline": "2017-02-18",
+      "port-version": 0
     },
     "clp": {
       "baseline": "1.17.6",

--- a/versions/c-/clockutils.json
+++ b/versions/c-/clockutils.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "2237e9baf08dfd3d91810731bf84c37a34d53f23",
-      "version-date": "2017-02-18",
-      "port-version": 0
+      "git-tree": "08f337ddf39f1cda9dd6431374cdb0ee748745da",
+      "version": "1.1.1",
+      "port-version": 1
     },
     {
       "git-tree": "1fb64c4ec3d5aced719df16f96e79be4bb64cee7",

--- a/versions/c-/clockutils.json
+++ b/versions/c-/clockutils.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9c5328d3f023312567e2cd4c00cf1db11dedb2a5",
+      "version-string": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
+      "port-version": 5
+    },
+    {
       "git-tree": "1fb64c4ec3d5aced719df16f96e79be4bb64cee7",
       "version-string": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
       "port-version": 4

--- a/versions/c-/clockutils.json
+++ b/versions/c-/clockutils.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "9c5328d3f023312567e2cd4c00cf1db11dedb2a5",
-      "version-string": "1.1.1-3651f232c27074c4ceead169e223edf5f00247c5",
-      "port-version": 5
+      "git-tree": "2237e9baf08dfd3d91810731bf84c37a34d53f23",
+      "version-date": "2017-02-18",
+      "port-version": 0
     },
     {
       "git-tree": "1fb64c4ec3d5aced719df16f96e79be4bb64cee7",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Note: still using `version-string` because of appended commit id

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Removed from CI baseline; all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

