### PR TITLE
Fix builing nuspell[tools] on Mingw

### DIFF
--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "getopt-win32",
-  "version-string": "0.1",
+  "version": "0.1",
   "port-version": 3,
   "description": "An implementation of getopt.",
   "homepage": "https://github.com/libimobiledevice-win32",

--- a/ports/getopt-win32/vcpkg.json
+++ b/ports/getopt-win32/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "getopt-win32",
   "version-string": "0.1",
-  "port-version": 2,
+  "port-version": 3,
   "description": "An implementation of getopt.",
   "homepage": "https://github.com/libimobiledevice-win32",
   "license": "LGPL-3.0-only",
-  "supports": "windows"
+  "supports": "windows & !mingw"
 }

--- a/ports/getopt/vcpkg.json
+++ b/ports/getopt/vcpkg.json
@@ -1,13 +1,13 @@
 {
   "name": "getopt",
   "version-string": "0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The getopt and getopt_long functions automate some of the chore involved in parsing typical unix command line options.",
   "supports": "!uwp",
   "dependencies": [
     {
       "name": "getopt-win32",
-      "platform": "windows"
+      "platform": "windows & !mingw"
     }
   ]
 }

--- a/ports/nuspell/fix-tools.patch
+++ b/ports/nuspell/fix-tools.patch
@@ -14,16 +14,16 @@ index 7b54c54..7c6f3a3 100644
  if (subproject)
      # if added as subproject just build Nuspell
 diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
-index 3e63610..9be98be 100644
+index 3e63610..7597a6d 100644
 --- a/src/tools/CMakeLists.txt
 +++ b/src/tools/CMakeLists.txt
 @@ -3,6 +3,10 @@ set_target_properties(nuspell-exe PROPERTIES RUNTIME_OUTPUT_NAME nuspell)
  target_compile_definitions(nuspell-exe PRIVATE
      PROJECT_VERSION=\"${PROJECT_VERSION}\")
  target_link_libraries(nuspell-exe Nuspell::nuspell)
-+if (WIN32)
++if (WIN32 AND NOT MINGW)
 +    find_library(GETOPT_WIN32_LIBRARY getopt)
-+    target_link_libraries(nuspell-exe Nuspell::nuspell ${GETOPT_WIN32_LIBRARY})
++    target_link_libraries(nuspell-exe ${GETOPT_WIN32_LIBRARY})
 +endif()
  if (BUILD_SHARED_LIBS AND WIN32)
      # This should be PRE_LINK (or PRE_BUILD), so Vcpkg's POST_BUILD

--- a/ports/nuspell/vcpkg.json
+++ b/ports/nuspell/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nuspell",
   "version-semver": "5.1.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Nuspell is a fast and safe spelling checker software program.",
     "It is designed for languages with rich morphology and complex word compounding.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2478,11 +2478,11 @@
     },
     "getopt": {
       "baseline": "0",
-      "port-version": 1
+      "port-version": 2
     },
     "getopt-win32": {
       "baseline": "0.1",
-      "port-version": 2
+      "port-version": 3
     },
     "gettext": {
       "baseline": "0.21",
@@ -4934,7 +4934,7 @@
     },
     "nuspell": {
       "baseline": "5.1.0",
-      "port-version": 1
+      "port-version": 2
     },
     "nvtt": {
       "baseline": "2.1.2",

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa72103125a2e5b5b478021694aa9da362decde9",
+      "version-string": "0.1",
+      "port-version": 3
+    },
+    {
       "git-tree": "93d03f637c26f2efa154dfd7c3efb02074cf5eda",
       "version-string": "0.1",
       "port-version": 2

--- a/versions/g-/getopt-win32.json
+++ b/versions/g-/getopt-win32.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "aa72103125a2e5b5b478021694aa9da362decde9",
-      "version-string": "0.1",
+      "git-tree": "97ccee735c01df1356a70d59bc114512f7ab77cc",
+      "version": "0.1",
       "port-version": 3
     },
     {

--- a/versions/g-/getopt.json
+++ b/versions/g-/getopt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "be2552adc01c2ba30044325925f7348121de5c3d",
+      "version-string": "0",
+      "port-version": 2
+    },
+    {
       "git-tree": "81815a8f433219e332659e07204f90df381a28a7",
       "version-string": "0",
       "port-version": 1

--- a/versions/n-/nuspell.json
+++ b/versions/n-/nuspell.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5719acdfd3465a7bb3dfac85ce2821c56d7c652a",
+      "version-semver": "5.1.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "02475776fc8cc0332efe7e0ea8851872c911de32",
       "version-semver": "5.1.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes building port nuspell on mingw triplet.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All, Yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes