### PR TITLE
Add vcpkg_from_*** and ${PORT} usage improvements to the `vcpkg create` templates.

### DIFF
--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -29,6 +29,12 @@
 #
 # 	See additional helpful variables in /docs/maintainers/vcpkg_common_definitions.md
 
+# Also consider vcpkg_from_* functions if you can; the generated code here is for any web accessable
+# source archive.
+#  vcpkg_from_github
+#  vcpkg_from_gitlab
+#  vcpkg_from_bitbucket
+#  vcpkg_from_sourceforge
 vcpkg_download_distfile(ARCHIVE
     URLS "@URL@"
     FILENAME "@FILENAME@"
@@ -74,5 +80,5 @@ vcpkg_cmake_install()
 #}
 # vcpkg_cmake_config_fixup(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
 
-# # Handle copyright
-# file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/@PORT@" RENAME copyright)
+# Uncomment the line below if necessary to install the license file for the port to share/${PORT}/copyright
+# file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -43,7 +43,7 @@ vcpkg_download_distfile(ARCHIVE
 
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
+    ARCHIVE "${ARCHIVE}"
     # (Optional) A friendly name to use instead of the filename of the archive (e.g.: a version number or tag).
     # REF 1.0.0
     # (Optional) Read the docs for how to generate patches at:
@@ -78,7 +78,7 @@ vcpkg_cmake_install()
 #    "name": "vcpkg-cmake-config",
 #    "host": true
 #}
-# vcpkg_cmake_config_fixup(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
+# vcpkg_cmake_config_fixup(CONFIG_PATH cmake TARGET_PATH "share/@PORT@")
 
 # Uncomment the line below if necessary to install the license file for the port to share/${PORT}/copyright
 # file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/scripts/templates/portfile.in.cmake
+++ b/scripts/templates/portfile.in.cmake
@@ -78,7 +78,7 @@ vcpkg_cmake_install()
 #    "name": "vcpkg-cmake-config",
 #    "host": true
 #}
-# vcpkg_cmake_config_fixup(CONFIG_PATH cmake TARGET_PATH "share/@PORT@")
+# vcpkg_cmake_config_fixup(CONFIG_PATH cmake TARGET_PATH share/@PORT@)
 
 # Uncomment the line below if necessary to install the license file for the port to share/${PORT}/copyright
 # file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/scripts/templates/vcpkg.json.in
+++ b/scripts/templates/vcpkg.json.in
@@ -1,6 +1,6 @@
 {
   "name": "@PORT@",
-  "version-string": "",
+  "version": "",
   "homepage": "",
   "description": "",
   "dependencies": [


### PR DESCRIPTION
Reported at: https://github.com/microsoft/vcpkg/pull/24680#discussion_r874483365
