### PR TITLE
[crashpad] Fix can't find build/build_config.h

### DIFF
--- a/ports/crashpad/portfile.cmake
+++ b/ports/crashpad/portfile.cmake
@@ -122,7 +122,7 @@ file(REMOVE_RECURSE
 configure_file("${CMAKE_CURRENT_LIST_DIR}/crashpadConfig.cmake.in"
         "${CURRENT_PACKAGES_DIR}/share/${PORT}/crashpadConfig.cmake" @ONLY)
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${PORT}/build")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${PORT}/build/config")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/${PORT}/util/mach/__pycache__")
 
 vcpkg_copy_pdbs()

--- a/ports/crashpad/vcpkg.json
+++ b/ports/crashpad/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "crashpad",
   "version-date": "2022-04-16",
+  "port-version": 1,
   "description": [
     "Crashpad is a crash-reporting system.",
     "Crashpad is a library for capturing, storing and transmitting postmortem crash reports from a client to an upstream collection server. Crashpad aims to make it possible for clients to capture process state at the time of crash with the best possible fidelity and coverage, with the minimum of fuss."

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -177,7 +177,6 @@ cppcoro:x64-uwp=fail
 cppgraphqlgen:x64-linux=fail
 crashpad:arm64-windows=fail
 crashpad:arm-uwp=fail
-crashpad:x64-linux=fail
 crashpad:x86-windows=fail
 ctemplate:x64-linux=fail
 ctemplate:x64-osx=fail

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1682,7 +1682,7 @@
     },
     "crashpad": {
       "baseline": "2022-04-16",
-      "port-version": 0
+      "port-version": 1
     },
     "crashrpt": {
       "baseline": "1.4.3",
@@ -2742,7 +2742,7 @@
     },
     "hareflow": {
       "baseline": "0.1.0",
-      "port-version": 0      
+      "port-version": 0
     },
     "harfbuzz": {
       "baseline": "4.2.0",

--- a/versions/c-/crashpad.json
+++ b/versions/c-/crashpad.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "aa3803e8f14e1a0467a2aa509403d9fc8c56e159",
+      "version-date": "2022-04-16",
+      "port-version": 1
+    },
+    {
       "git-tree": "448abcac90e97d8b5ee03843775dd7fcba971979",
       "version-date": "2022-04-16",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #25066. Fix can't find `build/build_config.h`, this is regression commit https://github.com/microsoft/vcpkg/pull/24066/commits/787ba23de724f04f3b01b48fe601c107a7b6e86e from PR #24066.
The error message:
```
Error: vcpkg_installed\x64-windows\include\crashpad\base/files/file_path.h(110): fatal error C1083: Cannot open include file: 'build/build_config.h': No such file or directory
```
Just remove empty directory: `${CURRENT_PACKAGES_DIR}/include/${PORT}/build/config`