### PR TITLE
[tiff] Fix libm as dependency for android

### DIFF
--- a/ports/tiff/android-libm.patch
+++ b/ports/tiff/android-libm.patch
@@ -1,0 +1,14 @@
+diff --color -Naur v4.4.0-1eba4caf45.clean/cmake/FindCMath.cmake v4.4.0-1eba4caf45.patched/cmake/FindCMath.cmake
+--- v4.4.0-1eba4caf45.clean/cmake/FindCMath.cmake	2022-06-09 13:28:09.894347027 +0200
++++ v4.4.0-1eba4caf45.patched/cmake/FindCMath.cmake	2022-06-09 13:29:36.220230025 +0200
+@@ -31,8 +31,9 @@
+ include(CheckLibraryExists)
+ 
+ check_symbol_exists(pow "math.h" CMath_HAVE_LIBC_POW)
++find_library(CMath_LIBRARY NAMES m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
++
+ if(NOT CMath_HAVE_LIBC_POW)
+-    find_library(CMath_LIBRARY NAMES m PATHS ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
+ 
+     set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
+     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${CMath_LIBRARY})

--- a/ports/tiff/portfile.cmake
+++ b/ports/tiff/portfile.cmake
@@ -7,8 +7,10 @@ vcpkg_from_gitlab(
     REF v${LIBTIFF_VERSION}
     SHA512 93955a2b802cf243e41d49048499da73862b5d3ffc005e3eddf0bf948a8bd1537f7c9e7f112e72d082549b4c49e256b9da9a3b6d8039ad8fc5c09a941b7e75d7
     HEAD_REF master
-    PATCHES cmakelists.patch
-    FindCMath.patch
+    PATCHES
+        cmakelists.patch
+        FindCMath.patch
+        android-libm.patch
 )
 
 set(EXTRA_OPTIONS "")

--- a/ports/tiff/vcpkg.json
+++ b/ports/tiff/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "tiff",
   "version": "4.4.0",
+  "port-version": 1,
   "description": "A library that supports the manipulation of TIFF image files",
   "homepage": "https://libtiff.gitlab.io/libtiff/",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6994,7 +6994,7 @@
     },
     "tiff": {
       "baseline": "4.4.0",
-      "port-version": 0
+      "port-version": 1
     },
     "tinkerforge": {
       "baseline": "2.1.25",

--- a/versions/t-/tiff.json
+++ b/versions/t-/tiff.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "7d5e9083d0072a4370b44f434cd4dac7b3bee7bc",
+      "version": "4.4.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "18c67848b7384af1ff6ad1c4e92b013376b136b6",
       "version": "4.4.0",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes `-lm` is missing as dependency on Android

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>

Followup https://github.com/microsoft/vcpkg/pull/22137 and https://github.com/microsoft/vcpkg/pull/24986

Upstream pull request: https://gitlab.com/libtiff/libtiff/-/merge_requests/350