### PR TITLE
fix-freetype-contrib

### DIFF
--- a/ports/opencv4/0016-fix-freetype-contrib.patch
+++ b/ports/opencv4/0016-fix-freetype-contrib.patch
@@ -9,8 +9,8 @@ index 6dd4aaf..e734e97 100644
 -ocv_check_modules(FREETYPE freetype2)
 -ocv_check_modules(HARFBUZZ harfbuzz)
 +if(WITH_FREETYPE)
-+find_package(freetype CONFIG REQUIRED)
-+find_package(harfbuzz CONFIG REQUIRED)
++find_package(Freetype REQUIRED)
++find_package(HARFBUZZ CONFIG REQUIRED)
 +endif()
 
  if(OPENCV_INITIAL_PASS)

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Describe the pull request**

find_package(freetype CONFIG REQUIRED)
variable freetype_FOUND will be set not FREETYPE_FOUND
same as harfbuzz

cmake has predefined FindFreetype.cmake,  find_package(freetype REQUIRED) will set variable FREETYPE_FOUND

- #### What does your PR fix?
  opencv2/freetype.hpp will be available

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  linux, windows
  No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
 yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
