### PR TITLE
[tracy] Add Tracy `profiler` and `capture` tools using CMake

### DIFF
--- a/ports/tracy/001-cmake-capture-profiler.patch
+++ b/ports/tracy/001-cmake-capture-profiler.patch
@@ -1,0 +1,570 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 42cc094..ff23db1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,27 @@ project(Tracy LANGUAGES CXX)
+ find_package(Threads REQUIRED)
+ 
+ add_library(TracyClient TracyClient.cpp)
++target_sources(TracyClient
++    PRIVATE
++        TracyClient.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/tracy_concurrentqueue.h
++        ${CMAKE_CURRENT_LIST_DIR}/client/tracy_rpmalloc.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/tracy_SPSCQueue.h
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyArmCpuTable.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyCallstack.h
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyCallstack.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyDebug.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyDxt1.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyFastVector.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyLock.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyProfiler.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyRingBuffer.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyScoped.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyStringHelpers.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracySysTime.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracySysTrace.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/client/TracyThread.hpp
++)
+ target_compile_features(TracyClient PUBLIC cxx_std_11)
+ target_include_directories(TracyClient SYSTEM PUBLIC 
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
+@@ -52,6 +73,27 @@ set_option(TRACY_NO_FRAME_IMAGE  "Disable the frame image support and its thread
+ set_option(TRACY_DELAYED_INIT "Enable delayed initialization of the library (init on first call)" OFF)
+ set_option(TRACY_MANUAL_LIFETIME "Enable the manual lifetime management of the profile" OFF)
+ set_option(TRACY_FIBERS "Enable fibers support" OFF)
++set_option(TRACY_BUILD_CAPTURE "Build capture tool" OFF)
++set_option(TRACY_BUILD_PROFILER "Build profiler tool" OFF)
++set_option(TRACY_USE_WAYLAND "Use Wayland backend for GLFW windows" OFF)
++
++if(TRACY_BUILD_CAPTURE OR TRACY_BUILD_PROFILER)
++    find_package(capstone CONFIG REQUIRED)
++    find_package(freetype CONFIG REQUIRED)
++    find_package(zstd CONFIG REQUIRED)
++    if(TRACY_BUILD_PROFILER)
++        find_package(glfw3 CONFIG REQUIRED)
++    endif()
++endif()
++
++if(UNIX AND NOT APPLE)
++    include(FindPkgConfig)
++    pkg_check_modules(GTK3 REQUIRED IMPORTED_TARGET gtk+-3.0)
++    pkg_check_modules(TBB REQUIRED IMPORTED_TARGET tbb)
++    if(TRACY_USE_WAYLAND)
++        pkg_check_modules(WAYLAND REQUIRED IMPORTED_TARGET wayland-client)
++    endif()
++endif()
+ 
+ if(BUILD_SHARED_LIBS)
+     target_compile_definitions(TracyClient PRIVATE TRACY_EXPORTS)
+@@ -61,6 +103,447 @@ endif()
+ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+ 
++add_library(TracyCommon STATIC)
++add_library(Tracy::TracyCommon ALIAS TracyCommon)
++
++target_sources(TracyCommon
++    PRIVATE
++        ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4hc.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4hc.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyAlign.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyAlloc.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyApi.h
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyColor.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyForceInline.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyMutex.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyProtocol.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyQueue.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracySocket.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracySocket.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyStackFrames.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyStackFrames.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracySystem.cpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracySystem.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyUwp.hpp
++        ${CMAKE_CURRENT_LIST_DIR}/common/TracyYield.hpp
++)
++target_include_directories(TracyCommon
++    PUBLIC
++        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/common>
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/common>
++)
++target_compile_definitions(TracyCommon
++    PRIVATE
++        $<$<PLATFORM_ID:Windows>:
++            _CRT_SECURE_NO_DEPRECATE
++            _CRT_NONSTDC_NO_DEPRECATE
++            WIN32_LEAN_AND_MEAN
++            NOMINMAX
++            _USE_MATH_DEFINES
++        >
++        $<$<CXX_COMPILER_ID:MSVC>:
++            /permissive-
++            /W3
++        >
++)
++target_link_libraries(TracyCommon
++    PUBLIC
++        $<$<PLATFORM_ID:Windows>:
++            ws2_32.lib
++        >
++        $<$<PLATFORM_ID:Linux>:
++            PkgConfig::TBB
++        >
++)
++target_compile_features(TracyCommon
++    PUBLIC
++        cxx_std_17
++)
++set_target_properties(TracyCommon
++    PROPERTIES
++        CXX_STANDARD          17
++        CXX_STANDARD_REQUIRED ON
++        CXX_EXTENSIONS        OFF
++)
++
++target_link_libraries(TracyClient PUBLIC TracyCommon)
++
++if(TRACY_BUILD_CAPTURE OR TRACY_BUILD_PROFILER)
++    if(WIN32)
++        enable_language(C)
++
++        add_library(TracyGetOpt STATIC)
++        add_library(Tracy::TracyGetOpt ALIAS TracyGetOpt)
++
++        target_sources(TracyGetOpt
++            PRIVATE
++                ${CMAKE_CURRENT_LIST_DIR}/getopt/getopt.c
++                ${CMAKE_CURRENT_LIST_DIR}/getopt/getopt.h
++        )
++        target_include_directories(TracyGetOpt
++            PUBLIC
++                $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/getopt>
++                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/getopt>
++        )
++        target_compile_definitions(TracyGetOpt
++            PRIVATE
++                $<$<CXX_COMPILER_ID:MSVC>:
++                    /permissive-
++                    /W3
++                >
++        )
++    endif()
++    
++    add_library(TracyImGui STATIC)
++    add_library(Tracy::TracyImGui ALIAS TracyImGui)
++
++    target_sources(TracyImGui
++        PRIVATE
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imconfig.h              
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui.cpp               
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui.h                 
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui_demo.cpp          
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui_draw.cpp          
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui_internal.h        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui_tables.cpp        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imgui_widgets.cpp       
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imstb_rectpack.h        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imstb_textedit.h        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/imstb_truetype.h        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/misc/freetype/imgui_freetype.cpp        
++            ${CMAKE_CURRENT_LIST_DIR}/imgui/misc/freetype/imgui_freetype.h        
++    )
++    target_include_directories(TracyImGui
++        PUBLIC
++            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/imgui>
++            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/imgui>
++    )
++    target_compile_definitions(TracyImGui
++        PUBLIC
++            IMGUI_ENABLE_FREETYPE
++        PRIVATE
++            $<$<PLATFORM_ID:Windows>:
++                _CRT_SECURE_NO_DEPRECATE
++                _CRT_NONSTDC_NO_DEPRECATE
++                WIN32_LEAN_AND_MEAN
++                NOMINMAX
++                _USE_MATH_DEFINES
++            >
++            $<$<CXX_COMPILER_ID:MSVC>:
++                /permissive-
++                /W3
++            >
++    )
++    target_link_libraries(TracyImGui
++        PRIVATE
++            freetype
++    )
++    target_compile_features(TracyImGui
++        PUBLIC
++            cxx_std_17
++    )
++    set_target_properties(TracyImGui
++        PROPERTIES
++            CXX_STANDARD          17
++            CXX_STANDARD_REQUIRED ON
++            CXX_EXTENSIONS        OFF
++    )
++
++    add_library(TracyServer STATIC)
++    add_library(Tracy::TracyServer ALIAS TracyServer)
++
++    target_sources(TracyServer
++        PRIVATE
++            ${CMAKE_CURRENT_LIST_DIR}/server/IconsFontAwesome5.h                
++            ${CMAKE_CURRENT_LIST_DIR}/server/tracy_pdqsort.h                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/tracy_robin_hood.h                 
++            ${CMAKE_CURRENT_LIST_DIR}/server/tracy_xxhash.h                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyBadVersion.cpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyBadVersion.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyBuzzAnim.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyCharUtil.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyColor.cpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyColor.hpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyDecayValue.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyEvent.hpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyEventDebug.cpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyEventDebug.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyFileHeader.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyFileRead.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyFilesystem.cpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyFilesystem.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyFileWrite.hpp                 
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyImGui.hpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMemory.cpp                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMemory.hpp                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMicroArchitecture.cpp         
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMicroArchitecture.hpp         
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMmap.cpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMmap.hpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMouse.cpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyMouse.hpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyPopcnt.hpp                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyPrint.cpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyPrint.hpp                     
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyShortPtr.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySlab.hpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySort.hpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySortedVector.hpp              
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceContents.cpp            
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceContents.hpp            
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceTokenizer.cpp           
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceTokenizer.hpp           
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceView.cpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracySourceView.hpp                
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyStorage.cpp                   
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyStorage.hpp                   
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyStringDiscovery.hpp           
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTaskDispatch.cpp              
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTaskDispatch.hpp              
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTexture.cpp                   
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTexture.hpp                   
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTextureCompression.cpp        
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyTextureCompression.hpp        
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyThreadCompress.cpp            
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyThreadCompress.hpp            
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyUserData.cpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyUserData.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyVarArray.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyVector.hpp                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyVersion.hpp                   
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyView.cpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyView.hpp                      
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyViewData.hpp                  
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyWeb.cpp                       
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyWeb.hpp                       
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyWorker.cpp                    
++            ${CMAKE_CURRENT_LIST_DIR}/server/TracyWorker.hpp                    
++    )
++    target_include_directories(TracyServer
++        PUBLIC
++            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/server>
++            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/server>
++    )
++    target_compile_definitions(TracyServer
++        PRIVATE
++            $<$<PLATFORM_ID:Windows>:
++                _CRT_SECURE_NO_DEPRECATE
++                _CRT_NONSTDC_NO_DEPRECATE
++                WIN32_LEAN_AND_MEAN
++                NOMINMAX
++                _USE_MATH_DEFINES
++            >
++            $<$<CXX_COMPILER_ID:MSVC>:
++                /permissive-
++                /W3
++            >
++    )
++    target_link_libraries(TracyServer
++        PUBLIC
++            TracyCommon
++            TracyImGui
++            $<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>
++        PRIVATE
++            capstone::capstone
++    )
++    target_compile_features(TracyServer
++        PUBLIC
++            cxx_std_17
++    )
++    set_target_properties(TracyServer
++        PROPERTIES
++            CXX_STANDARD          17
++            CXX_STANDARD_REQUIRED ON
++            CXX_EXTENSIONS        OFF
++    )
++    if(TRACY_BUILD_CAPTURE)
++        add_executable(TracyCapture)
++        add_executable(Tracy::TracyCapture ALIAS TracyCapture)
++
++        target_sources(TracyCapture
++            PRIVATE
++                ${CMAKE_CURRENT_LIST_DIR}/capture/src/capture.cpp
++        )
++        target_compile_definitions(TracyCapture
++            PRIVATE
++                TRACY_NO_STATISTICS
++                $<$<PLATFORM_ID:Windows>:
++                    _CRT_SECURE_NO_DEPRECATE
++                    _CRT_NONSTDC_NO_DEPRECATE
++                    WIN32_LEAN_AND_MEAN
++                    NOMINMAX
++                    _USE_MATH_DEFINES
++                >
++                $<$<CXX_COMPILER_ID:MSVC>:
++                    /permissive-
++                    /W3
++                >
++        )
++        target_link_libraries(TracyCapture
++            PRIVATE
++                TracyCommon
++                TracyServer
++                $<$<PLATFORM_ID:Windows>:TracyGetOpt>
++        )
++        target_compile_features(TracyCapture
++            PRIVATE
++                cxx_std_17
++        )
++        set_target_properties(TracyCapture
++            PROPERTIES
++                CXX_STANDARD          17
++                CXX_STANDARD_REQUIRED ON
++                CXX_EXTENSIONS        OFF
++                OUTPUT_NAME           "capture"
++        )
++    endif()
++    if(TRACY_BUILD_PROFILER)
++
++        add_library(TracyNFD STATIC)
++        add_library(Tracy::TracyNFD ALIAS TracyNFD)
++
++        target_sources(TracyNFD
++            PRIVATE
++                ${CMAKE_CURRENT_LIST_DIR}/nfd/common.h                 
++                ${CMAKE_CURRENT_LIST_DIR}/nfd/LICENSE                  
++                ${CMAKE_CURRENT_LIST_DIR}/nfd/nfd.h                    
++                ${CMAKE_CURRENT_LIST_DIR}/nfd/nfd_common.c             
++                ${CMAKE_CURRENT_LIST_DIR}/nfd/nfd_common.h             
++                $<$<PLATFORM_ID:Linux>:${CMAKE_CURRENT_LIST_DIR}/nfd/nfd_gtk.c>                
++                $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_LIST_DIR}/nfd/nfd_cocoa.m>              
++                $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_LIST_DIR}/nfd/nfd_win.cpp>       
++        )
++        target_include_directories(TracyNFD
++            PUBLIC
++                $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/nfd>
++                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/nfd>
++        )
++        target_compile_definitions(TracyNFD
++            PRIVATE
++                $<$<PLATFORM_ID:Windows>:
++                    _CRT_SECURE_NO_DEPRECATE
++                    _CRT_NONSTDC_NO_DEPRECATE
++                    WIN32_LEAN_AND_MEAN
++                    NOMINMAX
++                    _USE_MATH_DEFINES
++                >
++                $<$<CXX_COMPILER_ID:MSVC>:
++                    /permissive-
++                    /W3
++                >
++        )
++        target_link_libraries(TracyNFD
++            PRIVATE
++                $<$<PLATFORM_ID:Linux>:
++                    PkgConfig::GTK3
++                >
++                $<$<PLATFORM_ID:Darwin>:
++                    "-framework CoreFoundation"
++                    "-framework AppKit"
++                >
++        )
++
++        add_executable(TracyProfiler)
++        add_executable(Tracy::TracyProfiler ALIAS TracyProfiler)
++
++        target_sources(TracyProfiler
++            PRIVATE
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/DroidSans.hpp               
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/FiraCodeRetina.hpp          
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/FontAwesomeSolid.hpp        
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/HttpRequest.cpp             
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/HttpRequest.hpp             
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/icon.hpp   
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/imgui_impl_glfw.cpp         
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/imgui_impl_glfw.h           
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/imgui_impl_opengl3.cpp      
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/imgui_impl_opengl3.h        
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/imgui_impl_opengl3_loader.h                  
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/main.cpp                    
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/NativeWindow.cpp            
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/NativeWindow.hpp            
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/ResolvService.cpp           
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/ResolvService.hpp           
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/stb_image.h                 
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/winmain.cpp                 
++                ${CMAKE_CURRENT_LIST_DIR}/profiler/src/winmainArchDiscovery.cpp    
++                $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_LIST_DIR}/profiler/build/win32/Tracy.manifest>
++                $<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_LIST_DIR}/profiler/build/win32/Tracy.rc>
++        )
++        target_compile_definitions(TracyProfiler
++            PRIVATE
++                TRACY_NO_STATISTICS
++                $<$<PLATFORM_ID:Windows>:
++                    _CRT_SECURE_NO_DEPRECATE
++                    _CRT_NONSTDC_NO_DEPRECATE
++                    WIN32_LEAN_AND_MEAN
++                    NOMINMAX
++                    _USE_MATH_DEFINES
++                >
++                $<$<CXX_COMPILER_ID:MSVC>:
++                    /permissive-
++                    /W3
++                >
++        )
++        target_compile_features(TracyProfiler
++            PRIVATE
++                cxx_std_17
++        )
++        target_link_libraries(TracyProfiler
++            PRIVATE
++                TracyCommon
++                TracyImGui
++                TracyNFD
++                TracyServer
++                glfw
++        )
++        set_target_properties(TracyProfiler
++            PROPERTIES
++                CXX_STANDARD          17
++                CXX_STANDARD_REQUIRED ON
++                CXX_EXTENSIONS        OFF
++                OUTPUT_NAME           "Tracy"
++        )
++
++        if(UNIX AND NOT APPLE)
++            if(TRACY_USE_WAYLAND)
++                target_compile_definitions(TracyProfiler
++                    PRIVATE
++                        DISPLAY_SERVER_WAYLAND
++                )
++                target_link_libraries(TracyProfiler
++                    PRIVATE
++                        PkgConfig::WAYLAND
++                )
++            else()
++                target_compile_definitions(TracyProfiler
++                    PRIVATE
++                        DISPLAY_SERVER_X11
++                )
++            endif()
++        endif()
++    endif()
++endif()
++
++set(installed_targets
++    TracyClient
++    TracyCommon
++)
++if(TRACY_BUILD_CAPTURE)
++    list(APPEND installed_targets TracyCapture)
++endif()
++if(TRACY_BUILD_PROFILER)
++    list(APPEND installed_targets TracyProfiler)
++endif()
++
++install(TARGETS ${installed_targets}
++        EXPORT TracyConfig
++        RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
++        LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR})
++
+ set(includes
+     ${CMAKE_CURRENT_LIST_DIR}/TracyC.h
+     ${CMAKE_CURRENT_LIST_DIR}/Tracy.hpp
+@@ -71,55 +554,18 @@ set(includes
+     ${CMAKE_CURRENT_LIST_DIR}/TracyOpenGL.hpp
+     ${CMAKE_CURRENT_LIST_DIR}/TracyVulkan.hpp)
+ 
+-set(client_includes
+-    ${CMAKE_CURRENT_LIST_DIR}/client/tracy_concurrentqueue.h
+-    ${CMAKE_CURRENT_LIST_DIR}/client/tracy_rpmalloc.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/tracy_SPSCQueue.h
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyArmCpuTable.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyCallstack.h
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyCallstack.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyDebug.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyDxt1.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyFastVector.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyLock.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyProfiler.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyRingBuffer.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyScoped.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyStringHelpers.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracySysTime.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracySysTrace.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/client/TracyThread.hpp)
+-
+-set(common_includes
+-    ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/tracy_lz4hc.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyAlign.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyAlign.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyAlloc.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyApi.h
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyColor.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyForceInline.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyMutex.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyProtocol.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyQueue.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracySocket.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyStackFrames.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracySystem.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyUwp.hpp
+-    ${CMAKE_CURRENT_LIST_DIR}/common/TracyYield.hpp)
+-
+-install(TARGETS TracyClient
+-        EXPORT TracyConfig
+-        RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+-        LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES ${includes}
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
++get_target_property(client_includes TracyClient SOURCES)
++list(FILTER client_includes INCLUDE REGEX [[.*\.(h|hpp)]])
+ install(FILES ${client_includes}
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/client)
++get_target_property(common_includes TracyCommon SOURCES)
++list(FILTER common_includes INCLUDE REGEX [[.*\.(h|hpp)]])
+ install(FILES ${common_includes}
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/common)
+ install(EXPORT TracyConfig
+ 		NAMESPACE Tracy::
+         FILE TracyConfig.cmake
+-        DESTINATION share/Tracy)
++        DESTINATION ${CMAKE_INSTALL_DATADIR}/Tracy)

--- a/ports/tracy/002-fix-capstone-5.patch
+++ b/ports/tracy/002-fix-capstone-5.patch
@@ -1,0 +1,26 @@
+diff --git a/server/TracySourceView.cpp b/server/TracySourceView.cpp
+index cc56298..7b9370a 100644
+--- a/server/TracySourceView.cpp
++++ b/server/TracySourceView.cpp
+@@ -2,7 +2,7 @@
+ #include <inttypes.h>
+ #include <stdio.h>
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #include "imgui.h"
+ #include "TracyCharUtil.hpp"
+diff --git a/server/TracyWorker.cpp b/server/TracyWorker.cpp
+index fcb1718..2433e59 100644
+--- a/server/TracyWorker.cpp
++++ b/server/TracyWorker.cpp
+@@ -19,7 +19,7 @@
+ #include <inttypes.h>
+ #include <sys/stat.h>
+ 
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #define ZDICT_STATIC_LINKING_ONLY
+ #include "../zstd/zdict.h"

--- a/ports/tracy/003-vcpkg-zstd.patch
+++ b/ports/tracy/003-vcpkg-zstd.patch
@@ -1,0 +1,75 @@
+diff --git a/import-chrome/src/import-chrome.cpp b/import-chrome/src/import-chrome.cpp
+index d6a3ea7..39cc404 100644
+--- a/import-chrome/src/import-chrome.cpp
++++ b/import-chrome/src/import-chrome.cpp
+@@ -23,7 +23,7 @@
+ #include "../../server/TracyFileWrite.hpp"
+ #include "../../server/TracyMmap.hpp"
+ #include "../../server/TracyWorker.hpp"
+-#include "../../zstd/zstd.h"
++#include <zstd.h>
+ 
+ using json = nlohmann::json;
+ 
+diff --git a/server/TracyFileRead.hpp b/server/TracyFileRead.hpp
+index 382553c..cea723b 100644
+--- a/server/TracyFileRead.hpp
++++ b/server/TracyFileRead.hpp
+@@ -25,7 +25,7 @@
+ #include "../common/TracyYield.hpp"
+ #include "../common/tracy_lz4.hpp"
+ #include "../common/TracyForceInline.hpp"
+-#include "../zstd/zstd.h"
++#include <zstd.h>
+ 
+ namespace tracy
+ {
+diff --git a/server/TracyFileWrite.hpp b/server/TracyFileWrite.hpp
+index 099ab88..e849a5c 100644
+--- a/server/TracyFileWrite.hpp
++++ b/server/TracyFileWrite.hpp
+@@ -15,7 +15,7 @@
+ #include "../common/tracy_lz4.hpp"
+ #include "../common/tracy_lz4hc.hpp"
+ #include "../common/TracyForceInline.hpp"
+-#include "../zstd/zstd.h"
++#include <zstd.h>
+ 
+ namespace tracy
+ {
+diff --git a/server/TracyTextureCompression.cpp b/server/TracyTextureCompression.cpp
+index b39dce1..94b9675 100644
+--- a/server/TracyTextureCompression.cpp
++++ b/server/TracyTextureCompression.cpp
+@@ -1,4 +1,4 @@
+-#include "../zstd/zstd.h"
++#include <zstd.h>
+ 
+ #include "TracyEvent.hpp"
+ #include "TracyTextureCompression.hpp"
+diff --git a/server/TracyWorker.cpp b/server/TracyWorker.cpp
+index 2433e59..28d3628 100644
+--- a/server/TracyWorker.cpp
++++ b/server/TracyWorker.cpp
+@@ -22,7 +22,7 @@
+ #include <capstone/capstone.h>
+ 
+ #define ZDICT_STATIC_LINKING_ONLY
+-#include "../zstd/zdict.h"
++#include <zdict.h>
+ 
+ #include "../common/TracyProtocol.hpp"
+ #include "../common/TracySystem.hpp"
+diff --git a/update/src/update.cpp b/update/src/update.cpp
+index 0823fea..80bcbfe 100644
+--- a/update/src/update.cpp
++++ b/update/src/update.cpp
+@@ -12,7 +12,7 @@
+ #include "../../server/TracyPrint.hpp"
+ #include "../../server/TracyVersion.hpp"
+ #include "../../server/TracyWorker.hpp"
+-#include "../../zstd/zstd.h"
++#include <zstd.h>
+ #include "../../getopt/getopt.h"
+ 
+ #ifdef __APPLE__

--- a/ports/tracy/portfile.cmake
+++ b/ports/tracy/portfile.cmake
@@ -1,24 +1,64 @@
+
+# It is possible to run into some issues when profiling when we uses Tracy client as a shared client
+# As as safety measure let's build Tracy as a static library for now
+# More details on Tracy Discord (e.g. https://discord.com/channels/585214693895962624/585214693895962630/953599951328403506)
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
     REF 9ba7171c3dd6f728268a820ee268a62c75f2dfb6
     SHA512 a2898cd04a532a5cc71fd6c5fd3893ebff68df25fc38e8d988ba4a8a6cbe33e3d0049661029d002160b94b57421e5c5b7400658b404e51bfab721d204dd0cc5d
     HEAD_REF master
+    PATCHES
+        001-cmake-capture-profiler.patch
+        002-fix-capstone-5.patch
+        003-vcpkg-zstd.patch
 )
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        capture TRACY_BUILD_CAPTURE 
+        profiler TRACY_BUILD_PROFILER  
+        display-wayland TRACY_USE_WAYLAND  
+)
+
+if((TRACY_BUILD_CAPTURE OR TRACY_BUILD_PROFILER) AND VCPKG_TARGET_IS_LINUX)
+    message(
+"Tracy currently requires the following libraries from the system package manager:
+    gtk+-3.0
+    tbb
+
+These can be installed on Ubuntu systems via sudo apt install libgtk-3-dev libtbb-dev")
+endif()
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()
-
 vcpkg_copy_pdbs()
-
+vcpkg_cmake_config_fixup()
 vcpkg_fixup_pkgconfig()
 
-# Handle copyright
-file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+set(tracy_tools)
+if("capture" IN_LIST FEATURES)
+    list(APPEND tracy_tools capture)
+endif()
+if("profiler" IN_LIST FEATURES)
+    list(APPEND tracy_tools Tracy)
+endif()
+
+list(LENGTH tracy_tools tracy_tools_size)
+if(tracy_tools_size GREATER 0)
+    vcpkg_copy_tools(TOOL_NAMES ${tracy_tools} AUTO_CLEAN)
+endif()
 
 # Cleanup
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/tracy/usage
+++ b/ports/tracy/usage
@@ -1,0 +1,4 @@
+The package tracy provides CMake targets:
+
+    find_package(Tracy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Tracy::TracyClient)

--- a/ports/tracy/vcpkg.json
+++ b/ports/tracy/vcpkg.json
@@ -1,9 +1,14 @@
 {
   "name": "tracy",
-  "version": "0.8.0",
+  "version-semver": "0.8.0",
+  "port-version": 1,
   "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
   "homepage": "https://github.com/wolfpld/tracy",
   "supports": "!(windows & (arm | uwp))",
+  "default-features": [
+    "capture",
+    "profiler"
+  ],
   "dependencies": [
     {
       "name": "pthreads",
@@ -17,5 +22,28 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "capture": {
+      "description": "Build Tracy tool `capture`",
+      "dependencies": [
+        { "name": "capstone", "features":[ "arm", "arm64", "x86" ] },
+        "freetype",
+        "zstd"
+      ]
+    },
+    "profiler": {
+      "description": "Build Tracy tool `profiler` (aka `Tracy` executable)",
+      "dependencies": [
+        { "name": "capstone", "features":[ "arm", "arm64", "x86" ] },
+        "freetype",
+        "glfw3",
+        "zstd"
+      ]
+    },
+    "display-wayland": {
+      "description": "Use Wayland instead of X11 for display server",
+      "supports": "linux"
+    }
+  }
 }


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Adds `capture` and `profiler` features to `tracy` ports to be able to build its tools.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
