### PR TITLE
[vcpkg] Correct git version

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -43,7 +43,7 @@
         <archiveName>cmake-3.20.4.txz</archiveName>
     </tool>
     <tool name="git" os="windows">
-        <version>2.35.1</version>
+        <version>2.35.1.2</version>
         <exeRelativePath>mingw32\bin\git.exe</exeRelativePath>
         <url>https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-32-bit.7z.exe</url>
         <sha512>f98df16641a615bbc36c5c319c78abb780d824ff35ed5f2a095e2d5fce2acacfc7f6532c96f1c81d3d3cd8a642858cbd9de0e0e5fcde9ca11e6ad9f6598bb82f</sha512>

--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -43,7 +43,7 @@
         <archiveName>cmake-3.20.4.txz</archiveName>
     </tool>
     <tool name="git" os="windows">
-        <version>2.7.4</version>
+        <version>2.35.1</version>
         <exeRelativePath>mingw32\bin\git.exe</exeRelativePath>
         <url>https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-32-bit.7z.exe</url>
         <sha512>f98df16641a615bbc36c5c319c78abb780d824ff35ed5f2a095e2d5fce2acacfc7f6532c96f1c81d3d3cd8a642858cbd9de0e0e5fcde9ca11e6ad9f6598bb82f</sha512>


### PR DESCRIPTION
Git was updated in https://github.com/microsoft/vcpkg/pull/22985, but git version was wrongly restored by PR https://github.com/microsoft/vcpkg/pull/23424.

Fixes #25339.