### PR TITLE
[tinycbor] Fix file conflicts with libcbor

### DIFF
--- a/ports/tinycbor/CMakeLists.txt
+++ b/ports/tinycbor/CMakeLists.txt
@@ -6,4 +6,4 @@ list(FILTER sources EXCLUDE REGEX "cbortojson.c$")
 add_library(tinycbor ${sources})
 
 install(TARGETS tinycbor)
-install(FILES src/cbor.h src/cborjson.h src/tinycbor-version.h DESTINATION include)
+install(FILES src/cbor.h src/cborjson.h src/tinycbor-version.h DESTINATION include/tinycbor)

--- a/ports/tinycbor/portfile.cmake
+++ b/ports/tinycbor/portfile.cmake
@@ -8,13 +8,13 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_configure(SOURCE_PATH ${SOURCE_PATH})
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 
 vcpkg_cmake_install()
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
-
 # Remove duplicated include headers
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -1,15 +1,12 @@
 {
   "name": "tinycbor",
   "version-semver": "0.6.0",
+  "port-version": 1,
   "description": "Concise Binary Object Representation (CBOR) Library",
   "homepage": "https://github.com/intel/tinycbor",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
-      "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
       "host": true
     }
   ]

--- a/ports/tinycbor/vcpkg.json
+++ b/ports/tinycbor/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "Concise Binary Object Representation (CBOR) Library",
   "homepage": "https://github.com/intel/tinycbor",
+  "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6958,7 +6958,7 @@
     },
     "tinycbor": {
       "baseline": "0.6.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tinycthread": {
       "baseline": "2019-08-06",

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7d7076c2a8ad0959d3848419c968aae1e1b39cfb",
+      "git-tree": "0579e95478ca32302fe6680fb0f953441d043a27",
       "version-semver": "0.6.0",
       "port-version": 1
     },

--- a/versions/t-/tinycbor.json
+++ b/versions/t-/tinycbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d7076c2a8ad0959d3848419c968aae1e1b39cfb",
+      "version-semver": "0.6.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "ecf65457801ba4aa8d8ae75886f87e740fb04783",
       "version-semver": "0.6.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  I moved the header files from `include` to `include/tinycbor`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

