### PR TITLE
[dxut, effects11] ports updated for May 2022 releases

### DIFF
--- a/ports/dxut/portfile.cmake
+++ b/ports/dxut/portfile.cmake
@@ -3,18 +3,17 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/DXUT
-    REF jun2021
-    SHA512 4c95cefcf685e95b26677d0aba3d118df7860e3bf1b99b567013d326f890a3f67657be2c60677d3d996cccacce30f70d0c2fc60a692372053cce50318fa79a70
-    HEAD_REF master
+    REF may2022
+    SHA512 ea8ba759666acb4520c2dc1754e937433a1c54f1c83fe15396c573a6513d9b3fd49d1712eae9fc42fff9cddc4f3a4a759a7fc99377ef9750c6c55813d8c90000
+    HEAD_REF main
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/dxut/cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/dxut/vcpkg.json
+++ b/ports/dxut/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "name": "dxut",
-  "version": "11.26",
-  "port-version": 1,
+  "version": "11.27",
   "description": "A \"GLUT\"-like framework for Direct3D 11.x Win32 desktop applications",
   "homepage": "https://github.com/Microsoft/DXUT",
   "documentation": "https://github.com/microsoft/DXUT/wiki",
   "license": "MIT",
   "supports": "windows & !uwp",
   "dependencies": [
-    "directxmath"
+    "directxmath",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/effects11/portfile.cmake
+++ b/ports/effects11/portfile.cmake
@@ -1,20 +1,19 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO microsoft/FX11
-    REF feb2021
-    SHA512 bdf35347582646e782c20a96180c8286786da46583527b76b2d348cd76a75285a31ebb88297962cd279c09bbd416c15c0d25ae91881ffebbf9e8ce2f21912f16
-    HEAD_REF master
-    FILE_DISAMBIGUATOR 1
+    REF may2022
+    SHA512 e395071430d7e6cd717729846e8d0f44700185597684f722cceb084df2a89b89ef7c04b5dfe948790640134838f409f0a3071e5d74760f8a9fcd74b0840ce78c
+    HEAD_REF main
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
 )
 
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH share/effects11/cmake)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/effects11/vcpkg.json
+++ b/ports/effects11/vcpkg.json
@@ -1,10 +1,19 @@
 {
   "name": "effects11",
-  "version": "11.26",
-  "port-version": 2,
+  "version": "11.27",
   "description": "Effects for Direct3D 11 (FX11) is a management runtime for authoring HLSL shaders, render state, and runtime variables together.",
   "homepage": "https://github.com/Microsoft/FX11",
   "documentation": "https://github.com/microsoft/FX11/wiki",
   "license": "MIT",
-  "supports": "windows"
+  "supports": "windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1985,8 +1985,8 @@
       "port-version": 4
     },
     "dxut": {
-      "baseline": "11.26",
-      "port-version": 1
+      "baseline": "11.27",
+      "port-version": 0
     },
     "eabase": {
       "baseline": "2.09.12",
@@ -2037,8 +2037,8 @@
       "port-version": 1
     },
     "effects11": {
-      "baseline": "11.26",
-      "port-version": 2
+      "baseline": "11.27",
+      "port-version": 0
     },
     "effolkronium-random": {
       "baseline": "1.4.1",

--- a/versions/d-/dxut.json
+++ b/versions/d-/dxut.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5b6c7ea3b64d6446296a16c7ad5f8ebdeb2e9915",
+      "version": "11.27",
+      "port-version": 0
+    },
+    {
       "git-tree": "b8f2fd1c9674e75aee3d139934b3980a47b3d0eb",
       "version": "11.26",
       "port-version": 1

--- a/versions/e-/effects11.json
+++ b/versions/e-/effects11.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8a08f12302be72c15cea701a71122e62f4b7df5a",
+      "version": "11.27",
+      "port-version": 0
+    },
+    {
       "git-tree": "c2c6305e1ca4352d853c035f29d1d7daa3e47444",
       "version": "11.26",
       "port-version": 2


### PR DESCRIPTION
* Upstream changes improve CMake project files, use SDL switch recommendations, and use GNUInstallDirs
* Both ports now build with clang/LLVM via CMake as well as MSVC
* dxut can also build with the MinGW community triplets
* Both ports updated to use vcpkg-cmake, vcpkg-cmake-config