### PR TITLE
[quantlib] update to v1.26

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lballabio/QuantLib
-    REF QuantLib-v1.25
-    SHA512 9a08c3d825f85c93e7db74b31dc93d03d7ec487b7a09f86b6f3efb0404791e1b3e1ea19e06cea19fd04ab190d2e8eb7bad889660d47eb9988c36609967646aa3
+    REF QuantLib-v1.26
+    SHA512 597dcb4aa3e2701bea758c7b0c62ca0b303a16eda5f324b349ba4e8cc011f6a256fb26d5c42f2bb432da06df1c7b5ec208195e1104e620b69d2a7e8265fd6470
     HEAD_REF master
 )
 

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quantlib",
-  "version": "1.25",
+  "version": "1.26",
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "supports": "!(windows & !static)",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6005,7 +6005,7 @@
       "port-version": 1
     },
     "quantlib": {
-      "baseline": "1.25",
+      "baseline": "1.26",
       "port-version": 0
     },
     "quaternions": {

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3af9ced73240dfb4e1ec776c5f9a16ac277d1c27",
+      "version": "1.26",
+      "port-version": 0
+    },
+    {
       "git-tree": "4d702f6d14c1a91b83a4950dd05e3b200700cfd8",
       "version": "1.25",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Bumps quantlib from v1.25 to v1.26.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
all supported except windows dynamic, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes