### PR TITLE
[pffft] fix supports

### DIFF
--- a/ports/pffft/fix-invalid-command.patch
+++ b/ports/pffft/fix-invalid-command.patch
@@ -1,0 +1,17 @@
+diff --git a/pffft.c b/pffft.c
+index d12f572..7cc0546 100644
+--- a/pffft.c
++++ b/pffft.c
+@@ -173,7 +173,11 @@ typedef float32x4_t v4sf;
+ #  define VALIGNED(ptr) ((((long long)(ptr)) & 0x3) == 0)
+ #else
+ #  if !defined(PFFFT_SIMD_DISABLE)
+-#    warning "building with simd disabled !\n";
++#    ifdef _WIN32
++#    pragma message ("building with simd disabled !\n"")
++#    else
++#    warning "building with simd disabled !\n";
++#    endif
+ #    define PFFFT_SIMD_DISABLE // fallback to scalar code
+ #  endif
+ #endif

--- a/ports/pffft/fix-invalid-command.patch
+++ b/ports/pffft/fix-invalid-command.patch
@@ -7,10 +7,10 @@ index d12f572..7cc0546 100644
  #else
  #  if !defined(PFFFT_SIMD_DISABLE)
 -#    warning "building with simd disabled !\n";
-+#    ifdef _WIN32
-+#    pragma message ("building with simd disabled !\n"")
++#    ifdef COMPILER_MSVC
++#      pragma message ("building with simd disabled !\n");
 +#    else
-+#    warning "building with simd disabled !\n";
++#      warning "building with simd disabled !\n";
 +#    endif
  #    define PFFFT_SIMD_DISABLE // fallback to scalar code
  #  endif

--- a/ports/pffft/portfile.cmake
+++ b/ports/pffft/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_bitbucket(
     REF ed78751d751e51bbd94c41d24f748b400f272d69
     SHA512 44f65c7f7e5b71f549dca2e03d58b1fd64e698858f79e4c2833a9ae3dff8a835cf9d5e14be2341c6370f800012cb69b05b9226d6918b12e67f7f7e81ed8e9ad4
     HEAD_REF master
+    PATCHES
+        fix-invalid-command.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/pffft/vcpkg.json
+++ b/ports/pffft/vcpkg.json
@@ -1,9 +1,10 @@
 {
   "name": "pffft",
   "version-date": "2021-10-09",
+  "port-version": 1,
   "description": "PFFFT, a pretty fast Fourier Transform.",
   "homepage": "https://bitbucket.org/jpommier/pffft/",
-  "supports": "static",
+  "license": null,
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5426,7 +5426,7 @@
     },
     "pffft": {
       "baseline": "2021-10-09",
-      "port-version": 0
+      "port-version": 1
     },
     "pfring": {
       "baseline": "2019-10-17",

--- a/versions/p-/pffft.json
+++ b/versions/p-/pffft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fba14a7dc4c9eae35921364c590f3d12928ede45",
+      "git-tree": "3850eacc18b27a0464279d0a63ecf4db4aaf3a20",
       "version-date": "2021-10-09",
       "port-version": 1
     },

--- a/versions/p-/pffft.json
+++ b/versions/p-/pffft.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "3850eacc18b27a0464279d0a63ecf4db4aaf3a20",
+      "git-tree": "525bc1ec4fd9aa77feeaba44fc6f0cf717716ae1",
       "version-date": "2021-10-09",
       "port-version": 1
     },

--- a/versions/p-/pffft.json
+++ b/versions/p-/pffft.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fba14a7dc4c9eae35921364c590f3d12928ede45",
+      "version-date": "2021-10-09",
+      "port-version": 1
+    },
+    {
       "git-tree": "c425b1091069b34450a9b7e524f1cad202e4e709",
       "version-date": "2021-10-09",
       "port-version": 0


### PR DESCRIPTION
For https://github.com/microsoft/vcpkg/issues/25179

Removed `"supports": "static"`, build `pffft` on all triplets.

Fix `arm `build error: `C1021: invalid preprocessor command 'warning'`
Add patch to fix the invalid command.

> MSVC uses the syntax:
> #pragma message ( "your warning text here" )
> The usual #warning syntax generates a fatal error
> C1021: invalid preprocessor command 'warning'