### PR TITLE
[vcpkg-cmake] Fix the application of VCPKG_CMAKE_CONFIGURE_OPTIONS with more than one option

### DIFF
--- a/ports/vcpkg-cmake/vcpkg.json
+++ b/ports/vcpkg-cmake/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "vcpkg-cmake",
-  "version-date": "2022-05-10",
-  "port-version": 1,
+  "version-date": "2022-06-07",
   "documentation": "https://vcpkg.io/en/docs/README.html",
   "license": "MIT"
 }

--- a/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
+++ b/ports/vcpkg-cmake/vcpkg_cmake_configure.cmake
@@ -185,13 +185,13 @@ function(vcpkg_cmake_configure)
 
     # Allow overrides / additional configuration variables from triplets
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS)
-        vcpkg_list(APPEND arg_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS}")
+        vcpkg_list(APPEND arg_OPTIONS ${VCPKG_CMAKE_CONFIGURE_OPTIONS})
     endif()
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE)
-        vcpkg_list(APPEND arg_OPTIONS_RELEASE "${VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE}")
+        vcpkg_list(APPEND arg_OPTIONS_RELEASE ${VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE})
     endif()
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG)
-        vcpkg_list(APPEND arg_OPTIONS_DEBUG "${VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG}")
+        vcpkg_list(APPEND arg_OPTIONS_DEBUG ${VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG})
     endif()
 
     vcpkg_list(SET rel_command

--- a/scripts/cmake/vcpkg_configure_cmake.cmake
+++ b/scripts/cmake/vcpkg_configure_cmake.cmake
@@ -246,13 +246,13 @@ function(vcpkg_configure_cmake)
 
     # Allow overrides / additional configuration variables from triplets
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS)
-        vcpkg_list(APPEND arg_OPTIONS "${VCPKG_CMAKE_CONFIGURE_OPTIONS}")
+        vcpkg_list(APPEND arg_OPTIONS ${VCPKG_CMAKE_CONFIGURE_OPTIONS})
     endif()
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE)
-        vcpkg_list(APPEND arg_OPTIONS_RELEASE "${VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE}")
+        vcpkg_list(APPEND arg_OPTIONS_RELEASE ${VCPKG_CMAKE_CONFIGURE_OPTIONS_RELEASE})
     endif()
     if(DEFINED VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG)
-        vcpkg_list(APPEND arg_OPTIONS_DEBUG "${VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG}")
+        vcpkg_list(APPEND arg_OPTIONS_DEBUG ${VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG})
     endif()
 
     vcpkg_list(SET rel_command

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7349,8 +7349,8 @@
       "port-version": 1
     },
     "vcpkg-cmake": {
-      "baseline": "2022-05-10",
-      "port-version": 1
+      "baseline": "2022-06-07",
+      "port-version": 0
     },
     "vcpkg-cmake-config": {
       "baseline": "2022-02-06",

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -6,6 +6,11 @@
       "port-version": 0
     },
     {
+      "git-tree": "8b07d914c90cf8f611973318c85d3af13201e3f9",
+      "version-date": "2022-05-10",
+      "port-version": 1
+    },
+    {
       "git-tree": "e8db2f70aa8b584aac932fcff65d91bf52d57731",
       "version-date": "2022-05-10",
       "port-version": 0

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d7d00bd5179b04630039999dad32abb3f4185264",
+      "git-tree": "819e45a14fb875ec7e8373143c994b7bd8d8f7cb",
       "version-date": "2022-06-07",
       "port-version": 0
     },

--- a/versions/v-/vcpkg-cmake.json
+++ b/versions/v-/vcpkg-cmake.json
@@ -1,9 +1,9 @@
 {
   "versions": [
     {
-      "git-tree": "8b07d914c90cf8f611973318c85d3af13201e3f9",
-      "version-date": "2022-05-10",
-      "port-version": 1
+      "git-tree": "d7d00bd5179b04630039999dad32abb3f4185264",
+      "version-date": "2022-06-07",
+      "port-version": 0
     },
     {
       "git-tree": "e8db2f70aa8b584aac932fcff65d91bf52d57731",


### PR DESCRIPTION
**Describe the pull request**

VCPKG_CMAKE_CONFIGURE_OPTIONS (plural) is meant to be a list of options to be added to a cmake invocation.

But it was being applied quoted, which disallowed it from containing multiple options.
- If it was initialized with a list, cmake would get the options ";"-separated.
- If it was initialized with a blank-separated string, cmake would get the entire string quoted as a single argument.

The fix is simple: don't (ever) quote arguments to list(APPEND) unless they are really meant to be a single element to append to the list.

- #### What does your PR fix?

Fixes an issue I encountered when adding a custom triplet that uses a toolchain file.

I see issues #17750 and #23741 (and 23852 more indirectly) all contain reports of multiple options working correctly. Apparently PR #23259 inadvertently broke it by substituting list() with vcpkg_list().

vcpkg_list() top comments say "A replacement for CMake's `list()` function, which correctly handles elements
with internal semicolons (in other words, escaped semicolons)", but fail to explain what's the nature of the issue, and the code is  not trivial to follow, so I'm guiding myself from empirical observation. Explanations and insights are welcome. In the meantime, removing the quotes here works around the issue.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

N/A

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes (it's just basically a typo fix).

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

N/A

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
