### PR TITLE
[boringssl] Mark that arm-windows doesn't work 

### DIFF
--- a/ports/boringssl/vcpkg.json
+++ b/ports/boringssl/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "boringssl",
   "version-date": "2021-06-23",
-  "port-version": 1,
+  "port-version": 2,
   "description": "BoringSSl is a fork of OpenSSL developed by Google",
   "homepage": "https://boringssl.googlesource.com/boringssl",
-  "supports": "!uwp",
+  "supports": "!uwp & !(arm & windows)",
   "features": {
     "tools": {
       "description": "Build bssl executable"

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -584,11 +584,8 @@ libqcow:x64-linux=skip
 libqcow:x86-windows=skip
 libqcow:arm64-windows=skip
 # Conflicts with openssl
-boringssl:arm64-windows      = skip
-boringssl:arm-uwp            = skip
 boringssl:x64-linux          = skip
 boringssl:x64-osx            = skip
-boringssl:x64-uwp            = skip
 boringssl:x64-windows        = skip
 boringssl:x64-windows-static = skip
 boringssl:x64-windows-static-md=skip

--- a/versions/b-/boringssl.json
+++ b/versions/b-/boringssl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "61b7cadd536ab9dd4a603d77e53207784600d520",
+      "version-date": "2021-06-23",
+      "port-version": 2
+    },
+    {
       "git-tree": "ca35c06a32c83f385f840831a435c69231a7852a",
       "version-date": "2021-06-23",
       "port-version": 1

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1126,7 +1126,7 @@
     },
     "boringssl": {
       "baseline": "2021-06-23",
-      "port-version": 1
+      "port-version": 2
     },
     "botan": {
       "baseline": "2.18.1",


### PR DESCRIPTION
... due to arch detection in the port.

In testing https://github.com/microsoft/vcpkg/pull/24310 , I observed that boringssl fails to build on arm64-windows:

```
cmd.exe /C "cd . && C:\Dev\vcpkg-downloads\tools\cmake-3.22.2-windows\cmake-3.22.2-windows-i386\bin\cmake.exe -E vs_link_dll --intdir=crypto\CMakeFiles\crypto.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1431~1.311\bin\Hostx64\arm64\link.exe  @CMakeFiles\crypto.rsp  /out:crypto\crypto.dll /implib:crypto\crypto.lib /pdb:crypto\crypto.pdb /dll /version:0.0 /machine:ARM64 /nologo    /debug /INCREMENTAL  && cd ."
LINK Pass 1: command "C:\PROGRA~1\MIB055~1\2022\ENTERP~1\VC\Tools\MSVC\1431~1.311\bin\Hostx64\arm64\link.exe @CMakeFiles\crypto.rsp /out:crypto\crypto.dll /implib:crypto\crypto.lib /pdb:crypto\crypto.pdb /dll /version:0.0 /machine:ARM64 /nologo /debug /INCREMENTAL /MANIFEST /MANIFESTFILE:crypto\CMakeFiles\crypto.dir/intermediate.manifest crypto\CMakeFiles\crypto.dir/manifest.res" failed (exit code 1112) with the following output:
crypto\fipsmodule\CMakeFiles\fipsmodule.dir\aesni-gcm-x86_64.asm.obj : fatal error LNK1112: module machine type 'x64' conflicts with target machine type 'ARM64'
```

The port is switching on CMAKE_SYSTEM_PROCESSOR which is set to amd64 even when targeting arm64 on Windows.

Since this an upstream build system problem, I marked it in "supports".
