### PR TITLE
[mpmcqueue] Update version to 2021-12-01

### DIFF
--- a/ports/mpmcqueue/portfile.cmake
+++ b/ports/mpmcqueue/portfile.cmake
@@ -3,15 +3,16 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO rigtorp/MPMCQueue
-    REF 5883e32b07e8a60c22d532d9120ea5c11348aea9
-    SHA512 4adbbe5e014e0ef5c7030aaa9faa4e07e2c65753cd89c770da250811c13776576c4f1caf4144542318c41ebc7433b106e802c482a5d44572963a5ab59047257e
+    REF 28d05c021d68fc5280b593329d1982ed02f9d7b3
+    SHA512 e3305ecac05d48814d75adcb85fa165eec3a439a17dd99f8b0d2c095e40b2f98bd4bcf167cf8268f84d09aa172ab66b30573d9d3ad4908c10dc5bec632529b8a
     HEAD_REF master
 )
 
-file(COPY
-    ${SOURCE_PATH}/include/rigtorp/MPMCQueue.h
-    DESTINATION ${CURRENT_PACKAGES_DIR}/include/rigtorp
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/MPMCQueue)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib")
 
 # Handle copyright
-configure_file(${SOURCE_PATH}/LICENSE ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)
+configure_file("${SOURCE_PATH}/LICENSE" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/ports/mpmcqueue/vcpkg.json
+++ b/ports/mpmcqueue/vcpkg.json
@@ -1,7 +1,17 @@
 {
   "name": "mpmcqueue",
-  "version-string": "2019-07-26",
-  "port-version": 1,
+  "version-date": "2021-12-01",
   "description": "A bounded multi-producer multi-consumer lock-free queue written in C++11",
-  "homepage": "https://github.com/rigtorp/MPMCQueue"
+  "homepage": "https://github.com/rigtorp/MPMCQueue",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4653,8 +4653,8 @@
       "port-version": 0
     },
     "mpmcqueue": {
-      "baseline": "2019-07-26",
-      "port-version": 1
+      "baseline": "2021-12-01",
+      "port-version": 0
     },
     "mqtt-cpp": {
       "baseline": "12.0.0",

--- a/versions/m-/mpmcqueue.json
+++ b/versions/m-/mpmcqueue.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7986416e7dd33174b060331018a3b8aeee3018f0",
+      "version-date": "2021-12-01",
+      "port-version": 0
+    },
+    {
       "git-tree": "1953040343e61f40deb621b5ca28aed36ebc2008",
       "version-string": "2019-07-26",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Update the mpmcqueue package to a newer version (commit from 2021-12-01).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
I have not updated anything related to CI

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
I hope so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

I am still working on this PR