### PR TITLE
[zeroc-ice] correct windows-static and linux

### DIFF
--- a/ports/zeroc-ice/mcppd_fix.patch
+++ b/ports/zeroc-ice/mcppd_fix.patch
@@ -1,0 +1,23 @@
+--- a/config/Make.project.rules	2022-01-17 10:28:23.000000000 
++++ b/config/Make.project.rules	2022-04-18 12:15:19.000000000 
+@@ -1050,17 +1050,17 @@
+ #
+ # $(call make-lib,$1=libname)
+ #
+ define make-lib
+ ifneq ($($1_home),)
+ # Check for 3rd party libraries either in home/lib<platform specific subdir> or home/lib
+-$1_installdir   = $$($1_home)/lib$$(call platform-var,installdir,$1,$$($$2_platform),$$($$2_config),$$2)
+-$1_libdir       ?= $$(strip $$(if $$(wildcard $$($1_installdir)),$$($1_installdir),$$($1_home)/lib))
++$1_installdir   = $$($1_home)$$(if $$(filter no,$$(OPTIMIZE)),/debug)/lib$$(call platform-var,installdir,$1,$$($$2_platform),$$($$2_config),$$2)
++$1_libdir       ?= $$(strip $$(if $$(wildcard $$($1_installdir)),$$($1_installdir),$$($1_home)$$(if $$(filter no,$$(OPTIMIZE)),/debug)/lib))
+ $1_includedir   ?= $$($1_home)/include
+ endif
+-$1_ldflags      ?= -l$1
++$1_ldflags      ?= -l$$(if $$(and $$(filter mcpp,$1),$$(filter no,$$(OPTIMIZE))),$1d,$1)
+ endef
+ 
+ #
+ # $(call repathfromdir,path)
+ #
+ # Returns reversed relative path for directory (e.g.: test/Ice/operations

--- a/ports/zeroc-ice/mcppd_fix.patch
+++ b/ports/zeroc-ice/mcppd_fix.patch
@@ -9,9 +9,10 @@
  # Check for 3rd party libraries either in home/lib<platform specific subdir> or home/lib
 -$1_installdir   = $$($1_home)/lib$$(call platform-var,installdir,$1,$$($$2_platform),$$($$2_config),$$2)
 -$1_libdir       ?= $$(strip $$(if $$(wildcard $$($1_installdir)),$$($1_installdir),$$($1_home)/lib))
-+$1_installdir   = $$($1_home)$$(if $$(filter no,$$(OPTIMIZE)),/debug)/lib$$(call platform-var,installdir,$1,$$($$2_platform),$$($$2_config),$$2)
-+$1_libdir       ?= $$(strip $$(if $$(wildcard $$($1_installdir)),$$($1_installdir),$$($1_home)$$(if $$(filter no,$$(OPTIMIZE)),/debug)/lib))
- $1_includedir   ?= $$($1_home)/include
+-$1_includedir   ?= $$($1_home)/include
++$1_installdir   =
++$1_libdir       ?=
++$1_includedir   ?=
  endif
 -$1_ldflags      ?= -l$1
 +$1_ldflags      ?= -l$$(if $$(and $$(filter mcpp,$1),$$(filter no,$$(OPTIMIZE))),$1d,$1)

--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -4,16 +4,16 @@ vcpkg_from_github(
     REPO zeroc-ice/ice
     REF v3.7.7
     SHA512 73c3a2bb14c9e145383e4026206edd3e03b29c60a33af628611bfdab71d69a3aed108ce4e6cbfd67eb852560110e3495b4bd238c8cdf0de9d1f8e2f1088513ee
-    PATCHES md5i_fix.patch slice2swift.patch
+    PATCHES md5i_fix.patch slice2swift.patch mcppd_fix.patch
 )
 
 set(RELEASE_TRIPLET ${TARGET_TRIPLET}-rel)
 set(DEBUG_TRIPLET ${TARGET_TRIPLET}-dbg)
 
 get_filename_component(SOURCE_PATH_SUFFIX ${SOURCE_PATH} NAME)
+set(UNIX_BUILD_DIR "${SOURCE_PATH}")
 set(WIN_DEBUG_BUILD_DIR ${CURRENT_BUILDTREES_DIR}/${DEBUG_TRIPLET}/${SOURCE_PATH_SUFFIX})
 set(WIN_RELEASE_BUILD_DIR ${CURRENT_BUILDTREES_DIR}/${RELEASE_TRIPLET}/${SOURCE_PATH_SUFFIX})
-set(UNIX_BUILD_DIR ${CURRENT_BUILDTREES_DIR}/src/${SOURCE_PATH_SUFFIX})
 
 # install_includes
 function(install_includes ORIGINAL_PATH RELATIVE_PATHS)
@@ -132,6 +132,20 @@ if("icediscovery" IN_LIST FEATURES)
 endif()
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
+    # Clean up for the first round (important for install --editable)
+    vcpkg_execute_build_process(
+        COMMAND make distclean
+        WORKING_DIRECTORY ${SOURCE_PATH}/cpp
+        LOGNAME make-clean-${TARGET_TRIPLET}
+    )
+
+    if(EXISTS "${UNIX_BUILD_DIR}/cpp/lib")
+        file(REMOVE_RECURSE "${UNIX_BUILD_DIR}/cpp/lib")
+    endif()
+    if(EXISTS "${UNIX_BUILD_DIR}/cpp/lib64")
+        file(REMOVE_RECURSE "${UNIX_BUILD_DIR}/cpp/lib64")
+    endif()
+    file(REMOVE_RECURSE "${UNIX_BUILD_DIR}/cpp/bin")
 
     # Setting these as environment variables, as .d files aren't generated
     # the first time passing them as arguments to make.

--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -248,12 +248,12 @@ else() # VCPKG_TARGET_IS_WINDOWS
         SOURCE_PATH ${SOURCE_PATH}
         PROJECT_SUBPATH "cpp/msbuild/ice.${VCPKG_PLATFORM_TOOLSET}.sln"
         SKIP_CLEAN
-	      TARGET "C++11\\ice++11"
+        TARGET "C++11\\ice++11"
         USE_VCPKG_INTEGRATION
         OPTIONS
             /p:UseVcpkg=yes
             /p:IceBuildingSrc=yes
-	        ${ICE_OPTIONAL_COMPONENTS_MSBUILD}
+            ${ICE_OPTIONAL_COMPONENTS_MSBUILD}
     )
 
     if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/zeroc.icebuilder.msbuild.dll")

--- a/ports/zeroc-ice/portfile.cmake
+++ b/ports/zeroc-ice/portfile.cmake
@@ -253,7 +253,7 @@ else() # VCPKG_TARGET_IS_WINDOWS
         OPTIONS
             /p:UseVcpkg=yes
             /p:IceBuildingSrc=yes
-	          ${ICE_OPTIONAL_COMPONENTS_MSBUILD}
+	        ${ICE_OPTIONAL_COMPONENTS_MSBUILD}
     )
 
     if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/zeroc.icebuilder.msbuild.dll")

--- a/ports/zeroc-ice/vcpkg.json
+++ b/ports/zeroc-ice/vcpkg.json
@@ -24,7 +24,6 @@
     },
     "glacier2router": {
       "description": "Glacier2Router",
-      "supports": "!static",
       "dependencies": [
         {
           "name": "zeroc-ice",
@@ -39,8 +38,7 @@
       "description": "IceBox libraries and runtime"
     },
     "iceboxtools": {
-      "description": "IceBox tools",
-      "supports": "!static"
+      "description": "IceBox tools"
     },
     "icebridge": {
       "description": "IceBridge",
@@ -80,7 +78,6 @@
     },
     "icegridtools": {
       "description": "IceGrid tools",
-      "supports": "!static",
       "dependencies": [
         "expat",
         {
@@ -108,7 +105,6 @@
     },
     "icestormtools": {
       "description": "IceStorm tools",
-      "supports": "!static",
       "dependencies": [
         "lmdb",
         {

--- a/ports/zeroc-ice/vcpkg.json
+++ b/ports/zeroc-ice/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "name": "zeroc-ice",
   "version": "3.7.7",
+  "port-version": 1,
   "maintainers": "Benjamin Oldenburg <benjamin.oldenburg@ordis.co.th>",
   "description": "Comprehensive RPC framework with support for C++, CSharp, Java, JavaScript, Python and more.",
   "homepage": "https://github.com/zeroc-ice/ice",
   "license": null,
-  "supports": "!uwp & !(windows & arm) & !wasm32",
+  "supports": "!uwp & !(windows & arm) & !(windows & staticcrt) & !wasm32",
   "dependencies": [
     "bzip2",
     "expat",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7658,7 +7658,7 @@
     },
     "zeroc-ice": {
       "baseline": "3.7.7",
-      "port-version": 0
+      "port-version": 1
     },
     "zeromq": {
       "baseline": "4.3.4",

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e05ce0ff5ef744114ed88f09f702eccac310f9e3",
+      "git-tree": "566aa496611135845334e81601bcdfe99b68f32a",
       "version": "3.7.7",
       "port-version": 1
     },

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e05ce0ff5ef744114ed88f09f702eccac310f9e3",
+      "version": "3.7.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "bdb180069d461c04c1eee1a7937afa63d0ea752b",
       "version": "3.7.7",
       "port-version": 0

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "566aa496611135845334e81601bcdfe99b68f32a",
+      "git-tree": "813790998f0da139a77d1cd387d7a1f7d900045f",
       "version": "3.7.7",
       "port-version": 1
     },

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "19ff4530f3b42bfdc6d83f2fd3aca166dcb7aae8",
+      "git-tree": "f32e4c338e25d36018095348e632c794b13fc513",
       "version": "3.7.7",
       "port-version": 1
     },

--- a/versions/z-/zeroc-ice.json
+++ b/versions/z-/zeroc-ice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "813790998f0da139a77d1cd387d7a1f7d900045f",
+      "git-tree": "19ff4530f3b42bfdc6d83f2fd3aca166dcb7aae8",
       "version": "3.7.7",
       "port-version": 1
     },


### PR DESCRIPTION
This marks `windows & staticcrt` unsupported in zeroc-ice, and makes sure the mcpp library is actually installed as `mcpp`, not `mcppd` on non-Windows (to allow zeroc-ice to find it)

Tested installing `zeroc-ice[*]` on arm64-osx