### PR TITLE
[qtkeychain] Update to 0.13.2+2 to fix the exported CMake target

### DIFF
--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -3,8 +3,9 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF v0.13.2
-    SHA512 10f8b1c959a126ba14614b797ea5640404a0b95c71e452225c74856eae90e966aac581ca393508a2106033c3d5ad70427ea6f7ef3f2997eddf6d09a7b4fa26eb
+    # 0.13.2 plus two commits, for a CMake export target fix
+    REF e5eeb1763e295f6b05a3f008ee7ae192fd74ed0c
+    SHA512 c6f216c8acdd89607d16582305bff962a0049512565f8ead7bebf06bce1540cdf41cc8b6dc31b45396befd90a3bd65a2f8a969242f302cbb61438ff7a48aab1c
     HEAD_REF master
 )
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtkeychain",
   "version": "0.13.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5878,7 +5878,7 @@
     },
     "qtkeychain": {
       "baseline": "0.13.2",
-      "port-version": 1
+      "port-version": 2
     },
     "qtkeychain-qt6": {
       "baseline": "0.13.2",

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6311d9dd13b97c8a01a980d7b42ea6cfecc4f765",
+      "version": "0.13.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "ef01f1d6401814e50c0438d3a8a7770568ac93ca",
       "version": "0.13.2",
       "port-version": 1


### PR DESCRIPTION
This allows to link the target application using CMake < 3.18
and fixing a regression since v0.13.0

Since upstream is only two commits ahead, I have references the head commit, instead patching the source manual.
https://github.com/frankosterfeld/qtkeychain/commit/e5eeb1763e295f6b05a3f008ee7ae192fd74ed0c

- #### What does your PR fix?
It fixes the exported CMake target 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes