### PR TITLE
[mmloader] Fix `supports`

### DIFF
--- a/ports/mmloader/portfile.cmake
+++ b/ports/mmloader/portfile.cmake
@@ -1,4 +1,5 @@
-# source
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tishion/mmLoader
@@ -7,27 +8,19 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-# feature
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
         shellcode BUILD_SHELLCODE_GEN
 )
 
-# config
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${FEATURE_OPTIONS}
 )
 
-# pre-clean
-file(REMOVE_RECURSE "${SOURCE_PATH}/output")
+vcpkg_cmake_install(DISABLE_PARALLEL)
 
-# build and install
-vcpkg_install_cmake(DISABLE_PARALLEL)
-
-# remove the debug/include directory
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
-# collect license files
 file(INSTALL "${SOURCE_PATH}/License" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/mmloader/vcpkg.json
+++ b/ports/mmloader/vcpkg.json
@@ -5,7 +5,7 @@
   "description": "A library for loading dll module bypassing windows PE loader from memory (x86/x64)",
   "homepage": "http://tishion.github.io/mmLoader/",
   "license": "MIT",
-  "supports": "(x86 | x64) & windows",
+  "supports": "(x86 | x64) & windows & !uwp",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/mmloader/vcpkg.json
+++ b/ports/mmloader/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "mmloader",
-  "version-date": "2021-12-13",
+  "version": "1.0.1",
   "port-version": 2,
   "description": "A library for loading dll module bypassing windows PE loader from memory (x86/x64)",
   "homepage": "http://tishion.github.io/mmLoader/",

--- a/ports/mmloader/vcpkg.json
+++ b/ports/mmloader/vcpkg.json
@@ -1,10 +1,17 @@
 {
   "name": "mmloader",
   "version-date": "2021-12-13",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A library for loading dll module bypassing windows PE loader from memory (x86/x64)",
   "homepage": "http://tishion.github.io/mmLoader/",
-  "supports": "(x86 | x64) & windows & static",
+  "license": "MIT",
+  "supports": "(x86 | x64) & windows",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ],
   "features": {
     "shellcode": {
       "description": "Generate mmLoader shell code headers"

--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -654,13 +654,6 @@ microsoft-signalr:x64-windows-static-md=skip
 microsoft-signalr:x86-windows=skip
 # https://github.com/mlpack/mlpack/pull/2945
 mlpack:x64-uwp=fail
-mmloader:arm64-windows=fail
-mmloader:arm-uwp=fail
-mmloader:x64-linux=fail
-mmloader:x64-osx=fail
-mmloader:x64-uwp=fail
-mmloader:x64-windows=fail
-mmloader:x86-windows=fail
 # mmx installs many problematic headers, such as `json.h` and `sched.h`
 mmx:x64-windows=skip
 mmx:x64-windows-static=skip

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4601,7 +4601,7 @@
       "port-version": 5
     },
     "mmloader": {
-      "baseline": "2021-12-13",
+      "baseline": "1.0.1",
       "port-version": 1
     },
     "mmx": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4602,7 +4602,7 @@
     },
     "mmloader": {
       "baseline": "1.0.1",
-      "port-version": 1
+      "port-version": 2
     },
     "mmx": {
       "baseline": "2019-09-29",

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -2,12 +2,12 @@
   "versions": [
     {
       "git-tree": "104d16ae01f6ae753fde8406f75a01b9353aa1f2",
-      "version-date": "2021-12-13",
+      "version": "1.0.1",
       "port-version": 1
     },
     {
       "git-tree": "030c251ff729f1063950f5473cf393125f888ca2",
-      "version-date": "2021-12-13",
+      "version": "1.0.1",
       "port-version": 0
     },
     {

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "cbd5f87641f3e5cdd3cb46c512ba8c6d9188395f",
+      "version": "1.0.1",
+      "port-version": 2
+    },
+    {
       "git-tree": "104d16ae01f6ae753fde8406f75a01b9353aa1f2",
       "version": "1.0.1",
       "port-version": 1

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "cbd5f87641f3e5cdd3cb46c512ba8c6d9188395f",
+      "git-tree": "4b102ccdbd92919d2f3f62fff55b2a51839199ad",
       "version": "1.0.1",
       "port-version": 2
     },

--- a/versions/m-/mmloader.json
+++ b/versions/m-/mmloader.json
@@ -7,12 +7,12 @@
     },
     {
       "git-tree": "104d16ae01f6ae753fde8406f75a01b9353aa1f2",
-      "version": "1.0.1",
+      "version-date": "2021-12-13",
       "port-version": 1
     },
     {
       "git-tree": "030c251ff729f1063950f5473cf393125f888ca2",
-      "version": "1.0.1",
+      "version-date": "2021-12-13",
       "port-version": 0
     },
     {


### PR DESCRIPTION
For #25179
Build only static libs on x64-windows and x86-windows.
Fix version db: The port used `version-date` to point at version 1.0.1. I changed it to `version`.
Remove mmloader from CI baseline.
