### PR TITLE
[lz4] Patch for CVE-2021-3520

### DIFF
--- a/ports/lz4/0001-Fix-potential-memory-corruption-with-negative-memmov.patch
+++ b/ports/lz4/0001-Fix-potential-memory-corruption-with-negative-memmov.patch
@@ -1,0 +1,26 @@
+From 8301a21773ef61656225e264f4f06ae14462bca7 Mon Sep 17 00:00:00 2001
+From: Jasper Lievisse Adriaanse <j@jasper.la>
+Date: Fri, 26 Feb 2021 15:21:20 +0100
+Subject: [PATCH 001/120] Fix potential memory corruption with negative
+ memmove() size
+
+---
+ lib/lz4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/lz4.c b/lib/lz4.c
+index 5f524d0..c2f504e 100644
+--- a/lib/lz4.c
++++ b/lib/lz4.c
+@@ -1749,7 +1749,7 @@ LZ4_decompress_generic(
+                  const size_t dictSize         /* note : = 0 if noDict */
+                  )
+ {
+-    if (src == NULL) { return -1; }
++    if ((src == NULL) || (outputSize < 0)) { return -1; }
+ 
+     {   const BYTE* ip = (const BYTE*) src;
+         const BYTE* const iend = ip + srcSize;
+-- 
+2.36.1
+

--- a/ports/lz4/portfile.cmake
+++ b/ports/lz4/portfile.cmake
@@ -4,6 +4,8 @@ vcpkg_from_github(
     REF v1.9.3
     SHA512 c246b0bda881ee9399fa1be490fa39f43b291bb1d9db72dba8a85db1a50aad416a97e9b300eee3d2a4203c2bd88bda2762e81bc229c3aa409ad217eb306a454c
     HEAD_REF dev
+    PATCHES
+        0001-Fix-potential-memory-corruption-with-negative-memmov.patch
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/lz4/vcpkg.json
+++ b/ports/lz4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "lz4",
   "version": "1.9.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Lossless compression algorithm, providing compression speed at 400 MB/s per core.",
   "homepage": "https://github.com/lz4/lz4",
   "dependencies": [

--- a/ports/lz4/vcpkg.json
+++ b/ports/lz4/vcpkg.json
@@ -4,6 +4,7 @@
   "port-version": 4,
   "description": "Lossless compression algorithm, providing compression speed at 400 MB/s per core.",
   "homepage": "https://github.com/lz4/lz4",
+  "license": "BSD-2-Clause AND GPL-2.0-only",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -4370,7 +4370,7 @@
     },
     "lz4": {
       "baseline": "1.9.3",
-      "port-version": 3
+      "port-version": 4
     },
     "lzfse": {
       "baseline": "1.0",

--- a/versions/l-/lz4.json
+++ b/versions/l-/lz4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c0b8b0721a7f78c9cc15b3be583143b4e621ca7f",
+      "git-tree": "f3b3f8d7799086d118dd166c346665ad71b66c19",
       "version": "1.9.3",
       "port-version": 4
     },

--- a/versions/l-/lz4.json
+++ b/versions/l-/lz4.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "c0b8b0721a7f78c9cc15b3be583143b4e621ca7f",
+      "version": "1.9.3",
+      "port-version": 4
+    },
+    {
       "git-tree": "43957fa49e865966b52c6729db11aa067f790d49",
       "version": "1.9.3",
       "port-version": 3


### PR DESCRIPTION
- Fixes potential memory corruption

See https://nvd.nist.gov/vuln/detail/CVE-2021-3520 for more details

This is the upstream patch by Jasper Lievisse Adriaanse.

Commit message of upstream patch: "Fix potential memory corruption with negative memmove() size"
Merged upstream pull request https://github.com/lz4/lz4/pull/972


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
No change to triplets.

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
