### PR TITLE
[zziplib] Export unofficial targets

### DIFF
--- a/ports/zziplib/export-targets.patch
+++ b/ports/zziplib/export-targets.patch
@@ -1,0 +1,73 @@
+diff --git a/zzip/CMakeLists.txt b/zzip/CMakeLists.txt
+index 1883272..16d4380 100644
+--- a/zzip/CMakeLists.txt
++++ b/zzip/CMakeLists.txt
+@@ -175,7 +175,7 @@ set(libzzipmmapped_HDRS mmapped.h memdisk.h)
+ 
+ add_library(libzzip ${libzzip_SRCS} )
+ target_link_libraries(libzzip ZLIB::ZLIB )
+-target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
++target_include_directories (libzzip PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} PUBLIC $<INSTALL_INTERFACE:include/zzip>)
+ 
+ if(ZZIPFSEEKO)
+ add_library(libzzipfseeko ${libzzipfseeko_SRCS} )
+@@ -255,14 +255,14 @@ install(FILES ${outdir}/zziplib.pc ${outdir}/zzipmmapped.pc ${outdir}/zzipfseeko
+ endif()
+ 
+ install(FILES ${libzzip_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
+-install(TARGETS libzzip 
++install(TARGETS libzzip EXPORT unofficial-zziplibTargets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ if(ZZIPFSEEKO)
+ install(FILES ${libzzipfseeko_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
+-install(TARGETS libzzipfseeko 
++install(TARGETS libzzipfseeko EXPORT unofficial-zziplibTargets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+@@ -270,12 +270,28 @@ endif()
+ 
+ if(ZZIPMMAPPED)
+ install(FILES ${libzzipmmapped_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
+-install(TARGETS libzzipmmapped
++install(TARGETS libzzipmmapped EXPORT unofficial-zziplibTargets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
++install(EXPORT unofficial-zziplibTargets
++    NAMESPACE unofficial::zziplib::
++    DESTINATION share/unofficial-zziplib
++)
++
++file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/unofficial-zziplib-config.cmake.in"
++[[include(CMakeFindDependencyMacro)
++find_dependency(ZLIB)
++file(GLOB TARGET_FILES "${CMAKE_CURRENT_LIST_DIR}/*Targets.cmake")
++foreach (TARGET_FILE ${TARGET_FILES})
++    include("${TARGET_FILE}")
++endforeach()
++]])
++configure_file("${CMAKE_CURRENT_BINARY_DIR}/unofficial-zziplib-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/unofficial-zziplib-config.cmake" @ONLY)
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unofficial-zziplib-config.cmake DESTINATION share/unofficial-zziplib)
++
+ if(ZZIP_COMPAT)
+   install(FILES ${outdir}/compat/zzip.h ${outdir}/compat/zziplib.h ${outdir}/compat/zzip-io.h 
+           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+diff --git a/zzipwrap/CMakeLists.txt b/zzipwrap/CMakeLists.txt
+index ea7ea93..2d41f70 100644
+--- a/zzipwrap/CMakeLists.txt
++++ b/zzipwrap/CMakeLists.txt
+@@ -83,7 +83,7 @@ install(FILES ${outdir}/zzipwrap.pc
+ endif()
+ 
+ install(FILES ${libzzipwrap_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zzip )
+-install(TARGETS libzzipwrap
++install(TARGETS libzzipwrap EXPORT unofficial-zziplibTargets
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 

--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -5,6 +5,7 @@ vcpkg_from_github(
     SHA512 4bb089e74813c6fac9657cd96e44e4a6469bf86aba3980d885c4573e8db45e74fd07bbdfcec9f36297c72227c8c0b2c37dab1bc4326cef8529960e482fe501c8
     PATCHES
         no-release-postfix.patch
+        export-targets.patch
 )
 
 string(COMPARE EQUAL VCPKG_CRT_LINKAGE "static" MSVC_STATIC_RUNTIME)
@@ -25,6 +26,8 @@ vcpkg_cmake_configure(
         -DZZIPDOCS=OFF
 )
 vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME unofficial-zziplib)
 
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "zziplib",
   "version": "0.13.72",
+  "port-version": 1,
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7818,7 +7818,7 @@
     },
     "zziplib": {
       "baseline": "0.13.72",
-      "port-version": 0
+      "port-version": 1
     }
   }
 }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "571af9ee98bd4bf80bf21fc10a5ec5971678b954",
+      "version": "0.13.72",
+      "port-version": 1
+    },
+    {
       "git-tree": "e09e8bf85eff5c115f9dcf5372f8bdbab590ab6b",
       "version": "0.13.72",
       "port-version": 0


### PR DESCRIPTION
Upstream PR: https://github.com/gdraheim/zziplib/pull/135

Fixes #25186.
Already tested usage in x86-windows.