### PR TITLE
[speexdsp] Modify the name of dll to match lib

### DIFF
--- a/ports/speexdsp/CMakeLists.txt
+++ b/ports/speexdsp/CMakeLists.txt
@@ -100,7 +100,9 @@ add_library(speexdsp ${LIBSPEEXDSP_SOURCES} ${LIBSPEEXDSP_HEADERS})
 set_target_properties(speexdsp PROPERTIES PUBLIC_HEADER "${LIBSPEEXDSP_HEADERS_PUBLIC}")
 set_target_properties(speexdsp PROPERTIES VERSION "${LIBSPEEXDSP_VERSION}")
 set_target_properties(speexdsp PROPERTIES SOVERSION "${LIBSPEEXDSP_SOVERSION}")
-set_target_properties(speexdsp PROPERTIES RUNTIME_OUTPUT_NAME "libspeexdsp")
+if (WIN32)
+    set_target_properties(speexdsp PROPERTIES RUNTIME_OUTPUT_NAME "libspeexdsp")
+endif()
 
 # pkgconfig file
 set(prefix "${CMAKE_INSTALL_PREFIX}")

--- a/ports/speexdsp/CMakeLists.txt
+++ b/ports/speexdsp/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(speexdsp ${LIBSPEEXDSP_SOURCES} ${LIBSPEEXDSP_HEADERS})
 set_target_properties(speexdsp PROPERTIES PUBLIC_HEADER "${LIBSPEEXDSP_HEADERS_PUBLIC}")
 set_target_properties(speexdsp PROPERTIES VERSION "${LIBSPEEXDSP_VERSION}")
 set_target_properties(speexdsp PROPERTIES SOVERSION "${LIBSPEEXDSP_SOVERSION}")
+set_target_properties(speexdsp PROPERTIES RUNTIME_OUTPUT_NAME "libspeexdsp")
 
 # pkgconfig file
 set(prefix "${CMAKE_INSTALL_PREFIX}")

--- a/ports/speexdsp/portfile.cmake
+++ b/ports/speexdsp/portfile.cmake
@@ -21,7 +21,7 @@ else()
     )
 endif()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
 set(USE_SSE OFF)
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
@@ -32,19 +32,18 @@ if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUA
     set(USE_NEON ON)
 endif()
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
     -DUSE_SSE=${USE_SSE}
     -DUSE_NEON=${USE_NEON}
 )
 
-vcpkg_install_cmake()
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 
 vcpkg_fixup_pkgconfig()
 
-file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 
 file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME "copyright")

--- a/ports/speexdsp/vcpkg.json
+++ b/ports/speexdsp/vcpkg.json
@@ -4,7 +4,7 @@
   "port-version": 8,
   "description": "A patent-free, Open Source/Free Software DSP library.",
   "homepage": "https://speex.org/",
-  "license": null,
+  "license": "BSD-3-Clause",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/speexdsp/vcpkg.json
+++ b/ports/speexdsp/vcpkg.json
@@ -1,7 +1,14 @@
 {
   "name": "speexdsp",
   "version": "1.2.0",
-  "port-version": 7,
+  "port-version": 8,
   "description": "A patent-free, Open Source/Free Software DSP library.",
-  "homepage": "https://speex.org/"
+  "homepage": "https://speex.org/",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6750,7 +6750,7 @@
     },
     "speexdsp": {
       "baseline": "1.2.0",
-      "port-version": 7
+      "port-version": 8
     },
     "spirit-po": {
       "baseline": "1.1.2",

--- a/versions/s-/speexdsp.json
+++ b/versions/s-/speexdsp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "0e4f5a86b2952f55c11c37e10622da04460ebc03",
+      "version": "1.2.0",
+      "port-version": 8
+    },
+    {
       "git-tree": "6606b66ecc502c89de6a1e570c1407bf1f8b2d03",
       "version": "1.2.0",
       "port-version": 7

--- a/versions/s-/speexdsp.json
+++ b/versions/s-/speexdsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4fdc22559e0871fce447e44de1942a5b6aa8d9f1",
+      "git-tree": "602238d14eef169fff22244c05d364c55177bdbc",
       "version": "1.2.0",
       "port-version": 8
     },

--- a/versions/s-/speexdsp.json
+++ b/versions/s-/speexdsp.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "0e4f5a86b2952f55c11c37e10622da04460ebc03",
+      "git-tree": "4fdc22559e0871fce447e44de1942a5b6aa8d9f1",
       "version": "1.2.0",
       "port-version": 8
     },


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes https://github.com/microsoft/vcpkg/issues/25067

  Modify the `RUNTIME_OUTPUT_NAME` of target as libspeexdsp, because the `${SOURCE_PATH}\win32\libspeexdsp.def` include following contents:
```
  LIBRARY libspeexdsp
  EXPORTS
```
