### PR TITLE
[tree-sitter], [tree-sitter-c], and [tree-sitter-json] New ports

### DIFF
--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            "SamuelMarks/${PORT}"
+    REF             bf97c9482e90af607ff76346e14d4626aba0f1f9
+    SHA512          779f2eb4e57cab5fc26ed272af8e2a0249f4a683c7ee1ca929bacec0f925cd923e2a339423c1975b1c2081639cb9326f6760c163c94af1e4fc5d776712614aa9
+    HEAD_REF        cmake
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTING=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tree-sitter-c/portfile.cmake
+++ b/ports/tree-sitter-c/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             bf97c9482e90af607ff76346e14d4626aba0f1f9
-    SHA512          779f2eb4e57cab5fc26ed272af8e2a0249f4a683c7ee1ca929bacec0f925cd923e2a339423c1975b1c2081639cb9326f6760c163c94af1e4fc5d776712614aa9
+    REF             8aa3dd454aee6a8851b673d212a6954c357d6559
+    SHA512          7d83562f103734c53ca6ec05d3e9b918b4cfce13d965a8b38a0009e0eaa3390d9b98b61ddaae24f49f0d8d7559a609a66c05365761cd2ec1be548780dbfc12e0
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "tree-sitter-c",
+  "version": "0.20.6",
+  "description": "C grammar for tree-sitter. Adapted from a C99 grammar.",
+  "homepage": "https://github.com/tree-sitter/tree-sitter-c",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    "tree-sitter",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/tree-sitter-c/vcpkg.json
+++ b/ports/tree-sitter-c/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-c",
-  "version": "0.20.6",
+  "version": "0.20.1",
   "description": "C grammar for tree-sitter. Adapted from a C99 grammar.",
   "homepage": "https://github.com/tree-sitter/tree-sitter-c",
   "license": "MIT",

--- a/ports/tree-sitter-json/portfile.cmake
+++ b/ports/tree-sitter-json/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            "SamuelMarks/${PORT}"
+    REF             1a95fb5354d96dcdda56303f4ce131dd161375ac
+    SHA512          c16e3d4f43557e4fa40c042f799575a9da3cc0ab0e1f919885d1df18b7f4b8541cb06ac9a02d092177665adc2764b8544551b4329d3ac91e851cd3630297cba0
+    HEAD_REF        cmake
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTING=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tree-sitter-json/portfile.cmake
+++ b/ports/tree-sitter-json/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             d1f4f7e7593cfc5bb02a48d1ec8d27abf5ec5476
-    SHA512          436677932eacd38c7c1e752ea1e1abaab3b2247b05b6c7e0c701427d8015305225f40606a360933bbb7664592078419c93c947b4097cf5be86500a54a9fa0519
+    REF             45a6e5f4ded7b203c880432e73f9b216a04eeaf9
+    SHA512          a233b46535c61b5630cbed088f807b3868323e06757bec28ac2c2ff5d8db12d49625a296839d22c428ab28fc9dae58a5ff189b2e3e550b947948d59bc99037e3
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter-json/portfile.cmake
+++ b/ports/tree-sitter-json/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             a67fcad08d644588aaf2312fa9f6e69db2020f4e
-    SHA512          9876946b9e8e6b6c7db6ee098148d7fc06d4de30994d62ee958d0ebfca0d809f5d198d031d4ebe2c17bf583e9606d0cf28764322b023557746d54a4b060aea4e
+    REF             1b94a87adac6be20fa2997a40da659fe7ebdf1d0
+    SHA512          1cfacd0b763c8168c308ee2d6150e881add03d0e42d82f14f9a730900acb3ba55a7ac508509b4cf8f2d0130d2fc2254b95a9c6f81c75fd7d18d73217413ca709
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter-json/portfile.cmake
+++ b/ports/tree-sitter-json/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             1b94a87adac6be20fa2997a40da659fe7ebdf1d0
-    SHA512          1cfacd0b763c8168c308ee2d6150e881add03d0e42d82f14f9a730900acb3ba55a7ac508509b4cf8f2d0130d2fc2254b95a9c6f81c75fd7d18d73217413ca709
+    REF             d1f4f7e7593cfc5bb02a48d1ec8d27abf5ec5476
+    SHA512          436677932eacd38c7c1e752ea1e1abaab3b2247b05b6c7e0c701427d8015305225f40606a360933bbb7664592078419c93c947b4097cf5be86500a54a9fa0519
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter-json/portfile.cmake
+++ b/ports/tree-sitter-json/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             1a95fb5354d96dcdda56303f4ce131dd161375ac
-    SHA512          c16e3d4f43557e4fa40c042f799575a9da3cc0ab0e1f919885d1df18b7f4b8541cb06ac9a02d092177665adc2764b8544551b4329d3ac91e851cd3630297cba0
+    REF             a67fcad08d644588aaf2312fa9f6e69db2020f4e
+    SHA512          9876946b9e8e6b6c7db6ee098148d7fc06d4de30994d62ee958d0ebfca0d809f5d198d031d4ebe2c17bf583e9606d0cf28764322b023557746d54a4b060aea4e
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter-json/vcpkg.json
+++ b/ports/tree-sitter-json/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "tree-sitter-json",
+  "version": "0.20.0",
+  "description": "Tree-sitter is a parser generator tool and an incremental parsing library. This is its official JSON grammar.",
+  "homepage": "https://github.com/tree-sitter/tree-sitter-json",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             95773160c418a44449e1bd03e4c0aeae9e67cd11
-    SHA512          0946d9b02e0640293cf3d452843dbf1a2477e849a4b4f83c80fedf41e81c0c763b65762c998fc1171302f86a1ea7ec6ba18e64b424bacd1448c2bb43e3c145e2
+    REF             af293c7765d41836b0f55cae181c39199c36b9ff
+    SHA512          0a5b84ec31c9c40a2ce6ce5adecb38f3f5faeae6d8aa3266b115b8340af6117201a81aa75b10f3e0bc765222b2b34837b116477d7af7cce01edcf3cc25502fbf
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO            "SamuelMarks/${PORT}"
-    REF             982cdce15b88e41b1f6938cc0e103b0e7a3cc830
-    SHA512          f427f9ac2e7e7722819d7e4fd36d111b7fd745dac9d934a2fec46c87a98e45708143dd93460dcf12d120b168a0bb24ef6d7e1e06e5666e7028a9f825c5d52f63
+    REF             95773160c418a44449e1bd03e4c0aeae9e67cd11
+    SHA512          0946d9b02e0640293cf3d452843dbf1a2477e849a4b4f83c80fedf41e81c0c763b65762c998fc1171302f86a1ea7ec6ba18e64b424bacd1448c2bb43e3c145e2
     HEAD_REF        cmake
 )
 

--- a/ports/tree-sitter/portfile.cmake
+++ b/ports/tree-sitter/portfile.cmake
@@ -1,0 +1,19 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO            "SamuelMarks/${PORT}"
+    REF             982cdce15b88e41b1f6938cc0e103b0e7a3cc830
+    SHA512          f427f9ac2e7e7722819d7e4fd36d111b7fd745dac9d934a2fec46c87a98e45708143dd93460dcf12d120b168a0bb24ef6d7e1e06e5666e7028a9f825c5d52f63
+    HEAD_REF        cmake
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DBUILD_TESTING=OFF"
+)
+vcpkg_cmake_install()
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/tree-sitter/vcpkg.json
+++ b/ports/tree-sitter/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "tree-sitter",
+  "version": "0.20.6",
+  "description": "Tree-sitter is a parser generator tool and an incremental parsing library.",
+  "homepage": "https://github.com/tree-sitter/tree-sitter",
+  "license": "MIT",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7137,7 +7137,7 @@
       "port-version": 0
     },
     "tree-sitter-c": {
-      "baseline": "0.20.6",
+      "baseline": "0.20.1",
       "port-version": 0
     },
     "treehh": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7136,6 +7136,10 @@
       "baseline": "0.20.6",
       "port-version": 0
     },
+    "tree-sitter-json": {
+      "baseline": "0.20.0",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7136,6 +7136,10 @@
       "baseline": "0.20.6",
       "port-version": 0
     },
+    "tree-sitter-c": {
+      "baseline": "0.20.6",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7132,6 +7132,10 @@
       "baseline": "0.8.0",
       "port-version": 3
     },
+    "tree-sitter": {
+      "baseline": "0.20.6",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.16",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7140,6 +7140,10 @@
       "baseline": "0.20.1",
       "port-version": 0
     },
+    "tree-sitter-json": {
+      "baseline": "0.20.0",
+      "port-version": 0
+    },
     "treehh": {
       "baseline": "3.16",
       "port-version": 0

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "c08b241cdad1f83cfa75e3d5439fbcbb3095b4dd",
-      "version": "0.20.6",
+      "git-tree": "cd78439ea806a9f6b9e3b19309d5a5a5a6bf7433",
+      "version": "0.20.1",
       "port-version": 0
     }
   ]

--- a/versions/t-/tree-sitter-c.json
+++ b/versions/t-/tree-sitter-c.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "c08b241cdad1f83cfa75e3d5439fbcbb3095b4dd",
+      "version": "0.20.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tree-sitter-json.json
+++ b/versions/t-/tree-sitter-json.json
@@ -1,11 +1,7 @@
 {
   "versions": [
     {
-<<<<<<< HEAD
-      "git-tree": "1f3bc35d62fb3b38a92d0af91308a519fbe13b02",
-=======
       "git-tree": "d4ef005b096c5fed908061b43a59798e6f616295",
->>>>>>> tree-sitter-json
       "version": "0.20.0",
       "port-version": 0
     }

--- a/versions/t-/tree-sitter-json.json
+++ b/versions/t-/tree-sitter-json.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d4ef005b096c5fed908061b43a59798e6f616295",
+      "git-tree": "9166072a6a733d922943e0cd8b8652983790ec91",
       "version": "0.20.0",
       "port-version": 0
     }

--- a/versions/t-/tree-sitter-json.json
+++ b/versions/t-/tree-sitter-json.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "d4ef005b096c5fed908061b43a59798e6f616295",
+      "version": "0.20.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tree-sitter-json.json
+++ b/versions/t-/tree-sitter-json.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b089e9213ec9d214553459b8c9cb01f1bd2610d6",
+      "git-tree": "8c104569195f99958382a497995f1373259faac4",
       "version": "0.20.0",
       "port-version": 0
     }

--- a/versions/t-/tree-sitter-json.json
+++ b/versions/t-/tree-sitter-json.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9166072a6a733d922943e0cd8b8652983790ec91",
+      "git-tree": "b089e9213ec9d214553459b8c9cb01f1bd2610d6",
       "version": "0.20.0",
       "port-version": 0
     }

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e0c013b5db92f0df1ec09c96935b0196ddd173be",
+      "git-tree": "dea8b9fc4bad441e93c2e7e86577e0ef4295ab8b",
       "version": "0.20.6",
       "port-version": 0
     }

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "e0c013b5db92f0df1ec09c96935b0196ddd173be",
+      "version": "0.20.6",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/t-/tree-sitter.json
+++ b/versions/t-/tree-sitter.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "dea8b9fc4bad441e93c2e7e86577e0ef4295ab8b",
+      "git-tree": "6d1433f352dc88499b5f1ced4ca12f5549385449",
       "version": "0.20.6",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**
> Tree-sitter is a parser generator tool and an incremental parsing library. It can build a concrete syntax tree for a source file and efficiently update the syntax tree as the source file is edited.

https://github.com/tree-sitter/tree-sitter

This port is for the C grammar:
> C grammar for tree-sitter. Adapted from a C99 grammar.

https://github.com/tree-sitter/tree-sitter-c

This port is for JSON grammar:
> JSON grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter)

https://github.com/tree-sitter/tree-sitter-json

- #### What does your PR fix?
New ports

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
Maybe wait until these PRs are addressed by the maintainers?
  - https://github.com/tree-sitter/tree-sitter/pull/1749
  - https://github.com/tree-sitter/tree-sitter-c/pull/102
  - https://github.com/tree-sitter/tree-sitter-json/pull/25