### PR TITLE
[celero] Update to 2.8.3

### DIFF
--- a/ports/celero/fix-bin-install-path.patch
+++ b/ports/celero/fix-bin-install-path.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0158c4f..5be0fbc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -220,9 +220,11 @@ install(
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+ )
+ install(
+     TARGETS     celero
+-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     EXPORT      celero-targets
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib
+ )
+ install(
+     EXPORT      celero-targets

--- a/ports/celero/portfile.cmake
+++ b/ports/celero/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v2.8.3
     SHA512 f6774f6076bae5d37d4f5bd12153bc99b97893f43fe9253fe805b5b0c2475ffe878e32f3fc7391544ea24020e59d5ae48e44e5b3a302f7280ad15b6a6820f70b
     HEAD_REF master
+    PATCHES
+        fix-bin-install-path.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" CELERO_COMPILE_DYNAMIC_LIBRARIES)

--- a/ports/celero/portfile.cmake
+++ b/ports/celero/portfile.cmake
@@ -1,33 +1,29 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO DigitalInBlue/Celero
-    REF 6208b63dcd4baeea6817d3e84f79fb04ad99c720 #2.8.2
-    SHA512 13a486dafba394cc3e072292008d00e8a3e1b12b4fe7c82cf2ce43b3d24629d08b5762494c19da0a12b186a70114cba101553ed1b4cea90d090514307b06dec8
+    REF v2.8.3
+    SHA512 f6774f6076bae5d37d4f5bd12153bc99b97893f43fe9253fe805b5b0c2475ffe878e32f3fc7391544ea24020e59d5ae48e44e5b3a302f7280ad15b6a6820f70b
     HEAD_REF master
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" CELERO_COMPILE_DYNAMIC_LIBRARIES)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA # Disable this option if project cannot be built with Ninja
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCELERO_ENABLE_EXPERIMENTS=OFF
         -DCELERO_ENABLE_TESTS=OFF
-        -DCELERO_RUN_EXAMPLE_ON_BUILD=OFF
         -DCELERO_COMPILE_DYNAMIC_LIBRARIES=${CELERO_COMPILE_DYNAMIC_LIBRARIES}
         -DCELERO_TREAT_WARNINGS_AS_ERRORS=OFF
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH share)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/celero/Export.h "ifdef CELERO_STATIC" "if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/celero/Export.h" "#ifdef CELERO_STATIC" "#define CELERO_STATIC\n#ifdef CELERO_STATIC")
 endif()
 
-file(RENAME ${CURRENT_PACKAGES_DIR}/share/celero/celero-target.cmake ${CURRENT_PACKAGES_DIR}/share/celero/celero-config.cmake)
-
-file(INSTALL ${SOURCE_PATH}/license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/license.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/celero/vcpkg.json
+++ b/ports/celero/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "celero",
-  "version-string": "2.8.2",
-  "port-version": 1,
+  "version": "2.8.3",
   "description": "Celero is a modern cross-platform (Windows, Linux, MacOS) Microbenchmarking library for C++.",
-  "homepage": "https://github.com/DigitalInBlue/Celero"
+  "homepage": "https://github.com/DigitalInBlue/Celero",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1293,8 +1293,8 @@
       "port-version": 3
     },
     "celero": {
-      "baseline": "2.8.2",
-      "port-version": 1
+      "baseline": "2.8.3",
+      "port-version": 0
     },
     "cello": {
       "baseline": "2019-07-23",

--- a/versions/c-/celero.json
+++ b/versions/c-/celero.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "23896c3b65f35d5e9dfdb094f35c23e4550301b9",
+      "git-tree": "a9beee7ba313a9770888b114a8146bc1a983577e",
       "version": "2.8.3",
       "port-version": 0
     },

--- a/versions/c-/celero.json
+++ b/versions/c-/celero.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "23896c3b65f35d5e9dfdb094f35c23e4550301b9",
+      "version": "2.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "58fca5af8a14714f953c3d8a4653e90ac8d11e2f",
       "version-string": "2.8.2",
       "port-version": 1


### PR DESCRIPTION
Update celero port from 2.8.2 to 2.8.3.
Changelog : https://github.com/DigitalInBlue/Celero/releases/tag/v2.8.3