### PR TITLE
[pcre2] Update to 10.40, drop `-static` suffix

### DIFF
--- a/ports/pcre2/no-static-suffix.patch
+++ b/ports/pcre2/no-static-suffix.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fa2181e..3bf5317 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -711,8 +711,8 @@ IF(PCRE2_BUILD_PCRE2_8)
+     SET(targets ${targets} pcre2-posix-static)
+ 
+     IF(MSVC)
+-      SET_TARGET_PROPERTIES(pcre2-8-static PROPERTIES OUTPUT_NAME pcre2-8-static)
+-      SET_TARGET_PROPERTIES(pcre2-posix-static PROPERTIES OUTPUT_NAME pcre2-posix-static)
++      SET_TARGET_PROPERTIES(pcre2-8-static PROPERTIES OUTPUT_NAME pcre2-8)
++      SET_TARGET_PROPERTIES(pcre2-posix-static PROPERTIES OUTPUT_NAME pcre2-posix)
+     ELSE(MSVC)
+       SET_TARGET_PROPERTIES(pcre2-8-static PROPERTIES OUTPUT_NAME pcre2-8)
+       SET_TARGET_PROPERTIES(pcre2-posix-static PROPERTIES OUTPUT_NAME pcre2-posix)
+@@ -777,7 +777,7 @@ IF(PCRE2_BUILD_PCRE2_16)
+     SET(targets ${targets} pcre2-16-static)
+ 
+     IF(MSVC)
+-      SET_TARGET_PROPERTIES(pcre2-16-static PROPERTIES OUTPUT_NAME pcre2-16-static)
++      SET_TARGET_PROPERTIES(pcre2-16-static PROPERTIES OUTPUT_NAME pcre2-16)
+     ELSE(MSVC)
+       SET_TARGET_PROPERTIES(pcre2-16-static PROPERTIES OUTPUT_NAME pcre2-16)
+     ENDIF(MSVC)
+@@ -829,7 +829,7 @@ IF(PCRE2_BUILD_PCRE2_32)
+     SET(targets ${targets} pcre2-32-static)
+ 
+     IF(MSVC)
+-      SET_TARGET_PROPERTIES(pcre2-32-static PROPERTIES OUTPUT_NAME pcre2-32-static)
++      SET_TARGET_PROPERTIES(pcre2-32-static PROPERTIES OUTPUT_NAME pcre2-32)
+     ELSE(MSVC)
+       SET_TARGET_PROPERTIES(pcre2-32-static PROPERTIES OUTPUT_NAME pcre2-32)
+     ENDIF(MSVC)

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         pcre2-10.35_fix-uwp.patch
+        no-static-suffix.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)

--- a/ports/pcre2/portfile.cmake
+++ b/ports/pcre2/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO PhilipHazel/pcre2
-    REF 35fee4193b852cb504892352bd0155de10809889 # pcre2-10.39
-    SHA512 a6e50f3354dc4172df05e887dd8646d4ce6a3584fe180b17dc27b42b094e13d1d1a7e5ab3cb15dd352764d81ac33cfd03e81b0c890d9ddec72d823ca6f8bd667
+    REPO PCRE2Project/pcre2
+    REF pcre2-10.40
+    SHA512 098c21d60ecb3bb8449173f50c9ab8e6018fafd5d55548be08b15df37f8e08bcd4f851d75758c4d22505db30a3444bb65783d83cd876c63fdf0de2850815ef93
     HEAD_REF master
     PATCHES
         pcre2-10.35_fix-uwp.patch

--- a/ports/pcre2/vcpkg.json
+++ b/ports/pcre2/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "pcre2",
-  "version": "10.39",
-  "port-version": 2,
+  "version": "10.40",
   "description": "Regular Expression pattern matching using the same syntax and semantics as Perl 5.",
-  "homepage": "https://github.com/PhilipHazel/pcre2",
+  "homepage": "https://github.com/PCRE2Project/pcre2",
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5341,8 +5341,8 @@
       "port-version": 2
     },
     "pcre2": {
-      "baseline": "10.39",
-      "port-version": 2
+      "baseline": "10.40",
+      "port-version": 0
     },
     "pdal": {
       "baseline": "2.3.0",

--- a/versions/p-/pcre2.json
+++ b/versions/p-/pcre2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "725d8f25eea7d10b24944f314db69aa8b29d4932",
+      "version": "10.40",
+      "port-version": 0
+    },
+    {
       "git-tree": "9a15903858198c8a3b890972b5e8c0d2aa3f89f8",
       "version": "10.39",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Updates pcre2.
  Drops the `-static` lib name suffix for MSVC. That suffix is not contained in the pkg-config files, and it requires the name variant to be handled in downstream usage. This modification [is allowed by the Maintainer Guidelines](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md#do-not-rename-binaries-outside-the-names-given-by-upstream). Issue noticed in https://github.com/microsoft/vcpkg/pull/24483#issuecomment-1114430902.
  NB: In this PR, I didn't remove name variant handling from downstream ports (unicorn, qt5-base). For qt5-base, I want to use pc files (another PR).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes