### PR TITLE
Use variable $NINJA instead of hard coding name

### DIFF
--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -368,7 +368,7 @@ function(vcpkg_configure_cmake)
 
         message(STATUS "${configuring_message}")
         vcpkg_execute_required_process(
-            COMMAND ninja -v
+            COMMAND {NINJA} -v
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vcpkg-parallel-configure"
             LOGNAME "${arg_LOGNAME}"
         )


### PR DESCRIPTION
Use variable $NINJA instead of hard coding name that caused build fail on mingw.
