### PR TITLE
[igraph] add support for external BLAS/LAPACK

### DIFF
--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -18,9 +18,6 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         graphml         IGRAPH_GRAPHML_SUPPORT
         openmp          IGRAPH_OPENMP_SUPPORT
-    INVERTED_FEATURES
-        extern-linalg   IGRAPH_USE_INTERNAL_BLAS
-        extern-linalg   IGRAPH_USE_INTERNAL_LAPACK
 )
 
 # Allow cross-compilation. See https://igraph.org/c/html/latest/igraph-Installation.html#igraph-Installation-cross-compiling
@@ -48,6 +45,9 @@ vcpkg_cmake_configure(
         -DIGRAPH_USE_INTERNAL_GMP=ON
         # PLFIT is not yet available in vcpkg.
         -DIGRAPH_USE_INTERNAL_PLFIT=ON
+        # Use BLAS and LAPACK from vcpkg
+        -DIGRAPH_USE_INTERNAL_BLAS=OFF
+        -DIGRAPH_USE_INTERNAL_LAPACK=OFF
         -DF2C_EXTERNAL_ARITH_HEADER=${ARITH_H}
         ${FEATURE_OPTIONS}
 )

--- a/ports/igraph/portfile.cmake
+++ b/ports/igraph/portfile.cmake
@@ -16,8 +16,11 @@ vcpkg_extract_source_archive_ex(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-    graphml   IGRAPH_GRAPHML_SUPPORT
-    openmp    IGRAPH_OPENMP_SUPPORT
+        graphml         IGRAPH_GRAPHML_SUPPORT
+        openmp          IGRAPH_OPENMP_SUPPORT
+    INVERTED_FEATURES
+        extern-linalg   IGRAPH_USE_INTERNAL_BLAS
+        extern-linalg   IGRAPH_USE_INTERNAL_LAPACK
 )
 
 # Allow cross-compilation. See https://igraph.org/c/html/latest/igraph-Installation.html#igraph-Installation-cross-compiling
@@ -38,10 +41,6 @@ vcpkg_cmake_configure(
         -DIGRAPH_ENABLE_LTO=AUTO
         # ARPACK not yet available in vcpkg.
         -DIGRAPH_USE_INTERNAL_ARPACK=ON
-        # OpenBLAS provides BLAS/LAPACK but some tests fail with OpenBLAS on Windows.
-        # See https://github.com/igraph/igraph/issues/1491
-        -DIGRAPH_USE_INTERNAL_BLAS=ON
-        -DIGRAPH_USE_INTERNAL_LAPACK=ON
         -DIGRAPH_USE_INTERNAL_CXSPARSE=OFF
         # GLPK is not yet available in vcpkg.
         -DIGRAPH_USE_INTERNAL_GLPK=ON

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -6,6 +6,8 @@
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",
   "dependencies": [
+    "blas",
+    "lapack",
     "suitesparse",
     {
       "name": "vcpkg-cmake",
@@ -17,17 +19,9 @@
     }
   ],
   "default-features": [
-    "extern-linalg",
     "graphml"
   ],
   "features": {
-    "extern-linalg": {
-      "description": "Use external BLAS and LAPACK",
-      "dependencies": [
-        "blas",
-        "lapack"
-      ]
-    },
     "graphml": {
       "description": "Support for reading GraphML files",
       "dependencies": [

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -16,9 +16,17 @@
     }
   ],
   "default-features": [
+    "extern-linalg",
     "graphml"
   ],
   "features": {
+    "extern-linalg": {
+      "description": "Use external BLAS and LAPACK",
+      "dependencies": [
+        "lapack",
+        "openblas"
+      ]
+    },
     "graphml": {
       "description": "Support for reading GraphML files",
       "dependencies": [

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -23,8 +23,8 @@
     "extern-linalg": {
       "description": "Use external BLAS and LAPACK",
       "dependencies": [
-        "lapack",
-        "openblas"
+        "blas",
+        "lapack"
       ]
     },
     "graphml": {

--- a/ports/igraph/vcpkg.json
+++ b/ports/igraph/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "igraph",
   "version": "0.9.8",
+  "port-version": 1,
   "description": "igraph is a C library for network analysis and graph theory, with an emphasis on efficiency portability and ease of use.",
   "homepage": "https://igraph.org/",
   "license": "GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2894,7 +2894,7 @@
     },
     "igraph": {
       "baseline": "0.9.8",
-      "port-version": 0
+      "port-version": 1
     },
     "iir1": {
       "baseline": "1.9.0",

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a70295d597be8c10e3385207ff29b0297a2f2afa",
+      "git-tree": "635707a7146747b8b5a35ba35d5e94669e499d3b",
       "version": "0.9.8",
       "port-version": 1
     },

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8c729d0813b6ebbfe820721186f43e727c257c41",
+      "git-tree": "5af04d279a55817e0ca26a113a67cf48884f9aaf",
       "version": "0.9.8",
       "port-version": 0
     },

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4bfe607beaddbc8d95e56256401c7913b14a923e",
+      "git-tree": "8c729d0813b6ebbfe820721186f43e727c257c41",
       "version": "0.9.8",
       "port-version": 0
     },

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a70295d597be8c10e3385207ff29b0297a2f2afa",
+      "version": "0.9.8",
+      "port-version": 1
+    },
+    {
       "git-tree": "5af04d279a55817e0ca26a113a67cf48884f9aaf",
       "version": "0.9.8",
       "port-version": 0

--- a/versions/i-/igraph.json
+++ b/versions/i-/igraph.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5af04d279a55817e0ca26a113a67cf48884f9aaf",
+      "git-tree": "4bfe607beaddbc8d95e56256401c7913b14a923e",
       "version": "0.9.8",
       "port-version": 0
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Adds support for using external BLAS/LAPACK libraries.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `all`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
