### PR TITLE
[hdf5] Fix feature parallel on Linux

### DIFF
--- a/ports/hdf5/fix-parallel.patch
+++ b/ports/hdf5/fix-parallel.patch
@@ -1,0 +1,22 @@
+diff --git a/config/cmake/ConfigureChecks.cmake b/config/cmake/ConfigureChecks.cmake
+index 902ddd3..c333590 100644
+--- a/config/cmake/ConfigureChecks.cmake
++++ b/config/cmake/ConfigureChecks.cmake
+@@ -283,7 +283,7 @@ macro (C_RUN FUNCTION_NAME SOURCE_CODE RETURN_VAR)
+ 
+     if (${COMPILE_RESULT_VAR})
+       if (${RUN_RESULT_VAR} MATCHES 0)
+-        set (${RUN_RESULT_VAR} 1 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
++        set (${RETURN_VAR} 1 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
+         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+           message (VERBOSE "Testing C ${FUNCTION_NAME} - OK")
+         endif ()
+@@ -295,7 +295,7 @@ macro (C_RUN FUNCTION_NAME SOURCE_CODE RETURN_VAR)
+         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+           message (VERBOSE "Testing C ${FUNCTION_NAME} - Fail")
+         endif ()
+-        set (${RUN_RESULT_VAR} 0 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
++        set (${RETURN_VAR} 0 CACHE INTERNAL "Have C function ${FUNCTION_NAME}")
+         file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+             "Determining if the C ${FUNCTION_NAME} exists failed with the following output:\n"
+             "${OUTPUT_VAR}\n\n")

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_github(
         szip.patch
         pkgconfig-requires.patch
         pkgconfig-link-order.patch
-        fix-parallel.patch # Remove this patch in the next update
+        fix-parallel.patch # Remove this patch in the next update, see https://github.com/HDFGroup/hdf5/pull/860
 )
 
 set(ALLOW_UNSUPPORTED OFF)

--- a/ports/hdf5/portfile.cmake
+++ b/ports/hdf5/portfile.cmake
@@ -11,6 +11,7 @@ vcpkg_from_github(
         szip.patch
         pkgconfig-requires.patch
         pkgconfig-link-order.patch
+        fix-parallel.patch # Remove this patch in the next update
 )
 
 set(ALLOW_UNSUPPORTED OFF)

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 5,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
+  "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
     {

--- a/ports/hdf5/vcpkg.json
+++ b/ports/hdf5/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "hdf5",
   "version": "1.12.1",
-  "port-version": 4,
+  "port-version": 5,
   "description": "HDF5 is a data model, library, and file format for storing and managing data",
   "homepage": "https://www.hdfgroup.org/downloads/hdf5/",
   "supports": "!uwp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2754,7 +2754,7 @@
     },
     "hdf5": {
       "baseline": "1.12.1",
-      "port-version": 4
+      "port-version": 5
     },
     "healpix": {
       "baseline": "1.12.10",

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "8437b6cd6a0ad4b96ce17aaf29ed59b1ea511e87",
+      "git-tree": "c6491dde27884b1326e6f74f3862c1ae63a122ca",
       "version": "1.12.1",
       "port-version": 5
     },

--- a/versions/h-/hdf5.json
+++ b/versions/h-/hdf5.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8437b6cd6a0ad4b96ce17aaf29ed59b1ea511e87",
+      "version": "1.12.1",
+      "port-version": 5
+    },
+    {
       "git-tree": "1000a70aefebfdd856715d265c3421c80157b773",
       "version": "1.12.1",
       "port-version": 4


### PR DESCRIPTION
Use official changes https://github.com/HDFGroup/hdf5/pull/860 to fix the build issue on Linux when selecting feature `parallel`.

Thanks @dg0yt for figure out the root reason.

Related: https://github.com/microsoft/vcpkg/pull/24740.