### PR TITLE
[libigl] add cgal support

### DIFF
--- a/ports/libigl/portfile.cmake
+++ b/ports/libigl/portfile.cmake
@@ -19,6 +19,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         #png LIBIGL_WITH_PNG # Disable this feature due to issue https://github.com/libigl/libigl/issues/1199
         xml    LIBIGL_WITH_XML
         #python LIBIGL_WITH_PYTHON # Python binding are in the process of being redone.
+        cgal   LIBIGL_WITH_CGAL
 )
 
 vcpkg_cmake_configure(

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -18,6 +18,12 @@
     }
   ],
   "features": {
+    "cgal": {
+      "description": "Build with cgal",
+      "dependencies": [
+        "cgal"
+      ]
+    },
     "embree": {
       "description": "Build with embree",
       "dependencies": [
@@ -35,12 +41,6 @@
             "opengl"
           ]
         }
-      ]
-    },
-    "cgal": {
-      "description": "Build with cgal",
-      "dependencies": [
-        "cgal"
       ]
     },
     "imgui": {

--- a/ports/libigl/vcpkg.json
+++ b/ports/libigl/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "libigl",
   "version": "2.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "libigl is a simple C++ geometry processing library. We have a wide functionality including construction of sparse discrete differential geometry operators and finite-elements matrices such as the cotangent Laplacian and diagonalized mass matrix, simple facet and edge-based topology data structures, mesh-viewing utilities for OpenGL and GLSL, and many core functions for matrix manipulation which make Eigen feel a lot more like MATLAB.",
   "homepage": "https://github.com/libigl/libigl",
+  "license": "GPL-3.0-only",
   "supports": "!(arm | uwp)",
   "dependencies": [
     "eigen3",
@@ -34,6 +35,12 @@
             "opengl"
           ]
         }
+      ]
+    },
+    "cgal": {
+      "description": "Build with cgal",
+      "dependencies": [
+        "cgal"
       ]
     },
     "imgui": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3678,7 +3678,7 @@
     },
     "libigl": {
       "baseline": "2.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "libilbc": {
       "baseline": "3.0.4",

--- a/versions/l-/libigl.json
+++ b/versions/l-/libigl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3fbdb4cb097785d6b9814e4a4ec89f8530a51c1a",
+      "version": "2.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b4de37a62b3d7349f427f26ad38b8fe1f386d09d",
       "version": "2.3.0",
       "port-version": 1


### PR DESCRIPTION
Fix #19271

Add feature: cgal

All features passed with following triplets:
x86-windows
x64-windows
x64-windows-static