### PR TITLE
[xaudio2redist] port updated to version 1.2.9

### DIFF
--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -8,8 +8,8 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 c3b37640fb871523a63cd227653d8d972dd95d6e12ccf2f28c434f51bb77011c821a0cd5ae2a9fa311f005a0083798a3218a98c0a9db5db094a5ef54bb960675
 )
 
-vcpkg_extract_source_archive_ex(
-    OUT_SOURCE_PATH PACKAGE_PATH
+vcpkg_extract_source_archive(
+    PACKAGE_PATH
     ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL
 )

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 c3b37640fb871523a63cd227653d8d972dd95d6e12ccf2f28c434f51bb77011c821a0cd5ae2a9fa311f005a0083798a3218a98c0a9db5db094a5ef54bb960675
 )
 
-vcpkg_extract_source_archive_ex(
+vcpkg_extract_source_archive(
     OUT_SOURCE_PATH PACKAGE_PATH
     ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -1,9 +1,9 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/1.2.8"
-    FILENAME "xaudio2redist.1.2.8.zip"
-    SHA512 509b2783457b86ed1878fd4e14a01fa7288591925a2bb3cad4d68afd597fbff1f1349b619dad628b5d685169825a775120e1611559e9097837cff0fb6d39acf0
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/1.2.9"
+    FILENAME "xaudio2redist.1.2.9.zip"
+    SHA512 c3b37640fb871523a63cd227653d8d972dd95d6e12ccf2f28c434f51bb77011c821a0cd5ae2a9fa311f005a0083798a3218a98c0a9db5db094a5ef54bb960675
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -1,8 +1,10 @@
 vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
 
+set(XAUDIO2REDIST_VERSION 1.2.9)
+
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/1.2.9"
-    FILENAME "xaudio2redist.1.2.9.zip"
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.XAudio2.Redist/${XAUDIO2REDIST_VERSION}"
+    FILENAME "xaudio2redist.${XAUDIO2REDIST_VERSION}.zip"
     SHA512 c3b37640fb871523a63cd227653d8d972dd95d6e12ccf2f28c434f51bb77011c821a0cd5ae2a9fa311f005a0083798a3218a98c0a9db5db094a5ef54bb960675
 )
 

--- a/ports/xaudio2redist/portfile.cmake
+++ b/ports/xaudio2redist/portfile.cmake
@@ -8,7 +8,7 @@ vcpkg_download_distfile(ARCHIVE
     SHA512 c3b37640fb871523a63cd227653d8d972dd95d6e12ccf2f28c434f51bb77011c821a0cd5ae2a9fa311f005a0083798a3218a98c0a9db5db094a5ef54bb960675
 )
 
-vcpkg_extract_source_archive(
+vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH PACKAGE_PATH
     ARCHIVE ${ARCHIVE}
     NO_REMOVE_ONE_LEVEL

--- a/ports/xaudio2redist/vcpkg.json
+++ b/ports/xaudio2redist/vcpkg.json
@@ -1,9 +1,9 @@
 {
   "name": "xaudio2redist",
-  "version": "1.2.8",
-  "port-version": 3,
+  "version": "1.2.9",
   "description": "Redistributable version of XAudio 2.9 for Windows 7 SP1 or later",
   "homepage": "https://aka.ms/XAudio2Redist",
+  "documentation": "https://aka.ms/XAudio2Redist",
   "license": null,
   "supports": "windows & !arm & !uwp & !staticcrt"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7597,8 +7597,8 @@
       "port-version": 1
     },
     "xaudio2redist": {
-      "baseline": "1.2.8",
-      "port-version": 3
+      "baseline": "1.2.9",
+      "port-version": 0
     },
     "xbyak": {
       "baseline": "6.00",

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39b7b08528aca56ffbadb76d8bbb989fa6397348",
+      "git-tree": "b3f099fe5f1e43102f5cc53859908374b7186b25",
       "version": "1.2.9",
       "port-version": 0
     },

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b3f099fe5f1e43102f5cc53859908374b7186b25",
+      "git-tree": "39b7b08528aca56ffbadb76d8bbb989fa6397348",
       "version": "1.2.9",
       "port-version": 0
     },

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "daca709e74699b774ebb75d87047caeabcd859e5",
+      "git-tree": "39b7b08528aca56ffbadb76d8bbb989fa6397348",
       "version": "1.2.9",
       "port-version": 0
     },

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "daca709e74699b774ebb75d87047caeabcd859e5",
+      "version": "1.2.9",
+      "port-version": 0
+    },
+    {
       "git-tree": "fe3229572bacd0c7076a7a4d710f96e6b3a66a3f",
       "version": "1.2.8",
       "port-version": 3

--- a/versions/x-/xaudio2redist.json
+++ b/versions/x-/xaudio2redist.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "39b7b08528aca56ffbadb76d8bbb989fa6397348",
+      "git-tree": "49a7df46ef685eea76f3775dfebc458117e6c33c",
       "version": "1.2.9",
       "port-version": 0
     },


### PR DESCRIPTION
Update port for latest release of ``Microsoft.XAudio2.Redist`` on NuGet:

* When Virtual Surround Sound (VSS) is enabled on an audio endpoint, the Mastering Voice opens the audio endpoint in 7.1 channel mode.