### PR TITLE
[vlpp] fix to support ARM on unix

### DIFF
--- a/ports/vlpp/fix-arm.patch
+++ b/ports/vlpp/fix-arm.patch
@@ -3,7 +3,8 @@
 @@ -50,13 +50,12 @@
  #define abstract
  #endif
- 
+-
++#include <stdlib.h>
  #if defined VCZH_MSVC
  #include <intrin.h>
  #elif defined VCZH_GCC

--- a/ports/vlpp/fix-arm.patch
+++ b/ports/vlpp/fix-arm.patch
@@ -1,0 +1,33 @@
+--- a/Import/Vlpp.h
++++ b/Import/Vlpp.h
+@@ -50,13 +50,12 @@
+ #define abstract
+ #endif
+ 
+ #if defined VCZH_MSVC
+ #include <intrin.h>
+ #elif defined VCZH_GCC
+-#include <x86intrin.h>
+ #include <stdint.h>
+ #include <stddef.h>
+ #include <wchar.h>
+ #define abstract
+ #define __thiscall
+ #define __forceinline inline
+@@ -160,14 +159,14 @@
+ #define UI64TOA_S	_ui64toa_s
+ #define UI64TOW_S	_ui64tow_s
+ #if defined VCZH_MSVC
+ #define INCRC(x)	(_InterlockedIncrement((volatile long*)(x)))
+ #define DECRC(x)	(_InterlockedDecrement((volatile long*)(x)))
+ #elif defined VCZH_GCC
+-#define INCRC(x)	(__sync_add_and_fetch(x, 1))
+-#define DECRC(x)	(__sync_sub_and_fetch(x, 1))
++#define INCRC(x)	(__atomic_add_fetch(x, 1, __ATOMIC_SEQ_CST))
++#define DECRC(x)	(__atomic_sub_fetch(x, 1, __ATOMIC_SEQ_CST))
+ #endif
+ #endif
+ 
+ 	/***********************************************************************
+ 	Basic Types
+ 	***********************************************************************/

--- a/ports/vlpp/portfile.cmake
+++ b/ports/vlpp/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     REF 5dfe25c4f4997da2d7a23bdc80c2438e72d9813a # 0.11.0.0
     SHA512 5d585e561246385b074c625a3644b79defa22328dab0ab14112c846cb917f384abb617a5f400971ca29e4ee5ac391b88b17ee65d594caf9ebf279806db669a4a
     HEAD_REF master
+    PATCHES fix-arm.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/vlpp/vcpkg.json
+++ b/ports/vlpp/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 3,
   "description": "Common C++ construction, including string operation / generic container / linq / General-LR parser generator / multithreading / reflection for C++ / etc",
   "homepage": "https://github.com/vczh-libraries/Release",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/vlpp/vcpkg.json
+++ b/ports/vlpp/vcpkg.json
@@ -4,7 +4,6 @@
   "port-version": 3,
   "description": "Common C++ construction, including string operation / generic container / linq / General-LR parser generator / multithreading / reflection for C++ / etc",
   "homepage": "https://github.com/vczh-libraries/Release",
-  "supports": "!(osx & arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/vlpp/vcpkg.json
+++ b/ports/vlpp/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "vlpp",
-  "version-string": "0.11.0.0",
-  "port-version": 2,
+  "version": "0.11.0.0",
+  "port-version": 3,
   "description": "Common C++ construction, including string operation / generic container / linq / General-LR parser generator / multithreading / reflection for C++ / etc",
   "homepage": "https://github.com/vczh-libraries/Release",
+  "supports": "!(osx & arm)",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7366,7 +7366,7 @@
     },
     "vlpp": {
       "baseline": "0.11.0.0",
-      "port-version": 2
+      "port-version": 3
     },
     "volk": {
       "baseline": "1.3.204",

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b2db9ff8269874da2657dac113c320a7cef2c1b2",
+      "git-tree": "5c0dc543071b40d1a29db76597f13ee0d4244d0a",
       "version": "0.11.0.0",
       "port-version": 3
     },

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f9f7cf017e79e36b2158d1937a20bdc204ff50f7",
+      "git-tree": "b2db9ff8269874da2657dac113c320a7cef2c1b2",
       "version": "0.11.0.0",
       "port-version": 3
     },

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f9f7cf017e79e36b2158d1937a20bdc204ff50f7",
+      "version": "0.11.0.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "cfa763a8d53142b93748fde4a578ddbd95431ac2",
       "version-string": "0.11.0.0",
       "port-version": 2

--- a/versions/v-/vlpp.json
+++ b/versions/v-/vlpp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5c0dc543071b40d1a29db76597f13ee0d4244d0a",
+      "git-tree": "b4f56db04c13b5bf335e4e5939617596e15e89ac",
       "version": "0.11.0.0",
       "port-version": 3
     },


### PR DESCRIPTION
Fails with 
<details>

```
[1/6] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.cpp
FAILED: CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowLibrary.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.cpp
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:13:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:200:10: error: use of undeclared identifier '__builtin_ia32_readeflags_u32'
  return __builtin_ia32_readeflags_u32();
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:206:3: error: use of undeclared identifier '__builtin_ia32_writeeflags_u32'
  __builtin_ia32_writeeflags_u32(__f);
  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:288:10: error: use of undeclared identifier '__builtin_ia32_crc32qi'
  return __builtin_ia32_crc32qi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: error: use of undeclared identifier '__builtin_ia32_crc32hi'; did you mean '__builtin_arm_crc32h'?
  return __builtin_ia32_crc32hi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: note: '__builtin_arm_crc32h' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:330:10: error: use of undeclared identifier '__builtin_ia32_crc32si'
  return __builtin_ia32_crc32si(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: use of undeclared identifier '__builtin_ia32_rdpmc'; did you mean '__builtin_arm_dmb'?
  return __builtin_ia32_rdpmc(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: note: '__builtin_arm_dmb' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: argument to '__builtin_arm_dmb' must be a constant integer
  return __builtin_ia32_rdpmc(__A);
         ^                    ~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: error: use of undeclared identifier '__builtin_ia32_rdtscp'; did you mean '__builtin_arm_rsrp'?
  return __builtin_ia32_rdtscp(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: note: '__builtin_arm_rsrp' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:32: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'unsigned int *'
  return __builtin_ia32_rdtscp(__A);
                               ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:373:3: error: use of undeclared identifier '__builtin_ia32_wbinvd'
  __builtin_ia32_wbinvd();
  ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:13:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86gprintrin.h:15:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/hresetintrin.h:42:27: error: invalid input constraint 'a' in asm
  __asm__ ("hreset $0" :: "a"(__eax));
                          ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:17:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: note: '__builtin_isless' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:25: error: too few arguments to function call, expected 2, have 0
    __builtin_ia32_emms();
    ~~~~~~~~~~~~~~~~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:50:19: error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:67:12: error: use of undeclared identifier '__builtin_ia32_vec_ext_v2si'
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:129:19: error: use of undeclared identifier '__builtin_ia32_packsswb'
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:159:19: error: use of undeclared identifier '__builtin_ia32_packssdw'
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:189:19: error: use of undeclared identifier '__builtin_ia32_packuswb'
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:216:19: error: use of undeclared identifier '__builtin_ia32_punpckhbw'
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[2/6] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.cpp
FAILED: CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowRuntime.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.cpp
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppParser.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:13:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:200:10: error: use of undeclared identifier '__builtin_ia32_readeflags_u32'
  return __builtin_ia32_readeflags_u32();
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:206:3: error: use of undeclared identifier '__builtin_ia32_writeeflags_u32'
  __builtin_ia32_writeeflags_u32(__f);
  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:288:10: error: use of undeclared identifier '__builtin_ia32_crc32qi'
  return __builtin_ia32_crc32qi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: error: use of undeclared identifier '__builtin_ia32_crc32hi'; did you mean '__builtin_arm_crc32h'?
  return __builtin_ia32_crc32hi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: note: '__builtin_arm_crc32h' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:330:10: error: use of undeclared identifier '__builtin_ia32_crc32si'
  return __builtin_ia32_crc32si(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: use of undeclared identifier '__builtin_ia32_rdpmc'; did you mean '__builtin_arm_dmb'?
  return __builtin_ia32_rdpmc(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: note: '__builtin_arm_dmb' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: argument to '__builtin_arm_dmb' must be a constant integer
  return __builtin_ia32_rdpmc(__A);
         ^                    ~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: error: use of undeclared identifier '__builtin_ia32_rdtscp'; did you mean '__builtin_arm_rsrp'?
  return __builtin_ia32_rdtscp(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: note: '__builtin_arm_rsrp' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:32: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'unsigned int *'
  return __builtin_ia32_rdtscp(__A);
                               ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:373:3: error: use of undeclared identifier '__builtin_ia32_wbinvd'
  __builtin_ia32_wbinvd();
  ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppParser.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:13:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86gprintrin.h:15:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/hresetintrin.h:42:27: error: invalid input constraint 'a' in asm
  __asm__ ("hreset $0" :: "a"(__eax));
                          ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowRuntime.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppParser.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:17:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: note: '__builtin_isless' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:25: error: too few arguments to function call, expected 2, have 0
    __builtin_ia32_emms();
    ~~~~~~~~~~~~~~~~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:50:19: error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:67:12: error: use of undeclared identifier '__builtin_ia32_vec_ext_v2si'
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:129:19: error: use of undeclared identifier '__builtin_ia32_packsswb'
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:159:19: error: use of undeclared identifier '__builtin_ia32_packssdw'
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:189:19: error: use of undeclared identifier '__builtin_ia32_packuswb'
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:216:19: error: use of undeclared identifier '__builtin_ia32_punpckhbw'
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[3/6] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o -MF CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.cpp
FAILED: CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o -MF CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/Vlpp.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.cpp
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:13:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:200:10: error: use of undeclared identifier '__builtin_ia32_readeflags_u32'
  return __builtin_ia32_readeflags_u32();
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:206:3: error: use of undeclared identifier '__builtin_ia32_writeeflags_u32'
  __builtin_ia32_writeeflags_u32(__f);
  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:288:10: error: use of undeclared identifier '__builtin_ia32_crc32qi'
  return __builtin_ia32_crc32qi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: error: use of undeclared identifier '__builtin_ia32_crc32hi'; did you mean '__builtin_arm_crc32h'?
  return __builtin_ia32_crc32hi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: note: '__builtin_arm_crc32h' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:330:10: error: use of undeclared identifier '__builtin_ia32_crc32si'
  return __builtin_ia32_crc32si(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: use of undeclared identifier '__builtin_ia32_rdpmc'; did you mean '__builtin_arm_dmb'?
  return __builtin_ia32_rdpmc(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: note: '__builtin_arm_dmb' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: argument to '__builtin_arm_dmb' must be a constant integer
  return __builtin_ia32_rdpmc(__A);
         ^                    ~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: error: use of undeclared identifier '__builtin_ia32_rdtscp'; did you mean '__builtin_arm_rsrp'?
  return __builtin_ia32_rdtscp(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: note: '__builtin_arm_rsrp' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:32: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'unsigned int *'
  return __builtin_ia32_rdtscp(__A);
                               ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:373:3: error: use of undeclared identifier '__builtin_ia32_wbinvd'
  __builtin_ia32_wbinvd();
  ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:13:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86gprintrin.h:15:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/hresetintrin.h:42:27: error: invalid input constraint 'a' in asm
  __asm__ ("hreset $0" :: "a"(__eax));
                          ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:17:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: note: '__builtin_isless' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:25: error: too few arguments to function call, expected 2, have 0
    __builtin_ia32_emms();
    ~~~~~~~~~~~~~~~~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:50:19: error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:67:12: error: use of undeclared identifier '__builtin_ia32_vec_ext_v2si'
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:129:19: error: use of undeclared identifier '__builtin_ia32_packsswb'
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:159:19: error: use of undeclared identifier '__builtin_ia32_packssdw'
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:189:19: error: use of undeclared identifier '__builtin_ia32_packuswb'
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:216:19: error: use of undeclared identifier '__builtin_ia32_punpckhbw'
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[4/6] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.cpp
FAILED: CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DUNICODE -D_UNICODE -I/Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import -fPIC -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -std=gnu++14 -MD -MT CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o -MF CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o.d -o CMakeFiles/Vlpp.dir/Import/VlppWorkflowCompiler.cpp.o -c /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.cpp
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:13:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:200:10: error: use of undeclared identifier '__builtin_ia32_readeflags_u32'
  return __builtin_ia32_readeflags_u32();
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:206:3: error: use of undeclared identifier '__builtin_ia32_writeeflags_u32'
  __builtin_ia32_writeeflags_u32(__f);
  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:288:10: error: use of undeclared identifier '__builtin_ia32_crc32qi'
  return __builtin_ia32_crc32qi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: error: use of undeclared identifier '__builtin_ia32_crc32hi'; did you mean '__builtin_arm_crc32h'?
  return __builtin_ia32_crc32hi(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:309:10: note: '__builtin_arm_crc32h' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:330:10: error: use of undeclared identifier '__builtin_ia32_crc32si'
  return __builtin_ia32_crc32si(__C, __D);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: use of undeclared identifier '__builtin_ia32_rdpmc'; did you mean '__builtin_arm_dmb'?
  return __builtin_ia32_rdpmc(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: note: '__builtin_arm_dmb' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:358:10: error: argument to '__builtin_arm_dmb' must be a constant integer
  return __builtin_ia32_rdpmc(__A);
         ^                    ~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: error: use of undeclared identifier '__builtin_ia32_rdtscp'; did you mean '__builtin_arm_rsrp'?
  return __builtin_ia32_rdtscp(__A);
         ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:10: note: '__builtin_arm_rsrp' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:364:32: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'unsigned int *'
  return __builtin_ia32_rdtscp(__A);
                               ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/ia32intrin.h:373:3: error: use of undeclared identifier '__builtin_ia32_wbinvd'
  __builtin_ia32_wbinvd();
  ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:13:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86gprintrin.h:15:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/hresetintrin.h:42:27: error: invalid input constraint 'a' in asm
  __asm__ ("hreset $0" :: "a"(__eax));
                          ^
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.cpp:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowCompiler.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppWorkflowLibrary.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppReflection.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/VlppOS.h:5:
In file included from /Users/leanderSchulten/git_projekte/Lichtsteuerung/vcpkg/buildtrees/vlpp/src/8e72d9813a-85aae8be17.clean/Import/Vlpp.h:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/x86intrin.h:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/immintrin.h:17:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:5: note: '__builtin_isless' declared here
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:33:25: error: too few arguments to function call, expected 2, have 0
    __builtin_ia32_emms();
    ~~~~~~~~~~~~~~~~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:50:19: error: use of undeclared identifier '__builtin_ia32_vec_init_v2si'
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:67:12: error: use of undeclared identifier '__builtin_ia32_vec_ext_v2si'
    return __builtin_ia32_vec_ext_v2si((__v2si)__m, 0);
           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:129:19: error: use of undeclared identifier '__builtin_ia32_packsswb'
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:159:19: error: use of undeclared identifier '__builtin_ia32_packssdw'
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:189:19: error: use of undeclared identifier '__builtin_ia32_packuswb'
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.1.6/include/mmintrin.h:216:19: error: use of undeclared identifier '__builtin_ia32_punpckhbw'
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
                  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
ninja: build stopped: subcommand failed.

```
</details>