### PR TITLE
[pango] Used unused variable (fix for MacOS / Clang 13)

### DIFF
--- a/ports/pango/portfile.cmake
+++ b/ports/pango/portfile.cmake
@@ -5,7 +5,9 @@ vcpkg_from_gitlab(
     REF  37a427018c92a2bc679ef104097e07a619609c9c #v1.50.6
     SHA512 4990022cae2130b4842d0d9d3161545c7214ac3dd445d85a7ec49b0a89e39319b404fecc66d4025965cd2407823c7476b937e6ee53e2e6763b35048db8ff387f
     HEAD_REF master # branch name
-) 
+    PATCHES
+        set_but_not_used_var.patch
+)
 
 vcpkg_configure_meson(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/pango/set_but_not_used_var.patch
+++ b/ports/pango/set_but_not_used_var.patch
@@ -1,0 +1,21 @@
+diff --git a/pango/pangocoretext-fontmap.c b/pango/pangocoretext-fontmap.c
+index 40e62eed..36d1a358 100644
+--- a/pango/pangocoretext-fontmap.c
++++ b/pango/pangocoretext-fontmap.c
+@@ -860,7 +860,7 @@ get_scaled_size (PangoCoreTextFontMap       *fontmap,
+   double size = pango_font_description_get_size (desc);
+   const PangoMatrix *matrix = pango_context_get_matrix (context);
+   double scale_factor = pango_matrix_get_font_scale_factor (matrix);
+-  
++
+   if (!pango_font_description_get_size_is_absolute(desc))
+   {
+     double dpi = pango_core_text_font_map_get_resolution (fontmap, context);
+@@ -1700,6 +1700,7 @@ pango_core_text_fontset_load_font (PangoCoreTextFontset *ctfontset,
+   PangoCoreTextFont *font;
+ 
+   key = pango_core_text_fontset_get_key (ctfontset);
++  key;
+ 
+   /* For now, we will default the fallbacks to not have synthetic italic,
+    * in the future this may be improved.

--- a/ports/pango/vcpkg.json
+++ b/ports/pango/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "pango",
   "version": "1.50.6",
+  "port-version": 1,
   "description": "Text and font handling library.",
   "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5278,7 +5278,7 @@
     },
     "pango": {
       "baseline": "1.50.6",
-      "port-version": 0
+      "port-version": 1
     },
     "pangolin": {
       "baseline": "0.6",

--- a/versions/p-/pango.json
+++ b/versions/p-/pango.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "63ff8673d354f4c6a020efcc0a70a5c7d0ccb25e",
+      "version": "1.50.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "db85fd904e40578950bcc478e2bfad06c70e787a",
       "version": "1.50.6",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  see title

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
