### PR TITLE
[refl-cpp] update to 0.12.3

### DIFF
--- a/ports/refl-cpp/portfile.cmake
+++ b/ports/refl-cpp/portfile.cmake
@@ -1,10 +1,9 @@
 # header-only library
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO veselink1/refl-cpp
-    REF v0.12.2
-    SHA512 a124f12f2a491b3f2ea74bcf3b8cd3e14f1a4aa5ede105edbed90c3329af7d7fffa5c7a287f2e1e6079d9f0fad34190887700ae20a7d15f00299526317b41137
+    REF ce47c1355219f3b9af56ae91d997daf2b1555d97 v0.12.3
+    SHA512 f73e542a9ee00d677e2445c148b732cbdf6247adc1f4f412ad8e9587c5971b3cb02b39b15cdb9b0788f53e9efea6c5a485367505ecb569a367be012f6246ea92
     HEAD_REF master
 )
 

--- a/ports/refl-cpp/vcpkg.json
+++ b/ports/refl-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "refl-cpp",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Static reflection for C++17 (compile-time enumeration, attributes, proxies, overloads, template functions, metaprogramming).",
   "homepage": "https://github.com/veselink1/refl-cpp"
 }

--- a/ports/refl-cpp/vcpkg.json
+++ b/ports/refl-cpp/vcpkg.json
@@ -2,6 +2,5 @@
   "name": "refl-cpp",
   "version": "0.12.3",
   "description": "Static reflection for C++17 (compile-time enumeration, attributes, proxies, overloads, template functions, metaprogramming).",
-  "homepage": "https://github.com/veselink1/refl-cpp",
-  "license": null
+  "homepage": "https://github.com/veselink1/refl-cpp"
 }

--- a/ports/refl-cpp/vcpkg.json
+++ b/ports/refl-cpp/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "refl-cpp",
   "version": "0.12.3",
   "description": "Static reflection for C++17 (compile-time enumeration, attributes, proxies, overloads, template functions, metaprogramming).",
-  "homepage": "https://github.com/veselink1/refl-cpp"
+  "homepage": "https://github.com/veselink1/refl-cpp",
+  "license": null
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6141,7 +6141,7 @@
       "port-version": 0
     },
     "refl-cpp": {
-      "baseline": "0.12.2",
+      "baseline": "0.12.3",
       "port-version": 0
     },
     "refprop-headers": {

--- a/versions/r-/refl-cpp.json
+++ b/versions/r-/refl-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7018b2c10e3c2e2be8dd774fb43d2f04fa520a02",
+      "version": "0.12.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "f5aea911f8cfd7c6eecadb50142f00205a2e7f57",
       "version": "0.12.2",
       "port-version": 0


### PR DESCRIPTION
Fix #24339

Update refl-cpp to the latest version 0.12.3

Note: no feature need to test 

