### PR TITLE
[quill] Update to 2.0.0

### DIFF
--- a/ports/quill/portfile.cmake
+++ b/ports/quill/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO odygrd/quill
-    REF v1.7.2
-    SHA512 ea9671cab8a4cf641c413933bd7fb4f3b1f823ca1b17260b3217b13aff22513b4939ff722d74beada1730d47dca70858835733418593ed2df8abf5c1dea0b202
+    REF v2.0.0
+    SHA512 fed4362fcf32b20beeb44d1421fb58505f5fd0880518abc7c19e645beff9a1e2f83d79273404cd2c297a51c27555ce5fbd3bf96cc657268c7645b68e062e8c59
     HEAD_REF master
 )
 
@@ -16,6 +16,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/quill)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/quill/bundled")
 
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
     file(RENAME "${CURRENT_PACKAGES_DIR}/debug/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")

--- a/ports/quill/vcpkg.json
+++ b/ports/quill/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "1.7.2",
+  "version": "2.0.0",
   "description": "C++14 Asynchronous Low Latency Logging Library",
   "homepage": "https://github.com/odygrd/quill/",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6049,7 +6049,7 @@
       "port-version": 7
     },
     "quill": {
-      "baseline": "1.7.2",
+      "baseline": "2.0.0",
       "port-version": 0
     },
     "quirc": {

--- a/versions/q-/quill.json
+++ b/versions/q-/quill.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fb911c05f1ad501f9b87ea3918d4badef41d16e4",
+      "version": "2.0.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "d663be1266a5e973411f7bf422d3b901609098e8",
       "version": "1.7.2",
       "port-version": 0


### PR DESCRIPTION
Update quill from 1.7.2 to 2.0.0.
Changelogs :
https://github.com/odygrd/quill/releases/tag/v1.7.3
https://github.com/odygrd/quill/releases/tag/v2.0.0