### PR TITLE
[manifest/msbuild] Remove redundant `$(VcpkgTriplet)`

### DIFF
--- a/scripts/buildsystems/msbuild/vcpkg.targets
+++ b/scripts/buildsystems/msbuild/vcpkg.targets
@@ -51,7 +51,7 @@
   <Choose>
     <When Condition="'$(VcpkgEnableManifest)' == 'true'">
       <PropertyGroup>
-        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\$(VcpkgTriplet)\</_ZVcpkgInstalledDir>
+        <_ZVcpkgInstalledDir Condition="'$(_ZVcpkgInstalledDir)' == ''">$(_ZVcpkgManifestRoot)vcpkg_installed\</_ZVcpkgInstalledDir>
       </PropertyGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
This PR removes a redundant `$(VcpkgTriplet)` when using manifest MSBuild integration.
The other occurence of `$(VcpkgTriplet)` leading to redundancy is jsut below https://github.com/microsoft/vcpkg/blob/e809a42f87565e803b2178a0c11263f462d1800a/scripts/buildsystems/msbuild/vcpkg.targets#L65

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
N/A

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
