### PR TITLE
[tree-sitter] Add new port

### DIFF
--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            "SamuelMarks/${PORT}"
+    REF             982cdce15b88e41b1f6938cc0e103b0e7a3cc830
+    SHA512          f427f9ac2e7e7722819d7e4fd36d111b7fd745dac9d934a2fec46c87a98e45708143dd93460dcf12d120b168a0bb24ef6d7e1e06e5666e7028a9f825c5d52f63
+    HEAD_REF        cmake
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTING=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "tree-sitter",
+  "version": "0.20.6",
+  "description": "Tree-sitter is a parser generator tool and an incremental parsing library.",
+  "homepage": "https://github.com/tree-sitter/tree-sitter",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7132,6 +7132,10 @@
       "baseline": "0.8.0",
       "port-version": 3
     },
+    "tree-sitter": {
+      "baseline": "0.20.6",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.16",
       "port-version": 0

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e0c013b5db92f0df1ec09c96935b0196ddd173be",
+      "version": "0.20.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
**Describe the pull request**
> Tree-sitter is a parser generator tool and an incremental parsing library. It can build a concrete syntax tree for a source file and efficiently update the syntax tree as the source file is edited.

https://github.com/tree-sitter/tree-sitter

- #### What does your PR fix?
New port

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
Maybe wait until this PR is addressed by the maintainers? - https://github.com/tree-sitter/tree-sitter/pull/1749