### PR TITLE
[libiconv] Update to 1.17

### DIFF
--- a/ports/libiconv/0002-Config-for-MSVC.patch
+++ b/ports/libiconv/0002-Config-for-MSVC.patch
@@ -11,4 +11,17 @@ index 6dc011b..158ccdd 100644
  # ifdef mbstate_t
  #  define mbrtowc(pwc, s, n, ps) (mbrtowc)(pwc, s, n, 0)
  #  define mbsinit(ps) 1
+diff --git a/srclib/fcntl.c b/srclib/fcntl.c
+index f9753c4..02fc8be 100644
+--- a/srclib/fcntl.c
++++ b/srclib/fcntl.c
+@@ -37,6 +37,9 @@
+ /* Get declarations of the native Windows API functions.  */
+ # define WIN32_LEAN_AND_MEAN
+ # include <windows.h>
++#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
++#define HANDLE_FLAG_INHERIT 0
++#endif
  
+ /* Get _get_osfhandle.  */
+ # if GNULIB_MSVC_NOTHROW

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -5,17 +5,17 @@ if(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_ANDROID)
     return()
 endif()
 
-set(LIBICONV_VERSION 1.16)
+set(LIBICONV_VERSION 1.17)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://ftp.gnu.org/gnu/libiconv/libiconv-${LIBICONV_VERSION}.tar.gz" "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libiconv/libiconv-${LIBICONV_VERSION}.tar.gz"
     FILENAME "libiconv-${LIBICONV_VERSION}.tar.gz"
-    SHA512 365dac0b34b4255a0066e8033a8b3db4bdb94b9b57a9dca17ebf2d779139fe935caf51a465d17fd8ae229ec4b926f3f7025264f37243432075e5583925bb77b7
+    SHA512 18a09de2d026da4f2d8b858517b0f26d853b21179cf4fa9a41070b2d140030ad9525637dc4f34fc7f27abca8acdc84c6751dfb1d426e78bf92af4040603ced86
 )
 vcpkg_extract_source_archive_ex(
     OUT_SOURCE_PATH SOURCE_PATH
-    ARCHIVE ${ARCHIVE}
-    REF ${LIBICONV_VERSION}
+    ARCHIVE "${ARCHIVE}"
+    REF "${LIBICONV_VERSION}"
     PATCHES
         0002-Config-for-MSVC.patch
         0003-Add-export.patch

--- a/ports/libiconv/portfile.cmake
+++ b/ports/libiconv/portfile.cmake
@@ -50,4 +50,19 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}") # share contains un
 
 # Please keep, the default usage is broken
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
-file(INSTALL "${SOURCE_PATH}/COPYING.LIB" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(READ "${SOURCE_PATH}/COPYING.LIB" copying_lib)
+file(READ "${SOURCE_PATH}/COPYING" copying_tool)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "
+The libiconv and libcharset libraries and their header files are under LGPL,
+see COPYING.LIB below.
+
+The iconv program and the documentation are under GPL, see COPYING below.
+
+# COPYING.LIB
+
+${copying_lib}
+
+# COPYING
+
+${copying_tool}
+")

--- a/ports/libiconv/vcpkg.json
+++ b/ports/libiconv/vcpkg.json
@@ -2,5 +2,6 @@
   "name": "libiconv",
   "version": "1.17",
   "description": "GNU Unicode text conversion",
-  "homepage": "https://www.gnu.org/software/libiconv/"
+  "homepage": "https://www.gnu.org/software/libiconv/",
+  "license": null
 }

--- a/ports/libiconv/vcpkg.json
+++ b/ports/libiconv/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "libiconv",
-  "version": "1.16",
-  "port-version": 13,
+  "version": "1.17",
   "description": "GNU Unicode text conversion",
   "homepage": "https://www.gnu.org/software/libiconv/"
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3689,8 +3689,8 @@
       "port-version": 1
     },
     "libiconv": {
-      "baseline": "1.16",
-      "port-version": 13
+      "baseline": "1.17",
+      "port-version": 0
     },
     "libics": {
       "baseline": "1.6.5",

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "5542ccc197b1d3d4ad3d58cd33c0f52535e5c769",
+      "version": "1.17",
+      "port-version": 0
+    },
+    {
       "git-tree": "cc4f1edf5a444934d4a757420a6cd3fed596e1d5",
       "version": "1.16",
       "port-version": 13

--- a/versions/l-/libiconv.json
+++ b/versions/l-/libiconv.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5542ccc197b1d3d4ad3d58cd33c0f52535e5c769",
+      "git-tree": "1f92b7d29ce3243d3d51e07686869eca63ece88a",
       "version": "1.17",
       "port-version": 0
     },


### PR DESCRIPTION
- #### What does your PR fix?
  Updates `libiconv`.
  Adds an explicit distinction for licensing of lib vs. tool.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes
