### PR TITLE
[spdlog] fix wchar support

### DIFF
--- a/ports/spdlog/portfile.cmake
+++ b/ports/spdlog/portfile.cmake
@@ -12,14 +12,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         wchar     SPDLOG_WCHAR_SUPPORT
 )
 
-# configured in triplet file
+# SPDLOG_WCHAR_FILENAMES can only be configured in triplet file since it is an alternative (not additive)
 if(NOT DEFINED SPDLOG_WCHAR_FILENAMES)
     set(SPDLOG_WCHAR_FILENAMES OFF)
 endif()
 if(NOT VCPKG_TARGET_IS_WINDOWS)
     if("wchar" IN_LIST FEATURES)
         message(WARNING "Feature 'wchar' is only supported for Windows and has no effect on other platforms.")
-    elseif(SPDLOG_WCHAR_FILENAMES) 
+    elseif(SPDLOG_WCHAR_FILENAMES)
         message(FATAL_ERROR "Build option 'SPDLOG_WCHAR_FILENAMES' is for Windows.")
     endif()
 endif()
@@ -45,10 +45,23 @@ vcpkg_copy_pdbs()
 # use vcpkg-provided fmt library (see also option SPDLOG_FMT_EXTERNAL above)
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/include/spdlog/fmt/bundled)
 
+# add support for integration other than cmake
 vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
     "// #define SPDLOG_FMT_EXTERNAL"
-    "#define SPDLOG_FMT_EXTERNAL"
+    "#ifndef SPDLOG_FMT_EXTERNAL\n#define SPDLOG_FMT_EXTERNAL\n#endif"
 )
+if(SPDLOG_WCHAR_SUPPORT)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
+        "// #define SPDLOG_WCHAR_TO_UTF8_SUPPORT"
+        "#ifndef SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#define SPDLOG_WCHAR_TO_UTF8_SUPPORT\n#endif"
+    )
+endif()
+if(SPDLOG_WCHAR_FILENAMES)
+    vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/spdlog/tweakme.h
+        "// #define SPDLOG_WCHAR_FILENAMES"
+        "#ifndef SPDLOG_WCHAR_FILENAMES\n#define SPDLOG_WCHAR_FILENAMES\n#endif"
+    )
+endif()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include
                     ${CURRENT_PACKAGES_DIR}/debug/share)

--- a/ports/spdlog/vcpkg.json
+++ b/ports/spdlog/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "spdlog",
   "version-semver": "1.10.0",
+  "port-version": 1,
   "description": "Very fast, header only, C++ logging library",
   "homepage": "https://github.com/gabime/spdlog",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6690,7 +6690,7 @@
     },
     "spdlog": {
       "baseline": "1.10.0",
-      "port-version": 0
+      "port-version": 1
     },
     "spectra": {
       "baseline": "1.0.1",

--- a/versions/s-/spdlog.json
+++ b/versions/s-/spdlog.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3256ea88cc375fda2f977a2eb18435e23d498572",
+      "version-semver": "1.10.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "1ac795913d88241171b45d796d3fe5dd38519d5a",
       "version-semver": "1.10.0",
       "port-version": 0


### PR DESCRIPTION
#### What does your PR fix?

Errant code/bugs in the `spdlog` port itself

- correct errant vcpkg feature define
- remove vcpkg_replace_string() because it duplicates the defines already in  `vcpkg_cmake_configure()`.
  Such duplication leads to compiler errors+warning of dups/conflicts

#### Which triplets are supported/not supported? Have you updated the [CI baseline]

No change in triplet support.

#### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

yes

#### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

yes