### PR TITLE
[gdal] Fix building for 32bit Android and msvc with poppler

### DIFF
--- a/ports/gdal/dependency_win.cmake
+++ b/ports/gdal/dependency_win.cmake
@@ -137,7 +137,7 @@ macro(find_dependency_win)
 
     if("poppler" IN_LIST FEATURES)
         list(APPEND NMAKE_OPTIONS "POPPLER_ENABLED=YES")
-        list(APPEND NMAKE_OPTIONS "POPPLER_MAJOR_VERSION=22" "POPPLER_MINOR_VERSION=1") # Bump as needed
+        list(APPEND NMAKE_OPTIONS "POPPLER_MAJOR_VERSION=22" "POPPLER_MINOR_VERSION=3") # Bump as needed
         list(APPEND NMAKE_OPTIONS "POPPLER_CFLAGS=-I${CURRENT_INSTALLED_DIR}/include -I${CURRENT_INSTALLED_DIR}/include/poppler /std:c++17")
         x_vcpkg_pkgconfig_get_modules(PREFIX POPPLER MODULES --msvc-syntax poppler LIBS)
         list(APPEND NMAKE_OPTIONS_REL "POPPLER_LIBS=${POPPLER_LIBS_RELEASE}")

--- a/ports/gdal/portfile.cmake
+++ b/ports/gdal/portfile.cmake
@@ -288,6 +288,10 @@ else()
         list(APPEND CONF_OPTS "--with-tools=no")
     endif()
 
+    if(VCPKG_TARGET_IS_ANDROID AND (VCPKG_TARGET_ARCHITECTURE MATCHES "x86" OR VCPKG_TARGET_ARCHITECTURE MATCHES "arm"))
+        list(APPEND CONF_OPTS --with-unix-stdio-64=no)
+    endif()
+
     vcpkg_configure_make(
         SOURCE_PATH "${SOURCE_PATH}/gdal"
         AUTOCONFIG

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2458,7 +2458,7 @@
     },
     "gdal": {
       "baseline": "3.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "509d3e54670e6552cce8d811a329d6c28589392e",
+      "version-semver": "3.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "8bdf8b8ff951c1ce8719c789e66ac3a166eed063",
       "version-semver": "3.4.3",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes
  - building gdal for 32 bit android
  - building with poppler with msvc

Error:

> File API does not seem to support 64-bit offset.
> If you still want to build GDAL without > 4GB file support, 
> add the -DBUILD_WITHOUT_64BIT_OFFSET define

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
