### PR TITLE
[libcbor] Update to 0.9.0

### DIFF
--- a/ports/libcbor/portfile.cmake
+++ b/ports/libcbor/portfile.cmake
@@ -1,29 +1,31 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO PJK/libcbor
-    REF v0.8.0
-    SHA512 694d2d3a78d80072f96e0afb73590ca1f3572e41d2117330ef4313ed06271743b048d3ba3259c6ffe9a802d5e441379d0e54787d1d42fed08dc81ac4f06c6dbc
+    REF v0.9.0
+    SHA512 710239f69d770212a82e933e59df1aba0fb3ec516ef6666a366f30a950565a52981b0d46ca7e0eea739f5785d79cc21fc19acd857a4a0b135f4f6aa3ef5fd3b0
     HEAD_REF master
 )
 
-vcpkg_configure_cmake(
-        SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
-        OPTIONS
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DWITH_TESTS=OFF
         -DWITH_EXAMPLES=OFF
         -DVCPKG_VERBOSE=ON
-     )
+        -DSANITIZE=OFF
+        -DCBOR_CUSTOM_ALLOC=ON
+)
 
-vcpkg_build_cmake()
-vcpkg_install_cmake()
+vcpkg_cmake_build()
+vcpkg_cmake_install()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup()
 
 # Add Cmake Packagefile
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/LibCborConfig.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/LibCborConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE.md ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libcbor/portfile.cmake
+++ b/ports/libcbor/portfile.cmake
@@ -26,7 +26,5 @@ vcpkg_fixup_pkgconfig()
 # Add Cmake Packagefile
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/LibCborConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
-vcpkg_cmake_config_fixup()
-
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libcbor/portfile.cmake
+++ b/ports/libcbor/portfile.cmake
@@ -22,10 +22,11 @@ vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup()
 
 # Add Cmake Packagefile
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/LibCborConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_cmake_config_fixup()
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/libcbor/vcpkg.json
+++ b/ports/libcbor/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/libcbor/vcpkg.json
+++ b/ports/libcbor/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "libcbor",
-  "version": "0.8.0",
-  "port-version": 1,
+  "version": "0.9.0",
   "description": "libcbor is a C library for parsing and generating CBOR, the general-purpose schema-less binary data format",
-  "homepage": "https://github.com/PJK/libcbor"
+  "homepage": "https://github.com/PJK/libcbor",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3437,8 +3437,8 @@
       "port-version": 2
     },
     "libcbor": {
-      "baseline": "0.8.0",
-      "port-version": 1
+      "baseline": "0.9.0",
+      "port-version": 0
     },
     "libcds": {
       "baseline": "2.3.3",

--- a/versions/l-/libcbor.json
+++ b/versions/l-/libcbor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ff6ac31699540c9e8fff55a53d760c941fc2d2fb",
+      "git-tree": "ab505457056256f644f573d583fa54c7d9c2d35c",
       "version": "0.9.0",
       "port-version": 0
     },

--- a/versions/l-/libcbor.json
+++ b/versions/l-/libcbor.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ff6ac31699540c9e8fff55a53d760c941fc2d2fb",
+      "version": "0.9.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "02d970a2dac8b0abb941a5b445f7e14afc9c1e49",
       "version": "0.8.0",
       "port-version": 1

--- a/versions/l-/libcbor.json
+++ b/versions/l-/libcbor.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ab505457056256f644f573d583fa54c7d9c2d35c",
+      "git-tree": "5e881ce93b52a9b16f4c03e4bed79c661def7631",
       "version": "0.9.0",
       "port-version": 0
     },


### PR DESCRIPTION
Note: port doesn't build without `vcpkg_cmake_build`