### PR TITLE
[liblzma] Update wrapper, add feature tools

### DIFF
--- a/ports/liblzma/build-tools.patch
+++ b/ports/liblzma/build-tools.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cddbccb..63c8f3d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -492,6 +492,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblzmaConfig.cmake"
+         COMPONENT liblzma_Development)
+ 
+ 
++if(BUILD_TOOLS)
+ #############################################################################
+ # getopt_long
+ #############################################################################
+@@ -663,3 +664,4 @@ if(NOT MSVC AND HAVE_GETOPT_LONG)
+             DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
+             COMPONENT xz)
+ endif()
++endif()
+\ No newline at end of file

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -9,10 +9,17 @@ vcpkg_from_github(
         fix_config_include.patch
         win_output_name.patch # Fix output name on Windows. Autotool build does not generate lib prefixed libraries on windows. 
         add_support_ios.patch # add install bundle info for support ios 
+        build-tools.patch
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools BUILD_TOOLS
+)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/liblzma/vcpkg-cmake-wrapper.cmake
+++ b/ports/liblzma/vcpkg-cmake-wrapper.cmake
@@ -13,7 +13,7 @@ if(NOT "CONFIG" IN_LIST ARGS AND NOT "NO_MODULE" IN_LIST ARGS AND NOT CMAKE_DISA
     if(CMAKE_VERSION VERSION_LESS 3.16)
         # Older versions of FindLibLZMA.cmake need a single lib in LIBLZMA_LIBRARY.
         set(z_vcpkg_liblzma_fixup_needed 1)
-        set(LIBLZMA_LIBRARY "${LIBLZMA_LIBRARY_RELEASE}")
+        set(LIBLZMA_LIBRARY "${LIBLZMA_LIBRARY_RELEASE}" CACHE INTERNAL "")
     elseif(NOT TARGET LibLZMA::LibLZMA)
         set(z_vcpkg_liblzma_fixup_needed 1)
     endif()

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "liblzma",
   "version-semver": "5.2.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Compression library with an API similar to that of zlib.",
   "homepage": "https://github.com/xz-mirror/xz",
   "license": null,

--- a/ports/liblzma/vcpkg.json
+++ b/ports/liblzma/vcpkg.json
@@ -14,5 +14,11 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "tools": {
+      "description": "Build tools",
+      "supports": "!windows, mingw"
+    }
+  }
 }

--- a/scripts/test_ports/cmake-user/project/CMakeLists.txt
+++ b/scripts/test_ports/cmake-user/project/CMakeLists.txt
@@ -53,6 +53,8 @@ foreach(package ${FIND_PACKAGES})
         message(SEND_ERROR "find_package(${package}) check: failed")
         continue()
     endif()
+    # REQUIRED changes the behaviour find_package_handle_standard_args.
+    find_package("${package}" REQUIRED)
     message(STATUS "find_package(${package}) check: success")
 
     set(libraries_var "")

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3738,7 +3738,7 @@
     },
     "liblzma": {
       "baseline": "5.2.5",
-      "port-version": 5
+      "port-version": 6
     },
     "libmad": {
       "baseline": "0.15.1",

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "96b6aac6211ad3fd3da29508a519c3cd5f09716d",
+      "version-semver": "5.2.5",
+      "port-version": 6
+    },
+    {
       "git-tree": "18b7cbd0972b536a6bd4c0ef0f41dce9c3f047ac",
       "version-semver": "5.2.5",
       "port-version": 5


### PR DESCRIPTION
- #### What does your PR fix?
  Moves tools out of default (core) build of liblzma. (Unchanged: Tools are not built for windows.)
  Fixes the wrapper: `find_package(LibLZMA REQUIRED)` failed with older versions of CMake (3.7.2, 3.10). 
  Updates test port `cmake-user` to actually cover this case.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes