### PR TITLE
[hexl] Update to 1.2.4

### DIFF
--- a/ports/hexl/portfile.cmake
+++ b/ports/hexl/portfile.cmake
@@ -1,35 +1,30 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO intel/hexl
-    REF 0858760dc957280e8eb8953af4b4b83879d7b8a4
-    SHA512 f2400c4bf32d22904f5917a396fdf6fc625a8832455437429abd54cae70da51cfc42a57dc176d1faeb76f7cd4569dd7499a8f302aef2ea8463d3e8ddc3132050
-    HEAD_REF 1.2.3
+    REF b4589b6149a46dd287bcc0c81c746f72bcf6b37d # 1.2.4
+    SHA512 79eaec45cf5b83459e41cd26c58118a1d0fa4bc1f07ebb00ebd646c90effb0d1dc26f3c33d28f3f1d3cd1cdff8fd23053790156b1c1a736525681bb6fa1fe027
+    HEAD_REF development
 )
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    set(HEXL_SHARED OFF)
-else()
-    set(HEXL_SHARED ON)
-endif()
-
-vcpkg_find_acquire_program(GIT)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" HEXL_SHARED)
 
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
+    SOURCE_PATH "${SOURCE_PATH}"
     DISABLE_PARALLEL_CONFIGURE
     OPTIONS
-        "-DHEXL_BENCHMARK=OFF"
-        "-DHEXL_COVERAGE=OFF"
-        "-DHEXL_TESTING=OFF"
-        "-DHEXL_SHARED_LIB=${HEXL_SHARED}"
+        -DHEXL_BENCHMARK=OFF
+        -DHEXL_COVERAGE=OFF
+        -DHEXL_TESTING=OFF
+        -DHEXL_SHARED_LIB=${HEXL_SHARED}
 )
 
 vcpkg_cmake_install()
 vcpkg_fixup_pkgconfig()
-vcpkg_cmake_config_fixup(PACKAGE_NAME "HEXL" CONFIG_PATH "lib/cmake/hexl-1.2.3")
+vcpkg_cmake_config_fixup(PACKAGE_NAME "HEXL" CONFIG_PATH "lib/cmake/hexl-1.2.4")
+vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")
-
-vcpkg_copy_pdbs()

--- a/ports/hexl/vcpkg.json
+++ b/ports/hexl/vcpkg.json
@@ -1,10 +1,10 @@
 {
   "name": "hexl",
-  "version": "1.2.3",
-  "port-version": 1,
+  "version": "1.2.4",
   "description": "Intel® HEXL is an open-source library which provides efficient implementations of integer arithmetic on Galois fields.",
   "homepage": "https://github.com/intel/hexl",
-  "supports": "x64 & !(windows & !static)",
+  "license": "Apache-2.0",
+  "supports": "x64",
   "dependencies": [
     "cpu-features",
     "easyloggingpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2777,8 +2777,8 @@
       "port-version": 0
     },
     "hexl": {
-      "baseline": "1.2.3",
-      "port-version": 1
+      "baseline": "1.2.4",
+      "port-version": 0
     },
     "hffix": {
       "baseline": "1.0.0",

--- a/versions/h-/hexl.json
+++ b/versions/h-/hexl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4d048751f3f15d5536e3e26d096e5efe3d8713ac",
+      "version": "1.2.4",
+      "port-version": 0
+    },
+    {
       "git-tree": "c345ad60bfec1af5f712c6076de5d58ec497d889",
       "version": "1.2.3",
       "port-version": 1


### PR DESCRIPTION
- Update to 1.2.4
- Enable "mixed" triplets (like x64-windows) #25149
