### PR TITLE
[protobuf] update to v21.0

### DIFF
--- a/ports/protobuf/fix-static-build.patch
+++ b/ports/protobuf/fix-static-build.patch
@@ -1,18 +1,5 @@
-diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 51e8478..64347c4 100644
---- a/cmake/CMakeLists.txt
-+++ b/cmake/CMakeLists.txt
-@@ -182,7 +182,7 @@ else (protobuf_BUILD_SHARED_LIBS)
-   # making programmatic control difficult.  Prefer the functionality in newer
-   # CMake versions when available.
-   if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
--    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
-+    
-   else()
-     # In case we are building static libraries, link also the runtime library statically
-     # so that MSVCR*.DLL is not required at runtime.
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 4e1c5de..d3aa865 100644
+index c1f6f4a..88d4baa 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
 @@ -32,7 +32,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)

--- a/ports/protobuf/portfile.cmake
+++ b/ports/protobuf/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf
-    REF v3.19.4
-    SHA512 2653b9852e5ac69f1de9b6ac02887c366aa0a9efd2b29e53135f61a9a10f5a1b5853a8c4cbb3658f519dfdbde9f32c547c39751ab417f123162b08be9e76c9e1
+    REF 7062d0a2d0075d5e7d5c294fd3984df67a976da3    #v21.0
+    SHA512 765f21e95cf8b1843c2e0a54fa6646c4008985200ee5145feacafd01721327736289f5de4100c57f89a5c0319ba3cd547ac5d60a8d540bea57038d4589789c93
     HEAD_REF master
     PATCHES
         fix-static-build.patch
@@ -83,10 +83,6 @@ else()
     file(COPY "${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools")
 endif()
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-config.cmake"
-    "if(protobuf_MODULE_COMPATIBLE)"
-    "if(ON)"
-)
 if(NOT protobuf_BUILD_LIBPROTOC)
     vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/protobuf-module.cmake"
         "_protobuf_find_libraries(Protobuf_PROTOC protoc)"

--- a/ports/protobuf/vcpkg.json
+++ b/ports/protobuf/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "protobuf",
-  "version-semver": "3.19.4",
+  "version": "21.0",
   "description": "Protocol Buffers - Google's data interchange format",
   "homepage": "https://github.com/protocolbuffers/protobuf",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5593,7 +5593,7 @@
       "port-version": 0
     },
     "protobuf": {
-      "baseline": "3.19.4",
+      "baseline": "21.0",
       "port-version": 0
     },
     "protobuf-c": {

--- a/versions/p-/protobuf.json
+++ b/versions/p-/protobuf.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "540b8b6f44dc51409c8e1b47f18c3a68e35e5206",
+      "version": "21.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "984039810172eb397ca0ec6d426d60764d6dfe46",
       "version-semver": "3.19.4",
       "port-version": 0


### PR DESCRIPTION
Fix #24822 

Update protobuf to the latest version v21.0

Feature 'zlib' tested successfully in the following triplet:
- x86-windows
- x64-windows
- x64-windows-static