### PR TITLE
[sentry-native] Update portfile.cmake

### DIFF
--- a/ports/sentry-native/portfile.cmake
+++ b/ports/sentry-native/portfile.cmake
@@ -31,7 +31,7 @@ if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     set(VCPKG_C_FLAGS "/D_CRT_DECLARE_NONSTDC_NAMES ${VCPKG_C_FLAGS}")
 endif()
 
-vcpkg_cmake_configure(
+vcpkg_configure_cmake(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DSENTRY_BUILD_TESTS=OFF


### PR DESCRIPTION
Since than 'vcpkg_cmake_configure' is deprecated, it's cause to build error as is.

CMake Error at ports/sentry-native/portfile.cmake:34 (vcpkg_cmake_configure):
  Unknown CMake command "vcpkg_cmake_configure".

**Describe the pull request**

- #### What does your PR fix?
  Fixes #...

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <all / linux, windows, ...>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Your answer`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes / I am still working on this PR>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
