### PR TITLE
[dv-processing] Add New port for dv processing

### DIFF
--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_download_distfile(ARCHIVE_FILE
+	URLS "https://gitlab.com/inivation/dv/dv-processing/-/package_files/39407206/download"
+	FILENAME "dv-processing-1.4.0.tar.gz"
+	SHA512 c734ebeeb322939eb882cdfbfdddea38abcfdbb6d47237a4891d77952c75294080f27c9cb70e0a29ec6ffe5263259d2e1020d13b0114700f768d18da48642d7d
+)
+
+vcpkg_extract_source_archive_ex(
+	OUT_SOURCE_PATH SOURCE_PATH
+	ARCHIVE ${ARCHIVE_FILE}
+	REF 1.4.0
+	PATCHES
+		vcpkg-build.patch
+)
+
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+	        -DENABLE_TESTS=OFF
+		-DENABLE_SAMPLES=OFF
+		-DBUILD_CONFIG_VCPKG=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_fixup_pkgconfig()
+vcpkg_cmake_config_fixup(PACKAGE_NAME "dv-processing" CONFIG_PATH "share/dv-processing")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -22,7 +22,6 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-vcpkg_fixup_pkgconfig()
 vcpkg_cmake_config_fixup(PACKAGE_NAME "dv-processing" CONFIG_PATH "share/dv-processing")
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/dv-processing/portfile.cmake
+++ b/ports/dv-processing/portfile.cmake
@@ -1,22 +1,32 @@
-vcpkg_download_distfile(ARCHIVE_FILE
-	URLS "https://gitlab.com/inivation/dv/dv-processing/-/package_files/39407206/download"
-	FILENAME "dv-processing-1.4.0.tar.gz"
-	SHA512 c734ebeeb322939eb882cdfbfdddea38abcfdbb6d47237a4891d77952c75294080f27c9cb70e0a29ec6ffe5263259d2e1020d13b0114700f768d18da48642d7d
+vcpkg_from_gitlab(
+        GITLAB_URL https://gitlab.com/inivation
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO dv/dv-processing
+        REF rel_1.4
+        SHA512 c011ca0e6d9842913ff35b0a03f9053bfbc98c090b6936e01f6514b8a35d31ee6d0a821f491be96400113e93967aa2d3e8ab19e558f5c3e9f8eba9ad4e1fe013
+        HEAD_REF d4ffab46a2849372789c5a2084821011165086ab
+        PATCHES
+                vcpkg-build.patch
 )
 
-vcpkg_extract_source_archive_ex(
-	OUT_SOURCE_PATH SOURCE_PATH
-	ARCHIVE ${ARCHIVE_FILE}
-	REF 1.4.0
-	PATCHES
-		vcpkg-build.patch
+vcpkg_from_gitlab(
+        GITLAB_URL https://gitlab.com/inivation
+        OUT_SOURCE_PATH CMAKEMOD_SOURCE_PATH
+        REPO dv/cmakemod
+        REF a4d7eccfdc5f83e399786a77df79b178b762858b
+        SHA512 4fe9cc5099ab8b41c982df45cbf9a000b2cb1f1c6ed536685943a60520cff49e262ec43af8187177c50a0df2dfca57e7861bf2e7d07834fc16e85c30eb9a9edb
+        HEAD_REF a4d7eccfdc5f83e399786a77df79b178b762858b
 )
+
+file(GLOB CMAKEMOD_FILES ${CMAKEMOD_SOURCE_PATH}/*)
+file(COPY ${CMAKEMOD_FILES} DESTINATION ${SOURCE_PATH}/cmakemod)
 
 vcpkg_cmake_configure(
         SOURCE_PATH ${SOURCE_PATH}
         OPTIONS
 	        -DENABLE_TESTS=OFF
 		-DENABLE_SAMPLES=OFF
+		-DENABLE_PYTHON=OFF
 		-DBUILD_CONFIG_VCPKG=ON
 )
 

--- a/ports/dv-processing/vcpkg-build.patch
+++ b/ports/dv-processing/vcpkg-build.patch
@@ -1,18 +1,58 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c7775b5..52d2c85 100644
+index c7775b5..4201f4b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -86,8 +86,9 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT
- 
- INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+@@ -27,11 +27,15 @@ IF(Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+ 	ENDIF()
+ ENDIF()
  
 +OPTION(BUILD_CONFIG_VCPKG "Set build environment compatible with VCPKG" OFF)
++
+ # Basic setup, useful variables, see docs.
+ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmakemod ${CMAKE_MODULE_PATH})
+ SET(ENABLE_ALL_WARNINGS ON CACHE BOOL "Turn on all warnings for build" FORCE)
+ INCLUDE(inivation-setup)
+ 
++# Skip compiler compatibility checks when doing the VCPKG build
++if(NOT BUILD_CONFIG_VCPKG)
+ # Compiler compatibility testing starts GCC has to be at least version 10
+ IF(CC_GCC AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "10.0.0")
+ 	MESSAGE(
+@@ -56,6 +60,7 @@ IF(NOT CC_GCC AND NOT CC_GCC)
+ 	)
+ ENDIF()
+ # Compiler compatibility testing ends
++ENDIF()
+ 
+ # Boost support. Search in extra directory for custom version.
+ IF(EXISTS /opt/inivation/boost/)
+@@ -87,7 +92,7 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
  # Cmake find_package() support.
 -IF(CC_MSVC)
 +IF(BUILD_CONFIG_VCPKG)
  	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
  ELSE()
  	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+diff --git a/dv-processing-config.cmake.in b/dv-processing-config.cmake.in
+index 4dbf635..5557dd2 100644
+--- a/dv-processing-config.cmake.in
++++ b/dv-processing-config.cmake.in
+@@ -53,10 +53,9 @@ CHECK_REQUIRED_COMPONENTS(dv-processing)
+ # properly.
+ INCLUDE(@PACKAGE_CMAKE_EXPORT_DESTINATION@/inivation-setup.cmake)
+ 
+-# MSVC/VCPKG finds this differently.
+-IF(CC_MSVC)
+-	FIND_PACKAGE(lz4 CONFIG REQUIRED)
+-ENDIF()
++# MSVC/VCPKG finds this differently, try to find it quietly, so it does not complain on non-vcpkg installations
++# and find the package correctly when used with VCPKG.
++FIND_PACKAGE(lz4 CONFIG QUIET)
+ 
+ # Compiler compatibility testing starts GCC has to be at least version 10
+ IF(CC_GCC AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "10.0.0")
 diff --git a/include/dv-processing/CMakeLists.txt b/include/dv-processing/CMakeLists.txt
 index b83f4e4..621b3f2 100644
 --- a/include/dv-processing/CMakeLists.txt

--- a/ports/dv-processing/vcpkg-build.patch
+++ b/ports/dv-processing/vcpkg-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c7775b5..4201f4b 100644
+index c7775b5..acf6208 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -27,11 +27,15 @@ IF(Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
@@ -35,6 +35,22 @@ index c7775b5..4201f4b 100644
  	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
  ELSE()
  	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+@@ -103,8 +108,13 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+ 			  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+ 			  ${CMAKE_CURRENT_SOURCE_DIR}/cmakemod/inivation-setup.cmake DESTINATION ${CMAKE_EXPORT_DESTINATION})
+ 
+-# External libraries to build
+-ADD_SUBDIRECTORY(tests/external/cli11)
++IF (BUILD_CONFIG_VCPKG)
++	# Find CLI11 as an installed package
++	FIND_PACKAGE(CLI11 CONFIG REQUIRED)
++ELSE()
++	# External CLI11 checked-out as a submodule
++	ADD_SUBDIRECTORY(tests/external/cli11)
++ENDIF()
+ 
+ # Install header files.
+ ADD_SUBDIRECTORY(include)
 diff --git a/dv-processing-config.cmake.in b/dv-processing-config.cmake.in
 index 4dbf635..5557dd2 100644
 --- a/dv-processing-config.cmake.in

--- a/ports/dv-processing/vcpkg-build.patch
+++ b/ports/dv-processing/vcpkg-build.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c7775b5..52d2c85 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,8 +86,9 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT
+ 
+ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ 
++OPTION(BUILD_CONFIG_VCPKG "Set build environment compatible with VCPKG" OFF)
+ # Cmake find_package() support.
+-IF(CC_MSVC)
++IF(BUILD_CONFIG_VCPKG)
+ 	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
+ ELSE()
+ 	SET(CMAKE_EXPORT_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+diff --git a/include/dv-processing/CMakeLists.txt b/include/dv-processing/CMakeLists.txt
+index b83f4e4..621b3f2 100644
+--- a/include/dv-processing/CMakeLists.txt
++++ b/include/dv-processing/CMakeLists.txt
+@@ -23,7 +23,7 @@ IF(CC_MSVC)
+ ENDIF()
+ 
+ # Compression support
+-IF(CC_MSVC)
++IF(BUILD_CONFIG_VCPKG)
+ 	FIND_PACKAGE(lz4 CONFIG REQUIRED)
+ 	TARGET_LINK_LIBRARIES(processing INTERFACE lz4::lz4)
+ ELSE()

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -13,6 +13,7 @@
     "boost-property-tree",
     "boost-stacktrace",
     "boost-tti",
+    "cli11",
     "eigen3",
     "fmt",
     "libcaer",

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dv-processing",
-  "version-string": "1.4.0",
+  "version": "1.4.0",
   "description": "Generic algorithms for event cameras.",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "dv-processing",
+  "version-string": "1.4.0",
+  "port-version": 0,
+  "description": "Generic algorithms for event cameras.",
+  "homepage": "https://gitlab.com/inivation/dv/dv-processing",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "eigen3",
+    "libcaer",
+    "boost-nowide",
+    "boost-circular-buffer",
+    "boost-callable-traits",
+    "boost-stacktrace",
+    "boost-lockfree",
+    "boost-property-tree",
+    "boost-tti",
+    "boost-geometry",
+    "zlib",
+    "lz4",
+    "zstd",
+    "opencv4",
+    "fmt",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/dv-processing/vcpkg.json
+++ b/ports/dv-processing/vcpkg.json
@@ -1,26 +1,23 @@
 {
   "name": "dv-processing",
   "version-string": "1.4.0",
-  "port-version": 0,
   "description": "Generic algorithms for event cameras.",
   "homepage": "https://gitlab.com/inivation/dv/dv-processing",
   "license": "Apache-2.0",
   "dependencies": [
-    "eigen3",
-    "libcaer",
-    "boost-nowide",
-    "boost-circular-buffer",
     "boost-callable-traits",
-    "boost-stacktrace",
-    "boost-lockfree",
-    "boost-property-tree",
-    "boost-tti",
+    "boost-circular-buffer",
     "boost-geometry",
-    "zlib",
-    "lz4",
-    "zstd",
-    "opencv4",
+    "boost-lockfree",
+    "boost-nowide",
+    "boost-property-tree",
+    "boost-stacktrace",
+    "boost-tti",
+    "eigen3",
     "fmt",
+    "libcaer",
+    "lz4",
+    "opencv4",
     {
       "name": "vcpkg-cmake",
       "host": true
@@ -28,6 +25,8 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    }
+    },
+    "zlib",
+    "zstd"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1992,6 +1992,10 @@
       "baseline": "2.5.0",
       "port-version": 2
     },
+    "dv-processing": {
+      "baseline": "1.4.0",
+      "port-version": 0
+    },
     "dx": {
       "baseline": "1.0.1",
       "port-version": 2

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "beb6f5560d817d4de79e7ea429330dd80deab3d9",
+      "version": "1.4.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9d46fe7cdb2ef8279f7e6a81fe4b7d8d759d1695",
+      "git-tree": "757cc58887fefa1c48349b91bfaab2e3947b65d9",
       "version": "1.4.0",
       "port-version": 0
     }

--- a/versions/d-/dv-processing.json
+++ b/versions/d-/dv-processing.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "beb6f5560d817d4de79e7ea429330dd80deab3d9",
+      "git-tree": "9d46fe7cdb2ef8279f7e6a81fe4b7d8d759d1695",
       "version": "1.4.0",
       "port-version": 0
     }


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
Adds dv-processing: header-only library which contains generic algorithms for processing data from event cameras.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
Supports all built-in triplets.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-
guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
