### PR TITLE
[gdal] Adjust poppler version

### DIFF
--- a/ports/gdal/dependency_win.cmake
+++ b/ports/gdal/dependency_win.cmake
@@ -137,7 +137,7 @@ macro(find_dependency_win)
 
     if("poppler" IN_LIST FEATURES)
         list(APPEND NMAKE_OPTIONS "POPPLER_ENABLED=YES")
-        list(APPEND NMAKE_OPTIONS "POPPLER_MAJOR_VERSION=22" "POPPLER_MINOR_VERSION=1") # Bump as needed
+        list(APPEND NMAKE_OPTIONS "POPPLER_MAJOR_VERSION=22" "POPPLER_MINOR_VERSION=3") # Bump as needed
         list(APPEND NMAKE_OPTIONS "POPPLER_CFLAGS=-I${CURRENT_INSTALLED_DIR}/include -I${CURRENT_INSTALLED_DIR}/include/poppler /std:c++17")
         x_vcpkg_pkgconfig_get_modules(PREFIX POPPLER MODULES --msvc-syntax poppler LIBS)
         list(APPEND NMAKE_OPTIONS_REL "POPPLER_LIBS=${POPPLER_LIBS_RELEASE}")

--- a/ports/gdal/vcpkg.json
+++ b/ports/gdal/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdal",
   "version-semver": "3.4.3",
-  "port-version": 1,
+  "port-version": 2,
   "description": "The Geographic Data Abstraction Library for reading and writing geospatial raster and vector data",
   "homepage": "https://gdal.org",
   "license": null,

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2458,7 +2458,7 @@
     },
     "gdal": {
       "baseline": "3.4.3",
-      "port-version": 1
+      "port-version": 2
     },
     "gdcm": {
       "baseline": "3.0.12",

--- a/versions/g-/gdal.json
+++ b/versions/g-/gdal.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "8d5215fbe17770fd5d80f0932beed8008310c391",
+      "version-semver": "3.4.3",
+      "port-version": 2
+    },
+    {
       "git-tree": "8bdf8b8ff951c1ce8719c789e66ac3a166eed063",
       "version-semver": "3.4.3",
       "port-version": 1


### PR DESCRIPTION
Fixes a compile error

- #### What does your PR fix?
  Fixes the poppler dependency for gdal on windows

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all, yes

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes, but it's the second pull request with a fix for gdal and I wonder if the preferred way is to open multiple pull requests which will conflict or a monolithic one for ease of merge