### PR TITLE
[fontconfig] blacklist getopt detection on mingw (microsoft#24841)

### DIFF
--- a/ports/fontconfig/libgetopt.patch
+++ b/ports/fontconfig/libgetopt.patch
@@ -117,10 +117,10 @@ index f616600..6d82a16 100644
    conf.set('HAVE_SOLARIS_ATOMIC_OPS', 1)
  endif
  
-+if (host_machine.system() == 'windows') and (cc.get_id() != 'gcc')
++if (host_machine.system() == 'windows')
 +  conf.set('HAVE_GETOPT', 1)
 +  conf.set('HAVE_GETOPT_LONG', 1)
-+  getopt_dep = cc.find_library('getopt', required: true)
++  getopt_dep = cc.find_library('getopt', required: false)
 +else
 +  getopt_dep = dependency('', required: false)
 +endif

--- a/ports/fontconfig/libgetopt.patch
+++ b/ports/fontconfig/libgetopt.patch
@@ -117,7 +117,7 @@ index f616600..6d82a16 100644
    conf.set('HAVE_SOLARIS_ATOMIC_OPS', 1)
  endif
  
-+if host_machine.system() == 'windows'
++if (host_machine.system() == 'windows') and (cc.get_id() != 'gcc')
 +  conf.set('HAVE_GETOPT', 1)
 +  conf.set('HAVE_GETOPT_LONG', 1)
 +  getopt_dep = cc.find_library('getopt', required: true)

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fontconfig",
   "version": "2.14.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2290,7 +2290,7 @@
     },
     "fontconfig": {
       "baseline": "2.14.0",
-      "port-version": 1
+      "port-version": 2
     },
     "foonathan-memory": {
       "baseline": "2019-07-21",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "414160a25d6072ef5850de479784cc2d2501ce65",
+      "version": "2.14.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "b1b1de99dba230f78c88bb9d73329bed77227ad4",
       "version": "2.14.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #24841

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Triplets unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  I am still working on this PR

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
