### PR TITLE
[podofo] Re-fix export PoDoFoConfig.cmake

### DIFF
--- a/ports/podofo/install-cmake-config.patch
+++ b/ports/podofo/install-cmake-config.patch
@@ -1,10 +1,49 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index df623ef..b2f2201 100644
+index df623ef..8e653b8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -576,3 +576,4 @@ IF(PODOFO_BUILD_STATIC)
-   EXPORT(TARGETS podofo_static FILE "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake")
+@@ -569,10 +569,4 @@ CONFIGURE_FILE(${PoDoFo_SOURCE_DIR}/podofo_config.h.in ${PoDoFo_BINARY_DIR}/podo
+ # To use these dependencies set PODOFO_DIR to the podofo BUILD directory in
+ # your build (eg -DPODOFO_DIR=/path/to/podofo when running cmake to configure
+ # the app that'll use podofo). See: FIND_PACKAGE(...) in the cmake docs.
+-IF(PODOFO_BUILD_SHARED)
+-  EXPORT(TARGETS podofo_shared FILE "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake")
+-ENDIF(PODOFO_BUILD_SHARED)
+-IF(PODOFO_BUILD_STATIC)
+-  EXPORT(TARGETS podofo_static FILE "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake")
+-ENDIF(PODOFO_BUILD_STATIC)
+ 
+diff --git a/src/podofo/CMakeLists.txt b/src/podofo/CMakeLists.txt
+index bba6b5f..16f0798 100644
+--- a/src/podofo/CMakeLists.txt
++++ b/src/podofo/CMakeLists.txt
+@@ -275,10 +275,14 @@ IF(PODOFO_BUILD_STATIC)
+         CACHE INTERNAL "Which PoDoFo library variant to depend on")
+     SET(USING_SHARED_PODOFO FALSE)
+     INSTALL(TARGETS podofo_static
++        EXPORT PoDoFoConfig
+         RUNTIME DESTINATION "bin"
+         LIBRARY DESTINATION "${LIBDIRNAME}"
+         ARCHIVE DESTINATION "${LIBDIRNAME}"
+         )
++    INSTALL(EXPORT PoDoFoConfig
++        DESTINATION share/podofo
++        )
  ENDIF(PODOFO_BUILD_STATIC)
  
-+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/PoDoFoConfig.cmake" DESTINATION share/podofo)
-\ No newline at end of file
+ IF(PODOFO_BUILD_SHARED)
+@@ -301,10 +305,14 @@ IF(PODOFO_BUILD_SHARED)
+         CACHE INTERNAL "Which PoDoFo library variant to depend on")
+     SET(USING_SHARED_PODOFO TRUE)
+     INSTALL(TARGETS podofo_shared
++        EXPORT PoDoFoConfig
+         RUNTIME DESTINATION "bin"
+         LIBRARY DESTINATION "${LIBDIRNAME}"
+         ARCHIVE DESTINATION "${LIBDIRNAME}"
+         )
++    INSTALL(EXPORT PoDoFoConfig
++        DESTINATION share/podofo
++        )
+ 
+ 
+       # Create a pkg-config file for linking against shared library

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -54,8 +54,6 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
-
-vcpkg_cmake_config_fixup()
 vcpkg_replace_string( "${CURRENT_PACKAGES_DIR}/share/${PORT}/PoDoFoConfig.cmake"
     "# Create imported target podofo_shared"
 [[
@@ -64,6 +62,8 @@ find_dependency(OpenSSL)
 # Create imported target podofo_shared
 ]]
 )
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME PoDoFo)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -54,6 +54,8 @@ vcpkg_cmake_configure(
 )
 
 vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
 vcpkg_replace_string( "${CURRENT_PACKAGES_DIR}/share/${PORT}/PoDoFoConfig.cmake"
     "# Create imported target podofo_shared"
 [[
@@ -63,7 +65,7 @@ find_dependency(OpenSSL)
 ]]
 )
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME PoDoFo CONFIG_PATH share/podofo)
+vcpkg_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/podofo/portfile.cmake
+++ b/ports/podofo/portfile.cmake
@@ -63,7 +63,7 @@ find_dependency(OpenSSL)
 ]]
 )
 
-vcpkg_cmake_config_fixup(PACKAGE_NAME PoDoFo)
+vcpkg_cmake_config_fixup(PACKAGE_NAME PoDoFo CONFIG_PATH share/podofo)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 

--- a/ports/podofo/vcpkg.json
+++ b/ports/podofo/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "podofo",
   "version": "0.9.7",
-  "port-version": 1,
+  "port-version": 2,
   "description": "PoDoFo is a library to work with the PDF file format",
   "homepage": "https://sourceforge.net/projects/podofo/",
   "license": "LGPL-2.0-only",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5542,7 +5542,7 @@
     },
     "podofo": {
       "baseline": "0.9.7",
-      "port-version": 1
+      "port-version": 2
     },
     "poissonrecon": {
       "baseline": "2021-09-26",

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "fd4f161a136f02745af5888f196ee0623bb1ab3c",
+      "version": "0.9.7",
+      "port-version": 2
+    },
+    {
       "git-tree": "494b98ef9f42c9e4bafe58feff7d5738bb20f44e",
       "version": "0.9.7",
       "port-version": 1

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5436d6fc3c36a94c7aa36a241c8ada34f5cd8da7",
+      "git-tree": "f7f44c3594a2850412f1cb33ef1feaa78d35b7f9",
       "version": "0.9.7",
       "port-version": 2
     },

--- a/versions/p-/podofo.json
+++ b/versions/p-/podofo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "fd4f161a136f02745af5888f196ee0623bb1ab3c",
+      "git-tree": "5436d6fc3c36a94c7aa36a241c8ada34f5cd8da7",
       "version": "0.9.7",
       "port-version": 2
     },


### PR DESCRIPTION
The export in the original code will only generate a configuration file corresponding to the current configuration (debug or release). Use standard export to fix this.

Fixes #25328.

Already tested usage.