### PR TITLE
[quill] Update to 1.7.2

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v1.7.1
-    SHA512 93f8bd4b28f7568562b71abdfba89ca7f43133e6ebf6f80a46f2af81a88ec621420432c6e90a3dbd85944cecca57ec94e5bd25d896b0ffe9888f19ae4534f2f7
+    REF v1.7.2
+    SHA512 ea9671cab8a4cf641c413933bd7fb4f3b1f823ca1b17260b3217b13aff22513b4939ff722d74beada1730d47dca70858835733418593ed2df8abf5c1dea0b202
     HEAD_REF master
 )
 

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6029,7 +6029,7 @@
       "port-version": 7
     },
     "quill": {
-      "baseline": "1.7.1",
+      "baseline": "1.7.2",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d663be1266a5e973411f7bf422d3b901609098e8",
+      "version": "1.7.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "bfe7d0bbdf62856534c0d3783135b2bca1fea312",
       "version": "1.7.1",
       "port-version": 0


### PR DESCRIPTION
Update quill from 1.7.1 to 1.7.2.
Changelog : https://github.com/odygrd/quill/releases/tag/v1.7.2