### PR TITLE
[rtmidi] Fix cmake usage

### DIFF
--- a/ports/rtmidi/fix-cmake-usage.patch
+++ b/ports/rtmidi/fix-cmake-usage.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 616fdaf..e6af930 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -280,7 +280,7 @@ include(CMakePackageConfigHelpers)
+ 
+ # Write cmake package version file
+ write_basic_package_version_file(
+-    RtMidi-config-version.cmake
++    rtmidi-config-version.cmake
+     VERSION ${FULL_VER}
+     COMPATIBILITY SameMajorVersion
+ )
+@@ -288,15 +288,15 @@ write_basic_package_version_file(
+ # Write cmake package config file
+ configure_package_config_file (
+     cmake/RtMidi-config.cmake.in
+-    RtMidi-config.cmake
++    rtmidi-config.cmake
+     INSTALL_DESTINATION "${RTMIDI_CMAKE_DESTINATION}"
+ )
+ 
+ # Install package files
+ install (
+     FILES
+-        "${CMAKE_CURRENT_BINARY_DIR}/RtMidi-config.cmake"
+-        "${CMAKE_CURRENT_BINARY_DIR}/RtMidi-config-version.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config.cmake"
++        "${CMAKE_CURRENT_BINARY_DIR}/rtmidi-config-version.cmake"
+     DESTINATION
+         "${RTMIDI_CMAKE_DESTINATION}"
+ )

--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_github(
     REF 84a99422a3faf1ab417fe71c0903a48debb9376a # 5.0.0
     SHA512 388e280b7966281e22b0048d6fb2541921df1113d84e49bbc444fff591d2025588edd8d61dbe5ff017afd76c26fd05edc8f9f15d0cce16315ccc15e6aac1d57f
     HEAD_REF master
+    PATCHES fix-cmake-usage.patch # Remove this patch in the next update
 )
 
 vcpkg_cmake_configure(

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "rtmidi",
-  "version-semver": "5.0.0",
+  "version": "5.0.0",
   "port-version": 1,
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "rtmidi",
   "version-semver": "5.0.0",
+  "port-version": 1,
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6294,7 +6294,7 @@
     },
     "rtmidi": {
       "baseline": "5.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "rttr": {
       "baseline": "0.9.6",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,8 +1,8 @@
 {
   "versions": [
     {
-      "git-tree": "d2f10145159e71ffd4a759b9ff9e4f80ced814e4",
-      "version-semver": "5.0.0",
+      "git-tree": "30614a92baff91c2d2790029179dbb37122ca331",
+      "version": "5.0.0",
       "port-version": 1
     },
     {

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "d2f10145159e71ffd4a759b9ff9e4f80ced814e4",
+      "version-semver": "5.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "4eb19141251ff7759838e0ab10f35876583d367b",
       "version-semver": "5.0.0",
       "port-version": 0


### PR DESCRIPTION
Use upstream changes https://github.com/thestk/rtmidi/pull/283 to fix the cmake usage issue.

Fixes #24971.