### PR TITLE
[hidapi] Update  to 0.12.0

### DIFF
--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -16,6 +16,8 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/libhidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")
+
 file(INSTALL "${SOURCE_PATH}/LICENSE-bsd.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
-    REF hidapi-0.11.2
-    SHA512 c4d04bf570aa98dd88d7ce08ef1abb0675d500c9aa2c22f0437fa30b700a94446779f77e1170267926d5f6f0d9cdb2bb81ad1fe20d158c18587fddbca59e9517
+    REF hidapi-0.12.0
+    SHA512 8006591b6ce4924aebf2fdf8c46065ceaccad830
     HEAD_REF master
 )
 

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -16,8 +16,6 @@ vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_pdbs()
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/hidapi/hidapi.cmake" "\"/hidapi\"" "\"\${_IMPORT_PREFIX}/include\"")
-
 file(INSTALL "${SOURCE_PATH}/LICENSE-bsd.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
     REF hidapi-0.12.0
-    SHA512 0c4bc45706d99498950491091ba8a5e8ccdd3964
+    SHA512 0
     HEAD_REF master
 )
 

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
     REF hidapi-0.12.0
-    SHA512 0
+    SHA512 866268927698db6fa553e000ead3c0c4b8df67ea768d36acac9c71f06f0bd8283778e90eee03f81aaa930f38dbb5719391906c7d2742b74479ffa436104f5fa4
     HEAD_REF master
 )
 

--- a/ports/hidapi/portfile.cmake
+++ b/ports/hidapi/portfile.cmake
@@ -2,7 +2,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO libusb/hidapi
     REF hidapi-0.12.0
-    SHA512 8006591b6ce4924aebf2fdf8c46065ceaccad830
+    SHA512 0c4bc45706d99498950491091ba8a5e8ccdd3964
     HEAD_REF master
 )
 

--- a/ports/hidapi/vcpkg.json
+++ b/ports/hidapi/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "hidapi",
-  "version-semver": "0.11.2",
-  "port-version": 1,
+  "version-semver": "0.12.0",
   "description": "A Simple library for communicating with USB and Bluetooth HID devices on Linux, Mac and Windows.",
   "homepage": "https://github.com/libusb/hidapi",
   "license": "BSD-3-Clause-Clear",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2773,8 +2773,8 @@
       "port-version": 0
     },
     "hidapi": {
-      "baseline": "0.11.2",
-      "port-version": 1
+      "baseline": "0.12.0",
+      "port-version": 0
     },
     "highfive": {
       "baseline": "2.3",

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3bb72bc98d3527c69ef2a7aea83bd1d98ae44bb9",
+      "git-tree": "a95202186af8b0dd8cacf0fc234037cc04eba2d7",
       "version-semver": "0.12.0",
       "port-version": 0
     },

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a95202186af8b0dd8cacf0fc234037cc04eba2d7",
+      "git-tree": "803a911247de97c28264c5dee2102b368137562d",
       "version-semver": "0.12.0",
       "port-version": 0
     },

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "14038e8a0a4a688aaf75ce4fa6adaed1f22dd611",
+      "version-semver": "0.12.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "145fcc6e2c3aa564666793d494a6b90c1323e0ac",
       "version-semver": "0.11.2",
       "port-version": 1

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "14038e8a0a4a688aaf75ce4fa6adaed1f22dd611",
+      "git-tree": "0c4bc45706d99498950491091ba8a5e8ccdd3964",
       "version-semver": "0.12.0",
       "port-version": 0
     },

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8006591b6ce4924aebf2fdf8c46065ceaccad830",
+      "git-tree": "3bb72bc98d3527c69ef2a7aea83bd1d98ae44bb9",
       "version-semver": "0.12.0",
       "port-version": 0
     },

--- a/versions/h-/hidapi.json
+++ b/versions/h-/hidapi.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0c4bc45706d99498950491091ba8a5e8ccdd3964",
+      "git-tree": "8006591b6ce4924aebf2fdf8c46065ceaccad830",
       "version-semver": "0.12.0",
       "port-version": 0
     },


### PR DESCRIPTION
https://github.com/libusb/hidapi/releases/tag/hidapi-0.12.0

**Describe the pull request**

- #### What does your PR fix?
Updates the existing hidapi port to the latest release 0.12.0

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Unchanged

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**


This hidapi release adds two additional header files, which need to be included if platform specific functions are used:
- hidapi\mac\hidapi_darwin.h for Mac
- hidapi\windows\hidapi_winapi.h for Windows

I needed to change the replace command from https://github.com/microsoft/vcpkg/pull/22320 to make the static builds pass.