### PR TITLE
[nss] Version bump to 3.78

### DIFF
--- a/ports/nss/portfile.cmake
+++ b/ports/nss/portfile.cmake
@@ -1,10 +1,10 @@
-set(NSS_VERSION "3.77")
+set(NSS_VERSION "3.78")
 string(REPLACE "." "_" V_URL ${NSS_VERSION})
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.mozilla.org/pub/security/nss/releases/NSS_${V_URL}_RTM/src/nss-${NSS_VERSION}.tar.gz"
     FILENAME "nss-${NSS_VERSION}.tar.gz"
-    SHA512 bd62eeb8f90ecd2d3999fd78fea6652736c02a6530f29e98d0cad0707f3b901b30409132eb6a6d53b9f5c05c6b464615a946a2a3e255553c793e44d0ed93179e
+    SHA512 ab54d838f41f963fdd4b87477b1e769186ae1f138f7c5d764cd6873be4791146d14dcc85697a2ca92e08f3bfcbeb61d64e26e7b5398095272c18a8196d43ac6c
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/nss/vcpkg.json
+++ b/ports/nss/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "nss",
-  "version": "3.77",
+  "version": "3.78",
   "description": "Network Security Services from Mozilla",
   "homepage": "https://ftp.mozilla.org/pub/security/nss/releases/",
   "license": "MPL-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4905,7 +4905,7 @@
       "port-version": 1
     },
     "nss": {
-      "baseline": "3.77",
+      "baseline": "3.78",
       "port-version": 0
     },
     "nsync": {

--- a/versions/n-/nss.json
+++ b/versions/n-/nss.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6256143502011312dc467a9c57f0955617fee6d3",
+      "version": "3.78",
+      "port-version": 0
+    },
+    {
       "git-tree": "06e7680df336bb6be816c75e42c6304d11566a3d",
       "version": "3.77",
       "port-version": 0


### PR DESCRIPTION
NSS 3.78 was released:
https://groups.google.com/a/mozilla.org/g/dev-tech-crypto/c/hQUjX_jwbEk