### PR TITLE
[curl] Don't try to include OpenSSL headers when OpenSSL backends aren't selected.

### DIFF
--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "curl",
   "version": "7.83.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for transferring data with URLs",
   "homepage": "https://curl.se/",
   "license": null,

--- a/ports/curl/wolfssl-ntlm.patch
+++ b/ports/curl/wolfssl-ntlm.patch
@@ -32,7 +32,7 @@ diff -ur a/lib/curl_ntlm_core.h b/lib/curl_ntlm_core.h
  #  include <wolfssl/options.h>
 -#endif
 +#  include <wolfssl/openssl/ssl.h>
-+#else
++#elif defined(USE_OPENSSL)
  #  include <openssl/ssl.h>
  #endif
  

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1746,7 +1746,7 @@
     },
     "curl": {
       "baseline": "7.83.1",
-      "port-version": 1
+      "port-version": 2
     },
     "curlpp": {
       "baseline": "2018-06-15",

--- a/versions/c-/curl.json
+++ b/versions/c-/curl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "09dee7c9ae276d954fc8017b6a81002e43f81bb0",
+      "version": "7.83.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "69e1aaae731455f5ed18b7eea4da75ee10bd073a",
       "version": "7.83.1",
       "port-version": 1


### PR DESCRIPTION
Fixes regression introduced in https://github.com/microsoft/vcpkg/pull/24348

/cc @elms

Thanks to r41nm4ker on the vcpkg Discord for reporting this problem.