### PR TITLE
[zziplib] Fixed compiling zziplib when targeting android triplets

### DIFF
--- a/ports/zziplib/portfile.cmake
+++ b/ports/zziplib/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     PATCHES
         no-release-postfix.patch
         export-targets.patch
+        unix-cross-compile.patch
 )
 
 string(COMPARE EQUAL VCPKG_CRT_LINKAGE "static" MSVC_STATIC_RUNTIME)

--- a/ports/zziplib/unix-cross-compile.patch
+++ b/ports/zziplib/unix-cross-compile.patch
@@ -1,0 +1,13 @@
+diff --git a/zzip/CMakeLists.txt b/zzip/CMakeLists.txt
+index c95e1d3..4234b55 100644
+--- a/zzip/CMakeLists.txt
++++ b/zzip/CMakeLists.txt
+@@ -19,7 +19,7 @@ option(MSVC_STATIC_RUNTIME "Build with static runtime libs (/MT)" ON)
+ option(ZZIPMMAPPED "Build libzzipmmapped (not fully portable)" ON)
+ option(ZZIPFSEEKO "Build libzzipfseeko (based on posix.1 api)" ON)
+ 
+-if(UNIX)
++if(CMAKE_HOST_UNIX)
+ option(ZZIP_COMPAT "Build compatibility with old libzzip releases" ON)
+ option(ZZIP_LIBTOOL "Ensure binary compatibility with libtool" ON)
+ option(ZZIP_PKGCONFIG "Generate pkg-config files for linking" ON)

--- a/ports/zziplib/vcpkg.json
+++ b/ports/zziplib/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "zziplib",
   "version": "0.13.72",
-  "port-version": 1,
+  "port-version": 2,
   "description": "library providing read access on ZIP-archives",
   "homepage": "https://github.com/gdraheim/zziplib",
   "license": "LGPL-2.0-or-later OR MPL-1.1",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7838,7 +7838,7 @@
     },
     "zziplib": {
       "baseline": "0.13.72",
-      "port-version": 1
+      "port-version": 2
     }
   }
 }

--- a/versions/z-/zziplib.json
+++ b/versions/z-/zziplib.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b2964ca20c5c3d85ee7bdc22988cfbc593c9dce1",
+      "version": "0.13.72",
+      "port-version": 2
+    },
+    {
       "git-tree": "571af9ee98bd4bf80bf21fc10a5ec5971678b954",
       "version": "0.13.72",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**
The PR adds a patch for zziplib port to fix the detection of the host build system. See also upstream PR:
https://github.com/gdraheim/zziplib/pull/136

- #### What does your PR fix?
  Fixes #25187

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  Triplets: arm-android, arm64-android
  Baseline update: No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes
