### PR TITLE
[osg] Added OPENGL_PROFILE option to osg port as a triplet variable.

### DIFF
--- a/ports/osg/portfile.cmake
+++ b/ports/osg/portfile.cmake
@@ -74,6 +74,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
     set(BUILD_OSG_PLUGIN_RESTHTTPDEVICE OFF)
 endif()
 
+# The package osg can be configured to use different OpenGL profiles via a custom triplet file:
+# Possible values are GLCORE, GL2, GL3, GLES1, GLES2, GLES3, and GLES2+GLES3
+if(NOT DEFINED osg_OPENGL_PROFILE)
+    set(osg_OPENGL_PROFILE "GL3")
+endif()
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS ${FEATURE_OPTIONS}
@@ -89,6 +95,7 @@ vcpkg_configure_cmake(
         -DBUILD_OSG_PLUGIN_SVG=OFF
         -DBUILD_OSG_PLUGIN_VNC=OFF
         -DBUILD_OSG_PLUGIN_LUA=OFF
+        -DOPENGL_PROFILE=${osg_OPENGL_PROFILE}
         -DBUILD_OSG_PLUGIN_RESTHTTPDEVICE=${BUILD_OSG_PLUGIN_RESTHTTPDEVICE}
         -DBUILD_OSG_PLUGIN_ZEROCONFDEVICE=OFF
         -DBUILD_DASHBOARD_REPORTS=OFF
@@ -161,3 +168,6 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin/osgPlugins-${OSG_VER}/)
 file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
 
 vcpkg_fixup_pkgconfig()
+
+# Handle usage
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/osg/usage
+++ b/ports/osg/usage
@@ -1,0 +1,4 @@
+The package osg can be configured to use different OpenGL profiles via a custom triplet file.
+Possible values are GLCORE, GL2, GL3, GLES1, GLES2, GLES3 and GLES2+GLES3.
+The default value is GL3.
+set(osg_OPENGL_PROFILE GL2)

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -13,12 +13,12 @@
       "name": "fontconfig",
       "platform": "!windows"
     },
+    "opengl-registry",
     {
       "name": "openimageio",
       "platform": "osx"
     },
-    "zlib",
-    "opengl-registry"
+    "zlib"
   ],
   "features": {
     "collada": {

--- a/ports/osg/vcpkg.json
+++ b/ports/osg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "osg",
-  "version-string": "3.6.5",
-  "port-version": 11,
+  "version": "3.6.5",
+  "port-version": 12,
   "description": "The OpenSceneGraph is an open source high performance 3D graphics toolkit.",
   "homepage": "https://github.com/openscenegraph/OpenSceneGraph",
   "dependencies": [
@@ -17,7 +17,8 @@
       "name": "openimageio",
       "platform": "osx"
     },
-    "zlib"
+    "zlib",
+    "opengl-registry"
   ],
   "features": {
     "collada": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5218,7 +5218,7 @@
     },
     "osg": {
       "baseline": "3.6.5",
-      "port-version": 11
+      "port-version": 12
     },
     "osg-qt": {
       "baseline": "Qt5",

--- a/versions/o-/osg.json
+++ b/versions/o-/osg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f438ec006b58ffd222b0f3bdce8d05b21611204e",
+      "version": "3.6.5",
+      "port-version": 12
+    },
+    {
       "git-tree": "456c4454eee9f4a24916992b0870067f703ef374",
       "version-string": "3.6.5",
       "port-version": 11


### PR DESCRIPTION
This PR allows you to set the OPENGL_PROFILE used by osg as a triplet variable via the osg_OPENGL_PROFILE setting.  The default is GL3.  I've tested this locally on Windows x64-windows using GL2, GL3 and GLCORE and they all built as expected.  It's really useful to be able to switch between the different builds via triplets, thanks to @Osyotr for the suggestion to do it this way instead of as a feature.

- #### What does your PR fix?
Some applications that use OSG require the use of modern OpenGL and need OSG to be built in gl3 modes to function properly.  The main purpose of this to allow osg to create an OpenGL core context which lets it be used in tools like NVIDIA Nsight or in VMWare.  We are preparing a new osgEarth 3.3 release and it needs to be built against an OSG with GL3 support.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Same as previously supported.  I tested locally on x64-windows.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

