### PR TITLE
[soxr] fix `arm64-osx` build

### DIFF
--- a/ports/soxr/003_detect_arm.patch
+++ b/ports/soxr/003_detect_arm.patch
@@ -7,7 +7,7 @@ index 0686bef..e4cb094 100644
    ARM NEON support macros
  */
 -#elif !defined(PFFFT_SIMD_DISABLE) && defined(__arm__)
-+#elif !defined(PFFFT_SIMD_DISABLE) && (defined(__arm__) || defined(_M_ARM))
++#elif !defined(PFFFT_SIMD_DISABLE) && (defined(__arm__) || defined(_M_ARM) || defined(__aarch64__))
  #  include <arm_neon.h>
  typedef float32x4_t v4sf;
  #  define SIMD_SZ 4

--- a/ports/soxr/portfile.cmake
+++ b/ports/soxr/portfile.cmake
@@ -6,7 +6,7 @@ vcpkg_from_sourceforge(
     PATCHES
         001_initialize-resampler.patch
         002_disable_warning.patch
-        003_detect_arm_on_windows.patch
+        003_detect_arm.patch
 )
 
 vcpkg_check_features(

--- a/ports/soxr/vcpkg.json
+++ b/ports/soxr/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "soxr",
   "version": "0.1.3",
-  "port-version": 6,
+  "port-version": 7,
   "description": "High quality audio resampling",
   "homepage": "https://sourceforge.net/projects/soxr/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -6698,7 +6698,7 @@
     },
     "soxr": {
       "baseline": "0.1.3",
-      "port-version": 6
+      "port-version": 7
     },
     "spaceland": {
       "baseline": "7.8.2",

--- a/versions/s-/soxr.json
+++ b/versions/s-/soxr.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "9eaa72e750312e0bacbd2a02e1a16fcc680489dd",
+      "version": "0.1.3",
+      "port-version": 7
+    },
+    {
       "git-tree": "fca92eeca8f38c1662193dd443e401c5fe7fbfc7",
       "version": "0.1.3",
       "port-version": 6


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
  This PR fixes the `arm64-osx` build for `soxr`.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  `arm64-osx`, No

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  Yes

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  Yes