### PR TITLE
[imgui] Update to 1.88

### DIFF
--- a/ports/imgui-sfml/portfile.cmake
+++ b/ports/imgui-sfml/portfile.cmake
@@ -13,6 +13,8 @@ vcpkg_from_github(
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DCMAKE_CXX_STANDARD=11
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()

--- a/ports/imgui-sfml/vcpkg.json
+++ b/ports/imgui-sfml/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "imgui-sfml",
   "version": "2.5",
+  "port-version": 1,
   "description": "ImGui binding for use with SFML",
   "homepage": "https://github.com/eliasdaler/imgui-sfml",
   "license": "MIT",

--- a/ports/imgui/portfile.cmake
+++ b/ports/imgui/portfile.cmake
@@ -4,16 +4,16 @@ if ("docking-experimental" IN_LIST FEATURES)
     vcpkg_from_github(
        OUT_SOURCE_PATH SOURCE_PATH
        REPO ocornut/imgui
-       REF 1ee252772ae9c0a971d06257bb5c89f628fa696a
-       SHA512 942cd8e39f490c15d90b6feb6f919ebeab8f6f8f9aacfcbf552daef24b0f7e637ad5f630767a52fd9993d84a80b5954c7b05f7400a9f96b6b739cf5680368119
+       REF 9cd9c2eff99877a3f10a7f9c2a3a5b9c15ea36c6
+       SHA512 4a9bf74f5f3971bcb954449bdef27e491a0abebc55356bcf0491c7e17dc941c90cf81d539fe4de1e23137866f55456776fcded34a4df2fb16b9020fe1b8d7851
        HEAD_REF docking
        )
 else()
     vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ocornut/imgui
-    REF v1.87
-    SHA512 3255b06698ab9c8951953e1e0b6d160d64adfa4c011b21a4288547292a7f8fff586875faf9dae0677818bde65bd7e98da92f16f6beb1e6a66aa835edf32e8ce2
+    REF v1.88
+    SHA512 bfb7381334f1493d64386321401086e4136129b3cc57bf57505ec6183008dddab1a2056b0af2610bc3286c606bafdf9b6e3ebc103131e0504bab2336662bc2c1
     HEAD_REF master
     )
 endif()

--- a/ports/imgui/vcpkg.json
+++ b/ports/imgui/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "imgui",
-  "version": "1.87",
-  "port-version": 1,
+  "version": "1.88",
   "description": "Bloat-free Immediate Mode Graphical User interface for C++ with minimal dependencies.",
   "homepage": "https://github.com/ocornut/imgui",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2953,8 +2953,8 @@
       "port-version": 0
     },
     "imgui": {
-      "baseline": "1.87",
-      "port-version": 1
+      "baseline": "1.88",
+      "port-version": 0
     },
     "imgui-sfml": {
       "baseline": "2.5",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2958,7 +2958,7 @@
     },
     "imgui-sfml": {
       "baseline": "2.5",
-      "port-version": 0
+      "port-version": 1
     },
     "imguizmo": {
       "baseline": "1.83",

--- a/versions/i-/imgui-sfml.json
+++ b/versions/i-/imgui-sfml.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "998381d4b79034aba39b0fdb7bb6ef3a4187d1fb",
+      "version": "2.5",
+      "port-version": 1
+    },
+    {
       "git-tree": "8ece0f7736052672d61d85745b1fb6a3b1362720",
       "version": "2.5",
       "port-version": 0

--- a/versions/i-/imgui.json
+++ b/versions/i-/imgui.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c28ebbdbe22a87ce01c3b2b6c15bed036721c6a0",
+      "version": "1.88",
+      "port-version": 0
+    },
+    {
       "git-tree": "647accc743e0af0547fbf8671c170038e202fd1e",
       "version": "1.87",
       "port-version": 1


### PR DESCRIPTION
Update imgui from 1.87 to 1.88.
Changelog : https://github.com/ocornut/imgui/releases/tag/v1.88