### PR TITLE
[llvm] fix abi-breaking-checks to always be disabled

### DIFF
--- a/ports/llvm/portfile.cmake
+++ b/ports/llvm/portfile.cmake
@@ -76,13 +76,16 @@ elseif("disable-assertions" IN_LIST FEATURES)
 endif()
 
 # LLVM_ABI_BREAKING_CHECKS can be WITH_ASSERTS (default), FORCE_ON or FORCE_OFF.
-# By default abi-breaking checks are enabled if assertions are enabled.
+# By default in LLVM, abi-breaking checks are enabled if assertions are enabled.
+# however, this breaks linking with the debug versions, since the option is
+# baked into the header files; thus, we always turn off LLVM_ABI_BREAKING_CHECKS
+# unless the user asks for it
 if("enable-abi-breaking-checks" IN_LIST FEATURES)
     # Force enable abi-breaking checks.
     list(APPEND FEATURE_OPTIONS
         -DLLVM_ABI_BREAKING_CHECKS=FORCE_ON
     )
-elseif("disable-abi-breaking-checks" IN_LIST FEATURES)
+else()
     # Force disable abi-breaking checks.
     list(APPEND FEATURE_OPTIONS
         -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "13.0.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",

--- a/ports/llvm/vcpkg.json
+++ b/ports/llvm/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "llvm",
   "version": "13.0.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "The LLVM Compiler Infrastructure.",
   "homepage": "https://llvm.org",
   "license": "Apache-2.0",
@@ -99,7 +99,7 @@
       ]
     },
     "disable-abi-breaking-checks": {
-      "description": "Build LLVM with LLVM_ABI_BREAKING_CHECKS=FORCE_OFF."
+      "description": "Deprecated; this is the default"
     },
     "disable-assertions": {
       "description": "Build LLVM without assertions."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4254,7 +4254,7 @@
     },
     "llvm": {
       "baseline": "13.0.0",
-      "port-version": 3
+      "port-version": 5
     },
     "lmdb": {
       "baseline": "0.9.29",

--- a/versions/l-/llvm.json
+++ b/versions/l-/llvm.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c835fcc79ad542a73ac25fd939556039ff75cd1",
+      "version": "13.0.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "15418b7e938058677963d920b616403240eca37f",
       "version": "13.0.0",
       "port-version": 3


### PR DESCRIPTION
in Debug builds, LLVM_ABI_BREAKING_CHECKS was on by default;
however, they use the release headers (which set it to OFF)
this results in a mismatch,
and means you can't link LLVM