### PR TITLE
[vcpkg baseline][chmlib] Fix the failed in baseline

### DIFF
--- a/scripts/ci.baseline.txt
+++ b/scripts/ci.baseline.txt
@@ -104,8 +104,6 @@ charls:x64-windows=skip
 charls:x64-windows-static=skip
 charls:x64-windows-static-md=skip
 charls:x86-windows=skip
-chmlib:arm-uwp=fail
-chmlib:x64-uwp=fail
 # chartdir does not offer stable download URLs
 chartdir:arm64-windows=skip
 chartdir:arm-uwp=skip


### PR DESCRIPTION
`chmlib` in ci.baseline.txt was removed by PR #22831, but this regression was wrongly introduced by PR #23732.
So remove the following codes from ci.baseline.txt fix the baseline regression. 
````
chmlib:arm-uwp=fail
chmlib:x64-uwp=fail
````
The regression error message:
```
##[error]REGRESSIONS:
PASSING, REMOVE FROM FAIL LIST: chmlib:x64-uwp (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
##[error]REGRESSIONS:
PASSING, REMOVE FROM FAIL LIST: chmlib:arm-uwp (C:\a\1\s\scripts\azure-pipelines/../ci.baseline.txt).
```

