### PR TITLE
[podofo] Install PoDoFoConfig.cmake, fix usage

### DIFF
--- a/ports/podofo/install-cmake-config.patch
+++ b/ports/podofo/install-cmake-config.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df623ef..b2f2201 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -576,3 +576,4 @@ IF(PODOFO_BUILD_STATIC)
+   EXPORT(TARGETS podofo_static FILE "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake")
+ ENDIF(PODOFO_BUILD_STATIC)
+ 
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake" DESTINATION share/podofo)
+\ No newline at end of file

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -16,6 +16,7 @@ vcpkg_from_sourceforge(
         ${ADDITIONAL_PATCH}
         0005-fix-crypto.patch
         fix-x64-osx.patch
+        install-cmake-config.patch
 )
 
 set(PODOFO_NO_FONTMANAGER ON)
@@ -27,16 +28,15 @@ string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" PODOFO_BUILD_SHARED)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" PODOFO_BUILD_STATIC)
 
 set(IS_WIN32 OFF)
-if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" OR NOT VCPKG_CMAKE_SYSTEM_NAME)
+if(VCPKG_TARGET_IS_WINDOWS)
     set(IS_WIN32 ON)
 endif()
 
-file(REMOVE ${SOURCE_PATH}/cmake/modules/FindOpenSSL.cmake)
-file(REMOVE ${SOURCE_PATH}/cmake/modules/FindZLIB.cmake)
+file(REMOVE "${SOURCE_PATH}/cmake/modules/FindOpenSSL.cmake")
+file(REMOVE "${SOURCE_PATH}/cmake/modules/FindZLIB.cmake")
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DPODOFO_BUILD_LIB_ONLY=1
         -DPODOFO_BUILD_SHARED=${PODOFO_BUILD_SHARED}
@@ -47,10 +47,25 @@ vcpkg_configure_cmake(
         -DCMAKE_DISABLE_FIND_PACKAGE_LIBIDN=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_CppUnit=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_Boost
+        CMAKE_DISABLE_FIND_PACKAGE_CppUnit
+        CMAKE_DISABLE_FIND_PACKAGE_LIBCRYPTO
 )
 
-vcpkg_install_cmake()
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup()
+vcpkg_replace_string( "${CURRENT_PACKAGES_DIR}/share/${PORT}/PoDoFoConfig.cmake"
+    "# Create imported target podofo_shared"
+[[
+include(CMakeFindDependencyMacro)
+find_dependency(OpenSSL)
+# Create imported target podofo_shared
+]]
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 # Handle copyright
-file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 1,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://sourceforge.net/projects/podofo/",
-  "license": "GPL-2.0-only",
+  "license": "LGPL-2.0-only",
   "supports": "!uwp",
   "dependencies": [
     "freetype",

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 1,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://sourceforge.net/projects/podofo/",
+  "license": "GPL-2.0-only",
   "supports": "!uwp",
   "dependencies": [
     "freetype",

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "podofo",
   "version": "0.9.7",
+  "port-version": 1,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://sourceforge.net/projects/podofo/",
   "supports": "!uwp",
@@ -10,6 +11,14 @@
     "libpng",
     "openssl",
     "tiff",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
     "zlib"
   ],
   "features": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5542,7 +5542,7 @@
     },
     "podofo": {
       "baseline": "0.9.7",
-      "port-version": 0
+      "port-version": 1
     },
     "poissonrecon": {
       "baseline": "2021-09-26",

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4933f96111180b0dcd180b9695c8063bfa2146ef",
+      "git-tree": "40d7ee00aba762a2c0530cdcee8f756481c1014a",
       "version": "0.9.7",
       "port-version": 1
     },

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "40d7ee00aba762a2c0530cdcee8f756481c1014a",
+      "git-tree": "494b98ef9f42c9e4bafe58feff7d5738bb20f44e",
       "version": "0.9.7",
       "port-version": 1
     },

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "4933f96111180b0dcd180b9695c8063bfa2146ef",
+      "version": "0.9.7",
+      "port-version": 1
+    },
+    {
       "git-tree": "5dd647995b24991182eb684029b8629eb6d66e43",
       "version": "0.9.7",
       "port-version": 0


### PR DESCRIPTION
The upstream exports cmake configurations, but not install it.

Fixes #25310.

Already tested usage in x86-windows.