### PR TITLE
[ijg-libjpeg] update to 9e

### DIFF
--- a/ports/ijg-libjpeg/CMakeLists.txt
+++ b/ports/ijg-libjpeg/CMakeLists.txt
@@ -12,9 +12,9 @@ option(BUILD_EXECUTABLES OFF)
 include(CheckIncludeFile)
 check_include_file(stddef.h HAVE_STDDEF_H)
 check_include_file(stdlib.h HAVE_STDLIB_H)
-configure_file(jconfig.txt ${CMAKE_CURRENT_SOURCE_DIR}/jconfig.h)
+configure_file(jconfig.txt ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h)
 
-list(APPEND PUBLIC_HEADERS jpeglib.h jerror.h jmorecfg.h jconfig.h)
+list(APPEND PUBLIC_HEADERS jpeglib.h jerror.h jmorecfg.h ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h)
 
 add_library(jpeg
     ${PUBLIC_HEADERS} jinclude.h jpegint.h jversion.h
@@ -34,6 +34,8 @@ if(WIN32)
         _CRT_SECURE_NO_WARNINGS
     )
 endif()
+
+target_include_directories(jpeg PRIVATE include ${CMAKE_CURRENT_BINARY_DIR})
 
 install(FILES       ${PUBLIC_HEADERS}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include

--- a/ports/ijg-libjpeg/portfile.cmake
+++ b/ports/ijg-libjpeg/portfile.cmake
@@ -10,9 +10,9 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 vcpkg_download_distfile(ARCHIVE
-    URLS        "http://www.ijg.org/files/jpegsr9d.zip"
-    FILENAME    "jpegsr9d.zip"
-    SHA512      441a783c945fd549693dbe3932d8d35e1ea00d8464870646760ed84a636facb4d7afe0ca3ab988e7281a71e41c2e96be618b8c6a898f116517e639720bba82a3
+    URLS        "http://www.ijg.org/files/jpegsr9e.zip"
+    FILENAME    "jpegsr9e.zip"
+    SHA512      db7a2fb44e5cc20d61956c46334948af034c07cdcc0d6e41d9bd4f6611c0fbed8943d0a05029ba1bfb9d993f4acd0df5e95d0bc1cfb5a889b86a55b6b75fdf64
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -21,31 +21,30 @@ vcpkg_extract_source_archive_ex(
 
 # Replace some #define in jconfig.txt to #cmakedefine so the CMakeLists.txt can run `configure_file` command.
 # See https://github.com/LuaDist/libjpeg
-vcpkg_replace_string(${SOURCE_PATH}/jconfig.txt
+vcpkg_replace_string("${SOURCE_PATH}/jconfig.txt"
     "#define HAVE_STDDEF_H"
     "#cmakedefine HAVE_STDDEF_H"
 )
-vcpkg_replace_string(${SOURCE_PATH}/jconfig.txt
+vcpkg_replace_string("${SOURCE_PATH}/jconfig.txt"
     "#define HAVE_STDLIB_H"
     "#cmakedefine HAVE_STDLIB_H"
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DBUILD_EXECUTABLES=OFF # supports [tools] feature to enable this option?
 )
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 # There is no LICENSE file, but README containes some legal text.
-file(INSTALL ${SOURCE_PATH}/README DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
-    file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/ijg-libjpeg/vcpkg.json
+++ b/ports/ijg-libjpeg/vcpkg.json
@@ -1,7 +1,18 @@
 {
   "name": "ijg-libjpeg",
-  "version-string": "9d",
+  "version-string": "9e",
   "description": "Independent JPEG Group's JPEG software",
   "homepage": "http://www.ijg.org/",
-  "supports": "!emscripten & !wasm32"
+  "license": null,
+  "supports": "!emscripten & !wasm32",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2901,7 +2901,7 @@
       "port-version": 1
     },
     "ijg-libjpeg": {
-      "baseline": "9d",
+      "baseline": "9e",
       "port-version": 0
     },
     "ilmbase": {

--- a/versions/i-/ijg-libjpeg.json
+++ b/versions/i-/ijg-libjpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb37d14790c59df2657d83e21009faa54643f19d",
+      "version-string": "9e",
+      "port-version": 0
+    },
+    {
       "git-tree": "320dc4cbe69f8dea86bce50c1445f51f780de1a3",
       "version-string": "9d",
       "port-version": 0


### PR DESCRIPTION
Fix #24338
update `ijg-libjpeg` to `9e`

no feature needs to test.