### PR TITLE
[quantlib] Fix `supports`

### DIFF
--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Install custom usage
-configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}" @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" @ONLY)
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -26,7 +26,7 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Install custom usage
-file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}" @ONLY)
 
 # Handle copyright
 file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/quantlib/portfile.cmake
+++ b/ports/quantlib/portfile.cmake
@@ -22,9 +22,11 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 vcpkg_cmake_config_fixup(PACKAGE_NAME QuantLib CONFIG_PATH lib/cmake/QuantLib)
 vcpkg_copy_pdbs()
-# Install custom usage
-configure_file(${CMAKE_CURRENT_LIST_DIR}/usage ${CURRENT_PACKAGES_DIR}/share/${PORT}/usage @ONLY)
+
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
+# Install custom usage
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" @ONLY)
+
 # Handle copyright
-configure_file("${SOURCE_PATH}/LICENSE.TXT" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)
+file(INSTALL "${SOURCE_PATH}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "quantlib",
   "version": "1.26",
+  "port-version": 1,
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
-  "supports": "!(windows & !static)",
+  "license": "BSD-3-Clause",
   "dependencies": [
     "boost-accumulators",
     "boost-algorithm",

--- a/ports/quantlib/vcpkg.json
+++ b/ports/quantlib/vcpkg.json
@@ -5,6 +5,7 @@
   "description": "The QuantLib C++ library",
   "homepage": "https://www.quantlib.org/",
   "license": "BSD-3-Clause",
+  "supports": "!(windows & !staticcrt)",
   "dependencies": [
     "boost-accumulators",
     "boost-algorithm",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6058,7 +6058,7 @@
     },
     "quantlib": {
       "baseline": "1.26",
-      "port-version": 0
+      "port-version": 1
     },
     "quaternions": {
       "baseline": "1.0.0",

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a7dea362ff354da80849a0804931b4250e193aa7",
+      "version": "1.26",
+      "port-version": 1
+    },
+    {
       "git-tree": "3af9ced73240dfb4e1ec776c5f9a16ac277d1c27",
       "version": "1.26",
       "port-version": 0

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7b915c2c716d0a05aa1d45baabd8727e4976a6ff",
+      "git-tree": "f5eb0f25fa5fdff2d0fd4b5cc1f1bb2e98033b59",
       "version": "1.26",
       "port-version": 1
     },

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a7dea362ff354da80849a0804931b4250e193aa7",
+      "git-tree": "041e0d154ef62b2a804bdace8227262c7b610122",
       "version": "1.26",
       "port-version": 1
     },

--- a/versions/q-/quantlib.json
+++ b/versions/q-/quantlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "041e0d154ef62b2a804bdace8227262c7b610122",
+      "git-tree": "7b915c2c716d0a05aa1d45baabd8727e4976a6ff",
       "version": "1.26",
       "port-version": 1
     },


### PR DESCRIPTION
Fixes quantlib to not support dynamic CRT linkage on Windows.

For #25149