### PR TITLE
Change curl license from null -> "curl"

### DIFF
--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -3,7 +3,7 @@
   "version": "7.82.0",
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
-  "license": null,
+  "license": "curl",
   "dependencies": [
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
Curl has its own SPDX license: https://spdx.org/licenses/curl.html

Using `null` for the license triggers an error when building from cmake:

```
-- Running vcpkg install
Errors occurred while parsing ${EXTERNAL_DIR}/vcpkg/ports/curl/vcpkg.json
    $.license: mismatched type: expected an SPDX license expression
Error: Failed to load port curl from ${EXTERNAL_DIR}/vcpkg/ports
Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```

It looks like the license line was added in commit [2c0fb4f8200d6917ef79dab3e0d44126995974a1](https://github.com/microsoft/vcpkg/commit/2c0fb4f8200d6917ef79dab3e0d44126995974a1#diff-a91e0d663e8719fb2cb62552c202144c9be4e9a2548b555644fd3399673cddb0), where previously the value was not specified.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes, however running this produced no changes.
