### PR TITLE
[opencv] Fix import paths for debug Android builds

### DIFF
--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -377,11 +377,13 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME opencv CONFIG_PATH "share/opencv")
 vcpkg_copy_pdbs()
 
-# Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
-    "\${_IMPORT_PREFIX}/sdk"
-    "\${_IMPORT_PREFIX}/debug/sdk"
-)
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+  # Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
+      "\${_IMPORT_PREFIX}/sdk"
+      "\${_IMPORT_PREFIX}/debug/sdk"
+  )
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules.cmake" OPENCV_MODULES)

--- a/ports/opencv3/portfile.cmake
+++ b/ports/opencv3/portfile.cmake
@@ -377,6 +377,12 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME opencv CONFIG_PATH "share/opencv")
 vcpkg_copy_pdbs()
 
+# Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
+    "\${_IMPORT_PREFIX}/sdk"
+    "\${_IMPORT_PREFIX}/debug/sdk"
+)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)

--- a/ports/opencv3/vcpkg.json
+++ b/ports/opencv3/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv3",
   "version": "3.4.16",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Open Source Computer Vision Library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "BSD-3-Clause",

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -457,11 +457,13 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME opencv CONFIG_PATH "share/opencv")
 vcpkg_copy_pdbs()
 
-# Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
-    "\${_IMPORT_PREFIX}/sdk"
-    "\${_IMPORT_PREFIX}/debug/sdk"
-)
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+  # Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
+      "\${_IMPORT_PREFIX}/sdk"
+      "\${_IMPORT_PREFIX}/debug/sdk"
+  )
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules.cmake" OPENCV_MODULES)

--- a/ports/opencv4/portfile.cmake
+++ b/ports/opencv4/portfile.cmake
@@ -457,6 +457,12 @@ vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME opencv CONFIG_PATH "share/opencv")
 vcpkg_copy_pdbs()
 
+# Update debug paths for libs in Android builds (e.g. sdk/native/staticlibs/armeabi-v7a)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules-debug.cmake"
+    "\${_IMPORT_PREFIX}/sdk"
+    "\${_IMPORT_PREFIX}/debug/sdk"
+)
+
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
   file(READ "${CURRENT_PACKAGES_DIR}/share/opencv/OpenCVModules.cmake" OPENCV_MODULES)
   set(DEPS_STRING "include(CMakeFindDependencyMacro)

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.5",
-  "port-version": 3,
+  "port-version": 4,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5090,7 +5090,7 @@
     },
     "opencv3": {
       "baseline": "3.4.16",
-      "port-version": 7
+      "port-version": 8
     },
     "opencv4": {
       "baseline": "4.5.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5094,7 +5094,7 @@
     },
     "opencv4": {
       "baseline": "4.5.5",
-      "port-version": 3
+      "port-version": 4
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "dc24cbb7010c5ef7494ba6d65c76751ac0f76572",
+      "version": "3.4.16",
+      "port-version": 8
+    },
+    {
       "git-tree": "d3c28cb4da2e7da9d31cc72415aff26f0b4d8442",
       "version": "3.4.16",
       "port-version": 7

--- a/versions/o-/opencv3.json
+++ b/versions/o-/opencv3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dc24cbb7010c5ef7494ba6d65c76751ac0f76572",
+      "git-tree": "d8a8b60a98ada175921aadcd09ed66509c9be2a4",
       "version": "3.4.16",
       "port-version": 8
     },

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a32de059056b3f5c6033720a10d94a4e82ce7465",
+      "version": "4.5.5",
+      "port-version": 4
+    },
+    {
       "git-tree": "0771f6243ddde63a9b212efeb5ad51a74b640a62",
       "version": "4.5.5",
       "port-version": 3

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a32de059056b3f5c6033720a10d94a4e82ce7465",
+      "git-tree": "86073388865f7730e42d02768f8963156f2be82f",
       "version": "4.5.5",
       "port-version": 4
     },


### PR DESCRIPTION
- #### What does your PR fix?
Fixes OpenCV 4 import paths for Android debug builds.

For Android builds OpenCV places library outputs under a `sdk/native/staticlibs/<arch>` directory, and vcpkg correctly copies these to the install directory as either `vcpkg_installed/<triplet>/sdk/...` for release or `vcpkg_installed/<triplet>/debug/sdk/...` for debug, however the `OpenCVModules-debug.cmake` is not automatically updated by vcpkg_cmake_config_fixup to reference the debug directory.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
OpenCV will only use this `sdk` directory when the ANDROID cmake variable is set. I'm not aware of behaviour change based on the triplet.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I have read the guide and I think this PR follows it.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

