### PR TITLE
[wxwidgets] Update to latest version 3.1.6

### DIFF
--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
-  "version-semver": "3.1.5",
-  "port-version": 9,
+  "version-semver": "3.1.6",
+  "port-version": 0,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",


### PR DESCRIPTION
changed it to use latest of 3.16 instead of 3.15

**Describe the pull request**

- #### What does your PR fix?
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
