### PR TITLE
[numactl] Some other libraries depend on both static and dynamic libraries of numactl

### DIFF
--- a/ports/numactl/portfile.cmake
+++ b/ports/numactl/portfile.cmake
@@ -13,7 +13,7 @@ These can be installed on Ubuntu systems via sudo apt install autoconf libtool"
 )
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    set(SHARED_STATIC --enable-static --disable-shared)
+    set(SHARED_STATIC --enable-static --enable-shared)
 else()
     set(SHARED_STATIC --disable-static --enable-shared)
 endif()

--- a/ports/numactl/vcpkg.json
+++ b/ports/numactl/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "numactl",
   "version": "2.0.14",
-  "port-version": 1,
+  "port-version": 2,
   "description": "NUMA support for Linux",
   "homepage": "https://github.com/numactl/numactl",
   "supports": "linux"

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4962,7 +4962,7 @@
     },
     "numactl": {
       "baseline": "2.0.14",
-      "port-version": 1
+      "port-version": 2
     },
     "numcpp": {
       "baseline": "2.6.0",

--- a/versions/n-/numactl.json
+++ b/versions/n-/numactl.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "383e4228beea275f712d0485184ef855639246c8",
+      "version": "2.0.14",
+      "port-version": 2
+    },
+    {
       "git-tree": "38b7d6feca43ff05b6a059aae8ce218fa382853e",
       "version": "2.0.14",
       "port-version": 1


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Enabling the shared library build during the static build. Some other libraries such as DPDK will need both static and dynamic libraries to complete the compiling. Otherwise, the exact same error reported here will appear (https://mails.dpdk.org/archives/dev/2019-May/132290.html).

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `No.`

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  `Yes`
