### PR TITLE
Fix opencv freetype contrib

### DIFF
--- a/ports/opencv4/0016-fix-freetype-contrib.patch
+++ b/ports/opencv4/0016-fix-freetype-contrib.patch
@@ -2,16 +2,27 @@ diff --git a/modules/freetype/CMakeLists.txt b/modules/freetype/CMakeLists.txt
 index 6dd4aaf..e734e97 100644
 --- a/modules/freetype/CMakeLists.txt
 +++ b/modules/freetype/CMakeLists.txt
-@@ -3,8 +5,10 @@ if(APPLE_FRAMEWORK)
+@@ -3,8 +3,10 @@ if(APPLE_FRAMEWORK)
    ocv_module_disable(freetype)
  endif()
  
 -ocv_check_modules(FREETYPE freetype2)
 -ocv_check_modules(HARFBUZZ harfbuzz)
 +if(WITH_FREETYPE)
-+find_package(freetype CONFIG REQUIRED)
-+find_package(harfbuzz CONFIG REQUIRED)
++find_package(Freetype REQUIRED)
++find_package(HARFBUZZ CONFIG REQUIRED)
 +endif()
-
+ 
  if(OPENCV_INITIAL_PASS)
    if(NOT FREETYPE_FOUND)
+@@ -22,8 +24,8 @@ endif()
+ 
+ if(FREETYPE_FOUND AND HARFBUZZ_FOUND)
+   ocv_define_module(freetype opencv_core opencv_imgproc WRAP python)
+-  ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})
+-  ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} ${HARFBUZZ_INCLUDE_DIRS} )
++  ocv_target_link_libraries(${the_module} ${FREETYPE_LIBRARIES} harfbuzz harfbuzz::harfbuzz)
++  ocv_include_directories( ${FREETYPE_INCLUDE_DIRS} )
+ else()
+   ocv_module_disable(freetype)
+ endif()

--- a/ports/opencv4/vcpkg.json
+++ b/ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.5",
-  "port-version": 4,
+  "port-version": 5,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5118,7 +5118,7 @@
     },
     "opencv4": {
       "baseline": "4.5.5",
-      "port-version": 4
+      "port-version": 5
     },
     "opendnp3": {
       "baseline": "3.1.1",

--- a/versions/o-/opencv4.json
+++ b/versions/o-/opencv4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "037f184e07b954fa7b0e4cab75fa549fef22015e",
+      "version": "4.5.5",
+      "port-version": 5
+    },
+    {
       "git-tree": "86073388865f7730e42d02768f8963156f2be82f",
       "version": "4.5.5",
       "port-version": 4


### PR DESCRIPTION
**Describe the pull request**
find_package(freetype CONFIG REQUIRED)
variable freetype_FOUND will be set not FREETYPE_FOUND
same as harfbuzz

cmake has predefined FindFreetype.cmake, find_package(freetype REQUIRED) will set variable FREETYPE_FOUND

- #### What does your PR fix?
  opencv2/freetype.hpp will be available

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all
  no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes 

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
