### PR TITLE
[wtl] Remove 'wtl' subdirectory for upstream conformance

### DIFF
--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -14,4 +14,6 @@ file(INSTALL ${SOURCE_PATH}/Include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include
 file(COPY ${SOURCE_PATH}/Samples DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 file(COPY ${SOURCE_PATH}/AppWizard DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
 
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wtl/atlribbon.h" "#include <atl" "#include <wtl/atl")
+
 file(INSTALL ${SOURCE_PATH}/MS-PL.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -10,10 +10,8 @@ vcpkg_from_sourceforge(
         atlmisc.h-bug329.patch
 )
 
-file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.h")
+file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
 file(COPY "${SOURCE_PATH}/Samples" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wtl/atlribbon.h" "#include <atl" "#include <wtl/atl")
 
 file(INSTALL "${SOURCE_PATH}/MS-PL.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -4,16 +4,16 @@ vcpkg_from_sourceforge(
     REF WTL%2010.0.10320%20Release
     FILENAME "WTL10_10320_Release.zip"
     NO_REMOVE_ONE_LEVEL
-	SHA512 086a6cf6a49a4318a8c519136ba6019ded7aa7f2c1d85f78c30b21183654537b3428a400a64fcdacba3a7a10a9ef05137b6f2119f59594da300d55f9ebfb1309
-	PATCHES
-		appwizard_setup.js-vs2022.patch
-		atlmisc.h-bug329.patch
+    SHA512 086a6cf6a49a4318a8c519136ba6019ded7aa7f2c1d85f78c30b21183654537b3428a400a64fcdacba3a7a10a9ef05137b6f2119f59594da300d55f9ebfb1309
+    PATCHES
+        appwizard_setup.js-vs2022.patch
+        atlmisc.h-bug329.patch
 )
 
-file(INSTALL ${SOURCE_PATH}/Include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/${PORT} FILES_MATCHING PATTERN "*.h")
-file(COPY ${SOURCE_PATH}/Samples DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
-file(COPY ${SOURCE_PATH}/AppWizard DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.h")
+file(COPY "${SOURCE_PATH}/Samples" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION $"{CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wtl/atlribbon.h" "#include <atl" "#include <wtl/atl")
 
-file(INSTALL ${SOURCE_PATH}/MS-PL.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/MS-PL.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -12,7 +12,7 @@ vcpkg_from_sourceforge(
 
 file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.h")
 file(COPY "${SOURCE_PATH}/Samples" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION $"{CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wtl/atlribbon.h" "#include <atl" "#include <wtl/atl")
 

--- a/ports/wtl/vcpkg.json
+++ b/ports/wtl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wtl",
   "version-string": "10.0.10320",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Windows Template Library (WTL) is a C++ library for developing Windows applications and UI components.",
   "homepage": "https://sourceforge.net/projects/wtl/"
 }

--- a/ports/wtl/vcpkg.json
+++ b/ports/wtl/vcpkg.json
@@ -3,5 +3,6 @@
   "version": "10.0.10320",
   "port-version": 3,
   "description": "Windows Template Library (WTL) is a C++ library for developing Windows applications and UI components.",
-  "homepage": "https://sourceforge.net/projects/wtl/"
+  "homepage": "https://sourceforge.net/projects/wtl/",
+  "license": "MS-PL"
 }

--- a/ports/wtl/vcpkg.json
+++ b/ports/wtl/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wtl",
-  "version-string": "10.0.10320",
+  "version": "10.0.10320",
   "port-version": 3,
   "description": "Windows Template Library (WTL) is a C++ library for developing Windows applications and UI components.",
   "homepage": "https://sourceforge.net/projects/wtl/"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2742,7 +2742,7 @@
     },
     "hareflow": {
       "baseline": "0.1.0",
-      "port-version": 0      
+      "port-version": 0
     },
     "harfbuzz": {
       "baseline": "4.2.0",
@@ -7578,7 +7578,7 @@
     },
     "wtl": {
       "baseline": "10.0.10320",
-      "port-version": 2
+      "port-version": 3
     },
     "wxchartdir": {
       "baseline": "2.0.0",

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "b1b8e94e75ab0aecd6fa3814c161640851d35606",
+      "git-tree": "1edf05e155b3d36393b83243f61de20b8cc25a4d",
       "version": "10.0.10320",
       "port-version": 3
     },

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c53f87dbe7c641ec664148035d99f1e2f5d7c7f8",
+      "git-tree": "77302be4bab5f3221389c7948462e15ac941002b",
       "version": "10.0.10320",
       "port-version": 3
     },

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b1b8e94e75ab0aecd6fa3814c161640851d35606",
+      "version": "10.0.10320",
+      "port-version": 3
+    },
+    {
       "git-tree": "3345336300f47e924a80d3be0f3fb76c558a54fe",
       "version-string": "10.0.10320",
       "port-version": 2

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1edf05e155b3d36393b83243f61de20b8cc25a4d",
+      "git-tree": "c53f87dbe7c641ec664148035d99f1e2f5d7c7f8",
       "version": "10.0.10320",
       "port-version": 3
     },


### PR DESCRIPTION
The path to the internal files should add the wtl intermediate folder.

The installed header files that contain "#include <atl" are:
- _wtl/atlapp.h_:
```cpp
#include <atlstr.h>
```
- _wtl/atlapp.h_:
```cpp
 #include <atlcom.h>
```
- _wtl/atlmisc.h_:
```cpp
 #include <atlstr.h>
 #include <atltypes.h>
```
- _wtl/atlribbon.h_:
```cpp
#include <atlmisc.h>    // for RecentDocumentList classes
#include <atlframe.h>   // for Frame and UpdateUI classes
#include <atlctrls.h>   // required for atlctrlw.h
#include <atlctrlw.h>   // for CCommandBarCtrl
```
- _wtl/atlwinx.h_:
```cpp
#include <atlwin.h>
```
However only _wtl/atlribbon.h_ deals with this issue.

Fixes #24933.

Already tested the usage.