### PR TITLE
[dstorage, dxsdk-d3dx, xaudio2redist] ports updated to support static-md triplets

### DIFF
--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,8 +1,9 @@
 {
   "name": "dstorage",
   "version": "1.0.0",
+  "port-version": 1,
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "license": null,
-  "supports": "windows & !uwp & !static"
+  "supports": "windows & !uwp & !(static & staticcrt)"
 }

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -5,5 +5,5 @@
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "license": null,
-  "supports": "windows & !uwp & !(static & staticcrt)"
+  "supports": "windows & !uwp & !staticcrt"
 }

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "dxsdk-d3dx",
   "version": "9.29.952.8",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
   "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
   "license": null,
-  "supports": "windows & !arm & !uwp & !static"
+  "supports": "windows & !arm & !uwp & !(static & staticcrt)"
 }

--- a/ports/dxsdk-d3dx/vcpkg.json
+++ b/ports/dxsdk-d3dx/vcpkg.json
@@ -5,5 +5,5 @@
   "description": "Redistributable package for the legacy DirectX SDK's D3DX9, D3DX10, and/or D3DX11 utility libraries.",
   "homepage": "https://walbourn.github.io/legacy-d3dx-on-nuget/",
   "license": null,
-  "supports": "windows & !arm & !uwp & !(static & staticcrt)"
+  "supports": "windows & !arm & !uwp & !staticcrt"
 }

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -5,5 +5,5 @@
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "license": null,
-  "supports": "windows & !arm & !uwp & !(static & staticcrt)"
+  "supports": "windows & !arm & !uwp & !staticcrt"
 }

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xaudio2redist",
   "version": "1.2.8",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
   "license": null,
-  "supports": "windows & !arm & !uwp & !static"
+  "supports": "windows & !arm & !uwp & !(static & staticcrt)"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1946,7 +1946,7 @@
     },
     "dstorage": {
       "baseline": "1.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "dtl": {
       "baseline": "1.19",
@@ -1970,7 +1970,7 @@
     },
     "dxsdk-d3dx": {
       "baseline": "9.29.952.8",
-      "port-version": 3
+      "port-version": 4
     },
     "dxut": {
       "baseline": "11.26",
@@ -7526,7 +7526,7 @@
     },
     "xaudio2redist": {
       "baseline": "1.2.8",
-      "port-version": 2
+      "port-version": 3
     },
     "xbyak": {
       "baseline": "6.00",

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5fcdd5850cd949e7b08d9b00546036d96d9e098d",
+      "git-tree": "8b3e0c3eaf98dec92b8e97f19e10efac69c6a187",
       "version": "1.0.0",
       "port-version": 1
     },

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5fcdd5850cd949e7b08d9b00546036d96d9e098d",
+      "version": "1.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "b2494bc112c6d12ffbb8a8bc687a1ae2ad583221",
       "version": "1.0.0",
       "port-version": 0

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "04be889f8dd81029b8f4e37a74e348453c1bdbbc",
+      "git-tree": "14db52bb5daba8ba8e0a93b0e41ffa676935923a",
       "version": "9.29.952.8",
       "port-version": 4
     },

--- a/versions/d-/dxsdk-d3dx.json
+++ b/versions/d-/dxsdk-d3dx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "04be889f8dd81029b8f4e37a74e348453c1bdbbc",
+      "version": "9.29.952.8",
+      "port-version": 4
+    },
+    {
       "git-tree": "4f9cac012452363e92e36d5978972cee3b9154e5",
       "version": "9.29.952.8",
       "port-version": 3

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3c7cb7e25cd63531fb0a4be66deee41b0b6eae87",
+      "git-tree": "fe3229572bacd0c7076a7a4d710f96e6b3a66a3f",
       "version": "1.2.8",
       "port-version": 3
     },

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3c7cb7e25cd63531fb0a4be66deee41b0b6eae87",
+      "version": "1.2.8",
+      "port-version": 3
+    },
+    {
       "git-tree": "8ae7aaec9ebb9859356736f91710e8d9727d7a81",
       "version": "1.2.8",
       "port-version": 2


### PR DESCRIPTION
Per feedback in [24063](https://github.com/microsoft/vcpkg/pull/24063), I've updated the ``vcpkg.json`` supports statement to change the expression ``!static`` to ``!(static & staticcrt)``.

Since these ports use ``vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)``, they will fallback to using dynamic library automatically for the ``windows-static-md`` triplets, but they don't support ``windows-static``.