### PR TITLE
[rtmidi] Add new 'linux-alsa' feature

### DIFF
--- a/ports/rtmidi/portfile.cmake
+++ b/ports/rtmidi/portfile.cmake
@@ -11,12 +11,17 @@ vcpkg_from_github(
     PATCHES fix-cmake-usage.patch # Remove this patch in the next update
 )
 
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        alsa RTMIDI_API_ALSA
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DRTMIDI_API_ALSA=OFF
         -DRTMIDI_API_JACK=OFF
         -DRTMIDI_BUILD_TESTING=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/ports/rtmidi/vcpkg.json
+++ b/ports/rtmidi/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "rtmidi",
   "version": "5.0.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A set of C++ classes that provide a common API for realtime MIDI input/output across Linux (ALSA & JACK), Macintosh OS X (CoreMidi & JACK) and Windows (Multimedia)",
   "homepage": "https://github.com/thestk/rtmidi",
   "license": "MIT",
@@ -15,5 +15,14 @@
       "name": "vcpkg-cmake-config",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "alsa": {
+      "description": "Build ALSA API",
+      "supports": "linux",
+      "dependencies": [
+        "alsa"
+      ]
+    }
+  }
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6318,7 +6318,7 @@
     },
     "rtmidi": {
       "baseline": "5.0.0",
-      "port-version": 1
+      "port-version": 2
     },
     "rttr": {
       "baseline": "0.9.6",

--- a/versions/r-/rtmidi.json
+++ b/versions/r-/rtmidi.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "70873823ce910dcf80078a94f12191371523d84c",
+      "version": "5.0.0",
+      "port-version": 2
+    },
+    {
       "git-tree": "30614a92baff91c2d2790029179dbb37122ca331",
       "version": "5.0.0",
       "port-version": 1


### PR DESCRIPTION
- #### What does your PR fix?
Aims to fix https://github.com/microsoft/vcpkg/issues/6993 on Linux, where RtMidi is always compiled in Dummy mode (i.e. unusable).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
The change affects only the Linux triplet.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes.

