### PR TITLE
[openssl] Fix dynamic builds on UNIX

### DIFF
--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,7 +11,7 @@ It can be installed on alpine systems via apk add linux-headers.]]
     )
 endif()
 
-set(OPENSSL_VERSION 3.0.2) # Change unix/CMakeLists.txt#111 after next major release
+set(OPENSSL_VERSION 3.0.2)
 
 vcpkg_download_distfile(
     ARCHIVE

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -11,7 +11,7 @@ It can be installed on alpine systems via apk add linux-headers.]]
     )
 endif()
 
-set(OPENSSL_VERSION 3.0.2)
+set(OPENSSL_VERSION 3.0.2) # Change unix/CMakeLists.txt#111 after next major release
 
 vcpkg_download_distfile(
     ARCHIVE

--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -108,7 +108,11 @@ get_filename_component(MSYS_BIN_DIR "${MAKE}" DIRECTORY)
 
 if(BUILD_SHARED_LIBS)
     set(SHARED shared)
-    set(SHLIB_VERSION 3) # Change after next major release
+    file(STRINGS "${BUILDDIR}/VERSION.dat" SHLIB_VERSION
+        REGEX "^SHLIB_VERSION=.*")
+    string(REGEX REPLACE "^(SHLIB_VERSION=)(.*)$" "\\2"
+        SHLIB_VERSION "${SHLIB_VERSION}")
+
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
         set(LIB_EXT dylib)
         set(LIB_EXTS ${SHLIB_VERSION}.${LIB_EXT})

--- a/ports/openssl/unix/CMakeLists.txt
+++ b/ports/openssl/unix/CMakeLists.txt
@@ -108,10 +108,7 @@ get_filename_component(MSYS_BIN_DIR "${MAKE}" DIRECTORY)
 
 if(BUILD_SHARED_LIBS)
     set(SHARED shared)
-    file(STRINGS "${BUILDDIR}/include/openssl/opensslv.h" SHLIB_VERSION
-        REGEX "^#[\t ]*define[\t ]+SHLIB_VERSION_NUMBER[\t ]+\".*\".*")
-    string(REGEX REPLACE "^.*SHLIB_VERSION_NUMBER[\t ]+\"([^\"]*)\".*$" "\\1"
-        SHLIB_VERSION "${SHLIB_VERSION}")
+    set(SHLIB_VERSION 3) # Change after next major release
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
         set(LIB_EXT dylib)
         set(LIB_EXTS ${SHLIB_VERSION}.${LIB_EXT})

--- a/ports/openssl/vcpkg.json
+++ b/ports/openssl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "openssl",
   "version": "3.0.2",
-  "port-version": 1,
+  "port-version": 2,
   "description": "OpenSSL is an open source project that provides a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.",
   "homepage": "https://www.openssl.org",
   "license": "Apache-2.0",

--- a/ports/openssl/windows/portfile.cmake
+++ b/ports/openssl/windows/portfile.cmake
@@ -183,5 +183,3 @@ vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/openssl/rand.h"
 vcpkg_copy_pdbs()
 
 file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5150,7 +5150,7 @@
     },
     "openssl": {
       "baseline": "3.0.2",
-      "port-version": 1
+      "port-version": 2
     },
     "openssl-unix": {
       "baseline": "1.1.1h",

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d73d90b9b846dab2f4e95b5843a68a13352d6ab1",
+      "git-tree": "66e7ff434d21a4fc00cab9bbe6167db295ffefd3",
       "version": "3.0.2",
       "port-version": 2
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d73d90b9b846dab2f4e95b5843a68a13352d6ab1",
+      "version": "3.0.2",
+      "port-version": 2
+    },
+    {
       "git-tree": "3505d3717ae864160fdb273eb2ec9d614eb6711e",
       "version": "3.0.2",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
I removed the regex on the file `opensslv.h` because this file will be configured by the perl buildsystem after CMake configure. Because the affected variable only changes between major releases, I hardcoded the value.

I only tested this on Linux, but it should work on OSX as well.

- #### What does your PR fix?
  Fixes #24003

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
