### PR TITLE
[directxtk, directxtk12, directxtex, directxmesh, uvatlas] Update ports for May 2022 release

### DIFF
--- a/ports/directxmesh/portfile.cmake
+++ b/ports/directxmesh/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMesh
-    REF mar2022
-    SHA512 ec5cfcbba0f361a2a7d572284c77a88464fcf38a10b113f12b1e51a1c0c42a651abd6f8bbf257a3470b35c62c8d25af9a79925f2e0c79eb33a8b1c9ca6a9191b
+    REF may2022
+    SHA512 f82ac5bf8211cb5699caf79cf2fb13eb23b4c3c8de807bc114966cc8e933b3bdb2c98940c9add74ee9ad0addb1bdf91dd16cbe2efe2db2afd96f69fd3871d556
     HEAD_REF main
 )
 
@@ -30,14 +30,14 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmesh/cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MESHCONVERT_EXE
-    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/mar2022/meshconvert.exe"
-    FILENAME "meshconvert-mar2022.exe"
-    SHA512 43b4305b73994eccc086bf1812147a5156359f5d927475b915bbf8edde70189cc419b96703aeb736f76d9d52037657f10ba0c104f9713c1f0defb28ce7a46ac1
+    URLS "https://github.com/Microsoft/DirectXMesh/releases/download/may2022/meshconvert.exe"
+    FILENAME "meshconvert-may2022.exe"
+    SHA512 0fcc3728425bc9681bdc4e1fae79a0f3da638d1b43597171e6829fca85cec8e7f1aa30a51c2f9457074c0a7bb9f358da06df666b6ae054266ceb1c9c38874547
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxmesh/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${MESHCONVERT_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/directxmesh/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-mar2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert-may2022.exe ${CURRENT_PACKAGES_DIR}/tools/directxmesh/meshconvert.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxmesh/vcpkg.json
+++ b/ports/directxmesh/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmesh",
-  "version-date": "2022-03-24",
+  "version-date": "2022-05-09",
   "description": "DirectXMesh geometry processing library",
   "homepage": "https://github.com/Microsoft/DirectXMesh",
   "documentation": "https://github.com/microsoft/DirectXMesh/wiki",

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -1,10 +1,14 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if(VCPKG_TARGET_IS_MINGW)
+    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler fxc.exe also be in the PATH. See https://aka.ms/windowssdk.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTex
-    REF mar2022
-    SHA512 04f898b2cf2c76edd400147db9144e196fc8441739de3293f8851952ce8153bab033deba52a0d35e51c4fbc9705ffe183f1606a0fae29970dc2babe65ed78e19
+    REF may2022
+    SHA512 b5783c55a1faa9ac616f93d13af91d072e5cef65bcb02c402f2a4d072036135ae610264dc5ebe4e15c56b152c0b3fd0fb87666ab16e74507218906f4210687db
     HEAD_REF main
 )
 
@@ -57,28 +61,28 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtex/cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("openexr" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     TEXASSEMBLE_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texassemble.exe"
-    FILENAME "texassemble-mar2022.exe"
-    SHA512 2a2bec1f012ba6778d99f53a3b4f015f84e4ab76dd68a1980d77cdac588c60a21b30abbfc0de9f0b0ef790ef5ed8444f1648b80990053f8a1f967a04d20d3c33
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texassemble.exe"
+    FILENAME "texassemble-may2022.exe"
+    SHA512 22963920f3047533d2ec6d9751f4d2eb4d530e6c4a96099322a070f5f311785d79d07c2e79fd05daa9992deba116f630de14436df4f42b415d7511fd6193241e
   )
 
   vcpkg_download_distfile(
     TEXCONV_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texconv.exe"
-    FILENAME "texconv-mar2022.exe"
-    SHA512 fa0b12dcc7e4688f356bb591dedd07dcb27b6029c6490438b39368f72b77f90112360544e035f89e1098dc09b26fb921840ecae851ad5eba6a339cd46316c4e3
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texconv.exe"
+    FILENAME "texconv-may2022.exe"
+    SHA512 9f0c9307f00062883be8a2afff0f6428020d9f056db5a2f175ea3ff72e50f6fd5c57b2dbc448fe8352a86837b318bd3874995dc87d741bdeb413060618a0b08f
   )
 
   vcpkg_download_distfile(
     TEXDIAG_EXE
-    URLS "https://github.com/Microsoft/DirectXTex/releases/download/mar2022/texdiag.exe"
-    FILENAME "texdiag-mar2022.exe"
-    SHA512 7fe074a08599edca9ad8ad5ff930c9c4dbc74faad6502c288e9a555a4a79f51affbce51758c99518d54c4698457e0edb379ffaebfd3dcae0bd16a343195f8292
+    URLS "https://github.com/Microsoft/DirectXTex/releases/download/may2022/texdiag.exe"
+    FILENAME "texdiag-may2022.exe"
+    SHA512 01fc96ea5cc286dfea097d3b8bedb92d41dbbab949953315e640ee019578c33e2e1b0db476e51576c92763bacfa4cdf270ebad7cac1c59b185d5fdc0752f0393
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
@@ -89,9 +93,9 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${TEXDIAG_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtex/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texassemble.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texconv.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtex/texdiag-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtex/texadiag.exe")
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/directxtex/portfile.cmake
+++ b/ports/directxtex/portfile.cmake
@@ -56,6 +56,7 @@ vcpkg_cmake_configure(
     OPTIONS
         ${FEATURE_OPTIONS}
         ${EXTRA_OPTIONS}
+        -DBUILD_SAMPLE=OFF
         -DBC_USE_OPENMP=ON
         -DBUILD_DX11=ON
 )

--- a/ports/directxtex/vcpkg.json
+++ b/ports/directxtex/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtex",
-  "version-date": "2022-03-24",
+  "version-date": "2022-05-09",
   "description": "DirectXTex texture processing library",
   "homepage": "https://github.com/Microsoft/DirectXTex",
   "documentation": "https://github.com/microsoft/DirectXTex/wiki",

--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -1,10 +1,14 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if(VCPKG_TARGET_IS_MINGW)
+    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler fxc.exe also be in the PATH. See https://aka.ms/windowssdk.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF mar2022
-    SHA512 09264e19ff786b1f8cf56f0a789ce9df60b3682adba6dbb3e9c8c8c7d869b464c0ad869299fc5cda2d535db19c7a96b43cba2fd40d8cb6aa9dc14914b181d410
+    REF may2022
+    SHA512 739d50c8dfa88a8905e61a797889a33c8b5a32a2e8ded1eea4c4f5fea82a9e8c04f6414ce709410def905d711cf7c8daf40e38579b355071288423b193196444
     HEAD_REF main
 )
 
@@ -28,21 +32,21 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk/cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/mar2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-mar2022.exe"
-    SHA512 a24f76781ddb2c9baa2550d3ef26bf4cf6cb03bfd97caa3b202232a04730fd81e299a9f3549c3ff58c03fda827e44deac5e0b311e8e3fc795e393651ecb51752
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/may2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-may2022.exe"
+    SHA512 6f88fec787f9db0823cc0c5aa3d2579248c3dea566909a8d41417f42a3bd2af147ff9af82a3b96a3b1d0f8661dffda27530565bb8fed0a2e7d819d471e51493b
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/mar2022/XWBTool.exe"
-    FILENAME "xwbtool-mar2022.exe"
-    SHA512 32dd88e742211deaf0ca83e51ec510490456473c07fabbd6627960dc9abfa32289d99f2c8f53d7590a6a6733b3068ba25bff9a512fcf7d1072791dce931d463f
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/may2022/XWBTool.exe"
+    FILENAME "xwbtool-may2022.exe"
+    SHA512 505c7aa7a22ea78a793ba70f136b13548a69b36cd8ec1631969203deff6e93236460c674b219316793aa475f1350ad56f4a3f844e94c3adba0af7b1723c8765e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -52,8 +56,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2022-03-24",
+  "version-date": "2022-05-09",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",
@@ -22,7 +22,7 @@
       "description": "Build with XAudio 2.8 support for Windows 8.x or later"
     },
     "xaudio2-9": {
-      "description": "Build with XAudio 2.9 support for Windows 10"
+      "description": "Build with XAudio 2.9 support for Windows 10/11"
     },
     "xaudio2redist": {
       "description": "Build with XAudio2Redist support for Windows 7 SP1 or later",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,34 +1,45 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
+if(VCPKG_TARGET_IS_MINGW)
+    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler dxc.exe also be in the PATH. See https://github.com/microsoft/DirectXShaderCompiler.")
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF mar2022
-    SHA512 fc41450aad51491f4ac89f87bfd76a62179052db1b98ee626561ef3edb8716578c8dfee01613731cdd9fd91f03ed54a8ec73595374ae16e217cfc87d6f11eca4
+    REF may2022
+    SHA512 a306792c134458766ff0ce2672b4769d261080258207173aaff9e59c3a975859df2a540ea8537e28fc2aa1693237c3609665b87c4cf1d9115ac41c7a45ff5d61
     HEAD_REF main
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        xaudio2-9 BUILD_XAUDIO_WIN10
+        xaudio2redist BUILD_XAUDIO_REDIST
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS -DBUILD_XAUDIO_WIN10=ON -DBUILD_DXIL_SHADERS=ON
+    OPTIONS ${FEATURE_OPTIONS} -DBUILD_DXIL_SHADERS=ON
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12/cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/mar2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-mar2022.exe"
-    SHA512 a24f76781ddb2c9baa2550d3ef26bf4cf6cb03bfd97caa3b202232a04730fd81e299a9f3549c3ff58c03fda827e44deac5e0b311e8e3fc795e393651ecb51752
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/may2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-may2022.exe"
+    SHA512 6f88fec787f9db0823cc0c5aa3d2579248c3dea566909a8d41417f42a3bd2af147ff9af82a3b96a3b1d0f8661dffda27530565bb8fed0a2e7d819d471e51493b
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/mar2022/XWBTool.exe"
-    FILENAME "xwbtool-mar2022.exe"
-    SHA512 32dd88e742211deaf0ca83e51ec510490456473c07fabbd6627960dc9abfa32289d99f2c8f53d7590a6a6733b3068ba25bff9a512fcf7d1072791dce931d463f
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/may2022/XWBTool.exe"
+    FILENAME "xwbtool-may2022.exe"
+    SHA512 505c7aa7a22ea78a793ba70f136b13548a69b36cd8ec1631969203deff6e93236460c674b219316793aa475f1350ad56f4a3f844e94c3adba0af7b1723c8765e
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -38,8 +49,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-mar2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2022-03-24",
+  "version-date": "2022-05-09",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -17,5 +17,20 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "default-features": [ "xaudio2-9" ],
+  "features": {
+    "xaudio2-9": {
+      "description": "Build with XAudio 2.9 support for Windows 10/11"
+    },
+    "xaudio2redist": {
+      "description": "Build with XAudio2Redist",
+      "dependencies": [
+        {
+          "name": "xaudio2redist",
+          "platform": "!uwp & !arm"
+        }
+      ]
+    }
+  }
 }

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -18,7 +18,9 @@
       "host": true
     }
   ],
-  "default-features": [ "xaudio2-9" ],
+  "default-features": [
+    "xaudio2-9"
+  ],
   "features": {
     "xaudio2-9": {
       "description": "Build with XAudio 2.9 support for Windows 10/11"

--- a/ports/uvatlas/portfile.cmake
+++ b/ports/uvatlas/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/UVAtlas
-    REF mar2022
-    SHA512 8e532a754d1b07108c98e099221a1c6eb39e1386e2e61d8694e041fcdf0556d1aeaed703018b18aa0cc2972c1b874fedd4d7b5e5694c504e70d623a78e6eb421
+    REF may2022
+    SHA512 132c7570acd14e69f9a9888ce62aaa58f78d7d7e933bd3648af7208689693906fe6d8e17f4f41ba46a5151e09a0012874b0d11b96f30246337208c4f6f5ef8db
     HEAD_REF main
 )
 
@@ -30,14 +30,14 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/uvatlas/cmake)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT ("eigen" IN_LIST FEATURES)))
   vcpkg_download_distfile(
     UVATLASTOOL_EXE
-    URLS "https://github.com/Microsoft/UVAtlas/releases/download/mar2022/uvatlastool.exe"
-    FILENAME "uvatlastool-mar2022.exe"
-    SHA512 d4179b755a9f8d81c180c86ae7e2d177dd0842f78fc81d96b87fa6551407a038edb8250529e45a9b783514e27cbe2a806bac4af47c3db5c34a6e4adc602f5ff4
+    URLS "https://github.com/Microsoft/UVAtlas/releases/download/may2022/uvatlastool.exe"
+    FILENAME "uvatlastool-may2022.exe"
+    SHA512 8a58e54881b16dc2e2489cfb605c02d5368bbfe02182c4d64ee1e903496d2ebcfc9cfaca63d602572c2241109c4ee4591aa7bb4f8da65daeead99b8144049b84
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/uvatlas/")
@@ -46,7 +46,7 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64) AND (NOT 
     ${UVATLASTOOL_EXE}
     DESTINATION ${CURRENT_PACKAGES_DIR}/tools/uvatlas/)
 
-  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-mar2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
+  file(RENAME ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool-may2022.exe ${CURRENT_PACKAGES_DIR}/tools/uvatlas/uvatlastool.exe)
 
 elseif((VCPKG_TARGET_IS_WINDOWS) AND (NOT VCPKG_TARGET_IS_UWP))
 

--- a/ports/uvatlas/vcpkg.json
+++ b/ports/uvatlas/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "uvatlas",
-  "version-date": "2022-03-24",
+  "version-date": "2022-05-09",
   "description": "UVAtlas isochart texture atlas",
   "homepage": "https://github.com/Microsoft/UVAtlas",
   "documentation": "https://github.com/Microsoft/UVAtlas/wiki",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1865,7 +1865,7 @@
       "port-version": 0
     },
     "directxmesh": {
-      "baseline": "2022-03-24",
+      "baseline": "2022-05-09",
       "port-version": 0
     },
     "directxsdk": {
@@ -1873,15 +1873,15 @@
       "port-version": 5
     },
     "directxtex": {
-      "baseline": "2022-03-24",
+      "baseline": "2022-05-09",
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2022-03-24",
+      "baseline": "2022-05-09",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2022-03-24",
+      "baseline": "2022-05-09",
       "port-version": 0
     },
     "dirent": {
@@ -7277,7 +7277,7 @@
       "port-version": 2
     },
     "uvatlas": {
-      "baseline": "2022-03-24",
+      "baseline": "2022-05-09",
       "port-version": 0
     },
     "uvw": {

--- a/versions/d-/directxmesh.json
+++ b/versions/d-/directxmesh.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bf2c810ddbc4a551cb5fb561092bb6fe67ed986f",
+      "version-date": "2022-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "799bc935afc5a0b5d8d50037f28807512fc7c38e",
       "version-date": "2022-03-24",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "376ecf76d8242b061ff1bd1fce923749b41a0711",
+      "version-date": "2022-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "15870041c7dc7d9db536c8770c6334f96af9f92c",
       "version-date": "2022-03-24",
       "port-version": 0

--- a/versions/d-/directxtex.json
+++ b/versions/d-/directxtex.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "376ecf76d8242b061ff1bd1fce923749b41a0711",
+      "git-tree": "269e245ad8428d3a09059bc195bae935613478af",
       "version-date": "2022-05-09",
       "port-version": 0
     },

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e8707f957389d4329f61d4af69a47766fea2d6b9",
+      "version-date": "2022-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "d6e54dc5cc77469ecc88f949b6c149cb01f5a335",
       "version-date": "2022-03-24",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e513b241157a3eada954cdb4c2d353ed4dac27e3",
+      "version-date": "2022-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "c89638b81272f98ae99cfb782c1269ad7b1836a5",
       "version-date": "2022-03-24",
       "port-version": 0

--- a/versions/u-/uvatlas.json
+++ b/versions/u-/uvatlas.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2ac8444f59bd76ba38a620d4e0fe1a6a64969873",
+      "version-date": "2022-05-09",
+      "port-version": 0
+    },
+    {
       "git-tree": "100ee1b04f5da317153da9c52eb0c0def30e9b49",
       "version-date": "2022-03-24",
       "port-version": 0


### PR DESCRIPTION
DirectX Tool Kit for DX11 / DX12, DirectXTex, DirectXMesh, and UVAtlas all have new May 2022 releases on GitHub. In addition to a few bug fixes and minor features, this revision adds support for building with the MinGW toolset via CMake.

All ports now support building with **x86-mingw-static** and **x64-mingw-static** community triplets when using MinGW GNU 11. The directxtk, directxtk12, and directxtex ports also need the HLSL compiler in the path along with the appropriate compiler toolset. These ports all take advantage of the recent changes to directx-headers including conformance fixes for MinGW (#24490).

> Technically **x86-mingw-dynamic** and **x64-mingw-dynamic** community triplets also work, but they just end up switching back to static library linkage so they have the same result.

The **directxtk12** port now exposes an _xaudio2-9_ and _xaudio2redist_ feature because MinGW requires xaudio2redist to build (if xaudio2-9 is specified, the upstream CMake just turns it off if using MinGW). Therefore, to get *DirectX Tool Kit for Audio* support with either the **directxtk** or **directxtk12** ports when using MinGW, you need to use the xaudio2redist feature.
