### PR TITLE
[google-cloud-cpp] add missing subpackage

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -47,7 +47,7 @@ foreach(feature IN LISTS FEATURES)
 endforeach()
 # These packages are automatically installed depending on what features are
 # enabled.
-foreach(suffix common googleapis grpc_utils)
+foreach(suffix common googleapis grpc_utils rest_internal)
     set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
     if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
         continue()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "google-cloud-cpp",
   "version": "1.40.1",
+  "port-version": 1,
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2590,7 +2590,7 @@
     },
     "google-cloud-cpp": {
       "baseline": "1.40.1",
-      "port-version": 0
+      "port-version": 1
     },
     "google-cloud-cpp-common": {
       "baseline": "alias",

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "506bdfbf9040c856f8f3a4a2c183da38f9030817",
+      "version": "1.40.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "2a18f7bea0f4811da422b3099c4331305cb1f617",
       "version": "1.40.1",
       "port-version": 0


### PR DESCRIPTION
Add a missing `vcpkg_cmake_config_fixup()` for a

- #### What does your PR fix?

Fixes googleapis/google-cloud-cpp#8919 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.


Tested locally with `vcpkg install google-cloud-cpp[core,storage]`. Also tested with this Docker script:

```Dockerfile
FROM ubuntu:22.04

RUN apt-get update && \
    apt-get --no-install-recommends install -y apt-transport-https apt-utils \
        automake build-essential ca-certificates ccache cmake curl git \
        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
        libssl-dev m4 make ninja-build pkg-config tar wget zlib1g-dev

RUN apt-get update && apt-get --no-install-recommends install -y zip unzip tar cmake ninja-build

WORKDIR /var/tmp/build/vcpkg
RUN curl -sSL https://github.com/coryan/vcpkg/archive/d6f0a18c632b73cb5ee2e44e5ee1079a4f5832b4.tar.gz | \
     tar -xzf - --strip-components=1

RUN ./bootstrap-vcpkg.sh
RUN ./vcpkg install google-cloud-cpp[core,storage]

WORKDIR /var/tmp/build/google-cloud-cpp
RUN curl -sSL https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v1.40.1.tar.gz | \
     tar -xzf - --strip-components=1

WORKDIR /var/tmp/build/google-cloud-cpp/google/cloud/storage/quickstart
RUN cmake -H. -B.build -DCMAKE_TOOLCHAIN_FILE=/var/tmp/build/vcpkg/scripts/buildsystems/vcpkg.cmake
RUN cmake --build .build
```
