### PR TITLE
[SDL] enable hidapi

### DIFF
--- a/ports/sdl2/portfile.cmake
+++ b/ports/sdl2/portfile.cmake
@@ -38,6 +38,7 @@ vcpkg_cmake_configure(
         -DSDL_SHARED=${SDL_SHARED}
         -DSDL_FORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DSDL_LIBC=ON
+        -DSDL_HIDAPI_JOYSTICK=ON
 )
 
 vcpkg_cmake_install()

--- a/ports/sdl2/vcpkg.json
+++ b/ports/sdl2/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "sdl2",
   "version": "2.0.22",
+  "port-version": 1,
   "description": "Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.",
   "homepage": "https://www.libsdl.org/download-2.0.php",
   "license": "Zlib",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6406,7 +6406,7 @@
     },
     "sdl2": {
       "baseline": "2.0.22",
-      "port-version": 0
+      "port-version": 1
     },
     "sdl2-gfx": {
       "baseline": "1.0.4",

--- a/versions/s-/sdl2.json
+++ b/versions/s-/sdl2.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "879012d1bbd3ae67fc697109eedbe6ff713c2c34",
+      "version": "2.0.22",
+      "port-version": 1
+    },
+    {
       "git-tree": "6d875fe2feac0480f61fcf890136e045c12429f1",
       "version": "2.0.22",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #19252

SDL uses HIDAPI for some game controller features, most notably access to the gyroscope and accelerometer data. This isn't included currently in vcpkg, so only the buttons and joysticks work.
SDL uses its own bundled hidapi version, so we should just need to enable the DSDL_HIDAPI_JOYSTICK=ON cmake flag
