### PR TITLE
[vcpkg-requires] Add new port

### DIFF
--- a/docs/regenerate.ps1
+++ b/docs/regenerate.ps1
@@ -29,6 +29,7 @@ class CMakeDocumentation {
     'vcpkg-cmake'
     'vcpkg-cmake-config'
     'vcpkg-pkgconfig-get-modules'
+    'vcpkg-requires'
 )
 
 [CMakeDocumentation[]]$tableOfContents = @()

--- a/ports/vcpkg-requires/README.md
+++ b/ports/vcpkg-requires/README.md
@@ -1,0 +1,3 @@
+# vcpkg-requires
+
+This port contains cmake functions for checking the required items with a CMake buildsystem.

--- a/ports/vcpkg-requires/copyright
+++ b/ports/vcpkg-requires/copyright
@@ -1,0 +1,23 @@
+Copyright (c) Microsoft Corporation
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/vcpkg-requires/portfile.cmake
+++ b/ports/vcpkg-requires/portfile.cmake
@@ -1,0 +1,12 @@
+if(NOT TARGET_TRIPLET STREQUAL _HOST_TRIPLET)
+    # make FATAL_ERROR in CI when issue #16773 fixed
+    message(WARNING "vcpkg-requires is a host-only port; please mark it as a host port in your dependencies.")
+endif()
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg_requires_compiler_flags.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/copyright"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/ports/vcpkg-requires/requires_compiler_flags/CMakeLists.txt
+++ b/ports/vcpkg-requires/requires_compiler_flags/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.20)
+
+option(C_STANDARD "Check the supported c standard" "")
+option(CXX_STANDARD "Check the supported cxx standard" "")
+
+set(VCPKG_LANGUAGES "C;CXX" CACHE STRING "Languages to enables for this project")
+
+project(requires_compiler_flags LANGUAGES ${VCPKG_LANGUAGES})
+
+# Check c standard
+include(CheckCCompilerFlag)
+if (C_STANDARD)
+    if (MSVC)
+        check_c_compiler_flag(/std:c${C_STANDARD} c_standard_supported)
+    else()
+        check_c_compiler_flag(-std=c${C_STANDARD} c_standard_supported)
+    endif()
+    
+    if (NOT c_standard_supported)
+        message(FATAL_ERROR "The required c standard is not supported in this compiler")
+    endif()
+endif()
+
+# Check cxx standard
+include(CheckCXXCompilerFlag)
+if (CXX_STANDARD)
+    if (MSVC)
+        check_cxx_compiler_flag(/std:c++${CXX_STANDARD} cxx_standard_supported)
+    else()
+        check_cxx_compiler_flag(-std=c++${CXX_STANDARD} cxx_standard_supported)
+    endif()
+    
+    if (NOT cxx_standard_supported)
+        message(FATAL_ERROR "The required c standard is not supported in this compiler")
+    endif()
+endif()

--- a/ports/vcpkg-requires/vcpkg-port-config.cmake
+++ b/ports/vcpkg-requires/vcpkg-port-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_requires_compiler_flags.cmake")

--- a/ports/vcpkg-requires/vcpkg.json
+++ b/ports/vcpkg-requires/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "vcpkg-requires",
+  "version-date": "2022-04-25",
+  "license": "MIT"
+}

--- a/ports/vcpkg-requires/vcpkg_requires_compiler_flags.cmake
+++ b/ports/vcpkg-requires/vcpkg_requires_compiler_flags.cmake
@@ -1,0 +1,56 @@
+#[===[.md:
+# vcpkg_requires_compiler_flags
+
+Runs a cmake configure with a dummy project to check the required items
+
+## Usage
+```cmake
+vcpkg_requires_compiler_flags(
+    C_STANDARD <standard>
+    CXX_STANDARD <standard>
+)
+```
+
+#]===]
+
+set(Z_VCPKG_REQUIRES_COMPILER_FLAGS_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+function(vcpkg_requires_compiler_flags)
+    cmake_parse_arguments(PARSE_ARGV 1 arg "" "C_STANDARD;CXX_STANDARD" "")
+
+    if(DEFINED arg_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} was passed extra arguments: ${arg_UNPARSED_ARGUMENTS}")
+    endif()
+    
+    vcpkg_list(SET requires_flags)
+    if (arg_C_STANDARD)
+        vcpkg_list(APPEND requires_flags "-DC_STANDARD=${arg_C_STANDARD}")
+    endif()
+    
+    if (arg_CXX_STANDARD)
+        vcpkg_list(APPEND requires_flags "-DCXX_STANDARD=${arg_CXX_STANDARD}")
+    endif()
+
+    if(NOT DEFINED CACHE{Z_VCPKG_REQUIRES_COMPILER_FLAGS_FILE})
+        set(Z_VCPKG_REQUIRES_COMPILER_FLAGS_FILE "${CURRENT_BUILDTREES_DIR}/requires-compiler-flags-${TARGET_TRIPLET}.cmake.log"
+            CACHE PATH "The file to include to access the CMake variables from a generated project.")
+        vcpkg_cmake_configure(
+            SOURCE_PATH "${Z_VCPKG_REQUIRES_COMPILER_FLAGS_CURRENT_LIST_DIR}/requires_compiler_flags"
+            OPTIONS ${requires_flags}
+            OPTIONS_DEBUG "-DVCPKG_OUTPUT_FILE:PATH=${CURRENT_BUILDTREES_DIR}/requires-compiler-flags-${TARGET_TRIPLET}-dbg.cmake.log"
+            OPTIONS_RELEASE "-DVCPKG_OUTPUT_FILE:PATH=${CURRENT_BUILDTREES_DIR}/requires-compiler-flags-${TARGET_TRIPLET}-rel.cmake.log"
+            LOGFILE_BASE requires-compiler-flags-${TARGET_TRIPLET}
+            Z_CMAKE_GET_VARS_USAGE # be quiet, don't set variables...
+        )
+
+        set(include_string "")
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+            string(APPEND include_string "include(\"\${CMAKE_CURRENT_LIST_DIR}/requires-compiler-flags-${TARGET_TRIPLET}-rel.cmake.log\")\n")
+        endif()
+        if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+            string(APPEND include_string "include(\"\${CMAKE_CURRENT_LIST_DIR}/requires-compiler-flags-${TARGET_TRIPLET}-dbg.cmake.log\")\n")
+        endif()
+        file(WRITE "${Z_VCPKG_REQUIRES_COMPILER_FLAGS_FILE}" "${include_string}")
+    endif()
+
+endfunction()

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7328,6 +7328,10 @@
       "baseline": "2022-02-14",
       "port-version": 0
     },
+    "vcpkg-requires": {
+      "baseline": "2022-04-25",
+      "port-version": 0
+    },
     "vcpkg-tool-gyp-nss": {
       "baseline": "2022-03-04",
       "port-version": 0

--- a/versions/v-/vcpkg-requires.json
+++ b/versions/v-/vcpkg-requires.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "130a2e2f84aa971e5c244557fc886706468b05a0",
+      "version-date": "2022-04-25",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
Introduces a new vcpkg function group `vcpkg-requires` to ensure the build environment has the required items.
Such as:
- c / cxx standard
- compiler flags
- system libraries
- system headers

etc.

Related: https://github.com/microsoft/vcpkg/pull/24355#issuecomment-1107727783