### PR TITLE
[fontconfig] Fix mingw build

### DIFF
--- a/ports/fontconfig/fix-mingw-gperf-fallback.patch
+++ b/ports/fontconfig/fix-mingw-gperf-fallback.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index e5096bf..51c289f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -268,7 +268,7 @@ sh = find_program('sh', required : false)
+ 
+ if not sh.found() # host_machine.system() == 'windows' or not sh.found()
+   # TODO: This is not always correct
+-  if cc.get_id() == 'msvc'
++  if host_machine.system() == 'windows'
+     gperf_len_type = 'size_t'
+   else
+     gperf_len_type = 'unsigned'

--- a/ports/fontconfig/libgetopt.patch
+++ b/ports/fontconfig/libgetopt.patch
@@ -120,7 +120,7 @@ index f616600..6d82a16 100644
 +if host_machine.system() == 'windows'
 +  conf.set('HAVE_GETOPT', 1)
 +  conf.set('HAVE_GETOPT_LONG', 1)
-+  getopt_dep = cc.find_library('getopt', required: true)
++  getopt_dep = cc.find_library('getopt', required: false)
 +else
 +  getopt_dep = dependency('', required: false)
 +endif

--- a/ports/fontconfig/portfile.cmake
+++ b/ports/fontconfig/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_gitlab(
     PATCHES
         no-etc-symlinks.patch
         libgetopt.patch
+        fix-mingw-gperf-fallback.patch
 )
 
 vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/gperf")

--- a/ports/fontconfig/vcpkg.json
+++ b/ports/fontconfig/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "fontconfig",
   "version": "2.14.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Library for configuring and customizing font access.",
   "homepage": "https://www.freedesktop.org/wiki/Software/fontconfig",
   "license": "MIT",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2314,7 +2314,7 @@
     },
     "fontconfig": {
       "baseline": "2.14.0",
-      "port-version": 2
+      "port-version": 3
     },
     "foonathan-memory": {
       "baseline": "2019-07-21",

--- a/versions/f-/fontconfig.json
+++ b/versions/f-/fontconfig.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "edebefba0511e2f8ee4018707fe611d0035c4dd4",
+      "version": "2.14.0",
+      "port-version": 3
+    },
+    {
       "git-tree": "5c02d2ba027c9f390729a7e0899e63c853450dfb",
       "version": "2.14.0",
       "port-version": 2


### PR DESCRIPTION
- #### What does your PR fix?
  Fixes building fontconfig with mingw, on Windows.
  Includes #24893 - fixes #24841.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  unchanged, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  yes