### PR TITLE
[directxtk, directxtk12] update ports for June 2022 release

### DIFF
--- a/ports/directxtk/portfile.cmake
+++ b/ports/directxtk/portfile.cmake
@@ -7,8 +7,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK
-    REF may2022
-    SHA512 739d50c8dfa88a8905e61a797889a33c8b5a32a2e8ded1eea4c4f5fea82a9e8c04f6414ce709410def905d711cf7c8daf40e38579b355071288423b193196444
+    REF jun2022
+    SHA512 683adec36945611150393bb198f54a7d1e072cc9b41dd47ca9ee14459babff867d730b7031602383ed9373500f1541a5091021927bc15df59d47a3b2a1b3588c
     HEAD_REF main
 )
 
@@ -32,21 +32,21 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/may2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-may2022.exe"
-    SHA512 6f88fec787f9db0823cc0c5aa3d2579248c3dea566909a8d41417f42a3bd2af147ff9af82a3b96a3b1d0f8661dffda27530565bb8fed0a2e7d819d471e51493b
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-jun2022.exe"
+    SHA512 7cdc80e12a4a7be70733d582e4f613055a549345f83e24035cfce42d37568c4934c1bb68df5238f41df9d7fa0e84095aeb227d23450323e31a5d1d68cb505842
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK/releases/download/may2022/XWBTool.exe"
-    FILENAME "xwbtool-may2022.exe"
-    SHA512 505c7aa7a22ea78a793ba70f136b13548a69b36cd8ec1631969203deff6e93236460c674b219316793aa475f1350ad56f4a3f844e94c3adba0af7b1723c8765e
+    URLS "https://github.com/Microsoft/DirectXTK/releases/download/jun2022/XWBTool.exe"
+    FILENAME "xwbtool-jun2022.exe"
+    SHA512 b5782323e241641a429f66ad1ac511cfdfd6301851474dafdde274a4f93b49877406d5d0ab992097be7afe8db90fdb9488a9d6de5afce7e086df2e66a5bbca12
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
@@ -56,8 +56,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk/xwbtool.exe")
 
 elseif(NOT VCPKG_TARGET_IS_UWP)
 

--- a/ports/directxtk/vcpkg.json
+++ b/ports/directxtk/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk",
-  "version-date": "2022-05-09",
+  "version-date": "2022-06-15",
   "description": "A collection of helper classes for writing DirectX 11.x code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK",
   "documentation": "https://github.com/microsoft/DirectXTK/wiki",

--- a/ports/directxtk12/portfile.cmake
+++ b/ports/directxtk12/portfile.cmake
@@ -1,14 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-if(VCPKG_TARGET_IS_MINGW)
-    message(NOTICE "Building ${PORT} for MinGW requires the HLSL Compiler dxc.exe also be in the PATH. See https://github.com/microsoft/DirectXShaderCompiler.")
-endif()
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/DirectXTK12
-    REF may2022
-    SHA512 a306792c134458766ff0ce2672b4769d261080258207173aaff9e59c3a975859df2a540ea8537e28fc2aa1693237c3609665b87c4cf1d9115ac41c7a45ff5d61
+    REF jun2022b
+    SHA512 b72080d83ff894fcf5b9efd4f90715fc4a7d457150e1561a3093188d5533e4e856146f83277a5ddee8d7a84a193484cf9d13165a6a7ffb8ada931cf1ccb31eb3
     HEAD_REF main
 )
 
@@ -19,27 +15,28 @@ vcpkg_check_features(
         xaudio2redist BUILD_XAUDIO_REDIST
 )
 
+set(DXCPATH ${CURRENT_HOST_INSTALLED_DIR}/tools/directx-dxc)
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS ${FEATURE_OPTIONS} -DBUILD_DXIL_SHADERS=ON
+    OPTIONS ${FEATURE_OPTIONS} -DBUILD_DXIL_SHADERS=ON -DDIRECTX_DXC_PATH=${DXCPATH}
 )
 
 vcpkg_cmake_install()
-vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12/cmake)
+vcpkg_cmake_config_fixup(CONFIG_PATH share/directxtk12)
 
 if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
   vcpkg_download_distfile(
     MAKESPRITEFONT_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/may2022/MakeSpriteFont.exe"
-    FILENAME "makespritefont-may2022.exe"
-    SHA512 6f88fec787f9db0823cc0c5aa3d2579248c3dea566909a8d41417f42a3bd2af147ff9af82a3b96a3b1d0f8661dffda27530565bb8fed0a2e7d819d471e51493b
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2022/MakeSpriteFont.exe"
+    FILENAME "makespritefont-jun2022.exe"
+    SHA512 7cdc80e12a4a7be70733d582e4f613055a549345f83e24035cfce42d37568c4934c1bb68df5238f41df9d7fa0e84095aeb227d23450323e31a5d1d68cb505842
   )
 
   vcpkg_download_distfile(
     XWBTOOL_EXE
-    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/may2022/XWBTool.exe"
-    FILENAME "xwbtool-may2022.exe"
-    SHA512 505c7aa7a22ea78a793ba70f136b13548a69b36cd8ec1631969203deff6e93236460c674b219316793aa475f1350ad56f4a3f844e94c3adba0af7b1723c8765e
+    URLS "https://github.com/Microsoft/DirectXTK12/releases/download/jun2022/XWBTool.exe"
+    FILENAME "xwbtool-jun2022.exe"
+    SHA512 b5782323e241641a429f66ad1ac511cfdfd6301851474dafdde274a4f93b49877406d5d0ab992097be7afe8db90fdb9488a9d6de5afce7e086df2e66a5bbca12
   )
 
   file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
@@ -49,8 +46,8 @@ if((VCPKG_HOST_IS_WINDOWS) AND (VCPKG_TARGET_ARCHITECTURE MATCHES x64))
     ${XWBTOOL_EXE}
     DESTINATION "${CURRENT_PACKAGES_DIR}/tools/directxtk12/")
 
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
-  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-may2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/makespritefont.exe")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool-jun2022.exe" "${CURRENT_PACKAGES_DIR}/tools/directxtk12/xwbtool.exe")
 endif()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "directxtk12",
-  "version-date": "2022-05-09",
+  "version-date": "2022-06-15",
   "description": "A collection of helper classes for writing DirectX 12 code in C++.",
   "homepage": "https://github.com/Microsoft/DirectXTK12",
   "documentation": "https://github.com/microsoft/DirectXTK12/wiki",
@@ -9,6 +9,10 @@
   "dependencies": [
     "directx-headers",
     "directxmath",
+    {
+      "name": "directx-dxc",
+      "host": true
+    },
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/ports/directxtk12/vcpkg.json
+++ b/ports/directxtk12/vcpkg.json
@@ -7,12 +7,12 @@
   "license": "MIT",
   "supports": "windows",
   "dependencies": [
-    "directx-headers",
-    "directxmath",
     {
       "name": "directx-dxc",
       "host": true
     },
+    "directx-headers",
+    "directxmath",
     {
       "name": "vcpkg-cmake",
       "host": true

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1897,11 +1897,11 @@
       "port-version": 0
     },
     "directxtk": {
-      "baseline": "2022-05-09",
+      "baseline": "2022-06-15",
       "port-version": 0
     },
     "directxtk12": {
-      "baseline": "2022-05-09",
+      "baseline": "2022-06-15",
       "port-version": 0
     },
     "dirent": {

--- a/versions/d-/directxtk.json
+++ b/versions/d-/directxtk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "3cdf135528218c71f3aaf4f2ca69d7bc57b160a4",
+      "version-date": "2022-06-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "e8707f957389d4329f61d4af69a47766fea2d6b9",
       "version-date": "2022-05-09",
       "port-version": 0

--- a/versions/d-/directxtk12.json
+++ b/versions/d-/directxtk12.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "12033a288a049744a73de4d48c55210ba7201310",
+      "version-date": "2022-06-15",
+      "port-version": 0
+    },
+    {
       "git-tree": "e513b241157a3eada954cdb4c2d353ed4dac27e3",
       "version-date": "2022-05-09",
       "port-version": 0


### PR DESCRIPTION
There is a minor release update of *DirectX Tool Kit* for DX11 / DX12 for June 2022. This includes some cleanup of the CMakeLists. 

This port update also includes updating the *directxtk12* port to make use of *directx-dxc* as a tools port for ``DXC.EXE``.