### PR TITLE
[iir1] Fix find_package failed

### DIFF
--- a/ports/iir1/portfile.cmake
+++ b/ports/iir1/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+vcpkg_cmake_config_fixup(PACKAGE_NAME iir CONFIG_PATH lib/cmake/iir)
 
 vcpkg_copy_pdbs()
 

--- a/ports/iir1/vcpkg.json
+++ b/ports/iir1/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "iir1",
   "version": "1.9.0",
+  "port-version": 1,
   "description": "Realtime C++ filter library",
   "homepage": "https://github.com/berndporr/iir1",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2882,7 +2882,7 @@
     },
     "iir1": {
       "baseline": "1.9.0",
-      "port-version": 0
+      "port-version": 1
     },
     "ijg-libjpeg": {
       "baseline": "9d",

--- a/versions/i-/iir1.json
+++ b/versions/i-/iir1.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "393a498a50400c062dafdefbbbdbd3d1c3daef4a",
+      "version": "1.9.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "45098a249e45e71b1efa228efae07950b4499be4",
       "version": "1.9.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #23940

The port's name is "iir1" while using find_package(iir):

````
    find_package(iir CONFIG REQUIRED)
    target_link_libraries(main PRIVATE iir::iir iir::iir_static)
````

so the search path of iir-config.cmakewill be installed/x64-windows/share/iir

however, vcpkg only creates dir installed/x64-windows/share/iir1/iir, thus find_package(iir) failed

Solution:
I change vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake) to vcpkg_cmake_config_fixup(PACKAGE_NAME iir CONFIG_PATH lib/cmake/iir)  Fix this error,

I tested the usage locally:
````
1> CMake generation started for configuration: 'x64-Debug'.
1> Command line: "C:\WINDOWS\system32\cmd.exe" /c "%SYSTEMROOT%\System32\chcp.com 65001 >NUL && "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\CMake\bin\cmake.exe"  -G "Visual Studio 16 2019" -A x64  -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DCMAKE_INSTALL_PREFIX:PATH="C:\Users\test\source\repos\iir1-test\out\install\x64-Debug" -DCMAKE_TOOLCHAIN_FILE=F:/Feature-test/iir1/vcpkg/scripts/buildsystems/vcpkg.cmake "C:\Users\test\source\repos\iir1-test" 2>&1"
1> Working directory: C:\Users\test\source\repos\iir1-test\out\build\x64-Debug
1> [CMake] -- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19042.
1> [CMake] -- Configuring done
1> [CMake] -- Generating done
1> [CMake] -- Build files have been written to: C:/Users/test/source/repos/iir1-test/out/build/x64-Debug
1> Extracted CMake variables.
1> Extracted source files and headers.
1> Extracted code model.
1> Extracted toolchain configurations.
1> Extracted includes paths.
1> CMake generation finished.
````
````
Rebuild started...
1>------ Rebuild All started: Project: ZERO_CHECK, Configuration: Debug x64 ------
1>Checking Build System
2>------ Rebuild All started: Project: iir1-test, Configuration: Debug x64 ------
2>Building Custom Rule C:/Users/test/source/repos/iir1-test/iir1-test/CMakeLists.txt
2>iir1-test.cpp
2>iir1-test.vcxproj -> C:\Users\test\source\repos\iir1-test\out\build\x64-Debug\iir1-test\Debug\iir1-test.exe
3>------ Rebuild All started: Project: ALL_BUILD, Configuration: Debug x64 ------
3>Building Custom Rule C:/Users/test/source/repos/iir1-test/CMakeLists.txt
========== Rebuild All: 3 succeeded, 0 failed, 0 skipped ==========

````

