### PR TITLE
[hyperscan] update to 5.4.0

### DIFF
--- a/ports/hyperscan/portfile.cmake
+++ b/ports/hyperscan/portfile.cmake
@@ -1,12 +1,12 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-set(HYPERSCAN_VERSION 5.3.0)
+set(HYPERSCAN_VERSION 5.4.0)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/hyperscan
     REF v${HYPERSCAN_VERSION}
-    SHA512 a4d85ffd2264e8e6745340ba51431361775a1e7a2da78edd31f6f53552ac61fdef718710ae53a254b7d5000f9ec1aafe7a48d9c55e76f5c6822486150bbc6c56
+    SHA512 cfec3f43b9e8b3fbb2e761927f3a173c1230f2688da710ec7708f2941ce6f550a1d3cb48b0b0e2ccf709807390117a7e40047cb99190bcc341f37eb3da13ae62
     HEAD_REF master
     PATCHES
         0001-remove-Werror.patch
@@ -14,17 +14,16 @@ vcpkg_from_github(
 
 vcpkg_find_acquire_program(PYTHON3)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS "-DPYTHON_EXECUTABLE=${PYTHON3}"
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 
 vcpkg_fixup_pkgconfig()

--- a/ports/hyperscan/vcpkg.json
+++ b/ports/hyperscan/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "hyperscan",
-  "version-string": "5.3.0",
-  "port-version": 3,
+  "version": "5.4.0",
   "description": "A regular expression library with O(length of input) match times that takes advantage of Intel hardware to provide blazing speed.",
   "homepage": "https://www.hyperscan.io",
+  "license": "BSD-3-Clause",
   "supports": "!arm",
   "dependencies": [
     "boost-array",
@@ -26,6 +26,10 @@
     "boost-unordered",
     "boost-utility",
     "pcre",
-    "ragel"
+    "ragel",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2805,8 +2805,8 @@
       "port-version": 0
     },
     "hyperscan": {
-      "baseline": "5.3.0",
-      "port-version": 3
+      "baseline": "5.4.0",
+      "port-version": 0
     },
     "hypodermic": {
       "baseline": "2.5.3",

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "72c36aba3fff7cd403bdf02ad8f691ced9da30a9",
+      "version": "5.4.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "14beb85ac3a741f5504afa923832eb651795f530",
       "version-string": "5.3.0",
       "port-version": 3


### PR DESCRIPTION
Fix #24540 

Update hyperscan to the latest version 5.4.0

Note: no feature need to test