### PR TITLE
[duckx] fix vendoring

### DIFF
--- a/ports/duckx/fix-vendoring.patch
+++ b/ports/duckx/fix-vendoring.patch
@@ -1,0 +1,134 @@
+Makes the following changes:
+
+* pugixml and miniz are taken from vcpkg, as opposed to using the vendored copy
+* zip.h & zip.c[pp] - I couldn't find where they come from
+  (or if they come from something!), so they've been left the same;
+  since they're an internal library, though, I've stopped installing them,
+  and I've hidden the symbols in the `duckx` namespace
+  (this involved converting to C++).
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,15 +6,16 @@
+ 	include(CTest)
+ endif()
+ 
+ option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
+ option(BUILD_SAMPLE "Build provided sample" OFF)
+ 
+-set(HEADERS src/duckx.hpp src/zip.h src/miniz.h
+-	src/pugixml.hpp src/pugiconfig.hpp)
+-set(SOURCES src/duckx.cpp src/zip.c src/pugixml.cpp)
++set(HEADERS src/duckx.hpp)
++set(SOURCES src/duckx.cpp src/zip.cpp)
++find_package(miniz CONFIG REQUIRED)
++find_package(pugixml CONFIG REQUIRED)
+ 
+ if(BUILD_SHARED_LIBS)
+     add_library(duckx SHARED ${HEADERS} ${SOURCES})
+ else()
+     add_library(duckx STATIC ${HEADERS} ${SOURCES})
+ endif()
+@@ -22,12 +23,13 @@
+ add_library(duckx::duckx ALIAS duckx)
+ 
+ target_include_directories(duckx PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+     $<INSTALL_INTERFACE:include>
+ )
++target_link_libraries(duckx PRIVATE miniz::miniz pugixml::pugixml)
+ 
+ mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR)
+ 
+ if (BUILD_SAMPLE)
+ 	# Sample executable
+ 	set(SAMPLE_SOURCES samples/sample1.cpp)
+
+--- a/src/duckx.hpp
++++ b/src/duckx.hpp
+@@ -8,14 +8,13 @@
+ #define DUCKX_H
+ 
+ #include <stdlib.h>
+ #include <cstdio>
+ #include <string>
+ 
+-#include "pugixml.hpp"
+-#include "zip.h"
++#include <pugixml.hpp>
+ 
+ 
+ // TODO: Use container-iterator design pattern!
+ 
+ namespace duckx {
+     // Run contains runs in a paragraph
+
+--- a/src/duckx.cpp
++++ b/src/duckx.cpp
+@@ -1,7 +1,8 @@
+ #include "duckx.hpp"
++#include "zip.h"
+ 
+ // Hack on pugixml
+ // We need to write xml to std string (or char *)
+ // So overload the write function
+ struct xml_string_writer: pugi::xml_writer {
+     std::string result;
+
+diff --git a/src/zip.c b/src/zip.cpp
+rename from src/zip.c
+rename to src/zip.cpp
+--- a/src/zip.c
++++ b/src/zip.cpp
+@@ -36,11 +36,12 @@
+ 
+ #endif
+ 
+ #include "miniz.h"
+ #include "zip.h"
+ 
++namespace duckx {
+ #ifndef HAS_DEVICE
+ #define HAS_DEVICE(P) 0
+ #endif
+ 
+ #ifndef FILESYSTEM_PREFIX_LEN
+@@ -917,5 +918,6 @@
+     status = -1;
+   }
+ 
+   return status;
+ }
++} // namespace duckx
+
+--- a/src/zip.h
++++ b/src/zip.h
+@@ -12,15 +12,13 @@
+ #ifndef ZIP_H
+ #define ZIP_H
+ 
+ #include <string.h>
+ #include <sys/types.h>
+ 
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
++namespace duckx {
+ 
+ #if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
+     !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(__ssize_t_defined)
+ #define _SSIZE_T
+ // 64-bit Windows is the only mainstream platform
+ // where sizeof(long) != sizeof(void*)
+@@ -306,11 +304,9 @@
+     The return code - 0 on success, negative number (< 0) on error.
+ */
+ extern int zip_extract(const char *zipname, const char *dir,
+                        int (*on_extract_entry)(const char *filename, void *arg),
+                        void *arg);
+ 
+-#ifdef __cplusplus
+ }
+-#endif
+ 
+ #endif

--- a/ports/duckx/portfile.cmake
+++ b/ports/duckx/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     REPO amiremohamadi/DuckX
     REF v1.2.2
     SHA512 3f1e626973b4638adaffcc0a20f59791f3a70abda1d2d09fddca9312014cef86d097f24873e74ef58c775b27c71a637e44f340da01a301b00ef334600bd412d6
+    PATCHES fix-vendoring.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/duckx/vcpkg.json
+++ b/ports/duckx/vcpkg.json
@@ -1,10 +1,13 @@
 {
   "name": "duckx",
   "version": "1.2.2",
+  "port-version": 1,
   "description": "DuckX is a library for creation of Office docx files.",
   "homepage": "https://github.com/amiremohamadi/DuckX",
   "license": "MIT",
   "dependencies": [
+    "miniz",
+    "pugixml",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1958,7 +1958,7 @@
     },
     "duckx": {
       "baseline": "1.2.2",
-      "port-version": 0
+      "port-version": 1
     },
     "duilib": {
       "baseline": "2019-04-28",

--- a/versions/d-/duckx.json
+++ b/versions/d-/duckx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "97f6f39c0100627300f0367b08fcdb6591c0f05e",
+      "version": "1.2.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "6637b59789032a1ef84a1c6324bc7b672e346152",
       "version": "1.2.2",
       "port-version": 0


### PR DESCRIPTION
Fixes baseline issue

* pugixml and miniz are taken from vcpkg, as opposed to using the vendored copy
* zip.h & zip.c[pp] - I couldn't find where they come from
  (or if they come from something!), so they've been left the same;
  since they're an internal library, though, I've stopped installing them,
  and I've hidden the symbols in the `duckx` namespace
  (this involved converting to C++).