### PR TITLE
[libvpx] update to 1.11.0

### DIFF
--- a/ports/libvpx/portfile.cmake
+++ b/ports/libvpx/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(LIBVPX_VERSION 1.10.0)
+set(LIBVPX_VERSION 1.11.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO webmproject/libvpx
     REF v${LIBVPX_VERSION}
-    SHA512 f88c588145b5164e98531b75215e119056cd806a9dbe6599bb9dab35c0af0ecd4b3daabee7d795e412a58aeb543d5c7dc0107457c4bd8f4d434e966e8e22a32d
+    SHA512 7aa5d30afa956dccda60917fd82f6f9992944ca893437c8cd53a04d1b7a94e0210431954aa136594dc400340123cc166dcc855753e493c8d929667f4c42b65a5
     HEAD_REF master
     PATCHES
         0002-Fix-nasm-debug-format-flag.patch

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "1.11.0",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
-  "license": null,
+  "license": "BSD-3-Clause",
   "features": {
     "highbitdepth": {
       "description": "use VP9 high bit depth (10/12) profiles"

--- a/ports/libvpx/vcpkg.json
+++ b/ports/libvpx/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "libvpx",
-  "version-semver": "1.10.0",
-  "port-version": 2,
+  "version": "1.11.0",
   "description": "The reference software implementation for the video coding formats VP8 and VP9.",
   "homepage": "https://github.com/webmproject/libvpx",
+  "license": null,
   "features": {
     "highbitdepth": {
       "description": "use VP9 high bit depth (10/12) profiles"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4153,8 +4153,8 @@
       "port-version": 2
     },
     "libvpx": {
-      "baseline": "1.10.0",
-      "port-version": 2
+      "baseline": "1.11.0",
+      "port-version": 0
     },
     "libwandio": {
       "baseline": "4.2.1",

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "51baf1c55168894848e9e62344d479c448ee3f56",
+      "git-tree": "3ec8aec9ecbcb2e3b5a0af7cea8045359d9aec94",
       "version": "1.11.0",
       "port-version": 0
     },

--- a/versions/l-/libvpx.json
+++ b/versions/l-/libvpx.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "51baf1c55168894848e9e62344d479c448ee3f56",
+      "version": "1.11.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "79a7e2cf4e6df063990dc59d1aa221150eb0ce0e",
       "version-semver": "1.10.0",
       "port-version": 2


### PR DESCRIPTION
Fix #24330
Update [libvpx] version to 1.11.0
All features are tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-static