### PR TITLE
[cub] Update to 1.16.0

### DIFF
--- a/ports/cub/fix-usage.patch
+++ b/ports/cub/fix-usage.patch
@@ -1,0 +1,24 @@
+diff --git a/cub/cmake/cub-config.cmake b/cub/cmake/cub-config.cmake
+index 3d7f64b..213a95e 100644
+--- a/cub/cmake/cub-config.cmake
++++ b/cub/cmake/cub-config.cmake
+@@ -8,6 +8,7 @@ if (TARGET CUB::CUB)
+   return()
+ endif()
+ 
++include("${CMAKE_CURRENT_LIST_DIR}/cub-header-search.cmake")
+ function(_cub_declare_interface_alias alias_name ugly_name)
+   # 1) Only IMPORTED and ALIAS targets can be placed in a namespace.
+   # 2) When an IMPORTED library is linked to another target, its include
+diff --git a/cub/cmake/cub-header-search.cmake.in b/cub/cmake/cub-header-search.cmake.in
+index 2a46606..d2c38ef 100644
+--- a/cub/cmake/cub-header-search.cmake.in
++++ b/cub/cmake/cub-header-search.cmake.in
+@@ -3,6 +3,6 @@ unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
+ find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+-    "${CMAKE_CURRENT_LIST_DIR}/../../../@CMAKE_INSTALL_INCLUDEDIR@" # Install tree
++    "${CMAKE_CURRENT_LIST_DIR}/../../@CMAKE_INSTALL_INCLUDEDIR@" # Install tree
+ )
+ set_property(CACHE _CUB_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)

--- a/ports/cub/portfile.cmake
+++ b/ports/cub/portfile.cmake
@@ -1,11 +1,31 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO NVlabs/cub
-    REF 7cdf6dfc7ed60e4f44d025b84ea8260755f298e6 #v1.12.0
-    SHA512 aff3ba375a33844efdc57f8ba190e8880db6247bc1245340b2fe87f8933d3abfcbc7dcdffffd45cf00db4981cd2e37029061fca7161554a4c7c779a7d414aada
+    REF ed040d585c3237d706973d7ad290bfee40958270 #v1.16.0
+    SHA512 81e0bacb0aa4ee7a1c86f3c12e3135a133579678d3530e0e0b8310f716d0355e5096925ac6de5865140a7aac08d974ea5169d47e34951b932a23965f74fe4ee6
     HEAD_REF master
+    PATCHES fix-usage.patch
 )
 
-file(COPY ${SOURCE_PATH}/cub/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/cub)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCUB_ENABLE_INSTALL_RULES=ON
+        -DCUB_ENABLE_HEADER_TESTING=OFF
+        -DCUB_ENABLE_TESTING=OFF
+        -DCUB_ENABLE_EXAMPLES=OFF
+        -DCUB_ENABLE_CPP_DIALECT_IN_NAMES=ON
+)
 
-configure_file(${SOURCE_PATH}/LICENSE.TXT ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/cub)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/cub/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug"
+                    "${CURRENT_PACKAGES_DIR}/lib"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/cub/usage
+++ b/ports/cub/usage
@@ -1,0 +1,4 @@
+The package cub is header only and can be used from CMake via:
+
+    find_package(cub CONFIG REQUIRED)
+    target_include_directories(main PRIVATE CUB::CUB)

--- a/ports/cub/vcpkg.json
+++ b/ports/cub/vcpkg.json
@@ -1,9 +1,18 @@
 {
   "name": "cub",
-  "version": "1.12.0",
+  "version": "1.16.0",
   "description": "CUB is a flexible library of cooperative threadblock primitives and other utilities for CUDA kernel programming",
   "homepage": "https://github.com/NVIDIA/cub",
+  "license": "BSD-3-Clause",
   "dependencies": [
-    "cuda"
+    "cuda",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1713,7 +1713,7 @@
       "port-version": 0
     },
     "cub": {
-      "baseline": "1.12.0",
+      "baseline": "1.16.0",
       "port-version": 0
     },
     "cuda": {

--- a/versions/c-/cub.json
+++ b/versions/c-/cub.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d6fe5c753cf67eeb18b536ea933864d15a88331d",
+      "version": "1.16.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "ec58db0c42a8978215a38d7e9ac938dd1b936c1f",
       "version": "1.12.0",
       "port-version": 0


### PR DESCRIPTION
Upgrade cub to 1.16.0 to use [official patch](https://github.com/NVIDIA/cub/pull/423) to fix fatal bug:
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(338): error: invalid combination of type specifiers 
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(338): error: expected an identifier 
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(379): error: expected a member name
```
Also refactor the installation.