### PR TITLE
[gtk] Add a dependency on gettext[tools] to build translation files

### DIFF
--- a/ports/gtk/vcpkg.json
+++ b/ports/gtk/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "gtk",
   "version": "4.6.2",
+  "port-version": 1,
   "description": "Portable library for creating graphical user interfaces.",
   "homepage": "https://www.gtk.org/",
   "license": "LGPL-2.0-only",
@@ -23,6 +24,14 @@
     },
     "gdk-pixbuf",
     "gettext",
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
     "glib",
     {
       "name": "glib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2678,7 +2678,7 @@
     },
     "gtk": {
       "baseline": "4.6.2",
-      "port-version": 0
+      "port-version": 1
     },
     "gtkmm": {
       "baseline": "4.6.0",

--- a/versions/g-/gtk.json
+++ b/versions/g-/gtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2d59edf9986797558b8abafbff9c913bf4f02ca",
+      "version": "4.6.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "00d7796e9bcff96a64e45b977a72129b1dc7be43",
       "version": "4.6.2",
       "port-version": 0


### PR DESCRIPTION
GTK translation files are built only when gettext-tools is present

- #### What does your PR fix?
N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
