### PR TITLE
[rsm-binary-io] Update to 2.0.5

### DIFF
--- a/ports/rsm-binary-io/portfile.cmake
+++ b/ports/rsm-binary-io/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Ryan-rsm-McKenzie/binary_io
-    REF 2.0.4
-    SHA512 a2025be9db79e2d89ab28fdda98cfe88ae6a7f0f0a7e3b6d9f99a1bf8a7b4d89e8a34db21a9bdf11784c7f01fb27a6b083c8af81743919e04efb0736c151bb7e
+    REF 2.0.5
+    SHA512 787833487b9e2b64aeb73842024a52a6ad646d2609342983ebf1539878b96565bf329c8b05afca0fb35a1e40a91174131ad7a0bdc79b168a12bf02f3d6e0cd6d
     HEAD_REF main
 )
 

--- a/ports/rsm-binary-io/vcpkg.json
+++ b/ports/rsm-binary-io/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "rsm-binary-io",
-  "version-semver": "2.0.4",
-  "port-version": 1,
+  "version-semver": "2.0.5",
   "description": "A binary i/o library for C++, without the agonizing pain",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/binary_io",
   "documentation": "https://ryan-rsm-mckenzie.github.io/binary_io/",

--- a/ports/rsm-binary-io/vcpkg.json
+++ b/ports/rsm-binary-io/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "A binary i/o library for C++, without the agonizing pain",
   "homepage": "https://github.com/Ryan-rsm-McKenzie/binary_io",
   "documentation": "https://ryan-rsm-mckenzie.github.io/binary_io/",
+  "license": "MIT",
   "supports": "!osx & !uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6245,8 +6245,8 @@
       "port-version": 0
     },
     "rsm-binary-io": {
-      "baseline": "2.0.4",
-      "port-version": 1
+      "baseline": "2.0.5",
+      "port-version": 0
     },
     "rsm-bsa": {
       "baseline": "4.0.3",

--- a/versions/r-/rsm-binary-io.json
+++ b/versions/r-/rsm-binary-io.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a170dd2013d45c86b272169552cf4ac52a5d1c79",
+      "version-semver": "2.0.5",
+      "port-version": 0
+    },
+    {
       "git-tree": "954debdfb4b8f785728e7c263ea3ea3ee7093253",
       "version-semver": "2.0.4",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates [binary_io](https://github.com/Ryan-rsm-McKenzie/binary_io) to 2.0.5

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Just a port update

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
