### PR TITLE
[wtl] Add another post-release update

### DIFF
--- a/ports/wtl/atlribbon.h-wtl66.patch
+++ b/ports/wtl/atlribbon.h-wtl66.patch
@@ -1,0 +1,17 @@
+--- a/Include/atlribbon.h	2022-06-06 03:12:54.312690900 +0200
++++ b/Include/atlribbon.h	2022-06-06 03:13:24.337068900 +0200
+@@ -27,10 +27,10 @@
+ 	#error atlribbon.h requires atlapp.h to be included first
+ #endif
+ 
+-#include <atlmisc.h>    // for RecentDocumentList classes
+-#include <atlframe.h>   // for Frame and UpdateUI classes
+-#include <atlctrls.h>   // required for atlctrlw.h
+-#include <atlctrlw.h>   // for CCommandBarCtrl
++#include "atlmisc.h"    // for RecentDocumentList classes
++#include "atlframe.h"   // for Frame and UpdateUI classes
++#include "atlctrls.h"   // required for atlctrlw.h
++#include "atlctrlw.h"   // for CCommandBarCtrl
+ 
+ #ifndef __ATLSTR_H__
+   #pragma warning(push)

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_sourceforge(
     NO_REMOVE_ONE_LEVEL
     SHA512 086a6cf6a49a4318a8c519136ba6019ded7aa7f2c1d85f78c30b21183654537b3428a400a64fcdacba3a7a10a9ef05137b6f2119f59594da300d55f9ebfb1309
     PATCHES
+        # WTL 10 post-release updates; see
+        # https://sourceforge.net/projects/wtl/files/WTL%2010/WTL10%20Post-Release%20Updates.txt/download
         appwizard_setup.js-vs2022.patch
         atlmisc.h-bug329.patch
         atlribbon.h-wtl66.patch

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -8,6 +8,7 @@ vcpkg_from_sourceforge(
     PATCHES
         appwizard_setup.js-vs2022.patch
         atlmisc.h-bug329.patch
+        atlribbon.h-wtl66.patch
 )
 
 file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -11,7 +11,7 @@ vcpkg_from_sourceforge(
         atlribbon.h-wtl66.patch
 )
 
-file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
+file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.h")
 file(COPY "${SOURCE_PATH}/Samples" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/wtl/portfile.cmake
+++ b/ports/wtl/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_from_sourceforge(
         atlribbon.h-wtl66.patch
 )
 
-file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/${PORT}" FILES_MATCHING PATTERN "*.h")
+file(INSTALL "${SOURCE_PATH}/Include/" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.h")
 file(COPY "${SOURCE_PATH}/Samples" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(COPY "${SOURCE_PATH}/AppWizard" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 

--- a/ports/wtl/vcpkg.json
+++ b/ports/wtl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wtl",
   "version": "10.0.10320",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Windows Template Library (WTL) is a C++ library for developing Windows applications and UI components.",
   "homepage": "https://sourceforge.net/projects/wtl/",
   "license": "MS-PL"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7598,7 +7598,7 @@
     },
     "wtl": {
       "baseline": "10.0.10320",
-      "port-version": 3
+      "port-version": 4
     },
     "wxchartdir": {
       "baseline": "2.0.0",

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "390ddc037cd1f1818d8896dfdb816d8118b3c31b",
+      "git-tree": "e39a61547fff6f37fe27da24cac11de6554c9c0f",
       "version": "10.0.10320",
       "port-version": 4
     },

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "390ddc037cd1f1818d8896dfdb816d8118b3c31b",
+      "version": "10.0.10320",
+      "port-version": 4
+    },
+    {
       "git-tree": "77302be4bab5f3221389c7948462e15ac941002b",
       "version": "10.0.10320",
       "port-version": 3

--- a/versions/w-/wtl.json
+++ b/versions/w-/wtl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e39a61547fff6f37fe27da24cac11de6554c9c0f",
+      "git-tree": "c76ddf631b62e5d0b433859f7798c7ab06050f47",
       "version": "10.0.10320",
       "port-version": 4
     },


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Adds another WTL post-release update (change `<>` includes in `atlribbon.h` to `""`).

It also reverts #25108 by moving the WTL includes back into the `include/wtl` directory.

Rationale: #25108 will break all projects using WTL via vcpkg at their next `vcpkg upgrade`. This change was made only five days ago and has not yet caused a flood of bug reports regarding broken WTL installations. Therefore it appears useful to put the WTL includes back where they belong and avoid that flood. The prior change was grounded in the incorrect assumption that WTL's choice of include syntax indicated their preference for the location of the WTL include files. [Upstream has since clarified](https://sourceforge.net/p/wtl/patches/66/) that the use of `<>` includes instead of `""` was indeed a bug.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Same as before, and no change required.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes.