### PR TITLE
[zlib] extract the license from the README file

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -44,4 +44,7 @@ vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/README" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(READ "${SOURCE_PATH}/README" README_DATA)
+string(REGEX MATCHALL "Copyright notice:.*" COPYRIGHT_INFO ${README_DATA})
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" ${COPYRIGHT_INFO})

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zlib",
   "version": "1.2.12",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A compression library",
   "homepage": "https://www.zlib.net/",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7738,7 +7738,7 @@
     },
     "zlib": {
       "baseline": "1.2.12",
-      "port-version": 1
+      "port-version": 2
     },
     "zlib-ng": {
       "baseline": "2.0.6",

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7f4174a1a81f70ad53f148ad2733987dbc0f5cc1",
+      "version": "1.2.12",
+      "port-version": 2
+    },
+    {
       "git-tree": "ecc4c064d4911faf12d8bf5fd6bcd5c556d89774",
       "version": "1.2.12",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?

The zlib build currently creates a copyright file with a bunch of extra non-license text. This PR changes this so that only the license text appears in the output copyright file.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
All.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes.