### PR TITLE
[tinyobjloader] Update to 2.0.0rc9

### DIFF
--- a/ports/tinyobjloader/portfile.cmake
+++ b/ports/tinyobjloader/portfile.cmake
@@ -3,28 +3,33 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO syoyo/tinyobjloader
-    REF v2.0.0-rc2
-    SHA512 936f7897a87fe00d474231ad5f69816da127f14296c3591144c26c6058bd11ea1490c2db6b8c4a8adf629ae148423705d0c4020f4ed034921f0f2f711498f3bb
+    REF v2.0.0rc9
+    SHA512 e188d6077cb19f9044da9c98c2c4284cad09f4ee745f4746d0df5b22a379d3b32fe20aa998151d6dc08e7f113f50abf80a7509d63c36de46547ce43b5fe1fa54
     HEAD_REF master
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    double     TINYOBJLOADER_USE_DOUBLE
+    FEATURES
+        double TINYOBJLOADER_USE_DOUBLE
 )
 
-vcpkg_configure_cmake(
+vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    PREFER_NINJA
     OPTIONS
         -DCMAKE_INSTALL_DOCDIR:STRING=share/tinyobjloader
         # FEATURES
         ${FEATURE_OPTIONS}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 
-vcpkg_fixup_cmake_targets(CONFIG_PATH lib/tinyobjloader/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/tinyobjloader/cmake)
 
+if("double" IN_LIST FEATURES)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/tiny_obj_loader.h" "#ifdef TINYOBJLOADER_USE_DOUBLE" "#if 1")
+else()
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/tiny_obj_loader.h" "#ifdef TINYOBJLOADER_USE_DOUBLE" "#if 0")
+endif()
 file(
     REMOVE_RECURSE
     ${CURRENT_PACKAGES_DIR}/debug/include

--- a/ports/tinyobjloader/vcpkg.json
+++ b/ports/tinyobjloader/vcpkg.json
@@ -1,8 +1,18 @@
 {
   "name": "tinyobjloader",
-  "version-string": "2.0.0-rc2",
-  "port-version": 2,
+  "version": "2.0.0-rc9",
   "description": "Tiny but powerful single file wavefront obj loader",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
   "features": {
     "double": {
       "description": "enable double(64bit) precision"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7045,8 +7045,8 @@
       "port-version": 4
     },
     "tinyobjloader": {
-      "baseline": "2.0.0-rc2",
-      "port-version": 2
+      "baseline": "2.0.0-rc9",
+      "port-version": 0
     },
     "tinyply": {
       "baseline": "2020-05-22",

--- a/versions/t-/tinyobjloader.json
+++ b/versions/t-/tinyobjloader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c1e6a1c3ddc75a72ea801b5d0980a73e14358e5e",
+      "version": "2.0.0-rc9",
+      "port-version": 0
+    },
+    {
       "git-tree": "1e64b6f58d80d1ff9b43cd9700c8996d0b5b764d",
       "version-string": "2.0.0-rc2",
       "port-version": 2


### PR DESCRIPTION
Updates tinyobjloader to version 2.0.0rc9 and modernizes the port file.

- #### What does your PR fix?
It fixes a warning due to a missing `FEATURES` keyword.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
