### PR TITLE
[nanogui] add glad support

### DIFF
--- a/ports/nanogui/fix-glad-dependence.patch
+++ b/ports/nanogui/fix-glad-dependence.patch
@@ -1,0 +1,101 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3fe6f5d..22dc16f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -87,7 +87,7 @@ endif()
+ 
+ # Shared library mode: add dllimport/dllexport flags to all symbols
+ if (NANOGUI_BUILD_SHARED)
+-  list(APPEND NANOGUI_EXTRA_DEFS -DNANOGUI_SHARED -DNVG_SHARED -DGLAD_GLAPI_EXPORT)
++  list(APPEND NANOGUI_EXTRA_DEFS -DNANOGUI_SHARED -DNVG_SHARED)
+ endif()
+ 
+ if (MSVC)
+@@ -196,21 +196,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   endif()
+ endif()
+ 
+-if (NANOGUI_USE_GLAD)
+-  # Build and include GLAD on Windows
+-  list(APPEND LIBNANOGUI_EXTRA_SOURCE
+-     "${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/src/glad.c"
+-	 "${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/include/glad/glad.h"
+-	 "${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/include/KHR/khrplatform.h")
+-  if (MSVC)
+-    set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/src/glad.c"
+-      PROPERTIES COMPILE_FLAGS "/wd4055 ")
+-  endif()
+-  include_directories(ext/glad/include)
+-  list(APPEND NANOGUI_EXTRA_DEFS -DNANOGUI_GLAD)
+-  list(APPEND NANOGUI_EXTRA_INCS "${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/include")
+-endif()
+-
+ list(APPEND NANOGUI_EXTRA_INCS
+   "${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw/include"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ext/nanovg/src"
+@@ -299,8 +284,6 @@ if (APPLE)
+   add_compile_options(-fobjc-arc)
+ endif()
+ 
+-add_definitions(${NANOGUI_EXTRA_DEFS})
+-
+ # Compile main NanoGUI library
+ add_library(nanogui-obj OBJECT
+   # Merge NanoVG into the NanoGUI library
+@@ -373,6 +356,14 @@ find_package(Eigen3 CONFIG REQUIRED)
+ find_package(glfw3 CONFIG REQUIRED)
+ target_link_libraries(nanogui glfw nanovg::nanovg Eigen3::Eigen)
+ 
++if (NANOGUI_USE_GLAD)
++  find_package(glad CONFIG REQUIRED)
++  target_link_libraries(nanogui glad::glad)
++  list(APPEND NANOGUI_EXTRA_DEFS -DNANOGUI_GLAD)
++endif()
++
++add_definitions(${NANOGUI_EXTRA_DEFS})
++
+ if (NANOGUI_BUILD_SHARED)
+   set_property(TARGET nanogui-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
+ endif()
+@@ -380,11 +371,6 @@ endif()
+ # Compile/link flags for NanoGUI
+ set_property(TARGET nanogui-obj APPEND PROPERTY COMPILE_DEFINITIONS "NANOGUI_BUILD;NVG_BUILD")
+ 
+-if (NANOGUI_USE_GLAD AND NANOGUI_BUILD_SHARED)
+-  set_property(TARGET nanogui-obj APPEND PROPERTY COMPILE_DEFINITIONS
+-    "GLAD_GLAPI_EXPORT;GLAD_GLAPI_EXPORT_BUILD")
+-endif()
+-
+ if (NANOGUI_BUILD_SHARED)
+   target_link_libraries(nanogui ${NANOGUI_EXTRA_LIBS})
+ endif()
+diff --git a/include/nanogui/opengl.h b/include/nanogui/opengl.h
+index f5abcb2..1c20653 100644
+--- a/include/nanogui/opengl.h
++++ b/include/nanogui/opengl.h
+@@ -17,10 +17,6 @@
+ 
+ #ifndef DOXYGEN_SHOULD_SKIP_THIS
+ #if defined(NANOGUI_GLAD)
+-    #if defined(NANOGUI_SHARED) && !defined(GLAD_GLAPI_EXPORT)
+-        #define GLAD_GLAPI_EXPORT
+-    #endif
+-
+     #include <glad/glad.h>
+ #else
+     #if defined(__APPLE__)
+diff --git a/src/example3.cpp b/src/example3.cpp
+index 3d2ecfa..72deaa8 100644
+--- a/src/example3.cpp
++++ b/src/example3.cpp
+@@ -14,10 +14,6 @@
+ // GLFW
+ //
+ #if defined(NANOGUI_GLAD)
+-    #if defined(NANOGUI_SHARED) && !defined(GLAD_GLAPI_EXPORT)
+-        #define GLAD_GLAPI_EXPORT
+-    #endif
+-
+     #include <glad/glad.h>
+ #else
+     #if defined(__APPLE__)

--- a/ports/nanogui/portfile.cmake
+++ b/ports/nanogui/portfile.cmake
@@ -8,14 +8,18 @@ vcpkg_from_github(
         fix-cmakelists.patch
 )
 
-vcpkg_configure_cmake(
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+            glad   NANOGUI_USE_GLAD
+)
+vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DNANOGUI_EIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
         -DEIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 

--- a/ports/nanogui/portfile.cmake
+++ b/ports/nanogui/portfile.cmake
@@ -1,3 +1,10 @@
+if (VCPKG_HOST_IS_WINDOWS)
+  set(USE_GLAD -DNANOGUI_USE_GLAD=ON)
+  vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+else()
+  set(USE_GLAD -DNANOGUI_USE_GLAD=OFF)
+endif()
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wjakob/nanogui
@@ -6,17 +13,17 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         fix-cmakelists.patch
+        fix-glad-dependence.patch
 )
 
-if (VCPKG_HOST_IS_WINDOWS)
-  set(USE_GLAD -DNANOGUI_USE_GLAD=ON)
-else()
-  set(USE_GLAD -DNANOGUI_USE_GLAD=OFF)
-endif()
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+    "example"           NANOGUI_BUILD_EXAMPLE
+)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
+    OPTIONS ${FEATURE_OPTIONS}
         -DNANOGUI_EIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
         -DEIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
         ${USE_GLAD}

--- a/ports/nanogui/portfile.cmake
+++ b/ports/nanogui/portfile.cmake
@@ -8,20 +8,23 @@ vcpkg_from_github(
         fix-cmakelists.patch
 )
 
-vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-            glad   NANOGUI_USE_GLAD
-)
+if (VCPKG_HOST_IS_WINDOWS)
+  set(USE_GLAD -DNANOGUI_USE_GLAD=ON)
+else()
+  set(USE_GLAD -DNANOGUI_USE_GLAD=OFF)
+endif()
+
 vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS ${FEATURE_OPTIONS}
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
         -DNANOGUI_EIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
         -DEIGEN_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/eigen3
+        ${USE_GLAD}
 )
 
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -1,13 +1,30 @@
 {
   "name": "nanogui",
   "version-date": "2019-09-23",
-  "port-version": 3,
+  "port-version": 4,
   "description": "NanoGUI is a minimalistic cross-platform widget library for OpenGL 3.x or higher.",
   "homepage": "https://github.com/wjakob/nanogui",
+  "license": null,
   "supports": "!uwp",
   "dependencies": [
     "eigen3",
     "glfw3",
-    "nanovg"
-  ]
+    "nanovg",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "glad": {
+      "description": "Build with glad",
+      "dependencies": [
+        "glad"
+      ]
+    }
+  }
 }

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -7,9 +7,9 @@
   "supports": "!uwp",
   "dependencies": [
     "eigen3",
+    "glad",
     "glfw3",
     "nanovg",
-    "glad",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 4,
   "description": "NanoGUI is a minimalistic cross-platform widget library for OpenGL 3.x or higher.",
   "homepage": "https://github.com/wjakob/nanogui",
-  "license": null,
+  "license": "BSD-3-Clause",
   "supports": "!uwp",
   "dependencies": [
     "eigen3",

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -4,8 +4,8 @@
   "port-version": 4,
   "description": "NanoGUI is a minimalistic cross-platform widget library for OpenGL 3.x or higher.",
   "homepage": "https://github.com/wjakob/nanogui",
-  "supports": "!uwp",
   "license": null,
+  "supports": "!uwp",
   "dependencies": [
     "eigen3",
     "glad",

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -9,9 +9,15 @@
     "eigen3",
     "glfw3",
     "nanovg",
+    "glad",
     {
       "name": "vcpkg-cmake",
       "host": true
     }
-  ]
+  ],
+  "features": {
+    "example": {
+      "description": "Build NanoGUI example application"
+    }
+  }
 }

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "NanoGUI is a minimalistic cross-platform widget library for OpenGL 3.x or higher.",
   "homepage": "https://github.com/wjakob/nanogui",
   "supports": "!uwp",
+  "license": null,
   "dependencies": [
     "eigen3",
     "glad",

--- a/ports/nanogui/vcpkg.json
+++ b/ports/nanogui/vcpkg.json
@@ -4,7 +4,6 @@
   "port-version": 4,
   "description": "NanoGUI is a minimalistic cross-platform widget library for OpenGL 3.x or higher.",
   "homepage": "https://github.com/wjakob/nanogui",
-  "license": null,
   "supports": "!uwp",
   "dependencies": [
     "eigen3",
@@ -13,18 +12,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
-  ],
-  "features": {
-    "glad": {
-      "description": "Build with glad",
-      "dependencies": [
-        "glad"
-      ]
-    }
-  }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4762,7 +4762,7 @@
     },
     "nanogui": {
       "baseline": "2019-09-23",
-      "port-version": 3
+      "port-version": 4
     },
     "nanomsg": {
       "baseline": "1.1.5",

--- a/versions/n-/nanogui.json
+++ b/versions/n-/nanogui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "023c7db265fd37a5bf1d2f72b6a52194b21bb300",
+      "version-date": "2019-09-23",
+      "port-version": 4
+    },
+    {
       "git-tree": "55a7f3e088fe04ac01f7693c0685770ba865e6ae",
       "version-date": "2019-09-23",
       "port-version": 3

--- a/versions/n-/nanogui.json
+++ b/versions/n-/nanogui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5d83bdc05c643636195b6f5c793d9faf3384a738",
+      "git-tree": "70e269fb75620e20dd49a56c3bb28d0295b940d9",
       "version-date": "2019-09-23",
       "port-version": 4
     },

--- a/versions/n-/nanogui.json
+++ b/versions/n-/nanogui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "70e269fb75620e20dd49a56c3bb28d0295b940d9",
+      "git-tree": "6f72fef2df511d4891a37a77f0b323fb3ef5a7df",
       "version-date": "2019-09-23",
       "port-version": 4
     },

--- a/versions/n-/nanogui.json
+++ b/versions/n-/nanogui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "023c7db265fd37a5bf1d2f72b6a52194b21bb300",
+      "git-tree": "5d83bdc05c643636195b6f5c793d9faf3384a738",
       "version-date": "2019-09-23",
       "port-version": 4
     },

--- a/versions/n-/nanogui.json
+++ b/versions/n-/nanogui.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6f72fef2df511d4891a37a77f0b323fb3ef5a7df",
+      "git-tree": "7b0c7f8295a21f967bfd880956f6d51b98d26874",
       "version-date": "2019-09-23",
       "port-version": 4
     },


### PR DESCRIPTION
Fix #9707

Add option `NANOGUI_USE_GLAD` to use `GLAD` on windows(default). Use vcpkg's `glad `instead of the original glad in source code.
Add patch `fix-glad-dependence.patch` to fix the glad linkage issue.
`error LNK2019: unresolved external symbol __imp_glad_glDisable referenced in function "public: void __cdecl`

Add `ONLY_STATIC_LIBRARY`, because the Because the dependent `glad `is static-only library.

Add feature `example`.

All features passed with following triplets:
x86-windows
x64-windows
x64-windows-static