### PR TITLE
Added OpenGL mode features to OSG port

### DIFF
--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -67,7 +67,19 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     docs BUILD_DOCUMENTATION
     docs BUILD_REF_DOCS_SEARCHENGINE
     docs BUILD_REF_DOCS_TAGFILE
+    gl3  PROFILE_GL3
+    glcore PROFILE_GLCORE
 )
+
+if (PROFILE_GL3)
+    message("Building OSG with gl3")
+    list(APPEND OPTIONS -DOPENGL_PROFILE=GL3)
+endif()
+
+if (PROFILE_GLCORE)
+    message("Building OSG with glcore")
+    list(APPEND OPTIONS -DOPENGL_PROFILE=GLCORE)
+endif()
 
 set(BUILD_OSG_PLUGIN_RESTHTTPDEVICE ON)
 if(VCPKG_TARGET_IS_WINDOWS)

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
   "version-string": "3.6.5",
-  "port-version": 11,
+  "port-version": 12,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
   "dependencies": [
@@ -39,6 +39,15 @@
         },
         "sdl1",
         "sdl2"
+      ]
+    },
+    "gl3": {
+      "description": "Build with OPENGL_PROFILE=GL3"
+    },
+    "glcore": {
+      "description": "Build with OPENGL_PROFILE=GLCORE",
+      "dependencies": [
+        "opengl-registry"
       ]
     },
     "packages": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5218,7 +5218,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 11
+      "port-version": 12
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6a266b3e53dd6ecc6ae67a86c7a2cf960e7f5b6d",
+      "version-string": "3.6.5",
+      "port-version": 12
+    },
+    {
       "git-tree": "456c4454eee9f4a24916992b0870067f703ef374",
       "version-string": "3.6.5",
       "port-version": 11


### PR DESCRIPTION
This PR allows you to build OSG in either gl3 or glcore modes instead of the default gl2 mode using feature flags.  So you can install osg[gl3] or osg[glcore] and it will set the OPENGL_PROFILE cmake setting correctly during the build.

- #### What does your PR fix?
Some applications that use OSG require the use of modern OpenGL and need OSG to be built in gl3 or glcore modes to function properly.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Same as previously supported.  I tested locally on x64-windows.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
