### PR TITLE
[libgcrypt] new stable release (1.10.1)

### DIFF
--- a/ports/libgcrypt/portfile.cmake
+++ b/ports/libgcrypt/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
     URL git://git.gnupg.org/libgcrypt.git
-    FETCH_REF libgcrypt-1.9.4
-    REF 05422ca24a0391dad2a0b7790a904ce348819c10 # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=05422ca24a0391dad2a0b7790a904ce348819c10
+    FETCH_REF libgcrypt-1.10.1
+    REF ae0e567820c37f9640440b3cff77d7c185aa6742 # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=tag;h=a8a888c9d2ed8a25ff502b104860a1bac4c4f73c
     HEAD_REF master
 )
 

--- a/ports/libgcrypt/vcpkg.json
+++ b/ports/libgcrypt/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libgcrypt",
-  "version": "1.9.4",
-  "port-version": 2,
+  "version": "1.10.1",
   "description": "A general purpose cryptographic library",
   "homepage": "https://gnupg.org/software/libgcrypt/index.html",
   "supports": "linux | osx",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3569,8 +3569,8 @@
       "port-version": 3
     },
     "libgcrypt": {
-      "baseline": "1.9.4",
-      "port-version": 2
+      "baseline": "1.10.1",
+      "port-version": 0
     },
     "libgd": {
       "baseline": "2.3.2",

--- a/versions/l-/libgcrypt.json
+++ b/versions/l-/libgcrypt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ba183f10b284405f9b4b50720d7583131a87d393",
+      "version": "1.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "8c0737adf68a0ada3ed976e4acf201b4cbeb9dfe",
       "version": "1.9.4",
       "port-version": 2


### PR DESCRIPTION
**Describe the pull request**
Updates libgcrypt to a new stable 1.10.1 release.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
 Yes
