### PR TITLE
[boost] Add option to use old ABI for boost-test vcpkg

### DIFF
--- a/ports/boost-modular-build-helper/CMakeLists.txt
+++ b/ports/boost-modular-build-helper/CMakeLists.txt
@@ -231,6 +231,14 @@ endif()
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/user-config.jam.in ${CMAKE_CURRENT_BINARY_DIR}/user-config.jam @ONLY)
 
+message(STATUS "USE_OLD_ABI: $ENV{USE_OLD_ABI}")
+if(DEFINED ENV{USE_OLD_ABI})
+    set(_GLIBCXX_USE_CXX11_ABI 0)
+else()
+    set(_GLIBCXX_USE_CXX11_ABI 1)
+endif()
+message(STATUS "_GLIBCXX_USE_CXX11_ABI: ${_GLIBCXX_USE_CXX11_ABI}")
+
 add_custom_target(boost ALL
     COMMAND "${B2_EXE}"
         toolset=${USER_CONFIG_TOOLSET}
@@ -254,6 +262,7 @@ add_custom_target(boost ALL
         --ignore-site-config
         --hash
         -q
+        define=_GLIBCXX_USE_CXX11_ABI=${_GLIBCXX_USE_CXX11_ABI}
         debug-symbols=on
         # Enable debugging level 2.
         -d +2

--- a/ports/boost-modular-build-helper/vcpkg.json
+++ b/ports/boost-modular-build-helper/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "boost-modular-build-helper",
   "version": "1.79.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Internal vcpkg port used to build Boost libraries",
   "license": "MIT",
   "dependencies": [

--- a/versions/b-/boost-modular-build-helper.json
+++ b/versions/b-/boost-modular-build-helper.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a6978bf8e10eba7e4b4cc3c47be10fbce25a6e6c",
+      "version": "1.79.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "e02a1f1b06a492d932f309feab8ac7751b0327ca",
       "version": "1.79.0",
       "port-version": 2

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -830,7 +830,7 @@
     },
     "boost-modular-build-helper": {
       "baseline": "1.79.0",
-      "port-version": 2
+      "port-version": 3
     },
     "boost-move": {
       "baseline": "1.79.0",


### PR DESCRIPTION
- #### What does your PR fix?
This PR adds an option to build boost with _GLIBCXX_USE_CXX11_ABI=0 based on ENV variable USE_OLD_ABI set by the user.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
