### PR TITLE
[ffmpeg] disable mediafoundation

### DIFF
--- a/ports/ffmpeg/portfile.cmake
+++ b/ports/ffmpeg/portfile.cmake
@@ -307,6 +307,12 @@ else()
     set(OPTIONS "${OPTIONS} --disable-lzma")
 endif()
 
+if("mediafoundation" IN_LIST FEATURES)
+    set(OPTIONS "${OPTIONS} --enable-mediafoundation")
+else()
+    set(OPTIONS "${OPTIONS} --disable-mediafoundation")
+endif()
+
 if("mp3lame" IN_LIST FEATURES)
     set(OPTIONS "${OPTIONS} --enable-libmp3lame")
 else()

--- a/ports/ffmpeg/vcpkg.json
+++ b/ports/ffmpeg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "ffmpeg",
   "version": "4.4.1",
-  "port-version": 13,
+  "port-version": 14,
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
@@ -425,6 +425,10 @@
       "dependencies": [
         "liblzma"
       ]
+    },
+    "mediafoundation": {
+      "description": "Enable encoding via MediaFoundation",
+      "supports": "windows"
     },
     "modplug": {
       "description": "ModPlug via libmodplug",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -2226,7 +2226,7 @@
     },
     "ffmpeg": {
       "baseline": "4.4.1",
-      "port-version": 13
+      "port-version": 14
     },
     "ffnvcodec": {
       "baseline": "11.1.5.0",

--- a/versions/f-/ffmpeg.json
+++ b/versions/f-/ffmpeg.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "b0435f3422780a6130708fa476353d8ea93cb2c7",
+      "version": "4.4.1",
+      "port-version": 14
+    },
+    {
       "git-tree": "ad64f5ffe64b5fcd97e2e6d98273b70d498d6af0",
       "version": "4.4.1",
       "port-version": 13


### PR DESCRIPTION
**Describe the pull request**

- #### What does your PR fix?
FFmpeg 4.3 added a MediaFoundation wrapper.  This wrapper is enabled by default on Windows.

Windows Server and Windows 10/11 "N" ship without Media Foundation installed, and will fail to load `avcodec-58.dll` because it will depend on `mfplat.dll`.

This commit removes the dependency on mediafoundation by default.  Users can specify the `mediafoundation` option to add it back.

- #### Which triplets are supported/not supported? Have you updated the [CI baseline]
all, no

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
To the best of my knowledge

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
Yes
