### PR TITLE
[antlr4] Update to 4.10.1

### DIFF
--- a/ports/antlr4/fix_LNK2001.patch
+++ b/ports/antlr4/fix_LNK2001.patch
@@ -1,0 +1,50 @@
+diff --git a/runtime/src/misc/MurmurHash.cpp b/runtime/src/misc/MurmurHash.cpp
+index 73562cd..57aa3bf 100644
+--- a/runtime/src/misc/MurmurHash.cpp
++++ b/runtime/src/misc/MurmurHash.cpp
+@@ -63,23 +63,6 @@ size_t MurmurHash::update(size_t hash, size_t value) {
+   return hash;
+ }
+ 
+-size_t MurmurHash::update(size_t hash, const void *data, size_t size) {
+-  size_t value;
+-  const uint8_t *bytes = static_cast<const uint8_t*>(data);
+-  while (size >= sizeof(size_t)) {
+-    std::memcpy(&value, bytes, sizeof(size_t));
+-    hash = update(hash, value);
+-    bytes += sizeof(size_t);
+-    size -= sizeof(size_t);
+-  }
+-  if (size != 0) {
+-    value = 0;
+-    std::memcpy(&value, bytes, size);
+-    hash = update(hash, value);
+-  }
+-  return hash;
+-}
+-
+ size_t MurmurHash::finish(size_t hash, size_t entryCount) {
+   hash ^= entryCount * 8;
+   hash ^= hash >> 33;
+@@ -118,3 +101,20 @@ size_t MurmurHash::finish(size_t hash, size_t entryCount) {
+ #else
+ #error "Expected sizeof(size_t) to be 4 or 8."
+ #endif
++
++size_t MurmurHash::update(size_t hash, const void *data, size_t size) {
++  size_t value;
++  const uint8_t *bytes = static_cast<const uint8_t*>(data);
++  while (size >= sizeof(size_t)) {
++    std::memcpy(&value, bytes, sizeof(size_t));
++    hash = update(hash, value);
++    bytes += sizeof(size_t);
++    size -= sizeof(size_t);
++  }
++  if (size != 0) {
++    value = 0;
++    std::memcpy(&value, bytes, size);
++    hash = update(hash, value);
++  }
++  return hash;
++}
+\ No newline at end of file

--- a/ports/antlr4/fixed_build.patch
+++ b/ports/antlr4/fixed_build.patch
@@ -1,8 +1,8 @@
 diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
-index c8b16c6..53b47dd 100644
+index baf46ca..80fa49a 100644
 --- a/runtime/CMakeLists.txt
 +++ b/runtime/CMakeLists.txt
-@@ -21,10 +21,13 @@ file(GLOB libantlrcpp_SRC
+@@ -23,10 +23,13 @@ file(GLOB libantlrcpp_SRC
    "${PROJECT_SOURCE_DIR}/runtime/src/tree/xpath/*.cpp"
  )
  
@@ -17,7 +17,7 @@ index c8b16c6..53b47dd 100644
  message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
  
  # make sure 'make' works fine even if ${LIB_OUTPUT_DIR} is deleted.
-@@ -32,16 +35,22 @@ add_custom_target(make_lib_output_dir ALL
+@@ -34,8 +37,11 @@ add_custom_target(make_lib_output_dir ALL
      COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
      )
  
@@ -27,29 +27,9 @@ index c8b16c6..53b47dd 100644
  add_dependencies(antlr4_static make_lib_output_dir)
 +endif()
  
- find_package(utf8cpp QUIET)
- 
- set(INSTALL_utf8cpp FALSE)
- 
- if (utf8cpp_FOUND)
-+  if(BUILD_SHARED_LIBS)
-   target_link_libraries(antlr4_shared utf8cpp)
-+  else()
-   target_link_libraries(antlr4_static utf8cpp)
-+  endif()
- else()
- 
-   # older utf8cpp doesn't define the package above
-@@ -51,7 +60,7 @@ else()
- 
-   if (utf8cpp_HEADER)
-     include_directories(${utf8cpp_HEADER})
--  else()
-+  elseif(0)
-     include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
-     set(THIRDPARTY_DIR ${CMAKE_BINARY_DIR}/runtime/thirdparty)
-     set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
-@@ -76,11 +85,17 @@ else()
+ if (ANTLR_BUILD_CPP_TESTS)
+   include(FetchContent)
+@@ -70,11 +76,17 @@ if (ANTLR_BUILD_CPP_TESTS)
  endif()
  
  if(CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -67,7 +47,7 @@ index c8b16c6..53b47dd 100644
  endif()
  
  if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-@@ -102,7 +117,7 @@ if(WIN32)
+@@ -96,7 +108,7 @@ if(WIN32)
    set(extra_share_compile_flags "-DANTLR4CPP_EXPORTS")
    set(extra_static_compile_flags "-DANTLR4CPP_STATIC")
  endif(WIN32)
@@ -76,7 +56,7 @@ index c8b16c6..53b47dd 100644
    if(WITH_STATIC_CRT)
      target_compile_options(antlr4_shared PRIVATE "/MT$<$<CONFIG:Debug>:d>")
      target_compile_options(antlr4_static PRIVATE "/MT$<$<CONFIG:Debug>:d>")
-@@ -122,6 +137,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+@@ -116,6 +128,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
    set(extra_static_compile_flags "-DANTLR4CPP_STATIC -MP")
  endif()
  
@@ -84,7 +64,7 @@ index c8b16c6..53b47dd 100644
  set_target_properties(antlr4_shared
                        PROPERTIES VERSION   ${ANTLR_VERSION}
                                   SOVERSION ${ANTLR_VERSION}
-@@ -132,20 +148,25 @@ set_target_properties(antlr4_shared
+@@ -126,25 +139,27 @@ set_target_properties(antlr4_shared
                                   RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                   ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                   COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
@@ -96,19 +76,21 @@ index c8b16c6..53b47dd 100644
                                   OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
                                   ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                   COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
+-
 +endif()
- 
--install(TARGETS antlr4_shared
 +if(BUILD_SHARED_LIBS)
-+install(TARGETS antlr4_shared EXPORT antlr4-targets
-         DESTINATION lib
--        EXPORT antlr4-targets)
-+        RUNTIME DESTINATION bin
-+        )
+ install(TARGETS antlr4_shared
+         EXPORT antlr4-targets
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-
 +else()
  install(TARGETS antlr4_static
-         DESTINATION lib
-         EXPORT antlr4-targets)
+         EXPORT antlr4-targets
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 +endif()
  
  install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -1,9 +1,9 @@
-set(VERSION 4.9.3)
+set(VERSION 4.10.1)
 
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.antlr.org/download/antlr4-cpp-runtime-${VERSION}-source.zip"
     FILENAME "antlr4-cpp-runtime-${VERSION}-source.zip"
-    SHA512 23995a6fa661ff038142fa7220a195db3a9a26744d516011dedc3192f152b06a8e31f6cc8f969f8927b86392a960d03e89572e753f033f950839a5bd38d4c722
+    SHA512 f4926987946d17bf51b2d8a31ac06cf16eea7fb49ce535abb2d4759c9e6113d173c4504ffe4c8d2f9a58d845507dfdedaaba3dde70cc09c03c6bd6a2afe892a6
 )
 
 # license not exist in antlr folder.
@@ -21,13 +21,14 @@ vcpkg_extract_source_archive_ex(
     PATCHES
         fixed_build.patch
         uuid_discovery_fix.patch
-        export_guid.patch
+        fix_LNK2001.patch #The related upstream issue https://github.com/antlr/antlr4/issues/3674 
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DANTLR4_INSTALL=ON
+        -DANTLR_BUILD_CPP_TESTS=OFF
     OPTIONS_DEBUG -DLIB_OUTPUT_DIR=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/dist
     OPTIONS_RELEASE -DLIB_OUTPUT_DIR=${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/dist
 )
@@ -37,6 +38,13 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME antlr4-generator CONFIG_PATH lib/cmake/ant
 vcpkg_cmake_config_fixup(PACKAGE_NAME antlr4-runtime CONFIG_PATH lib/cmake/antlr4-runtime)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE 
+        "${CURRENT_PACKAGES_DIR}/bin" 
+        "${CURRENT_PACKAGES_DIR}/debug/bin"
+    )
+endif()
 
 vcpkg_copy_pdbs()
 

--- a/ports/antlr4/portfile.cmake
+++ b/ports/antlr4/portfile.cmake
@@ -39,13 +39,6 @@ vcpkg_cmake_config_fixup(PACKAGE_NAME antlr4-runtime CONFIG_PATH lib/cmake/antlr
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
 
-if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    file(REMOVE_RECURSE 
-        "${CURRENT_PACKAGES_DIR}/bin" 
-        "${CURRENT_PACKAGES_DIR}/debug/bin"
-    )
-endif()
-
 vcpkg_copy_pdbs()
 
 file(INSTALL "${LICENSE}" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/antlr4/uuid_discovery_fix.patch
+++ b/ports/antlr4/uuid_discovery_fix.patch
@@ -14,22 +14,3 @@ diff -urN a/CMakeLists.txt b/CMakeLists.txt
  endif()
  if(APPLE)
    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-diff --git a/runtime/src/support/Guid.cpp b/runtime/src/support/Guid.cpp
---- a/runtime/src/support/Guid.cpp
-+++ b/runtime/src/support/Guid.cpp
-@@ -24,6 +24,7 @@
- 
- #include <algorithm>
- 
-+#include "antlr4-common.h"
- #include "Guid.h"
- 
- #ifdef GUID_LIBUUID
-@@ -35,6 +36,7 @@
- #endif
- 
- #ifdef GUID_WINDOWS
-+#define NOMINMAX
- #include <objbase.h>
- #endif
- 

--- a/ports/antlr4/vcpkg.json
+++ b/ports/antlr4/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "antlr4",
-  "version": "4.9.3",
-  "port-version": 2,
+  "version": "4.10.1",
   "description": "ANother Tool for Language Recognition",
   "homepage": "https://www.antlr.org",
   "license": "BSD-3-Clause",

--- a/versions/a-/antlr4.json
+++ b/versions/a-/antlr4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "a66bc98e79cbed904d66d00d12f70b4eb73808fc",
+      "version": "4.10.1",
+      "port-version": 0
+    },
+    {
       "git-tree": "6a716f472a0639199a0a843a64795a88a39f5dee",
       "version": "4.9.3",
       "port-version": 2

--- a/versions/a-/antlr4.json
+++ b/versions/a-/antlr4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "a66bc98e79cbed904d66d00d12f70b4eb73808fc",
+      "git-tree": "77ce1d5e7b1ea96943b3917086e1b75d50ae903c",
       "version": "4.10.1",
       "port-version": 0
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -93,8 +93,8 @@
       "port-version": 3
     },
     "antlr4": {
-      "baseline": "4.9.3",
-      "port-version": 2
+      "baseline": "4.10.1",
+      "port-version": 0
     },
     "any-lite": {
       "baseline": "0.4.0",


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  Update `antlr4` to 4.10.1, fix old patches. 
  There is a upstream bug: https://github.com/antlr/antlr4/issues/3674, fix by patch `fix_LNK2001.patch`, it has been not merged  into version 4.10.1 of `antlr4`. So add this patch to fix the following error:
```
LINK Pass 1: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\x86\link.exe @CMakeFiles\antlr4_shared.rsp /out:dist\antlr4-runtime.dll /implib:dist\antlr4-runtime.lib /pdb:dist\antlr4-runtime.pdb /dll /version:4.10 /machine:X86 /nologo /debug /INCREMENTAL /MANIFEST /MANIFESTFILE:runtime\CMakeFiles\antlr4_shared.dir/intermediate.manifest runtime\CMakeFiles\antlr4_shared.dir/manifest.res" failed (exit code 1120) with the following output:
   Creating library dist\antlr4-runtime.lib and object dist\antlr4-runtime.exp
XPathWildcardAnywhereElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
XPathWildcardElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
XPathRuleAnywhereElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
XPathRuleElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
XPathTokenAnywhereElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
XPathTokenElement.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
Trees.cpp.obj : error LNK2001: unresolved external symbol "public: static unsigned int __cdecl antlr4::misc::MurmurHash::update(unsigned int,void const *,unsigned int)" (?update@MurmurHash@misc@antlr4@@SAIIPBXI@Z)
```