### PR TITLE
[poco] Update Version to 1.11.2

### DIFF
--- a/ports/poco/arm64_pcre.patch
+++ b/ports/poco/arm64_pcre.patch
@@ -1,16 +1,3 @@
-diff --git a/Foundation/include/Poco/Platform.h b/Foundation/include/Poco/Platform.h
-index 9a945f3..f5a9a7f 100644
---- a/Foundation/include/Poco/Platform.h
-+++ b/Foundation/include/Poco/Platform.h
-@@ -191,7 +191,7 @@
- 	#else
- 		#define POCO_ARCH_LITTLE_ENDIAN 1
- 	#endif
--#elif defined(__arm64__) || defined(__arm64)
-+#elif defined(__arm64__) || defined(__arm64) || defined(_M_ARM64)
- 	#define POCO_ARCH POCO_ARCH_ARM64
- 	#if defined(__ARMEB__)
- 		#define POCO_ARCH_BIG_ENDIAN 1
 diff --git a/Foundation/src/EventLogChannel.cpp b/Foundation/src/EventLogChannel.cpp
 index 1f51296..c67b71b 100644
 --- a/Foundation/src/EventLogChannel.cpp
@@ -24,7 +11,7 @@ index 1f51296..c67b71b 100644
  #include "Poco/EventLogChannel.h"
  #include "Poco/Message.h"
 diff --git a/Foundation/src/utils.h b/Foundation/src/utils.h
-index 4328344..5eeafcd 100644
+index 0a222c7..0843315 100644
 --- a/Foundation/src/utils.h
 +++ b/Foundation/src/utils.h
 @@ -91,7 +91,7 @@ int main(int argc, char** argv) {

--- a/ports/poco/portfile.cmake
+++ b/ports/poco/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO pocoproject/poco
-    REF de61f0049175a941cc83c2615c3bdc5e947b89f9 # poco-1.11.1-release
-    SHA512 0290eeeca8a85286efe8f583224062ea97668c2730f8f7db4e075ce75e997b0a0c969159d4034c27fbb2e8d4b9c6504888d8ffa001193f7eb0e450bca2d5d7a2
+    REF 9d1c428c861f2e5ccf09149bbe8d2149720c5896 # poco-1.11.2-release
+    SHA512 b812bb194783c94e2a048daf6659e0f0fa5e9040ebd49342a5d39636cee600754d0465f8b28725d76dcb2681d1b64dfd8b08ac9c85b95b4ac8edf9b53d68feb1
     HEAD_REF master
     PATCHES
         # Fix embedded copy of pcre in static linking mode

--- a/ports/poco/vcpkg.json
+++ b/ports/poco/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "poco",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Modern, powerful open source C++ class libraries for building network and internet-based applications that run on desktop, server, mobile and embedded systems.",
   "homepage": "https://github.com/pocoproject/poco",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5477,7 +5477,7 @@
       "port-version": 3
     },
     "poco": {
-      "baseline": "1.11.1",
+      "baseline": "1.11.2",
       "port-version": 0
     },
     "podofo": {

--- a/versions/p-/poco.json
+++ b/versions/p-/poco.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "de13e6b66833cb816a0f85528697c7ee63be89ae",
+      "version": "1.11.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "ae7e310067c34beca24a055b9b25e24fe1b42190",
       "version": "1.11.1",
       "port-version": 0


### PR DESCRIPTION
Fix #24378 

Update poco to the latest version 1.11.2

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static