### PR TITLE
[rtmidi] no absolute paths

### DIFF
--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -23,4 +23,6 @@ vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+vcpkg_fixup_pkgconfig()
+
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rtmidi",
-  "version-semver": "4.0.0",
-  "port-version": 5,
+  "version-semver": "5.0.0",
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6261,8 +6261,8 @@
       "port-version": 3
     },
     "rtmidi": {
-      "baseline": "4.0.0",
-      "port-version": 5
+      "baseline": "5.0.0",
+      "port-version": 0
     },
     "rttr": {
       "baseline": "0.9.6",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4eb19141251ff7759838e0ab10f35876583d367b",
+      "version-semver": "5.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "1d922425c684e2dd87ea1691b2ac8f1c0fd808e4",
       "version-semver": "4.0.0",
       "port-version": 5


### PR DESCRIPTION
Also the version was not properly updated here: https://github.com/microsoft/vcpkg/pull/24201/files#diff-56d7907c64bfc3961cf5c5f7d94ea31a04dcc8bf58f3cdbb8dc24b9628114205