### PR TITLE
[vcpkg] Prevent CMake from executing vcpkg toolchain file more than once

### DIFF
--- a/scripts/buildsystems/vcpkg.cmake
+++ b/scripts/buildsystems/vcpkg.cmake
@@ -1,3 +1,6 @@
+# On first run CMake includes toolchain file twice, stop subsequent includes early on.
+include_guard()
+
 # Mark variables as used so cmake doesn't complain about them
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 


### PR DESCRIPTION
CMake includes toolchain file twice on a first run.

On a first run, it invokes CMakeDetermineSystem.cmake, which generates CMakefiles/CMakeSystem.cmake . while doing so it includes toolchain file. Once CMakeSystem.cmake is generated it is includes again in the very same run, causing double include, because generated CMakeSystyem.cmake also includes toolchain.

On subsequent runs, because CMakeSystem.cmake is already present, it is just included as is, resulting in just a single include of a toolchain.

- #### What does your PR fix?

My toolchain was using `APPEND` operations and I had different results on first and subsequent runs, which was confusing to debug. I could `include_guard()` protect just my chainloaded toolcahin file, but IMHO doing it at `vcpkg.cmake` makes more sense and maybe will help someone else save time debugging their toolchains.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No triplet related changes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
- 
 Yes
