### PR TITLE
[vcpkg bootstrap] Allow user to set VCPKG_ROOT and CMAKE_TOOLCHAIN_FILE

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -62,13 +62,8 @@ if ($LASTEXITCODE -ne 0)
 }
 
 [Environment]::SetEnvironmentVariable("VCPKG_ROOT", "$vcpkgRootDir", "user")
+[Environment]::SetEnvironmentVariable("VCPKG_COMMAND", "$vcpkgRootDir\vcpkg.exe", "user")
 [Environment]::SetEnvironmentVariable("CMAKE_TOOLCHAIN_FILE", "$vcpkgRootDir\scripts\buildsystems\vcpkg.cmake", "user")
-
-$oldPATH = [Environment]::GetEnvironmentVariable("PATH", "user")
-if (-not ("$oldPATH" -split ';' -contains "$vcpkgRootDir"))
-{
-    [Environment]::SetEnvironmentVariable("PATH", "$vcpkgRootDir;$oldPATH", "user")
-}
 
 Write-Host ""
 

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -7,6 +7,7 @@ param(
     [Parameter(Mandatory=$False)][switch]$disableMetrics = $false
 )
 Set-StrictMode -Version Latest
+
 # Powershell2-compatible way of forcing named-parameters
 if ($badParam)
 {
@@ -60,6 +61,17 @@ if ($LASTEXITCODE -ne 0)
     throw
 }
 
+[Environment]::SetEnvironmentVariable("VCPKG_ROOT", "$vcpkgRootDir", "user")
+[Environment]::SetEnvironmentVariable("CMAKE_TOOLCHAIN_FILE", "$vcpkgRootDir\scripts\buildsystems\vcpkg.cmake", "user")
+
+$oldPATH = [Environment]::GetEnvironmentVariable("PATH", "user")
+if (-not ("$oldPATH" -split ';' -contains "$vcpkgRootDir"))
+{
+    [Environment]::SetEnvironmentVariable("PATH", "$vcpkgRootDir;$oldPATH", "user")
+}
+
+Write-Host ""
+
 if ($disableMetrics)
 {
     Set-Content -Value "" -Path "$vcpkgRootDir\vcpkg.disable-metrics" -Force
@@ -80,3 +92,8 @@ or by setting the VCPKG_DISABLE_METRICS environment variable.
 Read more about vcpkg telemetry at docs/about/privacy.md
 "@
 }
+
+Write-Host ""
+Write-Host "MSBuild integration"
+Write-Host "-------------------"
+Start-Process -FilePath "$vcpkgRootDir\vcpkg.exe" -ArgumentList "integrate install" -Wait -NoNewWindow

--- a/scripts/ports.cmake
+++ b/scripts/ports.cmake
@@ -63,6 +63,16 @@ include("${SCRIPTS}/cmake/z_vcpkg_get_cmake_vars.cmake")
 include("${SCRIPTS}/cmake/z_vcpkg_prettify_command_line.cmake")
 include("${SCRIPTS}/cmake/z_vcpkg_setup_pkgconfig_path.cmake")
 
+# Set up VCPKG_ROOT and VCPKG_COMMAND if needed
+if (NOT DEFINED VCPKG_ROOT)
+  get_filename_component(VCPKG_ROOT ${CMAKE_CURRENT_LIST_DIR}/.. ABSOLUTE)
+endif()
+if (NOT DEFINED VCPKG_COMMAND)
+  set(VCPKG_COMMAND ${VCPKG_ROOT}/vcpkg)
+endif()
+message(STATUS "VCPKG_ROOT = ${VCPKG_ROOT}")
+message(STATUS "VCPKG_COMMAND = ${VCPKG_COMMAND}")
+  
 function(debug_message)
     if(PORT_DEBUG)
         z_vcpkg_function_arguments(ARGS)


### PR DESCRIPTION
Allow user to set VCPKG_ROOT and CMAKE_TOOLCHAIN_FILE environment variables.  Variables can be set for the current user only, or for all users.

Also, allow user to copy VCPG.EXE to the system directory.

The script will now require elevation.

The fix only applies to Windows platforms.