### PR TITLE
[libcaer] Fixing libcaer cmake configuration issue on linux / macos

### DIFF
--- a/ports/libcaer/libcaer-static-build.patch
+++ b/ports/libcaer/libcaer-static-build.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3b1937a..a75db2b 100644
+index 3b1937a..b9bc122 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -20,6 +20,8 @@ OPTION(ENABLE_SERIALDEV "Enable support for serial port devices using libserialp
@@ -11,6 +11,15 @@ index 3b1937a..a75db2b 100644
  
  # Cross-compile support
  IF(NOT USER_LOCAL_PREFIX)
+@@ -50,7 +52,7 @@ MESSAGE(STATUS "Base libraries: ${BASE_LIBS}")
+ INCLUDE(FindPkgConfig)
+ 
+ # Required: basic USB devices support
+-IF(CC_MSVC)
++IF(ENABLE_BINDIR_INSTALLATION)
+ 	FIND_PACKAGE(libusb CONFIG REQUIRED)
+ ELSE()
+ 	PKG_CHECK_MODULES(
 @@ -98,7 +100,7 @@ INCLUDE(CMakePackageConfigHelpers)
  WRITE_BASIC_CONFIG_VERSION_FILE(${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake VERSION ${PROJECT_VERSION}
  								COMPATIBILITY SameMajorVersion)
@@ -21,7 +30,7 @@ index 3b1937a..a75db2b 100644
  ELSE()
  	SET(export_destination ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 377a556..d9c29d7 100644
+index 377a556..8461627 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -19,6 +19,10 @@ IF(NOT CC_MSVC)
@@ -35,7 +44,17 @@ index 377a556..d9c29d7 100644
  SET(LIBCAER_LINK_LIBRARIES_PRIVATE ${BASE_LIBS})
  
  IF(OS_LINUX)
-@@ -63,7 +67,7 @@ ENDIF()
+@@ -54,6 +58,9 @@ ENDIF()
+ 
+ IF(CC_MSVC)
+ 	LIST(APPEND LIBCAER_SOURCES ../thirdparty/simple-stdatomic/stdatomic.c)
++ENDIF()
++
++IF(ENABLE_BINDIR_INSTALLATION)
+ 	INCLUDE_DIRECTORIES(${LIBUSB_INCLUDE_DIRS})
+ 	LIST(APPEND LIBCAER_LINK_LIBRARIES_PRIVATE ${LIBUSB_LIBRARIES})
+ ELSE()
+@@ -63,7 +70,7 @@ ENDIF()
  # Set full RPATH
  SET(CMAKE_INSTALL_RPATH ${USER_LOCAL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
  
@@ -44,7 +63,7 @@ index 377a556..d9c29d7 100644
  IF(CC_MSVC)
  	# This flag needs to be propagated down to depending targets to avoid compilation errors
  	TARGET_COMPILE_OPTIONS(caer INTERFACE -DWIN32_LEAN_AND_MEAN=ON)
-@@ -94,7 +98,7 @@ IF(ENABLE_STATIC)
+@@ -94,7 +101,7 @@ IF(ENABLE_STATIC)
  
  	SET_TARGET_PROPERTIES(caerStatic PROPERTIES OUTPUT_NAME caer)
  

--- a/ports/libcaer/vcpkg.json
+++ b/ports/libcaer/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libcaer",
   "version": "3.3.14",
+  "port-version": 1,
   "description": "Minimal C library to access, configure and get data from neuromorphic sensors and processors.",
   "homepage": "https://gitlab.com/inivation/dv/libcaer",
   "license": "BSD-2-Clause",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -3470,7 +3470,7 @@
     },
     "libcaer": {
       "baseline": "3.3.14",
-      "port-version": 0
+      "port-version": 1
     },
     "libcanberra": {
       "baseline": "0.30",

--- a/versions/l-/libcaer.json
+++ b/versions/l-/libcaer.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "275713cf9dbdd13533fe379ad7f8c81fcf9a895c",
+      "version": "3.3.14",
+      "port-version": 1
+    },
+    {
       "git-tree": "4dffda61ffebd9440265c6edde057d1af909cf5c",
       "version": "3.3.14",
       "port-version": 0


### PR DESCRIPTION
- #### What does your PR fix?

Libcaer has an issue with vcpkg installation in linux / macos, while it compiles and installs successfully, the generated cmake throws an error due to incorrect flags used to detect usage over vcpkg. This is fixed by applying a different patch file on the source code.
