### PR TITLE
[many ports] Fix version files

### DIFF
--- a/versions/c-/color-console.json
+++ b/versions/c-/color-console.json
@@ -4,11 +4,6 @@
       "git-tree": "bdd7720df549670e50ef636219b7d093f7cc8bc6",
       "version-date": "2022-03-20",
       "port-version": 0
-    },
-    {
-      "git-tree": "9a371b999eb2e8c7d72d50267fbcad9c9b3967b1",
-      "version-semver": "1.0.0",
-      "port-version": 0
     }
   ]
 }

--- a/versions/c-/cuda.json
+++ b/versions/c-/cuda.json
@@ -21,11 +21,6 @@
       "port-version": 7
     },
     {
-      "git-tree": "cd48424964a6d19d032e14e84dbd41c5cdcb05ef",
-      "version-string": "10.1",
-      "port-version": 6
-    },
-    {
       "git-tree": "0022275f9aa9e2d70f6a35d7e28fb27ab21fd13e",
       "version-string": "10.1",
       "port-version": 5

--- a/versions/d-/directxsdk.json
+++ b/versions/d-/directxsdk.json
@@ -26,11 +26,6 @@
       "port-version": 1
     },
     {
-      "git-tree": "b3a7a8a22c780726a74fb673c31454ef83e9ea79",
-      "version-string": "jun10b",
-      "port-version": 0
-    },
-    {
       "git-tree": "dc3241d51d057a92ef8db501c80a749a46ed4461",
       "version-string": "jun10",
       "port-version": 0

--- a/versions/g-/glad.json
+++ b/versions/g-/glad.json
@@ -16,11 +16,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "d222f56675de6eedfc3a25e5a4b93fee39747f49",
-      "version-string": "0.1.34",
-      "port-version": 2
-    },
-    {
       "git-tree": "abaac8ade7697e7f6ae4a82c981aafa2cc6a5359",
       "version-string": "0.1.33-1",
       "port-version": 0

--- a/versions/l-/libao.json
+++ b/versions/l-/libao.json
@@ -9,11 +9,6 @@
       "git-tree": "931d3ed363323bdc4de00c91165f3a09e23fb6b1",
       "version": "1.2.2",
       "port-version": 3
-    },
-    {
-      "git-tree": "3ce3e18f2bb49577bbf0e0341cd0e5eb425e47bc",
-      "version": "1.2.2",
-      "port-version": 2
     }
   ]
 }

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -46,7 +46,7 @@
       "port-version": 6
     },
     {
-      "git-tree": "fe188805a906d5d853bc330253242c12029ae0de",
+      "git-tree": "a8318f61dfe300b1b980b2ecaf295bd626572ad4",
       "version-semver": "3.4.3",
       "port-version": 5
     },

--- a/versions/l-/libtcod.json
+++ b/versions/l-/libtcod.json
@@ -21,23 +21,8 @@
       "port-version": 2
     },
     {
-      "git-tree": "40587cd0b117a21791c1da332c89c6e1a820e2a9",
-      "version-semver": "1.16.7",
-      "port-version": 1
-    },
-    {
-      "git-tree": "c8498087d7b87609436a7c5fb85c391592add740",
-      "version-string": "1.16.7",
-      "port-version": 0
-    },
-    {
       "git-tree": "e2de0a47f3776252b6e04681c92d67b0730587ef",
       "version-string": "1.16.6",
-      "port-version": 0
-    },
-    {
-      "git-tree": "b4899dcf1740634e91d040b66259568ecafaa1b6",
-      "version-string": "1.16.4",
       "port-version": 0
     }
   ]

--- a/versions/m-/mailio.json
+++ b/versions/m-/mailio.json
@@ -6,7 +6,7 @@
       "port-version": 2
     },
     {
-      "git-tree": "f0fde0f6599aacd2b890c94326f504bf2af8f642",
+      "git-tree": "80186942edc09cad3c911ebbc6dd77d30af68502",
       "version": "0.21.0",
       "port-version": 1
     },

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -81,7 +81,7 @@
       "port-version": 0
     },
     {
-      "git-tree": "859d6618f0ff394cc940ede79ada4bff1b7655dc",
+      "git-tree": "ffd8270ed4798f25f3bd882a6089c72e86803466",
       "version": "3.4.12",
       "port-version": 1
     },

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -86,7 +86,7 @@
       "port-version": 0
     },
     {
-      "git-tree": "ba164060f8a9e69ccc4c484a24b5e8085d20b3bd",
+      "git-tree": "a0522dbbb44877b9d4618bfe31a376e07e49bc72",
       "version": "4.5.0",
       "port-version": 1
     },

--- a/versions/r-/robin-map.json
+++ b/versions/r-/robin-map.json
@@ -11,7 +11,7 @@
       "port-version": 1
     },
     {
-      "git-tree": "3a6eb0ea067edf2d06baa7706281caf96df4216a",
+      "git-tree": "84f1433234bb4813feee71e4042174ec9e8d5a7a",
       "version-semver": "0.6.3",
       "port-version": 0
     },

--- a/versions/s-/sleepy-discord.json
+++ b/versions/s-/sleepy-discord.json
@@ -14,11 +14,6 @@
       "git-tree": "9ef84b8cb8cdd5d278b005a551044a6635490bda",
       "version-date": "2021-07-07",
       "port-version": 0
-    },
-    {
-      "git-tree": "0d9d62b7213333d04c90878bb1e6573ad3f5316f",
-      "version-date": "2021-05-02",
-      "port-version": 0
     }
   ]
 }


### PR DESCRIPTION
Fix problems in version files detected by `x-ci-verify-versions --verify-git-trees`

### Ports with versions that are not in our Git history
These are caused when a PR adds multiple versions of a single port to the database in the same PR.
* `color-console`
* `cuda`
* `directxsdk`
* `glad`
* `libao`
* `libtcod`
* `sleepy-discord`


### Ports with version discrepancies between files in SHA and version declared in DB
These are often caused by bad merges when pulling upstream changes.
* `libarchive`
* `mailio`
* `opencv3`
* `opencv4`
* `robin-map`

### Ports with versions that contain errors on their `CONTROL` or `vcpkg.json` file.

- [ ] `abseil:2020-03-03#7`: features are improperly formatted 
`git show 28fa609b06eec70bb06e61891e94b94f35f7d06e:vcpkg.json`
- [ ] `blend2d:beta_2020_07_31`: features are improperly formatted
`git show ffce764b880d8cc24e3b00328aa3861f15bae91d:vcpkg.json`
- [ ] `libwebp:1.1.0`: CONTROL file contains `_` that is now disallowed
`git show a05e0de81085231df86f6902aba1e0a364e2ca7b:CONTROL`

After all this have been fixed we can enable `--verify-git-trees` on our CI to prevent these issues from popping up again.
- [ ] Enable `--verify-git-trees` on CI