### PR TITLE
[graphviz,libslirp] Limit msys to windows

### DIFF
--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -30,8 +30,10 @@ if(NOT VCPKG_TARGET_IS_WINDOWS)
     set(EXTRA_CMAKE_OPTION "-DCMAKE_INSTALL_RPATH=${CURRENT_INSTALLED_DIR}/lib")
 endif()
 
-vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk)
-vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+if(VCPKG_HOST_IS_WINDOWS)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES gawk)
+    vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+endif()
 
 vcpkg_find_acquire_program(BISON)
 vcpkg_find_acquire_program(FLEX)

--- a/ports/graphviz/portfile.cmake
+++ b/ports/graphviz/portfile.cmake
@@ -44,11 +44,11 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
-        -DBISON_EXECUTABLE=${BISON}
-        -DFLEX_EXECUTABLE=${FLEX}
-        -DGIT_EXECUTABLE=${GIT}
-        -DPython3_EXECUTABLE=${PYTHON3}
-        -DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf
+        "-DBISON_EXECUTABLE=${BISON}"
+        "-DFLEX_EXECUTABLE=${FLEX}"
+        "-DGIT_EXECUTABLE=${GIT}"
+        "-DPython3_EXECUTABLE=${PYTHON3}"
+        "-DPKG_CONFIG_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf"
         ${EXTRA_CMAKE_OPTION}
 )
 
@@ -67,7 +67,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
     file(COPY ${PLUGINS} DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
     vcpkg_execute_required_process(
         COMMAND dot -c
-        WORKING_DIRECTORY ${CURRENT_PACKAGES_DIR}/tools/${PORT}
+        WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}"
         LOGNAME configure-plugins
     )
     file(COPY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/config6" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")

--- a/ports/graphviz/vcpkg.json
+++ b/ports/graphviz/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "graphviz",
   "version-semver": "2.49.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Graph Visualization Tools",
   "homepage": "https://graphviz.org/",
   "license": "EPL-1.0",

--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -7,8 +7,10 @@ vcpkg_from_gitlab(
     HEAD_REF master
 )
 
-vcpkg_acquire_msys(MSYS_ROOT)
-vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+if(VCPKG_HOST_IS_WINDOWS)
+    vcpkg_acquire_msys(MSYS_ROOT)
+    vcpkg_add_to_path("${MSYS_ROOT}/usr/bin")
+endif()
 
 vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libslirp",
   "version-semver": "4.6.1",
+  "port-version": 1,
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2622,7 +2622,7 @@
     },
     "graphviz": {
       "baseline": "2.49.1",
-      "port-version": 2
+      "port-version": 3
     },
     "greatest": {
       "baseline": "1.5.0",
@@ -3978,7 +3978,7 @@
     },
     "libslirp": {
       "baseline": "4.6.1",
-      "port-version": 0
+      "port-version": 1
     },
     "libsmb2": {
       "baseline": "2021-04-29",

--- a/versions/g-/graphviz.json
+++ b/versions/g-/graphviz.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1f20d0e1aaccb1035e3fe3eb95d005b4161a56e",
+      "version-semver": "2.49.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "912ac6a1578bd9cf23c20ed7f3bc85c25058c872",
       "version-semver": "2.49.1",
       "port-version": 2

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3230fcf2c1b8018c5eac033b618f2cb35217772f",
+      "version-semver": "4.6.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "5a7b734c0850f035d3eb2abc2d3dbf6389124be5",
       "version-semver": "4.6.1",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes pointless acquisition of msys2 on non-windows hosts. 
  (Noticed in CI logs. It should be prevented in the script, but I don't want to trigger a world rebuild or break user ports.)

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes