### PR TITLE
[libjuice] update to 1.0.0

### DIFF
--- a/ports/libjuice/portfile.cmake
+++ b/ports/libjuice/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO paullouisageneau/libjuice
-    REF e2bb4df9c9a2d3a296312925f313bf6f26854010 #v0.9.8
-    SHA512 98fa9cf8a1f22c0f43ef7b2dd438bdd299483384b8d81f1196d8a0fe7fa41c63df7d7acfb94b9af3b8edfe569aeb73b33569bea2557ed2d0a554ba3a81603c2f
+    REF ae954be55f17a100e99650d6c1286e80929a66bb #v1.0.0
+    SHA512 1b303ddfc7b903e0ba5f35580a6ce2350e12d4ef6cbbe97dbd090e863b664ca7b2f13da24d70b20cfd30a9c1208779b9b9c8c2df9ff9a21f12f3fc1bfdc09b0e
     HEAD_REF master
     PATCHES
         fix-for-vcpkg.patch

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
+  "license": "LGPL-2.1",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
-  "license": "LGPL-2.1",
+  "license": "LGPL-2.1-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "libjuice",
-  "version": "0.9.8",
+  "version": "1.0.0",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
   "dependencies": [

--- a/ports/libjuice/vcpkg.json
+++ b/ports/libjuice/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "The library is a simplified implementation of the Interactive Connectivity Establishment (ICE) protocol in C for POSIX platforms (including Linux and Apple macOS) and Microsoft Windows.",
   "homepage": "https://github.com/paullouisageneau/libjuice",
-  "license": "LGPL-2.1-or-later",
+  "license": "LGPL-2.1-only",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3685,7 +3685,7 @@
       "port-version": 2
     },
     "libjuice": {
-      "baseline": "0.9.8",
+      "baseline": "1.0.0",
       "port-version": 0
     },
     "libjxl": {

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2cf9e448913780ecbae9e2bf4218b107405b4b89",
+      "version": "1.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "62c215b49c59158589a9bc98d02b20243ef1bf0b",
       "version": "0.9.8",
       "port-version": 0

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fd5023371125c2b751379633fd92c8f08236b4b",
+      "git-tree": "7ca00ccfd8b904bab5bf0fe65f7d7551c073aba4",
       "version": "1.0.0",
       "port-version": 0
     },

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ca00ccfd8b904bab5bf0fe65f7d7551c073aba4",
+      "git-tree": "02ea9a1ae4e054d9474f801747e5edd17a3d8ad1",
       "version": "1.0.0",
       "port-version": 0
     },

--- a/versions/l-/libjuice.json
+++ b/versions/l-/libjuice.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2cf9e448913780ecbae9e2bf4218b107405b4b89",
+      "git-tree": "4fd5023371125c2b751379633fd92c8f08236b4b",
       "version": "1.0.0",
       "port-version": 0
     },


### PR DESCRIPTION
Fix #24284

Update libjuice to the latest version 1.0.0

Feature tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static