### PR TITLE
[catch2] Set CMAKE_CXX_STANDARD to 17.

### DIFF
--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     REF v3.0.1
     SHA512 065094c19cdf98b40f96a390e887542f895495562a91cdc28d68ce03690866d846ec87d320405312a2b97eacaa5351d3e55f0012bb9de40073c8d4444d82b0a1
     HEAD_REF devel
-    PATCHES 
+    PATCHES
         fix-install-path.patch
 )
 
@@ -12,6 +12,7 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DCATCH_INSTALL_DOCS=OFF
+        -DCMAKE_CXX_STANDARD=17
 )
 
 vcpkg_cmake_install()

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "catch2",
   "version-semver": "3.0.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",
   "license": "BSL-1.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1278,7 +1278,7 @@
     },
     "catch2": {
       "baseline": "3.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "cccapstone": {
       "baseline": "9b4128ee1153e78288a1b5433e2c06a0d47a4c4e",

--- a/versions/c-/catch2.json
+++ b/versions/c-/catch2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1c528318ebe10c945563bf9942c8b2141253bf87",
+      "version-semver": "3.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "8de83e7d7f07a831293d15e747aa7a980a220ff7",
       "version-semver": "3.0.1",
       "port-version": 1


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/pull/24762#issuecomment-1139457412 indicates that building for C++17 will include extra catch2 formatters for types like std::string_view, so we should build catch2 with that version selected.
