### PR TITLE
[angle] declared cxx standard 17 on all platform

### DIFF
--- a/ports/angle/CMakeLists.txt
+++ b/ports/angle/CMakeLists.txt
@@ -13,12 +13,12 @@ else()
     set(LINUX 0)
 endif()
 
+# wstring_view needs CXX 17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(MSVC)
     add_compile_options(/d2guard4 /Wv:18 /guard:cf /permissive /bigobj)
-else()
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if (APPLE)

--- a/ports/angle/vcpkg.json
+++ b/ports/angle/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "angle",
   "version-string": "chromium_4472",
-  "port-version": 3,
+  "port-version": 4,
   "description": [
     "A conformant OpenGL ES implementation for Windows, Mac and Linux.",
     "The goal of ANGLE is to allow users of multiple operating systems to seamlessly run WebGL and other OpenGL ES content by translating OpenGL ES API calls to one of the hardware-supported APIs available for that platform. ANGLE currently provides translation from OpenGL ES 2.0 and 3.0 to desktop OpenGL, OpenGL ES, Direct3D 9, and Direct3D 11. Support for translation from OpenGL ES to Vulkan is underway, and future plans include compute shader support (ES 3.1) and MacOS support."

--- a/versions/a-/angle.json
+++ b/versions/a-/angle.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "52ae8b3a4d0613141d7244e3f8481e246743a91c",
+      "version-string": "chromium_4472",
+      "port-version": 4
+    },
+    {
       "git-tree": "c3b63c0d8bf584235c057cb40486152ebe3fa0a6",
       "version-string": "chromium_4472",
       "port-version": 3

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -90,7 +90,7 @@
     },
     "angle": {
       "baseline": "chromium_4472",
-      "port-version": 3
+      "port-version": 4
     },
     "antlr4": {
       "baseline": "4.9.3",


### PR DESCRIPTION
Angle uses `std::wstring_view` which requires CXX 17 : https://en.cppreference.com/w/cpp/string/basic_string_view
But we only declared it on non-Windows.
Fix that.

The reason why our CI doesn't catch this bug is because Visual Studio has internal compiler error and we skiped it.

Fixes #24945.