### PR TITLE
Keep config.log after config error

### DIFF
--- a/scripts/cmake/vcpkg_execute_required_process.cmake
+++ b/scripts/cmake/vcpkg_execute_required_process.cmake
@@ -80,7 +80,7 @@ Halting portfile execution.
         endforeach()
 
         z_vcpkg_prettify_command_line(pretty_command ${arg_COMMAND})
-        message(FATAL_ERROR
+        message(WARNING
             "  Command failed: ${pretty_command}\n"
             "  Working Directory: ${arg_WORKING_DIRECTORY}\n"
             "  Error code: ${error_code}\n"


### PR DESCRIPTION
Make ./configure build step error not fatal as a workaround to keep the error log.

https://github.com/daschuer/vcpkg/actions/runs/2475963864 is a failing build, that verifies that the config.log is kept.

- #### What does your PR fix?

Fixed deletion of config.log https://github.com/microsoft/vcpkg/issues/21422

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  No, not required 