### PR TITLE
[gmp | mpir] Add --with-pic

### DIFF
--- a/ports/gmp/portfile.cmake
+++ b/ports/gmp/portfile.cmake
@@ -49,6 +49,7 @@ vcpkg_configure_make(
     OPTIONS
         ${OPTIONS}
         --enable-cxx
+        --with-pic
 )
 
 set(tool_names bases fac fib jacobitab psqr trialdivtab)

--- a/ports/gmp/vcpkg.json
+++ b/ports/gmp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gmp",
   "version": "6.2.1",
-  "port-version": 9,
+  "port-version": 10,
   "description": "The GNU Multiple Precision Arithmetic Library",
   "homepage": "https://gmplib.org",
   "supports": "!(windows & (arm | arm64))",

--- a/ports/mpir/portfile.cmake
+++ b/ports/mpir/portfile.cmake
@@ -19,12 +19,12 @@ if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX)
     vcpkg_find_acquire_program(YASM)
 
     if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-        set(SHARED_STATIC "--enable-static --disable-shared")
+        set(SHARED_STATIC --enable-static --disable-shared --with-pic)
     else()
-        set(SHARED_STATIC "--disable-static --enable-shared")
+        set(SHARED_STATIC --disable-static --enable-shared)
     endif()
 
-    set(OPTIONS "--disable-silent-rules --enable-gmpcompat --enable-cxx ${SHARED_STATIC}")
+    set(OPTIONS --disable-silent-rules --enable-gmpcompat --enable-cxx ${SHARED_STATIC})
 
     string(APPEND VCPKG_C_FLAGS " -Wno-implicit-function-declaration")
     string(APPEND VCPKG_CXX_FLAGS " -Wno-implicit-function-declaration")

--- a/ports/mpir/vcpkg.json
+++ b/ports/mpir/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "mpir",
   "version-date": "2022-03-02",
+  "port-version": 1,
   "description": "Multiple Precision Integers and Rationals",
   "homepage": "https://github.com/wbhart/mpir",
   "license": "GPL-3.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2606,7 +2606,7 @@
     },
     "gmp": {
       "baseline": "6.2.1",
-      "port-version": 9
+      "port-version": 10
     },
     "gmsh": {
       "baseline": "4.9.0",
@@ -4686,7 +4686,7 @@
     },
     "mpir": {
       "baseline": "2022-03-02",
-      "port-version": 0
+      "port-version": 1
     },
     "mpmcqueue": {
       "baseline": "2021-12-01",

--- a/versions/g-/gmp.json
+++ b/versions/g-/gmp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "f4748213535c3fd004de44f6b1f15d123927cce6",
+      "version": "6.2.1",
+      "port-version": 10
+    },
+    {
       "git-tree": "7b9a71843073bf4a86bb64ddf219c9900ebb3dbd",
       "version": "6.2.1",
       "port-version": 9

--- a/versions/m-/mpir.json
+++ b/versions/m-/mpir.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9191f07cfaade82121abb4d37cb652182c0e55f6",
+      "version-date": "2022-03-02",
+      "port-version": 1
+    },
+    {
       "git-tree": "5358d4a724061eab499969ae3b56f8abbdea3347",
       "version-date": "2022-03-02",
       "port-version": 0


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Fixes #13827.

  Adding `-fPIC` is normally handled by the toolchain. However, GMP and MPIR need their own specific *define* `-DPIC`.

  See also the other attempt at https://github.com/microsoft/vcpkg/pull/25158.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  all

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes, I think so.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes.
