### PR TITLE
[asio-grpc] Update to 1.7.0

### DIFF
--- a/ports/asio-grpc/portfile.cmake
+++ b/ports/asio-grpc/portfile.cmake
@@ -20,6 +20,8 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+vcpkg_cmake_config_fixup()
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/asio-grpc/portfile.cmake
+++ b/ports/asio-grpc/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Tradias/asio-grpc
-    REF v1.6.0
-    SHA512 4ea06c09c869cb1752714f969366d794b67048b42bff0790543d3305ce656238a4dadd06dfff1c2229add8a0ff730f30c70d944681979e3e983d4ec1d3ce3208
+    REF v1.7.0
+    SHA512 2a9c583678026e1eed4b2128ecf7bb18dff9a39e26de9a29f035cd7c6c838edc5d95015319407d493b09fd650de8b1b7b0bed1b92ba88d40f69d806adf6a0af1
     HEAD_REF master
 )
 
@@ -15,13 +15,12 @@ vcpkg_check_features(
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS ${FEATURE_OPTIONS}
+        -DASIO_GRPC_CMAKE_CONFIG_INSTALL_DIR=share/asio-grpc
 )
 
 vcpkg_cmake_install()
 
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/asio-grpc)
-
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug" "${CURRENT_PACKAGES_DIR}/lib")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
 
 file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/asio-grpc/vcpkg.json
+++ b/ports/asio-grpc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "asio-grpc",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Asynchronous gRPC with Asio/unified executors",
   "homepage": "https://github.com/Tradias/asio-grpc",
   "license": "Apache-2.0",

--- a/ports/asio-grpc/vcpkg.json
+++ b/ports/asio-grpc/vcpkg.json
@@ -9,6 +9,10 @@
     {
       "name": "vcpkg-cmake",
       "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
   ],
   "features": {

--- a/ports/asio-grpc/vcpkg.json
+++ b/ports/asio-grpc/vcpkg.json
@@ -9,10 +9,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ],
   "features": {

--- a/versions/a-/asio-grpc.json
+++ b/versions/a-/asio-grpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a2f9a77dec7bcecaab942092f73118c5700e6eb3",
+      "git-tree": "3f73fa275b5f4d19d244b7212b8c7ae61135fc95",
       "version": "1.7.0",
       "port-version": 0
     },

--- a/versions/a-/asio-grpc.json
+++ b/versions/a-/asio-grpc.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a13e132361580d1b0b4009f3a1995e1596458336",
+      "version": "1.7.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "6decc4befbc311b08e2229bf58da567d8a86561c",
       "version": "1.6.0",
       "port-version": 0

--- a/versions/a-/asio-grpc.json
+++ b/versions/a-/asio-grpc.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a13e132361580d1b0b4009f3a1995e1596458336",
+      "git-tree": "a2f9a77dec7bcecaab942092f73118c5700e6eb3",
       "version": "1.7.0",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -185,7 +185,7 @@
       "port-version": 0
     },
     "asio-grpc": {
-      "baseline": "1.6.0",
+      "baseline": "1.7.0",
       "port-version": 0
     },
     "asiosdk": {


### PR DESCRIPTION
Updates asio-grpc to v1.7.0.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
