### PR TITLE
[freetype] switch from sourceforgr.net to github.com

### DIFF
--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -1,11 +1,8 @@
-set(FT_VERSION 2.12.1)
-
-vcpkg_from_sourceforge(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO freetype/freetype2
-    REF ${FT_VERSION}
-    FILENAME freetype-${FT_VERSION}.tar.xz
-    SHA512 6482de1748dc2cc01e033d21a3b492dadb1f039d13d9179685fdcf985e24d7f587cbca4c27ed8a7fdb7d9ad59612642ac5f4db062443154753295363f45c052f
+    REPO freetype/freetype
+    REF 2db58e061ecc0d738a41d13ed8908e967bd0014c #2.12.1
+    SHA512 66a04a96bb788faf5a3a4100143b98e9ec7de12fd562fd0c0c8a8936305cfad91c38f1d9859411e8218c61a2513f2045a0d752c96b768b07933da73218f58d84
     PATCHES
         0003-Fix-UWP.patch
         brotli-static.patch

--- a/ports/freetype/vcpkg.json
+++ b/ports/freetype/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "freetype",
   "version": "2.12.1",
+  "port-version": 1,
   "description": "A library to render fonts.",
   "homepage": "https://www.freetype.org/",
   "license": "FTL OR GPL-2.0-or-later",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2366,7 +2366,7 @@
     },
     "freetype": {
       "baseline": "2.12.1",
-      "port-version": 0
+      "port-version": 1
     },
     "freetype-gl": {
       "baseline": "2022-01-17",

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1e915bce3d29e36036ad2d5c313c0d84af4bcf76",
+      "version": "2.12.1",
+      "port-version": 1
+    },
+    {
       "git-tree": "bf7afc9d9fa4aba9747dfc7902c60ea7cfa09e72",
       "version": "2.12.1",
       "port-version": 0


### PR DESCRIPTION
Fix #25390

Switch from `sourceforgr.net` which uses 90 days certs to `github.com` which uses 365 days certs.

All features are tested successfully in the following triplet:

- x86-windows
- x64-windows
- x64-windows-stataic