### PR TITLE
[dstorage] port updated for 1.0.2 release

### DIFF
--- a/ports/dstorage/portfile.cmake
+++ b/ports/dstorage/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/1.0.0"
-    FILENAME "directstorage.1.0.0.zip"
-    SHA512 34f24842d509ccddf2c8a06e94a2f67c0746ed8acb6d90ab89453ed4ec9b123970cf1e802375af27e6d5be3c82211813009f8f4b83f233ce419a1467b8c10846
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Direct3D.DirectStorage/1.0.2"
+    FILENAME "directstorage.1.0.2.zip"
+    SHA512 42a8d21a1be9981d5fcaaa2aa90d1e4bfe20969ee7959803f6acb76b0846d91d49ad89cebac069463729d013532508c6fbe41af3a1e99187ac13e849d747dd7e
 )
 
 vcpkg_extract_source_archive_ex(
@@ -12,13 +12,13 @@ vcpkg_extract_source_archive_ex(
     NO_REMOVE_ONE_LEVEL
 )
 
-file(INSTALL "${PACKAGE_PATH}/Include/DirectStorage/dstorage.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
-file(INSTALL "${PACKAGE_PATH}/Include/DirectStorage/dstorageerr.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${PACKAGE_PATH}/native/include/dstorage.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(INSTALL "${PACKAGE_PATH}/native/include/dstorageerr.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
 
-file(INSTALL "${PACKAGE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/dstorage.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+file(INSTALL "${PACKAGE_PATH}/native/lib/${VCPKG_TARGET_ARCHITECTURE}/dstorage.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
 
-file(COPY "${PACKAGE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/dstorage.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
-file(COPY "${PACKAGE_PATH}/bin/${VCPKG_TARGET_ARCHITECTURE}/dstoragecore.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(COPY "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstorage.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+file(COPY "${PACKAGE_PATH}/native/bin/${VCPKG_TARGET_ARCHITECTURE}/dstoragecore.dll" DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
 
 file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug")
 file(COPY "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
+  "documentation": "https://github.com/microsoft/DirectStorage",
   "license": null,
   "supports": "windows & !uwp & !staticcrt"
 }

--- a/ports/dstorage/vcpkg.json
+++ b/ports/dstorage/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "dstorage",
-  "version": "1.0.0",
-  "port-version": 1,
+  "version": "1.0.2",
   "description": "DirectStorage for Windows",
   "homepage": "https://aka.ms/directstorage/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1957,8 +1957,8 @@
       "port-version": 0
     },
     "dstorage": {
-      "baseline": "1.0.0",
-      "port-version": 1
+      "baseline": "1.0.2",
+      "port-version": 0
     },
     "dtl": {
       "baseline": "1.19",

--- a/versions/d-/dstorage.json
+++ b/versions/d-/dstorage.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "6672c5472d42f2ba2e3fe0a0e8acf3d00879c129",
+      "version": "1.0.2",
+      "port-version": 0
+    },
+    {
       "git-tree": "8b3e0c3eaf98dec92b8e97f19e10efac69c6a187",
       "version": "1.0.0",
       "port-version": 1


### PR DESCRIPTION
* Updates the port for the latest release of `Microsoft.Direct3D.DirectStorage` per [this blog post](https://devblogs.microsoft.com/directx/directstorage-sdk-1-0-2/).
* Changes for upstream reorganization of package layout