### PR TITLE
[vcpkg baseline][nuspell] Add and fix feature tools

### DIFF
--- a/ports/nuspell/fix-tools.patch
+++ b/ports/nuspell/fix-tools.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7b54c54..7c6f3a3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,10 @@ find_package(ICU 60 REQUIRED COMPONENTS uc data)
+ get_directory_property(subproject PARENT_DIRECTORY)
+ 
+ add_subdirectory(src/nuspell)
++option(BUILD_TOOLS "Build the tools." OFF)
++if (BUILD_TOOLS)
+ add_subdirectory(src/tools)
++endif()
+ 
+ if (subproject)
+     # if added as subproject just build Nuspell
+diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
+index 3e63610..9be98be 100644
+--- a/src/tools/CMakeLists.txt
++++ b/src/tools/CMakeLists.txt
+@@ -3,6 +3,10 @@ set_target_properties(nuspell-exe PROPERTIES RUNTIME_OUTPUT_NAME nuspell)
+ target_compile_definitions(nuspell-exe PRIVATE
+     PROJECT_VERSION=\"${PROJECT_VERSION}\")
+ target_link_libraries(nuspell-exe Nuspell::nuspell)
++if (WIN32)
++    find_library(GETOPT_WIN32_LIBRARY getopt)
++    target_link_libraries(nuspell-exe Nuspell::nuspell ${GETOPT_WIN32_LIBRARY})
++endif()
+ if (BUILD_SHARED_LIBS AND WIN32)
+     # This should be PRE_LINK (or PRE_BUILD), so Vcpkg's POST_BUILD
+     # step (see VCPKG_APPLOCAL_DEPS) that copies dll can pick up nuspell.dll

--- a/ports/nuspell/portfile.cmake
+++ b/ports/nuspell/portfile.cmake
@@ -4,13 +4,23 @@ vcpkg_from_github(
     REF v5.1.0
     SHA512 08ce776d224c66ba4bdd8cb22943741f30e8e5ba03396bfef1db598321c9b0f8814dacffcb52287b3b669426c7b08e2c1a40323341a9ff9768a7187002e1d77a
     HEAD_REF master
+    PATCHES fix-tools.patch
 )
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DBUILD_TESTING=OFF
 )
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/nuspell)
 vcpkg_fixup_pkgconfig(
     # nuspell.pc depends on icu-uc.pc which has -lm specified as private
@@ -18,9 +28,14 @@ vcpkg_fixup_pkgconfig(
     # because it can't find this. -lm is part of glibc on Linux.
     SYSTEM_LIBRARIES m
 )
-vcpkg_copy_tools(TOOL_NAMES nuspell AUTO_CLEAN)
+
+if (BUILD_TOOLS)
+    vcpkg_copy_tools(TOOL_NAMES nuspell AUTO_CLEAN)
+endif()
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
 )
+
 file(INSTALL "${SOURCE_PATH}/COPYING.LESSER" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nuspell/vcpkg.json
+++ b/ports/nuspell/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "nuspell",
   "version-semver": "5.1.0",
+  "port-version": 1,
   "description": [
     "Nuspell is a fast and safe spelling checker software program.",
     "It is designed for languages with rich morphology and complex word compounding.",
@@ -18,5 +19,13 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools",
+      "dependencies": [
+        "getopt"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4922,7 +4922,7 @@
     },
     "nuspell": {
       "baseline": "5.1.0",
-      "port-version": 0
+      "port-version": 1
     },
     "nvtt": {
       "baseline": "2.1.2",

--- a/versions/n-/nuspell.json
+++ b/versions/n-/nuspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "02475776fc8cc0332efe7e0ea8851872c911de32",
+      "version-semver": "5.1.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "53fb93bbc0d441813026ef171e32d7479ab839f3",
       "version-semver": "5.1.0",
       "port-version": 0


### PR DESCRIPTION
Add feature `tools` and fix its dependency `getopt` since `getopt_long` isn't provided in Win32 api.

Related: https://github.com/microsoft/vcpkg/pull/22676
Fixes #24533

Already tested this feature on x86-windows.