### PR TITLE
[rxspencer] Avoid tests and docs

### DIFF
--- a/ports/rxspencer/disable-docs-and-tests.patch
+++ b/ports/rxspencer/disable-docs-and-tests.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 49faf30..e590001 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@
+ project ( rxspencer C )
+ cmake_minimum_required ( VERSION 3.0 )
+ option ( rxshared "build shared library instead of static" OFF )
+-enable_testing()
++#enable_testing()
+ 
+ # Define POSIX_MISTAKE to allow unmatched right parentheses as literals, as
+ # required by POSIX 1003.2.
+@@ -47,10 +47,12 @@ install ( TARGETS rxspencer
+   PUBLIC_HEADER DESTINATION ${RXSPENCER_INCLUDE_DIR} )
+ 
+ # Install docs
++if(FALSE)
+ set ( RXSPENCER_DATA_FILES "COPYRIGHT;README;WHATSNEW" )
+ install ( FILES ${RXSPENCER_DATA_FILES} DESTINATION ${RXSPENCER_DATA_DIR} )
+ install ( FILES rxspencer.3 DESTINATION ${RXSPENCER_MAN3_DIR} )
+ install ( FILES rxspencer.7 DESTINATION ${RXSPENCER_MAN7_DIR} )
++endif()
+ 
+ # generate cmake configuration file
+ include ( CMakePackageConfigHelpers )
+@@ -69,8 +71,9 @@ install ( EXPORT RXSpencerTargets DESTINATION ${CMAKE_CONFIG_DEST} )
+ install ( FILES
+   ${CMAKE_CURRENT_BINARY_DIR}/RXSpencerConfig.cmake
+   DESTINATION ${CMAKE_CONFIG_DEST} )
+-
++if(FALSE)
+ add_executable(tester ${RXSPENCER_SRCS} debug.c main.c split.c)
+ add_test(NAME test1 COMMAND sh -c "./tester -f ${CMAKE_CURRENT_SOURCE_DIR}/tests")
+ add_test(NAME test2 COMMAND sh -c "./tester -el -f ${CMAKE_CURRENT_SOURCE_DIR}/tests")
+ add_test(NAME test3 COMMAND sh -c "./tester -er -f ${CMAKE_CURRENT_SOURCE_DIR}/tests")
++endif()

--- a/ports/rxspencer/portfile.cmake
+++ b/ports/rxspencer/portfile.cmake
@@ -4,18 +4,21 @@ vcpkg_from_github(
     REF 9f835b523f1af617ca54e06863a1924c23f6e56a #v3.9.0
     SHA512 fe7721bd4b4e4f7d31fd5a7e42d34d0c9735d062d8b146ee47a25f87c809eead7133265fc37fa958c37bc4ffeaf101d143202080508d98efd160b8fd0a278598
     HEAD_REF master
+    PATCHES
+        disable-docs-and-tests.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCMAKE_CONFIG_DEST=share/rxspencer
         -Drxshared=${BUILD_SHARED}
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
 
 vcpkg_cmake_config_fixup(CONFIG_PATH "share/rxspencer")
 
@@ -25,5 +28,3 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/COPYRIGHT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_copy_pdbs()

--- a/ports/rxspencer/vcpkg.json
+++ b/ports/rxspencer/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "rxspencer",
   "version": "3.9.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Henry Spencer's BSD regular expression library.",
   "homepage": "https://garyhouston.github.io/regex/",
+  "license": "MIT AND CC0-1.0",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "rxspencer": {
       "baseline": "3.9.0",
-      "port-version": 1
+      "port-version": 2
     },
     "ryml": {
       "baseline": "2021-07-24",

--- a/versions/r-/rxspencer.json
+++ b/versions/r-/rxspencer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "423d711ba8013c78f3ca4931bf2d6c8a5ecc8ba0",
+      "version": "3.9.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "d0db813c47fd33b7e6f5ffb95790b66aafcaa53e",
       "version": "3.9.0",
       "port-version": 1


### PR DESCRIPTION
rxspencer builds tests and installs docs by default. The only way to disable this behaviour is via a patch.