### PR TITLE
[libunibreak] Update to 5.0

### DIFF
--- a/ports/libunibreak/CMakeLists.txt
+++ b/ports/libunibreak/CMakeLists.txt
@@ -3,22 +3,24 @@ cmake_minimum_required(VERSION 3.8.0)
 project(libunibreak)
 
 set(libunibreak_srcs
+  src/linebreak.c
   src/linebreakdata.c
   src/linebreakdef.c
-  src/linebreak.c
   src/wordbreak.c
+  src/wordbreakdata.c
   src/graphemebreak.c
+  src/graphemebreakdata.c
+  src/emojidef.c
   src/unibreakbase.c
   src/unibreakdef.c
 )
 
-
 include_directories(src)
 
-add_library(libunibreak ${libunibreak_srcs})
+add_library(unibreak ${libunibreak_srcs})
 
 install(
-  TARGETS libunibreak
+  TARGETS unibreak
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -27,12 +29,16 @@ install(
 if(NOT DISABLE_INSTALL_HEADERS)
   install(
     FILES
+    src/emojidef.h
+    src/graphemebreak.h
+    src/graphemebreakdef.h
     src/linebreak.h
     src/linebreakdef.h
-    src/wordbreak.h
-    src/wordbreakdef.h
+    src/test_skips.h
     src/unibreakbase.h
     src/unibreakdef.h
+    src/wordbreak.h
+    src/wordbreakdef.h
     DESTINATION include
   )
 endif()

--- a/ports/libunibreak/libunibreak-config.cmake.in
+++ b/ports/libunibreak/libunibreak-config.cmake.in
@@ -1,0 +1,24 @@
+# For old projects where the minimum CMake version is lower than 3.3.
+cmake_policy(SET CMP0057 NEW)
+include(CMakeFindDependencyMacro)
+
+if(TARGET libunibreak)
+  return()
+endif()
+
+add_library(unibreak INTERFACE IMPORTED GLOBAL)
+add_library(libunibreak::libunibreak ALIAS unibreak)
+
+find_library(LIBUNIBREAK_LIBRARY_DEBUG NAMES unibreak PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug" PATH_SUFFIXES lib NO_DEFAULT_PATH)
+if(LIBUNIBREAK_LIBRARY_DEBUG)
+    target_link_libraries(unibreak INTERFACE $<$<CONFIG:DEBUG>:${LIBUNIBREAK_LIBRARY_DEBUG}>)
+endif()
+
+find_library(LIBUNIBREAK_LIBRARY_RELEASE NAMES unibreak PATHS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}" PATH_SUFFIXES lib NO_DEFAULT_PATH)
+target_link_libraries(unibreak INTERFACE $<$<NOT:$<CONFIG:DEBUG>>:${LIBUNIBREAK_LIBRARY_RELEASE}>)
+
+set(LIBUNIBREAK_LIBRARY libunibreak::libunibreak PARENT_SCOPE)
+set(LIBUNIBREAK_LIBRARIES libunibreak::libunibreak PARENT_SCOPE)
+set(LIBUNIBREAK_INCLUDE_DIR "${_INSTALL_DIR}/include" PARENT_SCOPE)
+
+target_include_directories(unibreak INTERFACE ${_INSTALL_DIR}/include)

--- a/ports/libunibreak/portfile.cmake
+++ b/ports/libunibreak/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO adah1972/libunibreak
-  REF 8df6ef4ebe5dbd2a49539d05366337ab7fb57ae3 # libunibreak_4_3
-  SHA512 791e342dcc0e79e15f578ec93239d53a656f9e1804f9ec8b970cfac2b6c4f3456855513c36f18f8e72a91dac64060abc336e4716d584dbec86e1fb0c91eded69
+  REF libunibreak_5_0 # libunibreak_5_0
+  SHA512 909c12cf5df92f0374050fc7a0ef9e91bc1efe6a5dc5a80f4e2c81a507f1228ecaba417c3ee001e11b2422024bea68cc14eb66e08360ae69f830cdaa18764484
   HEAD_REF master
 )
 
@@ -17,5 +17,8 @@ vcpkg_configure_cmake(
 )
 
 vcpkg_install_cmake()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/libunibreak-config.cmake.in"
+        "${CURRENT_PACKAGES_DIR}/share/${PORT}/libunibreak-config.cmake" @ONLY)
 
 file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/libunibreak RENAME copyright)

--- a/ports/libunibreak/portfile.cmake
+++ b/ports/libunibreak/portfile.cmake
@@ -10,13 +10,12 @@ vcpkg_from_github(
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
     OPTIONS_DEBUG -DDISABLE_INSTALL_HEADERS=ON
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
 configure_file("${CMAKE_CURRENT_LIST_DIR}/libunibreak-config.cmake.in"
         "${CURRENT_PACKAGES_DIR}/share/${PORT}/libunibreak-config.cmake" @ONLY)

--- a/ports/libunibreak/vcpkg.json
+++ b/ports/libunibreak/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/libunibreak/vcpkg.json
+++ b/ports/libunibreak/vcpkg.json
@@ -2,5 +2,16 @@
   "name": "libunibreak",
   "version": "5.0",
   "description": "an implementation of the line breaking and word breaking algorithms as described in [Unicode Standard Annex 14] 1 and [Unicode Standard Annex 29] 2. Check the project's [home page] 3 for up-to-date information.",
-  "homepage": "https://github.com/adah1972/libunibreak"
+  "homepage": "https://github.com/adah1972/libunibreak",
+  "license": "zlib-acknowledgement",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/ports/libunibreak/vcpkg.json
+++ b/ports/libunibreak/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libunibreak",
-  "version-string": "4.3",
-  "port-version": 1,
+  "version": "5.0",
   "description": "an implementation of the line breaking and word breaking algorithms as described in [Unicode Standard Annex 14] 1 and [Unicode Standard Annex 29] 2. Check the project's [home page] 3 for up-to-date information.",
   "homepage": "https://github.com/adah1972/libunibreak"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4113,8 +4113,8 @@
       "port-version": 2
     },
     "libunibreak": {
-      "baseline": "4.3",
-      "port-version": 1
+      "baseline": "5.0",
+      "port-version": 0
     },
     "libunifex": {
       "baseline": "2021-12-07",

--- a/versions/l-/libunibreak.json
+++ b/versions/l-/libunibreak.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b9a7c4ca9b4d79735c83d7c81284ba323a9ce674",
+      "git-tree": "040e03046591a9c447c5664a93b0a66e4b5ff87e",
       "version": "5.0",
       "port-version": 0
     },

--- a/versions/l-/libunibreak.json
+++ b/versions/l-/libunibreak.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "040e03046591a9c447c5664a93b0a66e4b5ff87e",
+      "git-tree": "ab89a270477d6d97e3d70c4503ee573f1ca8e539",
       "version": "5.0",
       "port-version": 0
     },

--- a/versions/l-/libunibreak.json
+++ b/versions/l-/libunibreak.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b9a7c4ca9b4d79735c83d7c81284ba323a9ce674",
+      "version": "5.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "f1fb2965625f4dc28c5ab3c4e0a8a128901a0f0e",
       "version-string": "4.3",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates libunibreak to 5.0 and fixes a linker issue

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
