### PR TITLE
[google-cloud-cpp] update to latest release (v1.40.1)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.39.0
-    SHA512 d61ebcdb6680797f20147ee1d37b9d29c82e8c7267b944a346685bfa607cf0b7f1772854874b967f19b4f54ddcefc94a771a4686cafcd6a5fed426d64e553205
+    REF v1.40.1
+    SHA512 55c33f91cdbf5713fdc85ecd461c99fefb8d2a60e53e67c246370288f85e323c7a3a7915f4313ed3331fc1278ac4b910ce6fe20929378096a237c2fb31863b13
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.39.0",
-  "port-version": 1,
+  "version": "1.40.1",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -486,6 +485,18 @@
         }
       ]
     },
+    "logging": {
+      "description": "Google Cloud Logging C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "managedidentities": {
       "description": "Managed Service for Microsoft Active Directory API C++ Client Library",
       "dependencies": [
@@ -776,6 +787,18 @@
     },
     "spanner": {
       "description": "The Google Cloud Spanner C++ client library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "speech": {
+      "description": "The Google Cloud Speech-to-Text C++ client library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2589,8 +2589,8 @@
       "port-version": 1
     },
     "google-cloud-cpp": {
-      "baseline": "1.39.0",
-      "port-version": 1
+      "baseline": "1.40.1",
+      "port-version": 0
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2a18f7bea0f4811da422b3099c4331305cb1f617",
+      "version": "1.40.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "7f6839d85455e137c21bf5bf894e00e0327c3423",
       "version": "1.39.0",
       "port-version": 1


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v1.40.1), including new features.

I manually tested the features on `x64-linux`.

- #### What does your PR fix?

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.
