### PR TITLE
[direcxtmath] port updated for May 2022 release

### DIFF
--- a/ports/directxmath/portfile.cmake
+++ b/ports/directxmath/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXMath
-    REF jan2022
-    SHA512 8defaa693c8b8aed05791c83b99fa73aac2fc18475b0d51337a81f7d9807b53e426fdf530ed6f1d2d0ebd259e87cc42ac881bdb168387d883998f58a5c0a4886
+    REF may2022
+    SHA512 685e5a0cdd1bc66a5df628f864eae0959d5d5abdcc7e9242ea7af1d5b011cb0705447c366bacd456db96e39dac8cf0e0618a6e055a7db821cdcfa20a1ad08868
     HEAD_REF main
 )
 
@@ -11,7 +11,7 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxmath/cmake)
 
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     vcpkg_download_distfile(

--- a/ports/directxmath/vcpkg.json
+++ b/ports/directxmath/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxmath",
-  "version-date": "2022-01-18",
+  "version-date": "2022-05-18",
   "description": "DirectXMath SIMD C++ math library",
   "homepage": "https://github.com/Microsoft/DirectXMath",
   "documentation": "https://docs.microsoft.com/windows/win32/dxmath/directxmath-portal",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1865,7 +1865,7 @@
       "port-version": 0
     },
     "directxmath": {
-      "baseline": "2022-01-18",
+      "baseline": "2022-05-18",
       "port-version": 0
     },
     "directxmesh": {

--- a/versions/d-/directxmath.json
+++ b/versions/d-/directxmath.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "383135431007008f6d04e2cfbe55988b06054f15",
+      "version-date": "2022-05-18",
+      "port-version": 0
+    },
+    {
       "git-tree": "ebf69755284c5ea16a26b4dbfa4534af962c96a0",
       "version-date": "2022-01-18",
       "port-version": 0


### PR DESCRIPTION
DirectXMath 3.17b has a few hot-fixes applied:

* Hot-fix to address ``-Wreserved-identifier`` warnings with clang v13
* C++20 spaceship operators for XMFLOAT2, XMFLOAT3, etc. when building with ``/std:c++20 /Zc:_cplusplus``

> The upstream CMakeLists.txt was also updated to make use of the standard GNUInstallDirs.