### PR TITLE
[qpid-proton] Fix missing runtime dependencies

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -15,6 +15,11 @@ file(REMOVE "${SOURCE_PATH}/tools/cmake/Modules/FindJsonCpp.cmake")
 
 vcpkg_find_acquire_program(PYTHON3)
 
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    set(rpath "@loader_path")
+else()
+    set(rpath "\$ORIGIN")
+endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE # It may cause call CHECK_LIBRARY_EXISTS before call project to set the language
@@ -28,7 +33,7 @@ vcpkg_cmake_configure(
         -DENABLE_BENCHMARKS=OFF
         -DENABLE_FUZZ_TESTING=OFF
         -DBUILD_TESTING=OFF
-        -DCMAKE_INSTALL_RPATH='$ORIGIN'
+        -DCMAKE_INSTALL_RPATH=${rpath}
         -DPython_EXECUTABLE=${PYTHON3}
 )
 

--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -28,6 +28,7 @@ vcpkg_cmake_configure(
         -DENABLE_BENCHMARKS=OFF
         -DENABLE_FUZZ_TESTING=OFF
         -DBUILD_TESTING=OFF
+        -DCMAKE_INSTALL_RPATH='$ORIGIN'
         -DPython_EXECUTABLE=${PYTHON3}
 )
 

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.37.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5654,7 +5654,7 @@
     },
     "qpid-proton": {
       "baseline": "0.37.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qscintilla": {
       "baseline": "2.12.0",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c864f28f47edcb5fa10b5a143448e272826ee3a0",
+      "version": "0.37.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "543baa82530f5eb5ed9b3d6348a14b5e24ccda64",
       "version": "0.37.0",
       "port-version": 1

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c864f28f47edcb5fa10b5a143448e272826ee3a0",
+      "git-tree": "e019a7a0cb758104296c13689ca86f44db64cfb6",
       "version": "0.37.0",
       "port-version": 2
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #24449

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
 All, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes