### PR TITLE
[wxwidgets] Remove debug asserts from Release build.

### DIFF
--- a/ports/wxcharts/portfile.cmake
+++ b/ports/wxcharts/portfile.cmake
@@ -1,12 +1,14 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wxIshiko/wxCharts
-    REF c7c7eb4c4132eeb83f25546b1b981dc61e5c188f
-    SHA512 f46cf467b356e2ffa46db020de42f8aca9beab801e2ade50f7e75650bba9bc83c641702dcd5ee45e82425b96d4371b82e7f16dce3077050a86ba696ed5c326de
+    REF 070e1d6084623185c7337226fa562b1e3a772e3d
+    SHA512 4c52e4ad6d3c4ba496aad7e654ee75ddd9009aadc44be37fc64f3e3ac56001a7e9728f7fdd0c78f8261bff0bf8a6748f8a7649cb160ca37c2d686530c161c2f6
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_RELEASE
+        -DwxBUILD_DEBUG_LEVEL=0
 )
 
 vcpkg_cmake_install()

--- a/ports/wxcharts/vcpkg.json
+++ b/ports/wxcharts/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "wxcharts",
-  "version-date": "2022-04-22",
+  "version-date": "2022-06-16",
   "description": "Chart controls for the wxWidgets cross-platform GUI library",
   "homepage": "https://www.wxishiko.com/wxCharts",
   "license": "MIT",

--- a/ports/wxwidgets/example/CMakeLists.txt
+++ b/ports/wxwidgets/example/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.7)
 
 project(wxwidgets-example)
 
+option(wxBUILD_DEBUG_LEVEL "Debug Level" Default)
+if(NOT wxBUILD_DEBUG_LEVEL STREQUAL "Default")
+    add_compile_options("-DwxDEBUG_LEVEL=${wxBUILD_DEBUG_LEVEL}")
+endif()
+
 add_executable(main WIN32 popup.cpp)
 
 find_package(wxWidgets REQUIRED)

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -98,6 +98,8 @@ vcpkg_cmake_configure(
         # The minimum cmake version requirement for Cotire is 2.8.12.
         # however, we need to declare that the minimum cmake version requirement is at least 3.1 to use CMAKE_PREFIX_PATH as the path to find .pc.
         -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
+    OPTIONS_RELEASE
+        -DwxBUILD_DEBUG_LEVEL=0
 )
 
 vcpkg_cmake_install()

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "wxwidgets",
   "version": "3.1.6",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
     "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",

--- a/scripts/test_ports/vcpkg-ci-wxwidgets/portfile.cmake
+++ b/scripts/test_ports/vcpkg-ci-wxwidgets/portfile.cmake
@@ -12,6 +12,8 @@ vcpkg_cmake_configure(
         ${OPTIONS}
         -DCMAKE_CONFIG_RUN=1
         "-DPRINT_VARS=CMAKE_CONFIG_RUN;wxWidgets_LIBRARIES"
+    OPTIONS_RELEASE
+        -DwxBUILD_DEBUG_LEVEL=0
 )
 vcpkg_cmake_build()
 

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7609,12 +7609,12 @@
       "port-version": 0
     },
     "wxcharts": {
-      "baseline": "2022-04-22",
+      "baseline": "2022-06-16",
       "port-version": 0
     },
     "wxwidgets": {
       "baseline": "3.1.6",
-      "port-version": 1
+      "port-version": 2
     },
     "x-plane": {
       "baseline": "3.0.3",

--- a/versions/w-/wxcharts.json
+++ b/versions/w-/wxcharts.json
@@ -1,6 +1,16 @@
 {
   "versions": [
     {
+      "git-tree": "0d4c30893a28468249d63c0f4c1a1a9e231ac817",
+      "version-date": "2022-06-16",
+      "port-version": 0
+    },
+    {
+      "git-tree": "f225f20623b5900c26e2fb13ad06a72171751629",
+      "version-date": "2022-04-22",
+      "port-version": 1
+    },
+    {
       "git-tree": "b1e9c16349a281b499d1ff50cdee4dd21c4aafec",
       "version-date": "2022-04-22",
       "port-version": 0

--- a/versions/w-/wxcharts.json
+++ b/versions/w-/wxcharts.json
@@ -6,11 +6,6 @@
       "port-version": 0
     },
     {
-      "git-tree": "f225f20623b5900c26e2fb13ad06a72171751629",
-      "version-date": "2022-04-22",
-      "port-version": 1
-    },
-    {
       "git-tree": "b1e9c16349a281b499d1ff50cdee4dd21c4aafec",
       "version-date": "2022-04-22",
       "port-version": 0

--- a/versions/w-/wxwidgets.json
+++ b/versions/w-/wxwidgets.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "27a68f45cbdc9ab88864c353c7a8b91f76153509",
+      "version": "3.1.6",
+      "port-version": 2
+    },
+    {
       "git-tree": "793b49ce7710b440be0a451354614e282e6fc9fa",
       "version": "3.1.6",
       "port-version": 1


### PR DESCRIPTION
Currently when building wxWidgets in Release mode, the debug asserts are enabled.
This fixes this issue by providing a necessary define to disable them.

Ref: https://docs.wxwidgets.org/3.1.6/group__group__funcmacro__debug.html

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
