### PR TITLE
[at-spi2-atk] Add libxtst-dev

### DIFF
--- a/ports/at-spi2-atk/portfile.cmake
+++ b/ports/at-spi2-atk/portfile.cmake
@@ -1,0 +1,29 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev")
+endif()
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.gnome.org
+    REPO GNOME/at-spi2-atk
+    REF AT_SPI2_ATK_2_38_0
+    SHA512 d065a22e46f5d9459e14bc81050795e8b60ba8d6650ec9edf90ec6c205e68eb4ea3cc01f096cf636b066439b85892f203bc7a1c9d41f8ca899f29777556aa6cd
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dtests=false
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/at-spi2-atk/vcpkg.json
+++ b/ports/at-spi2-atk/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "at-spi2-atk",
+  "version": "2.38.0",
+  "description": "Implementation of the ATK interfaces in terms of the libatspi2 API.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    "at-spi2-core",
+    "atk",
+    "libxml2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/ports/at-spi2-core/portfile.cmake
+++ b/ports/at-spi2-core/portfile.cmake
@@ -1,0 +1,48 @@
+if(VCPKG_TARGET_IS_LINUX)
+    message(STATUS "${PORT} currently requires the following libraries from the system package manager:\n    libdbus-1\n    libxi-dev\n    libxtst-dev\n\nThese can be installed on Ubuntu systems via apt-get install libdbus-1-dev libxi-dev libxtst-dev")
+endif()
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.gnome.org
+    REPO GNOME/at-spi2-core
+    REF AT_SPI2_CORE_2_44_1
+    SHA512 4e98b76e019f33af698a5e2b7ae7ce17ce0ff57784b4d505fe4bad58b097080899c1ca82b443502068c5504b60886e2d4a341bba833e0279ebef352211bf3813
+)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dintrospection=no
+    ADDITIONAL_NATIVE_BINARIES
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+    ADDITIONAL_CROSS_BINARIES
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/atspi-2.pc"
+        "-DG_LOG_DOMAIN=\"dbind\"" ""
+    )
+endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/atspi-2.pc"
+        "-DG_LOG_DOMAIN=\"dbind\"" ""
+    )
+endif()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()

--- a/ports/at-spi2-core/vcpkg.json
+++ b/ports/at-spi2-core/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "at-spi2-core",
+  "version": "2.44.1",
+  "description": "Base DBus XML interfaces for accessibility, the accessibility registry daemon, and atspi library.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ]
+}

--- a/scripts/azure-pipelines/linux/provision-image.sh
+++ b/scripts/azure-pipelines/linux/provision-image.sh
@@ -53,8 +53,8 @@ APT_PACKAGES="$APT_PACKAGES guile-2.2-dev"
 # Additionally required by gtk
 APT_PACKAGES="$APT_PACKAGES libxdamage-dev"
 
-# Additionally required by gtk3 and at-spi2-atk
-APT_PACKAGES="$APT_PACKAGES libdbus-1-dev"
+# Additionally required by gtk3 and at-spi2-core
+APT_PACKAGES="$APT_PACKAGES libdbus-1-dev libxtst-dev"
 
 # Additionally required/installed by Azure DevOps Scale Set Agents
 APT_PACKAGES="$APT_PACKAGES liblttng-ust0 libkrb5-3 zlib1g libicu66"

--- a/versions/a-/at-spi2-atk.json
+++ b/versions/a-/at-spi2-atk.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "ebb28a9cdbd06d3185ba2e0cfc1945be23a0a608",
+      "version": "2.38.0",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/a-/at-spi2-core.json
+++ b/versions/a-/at-spi2-core.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "dd1e736f89692df6c27db81eed2269458666841b",
+      "version": "2.44.1",
+      "port-version": 0
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -208,6 +208,14 @@
       "baseline": "1.1",
       "port-version": 1
     },
+    "at-spi2-atk": {
+      "baseline": "2.38.0",
+      "port-version": 0
+    },
+    "at-spi2-core": {
+      "baseline": "2.44.1",
+      "port-version": 0
+    },
     "atk": {
       "baseline": "2.38.0",
       "port-version": 1


### PR DESCRIPTION
libxtst-dev is required for at-spi2-core (gtk3 dependency)

- #### What does your PR fix?


- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?

linux

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
`Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
`Yes`

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
