### PR TITLE
[fmt] fix format conflict

### DIFF
--- a/ports/fmt/fix-format-conflict.patch
+++ b/ports/fmt/fix-format-conflict.patch
@@ -1,0 +1,15 @@
+diff --git a/doc/api.rst b/doc/api.rst
+index 93fb3fa..a01ebda 100644
+--- a/doc/api.rst
++++ b/doc/api.rst
+@@ -225,8 +225,8 @@ template and implement ``parse`` and ``format`` methods::
+     auto format(const point& p, FormatContext& ctx) -> decltype(ctx.out()) {
+       // ctx.out() is an output iterator to write to.
+       return presentation == 'f'
+-                ? format_to(ctx.out(), "({:.1f}, {:.1f})", p.x, p.y)
+-                : format_to(ctx.out(), "({:.1e}, {:.1e})", p.x, p.y);
++                ? fmt::format_to(ctx.out(), "({:.1f}, {:.1f})", p.x, p.y)
++                : fmt::format_to(ctx.out(), "({:.1e}, {:.1e})", p.x, p.y);
+     }
+   };
+ 

--- a/ports/fmt/fix-format-conflict.patch
+++ b/ports/fmt/fix-format-conflict.patch
@@ -1,15 +1,15 @@
-diff --git a/doc/api.rst b/doc/api.rst
-index 93fb3fa..a01ebda 100644
---- a/doc/api.rst
-+++ b/doc/api.rst
-@@ -225,8 +225,8 @@ template and implement ``parse`` and ``format`` methods::
-     auto format(const point& p, FormatContext& ctx) -> decltype(ctx.out()) {
-       // ctx.out() is an output iterator to write to.
-       return presentation == 'f'
--                ? format_to(ctx.out(), "({:.1f}, {:.1f})", p.x, p.y)
--                : format_to(ctx.out(), "({:.1e}, {:.1e})", p.x, p.y);
-+                ? fmt::format_to(ctx.out(), "({:.1f}, {:.1f})", p.x, p.y)
-+                : fmt::format_to(ctx.out(), "({:.1e}, {:.1e})", p.x, p.y);
-     }
-   };
+diff --git a/include/fmt/format-inl.h b/include/fmt/format-inl.h
+index 2c51c50..fb3eba0 100644
+--- a/include/fmt/format-inl.h
++++ b/include/fmt/format-inl.h
+@@ -75,8 +75,8 @@ FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
+   error_code_size += detail::to_unsigned(detail::count_digits(abs_value));
+   auto it = buffer_appender<char>(out);
+   if (message.size() <= inline_buffer_size - error_code_size)
+-    format_to(it, FMT_STRING("{}{}"), message, SEP);
+-  format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
++    fmt::format_to(it, FMT_STRING("{}{}"), message, SEP);
++  fmt::format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
+   FMT_ASSERT(out.size() <= inline_buffer_size, "");
+ }
  

--- a/ports/fmt/fix-format-conflict.patch
+++ b/ports/fmt/fix-format-conflict.patch
@@ -13,3 +13,16 @@ index 2c51c50..fb3eba0 100644
    FMT_ASSERT(out.size() <= inline_buffer_size, "");
  }
  
+diff --git a/src/os.cc b/src/os.cc
+index 04b4dc5..fe2c7e4 100644
+--- a/src/os.cc
++++ b/src/os.cc
+@@ -167,7 +167,7 @@ void detail::format_windows_error(detail::buffer<char>& out, int error_code,
+     if (msg) {
+       utf16_to_utf8 utf8_message;
+       if (utf8_message.convert(msg) == ERROR_SUCCESS) {
+-        format_to(buffer_appender<char>(out), "{}: {}", message, utf8_message);
++        fmt::format_to(buffer_appender<char>(out), "{}: {}", message, utf8_message);
+         return;
+       }
+     }

--- a/ports/fmt/portfile.cmake
+++ b/ports/fmt/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_from_github(
     PATCHES
         fix-write-batch.patch
         fix-invalid-command.patch
+        fix-format-conflict.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/fmt/vcpkg.json
+++ b/ports/fmt/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "fmt",
   "version": "8.1.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "Formatting library for C++. It can be used as a safe alternative to printf or as a fast alternative to IOStreams.",
   "homepage": "https://github.com/fmtlib/fmt",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2278,7 +2278,7 @@
     },
     "fmt": {
       "baseline": "8.1.1",
-      "port-version": 1
+      "port-version": 2
     },
     "folly": {
       "baseline": "2022.03.21.00",

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "353e102d95cff59387f23f673604b131ffbfe776",
+      "git-tree": "9a9dd65eb454eb4643e01941cedc1477f2807dae",
       "version": "8.1.1",
       "port-version": 2
     },

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "353e102d95cff59387f23f673604b131ffbfe776",
+      "version": "8.1.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "602d9743b7957c9e82a06d0e81d58637c6df5222",
       "version": "8.1.1",
       "port-version": 1

--- a/versions/f-/fmt.json
+++ b/versions/f-/fmt.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9a9dd65eb454eb4643e01941cedc1477f2807dae",
+      "git-tree": "1f0a5cf3aa202e9833dcc5d3fa36688ecf295ca4",
       "version": "8.1.1",
       "port-version": 2
     },


### PR DESCRIPTION
Fix #25109 

Added patch `fix-format-conflict.patch`(https://github.com/fmtlib/fmt/issues/2896), use qualified format_to call to avoid ADL conflict with `std::format_to`.

No feature needs to test.