### PR TITLE
[gtk] update to v4.6.2

### DIFF
--- a/ports/gtk/0001-build.patch
+++ b/ports/gtk/0001-build.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 9fe9cd5ac..19a19e5c6 100644
+index 41cf592..cb4d638 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -845,24 +845,24 @@ subdir('po-properties')
+@@ -897,24 +897,24 @@ subdir('po-properties')
  subdir('docs/tools')
  subdir('docs/reference')
  
@@ -11,7 +11,7 @@ index 9fe9cd5ac..19a19e5c6 100644
 -    gnome.post_install(
 -      glib_compile_schemas: true,
 -      gio_querymodules: gio_module_dirs,
--      gtk_update_icon_cache: true,
+-      gtk_update_icon_cache: get_option('demos'),
 -    )
 -  else
 -    meson.add_install_script('build-aux/meson/post-install.py',
@@ -29,7 +29,7 @@ index 9fe9cd5ac..19a19e5c6 100644
 +#    gnome.post_install(
 +#      glib_compile_schemas: true,
 +#      gio_querymodules: gio_module_dirs,
-+#      gtk_update_icon_cache: true,
++#      gtk_update_icon_cache: get_option('demos'),
 +#    )
 +#  else
 +#    meson.add_install_script('build-aux/meson/post-install.py',

--- a/ports/gtk/portfile.cmake
+++ b/ports/gtk/portfile.cmake
@@ -1,11 +1,11 @@
-set(GTK_VERSION 4.6.0)
+set(GTK_VERSION 4.6.2)
 
 vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/gtk
-    REF  70cb61fb7104c76a15bc6494a10e6ff1d470f6d8 #v4.6.0
-    SHA512 dba6ce5a8306f9dda290f3785d6d15aee67c66329ab0756b7b7573387c1a512e96d3b53b24ed342ce7376832dcac20fb24025f2b8986f74d91a88e4fcf3de6ae
+    REF  aec7ca82007dbe07faee6be084d20758ebac2b91 #v4.6.2
+    SHA512 05ebba53e71a997b4dc04bc018f420f62d569cb66a2f3e713bd2b48abd7c0051f67939e42c812388bd0565d12a3f82b45731a086d3ab0e75d16eee200a3be95f
     HEAD_REF master # branch name
     PATCHES
         0001-build.patch
@@ -109,7 +109,7 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
 
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 set(TOOL_NAMES gtk4-builder-tool
                gtk4-encode-symbolic-svg

--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "gtk",
-  "version": "4.6.0",
+  "version": "4.6.2",
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2673,7 +2673,7 @@
       "port-version": 5
     },
     "gtk": {
-      "baseline": "4.6.0",
+      "baseline": "4.6.2",
       "port-version": 0
     },
     "gtkmm": {

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "00d7796e9bcff96a64e45b977a72129b1dc7be43",
+      "version": "4.6.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae837c3a08bb71e486641d8b4464c132dbf54464",
       "version": "4.6.0",
       "port-version": 0


### PR DESCRIPTION
Fix #24300
update gtk to v4.6.2
update patch

All features passed with following triplets:
x86-windows
x64-windows
x64-windows-static