### PR TITLE
[libzippp] Update to libzippp 5.1-1.8.0

### DIFF
--- a/ports/libzippp/portfile.cmake
+++ b/ports/libzippp/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ctabin/libzippp
-    REF 0e907d7ef8de46822602cb7633a5bc6fc0cc36de #v5.0-1.8.0 with CXX std version c++11
-    SHA512 f91724b0225bddcaf705e7e1493ad415b534096cfe3636d50995245982984e7420148206f4e24d72e596d75eac570d7b512c5aa836eaf4a8951e27737bcee9eb
+    REF 4248d7bf200e00b637cbd394c2b2369891de4e30 #v5.1-1.8.0 with CXX std version c++11
+    SHA512 171010da61ab4893648ceef80009925e7b79294008de220fe132c42843cb939e454812c0e70de29dfb0318e6bf11c7924a31da52f7703c523ab95c68ba61051a
     HEAD_REF master
     PATCHES fix-find-lzma.patch
 )
@@ -12,9 +12,8 @@ vcpkg_check_features(
         FEATURES    
         encryption LIBZIPPP_ENABLE_ENCRYPTION)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
         -DLIBZIPPP_BUILD_TESTS=OFF
@@ -22,16 +21,16 @@ vcpkg_configure_cmake(
         -DLIBZIPPP_INSTALL_HEADERS=OFF
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake/libzippp")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "cmake/libzippp")
 else()
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "share/libzippp")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "share/libzippp")
 endif()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Handle copyright
 file(INSTALL ${SOURCE_PATH}/LICENCE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/libzippp/vcpkg.json
+++ b/ports/libzippp/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libzippp",
-  "version-string": "5.0-1.8.0",
-  "port-version": 1,
+  "version": "5.1-1.8.0",
   "description": "Simple basic C++ wrapper around the libzip library. It is meant to be a portable and easy-to-use library for ZIP handling",
   "homepage": "https://github.com/ctabin/libzippp",
   "dependencies": [
@@ -11,6 +10,14 @@
       "features": [
         "bzip2"
       ]
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     },
     "zlib"
   ],

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4229,8 +4229,8 @@
       "port-version": 0
     },
     "libzippp": {
-      "baseline": "5.0-1.8.0",
-      "port-version": 1
+      "baseline": "5.1-1.8.0",
+      "port-version": 0
     },
     "licensepp": {
       "baseline": "2020-05-19",

--- a/versions/l-/libzippp.json
+++ b/versions/l-/libzippp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e5a10e0beabc7b9a1f9f313e62a1c73833e1c4f",
+      "version": "5.1-1.8.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "40f7e8d02ea29cb28b5c0c19257aebf97def3f8e",
       "version-string": "5.0-1.8.0",
       "port-version": 1


### PR DESCRIPTION
Upgrade to the latest [version](https://github.com/ctabin/libzippp/releases/tag/libzippp-v5.1-1.8.0) of libzippp.