### PR TITLE
[libproxy, nspr] Fix cmake warnings

### DIFF
--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -33,6 +33,12 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS ${FEATURE_OPTIONS}
         -DWITH_WEBKIT3=OFF
+    MAYBE_UNUSED_VARIABLES
+        WITH_DOTNET
+        WITH_PERL
+        WITH_PYTHON2
+        WITH_PYTHON3
+        WITH_VALA
 )
 
 vcpkg_cmake_install()

--- a/ports/libproxy/portfile.cmake
+++ b/ports/libproxy/portfile.cmake
@@ -38,12 +38,11 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(CONFIG_PATH share/cmake/Modules)
 vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake"
           "${CMAKE_CURRENT_LIST_DIR}/usage"
           DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(REMOVE_RECURSE "${LIBPROXY_TOOLS}" "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
-
-vcpkg_fixup_pkgconfig()

--- a/ports/libproxy/vcpkg.json
+++ b/ports/libproxy/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libproxy",
   "version": "0.4.17",
-  "port-version": 2,
+  "port-version": 3,
   "description": "libproxy is a library that provides automatic proxy configuration management.",
   "homepage": "https://github.com/libproxy/libproxy",
+  "license": "LGPL-2.1-only",
   "supports": "!uwp",
   "dependencies": [
     "libmodman",

--- a/ports/nspr/portfile.cmake
+++ b/ports/nspr/portfile.cmake
@@ -52,7 +52,7 @@ vcpkg_configure_make(
     OPTIONS ${OPTIONS}
     OPTIONS_DEBUG ${OPTIONS_DEBUG}
     OPTIONS_RELEASE ${OPTIONS_RELEASE}
-    DISABLE_VERBOSE_FLAGS true
+    DISABLE_VERBOSE_FLAGS
 )
 vcpkg_install_make()
 vcpkg_copy_pdbs()
@@ -97,4 +97,4 @@ if(NOT VCPKG_BUILD_TYPE)
 endif()
 
 # Copy license
-file(INSTALL "${SOURCE_PATH}/nspr/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/nspr" RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/nspr/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nspr/vcpkg.json
+++ b/ports/nspr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "nspr",
   "version": "4.33",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Netscape portable runtime",
   "homepage": "https://releases.mozilla.org/pub/nspr/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3918,7 +3918,7 @@
     },
     "libproxy": {
       "baseline": "0.4.17",
-      "port-version": 2
+      "port-version": 3
     },
     "libqcow": {
       "baseline": "20210419",
@@ -4902,7 +4902,7 @@
     },
     "nspr": {
       "baseline": "4.33",
-      "port-version": 1
+      "port-version": 2
     },
     "nss": {
       "baseline": "3.77",

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "ec50f0bd41677a8fae1ee7ffa0097063eaed6c52",
+      "version": "0.4.17",
+      "port-version": 3
+    },
+    {
       "git-tree": "a44c6a0f0d04d6ea82c7a29c879dfd13cadb38ca",
       "version": "0.4.17",
       "port-version": 2

--- a/versions/l-/libproxy.json
+++ b/versions/l-/libproxy.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ec50f0bd41677a8fae1ee7ffa0097063eaed6c52",
+      "git-tree": "ff241fdc3665ad4d1dce051fcdd8ee8dc8617c86",
       "version": "0.4.17",
       "port-version": 3
     },

--- a/versions/n-/nspr.json
+++ b/versions/n-/nspr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a07f5ffc6f4bd4a9154a599898fbac38115c8124",
+      "version": "4.33",
+      "port-version": 2
+    },
+    {
       "git-tree": "efd7b94673495b09ee48d1c2a4453f70c5e0bb7c",
       "version": "4.33",
       "port-version": 1


### PR DESCRIPTION
`libproxy`: Remove unused variable
`nspr`: Remove unparsed variable from `vcpkg_configure_make` call