### PR TITLE
[Fluidsynth] add sndfile feature

### DIFF
--- a/ports/fluidsynth/portfile.cmake
+++ b/ports/fluidsynth/portfile.cmake
@@ -25,7 +25,13 @@ if ("buildtools" IN_LIST FEATURES)
     vcpkg_add_to_path(APPEND "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 endif()
 
-set(feature_list dbus jack libinstpatch libsndfile midishare opensles oboe oss sdl2 pulseaudio readline lash alsa systemd coreaudio coremidi dart)
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sndfile     enable-libsndfile
+)
+
+set(feature_list dbus jack libinstpatch midishare opensles oboe oss sdl2 pulseaudio readline lash alsa systemd coreaudio coremidi dart)
 vcpkg_list(SET FEATURE_OPTIONS)
 foreach(_feature IN LISTS feature_list)
     list(APPEND FEATURE_OPTIONS -Denable-${_feature}:BOOL=OFF)

--- a/ports/fluidsynth/vcpkg.json
+++ b/ports/fluidsynth/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "fluidsynth",
   "version": "2.2.6",
+  "port-version": 1,
   "description": "FluidSynth reads and handles MIDI events from the MIDI input device. It is the software analogue of a MIDI synthesizer. FluidSynth can also play midifiles using a Soundfont.",
   "homepage": "https://github.com/FluidSynth/fluidsynth",
   "license": "LGPL-2.1-or-later",
@@ -21,6 +22,18 @@
   "features": {
     "buildtools": {
       "description": "Build tools gentables"
+    },
+    "sndfile": {
+      "description": "Enable rendering to file and SF3 support",
+      "dependencies": [
+        {
+          "name": "libsndfile",
+          "default-features": false,
+          "features": [
+            "external-libs"
+          ]
+        }
+      ]
     }
   }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2258,7 +2258,7 @@
     },
     "fluidsynth": {
       "baseline": "2.2.6",
-      "port-version": 0
+      "port-version": 1
     },
     "fmem": {
       "baseline": "c-libs-2ccee3d2fb",

--- a/versions/f-/fluidsynth.json
+++ b/versions/f-/fluidsynth.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e5c0f85546fe88c0e9aaf67734a929f2b717b1ef",
+      "version": "2.2.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "7740f8dfb97fa273a9f9ed740ade48f9953ff393",
       "version": "2.2.6",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
Fixes #24619. Add optional feature sndfile to fluidsynth, causing it to be built with libsndfile enabling extra functionality.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All triplets supported, no change to baseline

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes