### PR TITLE
[dlfcn-win32] support single-config release builds

### DIFF
--- a/ports/dlfcn-win32/portfile.cmake
+++ b/ports/dlfcn-win32/portfile.cmake
@@ -14,12 +14,14 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
-file(READ "${CURRENT_PACKAGES_DIR}/debug/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" dlfcn-win32_DEBUG_MODULE)
-string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" dlfcn-win32_DEBUG_MODULE "${dlfcn-win32_DEBUG_MODULE}")
-file(WRITE "${CURRENT_PACKAGES_DIR}/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" "${dlfcn-win32_DEBUG_MODULE}")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake")
+    file(READ "${CURRENT_PACKAGES_DIR}/debug/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" dlfcn-win32_DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" dlfcn-win32_DEBUG_MODULE "${dlfcn-win32_DEBUG_MODULE}")
+    file(WRITE "${CURRENT_PACKAGES_DIR}/share/dlfcn-win32/dlfcn-win32-targets-debug.cmake" "${dlfcn-win32_DEBUG_MODULE}")
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/dlfcn-win32/vcpkg.json
+++ b/ports/dlfcn-win32/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "dlfcn-win32",
   "version": "1.1.1",
-  "port-version": 6,
+  "port-version": 7,
   "description": "dlfcn-win32 is an implementation of dlfcn for Windows.",
   "homepage": "https://github.com/dlfcn-win32/dlfcn-win32",
   "supports": "windows & !uwp",

--- a/versions/d-/dlfcn-win32.json
+++ b/versions/d-/dlfcn-win32.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b56f9e1e6b32d5881dea4faf2badb50fb586bdd0",
+      "version": "1.1.1",
+      "port-version": 7
+    },
+    {
       "git-tree": "6ae0dd5fc5f29e2299690404410ce7129ec5c035",
       "version": "1.1.1",
       "port-version": 6


### PR DESCRIPTION
Support single-configuration build (`release` in particular) as per #6045.