### PR TITLE
[minimp3] Update to 2021-11-30

### DIFF
--- a/ports/minimp3/portfile.cmake
+++ b/ports/minimp3/portfile.cmake
@@ -6,8 +6,8 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${SOURCE_PATH}/minimp3.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
-file(COPY ${SOURCE_PATH}/minimp3_ex.h DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT})
+file(COPY "${SOURCE_PATH}/minimp3.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
+file(COPY "${SOURCE_PATH}/minimp3_ex.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/minimp3/portfile.cmake
+++ b/ports/minimp3/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO lieff/minimp3
-    REF 95864e8e0d3b34402a49ae9af6c66f7e98c13c35 #committed on Nov 27
-    SHA512 6e5364a83e882b54fd1eb5ba35ec7c7179b5b5c0ceb2c658615a2306ae0c28252ca8591ec6b515483c6ff0ed608db7eb73fba3d201a20ad4a85ce7b3a091a695
+    REF afb604c06bc8beb145fecd42c0ceb5bda8795144 # committed on 2021-11-30
+    SHA512 633da0b20982f6f22c87d872c69626b2939ffb4519339cd0c090d7538308007cf633c07af57020cd2332a75c6e7b9bf3ebd5bda1af59dc96a4f0e85ce1b3f751
     HEAD_REF master
 )
 

--- a/ports/minimp3/vcpkg.json
+++ b/ports/minimp3/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "minimp3",
-  "version-string": "2020-12-25",
-  "port-version": 1,
+  "version-date": "2021-11-30",
   "description": "Minimalistic, single-header library for decoding MP3. minimp3 is designed to be small, fast (with SSE and NEON support), and accurate (ISO conformant).",
   "homepage": "https://github.com/lieff/minimp3"
 }

--- a/ports/minimp3/vcpkg.json
+++ b/ports/minimp3/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "minimp3",
   "version-date": "2021-11-30",
   "description": "Minimalistic, single-header library for decoding MP3. minimp3 is designed to be small, fast (with SSE and NEON support), and accurate (ISO conformant).",
-  "homepage": "https://github.com/lieff/minimp3"
+  "homepage": "https://github.com/lieff/minimp3",
+  "license": "CC0-1.0"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4521,8 +4521,8 @@
       "port-version": 2
     },
     "minimp3": {
-      "baseline": "2020-12-25",
-      "port-version": 1
+      "baseline": "2021-11-30",
+      "port-version": 0
     },
     "minio-cpp": {
       "baseline": "2022-01-03",

--- a/versions/m-/minimp3.json
+++ b/versions/m-/minimp3.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a121d46b0685dd1ef9221541db18d3a534513a1e",
+      "git-tree": "2997f9c06f0831c803fca134a599171dc2399bc4",
       "version-date": "2021-11-30",
       "port-version": 0
     },

--- a/versions/m-/minimp3.json
+++ b/versions/m-/minimp3.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a121d46b0685dd1ef9221541db18d3a534513a1e",
+      "version-date": "2021-11-30",
+      "port-version": 0
+    },
+    {
       "git-tree": "4ed9d5474095c5aaecd2fc4ccab507523dd98241",
       "version-string": "2020-12-25",
       "port-version": 1


### PR DESCRIPTION
Updates minimp3 to 2021-11-30

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `vcpkg x-add-version minimp3`

