### PR TITLE
[pegtl] Update to 3.2.6 for MSVC and GCC fixes

### DIFF
--- a/ports/pegtl/portfile.cmake
+++ b/ports/pegtl/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO taocpp/pegtl
-    REF 3.2.5
-    SHA512 e531eaeef614d822e4bddbc6662fbe116cc1536fa308109f28ce5433607e6102f4e754a31094f9c349e4319914da6c83450dd2e8fa10dcfc3eee5a5dca547c14
-    HEAD_REF main
+    REF e65017d398a3b733aedab70bb64b8055472d47aa
+    SHA512 05ca3754a9c1c94a205c6823e4442dca1f11a890aadd4b0c96f6ccd8946eec061c0a723bc67f8b57b074154e1ab1171bdcdd035926f55e42b5517b9d5ecae873
+    HEAD_REF 3.x
 )
 
 vcpkg_cmake_configure(

--- a/ports/pegtl/vcpkg.json
+++ b/ports/pegtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pegtl",
-  "version-semver": "3.2.5",
+  "version-semver": "3.2.6",
   "description": "The Parsing Expression Grammar Template Library (PEGTL) is a zero-dependency C++ header-only parser combinator library for creating parsers according to a Parsing Expression Grammar (PEG).",
   "homepage": "https://github.com/taocpp/PEGTL",
   "license": "MIT",

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -172,12 +172,6 @@ cpp-netlib:x64-uwp=fail
 cppcoro:x64-linux=fail
 cppcoro:arm-uwp=fail
 cppcoro:x64-uwp=fail
-# VS 2022 17.2 miscompiles this:
-cppgraphqlgen:arm64-windows=fail
-cppgraphqlgen:x64-windows=fail
-cppgraphqlgen:x64-windows-static=fail
-cppgraphqlgen:x64-windows-static-md=fail
-cppgraphqlgen:x86-windows=fail
 # The x64-linux pipeline uses gcc 9.3.0, which lacks C++20 coroutine support.
 # This is known to work on x64-linux as of gcc 10.3.0.
 cppgraphqlgen:x64-linux=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5377,7 +5377,7 @@
       "port-version": 0
     },
     "pegtl": {
-      "baseline": "3.2.5",
+      "baseline": "3.2.6",
       "port-version": 0
     },
     "pegtl-2": {

--- a/versions/p-/pegtl.json
+++ b/versions/p-/pegtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ed96fd80f2820b9e5ad6f38a9ea24d7aebfb64be",
+      "version-semver": "3.2.6",
+      "port-version": 0
+    },
+    {
       "git-tree": "43adc8ee136a8dd0ea88b54a6a7fdc7325cf7327",
       "version-semver": "3.2.5",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?
  Recent versions of MSVC and GCC changed the behavior of built-in macros and template parsing, which breaks the PEGTL `demangle` function when it's used in `cppgraphlgen`. This shows up as a build break in the `cppgraphqlgen` port. This version of PEGTL includes workarounds/updates to work with these compiler versions.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  All, Yes (removing `cppgraphqlgen` failures on Windows).

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.
