### PR TITLE
[atk] Update atk to 2.38.0. Add ipv6 source code source 

### DIFF
--- a/ports/atk/portfile.cmake
+++ b/ports/atk/portfile.cmake
@@ -1,11 +1,11 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY ONLY_DYNAMIC_CRT)
 
-set(ATK_VERSION 2.36.0)
+set(ATK_VERSION 2.38.0)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://ftp.gnome.org/pub/GNOME/sources/atk/2.36/atk-${ATK_VERSION}.tar.xz"
-    FILENAME "atk-${ATK_VERSION}.tar.xz"
-    SHA512 d0f18204eaf96511e8448e3dfbc4b6953a7cf8b816151fb7caf5592cf578572b1cdb16836fe2157b11e3ad018ef171f1ca1bfdf255bb31bb455716d7519fd634
+    URLS "https://gitlab.gnome.org/GNOME/atk/-/archive/${ATK_VERSION}/atk-${ATK_VERSION}.tar.gz"
+    FILENAME "atk-${ATK_VERSION}.tar.gz"
+    SHA512 f31951ecbdace6a18fb9f772616137cb8732163b37448fef4daf1af60ba8479c94d498dcdaf4880468c80012c77a446da585926a99704a9a940b80e546080cf3
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/atk/vcpkg.json
+++ b/ports/atk/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "atk",
-  "version": "2.36.0",
-  "port-version": 2,
+  "version": "2.38.0",
   "description": "GNOME Accessibility Toolkit",
   "homepage": "https://developer.gnome.org/atk/",
   "supports": "!arm",

--- a/versions/a-/atk.json
+++ b/versions/a-/atk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9e43338e95e4bfeb688d23ade7792fb45b185356",
+      "version": "2.38.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "15723fa24f08f04e859253b16f5cbc05529d10cf",
       "version": "2.36.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -205,8 +205,8 @@
       "port-version": 1
     },
     "atk": {
-      "baseline": "2.36.0",
-      "port-version": 2
+      "baseline": "2.38.0",
+      "port-version": 0
     },
     "atkmm": {
       "baseline": "2.36.1",


### PR DESCRIPTION
- Update atk to 2.38.0
- Add ipv6 source code source
