### PR TITLE
[google-cloud-cpp] update to latest release (v1.42.0)

### DIFF
--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -3,8 +3,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO googleapis/google-cloud-cpp
-    REF v1.41.0
-    SHA512 41bee9fce6d7bbb0cdd201f9902b1bb0b3c94e4e42719332021fdd7ba1e1b1d503cd7e480c6318da658595100d63223f8f11c3d7f5e4965c1c815ab703a9c224
+    REF v1.42.0
+    SHA512 a4220aa4388bc3a1f3e24268c65193b6b01632fe661e952e8eaf898933e2bdc6e4f2254c5d1cc23b0853d8fbeb6de0510aa14f63b39d70d28b6430432430e468
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
@@ -17,6 +17,18 @@ list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "core")
 # This feature does not exist, but allows us to simplify the vcpkg.json file.
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "grpc-common")
 list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "googleapis")
+# google-cloud-cpp uses dialogflow_cx and dialogflow_es. Underscores
+# are invalid in `vcpkg` features, we use dashes (`-`) as a separator
+# for the `vcpkg` feature name, and convert it here to something that
+# `google-cloud-cpp` would like.
+if ("dialogflow-cx" IN_LIST "${FEATURES}")
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-cx")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_cx")
+endif ()
+if ("dialogflow-es" IN_LIST "${FEATURES}")
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
+endif ()
 
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
@@ -53,23 +65,6 @@ foreach(suffix common googleapis grpc_utils rest_internal)
         continue()
     endif()
     vcpkg_cmake_config_fixup(PACKAGE_NAME "google_cloud_cpp_${suffix}"
-                             CONFIG_PATH "${config_path}"
-                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
-endforeach()
-
-# These packages are only for backwards compability. The google-cloud-cpp team
-# is planning to remove them around 2022-02-15.
-foreach(package
-        googleapis
-        bigtable_client
-        pubsub_client
-        spanner_client
-        storage_client)
-    set(config_path "lib/cmake/${package}")
-    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
-        continue()
-    endif()
-    vcpkg_cmake_config_fixup(PACKAGE_NAME "${package}"
                              CONFIG_PATH "${config_path}"
                              DO_NOT_DELETE_PARENT_CONFIG_PATH)
 endforeach()

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "google-cloud-cpp",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "C++ Client Libraries for Google Cloud Platform APIs.",
   "homepage": "https://github.com/googleapis/google-cloud-cpp",
   "license": "Apache-2.0",
@@ -277,6 +277,18 @@
         }
       ]
     },
+    "dataplex": {
+      "description": "Cloud Dataplex API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
     "dataproc": {
       "description": "Cloud Dataproc API C++ Client Library",
       "dependencies": [
@@ -291,6 +303,30 @@
     },
     "debugger": {
       "description": "Stackdriver Debugger API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "dialogflow-cx": {
+      "description": "Cloud Dialogflow CX API C++ Client Library",
+      "dependencies": [
+        {
+          "name": "google-cloud-cpp",
+          "default-features": false,
+          "features": [
+            "grpc-common"
+          ]
+        }
+      ]
+    },
+    "dialogflow-es": {
+      "description": "Cloud Dialogflow ES API C++ Client Library",
       "dependencies": [
         {
           "name": "google-cloud-cpp",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2617,7 +2617,7 @@
       "port-version": 0
     },
     "google-cloud-cpp": {
-      "baseline": "1.41.0",
+      "baseline": "1.42.0",
       "port-version": 0
     },
     "google-cloud-cpp-common": {

--- a/versions/g-/google-cloud-cpp.json
+++ b/versions/g-/google-cloud-cpp.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "95315156a8c6fefdde56b6c4718062975ff7e0ce",
+      "version": "1.42.0",
+      "port-version": 0
+    },
+    {
       "git-tree": "a6fac62fee7c3ad470f81ac87fcdf19d5a85f8b8",
       "version": "1.41.0",
       "port-version": 0


### PR DESCRIPTION
Updates `google-cloud-cpp` to the latest release (v.1.42.0).
Adds new GA features included with this release.
Remove obsolete code.

- #### What does your PR fix?

N/A

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

No change.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?

Yes.

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?

Yes.
