### PR TITLE
[linmath] add new port 

### DIFF
--- a/ports/linmath/portfile.cmake
+++ b/ports/linmath/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO datenwolf/linmath.h
-    REF refs/heads/master
+    REF refs/heads/master/0538757
     SHA512 d32276efb6c0065bfb79dee3a3f624369c64e2ce4e5265e371be4c21e779a6dbf2a2e7ecfad1530cb70ad0d3ac8982faca330622df6d9ed13ce548e7e91f8de7
     HEAD_REF master
 )

--- a/ports/linmath/portfile.cmake
+++ b/ports/linmath/portfile.cmake
@@ -1,0 +1,13 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO datenwolf/linmath.h
+    REF refs/heads/master
+    SHA512 d32276efb6c0065bfb79dee3a3f624369c64e2ce4e5265e371be4c21e779a6dbf2a2e7ecfad1530cb70ad0d3ac8982faca330622df6d9ed13ce548e7e91f8de7
+    HEAD_REF master
+)
+
+# This is a header only library
+file(INSTALL "${SOURCE_PATH}/linmath.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/linmath.h")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENCE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")

--- a/ports/linmath/vcpkg.json
+++ b/ports/linmath/vcpkg.json
@@ -1,8 +1,7 @@
 {
-    "name": "linmath",
-    "version-date": "2021-01-06",
-    "description": "linmath.h -- A small library for linear math as required for computer graphics",
-    "homepage": "https://github.com/datenwolf/linmath.h",
-    "license": "WTFPL"
+  "name": "linmath",
+  "version-date": "2021-01-06",
+  "description": "linmath.h -- A small library for linear math as required for computer graphics",
+  "homepage": "https://github.com/datenwolf/linmath.h",
+  "license": "WTFPL"
 }
-    

--- a/ports/linmath/vcpkg.json
+++ b/ports/linmath/vcpkg.json
@@ -1,0 +1,8 @@
+{
+    "name": "linmath",
+    "version-date": "2021-01-06",
+    "description": "linmath.h -- A small library for linear math as required for computer graphics",
+    "homepage": "https://github.com/datenwolf/linmath.h",
+    "license": "WTFPL"
+}
+    

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4248,6 +4248,10 @@
       "baseline": "4754bee2d8eb3",
       "port-version": 2
     },
+    "linmath": {
+      "baseline": "2021-01-06",
+      "port-version": 0
+    },
     "lionkor-commandline": {
       "baseline": "2.0.0",
       "port-version": 0

--- a/versions/l-/linmath.json
+++ b/versions/l-/linmath.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "83f2687d6e3e0cac217ddbe58d4ea45ffe066d4c",
+      "version-date": "2021-01-06",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/l-/linmath.json
+++ b/versions/l-/linmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "83f2687d6e3e0cac217ddbe58d4ea45ffe066d4c",
+      "git-tree": "a46b16698c80681b80fb680ae8499c0526ad9897",
       "version-date": "2021-01-06",
       "port-version": 0
     }

--- a/versions/l-/linmath.json
+++ b/versions/l-/linmath.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a46b16698c80681b80fb680ae8499c0526ad9897",
+      "git-tree": "5537781d527f17580ea9cb6dc80ba8c664654bc3",
       "version-date": "2021-01-06",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**
 add port for linmath.h
- #### What does your PR fix?
  Fixes #...
It make the header only library linmath.h available via vcpkg
- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>
No
- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 Yes I believe so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
It is a new port with only one version so no update is required.

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
It is complete.

Fixes https://github.com/microsoft/vcpkg/issues/24657