### PR TITLE
[wxwidgets] Fix find dependency pcre2

### DIFF
--- a/ports/wxwidgets/fix-pcre2.patch
+++ b/ports/wxwidgets/fix-pcre2.patch
@@ -1,14 +1,12 @@
 diff --git a/build/cmake/modules/FindPCRE2.cmake b/build/cmake/modules/FindPCRE2.cmake
-index a27693a..1cf7249 100644
+index a27693a..455675a 100644
 --- a/build/cmake/modules/FindPCRE2.cmake
 +++ b/build/cmake/modules/FindPCRE2.cmake
-@@ -23,8 +23,11 @@ set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
- 
+@@ -24,7 +24,10 @@ set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
  
  find_package(PkgConfig QUIET)
--pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
-+pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH} IMPORTED_TARGET)
-+set(PCRE2_LIBRARIES PkgConfig::PC_PCRE2)
+ pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
++set(PCRE2_LIBRARIES ${PC_PCRE2_LINK_LIBRARIES})
 +set(PCRE2_INCLUDE_DIRS ${PC_PCRE2_INCLUDE_DIRS})
  
 +if (0)

--- a/ports/wxwidgets/fix-pcre2.patch
+++ b/ports/wxwidgets/fix-pcre2.patch
@@ -1,0 +1,23 @@
+diff --git a/build/cmake/modules/FindPCRE2.cmake b/build/cmake/modules/FindPCRE2.cmake
+index a27693a..372244d 100644
+--- a/build/cmake/modules/FindPCRE2.cmake
++++ b/build/cmake/modules/FindPCRE2.cmake
+@@ -31,13 +31,12 @@ find_path(PCRE2_INCLUDE_DIRS
+           ${PC_PCRE2_INCLUDE_DIRS}
+ )
+ 
+-find_library(PCRE2_LIBRARIES
+-    NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH}
+-    HINTS ${PC_PCRE2_LIBDIR}
+-          ${PC_PCRE2_LIBRARY_DIRS}
+-)
+-
+ include(FindPackageHandleStandardArgs)
++include(SelectLibraryConfigurations)
++find_library(PCRE2_LIBRARY_DEBUG NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH}d PATH_SUFFIXES lib REQUIRED)
++find_library(PCRE2_LIBRARY_RELEASE NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH} PATH_SUFFIXES debug/lib REQUIRED)
++select_library_configurations(PCRE2)
++
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 REQUIRED_VARS PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS VERSION_VAR PC_PCRE2_VERSION)
+ 
+ mark_as_advanced(PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)

--- a/ports/wxwidgets/fix-pcre2.patch
+++ b/ports/wxwidgets/fix-pcre2.patch
@@ -1,23 +1,25 @@
 diff --git a/build/cmake/modules/FindPCRE2.cmake b/build/cmake/modules/FindPCRE2.cmake
-index a27693a..372244d 100644
+index a27693a..1cf7249 100644
 --- a/build/cmake/modules/FindPCRE2.cmake
 +++ b/build/cmake/modules/FindPCRE2.cmake
-@@ -31,13 +31,12 @@ find_path(PCRE2_INCLUDE_DIRS
-           ${PC_PCRE2_INCLUDE_DIRS}
+@@ -23,8 +23,11 @@ set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
+ 
+ 
+ find_package(PkgConfig QUIET)
+-pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
++pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH} IMPORTED_TARGET)
++set(PCRE2_LIBRARIES PkgConfig::PC_PCRE2)
++set(PCRE2_INCLUDE_DIRS ${PC_PCRE2_INCLUDE_DIRS})
+ 
++if (0)
+ find_path(PCRE2_INCLUDE_DIRS
+     NAMES pcre2.h
+     HINTS ${PC_PCRE2_INCLUDEDIR}
+@@ -36,6 +39,7 @@ find_library(PCRE2_LIBRARIES
+     HINTS ${PC_PCRE2_LIBDIR}
+           ${PC_PCRE2_LIBRARY_DIRS}
  )
++endif()
  
--find_library(PCRE2_LIBRARIES
--    NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH}
--    HINTS ${PC_PCRE2_LIBDIR}
--          ${PC_PCRE2_LIBRARY_DIRS}
--)
--
  include(FindPackageHandleStandardArgs)
-+include(SelectLibraryConfigurations)
-+find_library(PCRE2_LIBRARY_DEBUG NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH}d PATH_SUFFIXES lib REQUIRED)
-+find_library(PCRE2_LIBRARY_RELEASE NAMES pcre2-${PCRE2_CODE_UNIT_WIDTH} PATH_SUFFIXES debug/lib REQUIRED)
-+select_library_configurations(PCRE2)
-+
  FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 REQUIRED_VARS PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS VERSION_VAR PC_PCRE2_VERSION)
- 
- mark_as_advanced(PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS)

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -36,6 +36,8 @@ vcpkg_check_features(
         sound   wxUSE_SOUND
 )
 
+vcpkg_find_acquire_program(PKGCONFIG)
+
 set(OPTIONS "")
 if(VCPKG_TARGET_IS_OSX)
     list(APPEND OPTIONS -DCOTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES=9999)
@@ -91,6 +93,10 @@ vcpkg_cmake_configure(
         -DwxUSE_STL=${WXWIDGETS_USE_STL}
         -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}
         ${OPTIONS}
+        -DPKG_CONFIG_EXECUTABLE="${PKGCONFIG}"
+        # The minimum cmake version requirement for Cotire is 2.8.12.
+        # however, we need to declare that the minimum cmake version requirement is at least 3.1 to use CMAKE_PREFIX_PATH as the path to find .pc.
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
         relocatable-wx-config.patch
         nanosvg-ext-depend.patch
         fix-libs-export.patch
+        fix-pcre2.patch
 )
 
 if(VCPKG_TARGET_IS_LINUX)

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -89,6 +89,7 @@ vcpkg_cmake_configure(
         -DwxUSE_LIBJPEG=sys
         -DwxUSE_LIBPNG=sys
         -DwxUSE_LIBTIFF=sys
+        -DwxUSE_SECRETSTORE=FALSE
         -DwxBUILD_DISABLE_PLATFORM_LIB_DIR=ON
         -DwxUSE_STL=${WXWIDGETS_USE_STL}
         -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -93,7 +93,7 @@ vcpkg_cmake_configure(
         -DwxUSE_STL=${WXWIDGETS_USE_STL}
         -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}
         ${OPTIONS}
-        -DPKG_CONFIG_EXECUTABLE="${PKGCONFIG}"
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
         # The minimum cmake version requirement for Cotire is 2.8.12.
         # however, we need to declare that the minimum cmake version requirement is at least 3.1 to use CMAKE_PREFIX_PATH as the path to find .pc.
         -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.1.6",
+  "port-version": 1,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7574,7 +7574,7 @@
     },
     "wxwidgets": {
       "baseline": "3.1.6",
-      "port-version": 0
+      "port-version": 1
     },
     "x-plane": {
       "baseline": "3.0.3",

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2fe6947f4745ce09aec0e33a43015ba40b94c675",
+      "git-tree": "68874302dce3aa7f5b3b45ae247eb9f73e7ba9d1",
       "version": "3.1.6",
       "port-version": 1
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "68874302dce3aa7f5b3b45ae247eb9f73e7ba9d1",
+      "git-tree": "793b49ce7710b440be0a451354614e282e6fc9fa",
       "version": "3.1.6",
       "port-version": 1
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "ac8fb83817b220e00ed82c5daebf9fa8e8d28fd3",
+      "git-tree": "2fe6947f4745ce09aec0e33a43015ba40b94c675",
       "version": "3.1.6",
       "port-version": 1
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7087fa9a8b503b33dd013078e15e31c466c13e8e",
+      "git-tree": "ac8fb83817b220e00ed82c5daebf9fa8e8d28fd3",
       "version": "3.1.6",
       "port-version": 1
     },

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7087fa9a8b503b33dd013078e15e31c466c13e8e",
+      "version": "3.1.6",
+      "port-version": 1
+    },
+    {
       "git-tree": "16d9f0aabf4f0df68bebd7b42ff6005d952f9392",
       "version": "3.1.6",
       "port-version": 0


### PR DESCRIPTION
Currently, only the release version of the dependency pcre2 is found during the configuration of wxwidgets, fix this.

Fixes #24851.