### PR TITLE
[qtbase] fix broken `gui` build

### DIFF
--- a/ports/qtbase/portfile.cmake
+++ b/ports/qtbase/portfile.cmake
@@ -73,9 +73,9 @@ FEATURES
     "framework"           FEATURE_framework
     "concurrent"          FEATURE_concurrent
     "concurrent"          FEATURE_future
-    "concurrent"          FEATURE_thread
     "dbus"                FEATURE_dbus
     "gui"                 FEATURE_gui
+    "thread"              FEATURE_thread
     "network"             FEATURE_network
     "sql"                 FEATURE_sql
     "widgets"             FEATURE_widgets

--- a/ports/qtbase/vcpkg.json
+++ b/ports/qtbase/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtbase",
   "version": "6.3.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Qt Application Framework Base Module. Includes Core, GUI, Widgets, Networking, SQL, Concurrent and other essential qt components.",
   "homepage": "https://www.qt.io/",
   "license": null,
@@ -63,6 +63,7 @@
     "sql-psql",
     "sql-sqlite",
     "testlib",
+    "thread",
     "widgets",
     "zstd"
   ],
@@ -84,7 +85,16 @@
       ]
     },
     "concurrent": {
-      "description": "Provides a high-level multi-threading API. Qt Concurrent"
+      "description": "Provides a high-level multi-threading API. Qt Concurrent",
+      "dependencies": [
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "thread"
+          ]
+        }
+      ]
     },
     "dbus": {
       "description": "Qt D-Bus"
@@ -167,6 +177,14 @@
           "features": [
             "freetype"
           ]
+        },
+        {
+          "name": "qtbase",
+          "default-features": false,
+          "features": [
+            "thread"
+          ],
+          "platform": "windows"
         }
       ]
     },
@@ -277,6 +295,9 @@
     },
     "testlib": {
       "description": "Qt Testlib"
+    },
+    "thread": {
+      "description": "Thread support; provides QThread and related classes."
     },
     "vulkan": {
       "description": "Enable Vulkan support"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5878,7 +5878,7 @@
     },
     "qtbase": {
       "baseline": "6.3.0",
-      "port-version": 1
+      "port-version": 2
     },
     "qtcharts": {
       "baseline": "6.3.0",

--- a/versions/q-/qtbase.json
+++ b/versions/q-/qtbase.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "bad99835f1e2cf63bc1ddcd9d5871e3081964bbc",
+      "version": "6.3.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "32ffa659c93542477ed0f0ee90f3a7f99c0035f0",
       "version": "6.3.0",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Qt6Gui requires the `thread` feature to be enabled on Windows, which leads to build failure if the default feature set is disabled and the `gui` port feature is enabled without the `concurrent` feature. This PR adds a new `thread` port feature that `concurrent` and `gui` (on Windows) depend on.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
