### PR TITLE
[google-cloud-cpp] update to latest release (v1.39.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.38.0
-    SHA512 8d13450d5d669c8f736a6b8cb57291e7de997ab8dcd3dbce8dabd6d71ff81096ef92f02cf64711d40a1465b47f8fd5ce21a355c9526c5900adc076e25b062fa7
+    REF v1.39.0
+    SHA512 d61ebcdb6680797f20147ee1d37b9d29c82e8c7267b944a346685bfa607cf0b7f1772854874b967f19b4f54ddcefc94a771a4686cafcd6a5fed426d64e553205
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,25 +1,24 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0e2b703..7097f06 100644
+diff --git a//CMakeLists.txt b/CMakeLists.txt
+index 4d03fee..42bb13c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,8 +28,13 @@ project(
-     VERSION 1.38.0
-     LANGUAGES CXX C)
+@@ -43,6 +43,14 @@ if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
+     set(CMAKE_CXX_STANDARD 11)
+ endif ()
  
--# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
--if (NOT CMAKE_CXX_STANDARD)
 +find_package(absl CONFIG REQUIRED)
 +
 +# Use CMAKE_CXX_STANDARD=17 if ABSL_USE_CXX17 is set
 +if (ABSL_USE_CXX17)
 +    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
 +    set(CMAKE_CXX_STANDARD 17)
-+elseif (NOT CMAKE_CXX_STANDARD)
-     set(CMAKE_CXX_STANDARD 11)
- endif ()
- if (CMAKE_CXX_STANDARD VERSION_LESS 11)
++endif ()
++
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+         message(
 diff --git a/google/cloud/internal/port_platform.h b/google/cloud/internal/port_platform.h
-index c9f34cf..e624004 100644
+index f02cb7a..0ea8c9c 100644
 --- a/google/cloud/internal/port_platform.h
 +++ b/google/cloud/internal/port_platform.h
 @@ -49,6 +49,8 @@

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.38.0",
-  "port-version": 2,
+  "version": "1.39.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2565,8 +2565,8 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "1.38.0",
-      "port-version": 2
+      "baseline": "1.39.0",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ca8e8015d59f4f5e03b0a257d46506c2b0219a71",
+      "version": "1.39.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a22f467e483356f9ce6b6d8502385d447c28912a",
       "version": "1.38.0",
       "port-version": 2


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.39.0)

- #### What does your PR fix?

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.
