### PR TITLE
Build "fixes" 2022-05-13

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1275,7 +1275,6 @@ lapack-reference:x64-uwp=skip
 
 # failures for x64-windows-static-md
 ace:x64-windows-static-md=fail
-akali:x64-windows-static-md=fail
 fastcgi:x64-windows-static-md=fail
 ijg-libjpeg:x64-windows-static-md=fail
 libcerf:x64-windows-static-md=fail
@@ -1310,3 +1309,13 @@ dimcli:x64-windows-static=fail
 zeroc-ice:arm64-windows=fail
 zeroc-ice:arm-uwp=fail
 zeroc-ice:x64-uwp=fail
+
+# ANGLE triggers an intermittent ice in C1XX
+# https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1472813
+angle:x86-windows=skip
+angle:x64-windows=skip
+angle:x64-windows-static=skip
+angle:x64-windows-static-md=skip
+angle:x64-uwp=skip
+angle:arm64-windows=skip
+angle:arm-uwp=skip


### PR DESCRIPTION
https://dev.azure.com/vcpkg/public/_build/results?buildId=72059&view=results

PASSING, REMOVE FROM FAIL LIST: akali:x64-windows-static-md (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).

Probably fixed by https://github.com/microsoft/vcpkg/pull/24648

REGRESSION: angle:x64-windows-static-md failed with BUILD_FAILED. If expected, add angle:x64-windows-static-md=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.
REGRESSION: angle:arm-uwp failed with BUILD_FAILED. If expected, add angle:arm-uwp=fail to C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt.

ICE :( https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1472813
