### PR TITLE
[libsndfile] Adjust depenedncies to libsndfile

### DIFF
--- a/ports/aubio/vcpkg.json
+++ b/ports/aubio/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "aubio",
   "version-semver": "0.4.9",
-  "port-version": 7,
+  "port-version": 8,
   "description": "Aubio is a tool designed for the extraction of annotations from audio signals. Its features include segmenting a sound file before each of its attacks, performing pitch detection, tapping the beat and producing midi streams from live audio.",
   "homepage": "https://github.com/aubio/aubio",
+  "license": "GPL-3.0-or-later",
   "dependencies": [
     {
       "name": "vcpkg-cmake",
@@ -34,7 +35,10 @@
         "libflac",
         "liblzma",
         "libogg",
-        "libsndfile",
+        {
+          "name": "libsndfile",
+          "default-features": false
+        },
         "libvorbis"
       ]
     }

--- a/ports/flashlight-cpu/vcpkg.json
+++ b/ports/flashlight-cpu/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "flashlight-cpu",
   "version": "0.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "A C++ standalone library for machine learning. CPU backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
+  "license": "MIT",
   "supports": "!(windows | osx)",
   "default-features": [
     "fl"
@@ -20,7 +21,13 @@
           ]
         },
         "gflags",
-        "libsndfile"
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
       ]
     },
     "fl": {

--- a/ports/flashlight-cuda/vcpkg.json
+++ b/ports/flashlight-cuda/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "flashlight-cuda",
   "version": "0.3",
-  "port-version": 2,
+  "port-version": 4,
   "description": "A C++ standalone library for machine learning. CUDA backend.",
   "homepage": "https://github.com/facebookresearch/flashlight",
+  "license": "MIT",
   "supports": "!(windows | osx)",
   "default-features": [
     "fl"
@@ -20,7 +21,13 @@
           ]
         },
         "gflags",
-        "libsndfile"
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
       ]
     },
     "fl": {

--- a/ports/gamma/vcpkg.json
+++ b/ports/gamma/vcpkg.json
@@ -1,11 +1,18 @@
 {
   "name": "gamma",
   "version-string": "gamma-2018-01-27",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Gamma is a cross-platform, C++ library for doing generic synthesis and filtering of signals. It is oriented towards real-time sound and graphics applications, but is equally useful for non-real-time tasks. Gamma is designed to be \"light-footed\" in terms of memory and processing making it highly suitable for plug-in development or embedding in other C++ projects.",
   "homepage": "https://github.com/LancePutnam/Gamma",
+  "license": "MIT",
   "dependencies": [
-    "libsndfile",
+    {
+      "name": "libsndfile",
+      "default-features": false,
+      "features": [
+        "external-libs"
+      ]
+    },
     "portaudio"
   ]
 }

--- a/ports/simage/vcpkg.json
+++ b/ports/simage/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "simage",
   "version-semver": "1.8.2",
+  "port-version": 1,
   "description": "Image file format library abstraction layer",
   "homepage": "https://github.com/coin3d/simage",
-  "license": null,
+  "license": "ISC",
   "supports": "!uwp",
   "dependencies": [
     {
@@ -129,8 +130,13 @@
     "sndfile": {
       "description": "Use libsndfile to load/save sampled sound",
       "dependencies": [
-        "libflac",
-        "libsndfile"
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
       ]
     },
     "tiff": {

--- a/ports/vamp-sdk/vcpkg.json
+++ b/ports/vamp-sdk/vcpkg.json
@@ -2,12 +2,16 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "vamp-sdk",
   "version": "2.10",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Library for Vamp plugins",
   "homepage": "https://www.vamp-plugins.org/develop.html",
+  "license": "MIT",
   "supports": "!uwp",
   "dependencies": [
-    "libsndfile",
+    {
+      "name": "libsndfile",
+      "default-features": false
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/a-/aubio.json
+++ b/versions/a-/aubio.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4888190139ae3bd7f3fdb15f79453b25f59a45f5",
+      "version-semver": "0.4.9",
+      "port-version": 8
+    },
+    {
       "git-tree": "b7115b787e5f71bf65454f4c3cff3ec85b4eb264",
       "version-semver": "0.4.9",
       "port-version": 7

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -222,7 +222,7 @@
     },
     "aubio": {
       "baseline": "0.4.9",
-      "port-version": 7
+      "port-version": 8
     },
     "audiofile": {
       "baseline": "1.1.0",
@@ -2234,11 +2234,11 @@
     },
     "flashlight-cpu": {
       "baseline": "0.3",
-      "port-version": 2
+      "port-version": 3
     },
     "flashlight-cuda": {
       "baseline": "0.3",
-      "port-version": 2
+      "port-version": 4
     },
     "flatbuffers": {
       "baseline": "2.0.6",
@@ -2410,7 +2410,7 @@
     },
     "gamma": {
       "baseline": "gamma-2018-01-27",
-      "port-version": 3
+      "port-version": 4
     },
     "gasol": {
       "baseline": "2018-01-04",
@@ -6494,7 +6494,7 @@
     },
     "simage": {
       "baseline": "1.8.2",
-      "port-version": 0
+      "port-version": 1
     },
     "simbody": {
       "baseline": "2022-01-04",
@@ -7294,7 +7294,7 @@
     },
     "vamp-sdk": {
       "baseline": "2.10",
-      "port-version": 2
+      "port-version": 3
     },
     "variant-lite": {
       "baseline": "2.0.0",

--- a/versions/f-/flashlight-cpu.json
+++ b/versions/f-/flashlight-cpu.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "217b238dc2abf773a66a004f21d4c89dcc9324e3",
+      "version": "0.3",
+      "port-version": 3
+    },
+    {
       "git-tree": "b37aa1e8b06ce24319b6969ed0fa87664e4ec308",
       "version": "0.3",
       "port-version": 2

--- a/versions/f-/flashlight-cuda.json
+++ b/versions/f-/flashlight-cuda.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0c59cec24c52379832bb5b227963c0b6681346a7",
+      "version": "0.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "afbc9bcce8e115033ecd9d1c64c2b4375c556e67",
       "version": "0.3",
       "port-version": 2

--- a/versions/g-/gamma.json
+++ b/versions/g-/gamma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "335e66b704d42844b1fef58f31a05545aec2e328",
+      "version-string": "gamma-2018-01-27",
+      "port-version": 4
+    },
+    {
       "git-tree": "69d699310fe2e651e63668d194c19dfae5fd9376",
       "version-string": "gamma-2018-01-27",
       "port-version": 3

--- a/versions/s-/simage.json
+++ b/versions/s-/simage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d877e927cdad3e67542b5c66c26bdc0bda9f5ade",
+      "version-semver": "1.8.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "9a3815e60349ce152d08a7f02abab301e3b6bceb",
       "version-semver": "1.8.2",
       "port-version": 0

--- a/versions/v-/vamp-sdk.json
+++ b/versions/v-/vamp-sdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ac0236fcb60d389d21fe96a9c96c5f21f9e905b0",
+      "version": "2.10",
+      "port-version": 3
+    },
+    {
       "git-tree": "9d2b2ab057b4e31d833668e82f95283c7afbc551",
       "version": "2.10",
       "port-version": 2


### PR DESCRIPTION
that only the really required additional external libraries are needed.

- #### What does your PR fix?
This fixes link failures in the target project, because libsndfile has more dependencies by default since https://github.com/microsoft/vcpkg/pull/23800

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>