### PR TITLE
[qtkeychain] Fix the CMake export target on windows

### DIFF
--- a/ports/qtkeychain-qt6/portfile.cmake
+++ b/ports/qtkeychain-qt6/portfile.cmake
@@ -3,8 +3,9 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    REF v0.13.2
-    SHA512 10f8b1c959a126ba14614b797ea5640404a0b95c71e452225c74856eae90e966aac581ca393508a2106033c3d5ad70427ea6f7ef3f2997eddf6d09a7b4fa26eb
+    # 0.13.2 plus three commits, for a CMake export target fix
+    REF cd4d73299b144d11c310f6ca9a6ab1ef50c45431
+    SHA512 a1af668bec23df5d696ad49129ec2aa6d332f043b43bb9875c2b025007452571bfd9431fd37c72189e957329491c04703e8c6d1104c7a117ebf28cb91249b639
     HEAD_REF master
 )
 

--- a/ports/qtkeychain-qt6/vcpkg.json
+++ b/ports/qtkeychain-qt6/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qtkeychain-qt6",
   "version": "0.13.2",
+  "port-version": 1,
   "description": "(Unaffiliated with Qt) Platform-independent Qt6 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/ports/qtkeychain/portfile.cmake
+++ b/ports/qtkeychain/portfile.cmake
@@ -3,9 +3,9 @@ message(WARNING "qtkeychain is a third-party extension to Qt and is not affiliat
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO frankosterfeld/qtkeychain
-    # 0.13.2 plus two commits, for a CMake export target fix
-    REF e5eeb1763e295f6b05a3f008ee7ae192fd74ed0c
-    SHA512 c6f216c8acdd89607d16582305bff962a0049512565f8ead7bebf06bce1540cdf41cc8b6dc31b45396befd90a3bd65a2f8a969242f302cbb61438ff7a48aab1c
+    # 0.13.2 plus three commits, for a CMake export target fix
+    REF cd4d73299b144d11c310f6ca9a6ab1ef50c45431
+    SHA512 a1af668bec23df5d696ad49129ec2aa6d332f043b43bb9875c2b025007452571bfd9431fd37c72189e957329491c04703e8c6d1104c7a117ebf28cb91249b639
     HEAD_REF master
 )
 

--- a/ports/qtkeychain/vcpkg.json
+++ b/ports/qtkeychain/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qtkeychain",
   "version": "0.13.2",
-  "port-version": 2,
+  "port-version": 3,
   "description": "(Unaffiliated with Qt) Platform-independent Qt5 API for storing passwords securely",
   "homepage": "https://github.com/frankosterfeld/qtkeychain",
   "license": "BSD-3-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5926,7 +5926,7 @@
     },
     "qtkeychain-qt6": {
       "baseline": "0.13.2",
-      "port-version": 0
+      "port-version": 1
     },
     "qtlocation": {
       "baseline": "6.3.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5922,7 +5922,7 @@
     },
     "qtkeychain": {
       "baseline": "0.13.2",
-      "port-version": 2
+      "port-version": 3
     },
     "qtkeychain-qt6": {
       "baseline": "0.13.2",

--- a/versions/q-/qtkeychain-qt6.json
+++ b/versions/q-/qtkeychain-qt6.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3733fba48696a40e64b18c2d52d4adc04e6eb22d",
+      "version": "0.13.2",
+      "port-version": 1
+    },
+    {
       "git-tree": "b3df36df3c274f528e53cd1f8366811231b15151",
       "version": "0.13.2",
       "port-version": 0

--- a/versions/q-/qtkeychain.json
+++ b/versions/q-/qtkeychain.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "eda48d2b83676b8209a40d68b286c570aeed785e",
+      "version": "0.13.2",
+      "port-version": 3
+    },
+    {
       "git-tree": "6311d9dd13b97c8a01a980d7b42ea6cfecc4f765",
       "version": "0.13.2",
       "port-version": 2


### PR DESCRIPTION
It turns out that the fix from https://github.com/microsoft/vcpkg/pull/24013 that allows to use CMake < 3.18 does not work on windows. This adds a patch that reintroduces the alias solution but under a cmake version guard.  
I have propose this also upstream https://github.com/frankosterfeld/qtkeychain/pull/212, but did not yet get a responds since May 8th. 

- #### What does your PR fix?
It fixes the exported CMake target on windows 

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes