### PR TITLE
[rsocket] Remove from ci.baseline.txt

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -1010,10 +1010,6 @@ rsasynccpp:x64-osx=fail
 rsm-binary-io:x64-linux=fail
 # Requires g++10 but CI compiler only has g++9
 rsm-bsa:x64-linux=fail
-# VS2022 17.2 ICE https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1490389
-rsocket:x64-windows=fail
-rsocket:x64-windows-static=fail
-rsocket:x64-windows-static-md=fail
 rtlsdr:x64-uwp=fail
 rtlsdr:arm64-windows=fail
 rtlsdr:arm-uwp=fail


### PR DESCRIPTION
Remove `rsocket` from ci.baseline.txt, because Visual Studio bug has been fixed.