### PR TITLE
[new port] Add rubberband

### DIFF
--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_download_distfile(
+  ARCHIVE URLS "https://breakfastquay.com/files/releases/rubberband-1.9.1.tar.bz2"
+  FILENAME "rubberband-1.9.1.tar.bz2"
+  SHA512 cb20ef8fb717a9e6b5b0b921541bd701e94326e12cdb20d50bed344d12fa1b4fd731335c3a0a7f2d2a5ce96031d965b209e7667c4d55fd8494b8e20d3409f0d3
+)
+
+vcpkg_extract_source_archive_ex(
+  OUT_SOURCE_PATH SOURCE_PATH
+  ARCHIVE ${ARCHIVE}
+)
+
+vcpkg_configure_meson(SOURCE_PATH ${SOURCE_PATH})
+
+vcpkg_install_meson()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+file(
+  INSTALL ${SOURCE_PATH}/COPYING
+  DESTINATION ${CURRENT_PACKAGES_DIR}/share/rubberband
+  RENAME copyright
+)

--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -38,11 +38,9 @@ else()
   vcpkg_clean_executables_in_bin(FILE_NAMES "${RUBBERBAND_PROGRAM_NAME}")
 endif()
 
-# lv2 feature is not supported on Windows yet because vcpkg can't isntall to 
+# lv2 feature is not supported yet because vcpkg can't isntall to 
 # %APPDATA%\LV2 or %COMMONPROGRAMFILES%\LV2 but also complains about dlls in "${CURRENT_PACKAGES_DIR}/lib/lv2"
-if(NOT "lv2" IN_LIST FEATURES)
-  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/lv2" "${CURRENT_PACKAGES_DIR}/debug/lib/lv2")
-endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/lv2" "${CURRENT_PACKAGES_DIR}/debug/lib/lv2")
 
 file(
   INSTALL "${SOURCE_PATH}/COPYING"

--- a/ports/rubberband/portfile.cmake
+++ b/ports/rubberband/portfile.cmake
@@ -21,10 +21,9 @@ vcpkg_install_meson()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-vcpkg_cmake_get_vars(cmake_vars_file)
-include("${cmake_vars_file}")
-
-if(VCPKG_DETECTED_MSVC)
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/rubberband-program${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+  # Rubberband uses a different executable name when compiled with msvc 
+  # Just looking for that file is faster than detecting msvc builds
   set(RUBBERBAND_PROGRAM_NAME rubberband-program)
 else()
   set(RUBBERBAND_PROGRAM_NAME rubberband)

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "rubberband",
+  "version": "1.9.1",
+  "description": "High quality software library for audio time-stretching and pitch-shifting.",
+  "homepage": "https://www.breakfastquay.com/rubberband/",
+  "dependencies": [
+    "kissfft"
+  ]
+}

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -1,9 +1,41 @@
 {
   "name": "rubberband",
-  "version": "1.9.1",
-  "description": "High quality software library for audio time-stretching and pitch-shifting.",
+  "version": "2.0.2",
+  "description": "A high quality software library for audio time-stretching and pitch-shifting.",
   "homepage": "https://www.breakfastquay.com/rubberband/",
+  "license": "GPL-2.0-or-later",
+  "supports": "!uwp",
   "dependencies": [
-    "kissfft"
-  ]
+    "fftw3",
+    "libsamplerate",
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "cli": {
+      "description": "Build the command-line utility",
+      "dependencies": [
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
+      ]
+    },
+    "lv2": {
+      "description": "Build the LV2 plugin",
+      "supports": "!windows",
+      "dependencies": [
+        "lv2"
+      ]
+    }
+  }
 }

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -29,13 +29,6 @@
           ]
         }
       ]
-    },
-    "lv2": {
-      "description": "Build the LV2 plugin",
-      "supports": "!windows",
-      "dependencies": [
-        "lv2"
-      ]
     }
   }
 }

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -9,10 +9,6 @@
     "fftw3",
     "libsamplerate",
     {
-      "name": "vcpkg-cmake-get-vars",
-      "host": true
-    },
-    {
       "name": "vcpkg-tool-meson",
       "host": true
     }

--- a/ports/rubberband/vcpkg.json
+++ b/ports/rubberband/vcpkg.json
@@ -4,7 +4,7 @@
   "description": "A high quality software library for audio time-stretching and pitch-shifting.",
   "homepage": "https://www.breakfastquay.com/rubberband/",
   "license": "GPL-2.0-or-later",
-  "supports": "!uwp",
+  "supports": "!uwp & !(windows & static)",
   "dependencies": [
     "fftw3",
     "libsamplerate",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6316,6 +6316,10 @@
       "baseline": "0.9.6",
       "port-version": 4
     },
+    "rubberband": {
+      "baseline": "2.0.2",
+      "port-version": 0
+    },
     "rxcpp": {
       "baseline": "4.1.0",
       "port-version": 2

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d006b646ea2747c896f59715ba1ce27053dd67dd",
+      "git-tree": "ae68cabf01008125ca16d8cc90debf1ed0b0d300",
       "version": "2.0.2",
       "port-version": 0
     }

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d006b646ea2747c896f59715ba1ce27053dd67dd",
+      "version": "2.0.2",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "36fb0f4ef0a3e3bdd46f1026dbf1de875eef2d97",
+      "git-tree": "75aeab834246d0e2ba7de5f07901e5d7131397f7",
       "version": "2.0.2",
       "port-version": 0
     }

--- a/versions/r-/rubberband.json
+++ b/versions/r-/rubberband.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ae68cabf01008125ca16d8cc90debf1ed0b0d300",
+      "git-tree": "36fb0f4ef0a3e3bdd46f1026dbf1de875eef2d97",
       "version": "2.0.2",
       "port-version": 0
     }


### PR DESCRIPTION
[rubberband](https://www.breakfastquay.com/rubberband/) is a small library for stretching sounds. 
This picks up https://github.com/microsoft/vcpkg/pull/17800

* #### What does your PR fix?
Fixes [[New Port Request] rubberband #17768](https://github.com/microsoft/vcpkg/issues/17768)

* #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

I have so far only tested it on my machine (linux). No I have not updated the CI baseline.

* #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes
 
* #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes
