### PR TITLE
[libslirp] update to 4.7.0

### DIFF
--- a/ports/libslirp/portfile.cmake
+++ b/ports/libslirp/portfile.cmake
@@ -2,8 +2,8 @@ vcpkg_from_gitlab(
     GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
     REPO slirp/libslirp
-    REF v4.6.1
-    SHA512 04a9dd88cd58c849a24b9cff405d951952760d99ea2bef0b070463dff088d79f44557a13c9427ba0043f58d4b9e06b68ff64a4f23a7b0d66df594e32e1521cae
+    REF v4.7.0
+    SHA512 387f4a6dad240ce633df2640bb49c6cb0041c8b3afc8d0ef38186d385f00dd9e4ef4443e93e1b71dbf05e22892b6f2771a87a202e815d8ec899ab5c147a1f09f
     HEAD_REF master
 )
 

--- a/ports/libslirp/vcpkg.json
+++ b/ports/libslirp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libslirp",
-  "version-semver": "4.6.1",
-  "port-version": 1,
+  "version-semver": "4.7.0",
   "description": "libslirp is a user-mode networking library used by virtual machines, containers or various tools.",
   "homepage": "https://gitlab.freedesktop.org/slirp/libslirp",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4001,8 +4001,8 @@
       "port-version": 1
     },
     "libslirp": {
-      "baseline": "4.6.1",
-      "port-version": 1
+      "baseline": "4.7.0",
+      "port-version": 0
     },
     "libsmb2": {
       "baseline": "2021-04-29",

--- a/versions/l-/libslirp.json
+++ b/versions/l-/libslirp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6946f40e08a89013e998d3bf397613bdf08cb581",
+      "version-semver": "4.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "3230fcf2c1b8018c5eac033b618f2cb35217772f",
       "version-semver": "4.6.1",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Updates the `libslirp` port to version 4.7.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
