### PR TITLE
[cpr] update to 1.8.3

### DIFF
--- a/ports/cpr/portfile.cmake
+++ b/ports/cpr/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libcpr/cpr
-    REF 1.8.1
-    SHA512 f586b63ddbd9bd03e5c5aa385aad0d4f16f79847e1a14f6dc8a5e0cad4ed89e097ab83484c9ed19e034abf0d2eece13a7609652bc6a1a9caba43189cf0a782db
+    REF db351ffbbadc6c4e9239daaa26e9aefa9f0ec82d #v1.8.3
+    SHA512 4ce4e791c5a29584eaf147b2efc4e5c0fb363cf254e6ec0c66734f7ec8da538b5b295300fee3de218da6daf4107fc11e0eac695885a3380e03a72720d328c3db
     HEAD_REF master
     PATCHES
         001-cpr-config.patch

--- a/ports/cpr/vcpkg.json
+++ b/ports/cpr/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cpr",
-  "version-semver": "1.8.1",
+  "version-semver": "1.8.3",
   "description": "C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.",
   "homepage": "https://github.com/libcpr/cpr",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1653,7 +1653,7 @@
       "port-version": 0
     },
     "cpr": {
-      "baseline": "1.8.1",
+      "baseline": "1.8.3",
       "port-version": 0
     },
     "cpu-features": {

--- a/versions/c-/cpr.json
+++ b/versions/c-/cpr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0699dd50434f04eeccbcd30ed9a3973c3143052b",
+      "version-semver": "1.8.3",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a73ff58e720c30c96a1f7d12f98c9553a62a0d7",
       "version-semver": "1.8.1",
       "port-version": 0


### PR DESCRIPTION
Fix #24579 

Update cpr to the latest version 1.8.3

All features are tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static