### PR TITLE
[qpid-proton] Stop using linker optimization

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -15,11 +15,12 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DPYTHON_EXECUTABLE=${PYTHON3}
-        -DLIB_SUFFIX=
         -DBUILD_GO=no
-        -DENABLE_JSONCPP=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_CyrusSASL=ON
+        -DENABLE_JSONCPP=ON
+        -DENABLE_LINKTIME_OPTIMIZATION=OFF
+        -DLIB_SUFFIX=
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "0.32.0",
   "port-version": 5,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/apache/qpid-proton",
   "dependencies": [
     "jsoncpp",

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -3,8 +3,8 @@
   "version": "0.32.0",
   "port-version": 5,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
-  "license": "Apache-2.0",
   "homepage": "https://github.com/apache/qpid-proton",
+  "license": "Apache-2.0",
   "dependencies": [
     "jsoncpp",
     {

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.32.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5646,7 +5646,7 @@
     },
     "qpid-proton": {
       "baseline": "0.32.0",
-      "port-version": 4
+      "port-version": 5
     },
     "qscintilla": {
       "baseline": "2.12.0",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2d43828eb37839563c86ce72da4c61a21671a5fe",
+      "git-tree": "bc437ca04548b4ca544af845a2e2327010aa3281",
       "version": "0.32.0",
       "port-version": 5
     },

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1b9b8fa3e5b7b6759cb19a7ed211c3720738dc30",
+      "git-tree": "2d43828eb37839563c86ce72da4c61a21671a5fe",
       "version": "0.32.0",
       "port-version": 5
     },

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b9b8fa3e5b7b6759cb19a7ed211c3720738dc30",
+      "version": "0.32.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "be327f08d64834a36d80a140832abbbc66e67207",
       "version": "0.32.0",
       "port-version": 4


### PR DESCRIPTION
These optimizations require the gold linker on Linux, and this linker is not typically available.

I've also reordered alphabetically CMake configuration's options for the qpid-proton port. 

**Describe the pull request**

- #### What does your PR fix?
  Fixes #24128

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes