### PR TITLE
use ninja --version instead of ninja -v

### DIFF
--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -381,7 +381,7 @@ function(vcpkg_configure_cmake)
 
         message(STATUS "${configuring_message}")
         vcpkg_execute_required_process(
-            COMMAND "${NINJA}" -v
+            COMMAND "${NINJA}" --version
             WORKING_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/vcpkg-parallel-configure"
             LOGNAME "${arg_LOGNAME}"
         )


### PR DESCRIPTION
**Describe the pull request**

When mingw is on the path,  `ninja` accepts `--version` as a command-line argument, but it doesn't accept `-v`. This is the actual issue:
https://github.com/ninja-build/ninja/issues/1463

```
> ninja -v                                        
ninja: error: loading 'build.ninja': The system cannot find the file specified.

> ninja --version 
1.10.2
```

Based on the source code, `-v` means `--verbose` for ninja. 
https://github.com/ninja-build/ninja/blob/7905dee5ac62f7a1e0dfec4d936b97d96c7566d7/src/ninja.cc#L223

I think wherever `ninja -v` is called should be replaced with `ninja --version`. 

- #### What does your PR fix?
  Fixes #17110 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
