### PR TITLE
[ceres]update SHA512

### DIFF
--- a/ports/ceres/portfile.cmake
+++ b/ports/ceres/portfile.cmake
@@ -10,7 +10,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ceres-solver/ceres-solver
     REF f68321e7de8929fbcdb95dd42877531e64f72f66 #2.1.0
-    SHA512 b482988d837187e348250122b1acacbb4fd6354709efa6335c0322a68234a38292c072499a886b69a30614f85c818d3d2e9eeb3d3d0ca17d8f013a38d9151207
+    SHA512 67bbd8a9385a40fe69d118fbc84da0fcc9aa1fbe14dd52f5403ed09686504213a1d931e95a1a0148d293b27ab5ce7c1d618fbf2e8fed95f2bbafab851a1ef449
     HEAD_REF master
     PATCHES
         0001_cmakelists_fixes.patch

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -19,7 +19,7 @@
   ],
   "features": {
     "cuda": {
-      "description": "Build darknet with support for CUDA",
+      "description": "Support for CUDA based dense solvers",
       "supports": "linux | (!osx & !uwp & !(arm64 & windows))",
       "dependencies": [
         "cuda"

--- a/ports/ceres/vcpkg.json
+++ b/ports/ceres/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "ceres",
   "version": "2.1.0",
+  "port-version": 1,
   "description": "non-linear optimization package",
   "homepage": "https://github.com/ceres-solver/ceres-solver",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1306,7 +1306,7 @@
     },
     "ceres": {
       "baseline": "2.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "cfitsio": {
       "baseline": "3.49",

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e0c9864b5a02340fcc83dce87ad537632868464",
+      "version": "2.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "d3ebf81bee31323b13ad3353b6dbf9944b03abe3",
       "version": "2.1.0",
       "port-version": 0

--- a/versions/c-/ceres.json
+++ b/versions/c-/ceres.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9e0c9864b5a02340fcc83dce87ad537632868464",
+      "git-tree": "85a5ff9f8727124ce91655f2d37b9a6c77f367e1",
       "version": "2.1.0",
       "port-version": 1
     },


### PR DESCRIPTION
Update [ceres] expected SHA512

````
Expected hash: [ b482988d837187e348250122b1acacbb4fd6354709efa6335c0322a68234a38292c072499a886b69a30614f85c818d3d2e9eeb3d3d0ca17d8f013a38d9151207 ]  
Actual hash: [ 67bbd8a9385a40fe69d118fbc84da0fcc9aa1fbe14dd52f5403ed09686504213a1d931e95a1a0148d293b27ab5ce7c1d618fbf2e8fed95f2bbafab851a1ef449 ] 
````
All features have been tested successfullly in the following triplet:

- x64-windows
- x86-windows
- x64-windows-static
