### PR TITLE
[hash-library] Put include files in a subdirectory

### DIFF
--- a/ports/hash-library/CMakeLists.txt
+++ b/ports/hash-library/CMakeLists.txt
@@ -23,10 +23,10 @@ set(SRCS
 
 add_library(hash-library ${SRCS})
 
-target_include_directories(hash-library PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+target_include_directories(hash-library PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/hash-library>)
 
 if(NOT DISABLE_INSTALL_HEADERS)
-    install(FILES ${HEADERS} DESTINATION include)
+    install(FILES ${HEADERS} DESTINATION include/hash-library)
 endif()
 
 install(

--- a/ports/hash-library/vcpkg.json
+++ b/ports/hash-library/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "hash-library",
   "version": "8",
+  "port-version": 1,
   "description": "Portable C++ hashing library",
   "homepage": "https://create.stephan-brumme.com/hash-library/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2726,7 +2726,7 @@
     },
     "hash-library": {
       "baseline": "8",
-      "port-version": 0
+      "port-version": 1
     },
     "hayai": {
       "baseline": "2019-08-10",

--- a/versions/h-/hash-library.json
+++ b/versions/h-/hash-library.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fad55dc152114a3f71c5eafd33a3facd7e3a2286",
+      "version": "8",
+      "port-version": 1
+    },
+    {
       "git-tree": "c7e4fae9255d5bdacac11e7a7dc550df777b8b37",
       "version": "8",
       "port-version": 0


### PR DESCRIPTION
to avoid:

```
Starting package 895/1846: hash-library:x86-windows
Building package hash-library[core]:x86-windows...
-- Note: hash-library only supports static library linkage. Building static library.
-- Downloading https://github.com/stbrumme/hash-library/archive/hash_library_v8.tar.gz -> stbrumme-hash-library-hash_library_v8.tar.gz...
-- Extracting source D:/downloads/stbrumme-hash-library-hash_library_v8.tar.gz
-- Applying patch 001-fix-macos.patch
-- Using source at D:/buildtrees/hash-library/src/library_v8-6124f7a6ce.clean
-- Found external ninja('1.10.2').
-- Configuring x86-windows
-- Building x86-windows-dbg
-- Building x86-windows-rel
-- Installing: D:/packages/hash-library_x86-windows/share/hash-library/copyright
-- Performing post-build validation
-- Performing post-build validation done
Uploaded binaries to 1 HTTP remotes.
Installing package hash-library[core]:x86-windows...
The following files are already installed in D:/installed/x86-windows and are in conflict with hash-library:x86-windows

Installed by czmq:x86-windows
    include/sha1.h

Elapsed time for package hash-library:x86-windows: 3.227 s
```
