### PR TITLE
[bento4] Correct license expression.

### DIFF
--- a/ports/bento4/vcpkg.json
+++ b/ports/bento4/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "bento4",
   "version": "1.6.0-639",
+  "port-version": 1,
   "description": "Bento4 is a C++ class library and tools designed to read and write ISO-MP4 files. This format is defined in international specifications ISO/IEC 14496-12, 14496-14 and 14496-15.",
   "homepage": "https://github.com/axiomatic-systems/Bento4",
-  "license": "GPL-2.0",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/b-/bento4.json
+++ b/versions/b-/bento4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4da8906f31697785969422135a52cb2d0861fe53",
+      "version": "1.6.0-639",
+      "port-version": 1
+    },
+    {
       "git-tree": "834cb05380588e07628713420e709264f168a567",
       "version": "1.6.0-639",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -426,7 +426,7 @@
     },
     "bento4": {
       "baseline": "1.6.0-639",
-      "port-version": 0
+      "port-version": 1
     },
     "berkeleydb": {
       "baseline": "4.8.30",


### PR DESCRIPTION
In https://github.com/microsoft/vcpkg/pull/24432 I noticed that the bento4 license was wrong, but it was a preexisting mistake so I didn't comment. This port is dual licensed under GPL v2 or a proprietary license, which is already described in share/bento4/copyright
