### PR TITLE
[lmdb] Remove 'd' suffix from debug libraries

### DIFF
--- a/ports/lmdb/cmake/CMakeLists.txt
+++ b/ports/lmdb/cmake/CMakeLists.txt
@@ -28,8 +28,7 @@ endif()
 set(SRCS lmdb mdb.c lmdb.h midl.c midl.h )
 add_library(lmdb ${SRCS})
 
-if (VCPKG_TARGET_IS_WINDOWS)
-  set_target_properties(lmdb PROPERTIES DEBUG_POSTFIX d)
+if (WIN32)
   target_link_libraries(lmdb PRIVATE ntdll.lib)
 endif()
 

--- a/ports/lmdb/cmake/CMakeLists.txt
+++ b/ports/lmdb/cmake/CMakeLists.txt
@@ -27,8 +27,9 @@ endif()
 
 set(SRCS lmdb mdb.c lmdb.h midl.c midl.h )
 add_library(lmdb ${SRCS})
-set_target_properties(lmdb PROPERTIES DEBUG_POSTFIX d)
-if (WIN32)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+  set_target_properties(lmdb PROPERTIES DEBUG_POSTFIX d)
   target_link_libraries(lmdb PRIVATE ntdll.lib)
 endif()
 

--- a/ports/lmdb/vcpkg.json
+++ b/ports/lmdb/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "lmdb",
   "version": "0.9.29",
+  "port-version": 1,
   "description": "LMDB is an extraordinarily fast, memory-efficient database",
   "homepage": "https://github.com/LMDB/lmdb",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4258,7 +4258,7 @@
     },
     "lmdb": {
       "baseline": "0.9.29",
-      "port-version": 0
+      "port-version": 1
     },
     "lodepng": {
       "baseline": "2021-12-04",

--- a/versions/l-/lmdb.json
+++ b/versions/l-/lmdb.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "29beb18917f15d952c6d37c2a4683c5366bf884d",
+      "version": "0.9.29",
+      "port-version": 1
+    },
+    {
       "git-tree": "980e2c4a26c75996e3940a9b46032356643e592b",
       "version": "0.9.29",
       "port-version": 0

--- a/versions/l-/lmdb.json
+++ b/versions/l-/lmdb.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "29beb18917f15d952c6d37c2a4683c5366bf884d",
+      "git-tree": "02d32452e2c5a3284fcdd1f448ab513dbb18a085",
       "version": "0.9.29",
       "port-version": 1
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  'd' won't be appended to library files on *nix platforms anymore

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
